### PR TITLE
trivial: crate name change

### DIFF
--- a/.github/actions/replay-verify/action.yaml
+++ b/.github/actions/replay-verify/action.yaml
@@ -10,7 +10,7 @@ runs:
         sudo apt-get update -y && sudo apt-get install -y expect
     - name: Build CLI binaries in release mode
       shell: bash
-      run: cargo build --release -p backup-cli --bin replay-verify --bin db-backup
+      run: cargo build --release -p aptos-backup-cli --bin replay-verify --bin db-backup
     - name: query latest version in backup, at the same time, pre-heat metadata cache
       shell: bash
       run: |


### PR DESCRIPTION
### Description

backup-cli is now aptos-backup-cli and one reference didn't get changed.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
