### PR TITLE
[docker] bug fix Add apt-get install lld

### DIFF
--- a/docker/rosetta/rosetta.Dockerfile
+++ b/docker/rosetta/rosetta.Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:20.04@sha256:a06ae92523384c2cd182dcfe7f8b2bf09075062e937d5653d7d0db0
 FROM rust:1.63.0-buster@sha256:0110d1b4193029735f1db1c0ed661676ed4b6f705b11b1ebe95c655b52e6906f AS rust-base
 
 WORKDIR /aptos
-RUN apt-get update && apt-get install -y cmake curl clang git pkg-config libssl-dev libpq-dev
+RUN apt-get update && apt-get install -y cmake curl clang git pkg-config libssl-dev libpq-dev lld
 
 ### Build Rust code ###
 FROM rust-base as builder


### PR DESCRIPTION
### Description
aptos-cli-v1.0.1 Docker fails to build rosetta
Missing lld
fixed #5477 
### Test Plan
```
 => => writing image sha256:10f2aedfa6c53609a42f8746c16377de3120fe115e4cd785f57297a3a85590f1                                                                                                                            0.0s 
 => => naming to docker.io/library/aptos-core:rosetta-aptos-cli-v1.0.1                                                                                                                                                  0.0s
 => => naming to docker.io/library/aptos-core:rosetta-latest 
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5503)
<!-- Reviewable:end -->
