### PR TITLE
[cli] aptos new

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
  "chrono",
  "clap 3.2.17",
  "clap_complete",
+ "convert_case 0.6.0",
  "dirs",
  "framework",
  "futures",
@@ -2802,6 +2803,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3307,7 +3317,7 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2 1.0.43",
  "quote 1.0.21",
  "rustc_version",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -38,6 +38,7 @@ tokio = { version = "1.21.0", features = ["full"] }
 tokio-util = { version = "0.7.2", features = ["compat"] }
 toml = "0.5.9"
 walkdir = "2.3.2"
+convert_case = "0.6.0"
 
 aptos-bitvec = { path = "../../crates/aptos-bitvec" }
 aptos-build-info = { path = "../../crates/aptos-build-info" }

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -35,6 +35,7 @@ pub enum Tool {
     Governance(governance::GovernanceTool),
     Info(InfoTool),
     Init(common::init::InitTool),
+    New(move_tool::NewPackage),
     #[clap(subcommand)]
     Key(op::key::KeyTool),
     #[clap(subcommand)]
@@ -56,6 +57,8 @@ impl Tool {
             Info(tool) => tool.execute_serialized().await,
             // TODO: Replace entirely with config init
             Init(tool) => tool.execute_serialized_success().await,
+            // Create a project with a basic structure
+            New(tool) => tool.execute_serialized_success().await,
             Key(tool) => tool.execute().await,
             Move(tool) => tool.execute().await,
             Node(tool) => tool.execute().await,


### PR DESCRIPTION
Creates a new Move package at the given location

This will create a directory for a Move package and a corresponding
<PROJECT_NAME>
─┐
 ├📂 `tests` folder
 │ └─ `tests/<PACKAGE_NAME>_tests.move`
 ├📂 `sources` folder
 │ └─ `sources/<PACKAGE_NAME>.move`
 └─  `Move.toml` file.

Examples:
$ aptos new ~/my_project
$ aptos new ~/my_project --named_addresses self=_,std=0x1
$ aptos new ~/my_project --name DemoProject --assume-yes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5554)
<!-- Reviewable:end -->
