### PR TITLE
[Cargo] Move some crates to workspace dependencies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,9 +2332,6 @@ name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
-dependencies = [
- "serde 1.0.144",
-]
 
 [[package]]
 name = "bzip2-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,7 @@ aptos-global-constants = { path = "config/global-constants" }
 aptos-id-generator = { path = "crates/aptos-id-generator" }
 aptos-indexer = { path = "crates/indexer" }
 aptos-infallible = { path = "crates/aptos-infallible" }
+aptos-jellyfish-merkle = { path = "storage/jellyfish-merkle" }
 aptos-keygen = { path = "crates/aptos-keygen" }
 aptos-logger = { path = "crates/aptos-logger" }
 aptos-mempool = { path = "mempool" }
@@ -193,6 +194,8 @@ aptos-node-checker = { path = "ecosystem/node-checker" }
 aptos-openapi = { path = "crates/aptos-openapi" }
 aptos-proptest-helpers = { path = "crates/aptos-proptest-helpers" }
 aptos-protos = { path = "crates/aptos-protos" }
+aptos-push-metrics = { path = "crates/aptos-push-metrics" }
+aptos-rate-limiter = { path = "crates/aptos-rate-limiter" }
 aptos-rest-client = { path = "crates/aptos-rest-client" }
 aptos-sdk = { path = "sdk" }
 aptos-secure-net = { path = "secure/net" }
@@ -200,7 +203,7 @@ aptos-secure-storage = { path = "secure/storage" }
 aptos-state-view = { path = "storage/state-view" }
 aptos-telemetry = { path = "crates/aptos-telemetry" }
 aptos-temppath = { path = "crates/aptos-temppath" }
-aptos-time-service = { path = "crates/aptos-time-service" }
+aptos-time-service = { path = "crates/aptos-time-service", features = ["async"] }
 aptos-types = { path = "types" }
 aptos-vault-client = { path = "secure/storage/vault" }
 aptos-vm = { path = "aptos-move/aptos-vm" }
@@ -222,9 +225,14 @@ fallible = { path = "crates/fallible" }
 framework = { path = "aptos-move/framework" }
 inspection-service = { path = "crates/inspection-service" }
 mempool-notifications = { path = "state-sync/inter-component/mempool-notifications" }
+memsocket = { path = "network/memsocket" }
 netcore = { path = "network/netcore" }
 network = { path = "network" }
 network-builder = { path = "network/builder" }
+network-discovery = { path = "network/discovery" }
+num-variants = { path = "crates/num-variants" }
+peer-monitoring-service-types = { path = "network/peer-monitoring-service/types" }
+proxy = { path = "crates/proxy" }
 safety-rules = { path = "consensus/safety-rules" }
 schemadb = { path = "storage/schemadb" }
 scratchpad = { path = "storage/scratchpad" }
@@ -261,12 +269,14 @@ fail = "0.5.0"
 field_count = "0.1.1"
 futures = "= 0.3.24" # Previously futures v0.3.23 caused some consensus network_tests to fail. We now pin the dependency to v0.3.24.
 futures-channel = "= 0.3.24"
+futures-util = "0.3.21"
 gcp-bigquery-client = "0.13.0"
 get_if_addrs = "0.5.3"
 goldenfile = "1.1.0"
 hex = "0.4.3"
 http = "0.2.3"
 hyper = { version = "0.14.18", features = ["full"] }
+indicatif = "0.15.0"
 indoc = "1.0.6"
 itertools = "0.10.3"
 jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
@@ -276,19 +286,23 @@ maplit = "1.0.2"
 mime = "0.3.16"
 mirai-annotations = "1.12.0"
 mockall = "0.11.0"
+num_cpus = "1.13.1"
 num-derive = "0.3.3"
 num-traits = "0.2.15"
 once_cell = "1.10.0"
 paste = "1.0.7"
 pbjson = "0.4.0"
 percent-encoding = "2.1.0"
+pin-project = "1.0.10"
 poem = { version = "1.3.40", features = ["anyhow", "rustls"] }
 poem-openapi = { version = "2.0.10", features = ["swagger-ui", "url"] }
 prometheus-parse = "0.2.2"
 proptest = "1.0.0"
+proptest-derive = "0.3.0"
 prost = "0.10.4"
 prost-types = "0.10.1"
 rand = "0.7.3"
+rand_core = "0.5.1"
 rayon = "1.5.2"
 regex = "1.5.5"
 reqwest = { version = "0.11.11", features = ["blocking", "cookies", "json"] }
@@ -296,14 +310,18 @@ reqwest-middleware = "0.1.6"
 reqwest-retry = "0.1.5"
 rusty-fork = "0.3.0"
 serde = { version = "1.0.137", features = ["derive", "rc"] }
+serde_bytes = "0.11.6"
 serde_json = { version = "1.0.81", features = ["preserve_order"] }
 serde_yaml = "0.8.24"
+structopt = "0.3.21"
 substreams = "0.0.17"
 tempfile = "3.3.0"
 thiserror = "1.0.31"
 tokio = { version = "1.21.0", features = ["full"] }
 tokio-retry = "0.3.0"
 tokio-stream = "0.1.8"
+tokio-util = { version = "0.7.2", features = ["compat", "codec"] }
+toml = "0.5.9"
 tonic = { version = "0.7.2", features = ["tls-roots", "transport", "prost", "compression", "codegen"] }
 url = { version = "2.2.2", features = ["serde"] }
 warp = { version = "0.3.2" }

--- a/execution/db-bootstrapper/Cargo.toml
+++ b/execution/db-bootstrapper/Cargo.toml
@@ -13,16 +13,14 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.57"
-bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" }
-structopt = "0.3.21"
-
-aptos-config = { path = "../../config" }
-aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-temppath = { path = "../../crates/aptos-temppath" }
-aptos-types = { path = "../../types" }
-aptos-vm = { path = "../../aptos-move/aptos-vm" }
-
-aptosdb = { path = "../../storage/aptosdb" }
-executor = { path = "../executor" }
-storage-interface = { path = "../../storage/storage-interface" }
+anyhow = { workspace = true }
+aptos-config = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-temppath = { workspace = true }
+aptos-types = { workspace = true }
+aptos-vm = { workspace = true }
+aptosdb = { workspace = true }
+bcs = { workspace = true }
+executor = { workspace = true }
+storage-interface = { workspace = true }
+structopt = { workspace = true }

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -13,41 +13,39 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-chrono = "0.4.19"
-criterion = "0.3.5"
-indicatif = "0.15.0"
-itertools = "0.10.3"
-num_cpus = "1.13.1"
-rand = "0.7.3"
-rayon = "1.5.2"
-serde = "1.0.137"
-structopt = "0.3.21"
-toml = "0.5.9"
-
-aptos-config = { path = "../../config" }
-aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-genesis = { path = "../../crates/aptos-genesis", features = ["testing"] }
-aptos-infallible = { path = "../../crates/aptos-infallible" }
-aptos-jellyfish-merkle = { path = "../../storage/jellyfish-merkle" }
-aptos-logger = { path = "../../crates/aptos-logger" }
-aptos-push-metrics = { path = "../../crates/aptos-push-metrics" }
-aptos-sdk = { path = "../../sdk" }
-aptos-state-view = { path = "../../storage/state-view" }
-aptos-types = { path = "../../types" }
-aptos-vm = { path = "../../aptos-move/aptos-vm" }
-
-aptosdb = { path = "../../storage/aptosdb" }
-executor = { path = "../executor" }
-executor-types = { path = "../executor-types" }
-schemadb = { path = "../../storage/schemadb" }
-scratchpad = { path = "../../storage/scratchpad" }
-storage-interface = { path = "../../storage/storage-interface" }
+aptos-config = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-genesis = { workspace = true, features = ["testing"] }
+aptos-infallible = { workspace = true }
+aptos-jellyfish-merkle = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-push-metrics =  { workspace = true }
+aptos-sdk = { workspace = true }
+aptos-state-view = { workspace = true }
+aptos-types = { workspace = true }
+aptos-vm = { workspace = true }
+aptosdb = { workspace = true }
+chrono = { workspace = true }
+criterion = { workspace = true }
+executor = { workspace = true }
+executor-types = { workspace = true }
+indicatif = { workspace = true }
+itertools = { workspace = true }
+num_cpus = { workspace = true }
+rand = { workspace = true }
+rayon = { workspace = true }
+schemadb = { workspace = true }
+scratchpad = { workspace = true }
+serde = { workspace = true }
+storage-interface = { workspace = true }
+structopt = { workspace = true }
+toml = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
+jemallocator = { workspace = true }
 
 [dev-dependencies]
-aptos-temppath = { path = "../../crates/aptos-temppath" }
+aptos-temppath = { workspace = true }
 
 [features]
 default = []

--- a/execution/executor-test-helpers/Cargo.toml
+++ b/execution/executor-test-helpers/Cargo.toml
@@ -13,21 +13,20 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.57"
-rand = "0.7.3"
-
-aptos-config = { path = "../../config" }
-aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-genesis = { path = "../../crates/aptos-genesis", features = ["testing"] }
-aptos-sdk = { path = "../../sdk" }
-aptos-state-view = { path = "../../storage/state-view" }
-aptos-temppath = { path = "../../crates/aptos-temppath" }
-aptos-types = { path = "../../types", features = ["fuzzing"] }
-aptos-vm = { path = "../../aptos-move/aptos-vm" }
-aptosdb = { path = "../../storage/aptosdb", features = ["fuzzing"] }
-cached-packages = { path = "../../aptos-move/framework/cached-packages" }
-consensus-types = { path = "../../consensus/consensus-types" }
-executor = { path = "../executor" }
-executor-types = { path = "../executor-types" }
-storage-interface = { path = "../../storage/storage-interface" }
-vm-genesis = { path = "../../aptos-move/vm-genesis" }
+anyhow = { workspace = true }
+aptos-config = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-genesis = { workspace = true }
+aptos-sdk = { workspace = true }
+aptos-state-view = { workspace = true }
+aptos-temppath = { workspace = true }
+aptos-types = { workspace = true }
+aptos-vm = { workspace = true }
+aptosdb = { workspace = true, features = ["fuzzing"] }
+cached-packages = { workspace = true }
+consensus-types = { workspace = true }
+executor = { workspace = true }
+executor-types = { workspace = true }
+rand = { workspace = true }
+storage-interface = { workspace = true }
+vm-genesis = { workspace = true }

--- a/execution/executor-types/Cargo.toml
+++ b/execution/executor-types/Cargo.toml
@@ -13,20 +13,18 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.57"
-bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" }
-itertools = "0.10.0"
-once_cell = "1.10.0"
-serde = { version = "1.0.137", default-features = false }
-thiserror = "1.0.31"
-
-aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-secure-net = { path = "../../secure/net" }
-aptos-state-view = { path = "../../storage/state-view" }
-aptos-types = { path = "../../types" }
-
-scratchpad = { path = "../../storage/scratchpad" }
-storage-interface = { path = "../../storage/storage-interface" }
+anyhow = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-secure-net = { workspace = true }
+aptos-state-view = { workspace = true }
+aptos-types = { workspace = true }
+bcs = { workspace = true }
+itertools = { workspace = true }
+once_cell = { workspace = true }
+scratchpad = { workspace = true }
+serde = { workspace = true }
+storage-interface = { workspace = true }
+thiserror = { workspace = true }
 
 [features]
 default = []

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -13,44 +13,40 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.57"
-bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" }
-fail = "0.5.0"
-itertools = { version = "0.10.0", default-features = false }
-once_cell = "1.10.0"
-rayon = "1.5.2"
-serde = { version = "1.0.137", features = ["derive"] }
-
-aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-gas = { path = "../../aptos-move/aptos-gas" }
-aptos-infallible = { path = "../../crates/aptos-infallible" }
-aptos-logger = { path = "../../crates/aptos-logger" }
-aptos-metrics-core = { path = "../../crates/aptos-metrics-core" }
-aptos-secure-net = { path = "../../secure/net" }
-aptos-state-view = { path = "../../storage/state-view" }
-aptos-types = { path = "../../types" }
-aptos-vm = { path = "../../aptos-move/aptos-vm" }
-
-consensus-types = { path = "../../consensus/consensus-types" }
-executor-types = { path = "../executor-types" }
-scratchpad = { path = "../../storage/scratchpad" }
-storage-interface = { path = "../../storage/storage-interface" }
-
+anyhow = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-gas = { workspace = true }
+aptos-infallible = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-metrics-core = { workspace = true }
+aptos-secure-net = { workspace = true }
+aptos-state-view = { workspace = true }
+aptos-types = { workspace = true }
+aptos-vm = { workspace = true }
+bcs = { workspace = true }
+consensus-types = { workspace = true }
+executor-types = { workspace = true }
+fail = { workspace = true }
+itertools = { workspace = true }
 move-core-types = { workspace = true }
+once_cell = { workspace = true }
+rayon = { workspace = true }
+scratchpad = { workspace = true }
+serde = { workspace = true }
+storage-interface = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.0.0"
-rand = "0.7.3"
-
-aptos-config = { path = "../../config" }
-aptos-genesis = { path = "../../crates/aptos-genesis", features = ["testing"] }
-aptos-temppath = { path = "../../crates/aptos-temppath" }
-aptos-types = { path = "../../types", features = ["fuzzing"] }
-aptosdb = { path = "../../storage/aptosdb" }
-cached-packages = { path = "../../aptos-move/framework/cached-packages" }
-executor-test-helpers = { path = "../executor-test-helpers" }
-storage-interface = { path = "../../storage/storage-interface", features = ["fuzzing"] }
-vm-genesis = { path = "../../aptos-move/vm-genesis" }
+aptos-config = { workspace = true }
+aptos-genesis = { workspace = true }
+aptos-temppath = { workspace = true }
+aptos-types = { workspace = true }
+aptosdb = { workspace = true }
+cached-packages = { workspace = true }
+executor-test-helpers = { workspace = true }
+proptest = { workspace = true }
+rand = { workspace = true }
+storage-interface = { workspace = true }
+vm-genesis = { workspace = true }
 
 [features]
 default = []

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -13,50 +13,47 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.57"
-async-trait = "0.1.53"
-bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" }
-fail = "0.5.0"
-futures = "0.3.21"
-itertools = "0.10.0"
-once_cell = "1.10.0"
-proptest = { version = "1.0.0", optional = true }
-rand = "0.7.3"
-rayon = "1.5.2"
-serde = { version = "1.0.137", default-features = false }
-serde_json = "1.0.81"
-thiserror = "1.0.31"
-tokio = { version = "1.21.0", features = ["full"] }
-tokio-stream = "0.1.8"
-
-aptos-config = { path = "../config" }
-aptos-crypto = { path = "../crates/aptos-crypto" }
-aptos-infallible = { path = "../crates/aptos-infallible" }
-aptos-logger = { path = "../crates/aptos-logger" }
-aptos-metrics-core = { path = "../crates/aptos-metrics-core" }
-aptos-proptest-helpers = { path = "../crates/aptos-proptest-helpers", optional = true }
-aptos-types = { path = "../types" }
-
-bounded-executor = { path = "../crates/bounded-executor" }
-channel = { path = "../crates/channel" }
-consensus-types = { path = "../consensus/consensus-types" }
-event-notifications = { path = "../state-sync/inter-component/event-notifications" }
-mempool-notifications = { path = "../state-sync/inter-component/mempool-notifications" }
-netcore = { path = "../network/netcore" }
-network = { path = "../network" }
-short-hex-str = { path = "../crates/short-hex-str" }
-storage-interface = { path = "../storage/storage-interface" }
-vm-validator = { path = "../vm-validator" }
+anyhow = { workspace = true }
+aptos-config = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-infallible = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-metrics-core = { workspace = true }
+aptos-proptest-helpers = { workspace = true, optional = true }
+aptos-types = { workspace = true }
+async-trait = { workspace = true }
+bcs = { workspace = true }
+bounded-executor = { workspace = true }
+channel = { workspace = true }
+consensus-types = { workspace = true }
+event-notifications = { workspace = true }
+fail = { workspace = true }
+futures = { workspace = true }
+itertools = { workspace = true }
+mempool-notifications = { workspace = true }
+netcore = { workspace = true }
+network = { workspace = true }
+once_cell = { workspace = true }
+proptest = { workspace = true, optional = true }
+rand = { workspace = true }
+rayon = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+short-hex-str = { workspace = true }
+storage-interface = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+vm-validator = { workspace = true }
 
 [dev-dependencies]
-enum_dispatch = "0.3.8"
-proptest = "1.0.0"
-
-aptos-compression = { path = "../crates/aptos-compression" }
-aptos-config = { path = "../config", features = ["fuzzing"] }
-aptos-id-generator = { path = "../crates/aptos-id-generator" }
-network = { path = "../network", features = ["fuzzing"] }
-storage-interface = { path = "../storage/storage-interface", features = ["fuzzing"] }
+aptos-compression = { workspace = true }
+aptos-config = { workspace = true }
+aptos-id-generator = { workspace = true }
+enum_dispatch = { workspace = true }
+network = { workspace = true, features = ["fuzzing"] }
+proptest = { workspace = true }
+storage-interface = { workspace = true, features = ["fuzzing"] }
 
 [features]
 default = []

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -13,62 +13,59 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.57"
-async-trait = "0.1.53"
-bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" }
-bytes = { version = "1.0.1", features = ["serde"] }
-futures = "0.3.21"
-futures-util = "0.3.21"
-hex = "0.4.3"
-itertools = "0.10.1"
-once_cell = "1.10.0"
-pin-project = "1.0.10"
-proptest = { version = "1.0.0", default-features = true, optional = true }
-proptest-derive = { version = "0.3.0", optional = true }
-rand = { version = "0.7.3", features = ["small_rng"] }
-serde = { version = "1.0.137", default-features = false }
-serde_bytes = "0.11.6"
-serde_json = "1.0.81"
-thiserror = "1.0.31"
-tokio = { version = "1.21.0", features = ["full"] }
-tokio-retry = "0.3.0"
-tokio-util = { version = "0.7.2", features = ["compat", "codec"] }
-
-aptos-compression = { path = "../crates/aptos-compression" }
-aptos-config = { path = "../config" }
-aptos-crypto = { path = "../crates/aptos-crypto" }
-aptos-crypto-derive = { path = "../crates/aptos-crypto-derive" }
-aptos-id-generator = { path = "../crates/aptos-id-generator" }
-aptos-infallible = { path = "../crates/aptos-infallible" }
-aptos-logger = { path = "../crates/aptos-logger" }
-aptos-metrics-core = { path = "../crates/aptos-metrics-core" }
-aptos-proptest-helpers = { path = "../crates/aptos-proptest-helpers", optional = true }
-aptos-rate-limiter = { path = "../crates/aptos-rate-limiter" }
-aptos-time-service = { path = "../crates/aptos-time-service", features = ["async"] }
-aptos-types = { path = "../types" }
-
-bitvec = { path = "../crates/aptos-bitvec", package = "aptos-bitvec" }
-channel = { path = "../crates/channel" }
-memsocket = { path = "./memsocket", optional = true }
-netcore = { path = "./netcore" }
-num-variants = { path = "../crates/num-variants" }
-short-hex-str = { path = "../crates/short-hex-str" }
+anyhow = { workspace = true }
+aptos-bitvec = { workspace = true }
+aptos-compression = { workspace = true }
+aptos-config = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-crypto-derive = { workspace = true }
+aptos-id-generator = { workspace = true }
+aptos-infallible = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-metrics-core = { workspace = true }
+aptos-proptest-helpers = { workspace = true, optional = true }
+aptos-rate-limiter = { workspace = true }
+aptos-time-service = { workspace = true }
+aptos-types = { workspace = true }
+async-trait = { workspace = true }
+bcs = { workspace = true }
+bytes = { workspace = true }
+channel = { workspace = true }
+futures = { workspace = true }
+futures-util = { workspace = true }
+hex = { workspace = true }
+itertools = { workspace = true }
+memsocket = { workspace = true, optional = true }
+netcore = { workspace = true }
+num-variants = { workspace = true }
+once_cell = { workspace = true }
+pin-project = { workspace = true }
+proptest ={ workspace = true, optional = true }
+proptest-derive = { workspace = true, optional = true }
+rand = { workspace = true, features = ["small_rng"] }
+serde = { workspace = true }
+serde_bytes = { workspace = true }
+serde_json = { workspace = true }
+short-hex-str = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-retry = { workspace = true }
+tokio-util = { workspace = true }
 
 [dev-dependencies]
-maplit = "1.0.2"
-proptest = { version = "1.0.0", default-features = true }
-proptest-derive = { version = "0.3.0" }
-rand_core = "0.5.1"
-
-aptos-config = { path = "../config", features = ["testing"] }
-aptos-proptest-helpers = { path = "../crates/aptos-proptest-helpers" }
-aptos-time-service = { path = "../crates/aptos-time-service", features = ["async", "testing"] }
-aptos-types = { path = "../types", features = ["fuzzing"] }
-bitvec = { path = "../crates/aptos-bitvec", package = "aptos-bitvec", features = ["fuzzing"] }
-memsocket = { path = "./memsocket" }
-netcore = { path = "./netcore", features = ["testing"] }
+aptos-bitvec = { workspace = true, features = ["fuzzing"] }
+aptos-config = { workspace = true, features = ["testing"] }
+aptos-proptest-helpers = { workspace = true }
+aptos-time-service = { workspace = true, features = ["testing"] }
+aptos-types = { workspace = true, features = ["fuzzing"] }
+maplit = { workspace = true }
+memsocket = { workspace = true }
+netcore = { workspace = true, features = ["testing"] }
+proptest = { workspace = true }
+proptest-derive = { workspace = true }
+rand_core = { workspace = true }
 
 [features]
 default = []
-fuzzing = ["bitvec/fuzzing", "aptos-config/fuzzing", "aptos-crypto/fuzzing", "aptos-types/fuzzing", "aptos-proptest-helpers", "aptos-time-service/testing", "aptos-types/fuzzing", "memsocket/testing", "netcore/fuzzing", "proptest", "proptest-derive"]
+fuzzing = ["aptos-bitvec/fuzzing", "aptos-config/fuzzing", "aptos-crypto/fuzzing", "aptos-types/fuzzing", "aptos-proptest-helpers", "aptos-time-service/testing", "aptos-types/fuzzing", "memsocket/testing", "netcore/fuzzing", "proptest", "proptest-derive"]
 testing = ["aptos-config/testing", "aptos-time-service/testing", "memsocket/testing", "netcore/testing"]

--- a/network/builder/Cargo.toml
+++ b/network/builder/Cargo.toml
@@ -13,23 +13,21 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-async-trait = "0.1.53"
-bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" }
-futures = "0.3.21"
-rand = "0.7.3"
-serde = { version = "1.0.137", default-features = false }
-tokio = { version = "1.21.0", features = ["full"] }
-
-aptos-config = { path = "../../config" }
-aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-infallible = { path = "../../crates/aptos-infallible" }
-aptos-logger = { path = "../../crates/aptos-logger" }
-aptos-secure-storage = { path = "../../secure/storage" }
-aptos-time-service = { path = "../../crates/aptos-time-service", features = ["async"] }
-aptos-types = { path = "../../types" }
-
-channel = { path = "../../crates/channel" }
-event-notifications = { path = "../../state-sync/inter-component/event-notifications" }
-netcore = { path = "../netcore" }
-network = { path = "../." }
-network-discovery = { path = "../discovery" }
+aptos-config = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-infallible = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-secure-storage = { workspace = true }
+aptos-time-service = { workspace = true }
+aptos-types = { workspace = true }
+async-trait = { workspace = true }
+bcs = { workspace = true }
+channel = { workspace = true }
+event-notifications = { workspace = true }
+futures = { workspace = true }
+netcore = { workspace = true }
+network = { workspace = true }
+network-discovery = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+tokio = { workspace = true }

--- a/network/discovery/Cargo.toml
+++ b/network/discovery/Cargo.toml
@@ -13,29 +13,26 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.57"
-bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" }
-futures = "0.3.21"
-once_cell = "1.10.0"
-serde_yaml = "0.8.24"
-tokio = { version = "1.21.0", features = ["full"] }
-
-aptos-config = { path = "../../config" }
-aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-logger = { path = "../../crates/aptos-logger" }
-aptos-metrics-core = { path = "../../crates/aptos-metrics-core" }
-aptos-secure-storage = { path = "../../secure/storage" }
-aptos-time-service = { path = "../../crates/aptos-time-service" }
-aptos-types = { path = "../../types" }
-
-channel = { path = "../../crates/channel" }
-event-notifications = { path = "../../state-sync/inter-component/event-notifications" }
-network = { path = "../../network" }
-short-hex-str = { path = "../../crates/short-hex-str" }
+anyhow = { workspace = true }
+aptos-config = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-metrics-core = { workspace = true }
+aptos-secure-storage = { workspace = true }
+aptos-time-service = { workspace = true }
+aptos-types = { workspace = true }
+bcs = { workspace = true }
+channel = { workspace = true }
+event-notifications = { workspace = true }
+futures = { workspace = true }
+network = { workspace = true }
+once_cell = { workspace = true }
+serde_yaml = { workspace = true }
+short-hex-str = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
-rand = "0.7.3"
-
-aptos-config = { path = "../../config", features = ["testing"] }
-aptos-temppath = { path = "../../crates/aptos-temppath" }
-netcore = { path = "../netcore", features = ["fuzzing"] }
+aptos-config = { workspace = true, features = ["testing"] }
+aptos-temppath = { workspace = true }
+netcore = { workspace = true, features = ["fuzzing"] }
+rand = { workspace = true }

--- a/network/memsocket/Cargo.toml
+++ b/network/memsocket/Cargo.toml
@@ -13,11 +13,10 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-bytes = "1.1.0"
-futures = "0.3.21"
-once_cell = "1.10.0"
-
-aptos-infallible = { path = "../../crates/aptos-infallible" }
+aptos-infallible = { workspace = true }
+bytes = { workspace = true }
+futures = { workspace = true }
+once_cell = { workspace = true }
 
 [features]
 default = []

--- a/network/netcore/Cargo.toml
+++ b/network/netcore/Cargo.toml
@@ -13,21 +13,20 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-bytes = "1.1.0"
-futures = "0.3.21"
-pin-project = "1.0.10"
-serde = { version = "1.0.137", default-features = false }
-tokio = { version = "1.21.0", features = ["full"] }
-tokio-util = { version = "0.7.2", features = ["compat"] }
-url = { version = "2.2.2" }
-
-aptos-types = { path = "../../types" }
-
-memsocket = { path = "../memsocket", optional = true }
-proxy = { path = "../../crates/proxy" }
+aptos-types = { workspace = true }
+bytes = { workspace = true }
+futures = { workspace = true }
+memsocket = { workspace = true }
+pin-project = { workspace = true }
+proxy = { workspace = true }
+serde = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
-memsocket = { path = "../memsocket" }
+aptos-types = { workspace = true, features = ["fuzzing"] }
+memsocket = { workspace = true }
 
 [features]
 default = []

--- a/network/peer-monitoring-service/client/Cargo.toml
+++ b/network/peer-monitoring-service/client/Cargo.toml
@@ -13,12 +13,10 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-async-trait = "0.1.42"
-thiserror = "1.0.24"
-
-aptos-config = { path = "../../../config" }
-aptos-types = { path = "../../../types" }
-
-channel = { path = "../../../crates/channel" }
-network = { path = "../../../network" }
-peer-monitoring-service-types = { path = "../types" }
+aptos-config = { workspace = true }
+aptos-types = { workspace = true }
+async-trait = { workspace = true }
+channel = { workspace = true }
+network = { workspace = true }
+peer-monitoring-service-types = { workspace = true }
+thiserror = { workspace = true }

--- a/network/peer-monitoring-service/server/Cargo.toml
+++ b/network/peer-monitoring-service/server/Cargo.toml
@@ -13,21 +13,19 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" }
-bytes = "1.0.1"
-futures = "0.3.12"
-once_cell = "1.7.2"
-serde = { version = "1.0.124", default-features = false }
-thiserror = "1.0.24"
-tokio = { version = "1.8.1", features = ["rt", "macros"], default-features = false }
-
-aptos-config = { path = "../../../config" }
-aptos-logger = { path = "../../../crates/aptos-logger" }
-aptos-metrics-core = { path = "../../../crates/aptos-metrics-core" }
-aptos-types = { path = "../../../types" }
-
-bounded-executor = { path = "../../../crates/bounded-executor" }
-channel = { path = "../../../crates/channel" }
-netcore = { path = "../../netcore" }
-network = { path = "../../../network" }
-peer-monitoring-service-types = { path = "../types" }
+aptos-config = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-metrics-core = { workspace = true }
+aptos-types = { workspace = true }
+bcs = { workspace = true }
+bounded-executor = { workspace = true }
+bytes = { workspace = true }
+channel = { workspace = true }
+futures = { workspace = true }
+netcore = { workspace = true }
+network = { workspace = true }
+once_cell = { workspace = true }
+peer-monitoring-service-types = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }

--- a/network/peer-monitoring-service/types/Cargo.toml
+++ b/network/peer-monitoring-service/types/Cargo.toml
@@ -13,9 +13,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-serde = { version = "1.0.124", default-features = false }
-thiserror = "1.0.24"
-
-aptos-config = { path = "../../../config" }
-
-network = { path = "../../../network" }
+aptos-config = { workspace = true }
+network = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -206,7 +206,7 @@ impl fmt::Display for ProtocolId {
 /// use on a new AptosNet connection.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
-pub struct ProtocolIdSet(bitvec::BitVec);
+pub struct ProtocolIdSet(aptos_bitvec::BitVec);
 
 impl ProtocolIdSet {
     pub fn empty() -> Self {

--- a/network/src/protocols/wire/handshake/v1/test.rs
+++ b/network/src/protocols/wire/handshake/v1/test.rs
@@ -147,14 +147,14 @@ fn ignore_unknown_protocols() {
     ]);
     let all_known_hs = HandshakeMsg::from_supported(all_known_protos);
 
-    let some_unknown_protos = ProtocolIdSet(bitvec::BitVec::from_iter([
+    let some_unknown_protos = ProtocolIdSet(aptos_bitvec::BitVec::from_iter([
         ProtocolId::MempoolDirectSend as u8,
         66,
         234,
     ]));
     let some_unknown_hs = HandshakeMsg::from_supported(some_unknown_protos.clone());
 
-    let all_unknown_protos = ProtocolIdSet(bitvec::BitVec::from_iter([42, 99, 123]));
+    let all_unknown_protos = ProtocolIdSet(aptos_bitvec::BitVec::from_iter([42, 99, 123]));
     let all_unknown_hs = HandshakeMsg::from_supported(all_unknown_protos.clone());
 
     // Case 1: the other set contains some unknown protocols, but we can still

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -13,20 +13,19 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.57"
-aptos-crypto = { path = "../crates/aptos-crypto" }
-aptos-global-constants = { path = "../config/global-constants" }
-aptos-rest-client = { path = "../crates/aptos-rest-client" }
-aptos-types = { path = "../types" }
-bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" }
-cached-packages = { path = "../aptos-move/framework/cached-packages" }
+anyhow = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-global-constants = { workspace = true }
+aptos-rest-client = { workspace = true }
+aptos-types = { workspace = true }
+bcs = { workspace = true }
+cached-packages = { workspace = true }
 move-core-types = { workspace = true }
-rand_core = "0.5.1"
-serde = { version = "1.0.137", features = ["derive"] }
+rand_core = { workspace = true }
+serde = { workspace = true }
 
-# Used by the examples.
 [dev-dependencies]
-once_cell = "1.13.0"
-rand = "0.7.3"
-tokio = { version = "1.21.0", features = ["macros", "rt-multi-thread"] }
-url = "2.2.2"
+once_cell = { workspace = true }
+rand = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }


### PR DESCRIPTION
### Description
This PR migrates several more crates to use workspace dependencies:
```
- execution/db-bootstrapper/Cargo.toml
- execution/executor-benchmark/Cargo.toml
- execution/executor-test-helpers/Cargo.toml
- execution/executor-types/Cargo.toml
- execution/executor/Cargo.toml
- mempool/Cargo.toml
- network/Cargo.toml
- network/builder/Cargo.toml
- network/discovery/Cargo.toml
- network/memsocket/Cargo.toml
- network/netcore/Cargo.toml
- network/peer-monitoring-service/client/Cargo.toml
- network/peer-monitoring-service/server/Cargo.toml
- network/peer-monitoring-service/types/Cargo.toml
- sdk/Cargo.toml
```

### Test Plan
Existing test infrastructure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5628)
<!-- Reviewable:end -->
