### PR TITLE
[forge] Fix more flaky forge

### DIFF
--- a/testsuite/testcases/src/consensus_reliability_tests.rs
+++ b/testsuite/testcases/src/consensus_reliability_tests.rs
@@ -19,6 +19,9 @@ pub struct ChangingWorkingQuorumTest {
     pub max_down_nodes: usize,
     pub num_large_validators: usize,
     pub add_execution_delay: bool,
+    /// Check that every given number of seconds all nodes make progress, without any failures.
+    /// It is good to make epoch length and this duration not be multiples of one another,
+    /// to test different timings
     pub check_period_s: usize,
 }
 


### PR DESCRIPTION
### Description

- performance test success criteria need to be dynamic, as we have 2 and 5 hour runs
- backoff for stress tests is not great, as it reduces consensus stress
- for stress test on the edge of quorum, increasing the time we look for TPS from 27s to 53s, to reduce flakiness. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
