### PR TITLE
[e2e move tests] fix broken tests when running individually

### DIFF
--- a/aptos-move/e2e-move-tests/Cargo.toml
+++ b/aptos-move/e2e-move-tests/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 aptos = { workspace = true }
 aptos-crypto = { workspace = true }
-aptos-gas = { workspace = true }
+aptos-gas = { workspace = true, features = ["testing"] }
 aptos-keygen = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-parallel-executor = { workspace = true }

--- a/aptos-move/e2e-testsuite/Cargo.toml
+++ b/aptos-move/e2e-testsuite/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 aptos-crypto = { workspace = true }
-aptos-gas = { workspace = true }
+aptos-gas = { workspace = true, features = ["testing"] }
 aptos-keygen = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-parallel-executor = { workspace = true }


### PR DESCRIPTION
Both `e2e-move-tests` and `e2e-testsuite` are broken when running individually. This gets it fixed by adding the feature flag they are missing.