### PR TITLE
[helm][testnet-addons] fix loadtest resource spec

### DIFF
--- a/terraform/helm/testnet-addons/templates/loadtest.yaml
+++ b/terraform/helm/testnet-addons/templates/loadtest.yaml
@@ -25,10 +25,6 @@ spec:
           - name: load-test
             image: {{ .Values.load_test.image.repo }}:{{ .Values.load_test.image.tag | default .Values.imageTag }}
             imagePullPolicy: {{ .Values.load_test.image.pullPolicy }}
-            {{- with .resources }}
-            resources:
-              {{- toYaml . | nindent 14 }}
-            {{- end }}
             command:
             - transaction-emitter
             - emit-tx
@@ -73,6 +69,10 @@ spec:
               value: "1"
             - name: REUSE_ACC
               value: "1"
+            {{- with .resources }}
+            resources:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
             securityContext:
               readOnlyRootFilesystem: true
               allowPrivilegeEscalation: false


### PR DESCRIPTION
### Description

So we load `.Values.load_test.resources` correctly. Previously, it was loading `.Values.resources` due to being in the wrong `with` block

### Test Plan

`helm template`

Load custom values with resource spec into `addons-values.yaml`, then run `helm template -s templates/loadtest.yaml . -f ../../../addons-values.yaml`:

```
---
# Source: testnet-addons/templates/loadtest.yaml
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  name: release-name-testnet-addons-load-test
  labels:
    helm.sh/chart: testnet-addons-0.1
    app.kubernetes.io/part-of: testnet-addons
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.1.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: load-test
spec:
  concurrencyPolicy: Replace
  schedule: "*/60 * * * *"
  jobTemplate:
    spec:
      template:
        metadata:
          labels:
            app.kubernetes.io/part-of: testnet-addons
            app.kubernetes.io/instance: release-name
            app.kubernetes.io/name: load-test
          annotations:
            seccomp.security.alpha.kubernetes.io/pod: runtime/default
        spec:
          restartPolicy: Never
          priorityClassName: release-name-testnet-addons-high
          containers:
          - name: load-test
            image: aptoslabs/tools:devnet
            imagePullPolicy: IfNotPresent
            command:
            - transaction-emitter
            - emit-tx
            - --mint-key=
            - --chain-id=
            # Build targets args for internal cluster targets
            # Either provide target TPS or mempool backlog
            - --target-tps=100000
            - --duration=3300
            - --txn-expiration-time-secs=60
            env:
            - name: RUST_BACKTRACE
              value: "1"
            - name: REUSE_ACC
              value: "1"
            resources:
              limits:
                cpu: "20"
                memory: 26Gi
              requests:
                cpu: "20"
                memory: 26Gi
            securityContext:
              readOnlyRootFilesystem: true
              allowPrivilegeEscalation: false
              capabilities:
                drop:
                - ALL
          securityContext:
            runAsNonRoot: true
            runAsUser: 6180
            runAsGroup: 6180
            fsGroup: 6180
          serviceAccountName: release-name-testnet-addons
```

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5585)
<!-- Reviewable:end -->
