### PR TITLE
Remove debug information for Release mode builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,6 @@ read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = 
 # END MOVE DEPENDENCIES
 
 [profile.release]
-debug = true
 overflow-checks = true
 
 # The performance build is not currently recommended


### PR DESCRIPTION
### Description

Release mode builds have debug information explicitly turned On (set to True).

This results in huge compiled binaries. For example, aptos-node is over 1.5 GB when built.

Setting debug to default False:
```
$ export CARGO_PROFILE_RELEASE_DEBUG=false
$ cargo build --locked --profile=release -p aptos-node
```

Compiled binary is a manageable 74M:
```
$ ls -lh target/release/aptos-node
-rwxr-xr-x 2 julian julian 74M Nov  7 13:37 target/release/aptos-node
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5488)
<!-- Reviewable:end -->
