### PR TITLE
[mempool] wait on init reconfig at startup

### DIFF
--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -13,12 +13,13 @@ use aptos_config::{
     network_id::NetworkId,
 };
 use aptos_infallible::{Mutex, RwLock};
+use aptos_types::on_chain_config::OnChainConfigPayload;
 use aptos_types::{
     account_config::AccountSequenceInfo, mempool_status::MempoolStatusCode,
-    on_chain_config::ON_CHAIN_CONFIG_REGISTRY, transaction::SignedTransaction,
+    transaction::SignedTransaction,
 };
 use channel::{self, aptos_channel, message_queues::QueueStyle};
-use event_notifications::EventSubscriptionService;
+use event_notifications::{ReconfigNotification, ReconfigNotificationListener};
 use futures::channel::mpsc;
 use mempool_notifications::{self, MempoolNotifier};
 use network::{
@@ -26,6 +27,7 @@ use network::{
     peer_manager::{conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{NewNetworkEvents, NewNetworkSender},
 };
+use std::collections::HashMap;
 use std::{collections::HashSet, sync::Arc};
 use storage_interface::{mock::MockDbReaderWriter, DbReaderWriter};
 use tokio::runtime::{Builder, Handle, Runtime};
@@ -115,11 +117,19 @@ impl MockSharedMempool {
         let (quorum_store_sender, quorum_store_receiver) = mpsc::channel(1_024);
         let (mempool_notifier, mempool_listener) =
             mempool_notifications::new_mempool_notifier_listener_pair();
-        let mut event_subscriber = EventSubscriptionService::new(
-            ON_CHAIN_CONFIG_REGISTRY,
-            Arc::new(RwLock::new(db.clone())),
-        );
-        let reconfig_event_subscriber = event_subscriber.subscribe_to_reconfigurations().unwrap();
+        let (reconfig_sender, reconfig_events) = aptos_channel::new(QueueStyle::LIFO, 1, None);
+        let reconfig_event_subscriber = ReconfigNotificationListener {
+            notification_receiver: reconfig_events,
+        };
+        reconfig_sender
+            .push(
+                (),
+                ReconfigNotification {
+                    version: 1,
+                    on_chain_configs: OnChainConfigPayload::new(1, Arc::new(HashMap::new())),
+                },
+            )
+            .unwrap();
         let network_handles = vec![(NetworkId::Validator, network_sender, network_events)];
         let peer_metadata_storage = PeerMetadataStorage::new(&[NetworkId::Validator]);
 

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -16,11 +16,14 @@ use aptos_config::{
 };
 use aptos_id_generator::U32IdGenerator;
 use aptos_infallible::{Mutex, RwLock};
+use aptos_types::on_chain_config::OnChainConfigPayload;
 use aptos_types::{
     account_address::AccountAddress, mempool_status::MempoolStatusCode,
-    on_chain_config::ON_CHAIN_CONFIG_REGISTRY, transaction::SignedTransaction,
+    transaction::SignedTransaction,
 };
-use event_notifications::EventSubscriptionService;
+use channel::aptos_channel;
+use channel::message_queues::QueueStyle;
+use event_notifications::{ReconfigNotification, ReconfigNotificationListener};
 use futures::{channel::oneshot, SinkExt};
 use mempool_notifications::MempoolNotifier;
 use network::{
@@ -41,7 +44,7 @@ use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
 };
-use storage_interface::{mock::MockDbReaderWriter, DbReaderWriter};
+use storage_interface::mock::MockDbReaderWriter;
 use tokio::{runtime::Handle, time::Duration};
 use tokio_stream::StreamExt;
 use vm_validator::mocks::mock_vm_validator::MockVMValidator;
@@ -488,11 +491,21 @@ fn setup_mempool(
 
     let mempool = Arc::new(Mutex::new(CoreMempool::new(&config)));
     let vm_validator = Arc::new(RwLock::new(MockVMValidator));
-    let db_rw = Arc::new(RwLock::new(DbReaderWriter::new(MockDbReaderWriter)));
     let db_ro = Arc::new(MockDbReaderWriter);
 
-    let mut event_subscriber = EventSubscriptionService::new(ON_CHAIN_CONFIG_REGISTRY, db_rw);
-    let reconfig_event_subscriber = event_subscriber.subscribe_to_reconfigurations().unwrap();
+    let (reconfig_sender, reconfig_events) = aptos_channel::new(QueueStyle::LIFO, 1, None);
+    let reconfig_event_subscriber = ReconfigNotificationListener {
+        notification_receiver: reconfig_events,
+    };
+    reconfig_sender
+        .push(
+            (),
+            ReconfigNotification {
+                version: 1,
+                on_chain_configs: OnChainConfigPayload::new(1, Arc::new(HashMap::new())),
+            },
+        )
+        .unwrap();
 
     start_shared_mempool(
         &Handle::current(),

--- a/vm-validator/src/mocks/mock_vm_validator.rs
+++ b/vm-validator/src/mocks/mock_vm_validator.rs
@@ -75,7 +75,7 @@ impl TransactionValidation for MockVMValidator {
     }
 
     fn restart(&mut self, _config: OnChainConfigPayload) -> Result<()> {
-        unimplemented!();
+        Ok(())
     }
 
     fn notify_commit(&mut self) {}


### PR DESCRIPTION
### Description

Previously mempool was not reading the initial config before starting, which seems like an oversight. For up-to-date nodes, the initial read will prevent a race on restart where mempool could initially handle transactions with old onchain configs. (Note though, this provides no guarantees for stale nodes or nodes that are currently undergoing an onchain config change.)

### Test Plan

Existing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5578)
<!-- Reviewable:end -->
