### PR TITLE
[mergify] block on more critical tests, and clarify the mergify title message

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -11,13 +11,16 @@ pull_request_rules:
               - check-success=ecosystem-lint
               - check-success=permission-check
               - check-success=scripts-lint
+              - check-success=python-lint-test
+              - check-success=helm-lint
+              - check-success=terraform-lint
               - check-success=rust-unit-test
               - check-success=rust-doc-test
               - check-success=rust-smoke-test
               - check-success=forge-e2e-test / forge
+              - check-success=forge-compat-test / forge
               - check-success=sdk-release / test-sdk-confirm-client-generated-publish
               - check-success=rust-images / rust-all
-              - check-success=terraform-lint
           - and:
               # for doc-only changes we only require docs-lint to pass
               - check-success=docs-lint

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -26,8 +26,26 @@ pull_request_rules:
               - check-success=docs-lint
               - -files~=^(?!developer-docs-site/)
     actions:
+      # Create an additional PR checklist item
+      # The title of which displays the test status, since mergify cannot distinguish between pending and failed
       post_check:
+        title: |
+          {% if not check_succeed %}
+          {% if check_pending|length > 0 %}
+          Some checks are still pending...
+          {% else %}
+          Tests failed
+          {% endif %}
+          {% else %}
+          Tests passed
+          {% endif %}
         summary: |
           {% if not check_succeed %}
           {{ check_conditions }}
           {% endif %}
+          {{ check_failure|length }} failure {{ check_failure }}
+          {{ check_neutral|length }} neutral {{ check_neutral }}
+          {{ check_pending|length }} pending {{ check_pending }}
+          {{ check_skipped|length }} skipped {{ check_skipped }}
+          {{ check_success|length }} success {{ check_success }}
+


### PR DESCRIPTION
### Description

Adds more stuff to be land-blocking, as it's in the critical test path:
* `forge-compat-test / forge` should be land-blocking, along with e2e
* `helm-lint` (helm charts used in all k8s deployments)
* `python-lint-test` (tests the forge wrapper)

Also, edit the `post_check` action for mergify, clarifying to the PR author the quirk that a failed status could mean either that  (1) the checks failed, or (2) checks are pending (mergify marks these as failure still https://docs.mergify.com/actions/post_check/). This will take effect post-land. Below snippets show some test runs in a sandbox repo:

For example, if a test is still pending that is required:

<img width="621" alt="image" src="https://user-images.githubusercontent.com/12578616/203457892-94cb9193-e64d-4378-aad1-d22116b6abcd.png">

And the more detailed summary:

<img width="542" alt="image" src="https://user-images.githubusercontent.com/12578616/203457925-f882a0d2-8a45-4a9d-96bf-1882e006605d.png">


### Test Plan

CI and testing in a sandbox repo with mergify set up. 

<!-- Please provide us with clear details for verifying that your changes work. -->
