### PR TITLE
[cli] Add expiration time to the CLI

### DIFF
--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use aptos_build_info::build_information;
 use aptos_logger::{debug, Level};
-use aptos_rest_client::{aptos_api_types::HashValue, Account, Client};
+use aptos_rest_client::{aptos_api_types::HashValue, Account, Client, State};
 use aptos_telemetry::service::telemetry_is_disabled;
 use aptos_types::{chain_id::ChainId, transaction::authenticator::AuthenticationKey};
 use itertools::Itertools;
@@ -232,8 +232,19 @@ pub async fn get_account(
         .get_account(address)
         .await
         .map_err(|err| CliError::ApiError(err.to_string()))?;
-    let account = account_response.inner();
-    Ok(account.clone())
+    Ok(account_response.into_inner())
+}
+
+/// Retrieves account resource from the rest client
+pub async fn get_account_with_state(
+    client: &aptos_rest_client::Client,
+    address: AccountAddress,
+) -> CliTypedResult<(Account, State)> {
+    let account_response = client
+        .get_account(address)
+        .await
+        .map_err(|err| CliError::ApiError(err.to_string()))?;
+    Ok(account_response.into_parts())
 }
 
 /// Retrieves sequence number from the rest client

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -389,14 +389,7 @@ impl CliTestFramework {
         amount: u64,
     ) -> CliTypedResult<Vec<TransactionSummary>> {
         AddStake {
-            txn_options: self.transaction_options(
-                index,
-                // TODO(greg): revisit after fixing gas estimation
-                Some(GasOptions {
-                    gas_unit_price: Some(1),
-                    max_gas: Some(10000),
-                }),
-            ),
+            txn_options: self.transaction_options(index, None),
             amount,
         }
         .execute()
@@ -563,14 +556,7 @@ impl CliTestFramework {
         operator_index: Option<usize>,
     ) -> CliTypedResult<TransactionSummary> {
         InitializeStakeOwner {
-            txn_options: self.transaction_options(
-                owner_index,
-                // TODO(greg): revisit after fixing gas estimation
-                Some(GasOptions {
-                    gas_unit_price: Some(1),
-                    max_gas: Some(100000),
-                }),
-            ),
+            txn_options: self.transaction_options(owner_index, None),
             initial_stake_amount,
             operator_address: operator_index.map(|idx| self.account_id(idx)),
             voter_address: voter_index.map(|idx| self.account_id(idx)),

--- a/testsuite/smoke-test/src/aptos_cli/account.rs
+++ b/testsuite/smoke-test/src/aptos_cli/account.rs
@@ -56,6 +56,7 @@ async fn test_account_flow() {
             Some(GasOptions {
                 gas_unit_price: Some(2),
                 max_gas: None,
+                expiration_secs: 30,
             }),
         )
         .await
@@ -77,6 +78,7 @@ async fn test_account_flow() {
             // NOTE(Gas): This should be equal to the min gas amount allowed.
             //            Read the comment above to understand why.
             max_gas: Some(150),
+            expiration_secs: 30,
         }),
     )
     .await

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -363,6 +363,7 @@ async fn test_account_balance() {
             Some(GasOptions {
                 gas_unit_price: None,
                 max_gas: Some(1000),
+                expiration_secs: 30,
             }),
         )
         .await
@@ -1686,6 +1687,7 @@ async fn test_invalid_transaction_gas_charged() {
             Some(GasOptions {
                 gas_unit_price: None,
                 max_gas: Some(1000),
+                expiration_secs: 30,
             }),
         )
         .await


### PR DESCRIPTION
### Description
As shown from some Discord conversations, the CLI didn't have expiration time configurable.  So, if you're trying to do something like submit a large transaction over a slow connection, it's possible your transaction doesn't make it.

### Test Plan
```
aptos account transfer --expiration-secs 1 --amount 1 --account default 
Do you want to submit a transaction for a range of [45500 - 68200] Octas at a gas unit price of 100 Octas? [yes/no] >
yes
{
  "Result": {
    "gas_unit_price": 100,
    "gas_used": 522,
    "balance_changes": {
      "b6dbf76636021a840c64da0ca6aa94297b4ead015f7398521f57347f68364898": {
        "coin": {
          "value": "99478000"
        },
        "deposit_events": {
          "counter": "11",
          "guid": {
            "id": {
              "addr": "0xb6dbf76636021a840c64da0ca6aa94297b4ead015f7398521f57347f68364898",
              "creation_num": "2"
            }
          }
        },
        "frozen": false,
        "withdraw_events": {
          "counter": "10",
          "guid": {
            "id": {
              "addr": "0xb6dbf76636021a840c64da0ca6aa94297b4ead015f7398521f57347f68364898",
              "creation_num": "3"
            }
          }
        }
      }
    },
    "sender": "b6dbf76636021a840c64da0ca6aa94297b4ead015f7398521f57347f68364898",
    "success": true,
    "version": 11063825,
    "vm_status": "Executed successfully",
    "transaction_hash": "0xd329834c5e068070a3aa3a8461103829c882ddf19e6a66491d7cfc3ce64cda69"
  }
}
```
https://explorer.aptoslabs.com/txn/11063825

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5498)
<!-- Reviewable:end -->
