### PR TITLE
update pnpm-lock.yaml and remove path-to-regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,5 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4",
     "zx": "^7.1.1"
-  },
-  "dependencies": {
-    "path-to-regex": "^1.3.8"
   }
 }


### PR DESCRIPTION
### Description

This lockfile was out of sync, which was causing grafana-sync jobs to fail: https://github.com/aptos-labs/aptos-core/actions/runs/3397890836/jobs/5650451505

```
   ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with package.json
```

Remove the unneeded `path-to-regex` dep and run `pnpm install --no-frozen-lockfile`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5514)
<!-- Reviewable:end -->
