### PR TITLE
Rewards improvements - yearly rate decrease and proper epoch rewards based on actual duration

### DIFF
--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -95,7 +95,7 @@ pub fn new_test_context(test_name: String, use_db_with_indexer: bool) -> TestCon
     )
     .unwrap()
     .with_init_genesis_config(Some(Arc::new(|genesis_config| {
-        genesis_config.recurring_lockup_duration_secs = 86400;
+        genesis_config.staking.recurring_lockup_duration_secs = 86400;
     })))
     .with_randomize_first_validator_ports(false);
 

--- a/aptos-move/framework/aptos-framework/doc/genesis.md
+++ b/aptos-move/framework/aptos-framework/doc/genesis.md
@@ -11,6 +11,7 @@
 -  [Struct `ValidatorConfigurationWithCommission`](#0x1_genesis_ValidatorConfigurationWithCommission)
 -  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_genesis_initialize)
+-  [Function `initialize_v2`](#0x1_genesis_initialize_v2)
 -  [Function `initialize_aptos_coin`](#0x1_genesis_initialize_aptos_coin)
 -  [Function `initialize_core_resources_and_aptos_coin`](#0x1_genesis_initialize_core_resources_and_aptos_coin)
 -  [Function `create_accounts`](#0x1_genesis_create_accounts)
@@ -280,7 +281,7 @@
 Genesis step 1: Initialize aptos framework account and core modules on chain.
 
 
-<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize">initialize</a>(<a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, initial_version: u64, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, epoch_interval_microsecs: u64, minimum_stake: u64, maximum_stake: u64, recurring_lockup_duration_secs: u64, allow_validator_set_change: bool, rewards_rate: u64, rewards_rate_denominator: u64, voting_power_increase_limit: u64)
+<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize">initialize</a>(<a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, initial_version: u64, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, epoch_interval_microsecs: u64, minimum_stake: u64, maximum_stake: u64, recurring_lockup_duration_secs: u64, allow_validator_set_change: bool, _rewards_rate: u64, _rewards_rate_denominator: u64, voting_power_increase_limit: u64)
 </code></pre>
 
 
@@ -299,9 +300,49 @@ Genesis step 1: Initialize aptos framework account and core modules on chain.
     maximum_stake: u64,
     recurring_lockup_duration_secs: u64,
     allow_validator_set_change: bool,
-    rewards_rate: u64,
-    rewards_rate_denominator: u64,
+    _rewards_rate: u64,
+    _rewards_rate_denominator: u64,
     voting_power_increase_limit: u64,
+) {
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_genesis_initialize_v2"></a>
+
+## Function `initialize_v2`
+
+Genesis step 1: Initialize aptos framework account and core modules on chain.
+
+
+<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize_v2">initialize_v2</a>(<a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, initial_version: u64, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, allow_validator_set_change: bool, epoch_interval_microsecs: u64, minimum_stake: u64, maximum_stake: u64, recurring_lockup_duration_secs: u64, voting_power_increase_limit: u64, initial_yearly_rewards_rate: u64, min_yearly_rewards_rate: u64, rewards_rate_denominator: u64, yearly_rewards_rate_decrease_numerator: u64, yearly_rewards_rate_decrease_denominator: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize_v2">initialize_v2</a>(
+    <a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8,
+    initial_version: u64,
+    <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    allow_validator_set_change: bool,
+    epoch_interval_microsecs: u64,
+    minimum_stake: u64,
+    maximum_stake: u64,
+    recurring_lockup_duration_secs: u64,
+    voting_power_increase_limit: u64,
+    initial_yearly_rewards_rate: u64,
+    min_yearly_rewards_rate: u64,
+    rewards_rate_denominator: u64,
+    yearly_rewards_rate_decrease_numerator: u64,
+    yearly_rewards_rate_decrease_denominator: u64,
 ) {
     // Initialize the aptos framework <a href="account.md#0x1_account">account</a>. This is the <a href="account.md#0x1_account">account</a> <b>where</b> system resources and modules will be
     // deployed <b>to</b>. This will be entirely managed by on-chain governance and no entities have the key or privileges
@@ -332,16 +373,23 @@ Genesis step 1: Initialize aptos framework account and core modules on chain.
     <a href="consensus_config.md#0x1_consensus_config_initialize">consensus_config::initialize</a>(&aptos_framework_account, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>);
     <a href="version.md#0x1_version_initialize">version::initialize</a>(&aptos_framework_account, initial_version);
     <a href="stake.md#0x1_stake_initialize">stake::initialize</a>(&aptos_framework_account);
-    <a href="staking_config.md#0x1_staking_config_initialize">staking_config::initialize</a>(
+    <a href="staking_config.md#0x1_staking_config_initialize_staking">staking_config::initialize_staking</a>(
         &aptos_framework_account,
         minimum_stake,
         maximum_stake,
         recurring_lockup_duration_secs,
         allow_validator_set_change,
-        rewards_rate,
-        rewards_rate_denominator,
         voting_power_increase_limit,
     );
+    <a href="staking_config.md#0x1_staking_config_initialize_rewards">staking_config::initialize_rewards</a>(
+        &aptos_framework_account,
+        initial_yearly_rewards_rate,
+        min_yearly_rewards_rate,
+        rewards_rate_denominator,
+        yearly_rewards_rate_decrease_numerator,
+        yearly_rewards_rate_decrease_denominator,
+    );
+
     <a href="storage_gas.md#0x1_storage_gas_initialize">storage_gas::initialize</a>(&aptos_framework_account);
     <a href="gas_schedule.md#0x1_gas_schedule_initialize">gas_schedule::initialize</a>(&aptos_framework_account, <a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>);
 
@@ -645,7 +693,7 @@ If it exists, it just returns the signer.
     // validators.
     <a href="aptos_coin.md#0x1_aptos_coin_destroy_mint_cap">aptos_coin::destroy_mint_cap</a>(aptos_framework);
 
-    <a href="stake.md#0x1_stake_on_new_epoch">stake::on_new_epoch</a>();
+    <a href="stake.md#0x1_stake_on_new_epoch">stake::on_new_epoch</a>(0, 0);
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/reconfiguration.md
+++ b/aptos-move/framework/aptos-framework/doc/reconfiguration.md
@@ -9,6 +9,7 @@ to synchronize configuration changes for the validators.
 
 -  [Struct `NewEpochEvent`](#0x1_reconfiguration_NewEpochEvent)
 -  [Resource `Configuration`](#0x1_reconfiguration_Configuration)
+-  [Resource `EpochConfiguration`](#0x1_reconfiguration_EpochConfiguration)
 -  [Resource `DisableReconfiguration`](#0x1_reconfiguration_DisableReconfiguration)
 -  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_reconfiguration_initialize)
@@ -106,6 +107,33 @@ Holds information about state of reconfiguration
 </dt>
 <dd>
  Event handle for reconfiguration events
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_reconfiguration_EpochConfiguration"></a>
+
+## Resource `EpochConfiguration`
+
+
+
+<pre><code><b>struct</b> <a href="reconfiguration.md#0x1_reconfiguration_EpochConfiguration">EpochConfiguration</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>epoch_interval: u64</code>
+</dt>
+<dd>
+ Time period between epochs.
 </dd>
 </dl>
 
@@ -355,11 +383,17 @@ Signal validators to start using new configuration. Must be called from friend c
         <b>return</b>
     };
 
+    <b>assert</b>!(current_time &gt; config_ref.last_reconfiguration_time, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="reconfiguration.md#0x1_reconfiguration_EINVALID_BLOCK_TIME">EINVALID_BLOCK_TIME</a>));
+    <b>let</b> epoch_duration = <b>if</b> (config_ref.last_reconfiguration_time == 0) {
+        0
+    } <b>else</b> {
+        current_time - config_ref.last_reconfiguration_time
+    };
+
     // Call <a href="stake.md#0x1_stake">stake</a> <b>to</b> compute the new validator set and distribute rewards.
-    <a href="stake.md#0x1_stake_on_new_epoch">stake::on_new_epoch</a>();
+    <a href="stake.md#0x1_stake_on_new_epoch">stake::on_new_epoch</a>(current_time, epoch_duration);
     <a href="storage_gas.md#0x1_storage_gas_on_reconfig">storage_gas::on_reconfig</a>();
 
-    <b>assert</b>!(current_time &gt; config_ref.last_reconfiguration_time, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="reconfiguration.md#0x1_reconfiguration_EINVALID_BLOCK_TIME">EINVALID_BLOCK_TIME</a>));
     config_ref.last_reconfiguration_time = current_time;
     <b>spec</b> {
         <b>assume</b> config_ref.epoch + 1 &lt;= MAX_U64;

--- a/aptos-move/framework/aptos-framework/doc/staking_config.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_config.md
@@ -7,21 +7,27 @@ Provides the configuration for staking and rewards
 
 
 -  [Resource `StakingConfig`](#0x1_staking_config_StakingConfig)
+-  [Resource `StakingRewardsConfig`](#0x1_staking_config_StakingRewardsConfig)
 -  [Constants](#@Constants_0)
--  [Function `initialize`](#0x1_staking_config_initialize)
+-  [Function `initialize_staking`](#0x1_staking_config_initialize_staking)
+-  [Function `initialize_rewards`](#0x1_staking_config_initialize_rewards)
 -  [Function `get`](#0x1_staking_config_get)
 -  [Function `get_allow_validator_set_change`](#0x1_staking_config_get_allow_validator_set_change)
 -  [Function `get_required_stake`](#0x1_staking_config_get_required_stake)
 -  [Function `get_recurring_lockup_duration`](#0x1_staking_config_get_recurring_lockup_duration)
 -  [Function `get_reward_rate`](#0x1_staking_config_get_reward_rate)
+-  [Function `get_epoch_reward_rate`](#0x1_staking_config_get_epoch_reward_rate)
+-  [Function `check_and_autodecrease_rewards_rate`](#0x1_staking_config_check_and_autodecrease_rewards_rate)
 -  [Function `get_voting_power_increase_limit`](#0x1_staking_config_get_voting_power_increase_limit)
 -  [Function `update_required_stake`](#0x1_staking_config_update_required_stake)
 -  [Function `update_recurring_lockup_duration_secs`](#0x1_staking_config_update_recurring_lockup_duration_secs)
 -  [Function `update_rewards_rate`](#0x1_staking_config_update_rewards_rate)
+-  [Function `update_rewards_config`](#0x1_staking_config_update_rewards_config)
 -  [Function `update_voting_power_increase_limit`](#0x1_staking_config_update_voting_power_increase_limit)
 -  [Function `validate_required_stake`](#0x1_staking_config_validate_required_stake)
 -  [Specification](#@Specification_1)
     -  [Resource `StakingConfig`](#@Specification_1_StakingConfig)
+    -  [Resource `StakingRewardsConfig`](#@Specification_1_StakingRewardsConfig)
 
 
 <pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
@@ -72,13 +78,13 @@ Validator set configurations that will be stored with the @aptos_framework accou
 
 </dd>
 <dt>
-<code>rewards_rate: u64</code>
+<code>_rewards_rate: u64</code>
 </dt>
 <dd>
 
 </dd>
 <dt>
-<code>rewards_rate_denominator: u64</code>
+<code>_rewards_rate_denominator: u64</code>
 </dt>
 <dd>
 
@@ -94,9 +100,82 @@ Validator set configurations that will be stored with the @aptos_framework accou
 
 </details>
 
+<a name="0x1_staking_config_StakingRewardsConfig"></a>
+
+## Resource `StakingRewardsConfig`
+
+
+
+<pre><code><b>struct</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> <b>has</b> <b>copy</b>, drop, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>yearly_rewards_rate: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>min_yearly_rewards_rate: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>rewards_rate_denominator: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>last_rate_decrease_time: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>yearly_rewards_rate_decrease_numerator: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>yearly_rewards_rate_decrease_denominator: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>year_in_micros: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
 <a name="@Constants_0"></a>
 
 ## Constants
+
+
+<a name="0x1_staking_config_EDEPRECATED_FUNCTION"></a>
+
+Deprecated function
+
+
+<pre><code><b>const</b> <a href="staking_config.md#0x1_staking_config_EDEPRECATED_FUNCTION">EDEPRECATED_FUNCTION</a>: u64 = 6;
+</code></pre>
+
 
 
 <a name="0x1_staking_config_EINVALID_REWARDS_RATE"></a>
@@ -149,24 +228,42 @@ Reward rate denominator cannot be zero.
 
 
 
-<a name="0x1_staking_config_MAX_REWARDS_RATE"></a>
+<a name="0x1_staking_config_MAX_EPOCH_REWARDS_RATE"></a>
 
 Limit the maximum value of <code>rewards_rate</code> in order to avoid any arithmetic overflow.
 
 
-<pre><code><b>const</b> <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>: u64 = 1000000;
+<pre><code><b>const</b> <a href="staking_config.md#0x1_staking_config_MAX_EPOCH_REWARDS_RATE">MAX_EPOCH_REWARDS_RATE</a>: u64 = 100000;
 </code></pre>
 
 
 
-<a name="0x1_staking_config_initialize"></a>
+<a name="0x1_staking_config_MAX_REWARDS_RATE"></a>
 
-## Function `initialize`
+
+
+<pre><code><b>const</b> <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>: u64 = 100000000;
+</code></pre>
+
+
+
+<a name="0x1_staking_config_ONE_YEAR_IN_MICROS"></a>
+
+
+
+<pre><code><b>const</b> <a href="staking_config.md#0x1_staking_config_ONE_YEAR_IN_MICROS">ONE_YEAR_IN_MICROS</a>: u64 = 31556926000000;
+</code></pre>
+
+
+
+<a name="0x1_staking_config_initialize_staking"></a>
+
+## Function `initialize_staking`
 
 Only called during genesis.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_config.md#0x1_staking_config_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, minimum_stake: u64, maximum_stake: u64, recurring_lockup_duration_secs: u64, allow_validator_set_change: bool, rewards_rate: u64, rewards_rate_denominator: u64, voting_power_increase_limit: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_config.md#0x1_staking_config_initialize_staking">initialize_staking</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, minimum_stake: u64, maximum_stake: u64, recurring_lockup_duration_secs: u64, allow_validator_set_change: bool, voting_power_increase_limit: u64)
 </code></pre>
 
 
@@ -175,14 +272,12 @@ Only called during genesis.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_config.md#0x1_staking_config_initialize">initialize</a>(
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_config.md#0x1_staking_config_initialize_staking">initialize_staking</a>(
     aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     minimum_stake: u64,
     maximum_stake: u64,
     recurring_lockup_duration_secs: u64,
     allow_validator_set_change: bool,
-    rewards_rate: u64,
-    rewards_rate_denominator: u64,
     voting_power_increase_limit: u64,
 ) {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
@@ -191,31 +286,75 @@ Only called during genesis.
     <a href="staking_config.md#0x1_staking_config_validate_required_stake">validate_required_stake</a>(minimum_stake, maximum_stake);
 
     <b>assert</b>!(recurring_lockup_duration_secs &gt; 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EZERO_LOCKUP_DURATION">EZERO_LOCKUP_DURATION</a>));
-    <b>assert</b>!(
-        rewards_rate_denominator &gt; 0,
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EZERO_REWARDS_RATE_DENOMINATOR">EZERO_REWARDS_RATE_DENOMINATOR</a>),
-    );
+
     <b>assert</b>!(
         voting_power_increase_limit &gt; 0 && voting_power_increase_limit &lt;= 50,
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_VOTING_POWER_INCREASE_LIMIT">EINVALID_VOTING_POWER_INCREASE_LIMIT</a>),
     );
-
-    // `rewards_rate` which is the numerator is limited <b>to</b> be `&lt;= <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>` in order <b>to</b> avoid the arithmetic
-    // overflow in the rewards calculation. `rewards_rate_denominator` can be adjusted <b>to</b> get the desired rewards
-    // rate (i.e., rewards_rate / rewards_rate_denominator).
-    <b>assert</b>!(rewards_rate &lt;= <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE">EINVALID_REWARDS_RATE</a>));
-
-    // We <b>assert</b> that (rewards_rate / rewards_rate_denominator &lt;= 1).
-    <b>assert</b>!(rewards_rate &lt;= rewards_rate_denominator, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE">EINVALID_REWARDS_RATE</a>));
 
     <b>move_to</b>(aptos_framework, <a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a> {
         minimum_stake,
         maximum_stake,
         recurring_lockup_duration_secs,
         allow_validator_set_change,
-        rewards_rate,
-        rewards_rate_denominator,
+        _rewards_rate: 0,
+        _rewards_rate_denominator: 1,
         voting_power_increase_limit,
+    });
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_staking_config_initialize_rewards"></a>
+
+## Function `initialize_rewards`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_config.md#0x1_staking_config_initialize_rewards">initialize_rewards</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, initial_yearly_rewards_rate: u64, min_yearly_rewards_rate: u64, rewards_rate_denominator: u64, yearly_rewards_rate_decrease_numerator: u64, yearly_rewards_rate_decrease_denominator: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_config.md#0x1_staking_config_initialize_rewards">initialize_rewards</a>(
+    aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    initial_yearly_rewards_rate: u64,
+    min_yearly_rewards_rate: u64,
+    rewards_rate_denominator: u64,
+    yearly_rewards_rate_decrease_numerator: u64,
+    yearly_rewards_rate_decrease_denominator: u64,
+) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
+
+    <b>assert</b>!(
+        rewards_rate_denominator &gt; 0,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EZERO_REWARDS_RATE_DENOMINATOR">EZERO_REWARDS_RATE_DENOMINATOR</a>),
+    );
+    // `yearly_rewards_rate` which is the numerator is limited <b>to</b> be `&lt;= <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>` in order <b>to</b> avoid the arithmetic
+    // overflow in the rewards calculation. `rewards_rate_denominator` can be adjusted <b>to</b> get the desired rewards
+    // rate (i.e., yearly_rewards_rate / rewards_rate_denominator).
+    <b>assert</b>!(initial_yearly_rewards_rate &lt;= <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE">EINVALID_REWARDS_RATE</a>));
+    <b>assert</b>!(min_yearly_rewards_rate &lt;= initial_yearly_rewards_rate, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE">EINVALID_REWARDS_RATE</a>));
+
+    // We <b>assert</b> that (initial_yearly_rewards_rate / rewards_rate_denominator &lt;= 1).
+    <b>assert</b>!(initial_yearly_rewards_rate &lt;= rewards_rate_denominator, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE">EINVALID_REWARDS_RATE</a>));
+    <b>assert</b>!(yearly_rewards_rate_decrease_numerator &lt;= yearly_rewards_rate_decrease_denominator, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE">EINVALID_REWARDS_RATE</a>));
+
+    <b>move_to</b>(aptos_framework, <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> {
+        yearly_rewards_rate: initial_yearly_rewards_rate,
+        min_yearly_rewards_rate,
+        rewards_rate_denominator,
+        last_rate_decrease_time: 0,
+        yearly_rewards_rate_decrease_numerator,
+        yearly_rewards_rate_decrease_denominator,
+        year_in_micros: <a href="staking_config.md#0x1_staking_config_ONE_YEAR_IN_MICROS">ONE_YEAR_IN_MICROS</a>,
     });
 }
 </code></pre>
@@ -331,7 +470,7 @@ withdraw all funds).
 Return the reward rate.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_get_reward_rate">get_reward_rate</a>(config: &<a href="staking_config.md#0x1_staking_config_StakingConfig">staking_config::StakingConfig</a>): (u64, u64)
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_get_reward_rate">get_reward_rate</a>(_config: &<a href="staking_config.md#0x1_staking_config_StakingConfig">staking_config::StakingConfig</a>): (u64, u64)
 </code></pre>
 
 
@@ -340,8 +479,80 @@ Return the reward rate.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_get_reward_rate">get_reward_rate</a>(config: &<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>): (u64, u64) {
-    (config.rewards_rate, config.rewards_rate_denominator)
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_get_reward_rate">get_reward_rate</a>(_config: &<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>): (u64, u64) {
+    <b>assert</b>!(<b>false</b>, <a href="staking_config.md#0x1_staking_config_EDEPRECATED_FUNCTION">EDEPRECATED_FUNCTION</a>);
+    (0, 1)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_staking_config_get_epoch_reward_rate"></a>
+
+## Function `get_epoch_reward_rate`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_get_epoch_reward_rate">get_epoch_reward_rate</a>(epoch_duration: u64): (u64, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_get_epoch_reward_rate">get_epoch_reward_rate</a>(epoch_duration: u64): (u64, u64) <b>acquires</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> {
+    <b>let</b> staking_rewards_config = <b>borrow_global</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(@aptos_framework);
+    <b>assert</b>!(staking_rewards_config.year_in_micros &gt; 0, <a href="staking_config.md#0x1_staking_config_EDEPRECATED_FUNCTION">EDEPRECATED_FUNCTION</a>);
+    <b>if</b> (epoch_duration &gt; 0) {
+        (staking_rewards_config.yearly_rewards_rate * epoch_duration / staking_rewards_config.year_in_micros, staking_rewards_config.rewards_rate_denominator)
+    } <b>else</b> {
+        (0, 1)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_staking_config_check_and_autodecrease_rewards_rate"></a>
+
+## Function `check_and_autodecrease_rewards_rate`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_check_and_autodecrease_rewards_rate">check_and_autodecrease_rewards_rate</a>(current_time: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_check_and_autodecrease_rewards_rate">check_and_autodecrease_rewards_rate</a>(current_time: u64) <b>acquires</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> {
+    <b>let</b> staking_rewards_config = <b>borrow_global_mut</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(@aptos_framework);
+
+    // initiliaze on first pass
+    <b>if</b> (staking_rewards_config.last_rate_decrease_time == 0) {
+        staking_rewards_config.last_rate_decrease_time = current_time;
+    };
+
+    <b>assert</b>!(current_time &gt;= staking_rewards_config.last_rate_decrease_time, 5);
+    <b>if</b> (current_time - staking_rewards_config.last_rate_decrease_time &gt;= staking_rewards_config.year_in_micros) {
+        <b>let</b> new_rate = staking_rewards_config.yearly_rewards_rate * staking_rewards_config.yearly_rewards_rate_decrease_numerator / staking_rewards_config.yearly_rewards_rate_decrease_denominator;
+        <b>assert</b>!(new_rate == staking_rewards_config.yearly_rewards_rate, new_rate);
+        <b>if</b> (new_rate &gt; staking_rewards_config.min_yearly_rewards_rate) {
+            staking_rewards_config.yearly_rewards_rate = new_rate;
+        } <b>else</b> {
+            staking_rewards_config.yearly_rewards_rate = staking_rewards_config.min_yearly_rewards_rate;
+        };
+        staking_rewards_config.last_rate_decrease_time = staking_rewards_config.last_rate_decrease_time + staking_rewards_config.year_in_micros;
+    };
 }
 </code></pre>
 
@@ -446,11 +657,9 @@ Can only be called as part of the Aptos governance proposal process established 
 
 ## Function `update_rewards_rate`
 
-Update the rewards rate.
-Can only be called as part of the Aptos governance proposal process established by the AptosGovernance module.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_update_rewards_rate">update_rewards_rate</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_rewards_rate: u64, new_rewards_rate_denominator: u64)
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_update_rewards_rate">update_rewards_rate</a>(_aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, _new_rewards_rate: u64, _new_rewards_rate_denominator: u64)
 </code></pre>
 
 
@@ -460,26 +669,64 @@ Can only be called as part of the Aptos governance proposal process established 
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_update_rewards_rate">update_rewards_rate</a>(
+    _aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    _new_rewards_rate: u64,
+    _new_rewards_rate_denominator: u64,
+) {
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_staking_config_update_rewards_config"></a>
+
+## Function `update_rewards_config`
+
+Update the rewards rate.
+Can only be called as part of the Aptos governance proposal process established by the AptosGovernance module.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_update_rewards_config">update_rewards_config</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, yearly_rewards_rate: u64, min_yearly_rewards_rate: u64, rewards_rate_denominator: u64, yearly_rewards_rate_decrease_numerator: u64, yearly_rewards_rate_decrease_denominator: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_update_rewards_config">update_rewards_config</a>(
     aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    new_rewards_rate: u64,
-    new_rewards_rate_denominator: u64,
-) <b>acquires</b> <a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a> {
+    yearly_rewards_rate: u64,
+    min_yearly_rewards_rate: u64,
+    rewards_rate_denominator: u64,
+    yearly_rewards_rate_decrease_numerator: u64,
+    yearly_rewards_rate_decrease_denominator: u64,
+) <b>acquires</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
+
     <b>assert</b>!(
-        new_rewards_rate_denominator &gt; 0,
+        rewards_rate_denominator &gt; 0,
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EZERO_REWARDS_RATE_DENOMINATOR">EZERO_REWARDS_RATE_DENOMINATOR</a>),
     );
-    // `rewards_rate` which is the numerator is limited <b>to</b> be `&lt;= <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>` in order <b>to</b> avoid the arithmetic
+    // `yearly_rewards_rate` which is the numerator is limited <b>to</b> be `&lt;= <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>` in order <b>to</b> avoid the arithmetic
     // overflow in the rewards calculation. `rewards_rate_denominator` can be adjusted <b>to</b> get the desired rewards
-    // rate (i.e., rewards_rate / rewards_rate_denominator).
-    <b>assert</b>!(new_rewards_rate &lt;= <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE">EINVALID_REWARDS_RATE</a>));
+    // rate (i.e., yearly_rewards_rate / rewards_rate_denominator).
+    <b>assert</b>!(yearly_rewards_rate &lt;= <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE">EINVALID_REWARDS_RATE</a>));
+    <b>assert</b>!(min_yearly_rewards_rate &lt;= <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE">EINVALID_REWARDS_RATE</a>));
 
-    // We <b>assert</b> that (rewards_rate / rewards_rate_denominator &lt;= 1).
-    <b>assert</b>!(new_rewards_rate &lt;= new_rewards_rate_denominator, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE">EINVALID_REWARDS_RATE</a>));
+    // We <b>assert</b> that (yearly_rewards_rate / rewards_rate_denominator &lt;= 1).
+    <b>assert</b>!(yearly_rewards_rate &lt;= rewards_rate_denominator, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE">EINVALID_REWARDS_RATE</a>));
+    <b>assert</b>!(yearly_rewards_rate_decrease_numerator &lt;= yearly_rewards_rate_decrease_denominator, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE">EINVALID_REWARDS_RATE</a>));
 
-    <b>let</b> <a href="staking_config.md#0x1_staking_config">staking_config</a> = <b>borrow_global_mut</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>&gt;(@aptos_framework);
-    <a href="staking_config.md#0x1_staking_config">staking_config</a>.rewards_rate = new_rewards_rate;
-    <a href="staking_config.md#0x1_staking_config">staking_config</a>.rewards_rate_denominator = new_rewards_rate_denominator;
+    <b>let</b> staking_rewards_config = <b>borrow_global_mut</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(@aptos_framework);
+    staking_rewards_config.yearly_rewards_rate = yearly_rewards_rate;
+    staking_rewards_config.min_yearly_rewards_rate = min_yearly_rewards_rate;
+    staking_rewards_config.rewards_rate_denominator = rewards_rate_denominator;
+    staking_rewards_config.yearly_rewards_rate_decrease_numerator = yearly_rewards_rate_decrease_numerator;
+    staking_rewards_config.yearly_rewards_rate_decrease_denominator = yearly_rewards_rate_decrease_denominator;
 }
 </code></pre>
 
@@ -554,6 +801,7 @@ Can only be called as part of the Aptos governance proposal process established 
 
 
 <pre><code><b>invariant</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>() ==&gt; <b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>&gt;(@aptos_framework);
+<b>invariant</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>() ==&gt; <b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(@aptos_framework);
 </code></pre>
 
 
@@ -594,13 +842,13 @@ Can only be called as part of the Aptos governance proposal process established 
 
 </dd>
 <dt>
-<code>rewards_rate: u64</code>
+<code>_rewards_rate: u64</code>
 </dt>
 <dd>
 
 </dd>
 <dt>
-<code>rewards_rate_denominator: u64</code>
+<code>_rewards_rate_denominator: u64</code>
 </dt>
 <dd>
 
@@ -615,9 +863,77 @@ Can only be called as part of the Aptos governance proposal process established 
 
 
 
-<pre><code><b>invariant</b> rewards_rate &lt;= <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>;
+<pre><code><b>invariant</b> minimum_stake &lt;= maximum_stake;
+<b>invariant</b> maximum_stake &gt; 0;
+<b>invariant</b> recurring_lockup_duration_secs &gt; 0;
+<b>invariant</b> voting_power_increase_limit &gt; 0;
+<b>invariant</b> voting_power_increase_limit &lt;= 50;
+</code></pre>
+
+
+
+<a name="@Specification_1_StakingRewardsConfig"></a>
+
+### Resource `StakingRewardsConfig`
+
+
+<pre><code><b>struct</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> <b>has</b> <b>copy</b>, drop, key
+</code></pre>
+
+
+
+<dl>
+<dt>
+<code>yearly_rewards_rate: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>min_yearly_rewards_rate: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>rewards_rate_denominator: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>last_rate_decrease_time: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>yearly_rewards_rate_decrease_numerator: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>yearly_rewards_rate_decrease_denominator: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>year_in_micros: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+
+<pre><code><b>invariant</b> yearly_rewards_rate &lt;= <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>;
 <b>invariant</b> rewards_rate_denominator &gt; 0;
-<b>invariant</b> rewards_rate &lt;= rewards_rate_denominator;
+<b>invariant</b> yearly_rewards_rate &lt;= rewards_rate_denominator;
+<b>invariant</b> min_yearly_rewards_rate &lt;= yearly_rewards_rate;
+<b>invariant</b> yearly_rewards_rate_decrease_numerator &lt;= yearly_rewards_rate_decrease_denominator;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -563,7 +563,7 @@ module aptos_framework::aptos_governance {
         account::create_account_for_test(signer::address_of(no_voter));
 
         // Initialize the governance.
-        staking_config::initialize_for_test(aptos_framework, 0, 1000, 2000, true, 0, 1, 100);
+        staking_config::initialize_for_test(aptos_framework, 0, 1000, 2000, true, 0, 1, 1, 100);
         initialize(aptos_framework, 10, 100, 1000);
         store_signer_cap(
             aptos_framework,

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
@@ -2,13 +2,23 @@ spec aptos_framework::staking_config {
     spec module {
         use aptos_framework::chain_status;
         invariant chain_status::is_operating() ==> exists<StakingConfig>(@aptos_framework);
+        invariant chain_status::is_operating() ==> exists<StakingRewardsConfig>(@aptos_framework);
     }
     spec StakingConfig {
+        invariant minimum_stake <= maximum_stake;
+        invariant maximum_stake > 0;
+        invariant recurring_lockup_duration_secs > 0;
+        invariant voting_power_increase_limit > 0;
+        invariant voting_power_increase_limit <= 50;
+    }
+    spec StakingRewardsConfig {
         // `rewards_rate` which is the numerator is limited to be `<= MAX_REWARDS_RATE` in order to avoid the arithmetic
         // overflow in the rewards calculation. `rewards_rate_denominator` can be adjusted to get the desired rewards
         // rate (i.e., rewards_rate / rewards_rate_denominator).
-        invariant rewards_rate <= MAX_REWARDS_RATE;
+        invariant yearly_rewards_rate <= MAX_REWARDS_RATE;
         invariant rewards_rate_denominator > 0;
-        invariant rewards_rate <= rewards_rate_denominator;
+        invariant yearly_rewards_rate <= rewards_rate_denominator;
+        invariant min_yearly_rewards_rate <= yearly_rewards_rate;
+        invariant yearly_rewards_rate_decrease_numerator <= yearly_rewards_rate_decrease_denominator;
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/vesting.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.move
@@ -1245,7 +1245,8 @@ module aptos_framework::vesting {
         commission = with_rewards(commission) + commission_on_staker_rewards;
         distribute(contract_address);
         // Rounding error leads to a dust amount of 1 transferred to the staker.
-        assert!(coin::balance<AptosCoin>(shareholder_address) == staker_rewards + 1, 0);
+        let shareholder_balance = coin::balance<AptosCoin>(shareholder_address);
+        assert!(shareholder_balance == staker_rewards + 1, shareholder_balance);
         assert!(coin::balance<AptosCoin>(operator_address) == commission - 1, 1);
     }
 

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -318,7 +318,7 @@ where
             .with_init_genesis_config(Some(Arc::new(|genesis_config| {
                 genesis_config.allow_new_validators = true;
                 genesis_config.epoch_duration_secs = EPOCH_LENGTH_SECS;
-                genesis_config.recurring_lockup_duration_secs = 7200;
+                genesis_config.staking.recurring_lockup_duration_secs = 7200;
             })))
             .with_randomize_first_validator_ports(random_ports);
 

--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -41,7 +41,10 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use vm_genesis::default_gas_schedule;
+use vm_genesis::{
+    default_gas_schedule, GenesisEmployeeVestingConfiguration, GenesisGovernanceConfiguration,
+    GenesisRewardsConfiguration, GenesisStakingConfiguration,
+};
 
 const VALIDATOR_IDENTITY: &str = "validator-identity.yaml";
 const VFN_IDENTITY: &str = "vfn-identity.yaml";
@@ -397,16 +400,12 @@ pub struct GenesisConfiguration {
     pub allow_new_validators: bool,
     pub epoch_duration_secs: u64,
     pub is_test: bool,
-    pub min_stake: u64,
-    pub max_stake: u64,
-    pub min_voting_threshold: u128,
-    pub recurring_lockup_duration_secs: u64,
-    pub required_proposer_stake: u64,
-    pub rewards_apy_percentage: u64,
-    pub voting_duration_secs: u64,
-    pub voting_power_increase_limit: u64,
-    pub employee_vesting_start: Option<u64>,
-    pub employee_vesting_period_duration: Option<u64>,
+
+    pub staking: GenesisStakingConfiguration,
+    pub rewards: GenesisRewardsConfiguration,
+    pub governance: GenesisGovernanceConfiguration,
+    pub employee_vesting: GenesisEmployeeVestingConfiguration,
+
     pub consensus_config: OnChainConsensusConfig,
     pub gas_schedule: GasScheduleV2,
 }
@@ -596,16 +595,24 @@ impl Builder {
             allow_new_validators: false,
             epoch_duration_secs: ONE_DAY,
             is_test: true,
-            min_stake: 0,
-            min_voting_threshold: 0,
-            max_stake: u64::MAX,
-            recurring_lockup_duration_secs: ONE_DAY,
-            required_proposer_stake: 0,
-            rewards_apy_percentage: 10,
-            voting_duration_secs: ONE_DAY / 24,
-            voting_power_increase_limit: 50,
-            employee_vesting_start: None,
-            employee_vesting_period_duration: None,
+            staking: GenesisStakingConfiguration {
+                min_stake: 0,
+                max_stake: u64::MAX,
+                recurring_lockup_duration_secs: ONE_DAY,
+                voting_power_increase_limit: 50,
+            },
+            rewards: GenesisRewardsConfiguration {
+                rewards_apy_percentage: 7,
+            },
+            governance: GenesisGovernanceConfiguration {
+                min_voting_threshold: 0,
+                required_proposer_stake: 0,
+                voting_duration_secs: ONE_DAY / 24,
+            },
+            employee_vesting: GenesisEmployeeVestingConfiguration {
+                employee_vesting_start: 1663456089,
+                employee_vesting_period_duration: 5 * 60, // 5 minutes
+            },
             consensus_config: OnChainConsensusConfig::default(),
             gas_schedule: default_gas_schedule(),
         };

--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -601,9 +601,7 @@ impl Builder {
                 recurring_lockup_duration_secs: ONE_DAY,
                 voting_power_increase_limit: 50,
             },
-            rewards: GenesisRewardsConfiguration {
-                rewards_apy_percentage: 7,
-            },
+            rewards: GenesisRewardsConfiguration::default(),
             governance: GenesisGovernanceConfiguration {
                 min_voting_threshold: 0,
                 required_proposer_stake: 0,

--- a/crates/aptos-genesis/src/config.rs
+++ b/crates/aptos-genesis/src/config.rs
@@ -88,9 +88,7 @@ impl Default for Layout {
                 recurring_lockup_duration_secs: 86_400,
                 voting_power_increase_limit: 20,
             },
-            rewards: GenesisRewardsConfiguration {
-                rewards_apy_percentage: 7,
-            },
+            rewards: GenesisRewardsConfiguration::default(),
             governance: GenesisGovernanceConfiguration {
                 min_voting_threshold: 100_000_000_000_000,
                 required_proposer_stake: 100_000_000_000_000,

--- a/crates/aptos-genesis/src/config.rs
+++ b/crates/aptos-genesis/src/config.rs
@@ -20,7 +20,11 @@ use std::{
     path::Path,
     str::FromStr,
 };
-use vm_genesis::{AccountBalance, EmployeePool, Validator, ValidatorWithCommissionRate};
+use vm_genesis::{
+    AccountBalance, EmployeePool, GenesisEmployeeVestingConfiguration,
+    GenesisGovernanceConfiguration, GenesisRewardsConfiguration, GenesisStakingConfiguration,
+    Validator, ValidatorWithCommissionRate,
+};
 
 /// Template for setting up Github for Genesis
 ///
@@ -45,28 +49,13 @@ pub struct Layout {
     /// Ignored for mainnet
     #[serde(default)]
     pub is_test: bool,
-    /// Minimum stake to be in the validator set
-    pub min_stake: u64,
-    /// Minimum number of votes to consider a proposal valid.
-    pub min_voting_threshold: u128,
-    /// Maximum stake to be in the validator set
-    pub max_stake: u64,
-    /// Minimum number of seconds to lockup staked coins
-    pub recurring_lockup_duration_secs: u64,
-    /// Required amount of stake to create proposals.
-    pub required_proposer_stake: u64,
-    /// Percentage of stake given out as rewards a year (0-100%).
-    pub rewards_apy_percentage: u64,
-    /// Voting duration for a proposal in seconds.
-    pub voting_duration_secs: u64,
-    /// % of current epoch's total voting power that can be added in this epoch.
-    pub voting_power_increase_limit: u64,
+
+    pub staking: GenesisStakingConfiguration,
+    pub rewards: GenesisRewardsConfiguration,
+    pub governance: GenesisGovernanceConfiguration,
+    pub employee_vesting: GenesisEmployeeVestingConfiguration,
     /// Total supply of coins
     pub total_supply: Option<u64>,
-    /// Timestamp (in seconds) when employee vesting starts.
-    pub employee_vesting_start: Option<u64>,
-    /// Duration of each vesting period (in seconds).
-    pub employee_vesting_period_duration: Option<u64>,
 }
 
 impl Layout {
@@ -93,17 +82,25 @@ impl Default for Layout {
             allow_new_validators: false,
             epoch_duration_secs: 7_200,
             is_test: true,
-            min_stake: 100_000_000_000_000,
-            min_voting_threshold: 100_000_000_000_000,
-            max_stake: 100_000_000_000_000_000,
-            recurring_lockup_duration_secs: 86_400,
-            required_proposer_stake: 100_000_000_000_000,
-            rewards_apy_percentage: 10,
-            voting_duration_secs: 43_200,
-            voting_power_increase_limit: 20,
+            staking: GenesisStakingConfiguration {
+                min_stake: 100_000_000_000_000,
+                max_stake: 100_000_000_000_000_000,
+                recurring_lockup_duration_secs: 86_400,
+                voting_power_increase_limit: 20,
+            },
+            rewards: GenesisRewardsConfiguration {
+                rewards_apy_percentage: 7,
+            },
+            governance: GenesisGovernanceConfiguration {
+                min_voting_threshold: 100_000_000_000_000,
+                required_proposer_stake: 100_000_000_000_000,
+                voting_duration_secs: 43_200,
+            },
+            employee_vesting: GenesisEmployeeVestingConfiguration {
+                employee_vesting_start: 1663456089,
+                employee_vesting_period_duration: 5 * 60, // 5 minutes
+            },
             total_supply: None,
-            employee_vesting_start: Some(1663456089),
-            employee_vesting_period_duration: Some(5 * 60), // 5 minutes
         }
     }
 }

--- a/crates/aptos-genesis/src/lib.rs
+++ b/crates/aptos-genesis/src/lib.rs
@@ -29,7 +29,10 @@ use aptosdb::AptosDB;
 use framework::ReleaseBundle;
 use std::convert::TryInto;
 use storage_interface::DbReaderWriter;
-use vm_genesis::Validator;
+use vm_genesis::{
+    GenesisEmployeeVestingConfiguration, GenesisGovernanceConfiguration,
+    GenesisRewardsConfiguration, GenesisStakingConfiguration, Validator,
+};
 
 /// Holder object for all pieces needed to generate a genesis transaction
 #[derive(Clone)]
@@ -50,22 +53,10 @@ pub struct GenesisInfo {
     /// Duration of an epoch
     pub epoch_duration_secs: u64,
     pub is_test: bool,
-    /// Minimum stake to be in the validator set
-    pub min_stake: u64,
-    /// Minimum number of votes to consider a proposal valid.
-    pub min_voting_threshold: u128,
-    /// Maximum stake to be in the validator set
-    pub max_stake: u64,
-    /// Minimum number of seconds to lockup staked coins
-    pub recurring_lockup_duration_secs: u64,
-    /// Required amount of stake to create proposals.
-    pub required_proposer_stake: u64,
-    /// Percentage of stake given out as rewards a year (0-100%).
-    pub rewards_apy_percentage: u64,
-    /// Voting duration for a proposal in seconds.
-    pub voting_duration_secs: u64,
-    /// Percent of current epoch's total voting power that can be added in this epoch.
-    pub voting_power_increase_limit: u64,
+    pub staking: GenesisStakingConfiguration,
+    pub rewards: GenesisRewardsConfiguration,
+    pub governance: GenesisGovernanceConfiguration,
+    pub employee_vesting: GenesisEmployeeVestingConfiguration,
 
     pub consensus_config: OnChainConsensusConfig,
     pub gas_schedule: GasScheduleV2,
@@ -94,14 +85,10 @@ impl GenesisInfo {
             allow_new_validators: genesis_config.allow_new_validators,
             epoch_duration_secs: genesis_config.epoch_duration_secs,
             is_test: genesis_config.is_test,
-            min_stake: genesis_config.min_stake,
-            min_voting_threshold: genesis_config.min_voting_threshold,
-            max_stake: genesis_config.max_stake,
-            recurring_lockup_duration_secs: genesis_config.recurring_lockup_duration_secs,
-            required_proposer_stake: genesis_config.required_proposer_stake,
-            rewards_apy_percentage: genesis_config.rewards_apy_percentage,
-            voting_duration_secs: genesis_config.voting_duration_secs,
-            voting_power_increase_limit: genesis_config.voting_power_increase_limit,
+            staking: genesis_config.staking,
+            rewards: genesis_config.rewards,
+            governance: genesis_config.governance,
+            employee_vesting: genesis_config.employee_vesting,
             consensus_config: genesis_config.consensus_config.clone(),
             gas_schedule: genesis_config.gas_schedule.clone(),
         })
@@ -126,16 +113,10 @@ impl GenesisInfo {
                 allow_new_validators: self.allow_new_validators,
                 epoch_duration_secs: self.epoch_duration_secs,
                 is_test: true,
-                min_stake: self.min_stake,
-                min_voting_threshold: self.min_voting_threshold,
-                max_stake: self.max_stake,
-                recurring_lockup_duration_secs: self.recurring_lockup_duration_secs,
-                required_proposer_stake: self.required_proposer_stake,
-                rewards_apy_percentage: self.rewards_apy_percentage,
-                voting_duration_secs: self.voting_duration_secs,
-                voting_power_increase_limit: self.voting_power_increase_limit,
-                employee_vesting_start: 1663456089,
-                employee_vesting_period_duration: 5 * 60, // 5 minutes
+                staking: self.staking,
+                rewards: self.rewards,
+                governance: self.governance,
+                employee_vesting: self.employee_vesting,
             },
             &self.consensus_config,
             &self.gas_schedule,

--- a/crates/aptos-genesis/src/mainnet.rs
+++ b/crates/aptos-genesis/src/mainnet.rs
@@ -12,7 +12,11 @@ use aptos_vm::AptosVM;
 use aptosdb::AptosDB;
 use framework::ReleaseBundle;
 use storage_interface::DbReaderWriter;
-use vm_genesis::{AccountBalance, EmployeePool, ValidatorWithCommissionRate};
+use vm_genesis::{
+    AccountBalance, EmployeePool, GenesisEmployeeVestingConfiguration,
+    GenesisGovernanceConfiguration, GenesisRewardsConfiguration, GenesisStakingConfiguration,
+    ValidatorWithCommissionRate,
+};
 
 /// Holder object for all pieces needed to generate a genesis transaction
 #[derive(Clone)]
@@ -26,22 +30,10 @@ pub struct MainnetGenesisInfo {
 
     /// Duration of an epoch
     pub epoch_duration_secs: u64,
-    /// Minimum stake to be in the validator set
-    pub min_stake: u64,
-    /// Minimum number of votes to consider a proposal valid.
-    pub min_voting_threshold: u128,
-    /// Maximum stake to be in the validator set
-    pub max_stake: u64,
-    /// Minimum number of seconds to lockup staked coins
-    pub recurring_lockup_duration_secs: u64,
-    /// Required amount of stake to create proposals.
-    pub required_proposer_stake: u64,
-    /// Percentage of stake given out as rewards a year (0-100%).
-    pub rewards_apy_percentage: u64,
-    /// Voting duration for a proposal in seconds.
-    pub voting_duration_secs: u64,
-    /// Percent of current epoch's total voting power that can be added in this epoch.
-    pub voting_power_increase_limit: u64,
+    pub staking: GenesisStakingConfiguration,
+    pub rewards: GenesisRewardsConfiguration,
+    pub governance: GenesisGovernanceConfiguration,
+    pub employee_vesting: GenesisEmployeeVestingConfiguration,
 
     // MAINNET SPECIFIC FIELDS.
     /// Initial accounts and balances.
@@ -50,10 +42,6 @@ pub struct MainnetGenesisInfo {
     employee_vesting_accounts: Vec<EmployeePool>,
     /// Set of configurations for validators who will be joining the genesis validator set.
     validators: Vec<ValidatorWithCommissionRate>,
-    /// Timestamp (in seconds) when employee vesting starts.
-    employee_vesting_start: u64,
-    /// Duration of each vesting period (in seconds).
-    employee_vesting_period_duration: u64,
 }
 
 impl MainnetGenesisInfo {
@@ -65,13 +53,6 @@ impl MainnetGenesisInfo {
         framework: ReleaseBundle,
         genesis_config: &GenesisConfiguration,
     ) -> anyhow::Result<MainnetGenesisInfo> {
-        let employee_vesting_start = genesis_config
-            .employee_vesting_start
-            .expect("Employee vesting start time (in secs) needs to be provided");
-        let employee_vesting_period_duration = genesis_config
-            .employee_vesting_period_duration
-            .expect("Employee vesting period duration (in secs) needs to be provided");
-
         Ok(MainnetGenesisInfo {
             chain_id,
             accounts,
@@ -83,16 +64,10 @@ impl MainnetGenesisInfo {
             framework,
             genesis: None,
             epoch_duration_secs: genesis_config.epoch_duration_secs,
-            min_stake: genesis_config.min_stake,
-            min_voting_threshold: genesis_config.min_voting_threshold,
-            max_stake: genesis_config.max_stake,
-            recurring_lockup_duration_secs: genesis_config.recurring_lockup_duration_secs,
-            required_proposer_stake: genesis_config.required_proposer_stake,
-            rewards_apy_percentage: genesis_config.rewards_apy_percentage,
-            voting_duration_secs: genesis_config.voting_duration_secs,
-            voting_power_increase_limit: genesis_config.voting_power_increase_limit,
-            employee_vesting_start,
-            employee_vesting_period_duration,
+            staking: genesis_config.staking,
+            rewards: genesis_config.rewards,
+            governance: genesis_config.governance,
+            employee_vesting: genesis_config.employee_vesting,
         })
     }
 
@@ -116,16 +91,10 @@ impl MainnetGenesisInfo {
                 allow_new_validators: true,
                 is_test: false,
                 epoch_duration_secs: self.epoch_duration_secs,
-                min_stake: self.min_stake,
-                min_voting_threshold: self.min_voting_threshold,
-                max_stake: self.max_stake,
-                recurring_lockup_duration_secs: self.recurring_lockup_duration_secs,
-                required_proposer_stake: self.required_proposer_stake,
-                rewards_apy_percentage: self.rewards_apy_percentage,
-                voting_duration_secs: self.voting_duration_secs,
-                voting_power_increase_limit: self.voting_power_increase_limit,
-                employee_vesting_start: self.employee_vesting_start,
-                employee_vesting_period_duration: self.employee_vesting_period_duration,
+                staking: self.staking,
+                rewards: self.rewards,
+                governance: self.governance,
+                employee_vesting: self.employee_vesting,
             },
         )
     }

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -240,16 +240,10 @@ pub fn fetch_mainnet_genesis_info(git_options: GitOptions) -> CliTypedResult<Mai
             allow_new_validators: true,
             epoch_duration_secs: layout.epoch_duration_secs,
             is_test: false,
-            min_stake: layout.min_stake,
-            min_voting_threshold: layout.min_voting_threshold,
-            max_stake: layout.max_stake,
-            recurring_lockup_duration_secs: layout.recurring_lockup_duration_secs,
-            required_proposer_stake: layout.required_proposer_stake,
-            rewards_apy_percentage: layout.rewards_apy_percentage,
-            voting_duration_secs: layout.voting_duration_secs,
-            voting_power_increase_limit: layout.voting_power_increase_limit,
-            employee_vesting_start: layout.employee_vesting_start,
-            employee_vesting_period_duration: layout.employee_vesting_period_duration,
+            staking: layout.staking,
+            rewards: layout.rewards,
+            governance: layout.governance,
+            employee_vesting: layout.employee_vesting,
             consensus_config: OnChainConsensusConfig::default(),
             gas_schedule: default_gas_schedule(),
         },
@@ -279,16 +273,10 @@ pub fn fetch_genesis_info(git_options: GitOptions) -> CliTypedResult<GenesisInfo
             allow_new_validators: layout.allow_new_validators,
             epoch_duration_secs: layout.epoch_duration_secs,
             is_test: layout.is_test,
-            min_stake: layout.min_stake,
-            min_voting_threshold: layout.min_voting_threshold,
-            max_stake: layout.max_stake,
-            recurring_lockup_duration_secs: layout.recurring_lockup_duration_secs,
-            required_proposer_stake: layout.required_proposer_stake,
-            rewards_apy_percentage: layout.rewards_apy_percentage,
-            voting_duration_secs: layout.voting_duration_secs,
-            voting_power_increase_limit: layout.voting_power_increase_limit,
-            employee_vesting_start: layout.employee_vesting_start,
-            employee_vesting_period_duration: layout.employee_vesting_period_duration,
+            staking: layout.staking,
+            rewards: layout.rewards,
+            governance: layout.governance,
+            employee_vesting: layout.employee_vesting,
             consensus_config: OnChainConsensusConfig::default(),
             gas_schedule: default_gas_schedule(),
         },
@@ -682,16 +670,16 @@ fn validate_validators(
                 validator.owner_account_address, name, owner_balance, validator.stake_amount
             )));
         }
-        if validator.stake_amount < layout.min_stake {
+        if validator.stake_amount < layout.staking.min_stake {
             errors.push(CliError::UnexpectedError(format!(
                 "Validator {} has stake {} under the min stake {}",
-                name, validator.stake_amount, layout.min_stake
+                name, validator.stake_amount, layout.staking.min_stake
             )));
         }
-        if validator.stake_amount > layout.max_stake {
+        if validator.stake_amount > layout.staking.max_stake {
             errors.push(CliError::UnexpectedError(format!(
                 "Validator {} has stake {} over the max stake {}",
-                name, validator.stake_amount, layout.max_stake
+                name, validator.stake_amount, layout.staking.max_stake
             )));
         }
 

--- a/terraform/helm/genesis/README.md
+++ b/terraform/helm/genesis/README.md
@@ -25,7 +25,7 @@ Aptos blockchain automated genesis ceremony for testnets
 | chain.name | string | `"testnet"` | Internal: name of the testnet to connect to |
 | chain.recurring_lockup_duration_secs | int | `86400` | Recurring lockup duration in seconds. Defaults to 1 day |
 | chain.required_proposer_stake | int | `100000000000` | Required stake to be a proposer. 1M APTOS coins with 8 decimals |
-| chain.rewards_apy_percentage | int | `10` | Rewards APY percentage |
+| chain.initial_yearly_rewards_rate | float | `0.07` | Rewards APY percentage |
 | chain.root_key | string | `"0x5243ca72b0766d9e9cbf2debf6153443b01a1e0e6d086c7ea206eaf6f8043956"` | If specified, the root key for the testnet |
 | chain.voting_duration_secs | int | `43200` | Voting duration in seconds. Defaults to 12 hours |
 | genesis.domain | string | `nil` | If set, the base domain name of the fullnode and validator endpoints |

--- a/terraform/helm/genesis/templates/genesis.yaml
+++ b/terraform/helm/genesis/templates/genesis.yaml
@@ -17,14 +17,17 @@ data:
     epoch_duration_secs: {{ .Values.chain.epoch_duration_secs | int }}
     is_test: {{ .Values.chain.is_test }}
     min_price_per_gas_unit: {{ .Values.chain.min_price_per_gas_unit }}
-    min_stake: {{ .Values.chain.min_stake | int }}
-    min_voting_threshold: {{ .Values.chain.min_voting_threshold | int }}
-    max_stake: {{ .Values.chain.max_stake | int }}
-    recurring_lockup_duration_secs: {{ .Values.chain.recurring_lockup_duration_secs | int }}
-    required_proposer_stake: {{ .Values.chain.required_proposer_stake | int }}
-    rewards_apy_percentage: {{ .Values.chain.rewards_apy_percentage | int }}
-    voting_duration_secs: {{ .Values.chain.voting_duration_secs | int }}
-    voting_power_increase_limit: {{ .Values.chain.voting_power_increase_limit | int }}
+    staking:
+      min_stake: {{ .Values.chain.min_stake | int }}
+      max_stake: {{ .Values.chain.max_stake | int }}
+      recurring_lockup_duration_secs: {{ .Values.chain.recurring_lockup_duration_secs | int }}
+      voting_power_increase_limit: {{ .Values.chain.voting_power_increase_limit | int }}
+    rewards:
+      rewards_apy_percentage: {{ .Values.chain.rewards_apy_percentage | int }}
+    governance:
+      min_voting_threshold: {{ .Values.chain.min_voting_threshold | int }}
+      required_proposer_stake: {{ .Values.chain.required_proposer_stake | int }}
+      voting_duration_secs: {{ .Values.chain.voting_duration_secs | int }}
 
 ---
 

--- a/terraform/helm/genesis/templates/genesis.yaml
+++ b/terraform/helm/genesis/templates/genesis.yaml
@@ -23,7 +23,7 @@ data:
       recurring_lockup_duration_secs: {{ .Values.chain.recurring_lockup_duration_secs | int }}
       voting_power_increase_limit: {{ .Values.chain.voting_power_increase_limit | int }}
     rewards:
-      rewards_apy_percentage: {{ .Values.chain.rewards_apy_percentage | int }}
+      initial_yearly_rewards_rate: {{ .Values.chain.initial_yearly_rewards_rate | float }}
     governance:
       min_voting_threshold: {{ .Values.chain.min_voting_threshold | int }}
       required_proposer_stake: {{ .Values.chain.required_proposer_stake | int }}

--- a/terraform/helm/genesis/values.yaml
+++ b/terraform/helm/genesis/values.yaml
@@ -27,8 +27,8 @@ chain:
   voting_duration_secs: 43200
   # -- Limit on how much voting power can join every epoch. Defaults to 20%.
   voting_power_increase_limit: 20
-  # -- Rewards APY percentage
-  rewards_apy_percentage: 10
+  # -- Yearly rewards rate
+  initial_yearly_rewards_rate: 0.07
   # -- Minimum price per gas unit
   min_price_per_gas_unit: 1
 

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -436,7 +436,7 @@ async fn test_nodes_rewards() {
             genesis_config.epoch_duration_secs = 4;
             genesis_config.staking.recurring_lockup_duration_secs = 4;
             genesis_config.governance.voting_duration_secs = 3;
-            genesis_config.rewards.rewards_apy_percentage = 10;
+            genesis_config.rewards.initial_yearly_rewards_rate = 0.1;
         }))
         .build_with_cli(0)
         .await;

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -363,8 +363,8 @@ async fn test_large_total_stake() {
         .with_init_genesis_config(Arc::new(|genesis_config| {
             genesis_config.allow_new_validators = true;
             genesis_config.epoch_duration_secs = 4;
-            genesis_config.recurring_lockup_duration_secs = 4;
-            genesis_config.voting_duration_secs = 3;
+            genesis_config.staking.recurring_lockup_duration_secs = 4;
+            genesis_config.governance.voting_duration_secs = 3;
         }))
         .build_with_cli(0)
         .await;
@@ -434,9 +434,9 @@ async fn test_nodes_rewards() {
         .with_init_genesis_config(Arc::new(|genesis_config| {
             genesis_config.allow_new_validators = true;
             genesis_config.epoch_duration_secs = 4;
-            genesis_config.recurring_lockup_duration_secs = 4;
-            genesis_config.voting_duration_secs = 3;
-            genesis_config.rewards_apy_percentage = 10;
+            genesis_config.staking.recurring_lockup_duration_secs = 4;
+            genesis_config.governance.voting_duration_secs = 3;
+            genesis_config.rewards.rewards_apy_percentage = 10;
         }))
         .build_with_cli(0)
         .await;
@@ -860,8 +860,8 @@ async fn test_join_and_leave_validator() {
         .with_init_genesis_config(Arc::new(|genesis_config| {
             genesis_config.allow_new_validators = true;
             genesis_config.epoch_duration_secs = 5;
-            genesis_config.recurring_lockup_duration_secs = 10;
-            genesis_config.voting_duration_secs = 5;
+            genesis_config.staking.recurring_lockup_duration_secs = 10;
+            genesis_config.governance.voting_duration_secs = 5;
         }))
         .build_with_cli(0)
         .await;
@@ -1022,9 +1022,9 @@ async fn test_owner_create_and_delegate_flow() {
         .with_init_genesis_config(Arc::new(|genesis_config| {
             genesis_config.allow_new_validators = true;
             genesis_config.epoch_duration_secs = 5;
-            genesis_config.recurring_lockup_duration_secs = 10;
-            genesis_config.voting_duration_secs = 5;
-            genesis_config.min_stake = 500000
+            genesis_config.staking.recurring_lockup_duration_secs = 10;
+            genesis_config.governance.voting_duration_secs = 5;
+            genesis_config.staking.min_stake = 500000
         }))
         .build_with_cli(0)
         .await;


### PR DESCRIPTION
### Description

- fix so that shorter epochs (due to governance proposals) give proportionally smaller rewards
- implemented yearly rate decrease, 1.5% per year, down to 3.5%

- Did a cleanup with it - to have yearly reward rate on chain, instead of per epoch - so that epoch duration change doesn't require changes to other configs.

### Test Plan
Current tests still passing. Will add few more tests.
