### PR TITLE
[smoke tests] use a random port instead of an OS-assigned port (with bind to 0)

### DIFF
--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -20,7 +20,7 @@ const RANDOM_PORT_RANGE: Range<u16> = 10000..30000;
 /// TIME_WAIT state ensuring that the OS won't hand out this port for some grace period.
 /// Callers should be able to bind to this port given they use SO_REUSEADDR.
 pub fn get_available_port() -> u16 {
-    for i in 0..MAX_PORT_RETRIES {
+    for _ in 0..MAX_PORT_RETRIES {
         if let Ok(port) = get_random_port() {
             return port;
         }

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -7,16 +7,21 @@ use aptos_types::{
     transaction::Transaction,
 };
 use get_if_addrs::get_if_addrs;
+use rand::rngs::OsRng;
+use rand::Rng;
 use std::net::{TcpListener, TcpStream};
+use std::ops::Range;
 
-/// Return an ephemeral, available port. On unix systems, the port returned will be in the
+const MAX_PORT_RETRIES: u16 = 1000;
+// Using non-ephemeral ports, to avoid conflicts with OS-selected ports (i.e., bind on port 0)
+const RANDOM_PORT_RANGE: Range<u16> = 10000..30000;
+
+/// Return a non-ephemeral, available port. On unix systems, the port returned will be in the
 /// TIME_WAIT state ensuring that the OS won't hand out this port for some grace period.
 /// Callers should be able to bind to this port given they use SO_REUSEADDR.
 pub fn get_available_port() -> u16 {
-    const MAX_PORT_RETRIES: u32 = 1000;
-
-    for _ in 0..MAX_PORT_RETRIES {
-        if let Ok(port) = get_ephemeral_port() {
+    for i in 0..MAX_PORT_RETRIES {
+        if let Ok(port) = get_random_port() {
             return port;
         }
     }
@@ -24,9 +29,10 @@ pub fn get_available_port() -> u16 {
     panic!("Error: could not find an available port");
 }
 
-fn get_ephemeral_port() -> ::std::io::Result<u16> {
-    // Request a random available port from the OS
-    let listener = TcpListener::bind(("localhost", 0))?;
+fn get_random_port() -> ::std::io::Result<u16> {
+    // Choose a random port and try to bind
+    let port = OsRng.gen_range(RANDOM_PORT_RANGE.start, RANDOM_PORT_RANGE.end);
+    let listener = TcpListener::bind(("localhost", port))?;
     let addr = listener.local_addr()?;
 
     // Create and accept a connection (which we'll promptly drop) in order to force the port


### PR DESCRIPTION
### Description

Trying to eliminate an entire class of smoke test flakiness in CICD due to conflicting ports.

Doing lsof on flaky tests in CICD, we observe that a new parallel test takes a port from a currently running node between the time it is stopped and started. When a node N goes down (by design, in the test) a port that was being used by that node N is stolen by a node M in another test. When node N restarts, the conflict occurs.

It seems very hard to hit if things were really random, yet in practice we see this at least once a day. Possibly the OS is prioritizing recently released ephemeral ports. In this PR we use pseudo-randomness, so the chances of a new process taking a port between process stop and restart should be fairly low.

(Note cargo nextest runs parallel tests in different processes, so we need to avoid conflicts between processes, so a static variable is not a solution.)

### Test Plan

Land and observe CICD for test flakiness.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5481)
<!-- Reviewable:end -->
