### PR TITLE
[TS][SDK] Use pagination in getAccountResources and getAccountModules

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 
 ## Unreleased
 
-N/A
+- `getAccountModules` and `getAccountResources` now use pagination under the hood. This addresses the issue raised here: https://github.com/aptos-labs/aptos-core/issues/5298. The changes are non-breaking, if you use these functions with an older node that hasn't updated to include the relevant support in its API service, it will still work as it did before.
+- To support the above, the generated client has been updated to attach the headers to the response object, as per the changes here: https://github.com/aptos-labs/openapi-typescript-codegen/compare/v0.23.0...aptos-labs:openapi-typescript-codegen:0.24.0?expand=1. Consider this an implementation detail, not a supported part of the SDK interface.
 
 ## 1.3.16 (2022-10-12)
 

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -62,7 +62,7 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.26.0",
     "jest": "28.1.3",
-    "openapi-typescript-codegen": "https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p5/openapi-typescript-codegen-v0.23.0-p5.tgz",
+    "openapi-typescript-codegen": "https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.24.0/openapi-typescript-codegen-v0.24.0.tgz",
     "prettier": "2.6.2",
     "ts-jest": "28.0.8",
     "ts-loader": "9.3.1",

--- a/ecosystem/typescript/sdk/pnpm-lock.yaml
+++ b/ecosystem/typescript/sdk/pnpm-lock.yaml
@@ -16,7 +16,7 @@ specifiers:
   eslint-plugin-import: 2.26.0
   form-data: 4.0.0
   jest: 28.1.3
-  openapi-typescript-codegen: https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p5/openapi-typescript-codegen-v0.23.0-p5.tgz
+  openapi-typescript-codegen: https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.24.0/openapi-typescript-codegen-v0.24.0.tgz
   prettier: 2.6.2
   ts-jest: 28.0.8
   ts-loader: 9.3.1
@@ -44,7 +44,7 @@ devDependencies:
   eslint-config-prettier: 8.5.0_eslint@8.23.0
   eslint-plugin-import: 2.26.0_iepzrjnvahcxaf6zc7cutko6om
   jest: 28.1.3_seampb7kvrlatjhbvs2ov4kp2i
-  openapi-typescript-codegen: '@github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p5/openapi-typescript-codegen-v0.23.0-p5.tgz'
+  openapi-typescript-codegen: '@github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.24.0/openapi-typescript-codegen-v0.24.0.tgz'
   prettier: 2.6.2
   ts-jest: 28.0.8_556mfp7b5dutuj2jcrj5i7zc5q
   ts-loader: 9.3.1_typescript@4.8.2
@@ -4175,10 +4175,10 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  '@github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p5/openapi-typescript-codegen-v0.23.0-p5.tgz':
-    resolution: {tarball: https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p5/openapi-typescript-codegen-v0.23.0-p5.tgz}
+  '@github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.24.0/openapi-typescript-codegen-v0.24.0.tgz':
+    resolution: {tarball: https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.24.0/openapi-typescript-codegen-v0.24.0.tgz}
     name: openapi-typescript-codegen
-    version: 0.23.0-p5
+    version: 0.24.0
     hasBin: true
     dependencies:
       camelcase: 6.3.0

--- a/ecosystem/typescript/sdk/src/generated/core/request.ts
+++ b/ecosystem/typescript/sdk/src/generated/core/request.ts
@@ -401,7 +401,14 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
 
                 catchErrorCodes(options, result);
 
-                resolve(result.body);
+                // Attach the response headers to the output. This is a hack to fix
+                // https://github.com/ferdikoomen/openapi-typescript-codegen/issues/1295
+                const out = result.body;
+                try {
+                    out["__headers"] = response.headers;
+                } catch (_) {}
+
+                resolve(out);
             }
         } catch (error) {
             reject(error);

--- a/ecosystem/typescript/sdk/src/utils/index.ts
+++ b/ecosystem/typescript/sdk/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./misc";
 export * from "./memoize-decorator";
+export * from "./pagination_helpers";

--- a/ecosystem/typescript/sdk/src/utils/pagination_helpers.ts
+++ b/ecosystem/typescript/sdk/src/utils/pagination_helpers.ts
@@ -1,0 +1,40 @@
+import { AnyNumber } from "../bcs";
+import { HexString, MaybeHexString } from "../hex_string";
+
+/// This function is a helper for paginating using a function wrapping an API
+export async function paginateWithCursor<T>(
+  apiFunction: (
+    address: string,
+    ledgerVersion?: string | undefined,
+    start?: string | undefined,
+    limit?: number | undefined,
+  ) => Promise<T[]>,
+  accountAddress: MaybeHexString,
+  limitPerRequest: number,
+  query?: { ledgerVersion?: AnyNumber },
+): Promise<T[]> {
+  const out = [];
+  let cursor: string | undefined;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // eslint-disable-next-line no-await-in-loop
+    const response = await apiFunction(
+      HexString.ensure(accountAddress).hex(),
+      query?.ledgerVersion?.toString(),
+      cursor,
+      limitPerRequest,
+    );
+    // Response is the main response, i.e. the T[]. Attached to that are the headers as `__headers`.
+    // eslint-disable-next-line no-underscore-dangle
+    cursor = (response as any).__headers["x-aptos-cursor"];
+    // Now that we have the cursor (if any), we remove the headers before
+    // adding these to the output of this function.
+    // eslint-disable-next-line no-underscore-dangle
+    delete (response as any).__headers;
+    out.push(...response);
+    if (cursor === null || cursor === undefined) {
+      break;
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
### Description
This PR makes getAccountResources and getAccountModules use pagination, leveraging the support added in https://github.com/aptos-labs/aptos-core/pull/5313. 

### Test Plan
I ran the below tests both against a local node built from main and prod devnet, to ensure compatibility with both.

Run the SDK tests:
```
yarn test
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5405)
<!-- Reviewable:end -->
