### PR TITLE
[tf/gcp][fullnode] fix nap scheduling and apply when disabled

### DIFF
--- a/terraform/fullnode/gcp/cluster.tf
+++ b/terraform/fullnode/gcp/cluster.tf
@@ -67,16 +67,16 @@ resource "google_container_cluster" "aptos" {
   cluster_autoscaling {
     enabled = var.gke_enable_node_autoprovisioning
 
-    resource_limits {
-      resource_type = "cpu"
-      minimum       = 1
-      maximum       = var.gke_node_autoprovisioning_max_cpu
-    }
-
-    resource_limits {
-      resource_type = "memory"
-      minimum       = 1
-      maximum       = var.gke_node_autoprovisioning_max_memory
+    dynamic "resource_limits" {
+      for_each = var.gke_enable_node_autoprovisioning ? {
+        "cpu"    = var.gke_node_autoprovisioning_max_cpu
+        "memory" = var.gke_node_autoprovisioning_max_memory
+      } : {}
+      content {
+        resource_type = resource_limits.key
+        minimum       = 1
+        maximum       = resource_limits.value
+      }
     }
   }
 }

--- a/terraform/fullnode/gcp/kubernetes.tf
+++ b/terraform/fullnode/gcp/kubernetes.tf
@@ -87,7 +87,7 @@ resource "helm_release" "fullnode" {
       image = {
         tag = var.image_tag
       }
-      nodeSelector = {
+      nodeSelector = var.gke_enable_node_autoprovisioning ? {} : {
         "cloud.google.com/gke-nodepool"          = "fullnodes"
         "iam.gke.io/gke-metadata-server-enabled" = "true"
       }


### PR DESCRIPTION
### Description

Fixes workload scheduling when node-auto-provisioning (NAP) is enabled, by removing the nodeSelector, which isn't present in nodes created by NAP. Also do not set NAP resource limits when it is disabled, as that results in API failure.

Related to and resolves the primary issue in https://github.com/aptos-labs/aptos-core/pull/5645

### Test Plan

Apply to cluster

<!-- Please provide us with clear details for verifying that your changes work. -->
