### PR TITLE
[Indexer] Make indexer snappy again

### DIFF
--- a/crates/indexer/src/indexer/fetcher.rs
+++ b/crates/indexer/src/indexer/fetcher.rs
@@ -432,11 +432,14 @@ impl TransactionFetcher {
 impl TransactionFetcherTrait for TransactionFetcher {
     /// Fetches the next batch based on its internal version counter
     async fn fetch_next_batch(&mut self) -> Vec<Transaction> {
+        // try_next is nonblocking unlike next. It'll try to fetch the next one and return immediately.
         match self.transaction_receiver.try_next() {
             Ok(Some(transactions)) => transactions,
             Ok(None) => {
+                // We never close the channel, so this should never happen
                 panic!("Transaction fetcher channel closed");
             }
+            // The error here is when the channel is empty which we definitely expect.
             Err(_) => vec![],
         }
     }

--- a/crates/indexer/src/indexer/tailer.rs
+++ b/crates/indexer/src/indexer/tailer.rs
@@ -132,6 +132,7 @@ impl Tailer {
             .await;
 
         let num_txns = transactions.len() as u64;
+        // When the batch is empty b/c we're caught up
         if num_txns == 0 {
             return (0, None);
         }

--- a/crates/indexer/src/indexer/tailer.rs
+++ b/crates/indexer/src/indexer/tailer.rs
@@ -120,7 +120,10 @@ impl Tailer {
 
     pub async fn process_next_batch(
         &self,
-    ) -> (u64, Result<ProcessingResult, TransactionProcessingError>) {
+    ) -> (
+        u64,
+        Option<Result<ProcessingResult, TransactionProcessingError>>,
+    ) {
         let transactions = self
             .transaction_fetcher
             .lock()
@@ -129,6 +132,9 @@ impl Tailer {
             .await;
 
         let num_txns = transactions.len() as u64;
+        if num_txns == 0 {
+            return (0, None);
+        }
         let start_version = transactions.first().unwrap().version();
         let end_version = transactions.last().unwrap().version();
 
@@ -156,7 +162,7 @@ impl Tailer {
             "Finished processing of transaction batch"
         );
 
-        (num_txns, results)
+        (num_txns, Some(results))
     }
 
     /// Store last processed version from database. We can assume that all previously processed

--- a/crates/indexer/src/runtime.rs
+++ b/crates/indexer/src/runtime.rs
@@ -224,8 +224,9 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
 
         for (num_txn, res) in batches {
             let processed_result: ProcessingResult = match res {
-                Ok(res) => res,
-                Err(tpe) => {
+                None => continue,
+                Some(Ok(res)) => res,
+                Some(Err(tpe)) => {
                     let (err, start_version, end_version, _) = tpe.inner();
                     error!(
                         processor_name = processor_name,


### PR DESCRIPTION
### Description
This makes indexer snappy again, by skipping empty processor threads. The issue before was that we were spawning 10 threads to process transactions but if fetcher channel < 10, then we'd just be stuck waiting.

### Test Plan
tested locally w/ 
`cargo run -p aptos-node --features "indexer" --release -- -f ./fullnode_token.yaml | grep -E _processor`

changed to fetch_task = 1 and observed that it was chunky, but after change it's snappy again!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5391)
<!-- Reviewable:end -->
