### PR TITLE
[forge] refactor and helm values config

### DIFF
--- a/terraform/aptos-node-testnet/forge.tf
+++ b/terraform/aptos-node-testnet/forge.tf
@@ -15,6 +15,11 @@ resource "helm_release" "forge" {
           tag = var.image_tag
         }
       }
+      serviceAccount = {
+        annotations = {
+          "eks.amazonaws.com/role-arn" = aws_iam_role.forge.arn
+        }
+      }
     }),
     jsonencode(var.forge_helm_values),
   ]
@@ -24,5 +29,57 @@ resource "helm_release" "forge" {
     name  = "chart_sha1"
     value = sha1(join("", [for f in fileset(local.forge_helm_chart_path, "**") : filesha1("${local.forge_helm_chart_path}/${f}")]))
   }
+}
+
+data "aws_iam_policy_document" "forge-assume-role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type = "Federated"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${module.validator.oidc_provider}"
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${module.validator.oidc_provider}:sub"
+      # the name of the default forge service account
+      values = ["system:serviceaccount:default:forge"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${module.validator.oidc_provider}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "forge" {
+  statement {
+    sid = "AllowS3"
+    actions = [
+      "s3:*",
+    ]
+    resources = [
+      "arn:aws:s3:::${var.forge_config_s3_bucket}*",
+      "arn:aws:s3:::${var.forge_config_s3_bucket}/*"
+    ]
+  }
+}
+
+resource "aws_iam_role" "forge" {
+  name                 = "aptos-node-testnet-${local.workspace_name}-forge"
+  path                 = var.iam_path
+  permissions_boundary = var.permissions_boundary_policy
+  assume_role_policy   = data.aws_iam_policy_document.forge-assume-role.json
+}
+
+resource "aws_iam_role_policy" "forge" {
+  name   = "Helm"
+  role   = aws_iam_role.forge.name
+  policy = data.aws_iam_policy_document.forge.json
 }
 

--- a/terraform/aptos-node-testnet/variables.tf
+++ b/terraform/aptos-node-testnet/variables.tf
@@ -179,6 +179,11 @@ variable "enable_forge" {
   default     = false
 }
 
+variable "forge_config_s3_bucket" {
+  description = "S3 bucket in which Forge config is stored"
+  default     = "forge-wrapper-config"
+}
+
 variable "forge_helm_values" {
   description = "Map of values to pass to Forge Helm"
   type        = any

--- a/terraform/helm/monitoring/values.yaml
+++ b/terraform/helm/monitoring/values.yaml
@@ -106,8 +106,13 @@ serviceAccount:
 kube-state-metrics:
   enabled: false
   namespaceOverride: kube-system
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
 
 prometheus-node-exporter:
   enabled: false
   namespaceOverride: kube-system
-
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9100"

--- a/testsuite/fixtures/forge-default-helm-values-after.fixture
+++ b/testsuite/fixtures/forge-default-helm-values-after.fixture
@@ -1,0 +1,21 @@
+{
+  "enabled_clusters": [
+    "banana"
+  ],
+  "all_clusters": [
+    "banana",
+    "apple"
+  ],
+  "default_helm_values": {
+    "aptos-genesis": {
+      "image": {
+        "repo": "apple"
+      }
+    },
+    "aptos-node": {
+      "image": {
+        "repo": "banana2"
+      }
+    }
+  }
+}

--- a/testsuite/fixtures/forge-default-helm-values-before.fixture
+++ b/testsuite/fixtures/forge-default-helm-values-before.fixture
@@ -1,0 +1,21 @@
+{
+  "enabled_clusters": [
+    "banana"
+  ],
+  "all_clusters": [
+    "banana",
+    "apple"
+  ],
+  "default_helm_values": {
+    "aptos-genesis": {
+      "image": {
+        "repo": "apple"
+      }
+    },
+    "aptos-node": {
+      "image": {
+        "repo": "banana"
+      }
+    }
+  }
+}

--- a/testsuite/fixtures/forge-default-helm-values-preview.fixture
+++ b/testsuite/fixtures/forge-default-helm-values-preview.fixture
@@ -1,0 +1,14 @@
+--- 
+
++++ 
+
+@@ -14,7 +14,7 @@
+
+     },
+     "aptos-node": {
+       "image": {
+-        "repo": "banana"
++        "repo": "banana2"
+       }
+     }
+   }

--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-import atexit
+import difflib
 import json
 import os
 from pprint import pprint
@@ -9,12 +9,11 @@ import pwd
 import random
 import re
 import resource
-import subprocess
 import sys
-import tempfile
 import textwrap
 import time
 from contextlib import contextmanager
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -32,6 +31,12 @@ from typing import (
     Union,
 )
 from urllib.parse import ParseResult, urlunparse, urlencode
+from forge_wrapper_core.filesystem import Filesystem, LocalFilesystem
+from forge_wrapper_core.git import Git
+from forge_wrapper_core.process import Processes, SystemProcesses
+
+from forge_wrapper_core.shell import LocalShell, Shell
+from forge_wrapper_core.time import SystemTime, Time
 
 
 @dataclass
@@ -48,77 +53,17 @@ class RunResult:
         return self.exit_code == 0
 
 
-class Shell:
-    def run(self, command: Sequence[str], stream_output: bool = False) -> RunResult:
-        raise NotImplementedError()
-
-    async def gen_run(
-        self, command: Sequence[str], stream_output: bool = False
-    ) -> RunResult:
-        raise NotImplementedError()
-
-
-@dataclass
-class LocalShell(Shell):
-    verbose: bool = False
-
-    def run(self, command: Sequence[str], stream_output: bool = False) -> RunResult:
-        # Write to a temp file, stream to stdout
-        tmpname = tempfile.mkstemp()[1]
-        with open(tmpname, "wb") as writer, open(tmpname, "rb") as reader:
-            if self.verbose:
-                print(f"+ {' '.join(command)}")
-            process = subprocess.Popen(command, stdout=writer, stderr=writer)
-            output = b""
-            while process.poll() is None:
-                chunk = reader.read()
-                output += chunk
-                if stream_output:
-                    sys.stdout.write(chunk.decode("utf-8"))
-                time.sleep(0.1)
-            output += reader.read()
-        return RunResult(process.returncode, output)
-
-    async def gen_run(
-        self, command: Sequence[str], stream_output: bool = False
-    ) -> RunResult:
-        # Write to a temp file, stream to stdout
-        tmpname = tempfile.mkstemp()[1]
-        with open(tmpname, "wb") as writer, open(tmpname, "rb") as reader:
-            if self.verbose:
-                print(f"+ {' '.join(command)}")
-            try:
-                process = await asyncio.create_subprocess_exec(
-                    command[0], *command[1:], stdout=writer, stderr=writer
-                )
-            except Exception as e:
-                raise Exception(f"Failed running {command}") from e
-            output = b""
-            while True:
-                wait_task = asyncio.create_task(process.wait())
-                finished, running = await asyncio.wait({wait_task}, timeout=1)
-                assert bool(finished) ^ bool(
-                    running
-                ), "Cannot have both finished and running"
-                if finished:
-                    break
-                chunk = reader.read()
-                output += chunk
-                if stream_output:
-                    sys.stdout.write(chunk.decode("utf-8"))
-                await asyncio.sleep(1)
-            output += reader.read()
-        exit_code = process.returncode
-        assert exit_code is not None, "Process must have exited"
-        return RunResult(exit_code, output)
+def get_prompt_answer(prompt: str, answer: Optional[str]=None) -> bool:
+    """Get a yes/no answer from the user, or use the default answer if provided."""
+    if not answer and not os.getenv("CI"):
+        answer = input(f"{prompt} (y/n) ").strip().lower() 
+    return answer in ("y", "yes", "yeet", "yessir", "si", "true")
 
 
 def install_dependency(dependency: str) -> None:
     print(f"{dependency} is not currently installed")
     answer = os.getenv("FORGE_INSTALL_DEPENDENCIES") or os.getenv("CI")
-    if not answer:
-        answer = input("Would you like to install it now? (y/n) ").strip().lower()
-    if answer in ("y", "yes", "yeet", "yessir", "si", "true"):
+    if get_prompt_answer("Would you like to install it now?", answer):
         shell = LocalShell(True)
         shell.run(["pip3", "install", dependency], stream_output=True).unwrap()
     else:
@@ -159,94 +104,14 @@ def envoption(name: str, default: Optional[Any] = None) -> Any:
     )
 
 
-class Filesystem:
-    def write(self, filename: str, contents: bytes) -> None:
-        raise NotImplementedError()
-
-    def read(self, filename: str) -> bytes:
-        raise NotImplementedError()
-
-    def mkstemp(self) -> str:
-        raise NotImplementedError()
-
-    def rlimit(self, resource_type: int, soft: int, hard: int) -> None:
-        raise NotImplementedError()
-
-    def unlink(self, filename: str) -> None:
-        raise NotImplementedError()
-
-
-class LocalFilesystem(Filesystem):
-    def write(self, filename: str, contents: bytes) -> None:
-        with open(filename, "wb") as f:
-            f.write(contents)
-
-    def read(self, filename: str) -> bytes:
-        with open(filename, "rb") as f:
-            return f.read()
-
-    def mkstemp(self) -> str:
-        return tempfile.mkstemp()[1]
-
-    def rlimit(self, resource_type: int, soft: int, hard: int) -> None:
-        resource.setrlimit(resource_type, (soft, hard))
-
-    def unlink(self, filename: str) -> None:
-        os.unlink(filename)
-
-
 # o11y resources
 GRAFANA_BASE_URL = (
     "https://o11y.aptosdev.com/grafana/d/overview/overview?orgId=1&refresh=10s&"
     "var-Datasource=VictoriaMetrics%20Global"
 )
 
-class Process:
-    def name(self) -> str:
-        raise NotImplementedError()
-
-    def ppid(self) -> int:
-        raise NotImplementedError()
-
-
-class Processes:
-    def processes(self) -> Generator[Process, None, None]:
-        raise NotImplementedError()
-
-    def get_pid(self) -> int:
-        raise NotImplementedError()
-
-    def atexit(self, callback: Callable[[], None]) -> None:
-        raise NotImplementedError()
-
-    def user(self) -> str:
-        raise NotImplementedError()
-
-
-@dataclass
-class SystemProcess(Process):
-    process: psutil.Process
-
-    def name(self) -> str:
-        return self.process.name()
-
-    def ppid(self) -> int:
-        return self.process.ppid()
-
-
-class SystemProcesses(Processes):
-    def processes(self) -> Generator[Process, None, None]:
-        for process in psutil.process_iter():
-            yield SystemProcess(process)
-
-    def get_pid(self) -> int:
-        return os.getpid()
-
-    def atexit(self, callback: Callable[[], None]) -> None:
-        atexit.register(callback)
-
-    def user(self) -> str:
-        return get_current_user()
+# helm chart default override values
+HELM_CHARTS = ["aptos-node", "aptos-genesis"]
 
 
 class ForgeState(Enum):
@@ -312,7 +177,7 @@ class ForgeResult:
                         context.shell,
                         context.forge_namespace,
                         context.forge_cluster.kubeconf,
-                    )
+                    ),
                 )
             )
         result._end_time = context.time.now()
@@ -334,27 +199,16 @@ class ForgeResult:
         output_lines = []
         if not self.succeeded():
             output_lines.append(self.debugging_output)
-        output_lines.extend([
-            f"Forge output: {self.output}",
-            f"Forge {self.state.value.lower()}ed",
-        ])
+        output_lines.extend(
+            [
+                f"Forge output: {self.output}",
+                f"Forge {self.state.value.lower()}ed",
+            ]
+        )
         return "\n".join(output_lines)
 
     def succeeded(self) -> bool:
         return self.state == ForgeState.PASS
-
-
-class Time:
-    def epoch(self) -> str:
-        return self.now().strftime("%s")
-
-    def now(self) -> datetime:
-        raise NotImplementedError()
-
-
-class SystemTime(Time):
-    def now(self) -> datetime:
-        return datetime.now(timezone.utc)
 
 
 @dataclass
@@ -390,11 +244,7 @@ class ForgeContext:
     github_actions: str
     github_job_url: Optional[str]
 
-    def report(
-        self,
-        result: ForgeResult,
-        outputs: List[ForgeFormatter]
-    ) -> None:
+    def report(self, result: ForgeResult, outputs: List[ForgeFormatter]) -> None:
         for formatter in outputs:
             output = formatter.format(self, result)
             print(f"=== Start {formatter} ===")
@@ -438,10 +288,8 @@ def format_report(context: ForgeContext, result: ForgeResult) -> str:
             error_buffer.append(line)
     report_output = "\n".join(report_lines)
     error_output = "\n".join(error_buffer)
-    debugging_appendix = (
-        "Trailing Log Lines:\n{}\nDebugging output:\n{}".format(
-            error_output, result.debugging_output
-        )
+    debugging_appendix = "Trailing Log Lines:\n{}\nDebugging output:\n{}".format(
+        error_output, result.debugging_output
     )
     if not report_lines:
         return "Forge test runner terminated:\n{}".format(debugging_appendix)
@@ -460,6 +308,7 @@ def format_report(context: ForgeContext, result: ForgeResult) -> str:
         if result.state == ForgeState.FAIL:
             return "{}\n{}".format(report_text, debugging_appendix)
         return report_text
+
 
 def get_dashboard_link(
     forge_namespace: str,
@@ -484,17 +333,18 @@ def get_dashboard_link(
 def shorten_link(link: str) -> str:
     headers = {
         "x-api-key": os.getenv("SHORTENER_API_KEY"),
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
     }
-    body = json.dumps({
-        "longUrl": link,
-    })
+    body = json.dumps(
+        {
+            "longUrl": link,
+        }
+    )
     try:
         import requests
+
         response = requests.post(
-            'https://api.aws3.link/shorten',
-            headers=headers,
-            data=body
+            "https://api.aws3.link/shorten", headers=headers, data=body
         )
         return f"https://{response.json()['shortUrl']}"
     # Dont fail if we fail to shorten
@@ -536,55 +386,38 @@ def get_humio_forge_link(
 ) -> str:
     columns = [
         {
-            'type': 'field',
-            'fieldName': '@timestamp',
-            'format': 'timestamp',
-            'width': 180
+            "type": "field",
+            "fieldName": "@timestamp",
+            "format": "timestamp",
+            "width": 180,
         },
         {
             "type": "link",
             "openInNewBrowserTab": "***",
             "style": "button",
-            "hrefTemplate": "https://github.com/aptos-labs/aptos-core/pull/{{fields[\"github_pr\"]}}",
-            "textTemplate": "{{fields[\"github_pr\"]}}",
+            "hrefTemplate": 'https://github.com/aptos-labs/aptos-core/pull/{{fields["github_pr"]}}',
+            "textTemplate": '{{fields["github_pr"]}}',
             "header": "Forge PR",
-            "width": 79
+            "width": 79,
         },
-        {
-            "type": "field",
-            "fieldName": "k8s.namespace",
-            "format": "text",
-            "width": 104
-        },
-        {
-            'type': 'field',
-            'fieldName': 'message',
-            'format': 'text',
-            'width': 3760
-        },
+        {"type": "field", "fieldName": "k8s.namespace", "format": "text", "width": 104},
+        {"type": "field", "fieldName": "message", "format": "text", "width": 3760},
     ]
     urlparts = {
-        'query': (
-            '$forgeLogs(validator_instance=*)'
-            f' | {forge_namespace}'
+        "query": (
+            "$forgeLogs(validator_instance=*)"
+            f" | {forge_namespace}"
             ' | "k8s.labels.app.kubernetes.io/name" = forge'
         ),
-        'widgetType': 'list-view',
-        'columns': json.dumps(columns),
-        'newestAtBottom': 'true',
-        'showOnlyFirstLine': 'false',
+        "widgetType": "list-view",
+        "columns": json.dumps(columns),
+        "newestAtBottom": "true",
+        "showOnlyFirstLine": "false",
     }
     urlparts = apply_humio_time_filter(urlparts, time_filter)
     query = urlencode(urlparts)
     return urlunparse(
-        ParseResult(
-            'https',
-            'cloud.us.humio.com',
-            '/k8s/search',
-            '',
-            query,
-            ''
-        )
+        ParseResult("https", "cloud.us.humio.com", "/k8s/search", "", query, "")
     )
 
 
@@ -592,71 +425,48 @@ def get_humio_logs_link(
     forge_namespace: str,
     time_filter: Union[bool, Tuple[datetime, datetime]],
 ) -> str:
-    query = f'$forgeLogs(validator_instance=*) | {forge_namespace}'
+    query = f"$forgeLogs(validator_instance=*) | {forge_namespace}"
     columns = [
         {
             "type": "field",
             "fieldName": "@timestamp",
             "format": "timestamp",
-            "width": 180
+            "width": 180,
         },
-        {
-            "type": "field",
-            "fieldName": "level",
-            "format": "text",
-            "width": 54
-        },
+        {"type": "field", "fieldName": "level", "format": "text", "width": 54},
         {
             "type": "link",
             "openInNewBrowserTab": "***",
             "style": "button",
-            "hrefTemplate": "https://github.com/aptos-labs/aptos-core/pull/{{fields[\"github_pr\"]}}",
-            "textTemplate": "{{fields[\"github_pr\"]}}",
+            "hrefTemplate": 'https://github.com/aptos-labs/aptos-core/pull/{{fields["github_pr"]}}',
+            "textTemplate": '{{fields["github_pr"]}}',
             "header": "Forge PR",
-            "width": 79
+            "width": 79,
         },
-        {
-            "type": "field",
-            "fieldName": "k8s.namespace",
-            "format": "text",
-            "width": 104
-        },
-        {
-            "type": "field",
-            "fieldName": "k8s.pod_name",
-            "format": "text",
-            "width": 126
-        },
+        {"type": "field", "fieldName": "k8s.namespace", "format": "text", "width": 104},
+        {"type": "field", "fieldName": "k8s.pod_name", "format": "text", "width": 126},
         {
             "type": "field",
             "fieldName": "k8s.container_name",
             "format": "text",
-            "width": 85
+            "width": 85,
         },
-        {
-            "type": "field",
-            "fieldName": "message",
-            "format": "text"
-        },
+        {"type": "field", "fieldName": "message", "format": "text"},
     ]
     urlparts = {
-        'query': query,
-        'widgetType': 'list-view',
-        'columns': json.dumps(columns),
-        'newestAtBottom': '***',
-        'showOnlyFirstLine': 'false',
+        "query": query,
+        "widgetType": "list-view",
+        "columns": json.dumps(columns),
+        "newestAtBottom": "***",
+        "showOnlyFirstLine": "false",
     }
     urlparts = apply_humio_time_filter(urlparts, time_filter)
     return urlunparse(
         ParseResult(
-            'https',
-            'cloud.us.humio.com',
-            '/k8s/search',
-            '',
-            urlencode(urlparts),
-            ''
+            "https", "cloud.us.humio.com", "/k8s/search", "", urlencode(urlparts), ""
         )
     )
+
 
 def format_github_info(context: ForgeContext) -> str:
     if not context.github_job_url:
@@ -717,17 +527,11 @@ def format_comment(context: ForgeContext, result: ForgeResult) -> str:
     )
 
     if result.state == ForgeState.PASS:
-        forge_comment_header = (
-            f"### :white_check_mark: Forge suite `{context.forge_test_suite}` success on {get_testsuite_images(context)}"
-        )
+        forge_comment_header = f"### :white_check_mark: Forge suite `{context.forge_test_suite}` success on {get_testsuite_images(context)}"
     elif result.state == ForgeState.FAIL:
-        forge_comment_header = (
-            f"### :x: Forge suite `{context.forge_test_suite}` failure on {get_testsuite_images(context)}"
-        )
+        forge_comment_header = f"### :x: Forge suite `{context.forge_test_suite}` failure on {get_testsuite_images(context)}"
     elif result.state == ForgeState.SKIP:
-        forge_comment_header = (
-            f"### :thought_balloon: Forge suite `{context.forge_test_suite}` preempted on {get_testsuite_images(context)}"
-        )
+        forge_comment_header = f"### :thought_balloon: Forge suite `{context.forge_test_suite}` preempted on {get_testsuite_images(context)}"
     else:
         raise Exception(f"Invalid forge state: {result.state}")
 
@@ -881,8 +685,11 @@ class K8sForgeRunner(ForgeRunner):
                     "--kubeconfig",
                     context.forge_cluster.kubeconf,
                     "apply",
-                    "-n", "default",
-                    "-f", specfile]
+                    "-n",
+                    "default",
+                    "-f",
+                    specfile,
+                ]
             ).unwrap()
             context.shell.run(
                 [
@@ -907,8 +714,10 @@ class K8sForgeRunner(ForgeRunner):
                         "--kubeconfig",
                         context.forge_cluster.kubeconf,
                         "logs",
-                        "-n", "default",
-                        "-f", forge_pod_name
+                        "-n",
+                        "default",
+                        "-f",
+                        forge_pod_name,
                     ],
                     stream_output=streaming,
                 )
@@ -1023,28 +832,18 @@ def get_current_cluster_name(shell: Shell) -> str:
     return matches[0]
 
 
-@dataclass
-class Git:
-    shell: Shell
-
-    def run(self, command) -> RunResult:
-        return self.shell.run(["git", *command])
-
-    def last(self, limit: int = 1) -> Generator[str, None, None]:
-        for i in range(limit):
-            yield self.run(["rev-parse", f"HEAD~{i}"]).unwrap().decode().strip()
-
-
 def assert_provided_image_tags_has_profile_or_features(
     image_tag: Optional[str],
     upgrade_image_tag: Optional[str],
-    enable_failpoints_feature: bool,
+    enable_testing_image: bool,
     enable_performance_profile: bool,
 ):
     for tag in [image_tag, upgrade_image_tag]:
         if not tag:
             continue
-        if enable_failpoints_feature:
+        if (
+            enable_testing_image
+        ):  # testing image requires the tag to be prefixed with failpoints_
             assert tag.startswith(
                 "failpoints"
             ), f"Missing failpoints_ feature prefix in {tag}"
@@ -1058,17 +857,19 @@ def find_recent_images_by_profile_or_features(
     shell: Shell,
     git: Git,
     num_images: int,
-    enable_failpoints_feature: Optional[bool],
+    enable_testing_image: Optional[bool],
     enable_performance_profile: Optional[bool],
 ) -> Generator[str, None, None]:
     image_name = "aptos/validator"
     image_tag_prefix = ""
-    if enable_failpoints_feature and enable_performance_profile:
-        raise Exception("Cannot yet set both failpoints and performance")
+    if enable_testing_image and enable_performance_profile:
+        raise Exception(
+            "Cannot yet set both testing (failpoints) image and performance"
+        )
 
     if enable_performance_profile:
         image_tag_prefix = "performance_"
-    if enable_failpoints_feature:
+    if enable_testing_image:
         image_tag_prefix = "failpoints_"
 
     return find_recent_images(
@@ -1168,43 +969,49 @@ def create_forge_command(
         ]
         if cargo_args:
             forge_args.extend(cargo_args)
-        forge_args.extend([
-            "-p",
-            "forge-cli",
-            "--",
-        ])
+        forge_args.extend(
+            [
+                "-p",
+                "forge-cli",
+                "--",
+            ]
+        )
     elif forge_runner_mode == "k8s":
         forge_args = ["forge"]
     else:
         return []
     if forge_test_suite:
-        forge_args.extend([
-            "--suite", forge_test_suite
-        ])
+        forge_args.extend(["--suite", forge_test_suite])
     if forge_runner_duration_secs:
-        forge_args.extend([
-            "--duration-secs", forge_runner_duration_secs
-        ])
+        forge_args.extend(["--duration-secs", forge_runner_duration_secs])
 
     if forge_num_validators:
         forge_args.extend(["--num-validators", forge_num_validators])
     if forge_num_validator_fullnodes:
-        forge_args.extend([
-            "--num-validator-fullnodes",
-            forge_num_validator_fullnodes,
-        ])
+        forge_args.extend(
+            [
+                "--num-validator-fullnodes",
+                forge_num_validator_fullnodes,
+            ]
+        )
 
     if forge_cli_args:
         forge_args.extend(forge_cli_args)
 
     # TODO: add support for other backend
     backend = "k8s-swarm"
-    forge_args.extend([
-        "test", backend,
-        "--image-tag", image_tag,
-        "--upgrade-image-tag", upgrade_image_tag,
-        "--namespace", forge_namespace,
-    ])
+    forge_args.extend(
+        [
+            "test",
+            backend,
+            "--image-tag",
+            image_tag,
+            "--upgrade-image-tag",
+            upgrade_image_tag,
+            "--namespace",
+            forge_namespace,
+        ]
+    )
 
     if forge_runner_mode == "local":
         forge_args.append("--port-forward")
@@ -1255,10 +1062,13 @@ async def run_multiple(
                     [
                         # TODO figure out which other args we should forward
                         # This might only work from github for starters
-                        sys.executable, __file__,
+                        sys.executable,
+                        __file__,
                         "test",
-                        "--forge-test-suite", suite,
-                        "--forge-namespace", new_namespace,
+                        "--forge-test-suite",
+                        suite,
+                        "--forge-namespace",
+                        new_namespace,
                     ],
                 )
             )
@@ -1278,26 +1088,24 @@ async def run_multiple(
         failed = False
         for i, result in enumerate(results):
             suite, namespace = pending_suites[i]
-            short_link = shorten_link(get_humio_forge_link(namespace, (start_time, stop_time)))
+            short_link = shorten_link(
+                get_humio_forge_link(namespace, (start_time, stop_time))
+            )
             if result.succeeded():
                 final_forge_comment.append(f"{suite} succeeded")
             else:
                 failed = suite not in disabled_suites
                 disabled = " (disabled)" if suite in disabled_suites else ""
                 final_forge_comment.append(f"{suite} failed{disabled}")
-        final_forge_comment.append(
-            f"Run {'failed' if failed else 'succeeded'}"
-        )
+        final_forge_comment.append(f"Run {'failed' if failed else 'succeeded'}")
         print("\n".join(final_forge_comment))
         if forge_comment:
             context.filesystem.write(
-                forge_comment,
-                "\n".join(final_forge_comment).encode()
+                forge_comment, "\n".join(final_forge_comment).encode()
             )
         if github_step_summary:
             context.filesystem.write(
-                github_step_summary,
-                "\n".join(final_forge_comment).encode()
+                github_step_summary, "\n".join(final_forge_comment).encode()
             )
 
 
@@ -1319,7 +1127,7 @@ async def run_multiple(
 @envoption("FORGE_NAMESPACE_KEEP")
 @envoption("FORGE_NAMESPACE_REUSE")
 @envoption("FORGE_ENABLE_HAPROXY")
-@envoption("FORGE_ENABLE_FAILPOINTS")
+@envoption("FORGE_ENABLE_TESTING_IMAGE")
 @envoption("FORGE_ENABLE_PERFORMANCE")
 @envoption("FORGE_TEST_SUITE")
 @envoption("FORGE_RUNNER_DURATION_SECS", "300")
@@ -1340,14 +1148,10 @@ async def run_multiple(
     help="Cargo args to pass to forge local runner",
 )
 @click.option(
-    "--forge-cli-args",
-    multiple=True,
-    help="Forge cli args to pass to forge cli"
+    "--forge-cli-args", multiple=True, help="Forge cli args to pass to forge cli"
 )
 @click.option(
-    "--test-args",
-    multiple=True,
-    help="Test args to pass to forge test subcommand"
+    "--test-args", multiple=True, help="Test args to pass to forge test subcommand"
 )
 @click.argument("test_suites", nargs=-1)
 def test(
@@ -1362,7 +1166,7 @@ def test(
     forge_num_validator_fullnodes: Optional[str],
     forge_namespace_keep: Optional[str],
     forge_namespace_reuse: Optional[str],
-    forge_enable_failpoints: Optional[str],
+    forge_enable_testing_image: Optional[str],
     forge_enable_performance: Optional[str],
     forge_enable_haproxy: Optional[str],
     forge_test_suite: str,
@@ -1413,19 +1217,13 @@ def test(
     for suite in all_suites:
         config_suites = config.get("test_suites")
         if suite in config_suites:
-            enabled_resolved_suites.extend(
-                config_suites[suite]["enabled_tests"].keys()
-            )
-            all_resolved_suites.extend(
-                config_suites[suite]["all_tests"].keys()
-            )
+            enabled_resolved_suites.extend(config_suites[suite]["enabled_tests"].keys())
+            all_resolved_suites.extend(config_suites[suite]["all_tests"].keys())
         else:
             enabled_resolved_suites.append(suite)
             all_resolved_suites.append(suite)
 
-    disabled_resolved_suites = (
-        set(all_resolved_suites) - set(enabled_resolved_suites)
-    )
+    disabled_resolved_suites = set(all_resolved_suites) - set(enabled_resolved_suites)
 
     if len(all_resolved_suites) == 0:
         print("No tests to run")
@@ -1461,13 +1259,13 @@ def test(
     assert forge_cluster_name, "Forge cluster name is required"
 
     # These features and profile flags are set as strings
-    enable_failpoints_feature = forge_enable_failpoints == "true"
+    enable_testing_image = forge_enable_testing_image == "true"
     enable_performance_profile = forge_enable_performance == "true"
 
     assert_provided_image_tags_has_profile_or_features(
         image_tag,
         upgrade_image_tag,
-        enable_failpoints_feature=enable_failpoints_feature,
+        enable_testing_image=enable_testing_image,
         enable_performance_profile=enable_performance_profile,
     )
 
@@ -1478,7 +1276,7 @@ def test(
                 shell,
                 git,
                 2,
-                enable_failpoints_feature=enable_failpoints_feature,
+                enable_testing_image=enable_testing_image,
                 enable_performance_profile=enable_performance_profile,
             )
         )
@@ -1495,7 +1293,7 @@ def test(
                 shell,
                 git,
                 1,
-                enable_failpoints_feature=enable_failpoints_feature,
+                enable_testing_image=enable_testing_image,
                 enable_performance_profile=enable_performance_profile,
             )
         )
@@ -1506,7 +1304,7 @@ def test(
     assert_provided_image_tags_has_profile_or_features(
         image_tag,
         upgrade_image_tag,
-        enable_failpoints_feature=enable_failpoints_feature,
+        enable_testing_image=enable_testing_image,
         enable_performance_profile=enable_performance_profile,
     )
 
@@ -1535,7 +1333,7 @@ def test(
         forge_cli_args=forge_cli_args,
         test_args=test_args,
     )
-    
+
     print(f"Using cluster: {forge_cluster_name}")
     temp = context.filesystem.mkstemp()
     forge_cluster = ForgeCluster(forge_cluster_name, temp)
@@ -1556,7 +1354,9 @@ def test(
         forge_test_suite=forge_test_suite,
         forge_blocking=forge_blocking == "true",
         github_actions=github_actions,
-        github_job_url=f"{github_server_url}/{github_repository}/actions/runs/{github_run_id}" if github_run_id else None,
+        github_job_url=f"{github_server_url}/{github_repository}/actions/runs/{github_run_id}"
+        if github_run_id
+        else None,
         forge_args=forge_args,
     )
     forge_runner_mapping = {
@@ -1583,9 +1383,7 @@ def test(
 
         outputs = []
         if forge_output:
-            outputs.append(
-                ForgeFormatter(forge_output, lambda *_: result.output)
-            )
+            outputs.append(ForgeFormatter(forge_output, lambda *_: result.output))
         if forge_report:
             outputs.append(ForgeFormatter(forge_report, format_report))
         else:
@@ -1605,14 +1403,16 @@ def test(
 
     except Exception as e:
         raise Exception(
-            "\n".join([
-                "Forge state:",
-                dump_forge_state(
-                    shell,
-                    forge_namespace,
-                    forge_cluster.kubeconf,
-                )
-            ])
+            "\n".join(
+                [
+                    "Forge state:",
+                    dump_forge_state(
+                        shell,
+                        forge_namespace,
+                        forge_cluster.kubeconf,
+                    ),
+                ]
+            )
         ) from e
 
 
@@ -1821,10 +1621,13 @@ class TestSuite(TypedDict):
 
 # All changes to this struct must be backwards compatible
 # i.e. its ok to add a new field, but not to remove one
+
+
 class ForgeConfigValue(TypedDict):
     enabled_clusters: List[str]
     all_clusters: List[str]
     test_suites: Dict[str, TestSuite]
+    default_helm_values: Dict
 
 
 def default_forge_config() -> ForgeConfigValue:
@@ -1834,7 +1637,22 @@ def default_forge_config() -> ForgeConfigValue:
     }
 
 
+def validate_forge_config_default_helm_values(value: Any) -> List[str]:
+    """Validate that the given forge config has a valid default_helm_values config. Returns a list of error messages"""
+    errors = []
+    try:
+        keys = value["default_helm_values"].keys()
+        for chart in HELM_CHARTS:
+            if chart not in keys:
+                errors.append(f"Missing required chart {chart} in default_helm_values")
+    except Exception as e:
+        errors.append(f"Invalid default_helm_values: {e}")
+
+    return errors
+
+
 def validate_forge_config(value: Any) -> List[str]:
+    """Validate that the given forge config has all the required fields. Returns a list of error messages"""
     errors = []
     if not isinstance(value, dict):
         return ["Value must be derived from dict"]
@@ -1847,6 +1665,7 @@ def validate_forge_config(value: Any) -> List[str]:
     for cluster in value["enabled_clusters"]:
         if not isinstance(cluster, str):
             errors.append("Cluster must be a string")
+
     return errors
 
 
@@ -1857,6 +1676,17 @@ def ensure_forge_config(value: Any) -> ForgeConfigValue:
         raise Exception("Type had errors:\n" + "\n".join(errors))
     return value
 
+def get_forge_config_diff(old_config: dict, new_config: dict, full_diff: Optional[bool]=False) -> list:
+    """Returns a list of diffs between the old and new config"""
+    config_string = json.dumps(new_config, indent=2)
+    old_config_string = json.dumps(old_config, indent=2)
+    old_lines = old_config_string.splitlines()
+    new_lines = config_string.splitlines()
+    if full_diff:
+        diff = difflib.Differ()
+        return diff.compare(old_lines, new_lines)
+    else:
+        return difflib.unified_diff(old_lines, new_lines)
 
 class ForgeConfigBackend:
     def create(self) -> None:
@@ -1876,28 +1706,39 @@ class S3ForgeConfigBackend(ForgeConfigBackend):
     key: str = DEFAULT_CONFIG_KEY
 
     def create(self) -> None:
-        self.system.shell.run([
-            "aws", "s3", "mb", f"s3://{self.name}"
-        ]).unwrap()
+        self.system.shell.run(["aws", "s3", "mb", f"s3://{self.name}"]).unwrap()
 
     def write(self, config: object) -> None:
         temp = self.system.filesystem.mkstemp()
         self.system.filesystem.write(temp, json.dumps(config).encode())
-        self.system.shell.run([
-            "aws", "s3api", "put-object",
-            "--bucket", self.name,
-            "--key", self.key,
-            "--body", temp,
-        ]).unwrap()
+        self.system.shell.run(
+            [
+                "aws",
+                "s3api",
+                "put-object",
+                "--bucket",
+                self.name,
+                "--key",
+                self.key,
+                "--body",
+                temp,
+            ]
+        ).unwrap()
 
     def read(self) -> object:
         temp = self.system.filesystem.mkstemp()
-        self.system.shell.run([
-            "aws", "s3api", "get-object",
-            "--bucket", self.name,
-            "--key", self.key,
-            temp,
-        ]).unwrap()
+        self.system.shell.run(
+            [
+                "aws",
+                "s3api",
+                "get-object",
+                "--bucket",
+                self.name,
+                "--key",
+                self.key,
+                temp,
+            ]
+        ).unwrap()
         return json.loads(self.system.filesystem.read(temp))
 
 
@@ -1936,7 +1777,7 @@ class ForgeConfig:
     def get(self, key: str, default: Optional[Any] = NONE_SENTINEL) -> Any:
         value = self.config.get(key, default)
         if value is self.NONE_SENTINEL:
-            raise Exception(f"Missing key {key}")
+            raise Exception(f"Missing key {key} in Forge config")
         return value
 
     def set(self, key, value, validate: bool = True) -> None:
@@ -1961,6 +1802,7 @@ def config() -> None:
 
 @config.command("create")
 def create_config() -> None:
+    """Create a new forge config at the default location"""
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
@@ -1971,7 +1813,9 @@ def create_config() -> None:
 
 
 @config.command("get")
-def get_config() -> None:
+@click.argument("key", type=str, required=False)
+def get_config(key: Optional[str]) -> None:
+    """Print the forge configuration"""
     shell = LocalShell(True)
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
@@ -1979,7 +1823,17 @@ def get_config() -> None:
     context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
     config.init()
-    pprint(config.dump())
+
+    try:
+        val = config.dump().get(key) if key else config.dump()
+        if not val:
+            raise Exception(f"No config value found for key {key}")
+    except Exception as e:
+        raise click.ClickException(str(e))
+
+    # print the config as JSON so it looks nicer
+    config_string = json.dumps(val, indent=2)
+    print(config_string)
 
 
 def keyword_argument(value: str) -> Tuple[str, str]:
@@ -1992,16 +1846,17 @@ def keyword_argument(value: str) -> Tuple[str, str]:
 @config.command("set")
 @click.option("--force", is_flag=True, help="Disable config validation")
 @click.option(
-    "--config",
-    "config_path",
-    help="Provide a file to replace the current config"
+    "--config", "config_path", help="Provide a file to replace the current config"
 )
 @click.argument("values", type=keyword_argument, nargs=-1)
+@click.option("-y", is_flag=True, help="Accept all interactive prompts")
 def set_config(
     force: Optional[bool],
     config_path: Optional[str],
-    values: List[Tuple[str, str]]
+    values: List[Tuple[str, str]],
+    y: bool,
 ) -> None:
+    """Replace forge configuration values with local config"""
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
@@ -2009,10 +1864,10 @@ def set_config(
     context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
+    old_config = deepcopy(config.dump())
+
     if config_path:
-        local_config = ForgeConfig(
-            FilesystemConfigBackend(config_path, context)
-        )
+        local_config = ForgeConfig(FilesystemConfigBackend(config_path, context))
         local_config.init()
         for k, v in local_config.dump().items():
             config.set(k, v, validate=not force)
@@ -2023,12 +1878,18 @@ def set_config(
     for k, v in values:
         config.set(k, v, validate=not force)
 
-    config.flush()
+    d = get_forge_config_diff(old_config, config.dump())
+    print("\n".join(d))
+    if y or get_prompt_answer("Would you like to apply the config change now?"):
+        config.flush()
+    else:
+        print("Config not updated")
 
 
 @config.command("edit")
 @click.pass_context
 def config_edit(ctx: click.Context) -> None:
+    """Edit forge configuration via interactive text editor"""
     shell = LocalShell(True)
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
@@ -2037,10 +1898,93 @@ def config_edit(ctx: click.Context) -> None:
     config.init()
 
     temp = filesystem.mkstemp()
-    filesystem.write(temp, json.dumps(config.dump(), indent=4).encode())
+    filesystem.write(temp, json.dumps(config.dump(), indent=2).encode())
     editor = os.getenv("EDITOR", "vim")
     os.system(f"{editor} {temp}")
     ctx.invoke(set_config, config_path=temp)
+
+
+@config.group("helm")
+def helm_config() -> None:
+    """Manage forge helm configuration"""
+    pass
+
+
+def assert_helm_chart_valid(chart: str) -> None:
+    if chart not in HELM_CHARTS:
+        raise Exception(f"Invalid helm chart {chart}")
+
+
+@helm_config.command("get")
+@click.argument("chart", type=str, required=True)
+def helm_config_get(chart: str) -> None:
+    shell = LocalShell()
+    filesystem = LocalFilesystem()
+    processes = SystemProcesses()
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
+    config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
+
+    assert_helm_chart_valid(chart)
+
+    config.init()
+
+    default_helm_values = config.get("default_helm_values").get(chart)
+    if not default_helm_values:
+        raise Exception(f"No helm values found for chart {chart}")
+    print(json.dumps(default_helm_values, indent=2))
+
+
+@helm_config.command("set")
+@click.argument("chart", type=str, required=True)
+@click.option(
+    "--config",
+    "config_path",
+    help="Provide a file to replace the current config",
+    required=True,
+)
+@click.option("--force", is_flag=True, help="Disable config validation")
+@click.option("-y", is_flag=True, help="Accept all interactive prompts")
+def helm_config_set(
+    chart: str, config_path: str, force: Optional[bool], y: bool
+) -> None:
+    shell = LocalShell()
+    filesystem = LocalFilesystem()
+    processes = SystemProcesses()
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
+    config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
+
+    assert_helm_chart_valid(chart)
+
+    # read existing config
+    config.init()
+
+    # read new helm config and set it as a corresponding key
+    local_config = FilesystemConfigBackend(config_path, context)
+    local_config_values = local_config.read()
+    old_config = deepcopy(config.dump())
+
+    # set the default_helm_values key if it doesnt exist
+    try:
+        config.get("default_helm_values")
+    except Exception:
+        config.set("default_helm_values", {}, validate=not force)
+
+    # merge the local configs into the existing config
+    new_default_helm_values = {
+        **config.get("default_helm_values"),
+        **{chart: local_config_values},
+    }
+
+    config.set("default_helm_values", new_default_helm_values, validate=not force)
+
+    d = get_forge_config_diff(old_config, config.dump())
+    print("\n".join(d))
+    if y or get_prompt_answer("Would you like to apply the config change now?"):
+        config.flush()
+    else:
+        print("Config not updated")
 
 
 @config.group("cluster")
@@ -2052,9 +1996,11 @@ def cluster_config() -> None:
 @cluster_config.command("delete")
 @click.argument("cluster")
 @click.option("--force", is_flag=True, help="Disable config validation")
+@click.option("-y", is_flag=True, help="Accept all interactive prompts")
 def cluster_config_delete(
     cluster: str,
     force: Optional[bool],
+    y: bool,
 ) -> None:
     shell = LocalShell()
     filesystem = LocalFilesystem()
@@ -2063,22 +2009,32 @@ def cluster_config_delete(
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
+    old_config = deepcopy(config.dump())
 
     enabled_clusters = config.get("enabled_clusters")
     if cluster in enabled_clusters and not force:
-        raise Exception(
-            f"Cluster {cluster} is enabled, use --force to delete anyway"
-        )
+        raise Exception(f"Cluster {cluster} is enabled, use --force to delete anyway")
     all_clusters = config.get("all_clusters")
-    all_clusters.remove(cluster)
+
+    try:
+        all_clusters.remove(cluster)
+    except ValueError:
+        raise Exception(f"Cluster {cluster} does not exist")
+
     config.set("all_clusters", all_clusters)
 
-    config.flush()
+    d = get_forge_config_diff(old_config, config.dump())
+    print("\n".join(d))
+    if y or get_prompt_answer("Would you like to apply the config change now?"):
+        config.flush()
+    else:
+        print("Config not updated")
 
 
 @cluster_config.command("add")
 @click.argument("cluster")
-def cluster_config_add(cluster: str) -> None:
+@click.option("-y", is_flag=True, help="Accept all interactive prompts")
+def cluster_config_add(cluster: str, y: bool) -> None:
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
@@ -2087,6 +2043,7 @@ def cluster_config_add(cluster: str) -> None:
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
+    old_config = deepcopy(config.dump())
 
     all_clusters = config.get("all_clusters")
     if cluster in all_clusters:
@@ -2094,12 +2051,18 @@ def cluster_config_add(cluster: str) -> None:
     all_clusters.append(cluster)
     config.set("all_clusters", all_clusters)
 
-    config.flush()
+    d = get_forge_config_diff(old_config, config.dump())
+    print("\n".join(d))
+    if y or get_prompt_answer("Would you like to apply the config change now?"):
+        config.flush()
+    else:
+        print("Config not updated")
 
 
 @cluster_config.command("enable")
 @click.argument("cluster")
-def cluster_config_enable(cluster: str) -> None:
+@click.option("-y", is_flag=True, help="Accept all interactive prompts")
+def cluster_config_enable(cluster: str, y: bool) -> None:
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
@@ -2108,22 +2071,28 @@ def cluster_config_enable(cluster: str) -> None:
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
+    old_config = deepcopy(config.dump())
 
     enabled_clusters = config.get("enabled_clusters")
     if cluster in enabled_clusters:
-        raise Exception(
-            f"Cluster {cluster} is already enabled"
-        )
+        raise Exception(f"Cluster {cluster} is already enabled")
     enabled_clusters.append(cluster)
     config.set("enabled_clusters", enabled_clusters)
 
-    config.flush()
+    d = get_forge_config_diff(old_config, config.dump())
+    print("\n".join(d))
+    if y or get_prompt_answer("Would you like to apply the config change now?"):
+        config.flush()
+    else:
+        print("Config not updated")
 
 
 @cluster_config.command("disable")
 @click.argument("cluster")
+@click.option("-y", is_flag=True, help="Accept all interactive prompts")
 def cluster_config_disable(
     cluster: str,
+    y: bool,
 ) -> None:
     shell = LocalShell()
     filesystem = LocalFilesystem()
@@ -2133,12 +2102,18 @@ def cluster_config_disable(
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
+    old_config = deepcopy(config.dump())
 
     enabled_clusters = config.get("enabled_clusters")
     enabled_clusters.remove(cluster)
     config.set("enabled_clusters", enabled_clusters)
 
-    config.flush()
+    d = get_forge_config_diff(old_config, config.dump())
+    print("\n".join(d))
+    if y or get_prompt_answer("Would you like to apply the config change now?"):
+        config.flush()
+    else:
+        print("Config not updated")
 
 
 @cluster_config.command("list")
@@ -2175,9 +2150,11 @@ def test_config() -> None:
 @test_config.command("add")
 @click.argument("suite_name")
 @click.argument("test_name", required=False)
+@click.option("-y", is_flag=True, help="Accept all interactive prompts")
 def test_config_add(
     suite_name: str,
     test_name: Optional[str],
+    y: bool,
 ) -> None:
     shell = LocalShell()
     filesystem = LocalFilesystem()
@@ -2187,6 +2164,7 @@ def test_config_add(
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
+    old_config = deepcopy(config.dump())
 
     suites = config.get("test_suites")
     if suites is None:
@@ -2197,7 +2175,7 @@ def test_config_add(
             "name": suite_name,
             "all_tests": {},
             "enabled_tests": {},
-        }
+        },
     )
 
     if test_name in test_suite["all_tests"]:
@@ -2211,7 +2189,13 @@ def test_config_add(
     suites[suite_name] = test_suite
 
     config.set("test_suites", suites)
-    config.flush()
+
+    d = get_forge_config_diff(old_config, config.dump())
+    print("\n".join(d))
+    if y or get_prompt_answer("Would you like to apply the config change now?"):
+        config.flush()
+    else:
+        print("Config not updated")
 
 
 @test_config.command("show")
@@ -2245,7 +2229,6 @@ def test_config_show(
             click.secho(f" - {test_name}{enabled}", fg=fg)
 
 
-
 @test_config.command("list")
 def test_config_list() -> None:
     shell = LocalShell()
@@ -2266,9 +2249,11 @@ def test_config_list() -> None:
 @test_config.command("delete")
 @click.argument("suite_name")
 @click.argument("test_name", required=False)
+@click.option("-y", is_flag=True, help="Accept all interactive prompts")
 def test_config_delete(
     suite_name: str,
     test_name: Optional[str],
+    y: bool,
 ) -> None:
     shell = LocalShell()
     filesystem = LocalFilesystem()
@@ -2278,6 +2263,7 @@ def test_config_delete(
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
+    old_config = deepcopy(config.dump())
 
     suites = config.get("test_suites")
 
@@ -2291,15 +2277,23 @@ def test_config_delete(
         del suites[suite_name]
 
     config.set("test_suites", suites)
-    config.flush()
+
+    d = get_forge_config_diff(old_config, config.dump())
+    print("\n".join(d))
+    if y or get_prompt_answer("Would you like to apply the config change now?"):
+        config.flush()
+    else:
+        print("Config not updated")
 
 
 @test_config.command("enable")
 @click.argument("suite_name")
 @click.argument("test_name")
+@click.option("-y", is_flag=True, help="Accept all interactive prompts")
 def test_config_enable(
     suite_name: str,
     test_name: str,
+    y: bool,
 ) -> None:
     shell = LocalShell()
     filesystem = LocalFilesystem()
@@ -2309,6 +2303,7 @@ def test_config_enable(
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
+    old_config = deepcopy(config.dump())
 
     suites = config.get("test_suites")
     suite_config = suites.get(suite_name)
@@ -2324,15 +2319,22 @@ def test_config_enable(
     suites[suite_name] = suite_config
 
     config.set("test_suites", suites)
-    config.flush()
 
+    d = get_forge_config_diff(old_config, config.dump())
+    print("\n".join(d))
+    if y or get_prompt_answer("Would you like to apply the config change now?"):
+        config.flush()
+    else:
+        print("Config not updated")
 
 @test_config.command("disable")
 @click.argument("suite_name")
 @click.argument("test_name")
+@click.option("-y", is_flag=True, help="Accept all interactive prompts")
 def test_config_disable(
     suite_name: str,
     test_name: str,
+    y: bool,
 ) -> None:
     shell = LocalShell()
     filesystem = LocalFilesystem()
@@ -2342,6 +2344,7 @@ def test_config_disable(
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
+    old_config = deepcopy(config.dump())
 
     suites = config.get("test_suites")
     suite_config = suites.get(suite_name)
@@ -2357,7 +2360,12 @@ def test_config_disable(
     suites[suite_name] = suite_config
 
     config.set("test_suites", suites)
-    config.flush()
+    d = get_forge_config_diff(old_config, config.dump())
+    print("\n".join(d))
+    if y or get_prompt_answer("Would you like to apply the config change now?"):
+        config.flush()
+    else:
+        print("Config not updated")
 
 if __name__ == "__main__":
     main()

--- a/testsuite/forge_test.py
+++ b/testsuite/forge_test.py
@@ -16,13 +16,12 @@ from typing import (
     Optional,
     Protocol,
     Sequence,
-    Union
+    Union,
 )
 from unittest.mock import patch
 
 import forge
 from forge import (
-    Filesystem,
     ForgeCluster,
     ForgeConfigBackend,
     ForgeContext,
@@ -34,16 +33,11 @@ from forge import (
     GetPodsItemMetadata,
     GetPodsItemStatus,
     GetPodsResult,
-    Git,
     K8sForgeRunner,
     ListClusterResult,
     LocalForgeRunner,
-    Process,
-    Processes,
     RunResult,
-    Shell,
     SystemContext,
-    Time,
     assert_provided_image_tags_has_profile_or_features,
     create_forge_command,
     find_recent_images,
@@ -63,6 +57,15 @@ from forge import (
 )
 
 from click.testing import CliRunner
+from forge_wrapper_core.filesystem import Filesystem
+from forge_wrapper_core.git import Git
+from forge_wrapper_core.process import Process, Processes
+
+from forge_wrapper_core.shell import Shell
+from forge_wrapper_core.time import Time
+
+# Show the entire diff when unittest fails assertion
+unittest.util._MAX_LENGTH = 2000
 
 
 class HasAssertMultiLineEqual(Protocol):
@@ -276,7 +279,11 @@ class SpyProcesses(FakeProcesses):
 
 
 def fake_context(
-    shell=None, filesystem=None, processes=None, time=None, mode=None,
+    shell=None,
+    filesystem=None,
+    processes=None,
+    time=None,
+    mode=None,
 ) -> ForgeContext:
     return ForgeContext(
         shell=shell if shell else FakeShell(),
@@ -317,28 +324,46 @@ class ForgeRunnerTests(unittest.TestCase):
     maxDiff = None
 
     def testLocalRunner(self) -> None:
-        cargo_run = " ".join([
-            "cargo", "run",
-            "--cargo-arg",
-            "-p", "forge-cli",
-            "--",
-            "--suite", "banana",
-            "--duration-secs", "123",
-            "--num-validators", "10",
-            "--num-validator-fullnodes", "20",
-            "--forge-cli-arg",
-            "test", "k8s-swarm",
-            "--image-tag", "asdf",
-            "--upgrade-image-tag", "upgrade_asdf",
-            "--namespace", "forge-potato",
-            "--port-forward",
-            "--test-arg"
-        ])
+        cargo_run = " ".join(
+            [
+                "cargo",
+                "run",
+                "--cargo-arg",
+                "-p",
+                "forge-cli",
+                "--",
+                "--suite",
+                "banana",
+                "--duration-secs",
+                "123",
+                "--num-validators",
+                "10",
+                "--num-validator-fullnodes",
+                "20",
+                "--forge-cli-arg",
+                "test",
+                "k8s-swarm",
+                "--image-tag",
+                "asdf",
+                "--upgrade-image-tag",
+                "upgrade_asdf",
+                "--namespace",
+                "forge-potato",
+                "--port-forward",
+                "--test-arg",
+            ]
+        )
         shell = SpyShell(
             OrderedDict(
                 [
-                    (cargo_run, RunResult(0, b"orange"),),
-                    ("kubectl --kubeconfig kubeconf get pods -n forge-potato", RunResult(0, b"Pods")),
+                    (
+                        cargo_run,
+                        RunResult(0, b"orange"),
+                    ),
+                    (
+                        "kubectl --kubeconfig kubeconf get pods -n forge-potato",
+                        RunResult(0, b"Pods"),
+                    ),
                 ]
             )
         )
@@ -443,11 +468,7 @@ class TestFindRecentImage(unittest.TestCase):
         )
         git = Git(shell)
         image_tags = find_recent_images_by_profile_or_features(
-            shell,
-            git,
-            1,
-            enable_performance_profile=False,
-            enable_failpoints_feature=True
+            shell, git, 1, enable_performance_profile=False, enable_testing_image=True
         )
         self.assertEqual(list(image_tags), ["failpoints_tomato"])
         shell.assert_commands(self)
@@ -470,7 +491,7 @@ class TestFindRecentImage(unittest.TestCase):
             git,
             1,
             enable_performance_profile=True,
-            enable_failpoints_feature=False,
+            enable_testing_image=False,
         )
         self.assertEqual(list(image_tags), ["performance_potato"])
         shell.assert_commands(self)
@@ -484,7 +505,7 @@ class TestFindRecentImage(unittest.TestCase):
                 git,
                 1,
                 enable_performance_profile=True,
-                enable_failpoints_feature=True,
+                enable_testing_image=True,
             )
 
     def testDidntFindRecentImage(self) -> None:
@@ -502,9 +523,7 @@ class TestFindRecentImage(unittest.TestCase):
         git = Git(shell)
         with self.assertRaises(Exception):
             list(
-                find_recent_images(
-                    shell, git, 1, "aptos/validator", commit_threshold=1
-                )
+                find_recent_images(shell, git, 1, "aptos/validator", commit_threshold=1)
             )
 
     def testFailpointsProvidedImageTag(self) -> None:
@@ -512,7 +531,7 @@ class TestFindRecentImage(unittest.TestCase):
             assert_provided_image_tags_has_profile_or_features(
                 "potato_tomato",
                 "failpoints_performance_potato",
-                enable_failpoints_feature=True,
+                enable_testing_image=True,
                 enable_performance_profile=False,
             )
 
@@ -520,7 +539,7 @@ class TestFindRecentImage(unittest.TestCase):
         assert_provided_image_tags_has_profile_or_features(
             None,
             None,
-            enable_failpoints_feature=True,
+            enable_testing_image=True,
             enable_performance_profile=False,
         )
 
@@ -601,7 +620,7 @@ class ForgeFormattingTests(unittest.TestCase, AssertFixtureMixin):
         self.assertIn(
             "var-namespace=forge-potato",
             pre_comment,
-            "Wrong forge namespace in pre comment"
+            "Wrong forge namespace in pre comment",
         )
         self.assertFixture(pre_comment, "testFormatPreComment.fixture")
 
@@ -615,7 +634,7 @@ class ForgeFormattingTests(unittest.TestCase, AssertFixtureMixin):
         self.assertIn(
             "var-namespace=forge-potato",
             forge_comment,
-            "Wrong forge namespace in comment"
+            "Wrong forge namespace in comment",
         )
         self.assertFixture(forge_comment, "testFormatComment.fixture")
 
@@ -649,76 +668,80 @@ class ForgeMainTests(unittest.TestCase, AssertFixtureMixin):
 
     def testMain(self) -> None:
         runner = CliRunner()
-        shell = SpyShell(OrderedDict([
-            ('aws sts get-caller-identity', RunResult(0, b'{"Account": "123456789012"}')),
-            ('git rev-parse HEAD~0', RunResult(0, b'banana')),
-            (
-                'aws ecr describe-images --repository-name aptos/validator --im'
-                'age-ids imageTag=banana',
-                RunResult(0, b''),
-            ),
-            (
-                'aws eks update-kubeconfig --name forge-big-1 --kubeconfig temp1',
-                RunResult(0, b''),
-            ),
-            (
-                'kubectl --kubeconfig temp1 delete pod -n default -l forge-namespace=forge-perry-1659078000 '
-                '--force',
-                RunResult(0, b''),
-            ),
-            (
-                'kubectl --kubeconfig temp1 wait -n default --for=delete pod -l '
-                'forge-namespace=forge-perry-1659078000',
-                RunResult(0, b''),
-            ),
-            (
-                'kubectl --kubeconfig temp1 apply -n default -f temp2',
-                RunResult(0, b''),
-            ),
-            (
-                'kubectl --kubeconfig temp1 wait -n default --timeout=5m --for=condition=Ready '
-                'pod/forge-perry-1659078000-1659078000-banana',
-                RunResult(0, b''),
-            ),
-            (
-                'kubectl --kubeconfig temp1 logs -n default -f forge-perry-1659078000-1659078000-banana',
-                RunResult(0, b''),
-            ),
-            (
-                'kubectl --kubeconfig temp1 get pod -n default forge-perry-1659078000-1659078000-banana -o '
-                "jsonpath='{.status.phase}'",
-                RunResult(0, b''),
-            ),
-            (
-                'kubectl --kubeconfig temp1 get pods -n forge-perry-1659078000',
-                RunResult(0, b''),
+        shell = SpyShell(
+            OrderedDict(
+                [
+                    (
+                        "aws sts get-caller-identity",
+                        RunResult(0, b'{"Account": "123456789012"}'),
+                    ),
+                    ("git rev-parse HEAD~0", RunResult(0, b"banana")),
+                    (
+                        "aws ecr describe-images --repository-name aptos/validator --im"
+                        "age-ids imageTag=banana",
+                        RunResult(0, b""),
+                    ),
+                    (
+                        "aws eks update-kubeconfig --name forge-big-1 --kubeconfig temp1",
+                        RunResult(0, b""),
+                    ),
+                    (
+                        "kubectl --kubeconfig temp1 delete pod -n default -l forge-namespace=forge-perry-1659078000 "
+                        "--force",
+                        RunResult(0, b""),
+                    ),
+                    (
+                        "kubectl --kubeconfig temp1 wait -n default --for=delete pod -l "
+                        "forge-namespace=forge-perry-1659078000",
+                        RunResult(0, b""),
+                    ),
+                    (
+                        "kubectl --kubeconfig temp1 apply -n default -f temp2",
+                        RunResult(0, b""),
+                    ),
+                    (
+                        "kubectl --kubeconfig temp1 wait -n default --timeout=5m --for=condition=Ready "
+                        "pod/forge-perry-1659078000-1659078000-banana",
+                        RunResult(0, b""),
+                    ),
+                    (
+                        "kubectl --kubeconfig temp1 logs -n default -f forge-perry-1659078000-1659078000-banana",
+                        RunResult(0, b""),
+                    ),
+                    (
+                        "kubectl --kubeconfig temp1 get pod -n default forge-perry-1659078000-1659078000-banana -o "
+                        "jsonpath='{.status.phase}'",
+                        RunResult(0, b""),
+                    ),
+                    (
+                        "kubectl --kubeconfig temp1 get pods -n forge-perry-1659078000",
+                        RunResult(0, b""),
+                    ),
+                ]
             )
-        ]))
-        filesystem = SpyFilesystem({
-            "temp-comment": get_fixture_path(
-                "testMainComment.fixture"
-            ).read_bytes(),
-            "temp-step-summary": get_fixture_path(
-                "testMainComment.fixture"
-            ).read_bytes(),
-            "temp-pre-comment": get_fixture_path(
-                "testMainPreComment.fixture"
-            ).read_bytes(),
-            "temp-report": get_fixture_path(
-                "testMainReport.fixture"
-            ).read_bytes(),
-        }, {})
+        )
+        filesystem = SpyFilesystem(
+            {
+                "temp-comment": get_fixture_path(
+                    "testMainComment.fixture"
+                ).read_bytes(),
+                "temp-step-summary": get_fixture_path(
+                    "testMainComment.fixture"
+                ).read_bytes(),
+                "temp-pre-comment": get_fixture_path(
+                    "testMainPreComment.fixture"
+                ).read_bytes(),
+                "temp-report": get_fixture_path("testMainReport.fixture").read_bytes(),
+            },
+            {},
+        )
         with ExitStack() as stack:
             stack.enter_context(runner.isolated_filesystem())
             stack.enter_context(
                 patch.object(forge, "LocalFilesystem", lambda: filesystem)
             )
-            stack.enter_context(
-                patch.object(forge, "LocalShell", lambda *_: shell)
-            )
-            stack.enter_context(
-                patch.object(forge, "SystemTime", lambda: FakeTime())
-            )
+            stack.enter_context(patch.object(forge, "LocalShell", lambda *_: shell))
+            stack.enter_context(patch.object(forge, "SystemTime", lambda: FakeTime()))
             stack.enter_context(
                 patch.object(forge, "SystemProcesses", lambda: FakeProcesses())
             )
@@ -726,11 +749,13 @@ class ForgeMainTests(unittest.TestCase, AssertFixtureMixin):
                 patch.object(
                     forge,
                     "S3ForgeConfigBackend",
-                    lambda *_: FakeConfigBackend({
-                        "enabled_clusters": ["forge-big-1"],
-                        "all_clusters": ["forge-big-1", "banana"],
-                        "test_suites": {},
-                    })
+                    lambda *_: FakeConfigBackend(
+                        {
+                            "enabled_clusters": ["forge-big-1"],
+                            "all_clusters": ["forge-big-1", "banana"],
+                            "test_suites": {},
+                        }
+                    ),
                 )
             )
 
@@ -744,23 +769,41 @@ class ForgeMainTests(unittest.TestCase, AssertFixtureMixin):
                 main,
                 [
                     "test",
-                    "--forge-cluster-name", "forge-big-1",
-                    "--forge-report", "temp-report",
-                    "--forge-pre-comment", "temp-pre-comment",
-                    "--forge-comment", "temp-comment",
-                    "--github-step-summary", "temp-step-summary",
-                    "--github-server-url", "None",
-                    "--github-repository", "None",
-                    "--github-run-id", "None",
+                    "--forge-cluster-name",
+                    "forge-big-1",
+                    "--forge-report",
+                    "temp-report",
+                    "--forge-pre-comment",
+                    "temp-pre-comment",
+                    "--forge-comment",
+                    "temp-comment",
+                    "--github-step-summary",
+                    "temp-step-summary",
+                    "--github-server-url",
+                    "None",
+                    "--github-repository",
+                    "None",
+                    "--github-run-id",
+                    "None",
                     "banana-test",
                 ],
                 catch_exceptions=False,
             )
             shell.assert_commands(self)
-            self.assertFixture(filesystem.get_write("temp-comment").decode(), "testMainComment.fixture")
-            self.assertFixture(filesystem.get_write("temp-step-summary").decode(), "testMainComment.fixture")
-            self.assertFixture(filesystem.get_write("temp-pre-comment").decode(), "testMainPreComment.fixture")
-            self.assertFixture(filesystem.get_write("temp-report").decode(), "testMainReport.fixture")
+            self.assertFixture(
+                filesystem.get_write("temp-comment").decode(), "testMainComment.fixture"
+            )
+            self.assertFixture(
+                filesystem.get_write("temp-step-summary").decode(),
+                "testMainComment.fixture",
+            )
+            self.assertFixture(
+                filesystem.get_write("temp-pre-comment").decode(),
+                "testMainPreComment.fixture",
+            )
+            self.assertFixture(
+                filesystem.get_write("temp-report").decode(), "testMainReport.fixture"
+            )
             self.assertFixture(result.output, "testMain.fixture")
 
 
@@ -809,7 +852,7 @@ class GetForgeJobsTests(unittest.IsolatedAsyncioTestCase):
     maxDiff = None
 
     async def testGetAllForgeJobs(self) -> None:
-        fake_clusters=["aptos-forge-banana", "aptos-forge-apple-2"]
+        fake_clusters = ["aptos-forge-banana", "aptos-forge-apple-2"]
         fake_first_pods = GetPodsResult(
             items=[
                 fake_pod_item("forge-first", "Running"),
@@ -895,9 +938,13 @@ class ForgeConfigTests(unittest.TestCase):
 
     def testCreate(self) -> None:
         runner = CliRunner()
-        shell = SpyShell(OrderedDict([
-            ('aws s3 mb s3://forge-wrapper-config', RunResult(0, b'')),
-        ]))
+        shell = SpyShell(
+            OrderedDict(
+                [
+                    ("aws s3 mb s3://forge-wrapper-config", RunResult(0, b"")),
+                ]
+            )
+        )
         with patch.object(forge, "LocalShell", lambda: shell):
             result = runner.invoke(
                 main,
@@ -918,36 +965,356 @@ class ForgeConfigTests(unittest.TestCase):
 
     def testValidateValidConfig(self) -> None:
         self.assertEqual(
-            validate_forge_config({
-                "enabled_clusters": ["banana"],
-                "all_clusters": ["banana", "apple"],
-            }),
+            validate_forge_config(
+                {
+                    "enabled_clusters": ["banana"],
+                    "all_clusters": ["banana", "apple"],
+                }
+            ),
+            [],
+        )
+
+    def testValidateValidHelmConfig(self) -> None:
+        self.assertEqual(
+            validate_forge_config(
+                {
+                    "enabled_clusters": ["banana"],
+                    "all_clusters": ["banana", "apple"],
+                    "default_helm_values": {
+                        "aptos-node": {"image": {"tag": "banana"}},
+                        "aptos-genesis": {"image": {"tag": "banana"}},
+                    },
+                }
+            ),
+            [],
+        )
+
+    def testValidateInvalidHelmConfig(self) -> None:
+        self.assertEqual(
+            validate_forge_config(
+                {
+                    "enabled_clusters": ["banana"],
+                    "all_clusters": ["banana", "apple"],
+                    "default_helm_values": {
+                        "apple": "enabled",
+                        "banana": {"enabled": "true"},
+                    },
+                }
+            ),
             [],
         )
 
     def testValidateMissingClusterConfig(self) -> None:
         self.assertEqual(
-            validate_forge_config({
-                "enabled_clusters": ["apple"],
-                "all_clusters": ["banana", "potato"],
-            }),
+            validate_forge_config(
+                {
+                    "enabled_clusters": ["apple"],
+                    "all_clusters": ["banana", "potato"],
+                }
+            ),
             [],
         )
 
+    def testHelmGetConfig(self) -> None:
+        helm_before = {
+            "enabled_clusters": ["banana"],
+            "all_clusters": ["banana", "apple"],
+        }
+        helm_after_missing = {
+            "enabled_clusters": ["banana"],
+            "all_clusters": ["banana", "apple"],
+            "default_helm_values": {
+                "aptos-node": {"apple": "enabled", "banana": {"enabled": "true"}}
+            },
+        }
+        helm_after_complete = {
+            "enabled_clusters": ["banana"],
+            "all_clusters": ["banana", "apple"],
+            "default_helm_values": {
+                "aptos-node": {"apple": "enabled", "banana": {"enabled": "true"}},
+                "aptos-genesis": {"apple": "enabled", "banana": {"enabled": "true"}},
+            },
+        }
+        runner = CliRunner()
+        shell = SpyShell(
+            OrderedDict(
+                [
+                    (
+                        "aws s3api get-object --bucket forge-wrapper-config --key "
+                        "forge-wrapper-config.json temp1",
+                        RunResult(0, json.dumps(helm_before).encode("utf-8")),
+                    ),
+                    (
+                        "aws s3api get-object --bucket forge-wrapper-config --key "
+                        "forge-wrapper-config.json temp2",
+                        RunResult(0, json.dumps(helm_after_missing).encode("utf-8")),
+                    ),
+                    (
+                        "aws s3api get-object --bucket forge-wrapper-config --key "
+                        "forge-wrapper-config.json temp3",
+                        RunResult(0, json.dumps(helm_after_complete).encode("utf-8")),
+                    ),
+                ]
+            )
+        )
+
+        filesystem = SpyFilesystem(
+            {},
+            {
+                "temp1": json.dumps(helm_before).encode(),
+                "temp2": json.dumps(helm_after_missing).encode(),
+                "temp3": json.dumps(helm_after_complete).encode(),
+            },
+        )
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(forge, "LocalShell", lambda: shell))
+            stack.enter_context(
+                patch.object(forge, "LocalFilesystem", lambda: filesystem)
+            )
+            result_helm_config_not_present = runner.invoke(
+                main,
+                ["config", "helm", "get", "aptos-node"],
+                catch_exceptions=True,
+            )
+            result_helm_config_present_missing = runner.invoke(
+                main,
+                ["config", "helm", "get", "aptos-genesis"],
+                catch_exceptions=True,
+            )
+            result_helm_config_present_complete = runner.invoke(
+                main,
+                ["config", "helm", "get", "aptos-node"],
+                catch_exceptions=True,
+            )
+            # assert all commands and filesystem calls are correct
+            shell.assert_commands(self)
+            filesystem.assert_reads(self)
+            filesystem.assert_writes(self)
+
+            # assert that we error with a message when the config is not present
+            self.assertEqual(result_helm_config_not_present.exit_code, 1)
+            self.assertEqual(
+                result_helm_config_not_present.exception.args,
+                Exception("Missing key default_helm_values in Forge config").args,
+            )
+
+            # assert that we error with a message when the config is missing partial information
+            self.assertEqual(result_helm_config_present_missing.exit_code, 1)
+            self.assertEqual(
+                result_helm_config_present_missing.exception.args,
+                Exception("No helm values found for chart aptos-genesis").args,
+            )
+
+            # we successfully get the config
+            self.assertEqual(result_helm_config_present_complete.exit_code, 0)
+            # the output config is printed with an extra newline
+            self.assertEqual(
+                result_helm_config_present_complete.stdout_bytes,
+                f'{json.dumps(helm_after_complete.get("default_helm_values").get("aptos-node"), indent=2)}\n'.encode(),
+            )
+
+    def testHelmSetConfig(self) -> None:
+        runner = CliRunner()
+        shell = SpyShell(
+            OrderedDict(
+                [
+                    (
+                        "aws s3api get-object --bucket forge-wrapper-config --key "
+                        "forge-wrapper-config.json temp1",
+                        RunResult(0, b""),
+                    ),
+                    (
+                        "aws s3api put-object --bucket forge-wrapper-config --key "
+                        "forge-wrapper-config.json --body temp2",
+                        RunResult(0, b""),
+                    ),
+                ]
+            )
+        )
+        config_before = {
+            "enabled_clusters": ["banana"],
+            "all_clusters": ["banana", "apple"],
+            "default_helm_values": {
+                "aptos-node": {"apple": "enabled", "banana": {"enabled": "false"}}
+            },
+        }
+        config_after = {
+            **config_before,
+            "default_helm_values": {
+                "aptos-node": {"apple": "enabled", "banana": {"enabled": "true"}}
+            },
+        }
+        filesystem = SpyFilesystem(
+            {
+                # new config which merges old config and new helm config written to temp file before pushing to s3
+                "temp2": json.dumps(config_after).encode(),
+            },
+            {
+                # read old config that has been written by s3 CLI
+                "temp1": json.dumps(config_before).encode(),
+                # read the new *helm* config from disk
+                "temp2": json.dumps(
+                    config_after["default_helm_values"]["aptos-node"]
+                ).encode(),
+            },
+        )
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(forge, "LocalShell", lambda: shell))
+            stack.enter_context(
+                patch.object(forge, "LocalFilesystem", lambda: filesystem)
+            )
+            ret = runner.invoke(
+                main,
+                ["config", "helm", "set", "aptos-node", "--config", "temp2", "-y"],
+                catch_exceptions=True,
+            )
+            shell.assert_commands(self)
+            filesystem.assert_reads(self)
+            filesystem.assert_writes(self)
+
+    def testHelmSetNewConfig(self) -> None:
+        runner = CliRunner()
+        shell = SpyShell(
+            OrderedDict(
+                [
+                    (
+                        "aws s3api get-object --bucket forge-wrapper-config --key "
+                        "forge-wrapper-config.json temp1",
+                        RunResult(0, b""),
+                    ),
+                    (
+                        "aws s3api put-object --bucket forge-wrapper-config --key "
+                        "forge-wrapper-config.json --body temp2",
+                        RunResult(0, b""),
+                    ),
+                ]
+            )
+        )
+        config_before = {
+            "enabled_clusters": ["banana"],
+            "all_clusters": ["banana", "apple"],
+            "default_helm_values": {},
+        }
+        config_after = {
+            **config_before,
+            "default_helm_values": {
+                "aptos-node": {"apple": "enabled", "banana": {"enabled": "true"}}
+            },
+        }
+        filesystem = SpyFilesystem(
+            {
+                # new config which merges old config and new helm config written to temp file before pushing to s3
+                "temp2": json.dumps(config_after).encode(),
+            },
+            {
+                # read old config that has been written by s3 CLI
+                "temp1": json.dumps(config_before).encode(),
+                # read the new *helm* config from disk
+                "temp2": json.dumps(
+                    config_after["default_helm_values"]["aptos-node"]
+                ).encode(),
+            },
+        )
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(forge, "LocalShell", lambda: shell))
+            stack.enter_context(
+                patch.object(forge, "LocalFilesystem", lambda: filesystem)
+            )
+            ret = runner.invoke(
+                main,
+                ["config", "helm", "set", "aptos-node", "--config", "temp2", "-y"],
+                catch_exceptions=True,
+            )
+            shell.assert_commands(self)
+            filesystem.assert_reads(self)
+            filesystem.assert_writes(self)
+
+    def testHelmSetConfigPreview(self) -> None:
+        runner = CliRunner()
+        shell = SpyShell(
+            OrderedDict(
+                [
+                    (
+                        "aws s3api get-object --bucket forge-wrapper-config --key "
+                        "forge-wrapper-config.json temp1",
+                        RunResult(0, b""),
+                    ),
+                    (
+                        "aws s3api put-object --bucket forge-wrapper-config --key "
+                        "forge-wrapper-config.json --body temp2",
+                        RunResult(0, b""),
+                    ),
+                ]
+            )
+        )
+        config_fixture_before = get_fixture_path(
+            "forge-default-helm-values-before.fixture"
+        )
+        config_fixture_after = get_fixture_path(
+            "forge-default-helm-values-after.fixture"
+        )
+        config_applied = json.loads(config_fixture_after.read_bytes().decode())[
+            "default_helm_values"
+        ]["aptos-node"]
+        config_fixture_preview = get_fixture_path(
+            "forge-default-helm-values-preview.fixture"
+        )
+        filesystem = SpyFilesystem(
+            {},
+            {
+                # read old config that has been written by s3 CLI
+                "temp1": config_fixture_before.read_bytes(),
+                # read the new *helm* config from disk
+                "temp2": json.dumps(config_applied).encode(),
+            },
+        )
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(forge, "LocalShell", lambda: shell))
+            stack.enter_context(
+                patch.object(forge, "LocalFilesystem", lambda: filesystem)
+            )
+            ret = runner.invoke(
+                main,
+                [
+                    "config",
+                    "helm",
+                    "set",
+                    "aptos-node",
+                    "--config",
+                    "temp2",
+                    "-y",
+                ],
+                catch_exceptions=False,
+            )
+            shell.assert_commands(self)
+            filesystem.assert_reads(self)
+            filesystem.assert_writes(self)
+            self.assertEqual(ret.exception, None)
+            self.assertEqual(ret.exit_code, 0)
+            assert(ret.stdout_bytes.decode("utf-8").strip())
+            self.assertEqual(
+                ret.stdout_bytes.decode("utf-8").strip(),
+                config_fixture_preview.read_bytes().decode("utf-8").strip(),
+            )
+
     def testClusterDelete(self) -> None:
         runner = CliRunner()
-        shell = SpyShell(OrderedDict([
-            (
-                'aws s3api get-object --bucket forge-wrapper-config --key '
-                'forge-wrapper-config.json temp1',
-                RunResult(0, b'')
-            ),
-            (
-                'aws s3api put-object --bucket forge-wrapper-config --key '
-                'forge-wrapper-config.json --body temp2',
-                RunResult(0, b'')
-            ),
-        ]))
+        shell = SpyShell(
+            OrderedDict(
+                [
+                    (
+                        "aws s3api get-object --bucket forge-wrapper-config --key "
+                        "forge-wrapper-config.json temp1",
+                        RunResult(0, b""),
+                    ),
+                    (
+                        "aws s3api put-object --bucket forge-wrapper-config --key "
+                        "forge-wrapper-config.json --body temp2",
+                        RunResult(0, b""),
+                    ),
+                ]
+            )
+        )
         clusters_before = {
             "enabled_clusters": ["banana"],
             "all_clusters": ["banana", "apple"],
@@ -965,15 +1332,13 @@ class ForgeConfigTests(unittest.TestCase):
             },
         )
         with ExitStack() as stack:
-            stack.enter_context(
-                patch.object(forge, "LocalShell", lambda: shell)
-            )
+            stack.enter_context(patch.object(forge, "LocalShell", lambda: shell))
             stack.enter_context(
                 patch.object(forge, "LocalFilesystem", lambda: filesystem)
             )
             runner.invoke(
                 main,
-                ["config", "cluster", "delete", "apple"],
+                ["config", "cluster", "delete", "apple", "-y"],
                 catch_exceptions=False,
             )
             shell.assert_commands(self)

--- a/testsuite/forge_wrapper_core/filesystem.py
+++ b/testsuite/forge_wrapper_core/filesystem.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import os
+import resource
+import tempfile
+
+
+class Filesystem:
+    def write(self, filename: str, contents: bytes) -> None:
+        raise NotImplementedError()
+
+    def read(self, filename: str) -> bytes:
+        raise NotImplementedError()
+
+    def mkstemp(self) -> str:
+        raise NotImplementedError()
+
+    def rlimit(self, resource_type: int, soft: int, hard: int) -> None:
+        raise NotImplementedError()
+
+    def unlink(self, filename: str) -> None:
+        raise NotImplementedError()
+
+
+class LocalFilesystem(Filesystem):
+    def write(self, filename: str, contents: bytes) -> None:
+        with open(filename, "wb") as f:
+            f.write(contents)
+
+    def read(self, filename: str) -> bytes:
+        with open(filename, "rb") as f:
+            return f.read()
+
+    def mkstemp(self) -> str:
+        return tempfile.mkstemp()[1]
+
+    def rlimit(self, resource_type: int, soft: int, hard: int) -> None:
+        resource.setrlimit(resource_type, (soft, hard))
+
+    def unlink(self, filename: str) -> None:
+        os.unlink(filename)

--- a/testsuite/forge_wrapper_core/git.py
+++ b/testsuite/forge_wrapper_core/git.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from typing import Generator
+from .shell import Shell, RunResult
+
+
+@dataclass
+class Git:
+    shell: Shell
+
+    def run(self, command) -> RunResult:
+        return self.shell.run(["git", *command])
+
+    def last(self, limit: int = 1) -> Generator[str, None, None]:
+        for i in range(limit):
+            yield self.run(["rev-parse", f"HEAD~{i}"]).unwrap().decode().strip()

--- a/testsuite/forge_wrapper_core/process.py
+++ b/testsuite/forge_wrapper_core/process.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import atexit
+import os
+from dataclasses import dataclass
+from typing import (
+    Callable,
+    Generator,
+)
+
+
+class Process:
+    def name(self) -> str:
+        raise NotImplementedError()
+
+    def ppid(self) -> int:
+        raise NotImplementedError()
+
+
+class Processes:
+    def processes(self) -> Generator[Process, None, None]:
+        raise NotImplementedError()
+
+    def get_pid(self) -> int:
+        raise NotImplementedError()
+
+    def atexit(self, callback: Callable[[], None]) -> None:
+        raise NotImplementedError()
+
+    def user(self) -> str:
+        raise NotImplementedError()
+
+
+@dataclass
+class SystemProcess(Process):
+    process: psutil.Process
+
+    def name(self) -> str:
+        return self.process.name()
+
+    def ppid(self) -> int:
+        return self.process.ppid()
+
+
+class SystemProcesses(Processes):
+    def processes(self) -> Generator[Process, None, None]:
+        for process in psutil.process_iter():
+            yield SystemProcess(process)
+
+    def get_pid(self) -> int:
+        return os.getpid()
+
+    def atexit(self, callback: Callable[[], None]) -> None:
+        atexit.register(callback)
+
+    def user(self) -> str:
+        return get_current_user()

--- a/testsuite/forge_wrapper_core/shell.py
+++ b/testsuite/forge_wrapper_core/shell.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from typing import Sequence
+
+
+@dataclass
+class RunResult:
+    exit_code: int
+    output: bytes
+
+    def unwrap(self) -> bytes:
+        if not self.succeeded():
+            raise Exception(self.output.decode("utf-8"))
+        return self.output
+
+    def succeeded(self) -> bool:
+        return self.exit_code == 0
+
+
+class Shell:
+    def run(self, command: Sequence[str], stream_output: bool = False) -> RunResult:
+        raise NotImplementedError()
+
+    async def gen_run(
+        self, command: Sequence[str], stream_output: bool = False
+    ) -> RunResult:
+        raise NotImplementedError()
+
+
+@dataclass
+class LocalShell(Shell):
+    verbose: bool = False
+
+    def run(self, command: Sequence[str], stream_output: bool = False) -> RunResult:
+        # Write to a temp file, stream to stdout
+        tmpname = tempfile.mkstemp()[1]
+        with open(tmpname, "wb") as writer, open(tmpname, "rb") as reader:
+            if self.verbose:
+                print(f"+ {' '.join(command)}")
+            process = subprocess.Popen(command, stdout=writer, stderr=writer)
+            output = b""
+            while process.poll() is None:
+                chunk = reader.read()
+                output += chunk
+                if stream_output:
+                    sys.stdout.write(chunk.decode("utf-8"))
+                time.sleep(0.1)
+            output += reader.read()
+        return RunResult(process.returncode, output)
+
+    async def gen_run(
+        self, command: Sequence[str], stream_output: bool = False
+    ) -> RunResult:
+        # Write to a temp file, stream to stdout
+        tmpname = tempfile.mkstemp()[1]
+        with open(tmpname, "wb") as writer, open(tmpname, "rb") as reader:
+            if self.verbose:
+                print(f"+ {' '.join(command)}")
+            try:
+                process = await asyncio.create_subprocess_exec(
+                    command[0], *command[1:], stdout=writer, stderr=writer
+                )
+            except Exception as e:
+                raise Exception(f"Failed running {command}") from e
+            output = b""
+            while True:
+                wait_task = asyncio.create_task(process.wait())
+                finished, running = await asyncio.wait({wait_task}, timeout=1)
+                assert bool(finished) ^ bool(
+                    running
+                ), "Cannot have both finished and running"
+                if finished:
+                    break
+                chunk = reader.read()
+                output += chunk
+                if stream_output:
+                    sys.stdout.write(chunk.decode("utf-8"))
+                await asyncio.sleep(1)
+            output += reader.read()
+        exit_code = process.returncode
+        assert exit_code is not None, "Process must have exited"
+        return RunResult(exit_code, output)

--- a/testsuite/forge_wrapper_core/time.py
+++ b/testsuite/forge_wrapper_core/time.py
@@ -1,0 +1,14 @@
+from datetime import datetime, timezone
+
+
+class Time:
+    def epoch(self) -> str:
+        return self.now().strftime("%s")
+
+    def now(self) -> datetime:
+        raise NotImplementedError()
+
+
+class SystemTime(Time):
+    def now(self) -> datetime:
+        return datetime.now(timezone.utc)


### PR DESCRIPTION
### Description

Add the `default_helm_values` config, which allows a per-chart override of default helm values. Previously, Forge runs just inherited the helm values from the `aptos-node` and `aptos-genesis` helm releases in the `default` namespace. Moving it to a config makes it easier to tune across all clusters at once.

Bonus:
* start to separate out some of the common core abstractions for testable python CLIs (process, filesystem, git, etc)
* fix metrics scraping for node exporter and kube-state-metrics, which now relies on scrape annotations by default
* grant the `forge` service account access to the config bucket
* format and lint python code

### Test Plan

Added new unit tests

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5452)
<!-- Reviewable:end -->
