### PR TITLE
Fix functions for getting all resources / modules on an account by using pagination

### DIFF
--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -112,6 +112,10 @@ jobs:
       - run: wait-on -t 60000 --httpTimeout 60000 http-get://127.0.0.1:8080/v1
       - run: wait-on -t 60000 --httpTimeout 60000 http-get://127.0.0.1:8081/health
 
+      # Confirm the Rust API client examples pass.
+      - uses: ./.github/actions/rust-setup
+      - run: cargo run -p aptos-rest-client --example account -- --api-url http://127.0.01:8080
+
       # Test and build.
       - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
         name: sdk-pnpm-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,6 +1113,7 @@ dependencies = [
  "aptos-types",
  "bcs 0.1.3 (git+https://github.com/aptos-labs/bcs?rev=2cde3e8446c460cb17b0c1d6bac7e27e964ac169)",
  "bytes 1.2.1",
+ "clap 3.2.17",
  "futures",
  "hex",
  "move-binary-format",

--- a/api/types/src/headers.rs
+++ b/api/types/src/headers.rs
@@ -15,3 +15,5 @@ pub const X_APTOS_BLOCK_HEIGHT: &str = "X-Aptos-Block-Height";
 pub const X_APTOS_OLDEST_BLOCK_HEIGHT: &str = "X-Aptos-Oldest-Block-Height";
 /// Current timestamp of the chain
 pub const X_APTOS_LEDGER_TIMESTAMP: &str = "X-Aptos-Ledger-TimestampUsec";
+/// Cursor used for pagination.
+pub const X_APTOS_CURSOR: &str = "X-Aptos-Cursor";

--- a/crates/aptos-rest-client/Cargo.toml
+++ b/crates/aptos-rest-client/Cargo.toml
@@ -36,3 +36,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
+
+[dev-dependencies]
+clap = { workspace = true }

--- a/crates/aptos-rest-client/examples/README.md
+++ b/crates/aptos-rest-client/examples/README.md
@@ -1,0 +1,13 @@
+# REST client examples
+
+Really these examples serve as end-to-end tests for the REST client. These are not standard tests because they are should not be run as part of the standard `cargo test` infra, since they expect an Aptos API to be running already.
+
+You can run examples like this, from the parent directory:
+```
+cargo run --example <dir>
+```
+
+For example:
+```
+cargo run --example account -- --api-url http://127.0.0.1:8080
+```

--- a/crates/aptos-rest-client/examples/account/main.rs
+++ b/crates/aptos-rest-client/examples/account/main.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use aptos_logger::{debug, info};
+use aptos_rest_client::Client;
+use aptos_types::{account_address::AccountAddress, chain_id::ChainId};
+use clap::Parser;
+use reqwest::Url;
+
+#[derive(Debug, Parser)]
+#[clap(author, version, about)]
+pub struct Args {
+    /// This should include the port, e.g. http://127.0.0.1:8080
+    #[clap(long)]
+    api_url: Url,
+}
+
+// It isn't great to have all these tests together like this, but it's an okay
+// start given we had nothing at all prior to this.
+#[tokio::main]
+async fn main() -> Result<()> {
+    aptos_logger::Logger::new().init();
+
+    let args = Args::parse();
+    debug!("Running with args: {:#?}", args);
+
+    let client = Client::new(args.api_url);
+
+    let address = AccountAddress::ONE;
+    info!("Running all queries against account: {}", address);
+
+    let results = client
+        .get_account_resources(address)
+        .await
+        .context("Failed get_account_resources")?;
+    info!(
+        "Successfully retrieved {} account resources with JSON",
+        results.inner().len()
+    );
+
+    let results = client
+        .get_account_resources_bcs(address)
+        .await
+        .context("Failed get_account_resources_bcs")?;
+    info!(
+        "Successfully retrieved {} account resources with BCS",
+        results.inner().len()
+    );
+
+    let results = client
+        .get_account_modules(address)
+        .await
+        .context("Failed get_account_modules")?;
+    info!(
+        "Successfully retrieved {} account modules with JSON",
+        results.inner().len()
+    );
+
+    let results = client
+        .get_account_modules_bcs(address)
+        .await
+        .context("Failed get_account_modules_bcs")?;
+    info!(
+        "Successfully retrieved {} account modules with BCS",
+        results.inner().len()
+    );
+
+    let resource = "0x1::chain_id::ChainId";
+
+    client
+        .get_account_resource(address, resource)
+        .await
+        .context("Failed get_account_resource")?;
+    info!("Successfully retrieved resource {} with JSON", resource);
+
+    client
+        .get_account_resource_bcs::<ChainId>(address, resource)
+        .await
+        .context("Failed get_account_resource_bcs")?;
+    info!("Successfully retrieved resource {} with BCS", resource);
+
+    Ok(())
+}

--- a/crates/aptos-rest-client/src/state.rs
+++ b/crates/aptos-rest-client/src/state.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_api_types::{
-    X_APTOS_BLOCK_HEIGHT, X_APTOS_CHAIN_ID, X_APTOS_EPOCH, X_APTOS_LEDGER_OLDEST_VERSION,
-    X_APTOS_LEDGER_TIMESTAMP, X_APTOS_LEDGER_VERSION, X_APTOS_OLDEST_BLOCK_HEIGHT,
+    X_APTOS_BLOCK_HEIGHT, X_APTOS_CHAIN_ID, X_APTOS_CURSOR, X_APTOS_EPOCH,
+    X_APTOS_LEDGER_OLDEST_VERSION, X_APTOS_LEDGER_TIMESTAMP, X_APTOS_LEDGER_VERSION,
+    X_APTOS_OLDEST_BLOCK_HEIGHT,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
@@ -15,6 +16,7 @@ pub struct State {
     pub oldest_ledger_version: u64,
     pub oldest_block_height: u64,
     pub block_height: u64,
+    pub cursor: Option<String>,
 }
 
 impl State {
@@ -47,6 +49,10 @@ impl State {
             .get(X_APTOS_OLDEST_BLOCK_HEIGHT)
             .and_then(|h| h.to_str().ok())
             .and_then(|s| s.parse().ok());
+        let cursor = headers
+            .get(X_APTOS_CURSOR)
+            .and_then(|h| h.to_str().ok())
+            .map(|s| s.to_string());
 
         let state = if let (
             Some(chain_id),
@@ -56,6 +62,7 @@ impl State {
             Some(oldest_ledger_version),
             Some(block_height),
             Some(oldest_block_height),
+            cursor,
         ) = (
             maybe_chain_id,
             maybe_version,
@@ -64,6 +71,7 @@ impl State {
             maybe_oldest_ledger_version,
             maybe_block_height,
             maybe_oldest_block_height,
+            cursor,
         ) {
             Self {
                 chain_id,
@@ -73,6 +81,7 @@ impl State {
                 oldest_ledger_version,
                 block_height,
                 oldest_block_height,
+                cursor,
             }
         } else {
             anyhow::bail!(


### PR DESCRIPTION
### Description
This PR adds support for using the pagination added in https://github.com/aptos-labs/aptos-core/pull/5313.

You'll see that there are two functions, `paginate_with_cursor` and `paginate_with_cursor_bcs`. They're pretty similar, but I think the extra logic required to have just one function would be more complex than it's worth (it'd probably necessitate a trait and/or some extra closures passed into the function for building the collections).

### Test Plan
For now I've tested manually by lowering the limit values and adding printing and I can see that it indeed makes multiple requests, doesn't loop forever, merges the data correctly, etc. We should add tests, though the client is currently totally untested, so that'd require a bit of extra testing boilerplate.

I also need to see if CI passes, lots of stuff out there reaches into this crate in ways that we probably shouldn't have exposed.

**Update**: I have added tests by using cargo examples and added them to CI. They don't test the pagination case directly though (yet), since the account in question doesn't have more than 10k resources. That'll be harder to seed.