### PR TITLE
"Message" should be "message"

### DIFF
--- a/developer-docs-site/docs/tutorials/first-dapp.md
+++ b/developer-docs-site/docs/tutorials/first-dapp.md
@@ -326,7 +326,7 @@ function App() {
     client.getAccountModules(address).then(setModules);
   }, [address]);
 
-  const hasModule = modules.some((m) => m.abi?.name === 'Message');
+  const hasModule = modules.some((m) => m.abi?.name === 'message');
   const publishInstructions = (
     <pre>
       Run this command to publish the module:


### PR DESCRIPTION


### Description
While testing AptosClient, client.getAccountModules returns modules[0].abi.name = "message"

### Test Plan
Testing with module from 'first-move-module' quick-start.
1) Compile first-move-module from quick-start example.
2) Publish HelloBlockchain
3) Follow quick-start for 'first-dapp' up until hasModules point.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5448)
<!-- Reviewable:end -->
