### PR TITLE
[crates] Rename accumulator to aptos-accumulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,17 +13,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "accumulator"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "aptos-crypto",
- "aptos-types",
- "proptest",
- "rand 0.7.3",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +184,17 @@ dependencies = [
  "toml",
  "vm-genesis",
  "walkdir",
+]
+
+[[package]]
+name = "aptos-accumulator"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-crypto",
+ "aptos-types",
+ "proptest",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -586,8 +586,8 @@ dependencies = [
 name = "aptos-fuzzer"
 version = "0.1.0"
 dependencies = [
- "accumulator",
  "anyhow",
+ "aptos-accumulator",
  "aptos-crypto",
  "aptos-jellyfish-merkle",
  "aptos-mempool",
@@ -1524,8 +1524,8 @@ dependencies = [
 name = "aptosdb"
 version = "0.1.0"
 dependencies = [
- "accumulator",
  "anyhow",
+ "aptos-accumulator",
  "aptos-config",
  "aptos-crypto",
  "aptos-infallible",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,8 +166,8 @@ rust-version = "1.64"
 [workspace.dependencies]
 # Internal crate dependencies.
 # Please do not add any test features here: they should be declared by the individual crate.
-accumulator = { path = "storage/accumulator" }
 aptos = { path = "crates/aptos" }
+aptos-accumulator = { path = "storage/accumulator" }
 aptos-aggregator = { path = "aptos-move/aptos-aggregator" }
 aptos-api = { path = "api" }
 aptos-api-test-context = { path = "api/test-context" }

--- a/storage/accumulator/Cargo.toml
+++ b/storage/accumulator/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "accumulator"
+name = "aptos-accumulator"
 description = "Aptos merkle tree accumulator"
 version = "0.1.0"
 

--- a/storage/aptosdb/Cargo.toml
+++ b/storage/aptosdb/Cargo.toml
@@ -13,8 +13,8 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-accumulator = { workspace = true }
 anyhow = { workspace = true }
+aptos-accumulator = { workspace = true }
 aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-infallible = { workspace = true }

--- a/storage/aptosdb/src/event_store/mod.rs
+++ b/storage/aptosdb/src/event_store/mod.rs
@@ -14,8 +14,8 @@ use crate::{
         event_by_key::EventByKeySchema, event_by_version::EventByVersionSchema,
     },
 };
-use accumulator::{HashReader, MerkleAccumulator};
 use anyhow::{bail, ensure, format_err, Result};
+use aptos_accumulator::{HashReader, MerkleAccumulator};
 use aptos_crypto::{
     hash::{CryptoHash, EventAccumulatorHasher},
     HashValue,

--- a/storage/aptosdb/src/ledger_store/mod.rs
+++ b/storage/aptosdb/src/ledger_store/mod.rs
@@ -13,8 +13,8 @@ use crate::{
         transaction_info::TransactionInfoSchema,
     },
 };
-use accumulator::{HashReader, MerkleAccumulator};
 use anyhow::{ensure, format_err, Result};
+use aptos_accumulator::{HashReader, MerkleAccumulator};
 use aptos_crypto::{
     hash::{CryptoHash, TransactionAccumulatorHasher},
     HashValue,

--- a/storage/aptosdb/src/pruner/transaction_store/test.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/test.rs
@@ -12,7 +12,7 @@ use aptos_types::{
     transaction::{SignedTransaction, Transaction},
 };
 
-use accumulator::HashReader;
+use aptos_accumulator::HashReader;
 use aptos_config::config::LedgerPrunerConfig;
 use aptos_types::{
     proof::position::Position,

--- a/testsuite/aptos-fuzzer/Cargo.toml
+++ b/testsuite/aptos-fuzzer/Cargo.toml
@@ -13,8 +13,8 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-accumulator = { workspace = true, features = ["fuzzing"] }
 anyhow = { workspace = true }
+aptos-accumulator = { workspace = true, features = ["fuzzing"] }
 aptos-crypto = { workspace = true, features = ["fuzzing"] }
 aptos-jellyfish-merkle = { workspace = true, features = ["fuzzing"] }
 aptos-mempool = { workspace = true }

--- a/testsuite/aptos-fuzzer/src/fuzz_targets/storage.rs
+++ b/testsuite/aptos-fuzzer/src/fuzz_targets/storage.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{corpus_from_strategy, fuzz_data_to_value, FuzzTargetImpl};
-use accumulator::test_helpers::{
+use aptos_accumulator::test_helpers::{
     arb_hash_batch, arb_list_of_hash_batches, arb_three_hash_batches, arb_two_hash_batches,
     test_append_empty_impl, test_append_many_impl, test_consistency_proof_impl,
     test_get_frozen_subtree_hashes_impl, test_proof_impl, test_range_proof_impl,


### PR DESCRIPTION
### Description
Just one crate to start with, then I'll start batching these changes. This is part of the plan to name all crates `aptos-<name>`.

### Test Plan
CI.
