### PR TITLE
[Forge] Update broken state sync tests to use txn output syncing.

### DIFF
--- a/.github/workflows/continuous-e2e-state-sync-failures-catching-up-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-failures-catching-up-test.yaml
@@ -10,14 +10,13 @@ on:
     - cron: "0 */3 * * *"
 
 jobs:
-  ### Please remember to use different namespace for different tests
-  run-state-sync-failures-catching-up-test:
+  run-forge-state-sync-failures-catching-up-test:
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-state-sync-failures-catching-up-test
       FORGE_CLUSTER_NAME: aptos-forge-big-1
       FORGE_RUNNER_DURATION_SECS: 900
-      FORGE_TEST_SUITE: failures_catching_up
+      FORGE_TEST_SUITE: state_sync_failures_catching_up
       POST_TO_SLACK: true
       FORGE_ENABLE_FAILPOINTS: true

--- a/.github/workflows/continuous-e2e-state-sync-slow-processing-catching-up-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-slow-processing-catching-up-test.yaml
@@ -10,14 +10,13 @@ on:
     - cron: "0 */3 * * *"
 
 jobs:
-  ### Please remember to use different namespace for different tests
-  run-state-sync-slow-processing-catching-up-test:
+  run-forge-state-sync-slow-processing-catching-up-test:
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-state-sync-slow-processing-catching-up-test
       FORGE_CLUSTER_NAME: aptos-forge-big-1
       FORGE_RUNNER_DURATION_SECS: 900
-      FORGE_TEST_SUITE: slow_processing_catching_up
+      FORGE_TEST_SUITE: state_sync_slow_processing_catching_up
       POST_TO_SLACK: true
       FORGE_ENABLE_FAILPOINTS: true


### PR DESCRIPTION
### Description
This PR updates the broken forge tests for state sync by moving to transaction output syncing (making state sync faster and thus able to catch up). This is a temporary workaround until we make transaction output syncing the default.

Note: I've also renamed the tests and github jobs to be consistent with the rest of the state sync tests.

### Test Plan
Existing test infrastructure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5563)
<!-- Reviewable:end -->
