### PR TITLE
Remove CLI option true defaults to enable negation

### DIFF
--- a/aptos-move/framework/src/docgen.rs
+++ b/aptos-move/framework/src/docgen.rs
@@ -15,8 +15,8 @@ pub struct DocgenOptions {
     #[clap(long)]
     pub include_impl: bool,
 
-    /// Whether to include specifications in the generated documentation. Defaults to true.
-    #[clap(long, global = true)]
+    /// Whether to include specifications in the generated documentation. Defaults to false.
+    #[clap(long)]
     pub include_specs: bool,
 
     /// Whether specifications should be put side-by-side with declarations or into a separate
@@ -29,8 +29,8 @@ pub struct DocgenOptions {
     pub include_dep_diagram: bool,
 
     /// Whether details should be put into collapsed sections. This is not supported by
-    /// all markdown, but the github dialect. Defaults to true.
-    #[clap(long, global = true)]
+    /// all markdown, but the github dialect. Defaults to false.
+    #[clap(long)]
     pub collapsed_sections: bool,
 
     /// Package-relative path to an optional markdown template which is a used to create a


### PR DESCRIPTION
@wrwg @davidiw @gregnazario @alinush 

Per #5581 , DocGen CLI options defaulting to true prohibit negation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5582)
<!-- Reviewable:end -->
