### PR TITLE
Revert changes to pyproject.toml from 8958b01

### DIFF
--- a/ecosystem/python/sdk/Makefile
+++ b/ecosystem/python/sdk/Makefile
@@ -7,7 +7,7 @@ test:
 fmt:
 	- find ./examples ./aptos_sdk *.py -type f -name "*.py" | xargs poetry run autoflake -i -r --remove-all-unused-imports --remove-unused-variables --ignore-init-module-imports
 	- find ./examples ./aptos_sdk *.py -type f -name "*.py" | xargs poetry run black
-        - find ./examples ./aptos_sdk *.py -type f -name "*.py" | xargs poetry run isort
+	- find ./examples ./aptos_sdk *.py -type f -name "*.py" | xargs poetry run isort
 
 lint:
 	- poetry run mypy aptos_sdk

--- a/ecosystem/python/sdk/README.md
+++ b/ecosystem/python/sdk/README.md
@@ -12,8 +12,8 @@ Currently this is still in development and is unsuitable for directly interfacin
 We use [Poetry](https://python-poetry.org/docs/#installation) for packaging and dependency management:
 
 ```
-curl -sSL https://install.python-poetry.org | python3
-poetry update
+curl -sSL https://install.python-poetry.org | python3 -
+poetry install
 ```
 
 ## Unit testing

--- a/ecosystem/python/sdk/pyproject.toml
+++ b/ecosystem/python/sdk/pyproject.toml
@@ -1,29 +1,22 @@
 [tool.poetry]
 name = "aptos-sdk"
-description = "Aptos SDK"
 version = "0.2.0"
-
-# Workspace inherited keys
-authors = { workspace = true }
-edition = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
-publish = { workspace = true }
-repository = { workspace = true }
-rust-version = { workspace = true }
+description = "Aptos SDK"
+authors = ["Aptos Labs <opensource@aptoslabs.com>"]
+license = "Apache-2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<4.0"
 httpx = "^0.23.0"
-PyNaCl = "^1.5.0"
 mypy = "^0.982"
+PyNaCl = "^1.5.0"
+python = ">=3.7,<4.0"
 
 [tool.poetry.dev-dependencies]
-black = "^22.6.0"
-isort = "^5.10.1"
 autoflake = "1.4.0"
-mypy = "^0.982"
+black = "^22.6.0"
 flake8 = ">=3.8.3,<6.0.0"
+isort = "^5.10.1"
+mypy = "^0.982"
 mypy-extensions = "^0.4.3"
 typing-extensions = "^4.4.0"
 


### PR DESCRIPTION
### Description
I believe this was picked up by accident (because it is a toml file) as part of the change to workspace dependencies: https://github.com/aptos-labs/aptos-core/pull/5342.

I fix an issue with the Makefile while I'm here and because I'm crazy I also sort the deps alphabetically.

### Test Plan
```
cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes --with-faucet
```
```
cd ecosystem/python/sdk
make examples
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5617)
<!-- Reviewable:end -->
