### PR TITLE
[forge] make invoking failpoints explicit

### DIFF
--- a/testsuite/forge_test.py
+++ b/testsuite/forge_test.py
@@ -468,7 +468,7 @@ class TestFindRecentImage(unittest.TestCase):
         )
         git = Git(shell)
         image_tags = find_recent_images_by_profile_or_features(
-            shell, git, 1, enable_performance_profile=False, enable_testing_image=True
+            shell, git, 1, enable_performance_profile=False, enable_failpoints=True
         )
         self.assertEqual(list(image_tags), ["failpoints_tomato"])
         shell.assert_commands(self)
@@ -491,7 +491,7 @@ class TestFindRecentImage(unittest.TestCase):
             git,
             1,
             enable_performance_profile=True,
-            enable_testing_image=False,
+            enable_failpoints=False,
         )
         self.assertEqual(list(image_tags), ["performance_potato"])
         shell.assert_commands(self)
@@ -505,7 +505,7 @@ class TestFindRecentImage(unittest.TestCase):
                 git,
                 1,
                 enable_performance_profile=True,
-                enable_testing_image=True,
+                enable_failpoints=True,
             )
 
     def testDidntFindRecentImage(self) -> None:
@@ -531,7 +531,7 @@ class TestFindRecentImage(unittest.TestCase):
             assert_provided_image_tags_has_profile_or_features(
                 "potato_tomato",
                 "failpoints_performance_potato",
-                enable_testing_image=True,
+                enable_failpoints=True,
                 enable_performance_profile=False,
             )
 
@@ -539,7 +539,7 @@ class TestFindRecentImage(unittest.TestCase):
         assert_provided_image_tags_has_profile_or_features(
             None,
             None,
-            enable_testing_image=True,
+            enable_failpoints=True,
             enable_performance_profile=False,
         )
 

--- a/testsuite/forge_wrapper_core/process.py
+++ b/testsuite/forge_wrapper_core/process.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import atexit
 import os
+import psutil
+import pwd
 from dataclasses import dataclass
 from typing import (
     Callable,
@@ -54,4 +56,4 @@ class SystemProcesses(Processes):
         atexit.register(callback)
 
     def user(self) -> str:
-        return get_current_user()
+        return pwd.getpwuid(os.getuid())[0]


### PR DESCRIPTION
### Description

Make the usage of the `failpoints` feature explicit with `FORGE_ENABLE_FAILPOINTS` env var, rather than something generic like `FORGE_ENABLE_TESTING_IMAGE`. The notion of "testing image" is a bit ambiguous since it doesn't say anything about how the underlying aptos binary is built.

Also the change that had renamed failpoints --> testing image did not change the GHA workflows which specified `FORGE_ENABLE_FAILPOINTS: true` anyways, so it wasn't working as intended

For now, if you want to run a Forge test with failpoints, override `enable_failpoints = "true"` in the wrapper's main function

Also fix a bug in python imports..

### Test Plan

run from CLI with the env var set to enable failpoints. The subsequent job that spins up uses the latest revision built with failpoints.

```
$ FORGE_TEST_SUITE=land_blocking FORGE_ENABLE_FAILPOINTS=true ./testsuite/run_forge.sh
Warning: run_forge.sh is deprecated. Please use forge.py instead.
Executing python testsuite/forge.py test
Using the following image tags:
        forge:  failpoints_9861fe249d5801c178e397d1c16d8b45ed4171da
        swarm:  failpoints_9861fe249d5801c178e397d1c16d8b45ed4171da
        swarm upgrade (if applicable):  failpoints_9861fe249d5801c178e397d1c16d8b45ed4171da
```

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5529)
<!-- Reviewable:end -->
