### PR TITLE
[framework] governance multi-step proposal

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/voting.md
+++ b/aptos-move/framework/aptos-framework/doc/voting.md
@@ -37,14 +37,18 @@
 -  [Constants](#@Constants_0)
 -  [Function `register`](#0x1_voting_register)
 -  [Function `create_proposal`](#0x1_voting_create_proposal)
+-  [Function `create_proposal_v2`](#0x1_voting_create_proposal_v2)
 -  [Function `vote`](#0x1_voting_vote)
+-  [Function `is_proposal_resolvable`](#0x1_voting_is_proposal_resolvable)
 -  [Function `resolve`](#0x1_voting_resolve)
+-  [Function `resolve_proposal_v2`](#0x1_voting_resolve_proposal_v2)
 -  [Function `is_voting_closed`](#0x1_voting_is_voting_closed)
 -  [Function `can_be_resolved_early`](#0x1_voting_can_be_resolved_early)
 -  [Function `get_proposal_state`](#0x1_voting_get_proposal_state)
 -  [Function `get_proposal_expiration_secs`](#0x1_voting_get_proposal_expiration_secs)
 -  [Function `get_execution_hash`](#0x1_voting_get_execution_hash)
 -  [Function `is_resolved`](#0x1_voting_is_resolved)
+-  [Function `is_multi_step_proposal_in_execution`](#0x1_voting_is_multi_step_proposal_in_execution)
 -  [Function `is_voting_period_over`](#0x1_voting_is_voting_period_over)
 
 
@@ -99,8 +103,12 @@ Extra metadata (e.g. description, code url) can be part of the ProposalType stru
 <code>metadata: <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;</code>
 </dt>
 <dd>
- Optional. Extra metadata about the proposal and can be empty.
- Value is serialized value of an attribute.
+ Optional. Value is serialized value of an attribute.
+ Currently, we have three attributes that are used by the voting flow.
+ 1. RESOLVABLE_TIME_METADATA_KEY: this is uesed to record the resolvable time to ensure that resolution has to be done non-atomically.
+ 2. IS_MULTI_STEP_PROPOSAL_KEY: this is used to track if a proposal is single-step or multi-step.
+ 3. IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY: this attribute only exists for and applies to multi-step proposals. The value is used to
+ indicate if a multi-step proposal is in execution. If yes, we will disable further voting for this multi-step proposal.
 </dd>
 <dt>
 <code>creation_time_secs: u64</code>
@@ -434,6 +442,27 @@ Minimum vote threshold cannot be higher than early resolution threshold.
 
 
 
+<a name="0x1_voting_EMULTI_STEP_PROPOSAL_CANNOT_USE_SINGLE_STEP_RESOLVE_FUNCTION"></a>
+
+If a proposal is multi-step, we need to use <code><a href="voting.md#0x1_voting_resolve_proposal_v2">resolve_proposal_v2</a>()</code> to resolve it.
+If we use <code><a href="voting.md#0x1_voting_resolve">resolve</a>()</code> to resolve a multi-step proposal, it will fail with EMULTI_STEP_PROPOSAL_CANNOT_USE_SINGLE_STEP_RESOLVE_FUNCTION.
+
+
+<pre><code><b>const</b> <a href="voting.md#0x1_voting_EMULTI_STEP_PROPOSAL_CANNOT_USE_SINGLE_STEP_RESOLVE_FUNCTION">EMULTI_STEP_PROPOSAL_CANNOT_USE_SINGLE_STEP_RESOLVE_FUNCTION</a>: u64 = 10;
+</code></pre>
+
+
+
+<a name="0x1_voting_EMULTI_STEP_PROPOSAL_IN_EXECUTION"></a>
+
+Cannot vote if the specified multi-step proposal is in execution.
+
+
+<pre><code><b>const</b> <a href="voting.md#0x1_voting_EMULTI_STEP_PROPOSAL_IN_EXECUTION">EMULTI_STEP_PROPOSAL_IN_EXECUTION</a>: u64 = 9;
+</code></pre>
+
+
+
 <a name="0x1_voting_EPROPOSAL_ALREADY_RESOLVED"></a>
 
 Proposal cannot be resolved more than once
@@ -474,6 +503,16 @@ Current script's execution hash does not match the specified proposal's
 
 
 
+<a name="0x1_voting_EPROPOSAL_IS_SINGLE_STEP"></a>
+
+Cannot call <code><a href="voting.md#0x1_voting_is_multi_step_proposal_in_execution">is_multi_step_proposal_in_execution</a>()</code> on single-step proposals.
+
+
+<pre><code><b>const</b> <a href="voting.md#0x1_voting_EPROPOSAL_IS_SINGLE_STEP">EPROPOSAL_IS_SINGLE_STEP</a>: u64 = 12;
+</code></pre>
+
+
+
 <a name="0x1_voting_EPROPOSAL_VOTING_ALREADY_ENDED"></a>
 
 Proposal's voting period has already ended.
@@ -494,12 +533,42 @@ Resolution of a proposal cannot happen atomically in the same transaction as the
 
 
 
+<a name="0x1_voting_ESINGLE_STEP_PROPOSAL_CANNOT_HAVE_NEXT_EXECUTION_HASH"></a>
+
+If we call <code><a href="voting.md#0x1_voting_resolve_proposal_v2">resolve_proposal_v2</a>()</code> to resolve a single-step proposal, the <code>next_execution_hash</code> parameter should be an empty vector.
+
+
+<pre><code><b>const</b> <a href="voting.md#0x1_voting_ESINGLE_STEP_PROPOSAL_CANNOT_HAVE_NEXT_EXECUTION_HASH">ESINGLE_STEP_PROPOSAL_CANNOT_HAVE_NEXT_EXECUTION_HASH</a>: u64 = 11;
+</code></pre>
+
+
+
 <a name="0x1_voting_EVOTING_FORUM_ALREADY_REGISTERED"></a>
 
 Voting forum has already been registered.
 
 
 <pre><code><b>const</b> <a href="voting.md#0x1_voting_EVOTING_FORUM_ALREADY_REGISTERED">EVOTING_FORUM_ALREADY_REGISTERED</a>: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x1_voting_IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY"></a>
+
+Key used to track if the multi-step proposal is in execution / resolving in progress.
+
+
+<pre><code><b>const</b> <a href="voting.md#0x1_voting_IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY">IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; = [73, 83, 95, 77, 85, 76, 84, 73, 95, 83, 84, 69, 80, 95, 80, 82, 79, 80, 79, 83, 65, 76, 95, 73, 78, 95, 69, 88, 69, 67, 85, 84, 73, 79, 78];
+</code></pre>
+
+
+
+<a name="0x1_voting_IS_MULTI_STEP_PROPOSAL_KEY"></a>
+
+Key used to track if the proposal is multi-step
+
+
+<pre><code><b>const</b> <a href="voting.md#0x1_voting_IS_MULTI_STEP_PROPOSAL_KEY">IS_MULTI_STEP_PROPOSAL_KEY</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; = [73, 83, 95, 77, 85, 76, 84, 73, 95, 83, 84, 69, 80, 95, 80, 82, 79, 80, 79, 83, 65, 76, 95, 75, 69, 89];
 </code></pre>
 
 
@@ -593,7 +662,7 @@ Key used to track the resolvable time in the proposal's metadata.
 
 ## Function `create_proposal`
 
-Create a proposal with the given parameters
+Create a single-step proposal with the given parameters
 
 @param voting_forum_address The forum's address where the proposal will be stored.
 @param execution_content The execution content that will be given back at resolution time. This can contain
@@ -602,6 +671,8 @@ data such as a capability resource used to scope the execution.
 this proposal.
 @param min_vote_threshold The minimum number of votes needed to consider this proposal successful.
 @param expiration_secs The time in seconds at which the proposal expires and can potentially be resolved.
+@param early_resolution_vote_threshold The vote threshold for early resolution of this proposal.
+@param metadata A simple_map that stores information about this proposal.
 @return The proposal id.
 
 
@@ -624,6 +695,63 @@ this proposal.
     early_resolution_vote_threshold: Option&lt;u128&gt;,
     metadata: SimpleMap&lt;String, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
 ): u64 <b>acquires</b> <a href="voting.md#0x1_voting_VotingForum">VotingForum</a> {
+    <a href="voting.md#0x1_voting_create_proposal_v2">create_proposal_v2</a>(
+        proposer,
+        voting_forum_address,
+        execution_content,
+        execution_hash,
+        min_vote_threshold,
+        expiration_secs,
+        early_resolution_vote_threshold,
+        metadata,
+        <b>false</b>
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_voting_create_proposal_v2"></a>
+
+## Function `create_proposal_v2`
+
+Create a single-step or a multi-step proposal with the given parameters
+
+@param voting_forum_address The forum's address where the proposal will be stored.
+@param execution_content The execution content that will be given back at resolution time. This can contain
+data such as a capability resource used to scope the execution.
+@param execution_hash The hash for the execution script module. Only the same exact script module can resolve
+this proposal.
+@param min_vote_threshold The minimum number of votes needed to consider this proposal successful.
+@param expiration_secs The time in seconds at which the proposal expires and can potentially be resolved.
+@param early_resolution_vote_threshold The vote threshold for early resolution of this proposal.
+@param metadata A simple_map that stores information about this proposal.
+@param is_multi_step_proposal A bool value that indicates if the proposal is single-step or multi-step.
+@return The proposal id.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_create_proposal_v2">create_proposal_v2</a>&lt;ProposalType: store&gt;(proposer: <b>address</b>, voting_forum_address: <b>address</b>, execution_content: ProposalType, execution_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, min_vote_threshold: u128, expiration_secs: u64, early_resolution_vote_threshold: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u128&gt;, metadata: <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, is_multi_step_proposal: bool): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_create_proposal_v2">create_proposal_v2</a>&lt;ProposalType: store&gt;(
+    proposer: <b>address</b>,
+    voting_forum_address: <b>address</b>,
+    execution_content: ProposalType,
+    execution_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    min_vote_threshold: u128,
+    expiration_secs: u64,
+    early_resolution_vote_threshold: Option&lt;u128&gt;,
+    metadata: SimpleMap&lt;String, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
+    is_multi_step_proposal: bool,
+): u64 <b>acquires</b> <a href="voting.md#0x1_voting_VotingForum">VotingForum</a> {
     <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&early_resolution_vote_threshold)) {
         <b>assert</b>!(
             min_vote_threshold &lt;= *<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&early_resolution_vote_threshold),
@@ -636,6 +764,21 @@ this proposal.
     <b>let</b> voting_forum = <b>borrow_global_mut</b>&lt;<a href="voting.md#0x1_voting_VotingForum">VotingForum</a>&lt;ProposalType&gt;&gt;(voting_forum_address);
     <b>let</b> proposal_id = voting_forum.next_proposal_id;
     voting_forum.next_proposal_id = voting_forum.next_proposal_id + 1;
+
+    // Add a flag <b>to</b> indicate <b>if</b> this proposal is single-step or multi-step.
+    <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_add">simple_map::add</a>(&<b>mut</b> metadata, utf8(<a href="voting.md#0x1_voting_IS_MULTI_STEP_PROPOSAL_KEY">IS_MULTI_STEP_PROPOSAL_KEY</a>), to_bytes(&is_multi_step_proposal));
+
+    <b>let</b> is_multi_step_in_execution_key = utf8(<a href="voting.md#0x1_voting_IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY">IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY</a>);
+    <b>if</b> (is_multi_step_proposal) {
+        // If the given proposal is a multi-step proposal, we will add a flag <b>to</b> indicate <b>if</b> this multi-step proposal is in execution.
+        // This value is by default <b>false</b>. We turn this value <b>to</b> <b>true</b> when we start executing the multi-step proposal. This value
+        // will be used <b>to</b> disable further <a href="voting.md#0x1_voting">voting</a> after we started executing the multi-step proposal.
+        <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_add">simple_map::add</a>(&<b>mut</b> metadata, is_multi_step_in_execution_key, to_bytes(&<b>false</b>));
+    // If the proposal is a single-step proposal, we check <b>if</b> the metadata passed by the client <b>has</b> the <a href="voting.md#0x1_voting_IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY">IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY</a> key.
+    // If they have the key, we will remove it, because a single-step proposal that doesn't need this key.
+    } <b>else</b> <b>if</b> (<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_contains_key">simple_map::contains_key</a>(&<b>mut</b> metadata, &is_multi_step_in_execution_key)) {
+        <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_remove">simple_map::remove</a>(&<b>mut</b> metadata, &is_multi_step_in_execution_key);
+    };
 
     <a href="../../aptos-stdlib/doc/table.md#0x1_table_add">table::add</a>(&<b>mut</b> voting_forum.proposals, proposal_id, <a href="voting.md#0x1_voting_Proposal">Proposal</a> {
         proposer,
@@ -711,6 +854,10 @@ This guarantees that voting eligibility and voting power are controlled by the r
     // appropriate.
     <b>assert</b>!(!<a href="voting.md#0x1_voting_is_voting_period_over">is_voting_period_over</a>(proposal), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="voting.md#0x1_voting_EPROPOSAL_VOTING_ALREADY_ENDED">EPROPOSAL_VOTING_ALREADY_ENDED</a>));
     <b>assert</b>!(!proposal.is_resolved, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="voting.md#0x1_voting_EPROPOSAL_ALREADY_RESOLVED">EPROPOSAL_ALREADY_RESOLVED</a>));
+    // Assert this proposal is single-step, or <b>if</b> the proposal is multi-step, it is not in execution yet.
+    <b>assert</b>!(!<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_contains_key">simple_map::contains_key</a>(&proposal.metadata, &utf8(<a href="voting.md#0x1_voting_IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY">IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY</a>))
+            || *<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_borrow">simple_map::borrow</a>(&proposal.metadata, &utf8(<a href="voting.md#0x1_voting_IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY">IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY</a>)) == to_bytes(&<b>false</b>),
+            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="voting.md#0x1_voting_EMULTI_STEP_PROPOSAL_IN_EXECUTION">EMULTI_STEP_PROPOSAL_IN_EXECUTION</a>));
 
     <b>if</b> (should_pass) {
         proposal.yes_votes = proposal.yes_votes + (num_votes <b>as</b> u128);
@@ -738,11 +885,53 @@ This guarantees that voting eligibility and voting power are controlled by the r
 
 </details>
 
+<a name="0x1_voting_is_proposal_resolvable"></a>
+
+## Function `is_proposal_resolvable`
+
+
+
+<pre><code><b>fun</b> <a href="voting.md#0x1_voting_is_proposal_resolvable">is_proposal_resolvable</a>&lt;ProposalType: store&gt;(voting_forum_address: <b>address</b>, proposal_id: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="voting.md#0x1_voting_is_proposal_resolvable">is_proposal_resolvable</a>&lt;ProposalType: store&gt;(
+    voting_forum_address: <b>address</b>,
+    proposal_id: u64,
+) <b>acquires</b> <a href="voting.md#0x1_voting_VotingForum">VotingForum</a> {
+    <b>let</b> proposal_state = <a href="voting.md#0x1_voting_get_proposal_state">get_proposal_state</a>&lt;ProposalType&gt;(voting_forum_address, proposal_id);
+    <b>assert</b>!(proposal_state == <a href="voting.md#0x1_voting_PROPOSAL_STATE_SUCCEEDED">PROPOSAL_STATE_SUCCEEDED</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="voting.md#0x1_voting_EPROPOSAL_CANNOT_BE_RESOLVED">EPROPOSAL_CANNOT_BE_RESOLVED</a>));
+
+    <b>let</b> voting_forum = <b>borrow_global_mut</b>&lt;<a href="voting.md#0x1_voting_VotingForum">VotingForum</a>&lt;ProposalType&gt;&gt;(voting_forum_address);
+    <b>let</b> proposal = <a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> voting_forum.proposals, proposal_id);
+    <b>assert</b>!(!proposal.is_resolved, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="voting.md#0x1_voting_EPROPOSAL_ALREADY_RESOLVED">EPROPOSAL_ALREADY_RESOLVED</a>));
+
+    // We need <b>to</b> make sure that the resolution is happening in
+    // a separate transaction from the last vote <b>to</b> guard against <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> potential flashloan attacks.
+    <b>let</b> resolvable_time = to_u64(*<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_borrow">simple_map::borrow</a>(&proposal.metadata, &utf8(<a href="voting.md#0x1_voting_RESOLVABLE_TIME_METADATA_KEY">RESOLVABLE_TIME_METADATA_KEY</a>)));
+    <b>assert</b>!(<a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>() &gt; resolvable_time, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="voting.md#0x1_voting_ERESOLUTION_CANNOT_BE_ATOMIC">ERESOLUTION_CANNOT_BE_ATOMIC</a>));
+
+    <b>assert</b>!(
+        <a href="transaction_context.md#0x1_transaction_context_get_script_hash">transaction_context::get_script_hash</a>() == proposal.execution_hash,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="voting.md#0x1_voting_EPROPOSAL_EXECUTION_HASH_NOT_MATCHING">EPROPOSAL_EXECUTION_HASH_NOT_MATCHING</a>),
+    );
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x1_voting_resolve"></a>
 
 ## Function `resolve`
 
-Resolve the proposal with given id. Can only be done if there are at least as many votes as min required and
+Resolve a single-step proposal with given id. Can only be done if there are at least as many votes as min required and
 there are more yes votes than no. If either of these conditions is not met, this will revert.
 
 @param voting_forum_address The address of the forum where the proposals are stored.
@@ -762,26 +951,22 @@ there are more yes votes than no. If either of these conditions is not met, this
     voting_forum_address: <b>address</b>,
     proposal_id: u64,
 ): ProposalType <b>acquires</b> <a href="voting.md#0x1_voting_VotingForum">VotingForum</a> {
-    <b>let</b> proposal_state = <a href="voting.md#0x1_voting_get_proposal_state">get_proposal_state</a>&lt;ProposalType&gt;(voting_forum_address, proposal_id);
-    <b>assert</b>!(proposal_state == <a href="voting.md#0x1_voting_PROPOSAL_STATE_SUCCEEDED">PROPOSAL_STATE_SUCCEEDED</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="voting.md#0x1_voting_EPROPOSAL_CANNOT_BE_RESOLVED">EPROPOSAL_CANNOT_BE_RESOLVED</a>));
+    <a href="voting.md#0x1_voting_is_proposal_resolvable">is_proposal_resolvable</a>&lt;ProposalType&gt;(voting_forum_address, proposal_id);
 
     <b>let</b> voting_forum = <b>borrow_global_mut</b>&lt;<a href="voting.md#0x1_voting_VotingForum">VotingForum</a>&lt;ProposalType&gt;&gt;(voting_forum_address);
     <b>let</b> proposal = <a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> voting_forum.proposals, proposal_id);
-    <b>assert</b>!(!proposal.is_resolved, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="voting.md#0x1_voting_EPROPOSAL_ALREADY_RESOLVED">EPROPOSAL_ALREADY_RESOLVED</a>));
 
-    // We need <b>to</b> make sure that the resolution is happening in
-    // a separate transaction from the last vote <b>to</b> guard against <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> potential flashloan attacks.
-    <b>let</b> resolvable_time = to_u64(*<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_borrow">simple_map::borrow</a>(&proposal.metadata, &utf8(<a href="voting.md#0x1_voting_RESOLVABLE_TIME_METADATA_KEY">RESOLVABLE_TIME_METADATA_KEY</a>)));
-    <b>assert</b>!(<a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>() &gt; resolvable_time, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="voting.md#0x1_voting_ERESOLUTION_CANNOT_BE_ATOMIC">ERESOLUTION_CANNOT_BE_ATOMIC</a>));
+    // Assert that the specified proposal is not a multi-step proposal.
+    <b>let</b> multi_step_key = utf8(<a href="voting.md#0x1_voting_IS_MULTI_STEP_PROPOSAL_KEY">IS_MULTI_STEP_PROPOSAL_KEY</a>);
+    <b>let</b> has_multi_step_key = <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_contains_key">simple_map::contains_key</a>(&proposal.metadata, &multi_step_key);
+    <b>if</b> (has_multi_step_key) {
+        <b>let</b> is_multi_step_proposal = <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs_to_bool">from_bcs::to_bool</a>(*<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_borrow">simple_map::borrow</a>(&proposal.metadata, &multi_step_key));
+        <b>assert</b>!(!is_multi_step_proposal, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="voting.md#0x1_voting_EMULTI_STEP_PROPOSAL_CANNOT_USE_SINGLE_STEP_RESOLVE_FUNCTION">EMULTI_STEP_PROPOSAL_CANNOT_USE_SINGLE_STEP_RESOLVE_FUNCTION</a>));
+    };
 
     <b>let</b> resolved_early = <a href="voting.md#0x1_voting_can_be_resolved_early">can_be_resolved_early</a>(proposal);
     proposal.is_resolved = <b>true</b>;
     proposal.resolution_time_secs = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
-
-    <b>assert</b>!(
-        <a href="transaction_context.md#0x1_transaction_context_get_script_hash">transaction_context::get_script_hash</a>() == proposal.execution_hash,
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="voting.md#0x1_voting_EPROPOSAL_EXECUTION_HASH_NOT_MATCHING">EPROPOSAL_EXECUTION_HASH_NOT_MATCHING</a>),
-    );
 
     <a href="event.md#0x1_event_emit_event">event::emit_event</a>&lt;<a href="voting.md#0x1_voting_ResolveProposal">ResolveProposal</a>&gt;(
         &<b>mut</b> voting_forum.events.resolve_proposal_events,
@@ -794,6 +979,91 @@ there are more yes votes than no. If either of these conditions is not met, this
     );
 
     <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> proposal.execution_content)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_voting_resolve_proposal_v2"></a>
+
+## Function `resolve_proposal_v2`
+
+Resolve a single-step or a multi-step proposal with the given id.
+Can only be done if there are at least as many votes as min required and
+there are more yes votes than no. If either of these conditions is not met, this will revert.
+
+
+@param voting_forum_address The address of the forum where the proposals are stored.
+@param proposal_id The proposal id.
+@param next_execution_hash The next execution hash if the given proposal is multi-step.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_resolve_proposal_v2">resolve_proposal_v2</a>&lt;ProposalType: store&gt;(voting_forum_address: <b>address</b>, proposal_id: u64, next_execution_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_resolve_proposal_v2">resolve_proposal_v2</a>&lt;ProposalType: store&gt;(
+    voting_forum_address: <b>address</b>,
+    proposal_id: u64,
+    next_execution_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+) <b>acquires</b> <a href="voting.md#0x1_voting_VotingForum">VotingForum</a> {
+    <a href="voting.md#0x1_voting_is_proposal_resolvable">is_proposal_resolvable</a>&lt;ProposalType&gt;(voting_forum_address, proposal_id);
+
+    <b>let</b> voting_forum = <b>borrow_global_mut</b>&lt;<a href="voting.md#0x1_voting_VotingForum">VotingForum</a>&lt;ProposalType&gt;&gt;(voting_forum_address);
+    <b>let</b> proposal = <a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> voting_forum.proposals, proposal_id);
+
+    <b>let</b> multi_step_in_execution_key = utf8(<a href="voting.md#0x1_voting_IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY">IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY</a>);
+    <b>if</b> (<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_contains_key">simple_map::contains_key</a>(&proposal.metadata, &multi_step_in_execution_key)) {
+        <b>let</b> is_multi_step_proposal_in_execution_value = <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_borrow_mut">simple_map::borrow_mut</a>(&<b>mut</b> proposal.metadata, &multi_step_in_execution_key);
+        *is_multi_step_proposal_in_execution_value = to_bytes(&<b>true</b>);
+    };
+
+    <b>let</b> multi_step_key = utf8(<a href="voting.md#0x1_voting_IS_MULTI_STEP_PROPOSAL_KEY">IS_MULTI_STEP_PROPOSAL_KEY</a>);
+    <b>let</b> is_multi_step = <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_contains_key">simple_map::contains_key</a>(&proposal.metadata, &multi_step_key) && <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs_to_bool">from_bcs::to_bool</a>(*<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_borrow">simple_map::borrow</a>(&proposal.metadata, &multi_step_key));
+    <b>let</b> next_execution_hash_is_empty = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&next_execution_hash) == 0;
+
+    // Assert that <b>if</b> this proposal is single-step, the `next_execution_hash` parameter is empty.
+    <b>assert</b>!(is_multi_step || next_execution_hash_is_empty, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="voting.md#0x1_voting_ESINGLE_STEP_PROPOSAL_CANNOT_HAVE_NEXT_EXECUTION_HASH">ESINGLE_STEP_PROPOSAL_CANNOT_HAVE_NEXT_EXECUTION_HASH</a>));
+
+    // If the `next_execution_hash` parameter is empty, it means that either
+    // - this proposal is a single-step proposal, or
+    // - this proposal is multi-step and we're currently resolving the last step in the multi-step proposal.
+    // We can mark that this proposal is resolved.
+    <b>if</b> (next_execution_hash_is_empty) {
+        proposal.is_resolved = <b>true</b>;
+        proposal.resolution_time_secs = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
+
+        // Set the `<a href="voting.md#0x1_voting_IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY">IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY</a>` value <b>to</b> <b>false</b> upon successful resolution of the last step of a multi-step proposal.
+        <b>if</b> (is_multi_step) {
+            <b>let</b> is_multi_step_proposal_in_execution_value = <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_borrow_mut">simple_map::borrow_mut</a>(&<b>mut</b> proposal.metadata, &multi_step_in_execution_key);
+            *is_multi_step_proposal_in_execution_value = to_bytes(&<b>false</b>);
+        };
+    } <b>else</b> {
+        // If the current step is not the last step,
+        // <b>update</b> the proposal's execution <a href="../../aptos-stdlib/doc/hash.md#0x1_hash">hash</a> on-chain <b>to</b> the execution <a href="../../aptos-stdlib/doc/hash.md#0x1_hash">hash</a> of the next step.
+        proposal.execution_hash = next_execution_hash;
+    };
+
+    // For single-step proposals, we emit one `<a href="voting.md#0x1_voting_ResolveProposal">ResolveProposal</a>` <a href="event.md#0x1_event">event</a> per proposal.
+    // For multi-step proposals, we emit one `<a href="voting.md#0x1_voting_ResolveProposal">ResolveProposal</a>` <a href="event.md#0x1_event">event</a> per step in the multi-step proposal. This means
+    // that we emit multiple `<a href="voting.md#0x1_voting_ResolveProposal">ResolveProposal</a>` events for the same multi-step proposal.
+    <b>let</b> resolved_early = <a href="voting.md#0x1_voting_can_be_resolved_early">can_be_resolved_early</a>(proposal);
+    <a href="event.md#0x1_event_emit_event">event::emit_event</a>&lt;<a href="voting.md#0x1_voting_ResolveProposal">ResolveProposal</a>&gt;(
+        &<b>mut</b> voting_forum.events.resolve_proposal_events,
+        <a href="voting.md#0x1_voting_ResolveProposal">ResolveProposal</a> {
+            proposal_id,
+            yes_votes: proposal.yes_votes,
+            no_votes: proposal.no_votes,
+            resolved_early,
+        },
+    );
 }
 </code></pre>
 
@@ -986,6 +1256,38 @@ Return true if the governance proposal has already been resolved.
     <b>let</b> voting_forum = <b>borrow_global_mut</b>&lt;<a href="voting.md#0x1_voting_VotingForum">VotingForum</a>&lt;ProposalType&gt;&gt;(voting_forum_address);
     <b>let</b> proposal = <a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> voting_forum.proposals, proposal_id);
     proposal.is_resolved
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_voting_is_multi_step_proposal_in_execution"></a>
+
+## Function `is_multi_step_proposal_in_execution`
+
+Return true if the multi-step governance proposal is in execution.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_is_multi_step_proposal_in_execution">is_multi_step_proposal_in_execution</a>&lt;ProposalType: store&gt;(voting_forum_address: <b>address</b>, proposal_id: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_is_multi_step_proposal_in_execution">is_multi_step_proposal_in_execution</a>&lt;ProposalType: store&gt;(
+    voting_forum_address: <b>address</b>,
+    proposal_id: u64,
+): bool <b>acquires</b> <a href="voting.md#0x1_voting_VotingForum">VotingForum</a> {
+    <b>let</b> voting_forum = <b>borrow_global_mut</b>&lt;<a href="voting.md#0x1_voting_VotingForum">VotingForum</a>&lt;ProposalType&gt;&gt;(voting_forum_address);
+    <b>let</b> proposal = <a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> voting_forum.proposals, proposal_id);
+    <b>let</b> is_multi_step_in_execution_key = utf8(<a href="voting.md#0x1_voting_IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY">IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY</a>);
+    <b>assert</b>!(<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_contains_key">simple_map::contains_key</a>(&proposal.metadata, &is_multi_step_in_execution_key), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="voting.md#0x1_voting_EPROPOSAL_IS_SINGLE_STEP">EPROPOSAL_IS_SINGLE_STEP</a>));
+    <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs_to_bool">from_bcs::to_bool</a>(*<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_borrow">simple_map::borrow</a>(&proposal.metadata, &is_multi_step_in_execution_key))
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/sources/voting.move
+++ b/aptos-move/framework/aptos-framework/sources/voting.move
@@ -22,7 +22,6 @@
  */
 module aptos_framework::voting {
     use std::bcs::to_bytes;
-
     use std::error;
     use std::option::{Self, Option};
     use std::signer;
@@ -38,6 +37,7 @@ module aptos_framework::voting {
     use aptos_framework::event::{Self, EventHandle};
     use aptos_framework::timestamp;
     use aptos_framework::transaction_context;
+    use aptos_std::from_bcs;
 
     /// Current script's execution hash does not match the specified proposal's
     const EPROPOSAL_EXECUTION_HASH_NOT_MATCHING: u64 = 1;
@@ -55,6 +55,15 @@ module aptos_framework::voting {
     const EINVALID_MIN_VOTE_THRESHOLD: u64 = 7;
     /// Resolution of a proposal cannot happen atomically in the same transaction as the last vote.
     const ERESOLUTION_CANNOT_BE_ATOMIC: u64 = 8;
+    /// Cannot vote if the specified multi-step proposal is in execution.
+    const EMULTI_STEP_PROPOSAL_IN_EXECUTION: u64 = 9;
+    /// If a proposal is multi-step, we need to use `resolve_proposal_v2()` to resolve it.
+    /// If we use `resolve()` to resolve a multi-step proposal, it will fail with EMULTI_STEP_PROPOSAL_CANNOT_USE_SINGLE_STEP_RESOLVE_FUNCTION.
+    const EMULTI_STEP_PROPOSAL_CANNOT_USE_SINGLE_STEP_RESOLVE_FUNCTION: u64 = 10;
+    /// If we call `resolve_proposal_v2()` to resolve a single-step proposal, the `next_execution_hash` parameter should be an empty vector.
+    const ESINGLE_STEP_PROPOSAL_CANNOT_HAVE_NEXT_EXECUTION_HASH: u64 = 11;
+    /// Cannot call `is_multi_step_proposal_in_execution()` on single-step proposals.
+    const EPROPOSAL_IS_SINGLE_STEP: u64 = 12;
 
     /// ProposalStateEnum representing proposal state.
     const PROPOSAL_STATE_PENDING: u64 = 0;
@@ -64,6 +73,10 @@ module aptos_framework::voting {
 
     /// Key used to track the resolvable time in the proposal's metadata.
     const RESOLVABLE_TIME_METADATA_KEY: vector<u8> = b"RESOLVABLE_TIME_METADATA_KEY";
+    /// Key used to track if the proposal is multi-step
+    const IS_MULTI_STEP_PROPOSAL_KEY: vector<u8> = b"IS_MULTI_STEP_PROPOSAL_KEY";
+    /// Key used to track if the multi-step proposal is in execution / resolving in progress.
+    const IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY: vector<u8> = b"IS_MULTI_STEP_PROPOSAL_IN_EXECUTION";
 
     /// Extra metadata (e.g. description, code url) can be part of the ProposalType struct.
     struct Proposal<ProposalType: store> has store {
@@ -74,8 +87,13 @@ module aptos_framework::voting {
         /// This is stored as an option so we can return it to governance when the proposal is resolved.
         execution_content: Option<ProposalType>,
 
-        /// Optional. Extra metadata about the proposal and can be empty.
-        /// Value is serialized value of an attribute.
+        /// Optional. Value is serialized value of an attribute.
+        /// Currently, we have three attributes that are used by the voting flow.
+        /// 1. RESOLVABLE_TIME_METADATA_KEY: this is uesed to record the resolvable time to ensure that resolution has to be done non-atomically.
+        /// 2. IS_MULTI_STEP_PROPOSAL_KEY: this is used to track if a proposal is single-step or multi-step.
+        /// 3. IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY: this attribute only applies to multi-step proposals. A single-step proposal will not have
+        /// this field in its metadata map. The value is used to indicate if a multi-step proposal is in execution. If yes, we will disable further
+        /// voting for this multi-step proposal.
         metadata: SimpleMap<String, vector<u8>>,
 
         /// Timestamp when the proposal was created.
@@ -174,7 +192,7 @@ module aptos_framework::voting {
         move_to(account, voting_forum);
     }
 
-    /// Create a proposal with the given parameters
+    /// Create a single-step proposal with the given parameters
     ///
     /// @param voting_forum_address The forum's address where the proposal will be stored.
     /// @param execution_content The execution content that will be given back at resolution time. This can contain
@@ -183,6 +201,8 @@ module aptos_framework::voting {
     /// this proposal.
     /// @param min_vote_threshold The minimum number of votes needed to consider this proposal successful.
     /// @param expiration_secs The time in seconds at which the proposal expires and can potentially be resolved.
+    /// @param early_resolution_vote_threshold The vote threshold for early resolution of this proposal.
+    /// @param metadata A simple_map that stores information about this proposal.
     /// @return The proposal id.
     public fun create_proposal<ProposalType: store>(
         proposer: address,
@@ -193,6 +213,43 @@ module aptos_framework::voting {
         expiration_secs: u64,
         early_resolution_vote_threshold: Option<u128>,
         metadata: SimpleMap<String, vector<u8>>,
+    ): u64 acquires VotingForum {
+        create_proposal_v2(
+            proposer,
+            voting_forum_address,
+            execution_content,
+            execution_hash,
+            min_vote_threshold,
+            expiration_secs,
+            early_resolution_vote_threshold,
+            metadata,
+            false
+        )
+    }
+
+    /// Create a single-step or a multi-step proposal with the given parameters
+    ///
+    /// @param voting_forum_address The forum's address where the proposal will be stored.
+    /// @param execution_content The execution content that will be given back at resolution time. This can contain
+    /// data such as a capability resource used to scope the execution.
+    /// @param execution_hash The hash for the execution script module. Only the same exact script module can resolve
+    /// this proposal.
+    /// @param min_vote_threshold The minimum number of votes needed to consider this proposal successful.
+    /// @param expiration_secs The time in seconds at which the proposal expires and can potentially be resolved.
+    /// @param early_resolution_vote_threshold The vote threshold for early resolution of this proposal.
+    /// @param metadata A simple_map that stores information about this proposal.
+    /// @param is_multi_step_proposal A bool value that indicates if the proposal is single-step or multi-step.
+    /// @return The proposal id.
+    public fun create_proposal_v2<ProposalType: store>(
+        proposer: address,
+        voting_forum_address: address,
+        execution_content: ProposalType,
+        execution_hash: vector<u8>,
+        min_vote_threshold: u128,
+        expiration_secs: u64,
+        early_resolution_vote_threshold: Option<u128>,
+        metadata: SimpleMap<String, vector<u8>>,
+        is_multi_step_proposal: bool,
     ): u64 acquires VotingForum {
         if (option::is_some(&early_resolution_vote_threshold)) {
             assert!(
@@ -206,6 +263,21 @@ module aptos_framework::voting {
         let voting_forum = borrow_global_mut<VotingForum<ProposalType>>(voting_forum_address);
         let proposal_id = voting_forum.next_proposal_id;
         voting_forum.next_proposal_id = voting_forum.next_proposal_id + 1;
+
+        // Add a flag to indicate if this proposal is single-step or multi-step.
+        simple_map::add(&mut metadata, utf8(IS_MULTI_STEP_PROPOSAL_KEY), to_bytes(&is_multi_step_proposal));
+
+        let is_multi_step_in_execution_key = utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
+        if (is_multi_step_proposal) {
+            // If the given proposal is a multi-step proposal, we will add a flag to indicate if this multi-step proposal is in execution.
+            // This value is by default false. We turn this value to true when we start executing the multi-step proposal. This value
+            // will be used to disable further voting after we started executing the multi-step proposal.
+            simple_map::add(&mut metadata, is_multi_step_in_execution_key, to_bytes(&false));
+        // If the proposal is a single-step proposal, we check if the metadata passed by the client has the IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY key.
+        // If they have the key, we will remove it, because a single-step proposal that doesn't need this key.
+        } else if (simple_map::contains_key(&mut metadata, &is_multi_step_in_execution_key)) {
+            simple_map::remove(&mut metadata, &is_multi_step_in_execution_key);
+        };
 
         table::add(&mut voting_forum.proposals, proposal_id, Proposal {
             proposer,
@@ -261,6 +333,10 @@ module aptos_framework::voting {
         // appropriate.
         assert!(!is_voting_period_over(proposal), error::invalid_state(EPROPOSAL_VOTING_ALREADY_ENDED));
         assert!(!proposal.is_resolved, error::invalid_state(EPROPOSAL_ALREADY_RESOLVED));
+        // Assert this proposal is single-step, or if the proposal is multi-step, it is not in execution yet.
+        assert!(!simple_map::contains_key(&proposal.metadata, &utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY))
+                || *simple_map::borrow(&proposal.metadata, &utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY)) == to_bytes(&false),
+                error::invalid_state(EMULTI_STEP_PROPOSAL_IN_EXECUTION));
 
         if (should_pass) {
             proposal.yes_votes = proposal.yes_votes + (num_votes as u128);
@@ -283,15 +359,11 @@ module aptos_framework::voting {
         );
     }
 
-    /// Resolve the proposal with given id. Can only be done if there are at least as many votes as min required and
-    /// there are more yes votes than no. If either of these conditions is not met, this will revert.
-    ///
-    /// @param voting_forum_address The address of the forum where the proposals are stored.
-    /// @param proposal_id The proposal id.
-    public fun resolve<ProposalType: store>(
+    /// Common checks on if a proposal is resolvable, regardless if the proposal is single-step or multi-step.
+    fun is_proposal_resolvable<ProposalType: store>(
         voting_forum_address: address,
         proposal_id: u64,
-    ): ProposalType acquires VotingForum {
+    ) acquires VotingForum {
         let proposal_state = get_proposal_state<ProposalType>(voting_forum_address, proposal_id);
         assert!(proposal_state == PROPOSAL_STATE_SUCCEEDED, error::invalid_state(EPROPOSAL_CANNOT_BE_RESOLVED));
 
@@ -304,14 +376,37 @@ module aptos_framework::voting {
         let resolvable_time = to_u64(*simple_map::borrow(&proposal.metadata, &utf8(RESOLVABLE_TIME_METADATA_KEY)));
         assert!(timestamp::now_seconds() > resolvable_time, error::invalid_state(ERESOLUTION_CANNOT_BE_ATOMIC));
 
-        let resolved_early = can_be_resolved_early(proposal);
-        proposal.is_resolved = true;
-        proposal.resolution_time_secs = timestamp::now_seconds();
-
         assert!(
             transaction_context::get_script_hash() == proposal.execution_hash,
             error::invalid_argument(EPROPOSAL_EXECUTION_HASH_NOT_MATCHING),
         );
+    }
+
+    /// Resolve a single-step proposal with given id. Can only be done if there are at least as many votes as min required and
+    /// there are more yes votes than no. If either of these conditions is not met, this will revert.
+    ///
+    /// @param voting_forum_address The address of the forum where the proposals are stored.
+    /// @param proposal_id The proposal id.
+    public fun resolve<ProposalType: store>(
+        voting_forum_address: address,
+        proposal_id: u64,
+    ): ProposalType acquires VotingForum {
+        is_proposal_resolvable<ProposalType>(voting_forum_address, proposal_id);
+
+        let voting_forum = borrow_global_mut<VotingForum<ProposalType>>(voting_forum_address);
+        let proposal = table::borrow_mut(&mut voting_forum.proposals, proposal_id);
+
+        // Assert that the specified proposal is not a multi-step proposal.
+        let multi_step_key = utf8(IS_MULTI_STEP_PROPOSAL_KEY);
+        let has_multi_step_key = simple_map::contains_key(&proposal.metadata, &multi_step_key);
+        if (has_multi_step_key) {
+            let is_multi_step_proposal = from_bcs::to_bool(*simple_map::borrow(&proposal.metadata, &multi_step_key));
+            assert!(!is_multi_step_proposal, error::permission_denied(EMULTI_STEP_PROPOSAL_CANNOT_USE_SINGLE_STEP_RESOLVE_FUNCTION));
+        };
+
+        let resolved_early = can_be_resolved_early(proposal);
+        proposal.is_resolved = true;
+        proposal.resolution_time_secs = timestamp::now_seconds();
 
         event::emit_event<ResolveProposal>(
             &mut voting_forum.events.resolve_proposal_events,
@@ -324,6 +419,72 @@ module aptos_framework::voting {
         );
 
         option::extract(&mut proposal.execution_content)
+    }
+
+    /// Resolve a single-step or a multi-step proposal with the given id.
+    /// Can only be done if there are at least as many votes as min required and
+    /// there are more yes votes than no. If either of these conditions is not met, this will revert.
+    ///
+    ///
+    /// @param voting_forum_address The address of the forum where the proposals are stored.
+    /// @param proposal_id The proposal id.
+    /// @param next_execution_hash The next execution hash if the given proposal is multi-step.
+    public fun resolve_proposal_v2<ProposalType: store>(
+        voting_forum_address: address,
+        proposal_id: u64,
+        next_execution_hash: vector<u8>,
+    ) acquires VotingForum {
+        is_proposal_resolvable<ProposalType>(voting_forum_address, proposal_id);
+
+        let voting_forum = borrow_global_mut<VotingForum<ProposalType>>(voting_forum_address);
+        let proposal = table::borrow_mut(&mut voting_forum.proposals, proposal_id);
+
+        // Update the IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY key to indicate that the multi-step proposal is in execution.
+        let multi_step_in_execution_key = utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
+        if (simple_map::contains_key(&proposal.metadata, &multi_step_in_execution_key)) {
+            let is_multi_step_proposal_in_execution_value = simple_map::borrow_mut(&mut proposal.metadata, &multi_step_in_execution_key);
+            *is_multi_step_proposal_in_execution_value = to_bytes(&true);
+        };
+
+        let multi_step_key = utf8(IS_MULTI_STEP_PROPOSAL_KEY);
+        let is_multi_step = simple_map::contains_key(&proposal.metadata, &multi_step_key) && from_bcs::to_bool(*simple_map::borrow(&proposal.metadata, &multi_step_key));
+        let next_execution_hash_is_empty = vector::length(&next_execution_hash) == 0;
+
+        // Assert that if this proposal is single-step, the `next_execution_hash` parameter is empty.
+        assert!(is_multi_step || next_execution_hash_is_empty, error::invalid_argument(ESINGLE_STEP_PROPOSAL_CANNOT_HAVE_NEXT_EXECUTION_HASH));
+
+        // If the `next_execution_hash` parameter is empty, it means that either
+        // - this proposal is a single-step proposal, or
+        // - this proposal is multi-step and we're currently resolving the last step in the multi-step proposal.
+        // We can mark that this proposal is resolved.
+        if (next_execution_hash_is_empty) {
+            proposal.is_resolved = true;
+            proposal.resolution_time_secs = timestamp::now_seconds();
+
+            // Set the `IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY` value to false upon successful resolution of the last step of a multi-step proposal.
+            if (is_multi_step) {
+                let is_multi_step_proposal_in_execution_value = simple_map::borrow_mut(&mut proposal.metadata, &multi_step_in_execution_key);
+                *is_multi_step_proposal_in_execution_value = to_bytes(&false);
+            };
+        } else {
+            // If the current step is not the last step,
+            // update the proposal's execution hash on-chain to the execution hash of the next step.
+            proposal.execution_hash = next_execution_hash;
+        };
+
+        // For single-step proposals, we emit one `ResolveProposal` event per proposal.
+        // For multi-step proposals, we emit one `ResolveProposal` event per step in the multi-step proposal. This means
+        // that we emit multiple `ResolveProposal` events for the same multi-step proposal.
+        let resolved_early = can_be_resolved_early(proposal);
+        event::emit_event<ResolveProposal>(
+            &mut voting_forum.events.resolve_proposal_events,
+            ResolveProposal {
+                proposal_id,
+                yes_votes: proposal.yes_votes,
+                no_votes: proposal.no_votes,
+                resolved_early,
+            },
+        );
     }
 
     public fun is_voting_closed<ProposalType: store>(voting_forum_address: address, proposal_id: u64): bool acquires VotingForum {
@@ -398,6 +559,18 @@ module aptos_framework::voting {
         proposal.is_resolved
     }
 
+    /// Return true if the multi-step governance proposal is in execution.
+    public fun is_multi_step_proposal_in_execution<ProposalType: store>(
+        voting_forum_address: address,
+        proposal_id: u64,
+    ): bool acquires VotingForum {
+        let voting_forum = borrow_global_mut<VotingForum<ProposalType>>(voting_forum_address);
+        let proposal = table::borrow_mut(&mut voting_forum.proposals, proposal_id);
+        let is_multi_step_in_execution_key = utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
+        assert!(simple_map::contains_key(&proposal.metadata, &is_multi_step_in_execution_key), error::invalid_argument(EPROPOSAL_IS_SINGLE_STEP));
+        from_bcs::to_bool(*simple_map::borrow(&proposal.metadata, &is_multi_step_in_execution_key))
+    }
+
     /// Return true if the voting period of the given proposal has already ended.
     fun is_voting_period_over<ProposalType: store>(proposal: &Proposal<ProposalType>): bool {
         timestamp::now_seconds() > proposal.expiration_secs
@@ -410,9 +583,10 @@ module aptos_framework::voting {
     const VOTING_DURATION_SECS: u64 = 100000;
 
     #[test_only]
-    public fun create_test_proposal(
+    public fun create_test_proposal_generic(
         governance: &signer,
         early_resolution_threshold: Option<u128>,
+        use_generic_create_proposal_function: bool,
     ): u64 acquires VotingForum {
         // Register voting forum and create a proposal.
         register<TestProposal>(governance);
@@ -422,23 +596,60 @@ module aptos_framework::voting {
         // This works because our Move unit test extensions mock out the execution hash to be [1].
         let execution_hash = vector::empty<u8>();
         vector::push_back(&mut execution_hash, 1);
-        let proposal_id = create_proposal<TestProposal>(
-            governance_address,
-            governance_address,
-            proposal,
-            execution_hash,
-            10,
-            timestamp::now_seconds() + VOTING_DURATION_SECS,
-            early_resolution_threshold,
-            simple_map::create<String, vector<u8>>(),
-        );
+        let metadata = simple_map::create<String, vector<u8>>();
 
-        proposal_id
+        if (use_generic_create_proposal_function) {
+            create_proposal_v2<TestProposal>(
+                governance_address,
+                governance_address,
+                proposal,
+                execution_hash,
+                10,
+                timestamp::now_seconds() + VOTING_DURATION_SECS,
+                early_resolution_threshold,
+                metadata,
+                use_generic_create_proposal_function
+            )
+        } else {
+            create_proposal<TestProposal>(
+                governance_address,
+                governance_address,
+                proposal,
+                execution_hash,
+                10,
+                timestamp::now_seconds() + VOTING_DURATION_SECS,
+                early_resolution_threshold,
+                metadata,
+            )
+        }
     }
 
-    #[test(governance = @0x123)]
-    #[expected_failure(abort_code = 0x10004)]
-    public fun create_proposal_with_empty_execution_hash_should_fail(governance: &signer) acquires VotingForum {
+    #[test_only]
+    public fun resolve_proposal_for_test<ProposalType>(voting_forum_address: address, proposal_id: u64, is_multi_step: bool, finish_multi_step_execution: bool) acquires VotingForum {
+        if (is_multi_step) {
+            let execution_hash = vector::empty<u8>();
+            vector::push_back(&mut execution_hash, 1);
+            resolve_proposal_v2<TestProposal>(voting_forum_address, proposal_id, execution_hash);
+
+            if (finish_multi_step_execution) {
+                resolve_proposal_v2<TestProposal>(voting_forum_address, proposal_id, vector::empty<u8>());
+            };
+        } else {
+            let proposal = resolve<TestProposal>(voting_forum_address, proposal_id);
+            let TestProposal {} = proposal;
+        };
+    }
+
+    #[test_only]
+    public fun create_test_proposal(
+        governance: &signer,
+        early_resolution_threshold: Option<u128>,
+    ): u64 acquires VotingForum {
+        create_test_proposal_generic(governance, early_resolution_threshold, false)
+    }
+
+    #[test_only]
+    public fun create_proposal_with_empty_execution_hash_should_fail_generic(governance: &signer, is_multi_step: bool) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         let governance_address = signer::address_of(governance);
         account::create_account_for_test(governance_address);
@@ -446,27 +657,53 @@ module aptos_framework::voting {
         let proposal = TestProposal {};
 
         // This should fail because execution hash is empty.
-        create_proposal<TestProposal>(
-            governance_address,
-            governance_address,
-            proposal,
-            b"",
-            10,
-            100000,
-            option::none<u128>(),
-            simple_map::create<String, vector<u8>>(),
-        );
+        if (is_multi_step) {
+            create_proposal_v2<TestProposal>(
+                governance_address,
+                governance_address,
+                proposal,
+                b"",
+                10,
+                100000,
+                option::none<u128>(),
+                simple_map::create<String, vector<u8>>(),
+                is_multi_step
+            );
+        } else {
+            create_proposal<TestProposal>(
+                governance_address,
+                governance_address,
+                proposal,
+                b"",
+                10,
+                100000,
+                option::none<u128>(),
+                simple_map::create<String, vector<u8>>(),
+            );
+        };
     }
 
-    #[test(aptos_framework = @aptos_framework, governance = @0x123)]
-    public entry fun test_voting_passed(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+    #[test(governance = @0x123)]
+    #[expected_failure(abort_code = 0x10004)]
+    public fun create_proposal_with_empty_execution_hash_should_fail(governance: &signer) acquires VotingForum {
+        create_proposal_with_empty_execution_hash_should_fail_generic(governance, false);
+    }
+
+    #[test(governance = @0x123)]
+    #[expected_failure(abort_code = 0x10004)]
+    public fun create_proposal_with_empty_execution_hash_should_fail_multi_step(governance: &signer) acquires VotingForum {
+        create_proposal_with_empty_execution_hash_should_fail_generic(governance, true);
+    }
+
+    #[test_only]
+    public entry fun test_voting_passed_generic(aptos_framework: &signer, governance: &signer, use_create_multi_step: bool, use_resolve_multi_step: bool) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(aptos_framework);
 
         // Register voting forum and create a proposal.
         let governance_address = signer::address_of(governance);
         account::create_account_for_test(governance_address);
-        let proposal_id = create_test_proposal(governance, option::none<u128>());
+        let proposal_id = create_test_proposal_generic(governance, option::none<u128>(), use_create_multi_step);
         assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_PENDING, 0);
 
         // Vote.
@@ -477,49 +714,90 @@ module aptos_framework::voting {
         // Resolve.
         timestamp::fast_forward_seconds(VOTING_DURATION_SECS + 1);
         assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_SUCCEEDED, 1);
-        let proposal = resolve<TestProposal>(governance_address, proposal_id);
+
+        // This if statement is specifically for the test `test_voting_passed_single_step_can_use_generic_function()`.
+        // It's testing when we have a single-step proposal that was created by the single-step `create_proposal()`,
+        // we should be able to successfully resolve it using the generic `resolve_proposal_v2` function.
+        if (!use_create_multi_step && use_resolve_multi_step) {
+            resolve_proposal_v2<TestProposal>(governance_address, proposal_id, vector::empty<u8>());
+        } else {
+            resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, use_resolve_multi_step, true);
+        };
         let voting_forum = borrow_global<VotingForum<TestProposal>>(governance_address);
         assert!(table::borrow(&voting_forum.proposals, proposal_id).is_resolved, 2);
+    }
 
-        let TestProposal {} = proposal;
+    #[test(aptos_framework = @aptos_framework, governance = @0x123)]
+    public entry fun test_voting_passed(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+        test_voting_passed_generic(aptos_framework, governance, false, false);
+    }
+
+    #[test(aptos_framework = @aptos_framework, governance = @0x123)]
+    public entry fun test_voting_passed_multi_step(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+        test_voting_passed_generic(aptos_framework, governance, true, true);
+    }
+
+    #[test(aptos_framework = @aptos_framework, governance = @0x123)]
+    #[expected_failure(abort_code=0x5000a)]
+    public entry fun test_voting_passed_multi_step_cannot_use_single_step_resolve_function(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+        test_voting_passed_generic(aptos_framework, governance, true, false);
+    }
+
+    #[test(aptos_framework = @aptos_framework, governance = @0x123)]
+    public entry fun test_voting_passed_single_step_can_use_generic_function(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+        test_voting_passed_generic(aptos_framework, governance, false, true);
+    }
+
+    #[test_only]
+    public entry fun test_cannot_resolve_twice_generic(aptos_framework: &signer, governance: &signer, is_multi_step: bool) acquires VotingForum {
+        account::create_account_for_test(@aptos_framework);
+        timestamp::set_time_has_started_for_testing(aptos_framework);
+
+        // Register voting forum and create a proposal.
+        let governance_address = signer::address_of(governance);
+        account::create_account_for_test(governance_address);
+        let proposal_id = create_test_proposal_generic(governance, option::none<u128>(), is_multi_step);
+        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_PENDING, 0);
+
+        // Vote.
+        let proof = TestProposal {};
+        vote<TestProposal>(&proof, governance_address, proposal_id, 10, true);
+        let TestProposal {} = proof;
+
+        // Resolve.
+        timestamp::fast_forward_seconds(VOTING_DURATION_SECS + 1);
+        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_SUCCEEDED, 1);
+        resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, is_multi_step, true);
+        resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, is_multi_step, true);
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     #[expected_failure(abort_code = 0x30003)]
     public entry fun test_cannot_resolve_twice(aptos_framework: &signer, governance: &signer) acquires VotingForum {
-        account::create_account_for_test(@aptos_framework);
-        timestamp::set_time_has_started_for_testing(aptos_framework);
-
-        // Register voting forum and create a proposal.
-        let governance_address = signer::address_of(governance);
-        account::create_account_for_test(governance_address);
-        let proposal_id = create_test_proposal(governance, option::none<u128>());
-        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_PENDING, 0);
-
-        // Vote.
-        let proof = TestProposal {};
-        vote<TestProposal>(&proof, governance_address, proposal_id, 10, true);
-        let TestProposal {} = proof;
-
-        // Resolve.
-        timestamp::fast_forward_seconds(VOTING_DURATION_SECS + 1);
-        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_SUCCEEDED, 1);
-        let TestProposal {} = resolve<TestProposal>(governance_address, proposal_id);
-
-        // Resolve a second time should fail.
-        let TestProposal {} = resolve<TestProposal>(governance_address, proposal_id);
+        test_cannot_resolve_twice_generic(aptos_framework, governance, false);
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
-    public entry fun test_voting_passed_early(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+    #[expected_failure(abort_code = 0x30003)]
+    public entry fun test_cannot_resolve_twice_multi_step(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+        test_cannot_resolve_twice_generic(aptos_framework, governance, true);
+    }
+
+    #[test_only]
+    public entry fun test_voting_passed_early_generic(aptos_framework: &signer, governance: &signer, is_multi_step: bool) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(aptos_framework);
 
         // Register voting forum and create a proposal.
         let governance_address = signer::address_of(governance);
         account::create_account_for_test(governance_address);
-        let proposal_id = create_test_proposal(governance, option::some(100));
+        let proposal_id = create_test_proposal_generic(governance, option::some(100), is_multi_step);
         assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_PENDING, 0);
+
+        // Assert that IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY has value `false` in proposal.metadata.
+        if (is_multi_step) {
+            assert!(!is_multi_step_proposal_in_execution<TestProposal>(governance_address, 0), 1);
+        };
 
         // Vote.
         let proof = TestProposal {};
@@ -529,43 +807,87 @@ module aptos_framework::voting {
 
         // Resolve early. Need to increase timestamp as resolution cannot happen in the same tx.
         timestamp::fast_forward_seconds(1);
-        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_SUCCEEDED, 1);
-        let proposal = resolve<TestProposal>(governance_address, proposal_id);
-        let voting_forum = borrow_global<VotingForum<TestProposal>>(governance_address);
-        assert!(table::borrow(&voting_forum.proposals, proposal_id).is_resolved, 2);
+        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_SUCCEEDED, 2);
 
-        let TestProposal {} = proposal;
+        if (is_multi_step) {
+            // Assert that IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY still has value `false` in proposal.metadata before execution.
+            assert!(!is_multi_step_proposal_in_execution<TestProposal>(governance_address, 0), 3);
+            resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, is_multi_step, false);
+
+            // Assert that the multi-step proposal is in execution but not resolved yet.
+            assert!(is_multi_step_proposal_in_execution<TestProposal>(governance_address, 0), 4);
+            let voting_forum = borrow_global_mut<VotingForum<TestProposal>>(governance_address);
+            let proposal = table::borrow_mut(&mut voting_forum.proposals, proposal_id);
+            assert!(!proposal.is_resolved, 5);
+        };
+
+        resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, is_multi_step, true);
+        let voting_forum = borrow_global_mut<VotingForum<TestProposal>>(governance_address);
+        assert!(table::borrow(&voting_forum.proposals, proposal_id).is_resolved, 6);
+
+        // Assert that the IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY value is set back to `false` upon successful resolution of this multi-step proposal.
+        if (is_multi_step) {
+            assert!(!is_multi_step_proposal_in_execution<TestProposal>(governance_address, 0), 7);
+        };
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
-    #[expected_failure(abort_code = 0x30008)]
-    public entry fun test_voting_passed_early_in_same_tx_should_fail(
-        aptos_framework: &signer, governance: &signer) acquires VotingForum {
+    public entry fun test_voting_passed_early(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+        test_voting_passed_early_generic(aptos_framework, governance, false);
+    }
+
+    #[test(aptos_framework = @aptos_framework, governance = @0x123)]
+    public entry fun test_voting_passed_early_multi_step(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+        test_voting_passed_early_generic(aptos_framework, governance, true);
+    }
+
+    #[test_only]
+    public entry fun test_voting_passed_early_in_same_tx_should_fail_generic(
+        aptos_framework: &signer,
+        governance: &signer,
+        is_multi_step: bool
+    ) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(aptos_framework);
         let governance_address = signer::address_of(governance);
         account::create_account_for_test(governance_address);
-        let proposal_id = create_test_proposal(governance, option::some(100));
+        let proposal_id = create_test_proposal_generic(governance, option::some(100), is_multi_step);
         let proof = TestProposal {};
         vote<TestProposal>(&proof, governance_address, proposal_id, 40, true);
         vote<TestProposal>(&proof, governance_address, proposal_id, 60, true);
         let TestProposal {} = proof;
 
         // Resolving early should fail since timestamp hasn't changed since the last vote.
-        let proposal = resolve<TestProposal>(governance_address, proposal_id);
-        let TestProposal {} = proposal;
+        resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, is_multi_step, true);
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
-    #[expected_failure(abort_code = 0x30002)]
-    public entry fun test_voting_failed(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+    #[expected_failure(abort_code = 0x30008)]
+    public entry fun test_voting_passed_early_in_same_tx_should_fail(
+        aptos_framework: &signer,
+        governance: &signer
+    ) acquires VotingForum {
+        test_voting_passed_early_in_same_tx_should_fail_generic(aptos_framework, governance, false);
+    }
+
+    #[test(aptos_framework = @aptos_framework, governance = @0x123)]
+    #[expected_failure(abort_code = 0x30008)]
+    public entry fun test_voting_passed_early_in_same_tx_should_fail_multi_step(
+        aptos_framework: &signer,
+        governance: &signer
+    ) acquires VotingForum {
+        test_voting_passed_early_in_same_tx_should_fail_generic(aptos_framework, governance, true);
+    }
+
+    #[test_only]
+    public entry fun test_voting_failed_generic(aptos_framework: &signer, governance: &signer, is_multi_step: bool) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(aptos_framework);
 
         // Register voting forum and create a proposal.
         let governance_address = signer::address_of(governance);
         account::create_account_for_test(governance_address);
-        let proposal_id = create_test_proposal(governance, option::none<u128>());
+        let proposal_id = create_test_proposal_generic(governance, option::none<u128>(), is_multi_step);
 
         // Vote.
         let proof = TestProposal {};
@@ -576,14 +898,27 @@ module aptos_framework::voting {
         // Resolve.
         timestamp::fast_forward_seconds(VOTING_DURATION_SECS + 1);
         assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_FAILED, 1);
-        let proposal = resolve<TestProposal>(governance_address, proposal_id);
-        let TestProposal {} = proposal;
+        resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, is_multi_step, true);
+    }
+
+    #[test(aptos_framework = @aptos_framework, governance = @0x123)]
+    #[expected_failure(abort_code = 0x30002)]
+    public entry fun test_voting_failed(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+        test_voting_failed_generic(aptos_framework, governance, false);
+    }
+
+    #[test(aptos_framework = @aptos_framework, governance = @0x123)]
+    #[expected_failure(abort_code = 0x30002)]
+    public entry fun test_voting_failed_multi_step(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+        test_voting_failed_generic(aptos_framework, governance, true);
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     #[expected_failure(abort_code = 0x30005)]
     public entry fun test_cannot_vote_after_voting_period_is_over(
-        aptos_framework: signer, governance: signer) acquires VotingForum {
+        aptos_framework: signer,
+        governance: signer
+    ) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(&aptos_framework);
         let governance_address = signer::address_of(&governance);
@@ -597,15 +932,41 @@ module aptos_framework::voting {
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
-    #[expected_failure(abort_code = 0x30002)]
-    public entry fun test_voting_failed_early(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+    #[expected_failure(abort_code=0x30009)]
+    public entry fun test_cannot_vote_after_multi_step_proposal_starts_executing(
+        aptos_framework: signer,
+        governance: signer
+    ) acquires VotingForum {
+        account::create_account_for_test(@aptos_framework);
+        timestamp::set_time_has_started_for_testing(&aptos_framework);
+
+        // Register voting forum and create a proposal.
+        let governance_address = signer::address_of(&governance);
+        account::create_account_for_test(governance_address);
+        let proposal_id = create_test_proposal_generic(&governance, option::some(100), true);
+        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_PENDING, 0);
+
+        // Vote.
+        let proof = TestProposal {};
+        vote<TestProposal>(&proof, governance_address, proposal_id, 100, true);
+
+        // Resolve early.
+        timestamp::fast_forward_seconds(1);
+        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_SUCCEEDED, 1);
+        resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, true, false);
+        vote<TestProposal>(&proof, governance_address, proposal_id, 100, false);
+        let TestProposal {} = proof;
+    }
+
+    #[test_only]
+    public entry fun test_voting_failed_early_generic(aptos_framework: &signer, governance: &signer, is_multi_step: bool) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(aptos_framework);
 
         // Register voting forum and create a proposal.
         let governance_address = signer::address_of(governance);
         account::create_account_for_test(governance_address);
-        let proposal_id = create_test_proposal(governance, option::some(100));
+        let proposal_id = create_test_proposal_generic(governance, option::some(100), is_multi_step);
 
         // Vote.
         let proof = TestProposal {};
@@ -616,18 +977,49 @@ module aptos_framework::voting {
         // Resolve.
         timestamp::fast_forward_seconds(VOTING_DURATION_SECS + 1);
         assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_FAILED, 1);
-        let proposal = resolve<TestProposal>(governance_address, proposal_id);
-        let TestProposal {} = proposal;
+        resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, is_multi_step, true);
+    }
+
+    #[test(aptos_framework = @aptos_framework, governance = @0x123)]
+    #[expected_failure(abort_code = 0x30002)]
+    public entry fun test_voting_failed_early(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+        test_voting_failed_early_generic(aptos_framework, governance, true);
+    }
+
+    #[test(aptos_framework = @aptos_framework, governance = @0x123)]
+    #[expected_failure(abort_code = 0x30002)]
+    public entry fun test_voting_failed_early_multi_step(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+        test_voting_failed_early_generic(aptos_framework, governance, false);
+    }
+
+    #[test_only]
+    public entry fun test_cannot_set_min_threshold_higher_than_early_resolution_generic(
+        aptos_framework: &signer,
+        governance: &signer,
+        is_multi_step: bool,
+    ) acquires VotingForum {
+        account::create_account_for_test(@aptos_framework);
+        timestamp::set_time_has_started_for_testing(aptos_framework);
+        account::create_account_for_test(signer::address_of(governance));
+        // This should fail.
+        create_test_proposal_generic(governance, option::some(5), is_multi_step);
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     #[expected_failure(abort_code = 0x10007)]
     public entry fun test_cannot_set_min_threshold_higher_than_early_resolution(
-        aptos_framework: &signer, governance: &signer) acquires VotingForum {
-        account::create_account_for_test(@aptos_framework);
-        timestamp::set_time_has_started_for_testing(aptos_framework);
-        account::create_account_for_test(signer::address_of(governance));
-        // This should fail.
-        create_test_proposal(governance, option::some(5));
+        aptos_framework: &signer,
+        governance: &signer,
+    ) acquires VotingForum {
+        test_cannot_set_min_threshold_higher_than_early_resolution_generic(aptos_framework, governance, false);
+    }
+
+    #[test(aptos_framework = @aptos_framework, governance = @0x123)]
+    #[expected_failure(abort_code = 0x10007)]
+    public entry fun test_cannot_set_min_threshold_higher_than_early_resolution_multi_step(
+        aptos_framework: &signer,
+        governance: &signer,
+    ) acquires VotingForum {
+        test_cannot_set_min_threshold_higher_than_early_resolution_generic(aptos_framework, governance, true);
     }
 }


### PR DESCRIPTION
### Description
Implementation of this AIP: https://github.com/aptos-foundation/AIPs/issues/3. 

TLDR: we're supporting multi-step proposals in this PR. We do so by updating `proposal.execution_hash` and `ApprovedExecutionHashes` on-chain to the `next_execution_hash`. 

Summary of changes included in this PR:

`aptos_governance` module: 
Added:
- `aptos_governance::create_proposal_v2()`: this is similar to the existing `aptos_governance::create_proposal`, but here we call the newly added `voting::create_proposal_v2` to create an Aptos governance proposal. 

- `aptos_governance::resolve_multi_step_proposal()`: similar to the existing `aptos_governance::resolve()`, but here we replace the current execution hash in `ApprovedExecutionHashes` with `next_execution_hash`, and call `voting::resolve_proposal_v2` to resolve the proposal. 

Modified:
- `aptos_governance::add_approved_script_hash()`: previously, we immediately return if the `ApprovedExecutionHashes` map already contains the given `proposal_id`. In the updated code, if the `ApprovedExecutionHashes` map already contains the given `proposal_id`, we will replace the existing value in `ApprovedExecutionHashes` with the updated execution hash.  

- `aptos_governance::create_proposal()`: redirected this function to call the newly added `aptos_governance::create_proposal_v2()`, so that we'll have metadata information about if this proposal is single-step or multi-step. 

`voting` module: 
Added:
- Two new constants: `IS_MULTI_STEP_PROPOSAL_KEY` and `IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY`. They will be stored in the `proposal.metadata` map upon creation of a proposal. 

- `voting:: create_proposal_v2()`: the flow of this function is similar to the existing `voting:: create_proposal()` function except that we are also adding metadata about this proposal in the `proposal.metadata` map. 
     - `IS_MULTI_STEP_PROPOSAL_KEY`: `true` for multi-step proposals, `false` for single-step proposals;
     - `IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY` only exists in multi-step proposals. Its value is by default `false`. 
         We update it to true when we start resolving the multi-step proposal. This flag is used to disable further voting when a multi-step proposal is already in execution. 

- `voting:: is_proposal_resolvable()`: this includes all common checks on if a proposal is resolvable regardless if the proposal is single-step or multi-step. 

- `voting:: resolve_proposal_v2()`: this function can resolve a single-step proposal or a multi-step proposal. The flow for a single-step proposal remains mostly unchanged. The flow for a multi-step proposal will update the `proposal.execution_hash` with the `next_execution_hash` on-chain, and check/update `proposal.metadata` values. 

- `voting:: is_multi_step_proposal_in_execution()`: this function returns true if the specified multi-step proposal is in execution. 

Modified:
- `voting::vote()`: added a check to abort when the specified proposal is multi-step and already in execution. 

- `voting::resolve()`: added a check to ensure that this function can only be called to resolve single-step proposals.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Unit tests in this PR, smoke + e2e tests to come in future PRs. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5445)
<!-- Reviewable:end -->
