### PR TITLE
[docs] specify @stoplight css version to avoid integrity failure

### DIFF
--- a/developer-docs-site/docusaurus.config.js
+++ b/developer-docs-site/docusaurus.config.js
@@ -62,9 +62,9 @@ const config = {
       crossorigin: "anonymous",
     },
     {
-      href: "https://unpkg.com/@stoplight/elements/styles.min.css",
+      href: "https://unpkg.com/@stoplight/elements@7.7.5/styles.min.css",
       type: "text/css",
-      integrity: "sha384-mS2+08UV7BvSC96l6SGdnZv1SexFzKSJnHwTETEb4+97GyWualVrW9nAU2MwDu16",
+      integrity: "sha384-1lLf7J28IOR7k5RlItk6Y+G3hDgVB3y4RCgWNq6ZSwjYfvJXPtZAdW0uklsAZbGW",
       crossorigin: "anonymous",
     },
   ],


### PR DESCRIPTION
### Description
Specify `@stoplight` css version to avoid integrity attribute failure which prevented script from loading after version bumps.

### Test Plan
Ensure no console errors when loading script and verify correct layout @ `/nodes/aptos-api-spec/`
<img width="1769" alt="image" src="https://user-images.githubusercontent.com/98909677/201745245-42e7fd6c-7cc0-40f0-87e3-8d57de7498df.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5557)
<!-- Reviewable:end -->
