### PR TITLE
[mergify] check title reflects skipped status

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -33,6 +33,8 @@ pull_request_rules:
           {% if not check_succeed %}
           {% if check_pending|length > 0 %}
           Some checks are still pending...
+          {% elif check_skipped|length > 0 %}
+          Some checks were skipped (try rebasing, toggling automerge, or applying the corresponding labels)...
           {% else %}
           Tests failed
           {% endif %}


### PR DESCRIPTION
### Description

If a PR has not triggered `automerge` or has not been labelled with the corresponding e2e test or build labels, the title message displayed by `post_check` action in mergify is misleading.

Now, if a check has been skipped, it displays: `Some checks were skipped (try rebasing, toggling automerge, or applying the corresponding labels)...`

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
