### PR TITLE
cicd: introduce checkgroup github app to conditionally require status checks

### DIFF
--- a/.github/checkgroup.yml
+++ b/.github/checkgroup.yml
@@ -1,0 +1,30 @@
+# This file leverages https://github.com/tianhaoz95/check-group
+# to define groups of status checks which are required depending on the files changed in a PR.
+# This allows us to make certain checks required/optional depending on the PR content,
+# which is useful in a Monorepo context.
+# Example: If only a doc change was made (in developer-docs-site) require only the `docs-lint` check to pass.
+# In GitHub's branch protection rule we only mark the result of the check group service as required,
+# not the individual checks.
+custom_service_name: Required checks
+subprojects:
+  - id: docs
+    paths:
+      - developer-docs-site/**
+    checks:
+      - docs-lint
+  # everything, but docs
+  - id: catch_all
+    paths:
+      - "!developer-docs-site/**"
+    checks:
+      - rust-lint
+      - ecosystem-lint
+      - permission-check
+      - scripts-lint
+      - rust-unit-test
+      - rust-doc-test
+      - rust-smoke-test
+      - forge-e2e-test / forge
+      - sdk-release / test-sdk-confirm-client-generated-publish
+      - rust-images / rust-all
+      - terraform-lint


### PR DESCRIPTION
This leverages https://tianhaoz95.github.io/check-group/#/.
This should make us more productive as it allows to only require a subset of checks to pass depending on which files in the repo have changed.
In the first phase this will allow doc changes to bypass all the other changes, hence allowing them to merge (for example via auto-merge) a lot faster.

### Test Plan
I tested out this app (and other alternatives) in the aptos-core-playground repo https://github.com/aptos-labs/aptos-core-cicd-playground/pull/9.
Seems like check-groups does exactly what we want.
<img width="844" alt="image" src="https://user-images.githubusercontent.com/1221897/202619219-c84af6a9-4b99-4a1c-a65d-50216f5ab7ee.png">

### Rollout plan

Once this is merged I will remove the required status checks in githubs branch protection rule and simply add the `Required checks` as the single requirement.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5630)
<!-- Reviewable:end -->
