### PR TITLE
Promote Stack Overflow on landing page of Aptos.dev and announce in W…

### DIFF
--- a/developer-docs-site/docs/index.md
+++ b/developer-docs-site/docs/index.md
@@ -114,7 +114,7 @@ Welcome! At Aptos Labs we are building a Layer 1 for everyone. This documentatio
 
 ## Connect to Aptos networks
 
-Aptos offers running a local testnet, as well as using the shared devnet and testnet, with mainnet on the way. See the [System Integrators Guide](guides/system-integrators-guide.md#networks) for a summary of the available networks and the means to connect to them.
+Aptos offers running a local testnet, as well as using the shared devnet and testnet, with mainnet now launched. See the [System Integrators Guide](guides/system-integrators-guide.md#networks) for a summary of the available networks and the means to connect to them.
 
 :::tip Aptos Devnet Resets
 The Aptos devnet is reset every Thursday. See the latest updates in [Aptos Discord](https://discord.gg/aptoslabs).
@@ -124,27 +124,27 @@ The Aptos devnet is reset every Thursday. See the latest updates in [Aptos Disco
 
 Join [Aptos Discord](https://discord.gg/aptoslabs) to speak with developers and hop into the Aptos community. It's the best way to keep up to date with news and developments in the Aptos universe. Be sure to check pinned messages in the channels - this is where we like to keep topic-specific links, events, and more.
 
-Or even if you just want to stop by to say "Good Morning!". There's a little something for everyone!
+For technical questions, we recommend [Stack Overflow](https://stackoverflow.com/questions/tagged/aptos) so anyone in the world may search for, benefit from, and upvote questions and answers in a persistent location.
 
-:::caution Be safe out there
+:::caution Be safe with communications
 
-It's dangerous to go alone. Please remember, community managers will never message or DM you first, and they will never ask you to send them money or share any sensitive, private, or personal information. If this happens to you, please report it to us in [Aptos Discord](https://discord.gg/aptoslabs), or by sending an email to [security@aptoslabs.com](mailto:security@aptoslabs.com).
+Please remember, community managers will never message or DM you first, and they will never ask you to send them money or share any sensitive, private, or personal information. If this happens to you, please report it to us in [Aptos Discord](https://discord.gg/aptoslabs), or by sending an email to [security@aptoslabs.com](mailto:security@aptoslabs.com).
 
 :::
 
-## Join us
+## Join the team
 
-Want to join a great team working on amazing world-scale problems? Take a look at [active roles](https://boards.greenhouse.io/aptoslabs), and come build with us!
+Want to join a great team working on amazing world-scale problems? Take a look at [active roles](https://aptoslabs.com/careers) on [AptosLabs.com](https://www.aptoslabs.com/) and come build with us!
 
 Or simply [create a pull request](https://github.com/aptos-labs/aptos-core/pulls) to make updates and [file issues](https://github.com/aptos-labs/aptos-core/issues) to report problems.
 
-## Have fun!
+## Find the ecosystem
 
-We are excited that you are here, and we look forward to getting to know you. Welcome to the Aptos community! Find out more about us at:
+We are excited that you are here, and we look forward to getting to know you. Welcome to the Aptos community! Find out more about us and exchange ideas at:
 
-* [AptosLabs.com](https://www.aptoslabs.com/)
+* [Aptos Discord](https://discord.gg/aptoslabs)
+* [Stack Overflow](https://stackoverflow.com/questions/tagged/aptos)
 * [Forum](https://forum.aptoslabs.com/)
-* [Discord](https://discord.gg/aptoslabs)
 * [Medium](https://medium.com/aptoslabs)
 * [Telegram](https://t.me/aptos_official)
 * [Twitter](https://twitter.com/AptosLabs)

--- a/developer-docs-site/docs/whats-new-in-docs.md
+++ b/developer-docs-site/docs/whats-new-in-docs.md
@@ -7,9 +7,17 @@ slug: "whats-new-in-docs"
 
 This page shows the key updates to the developer documentation on this site.
 
+## 07 November 2022
+
+- Created an Aptos tag on [Stack Overflow](https://stackoverflow.com/questions/tagged/aptos) and started populating it with common questions and answers.
+
 ## 04 November 2022
 
 - Added a guide on [Resource Accounts](/docs/guides/resource-accounts.md) used by developers to publish modules and automatically sign transactions.
+
+## 02 November 2022
+
+- Created a #docs-feedback channel on [Discord](https://discord.com/channels/945856774056083548/1034215378299133974) seeking input on Aptos.dev and taking action with updates to the documentation.
 
 ## 25 October 2022
 


### PR DESCRIPTION
### Description

Announce new Stack Overflow tag and Q&A:
https://stackoverflow.com/questions/tagged/aptos

Add it to landing page

Reorder supporting links

Tidy up some headers

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5456)
<!-- Reviewable:end -->
