### PR TITLE
Alternative error reporting to failure in init module while publishing

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -20,6 +20,7 @@ pub enum FeatureFlag {
     CodeDependencyCheck,
     TreatFriendAsPrivate,
     VMBinaryFormatV6,
+    InitLinkingFailureReported,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -94,6 +95,9 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::CodeDependencyCheck => AptosFeatureFlag::CODE_DEPENDENCY_CHECK,
             FeatureFlag::TreatFriendAsPrivate => AptosFeatureFlag::TREAT_FRIEND_AS_PRIVATE,
             FeatureFlag::VMBinaryFormatV6 => AptosFeatureFlag::VM_BINARY_FORMAT_V6,
+            FeatureFlag::InitLinkingFailureReported => {
+                AptosFeatureFlag::INIT_LINKING_FAILURE_REPORTED
+            },
         }
     }
 }
@@ -105,6 +109,9 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::CODE_DEPENDENCY_CHECK => FeatureFlag::CodeDependencyCheck,
             AptosFeatureFlag::TREAT_FRIEND_AS_PRIVATE => FeatureFlag::TreatFriendAsPrivate,
             AptosFeatureFlag::VM_BINARY_FORMAT_V6 => FeatureFlag::VMBinaryFormatV6,
+            AptosFeatureFlag::INIT_LINKING_FAILURE_REPORTED => {
+                FeatureFlag::InitLinkingFailureReported
+            },
         }
     }
 }

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -19,6 +19,7 @@ mod memory_quota;
 mod mint_nft;
 mod new_integer_types;
 mod offer_signer_capability;
+mod publish_init_cases;
 mod rotate_auth_key;
 mod scripts;
 mod simple_defi;

--- a/aptos-move/e2e-move-tests/src/tests/publish_init_cases.rs
+++ b/aptos-move/e2e-move-tests/src/tests/publish_init_cases.rs
@@ -1,0 +1,226 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{assert_abort, assert_success, assert_vm_status, tests::common, MoveHarness};
+use aptos_framework::{BuildOptions, BuiltPackage};
+use aptos_types::{account_address::AccountAddress, on_chain_config::FeatureFlag};
+use move_core_types::vm_status::StatusCode;
+use rstest::rstest;
+
+/// Run with `cargo test <test_name> -- --nocapture` to see output.
+
+#[test]
+fn publish_init_ok1() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
+
+    // publish State(v0)
+    assert_success!(h.publish_package(
+        &acc,
+        &common::test_dir_path("publish_init_cases/generic/state_v0"),
+    ));
+
+    // publish transaction test publish_and_use
+    assert_success!(h.publish_package(
+        &acc,
+        &common::test_dir_path("publish_init_cases/publish_and_use"),
+    ));
+
+    // publish State(v1) and UseState
+    assert_success!(h.publish_package(
+        &acc,
+        &common::test_dir_path("publish_init_cases/generic/use_state_ok"),
+    ));
+}
+
+#[test]
+fn publish_init_ok2() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
+
+    // publish State(v0)
+    assert_success!(h.publish_package(
+        &acc,
+        &common::test_dir_path("publish_init_cases/generic/state_v0"),
+    ));
+
+    // publish transaction test publish_and_use
+    assert_success!(h.publish_package(
+        &acc,
+        &common::test_dir_path("publish_init_cases/publish_and_use"),
+    ));
+
+    // build State(v1) and UseState
+    let package = BuiltPackage::build(
+        common::test_dir_path("publish_init_cases/generic/use_state_ok"),
+        BuildOptions::default(),
+    )
+    .expect("building package must succeed");
+    let metadata = package
+        .extract_metadata()
+        .expect("extracting package metadata must succeed");
+    let metadata = bcs::to_bytes(&metadata).expect("PackageMetadata has BCS");
+    let code = package.extract_code();
+    let args = vec![
+        bcs::to_bytes(&metadata).unwrap(),
+        bcs::to_bytes(&code).unwrap(),
+    ];
+
+    // run transaction that publishes State(v1) and UseState
+    let result = h.run_entry_function(&acc, str::parse("0xbeef::test::run").unwrap(), vec![], args);
+    assert_success!(result);
+}
+
+#[test]
+fn publish_init_assert1() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
+
+    // publish State(v0)
+    assert_success!(h.publish_package(
+        &acc,
+        &common::test_dir_path("publish_init_cases/generic/state_v0"),
+    ));
+
+    // publish transaction test publish_and_use
+    assert_success!(h.publish_package(
+        &acc,
+        &common::test_dir_path("publish_init_cases/publish_and_use"),
+    ));
+
+    // publish State(v1) and UseState
+    // NOTICE: if the behavior of running the init changes to run in the
+    // context of the update, this test will succeed and has to be changes.
+    // It is here exactly to make us notice the difference
+    assert_abort!(
+        h.publish_package(
+            &acc,
+            &common::test_dir_path("publish_init_cases/generic/use_state_assert")
+        ),
+        300
+    );
+}
+
+#[test]
+fn publish_init_assert2() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
+
+    // publish State(v0)
+    assert_success!(h.publish_package(
+        &acc,
+        &common::test_dir_path("publish_init_cases/generic/state_v0"),
+    ));
+
+    // publish transaction test publish_and_use
+    assert_success!(h.publish_package(
+        &acc,
+        &common::test_dir_path("publish_init_cases/publish_and_use"),
+    ));
+
+    // build State(v1) and UseState
+    let package = BuiltPackage::build(
+        common::test_dir_path("publish_init_cases/generic/use_state_assert"),
+        BuildOptions::default(),
+    )
+    .expect("building package must succeed");
+    let metadata = package
+        .extract_metadata()
+        .expect("extracting package metadata must succeed");
+    let metadata = bcs::to_bytes(&metadata).expect("PackageMetadata has BCS");
+    let code = package.extract_code();
+    let args = vec![
+        bcs::to_bytes(&metadata).unwrap(),
+        bcs::to_bytes(&code).unwrap(),
+    ];
+
+    // run transaction that publishes State(v1) and UseState
+    let result = h.run_entry_function(&acc, str::parse("0xbeef::test::run").unwrap(), vec![], args);
+    // NOTICE: if the behavior of running the init changes to run in the
+    // context of the update, this test will succeed and has to be changes.
+    // It is here exactly to make us notice the difference
+    assert_abort!(result, 300);
+}
+
+#[rstest(enabled, disabled,
+    case(vec![], vec![FeatureFlag::INIT_LINKING_FAILURE_REPORTED]),
+    case(vec![FeatureFlag::INIT_LINKING_FAILURE_REPORTED], vec![]),
+)]
+fn publish_init_error1(enabled: Vec<FeatureFlag>, disabled: Vec<FeatureFlag>) {
+    let mut h = MoveHarness::new_with_features(enabled.clone(), disabled);
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
+
+    // publish State(v0)
+    assert_success!(h.publish_package(
+        &acc,
+        &common::test_dir_path("publish_init_cases/generic/state_v0"),
+    ));
+
+    // publish transaction test publish_and_use
+    assert_success!(h.publish_package(
+        &acc,
+        &common::test_dir_path("publish_init_cases/publish_and_use"),
+    ));
+
+    // publish State(v1) and UseState
+    let result = h.publish_package(
+        &acc,
+        &common::test_dir_path("publish_init_cases/generic/use_state_error"),
+    );
+    // NOTICE: if the behavior of running the init changes to run in the
+    // context of the update, this test will succeed and has to be changes.
+    // It is here exactly to make us notice the difference
+    if enabled.contains(&FeatureFlag::INIT_LINKING_FAILURE_REPORTED) {
+        assert_vm_status!(result, StatusCode::CONSTRAINT_NOT_SATISFIED);
+    } else {
+        assert_success!(result)
+    }
+}
+
+#[rstest(enabled, disabled,
+    case(vec![], vec![FeatureFlag::INIT_LINKING_FAILURE_REPORTED]),
+    case(vec![FeatureFlag::INIT_LINKING_FAILURE_REPORTED], vec![]),
+)]
+fn publish_init_error2(enabled: Vec<FeatureFlag>, disabled: Vec<FeatureFlag>) {
+    let mut h = MoveHarness::new_with_features(enabled.clone(), disabled);
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
+
+    // publish State(v0)
+    assert_success!(h.publish_package(
+        &acc,
+        &common::test_dir_path("publish_init_cases/generic/state_v0"),
+    ));
+
+    // publish transaction test publish_and_use
+    assert_success!(h.publish_package(
+        &acc,
+        &common::test_dir_path("publish_init_cases/publish_and_use"),
+    ));
+
+    // build State(v1) and UseState
+    let package = BuiltPackage::build(
+        common::test_dir_path("publish_init_cases/generic/use_state_error"),
+        BuildOptions::default(),
+    )
+    .expect("building package must succeed");
+    let metadata = package
+        .extract_metadata()
+        .expect("extracting package metadata must succeed");
+    let metadata = bcs::to_bytes(&metadata).expect("PackageMetadata has BCS");
+    let code = package.extract_code();
+    let args = vec![
+        bcs::to_bytes(&metadata).unwrap(),
+        bcs::to_bytes(&code).unwrap(),
+    ];
+
+    // run transaction that publishes State(v1) and UseState
+    let result = h.run_entry_function(&acc, str::parse("0xbeef::test::run").unwrap(), vec![], args);
+    // NOTICE: if the behavior of running the init changes to run in the
+    // context of the update, this test will succeed and has to be changed.
+    // It is here exactly to make us notice the difference
+    if enabled.contains(&FeatureFlag::INIT_LINKING_FAILURE_REPORTED) {
+        assert_vm_status!(result, StatusCode::CONSTRAINT_NOT_SATISFIED);
+    } else {
+        assert_success!(result)
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/state_v0/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/state_v0/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "State"
+version = "0.0.0"
+upgrade_policy = "compatible"
+
+[dependencies]
+MoveStdlib = { local = "../../../../../../framework/move-stdlib" }

--- a/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/state_v0/sources/State.move
+++ b/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/state_v0/sources/State.move
@@ -1,0 +1,13 @@
+module 0xbeef::State {
+    struct State has key {
+        value: u64
+    }
+
+    public fun create_state(value: u64): State {
+        State {value}
+    }
+
+    public fun version(): u64 {
+        0
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_assert/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_assert/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "State"
+version = "0.0.0"
+upgrade_policy = "compatible"
+
+[dependencies]
+MoveStdlib = { local = "../../../../../../framework/move-stdlib" }

--- a/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_assert/sources/State.move
+++ b/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_assert/sources/State.move
@@ -1,0 +1,17 @@
+module 0xbeef::State {
+    struct State has key {
+        value: u64
+    }
+
+    public fun create_state(value: u64): State {
+        State {value}
+    }
+
+    public fun something_new(): u64 {
+        22
+    }
+
+    public fun version(): u64 {
+        1
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_assert/sources/UseState.move
+++ b/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_assert/sources/UseState.move
@@ -1,0 +1,13 @@
+module 0xbeef::UseState {
+    use 0xbeef::State;
+
+    public fun state_version(): u64 {
+        State::version()
+    }
+
+    fun init_module(_s: &signer) {
+        // this code asserts because the State used is not
+        // the one published with this code
+        assert!(state_version() == 1, 300);
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_error/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_error/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "State"
+version = "0.0.0"
+upgrade_policy = "compatible"
+
+[dependencies]
+MoveStdlib = { local = "../../../../../../framework/move-stdlib" }

--- a/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_error/sources/State.move
+++ b/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_error/sources/State.move
@@ -1,0 +1,17 @@
+module 0xbeef::State {
+    struct State has key {
+        value: u64
+    }
+
+    public fun create_state(value: u64): State {
+        State {value}
+    }
+
+    public fun something_new(): u64 {
+        22
+    }
+
+    public fun version(): u64 {
+        1
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_error/sources/UseState.move
+++ b/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_error/sources/UseState.move
@@ -1,0 +1,19 @@
+module 0xbeef::UseState {
+    use 0xbeef::State;
+
+    public fun version(): u64 {
+        0
+    }
+
+    public fun state_version(): u64 {
+        State::version()
+    }
+
+    fun init_module(_s: &signer) {
+        // this leads to a verifier error when the init_module is
+        // "loaded" (`load_function`) because State used is v0,
+        // which does not contain `something_new`.
+        // Make sure the publishing fails, so we alert the user
+        assert!(State::something_new() == 22, 200);
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_ok/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_ok/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "State"
+version = "0.0.0"
+upgrade_policy = "compatible"
+
+[dependencies]
+MoveStdlib = { local = "../../../../../../framework/move-stdlib" }

--- a/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_ok/sources/State.move
+++ b/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_ok/sources/State.move
@@ -1,0 +1,17 @@
+module 0xbeef::State {
+    struct State has key {
+        value: u64
+    }
+
+    public fun create_state(value: u64): State {
+        State {value}
+    }
+
+    public fun something_new(): u64 {
+        22
+    }
+
+    public fun version(): u64 {
+        1
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_ok/sources/UseState.move
+++ b/aptos-move/e2e-move-tests/src/tests/publish_init_cases/generic/use_state_ok/sources/UseState.move
@@ -1,0 +1,17 @@
+module 0xbeef::UseState {
+    use 0xbeef::State;
+    use std::signer::address_of;
+
+    public fun version(): u64 {
+        0
+    }
+
+    public fun state_version(): u64 {
+        State::version()
+    }
+
+    // init_module
+    fun init_module(s: &signer) {
+        assert!(@0x0 != address_of(s), 100);
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/publish_init_cases/publish_and_use/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/publish_init_cases/publish_and_use/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "test"
+version = "0.0.0"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }
+AptosStdlib = { local = "../../../../../framework/aptos-stdlib" }
+MoveStdlib = { local = "../../../../../framework/move-stdlib" }
+State = { local = "../generic/state_v0" }

--- a/aptos-move/e2e-move-tests/src/tests/publish_init_cases/publish_and_use/sources/test.move
+++ b/aptos-move/e2e-move-tests/src/tests/publish_init_cases/publish_and_use/sources/test.move
@@ -1,0 +1,11 @@
+module 0xbeef::test {
+    use aptos_framework::code::publish_package_txn;
+
+    public entry fun run(
+        s: &signer,
+        metadata: vector<u8>,
+        code: vector<vector<u8>>,
+    ) {
+        publish_package_txn(s, metadata, code);
+    }
+}

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -159,6 +159,10 @@ impl FakeExecutor {
         }
     }
 
+    pub fn get_features(&self) -> &Features {
+        &self.features
+    }
+
     pub fn set_golden_file(&mut self, test_name: &str) {
         // 'test_name' includes ':' in the names, lets re-write these to be '_'s so that these
         // files can persist on windows machines.

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -23,6 +23,7 @@ the Move stdlib, the Aptos stdlib, and the Aptos framework.
 -  [Function `multi_ed25519_pk_validate_v2_enabled`](#0x1_features_multi_ed25519_pk_validate_v2_enabled)
 -  [Function `get_blake2b_256_feature`](#0x1_features_get_blake2b_256_feature)
 -  [Function `blake2b_256_enabled`](#0x1_features_blake2b_256_enabled)
+-  [Function `init_linking_failure_reported`](#0x1_features_init_linking_failure_reported)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `is_enabled`](#0x1_features_is_enabled)
 -  [Function `set`](#0x1_features_set)
@@ -127,6 +128,18 @@ The provided signer has not a framework address.
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_EFRAMEWORK_SIGNER_NEEDED">EFRAMEWORK_SIGNER_NEEDED</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_features_INIT_LINKING_FAILURE_REPORTED"></a>
+
+Whether during upgrade compatibility checking, friend functions should be treated similar like
+private functions.
+Lifetime: ephemeral
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_INIT_LINKING_FAILURE_REPORTED">INIT_LINKING_FAILURE_REPORTED</a>: u64 = 9;
 </code></pre>
 
 
@@ -495,6 +508,30 @@ Lifetime: transient
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_blake2b_256_enabled">blake2b_256_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_BLAKE2B_256_NATIVE">BLAKE2B_256_NATIVE</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_features_init_linking_failure_reported"></a>
+
+## Function `init_linking_failure_reported`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_init_linking_failure_reported">init_linking_failure_reported</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_init_linking_failure_reported">init_linking_failure_reported</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_INIT_LINKING_FAILURE_REPORTED">INIT_LINKING_FAILURE_REPORTED</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -111,6 +111,14 @@ module std::features {
         is_enabled(BLAKE2B_256_NATIVE)
     }
 
+    /// Whether during upgrade compatibility checking, friend functions should be treated similar like
+    /// private functions.
+    /// Lifetime: ephemeral
+    const INIT_LINKING_FAILURE_REPORTED: u64 = 9;
+    public fun init_linking_failure_reported(): bool acquires Features {
+        is_enabled(INIT_LINKING_FAILURE_REPORTED)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -11,6 +11,7 @@ pub enum FeatureFlag {
     CODE_DEPENDENCY_CHECK = 1,
     TREAT_FRIEND_AS_PRIVATE = 2,
     VM_BINARY_FORMAT_V6 = 5,
+    INIT_LINKING_FAILURE_REPORTED = 9,
 }
 
 /// Representation of features on chain as a bitset.


### PR DESCRIPTION
### Description
Proposal to report an error when `init_module` runs in edge case failures.
The check right now is very strict and it should work for `init_module` missing and if it errors otherwise. That check could be made more relaxed.
The change is in `aptos_vm.rs` and pretty small, everything else is testing.
Returning any error (so error propagation) is an option, however returning a verifier error leads to the transaction being discarded (not keep) with all implications. The way it is makes it less clear to the user as it does not expose the problem clearly. We could adopt in between solutions like specific errors. 
We may want to gate this change or let it go according to history, not sure

Comments welcome


### Test Plan
Tests added. We'll see if there are other problems.
```
cd aptos-move/e2e-move-tests
cargo test publish_init -- --nocapture 
// to run all init tests
cargo test publish_init_error -- --nocapture
// for the specific problem
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5615)
<!-- Reviewable:end -->
