### PR TITLE
[TS][SDK] export aptos abi methods and add some serializer samples

### DIFF
--- a/ecosystem/typescript/sdk/src/aptos_types/abi.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/abi.test.ts
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { HexString } from "../hex_string";
-import { Deserializer } from "../bcs";
-import { ScriptABI, EntryFunctionABI, TransactionScriptABI } from "./abi";
+import { Deserializer, Serializer } from "../bcs";
+import { ScriptABI, EntryFunctionABI, TransactionScriptABI, TypeArgumentABI, ArgumentABI } from "./abi";
 import { TypeTagAddress, TypeTagU64 } from "./type_tag";
+import { ModuleId } from "./transaction";
 
 // eslint-disable-next-line operator-linebreak
 const SCRIPT_FUNCTION_ABI =
@@ -17,7 +18,16 @@ const TRANSACTION_SCRIPT_ABI =
   "00046D61696E0F20412074657374207363726970742E8B01A11CEB0B050000000501000403040A050E0B071924083D200000000101020301000003010400020C0301050001060C0101074163636F756E74065369676E65720A616464726573735F6F66096578697374735F617400000000000000000000000000000000000000000000000000000000000000010000010A0E0011000C020B021101030705090B0127020001016902";
 
 describe("ABI", () => {
-  it("parses create_acount successfully", async () => {
+  it("parses create_account successfully", async () => {
+    const name = "create_account";
+    const doc = " Basic account creation methods.";
+    const typeArgABIs = [new ArgumentABI("auth_key", new TypeTagAddress())];
+
+    const abi = new EntryFunctionABI(name, ModuleId.fromStr("0x1::Account"), doc, [], typeArgABIs);
+    const serializer = new Serializer();
+    abi.serialize(serializer);
+    expect(HexString.fromUint8Array(serializer.getBytes()).noPrefix()).toBe(SCRIPT_FUNCTION_ABI.toLowerCase());
+
     const deserializer = new Deserializer(new HexString(SCRIPT_FUNCTION_ABI).toUint8Array());
     const entryFunctionABI = ScriptABI.deserialize(deserializer) as EntryFunctionABI;
     const { address: moduleAddress, name: moduleName } = entryFunctionABI.module_name;
@@ -32,15 +42,23 @@ describe("ABI", () => {
   });
 
   it("parses script abi successfully", async () => {
+    const name = "main";
+    // eslint-disable-next-line max-len
+    const code =
+      "0xa11ceb0b050000000501000403040a050e0b071924083d200000000101020301000003010400020c0301050001060c0101074163636f756e74065369676e65720a616464726573735f6f66096578697374735f617400000000000000000000000000000000000000000000000000000000000000010000010a0e0011000c020b021101030705090b012702";
+    const doc = " A test script.";
+    const typeArgABIs = [new ArgumentABI("i", new TypeTagU64())];
+    const abi = new TransactionScriptABI(name, doc, HexString.ensure(code).toUint8Array(), [], typeArgABIs);
+    const serializer = new Serializer();
+    abi.serialize(serializer);
+    expect(HexString.fromUint8Array(serializer.getBytes()).noPrefix()).toBe(TRANSACTION_SCRIPT_ABI.toLowerCase());
+
     const deserializer = new Deserializer(new HexString(TRANSACTION_SCRIPT_ABI).toUint8Array());
     const transactionScriptABI = ScriptABI.deserialize(deserializer) as TransactionScriptABI;
     expect(transactionScriptABI.name).toBe("main");
     expect(transactionScriptABI.doc.trim()).toBe("A test script.");
 
-    expect(HexString.fromUint8Array(transactionScriptABI.code).hex()).toBe(
-      // eslint-disable-next-line max-len
-      "0xa11ceb0b050000000501000403040a050e0b071924083d200000000101020301000003010400020c0301050001060c0101074163636f756e74065369676e65720a616464726573735f6f66096578697374735f617400000000000000000000000000000000000000000000000000000000000000010000010a0e0011000c020b021101030705090b012702",
-    );
+    expect(HexString.fromUint8Array(transactionScriptABI.code).hex()).toBe(code);
 
     const arg = transactionScriptABI.args[0];
     expect(arg.name).toBe("i");

--- a/ecosystem/typescript/sdk/src/aptos_types/index.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+export * from "./abi";
 export * from "./account_address";
 export * from "./authenticator";
 export * from "./transaction";


### PR DESCRIPTION
### Description

This PR `export` the [aptos_types/abi.ts](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/typescript/sdk/src/aptos_types/abi.ts) and adds some `serialize` samples. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
```js
yarn test 
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5431)
<!-- Reviewable:end -->
