### PR TITLE
[Token] parse string type in property map

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 ## Unreleased
 
 - Export classes from property_map_serde
+- User can specify token string property type using "string", "String" or "0x1::string::String" to serde the string token property on-chain
 
 ## 1.4.0 (2022-11-30)
 

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.ts
@@ -24,6 +24,13 @@ import {
 } from "../aptos_types";
 import { Serializer } from "../bcs";
 
+export const stringStructTag = new StructTag(
+  AccountAddress.fromHex("0x1"),
+  new Identifier("string"),
+  new Identifier("String"),
+  [],
+);
+
 function assertType(val: any, types: string[] | string, message?: string) {
   if (!types?.includes(typeof val)) {
     throw new Error(

--- a/ecosystem/typescript/sdk/src/utils/property_map_serde.test.ts
+++ b/ecosystem/typescript/sdk/src/utils/property_map_serde.test.ts
@@ -1,4 +1,4 @@
-import { deserializeValueBasedOnTypeTag, getPropertyValueRaw } from "./property_map_serde";
+import { deserializeValueBasedOnTypeTag, getPropertyType, getPropertyValueRaw } from "./property_map_serde";
 import {
   bcsSerializeBool,
   bcsSerializeStr,
@@ -16,8 +16,16 @@ test("test property_map_serializer", () => {
   function isSame(array1: Bytes, array2: Bytes): boolean {
     return array1.length === array2.length && array1.every((element, index) => element === array2[index]);
   }
-  const values = ["false", "10", "18446744073709551615", "340282366920938463463374607431768211455", "hello", "0x1"];
-  const types = ["bool", "u8", "u64", "u128", "0x1::string::String", "address"];
+  const values = [
+    "false",
+    "10",
+    "18446744073709551615",
+    "340282366920938463463374607431768211455",
+    "hello",
+    "0x1",
+    "I am a string",
+  ];
+  const types = ["bool", "u8", "u64", "u128", "0x1::string::String", "address", "string"];
   const newValues = getPropertyValueRaw(values, types);
   expect(isSame(newValues[0], bcsSerializeBool(false))).toBe(true);
   expect(isSame(newValues[1], bcsSerializeU8(10))).toBe(true);
@@ -38,12 +46,11 @@ test("test propertymap deserializer", () => {
     "340282366920938463463374607431768211455",
     "hello",
     "0x0000000000000000000000000000000000000000000000000000000000000001",
+    "I am a string",
   ];
-  const types = ["bool", "u8", "u64", "u128", "0x1::string::String", "address"];
+  const types = ["bool", "u8", "u64", "u128", "0x1::string::String", "address", "string"];
   const newValues = getPropertyValueRaw(values, types);
   for (let i = 0; i < values.length; i += 1) {
-    expect(deserializeValueBasedOnTypeTag(new TypeTagParser(types[i]).parseTypeTag(), toHexString(newValues[i]))).toBe(
-      values[i],
-    );
+    expect(deserializeValueBasedOnTypeTag(getPropertyType(types[i]), toHexString(newValues[i]))).toBe(values[i]);
   }
 });


### PR DESCRIPTION
### Description
currently, string type is "0x1::string::String", which is not consistent with convension

This PR basically allows people to parse string/String and they will be converted to aptos String type on-chain

### Test Plan
added unit test
<!-- Please provide us with clear details for verifying that your changes work. -->
