### PR TITLE
[Aptos Network Checker] Fix required dependency.

### DIFF
--- a/crates/aptos-network-checker/Cargo.toml
+++ b/crates/aptos-network-checker/Cargo.toml
@@ -18,7 +18,7 @@ aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../aptos-crypto" }
 aptos-logger = { path = "../aptos-logger" }
 aptos-types = { path = "../../types" }
-clap = "3.2.17"
+clap = { version = "3.2.17", features = ["derive"] }
 futures = "0.3.21"
 network = { path = "../../network" }
 serde = { version = "1.0.137", features = ["derive"] }


### PR DESCRIPTION
### Description
This PR adds the missing dependency feature required to build the Aptos network checker (see: https://github.com/aptos-labs/aptos-core/issues/5504).

### Test Plan
`cargo build -p aptos-network-checker` now works 😄

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5560)
<!-- Reviewable:end -->
