### PR TITLE
[replay-verify] Add an option to skip txns that are known to broke backward compatibility

### DIFF
--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -3,7 +3,11 @@
 
 #![forbid(unsafe_code)]
 
-use std::{cmp::max, collections::HashMap, sync::Arc};
+use std::{
+    cmp::max,
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -122,6 +126,9 @@ pub trait TransactionReplayer: Send {
         &self,
         transactions: Vec<Transaction>,
         transaction_infos: Vec<TransactionInfo>,
+        writesets: Vec<WriteSet>,
+        events: Vec<Vec<ContractEvent>>,
+        txns_to_skip: Arc<BTreeSet<Version>>,
     ) -> Result<()>;
 
     fn commit(&self) -> Result<Arc<ExecutedChunk>>;

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -15,7 +15,7 @@ use crate::{
         APTOS_EXECUTOR_EXECUTE_CHUNK_SECONDS, APTOS_EXECUTOR_VM_EXECUTE_CHUNK_SECONDS,
     },
 };
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use aptos_executor_types::{
     ChunkCommitNotification, ChunkExecutorTrait, ExecutedChunk, TransactionReplayer,
 };
@@ -23,14 +23,17 @@ use aptos_infallible::{Mutex, RwLock};
 use aptos_logger::prelude::*;
 use aptos_state_view::StateViewId;
 use aptos_types::{
+    contract_event::ContractEvent,
     ledger_info::LedgerInfoWithSignatures,
     transaction::{
-        Transaction, TransactionInfo, TransactionListWithProof, TransactionOutputListWithProof,
+        Transaction, TransactionInfo, TransactionListWithProof, TransactionOutput,
+        TransactionOutputListWithProof, TransactionStatus, Version,
     },
+    write_set::WriteSet,
 };
 use aptos_vm::VMExecutor;
 use fail::fail_point;
-use std::{marker::PhantomData, sync::Arc};
+use std::{collections::BTreeSet, marker::PhantomData, sync::Arc};
 use storage_interface::{
     cached_state_view::CachedStateView, sync_proof_fetcher::SyncProofFetcher, DbReaderWriter,
     ExecutedTrees,
@@ -297,13 +300,18 @@ impl<V: VMExecutor> TransactionReplayer for ChunkExecutor<V> {
         &self,
         transactions: Vec<Transaction>,
         transaction_infos: Vec<TransactionInfo>,
+        writesets: Vec<WriteSet>,
+        events: Vec<Vec<ContractEvent>>,
+        txns_to_skip: Arc<BTreeSet<Version>>,
     ) -> Result<()> {
         self.maybe_initialize()?;
-        self.inner
-            .read()
-            .as_ref()
-            .expect("not reset")
-            .replay(transactions, transaction_infos)
+        self.inner.read().as_ref().expect("not reset").replay(
+            transactions,
+            transaction_infos,
+            writesets,
+            events,
+            txns_to_skip,
+        )
     }
 
     fn commit(&self) -> Result<Arc<ExecutedChunk>> {
@@ -314,6 +322,60 @@ impl<V: VMExecutor> TransactionReplayer for ChunkExecutor<V> {
 impl<V: VMExecutor> TransactionReplayer for ChunkExecutorInner<V> {
     fn replay(
         &self,
+        mut transactions: Vec<Transaction>,
+        mut transaction_infos: Vec<TransactionInfo>,
+        writesets: Vec<WriteSet>,
+        events: Vec<Vec<ContractEvent>>,
+        txns_to_skip: Arc<BTreeSet<Version>>,
+    ) -> Result<()> {
+        let current_begin_version = {
+            self.commit_queue
+                .lock()
+                .persisted_and_latest_view()
+                .1
+                .version()
+                .ok_or_else(|| anyhow!("Current version is not available"))?
+        };
+
+        let mut offset = current_begin_version;
+        let total_length = transactions.len();
+
+        for version in txns_to_skip
+            .range(current_begin_version + 1..current_begin_version + total_length as u64 + 1)
+        {
+            let remaining = transactions.split_off((version - offset) as usize);
+            let remaining_info = transaction_infos.split_off((version - offset) as usize);
+            let txn_to_skip = transactions.pop().unwrap();
+            let txn_info = transaction_infos.pop().unwrap();
+
+            self.replay_impl(transactions, transaction_infos)?;
+
+            self.apply_transaction_and_output(
+                txn_to_skip,
+                TransactionOutput::new(
+                    writesets[(version - current_begin_version - 1) as usize].clone(),
+                    events[(version - current_begin_version - 1) as usize].clone(),
+                    txn_info.gas_used(),
+                    TransactionStatus::Keep(txn_info.status().clone()),
+                ),
+                txn_info,
+            )?;
+
+            transactions = remaining;
+            transaction_infos = remaining_info;
+            offset = version + 1;
+        }
+        self.replay_impl(transactions, transaction_infos)
+    }
+
+    fn commit(&self) -> Result<Arc<ExecutedChunk>> {
+        self.commit_chunk_impl()
+    }
+}
+
+impl<V: VMExecutor> ChunkExecutorInner<V> {
+    fn replay_impl(
+        &self,
         transactions: Vec<Transaction>,
         mut transaction_infos: Vec<TransactionInfo>,
     ) -> Result<()> {
@@ -322,13 +384,14 @@ impl<V: VMExecutor> TransactionReplayer for ChunkExecutorInner<V> {
 
         let mut executed_chunk = ExecutedChunk::default();
         let mut to_run = Some(transactions);
+
         while !to_run.as_ref().unwrap().is_empty() {
             // Execute transactions.
             let state_view = self.state_view(&latest_view)?;
             let txns = to_run.take().unwrap();
-            let (executed, to_discard, to_retry) =
-                ChunkOutput::by_transaction_execution::<V>(txns, state_view)?
-                    .apply_to_ledger(&latest_view)?;
+            let chunk_output = ChunkOutput::by_transaction_execution::<V>(txns, state_view)?;
+
+            let (executed, to_discard, to_retry) = chunk_output.apply_to_ledger(&latest_view)?;
 
             // Accumulate result and deal with retry
             ensure_no_discard(to_discard)?;
@@ -347,7 +410,30 @@ impl<V: VMExecutor> TransactionReplayer for ChunkExecutorInner<V> {
         Ok(())
     }
 
-    fn commit(&self) -> Result<Arc<ExecutedChunk>> {
-        self.commit_chunk_impl()
+    fn apply_transaction_and_output(
+        &self,
+        txn: Transaction,
+        output: TransactionOutput,
+        expected_info: TransactionInfo,
+    ) -> Result<()> {
+        let (_persisted_view, latest_view) = self.commit_queue.lock().persisted_and_latest_view();
+
+        info!(
+            "Overiding the output of txn at version: {:?}",
+            latest_view.version().unwrap(),
+        );
+
+        let chunk_output = ChunkOutput::by_transaction_output(
+            vec![(txn, output)],
+            self.state_view(&latest_view)?,
+        )?;
+
+        let (executed, to_discard, _to_retry) = chunk_output.apply_to_ledger(&latest_view)?;
+
+        // Accumulate result and deal with retry
+        ensure_no_discard(to_discard)?;
+        executed.ensure_transaction_infos_match(&vec![expected_info])?;
+        self.commit_queue.lock().enqueue(executed);
+        Ok(())
     }
 }

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{iter::once, sync::Arc};
+use std::{collections::BTreeSet, iter::once, sync::Arc};
 
 use proptest::prelude::*;
 
@@ -661,7 +661,7 @@ proptest! {
             // replay txns in one batch across epoch boundary,
             // and the replayer should deal with `Retry`s automatically
             let replayer = chunk_executor_tests::TestExecutor::new();
-            replayer.executor.replay(block.txns, txn_infos).unwrap();
+            replayer.executor.replay(block.txns, txn_infos, vec![], vec![], Arc::new(BTreeSet::new())).unwrap();
             replayer.executor.commit().unwrap();
             let replayed_db = replayer.db.reader.clone();
             prop_assert_eq!(

--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -154,6 +154,7 @@ fn test_end_to_end_impl(d: TestData) {
             global_restore_opt,
             store,
             None, /* epoch_history */
+            vec![],
         )
         .run(),
     )

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -90,6 +90,7 @@ fn end_to_end() {
             .unwrap(),
             store,
             None, /* epoch_history */
+            vec![],
         )
         .run(),
     )

--- a/storage/backup/backup-cli/src/bin/db-restore.rs
+++ b/storage/backup/backup-cli/src/bin/db-restore.rs
@@ -92,6 +92,7 @@ async fn main_impl() -> Result<()> {
                 global_opt,
                 storage.init_storage().await?,
                 None, /* epoch_history */
+                vec![],
             )
             .run()
             .await?;

--- a/storage/backup/backup-cli/src/bin/replay-verify.rs
+++ b/storage/backup/backup-cli/src/bin/replay-verify.rs
@@ -48,6 +48,12 @@ struct Opt {
     end_version: Option<Version>,
     #[clap(long)]
     validate_modules: bool,
+    #[clap(
+        long,
+        multiple = true,
+        help = "Skip the execution for txns that are known to break compatibility."
+    )]
+    txns_to_skip: Vec<Version>,
 }
 
 #[tokio::main]
@@ -82,6 +88,7 @@ async fn main_impl() -> Result<()> {
         opt.start_version.unwrap_or(0),
         opt.end_version.unwrap_or(Version::MAX),
         opt.validate_modules,
+        opt.txns_to_skip,
     )?
     .run()
     .await

--- a/storage/backup/backup-cli/src/coordinators/replay_verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/replay_verify.rs
@@ -28,6 +28,7 @@ pub struct ReplayVerifyCoordinator {
     start_version: Version,
     end_version: Version,
     validate_modules: bool,
+    txns_to_skip: Vec<Version>,
 }
 
 impl ReplayVerifyCoordinator {
@@ -41,6 +42,7 @@ impl ReplayVerifyCoordinator {
         start_version: Version,
         end_version: Version,
         validate_modules: bool,
+        txns_to_skip: Vec<Version>,
     ) -> Result<Self> {
         Ok(Self {
             storage,
@@ -52,6 +54,7 @@ impl ReplayVerifyCoordinator {
             start_version,
             end_version,
             validate_modules,
+            txns_to_skip,
         })
     }
 
@@ -132,6 +135,7 @@ impl ReplayVerifyCoordinator {
             txn_manifests,
             Some(replay_transactions_from_version), /* replay_from_version */
             None,                                   /* epoch_history */
+            self.txns_to_skip,
         )
         .run()
         .await?;

--- a/storage/backup/backup-cli/src/coordinators/restore.rs
+++ b/storage/backup/backup-cli/src/coordinators/restore.rs
@@ -186,6 +186,7 @@ impl RestoreCoordinator {
             txn_manifests,
             Some(version + 1),
             epoch_history,
+            vec![],
         )
         .run()
         .await?;

--- a/storage/backup/backup-cli/src/coordinators/verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/verify.rs
@@ -117,6 +117,7 @@ impl VerifyCoordinator {
             txn_manifests,
             None, /* replay_from_version */
             Some(epoch_history),
+            vec![],
         )
         .run()
         .await?;


### PR DESCRIPTION
### Description

Add an option to intentionally skip re-execution for txns that broke backwards compatibility

### Test Plan

Ran the logic with the known transactions on chain that broke backwards compatibility and made sure those txn info were correct.