### PR TITLE
[docs] Adjust Primary Color for Search within light mode

### DIFF
--- a/developer-docs-site/src/css/custom.css
+++ b/developer-docs-site/src/css/custom.css
@@ -26,7 +26,6 @@ html[data-theme='dark'] {
   --ifm-background-color: #121616;
   --ifm-color-primary: #ffffff;
   --ifm-color-primary-inverse: black;
-
   --ifm-color-primary-dark: #06f7f7;
   --ifm-color-primary-darker: #00dadc;
   --ifm-color-primary-darkest: #00adb2;
@@ -55,7 +54,7 @@ img.deep-dive-image {
 }
 
 [data-theme='light'] .DocSearch {
-  --docsearch-primary-color: var(--ifm-color-primary-light);
+  --docsearch-primary-color: var(--ifm-color-primary-dark);
   /* --docsearch-text-color: var(--ifm-font-color-base); */
   --docsearch-muted-color: var(--ifm-color-secondary-darkest);
   --docsearch-container-background: rgba(94, 100, 112, 0.7);


### PR DESCRIPTION
### Description
Fixes color contrast issue for Algolia Search within light mode. 

Before:

<img width="1479" alt="image" src="https://user-images.githubusercontent.com/98909677/202314242-6acfa3c5-57a9-47a7-ac4b-8f6b086fcfdb.png">

After:

<img width="1479" alt="image" src="https://user-images.githubusercontent.com/98909677/202314275-e2cfcfd6-6122-4c7b-b949-1e824d0d6f3b.png">


### Test Plan
Review Docs in light mode and test search for readability issues related to color contrast.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5598)
<!-- Reviewable:end -->
