### PR TITLE
[gha] deprecate set-output for determinator

### DIFF
--- a/.github/workflows/check-minimum-revision.yaml
+++ b/.github/workflows/check-minimum-revision.yaml
@@ -42,7 +42,7 @@ jobs:
           FAILED=$?
           set -e
 
-          echo "::set-output name=FAIL_MERGE_BASE::$FAILED"
+          echo "FAIL_MERGE_BASE=${FAILED}" >> $GITHUB_OUTPUT
           MERGE_BASE="$(git merge-base origin/main ${{ env.GIT_SHA }})"
 
           if [[ $FAILED == 1 ]]; then

--- a/testsuite/determinator_test.py
+++ b/testsuite/determinator_test.py
@@ -1,7 +1,19 @@
 import unittest
+import tempfile
+import os
 
 from click.testing import CliRunner
 from determinator import main, ChangedFilesPredicate, ChangedFilesContext
+
+
+# If this test is run from Github Actions, $GITHUB_OUTPUT will be set
+# Otherwise, create a tempfile for it, which exists for the duration of the test
+if "GITHUB_OUTPUT" not in os.environ:
+    temp_github_output = tempfile.NamedTemporaryFile(
+        prefix="determinator_github_output_"
+    )
+    os.environ["GITHUB_OUTPUT"] = temp_github_output.name
+print("GITHUB_OUTPUT set to", os.environ["GITHUB_OUTPUT"])
 
 
 class ChangedFilesPredicateTestCase(unittest.TestCase):
@@ -33,7 +45,7 @@ class DeterminatorTestCase(unittest.TestCase):
         )
         self.assertEqual(
             result.output,
-            "FAILED because Matched files: []\n" "::set-output name=BANANA::false\n",
+            "FAILED because Matched files: []\n" "BANANA=false\n",
         )
         self.assertEqual(result.exit_code, 0)
 
@@ -55,6 +67,6 @@ class DeterminatorTestCase(unittest.TestCase):
             result.output,
             "PASSED because Matched files: "
             "['testsuite/fixtures/helm/banana.ts']\n"
-            "::set-output name=BANANA::true\n",
+            "BANANA=true\n",
         )
         self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
### Description

`::save-state` and `::set-output` GHA commands will be deprecated soon, as per: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ and the warnings on runs such as: https://github.com/aptos-labs/aptos-core/actions/runs/3526688470

![image](https://user-images.githubusercontent.com/12578616/203412717-6741ae9a-a5a1-4772-8526-31951a3c1422.png)

The warnings are visually noisy and you have to scroll past all of them to view test summaries.

This is mostly used in python test code and whatever sits behind our mini python target determinator determinator. There are some 3rd party Github Actions that still use it as well. For these we can either update the git ref for these if it's been updated upstream already, otherwise just leave it as is.

### Test Plan

Determinator still works

<!-- Please provide us with clear details for verifying that your changes work. -->
