### PR TITLE
[leader election] Improve leader election for first 20 rounds

### DIFF
--- a/consensus/src/liveness/cached_proposer_election.rs
+++ b/consensus/src/liveness/cached_proposer_election.rs
@@ -4,6 +4,7 @@
 use std::collections::BTreeMap;
 
 use aptos_infallible::Mutex;
+use aptos_logger::prelude::info;
 use consensus_types::common::{Author, Round};
 
 use crate::counters::PROPOSER_ELECTION_DURATION;
@@ -15,6 +16,7 @@ use super::proposer_election::ProposerElection;
 // Function get_valid_proposer can be expensive, and we want to make sure
 // it is computed only once for a given round.
 pub struct CachedProposerElection {
+    epoch: u64,
     proposer_election: Box<dyn ProposerElection + Send + Sync>,
     // We use BTreeMap since we want a fixed window of cached elements
     // to look back (and caller knows how big of a window it needs).
@@ -25,8 +27,13 @@ pub struct CachedProposerElection {
 }
 
 impl CachedProposerElection {
-    pub fn new(proposer_election: Box<dyn ProposerElection + Send + Sync>, window: usize) -> Self {
+    pub fn new(
+        epoch: u64,
+        proposer_election: Box<dyn ProposerElection + Send + Sync>,
+        window: usize,
+    ) -> Self {
         Self {
+            epoch,
             proposer_election,
             recent_elections: Mutex::new(BTreeMap::new()),
             window,
@@ -42,8 +49,14 @@ impl CachedProposerElection {
 
         *recent_elections.entry(round).or_insert_with(|| {
             let _timer = PROPOSER_ELECTION_DURATION.start_timer();
-            self.proposer_election
-                .get_valid_proposer_and_voting_power_participation_ratio(round)
+            let result = self
+                .proposer_election
+                .get_valid_proposer_and_voting_power_participation_ratio(round);
+            info!(
+                "ProposerElection for epoch {} and round {}: {:?}",
+                self.epoch, round, result
+            );
+            result
         })
     }
 }

--- a/consensus/src/liveness/cached_proposer_election_test.rs
+++ b/consensus/src/liveness/cached_proposer_election_test.rs
@@ -35,6 +35,7 @@ fn test_get_valid_proposer_caching() {
     let asked = Arc::new(Mutex::new(Cell::new(0)));
     let authors: Vec<Author> = (0..4).map(|_| Author::random()).collect();
     let cpe = CachedProposerElection::new(
+        1,
         Box::new(MockProposerElection::new(authors.clone(), asked.clone())),
         10,
     );


### PR DESCRIPTION
exclude_rounds is 20 by default, which means we don't consider last 20 rounds in leader reputation history - but we do so from the same epoch - we consider everyone is caught up with the previous epoch.

genesis is epoch=0, round=0
first block is epoch=1 round=1, and that is a reconfig, that triggers epoch 2. because votes in block metadata are for previous round, they are empty in that round. So in that round - only "active" node is proposer.

For first 20 rounds of epoch 2, that is the only history we have - and so proposer of epoch=1 round=1 will always be elected for the first 20 rounds.

That can cause issues in tests, as they might be executed over very few rounds. So removing epoch=1,round=1 from being considered for history in epoch 2.

We can make this change without backward compatible gating, as this only affects first window rounds (10 * num validators), and chain will continue successfully after that (and all active chains are pass the epoch 2)

### Description

### Test Plan
used test_basic_fault_tolerance test, and confirmed before the change that leader doesn't change for first 20 rounds, and after this change it does.
