### PR TITLE
[Executor] Introduce min block size for parallel execution

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -611,6 +611,9 @@ pub fn setup_environment(
         node_config.execution.paranoid_hot_potato_verification,
     );
     AptosVM::set_concurrency_level_once(node_config.execution.concurrency_level as usize);
+    AptosVM::set_min_block_len_for_parallel_once(
+        node_config.execution.min_block_len_for_parallel as usize,
+    );
     AptosVM::set_num_proof_reading_threads_once(
         node_config.execution.num_proof_reading_threads as usize,
     );

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -19,6 +19,7 @@ pub struct ExecutionConfig {
     pub genesis: Option<Transaction>,
     pub genesis_file_location: PathBuf,
     pub concurrency_level: u16,
+    pub min_block_len_for_parallel: u16,
     pub num_proof_reading_threads: u16,
     pub paranoid_type_verification: bool,
     pub paranoid_hot_potato_verification: bool,
@@ -48,6 +49,8 @@ impl Default for ExecutionConfig {
             genesis_file_location: PathBuf::new(),
             // Parallel execution by default.
             concurrency_level: 8,
+            // Run blocks smaller than 10 txns sequentially.
+            min_block_len_for_parallel: 10,
             num_proof_reading_threads: 32,
             paranoid_type_verification: true,
             paranoid_hot_potato_verification: true,


### PR DESCRIPTION
Proposing to introduce min block size for parallel execution, smaller blocks will run sequentially. setting default to 10.
If this makes sense, I'll test it does what I think it does.