### PR TITLE
[move] fix MultiEd25519 PK validation small bug

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib/sources/configs/features.move
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib/sources/configs/features.move
@@ -89,6 +89,17 @@ module std::features {
         is_enabled(COLLECT_AND_DISTRIBUTE_GAS_FEES)
     }
 
+    /// Whether the new `aptos_stdlib::multi_ed25519::public_key_validate_internal_v2()` native is enabled.
+    /// This is needed because of the introduction of a new native function.
+    /// Lifetime: transient
+    const MULTI_ED25519_PK_VALIDATE_V2_NATIVES: u64 = 7;
+
+    public fun multi_ed25519_pk_validate_v2_feature(): u64 { MULTI_ED25519_PK_VALIDATE_V2_NATIVES }
+
+    public fun multi_ed25519_pk_validate_v2_enabled(): bool acquires Features {
+        is_enabled(MULTI_ED25519_PK_VALIDATE_V2_NATIVES)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/multi_ed25519.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/multi_ed25519.spec.move
@@ -20,6 +20,12 @@ spec aptos_std::multi_ed25519 {
         ensures !cond ==> result == option::spec_none<ValidatedPublicKey>();
     }
 
+    spec new_validated_public_key_from_bytes_v2(bytes: vector<u8>): Option<ValidatedPublicKey> {
+        let cond = spec_public_key_validate_v2_internal(bytes);
+        ensures cond ==> result == option::spec_some(ValidatedPublicKey{bytes});
+        ensures !cond ==> result == option::spec_none<ValidatedPublicKey>();
+    }
+
     spec new_signature_from_bytes(bytes: vector<u8>): Signature {
         aborts_if len(bytes) % INDIVIDUAL_SIGNATURE_NUM_BYTES != BITMAP_NUM_OF_BYTES;
         ensures result == Signature { bytes };
@@ -31,6 +37,7 @@ spec aptos_std::multi_ed25519 {
     // ----------------
 
     spec fun spec_public_key_validate_internal(bytes: vector<u8>): bool;
+    spec fun spec_public_key_validate_v2_internal(bytes: vector<u8>): bool;
 
     spec fun spec_signature_verify_strict_internal(
         multisignature: vector<u8>,
@@ -42,6 +49,11 @@ spec aptos_std::multi_ed25519 {
         pragma opaque;
         aborts_if len(bytes) / INDIVIDUAL_PUBLIC_KEY_NUM_BYTES > MAX_NUMBER_OF_PUBLIC_KEYS;
         ensures result == spec_public_key_validate_internal(bytes);
+    }
+
+    spec public_key_validate_v2_internal(bytes: vector<u8>): bool {
+        pragma opaque;
+        ensures result == spec_public_key_validate_v2_internal(bytes);
     }
 
     spec signature_verify_strict_internal(

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -19,6 +19,8 @@ the Move stdlib, the Aptos stdlib, and the Aptos framework.
 -  [Function `allow_vm_binary_format_v6`](#0x1_features_allow_vm_binary_format_v6)
 -  [Function `get_collect_and_distribute_gas_fees_feature`](#0x1_features_get_collect_and_distribute_gas_fees_feature)
 -  [Function `collect_and_distribute_gas_fees`](#0x1_features_collect_and_distribute_gas_fees)
+-  [Function `multi_ed25519_pk_validate_v2_feature`](#0x1_features_multi_ed25519_pk_validate_v2_feature)
+-  [Function `multi_ed25519_pk_validate_v2_enabled`](#0x1_features_multi_ed25519_pk_validate_v2_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `is_enabled`](#0x1_features_is_enabled)
 -  [Function `set`](#0x1_features_set)
@@ -111,6 +113,18 @@ The provided signer has not a framework address.
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_EFRAMEWORK_SIGNER_NEEDED">EFRAMEWORK_SIGNER_NEEDED</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_features_MULTI_ED25519_PK_VALIDATE_V2_NATIVES"></a>
+
+Whether the new <code>aptos_stdlib::multi_ed25519::public_key_validate_internal_v2()</code> native is enabled.
+This is needed because of the introduction of a new native function.
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_MULTI_ED25519_PK_VALIDATE_V2_NATIVES">MULTI_ED25519_PK_VALIDATE_V2_NATIVES</a>: u64 = 7;
 </code></pre>
 
 
@@ -375,6 +389,52 @@ Lifetime: transient
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_collect_and_distribute_gas_fees">collect_and_distribute_gas_fees</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_COLLECT_AND_DISTRIBUTE_GAS_FEES">COLLECT_AND_DISTRIBUTE_GAS_FEES</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_features_multi_ed25519_pk_validate_v2_feature"></a>
+
+## Function `multi_ed25519_pk_validate_v2_feature`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_multi_ed25519_pk_validate_v2_feature">multi_ed25519_pk_validate_v2_feature</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_multi_ed25519_pk_validate_v2_feature">multi_ed25519_pk_validate_v2_feature</a>(): u64 { <a href="features.md#0x1_features_MULTI_ED25519_PK_VALIDATE_V2_NATIVES">MULTI_ED25519_PK_VALIDATE_V2_NATIVES</a> }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_features_multi_ed25519_pk_validate_v2_enabled"></a>
+
+## Function `multi_ed25519_pk_validate_v2_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_multi_ed25519_pk_validate_v2_enabled">multi_ed25519_pk_validate_v2_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_multi_ed25519_pk_validate_v2_enabled">multi_ed25519_pk_validate_v2_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_MULTI_ED25519_PK_VALIDATE_V2_NATIVES">MULTI_ED25519_PK_VALIDATE_V2_NATIVES</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -89,6 +89,17 @@ module std::features {
         is_enabled(COLLECT_AND_DISTRIBUTE_GAS_FEES)
     }
 
+    /// Whether the new `aptos_stdlib::multi_ed25519::public_key_validate_internal_v2()` native is enabled.
+    /// This is needed because of the introduction of a new native function.
+    /// Lifetime: transient
+    const MULTI_ED25519_PK_VALIDATE_V2_NATIVES: u64 = 7;
+
+    public fun multi_ed25519_pk_validate_v2_feature(): u64 { MULTI_ED25519_PK_VALIDATE_V2_NATIVES }
+
+    public fun multi_ed25519_pk_validate_v2_enabled(): bool acquires Features {
+        is_enabled(MULTI_ED25519_PK_VALIDATE_V2_NATIVES)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/framework/src/natives/cryptography/multi_ed25519.rs
+++ b/aptos-move/framework/src/natives/cryptography/multi_ed25519.rs
@@ -9,8 +9,6 @@ use crate::natives::util::make_test_only_native_from_func;
 use aptos_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use aptos_crypto::ed25519::{ED25519_PUBLIC_KEY_LENGTH, ED25519_SIGNATURE_LENGTH};
 #[cfg(feature = "testing")]
-use aptos_crypto::multi_ed25519::{MultiEd25519PrivateKey, MultiEd25519PublicKey};
-#[cfg(feature = "testing")]
 use aptos_crypto::test_utils::KeyPair;
 use aptos_crypto::{multi_ed25519, traits::*};
 use curve25519_dalek::edwards::CompressedEdwardsY;
@@ -28,6 +26,11 @@ use rand_core::OsRng;
 use smallvec::smallvec;
 use std::{collections::VecDeque, convert::TryFrom};
 
+/// DEPRECATED: See `public_key_validate_internal` comments in `multi_ed25519.move`.
+///
+/// Simply put, this function should have checked that `num_sub_pks > 0` and should abort PK
+/// validation as soon as an invalid sub-PK is found, charging gas accordingly, rather than charge
+/// gas for validating all `num_sub_pks` sub-PKs.
 fn native_public_key_validate(
     gas_params: &GasParameters,
     _context: &mut NativeContext,
@@ -66,6 +69,29 @@ fn native_public_key_validate(
     let num_checked = NumArgs::new(num_checked as u64);
     cost += gas_params.per_pubkey_deserialize * num_checked
         + gas_params.per_pubkey_small_order_check * num_checked;
+
+    Ok(NativeResult::ok(cost, smallvec![Value::bool(all_valid)]))
+}
+
+/// See `public_key_validate_v2_internal` comments in `multi_ed25519.move`.
+fn native_public_key_validate_v2(
+    gas_params: &GasParameters,
+    _context: &mut NativeContext,
+    _ty_args: Vec<Type>,
+    mut arguments: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(_ty_args.is_empty());
+    debug_assert!(arguments.len() == 1);
+
+    let pks_bytes = pop_arg!(arguments, Vec<u8>);
+
+    let mut cost = gas_params.base;
+
+    let (all_valid, num_deserializations, num_small_order_checks) =
+        multi_ed25519::MultiEd25519PublicKey::validate_bytes_and_count_checks(pks_bytes.as_slice());
+
+    cost += gas_params.per_pubkey_deserialize * NumArgs::new(num_deserializations as u64)
+        + gas_params.per_pubkey_small_order_check * NumArgs::new(num_small_order_checks as u64);
 
     Ok(NativeResult::ok(cost, smallvec![Value::bool(all_valid)]))
 }
@@ -137,8 +163,8 @@ fn native_generate_keys(
         .iter()
         .map(|pair| pair.public_key.clone())
         .collect();
-    let group_sk = MultiEd25519PrivateKey::new(private_keys, threshold).unwrap();
-    let group_pk = MultiEd25519PublicKey::new(public_keys, threshold).unwrap();
+    let group_sk = multi_ed25519::MultiEd25519PrivateKey::new(private_keys, threshold).unwrap();
+    let group_pk = multi_ed25519::MultiEd25519PublicKey::new(public_keys, threshold).unwrap();
     Ok(NativeResult::ok(
         InternalGas::zero(),
         smallvec![
@@ -156,7 +182,7 @@ fn native_sign(
 ) -> PartialVMResult<NativeResult> {
     let message = pop_arg!(arguments, Vec<u8>);
     let sk_bytes = pop_arg!(arguments, Vec<u8>);
-    let group_sk = MultiEd25519PrivateKey::try_from(sk_bytes.as_slice()).unwrap();
+    let group_sk = multi_ed25519::MultiEd25519PrivateKey::try_from(sk_bytes.as_slice()).unwrap();
     let sig = group_sk.sign_arbitrary_message(message.as_slice());
     Ok(NativeResult::ok(
         InternalGas::zero(),
@@ -175,6 +201,10 @@ pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, Nati
         (
             "public_key_validate_internal",
             make_native_from_func(gas_params.clone(), native_public_key_validate),
+        ),
+        (
+            "public_key_validate_v2_internal",
+            make_native_from_func(gas_params.clone(), native_public_key_validate_v2),
         ),
         (
             "signature_verify_strict_internal",

--- a/crates/aptos-crypto/src/multi_ed25519.rs
+++ b/crates/aptos-crypto/src/multi_ed25519.rs
@@ -17,6 +17,7 @@ use crate::{
 use anyhow::{anyhow, Result};
 use aptos_crypto_derive::{DeserializeKey, SerializeKey, SilentDebug, SilentDisplay};
 use core::convert::TryFrom;
+use curve25519_dalek::edwards::CompressedEdwardsY;
 use rand::Rng;
 use serde::Serialize;
 use std::{convert::TryInto, fmt};
@@ -115,6 +116,61 @@ impl MultiEd25519PublicKey {
     /// Serialize a MultiEd25519PublicKey.
     pub fn to_bytes(&self) -> Vec<u8> {
         to_bytes(&self.public_keys, self.threshold)
+    }
+
+    /// Checks that all sub PKs would deserialize correctly and are NOT in the small order subgroup.
+    ///
+    /// This function is called by our MultiEd25519 PK validation APIs in Move.
+    ///
+    /// We cannot rely on `TryFrom<&[u8]> for MultiEd25519PublicKey` since it does not exclude
+    /// sub-PKs that are of small order. (Due to limitations in `ed25519_dalek`'s APIs, we cannot
+    /// call the small-subgroup check API on an `ed25519_dalek::PublicKey` struct.) As a result, we
+    /// are forced to replicate some of its code here.
+    ///
+    /// Returns a tuple (`success`, `num_deserializations`, `num_small_order_checks`), where
+    /// `success` is true if the bytes represent a valid MultiEd25519 PK and false otherwise,
+    /// `num_deserializations` is the number of deserialization attempts on a sub PK, and
+    /// `num_small_order_checks` is the number of small order checks on a successfully-deserialized
+    /// PK.
+    ///
+    /// This function returns early as soon as a sub PK fails a check.
+    pub fn validate_bytes_and_count_checks(bytes: &[u8]) -> (bool, usize, usize) {
+        let mut num_deserializations = 0;
+        let mut num_small_order_checks = 0;
+
+        if bytes.is_empty() {
+            return (false, num_deserializations, num_small_order_checks);
+        }
+
+        // Checks that the threshold is correctly encoded in the last bytes of the PK, and that the
+        // # of sub-PKs is > 0 and <= MAX_NUM_OF_KEYS.
+        match check_and_get_threshold(bytes, ED25519_PUBLIC_KEY_LENGTH) {
+            Err(_) => return (false, num_deserializations, num_small_order_checks),
+            _ => {}
+        };
+
+        for chunk in bytes.chunks_exact(ED25519_PUBLIC_KEY_LENGTH) {
+            // Parse as a slice
+            let slice = match <[u8; ED25519_PUBLIC_KEY_LENGTH]>::try_from(chunk) {
+                Ok(slice) => slice,
+                Err(_) => return (false, num_deserializations, num_small_order_checks), // This should never happen because this is a ChunksExact iterator
+            };
+
+            // First, check this is a valid point on the curve.
+            num_deserializations += 1;
+            let point = match CompressedEdwardsY(slice).decompress() {
+                Some(point) => point,
+                None => return (false, num_deserializations, num_small_order_checks),
+            };
+
+            // Second, check this is NOT a small order point.
+            num_small_order_checks += 1;
+            if point.is_small_order() {
+                return (false, num_deserializations, num_small_order_checks);
+            }
+        }
+
+        (true, num_deserializations, num_small_order_checks)
     }
 }
 

--- a/crates/aptos-crypto/src/unit_tests/multi_ed25519_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/multi_ed25519_test.rs
@@ -39,6 +39,11 @@ fn test_successful_public_key_serialization(original_keys: &[Ed25519PublicKey], 
     assert_eq!(serialized.len(), num_pks * ED25519_PUBLIC_KEY_LENGTH + 1);
     let reserialized = MultiEd25519PublicKey::try_from(&serialized[..]);
     assert!(reserialized.is_ok());
+    let (success, num_deser, num_small_order) =
+        MultiEd25519PublicKey::validate_bytes_and_count_checks(&serialized[..]);
+    assert!(success);
+    assert_eq!(num_deser, num_pks);
+    assert_eq!(num_small_order, num_pks);
     assert_eq!(public_key, reserialized.unwrap());
 }
 
@@ -100,31 +105,69 @@ fn test_multi_ed25519_public_key_serialization() {
 
     // Test try_from empty bytes (should fail).
     let multi_key_empty_bytes = MultiEd25519PublicKey::try_from(&[] as &[u8]);
+    let (success, num_deser, num_small_order) =
+        MultiEd25519PublicKey::validate_bytes_and_count_checks(&[] as &[u8]);
+    assert!(!success);
+    assert_eq!(num_deser, 0);
+    assert_eq!(num_small_order, 0);
     test_failed_public_key_serialization(multi_key_empty_bytes, WrongLengthError);
 
     // Test try_from 1 byte (should fail).
     let multi_key_1_byte = MultiEd25519PublicKey::try_from(&[0u8][..]);
+    let (success, num_deser, num_small_order) =
+        MultiEd25519PublicKey::validate_bytes_and_count_checks(&[0u8] as &[u8]);
+    assert!(!success);
+    assert_eq!(num_deser, 0);
+    assert_eq!(num_small_order, 0);
     test_failed_public_key_serialization(multi_key_1_byte, WrongLengthError);
 
     // Test try_from 31 bytes (should fail).
     let multi_key_31_bytes =
         MultiEd25519PublicKey::try_from(&[0u8; ED25519_PUBLIC_KEY_LENGTH - 1][..]);
+    let (success, num_deser, num_small_order) =
+        MultiEd25519PublicKey::validate_bytes_and_count_checks(
+            &[0u8; ED25519_PUBLIC_KEY_LENGTH - 1][..],
+        );
+    assert!(!success);
+    assert_eq!(num_deser, 0);
+    assert_eq!(num_small_order, 0);
     test_failed_public_key_serialization(multi_key_31_bytes, WrongLengthError);
 
     // Test try_from 32 bytes (should fail) because we always need ED25519_PUBLIC_KEY_LENGTH * N + 1
     // bytes (thus 32N + 1).
     let multi_key_32_bytes = MultiEd25519PublicKey::try_from(&[0u8; ED25519_PUBLIC_KEY_LENGTH][..]);
+    let (success, num_deser, num_small_order) =
+        MultiEd25519PublicKey::validate_bytes_and_count_checks(
+            &[0u8; ED25519_PUBLIC_KEY_LENGTH][..],
+        );
+    assert!(!success);
+    assert_eq!(num_deser, 0);
+    assert_eq!(num_small_order, 0);
     test_failed_public_key_serialization(multi_key_32_bytes, WrongLengthError);
 
     // Test try_from 34 bytes (should fail).
     let multi_key_34_bytes =
         MultiEd25519PublicKey::try_from(&[0u8; ED25519_PUBLIC_KEY_LENGTH + 2][..]);
+    let (success, num_deser, num_small_order) =
+        MultiEd25519PublicKey::validate_bytes_and_count_checks(
+            &[0u8; ED25519_PUBLIC_KEY_LENGTH + 2][..],
+        );
+    assert!(!success);
+    assert_eq!(num_deser, 0);
+    assert_eq!(num_small_order, 0);
     test_failed_public_key_serialization(multi_key_34_bytes, WrongLengthError);
 
     // Test try_from 33 all zero bytes (size is fine, but it should fail due to
     // validation issues).
     let multi_key_33_zero_bytes =
         MultiEd25519PublicKey::try_from(&[0u8; ED25519_PUBLIC_KEY_LENGTH + 1][..]);
+    let (success, num_deser, num_small_order) =
+        MultiEd25519PublicKey::validate_bytes_and_count_checks(
+            &[0u8; ED25519_PUBLIC_KEY_LENGTH + 1][..],
+        );
+    assert!(!success);
+    assert_eq!(num_deser, 0); // all 33 bytes are zero => threshold is 0 => invalid multisig PK dismissed early
+    assert_eq!(num_small_order, 0);
     test_failed_public_key_serialization(multi_key_33_zero_bytes, ValidationError);
 
     let priv_keys_10 = generate_keys(10);
@@ -164,7 +207,14 @@ fn test_publickey_smallorder() {
         0, 0, 1,
     ];
 
+    let (success, num_deser, num_small_order) =
+        MultiEd25519PublicKey::validate_bytes_and_count_checks(&torsion_point_with_threshold_1[..]);
+    assert!(!success);
+    assert_eq!(num_deser, 1);
+    assert_eq!(num_small_order, 1);
+
     let torsion_key = MultiEd25519PublicKey::try_from(&torsion_point_with_threshold_1[..]);
+
     assert!(torsion_key.is_err());
     assert_eq!(
         torsion_key.err().unwrap(),


### PR DESCRIPTION
### Description

Our MultiEd25519 Move module allowed for some invalid MultiEd25519 PKs to be deserialized as `ValidatedPublicKey` structs. Such incorrectly-deserialized structs would've been caught later on during signature verification. Nonetheless, we will fix this bug to guarantee correct semantics of MultiEd25519 validated PKs.

**TODO:** <strike>`grep` for uses of deprecated APIs, if any and update this description.</strike>

#### Details

Our native implementation of the `public_key_validate_internal` Move function did not check that a MultiEd25519 PK had >= 1 sub-PKs. 

Furthermore, this implementation did not minimize the gas costs charged to the user, when aborting early.

#### Fix

This PR introduces a new `public_key_validate_v2_internal` API that addresses these two issues. As a result, it deprecates two public functions that used the old version:

 - Deprecates `new_validated_public_key_from_bytes` for `new_validated_public_key_from_bytes_v2`
 - Deprecates `public_key_validate` for `public_key_validate_v2`

Our `public_key_validate_v2_internal` API uses a new `MultiEd25519PublicKey::validate_bytes_and_count_checks` in the `aptos_crypto` crate to check the well-formedness of a public key.

### Test Plan

 - Added a test case with a MultiEd25519 PK with 1 sub-PKs but no byte encoding the threshold
 - Added a test case with a MultiEd25519 PK with 0 sub-PKs
 - Added a test case for a 1-out-of-1 MultiEd25519 PK where the sub-PK is of small order
 - Tested `validate_bytes_and_count_checks` against `MultiEd25519PublicKey::try_from`