### PR TITLE
[docs] Fix list styling (bullets) due to @stoplight css conflict

### DIFF
--- a/developer-docs-site/src/css/custom.css
+++ b/developer-docs-site/src/css/custom.css
@@ -101,6 +101,10 @@ audio,canvas,embed,iframe,img,object,svg,video {
     display:inline;
 }
 
+ol, ul {
+    list-style: disc;
+}
+
 footer.footer {
   background-color: var(--ifm-background-color);
   color:var(--ifm-navbar-link-color);


### PR DESCRIPTION
### Description

`@stoplight` external CSS was disabling `list-style`.  Since our custom.css doesn't define `list-style` (relies on browser default), we needed to override this:

<img width="735" alt="image" src="https://user-images.githubusercontent.com/98909677/202499364-75d5654d-e705-4b28-8f56-594c8e3ba04a.png">

Now fixed:
<img width="1775" alt="image" src="https://user-images.githubusercontent.com/98909677/202500396-38066a5a-69f8-41b7-ab8f-18b5512b567b.png">



### Test Plan
Review lists and ensure bullet point styling has been restored.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5616)
<!-- Reviewable:end -->
