### PR TITLE
Add wallet connection step

### DIFF
--- a/developer-docs-site/docs/tutorials/first-dapp.md
+++ b/developer-docs-site/docs/tutorials/first-dapp.md
@@ -130,6 +130,8 @@ export default App;
 
 Refresh the page and you will see your account address.
 
+Note - You will have to authorize the application once from your wallet. For that use `window.aptos.connect()` on console, and sign the transaction for approval. 
+
 ### Add some CSS
 
 Next, replace the contents of `src/App.css`:


### PR DESCRIPTION
* Add step for wallet connection

### Description

Hi!

I was following the documentation for building first dapp. I run into an issue where my wallet address wasn't visible on the browser at the end of the second step. On [asking on discord](https://discord.com/channels/945856774056083548/946123778793029683/1042012162488533002), I realised that I need to connect the wallet manually using a short code snippet. 

Most of the people trying out this tutorial would run into this issue, hence added an additional note about it at the end of the step. 

Hope this helps!

### Test Plan

NA

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5572)
<!-- Reviewable:end -->
