### PR TITLE
cicd: introduce mergify as check-group alternative due to check-group bug

### DIFF
--- a/.github/checkgroup.yml
+++ b/.github/checkgroup.yml
@@ -1,7 +1,3 @@
-
-# This is temporarily not used due to a bug in check-group with evaluating checks that have been triggered by both pull_request and pull_request_target (duplicate checks).
-# Using mergify instead.
-
 # This file leverages https://github.com/tianhaoz95/check-group
 # to define groups of status checks which are required depending on the files changed in a PR.
 # This allows us to make certain checks required/optional depending on the PR content,
@@ -23,7 +19,6 @@ subprojects:
     checks:
       - rust-lint
       - ecosystem-lint
-      - permission-check
       - scripts-lint
       - rust-unit-test
       - rust-doc-test

--- a/.github/checkgroup.yml
+++ b/.github/checkgroup.yml
@@ -1,3 +1,7 @@
+
+# This is temporarily not used due to a bug in check-group with evaluating checks that have been triggered by both pull_request and pull_request_target (duplicate checks).
+# Using mergify instead.
+
 # This file leverages https://github.com/tianhaoz95/check-group
 # to define groups of status checks which are required depending on the files changed in a PR.
 # This allows us to make certain checks required/optional depending on the PR content,

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,32 @@
+# This defines the rules used by https://mergify.com/
+
+pull_request_rules:
+  - name: required status checks
+    conditions:
+      - base=main
+      - or:
+          - and:
+              - check-success=check-a
+              - check-success=check-b
+              - check-success=docs-lint
+              - check-success=rust-lint
+              - check-success=ecosystem-lint
+              - check-success=permission-check
+              - check-success=scripts-lint
+              - check-success=rust-unit-test
+              - check-success=rust-doc-test
+              - check-success=rust-smoke-test
+              - check-success=forge-e2e-test / forge
+              - check-success=sdk-release / test-sdk-confirm-client-generated-publish
+              - check-success=rust-images / rust-all
+              - check-success=terraform-lint
+          - and:
+              # for doc-only changes we only require docs-lint to pass
+              - check-success=docs-lint
+              - -files~=^(!?developer-docs-site/)
+    actions:
+      post_check:
+        summary: |
+          {% if not check_succeed %}
+          {{ check_conditions }}
+          {% endif %}


### PR DESCRIPTION
### Description

### Test Plan
semi tested manually in the cicd-playground repo.

### Rollout
will modify the branch protection rule to block on the mergify check instead of check-group.

