### PR TITLE
Install lld in rust-setup action, use in Linux jobs of CLI release workflow

### DIFF
--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -1,7 +1,7 @@
 runs:
   using: composite
   steps:
-    - run: sudo apt-get update && sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config lsof --no-install-recommends --assume-yes
+    - run: sudo apt-get update && sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config lsof lld --no-install-recommends --assume-yes
       shell: bash
     - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
       with:

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
+      - uses: ./.github/actions/rust-setup
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Ubuntu"
       - name: Upload Binary
@@ -42,6 +43,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
+      - uses: ./.github/actions/rust-setup
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Ubuntu-22.04"
       - name: Upload Binary


### PR DESCRIPTION
### Description
Fixing the CLI build because on Linux they need lld. More context here: https://aptos-org.slack.com/archives/C036X27DZNG/p1667351722975209.

### Test Plan
Probably fork and try it there. I'd say we just land this though and if this doesn't work, then I'll go through that whole process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5416)
<!-- Reviewable:end -->
