### PR TITLE
[smoke tests] fix artifact upload so it works on failure again

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -139,6 +139,7 @@ jobs:
       # We always try to create the artifact, but it only creates on flaky or failed smoke tests -- when the directories are empty.
       - name: Upload smoke test logs for failed and flaky tests
         uses: actions/upload-artifact@v3
+        if: ${{ failure() || success() }}
         with:
           name: failed-smoke-test-logs
           # Retain all smoke test data except for the db (which may be large).

--- a/testsuite/smoke-test/src/aptos_cli/account.rs
+++ b/testsuite/smoke-test/src/aptos_cli/account.rs
@@ -130,4 +130,6 @@ async fn test_account_key_rotation() {
     cli.transfer_coins(0, 1, 5, None)
         .await
         .expect("New key should be able to transfer");
+
+    panic!("INJECT to test artifact upload")
 }

--- a/testsuite/smoke-test/src/aptos_cli/account.rs
+++ b/testsuite/smoke-test/src/aptos_cli/account.rs
@@ -130,6 +130,4 @@ async fn test_account_key_rotation() {
     cli.transfer_coins(0, 1, 5, None)
         .await
         .expect("New key should be able to transfer");
-
-    panic!("INJECT to test artifact upload")
 }


### PR DESCRIPTION
### Description

Previously the condition was removed, but that defaults to `success()` so would only upload the artifact for flaky test runs and not actually failed test runs. 

### Test Plan

Confirm upload on flaky and injected final failure.