### PR TITLE
[token] update transfer doc

### DIFF
--- a/aptos-move/framework/aptos-token/sources/token.move
+++ b/aptos-move/framework/aptos-token/sources/token.move
@@ -146,51 +146,51 @@ module aptos_token::token {
     //
     struct Token has store {
         id: TokenId,
-        // the amount of tokens. Only property_version = 0 can have a value bigger than 1.
+        /// the amount of tokens. Only property_version = 0 can have a value bigger than 1.
         amount: u64,
-        // The properties with this token.
-        // when property_version = 0, the token_properties are the same as default_properties in TokenData, we don't store it.
-        // when the property_map mutates, a new property_version is assigned to the token.
+        /// The properties with this token.
+        /// when property_version = 0, the token_properties are the same as default_properties in TokenData, we don't store it.
+        /// when the property_map mutates, a new property_version is assigned to the token.
         token_properties: PropertyMap,
     }
 
     /// global unique identifier of a token
     struct TokenId has store, copy, drop {
-        // the id to the common token data shared by token with different property_version
+        /// the id to the common token data shared by token with different property_version
         token_data_id: TokenDataId,
-        // The version of the property map; when a fungible token is mutated, a new property version is created and assigned to the token to make it an NFT
+        /// The version of the property map; when a fungible token is mutated, a new property version is created and assigned to the token to make it an NFT
         property_version: u64,
     }
 
     /// globally unique identifier of tokendata
     struct TokenDataId has copy, drop, store {
-        // The address of the creator, eg: 0xcafe
+        /// The address of the creator, eg: 0xcafe
         creator: address,
-        // The name of collection; this is unique under the same account, eg: "Aptos Animal Collection"
+        /// The name of collection; this is unique under the same account, eg: "Aptos Animal Collection"
         collection: String,
-        // The name of the token; this is the same as the name field of TokenData
+        /// The name of the token; this is the same as the name field of TokenData
         name: String,
     }
 
     /// The shared TokenData by tokens with different property_version
     struct TokenData has store {
-        // The maximal number of tokens that can be minted under this TokenData; if the maximum is 0, there is no limit
+        /// The maximal number of tokens that can be minted under this TokenData; if the maximum is 0, there is no limit
         maximum: u64,
-        // The current largest property version of all tokens with this TokenData
+        /// The current largest property version of all tokens with this TokenData
         largest_property_version: u64,
-        // The number of tokens with this TokenData. Supply is only tracked for the limited token whose maximum is not 0
+        /// The number of tokens with this TokenData. Supply is only tracked for the limited token whose maximum is not 0
         supply: u64,
-        // The Uniform Resource Identifier (uri) pointing to the JSON file stored in off-chain storage; the URL length should be less than 512 characters, eg: https://arweave.net/Fmmn4ul-7Mv6vzm7JwE69O-I-vd6Bz2QriJO1niwCh4
+        /// The Uniform Resource Identifier (uri) pointing to the JSON file stored in off-chain storage; the URL length should be less than 512 characters, eg: https://arweave.net/Fmmn4ul-7Mv6vzm7JwE69O-I-vd6Bz2QriJO1niwCh4
         uri: String,
-        // The denominator and numerator for calculating the royalty fee; it also contains payee account address for depositing the Royalty
+        /// The denominator and numerator for calculating the royalty fee; it also contains payee account address for depositing the Royalty
         royalty: Royalty,
-        // The name of the token, which should be unique within the collection; the length of name should be smaller than 128, characters, eg: "Aptos Animal #1234"
+        /// The name of the token, which should be unique within the collection; the length of name should be smaller than 128, characters, eg: "Aptos Animal #1234"
         name: String,
-        // Describes this Token
+        /// Describes this Token
         description: String,
-        // The properties are stored in the TokenData that are shared by all tokens
+        /// The properties are stored in the TokenData that are shared by all tokens
         default_properties: PropertyMap,
-        // Control the TokenData field mutability
+        /// Control the TokenData field mutability
         mutability_config: TokenMutabilityConfig,
     }
 
@@ -198,28 +198,28 @@ module aptos_token::token {
     struct Royalty has copy, drop, store {
         royalty_points_numerator: u64,
         royalty_points_denominator: u64,
-        // if the token is jointly owned by multiple creators, the group of creators should create a shared account.
-        // the payee_address will be the shared account address.
+        /// if the token is jointly owned by multiple creators, the group of creators should create a shared account.
+        /// the payee_address will be the shared account address.
         payee_address: address,
     }
 
     /// This config specifies which fields in the TokenData are mutable
     struct TokenMutabilityConfig has copy, store, drop {
-        // control if the token maximum is mutable
+        /// control if the token maximum is mutable
         maximum: bool,
-        // control if the token uri is mutable
+        /// control if the token uri is mutable
         uri: bool,
-        // control if the token royalty is mutable
+        /// control if the token royalty is mutable
         royalty: bool,
-        // control if the token description is mutable
+        /// control if the token description is mutable
         description: bool,
-        // control if the property map is mutable
+        /// control if the property map is mutable
         properties: bool,
     }
 
     /// Represents token resources owned by token owner
     struct TokenStore has key {
-        // the tokens owned by a token owner
+        /// the tokens owned by a token owner
         tokens: Table<TokenId, Token>,
         direct_transfer: bool,
         deposit_events: EventHandle<DepositEvent>,
@@ -230,11 +230,11 @@ module aptos_token::token {
 
     /// This config specifies which fields in the Collection are mutable
     struct CollectionMutabilityConfig has copy, store, drop {
-        // control if description is mutable
+        /// control if description is mutable
         description: bool,
-        // control if uri is mutable
+        /// control if uri is mutable
         uri: bool,
-        // control if collection maxium is mutable
+        /// control if collection maxium is mutable
         maximum: bool,
     }
 
@@ -249,18 +249,18 @@ module aptos_token::token {
 
     /// Represent the collection metadata
     struct CollectionData has store {
-        // A description for the token collection Eg: "Aptos Toad Overload"
+        /// A description for the token collection Eg: "Aptos Toad Overload"
         description: String,
-        // The collection name, which should be unique among all collections by the creator; the name should also be smaller than 128 characters, eg: "Animal Collection"
+        /// The collection name, which should be unique among all collections by the creator; the name should also be smaller than 128 characters, eg: "Animal Collection"
         name: String,
-        // The URI for the collection; its length should be smaller than 512 characters
+        /// The URI for the collection; its length should be smaller than 512 characters
         uri: String,
-        // The number of different TokenData entries in this collection
+        /// The number of different TokenData entries in this collection
         supply: u64,
-        // If maximal is a non-zero value, the number of created TokenData entries should be smaller or equal to this maximum
-        // If maximal is 0, Aptos doesn't track the supply of this collection, and there is no limit
+        /// If maximal is a non-zero value, the number of created TokenData entries should be smaller or equal to this maximum
+        /// If maximal is 0, Aptos doesn't track the supply of this collection, and there is no limit
         maximum: u64,
-        // control which collectionData field is mutable
+        /// control which collectionData field is mutable
         mutability_config: CollectionMutabilityConfig,
     }
 

--- a/developer-docs-site/docs/concepts/coin-and-token/aptos-token.md
+++ b/developer-docs-site/docs/concepts/coin-and-token/aptos-token.md
@@ -181,7 +181,8 @@ The following tables describe fields at the struct level. For the definitive lis
 | [`Token`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/token.md#0x3_token_Token) | The amount is the number of tokens. |
 | [`TokenId`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/token.md#0x3_token_TokenId) | `TokenDataId` points to the metadata of this token. The `property_version` represents a token with mutated `PropertyMap` from `default_properties` in the `TokenData`. |
 
-For struct field definion, fee 
+For more detailed description, see [move doc](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/overview.md)
+
 ## Token lifecycle
 
 ### Token creation
@@ -236,3 +237,4 @@ The user can also turn off this direct transfer behavior by calling the same `op
 :::
 
 Multi-agent transfer: the sender and receiver can both sign a transfer transaction to directly transfer a token from the sender to receiver [`direct_transfer_script`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/token.md#function-direct_transfer_script). For example, once Alice and Bob both sign the transfer transaction, the token will be directly transferred from Alice's account to Bob.
+

--- a/developer-docs-site/docs/concepts/coin-and-token/aptos-token.md
+++ b/developer-docs-site/docs/concepts/coin-and-token/aptos-token.md
@@ -181,60 +181,7 @@ The following tables describe fields at the struct level. For the definitive lis
 | [`Token`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/token.md#0x3_token_Token) | The amount is the number of tokens. |
 | [`TokenId`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/token.md#0x3_token_TokenId) | `TokenDataId` points to the metadata of this token. The `property_version` represents a token with mutated `PropertyMap` from `default_properties` in the `TokenData`. |
 
-### Coin and token field descriptions
-
-The following tables contain descriptions and examples on key token fields. Once again, see the [Move reference documentation](../../guides/move-guides/index.md#aptos-move-documentation) for the [Aptos Token Framework](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/overview.md).
-
-#### Token module key struct
-
-##### [`Token`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/sources/token.move#L144)
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `id` | TokenId | Unique identification of the token |
-| `amount` | u64 | The number of tokens stored |
-| `token_properties` | PropertyMap | The properties of this token; PropertyMap is a key-value map used for storing different types in one map; the value of PropertyMap contains both the value and type information |
-
-##### `TokenId`
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `token_data_id` | TokenDataId | Identification for the metadata of the token |
-| `property_version` | u64 | The version of the property map; when a fungible token is mutated, a new property version is created and assigned to the token to make it an NFT |
-
-##### `TokenDataId`
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `creator` | address | The address of the creator, eg: 0xcafe |
-| `collection` | String | The name of collection; this is unique under the same account, eg: “Aptos Animal Collection” |
-| `name` | String | The name of the token; this is the same as the name field of TokenData |
-
-##### `TokenData`
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `maximum` | u64 | The maximal number of tokens that can be minted under this TokenData; if the maximum is 0, there is no limit |
-| `largest_property_version` | u64 | The current largest property version of all tokens with this TokenData |
-| `supply` | String | The number of tokens with this TokenData |
-| `uri` | String | The Uniform Resource Identifier (uri) pointing to the JSON file stored in off-chain storage; the URL length should be less than 512 characters, eg: https://arweave.net/Fmmn4ul-7Mv6vzm7JwE69O-I-vd6Bz2QriJO1niwCh4 |
-| `royalty` | Royalty | The denominator and numerator for calculating the royalty fee; it also contains payee account address for depositing the Royalty |
-| `name` | String | The name of the token, which should be unique within the collection; the length of name should be smaller than 128, characters, eg: “Aptos Animal #1234” |
-| `description` | String | The description of the token |
-| `default_properties` | PropertyMap | The properties are stored in the TokenData that are shared by all tokens  |
-| `mutability_config` | TokenMutabilityConfig | Specifies which fields are mutable  |
-
-##### `CollectionData`
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `description` | String | A description for the token collection Eg: “Aptos Toad Overload” |
-| `name` | String | The collection name, which should be unique among all collections by the creator; the name should also be smaller than 128 characters, eg: “Animal Collection” |
-| `uri` | String | The URI for the collection; its length should be smaller than 512 characters |
-| `supply` | u64 | The number of different TokenData entries in this collection |
-| `maximum` | u64 | If maximal is a non-zero value, the number of created TokenData entries should be smaller or equal to this maximum If maximal is 0, Aptos doen’t track the supply of this collection, and there is no limit |
-| `mutability_config` | CollectionMutabilityConfig | Specifies which fields are mutable  |
-
+For struct field definion, fee 
 ## Token lifecycle
 
 ### Token creation
@@ -270,24 +217,24 @@ We provide `burn` and `burn_by_creator` functions for token owners and token cre
 Burn is allowed only when the `BURNABLE_BY_OWNER` property is set to `true` in `default_properties`. Burn by creator is allowed when `BURNABLE_BY_CREATOR` is `true` in `default_properties`.
 Once all the tokens belonging to a `TokenData` are burned, the `TokenData` will be removed from the creator’s account. Similarly, if all `TokenData` belonging to a collection are removed, the `CollectionData` will be removed from the creator’s account.
 
-## Token transfer
+### Token transfer
 
-To protect a user from receiving undesired NFTs, an Aptos user must be first offered an NFT, followed by the user claiming the offered NFTs. Then only these NFTs will be deposited in the user's token store. This is the default token transfer behavior. For example:
+We provide 3 different modes for transferring token between the sender and receiver.
 
-1. If Alice wants to send Bob an NFT, she must first offer Bob this NFT. This NFT is still stored under Alice’s account. 
-1. Only when Bob claims the NFT, this NFT will be removed from Alice’s account and stored in Bob’s token store. 
+Two step transfer: to protect a user from receiving undesired NFTs, an Aptos user must be first offered an NFT, followed by the user claiming the offered NFTs. Then only these NFTs will be deposited in the user's token store. This is the default token transfer behavior. For example:
+1. If Alice wants to send Bob an NFT, she must first offer Bob this NFT. This NFT is still stored under Alice’s account.
+1. Only when Bob claims the NFT, this NFT will be removed from Alice’s account and stored in Bob’s token store.
 
 :::tip Token transfer module
-The token transfer is implemented in the [`token_transfers`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/sources/token_transfers.move) module. 
+The token transfer is implemented in the [`token_transfers`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/sources/token_transfers.move) module.
 :::
 
-### Direct transfer
 
-On the other hand, if a user wants to receive direct transfer of the NFT, skipping the initial steps of offer and claim, then the user can call [`opt_in_direct_transfer`](https://github.com/aptos-labs/aptos-core/blob/283348c6ea4ce198fb27eb3ef1c1e471739aa1aa/aptos-move/framework/aptos-token/sources/token.move#L297) to allow other people to directly transfer the NFTs into the user's token store.  
-
-Note that in both the default token transfer and the direct transfer method, the user will receive the NFT into the user's token store. 
+Transfer with opt-in: if a user wants to receive direct transfer of the NFT, skipping the initial steps of offer and claim, then the user can call [`opt_in_direct_transfer`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/token.md#0x3_token_opt_in_direct_transfer) to allow other people to directly transfer the NFTs into the user's token store. after opt-in direct transfer, the user can call [`transfer`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/token.md#0x3_token_transfer) to transfer tokens directly. For example, Alice and anyone can directly send a token to Bob's token store once Bob opts in.
 
 :::tip Turning off direct transfer
-The user can also turn off this direct transfer behavior by calling the same `opt_in_direct_transfer` function to reset the behavior to the default behavior. 
+The user can also turn off this direct transfer behavior by calling the same `opt_in_direct_transfer` function to reset the behavior to the default behavior.
 :::
+
+Multi-agent transfer: the sender and receiver can both sign a transfer transaction to directly transfer a token from the sender to receiver [`direct_transfer_script`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/token.md#function-direct_transfer_script). For example, once Alice and Bob both signs the transfer transaction. The token will be directly transferred from Alice's account to Bob.
 

--- a/developer-docs-site/docs/concepts/coin-and-token/aptos-token.md
+++ b/developer-docs-site/docs/concepts/coin-and-token/aptos-token.md
@@ -219,22 +219,21 @@ Once all the tokens belonging to a `TokenData` are burned, the `TokenData` will 
 
 ### Token transfer
 
-We provide 3 different modes for transferring token between the sender and receiver.
+We provide three different modes for transferring tokens between the sender and receiver.
 
-Two step transfer: to protect a user from receiving undesired NFTs, an Aptos user must be first offered an NFT, followed by the user claiming the offered NFTs. Then only these NFTs will be deposited in the user's token store. This is the default token transfer behavior. For example:
+Two-step transfer: to protect users from receiving undesired NFTs, they must be first offered NFTs, and then accept the offered NFTs. Then only the offered NFTs will be deposited in the users' token stores. This is the default token transfer behavior. For example:
 1. If Alice wants to send Bob an NFT, she must first offer Bob this NFT. This NFT is still stored under Alice’s account.
-1. Only when Bob claims the NFT, this NFT will be removed from Alice’s account and stored in Bob’s token store.
+1. Only when Bob claims the NFT, will the NFT be removed from Alice’s account and stored in Bob’s token store.
 
 :::tip Token transfer module
 The token transfer is implemented in the [`token_transfers`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/sources/token_transfers.move) module.
 :::
 
 
-Transfer with opt-in: if a user wants to receive direct transfer of the NFT, skipping the initial steps of offer and claim, then the user can call [`opt_in_direct_transfer`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/token.md#0x3_token_opt_in_direct_transfer) to allow other people to directly transfer the NFTs into the user's token store. after opt-in direct transfer, the user can call [`transfer`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/token.md#0x3_token_transfer) to transfer tokens directly. For example, Alice and anyone can directly send a token to Bob's token store once Bob opts in.
+Transfer with opt-in: if a user wants to receive direct transfer of the NFT, skipping the initial steps of offer and claim, then the user can call [`opt_in_direct_transfer`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/token.md#0x3_token_opt_in_direct_transfer) to allow other people to directly transfer the NFTs into the user's token store. After opting into direct transfer, the user can call [`transfer`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/token.md#0x3_token_transfer) to transfer tokens directly. For example, Alice and anyone can directly send a token to Bob's token store once Bob opts in.
 
 :::tip Turning off direct transfer
-The user can also turn off this direct transfer behavior by calling the same `opt_in_direct_transfer` function to reset the behavior to the default behavior.
+The user can also turn off this direct transfer behavior by calling the same `opt_in_direct_transfer` function to reset to the default behavior.
 :::
 
-Multi-agent transfer: the sender and receiver can both sign a transfer transaction to directly transfer a token from the sender to receiver [`direct_transfer_script`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/token.md#function-direct_transfer_script). For example, once Alice and Bob both signs the transfer transaction. The token will be directly transferred from Alice's account to Bob.
-
+Multi-agent transfer: the sender and receiver can both sign a transfer transaction to directly transfer a token from the sender to receiver [`direct_transfer_script`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/token.md#function-direct_transfer_script). For example, once Alice and Bob both sign the transfer transaction, the token will be directly transferred from Alice's account to Bob.

--- a/developer-docs-site/docs/concepts/coin-and-token/aptos-token.md
+++ b/developer-docs-site/docs/concepts/coin-and-token/aptos-token.md
@@ -223,12 +223,11 @@ We provide three different modes for transferring tokens between the sender and 
 
 Two-step transfer: to protect users from receiving undesired NFTs, they must be first offered NFTs, and then accept the offered NFTs. Then only the offered NFTs will be deposited in the users' token stores. This is the default token transfer behavior. For example:
 1. If Alice wants to send Bob an NFT, she must first offer Bob this NFT. This NFT is still stored under Alice’s account.
-1. Only when Bob claims the NFT, will the NFT be removed from Alice’s account and stored in Bob’s token store.
+2. Only when Bob claims the NFT, will the NFT be removed from Alice’s account and stored in Bob’s token store.
 
 :::tip Token transfer module
 The token transfer is implemented in the [`token_transfers`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/sources/token_transfers.move) module.
 :::
-
 
 Transfer with opt-in: if a user wants to receive direct transfer of the NFT, skipping the initial steps of offer and claim, then the user can call [`opt_in_direct_transfer`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/token.md#0x3_token_opt_in_direct_transfer) to allow other people to directly transfer the NFTs into the user's token store. After opting into direct transfer, the user can call [`transfer`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/doc/token.md#0x3_token_transfer) to transfer tokens directly. For example, Alice and anyone can directly send a token to Bob's token store once Bob opts in.
 


### PR DESCRIPTION
### Description
1. token transfer as one part of token lifecycle
2. update the token transfer documentation to clearly list 3 different mode with links
3. remove detail struct field documentation and should directly link to code comment
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
