### PR TITLE
feat: get resource account address out of source address and seed

### DIFF
--- a/ecosystem/typescript/sdk/src/aptos_account.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_account.test.ts
@@ -65,3 +65,12 @@ test("Signs Strings", () => {
     "0xc5de9e40ac00b371cd83b1c197fa5b665b7449b33cd3cdd305bb78222e06a671a49625ab9aea8a039d4bb70e275768084d62b094bc1b31964f2357b7c1af7e0d",
   );
 });
+
+test("Gets the resource account address", () => {
+  const sourceAddress = "0xca843279e3427144cead5e4d5999a3d0";
+  const seed = new Uint8Array([1]);
+
+  expect(AptosAccount.getResourceAccountAddress(sourceAddress, seed).hex()).toBe(
+    "0xcbed05b37b6981a57f535c1f5d136734df822abaf4cd30c51c9b4d60eae79d5d",
+  );
+});

--- a/ecosystem/typescript/sdk/src/aptos_types/authentication_key.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/authentication_key.ts
@@ -21,6 +21,8 @@ export class AuthenticationKey {
 
   static readonly ED25519_SCHEME: number = 0;
 
+  static readonly DERIVE_RESOURCE_ACCOUNT_SCHEME: number = 255;
+
   readonly bytes: Bytes;
 
   constructor(bytes: Bytes) {


### PR DESCRIPTION
### Description
Added a function to get resource account addresses in SDK.

### Test Plan
pnpm test -- -t "Gets the resource account address"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5506)
<!-- Reviewable:end -->
