### PR TITLE
[forge] Fix flaky forge tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,6 +3958,7 @@ name = "forge-cli"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "aptos-config",
  "aptos-global-constants",
  "aptos-logger",
  "aptos-rest-client",

--- a/testsuite/forge-cli/Cargo.toml
+++ b/testsuite/forge-cli/Cargo.toml
@@ -19,6 +19,7 @@ structopt = "0.3.21"
 tokio = { version = "1.21.0", features = ["full"] }
 url = "2.2.2"
 
+aptos-config = { path = "../../config" }
 aptos-global-constants = { path = "../../config/global-constants" }
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-rest-client = { path = "../../crates/aptos-rest-client" }


### PR DESCRIPTION
### Description
- using output state sync for a few more tests
- updating gracefull backoff for tests where block sizes are reduced 
- not retrying transaction waiting, waiting is now fixed to wait as much as needed. reduced parallelism a bit, as we have failures like these sometimes - https://github.com/aptos-labs/aptos-core/actions/runs/3461311500/jobs/5778754867

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5595)
<!-- Reviewable:end -->
