### PR TITLE
[consensus][e2e] Add e2e smoke test for changing onchain config and voting history fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8802,6 +8802,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos",
+ "aptos-bitvec",
  "aptos-config",
  "aptos-crypto",
  "aptos-debugger",

--- a/crates/aptos/src/node/analyze/fetch_metadata.rs
+++ b/crates/aptos/src/node/analyze/fetch_metadata.rs
@@ -15,7 +15,7 @@ const MAX_FETCH_BATCH_SIZE: u16 = 1000;
 pub struct ValidatorInfo {
     pub address: AccountAddress,
     pub voting_power: u64,
-    pub validator_index: u64,
+    pub validator_index: u16,
 }
 
 pub struct EpochInfo {

--- a/testsuite/forge/src/interface/aptos.rs
+++ b/testsuite/forge/src/interface/aptos.rs
@@ -12,7 +12,10 @@ use aptos_sdk::{
     types::{
         account_address::AccountAddress,
         chain_id::ChainId,
-        transaction::authenticator::{AuthenticationKey, AuthenticationKeyPreimage},
+        transaction::{
+            authenticator::{AuthenticationKey, AuthenticationKeyPreimage},
+            SignedTransaction,
+        },
         LocalAccount,
     },
 };
@@ -245,17 +248,22 @@ pub async fn reconfig(
     root_account: &mut LocalAccount,
 ) -> State {
     let aptos_version = client.get_aptos_version().await.unwrap();
-    let (current, state) = aptos_version.into_parts();
+    let current = aptos_version.into_inner();
     let current_version = *current.major.inner();
     let txn = root_account.sign_with_transaction_builder(
         transaction_factory
             .clone()
             .payload(aptos_stdlib::version_set_version(current_version + 1)),
     );
+    submit_and_wait_reconfig(client, txn).await
+}
+
+pub async fn submit_and_wait_reconfig(client: &RestClient, txn: SignedTransaction) -> State {
+    let state = client.get_ledger_information().await.unwrap().into_inner();
     let result = client.submit_and_wait(&txn).await;
     if let Err(e) = result {
         let last_transactions = client
-            .get_account_transactions(root_account.address(), None, None)
+            .get_account_transactions(txn.sender(), None, None)
             .await
             .map(|result| {
                 result
@@ -277,7 +285,7 @@ pub async fn reconfig(
         panic!(
             "Couldn't execute {:?}, for account {:?}, error {:?}, last account transactions: {:?}",
             txn,
-            root_account,
+            txn.sender(),
             e,
             last_transactions.unwrap_or_default()
         )
@@ -291,13 +299,8 @@ pub async fn reconfig(
         .unwrap();
 
     info!(
-        "Changed aptos version from {} (epoch={}, ledger_v={}), to {}, (epoch={}, ledger_v={})",
-        current_version,
-        state.epoch,
-        state.version,
-        current_version + 1,
-        new_state.epoch,
-        new_state.version
+        "Applied reconfig from (epoch={}, ledger_v={}), to (epoch={}, ledger_v={})",
+        state.epoch, state.version, new_state.epoch, new_state.version
     );
     assert_ne!(state.epoch, new_state.epoch);
 

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos = { workspace = true, features = ["fuzzing"] }
+aptos-bitvec = { path = "../../crates/aptos-bitvec" }
 aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-debugger = { workspace = true }


### PR DESCRIPTION
running locally with:
LOCAL_SWARM_NODE_RELEASE=1 cargo test --release --package smoke-test --lib -- aptos_cli::validator::test_onchain_config_change --exact --nocapture

we get:
With new config: 23 rounds from vote to elected: Some(20) to Some(43)
With old config: 61 rounds from vote to elected: Some(12) to Some(73)


copy of #4986, as it was incorrectly merged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5594)
<!-- Reviewable:end -->
