### PR TITLE
[gha] remove docker build performance dependency

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -127,7 +127,7 @@ jobs:
       FEATURES: indexer
       BUILD_ADDL_TESTING_IMAGES: true
 
-  rust-images-testing:
+  rust-images-failpoints:
     needs: [permission-check, determine-docker-build-metadata]
     uses: ./.github/workflows/docker-rust-build.yaml
     secrets: inherit
@@ -163,7 +163,7 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
 
   forge-e2e-test:
-    needs: [rust-images, rust-images-testing, rust-images-performance, determine-docker-build-metadata]
+    needs: [rust-images, rust-images-failpoints, determine-docker-build-metadata]
     if: |
       !contains(github.event.pull_request.labels.*.name, 'CICD:skip-forge-e2e-test') && (
         (github.event_name == 'push' && github.ref_name != 'main') ||


### PR DESCRIPTION
### Description

Performance images take on average 2x longer to build. Since we're not using them for forge land-blocking tests, remove them from the GHA dependency tree. We could also do this with the `failpoints` image, but keeping that for now as the build time is roughly the same. (We can potentially add some quick safety checks using the failpoints image too to land-blocking)

Also rename the GHA job  `rust-images-testing` to  `rust-images-failpoints` to be more clear. This separates it from the concept of "testing" images

### Test Plan

Some GHA data analysis...

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5492)
<!-- Reviewable:end -->
