### PR TITLE
[Forge] Add simple test for fast sync throughput.

### DIFF
--- a/.github/workflows/continuous-e2e-state-sync-perf-fullnode-fast-sync-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-perf-fullnode-fast-sync-test.yaml
@@ -1,0 +1,22 @@
+name: Continuous E2E State Sync Performance Test For Fullnode Fast Sync
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */3 * * *"
+
+jobs:
+  # Performance test in an optimal setting
+  run-forge-state-sync-perf-fullnode-fast-sync-test:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-fast-sync
+      # Run for 40 minutes
+      FORGE_RUNNER_DURATION_SECS: 2400
+      FORGE_TEST_SUITE: state_sync_perf_fullnodes_fast_sync
+      POST_TO_SLACK: true

--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -121,7 +121,7 @@ impl<'t> AccountMinter<'t> {
                 coins_for_source
             );
 
-            if req.promt_before_spending {
+            if req.prompt_before_spending {
                 if !prompt_yes(&format!(
                     "plan will consume in total {} balance, are you sure you want to proceed",
                     coins_for_source

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -125,7 +125,7 @@ pub struct EmitJobRequest {
     txn_expiration_time_secs: u64,
     expected_max_txns: u64,
     expected_gas_per_txn: u64,
-    promt_before_spending: bool,
+    prompt_before_spending: bool,
 }
 
 impl Default for EmitJobRequest {
@@ -145,7 +145,7 @@ impl Default for EmitJobRequest {
             txn_expiration_time_secs: 60,
             expected_max_txns: MAX_TXNS,
             expected_gas_per_txn: aptos_global_constants::MAX_GAS_AMOUNT,
-            promt_before_spending: false,
+            prompt_before_spending: false,
         }
     }
 }
@@ -175,8 +175,8 @@ impl EmitJobRequest {
         self
     }
 
-    pub fn promt_before_spending(mut self) -> Self {
-        self.promt_before_spending = true;
+    pub fn prompt_before_spending(mut self) -> Self {
+        self.prompt_before_spending = true;
         self
     }
 

--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -75,7 +75,7 @@ pub async fn emit_transactions_with_cluster(
         emit_job_request = emit_job_request.expected_gas_per_txn(expected_gas_per_txn);
     }
     if !cluster.coin_source_is_root {
-        emit_job_request = emit_job_request.promt_before_spending();
+        emit_job_request = emit_job_request.prompt_before_spending();
     }
     let stats = emitter
         .emit_txn_for_with_stats(

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -18,7 +18,9 @@ use testcases::load_vs_perf_benchmark::LoadVsPerfBenchmark;
 use testcases::network_bandwidth_test::NetworkBandwidthTest;
 use testcases::network_loss_test::NetworkLossTest;
 use testcases::performance_with_fullnode_test::PerformanceBenchmarkWithFN;
-use testcases::state_sync_performance::StateSyncValidatorPerformance;
+use testcases::state_sync_performance::{
+    StateSyncFullnodeFastSyncPerformance, StateSyncValidatorPerformance,
+};
 use testcases::three_region_simulation_test::ThreeRegionSimulationTest;
 use testcases::twin_validator_test::TwinValidatorTest;
 use testcases::validator_join_leave_test::ValidatorJoinLeaveTest;
@@ -437,6 +439,7 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
         "state_sync_perf_fullnodes_execute_transactions" => {
             state_sync_perf_fullnodes_execute_transactions(config)
         }
+        "state_sync_perf_fullnodes_fast_sync" => state_sync_perf_fullnodes_fast_sync(config),
         "state_sync_perf_validators" => state_sync_perf_validators(config),
         "validators_join_and_leave" => validators_join_and_leave(config),
         "compat" => config
@@ -749,7 +752,6 @@ fn state_sync_perf_fullnodes_config(forge_config: ForgeConfig<'static>) -> Forge
     forge_config
         .with_initial_validator_count(NonZeroUsize::new(4).unwrap())
         .with_initial_fullnode_count(4)
-        .with_network_tests(vec![&StateSyncFullnodePerformance])
 }
 
 /// The config for running a state sync performance test when applying
@@ -758,6 +760,7 @@ fn state_sync_perf_fullnodes_apply_outputs(
     forge_config: ForgeConfig<'static>,
 ) -> ForgeConfig<'static> {
     state_sync_perf_fullnodes_config(forge_config)
+        .with_network_tests(vec![&StateSyncFullnodePerformance])
         .with_genesis_helm_config_fn(Arc::new(|helm_values| {
             helm_values["chain"]["epoch_duration_secs"] = 600.into();
         }))
@@ -776,6 +779,7 @@ fn state_sync_perf_fullnodes_execute_transactions(
     forge_config: ForgeConfig<'static>,
 ) -> ForgeConfig<'static> {
     state_sync_perf_fullnodes_config(forge_config)
+        .with_network_tests(vec![&StateSyncFullnodePerformance])
         .with_genesis_helm_config_fn(Arc::new(|helm_values| {
             helm_values["chain"]["epoch_duration_secs"] = 600.into();
         }))
@@ -786,6 +790,29 @@ fn state_sync_perf_fullnodes_execute_transactions(
                 ["continuous_syncing_mode"] = "ExecuteTransactions".into();
         }))
         .with_success_criteria(SuccessCriteria::new(5000, 10000, false, None, None, None))
+}
+
+/// The config for running a state sync performance test when fast syncing
+/// to the latest epoch.
+fn state_sync_perf_fullnodes_fast_sync(forge_config: ForgeConfig<'static>) -> ForgeConfig<'static> {
+    state_sync_perf_fullnodes_config(forge_config)
+        .with_network_tests(vec![&StateSyncFullnodeFastSyncPerformance])
+        .with_genesis_helm_config_fn(Arc::new(|helm_values| {
+            helm_values["chain"]["epoch_duration_secs"] = 180.into(); // Frequent epochs
+        }))
+        .with_emit_job(
+            EmitJobRequest::default()
+                .mode(EmitJobMode::MaxLoad {
+                    mempool_backlog: 30000,
+                })
+                .transaction_type(TransactionType::AccountGeneration), // Create many state values
+        )
+        .with_node_helm_config_fn(Arc::new(|helm_values| {
+            helm_values["fullnode"]["config"]["state_sync"]["state_sync_driver"]
+                ["bootstrapping_mode"] = "DownloadLatestStates".into();
+            helm_values["fullnode"]["config"]["state_sync"]["state_sync_driver"]
+                ["continuous_syncing_mode"] = "ApplyTransactionOutputs".into();
+        }))
 }
 
 /// The config for running a state sync performance test when applying

--- a/testsuite/testcases/src/state_sync_performance.rs
+++ b/testsuite/testcases/src/state_sync_performance.rs
@@ -4,11 +4,17 @@
 use crate::generate_traffic;
 use anyhow::bail;
 use aptos_logger::info;
-use forge::{get_highest_synced_version, NetworkContext, NetworkTest, Result, SwarmExt, Test};
+use aptos_sdk::move_types::account_address::AccountAddress;
+use forge::{
+    get_highest_synced_epoch, get_highest_synced_version, NetworkContext, NetworkTest, Result,
+    SwarmExt, Test,
+};
 use std::time::Instant;
 use tokio::{runtime::Runtime, time::Duration};
 
-const MAX_NODE_LAG_SECS: u64 = 10; // Max amount of lag (in seconds) that nodes should adhere to
+const MAX_EPOCH_CHANGE_SECS: u64 = 300; // Max amount of time (in seconds) to wait for an epoch change
+const MAX_NODE_LAG_SECS: u64 = 30; // Max amount of lag (in seconds) that nodes should adhere to
+const NUM_STATE_VALUE_COUNTER_NAME: &str = "aptos_jellyfish_leaf_count"; // The metric to fetch for the number of state values
 
 /// A state sync performance test that measures fullnode sync performance.
 /// In the test, all fullnodes are wiped, restarted and timed to synchronize.
@@ -22,73 +28,93 @@ impl Test for StateSyncFullnodePerformance {
 
 impl NetworkTest for StateSyncFullnodePerformance {
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
-        // Verify we have at least 1 fullnode
-        let all_fullnodes = ctx
-            .swarm()
-            .full_nodes()
-            .map(|v| v.peer_id())
-            .collect::<Vec<_>>();
-        if all_fullnodes.is_empty() {
-            return Err(anyhow::format_err!(
-                "Fullnode performance tests require at least 1 fullnode!"
-            ));
-        }
+        let all_fullnodes = get_fullnodes_and_check_setup(ctx, self.name())?;
 
-        // Log the test setup
-        let all_validators = ctx
-            .swarm()
-            .validators()
-            .map(|v| v.peer_id())
-            .collect::<Vec<_>>();
-        info!(
-            "Running state sync test {:?} with {:?} validators and {:?} fullnodes.",
-            self.name(),
-            all_validators.len(),
-            all_fullnodes.len()
-        );
+        // Emit a lot of traffic and ensure the fullnodes can all sync
+        emit_traffic_and_ensure_bounded_sync(ctx, &all_fullnodes)?;
 
-        // Generate some traffic through the fullnodes.
-        // We do this for half the test time.
-        let emit_txn_duration = ctx.global_duration.checked_div(2).unwrap();
-        info!(
-            "Generating the initial traffic for {:?} seconds.",
-            emit_txn_duration.as_secs()
-        );
-        let _txn_stat = generate_traffic(
-            ctx,
-            &all_fullnodes,
-            emit_txn_duration,
-            aptos_global_constants::GAS_UNIT_PRICE,
-        )?;
-
-        // Wait for all nodes to synchronize. We time bound this to ensure
-        // fullnodes don't fall too far behind the validators.
-        info!("Waiting for the validators and fullnodes to be synchronized.");
-        let runtime = Runtime::new().unwrap();
-        runtime.block_on(async {
-            ctx.swarm()
-                .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_NODE_LAG_SECS))
-                .await
-        })?;
-
-        // Stop and reset all fullnodes
-        info!("Deleting all fullnode data!");
-        for fullnode_id in &all_fullnodes {
-            let fullnode = ctx.swarm().full_node_mut(*fullnode_id).unwrap();
-            runtime.block_on(async { fullnode.clear_storage().await })?;
-        }
-
-        // Restart the nodes so they start syncing from a fresh state
-        // and start the timer.
-        for fullnode_id in &all_fullnodes {
-            let fullnode = ctx.swarm().full_node_mut(*fullnode_id).unwrap();
-            runtime.block_on(async { fullnode.start().await })?;
-        }
-        let timer = Instant::now();
+        // Stop and reset the fullnodes so they start syncing from genesis
+        stop_and_reset_nodes(ctx, &all_fullnodes, &[])?;
 
         // Wait for all nodes to catch up to the highest synced version
         // then calculate and display the throughput results.
-        ensure_state_sync_throughput(ctx, timer, self.name())
+        ensure_state_sync_transaction_throughput(ctx, self.name())
+    }
+}
+
+/// A state sync performance test that measures fast sync performance.
+/// In the test, all fullnodes are wiped, restarted and timed to synchronize.
+pub struct StateSyncFullnodeFastSyncPerformance;
+
+impl Test for StateSyncFullnodeFastSyncPerformance {
+    fn name(&self) -> &'static str {
+        "StateSyncFullnodeFastSyncPerformance"
+    }
+}
+
+impl NetworkTest for StateSyncFullnodeFastSyncPerformance {
+    fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
+        let all_fullnodes = get_fullnodes_and_check_setup(ctx, self.name())?;
+
+        // Emit a lot of traffic and ensure the fullnodes can all sync
+        emit_traffic_and_ensure_bounded_sync(ctx, &all_fullnodes)?;
+
+        // Wait for an epoch change to ensure fast sync can download all the latest states
+        info!("Waiting for an epoch change.");
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(async {
+            ctx.swarm()
+                .wait_for_all_nodes_to_change_epoch(Duration::from_secs(MAX_EPOCH_CHANGE_SECS))
+                .await
+        })?;
+
+        // Get the highest known epoch in the chain
+        let highest_synced_epoch = runtime.block_on(async {
+            get_highest_synced_epoch(&ctx.swarm().get_all_nodes_clients_with_names())
+                .await
+                .unwrap_or(0)
+        });
+        if highest_synced_epoch == 0 {
+            return Err(anyhow::format_err!(
+                "The swarm has synced 0 epochs! Something has gone wrong!"
+            ));
+        }
+
+        // Fetch the number of state values held on-chain
+        let fullnode_name = ctx.swarm().full_nodes().next().unwrap().name();
+        let prom_query = format!(
+            "{}{{instance=\"{}\"}}",
+            NUM_STATE_VALUE_COUNTER_NAME, &fullnode_name
+        );
+        let promql_result = runtime.block_on(ctx.swarm().query_metrics(&prom_query, None, None))?;
+        let number_of_state_values = match promql_result.as_instant().unwrap().first() {
+            Some(instant_vector) => instant_vector.sample().value() as u64,
+            None => {
+                return Err(anyhow::format_err!(
+                    "No instant vectors found for prom query {}",
+                    prom_query
+                ));
+            }
+        };
+        info!(
+            "Number of reported state values found on-chain is: {}",
+            number_of_state_values
+        );
+
+        // Stop and reset the fullnodes so they start syncing from genesis
+        stop_and_reset_nodes(ctx, &all_fullnodes, &[])?;
+
+        // Wait for all nodes to catch up to the highest synced epoch
+        // then calculate and display the throughput results.
+        display_state_sync_state_throughput(
+            ctx,
+            self.name(),
+            highest_synced_epoch,
+            number_of_state_values,
+        )?;
+
+        // TODO: add a minimum expected throughput that could fail the test
+        Ok(())
     }
 }
 
@@ -128,57 +154,178 @@ impl NetworkTest for StateSyncValidatorPerformance {
         );
 
         // Generate some traffic through the validators.
-        // We do this for half the test time.
-        let emit_txn_duration = ctx.global_duration.checked_div(2).unwrap();
-        info!(
-            "Generating the initial traffic for {:?} seconds.",
-            emit_txn_duration.as_secs()
-        );
-        let _txn_stat = generate_traffic(
-            ctx,
-            &all_validators,
-            emit_txn_duration,
-            aptos_global_constants::GAS_UNIT_PRICE,
-        )?;
+        emit_traffic_and_ensure_bounded_sync(ctx, &all_validators)?;
 
-        // Wait for all nodes to synchronize and stabilize.
-        info!("Waiting for the validators to be synchronized.");
-        let runtime = Runtime::new().unwrap();
-        runtime.block_on(async {
-            ctx.swarm()
-                .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_NODE_LAG_SECS))
-                .await
-        })?;
-
-        // Stop and reset two validators
+        // Stop and reset two validators so they start syncing from genesis
         info!("Deleting data for two validators!");
-        let validators_to_restart = &all_validators[0..2];
-        for validator_id in validators_to_restart {
-            let validator = ctx.swarm().validator_mut(*validator_id).unwrap();
-            runtime.block_on(async { validator.clear_storage().await })?;
-        }
-
-        // Restart the validators so they start syncing from a fresh state
-        // and start the timer.
-        for validator_id in validators_to_restart {
-            let validator = ctx.swarm().validator_mut(*validator_id).unwrap();
-            runtime.block_on(async { validator.start().await })?;
-        }
-        let timer = Instant::now();
+        let validators_to_reset = &all_validators[0..2];
+        stop_and_reset_nodes(ctx, &[], validators_to_reset)?;
 
         // Wait for all nodes to catch up to the highest synced version
         // then calculate and display the throughput results.
-        ensure_state_sync_throughput(ctx, timer, self.name())
+        ensure_state_sync_transaction_throughput(ctx, self.name())
     }
 }
 
-/// Calculates, enforces and displays the state sync throughput using
-/// the synced version and sync duration.
-fn ensure_state_sync_throughput(
+/// Verifies the setup for the given fullnode test and returns the
+/// set of fullnodes.
+fn get_fullnodes_and_check_setup(
+    ctx: &mut NetworkContext,
+    test_name: &'static str,
+) -> Result<Vec<AccountAddress>> {
+    // Verify we have at least 1 fullnode
+    let all_fullnodes = ctx
+        .swarm()
+        .full_nodes()
+        .map(|v| v.peer_id())
+        .collect::<Vec<_>>();
+    if all_fullnodes.is_empty() {
+        return Err(anyhow::format_err!(
+            "Fullnode test {} requires at least 1 fullnode!",
+            test_name
+        ));
+    }
+
+    // Log the test setup
+    let all_validators = ctx
+        .swarm()
+        .validators()
+        .map(|v| v.peer_id())
+        .collect::<Vec<_>>();
+    info!(
+        "Running state sync test {:?} with {:?} validators and {:?} fullnodes.",
+        test_name,
+        all_validators.len(),
+        all_fullnodes.len()
+    );
+
+    Ok(all_fullnodes)
+}
+
+/// Emits traffic through all specified nodes and ensures all nodes can
+/// sync within a reasonable time bound.
+fn emit_traffic_and_ensure_bounded_sync(
+    ctx: &mut NetworkContext,
+    nodes_to_send_traffic: &[AccountAddress],
+) -> Result<()> {
+    // Generate some traffic through the specified nodes.
+    // We do this for half the test time.
+    let emit_txn_duration = ctx.global_duration.checked_div(2).unwrap();
+    info!(
+        "Generating the initial traffic for {:?} seconds.",
+        emit_txn_duration.as_secs()
+    );
+    let _txn_stat = generate_traffic(
+        ctx,
+        nodes_to_send_traffic,
+        emit_txn_duration,
+        aptos_global_constants::GAS_UNIT_PRICE,
+    )?;
+
+    // Wait for all nodes to synchronize. We time bound this to ensure
+    // nodes don't fall too far behind.
+    info!("Waiting for the validators and fullnodes to be synchronized.");
+    Runtime::new().unwrap().block_on(async {
+        ctx.swarm()
+            .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_NODE_LAG_SECS))
+            .await
+    })?;
+
+    Ok(())
+}
+
+/// Stops and resets all specified nodes
+fn stop_and_reset_nodes(
+    ctx: &mut NetworkContext,
+    fullnodes_to_reset: &[AccountAddress],
+    validators_to_reset: &[AccountAddress],
+) -> Result<()> {
+    let runtime = Runtime::new().unwrap();
+
+    // Stop and reset all fullnodes
+    info!("Deleting all fullnode data!");
+    for fullnode_id in fullnodes_to_reset {
+        let fullnode = ctx.swarm().full_node_mut(*fullnode_id).unwrap();
+        runtime.block_on(async { fullnode.clear_storage().await })?;
+    }
+
+    // Stop and reset all validators
+    info!("Deleting all validator data!");
+    for valdiator_id in validators_to_reset {
+        let validator = ctx.swarm().validator_mut(*valdiator_id).unwrap();
+        runtime.block_on(async { validator.clear_storage().await })?;
+    }
+
+    // Restart the fullnodes so they start syncing from a fresh state
+    for fullnode_id in fullnodes_to_reset {
+        let fullnode = ctx.swarm().full_node_mut(*fullnode_id).unwrap();
+        runtime.block_on(async { fullnode.start().await })?;
+    }
+
+    // Restart the validators so they start syncing from a fresh state
+    for valdiator_id in validators_to_reset {
+        let validator = ctx.swarm().validator_mut(*valdiator_id).unwrap();
+        runtime.block_on(async { validator.start().await })?;
+    }
+
+    Ok(())
+}
+
+/// Calculates and displays the state sync state value throughput
+/// when fast syncing to the latest epoch.
+fn display_state_sync_state_throughput(
     ctx: &mut NetworkContext<'_>,
-    timer: Instant,
+    test_name: &str,
+    highest_synced_epoch: u64,
+    number_of_state_values: u64,
+) -> Result<()> {
+    // Start the timer
+    let timer = Instant::now();
+    let runtime = Runtime::new().unwrap();
+
+    // Wait for all nodes to catch up to the same epoch (that is when fast sync completes).
+    // We allow up to half the test time to do this.
+    let node_sync_duration = ctx.global_duration.checked_div(2).unwrap();
+    runtime.block_on(async {
+        ctx.swarm()
+            .wait_for_all_nodes_to_catchup_to_epoch(highest_synced_epoch, node_sync_duration)
+            .await
+    })?;
+
+    // Stop the syncing timer
+    let seconds_to_sync = timer.elapsed().as_secs();
+    if seconds_to_sync == 0 {
+        return Err(anyhow::format_err!(
+            "The time taken to state sync was 0 seconds! Something has gone wrong!"
+        ));
+    }
+
+    // Calculate and report the syncing throughput
+    let state_sync_throughput = number_of_state_values / seconds_to_sync;
+    let throughput_message = format!(
+        "State sync throughput : {} state values / sec",
+        state_sync_throughput
+    );
+    info!("Measured state sync throughput: {:?}", throughput_message);
+    ctx.report.report_text(throughput_message);
+    ctx.report.report_metric(
+        test_name,
+        "state_sync_throughput",
+        state_sync_throughput as f64,
+    );
+
+    Ok(())
+}
+
+/// Calculates, enforces and displays the state sync transaction
+/// throughput using the synced version and sync duration.
+fn ensure_state_sync_transaction_throughput(
+    ctx: &mut NetworkContext<'_>,
     test_name: &str,
 ) -> Result<()> {
+    // Start the timer
+    let timer = Instant::now();
+
     // Get the highest synced version for the chain
     let runtime = Runtime::new().unwrap();
     let highest_synced_version = runtime.block_on(async {


### PR DESCRIPTION
### Description
This PR adds a simple forge test that benchmarks the throughput of state sync when running fast sync. Specifically, it counts and displays the throughput of the number of state values synced per second.

Note: most of this PR is simply just refactoring code into reusable methods to avoid code duplication 😄 

### Test Plan
Ran this on forge and verified the results, e.g., a very quick run showed:

```
State sync throughput : 21837 state values / sec
Test Ok
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5584)
<!-- Reviewable:end -->
