### PR TITLE
[move-examples] updated nft tutorial

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/mint_nft.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mint_nft.rs
@@ -204,3 +204,49 @@ fn sample_mint_nft_signature() {
         mint_proof_signature2
     );
 }
+
+/// run `cargo test sample_tutorial_signature -- --nocapture`
+/// to sample a valid signature for calling `resource_account_address::minting::mint_nft()`
+/// in `aptos-move/move-exampels/mint_nft`
+#[test]
+fn sample_tutorial_signature() {
+    let mut h = MoveHarness::new();
+
+    // supply the actual resource_address
+    // let resource_address = h.new_account_at(AccountAddress::from_hex_literal("0x[resource account's address]").unwrap());
+    let resource_address = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+
+    // supply the actual nft_receiver's address
+    // let nft_receiver = h.new_account_at(AccountAddress::from_hex_literal("0x[nft-receiver's address]").unwrap());
+    let nft_receiver = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+
+    let admin_account = h.new_account_with_key_pair();
+    // supply the actual private key of the admin
+    // let admin_private_key = Ed25519PrivateKey::from_encoded_string("...").unwrap();
+    let admin_private_key = admin_account.privkey;
+
+    // construct the token_data_id and mint_proof, which are required to mint the nft
+    let token_data_id = TokenDataId {
+        creator: *resource_address.address(),
+        collection: String::from("Collection name").into_bytes(),
+        name: String::from("Token name").into_bytes(),
+    };
+
+    let mint_proof = MintProofChallenge {
+        account_address: *resource_address.address(),
+        module_name: String::from("minting"),
+        struct_name: String::from("MintProofChallenge"),
+        receiver_account_sequence_number: 0,
+        receiver_account_address: *nft_receiver.address(),
+        token_data_id,
+    };
+
+    // sign the MintProofChallenge using the resource account's private key
+    let mint_proof_msg = bcs::to_bytes(&mint_proof);
+
+    let mint_proof_signature = admin_private_key.sign_arbitrary_message(&mint_proof_msg.unwrap());
+    println!(
+        "Mint Proof Signature for NFT receiver: {:?}",
+        mint_proof_signature
+    );
+}

--- a/aptos-move/move-examples/mint_nft/Move.toml
+++ b/aptos-move/move-examples/mint_nft/Move.toml
@@ -8,5 +8,7 @@ AptosToken = { local = "../../framework/aptos-token" }
 
 [addresses]
 aptos_framework = "0x1"
-# change it to `source_addr = "_" when calling `create-resource-account-and-publish-package` from the cli
+# change it to the actual source address when publishing the module
 source_addr = "0xcafe"
+# change it to the actual admin address when publishing the module
+admin_addr = "0xad"

--- a/aptos-move/move-examples/mint_nft/sources/minting.move
+++ b/aptos-move/move-examples/mint_nft/sources/minting.move
@@ -1,21 +1,55 @@
 /// This module is an example of how one can create a NFT collection from a resource account
 /// and allow users to mint from the NFT collection.
-/// Check aptos/move-e2e-tests/src/tests /mint.nft.rs for an e2e example.
+/// Check aptos-move/move-e2e-tests/src/tests/mint_nft.rs for an e2e example.
 ///
 /// - Initialization of this module
-/// Let's say we have an original account at address `0xcafe`. We can use it to call
+/// Let's say we have an original account at address `0xcafe`. We can use it to call the smart contract function
 /// `create_resource_account_and_publish_package(origin, vector::empty<>(), ...)` - this will create a resource address at
 /// `0xc3bb8488ab1a5815a9d543d7e41b0e0df46a7396f89b22821f07a4362f75ddc5`. The module `mint_nft` will be published under the
 /// resource account's address.
 ///
+/// - Accounts of this module
+/// > source account: the account used to create the resource account.
+/// > resource account: resource account is the account in charge of creating the collection and minting the tokens. A resource account is
+/// meant to programmatically sign for transactions so nobody has the private key of the resource account. The signer capability of
+/// the resource account is store in `ModuleData` to programmatically create a NFT collection and mint tokens.
+/// > admin account: admin account is the account in charge of updating the config of this contract. The admin account can update the
+/// expiration time, minting_enabled flag, and the public key of the admin account.
+///
 /// - When using this module, we expect the flow to look like:
-/// (1) call create_resource_account_and_publish_package() to publish this module under the resource account's address.
-/// init_module() will be called as part of publishing the package. In init_module(), we set up the NFT collection to mint.
-/// (2) call mint_nft(): this will check if this token minting is still valid, verify the `MintProofChallenge` struct against
-/// the resource signer's public key, and mint a token to the `receiver` upon successful verification. We will also emit an event
+/// 1. call create_resource_account_and_publish_package() (in a script or cli) to publish this module under the resource account's address.
+/// init_module() will be called automatically as part of publishing the package. In init_module(), we set up the NFT collection to mint.
+/// 2. call mint_nft() from a nft receiver's account: this will check if this token minting is still valid, verify the `MintProofChallenge` struct
+/// against the admin's public key, and mint a token to the `receiver` upon successful verification. We will also emit an event
 /// and mutate the token property (update the token version) upon successful token transfer.
-/// (3) (optional) update `expiration_timestamp` or `minting_enabled` of this CollectionTokenMinter by calling
-/// `set_timestamp()` or `set_minting_enabled()` from the resource signer.
+/// 3. (optional) the admin account can update `expiration_timestamp`, `minting_enabled`, and `public_key` when needed.
+///
+/// - How to run this on cli
+/// 1. Create three accounts: source-account (default), admin-account, and nft-receiver account
+/// aptos init (create source account)
+/// aptos init --profile admin-account (create admin-account)
+/// aptos init --profile nft-receiver (create nft-receiver account)
+/// 2. Fund all accounts
+/// aptos account fund-with-faucet --account default (repeat multiple times for the source account, because publishing a module costs more gas)
+/// aptos account fund-with-faucet --account admin-account
+/// aptos account fund-with-faucet --account nft-receiver
+/// 3. Run create_resource_account_and_publish_package to publish this contract under the resource account's address
+/// (need to change the named address in Move.toml file to the actual values first. also, the seed here is just an example)
+/// cargo run -p aptos -- move create-resource-account-and-publish-package --seed hex_array:4321 --address-name mint_nft --profile default
+/// 4. Update the admin's public key from the admin's account
+/// aptos move run --function-id [resource account's address]::minting::set_public_key --profile admin-account --args hex:[admin account's public key]
+/// for example: aptos move run --function-id 9a0e3291258d2a3d7698fe850509d37bc8ae29d83b9f9796dea188fe9a7b5cd3::minting::set_public_key --profile admin-account --args hex:E563FA6BC769ACD4EA99F7206156F1EACE2129DB56AEEC00D8E5DE992ADC1495
+/// 5. Update the timestamp of the colleciton from the admin's account
+/// aptos move run --function-id [resource account's address]::minting::set_timestamp --args u64:1000000000000000 --profile admin-account
+/// 6. Call `mint_nft` from the nft-receiver's account
+/// 6.1 Generate a valid signature.
+///     Go to aptos-core/aptos/move-e2e-tests/src/tests/mint_nft.rs
+///     In function `sample_tutorial_signature`, change the `resource_address`, `nft_receiver`, `admin_private_key` to the actual values.
+///     run `cargo test sample_tutorial_signature -- --nocapture` to generate a valid signature that we'll use in the next step.
+/// 6.2 Run `mint_nft` from the nft-receiver's account
+///     aptos move run --function-id [resource account's address]::minting::mint_nft --args hex:[valid signature] --profile nft-receiver
+///     for example: aptos move run --function-id 9a0e3291258d2a3d7698fe850509d37bc8ae29d83b9f9796dea188fe9a7b5cd3::minting::mint_nft --args hex:cf32699cf84a5390e021b8e775ff7627ee8c7a0c049bd3d774ea7880632a5638a200852f167ccb12590436bedd5b0d86187871f4836e3a0c47c55e8f5709440c --profile nft-receiver
+/// 7. (Optional) Go to devnet explorer and check out the resources of these accounts
 module mint_nft::minting {
     use std::error;
     use std::signer;
@@ -39,7 +73,7 @@ module mint_nft::minting {
     }
 
     // This struct stores an NFT collection's relevant information
-    struct CollectionTokenMinter has key {
+    struct ModuleData has key {
         public_key: ed25519::ValidatedPublicKey,
         signer_cap: account::SignerCapability,
         token_data_id: TokenDataId,
@@ -56,13 +90,13 @@ module mint_nft::minting {
         token_data_id: TokenDataId,
     }
 
-    /// Action not authorized because the signer is not the owner of this module
+    /// Action not authorized because the signer is not the admin of this module
     const ENOT_AUTHORIZED: u64 = 1;
     /// The collection minting is expired
     const ECOLLECTION_EXPIRED: u64 = 2;
     /// The collection minting is disabled
     const EMINTING_DISABLED: u64 = 3;
-    /// Specified public key is not the same as the collection token minter's public key
+    /// Specified public key is not the same as the admin's public key
     const EWRONG_PUBLIC_KEY: u64 = 4;
     /// Specified scheme required to proceed with the smart contract operation - can only be ED25519_SCHEME(0) OR MULTI_ED25519_SCHEME(1)
     const EINVALID_SCHEME: u64 = 5;
@@ -71,12 +105,12 @@ module mint_nft::minting {
 
     /// Initialize this module: create a resource account, a collection, and a token data id
     fun init_module(resource_account: &signer) {
-        // NOTE: This is just an example PK; please replace this with your desired minting PK.
+        // NOTE: This is just an example PK; please replace this with your desired admin PK.
         let hardcoded_pk = x"f66bf0ce5ceb582b93d6780820c2025b9967aedaa259bdbb9f3d0297eced0e18";
-        init_module_with_minter_public_key(resource_account, hardcoded_pk);
+        init_module_with_admin_public_key(resource_account, hardcoded_pk);
     }
 
-    fun init_module_with_minter_public_key(resource_account: &signer, pk_bytes: vector<u8>) {
+    fun init_module_with_admin_public_key(resource_account: &signer, pk_bytes: vector<u8>) {
         let collection_name = string::utf8(b"Collection name");
         let description = string::utf8(b"Description");
         let collection_uri = string::utf8(b"Collection uri");
@@ -84,8 +118,7 @@ module mint_nft::minting {
         let token_uri = string::utf8(b"Token uri");
         let expiration_timestamp = 1000000;
 
-        // create the resource account that we'll use to create tokens
-        // change source_addr to the actually account that called `create_resource_account`
+        // change source_addr to the actual account that created the resource account
         let resource_signer_cap = resource_account::retrieve_resource_account_cap(resource_account, @source_addr);
         let resource_signer = account::create_signer_with_capability(&resource_signer_cap);
 
@@ -117,7 +150,7 @@ module mint_nft::minting {
 
         let public_key = std::option::extract(&mut ed25519::new_validated_public_key_from_bytes(pk_bytes));
 
-        move_to(resource_account, CollectionTokenMinter {
+        move_to(resource_account, ModuleData {
             public_key,
             signer_cap: resource_signer_cap,
             token_data_id,
@@ -127,51 +160,59 @@ module mint_nft::minting {
         });
     }
 
-    /// Set if minting is enabled for this collection token minter
-    public entry fun set_minting_enabled(minter: &signer, minting_enabled: bool) acquires CollectionTokenMinter {
-        let minter_address = signer::address_of(minter);
-        assert!(minter_address == @mint_nft, error::permission_denied(ENOT_AUTHORIZED));
-        let collection_token_minter = borrow_global_mut<CollectionTokenMinter>(minter_address);
-        collection_token_minter.minting_enabled = minting_enabled;
+    /// Set if minting is enabled for this minting contract
+    public entry fun set_minting_enabled(caller: &signer, minting_enabled: bool) acquires ModuleData {
+        let caller_address = signer::address_of(caller);
+        assert!(caller_address == @admin_addr, error::permission_denied(ENOT_AUTHORIZED));
+        let module_data = borrow_global_mut<ModuleData>(@mint_nft);
+        module_data.minting_enabled = minting_enabled;
     }
 
-    /// Set the expiration timestamp of this collection token minter
-    public entry fun set_timestamp(minter: &signer, expiration_timestamp: u64) acquires CollectionTokenMinter {
-        let minter_address = signer::address_of(minter);
-        assert!(minter_address == @mint_nft, error::permission_denied(ENOT_AUTHORIZED));
-        let collection_token_minter = borrow_global_mut<CollectionTokenMinter>(minter_address);
-        collection_token_minter.expiration_timestamp = expiration_timestamp;
+    /// Set the expiration timestamp of this minting contract
+    public entry fun set_timestamp(caller: &signer, expiration_timestamp: u64) acquires ModuleData {
+        let caller_address = signer::address_of(caller);
+        assert!(caller_address == @admin_addr, error::permission_denied(ENOT_AUTHORIZED));
+        let module_data = borrow_global_mut<ModuleData>(@mint_nft);
+        module_data.expiration_timestamp = expiration_timestamp;
+    }
+
+    /// Set the public key of this minting contract
+    public entry fun set_public_key(caller: &signer, pk_bytes: vector<u8>) acquires ModuleData {
+        let caller_address = signer::address_of(caller);
+        assert!(caller_address == @admin_addr, error::permission_denied(ENOT_AUTHORIZED));
+        let module_data = borrow_global_mut<ModuleData>(@mint_nft);
+        module_data.public_key = std::option::extract(&mut ed25519::new_validated_public_key_from_bytes(pk_bytes));
     }
 
     /// Mint an NFT to the receiver.
-    /// `mint_proof_signature` should be the `MintProofChallenge` signed by the resource signer's private key
-    /// `public_key_bytes` should be the public key of the resource signer
-    public entry fun mint_nft(receiver: &signer, mint_proof_signature: vector<u8>) acquires CollectionTokenMinter {
+    /// `mint_proof_signature` should be the `MintProofChallenge` signed by the admin's private key
+    /// `public_key_bytes` should be the public key of the admin
+    public entry fun mint_nft(receiver: &signer, mint_proof_signature: vector<u8>) acquires ModuleData {
         let receiver_addr = signer::address_of(receiver);
 
         // get the collection minter and check if the collection minting is disabled or expired
-        let collection_token_minter = borrow_global_mut<CollectionTokenMinter>(@mint_nft);
-        assert!(timestamp::now_seconds() < collection_token_minter.expiration_timestamp, error::permission_denied(ECOLLECTION_EXPIRED));
-        assert!(collection_token_minter.minting_enabled, error::permission_denied(EMINTING_DISABLED));
+        let module_data = borrow_global_mut<ModuleData>(@mint_nft);
+        assert!(timestamp::now_seconds() < module_data.expiration_timestamp, error::permission_denied(ECOLLECTION_EXPIRED));
+        assert!(module_data.minting_enabled, error::permission_denied(EMINTING_DISABLED));
 
-        // verify that the `mint_proof_signature` is valid against the collection token minter's public key
-        verify_proof_of_knowledge(receiver_addr, mint_proof_signature, collection_token_minter.token_data_id, collection_token_minter.public_key);
+        // verify that the `mint_proof_signature` is valid against the admin's public key
+        verify_proof_of_knowledge(receiver_addr, mint_proof_signature, module_data.token_data_id, module_data.public_key);
 
         // mint token to the receiver
-        let resource_signer = account::create_signer_with_capability(&collection_token_minter.signer_cap);
-        let token_id = token::mint_token(&resource_signer, collection_token_minter.token_data_id, 1);
+        let resource_signer = account::create_signer_with_capability(&module_data.signer_cap);
+        let token_id = token::mint_token(&resource_signer, module_data.token_data_id, 1);
         token::direct_transfer(&resource_signer, receiver, token_id, 1);
 
         event::emit_event<TokenMintingEvent>(
-            &mut collection_token_minter.token_minting_events,
+            &mut module_data.token_minting_events,
             TokenMintingEvent {
                 token_receiver_address: receiver_addr,
-                token_data_id: collection_token_minter.token_data_id,
+                token_data_id: module_data.token_data_id,
             }
         );
 
         // mutate the token properties to update the property version of this token
-        let (creator_address, collection, name) = token::get_token_data_id_fields(&collection_token_minter.token_data_id);
+        let (creator_address, collection, name) = token::get_token_data_id_fields(&module_data.token_data_id);
         token::mutate_token_properties(
             &resource_signer,
             receiver_addr,
@@ -208,7 +249,7 @@ module mint_nft::minting {
     #[test_only]
     public fun set_up_test(
         origin_account: signer,
-        collection_token_minter: &signer,
+        resource_account: &signer,
         collection_token_minter_public_key: &ValidatedPublicKey,
         aptos_framework: signer,
         nft_receiver: &signer,
@@ -224,30 +265,32 @@ module mint_nft::minting {
         resource_account::create_resource_account(&origin_account, vector::empty<u8>(), vector::empty<u8>());
 
         let pk_bytes = ed25519::validated_public_key_to_bytes(collection_token_minter_public_key);
-        init_module_with_minter_public_key(collection_token_minter, pk_bytes);
+        init_module_with_admin_public_key(resource_account, pk_bytes);
 
         create_account_for_test(signer::address_of(nft_receiver));
+
+        create_account_for_test(@admin_addr);
     }
 
-    #[test (origin_account = @0xcafe, collection_token_minter = @0xc3bb8488ab1a5815a9d543d7e41b0e0df46a7396f89b22821f07a4362f75ddc5, nft_receiver = @0x123, nft_receiver2 = @0x234, aptos_framework = @aptos_framework)]
-    public entry fun test_happy_path(origin_account: signer, collection_token_minter: signer, nft_receiver: signer, nft_receiver2: signer, aptos_framework: signer) acquires CollectionTokenMinter {
-        let (minter_sk, minter_pk) = ed25519::generate_keys();
-        set_up_test(origin_account, &collection_token_minter, &minter_pk, aptos_framework, &nft_receiver, 10);
+    #[test (origin_account = @0xcafe, resource_account = @0xc3bb8488ab1a5815a9d543d7e41b0e0df46a7396f89b22821f07a4362f75ddc5, nft_receiver = @0x123, nft_receiver2 = @0x234, aptos_framework = @aptos_framework)]
+    public entry fun test_happy_path(origin_account: signer, resource_account: signer, nft_receiver: signer, nft_receiver2: signer, aptos_framework: signer) acquires ModuleData {
+        let (admin_sk, admin_pk) = ed25519::generate_keys();
+        set_up_test(origin_account, &resource_account, &admin_pk, aptos_framework, &nft_receiver, 10);
         let receiver_addr = signer::address_of(&nft_receiver);
         let proof_challenge = MintProofChallenge {
             receiver_account_sequence_number: account::get_sequence_number(receiver_addr),
             receiver_account_address: receiver_addr,
-            token_data_id: borrow_global<CollectionTokenMinter>(@mint_nft).token_data_id,
+            token_data_id: borrow_global<ModuleData>(@mint_nft).token_data_id,
         };
 
-        let sig = ed25519::sign_struct(&minter_sk, proof_challenge);
+        let sig = ed25519::sign_struct(&admin_sk, proof_challenge);
 
         // mint nft to this nft receiver
         mint_nft(&nft_receiver, ed25519::signature_to_bytes(&sig));
 
         // check that the nft_receiver has the token in their token store
-        let collection_token_minter = borrow_global_mut<CollectionTokenMinter>(@mint_nft);
-        let resource_signer = account::create_signer_with_capability(&collection_token_minter.signer_cap);
+        let module_data = borrow_global_mut<ModuleData>(@mint_nft);
+        let resource_signer = account::create_signer_with_capability(&module_data.signer_cap);
         let resource_signer_addr = signer::address_of(&resource_signer);
         let token_id = token::create_token_id_raw(resource_signer_addr, string::utf8(b"Collection name"), string::utf8(b"Token name"), 1);
         let new_token = token::withdraw_token(&nft_receiver, token_id, 1);
@@ -262,10 +305,10 @@ module mint_nft::minting {
         let proof_challenge_2 = MintProofChallenge {
             receiver_account_sequence_number: account::get_sequence_number(receiver_addr_2),
             receiver_account_address: receiver_addr_2,
-            token_data_id: borrow_global<CollectionTokenMinter>(@mint_nft).token_data_id,
+            token_data_id: borrow_global<ModuleData>(@mint_nft).token_data_id,
         };
 
-        let sig2 = ed25519::sign_struct(&minter_sk, proof_challenge_2);
+        let sig2 = ed25519::sign_struct(&admin_sk, proof_challenge_2);
         mint_nft(&nft_receiver2, ed25519::signature_to_bytes(&sig2));
 
         //  check the property version is properly updated
@@ -274,72 +317,72 @@ module mint_nft::minting {
         token::deposit_token(&nft_receiver2, new_token2);
     }
 
-    #[test (origin_account = @0xcafe, collection_token_minter = @0xc3bb8488ab1a5815a9d543d7e41b0e0df46a7396f89b22821f07a4362f75ddc5, nft_receiver = @0x123, aptos_framework = @aptos_framework)]
-    #[expected_failure(abort_code = 327682)]
-    public entry fun test_minting_expired(origin_account: signer, collection_token_minter: signer, nft_receiver: signer, aptos_framework: signer) acquires CollectionTokenMinter {
-        let (minter_sk, minter_pk) = ed25519::generate_keys();
-        set_up_test(origin_account, &collection_token_minter, &minter_pk, aptos_framework, &nft_receiver, 10000000);
+    #[test (origin_account = @0xcafe, resource_account = @0xc3bb8488ab1a5815a9d543d7e41b0e0df46a7396f89b22821f07a4362f75ddc5, nft_receiver = @0x123, aptos_framework = @aptos_framework)]
+    #[expected_failure(abort_code = 0x50002)]
+    public entry fun test_minting_expired(origin_account: signer, resource_account: signer, nft_receiver: signer, aptos_framework: signer) acquires ModuleData {
+        let (admin_sk, admin_pk) = ed25519::generate_keys();
+        set_up_test(origin_account, &resource_account, &admin_pk, aptos_framework, &nft_receiver, 10000000);
         let receiver_addr = signer::address_of(&nft_receiver);
         let proof_challenge = MintProofChallenge {
             receiver_account_sequence_number: account::get_sequence_number(receiver_addr),
             receiver_account_address: receiver_addr,
-            token_data_id: borrow_global<CollectionTokenMinter>(@mint_nft).token_data_id,
+            token_data_id: borrow_global<ModuleData>(@mint_nft).token_data_id,
         };
-        let sig = ed25519::sign_struct(&minter_sk, proof_challenge);
+        let sig = ed25519::sign_struct(&admin_sk, proof_challenge);
         mint_nft(&nft_receiver, ed25519::signature_to_bytes(&sig));
     }
 
-    #[test (origin_account = @0xcafe, collection_token_minter = @0xc3bb8488ab1a5815a9d543d7e41b0e0df46a7396f89b22821f07a4362f75ddc5, nft_receiver = @0x123, aptos_framework = @aptos_framework)]
-    #[expected_failure(abort_code = 327682)]
-    public entry fun test_update_expiration_time(origin_account: signer, collection_token_minter: signer, nft_receiver: signer, aptos_framework: signer) acquires CollectionTokenMinter {
-        let (minter_sk, minter_pk) = ed25519::generate_keys();
-        set_up_test(origin_account, &collection_token_minter, &minter_pk, aptos_framework, &nft_receiver, 10);
+    #[test (origin_account = @0xcafe, resource_account = @0xc3bb8488ab1a5815a9d543d7e41b0e0df46a7396f89b22821f07a4362f75ddc5, admin = @admin_addr, nft_receiver = @0x123, aptos_framework = @aptos_framework)]
+    #[expected_failure(abort_code = 0x50002)]
+    public entry fun test_update_expiration_time(origin_account: signer, resource_account: signer, admin: signer, nft_receiver: signer, aptos_framework: signer) acquires ModuleData {
+        let (admin_sk, admin_pk) = ed25519::generate_keys();
+        set_up_test(origin_account, &resource_account, &admin_pk, aptos_framework, &nft_receiver, 10);
         let receiver_addr = signer::address_of(&nft_receiver);
         let proof_challenge = MintProofChallenge {
             receiver_account_sequence_number: account::get_sequence_number(receiver_addr),
             receiver_account_address: receiver_addr,
-            token_data_id: borrow_global<CollectionTokenMinter>(@mint_nft).token_data_id,
+            token_data_id: borrow_global<ModuleData>(@mint_nft).token_data_id,
         };
 
-        let sig = ed25519::sign_struct(&minter_sk, proof_challenge);
+        let sig = ed25519::sign_struct(&admin_sk, proof_challenge);
 
         // set the expiration time of the minting to be earlier than the current time
-        set_timestamp(&collection_token_minter, 5);
+        set_timestamp(&admin, 5);
         mint_nft(&nft_receiver, ed25519::signature_to_bytes(&sig));
     }
 
-    #[test (origin_account = @0xcafe, collection_token_minter = @0xc3bb8488ab1a5815a9d543d7e41b0e0df46a7396f89b22821f07a4362f75ddc5, nft_receiver = @0x123, aptos_framework = @aptos_framework)]
-    #[expected_failure(abort_code = 327683)]
-    public entry fun test_update_minting_enabled(origin_account: signer, collection_token_minter: signer, nft_receiver: signer, aptos_framework: signer) acquires CollectionTokenMinter {
-        let (minter_sk, minter_pk) = ed25519::generate_keys();
-        set_up_test(origin_account, &collection_token_minter, &minter_pk, aptos_framework, &nft_receiver, 10);
+    #[test (origin_account = @0xcafe, resource_account = @0xc3bb8488ab1a5815a9d543d7e41b0e0df46a7396f89b22821f07a4362f75ddc5, admin = @admin_addr, nft_receiver = @0x123, aptos_framework = @aptos_framework)]
+    #[expected_failure(abort_code = 0x50003)]
+    public entry fun test_update_minting_enabled(origin_account: signer, resource_account: signer, admin: signer, nft_receiver: signer, aptos_framework: signer) acquires ModuleData {
+        let (admin_sk, admin_pk) = ed25519::generate_keys();
+        set_up_test(origin_account, &resource_account, &admin_pk, aptos_framework, &nft_receiver, 10);
         let receiver_addr = signer::address_of(&nft_receiver);
         let proof_challenge = MintProofChallenge {
             receiver_account_sequence_number: account::get_sequence_number(receiver_addr),
             receiver_account_address: receiver_addr,
-            token_data_id: borrow_global<CollectionTokenMinter>(@mint_nft).token_data_id,
+            token_data_id: borrow_global<ModuleData>(@mint_nft).token_data_id,
         };
 
-        let sig = ed25519::sign_struct(&minter_sk, proof_challenge);
+        let sig = ed25519::sign_struct(&admin_sk, proof_challenge);
 
         // disable token minting
-        set_minting_enabled(&collection_token_minter, false);
+        set_minting_enabled(&admin, false);
         mint_nft(&nft_receiver, ed25519::signature_to_bytes(&sig));
     }
 
-    #[test (origin_account = @0xcafe, collection_token_minter = @0xc3bb8488ab1a5815a9d543d7e41b0e0df46a7396f89b22821f07a4362f75ddc5, nft_receiver = @0x123, aptos_framework = @aptos_framework)]
-    #[expected_failure(abort_code = 65542)]
-    public entry fun test_invalid_signature(origin_account: signer, collection_token_minter: signer, nft_receiver: signer, aptos_framework: signer) acquires CollectionTokenMinter {
-        let (minter_sk, minter_pk) = ed25519::generate_keys();
-        set_up_test(origin_account, &collection_token_minter, &minter_pk, aptos_framework, &nft_receiver, 10);
+    #[test (origin_account = @0xcafe, resource_account = @0xc3bb8488ab1a5815a9d543d7e41b0e0df46a7396f89b22821f07a4362f75ddc5, nft_receiver = @0x123, aptos_framework = @aptos_framework)]
+    #[expected_failure(abort_code = 0x10006)]
+    public entry fun test_invalid_signature(origin_account: signer, resource_account: signer, nft_receiver: signer, aptos_framework: signer) acquires ModuleData {
+        let (admin_sk, admin_pk) = ed25519::generate_keys();
+        set_up_test(origin_account, &resource_account, &admin_pk, aptos_framework, &nft_receiver, 10);
         let receiver_addr = signer::address_of(&nft_receiver);
         let proof_challenge = MintProofChallenge {
             receiver_account_sequence_number: account::get_sequence_number(receiver_addr),
             receiver_account_address: receiver_addr,
-            token_data_id: borrow_global<CollectionTokenMinter>(@mint_nft).token_data_id,
+            token_data_id: borrow_global<ModuleData>(@mint_nft).token_data_id,
         };
 
-        let sig = ed25519::sign_struct(&minter_sk, proof_challenge);
+        let sig = ed25519::sign_struct(&admin_sk, proof_challenge);
         let sig_bytes = ed25519::signature_to_bytes(&sig);
 
         // Pollute signature.


### PR DESCRIPTION
### Description
added the concept of `admin_account` in `mint_nft` module, and assert the caller is the admin signer instead of the resource signer. for details, pls see added / modified comments in the files. 

tested manually with devnet (plus existing unit tests + e2e tests).

devnet explorer links: 
- resource account: https://explorer.aptoslabs.com/account/9a0e3291258d2a3d7698fe850509d37bc8ae29d83b9f9796dea188fe9a7b5cd3
- nft receiver's account:
https://explorer.aptoslabs.com/account/0x5343d6d52df22187ea922ab08668d2f551cdc1d5e9a6490db663a15f0f57400/resources

testing steps:
```
chloe@Chloes-MBP mint_nft % cargo run -p aptos -- move create-resource-account-and-publish-package --seed hex_array:4321 --address-name mint_nft --named-addresses source_addr=default                                          
    Finished dev [unoptimized + debuginfo] target(s) in 1.10s
     Running `/Users/chloe/aptos-core/target/debug/aptos move create-resource-account-and-publish-package --seed 'hex_array:4321' --address-name mint_nft --named-addresses source_addr=default`
Compiling, may take a little while to download git dependencies...
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY AptosToken
INCLUDING DEPENDENCY MoveStdlib
BUILDING Examples
Do you want to publish this package under the resource account's address 9a0e3291258d2a3d7698fe850509d37bc8ae29d83b9f9796dea188fe9a7b5cd3? [yes/no] >
yes
package size 7951 bytes
Do you want to submit a transaction for a range of [1732100 - 2598100] Octas at a gas unit price of 100 Octas? [yes/no] >
yes
{
  "Result": "Success"
}

chloe@Chloes-MBP mint_nft % aptos move run --function-id 9a0e3291258d2a3d7698fe850509d37bc8ae29d83b9f9796dea188fe9a7b5cd3::minting::set_public_key --profile admin-account --args hex:E563FA6BC769ACD4EA99F7206156F1EACE2129DB56AEEC00D8E5DE992ADC1495 
Do you want to submit a transaction for a range of [35200 - 52800] Octas at a gas unit price of 100 Octas? [yes/no] >
yes
{
  "Result": {
    "transaction_hash": "0x3a111105025b8ebcaa38f1661543f3bc2e5cfdbb272ca31f81c8aa790f6e08d7",
    "gas_used": 352,
    "gas_unit_price": 100,
    "sender": "bd0838054fbfb44e26496f238be752686819d460ea4f997de0c9d33d4cbf38f4",
    "sequence_number": 0,
    "success": true,
    "timestamp_us": 1667281002289779,
    "version": 21985067,
    "vm_status": "Executed successfully"
  }
}

chloe@Chloes-MBP mint_nft % aptos move run --function-id 9a0e3291258d2a3d7698fe850509d37bc8ae29d83b9f9796dea188fe9a7b5cd3::minting::set_timestamp --args u64:1000000000000000 --profile admin-account
Do you want to submit a transaction for a range of [23400 - 35100] Octas at a gas unit price of 100 Octas? [yes/no] >
yes
{
  "Result": {
    "transaction_hash": "0x15f2271c6397a5caf79dabb8ba000a9168f636bdc21143dd736843fed7d2c4ec",
    "gas_used": 234,
    "gas_unit_price": 100,
    "sender": "bd0838054fbfb44e26496f238be752686819d460ea4f997de0c9d33d4cbf38f4",
    "sequence_number": 1,
    "success": true,
    "timestamp_us": 1667281105256900,
    "version": 21989068,
    "vm_status": "Executed successfully"
  }
}

chloe@Chloes-MBP mint_nft % aptos move run --function-id 9a0e3291258d2a3d7698fe850509d37bc8ae29d83b9f9796dea188fe9a7b5cd3::minting::mint_nft --args hex:cf32699cf84a5390e021b8e775ff7627ee8c7a0c049bd3d774ea7880632a5638a200852f167ccb12590436bedd5b0d86187871f4836e3a0c47c55e8f5709440c --profile nft_receiver
Do you want to submit a transaction for a range of [661900 - 992800] Octas at a gas unit price of 100 Octas? [yes/no] >
yes
{
  "Result": {
    "transaction_hash": "0xac43608215b3ab905745c5504a6d1985984a8c957abee62ace7b53c9eba84adf",
    "gas_used": 6683,
    "gas_unit_price": 100,
    "sender": "05343d6d52df22187ea922ab08668d2f551cdc1d5e9a6490db663a15f0f57400",
    "sequence_number": 0,
    "success": true,
    "timestamp_us": 1667281564197033,
    "version": 22006914,
    "vm_status": "Executed successfully"
  }
}
```

### Test Plan
unit tests, e2e tests
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5388)
<!-- Reviewable:end -->
