### PR TITLE
Update variables.tf

### DIFF
--- a/terraform/fullnode/gcp/variables.tf
+++ b/terraform/fullnode/gcp/variables.tf
@@ -161,7 +161,7 @@ variable "gke_enable_private_nodes" {
 
 variable "gke_enable_node_autoprovisioning" {
   description = "Enable node autoprovisioning for GKE cluster. See https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning"
-  default     = false
+  default     = true
 }
 
 variable "gke_node_autoprovisioning_max_cpu" {


### PR DESCRIPTION
Fix error in autoprovisioning default.  When this is set to `false`, the terraform cannot set auto provisioning parameters and fails with this error:

```
module.fullnode.data.google_compute_subnetwork.region: Read complete after 0s [id=projects/nutrios-stack/regions/us-central1/subnetworks/aptos-default]

│ Error: googleapi: Error 400: Resource limits are supported only with node autoprovisioning., badRequest
│ 
│   with module.fullnode.google_container_cluster.aptos,
│   on .[terraform/modules/fullnode/terraform/fullnode/gcp/cluster.tf](http://terraform/modules/fullnode/terraform/fullnode/gcp/cluster.tf) line 1, in resource "google_container_cluster" "aptos":
│    1: resource "google_container_cluster" "aptos" {
```
Editing `variables.tf` before running `terraform apply` enables the script to complete successfully. Several reported this error in Discord #node-support after the 17 Oct commit where this change was introduced.

