### PR TITLE
[aptos-vm] Adjust severity of some error codes.

### DIFF
--- a/aptos-move/aptos-vm/src/errors.rs
+++ b/aptos-move/aptos-vm/src/errors.rs
@@ -172,8 +172,9 @@ pub fn expect_only_successful_execution(
         VMStatus::Executed => VMStatus::Executed,
 
         status => {
-            log_context.alert();
-            error!(
+            // Only trigger a warning here as some errors could be a result of the speculative parallel execution.
+            // We will report the errors after we obtained the final transaction output in update_counters_for_processed_chunk
+            warn!(
                 *log_context,
                 "[aptos_vm] Unexpected error from known Move function, '{}'. Error: {:?}",
                 function_name,


### PR DESCRIPTION
### Description

Adjust the error severity of Move functions inside AptosVM. Currently the known move functions such as block prologue, txn prologue and epilogue are viewed as non fallible from `AptosVM`. This should be the case only with sequential execution though, as with speculative parallel execution, some of the functions may fail because prior txn hasn't been scheduled to be executed yet. 

This happens quite frequently to the blockmetadata transaction during state sync where multiple block metadata transactions are executed at once, which created very nasty false positive alarms for on call.

### Test Plan

TBD

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5586)
<!-- Reviewable:end -->
