### PR TITLE
[CLI] Give 1 APT for `fund-with-faucet`

### DIFF
--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -7,9 +7,8 @@ use async_trait::async_trait;
 use cached_packages::aptos_stdlib;
 use clap::Parser;
 
-// TODO(Gas): double check if this is correct
-// TODO(greg): revisit after fixing gas estimation
-pub const DEFAULT_FUNDED_COINS: u64 = 500_000;
+// 1 APT
+pub const DEFAULT_FUNDED_COINS: u64 = 100_000_000;
 
 /// Create a new account on-chain
 ///


### PR DESCRIPTION
### Description
The devnet faucet (the only prod faucet `fund-with-faucet` works with), gives out 1 APT max, so let's request that.

Really the tap doesn't even need to be given an amount, it will just use the max by default, but that can come later.

I confirmed the faucet run with the local testnet has no max, so this change should work in that case too.

### Test Plan
```
cargo test
```

```
cargo run -p aptos --  account fund-with-faucet --account 0xb078d693856a65401d492f99ca0d6a29a0c5c0e371bc2521570a86e40d95f823
```