### PR TITLE
[docs] Fix Ordered List styling to display numbers

### DIFF
--- a/developer-docs-site/src/css/custom.css
+++ b/developer-docs-site/src/css/custom.css
@@ -98,11 +98,15 @@ img.deep-dive-image {
 }
 
 audio,canvas,embed,iframe,img,object,svg,video {
-    display:inline;
+  display:inline;
 }
 
-ol, ul {
-    list-style: disc;
+ul {
+  list-style: disc;
+}
+
+ol {
+  list-style-type: decimal;
 }
 
 footer.footer {


### PR DESCRIPTION
### Description
Update `<ol>` elements to utilize `list-style-type: decimal;` to enable ordered lists styling to display numbers

### Test Plan
Verify numbers are displayed to the left of ordered lists instead of bullet points (disc). Eg: `/nodes/validator-node/operator/update-validator-node`
