### PR TITLE
[gha] build additional testing images for all profile and features builds

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -114,6 +114,7 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       TARGET_CACHE_ID: ${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
       PROFILE: release
+      BUILD_ADDL_TESTING_IMAGES: true
 
   rust-images-indexer:
     needs: [permission-check, determine-docker-build-metadata]
@@ -124,6 +125,7 @@ jobs:
       TARGET_CACHE_ID: ${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
       PROFILE: release
       FEATURES: indexer
+      BUILD_ADDL_TESTING_IMAGES: true
 
   rust-images-testing:
     needs: [permission-check, determine-docker-build-metadata]
@@ -134,7 +136,7 @@ jobs:
       TARGET_CACHE_ID: ${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
       PROFILE: release
       FEATURES: failpoints
-      BUILD_TEST_IMAGES: true
+      BUILD_ADDL_TESTING_IMAGES: true
 
   rust-images-performance:
     needs: [permission-check, determine-docker-build-metadata]
@@ -144,6 +146,7 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       TARGET_CACHE_ID: ${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
       PROFILE: performance
+      BUILD_ADDL_TESTING_IMAGES: true
 
   sdk-release:
     needs: [rust-images, determine-docker-build-metadata]

--- a/.github/workflows/docker-rust-build.yaml
+++ b/.github/workflows/docker-rust-build.yaml
@@ -6,27 +6,32 @@ on:
       GIT_SHA:
         required: true
         type: string
+        description: The git SHA1 to build. If not specified, the latest commit on the triggering branch will be built
       TARGET_CACHE_ID:
         required: true
         type: string
+        description: ID of the docker cache to use for the build
       FEATURES:
         required: false
         type: string
+        description: The cargo features to build. If not specified, none will be built other than those specified in cargo config
       PROFILE:
         default: release
         required: false
         type: string
-      BUILD_TEST_IMAGES:
+        description: The cargo profile to build. If not specified, the default release profile will be used
+      BUILD_ADDL_TESTING_IMAGES:
         default: false
         required: false
         type: boolean
+        description: Whether to build additional testing images. If not specified, only the base release images will be built
 
 env:
   GIT_SHA: ${{ inputs.GIT_SHA }}
   TARGET_CACHE_ID: ${{ inputs.TARGET_CACHE_ID }}
   PROFILE: ${{ inputs.PROFILE }}
   FEATURES: ${{ inputs.FEATURES }}
-  BUILD_TEST_IMAGES: ${{ inputs.BUILD_TEST_IMAGES }}
+  BUILD_ADDL_TESTING_IMAGES: ${{ inputs.BUILD_ADDL_TESTING_IMAGES }}
   GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
   AWS_ECR_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
 
@@ -59,4 +64,4 @@ jobs:
         env:
           PROFILE: ${{ env.PROFILE }}
           FEATURES: ${{ env.FEATURES }}
-          BUILD_TEST_IMAGES: ${{ env.BUILD_TEST_IMAGES }}
+          BUILD_ADDL_TESTING_IMAGES: ${{ env.BUILD_ADDL_TESTING_IMAGES }}

--- a/docker/docker-bake-rust-all.hcl
+++ b/docker/docker-bake-rust-all.hcl
@@ -37,8 +37,8 @@ variable "ecr_base" {
 
 variable "NORMALIZED_GIT_BRANCH_OR_PR" {}
 variable "IMAGE_TAG_PREFIX" {}
-variable "BUILD_TEST_IMAGES" {
-  // Whether to build test images
+variable "BUILD_ADDL_TESTING_IMAGES" {
+  // Whether to build additional testing images
   default = "false"
 }
 variable "PROFILE" {
@@ -57,7 +57,7 @@ group "all" {
     "faucet",
     "forge",
     "telemetry-service",
-    BUILD_TEST_IMAGES == "true" ? [
+    BUILD_ADDL_TESTING_IMAGES == "true" ? [
       "validator-testing"
     ] : []
   ])


### PR DESCRIPTION
### Description

`validator-testing` image is the `validator` image, but with a bunch of debug tools installed on top of it, which is useful for testing purposes. Use the `BUILD_ADDL_TESTING_IMAGES` env var to trigger building the extra `validator-testing` image for each of our image build workflows

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5482)
<!-- Reviewable:end -->
