### PR TITLE
Improve simple_map gas cost

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/gas.rs
+++ b/aptos-move/e2e-move-tests/src/tests/gas.rs
@@ -202,7 +202,7 @@ fn test_gas() {
         keys.push(format!("attr_{}", i).as_bytes().to_vec());
         vals.push(format!("{}", i).as_bytes().to_vec());
         typs.push("u64".as_bytes().to_vec());
-    };
+    }
     print_gas_cost(
         "MutateTokenAdd10NewProperties",
         harness.evaluate_gas(
@@ -237,6 +237,7 @@ fn test_gas() {
             ),
         ),
     );
+
     let publisher = &harness.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
     print_gas_cost(
         "PublishSmall",

--- a/aptos-move/e2e-move-tests/src/tests/gas.rs
+++ b/aptos-move/e2e-move-tests/src/tests/gas.rs
@@ -167,13 +167,73 @@ fn test_gas() {
             aptos_token_sdk_builder::token_mutate_token_properties(
                 account_1_address,
                 account_1_address,
-                collection_name,
-                token_name,
+                collection_name.clone(),
+                token_name.clone(),
                 0,
                 1,
-                vec![],
-                vec![],
-                vec![],
+                vec!["age".as_bytes().to_vec()],
+                vec!["4".as_bytes().to_vec()],
+                vec!["int".as_bytes().to_vec()],
+            ),
+        ),
+    );
+    print_gas_cost(
+        "MutateToken2ndTime",
+        harness.evaluate_gas(
+            account_1,
+            aptos_token_sdk_builder::token_mutate_token_properties(
+                account_1_address,
+                account_1_address,
+                collection_name.clone(),
+                token_name.clone(),
+                1,
+                1,
+                vec!["age".as_bytes().to_vec()],
+                vec!["5".as_bytes().to_vec()],
+                vec!["int".as_bytes().to_vec()],
+            ),
+        ),
+    );
+
+    let mut keys = vec![];
+    let mut vals = vec![];
+    let mut typs = vec![];
+    for i in 0..10 {
+        keys.push(format!("attr_{}", i).as_bytes().to_vec());
+        vals.push(format!("{}", i).as_bytes().to_vec());
+        typs.push("u64".as_bytes().to_vec());
+    };
+    print_gas_cost(
+        "MutateTokenAdd10NewProperties",
+        harness.evaluate_gas(
+            account_1,
+            aptos_token_sdk_builder::token_mutate_token_properties(
+                account_1_address,
+                account_1_address,
+                collection_name.clone(),
+                token_name.clone(),
+                1,
+                1,
+                keys.clone(),
+                vals.clone(),
+                typs.clone(),
+            ),
+        ),
+    );
+    print_gas_cost(
+        "MutateTokenMutate10ExistingProperties",
+        harness.evaluate_gas(
+            account_1,
+            aptos_token_sdk_builder::token_mutate_token_properties(
+                account_1_address,
+                account_1_address,
+                collection_name,
+                token_name,
+                1,
+                1,
+                keys,
+                vals,
+                typs,
             ),
         ),
     );

--- a/aptos-move/framework/aptos-stdlib/doc/simple_map.md
+++ b/aptos-move/framework/aptos-stdlib/doc/simple_map.md
@@ -22,7 +22,6 @@ This module provides a solution for sorted maps, that is it has the properties t
 -  [Function `destroy_empty`](#0x1_simple_map_destroy_empty)
 -  [Function `add`](#0x1_simple_map_add)
 -  [Function `remove`](#0x1_simple_map_remove)
--  [Function `find_element`](#0x1_simple_map_find_element)
 -  [Function `find`](#0x1_simple_map_find)
 -  [Specification](#@Specification_1)
     -  [Struct `SimpleMap`](#@Specification_1_SimpleMap)
@@ -106,16 +105,6 @@ This module provides a solution for sorted maps, that is it has the properties t
 <a name="@Constants_0"></a>
 
 ## Constants
-
-
-<a name="0x1_simple_map_EDEPRECATED_FUNCTION"></a>
-
-Deprecated method
-
-
-<pre><code><b>const</b> <a href="simple_map.md#0x1_simple_map_EDEPRECATED_FUNCTION">EDEPRECATED_FUNCTION</a>: u64 = 3;
-</code></pre>
-
 
 
 <a name="0x1_simple_map_EKEY_ALREADY_EXISTS"></a>
@@ -207,7 +196,7 @@ Map key is not found
     map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     key: &Key,
 ): &Value {
-    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find_element">find_element</a>(map, key);
+    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find">find</a>(map, key);
     <b>assert</b>!(<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&maybe_idx), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="simple_map.md#0x1_simple_map_EKEY_NOT_FOUND">EKEY_NOT_FOUND</a>));
     <b>let</b> idx = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> maybe_idx);
     &<a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&map.data, idx).value
@@ -237,7 +226,7 @@ Map key is not found
     map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     key: &Key,
 ): &<b>mut</b> Value {
-    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find_element">find_element</a>(map, key);
+    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find">find</a>(map, key);
     <b>assert</b>!(<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&maybe_idx), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="simple_map.md#0x1_simple_map_EKEY_NOT_FOUND">EKEY_NOT_FOUND</a>));
     <b>let</b> idx = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> maybe_idx);
     &<b>mut</b> <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> map.data, idx).value
@@ -267,7 +256,7 @@ Map key is not found
     map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     key: &Key,
 ): bool {
-    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find_element">find_element</a>(map, key);
+    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find">find</a>(map, key);
     <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&maybe_idx)
 }
 </code></pre>
@@ -321,10 +310,9 @@ Map key is not found
     key: Key,
     value: Value,
 ) {
-    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find_element">find_element</a>(map, &key);
+    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find">find</a>(map, &key);
     <b>assert</b>!(<a href="../../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(&maybe_idx), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="simple_map.md#0x1_simple_map_EKEY_ALREADY_EXISTS">EKEY_ALREADY_EXISTS</a>));
 
-    // Append <b>to</b> the end and then swap elements until the list is ordered again
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> map.data, <a href="simple_map.md#0x1_simple_map_Element">Element</a> { key, value });
 }
 </code></pre>
@@ -352,7 +340,7 @@ Map key is not found
     map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     key: &Key,
 ): (Key, Value) {
-    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find_element">find_element</a>(map, key);
+    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find">find</a>(map, key);
     <b>assert</b>!(<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&maybe_idx), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="simple_map.md#0x1_simple_map_EKEY_NOT_FOUND">EKEY_NOT_FOUND</a>));
 
     <b>let</b> placement = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> maybe_idx);
@@ -372,13 +360,13 @@ Map key is not found
 
 </details>
 
-<a name="0x1_simple_map_find_element"></a>
+<a name="0x1_simple_map_find"></a>
 
-## Function `find_element`
+## Function `find`
 
 
 
-<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find_element">find_element</a>&lt;Key: store, Value: store&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
+<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find">find</a>&lt;Key: store, Value: store&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
 </code></pre>
 
 
@@ -387,7 +375,7 @@ Map key is not found
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find_element">find_element</a>&lt;Key: store, Value: store&gt;(
+<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find">find</a>&lt;Key: store, Value: store&gt;(
     map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     key: &Key,
 ): <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;{
@@ -398,36 +386,9 @@ Map key is not found
         <b>if</b> (&element.key == key){
             <b>return</b> <a href="../../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(i)
         };
-      i = i + 1;
+        i = i + 1;
     };
     <a href="../../move-stdlib/doc/option.md#0x1_option_none">option::none</a>&lt;u64&gt;()
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x1_simple_map_find"></a>
-
-## Function `find`
-
-
-
-<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find">find</a>&lt;Key: store, Value: store&gt;(_map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, _key: &Key): (<a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find">find</a>&lt;Key: store, Value: store&gt;(
-    _map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
-    _key: &Key,
-): (<a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;) {
-    <b>abort</b> <a href="../../move-stdlib/doc/error.md#0x1_error_unavailable">error::unavailable</a>(<a href="simple_map.md#0x1_simple_map_EDEPRECATED_FUNCTION">EDEPRECATED_FUNCTION</a>)
 }
 </code></pre>
 
@@ -612,7 +573,7 @@ Map key is not found
 ### Function `find`
 
 
-<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find">find</a>&lt;Key: store, Value: store&gt;(_map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, _key: &Key): (<a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find">find</a>&lt;Key: store, Value: store&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/simple_map.md
+++ b/aptos-move/framework/aptos-stdlib/doc/simple_map.md
@@ -22,6 +22,7 @@ This module provides a solution for sorted maps, that is it has the properties t
 -  [Function `destroy_empty`](#0x1_simple_map_destroy_empty)
 -  [Function `add`](#0x1_simple_map_add)
 -  [Function `remove`](#0x1_simple_map_remove)
+-  [Function `find_element`](#0x1_simple_map_find_element)
 -  [Function `find`](#0x1_simple_map_find)
 -  [Specification](#@Specification_1)
     -  [Struct `SimpleMap`](#@Specification_1_SimpleMap)
@@ -36,8 +37,7 @@ This module provides a solution for sorted maps, that is it has the properties t
     -  [Function `find`](#@Specification_1_find)
 
 
-<pre><code><b>use</b> <a href="comparator.md#0x1_comparator">0x1::comparator</a>;
-<b>use</b> <a href="../../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<pre><code><b>use</b> <a href="../../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="../../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
 </code></pre>
 
@@ -106,6 +106,16 @@ This module provides a solution for sorted maps, that is it has the properties t
 <a name="@Constants_0"></a>
 
 ## Constants
+
+
+<a name="0x1_simple_map_EDEPRECATED_FUNCTION"></a>
+
+Deprecated method
+
+
+<pre><code><b>const</b> <a href="simple_map.md#0x1_simple_map_EDEPRECATED_FUNCTION">EDEPRECATED_FUNCTION</a>: u64 = 3;
+</code></pre>
+
 
 
 <a name="0x1_simple_map_EKEY_ALREADY_EXISTS"></a>
@@ -197,7 +207,7 @@ Map key is not found
     map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     key: &Key,
 ): &Value {
-    <b>let</b> (maybe_idx, _) = <a href="simple_map.md#0x1_simple_map_find">find</a>(map, key);
+    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find_element">find_element</a>(map, key);
     <b>assert</b>!(<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&maybe_idx), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="simple_map.md#0x1_simple_map_EKEY_NOT_FOUND">EKEY_NOT_FOUND</a>));
     <b>let</b> idx = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> maybe_idx);
     &<a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&map.data, idx).value
@@ -227,7 +237,7 @@ Map key is not found
     map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     key: &Key,
 ): &<b>mut</b> Value {
-    <b>let</b> (maybe_idx, _) = <a href="simple_map.md#0x1_simple_map_find">find</a>(map, key);
+    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find_element">find_element</a>(map, key);
     <b>assert</b>!(<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&maybe_idx), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="simple_map.md#0x1_simple_map_EKEY_NOT_FOUND">EKEY_NOT_FOUND</a>));
     <b>let</b> idx = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> maybe_idx);
     &<b>mut</b> <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> map.data, idx).value
@@ -257,7 +267,7 @@ Map key is not found
     map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     key: &Key,
 ): bool {
-    <b>let</b> (maybe_idx, _) = <a href="simple_map.md#0x1_simple_map_find">find</a>(map, key);
+    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find_element">find_element</a>(map, key);
     <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&maybe_idx)
 }
 </code></pre>
@@ -311,18 +321,11 @@ Map key is not found
     key: Key,
     value: Value,
 ) {
-    <b>let</b> (maybe_idx, maybe_placement) = <a href="simple_map.md#0x1_simple_map_find">find</a>(map, &key);
+    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find_element">find_element</a>(map, &key);
     <b>assert</b>!(<a href="../../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(&maybe_idx), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="simple_map.md#0x1_simple_map_EKEY_ALREADY_EXISTS">EKEY_ALREADY_EXISTS</a>));
 
     // Append <b>to</b> the end and then swap elements until the list is ordered again
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> map.data, <a href="simple_map.md#0x1_simple_map_Element">Element</a> { key, value });
-
-    <b>let</b> placement = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> maybe_placement);
-    <b>let</b> end = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&map.data) - 1;
-    <b>while</b> (placement &lt; end) {
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(&<b>mut</b> map.data, placement, end);
-        placement = placement + 1;
-    };
 }
 </code></pre>
 
@@ -349,7 +352,7 @@ Map key is not found
     map: &<b>mut</b> <a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
     key: &Key,
 ): (Key, Value) {
-    <b>let</b> (maybe_idx, _) = <a href="simple_map.md#0x1_simple_map_find">find</a>(map, key);
+    <b>let</b> maybe_idx = <a href="simple_map.md#0x1_simple_map_find_element">find_element</a>(map, key);
     <b>assert</b>!(<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&maybe_idx), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="simple_map.md#0x1_simple_map_EKEY_NOT_FOUND">EKEY_NOT_FOUND</a>));
 
     <b>let</b> placement = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> maybe_idx);
@@ -369,13 +372,49 @@ Map key is not found
 
 </details>
 
+<a name="0x1_simple_map_find_element"></a>
+
+## Function `find_element`
+
+
+
+<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find_element">find_element</a>&lt;Key: store, Value: store&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find_element">find_element</a>&lt;Key: store, Value: store&gt;(
+    map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
+    key: &Key,
+): <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;{
+    <b>let</b> leng = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&map.data);
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; leng) {
+        <b>let</b> element = <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&map.data, i);
+        <b>if</b> (&element.key == key){
+            <b>return</b> <a href="../../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(i)
+        };
+      i = i + 1;
+    };
+    <a href="../../move-stdlib/doc/option.md#0x1_option_none">option::none</a>&lt;u64&gt;()
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x1_simple_map_find"></a>
 
 ## Function `find`
 
 
 
-<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find">find</a>&lt;Key: store, Value: store&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): (<a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find">find</a>&lt;Key: store, Value: store&gt;(_map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, _key: &Key): (<a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -385,33 +424,10 @@ Map key is not found
 
 
 <pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find">find</a>&lt;Key: store, Value: store&gt;(
-    map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
-    key: &Key,
+    _map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
+    _key: &Key,
 ): (<a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;) {
-    <b>let</b> length = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&map.data);
-
-    <b>if</b> (length == 0) {
-        <b>return</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_none">option::none</a>(), <a href="../../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(0))
-    };
-
-    <b>let</b> left = 0;
-    <b>let</b> right = length;
-
-    <b>while</b> (left != right) {
-        <b>let</b> mid = left + (right - left) / 2;
-        <b>let</b> potential_key = &<a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&map.data, mid).key;
-        <b>if</b> (<a href="comparator.md#0x1_comparator_is_smaller_than">comparator::is_smaller_than</a>(&<a href="comparator.md#0x1_comparator_compare">comparator::compare</a>(potential_key, key))) {
-            left = mid + 1;
-        } <b>else</b> {
-            right = mid;
-        };
-    };
-
-    <b>if</b> (left != length && key == &<a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&map.data, left).key) {
-        (<a href="../../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(left), <a href="../../move-stdlib/doc/option.md#0x1_option_none">option::none</a>())
-    } <b>else</b> {
-        (<a href="../../move-stdlib/doc/option.md#0x1_option_none">option::none</a>(), <a href="../../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(left))
-    }
+    <b>abort</b> <a href="../../move-stdlib/doc/error.md#0x1_error_unavailable">error::unavailable</a>(<a href="simple_map.md#0x1_simple_map_EDEPRECATED_FUNCTION">EDEPRECATED_FUNCTION</a>)
 }
 </code></pre>
 
@@ -596,7 +612,7 @@ Map key is not found
 ### Function `find`
 
 
-<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find">find</a>&lt;Key: store, Value: store&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, key: &Key): (<a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;)
+<pre><code><b>fun</b> <a href="simple_map.md#0x1_simple_map_find">find</a>&lt;Key: store, Value: store&gt;(_map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, _key: &Key): (<a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;)
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/sources/simple_map.move
+++ b/aptos-move/framework/aptos-stdlib/sources/simple_map.move
@@ -8,12 +8,13 @@ module aptos_std::simple_map {
     use std::error;
     use std::option;
     use std::vector;
-    use aptos_std::comparator;
 
     /// Map key already exists
     const EKEY_ALREADY_EXISTS: u64 = 1;
     /// Map key is not found
     const EKEY_NOT_FOUND: u64 = 2;
+    /// Deprecated method
+    const EDEPRECATED_FUNCTION: u64 = 3;
 
     struct SimpleMap<Key, Value> has copy, drop, store {
         data: vector<Element<Key, Value>>,
@@ -38,7 +39,7 @@ module aptos_std::simple_map {
         map: &SimpleMap<Key, Value>,
         key: &Key,
     ): &Value {
-        let (maybe_idx, _) = find(map, key);
+        let maybe_idx = find_element(map, key);
         assert!(option::is_some(&maybe_idx), error::invalid_argument(EKEY_NOT_FOUND));
         let idx = option::extract(&mut maybe_idx);
         &vector::borrow(&map.data, idx).value
@@ -48,7 +49,7 @@ module aptos_std::simple_map {
         map: &mut SimpleMap<Key, Value>,
         key: &Key,
     ): &mut Value {
-        let (maybe_idx, _) = find(map, key);
+        let maybe_idx = find_element(map, key);
         assert!(option::is_some(&maybe_idx), error::invalid_argument(EKEY_NOT_FOUND));
         let idx = option::extract(&mut maybe_idx);
         &mut vector::borrow_mut(&mut map.data, idx).value
@@ -58,7 +59,7 @@ module aptos_std::simple_map {
         map: &SimpleMap<Key, Value>,
         key: &Key,
     ): bool {
-        let (maybe_idx, _) = find(map, key);
+        let maybe_idx = find_element(map, key);
         option::is_some(&maybe_idx)
     }
 
@@ -72,25 +73,18 @@ module aptos_std::simple_map {
         key: Key,
         value: Value,
     ) {
-        let (maybe_idx, maybe_placement) = find(map, &key);
+        let maybe_idx = find_element(map, &key);
         assert!(option::is_none(&maybe_idx), error::invalid_argument(EKEY_ALREADY_EXISTS));
 
         // Append to the end and then swap elements until the list is ordered again
         vector::push_back(&mut map.data, Element { key, value });
-
-        let placement = option::extract(&mut maybe_placement);
-        let end = vector::length(&map.data) - 1;
-        while (placement < end) {
-            vector::swap(&mut map.data, placement, end);
-            placement = placement + 1;
-        };
     }
 
     public fun remove<Key: store, Value: store>(
         map: &mut SimpleMap<Key, Value>,
         key: &Key,
     ): (Key, Value) {
-        let (maybe_idx, _) = find(map, key);
+        let maybe_idx = find_element(map, key);
         assert!(option::is_some(&maybe_idx), error::invalid_argument(EKEY_NOT_FOUND));
 
         let placement = option::extract(&mut maybe_idx);
@@ -105,34 +99,27 @@ module aptos_std::simple_map {
         (key, value)
     }
 
-    fun find<Key: store, Value: store>(
+    fun find_element<Key: store, Value: store>(
         map: &SimpleMap<Key, Value>,
         key: &Key,
-    ): (option::Option<u64>, option::Option<u64>) {
-        let length = vector::length(&map.data);
-
-        if (length == 0) {
-            return (option::none(), option::some(0))
-        };
-
-        let left = 0;
-        let right = length;
-
-        while (left != right) {
-            let mid = left + (right - left) / 2;
-            let potential_key = &vector::borrow(&map.data, mid).key;
-            if (comparator::is_smaller_than(&comparator::compare(potential_key, key))) {
-                left = mid + 1;
-            } else {
-                right = mid;
+    ): option::Option<u64>{
+        let leng = vector::length(&map.data);
+        let i = 0;
+        while (i < leng) {
+            let element = vector::borrow(&map.data, i);
+            if (&element.key == key){
+                return option::some(i)
             };
+          i = i + 1;
         };
+        option::none<u64>()
+    }
 
-        if (left != length && key == &vector::borrow(&map.data, left).key) {
-            (option::some(left), option::none())
-        } else {
-            (option::none(), option::some(left))
-        }
+    fun find<Key: store, Value: store>(
+        _map: &SimpleMap<Key, Value>,
+        _key: &Key,
+    ): (option::Option<u64>, option::Option<u64>) {
+        abort error::unavailable(EDEPRECATED_FUNCTION)
     }
 
     #[test]

--- a/aptos-move/framework/aptos-token/doc/property_map.md
+++ b/aptos-move/framework/aptos-token/doc/property_map.md
@@ -676,7 +676,7 @@ Allow updating existing keys' value and add new key-value pairs
     <b>assert</b>!(key_len == typ_len, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="property_map.md#0x3_property_map_EKEY_COUNT_NOT_MATCH_TYPE_COUNT">EKEY_COUNT_NOT_MATCH_TYPE_COUNT</a>));
 
     <b>let</b> i = 0;
-    <b>while</b> (i &lt; <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&keys)) {
+    <b>while</b> (i &lt; key_len) {
         <b>let</b> key = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&keys, i);
         <b>let</b> prop_val = <a href="property_map.md#0x3_property_map_PropertyValue">PropertyValue</a> {
             value: *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&values, i),

--- a/aptos-move/framework/aptos-token/doc/property_map.md
+++ b/aptos-move/framework/aptos-token/doc/property_map.md
@@ -353,7 +353,6 @@ Create property map directly from key and property value
 
 <pre><code><b>public</b> <b>fun</b> <a href="property_map.md#0x3_property_map_add">add</a>(map: &<b>mut</b> <a href="property_map.md#0x3_property_map_PropertyMap">PropertyMap</a>, key: String, value: <a href="property_map.md#0x3_property_map_PropertyValue">PropertyValue</a>) {
     <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&key) &lt;= <a href="property_map.md#0x3_property_map_MAX_PROPERTY_NAME_LENGTH">MAX_PROPERTY_NAME_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="property_map.md#0x3_property_map_EPROPERTY_MAP_NAME_TOO_LONG">EPROPERTY_MAP_NAME_TOO_LONG</a>));
-    <b>assert</b>!(!<a href="../../aptos-framework/../aptos-stdlib/doc/simple_map.md#0x1_simple_map_contains_key">simple_map::contains_key</a>(&map.map, &key), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_already_exists">error::already_exists</a>(<a href="property_map.md#0x3_property_map_EKEY_AREADY_EXIST_IN_PROPERTY_MAP">EKEY_AREADY_EXIST_IN_PROPERTY_MAP</a>));
     <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/doc/simple_map.md#0x1_simple_map_length">simple_map::length</a>&lt;String, <a href="property_map.md#0x3_property_map_PropertyValue">PropertyValue</a>&gt;(&map.map) &lt; <a href="property_map.md#0x3_property_map_MAX_PROPERTY_MAP_SIZE">MAX_PROPERTY_MAP_SIZE</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="property_map.md#0x3_property_map_EPROPERTY_NUMBER_EXCEED_LIMIT">EPROPERTY_NUMBER_EXCEED_LIMIT</a>));
     <a href="../../aptos-framework/../aptos-stdlib/doc/simple_map.md#0x1_simple_map_add">simple_map::add</a>(&<b>mut</b> map.map, key, value);
 }
@@ -716,8 +715,6 @@ Allow updating existing keys' value and add new key-value pairs
     key: &String,
     value: <a href="property_map.md#0x3_property_map_PropertyValue">PropertyValue</a>
 ) {
-    <b>let</b> found = <a href="property_map.md#0x3_property_map_contains_key">contains_key</a>(map, key);
-    <b>assert</b>!(found, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="property_map.md#0x3_property_map_EPROPERTY_NOT_EXIST">EPROPERTY_NOT_EXIST</a>));
     <b>let</b> property_val = <a href="../../aptos-framework/../aptos-stdlib/doc/simple_map.md#0x1_simple_map_borrow_mut">simple_map::borrow_mut</a>(&<b>mut</b> map.map, key);
     *property_val = value;
 }

--- a/aptos-move/framework/aptos-token/doc/token.md
+++ b/aptos-move/framework/aptos-token/doc/token.md
@@ -2245,6 +2245,7 @@ Allow creator to mutate the default properties in TokenData
 
 ## Function `mutate_one_token`
 
+Mutate the token_properties of one token.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x3_token_mutate_one_token">mutate_one_token</a>(<a href="../../aptos-framework/doc/account.md#0x1_account">account</a>: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, token_owner: <b>address</b>, token_id: <a href="token.md#0x3_token_TokenId">token::TokenId</a>, keys: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;, values: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, types: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;): <a href="token.md#0x3_token_TokenId">token::TokenId</a>

--- a/aptos-move/framework/aptos-token/sources/property_map.move
+++ b/aptos-move/framework/aptos-token/sources/property_map.move
@@ -117,7 +117,6 @@ module aptos_token::property_map {
 
     public fun add(map: &mut PropertyMap, key: String, value: PropertyValue) {
         assert!(string::length(&key) <= MAX_PROPERTY_NAME_LENGTH, error::invalid_argument(EPROPERTY_MAP_NAME_TOO_LONG));
-        assert!(!simple_map::contains_key(&map.map, &key), error::already_exists(EKEY_AREADY_EXIST_IN_PROPERTY_MAP));
         assert!(simple_map::length<String, PropertyValue>(&map.map) < MAX_PROPERTY_MAP_SIZE, error::invalid_state(EPROPERTY_NUMBER_EXCEED_LIMIT));
         simple_map::add(&mut map.map, key, value);
     }
@@ -220,8 +219,6 @@ module aptos_token::property_map {
         key: &String,
         value: PropertyValue
     ) {
-        let found = contains_key(map, key);
-        assert!(found, error::not_found(EPROPERTY_NOT_EXIST));
         let property_val = simple_map::borrow_mut(&mut map.map, key);
         *property_val = value;
     }

--- a/aptos-move/framework/aptos-token/sources/property_map.move
+++ b/aptos-move/framework/aptos-token/sources/property_map.move
@@ -200,7 +200,7 @@ module aptos_token::property_map {
         assert!(key_len == typ_len, error::invalid_state(EKEY_COUNT_NOT_MATCH_TYPE_COUNT));
 
         let i = 0;
-        while (i < vector::length(&keys)) {
+        while (i < key_len) {
             let key = vector::borrow(&keys, i);
             let prop_val = PropertyValue {
                 value: *vector::borrow(&values, i),

--- a/aptos-move/framework/aptos-token/sources/token.move
+++ b/aptos-move/framework/aptos-token/sources/token.move
@@ -776,6 +776,7 @@ module aptos_token::token {
         token_event_store::emit_default_property_mutate_event(creator, token_data_id.collection, token_data_id.name, keys, old_values, new_values);
     }
 
+    /// Mutate the token_properties of one token.
     public fun mutate_one_token(
         account: &signer,
         token_owner: address,


### PR DESCRIPTION
# AIP: Update Simple Map To Save Gas

## Summary

Change the internal implementation of SimpleMap in order to reduce gas prices with minimal impact on Move and Public APIs.

## Motivation

The current implementation of SimpleMap uses a BCS-based logarithmic comparator identifying slots on where to store data in a Vector. Unfortunately this is substantially more expensive than a trivial linear implementation, because each comparison requires BCS serialization followed by a comparison. The conversion to BCS cannot be resolved as quickly as traditional comparator can and substantially impacts gas prices.

## Proposal

- Replace the internal definition of `find` from the current logarithmic implementation to a linear search across the vector.
- Replace the functionality within `add` to call `vector::push_back` and append new values instead of inserting them into their sorted position.

## Rationale

This will result in the following performance differences:

| Operation | Gas Unit Before | Gas Unit After | Delta |
| --- | --- | --- | --- |
| CreateCollection | 174200 | 174200 |  |
| CreateTokenFirstTime | 384800 | 384800 |  |
| MintToken | 117100 | 117100 |  |
| MutateToken | 249200 | 249200 |  |
| MutateTokenAdd10NewProperties | 1148700 | 390700 | 64% |
| MutateTokenMutate10ExistingProperties | 1698300 | 411200 | 75% |
| MutateTokenAdd90NewProperties | 20791800 | 10031700 | 51% |
| MutateTokenMutate100ExistingProperties | 27184500 | 10215200 | 62% |
| MutateTokenAdd300NewProperties (100 existing, 300 new) | 126269000 | 135417900 | -7% |
| MutateTokenMutate400ExistingProperties | 143254200 | 136036800 | 5% |

When the token only has 1 property on-chain, we can see the mutation token cost doesn’t change. However, 

if the user wants to add 10 new properties or update existing properties, the gas cost is reduced by **64% and 75%.** 

if the user wants to store 100 properties on-chain, the gas cost is reduced by 51% and 62%.

600 property mutations were also tested, but failed due to exceeding maximum gas.

## Implementation

Draft benchmark PR https://github.com/aptos-labs/aptos-core/pull/5765/files

```rust
// Before the proposed change
public fun add<Key: store, Value: store>(
        map: &mut SimpleMap<Key, Value>,
        key: Key,
        value: Value,
  ) {
      let (maybe_idx, maybe_placement) = find(map, &key);
      assert!(option::is_none(&maybe_idx), error::invalid_argument(EKEY_ALREADY_EXISTS));

      // Append to the end and then swap elements until the list is ordered again
      vector::push_back(&mut map.data, Element { key, value });

      let placement = option::extract(&mut maybe_placement);
      let end = vector::length(&map.data) - 1;
      while (placement < end) {
          vector::swap(&mut map.data, placement, end);
          placement = placement + 1;
      };
 }
// After the change
public fun add<Key: store, Value: store>(
    map: &mut SimpleMap<Key, Value>,
    key: Key,
    value: Value,
) {
    let maybe_idx = find_element(map, &key);
    assert!(option::is_none(&maybe_idx), error::invalid_argument(EKEY_ALREADY_EXISTS));

    vector::push_back(&mut map.data, Element { key, value });
}
```

```rust
// Before the proposed change
fun find<Key: store, Value: store>(
    map: &SimpleMap<Key, Value>,
    key: &Key,
): (option::Option<u64>, option::Option<u64>) {
    let length = vector::length(&map.data);

    if (length == 0) {
        return (option::none(), option::some(0))
    };

    let left = 0;
    let right = length;

    while (left != right) {
        let mid = left + (right - left) / 2;
        let potential_key = &vector::borrow(&map.data, mid).key;
        if (comparator::is_smaller_than(&comparator::compare(potential_key, key))) {
            left = mid + 1;
        } else {
            right = mid;
        };
    };

    if (left != length && key == &vector::borrow(&map.data, left).key) {
        (option::some(left), option::none())
    } else {
        (option::none(), option::some(left))
    }
}

// After the change
fun find_element<Key: store, Value: store>(
    map: &SimpleMap<Key, Value>,
    key: &Key,
): option::Option<u64>{
    let leng = vector::length(&map.data);
    let i = 0;
    while (i < leng) {
        let element = vector::borrow(&map.data, i);
        if (&element.key == key){
            return option::some(i)
        };
      i = i + 1;
    };
    option::none<u64>()
}
```

## **Risks and Drawbacks**

The internal representation for two SimpleMaps generated before and after the change will be different. For example, assuming a set of `{c: 1, b: 2, a: 3}` . The behavior before would create a set with an internal vector of the following: `{a: 3, b: 2, c: 1}` . After this change, it will be stored as `{c: 1, b: 2, a: 3}` . This results in two forms of breaking changes:

- Within Move, a SimpleMap’s equality property changes.
- As a client, the internal layout for SimpleMap changes.

The impact of these risks is relatively limited from our knowledge. Using a SimpleMap for equality is an esoteric application that the team has yet to see in the wild. The layout of SimpleMap is not considered at either the API layer or any of the AptosLabs SDKs.

We also see a performance drop for a very large simple_map once there are over 400 properties on-chain. 

**Timeline**

TBD