### PR TITLE
[docs] fix compile error due to missing section_name

### DIFF
--- a/aptos-move/move-examples/moon_coin/scripts/register.move
+++ b/aptos-move/move-examples/moon_coin/scripts/register.move
@@ -1,5 +1,7 @@
+//:!:>moon
 script {
     fun register(account: &signer) {
         aptos_framework::managed_coin::register<MoonCoin::moon_coin::MoonCoin>(account)
     }
 }
+//<:!:moon

--- a/developer-docs-site/docs/tutorials/first-coin.md
+++ b/developer-docs-site/docs/tutorials/first-coin.md
@@ -256,7 +256,7 @@ public entry fun registerCoinType(account: &signer) {
 MoonCoin uses `ManagedCoin` that provides an entry function wrapper: `managed_coin::register`. Here is an example script for registration:
 
 ```rust
-:!: static/move-examples/moon_coin/scripts/register.move
+:!: static/move-examples/moon_coin/scripts/register.move moon
 ```
 
 ---


### PR DESCRIPTION
### Description

Docs were not compiling due to missing `section_name` within `/docs/tutorials/first-coin.md`

<img width="754" alt="image" src="https://user-images.githubusercontent.com/98909677/202308954-7140f883-6433-4420-b2a4-030e20187cb9.png">
<img width="1272" alt="image" src="https://user-images.githubusercontent.com/98909677/202309065-568876a1-7966-4a4e-a068-608503c6f8ca.png">

### Test Plan
Compile docs and verify `/tutorials/your-first-coin/#step-432-registering-a-coin`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5596)
<!-- Reviewable:end -->
