### PR TITLE
Replace global RwLock over HashMap w. a DashMap. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3211,6 +3211,7 @@ dependencies = [
  "cfg-if",
  "num_cpus",
  "parking_lot 0.12.1",
+ "rayon",
 ]
 
 [[package]]
@@ -8941,6 +8942,7 @@ dependencies = [
  "assert_unordered",
  "bcs 0.1.3 (git+https://github.com/aptos-labs/bcs?rev=2cde3e8446c460cb17b0c1d6bac7e27e964ac169)",
  "crossbeam-channel",
+ "dashmap",
  "move-core-types",
  "once_cell",
  "parking_lot 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,7 +311,7 @@ crossbeam = "0.8.1"
 crossbeam-channel = "0.5.4"
 crossbeam-queue = "0.3.5"
 curve25519-dalek = "3"
-dashmap = "5.2.0"
+dashmap = { version = "5.2.0", features = ["rayon"] }
 datatest-stable = "0.1.1"
 debug-ignore = { version = "1.0.3", features = ["serde"] }
 diesel = { version = "2.0.0", features = ["chrono", "postgres", "r2d2", "numeric", "serde_json"] }

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -23,6 +23,7 @@ aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
 bcs = { workspace = true }
 crossbeam-channel = { workspace = true }
+dashmap = { workspace = true }
 move-core-types = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }


### PR DESCRIPTION
Should hopefully help w. observed behavior of perf degradation on storage reads for more threads (consistent w. what would be expected from rwlock readers scalability).