### PR TITLE
 [tf/gcp] option to increase GKE node disk size

### DIFF
--- a/terraform/aptos-node/gcp/cluster.tf
+++ b/terraform/aptos-node/gcp/cluster.tf
@@ -68,7 +68,7 @@ resource "google_container_node_pool" "utilities" {
   node_config {
     machine_type    = var.utility_instance_type
     image_type      = "COS_CONTAINERD"
-    disk_size_gb    = 20
+    disk_size_gb    = var.utility_instance_disk_size_gb
     service_account = google_service_account.gke.email
     tags            = ["utilities"]
     oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
@@ -103,7 +103,7 @@ resource "google_container_node_pool" "validators" {
   node_config {
     machine_type    = var.validator_instance_type
     image_type      = "COS_CONTAINERD"
-    disk_size_gb    = 20
+    disk_size_gb    = var.validator_instance_disk_size_gb
     service_account = google_service_account.gke.email
     tags            = ["validators"]
     oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]

--- a/terraform/aptos-node/gcp/variables.tf
+++ b/terraform/aptos-node/gcp/variables.tf
@@ -95,6 +95,11 @@ variable "utility_instance_enable_taint" {
   default     = false
 }
 
+variable "utility_instance_disk_size_gb" {
+  description = "Disk size for utility instances"
+  default     = 20
+}
+
 variable "validator_instance_type" {
   description = "Instance type used for validator and fullnodes"
   default     = "n2-standard-32"
@@ -108,6 +113,11 @@ variable "validator_instance_num" {
 variable "validator_instance_enable_taint" {
   description = "Whether to taint instances in the validator nodegroup"
   default     = false
+}
+
+variable "validator_instance_disk_size_gb" {
+  description = "Disk size for validator instances"
+  default     = 20
 }
 
 variable "enable_logger" {

--- a/terraform/fullnode/gcp/cluster.tf
+++ b/terraform/fullnode/gcp/cluster.tf
@@ -91,7 +91,7 @@ resource "google_container_node_pool" "fullnodes" {
   node_config {
     machine_type    = var.machine_type
     image_type      = "COS_CONTAINERD"
-    disk_size_gb    = 100
+    disk_size_gb    = var.instance_disk_size_gb
     service_account = google_service_account.gke.email
     tags            = ["fullnodes"]
 

--- a/terraform/fullnode/gcp/variables.tf
+++ b/terraform/fullnode/gcp/variables.tf
@@ -93,6 +93,11 @@ variable "num_extra_instance" {
   description = "Number of extra instances to add into node pool"
 }
 
+variable "instance_disk_size_gb" {
+  default     = 100
+  description = "Disk size for fullnode instance"
+}
+
 variable "image_tag" {
   default     = "devnet"
   description = "Docker image tag to use for the fullnode"


### PR DESCRIPTION
### Description

Enables pulling the many images into a k8s host. Useful for systems like Forge, which pulls many images, as well as enabling backup-restore, which uses the `tools` image (which is really big).

Note that this does not make the default disk size larger, as that would trigger re-provisioning nodes and could result in some downtime for existing deployments. We can consider bumping this in a later PR though (e.g. to enable backup-restore for all clusters, not just PFNs), once we make it clear the immediate consequences. 

### Test Plan

apply

<!-- Please provide us with clear details for verifying that your changes work. -->
