### PR TITLE
[Indexer] decode BCS in some token fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,7 @@ dependencies = [
  "aptos-types",
  "aptos-vm",
  "async-trait",
+ "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigdecimal",
  "chrono",
  "clap 3.2.17",

--- a/aptos-move/framework/aptos-token/doc/token.md
+++ b/aptos-move/framework/aptos-token/doc/token.md
@@ -2212,6 +2212,8 @@ Burn a token by the token owner
     <a href="token.md#0x3_token_assert_tokendata_exists">assert_tokendata_exists</a>(creator, token_data_id);
     <b>let</b> all_token_data = &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="token.md#0x3_token_Collections">Collections</a>&gt;(token_data_id.creator).token_data;
     <b>let</b> token_data = <a href="../../aptos-framework/../aptos-stdlib/doc/table.md#0x1_table_borrow_mut">table::borrow_mut</a>(all_token_data, token_data_id);
+    // cannot change maximum from 0 and cannot change maximum <b>to</b> 0
+    <b>assert</b>!(token_data.maximum != 0 && maximum != 0, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="token.md#0x3_token_EINVALID_MAXIMUM">EINVALID_MAXIMUM</a>));
     <b>assert</b>!(maximum &gt;= token_data.supply, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="token.md#0x3_token_EINVALID_MAXIMUM">EINVALID_MAXIMUM</a>));
     <b>assert</b>!(token_data.mutability_config.maximum, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="token.md#0x3_token_EFIELD_NOT_MUTABLE">EFIELD_NOT_MUTABLE</a>));
     token_data.maximum = maximum;

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -19,6 +19,7 @@ aptos-api-types = { path = "../../api/types" }
 aptos-bitvec = { path = "../aptos-bitvec" }
 aptos-config = { path = "../../config" }
 async-trait = "0.1.53"
+bcs = "0.1.3"
 bigdecimal = { version = "0.3.0", features = ["serde"] }
 chrono = { version = "0.4.19", default-features = false, features = [
   "clock",

--- a/crates/indexer/src/models/mod.rs
+++ b/crates/indexer/src/models/mod.rs
@@ -10,6 +10,7 @@ pub mod move_resources;
 pub mod move_tables;
 pub mod processor_status;
 pub mod processor_statuses;
+pub mod property_map;
 pub mod signatures;
 pub mod stake_models;
 pub mod token_models;

--- a/crates/indexer/src/models/property_map.rs
+++ b/crates/indexer/src/models/property_map.rs
@@ -1,0 +1,56 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use serde_json::Result;
+use serde_json::Value;
+use std::collections::HashMap;
+
+use crate::util;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PropertyValue {
+    value: String,
+    typ: String,
+}
+
+pub fn create_property_value(typ: String, value: String) -> Result<PropertyValue> {
+    Ok(PropertyValue {
+        value: util::convert_bcs_hex(typ.clone(), value.clone()).unwrap_or(value),
+        typ,
+    })
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PropertyMap {
+    data: HashMap<String, PropertyValue>,
+}
+
+impl PropertyMap {
+    /// Deserializes PropertyValue from bcs encoded json
+    pub fn from_bsc_encode_str(val: Value) -> Option<Value> {
+        let mut pm = PropertyMap {
+            data: HashMap::new(),
+        };
+        let records: &Vec<Value> = val.get("map")?.get("data")?.as_array()?;
+        for entry in records {
+            let key = entry.get("key")?.as_str()?;
+            let val = entry.get("value")?.get("value")?.as_str()?;
+            let typ = entry.get("value")?.get("type")?.as_str()?;
+            let pv = create_property_value(typ.to_string(), val.to_string()).ok()?;
+            pm.data.insert(key.to_string(), pv);
+        }
+        Some(Self::to_flat_json(pm))
+    }
+
+    /// Flattens PropertyMap which can't be easily consumable by downstream.
+    /// For example: Object {"data": Object {"creation_time_sec": Object {"value": String("1666125588")}}}
+    /// becomes Object {"creation_time_sec": "1666125588"}
+    fn to_flat_json(val: PropertyMap) -> Value {
+        let mut map = HashMap::new();
+        for (k, v) in val.data {
+            map.insert(k, v.value);
+        }
+        serde_json::to_value(map).unwrap()
+    }
+}

--- a/crates/indexer/src/models/property_map.rs
+++ b/crates/indexer/src/models/property_map.rs
@@ -28,7 +28,7 @@ pub struct PropertyMap {
 
 impl PropertyMap {
     /// Deserializes PropertyValue from bcs encoded json
-    pub fn from_bsc_encode_str(val: Value) -> Option<Value> {
+    pub fn from_bcs_encode_str(val: Value) -> Option<Value> {
         let mut pm = PropertyMap {
             data: HashMap::new(),
         };

--- a/crates/indexer/src/models/token_models/token_utils.rs
+++ b/crates/indexer/src/models/token_models/token_utils.rs
@@ -4,7 +4,10 @@
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]
 
-use crate::util::{hash_str, truncate_str};
+use crate::util::{
+    deserialize_property_map_from_bcs_hexstring, deserialize_string_from_hexstring, hash_str,
+    truncate_str,
+};
 use anyhow::{Context, Result};
 use aptos_api_types::deserialize_from_string;
 use bigdecimal::BigDecimal;
@@ -93,7 +96,7 @@ impl fmt::Display for TokenIdType {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TokenDataType {
-    // TODO: decode bcs
+    #[serde(deserialize_with = "deserialize_property_map_from_bcs_hexstring")]
     pub default_properties: serde_json::Value,
     pub description: String,
     #[serde(deserialize_with = "deserialize_from_string")]
@@ -141,7 +144,7 @@ pub struct TokenType {
     #[serde(deserialize_with = "deserialize_from_string")]
     pub amount: BigDecimal,
     pub id: TokenIdType,
-    // TODO: decode bcs
+    #[serde(deserialize_with = "deserialize_property_map_from_bcs_hexstring")]
     pub token_properties: serde_json::Value,
 }
 
@@ -175,20 +178,6 @@ impl CollectionDataType {
 pub struct TokenOfferIdType {
     pub to_addr: String,
     pub token_id: TokenIdType,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TokenCoinSwapType {
-    #[serde(deserialize_with = "deserialize_from_string")]
-    pub min_price_per_token: BigDecimal,
-    pub token_amount: BigDecimal,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TokenEscrowType {
-    #[serde(deserialize_with = "deserialize_from_string")]
-    pub locked_until_secs: BigDecimal,
-    pub token: TokenType,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -273,9 +262,9 @@ pub struct ClaimTokenEventType {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TypeInfo {
     pub account_address: String,
-    // TODO: decode hexstring
+    #[serde(deserialize_with = "deserialize_string_from_hexstring")]
     pub module_name: String,
-    // TODO: decode hexstring
+    #[serde(deserialize_with = "deserialize_string_from_hexstring")]
     pub struct_name: String,
 }
 

--- a/crates/indexer/src/processors/token_processor.rs
+++ b/crates/indexer/src/processors/token_processor.rs
@@ -180,7 +180,7 @@ fn insert_tokens(
                 .on_conflict((token_data_id_hash, property_version, transaction_version))
                 .do_update()
                 .set((
-                    collection_data_id_hash.eq(excluded(collection_data_id_hash)),
+                    token_properties.eq(excluded(token_properties)),
                     inserted_at.eq(excluded(inserted_at)),
                 )),
             None,
@@ -210,11 +210,7 @@ fn insert_token_ownerships(
                     transaction_version,
                     table_handle,
                 ))
-                .do_update()
-                .set((
-                    collection_data_id_hash.eq(excluded(collection_data_id_hash)),
-                    inserted_at.eq(excluded(inserted_at)),
-                )),
+                .do_nothing(),
             None,
         )?;
     }
@@ -236,7 +232,7 @@ fn insert_token_datas(
                 .on_conflict((token_data_id_hash, transaction_version))
                 .do_update()
                 .set((
-                    collection_data_id_hash.eq(excluded(collection_data_id_hash)),
+                    default_properties.eq(excluded(default_properties)),
                     inserted_at.eq(excluded(inserted_at)),
                 )),
             None,
@@ -397,11 +393,7 @@ fn insert_token_activities(
                     event_creation_number,
                     event_sequence_number,
                 ))
-                .do_update()
-                .set((
-                    collection_data_id_hash.eq(excluded(collection_data_id_hash)),
-                    inserted_at.eq(excluded(inserted_at)),
-                )),
+                .do_nothing(),
             None,
         )?;
     }

--- a/crates/indexer/src/util.rs
+++ b/crates/indexer/src/util.rs
@@ -1,9 +1,14 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+// use crate::models::property_map::PropertyMap;
+use aptos_api_types::Address;
 use bigdecimal::{BigDecimal, Signed, ToPrimitive, Zero};
+use serde::{Deserialize, Deserializer};
 use serde_json::Value;
 use sha2::Digest;
+
+use crate::models::property_map::PropertyMap;
 
 // 9999-12-31 23:59:59, this is the max supported by Google BigQuery
 pub const MAX_TIMESTAMP_SECS: i64 = 253_402_300_799;
@@ -84,10 +89,82 @@ fn string_null_byte_replacement(value: &mut str) -> String {
     value.replace('\u{0000}', "").replace("\\u0000", "")
 }
 
+/// convert the bcs encoded inner value of property_map to its original value in string format
+pub fn deserialize_property_map_from_bcs_hexstring<'de, D>(
+    deserializer: D,
+) -> core::result::Result<Value, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = serde_json::Value::deserialize(deserializer)?;
+    // iterate the json string to convert key-value pair
+    // assume the format of {“map”: {“data”: [{“key”: “Yuri”, “value”: {“type”: “String”, “value”: “0x42656e”}}, {“key”: “Tarded”, “value”: {“type”: “String”, “value”: “0x446f766572"}}]}}
+    // if successfully parsing we return the decoded property_map string otherwise return the original string
+    Ok(convert_bcs_propertymap(s.clone()).unwrap_or(s))
+}
+
+pub fn deserialize_string_from_hexstring<'de, D>(
+    deserializer: D,
+) -> core::result::Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = <String>::deserialize(deserializer)?;
+    Ok(convert_hex(s.clone()).unwrap_or(s))
+}
+
+/// Convert the bcs serialized vector<u8> to its original string format
+pub fn convert_bcs_hex(typ: String, value: String) -> Option<String> {
+    let decoded = hex::decode(value.strip_prefix("0x").unwrap_or(&*value)).ok()?;
+
+    match typ.as_str() {
+        "0x1::string::String" => bcs::from_bytes::<String>(decoded.as_slice()),
+        "u8" => bcs::from_bytes::<u8>(decoded.as_slice()).map(|e| format!("{}", e)),
+        "u64" => bcs::from_bytes::<u64>(decoded.as_slice()).map(|e| format!("{}", e)),
+        "u128" => bcs::from_bytes::<u128>(decoded.as_slice()).map(|e| format!("{}", e)),
+        "bool" => bcs::from_bytes::<bool>(decoded.as_slice()).map(|e| format!("{}", e)),
+        "address" => bcs::from_bytes::<Address>(decoded.as_slice()).map(|e| format!("{}", e)),
+        _ => Ok(value),
+    }
+    .ok()
+}
+
+/// Convert the json serialized PropertyMap's inner BCS fields to their original value in string format
+pub fn convert_bcs_propertymap(s: Value) -> Option<Value> {
+    match PropertyMap::from_bsc_encode_str(s) {
+        Some(e) => match serde_json::to_value(&e) {
+            Ok(val) => Some(val),
+            Err(_) => None,
+        },
+        None => None,
+    }
+}
+
+/// Convert the vector<u8> that is directly generated from b"xxx"
+pub fn convert_hex(val: String) -> Option<String> {
+    let decoded = hex::decode(val.strip_prefix("0x").unwrap_or(&*val)).ok()?;
+    String::from_utf8(decoded).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use chrono::Datelike;
+    use serde::Serialize;
+
+    #[derive(Serialize, Deserialize, Debug)]
+    struct TypeInfoMock {
+        #[serde(deserialize_with = "deserialize_string_from_hexstring")]
+        pub module_name: String,
+        #[serde(deserialize_with = "deserialize_string_from_hexstring")]
+        pub struct_name: String,
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    struct TokenDataMock {
+        #[serde(deserialize_with = "deserialize_property_map_from_bcs_hexstring")]
+        pub default_properties: serde_json::Value,
+    }
 
     #[test]
     fn test_parse_timestamp() {
@@ -102,5 +179,72 @@ mod tests {
 
         let ts3 = parse_timestamp_secs(1659386386, 2);
         assert_eq!(ts3.timestamp(), 1659386386);
+    }
+
+    #[test]
+    fn test_deserialize_string_from_bcs() {
+        let test_struct = TypeInfoMock {
+            module_name: String::from("0x6170746f735f636f696e"),
+            struct_name: String::from("0x4170746f73436f696e"),
+        };
+        let val = serde_json::to_string(&test_struct).unwrap();
+        let d: TypeInfoMock = serde_json::from_str(val.as_str()).unwrap();
+        assert_eq!(d.module_name.as_str(), "aptos_coin");
+        assert_eq!(d.struct_name.as_str(), "AptosCoin");
+    }
+
+    #[test]
+    fn test_deserialize_property_map() {
+        let test_property_json = r#"
+        {
+            "map":{
+               "data":[
+                  {
+                     "key":"type",
+                     "value":{
+                        "type":"0x1::string::String",
+                        "value":"0x06646f6d61696e"
+                     }
+                  },
+                  {
+                     "key":"creation_time_sec",
+                     "value":{
+                        "type":"u64",
+                        "value":"0x140f4f6300000000"
+                     }
+                  },
+                  {
+                     "key":"expiration_time_sec",
+                     "value":{
+                        "type":"u64",
+                        "value":"0x9442306500000000"
+                     }
+                  }
+               ]
+            }
+        }"#;
+        let test_property_json: serde_json::Value =
+            serde_json::from_str(test_property_json).unwrap();
+        let test_struct = TokenDataMock {
+            default_properties: test_property_json,
+        };
+        let val = serde_json::to_string(&test_struct).unwrap();
+        let d: TokenDataMock = serde_json::from_str(val.as_str()).unwrap();
+        assert_eq!(d.default_properties["type"], "domain");
+        assert_eq!(d.default_properties["creation_time_sec"], "1666125588");
+        assert_eq!(d.default_properties["expiration_time_sec"], "1697661588");
+    }
+
+    #[test]
+    fn test_empty_property_map() {
+        let test_property_json = r#"{"map": {"data": []}}"#;
+        let test_property_json: serde_json::Value =
+            serde_json::from_str(test_property_json).unwrap();
+        let test_struct = TokenDataMock {
+            default_properties: test_property_json,
+        };
+        let val = serde_json::to_string(&test_struct).unwrap();
+        let d: TokenDataMock = serde_json::from_str(val.as_str()).unwrap();
+        assert_eq!(d.default_properties, Value::Object(serde_json::Map::new()));
     }
 }

--- a/crates/indexer/src/util.rs
+++ b/crates/indexer/src/util.rs
@@ -131,7 +131,7 @@ pub fn convert_bcs_hex(typ: String, value: String) -> Option<String> {
 
 /// Convert the json serialized PropertyMap's inner BCS fields to their original value in string format
 pub fn convert_bcs_propertymap(s: Value) -> Option<Value> {
-    match PropertyMap::from_bsc_encode_str(s) {
+    match PropertyMap::from_bcs_encode_str(s) {
         Some(e) => match serde_json::to_value(&e) {
             Ok(val) => Some(val),
             Err(_) => None,


### PR DESCRIPTION
### Description
* Decoding and flatten property map. Instead of 
```
{
   "map":{
      "data":[
         {
            "key":"type",
            "value":{
               "type":"0x1::string::String",
               "value":"0x06646f6d61696e"
            }
         },
         ....
```
we now have 
```
{
   "type": "domain",
    ...
}
```
* Also some fields can be bcs encoded, adding a bcs decoding deserializer. 

### Test Plan
Before
<img width="337" alt="image" src="https://user-images.githubusercontent.com/11738325/199659365-5d33b818-e4c0-49fc-a3a7-f7d1e4de2b0b.png">

Well this cleaned up nicely :)
<img width="701" alt="image" src="https://user-images.githubusercontent.com/11738325/199658166-9e55d995-200c-4cb3-8ca5-55bf37fd0d31.png">
<img width="869" alt="image" src="https://user-images.githubusercontent.com/11738325/199659290-df9ff35a-c2aa-44a2-b6b0-f4b43a779fd4.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5427)
<!-- Reviewable:end -->
