### PR TITLE
[helm][testnet-addons] specify resources for load test

### DIFF
--- a/terraform/helm/testnet-addons/templates/loadtest.yaml
+++ b/terraform/helm/testnet-addons/templates/loadtest.yaml
@@ -19,6 +19,7 @@ spec:
           annotations:
             seccomp.security.alpha.kubernetes.io/pod: runtime/default
         spec:
+          parallelism: {{ .Values.load_test.parallelism }}
           restartPolicy: Never
           priorityClassName: {{ include "testnet-addons.fullname" . }}-high
           containers:
@@ -85,6 +86,10 @@ spec:
           {{- end }}
           {{- with .tolerations }}
           tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .resources }}
+          resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           securityContext:

--- a/terraform/helm/testnet-addons/values.yaml
+++ b/terraform/helm/testnet-addons/values.yaml
@@ -28,6 +28,8 @@ waypoint:
 load_test:
   # -- Whether to enable the load test CronJob
   enabled: false
+  # -- Job parallelism
+  parallelism: 1
   image:
     # -- Image repo to use for tools image for running load tests
     repo: aptoslabs/tools


### PR DESCRIPTION
### Description

So we can run load test with more resources as a CronJob. Also be able to adjust the parallelism

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5455)
<!-- Reviewable:end -->
