### PR TITLE
[rosetta] Add reset lockup command

### DIFF
--- a/crates/aptos-rosetta/src/client.rs
+++ b/crates/aptos-rosetta/src/client.rs
@@ -311,6 +311,44 @@ impl RosettaClient {
         .await
     }
 
+    pub async fn reset_lockup(
+        &self,
+        network_identifier: &NetworkIdentifier,
+        private_key: &Ed25519PrivateKey,
+        operator: Option<AccountAddress>,
+        expiry_time_secs: u64,
+        sequence_number: Option<u64>,
+        max_gas: Option<u64>,
+        gas_unit_price: Option<u64>,
+    ) -> anyhow::Result<TransactionIdentifier> {
+        let sender = self
+            .get_account_address(network_identifier.clone(), private_key)
+            .await?;
+        let mut keys = HashMap::new();
+        keys.insert(sender, private_key);
+
+        // A transfer operation is made up of a withdraw and a deposit
+        let operations = vec![Operation::reset_lockup(
+            0,
+            None,
+            sender,
+            operator.map(AccountIdentifier::base_account),
+        )];
+
+        self.submit_operations(
+            sender,
+            network_identifier.clone(),
+            &keys,
+            operations,
+            expiry_time_secs,
+            sequence_number,
+            max_gas,
+            gas_unit_price,
+            operator.is_none(),
+        )
+        .await
+    }
+
     pub async fn create_stake_pool(
         &self,
         network_identifier: &NetworkIdentifier,

--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -90,6 +90,7 @@ pub enum OperationType {
     SetOperator,
     SetVoter,
     InitializeStakePool,
+    ResetLockup,
     // Fee must always be last for ordering
     Fee,
 }
@@ -103,6 +104,7 @@ impl OperationType {
     const SET_OPERATOR: &'static str = "set_operator";
     const SET_VOTER: &'static str = "set_voter";
     const INITIALIZE_STAKE_POOL: &'static str = "initialize_stake_pool";
+    const RESET_LOCKUP: &'static str = "reset_lockup";
 
     pub fn all() -> Vec<OperationType> {
         use OperationType::*;
@@ -115,6 +117,7 @@ impl OperationType {
             SetVoter,
             StakingReward,
             InitializeStakePool,
+            ResetLockup,
         ]
     }
 }
@@ -132,6 +135,7 @@ impl FromStr for OperationType {
             Self::SET_OPERATOR => Ok(OperationType::SetOperator),
             Self::SET_VOTER => Ok(OperationType::SetVoter),
             Self::INITIALIZE_STAKE_POOL => Ok(OperationType::InitializeStakePool),
+            Self::RESET_LOCKUP => Ok(OperationType::ResetLockup),
             _ => Err(ApiError::DeserializationFailed(Some(format!(
                 "Invalid OperationType: {}",
                 s
@@ -151,6 +155,7 @@ impl Display for OperationType {
             SetOperator => Self::SET_OPERATOR,
             SetVoter => Self::SET_VOTER,
             InitializeStakePool => Self::INITIALIZE_STAKE_POOL,
+            ResetLockup => Self::RESET_LOCKUP,
             Fee => Self::FEE,
         })
     }

--- a/crates/aptos-rosetta/src/types/move_types.rs
+++ b/crates/aptos-rosetta/src/types/move_types.rs
@@ -29,7 +29,8 @@ pub const VESTING_RESOURCE: &str = "Vesting";
 
 pub const CREATE_ACCOUNT_FUNCTION: &str = "create_account";
 pub const TRANSFER_FUNCTION: &str = "transfer";
-pub const CREATE_STAKING_CONTRACT: &str = "create_staking_contract";
+pub const RESET_LOCKUP_FUNCTION: &str = "reset_lockup";
+pub const CREATE_STAKING_CONTRACT_FUNCTION: &str = "create_staking_contract";
 pub const SWITCH_OPERATOR_WITH_SAME_COMMISSION_FUNCTION: &str =
     "switch_operator_with_same_commission";
 pub const UPDATE_VOTER_FUNCTION: &str = "update_voter";

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -6,7 +6,10 @@
 //! [Spec](https://www.rosetta-api.org/docs/api_objects.html)
 
 use crate::common::native_coin_tag;
-use crate::construction::{parse_set_operator_operation, parse_set_voter_operation};
+use crate::construction::{
+    parse_create_stake_pool_operation, parse_reset_lockup_operation, parse_set_operator_operation,
+    parse_set_voter_operation,
+};
 use crate::types::move_types::*;
 use crate::{
     common::{is_native_coin, native_coin},
@@ -351,6 +354,22 @@ impl Operation {
             Some(OperationMetadata::set_voter(operator, new_voter)),
         )
     }
+
+    pub fn reset_lockup(
+        operation_index: u64,
+        status: Option<OperationStatusType>,
+        owner: AccountAddress,
+        operator: Option<AccountIdentifier>,
+    ) -> Operation {
+        Operation::new(
+            OperationType::ResetLockup,
+            operation_index,
+            status,
+            AccountIdentifier::base_account(owner),
+            None,
+            Some(OperationMetadata::reset_lockup(operator)),
+        )
+    }
 }
 
 impl std::cmp::PartialOrd for Operation {
@@ -437,6 +456,13 @@ impl OperationMetadata {
             new_operator,
             new_voter,
             staked_balance: staked_balance.map(U64::from),
+            ..Default::default()
+        }
+    }
+
+    pub fn reset_lockup(operator: Option<AccountIdentifier>) -> Self {
+        OperationMetadata {
+            operator,
             ..Default::default()
         }
     }
@@ -699,9 +725,9 @@ fn parse_failed_operations_from_txn_payload(
                 if let Ok(mut ops) =
                     parse_set_operator_operation(sender, inner.ty_args(), inner.args())
                 {
-                    let mut operation = ops.remove(0);
-                    operation.status = Some(OperationStatusType::Failure.to_string());
-                    operations.push(operation);
+                    if let Some(operation) = ops.get_mut(0) {
+                        operation.status = Some(OperationStatusType::Failure.to_string());
+                    }
                 } else {
                     warn!("Failed to parse set operator {:?}", inner);
                 }
@@ -710,11 +736,33 @@ fn parse_failed_operations_from_txn_payload(
                 if let Ok(mut ops) =
                     parse_set_voter_operation(sender, inner.ty_args(), inner.args())
                 {
-                    let mut operation = ops.remove(0);
-                    operation.status = Some(OperationStatusType::Failure.to_string());
-                    operations.push(operation);
+                    if let Some(operation) = ops.get_mut(0) {
+                        operation.status = Some(OperationStatusType::Failure.to_string());
+                    }
                 } else {
                     warn!("Failed to parse set voter {:?}", inner);
+                }
+            }
+            (AccountAddress::ONE, STAKING_CONTRACT_MODULE, RESET_LOCKUP_FUNCTION) => {
+                if let Ok(mut ops) =
+                    parse_reset_lockup_operation(sender, inner.ty_args(), inner.args())
+                {
+                    if let Some(operation) = ops.get_mut(0) {
+                        operation.status = Some(OperationStatusType::Failure.to_string());
+                    }
+                } else {
+                    warn!("Failed to parse reset lockup {:?}", inner);
+                }
+            }
+            (AccountAddress::ONE, STAKING_CONTRACT_MODULE, CREATE_STAKING_CONTRACT_FUNCTION) => {
+                if let Ok(mut ops) =
+                    parse_create_stake_pool_operation(sender, inner.ty_args(), inner.args())
+                {
+                    if let Some(operation) = ops.get_mut(0) {
+                        operation.status = Some(OperationStatusType::Failure.to_string());
+                    }
+                } else {
+                    warn!("Failed to parse create staking pool {:?}", inner);
                 }
             }
             _ => {
@@ -1313,6 +1361,7 @@ pub enum InternalOperation {
     SetOperator(SetOperator),
     SetVoter(SetVoter),
     InitializeStakePool(InitializeStakePool),
+    ResetLockup(ResetLockup),
 }
 
 impl InternalOperation {
@@ -1415,6 +1464,23 @@ impl InternalOperation {
                                 }));
                             }
                         }
+                        Ok(OperationType::ResetLockup) => {
+                            if let (Some(OperationMetadata { operator, .. }), Some(account)) =
+                                (&operation.metadata, &operation.account)
+                            {
+                                let operator = if let Some(operator) = operator {
+                                    operator.account_address()?
+                                } else {
+                                    return Err(ApiError::InvalidInput(Some(
+                                        "Reset lockup missing operator field".to_string(),
+                                    )));
+                                };
+                                return Ok(Self::ResetLockup(ResetLockup {
+                                    owner: account.account_address()?,
+                                    operator,
+                                }));
+                            }
+                        }
                         _ => {}
                     }
                 }
@@ -1441,6 +1507,7 @@ impl InternalOperation {
             Self::SetOperator(inner) => inner.owner,
             Self::SetVoter(inner) => inner.owner,
             Self::InitializeStakePool(inner) => inner.owner,
+            Self::ResetLockup(inner) => inner.owner,
         }
     }
 
@@ -1496,6 +1563,10 @@ impl InternalOperation {
                     init_stake_pool.seed.clone(),
                 ),
                 init_stake_pool.owner,
+            ),
+            InternalOperation::ResetLockup(reset_lockup) => (
+                aptos_stdlib::staking_contract_reset_lockup(reset_lockup.operator),
+                reset_lockup.owner,
             ),
         })
     }
@@ -1648,4 +1719,10 @@ pub struct InitializeStakePool {
     pub amount: u64,
     pub commission_percentage: u64,
     pub seed: Vec<u8>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ResetLockup {
+    pub owner: AccountAddress,
+    pub operator: AccountAddress,
 }

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -689,6 +689,7 @@ async fn test_block() {
     // Do some transfers
     let account_id_0 = cli.account_id(0);
     let account_id_1 = cli.account_id(1);
+    let account_id_2 = cli.account_id(2);
     let account_id_3 = cli.account_id(3);
 
     // TODO(greg): revisit after fixing gas estimation
@@ -909,6 +910,41 @@ async fn test_block() {
     )
     .await
     .unwrap_err();
+
+    // Test native stake pool and reset lockup support
+    cli.fund_account(2, Some(1000000000000000)).await.unwrap();
+    create_stake_pool_and_wait(
+        &rosetta_client,
+        &rest_client,
+        &network_identifier,
+        private_key_2,
+        Some(account_id_2),
+        Some(account_id_2),
+        Some(100000000000000),
+        Duration::from_secs(5),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("Should successfully create stake pool");
+
+    // TODO: Verify lockup time changes
+
+    // Reset lockup
+    reset_lockup_and_wait(
+        &rosetta_client,
+        &rest_client,
+        &network_identifier,
+        private_key_2,
+        Some(account_id_2),
+        Duration::from_secs(5),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("Should successfully reset lockup");
 
     // Successfully, and fail setting a voter
     set_voter_and_wait(
@@ -1461,8 +1497,114 @@ async fn parse_operations(
                     }
                 };
             }
+            OperationType::ResetLockup => {
+                if actual_successful {
+                    assert_eq!(
+                        OperationStatusType::Success,
+                        status,
+                        "Successful transaction should have successful reset lockup operation"
+                    );
+                } else {
+                    assert_eq!(
+                        OperationStatusType::Failure,
+                        status,
+                        "Failed transaction should have failed reset lockup operation"
+                    );
+                }
+
+                // Check that reset lockup was set the same
+                if let aptos_types::transaction::Transaction::UserTransaction(ref txn) =
+                    actual_txn.transaction
+                {
+                    if let aptos_types::transaction::TransactionPayload::EntryFunction(
+                        ref payload,
+                    ) = txn.payload()
+                    {
+                        let actual_operator_address: AccountAddress =
+                            bcs::from_bytes(payload.args().first().unwrap()).unwrap();
+                        let operator = operation
+                            .metadata
+                            .as_ref()
+                            .unwrap()
+                            .operator
+                            .as_ref()
+                            .unwrap()
+                            .account_address()
+                            .unwrap();
+                        assert_eq!(actual_operator_address, operator)
+                    } else {
+                        panic!("Not an entry function");
+                    }
+                } else {
+                    panic!("Not a user transaction");
+                }
+            }
             OperationType::InitializeStakePool => {
-                // This is not supported in block reads
+                if actual_successful {
+                    assert_eq!(
+                        OperationStatusType::Success,
+                        status,
+                        "Successful transaction should have successful initialize stake pool operation"
+                    );
+                } else {
+                    assert_eq!(
+                        OperationStatusType::Failure,
+                        status,
+                        "Failed transaction should have failed initialize stake pool operation"
+                    );
+                }
+
+                // Check that reset lockup was set the same
+                if let aptos_types::transaction::Transaction::UserTransaction(ref txn) =
+                    actual_txn.transaction
+                {
+                    if let aptos_types::transaction::TransactionPayload::EntryFunction(
+                        ref payload,
+                    ) = txn.payload()
+                    {
+                        let actual_operator_address: AccountAddress =
+                            bcs::from_bytes(payload.args().get(0).unwrap()).unwrap();
+                        let operator = operation
+                            .metadata
+                            .as_ref()
+                            .unwrap()
+                            .new_operator
+                            .as_ref()
+                            .unwrap()
+                            .account_address()
+                            .unwrap();
+                        assert_eq!(actual_operator_address, operator);
+
+                        let actual_voter_address: AccountAddress =
+                            bcs::from_bytes(payload.args().get(1).unwrap()).unwrap();
+                        let voter = operation
+                            .metadata
+                            .as_ref()
+                            .unwrap()
+                            .new_voter
+                            .as_ref()
+                            .unwrap()
+                            .account_address()
+                            .unwrap();
+                        assert_eq!(actual_voter_address, voter);
+
+                        let actual_stake_amount: u64 =
+                            bcs::from_bytes(payload.args().get(2).unwrap()).unwrap();
+                        let stake = operation
+                            .metadata
+                            .as_ref()
+                            .unwrap()
+                            .staked_balance
+                            .as_ref()
+                            .unwrap()
+                            .0;
+                        assert_eq!(actual_stake_amount, stake);
+                    } else {
+                        panic!("Not an entry function");
+                    }
+                } else {
+                    panic!("Not a user transaction");
+                }
             }
         }
     }
@@ -1865,6 +2007,70 @@ async fn set_voter_and_wait(
             sender_key,
             operator,
             new_voter,
+            expiry_time.as_secs(),
+            sequence_number,
+            max_gas,
+            gas_unit_price,
+        )
+        .await
+        .map_err(ErrorWrapper::BeforeSubmission)?
+        .hash;
+    wait_for_transaction(rest_client, expiry_time, txn_hash)
+        .await
+        .map_err(ErrorWrapper::AfterSubmission)
+}
+
+async fn create_stake_pool_and_wait(
+    rosetta_client: &RosettaClient,
+    rest_client: &aptos_rest_client::Client,
+    network_identifier: &NetworkIdentifier,
+    sender_key: &Ed25519PrivateKey,
+    operator: Option<AccountAddress>,
+    voter: Option<AccountAddress>,
+    stake_amount: Option<u64>,
+    txn_expiry_duration: Duration,
+    sequence_number: Option<u64>,
+    max_gas: Option<u64>,
+    gas_unit_price: Option<u64>,
+) -> Result<Box<UserTransaction>, ErrorWrapper> {
+    let expiry_time = expiry_time(txn_expiry_duration);
+    let txn_hash = rosetta_client
+        .create_stake_pool(
+            network_identifier,
+            sender_key,
+            operator,
+            voter,
+            stake_amount,
+            expiry_time.as_secs(),
+            sequence_number,
+            max_gas,
+            gas_unit_price,
+        )
+        .await
+        .map_err(ErrorWrapper::BeforeSubmission)?
+        .hash;
+    wait_for_transaction(rest_client, expiry_time, txn_hash)
+        .await
+        .map_err(ErrorWrapper::AfterSubmission)
+}
+
+async fn reset_lockup_and_wait(
+    rosetta_client: &RosettaClient,
+    rest_client: &aptos_rest_client::Client,
+    network_identifier: &NetworkIdentifier,
+    sender_key: &Ed25519PrivateKey,
+    operator: Option<AccountAddress>,
+    txn_expiry_duration: Duration,
+    sequence_number: Option<u64>,
+    max_gas: Option<u64>,
+    gas_unit_price: Option<u64>,
+) -> Result<Box<UserTransaction>, ErrorWrapper> {
+    let expiry_time = expiry_time(txn_expiry_duration);
+    let txn_hash = rosetta_client
+        .reset_lockup(
+            network_identifier,
+            sender_key,
+            operator,
             expiry_time.as_secs(),
             sequence_number,
             max_gas,


### PR DESCRIPTION
### Description
Adds Reset Lockup command to Rosetta for staking pools

### Test Plan
Smoke test now covers reset lockup and create staking pool