### PR TITLE
[aptos-transaction-benchmark] Fix benchmark regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,6 +1390,7 @@ version = "0.1.0"
 dependencies = [
  "aptos-bitvec",
  "aptos-crypto",
+ "aptos-gas",
  "aptos-types",
  "aptos-vm",
  "criterion",

--- a/aptos-move/aptos-transaction-benchmarks/Cargo.toml
+++ b/aptos-move/aptos-transaction-benchmarks/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 aptos-bitvec = { workspace = true }
 aptos-crypto = { workspace = true }
+aptos-gas = { workspace = true, features = ["testing"] }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
 criterion = { workspace = true }


### PR DESCRIPTION
### Description

Fix the benchmark regression because of feature unification. Previously benchmark runner is always executing failed transaction and thus not providing any useful information. 

### Test Plan
Manually ran the benchmarker and print the transaction output to make sure we all transaction are executed successfully.