### PR TITLE
[Cargo] Migrate several crates to use workspace deps.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,7 +965,7 @@ dependencies = [
  "async-trait",
  "clap 3.2.17",
  "const_format",
- "env_logger 0.8.4",
+ "env_logger 0.9.0",
  "futures",
  "log",
  "once_cell",
@@ -3592,19 +3592,6 @@ checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
  "humantime 1.3.0",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "atty",
- "humantime 2.1.0",
  "log",
  "regex",
  "termcolor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,81 +175,137 @@ aptos-build-info = { path = "crates/aptos-build-info" }
 aptos-compression = { path = "crates/aptos-compression" }
 aptos-config = { path = "config" }
 aptos-crypto = { path = "crates/aptos-crypto" }
+aptos-crypto-derive = { path = "crates/aptos-crypto-derive" }
 aptos-data-client = { path = "state-sync/aptos-data-client" }
+aptos-fh-stream = { path = "ecosystem/sf-indexer/firehose-stream" }
 aptos-gas = { path = "aptos-move/aptos-gas" }
 aptos-genesis = { path = "crates/aptos-genesis" }
+aptos-global-constants = { path = "config/global-constants" }
 aptos-id-generator = { path = "crates/aptos-id-generator" }
+aptos-indexer = { path = "crates/indexer" }
 aptos-infallible = { path = "crates/aptos-infallible" }
+aptos-keygen = { path = "crates/aptos-keygen" }
 aptos-logger = { path = "crates/aptos-logger" }
 aptos-mempool = { path = "mempool" }
 aptos-metrics-core = { path = "crates/aptos-metrics-core" }
+aptos-network-checker = { path = "crates/aptos-network-checker" }
+aptos-node-checker = { path = "ecosystem/node-checker" }
 aptos-openapi = { path = "crates/aptos-openapi" }
 aptos-proptest-helpers = { path = "crates/aptos-proptest-helpers" }
+aptos-protos = { path = "crates/aptos-protos" }
+aptos-rest-client = { path = "crates/aptos-rest-client" }
 aptos-sdk = { path = "sdk" }
+aptos-secure-net = { path = "secure/net" }
+aptos-secure-storage = { path = "secure/storage" }
 aptos-state-view = { path = "storage/state-view" }
+aptos-telemetry = { path = "crates/aptos-telemetry" }
 aptos-temppath = { path = "crates/aptos-temppath" }
 aptos-time-service = { path = "crates/aptos-time-service" }
 aptos-types = { path = "types" }
+aptos-vault-client = { path = "secure/storage/vault" }
 aptos-vm = { path = "aptos-move/aptos-vm" }
 aptosdb = { path = "storage/aptosdb" }
+backup-service = { path = "storage/backup/backup-service" }
 bounded-executor = { path = "crates/bounded-executor" }
 cached-packages = { path = "aptos-move/framework/cached-packages" }
 channel = { path = "crates/channel" }
+consensus = { path = "consensus" }
 consensus-notifications = { path = "state-sync/inter-component/consensus-notifications" }
+consensus-types = { path = "consensus/consensus-types" }
+crash-handler = { path = "crates/crash-handler" }
 data-streaming-service = { path = "state-sync/state-sync-v2/data-streaming-service" }
 event-notifications = { path = "state-sync/inter-component/event-notifications" }
 executor = { path = "execution/executor" }
 executor-test-helpers = { path = "execution/executor-test-helpers" }
 executor-types = { path = "execution/executor-types" }
+fallible = { path = "crates/fallible" }
+framework = { path = "aptos-move/framework" }
+inspection-service = { path = "crates/inspection-service" }
 mempool-notifications = { path = "state-sync/inter-component/mempool-notifications" }
 netcore = { path = "network/netcore" }
 network = { path = "network" }
+network-builder = { path = "network/builder" }
+safety-rules = { path = "consensus/safety-rules" }
 schemadb = { path = "storage/schemadb" }
 scratchpad = { path = "storage/scratchpad" }
 short-hex-str = { path = "crates/short-hex-str" }
+state-sync-driver = { path = "state-sync/state-sync-v2/state-sync-driver" }
 storage-interface = { path = "storage/storage-interface" }
 storage-service-client = { path = "state-sync/storage-service/client" }
 storage-service-server = { path = "state-sync/storage-service/server" }
 storage-service-types = { path = "state-sync/storage-service/types" }
+transaction-emitter-lib = { path = "crates/transaction-emitter-lib" }
 vm-genesis = { path = "aptos-move/vm-genesis" }
 vm-validator = { path = "vm-validator" }
 
 # External crate dependencies.
 # Please do not add any test features here: they should be declared by the individual crate.
-anyhow = "1.0.57"
+anyhow = "1.0.62"
+async-stream = "0.3"
 async-trait = "0.1.53"
+base64 = "0.13.0"
 bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" }
+bigdecimal = { version = "0.3.0", features = ["serde"] }
+byteorder = "1.4.3"
 bytes = "1.1.0"
+chrono = { version = "0.4.19", features = ["clock", "serde"] }
 claims = "0.7"
-clap = "3.1.17"
+clap = "3.2.17"
+const_format = "0.2.26"
+criterion = "0.3.5"
+diesel = { version = "1.4.8", features = ["chrono", "postgres", "r2d2", "numeric", "serde_json"] }
+diesel_migrations = { version = "1.4.0", features = ["postgres"] }
 enum_dispatch = "0.3.8"
+env_logger = "0.9.0"
 fail = "0.5.0"
-futures = "0.3.21"
+field_count = "0.1.1"
+futures = "= 0.3.24" # Previously futures v0.3.23 caused some consensus network_tests to fail. We now pin the dependency to v0.3.24.
+futures-channel = "= 0.3.24"
+gcp-bigquery-client = "0.13.0"
+get_if_addrs = "0.5.3"
 goldenfile = "1.1.0"
 hex = "0.4.3"
-hyper = "0.14.18"
+http = "0.2.3"
+hyper = { version = "0.14.18", features = ["full"] }
 indoc = "1.0.6"
 itertools = "0.10.3"
+jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
+log = "0.4.17"
 lru = "0.7.5"
 maplit = "1.0.2"
 mime = "0.3.16"
+mirai-annotations = "1.12.0"
 mockall = "0.11.0"
+num-derive = "0.3.3"
 num-traits = "0.2.15"
 once_cell = "1.10.0"
 paste = "1.0.7"
+pbjson = "0.4.0"
 percent-encoding = "2.1.0"
 poem = { version = "1.3.40", features = ["anyhow", "rustls"] }
-poem-openapi = { version = "2.0.10", features = ["url"] }
+poem-openapi = { version = "2.0.10", features = ["swagger-ui", "url"] }
+prometheus-parse = "0.2.2"
 proptest = "1.0.0"
+prost = "0.10.4"
+prost-types = "0.10.1"
 rand = "0.7.3"
+rayon = "1.5.2"
 regex = "1.5.5"
-reqwest = { version = "0.11.10", features = ["blocking", "json"] }
-serde = { version = "1.0.137", features = ["derive"] }
+reqwest = { version = "0.11.11", features = ["blocking", "cookies", "json"] }
+reqwest-middleware = "0.1.6"
+reqwest-retry = "0.1.5"
+rusty-fork = "0.3.0"
+serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = { version = "1.0.81", features = ["preserve_order"] }
+serde_yaml = "0.8.24"
+substreams = "0.0.17"
+tempfile = "3.3.0"
 thiserror = "1.0.31"
 tokio = { version = "1.21.0", features = ["full"] }
+tokio-retry = "0.3.0"
 tokio-stream = "0.1.8"
-url = "2.2.2"
+tonic = { version = "0.7.2", features = ["tls-roots", "transport", "prost", "compression", "codegen"] }
+url = { version = "2.2.2", features = ["serde"] }
 warp = { version = "0.3.2" }
 warp-reverse-proxy = "0.5.0"
 

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -13,58 +13,56 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.58"
-bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" }
-clap = "3.1.8"
-fail = "0.5.0"
-futures = "0.3.21"
-hex = "0.4.3"
-rand = "0.7.3"
-rayon = "1.5.2"
-tokio = { version = "1.21.0", features = ["full"] }
-tokio-stream = "0.1.8"
-
-aptos-api = { path = "../api" }
-aptos-build-info = { path = "../crates/aptos-build-info" }
-aptos-config = { path = "../config" }
-aptos-crypto = { path = "../crates/aptos-crypto" }
-aptos-data-client = { path = "../state-sync/aptos-data-client" }
-aptos-fh-stream = { path = "../ecosystem/sf-indexer/firehose-stream" }
-aptos-genesis = { path = "../crates/aptos-genesis", features = ["testing"] }
-aptos-indexer = { path = "../crates/indexer", optional = true }
-aptos-infallible = { path = "../crates/aptos-infallible" }
-aptos-logger = { path = "../crates/aptos-logger" }
-aptos-mempool = { path = "../mempool" }
-aptos-secure-storage = { path = "../secure/storage" }
-aptos-state-view = { path = "../storage/state-view" }
-aptos-telemetry = { path = "../crates/aptos-telemetry" }
-aptos-temppath = { path = "../crates/aptos-temppath" }
-aptos-time-service = { path = "../crates/aptos-time-service" }
-aptos-types = { path = "../types" }
-aptos-vm = { path = "../aptos-move/aptos-vm" }
-
-aptosdb = { path = "../storage/aptosdb" }
-backup-service = { path = "../storage/backup/backup-service" }
-cached-packages = { path = "../aptos-move/framework/cached-packages" }
-consensus = { path = "../consensus" }
-consensus-notifications = { path = "../state-sync/inter-component/consensus-notifications" }
-crash-handler = { path = "../crates/crash-handler" }
-data-streaming-service = { path = "../state-sync/state-sync-v2/data-streaming-service" }
-event-notifications = { path = "../state-sync/inter-component/event-notifications" }
-executor = { path = "../execution/executor" }
-executor-types = { path = "../execution/executor-types" }
-framework = { path = "../aptos-move/framework" }
-inspection-service = { path = "../crates/inspection-service" }
-mempool-notifications = { path = "../state-sync/inter-component/mempool-notifications" }
-network = { path = "../network" }
-network-builder = { path = "../network/builder" }
-state-sync-driver = { path = "../state-sync/state-sync-v2/state-sync-driver" }
-storage-interface = { path = "../storage/storage-interface" }
-storage-service-client = { path = "../state-sync/storage-service/client" }
-storage-service-server = { path = "../state-sync/storage-service/server" }
+anyhow = { workspace = true }
+aptos-api = { workspace = true }
+aptos-build-info = { workspace = true }
+aptos-config = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-data-client = { workspace = true }
+aptos-fh-stream = { workspace = true }
+aptos-genesis = { workspace = true }
+aptos-indexer = { workspace = true, optional = true }
+aptos-infallible = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-mempool = { workspace = true }
+aptos-secure-storage = { workspace = true }
+aptos-state-view = { workspace = true }
+aptos-telemetry = { workspace = true }
+aptos-temppath = { workspace = true }
+aptos-time-service = { workspace = true }
+aptos-types = { workspace = true }
+aptos-vm = { workspace = true }
+aptosdb = { workspace = true }
+backup-service = { workspace = true }
+bcs = { workspace = true }
+cached-packages = { workspace = true }
+clap = { workspace = true }
+consensus = { workspace = true }
+consensus-notifications = { workspace = true }
+crash-handler = { workspace = true }
+data-streaming-service = { workspace = true }
+event-notifications = { workspace = true }
+executor = { workspace = true }
+executor-types = { workspace = true }
+fail = { workspace = true }
+framework = { workspace = true }
+futures = { workspace = true }
+hex = { workspace = true }
+inspection-service = { workspace = true }
+mempool-notifications = { workspace = true }
+network = { workspace = true }
+network-builder = { workspace = true }
+rand = { workspace = true }
+rayon = { workspace = true }
+state-sync-driver = { workspace = true }
+storage-interface = { workspace = true }
+storage-service-client = { workspace = true }
+storage-service-server = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
+jemallocator = { workspace = true }
 
 [features]
 default = []

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -13,29 +13,27 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.57"
-bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" }
-byteorder = "1.4.3"
-get_if_addrs = { version = "0.5.3", default-features = false }
-mirai-annotations = "1.12.0"
-poem-openapi = { version = "2.0.10", features = ["url"] }
-rand = "0.7.3"
-serde = { version = "1.0.137", features = ["rc"], default-features = false }
-serde_yaml = "0.8.24"
-thiserror = "1.0.31"
-
-aptos-crypto = { path = "../crates/aptos-crypto" }
-aptos-crypto-derive = { path = "../crates/aptos-crypto-derive" }
-aptos-global-constants = { path = "./global-constants" }
-aptos-logger = { path = "../crates/aptos-logger" }
-aptos-secure-storage = { path = "../secure/storage" }
-aptos-temppath = { path = "../crates/aptos-temppath" }
-aptos-types = { path = "../types" }
-
-short-hex-str = { path = "../crates/short-hex-str" }
+anyhow = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-crypto-derive = { workspace = true }
+aptos-global-constants = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-secure-storage = { workspace = true }
+aptos-temppath = { workspace = true }
+aptos-types = { workspace = true }
+bcs = { workspace = true }
+byteorder = { workspace = true }
+get_if_addrs = { workspace = true }
+mirai-annotations = { workspace = true }
+poem-openapi = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_yaml = { workspace = true }
+short-hex-str = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-aptos-crypto = { path = "../crates/aptos-crypto", features = ["fuzzing"] }
+aptos-crypto = { workspace = true }
 
 [features]
 default = []

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -13,66 +13,61 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.57"
-async-trait = "0.1.53"
-bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" }
-byteorder = { version = "1.4.3" }
-bytes = "1.1.0"
-fail = "0.5.0"
-# Previously: Pinning futures to 0.3.21, since release v0.3.23 is causing the network_tests to fail because messages are not received in the channel.
-# Now: Some futures crates were using 0.3.23 as well, which is not a good idea. 0.3.23 has a known issues, so moving to 0.3.24.
-futures = "= 0.3.24"
-futures-channel = "= 0.3.24"
-itertools = { version = "0.10.3", default-features = false }
-mirai-annotations = { version = "1.12.0", default-features = false }
-num-derive = { version = "0.3.3", default-features = false }
-num-traits = { version = "0.2.15", default-features = false }
-once_cell = "1.10.0"
-rand = { version = "0.7.3", default-features = false }
-serde = { version = "1.0.137", default-features = false }
-serde_json = "1.0.81"
-thiserror = "1.0.31"
-tokio = { version = "1.21.0", features = ["full"] }
-
-aptos-bitvec = { path = "../crates/aptos-bitvec" }
-aptos-config = { path = "../config" }
-aptos-crypto = { path = "../crates/aptos-crypto" }
-aptos-infallible = { path = "../crates/aptos-infallible" }
-aptos-logger = { path = "../crates/aptos-logger" }
-aptos-mempool = { path = "../mempool" }
-aptos-metrics-core = { path = "../crates/aptos-metrics-core" }
-aptos-secure-storage = { path = "../secure/storage" }
-aptos-temppath = { path = "../crates/aptos-temppath" }
-aptos-types = { path = "../types" }
-aptos-vm = { path = "../aptos-move/aptos-vm" }
-
-channel = { path = "../crates/channel" }
-consensus-notifications = { path = "../state-sync/inter-component/consensus-notifications" }
-consensus-types = { path = "consensus-types", default-features = false }
-event-notifications = { path = "../state-sync/inter-component/event-notifications" }
-executor = { path = "../execution/executor" }
-executor-types = { path = "../execution/executor-types" }
-fallible = { path = "../crates/fallible" }
-network = { path = "../network" }
-safety-rules = { path = "safety-rules" }
-schemadb = { path = "../storage/schemadb" }
-short-hex-str = { path = "../crates/short-hex-str" }
-storage-interface = { path = "../storage/storage-interface" }
+anyhow = { workspace = true }
+aptos-bitvec = { workspace = true }
+aptos-config = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-infallible = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-mempool = { workspace = true }
+aptos-metrics-core = { workspace = true }
+aptos-secure-storage = { workspace = true }
+aptos-temppath = { workspace = true }
+aptos-types = { workspace = true }
+aptos-vm = { workspace = true }
+async-trait = { workspace = true }
+bcs = { workspace = true }
+byteorder = { workspace = true }
+bytes = { workspace = true }
+channel = { workspace = true }
+consensus-notifications = { workspace = true }
+consensus-types = { workspace = true }
+event-notifications = { workspace = true }
+executor = { workspace = true }
+executor-types = { workspace = true }
+fail = { workspace = true }
+fallible = { workspace = true }
+futures = { workspace = true }
+futures-channel = { workspace = true }
+itertools = { workspace = true }
+mirai-annotations = { workspace = true }
+network = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
+once_cell = { workspace = true }
+rand = { workspace = true }
+safety-rules = { workspace = true }
+schemadb = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+short-hex-str = { workspace = true }
+storage-interface = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
-claims = "0.7"
-proptest = "1.0.0"
-tempfile = "3.3.0"
-
-aptos-config = { path = "../config", features = ["fuzzing"] }
-aptos-keygen = { path = "../crates/aptos-keygen" }
-aptos-mempool = { path = "../mempool", features = ["fuzzing"] }
-consensus-types = { path = "consensus-types", default-features = false, features = ["fuzzing"] }
-executor-test-helpers = { path = "../execution/executor-test-helpers" }
+aptos-config = { workspace = true, features = ["fuzzing"] }
+aptos-keygen = { workspace = true }
+aptos-mempool = { workspace = true, features = ["fuzzing"] }
+claims = { workspace = true }
+consensus-types = { workspace = true, features = ["fuzzing"] }
+executor-test-helpers = { workspace = true }
 move-core-types = { workspace = true }
-network = { path = "../network", features = ["fuzzing"] }
-safety-rules = { path = "safety-rules", features = ["testing"] }
-vm-validator = { path = "../vm-validator" }
+network = { workspace = true, features = ["fuzzing"] }
+proptest = { workspace = true }
+safety-rules = { workspace = true, features = ["testing"] }
+tempfile = { workspace = true }
+vm-validator = { workspace = true }
 
 [features]
 default = []

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -13,29 +13,26 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.57"
-bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" }
-futures = "0.3.12"
-itertools = "0.10.3"
-mirai-annotations = { version = "1.12.0", default-features = false }
-proptest = { version = "1.0.0", optional = true }
-rayon = "1.5.2"
-serde = { version = "1.0.137", default-features = false }
-
-aptos-bitvec = { path = "../../crates/aptos-bitvec" }
-aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-crypto-derive = { path = "../../crates/aptos-crypto-derive" }
-aptos-infallible = { path = "../../crates/aptos-infallible" }
-aptos-types = { path = "../../types" }
-
-executor-types = { path = "../../execution/executor-types" }
-short-hex-str = { path = "../../crates/short-hex-str" }
+anyhow = { workspace = true }
+aptos-bitvec = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-crypto-derive = { workspace = true }
+aptos-infallible = { workspace = true }
+aptos-types = { workspace = true }
+bcs = { workspace = true }
+executor-types = { workspace = true }
+futures = { workspace = true }
+itertools = { workspace = true }
+mirai-annotations = { workspace = true }
+proptest = { workspace = true, optional = true }
+rayon = { workspace = true }
+serde = { workspace = true }
+short-hex-str = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.0.0"
-serde_json = "1.0.81"
-
-aptos-types = { path = "../../types", features = ["fuzzing"] }
+aptos-types = { workspace = true, features = ["fuzzing"] }
+proptest = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 default = []

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -13,37 +13,35 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-once_cell = "1.10.0"
-proptest = { version = "1.0.0", optional = true }
-rand = { version = "0.7.3", default-features = false }
-serde = { version = "1.0.137", default-features = false }
-serde_json = "1.0.81"
-thiserror = "1.0.31"
-
-aptos-config = { path = "../../config" }
-aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-global-constants = { path = "../../config/global-constants" }
-aptos-infallible = { path = "../../crates/aptos-infallible" }
-aptos-logger = { path = "../../crates/aptos-logger" }
-aptos-metrics-core = { path = "../../crates/aptos-metrics-core" }
-aptos-proptest-helpers = { path = "../../crates/aptos-proptest-helpers", optional = true }
-aptos-secure-net = { path = "../../secure/net" }
-aptos-secure-storage = { path = "../../secure/storage" }
-aptos-temppath = { path = "../../crates/aptos-temppath" }
-aptos-types = { path = "../../types" }
-aptos-vault-client = { path = "../../secure/storage/vault" }
-consensus-types = { path = "../consensus-types" }
+aptos-config = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-global-constants = { workspace = true }
+aptos-infallible = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-metrics-core = { workspace = true }
+aptos-proptest-helpers = { workspace = true, optional = true }
+aptos-secure-net = { workspace = true }
+aptos-secure-storage = { workspace = true }
+aptos-temppath = { workspace = true }
+aptos-types = { workspace = true }
+aptos-vault-client = { workspace = true }
+consensus-types = { workspace = true }
+once_cell = { workspace = true }
+proptest = { workspace = true, optional = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-criterion = "0.3.5"
-proptest = "1.0.0"
-rusty-fork = "0.3.0"
-tempfile = "3.3.0"
-
-aptos-config = { path = "../../config", features = ["fuzzing"] }
-aptos-proptest-helpers = { path = "../../crates/aptos-proptest-helpers" }
-aptos-secure-storage = { path = "../../secure/storage", features = ["testing"] }
-consensus-types = { path = "../consensus-types", features = ["fuzzing"] }
+aptos-config = { workspace = true, features = ["fuzzing"] }
+aptos-proptest-helpers = { workspace = true }
+aptos-secure-storage = { workspace = true, features = ["testing"] }
+consensus-types = { workspace = true, features = ["fuzzing"] }
+criterion = { workspace = true }
+proptest = { workspace = true }
+rusty-fork = { workspace = true }
+tempfile = { workspace = true }
 
 [[bench]]
 name = "safety_rules"

--- a/ecosystem/node-checker/Cargo.toml
+++ b/ecosystem/node-checker/Cargo.toml
@@ -13,34 +13,32 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.57"
-async-trait = "0.1.53"
-clap = { version = "3.1.17", features = ["derive"] }
-const_format = "0.2.26"
-env_logger = "0.8.4"
-futures = "0.3.21"
-log = "0.4"
-once_cell = "1.10.0"
-poem = { version = "1.3.40", features = ["anyhow"] }
-poem-openapi = { version = "2.0.10", features = ["swagger-ui", "url"] }
-prometheus-parse = "0.2.2"
-reqwest = { version = "0.11.10", features = ["cookies"] }
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
-serde_yaml = "0.8.24"
-thiserror = "1.0.31"
-tokio = { version = "1.21.0", features = ["full"] }
-url = { version = "2.2.2", features = ["serde"] }
-
-aptos-api = { path = "../../api" }
-aptos-config = { path = "../../config" }
-aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-logger = { path = "../../crates/aptos-logger" }
-aptos-network-checker = { path = "../../crates/aptos-network-checker" }
-aptos-rest-client = { path = "../../crates/aptos-rest-client" }
-aptos-sdk = { path = "../../sdk" }
-
-transaction-emitter-lib = { path = "../../crates/transaction-emitter-lib" }
+anyhow = { workspace = true }
+aptos-api = { workspace = true }
+aptos-config = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-network-checker = { workspace = true }
+aptos-rest-client = { workspace = true }
+aptos-sdk = { workspace = true }
+async-trait = { workspace = true }
+clap = { workspace = true }
+const_format = { workspace = true }
+env_logger = { workspace = true }
+futures = { workspace = true }
+log = { workspace = true }
+once_cell = { workspace = true }
+poem = { workspace = true }
+poem-openapi = { workspace = true }
+prometheus-parse = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+transaction-emitter-lib = { workspace = true }
+url = { workspace = true }
 
 [lib]
 name = "aptos_node_checker_lib"

--- a/ecosystem/node-checker/fn-check-client/Cargo.toml
+++ b/ecosystem/node-checker/fn-check-client/Cargo.toml
@@ -13,15 +13,15 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.62"
-aptos-node-checker = { path = "../" }
-aptos-sdk = { path = "../../../sdk" }
-clap = "3.2.17"
-env_logger = "0.9.0"
-futures = "0.3.21"
-gcp-bigquery-client = "0.13.0"
-log = "0.4.17"
-reqwest = "0.11.11"
-serde = "1.0.144"
-serde_json = "1.0.85"
-tokio = { version = "1.21.0", features = ["macros", "rt-multi-thread"] }
+anyhow = { workspace = true }
+aptos-node-checker = { workspace = true }
+aptos-sdk = { workspace = true }
+clap = { workspace = true }
+env_logger = { workspace = true }
+futures = { workspace = true }
+gcp-bigquery-client = { workspace = true }
+log = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }

--- a/ecosystem/sf-indexer/firehose-stream/Cargo.toml
+++ b/ecosystem/sf-indexer/firehose-stream/Cargo.toml
@@ -13,57 +13,54 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.57"
-base64 = "0.13.0"
-bytes = "1.1.0"
-chrono = { version = "0.4.19", default-features = false, features = ["clock", "serde"] }
-fail = "0.5.0"
-futures = "0.3.21"
-hex = "0.4.3"
-hyper = "0.14.18"
-once_cell = "1.10.0"
-prost = "0.10.4"
-serde = { version = "1.0.137", features = ["derive"], default-features = false }
-serde_json = { version = "1.0.81", features = ["preserve_order"] }
-tokio = { version = "1.21.0", features = ["full"] }
-
-aptos-api = { path = "../../../api", package = "aptos-api" }
-aptos-api-types = { path = "../../../api/types" }
-aptos-bitvec = { path = "../../../crates/aptos-bitvec" }
-aptos-config = { path = "../../../config" }
-aptos-logger = { path = "../../../crates/aptos-logger" }
-aptos-mempool = { path = "../../../mempool" }
-aptos-metrics-core = { path = "../../../crates/aptos-metrics-core" }
-aptos-protos = { path = "../../../crates/aptos-protos" }
-aptos-types = { path = "../../../types" }
-aptos-vm = { path = "../../../aptos-move/aptos-vm" }
-storage-interface = { path = "../../../storage/storage-interface" }
-
+anyhow = { workspace = true }
+aptos-api = { workspace = true }
+aptos-api-types = { workspace = true }
+aptos-bitvec = { workspace = true }
+aptos-config = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-mempool = { workspace = true }
+aptos-metrics-core = { workspace = true }
+aptos-protos = { workspace = true }
+aptos-types = { workspace = true }
+aptos-vm = { workspace = true }
+base64 = { workspace = true }
+bytes = { workspace = true }
+chrono = { workspace = true }
+fail = { workspace = true }
+futures = { workspace = true }
+hex = { workspace = true }
+hyper = { workspace = true }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 move-package = { workspace = true }
+once_cell = { workspace = true }
+prost = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+storage-interface = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
-goldenfile = "1.1.0"
-rand = "0.7.3"
-regex = "1.5.5"
-
-aptos-api-test-context  = { path = "../../../api/test-context" }
-aptos-crypto = { path = "../../../crates/aptos-crypto" }
-aptos-genesis = { path = "../../../crates/aptos-genesis", features = ["testing"] }
-aptos-global-constants = { path = "../../../config/global-constants" }
-aptos-mempool = { path = "../../../mempool", features = ["fuzzing"] }
-aptos-proptest-helpers = { path = "../../../crates/aptos-proptest-helpers" }
-aptos-sdk = { path = "../../../sdk" }
-aptos-secure-storage = { path = "../../../secure/storage" }
-aptos-temppath = { path = "../../../crates/aptos-temppath" }
-aptos-vm = { path = "../../../aptos-move/aptos-vm" }
-aptosdb = { path = "../../../storage/aptosdb", features = ["fuzzing"] }
-executor = { path = "../../../execution/executor" }
-executor-types = { path = "../../../execution/executor-types" }
-framework = { path = "../../../aptos-move/framework" }
-mempool-notifications = { path = "../../../state-sync/inter-component/mempool-notifications" }
-vm-validator = { path = "../../../vm-validator" }
+aptos-api-test-context  = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-genesis = { workspace = true }
+aptos-global-constants = { workspace = true }
+aptos-mempool = { workspace = true }
+aptos-proptest-helpers = { workspace = true }
+aptos-sdk = { workspace = true }
+aptos-secure-storage = { workspace = true }
+aptos-temppath = { workspace = true }
+aptos-vm = { workspace = true }
+aptosdb = { workspace = true }
+executor = { workspace = true }
+executor-types = { workspace = true }
+framework = { workspace = true }
+goldenfile = { workspace = true }
+mempool-notifications = { workspace = true }
+rand = { workspace = true }
+regex = { workspace = true }
+vm-validator = { workspace = true }
 
 [features]
 failpoints = ["fail/failpoints"]


### PR DESCRIPTION
### Description
This PR migrates several crates to use workspace dependencies:
- `aptos-node`
- `config`
- `consensus`
- `consensus/consensus-types`
- `consensus/safety-rules`
- `ecosystem/node-checker`
- `ecosystem/node-checker/fn-check-client`
- `ecosystem/sf-indexer/firehose-stream`

Note: the rest of the `ecosystem` crates will be deleted, so I've avoided updating them here.

### Test Plan
Existing test infrastructure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5605)
<!-- Reviewable:end -->
