### PR TITLE
use available machine type for mainnet replay job

### DIFF
--- a/.github/workflows/replay-verify-mainnet.yaml
+++ b/.github/workflows/replay-verify-mainnet.yaml
@@ -22,7 +22,7 @@ env:
 jobs:
   replay-transactions:
     timeout-minutes: 720
-    runs-on: high-perf-docker
+    runs-on: high-perf-docker-with-local-ssd
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:

--- a/.github/workflows/replay-verify-testnet.yaml
+++ b/.github/workflows/replay-verify-testnet.yaml
@@ -8,7 +8,7 @@ on:
         type: string
         description: The git SHA1 to test. If not specified, Forge will check the latest commits on the current branch
   schedule:
-    - cron: "0 9/12 * * *"
+    - cron: "5 9/12 * * *"
   pull_request:
     paths:
       - ".github/workflows/nightly-replay-verify.yaml"


### PR DESCRIPTION
"high-perf-docker" was gone.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5483)
<!-- Reviewable:end -->
