### PR TITLE
terraform k8s separation

### DIFF
--- a/terraform/aptos-node-testnet/addons.tf
+++ b/terraform/aptos-node-testnet/addons.tf
@@ -226,12 +226,26 @@ resource "helm_release" "external-dns" {
   ]
 }
 
+locals {
+  # these values are the most likely to be changed by the user and may be managed by terraform to trigger re-deployment
+  testnet_addons_helm_values_managed = {
+    "imageTag"    = var.image_tag
+    "genesis.era" = var.era
+  }
+}
+
 resource "helm_release" "testnet-addons" {
   count       = var.enable_forge ? 0 : 1
   name        = "testnet-addons"
   chart       = local.testnet_addons_helm_chart_path
   max_history = 5
   wait        = false
+
+  lifecycle {
+    ignore_changes = [
+      values,
+    ]
+  }
 
   values = [
     jsonencode({
@@ -259,6 +273,14 @@ resource "helm_release" "testnet-addons" {
     }),
     jsonencode(var.testnet_addons_helm_values)
   ]
+
+  dynamic "set" {
+    for_each = var.manage_via_tf ? local.testnet_addons_helm_values_managed : {}
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
 
   # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
   set {

--- a/terraform/aptos-node-testnet/variables.tf
+++ b/terraform/aptos-node-testnet/variables.tf
@@ -207,3 +207,8 @@ variable "fullnode_storage_class" {
     error_message = "Supported storage classes are gp3, io1, io2"
   }
 }
+
+variable "manage_via_tf" {
+  description = "Whether to manage the aptos-node k8s workload via Terraform"
+  default     = true
+}

--- a/terraform/aptos-node/aws/kubernetes.tf
+++ b/terraform/aptos-node/aws/kubernetes.tf
@@ -169,6 +169,12 @@ locals {
 
   # override the helm release name if an override exists, otherwise adopt the workspace name
   helm_release_name = var.helm_release_name_override != "" ? var.helm_release_name_override : local.workspace_name
+
+  # these values are the most likely to be changed by the user and may be managed by terraform to trigger re-deployment
+  helm_values_managed = {
+    "imageTag" = var.image_tag
+    "chain.era" = var.era
+  }
 }
 
 resource "helm_release" "validator" {
@@ -178,11 +184,25 @@ resource "helm_release" "validator" {
   max_history = 5
   wait        = false
 
+  lifecycle {
+    ignore_changes = [
+      values,
+    ]
+  }
+
   values = [
     local.helm_values,
     var.helm_values_file != "" ? file(var.helm_values_file) : "{}",
     jsonencode(var.helm_values),
   ]
+
+  dynamic "set" {
+    for_each = var.manage_via_tf ? local.helm_values_managed : {}
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
 
   # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
   set {

--- a/terraform/aptos-node/aws/kubernetes.tf
+++ b/terraform/aptos-node/aws/kubernetes.tf
@@ -172,7 +172,7 @@ locals {
 
   # these values are the most likely to be changed by the user and may be managed by terraform to trigger re-deployment
   helm_values_managed = {
-    "imageTag" = var.image_tag
+    "imageTag"  = var.image_tag
     "chain.era" = var.era
   }
 }

--- a/terraform/aptos-node/aws/variables.tf
+++ b/terraform/aptos-node/aws/variables.tf
@@ -265,3 +265,8 @@ variable "fullnode_storage_class" {
     error_message = "Supported storage classes are gp3, io1, io2"
   }
 }
+
+variable "manage_via_tf" {
+  description = "Whether to manage the aptos-node k8s workload via Terraform"
+  default     = true
+}

--- a/terraform/aptos-node/gcp/variables.tf
+++ b/terraform/aptos-node/gcp/variables.tf
@@ -142,3 +142,8 @@ variable "node_exporter_helm_values" {
   type        = any
   default     = {}
 }
+
+variable "manage_via_tf" {
+  description = "Whether to manage the aptos-node k8s workload via Terraform"
+  default     = true
+}


### PR DESCRIPTION
### Description

Add a variable `manage_via_tf` which allows operators to choose whether to use Terraform to manage their aptos-node (application) deployment, or simply deploy it once (re-deploying on infra changes), but otherwise relying on other toolling such as another k8s client to update the application.

The way it works is:
* all changes to `values` blocks are ignored via lifecycle ignore. This prevents re-deploy (or at least a helm re-evaluation) on small changes like irrelevant helm values.
* all changes `set` blocks are conditionally ignored depending on whether `manage_via_tf` is set or not. The type of values set using `set` blocks are those such as `imageTag` and `era`, which we *would* expect a re-deployment of the application if we want TF to manage the k8s deployment

### Test Plan

Apply while toggling `manage_via_tf`, and observing the TF plan output <paste output here>

<!-- Please provide us with clear details for verifying that your changes work. -->
