### PR TITLE
[docs] fix wrong `token_data_id` type

### DIFF
--- a/developer-docs-site/docs/concepts/coin-and-token/aptos-token.md
+++ b/developer-docs-site/docs/concepts/coin-and-token/aptos-token.md
@@ -199,7 +199,7 @@ The following tables contain descriptions and examples on key token fields. Once
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `token_data_id` | TokenId | Identification for the metadata of the token |
+| `token_data_id` | TokenDataId | Identification for the metadata of the token |
 | `property_version` | u64 | The version of the property map; when a fungible token is mutated, a new property version is created and assigned to the token to make it an NFT |
 
 ##### `TokenDataId`


### PR DESCRIPTION
### Description
Fix the wrong `token_data_id` type

### Test Plan
Before
`token_data_id: TokenId`

After
`token_data_id: TokenDataId`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5426)
<!-- Reviewable:end -->
