### PR TITLE
[helm][testnet-addons] revert loadtest parallelism

### DIFF
--- a/terraform/helm/testnet-addons/templates/loadtest.yaml
+++ b/terraform/helm/testnet-addons/templates/loadtest.yaml
@@ -19,7 +19,6 @@ spec:
           annotations:
             seccomp.security.alpha.kubernetes.io/pod: runtime/default
         spec:
-          parallelism: {{ .Values.load_test.parallelism }}
           restartPolicy: Never
           priorityClassName: {{ include "testnet-addons.fullname" . }}-high
           containers:

--- a/terraform/helm/testnet-addons/values.yaml
+++ b/terraform/helm/testnet-addons/values.yaml
@@ -28,8 +28,6 @@ waypoint:
 load_test:
   # -- Whether to enable the load test CronJob
   enabled: false
-  # -- Job parallelism
-  parallelism: 1
   image:
     # -- Image repo to use for tools image for running load tests
     repo: aptoslabs/tools


### PR DESCRIPTION
### Description

partial revert of 9da65d76aed757231cdfb22480abc81678bda1dd, removing parallelism on the k8s job due to invalid spec

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
