### PR TITLE
[Spec] Added more specs to the `coin` and `account` modules

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/account.md
+++ b/aptos-move/framework/aptos-framework/doc/account.md
@@ -1724,7 +1724,20 @@ The length of new_auth_key is 32.
 
 
 
-<pre><code><b>pragma</b> aborts_if_is_partial;
+<pre><code><b>include</b> scheme == <a href="account.md#0x1_account_ED25519_SCHEME">ED25519_SCHEME</a> ==&gt; <a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519_NewUnvalidatedPublicKeyFromBytesAbortsIf">ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf</a> { bytes: public_key_bytes };
+<b>include</b> scheme == <a href="account.md#0x1_account_ED25519_SCHEME">ED25519_SCHEME</a> ==&gt; <a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519_NewSignatureFromBytesAbortsIf">ed25519::NewSignatureFromBytesAbortsIf</a> { bytes: signature };
+<b>aborts_if</b> scheme == <a href="account.md#0x1_account_ED25519_SCHEME">ED25519_SCHEME</a> && !<a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519_spec_signature_verify_strict_t">ed25519::spec_signature_verify_strict_t</a>(
+    <a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519_Signature">ed25519::Signature</a> { bytes: signature },
+    <a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519_UnvalidatedPublicKey">ed25519::UnvalidatedPublicKey</a> { bytes: public_key_bytes },
+    challenge
+);
+<b>include</b> scheme == <a href="account.md#0x1_account_MULTI_ED25519_SCHEME">MULTI_ED25519_SCHEME</a> ==&gt; <a href="../../aptos-stdlib/doc/multi_ed25519.md#0x1_multi_ed25519_NewUnvalidatedPublicKeyFromBytesAbortsIf">multi_ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf</a> { bytes: public_key_bytes };
+<b>include</b> scheme == <a href="account.md#0x1_account_MULTI_ED25519_SCHEME">MULTI_ED25519_SCHEME</a> ==&gt; <a href="../../aptos-stdlib/doc/multi_ed25519.md#0x1_multi_ed25519_NewSignatureFromBytesAbortsIf">multi_ed25519::NewSignatureFromBytesAbortsIf</a> { bytes: signature };
+<b>aborts_if</b> scheme == <a href="account.md#0x1_account_MULTI_ED25519_SCHEME">MULTI_ED25519_SCHEME</a> && !<a href="../../aptos-stdlib/doc/multi_ed25519.md#0x1_multi_ed25519_spec_signature_verify_strict_t">multi_ed25519::spec_signature_verify_strict_t</a>(
+    <a href="../../aptos-stdlib/doc/multi_ed25519.md#0x1_multi_ed25519_Signature">multi_ed25519::Signature</a> { bytes: signature },
+    <a href="../../aptos-stdlib/doc/multi_ed25519.md#0x1_multi_ed25519_UnvalidatedPublicKey">multi_ed25519::UnvalidatedPublicKey</a> { bytes: public_key_bytes },
+    challenge
+);
 <b>aborts_if</b> scheme != <a href="account.md#0x1_account_ED25519_SCHEME">ED25519_SCHEME</a> && scheme != <a href="account.md#0x1_account_MULTI_ED25519_SCHEME">MULTI_ED25519_SCHEME</a>;
 </code></pre>
 
@@ -1767,9 +1780,37 @@ The Account existed under the signer.
 The authentication scheme is ED25519_SCHEME and MULTI_ED25519_SCHEME.
 
 
-<pre><code><b>pragma</b> aborts_if_is_partial;
-<b>let</b> source_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+<pre><code><b>let</b> source_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+<b>let</b> account_resource = <b>global</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(source_address);
+<b>let</b> proof_challenge = <a href="account.md#0x1_account_SignerCapabilityOfferProofChallengeV2">SignerCapabilityOfferProofChallengeV2</a> {
+    sequence_number: account_resource.sequence_number,
+    source_address,
+    recipient_address,
+};
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(recipient_address);
+<b>aborts_if</b> !<b>exists</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(source_address);
+<b>include</b> account_scheme == <a href="account.md#0x1_account_ED25519_SCHEME">ED25519_SCHEME</a> ==&gt; <a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519_NewUnvalidatedPublicKeyFromBytesAbortsIf">ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf</a> { bytes: account_public_key_bytes };
+<b>aborts_if</b> account_scheme == <a href="account.md#0x1_account_ED25519_SCHEME">ED25519_SCHEME</a> && ({
+    <b>let</b> expected_auth_key = <a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519_spec_public_key_bytes_to_authentication_key">ed25519::spec_public_key_bytes_to_authentication_key</a>(account_public_key_bytes);
+    account_resource.authentication_key != expected_auth_key
+});
+<b>include</b> account_scheme == <a href="account.md#0x1_account_ED25519_SCHEME">ED25519_SCHEME</a> ==&gt; <a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519_NewSignatureFromBytesAbortsIf">ed25519::NewSignatureFromBytesAbortsIf</a> { bytes: signer_capability_sig_bytes };
+<b>aborts_if</b> account_scheme == <a href="account.md#0x1_account_ED25519_SCHEME">ED25519_SCHEME</a> && !<a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519_spec_signature_verify_strict_t">ed25519::spec_signature_verify_strict_t</a>(
+    <a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519_Signature">ed25519::Signature</a> { bytes: signer_capability_sig_bytes },
+    <a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519_UnvalidatedPublicKey">ed25519::UnvalidatedPublicKey</a> { bytes: account_public_key_bytes },
+    proof_challenge
+);
+<b>include</b> account_scheme == <a href="account.md#0x1_account_MULTI_ED25519_SCHEME">MULTI_ED25519_SCHEME</a> ==&gt; <a href="../../aptos-stdlib/doc/multi_ed25519.md#0x1_multi_ed25519_NewUnvalidatedPublicKeyFromBytesAbortsIf">multi_ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf</a> { bytes: account_public_key_bytes };
+<b>aborts_if</b> account_scheme == <a href="account.md#0x1_account_MULTI_ED25519_SCHEME">MULTI_ED25519_SCHEME</a> && ({
+    <b>let</b> expected_auth_key = <a href="../../aptos-stdlib/doc/multi_ed25519.md#0x1_multi_ed25519_spec_public_key_bytes_to_authentication_key">multi_ed25519::spec_public_key_bytes_to_authentication_key</a>(account_public_key_bytes);
+    account_resource.authentication_key != expected_auth_key
+});
+<b>include</b> account_scheme == <a href="account.md#0x1_account_MULTI_ED25519_SCHEME">MULTI_ED25519_SCHEME</a> ==&gt; <a href="../../aptos-stdlib/doc/multi_ed25519.md#0x1_multi_ed25519_NewSignatureFromBytesAbortsIf">multi_ed25519::NewSignatureFromBytesAbortsIf</a> { bytes: signer_capability_sig_bytes };
+<b>aborts_if</b> account_scheme == <a href="account.md#0x1_account_MULTI_ED25519_SCHEME">MULTI_ED25519_SCHEME</a> && !<a href="../../aptos-stdlib/doc/multi_ed25519.md#0x1_multi_ed25519_spec_signature_verify_strict_t">multi_ed25519::spec_signature_verify_strict_t</a>(
+    <a href="../../aptos-stdlib/doc/multi_ed25519.md#0x1_multi_ed25519_Signature">multi_ed25519::Signature</a> { bytes: signer_capability_sig_bytes },
+    <a href="../../aptos-stdlib/doc/multi_ed25519.md#0x1_multi_ed25519_UnvalidatedPublicKey">multi_ed25519::UnvalidatedPublicKey</a> { bytes: account_public_key_bytes },
+    proof_challenge
+);
 <b>aborts_if</b> account_scheme != <a href="account.md#0x1_account_ED25519_SCHEME">ED25519_SCHEME</a> && account_scheme != <a href="account.md#0x1_account_MULTI_ED25519_SCHEME">MULTI_ED25519_SCHEME</a>;
 <b>modifies</b> <b>global</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(source_address);
 </code></pre>
@@ -1853,7 +1894,19 @@ The Account existed under the signer
 The value of signer_capability_offer.for of Account resource under the signer is to_be_revoked_address
 
 
-<pre><code><b>pragma</b> verify = <b>false</b>;
+<pre><code><b>pragma</b> opaque;
+<b>pragma</b> aborts_if_is_strict = <b>false</b>;
+<b>aborts_if</b> [abstract] <b>false</b>;
+<b>ensures</b> [abstract] result == <a href="account.md#0x1_account_spec_create_resource_address">spec_create_resource_address</a>(source, seed);
+</code></pre>
+
+
+
+
+<a name="0x1_account_spec_create_resource_address"></a>
+
+
+<pre><code><b>fun</b> <a href="account.md#0x1_account_spec_create_resource_address">spec_create_resource_address</a>(source: <b>address</b>, seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <b>address</b>;
 </code></pre>
 
 
@@ -1970,8 +2023,8 @@ The guid_creation_num of the Account is up to MAX_U64.
 
 
 
-<pre><code><b>pragma</b> aborts_if_is_partial;
-<b>aborts_if</b> !<b>exists</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(account_addr);
+<pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(account_addr);
+<b>aborts_if</b> !<a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_spec_is_struct">type_info::spec_is_struct</a>&lt;CoinType&gt;();
 <b>modifies</b> <b>global</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(account_addr);
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/coin.md
+++ b/aptos-move/framework/aptos-framework/doc/coin.md
@@ -2310,11 +2310,11 @@ An account can only be registered once.
 Updating <code>Account.guid_creation_num</code> will not overflow.
 
 
-<pre><code><b>pragma</b> aborts_if_is_partial;
-<b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+<pre><code><b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
 <b>let</b> acc = <b>global</b>&lt;<a href="account.md#0x1_account_Account">account::Account</a>&gt;(account_addr);
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="coin.md#0x1_coin_CoinStore">CoinStore</a>&lt;CoinType&gt;&gt;(account_addr) && acc.guid_creation_num + 2 &gt; <a href="coin.md#0x1_coin_MAX_U64">MAX_U64</a>;
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="coin.md#0x1_coin_CoinStore">CoinStore</a>&lt;CoinType&gt;&gt;(account_addr) && !<b>exists</b>&lt;<a href="account.md#0x1_account_Account">account::Account</a>&gt;(account_addr);
+<b>aborts_if</b> !<b>exists</b>&lt;<a href="coin.md#0x1_coin_CoinStore">CoinStore</a>&lt;CoinType&gt;&gt;(account_addr) && !<a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_spec_is_struct">type_info::spec_is_struct</a>&lt;CoinType&gt;();
 <b>ensures</b> <b>exists</b>&lt;<a href="coin.md#0x1_coin_CoinStore">CoinStore</a>&lt;CoinType&gt;&gt;(account_addr);
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/sources/account.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/account.spec.move
@@ -81,8 +81,21 @@ spec aptos_framework::account {
     }
 
     spec assert_valid_signature_and_get_auth_key(scheme: u8, public_key_bytes: vector<u8>, signature: vector<u8>, challenge: &RotationProofChallenge): vector<u8> {
-        // TODO: complex aborts conditions.
-        pragma aborts_if_is_partial;
+        include scheme == ED25519_SCHEME ==> ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: public_key_bytes };
+        include scheme == ED25519_SCHEME ==> ed25519::NewSignatureFromBytesAbortsIf { bytes: signature };
+        aborts_if scheme == ED25519_SCHEME && !ed25519::spec_signature_verify_strict_t(
+            ed25519::Signature { bytes: signature },
+            ed25519::UnvalidatedPublicKey { bytes: public_key_bytes },
+            challenge
+        );
+
+        include scheme == MULTI_ED25519_SCHEME ==> multi_ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: public_key_bytes };
+        include scheme == MULTI_ED25519_SCHEME ==> multi_ed25519::NewSignatureFromBytesAbortsIf { bytes: signature };
+        aborts_if scheme == MULTI_ED25519_SCHEME && !multi_ed25519::spec_signature_verify_strict_t(
+            multi_ed25519::Signature { bytes: signature },
+            multi_ed25519::UnvalidatedPublicKey { bytes: public_key_bytes },
+            challenge
+        );
         aborts_if scheme != ED25519_SCHEME && scheme != MULTI_ED25519_SCHEME;
     }
 
@@ -116,11 +129,43 @@ spec aptos_framework::account {
         account_public_key_bytes: vector<u8>,
         recipient_address: address
     ) {
-        // TODO: complex aborts conditions.
-        pragma aborts_if_is_partial;
         let source_address = signer::address_of(account);
+        let account_resource = global<Account>(source_address);
+        let proof_challenge = SignerCapabilityOfferProofChallengeV2 {
+            sequence_number: account_resource.sequence_number,
+            source_address,
+            recipient_address,
+        };
+
         aborts_if !exists<Account>(recipient_address);
+        aborts_if !exists<Account>(source_address);
+
+        include account_scheme == ED25519_SCHEME ==> ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: account_public_key_bytes };
+        aborts_if account_scheme == ED25519_SCHEME && ({
+            let expected_auth_key = ed25519::spec_public_key_bytes_to_authentication_key(account_public_key_bytes);
+            account_resource.authentication_key != expected_auth_key
+        });
+        include account_scheme == ED25519_SCHEME ==> ed25519::NewSignatureFromBytesAbortsIf { bytes: signer_capability_sig_bytes };
+        aborts_if account_scheme == ED25519_SCHEME && !ed25519::spec_signature_verify_strict_t(
+            ed25519::Signature { bytes: signer_capability_sig_bytes },
+            ed25519::UnvalidatedPublicKey { bytes: account_public_key_bytes },
+            proof_challenge
+        );
+
+        include account_scheme == MULTI_ED25519_SCHEME ==> multi_ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: account_public_key_bytes };
+        aborts_if account_scheme == MULTI_ED25519_SCHEME && ({
+            let expected_auth_key = multi_ed25519::spec_public_key_bytes_to_authentication_key(account_public_key_bytes);
+            account_resource.authentication_key != expected_auth_key
+        });
+        include account_scheme == MULTI_ED25519_SCHEME ==> multi_ed25519::NewSignatureFromBytesAbortsIf { bytes: signer_capability_sig_bytes };
+        aborts_if account_scheme == MULTI_ED25519_SCHEME && !multi_ed25519::spec_signature_verify_strict_t(
+            multi_ed25519::Signature { bytes: signer_capability_sig_bytes },
+            multi_ed25519::UnvalidatedPublicKey { bytes: account_public_key_bytes },
+            proof_challenge
+        );
+
         aborts_if account_scheme != ED25519_SCHEME && account_scheme != MULTI_ED25519_SCHEME;
+
         modifies global<Account>(source_address);
     }
 
@@ -160,8 +205,14 @@ spec aptos_framework::account {
     /// The Account existed under the signer
     /// The value of signer_capability_offer.for of Account resource under the signer is to_be_revoked_address
     spec create_resource_address(source: &address, seed: vector<u8>): address {
-        pragma verify = false;
+        pragma opaque;
+        pragma aborts_if_is_strict = false;
+        // This function should not abort assuming the result of `sha3_256` is deserializable into an address.
+        aborts_if [abstract] false;
+        ensures [abstract] result == spec_create_resource_address(source, seed);
     }
+
+    spec fun spec_create_resource_address(source: address, seed: vector<u8>): address;
 
     spec create_resource_account(source: &signer, seed: vector<u8>): (signer, SignerCapability) {
         pragma verify = false;
@@ -210,9 +261,8 @@ spec aptos_framework::account {
     }
 
     spec register_coin<CoinType>(account_addr: address) {
-        // TODO: Add the abort condition about `type_info::type_of`
-        pragma aborts_if_is_partial;
         aborts_if !exists<Account>(account_addr);
+        aborts_if !type_info::spec_is_struct<CoinType>();
         modifies global<Account>(account_addr);
     }
 

--- a/aptos-move/framework/aptos-framework/sources/coin.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.spec.move
@@ -218,12 +218,11 @@ spec aptos_framework::coin {
     /// An account can only be registered once.
     /// Updating `Account.guid_creation_num` will not overflow.
     spec register<CoinType>(account: &signer) {
-        // TODO: Add the abort condition about `type_info::type_of`
-        pragma aborts_if_is_partial;
         let account_addr = signer::address_of(account);
         let acc = global<account::Account>(account_addr);
         aborts_if !exists<CoinStore<CoinType>>(account_addr) && acc.guid_creation_num + 2 > MAX_U64;
         aborts_if !exists<CoinStore<CoinType>>(account_addr) && !exists<account::Account>(account_addr);
+        aborts_if !exists<CoinStore<CoinType>>(account_addr) && !type_info::spec_is_struct<CoinType>();
         ensures exists<CoinStore<CoinType>>(account_addr);
     }
 

--- a/aptos-move/framework/aptos-stdlib/doc/ed25519.md
+++ b/aptos-move/framework/aptos-stdlib/doc/ed25519.md
@@ -34,6 +34,7 @@ Contains functions for:
     -  [Function `new_unvalidated_public_key_from_bytes`](#@Specification_1_new_unvalidated_public_key_from_bytes)
     -  [Function `new_validated_public_key_from_bytes`](#@Specification_1_new_validated_public_key_from_bytes)
     -  [Function `new_signature_from_bytes`](#@Specification_1_new_signature_from_bytes)
+    -  [Function `public_key_bytes_to_authentication_key`](#@Specification_1_public_key_bytes_to_authentication_key)
     -  [Function `public_key_validate_internal`](#@Specification_1_public_key_validate_internal)
     -  [Function `signature_verify_strict_internal`](#@Specification_1_signature_verify_strict_internal)
 
@@ -689,6 +690,19 @@ Returns <code><b>false</b></code> if either:
 ## Specification
 
 
+
+<a name="0x1_ed25519_spec_signature_verify_strict_internal"></a>
+
+
+<pre><code><b>fun</b> <a href="ed25519.md#0x1_ed25519_spec_signature_verify_strict_internal">spec_signature_verify_strict_internal</a>(
+   signature: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+   public_key: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+   message: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+): bool;
+</code></pre>
+
+
+
 <a name="@Specification_1_new_unvalidated_public_key_from_bytes"></a>
 
 ### Function `new_unvalidated_public_key_from_bytes`
@@ -700,9 +714,20 @@ Returns <code><b>false</b></code> if either:
 
 
 
-<pre><code><b>let</b> length = len(bytes);
-<b>aborts_if</b> length != <a href="ed25519.md#0x1_ed25519_PUBLIC_KEY_NUM_BYTES">PUBLIC_KEY_NUM_BYTES</a>;
+<pre><code><b>include</b> <a href="ed25519.md#0x1_ed25519_NewUnvalidatedPublicKeyFromBytesAbortsIf">NewUnvalidatedPublicKeyFromBytesAbortsIf</a>;
 <b>ensures</b> result == <a href="ed25519.md#0x1_ed25519_UnvalidatedPublicKey">UnvalidatedPublicKey</a> { bytes };
+</code></pre>
+
+
+
+
+<a name="0x1_ed25519_NewUnvalidatedPublicKeyFromBytesAbortsIf"></a>
+
+
+<pre><code><b>schema</b> <a href="ed25519.md#0x1_ed25519_NewUnvalidatedPublicKeyFromBytesAbortsIf">NewUnvalidatedPublicKeyFromBytesAbortsIf</a> {
+    bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+    <b>aborts_if</b> len(bytes) != <a href="ed25519.md#0x1_ed25519_PUBLIC_KEY_NUM_BYTES">PUBLIC_KEY_NUM_BYTES</a>;
+}
 </code></pre>
 
 
@@ -737,30 +762,38 @@ Returns <code><b>false</b></code> if either:
 
 
 
-<pre><code><b>aborts_if</b> len(bytes)!= <a href="ed25519.md#0x1_ed25519_SIGNATURE_NUM_BYTES">SIGNATURE_NUM_BYTES</a>;
+<pre><code><b>include</b> <a href="ed25519.md#0x1_ed25519_NewSignatureFromBytesAbortsIf">NewSignatureFromBytesAbortsIf</a>;
 <b>ensures</b> result == <a href="ed25519.md#0x1_ed25519_Signature">Signature</a> { bytes };
 </code></pre>
 
 
 
 
-<a name="0x1_ed25519_spec_public_key_validate_internal"></a>
+<a name="0x1_ed25519_NewSignatureFromBytesAbortsIf"></a>
 
 
-<pre><code><b>fun</b> <a href="ed25519.md#0x1_ed25519_spec_public_key_validate_internal">spec_public_key_validate_internal</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool;
+<pre><code><b>schema</b> <a href="ed25519.md#0x1_ed25519_NewSignatureFromBytesAbortsIf">NewSignatureFromBytesAbortsIf</a> {
+    bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+    <b>aborts_if</b> len(bytes) != <a href="ed25519.md#0x1_ed25519_SIGNATURE_NUM_BYTES">SIGNATURE_NUM_BYTES</a>;
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_public_key_bytes_to_authentication_key"></a>
+
+### Function `public_key_bytes_to_authentication_key`
+
+
+<pre><code><b>fun</b> <a href="ed25519.md#0x1_ed25519_public_key_bytes_to_authentication_key">public_key_bytes_to_authentication_key</a>(pk_bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
 
 
-<a name="0x1_ed25519_spec_signature_verify_strict_internal"></a>
-
-
-<pre><code><b>fun</b> <a href="ed25519.md#0x1_ed25519_spec_signature_verify_strict_internal">spec_signature_verify_strict_internal</a>(
-   signature: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-   public_key: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-   message: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-): bool;
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> [abstract] result == <a href="ed25519.md#0x1_ed25519_spec_public_key_bytes_to_authentication_key">spec_public_key_bytes_to_authentication_key</a>(pk_bytes);
 </code></pre>
 
 
@@ -797,6 +830,40 @@ Returns <code><b>false</b></code> if either:
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="ed25519.md#0x1_ed25519_spec_signature_verify_strict_internal">spec_signature_verify_strict_internal</a>(signature, public_key, message);
+</code></pre>
+
+
+
+
+<a name="0x1_ed25519_spec_public_key_validate_internal"></a>
+
+
+<pre><code><b>fun</b> <a href="ed25519.md#0x1_ed25519_spec_public_key_validate_internal">spec_public_key_validate_internal</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool;
+</code></pre>
+
+
+
+
+<a name="0x1_ed25519_spec_public_key_bytes_to_authentication_key"></a>
+
+
+<pre><code><b>fun</b> <a href="ed25519.md#0x1_ed25519_spec_public_key_bytes_to_authentication_key">spec_public_key_bytes_to_authentication_key</a>(pk_bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+
+<a name="0x1_ed25519_spec_signature_verify_strict_t"></a>
+
+
+<pre><code><b>fun</b> <a href="ed25519.md#0x1_ed25519_spec_signature_verify_strict_t">spec_signature_verify_strict_t</a>&lt;T&gt;(signature: <a href="ed25519.md#0x1_ed25519_Signature">Signature</a>, public_key: <a href="ed25519.md#0x1_ed25519_UnvalidatedPublicKey">UnvalidatedPublicKey</a>, data: T): bool {
+   <b>let</b> encoded = <a href="ed25519.md#0x1_ed25519_SignedMessage">SignedMessage</a>&lt;T&gt; {
+       <a href="type_info.md#0x1_type_info">type_info</a>: <a href="type_info.md#0x1_type_info_type_of">type_info::type_of</a>&lt;T&gt;(),
+       inner: data,
+   };
+   <b>let</b> message = <a href="../../move-stdlib/doc/bcs.md#0x1_bcs_serialize">bcs::serialize</a>(encoded);
+   <a href="ed25519.md#0x1_ed25519_spec_signature_verify_strict_internal">spec_signature_verify_strict_internal</a>(signature.bytes, public_key.bytes, message)
+}
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/multi_ed25519.md
+++ b/aptos-move/framework/aptos-stdlib/doc/multi_ed25519.md
@@ -35,6 +35,7 @@ This module has the exact same interface as the Ed25519 module.
     -  [Function `new_validated_public_key_from_bytes`](#@Specification_1_new_validated_public_key_from_bytes)
     -  [Function `new_validated_public_key_from_bytes_v2`](#@Specification_1_new_validated_public_key_from_bytes_v2)
     -  [Function `new_signature_from_bytes`](#@Specification_1_new_signature_from_bytes)
+    -  [Function `public_key_bytes_to_authentication_key`](#@Specification_1_public_key_bytes_to_authentication_key)
     -  [Function `public_key_validate_internal`](#@Specification_1_public_key_validate_internal)
     -  [Function `public_key_validate_v2_internal`](#@Specification_1_public_key_validate_v2_internal)
     -  [Function `signature_verify_strict_internal`](#@Specification_1_signature_verify_strict_internal)
@@ -813,10 +814,22 @@ Returns <code><b>false</b></code> if either:
 
 
 
-<pre><code><b>let</b> length = len(bytes);
-<b>aborts_if</b> length / <a href="multi_ed25519.md#0x1_multi_ed25519_INDIVIDUAL_PUBLIC_KEY_NUM_BYTES">INDIVIDUAL_PUBLIC_KEY_NUM_BYTES</a> &gt; <a href="multi_ed25519.md#0x1_multi_ed25519_MAX_NUMBER_OF_PUBLIC_KEYS">MAX_NUMBER_OF_PUBLIC_KEYS</a>;
-<b>aborts_if</b> length % <a href="multi_ed25519.md#0x1_multi_ed25519_INDIVIDUAL_PUBLIC_KEY_NUM_BYTES">INDIVIDUAL_PUBLIC_KEY_NUM_BYTES</a> != <a href="multi_ed25519.md#0x1_multi_ed25519_THRESHOLD_SIZE_BYTES">THRESHOLD_SIZE_BYTES</a>;
+<pre><code><b>include</b> <a href="multi_ed25519.md#0x1_multi_ed25519_NewUnvalidatedPublicKeyFromBytesAbortsIf">NewUnvalidatedPublicKeyFromBytesAbortsIf</a>;
 <b>ensures</b> result == <a href="multi_ed25519.md#0x1_multi_ed25519_UnvalidatedPublicKey">UnvalidatedPublicKey</a> { bytes };
+</code></pre>
+
+
+
+
+<a name="0x1_multi_ed25519_NewUnvalidatedPublicKeyFromBytesAbortsIf"></a>
+
+
+<pre><code><b>schema</b> <a href="multi_ed25519.md#0x1_multi_ed25519_NewUnvalidatedPublicKeyFromBytesAbortsIf">NewUnvalidatedPublicKeyFromBytesAbortsIf</a> {
+    bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+    <b>let</b> length = len(bytes);
+    <b>aborts_if</b> length / <a href="multi_ed25519.md#0x1_multi_ed25519_INDIVIDUAL_PUBLIC_KEY_NUM_BYTES">INDIVIDUAL_PUBLIC_KEY_NUM_BYTES</a> &gt; <a href="multi_ed25519.md#0x1_multi_ed25519_MAX_NUMBER_OF_PUBLIC_KEYS">MAX_NUMBER_OF_PUBLIC_KEYS</a>;
+    <b>aborts_if</b> length % <a href="multi_ed25519.md#0x1_multi_ed25519_INDIVIDUAL_PUBLIC_KEY_NUM_BYTES">INDIVIDUAL_PUBLIC_KEY_NUM_BYTES</a> != <a href="multi_ed25519.md#0x1_multi_ed25519_THRESHOLD_SIZE_BYTES">THRESHOLD_SIZE_BYTES</a>;
+}
 </code></pre>
 
 
@@ -832,8 +845,7 @@ Returns <code><b>false</b></code> if either:
 
 
 
-<pre><code><b>aborts_if</b> len(bytes) % <a href="multi_ed25519.md#0x1_multi_ed25519_INDIVIDUAL_PUBLIC_KEY_NUM_BYTES">INDIVIDUAL_PUBLIC_KEY_NUM_BYTES</a> == <a href="multi_ed25519.md#0x1_multi_ed25519_THRESHOLD_SIZE_BYTES">THRESHOLD_SIZE_BYTES</a>
-    && len(bytes) / <a href="multi_ed25519.md#0x1_multi_ed25519_INDIVIDUAL_PUBLIC_KEY_NUM_BYTES">INDIVIDUAL_PUBLIC_KEY_NUM_BYTES</a> &gt; <a href="multi_ed25519.md#0x1_multi_ed25519_MAX_NUMBER_OF_PUBLIC_KEYS">MAX_NUMBER_OF_PUBLIC_KEYS</a>;
+<pre><code><b>aborts_if</b> <b>false</b>;
 <b>let</b> cond = len(bytes) % <a href="multi_ed25519.md#0x1_multi_ed25519_INDIVIDUAL_PUBLIC_KEY_NUM_BYTES">INDIVIDUAL_PUBLIC_KEY_NUM_BYTES</a> == <a href="multi_ed25519.md#0x1_multi_ed25519_THRESHOLD_SIZE_BYTES">THRESHOLD_SIZE_BYTES</a>
     && <a href="multi_ed25519.md#0x1_multi_ed25519_spec_public_key_validate_internal">spec_public_key_validate_internal</a>(bytes);
 <b>ensures</b> cond ==&gt; result == <a href="../../move-stdlib/doc/option.md#0x1_option_spec_some">option::spec_some</a>(<a href="multi_ed25519.md#0x1_multi_ed25519_ValidatedPublicKey">ValidatedPublicKey</a>{bytes});
@@ -871,26 +883,38 @@ Returns <code><b>false</b></code> if either:
 
 
 
-<pre><code><b>aborts_if</b> len(bytes) % <a href="multi_ed25519.md#0x1_multi_ed25519_INDIVIDUAL_SIGNATURE_NUM_BYTES">INDIVIDUAL_SIGNATURE_NUM_BYTES</a> != <a href="multi_ed25519.md#0x1_multi_ed25519_BITMAP_NUM_OF_BYTES">BITMAP_NUM_OF_BYTES</a>;
+<pre><code><b>include</b> <a href="multi_ed25519.md#0x1_multi_ed25519_NewSignatureFromBytesAbortsIf">NewSignatureFromBytesAbortsIf</a>;
 <b>ensures</b> result == <a href="multi_ed25519.md#0x1_multi_ed25519_Signature">Signature</a> { bytes };
 </code></pre>
 
 
 
 
-<a name="0x1_multi_ed25519_spec_public_key_validate_internal"></a>
+<a name="0x1_multi_ed25519_NewSignatureFromBytesAbortsIf"></a>
 
 
-<pre><code><b>fun</b> <a href="multi_ed25519.md#0x1_multi_ed25519_spec_public_key_validate_internal">spec_public_key_validate_internal</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool;
+<pre><code><b>schema</b> <a href="multi_ed25519.md#0x1_multi_ed25519_NewSignatureFromBytesAbortsIf">NewSignatureFromBytesAbortsIf</a> {
+    bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+    <b>aborts_if</b> len(bytes) % <a href="multi_ed25519.md#0x1_multi_ed25519_INDIVIDUAL_SIGNATURE_NUM_BYTES">INDIVIDUAL_SIGNATURE_NUM_BYTES</a> != <a href="multi_ed25519.md#0x1_multi_ed25519_BITMAP_NUM_OF_BYTES">BITMAP_NUM_OF_BYTES</a>;
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_public_key_bytes_to_authentication_key"></a>
+
+### Function `public_key_bytes_to_authentication_key`
+
+
+<pre><code><b>fun</b> <a href="multi_ed25519.md#0x1_multi_ed25519_public_key_bytes_to_authentication_key">public_key_bytes_to_authentication_key</a>(pk_bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
 
 
-<a name="0x1_multi_ed25519_spec_public_key_validate_v2_internal"></a>
-
-
-<pre><code><b>fun</b> <a href="multi_ed25519.md#0x1_multi_ed25519_spec_public_key_validate_v2_internal">spec_public_key_validate_v2_internal</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool;
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> [abstract] result == <a href="multi_ed25519.md#0x1_multi_ed25519_spec_public_key_bytes_to_authentication_key">spec_public_key_bytes_to_authentication_key</a>(pk_bytes);
 </code></pre>
 
 
@@ -920,7 +944,8 @@ Returns <code><b>false</b></code> if either:
 
 
 <pre><code><b>pragma</b> opaque;
-<b>aborts_if</b> len(bytes) / <a href="multi_ed25519.md#0x1_multi_ed25519_INDIVIDUAL_PUBLIC_KEY_NUM_BYTES">INDIVIDUAL_PUBLIC_KEY_NUM_BYTES</a> &gt; <a href="multi_ed25519.md#0x1_multi_ed25519_MAX_NUMBER_OF_PUBLIC_KEYS">MAX_NUMBER_OF_PUBLIC_KEYS</a>;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> (len(bytes) / <a href="multi_ed25519.md#0x1_multi_ed25519_INDIVIDUAL_PUBLIC_KEY_NUM_BYTES">INDIVIDUAL_PUBLIC_KEY_NUM_BYTES</a> &gt; <a href="multi_ed25519.md#0x1_multi_ed25519_MAX_NUMBER_OF_PUBLIC_KEYS">MAX_NUMBER_OF_PUBLIC_KEYS</a>) ==&gt; (result == <b>false</b>);
 <b>ensures</b> result == <a href="multi_ed25519.md#0x1_multi_ed25519_spec_public_key_validate_internal">spec_public_key_validate_internal</a>(bytes);
 </code></pre>
 
@@ -957,6 +982,46 @@ Returns <code><b>false</b></code> if either:
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="multi_ed25519.md#0x1_multi_ed25519_spec_signature_verify_strict_internal">spec_signature_verify_strict_internal</a>(multisignature, public_key, message);
+</code></pre>
+
+
+
+
+<a name="0x1_multi_ed25519_spec_public_key_validate_internal"></a>
+
+
+<pre><code><b>fun</b> <a href="multi_ed25519.md#0x1_multi_ed25519_spec_public_key_validate_internal">spec_public_key_validate_internal</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool;
+</code></pre>
+
+
+
+
+<a name="0x1_multi_ed25519_spec_public_key_validate_v2_internal"></a>
+
+
+<pre><code><b>fun</b> <a href="multi_ed25519.md#0x1_multi_ed25519_spec_public_key_validate_v2_internal">spec_public_key_validate_v2_internal</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool;
+</code></pre>
+
+
+
+
+<a name="0x1_multi_ed25519_spec_public_key_bytes_to_authentication_key"></a>
+
+
+<pre><code><b>fun</b> <a href="multi_ed25519.md#0x1_multi_ed25519_spec_public_key_bytes_to_authentication_key">spec_public_key_bytes_to_authentication_key</a>(pk_bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+
+<a name="0x1_multi_ed25519_spec_signature_verify_strict_t"></a>
+
+
+<pre><code><b>fun</b> <a href="multi_ed25519.md#0x1_multi_ed25519_spec_signature_verify_strict_t">spec_signature_verify_strict_t</a>&lt;T&gt;(signature: <a href="multi_ed25519.md#0x1_multi_ed25519_Signature">Signature</a>, public_key: <a href="multi_ed25519.md#0x1_multi_ed25519_UnvalidatedPublicKey">UnvalidatedPublicKey</a>, data: T): bool {
+   <b>let</b> encoded = <a href="ed25519.md#0x1_ed25519_new_signed_message">ed25519::new_signed_message</a>&lt;T&gt;(data);
+   <b>let</b> message = <a href="../../move-stdlib/doc/bcs.md#0x1_bcs_serialize">bcs::serialize</a>(encoded);
+   <a href="multi_ed25519.md#0x1_multi_ed25519_spec_signature_verify_strict_internal">spec_signature_verify_strict_internal</a>(signature.bytes, public_key.bytes, message)
+}
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/type_info.md
+++ b/aptos-move/framework/aptos-stdlib/doc/type_info.md
@@ -18,6 +18,9 @@
 -  [Function `verify_type_of`](#0x1_type_info_verify_type_of)
 -  [Function `verify_type_of_generic`](#0x1_type_info_verify_type_of_generic)
 -  [Specification](#@Specification_1)
+    -  [Function `chain_id`](#@Specification_1_chain_id)
+    -  [Function `type_of`](#@Specification_1_type_of)
+    -  [Function `type_name`](#@Specification_1_type_name)
     -  [Function `chain_id_internal`](#@Specification_1_chain_id_internal)
     -  [Function `verify_type_of_generic`](#@Specification_1_verify_type_of_generic)
 
@@ -353,6 +356,44 @@ analysis of vector size dynamism.
 ## Specification
 
 
+<a name="@Specification_1_chain_id"></a>
+
+### Function `chain_id`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_chain_id">chain_id</a>(): u8
+</code></pre>
+
+
+
+
+<pre><code><b>ensures</b> result == <a href="type_info.md#0x1_type_info_spec_chain_id_internal">spec_chain_id_internal</a>();
+</code></pre>
+
+
+
+<a name="@Specification_1_type_of"></a>
+
+### Function `type_of`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_type_of">type_of</a>&lt;T&gt;(): <a href="type_info.md#0x1_type_info_TypeInfo">type_info::TypeInfo</a>
+</code></pre>
+
+
+
+
+<a name="@Specification_1_type_name"></a>
+
+### Function `type_name`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_type_name">type_name</a>&lt;T&gt;(): <a href="../../move-stdlib/doc/string.md#0x1_string_String">string::String</a>
+</code></pre>
+
+
+
+
 <a name="@Specification_1_chain_id_internal"></a>
 
 ### Function `chain_id_internal`
@@ -367,6 +408,15 @@ analysis of vector size dynamism.
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <a href="type_info.md#0x1_type_info_spec_chain_id_internal">spec_chain_id_internal</a>();
+</code></pre>
+
+
+
+
+<a name="0x1_type_info_spec_chain_id_internal"></a>
+
+
+<pre><code><b>fun</b> <a href="type_info.md#0x1_type_info_spec_chain_id_internal">spec_chain_id_internal</a>(): u8;
 </code></pre>
 
 
@@ -392,15 +442,6 @@ analysis of vector size dynamism.
 
 
 <pre><code><b>native</b> <b>fun</b> <a href="type_info.md#0x1_type_info_spec_is_struct">spec_is_struct</a>&lt;T&gt;(): bool;
-</code></pre>
-
-
-
-
-<a name="0x1_type_info_spec_chain_id_internal"></a>
-
-
-<pre><code><b>fun</b> <a href="type_info.md#0x1_type_info_spec_chain_id_internal">spec_chain_id_internal</a>(): u8;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ed25519.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ed25519.spec.move
@@ -5,9 +5,12 @@ spec aptos_std::ed25519 {
     // -----------------------
 
     spec new_unvalidated_public_key_from_bytes(bytes: vector<u8>): UnvalidatedPublicKey {
-        let length = len(bytes);
-        aborts_if length != PUBLIC_KEY_NUM_BYTES;
+        include NewUnvalidatedPublicKeyFromBytesAbortsIf;
         ensures result == UnvalidatedPublicKey { bytes };
+    }
+    spec schema NewUnvalidatedPublicKeyFromBytesAbortsIf {
+        bytes: vector<u8>;
+        aborts_if len(bytes) != PUBLIC_KEY_NUM_BYTES;
     }
 
     spec new_validated_public_key_from_bytes(bytes: vector<u8>): Option<ValidatedPublicKey> {
@@ -18,16 +21,24 @@ spec aptos_std::ed25519 {
     }
 
     spec new_signature_from_bytes(bytes: vector<u8>): Signature {
-        aborts_if len(bytes)!= SIGNATURE_NUM_BYTES;
+        include NewSignatureFromBytesAbortsIf;
         ensures result == Signature { bytes };
+    }
+    spec schema NewSignatureFromBytesAbortsIf {
+        bytes: vector<u8>;
+        aborts_if len(bytes) != SIGNATURE_NUM_BYTES;
+    }
+
+    spec public_key_bytes_to_authentication_key(pk_bytes: vector<u8>): vector<u8> {
+        pragma opaque;
+        aborts_if false;
+        ensures [abstract] result == spec_public_key_bytes_to_authentication_key(pk_bytes);
     }
 
 
     // ----------------
     // Native functions
     // ----------------
-
-    spec fun spec_public_key_validate_internal(bytes: vector<u8>): bool;
 
     spec fun spec_signature_verify_strict_internal(
         signature: vector<u8>,
@@ -50,4 +61,23 @@ spec aptos_std::ed25519 {
         aborts_if false;
         ensures result == spec_signature_verify_strict_internal(signature, public_key, message);
     }
+
+
+    // ----------------
+    // Helper functions
+    // ----------------
+
+    spec fun spec_public_key_validate_internal(bytes: vector<u8>): bool;
+
+    spec fun spec_public_key_bytes_to_authentication_key(pk_bytes: vector<u8>): vector<u8>;
+
+    spec fun spec_signature_verify_strict_t<T>(signature: Signature, public_key: UnvalidatedPublicKey, data: T): bool {
+        let encoded = SignedMessage<T> {
+            type_info: type_info::type_of<T>(),
+            inner: data,
+        };
+        let message = bcs::serialize(encoded);
+        spec_signature_verify_strict_internal(signature.bytes, public_key.bytes, message)
+    }
+
 }

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/multi_ed25519.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/multi_ed25519.spec.move
@@ -5,15 +5,18 @@ spec aptos_std::multi_ed25519 {
     // -----------------------
 
     spec new_unvalidated_public_key_from_bytes(bytes: vector<u8>): UnvalidatedPublicKey {
+        include NewUnvalidatedPublicKeyFromBytesAbortsIf;
+        ensures result == UnvalidatedPublicKey { bytes };
+    }
+    spec schema NewUnvalidatedPublicKeyFromBytesAbortsIf {
+        bytes: vector<u8>;
         let length = len(bytes);
         aborts_if length / INDIVIDUAL_PUBLIC_KEY_NUM_BYTES > MAX_NUMBER_OF_PUBLIC_KEYS;
         aborts_if length % INDIVIDUAL_PUBLIC_KEY_NUM_BYTES != THRESHOLD_SIZE_BYTES;
-        ensures result == UnvalidatedPublicKey { bytes };
     }
 
     spec new_validated_public_key_from_bytes(bytes: vector<u8>): Option<ValidatedPublicKey> {
-        aborts_if len(bytes) % INDIVIDUAL_PUBLIC_KEY_NUM_BYTES == THRESHOLD_SIZE_BYTES
-            && len(bytes) / INDIVIDUAL_PUBLIC_KEY_NUM_BYTES > MAX_NUMBER_OF_PUBLIC_KEYS;
+        aborts_if false;
         let cond = len(bytes) % INDIVIDUAL_PUBLIC_KEY_NUM_BYTES == THRESHOLD_SIZE_BYTES
             && spec_public_key_validate_internal(bytes);
         ensures cond ==> result == option::spec_some(ValidatedPublicKey{bytes});
@@ -27,17 +30,23 @@ spec aptos_std::multi_ed25519 {
     }
 
     spec new_signature_from_bytes(bytes: vector<u8>): Signature {
-        aborts_if len(bytes) % INDIVIDUAL_SIGNATURE_NUM_BYTES != BITMAP_NUM_OF_BYTES;
+        include NewSignatureFromBytesAbortsIf;
         ensures result == Signature { bytes };
     }
+    spec schema NewSignatureFromBytesAbortsIf {
+        bytes: vector<u8>;
+        aborts_if len(bytes) % INDIVIDUAL_SIGNATURE_NUM_BYTES != BITMAP_NUM_OF_BYTES;
+    }
 
+    spec public_key_bytes_to_authentication_key(pk_bytes: vector<u8>): vector<u8> {
+        pragma opaque;
+        aborts_if false;
+        ensures [abstract] result == spec_public_key_bytes_to_authentication_key(pk_bytes);
+    }
 
     // ----------------
     // Native functions
     // ----------------
-
-    spec fun spec_public_key_validate_internal(bytes: vector<u8>): bool;
-    spec fun spec_public_key_validate_v2_internal(bytes: vector<u8>): bool;
 
     spec fun spec_signature_verify_strict_internal(
         multisignature: vector<u8>,
@@ -47,7 +56,8 @@ spec aptos_std::multi_ed25519 {
 
     spec public_key_validate_internal(bytes: vector<u8>): bool {
         pragma opaque;
-        aborts_if len(bytes) / INDIVIDUAL_PUBLIC_KEY_NUM_BYTES > MAX_NUMBER_OF_PUBLIC_KEYS;
+        aborts_if false;
+        ensures (len(bytes) / INDIVIDUAL_PUBLIC_KEY_NUM_BYTES > MAX_NUMBER_OF_PUBLIC_KEYS) ==> (result == false);
         ensures result == spec_public_key_validate_internal(bytes);
     }
 
@@ -64,5 +74,22 @@ spec aptos_std::multi_ed25519 {
         pragma opaque;
         aborts_if false;
         ensures result == spec_signature_verify_strict_internal(multisignature, public_key, message);
+    }
+
+
+    // ----------------
+    // Helper functions
+    // ----------------
+
+    spec fun spec_public_key_validate_internal(bytes: vector<u8>): bool;
+
+    spec fun spec_public_key_validate_v2_internal(bytes: vector<u8>): bool;
+
+    spec fun spec_public_key_bytes_to_authentication_key(pk_bytes: vector<u8>): vector<u8>;
+
+    spec fun spec_signature_verify_strict_t<T>(signature: Signature, public_key: UnvalidatedPublicKey, data: T): bool {
+        let encoded = ed25519::new_signed_message<T>(data);
+        let message = bcs::serialize(encoded);
+        spec_signature_verify_strict_internal(signature.bytes, public_key.bytes, message)
     }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/type_info.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.spec.move
@@ -1,14 +1,27 @@
 spec aptos_std::type_info {
-    // Move Prover natively supports `type_of` and `type_name`.
 
     spec native fun spec_is_struct<T>(): bool;
 
-    // The chain ID is modeled as an uninterpreted function.
-    spec fun spec_chain_id_internal(): u8;
+    spec type_of<T>(): TypeInfo {
+        // Move Prover natively supports this function.
+        // This function will abort if `T` is not a struct type.
+    }
+
+    spec type_name<T>(): string::String {
+        // Move Prover natively supports this function.
+    }
+
+    spec chain_id(): u8 {
+        // TODO: Requires the bit operation support to specify the aborts_if condition.
+        ensures result == spec_chain_id_internal();
+    }
 
     spec chain_id_internal(): u8 {
         pragma opaque;
         aborts_if false;
         ensures result == spec_chain_id_internal();
     }
+
+    // The chain ID is modeled as an uninterpreted function.
+    spec fun spec_chain_id_internal(): u8;
 }

--- a/aptos-move/framework/move-stdlib/doc/option.md
+++ b/aptos-move/framework/move-stdlib/doc/option.md
@@ -898,6 +898,7 @@ because it's 0 for "none" or 1 for "some".
 
 
 <pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == <b>old</b>(t);
 <b>ensures</b> <a href="option.md#0x1_option_borrow">borrow</a>(t) == e;
 </code></pre>

--- a/aptos-move/framework/move-stdlib/sources/option.move
+++ b/aptos-move/framework/move-stdlib/sources/option.move
@@ -189,6 +189,7 @@ module std::option {
     }
     spec swap_or_fill {
         pragma opaque;
+        aborts_if false;
         ensures result == old(t);
         ensures borrow(t) == e;
     }


### PR DESCRIPTION
### Description
- this PR completes many TODOs in the specs of coin and account modules.
- added more specs and helper spec functions to `ed25519` and `multi_ed25519` modules
- enhanced the spec of `type_info` module
  - TODO: the spec of `chain_id()` is blocked by the bit operation support.

### Test Plan
`move prove`