### PR TITLE
fix: improve default max gas amount and expire timestamp

### DIFF
--- a/ecosystem/typescript/sdk/src/utils/misc.ts
+++ b/ecosystem/typescript/sdk/src/utils/misc.ts
@@ -24,9 +24,11 @@ export function fixNodeUrl(nodeUrl: string): string {
   return out;
 }
 
-export const DEFAULT_MAX_GAS_AMOUNT = 200000;
+// Value of `txn.maximum_number_of_gas_units` from `0x1::gas_schedule::GasScheduleV2`
+// This value can be retrieved from chain. But it is pretty heavy.
+export const DEFAULT_MAX_GAS_AMOUNT = 2000000;
 // Transaction expire timestamp
 export const DEFAULT_TXN_EXP_SEC_FROM_NOW = 20;
-// How long does SDK wait for txhn to finish
+// How long does SDK wait for txn to finish
 export const DEFAULT_TXN_TIMEOUT_SEC = 20;
 export const APTOS_COIN = "0x1::aptos_coin::AptosCoin";


### PR DESCRIPTION
### Description
This is a breaking change, should get into the next major release 2.0.0-alpha. This PR mainly addresses two issues:
1) Use on-chain timestmap + 20s as the default expire timestamp of txns. This fixes the issue that `new Date()` on client machines lags behind.
2) Use an account's balance as the default maxGasAmount. It is hard to guess the default gas amount without simulating the actual transaction. Using an account balance as the default prioritizes the txn success rate. This fixes the issue of using the hard-coded 200000. If an account's balance cannot cover `unit_price * 200000`, the txns will fail.


### Test Plan
yarn test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5392)
<!-- Reviewable:end -->
