### PR TITLE
[aptos-stdlib] fix comparator tests

### DIFF
--- a/aptos-move/framework/aptos-stdlib/sources/comparator.move
+++ b/aptos-move/framework/aptos-stdlib/sources/comparator.move
@@ -86,7 +86,8 @@ module aptos_std::comparator {
 
     #[test]
     #[expected_failure]
-    public fun test_u128() {
+    public fun test_integer() {
+        // 1(0x1) will be larger than 256(0x100) after BCS serialization. 
         let value0: u128 = 1;
         let value1: u128 = 256;
 
@@ -95,6 +96,26 @@ module aptos_std::comparator {
 
         assert!(is_smaller_than(&compare(&value0, &value1)), 2);
         assert!(is_greater_than(&compare(&value1, &value0)), 3);
+    }
+
+    #[test]
+    public fun test_u128() {
+        let value0: u128 = 5;
+        let value1: u128 = 152;
+        let value2: u128 = 511; // 0x1ff
+
+        assert!(is_equal(&compare(&value0, &value0)), 0);
+        assert!(is_equal(&compare(&value1, &value1)), 1);
+        assert!(is_equal(&compare(&value2, &value2)), 2);
+
+        assert!(is_smaller_than(&compare(&value0, &value1)), 2);
+        assert!(is_greater_than(&compare(&value1, &value0)), 3);
+
+        assert!(is_smaller_than(&compare(&value0, &value2)), 3);
+        assert!(is_greater_than(&compare(&value2, &value0)), 4);
+
+        assert!(is_smaller_than(&compare(&value1, &value2)), 5);
+        assert!(is_greater_than(&compare(&value2, &value1)), 6);
     }
 
     #[test_only]

--- a/aptos-move/framework/aptos-stdlib/sources/comparator.move
+++ b/aptos-move/framework/aptos-stdlib/sources/comparator.move
@@ -24,9 +24,9 @@ module aptos_std::comparator {
     }
 
     // Performs a comparison of two types after BCS serialization.
-    // BCS uses little endian encoding for all integer types, 
+    // BCS uses little endian encoding for all integer types,
     // so comparison between primitive integer types will not behave as expected.
-    // For example, 1(0x1) will be larger than 256(0x100) after BCS serialization. 
+    // For example, 1(0x1) will be larger than 256(0x100) after BCS serialization.
     public fun compare<T>(left: &T, right: &T): Result {
         let left_bytes = bcs::to_bytes(left);
         let right_bytes = bcs::to_bytes(right);
@@ -87,7 +87,7 @@ module aptos_std::comparator {
     #[test]
     #[expected_failure]
     public fun test_integer() {
-        // 1(0x1) will be larger than 256(0x100) after BCS serialization. 
+        // 1(0x1) will be larger than 256(0x100) after BCS serialization.
         let value0: u128 = 1;
         let value1: u128 = 256;
 

--- a/aptos-move/framework/aptos-stdlib/sources/comparator.move
+++ b/aptos-move/framework/aptos-stdlib/sources/comparator.move
@@ -24,6 +24,9 @@ module aptos_std::comparator {
     }
 
     // Performs a comparison of two types after BCS serialization.
+    // BCS uses little endian encoding for all integer types, 
+    // so comparison between primitive integer types will not behave as expected.
+    // For example, 1(0x1) will be larger than 256(0x100) after BCS serialization. 
     public fun compare<T>(left: &T, right: &T): Result {
         let left_bytes = bcs::to_bytes(left);
         let right_bytes = bcs::to_bytes(right);
@@ -82,23 +85,16 @@ module aptos_std::comparator {
     }
 
     #[test]
+    #[expected_failure]
     public fun test_u128() {
-        let value0: u128 = 5;
-        let value1: u128 = 152;
-        let value2: u128 = 511; // 0x1ff
+        let value0: u128 = 1;
+        let value1: u128 = 256;
 
         assert!(is_equal(&compare(&value0, &value0)), 0);
         assert!(is_equal(&compare(&value1, &value1)), 1);
-        assert!(is_equal(&compare(&value2, &value2)), 2);
 
         assert!(is_smaller_than(&compare(&value0, &value1)), 2);
         assert!(is_greater_than(&compare(&value1, &value0)), 3);
-
-        assert!(is_smaller_than(&compare(&value0, &value2)), 3);
-        assert!(is_greater_than(&compare(&value2, &value0)), 4);
-
-        assert!(is_smaller_than(&compare(&value1, &value2)), 5);
-        assert!(is_greater_than(&compare(&value2, &value1)), 6);
     }
 
     #[test_only]


### PR DESCRIPTION
### Description

The [comarator](https://github.com/0xpause/aptos-core/blob/49d77e6d466b9b0a22a5765d35393bb27a035cd3/aptos-move/framework/aptos-stdlib/sources/comparator.move#L27) is not suitable for Move integer types. Add more comment to describe this and fix the unittest.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

No
