### PR TITLE
[Cargo] Rename a few crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-channels"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-infallible",
+ "aptos-metrics-core",
+ "aptos-types",
+ "futures",
+ "tokio",
+]
+
+[[package]]
 name = "aptos-compression"
 version = "0.1.0"
 dependencies = [
@@ -507,6 +519,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
+ "aptos-channels",
  "aptos-config",
  "aptos-consensus-notifications",
  "aptos-consensus-types",
@@ -536,7 +549,6 @@ dependencies = [
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "byteorder",
  "bytes 1.2.1",
- "channel",
  "claims",
  "fail 0.5.0",
  "futures",
@@ -656,6 +668,7 @@ dependencies = [
 name = "aptos-data-client"
 version = "0.1.0"
 dependencies = [
+ "aptos-channels",
  "aptos-config",
  "aptos-crypto",
  "aptos-id-generator",
@@ -671,7 +684,6 @@ dependencies = [
  "aptos-types",
  "async-trait",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
- "channel",
  "claims",
  "futures",
  "itertools",
@@ -686,6 +698,7 @@ dependencies = [
 name = "aptos-data-streaming-service"
 version = "0.1.0"
 dependencies = [
+ "aptos-channels",
  "aptos-config",
  "aptos-crypto",
  "aptos-data-client",
@@ -698,7 +711,6 @@ dependencies = [
  "aptos-storage-service-types",
  "aptos-types",
  "async-trait",
- "channel",
  "claims",
  "enum_dispatch",
  "futures",
@@ -749,6 +761,23 @@ dependencies = [
  "rayon",
  "serde 1.0.149",
  "thiserror",
+]
+
+[[package]]
+name = "aptos-db-bootstrapper"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-config",
+ "aptos-crypto",
+ "aptos-db",
+ "aptos-executor",
+ "aptos-storage-interface",
+ "aptos-temppath",
+ "aptos-types",
+ "aptos-vm",
+ "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
+ "structopt",
 ]
 
 [[package]]
@@ -807,6 +836,7 @@ dependencies = [
 name = "aptos-event-notifications"
 version = "0.1.0"
 dependencies = [
+ "aptos-channels",
  "aptos-crypto",
  "aptos-db",
  "aptos-executor-test-helpers",
@@ -820,7 +850,6 @@ dependencies = [
  "aptos-vm-genesis",
  "async-trait",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
- "channel",
  "claims",
  "futures",
  "move-binary-format",
@@ -863,6 +892,41 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde 1.0.149",
+]
+
+[[package]]
+name = "aptos-executor-benchmark"
+version = "0.1.0"
+dependencies = [
+ "aptos-config",
+ "aptos-crypto",
+ "aptos-db",
+ "aptos-executor",
+ "aptos-executor-types",
+ "aptos-genesis",
+ "aptos-infallible",
+ "aptos-jellyfish-merkle",
+ "aptos-logger",
+ "aptos-push-metrics",
+ "aptos-schemadb",
+ "aptos-scratchpad",
+ "aptos-sdk",
+ "aptos-state-view",
+ "aptos-storage-interface",
+ "aptos-temppath",
+ "aptos-types",
+ "aptos-vm",
+ "chrono",
+ "criterion",
+ "indicatif",
+ "itertools",
+ "jemallocator",
+ "num_cpus",
+ "rand 0.7.3",
+ "rayon",
+ "serde 1.0.149",
+ "structopt",
+ "toml",
 ]
 
 [[package]]
@@ -1403,6 +1467,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
+ "aptos-channels",
  "aptos-compression",
  "aptos-config",
  "aptos-consensus-types",
@@ -1422,7 +1487,6 @@ dependencies = [
  "aptos-vm-validator",
  "async-trait",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
- "channel",
  "enum_dispatch",
  "fail 0.5.0",
  "futures",
@@ -1532,6 +1596,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
+ "aptos-channels",
  "aptos-compression",
  "aptos-config",
  "aptos-crypto",
@@ -1551,7 +1616,6 @@ dependencies = [
  "async-trait",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "bytes 1.2.1",
- "channel",
  "futures",
  "futures-util",
  "hex",
@@ -1576,6 +1640,7 @@ dependencies = [
 name = "aptos-network-builder"
 version = "0.1.0"
 dependencies = [
+ "aptos-channels",
  "aptos-config",
  "aptos-crypto",
  "aptos-event-notifications",
@@ -1589,7 +1654,6 @@ dependencies = [
  "aptos-types",
  "async-trait",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
- "channel",
  "futures",
  "rand 0.7.3",
  "serde 1.0.149",
@@ -1617,6 +1681,7 @@ name = "aptos-network-discovery"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-channels",
  "aptos-config",
  "aptos-crypto",
  "aptos-event-notifications",
@@ -1630,7 +1695,6 @@ dependencies = [
  "aptos-time-service",
  "aptos-types",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
- "channel",
  "futures",
  "once_cell",
  "rand 0.7.3",
@@ -1787,12 +1851,12 @@ dependencies = [
 name = "aptos-peer-monitoring-service-client"
 version = "0.1.0"
 dependencies = [
+ "aptos-channels",
  "aptos-config",
  "aptos-network",
  "aptos-peer-monitoring-service-types",
  "aptos-types",
  "async-trait",
- "channel",
  "thiserror",
 ]
 
@@ -1801,6 +1865,7 @@ name = "aptos-peer-monitoring-service-server"
 version = "0.1.0"
 dependencies = [
  "aptos-bounded-executor",
+ "aptos-channels",
  "aptos-config",
  "aptos-logger",
  "aptos-metrics-core",
@@ -1810,7 +1875,6 @@ dependencies = [
  "aptos-types",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "bytes 1.2.1",
- "channel",
  "futures",
  "once_cell",
  "serde 1.0.149",
@@ -2142,6 +2206,7 @@ name = "aptos-state-sync-driver"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-channels",
  "aptos-config",
  "aptos-consensus-notifications",
  "aptos-crypto",
@@ -2170,7 +2235,6 @@ dependencies = [
  "aptos-vm-genesis",
  "async-trait",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
- "channel",
  "claims",
  "futures",
  "mockall",
@@ -2224,12 +2288,12 @@ dependencies = [
 name = "aptos-storage-service-client"
 version = "0.1.0"
 dependencies = [
+ "aptos-channels",
  "aptos-config",
  "aptos-network",
  "aptos-storage-service-types",
  "aptos-types",
  "async-trait",
- "channel",
  "thiserror",
 ]
 
@@ -2240,6 +2304,7 @@ dependencies = [
  "anyhow",
  "aptos-bitvec",
  "aptos-bounded-executor",
+ "aptos-channels",
  "aptos-config",
  "aptos-crypto",
  "aptos-infallible",
@@ -2252,7 +2317,6 @@ dependencies = [
  "aptos-types",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "bytes 1.2.1",
- "channel",
  "claims",
  "futures",
  "lru",
@@ -2420,6 +2484,23 @@ dependencies = [
  "criterion-cpu-time",
  "num_cpus",
  "proptest",
+]
+
+[[package]]
+name = "aptos-transaction-emitter"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "aptos-global-constants",
+ "aptos-logger",
+ "aptos-sdk",
+ "aptos-transaction-emitter-lib",
+ "clap 3.2.17",
+ "futures",
+ "itertools",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "tokio",
 ]
 
 [[package]]
@@ -3407,18 +3488,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "channel"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "aptos-infallible",
- "aptos-metrics-core",
- "aptos-types",
- "futures",
- "tokio",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4129,23 +4198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "db-bootstrapper"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "aptos-config",
- "aptos-crypto",
- "aptos-db",
- "aptos-executor",
- "aptos-storage-interface",
- "aptos-temppath",
- "aptos-types",
- "aptos-vm",
- "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
- "structopt",
-]
-
-[[package]]
 name = "debug-ignore"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4522,41 +4574,6 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "executor-benchmark"
-version = "0.1.0"
-dependencies = [
- "aptos-config",
- "aptos-crypto",
- "aptos-db",
- "aptos-executor",
- "aptos-executor-types",
- "aptos-genesis",
- "aptos-infallible",
- "aptos-jellyfish-merkle",
- "aptos-logger",
- "aptos-push-metrics",
- "aptos-schemadb",
- "aptos-scratchpad",
- "aptos-sdk",
- "aptos-state-view",
- "aptos-storage-interface",
- "aptos-temppath",
- "aptos-types",
- "aptos-vm",
- "chrono",
- "criterion",
- "indicatif",
- "itertools",
- "jemallocator",
- "num_cpus",
- "rand 0.7.3",
- "rayon",
- "serde 1.0.149",
- "structopt",
- "toml",
-]
 
 [[package]]
 name = "fail"
@@ -9913,23 +9930,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "transaction-emitter"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "aptos-global-constants",
- "aptos-logger",
- "aptos-sdk",
- "aptos-transaction-emitter-lib",
- "clap 3.2.17",
- "futures",
- "itertools",
- "rand 0.7.3",
- "rand_core 0.5.1",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,7 @@ aptos-block-executor = { path = "aptos-move/block-executor" }
 aptos-bitvec = { path = "crates/aptos-bitvec" }
 aptos-build-info = { path = "crates/aptos-build-info" }
 aptos-cached-packages = { path = "aptos-move/framework/cached-packages" }
+aptos-channels = { path = "crates/channel" }
 aptos-compression = { path = "crates/aptos-compression" }
 aptos-consensus = { path = "consensus" }
 aptos-consensus-notifications = { path = "state-sync/inter-component/consensus-notifications" }
@@ -273,7 +274,6 @@ aptos-vm-genesis = { path = "aptos-move/vm-genesis" }
 aptos-vm-validator = { path = "vm-validator" }
 aptos-warp-webserver = { path = "crates/aptos-warp-webserver" }
 aptos-writeset-generator = { path = "aptos-move/writeset-transaction-generator" }
-channel = { path = "crates/channel" }
 
 # External crate dependencies.
 # Please do not add any test features here: they should be declared by the individual crate.

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-bitvec = { workspace = true }
+aptos-channels = { workspace = true }
 aptos-config = { workspace = true }
 aptos-consensus-notifications = { workspace = true }
 aptos-consensus-types = { workspace = true }
@@ -41,7 +42,6 @@ async-trait = { workspace = true }
 bcs = { workspace = true }
 byteorder = { workspace = true }
 bytes = { workspace = true }
-channel = { workspace = true }
 fail = { workspace = true }
 futures = { workspace = true }
 futures-channel = { workspace = true }

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -63,8 +63,9 @@ pub fn start_consensus(
 
     let time_service = Arc::new(ClockTimeService::new(runtime.handle().clone()));
 
-    let (timeout_sender, timeout_receiver) = channel::new(1_024, &counters::PENDING_ROUND_TIMEOUTS);
-    let (self_sender, self_receiver) = channel::new(1_024, &counters::PENDING_SELF_MESSAGES);
+    let (timeout_sender, timeout_receiver) =
+        aptos_channels::new(1_024, &counters::PENDING_ROUND_TIMEOUTS);
+    let (self_sender, self_receiver) = aptos_channels::new(1_024, &counters::PENDING_SELF_MESSAGES);
     network_sender.initialize(peer_metadata_storage);
 
     let epoch_mgr = EpochManager::new(

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -40,6 +40,7 @@ use crate::{
     util::time_service::TimeService,
 };
 use anyhow::{bail, ensure, Context};
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::config::{ConsensusConfig, NodeConfig};
 use aptos_consensus_types::{
     common::{Author, Round},
@@ -62,7 +63,6 @@ use aptos_types::{
     },
     validator_verifier::ValidatorVerifier,
 };
-use channel::{aptos_channel, message_queues::QueueStyle};
 use fail::fail_point;
 use futures::{
     channel::{
@@ -100,9 +100,9 @@ pub struct EpochManager {
     author: Author,
     config: ConsensusConfig,
     time_service: Arc<dyn TimeService>,
-    self_sender: channel::Sender<Event<ConsensusMsg>>,
+    self_sender: aptos_channels::Sender<Event<ConsensusMsg>>,
     network_sender: ConsensusNetworkSender,
-    timeout_sender: channel::Sender<Round>,
+    timeout_sender: aptos_channels::Sender<Round>,
     quorum_store_enabled: bool,
     quorum_store_to_mempool_sender: Sender<QuorumStoreRequest>,
     commit_state_computer: Arc<dyn StateComputer>,
@@ -126,9 +126,9 @@ impl EpochManager {
     pub fn new(
         node_config: &NodeConfig,
         time_service: Arc<dyn TimeService>,
-        self_sender: channel::Sender<Event<ConsensusMsg>>,
+        self_sender: aptos_channels::Sender<Event<ConsensusMsg>>,
         network_sender: ConsensusNetworkSender,
-        timeout_sender: channel::Sender<Round>,
+        timeout_sender: aptos_channels::Sender<Round>,
         quorum_store_to_mempool_sender: Sender<QuorumStoreRequest>,
         commit_state_computer: Arc<dyn StateComputer>,
         storage: Arc<dyn PersistentLivenessStorage>,
@@ -173,7 +173,7 @@ impl EpochManager {
     fn create_round_state(
         &self,
         time_service: Arc<dyn TimeService>,
-        timeout_sender: channel::Sender<Round>,
+        timeout_sender: aptos_channels::Sender<Round>,
     ) -> RoundState {
         let time_interval = Box::new(ExponentialTimeInterval::new(
             Duration::from_millis(self.config.round_initial_timeout_ms),
@@ -904,7 +904,7 @@ impl EpochManager {
 
     pub async fn start(
         mut self,
-        mut round_timeout_sender_rx: channel::Receiver<Round>,
+        mut round_timeout_sender_rx: aptos_channels::Receiver<Round>,
         mut network_receivers: NetworkReceivers,
     ) {
         // initial start of the processor

--- a/consensus/src/experimental/buffer_manager.rs
+++ b/consensus/src/experimental/buffer_manager.rs
@@ -87,7 +87,7 @@ pub struct BufferManager {
     signing_phase_rx: Receiver<SigningResponse>,
 
     commit_msg_tx: NetworkSender,
-    commit_msg_rx: channel::aptos_channel::Receiver<AccountAddress, VerifiedEvent>,
+    commit_msg_rx: aptos_channels::aptos_channel::Receiver<AccountAddress, VerifiedEvent>,
 
     // we don't hear back from the persisting phase
     persisting_phase_tx: Sender<CountedRequest<PersistingRequest>>,
@@ -118,7 +118,7 @@ impl BufferManager {
         signing_phase_tx: Sender<CountedRequest<SigningRequest>>,
         signing_phase_rx: Receiver<SigningResponse>,
         commit_msg_tx: NetworkSender,
-        commit_msg_rx: channel::aptos_channel::Receiver<AccountAddress, VerifiedEvent>,
+        commit_msg_rx: aptos_channels::aptos_channel::Receiver<AccountAddress, VerifiedEvent>,
         persisting_phase_tx: Sender<CountedRequest<PersistingRequest>>,
         block_rx: UnboundedReceiver<OrderedBlocks>,
         reset_rx: UnboundedReceiver<ResetRequest>,

--- a/consensus/src/experimental/decoupled_execution_utils.rs
+++ b/consensus/src/experimental/decoupled_execution_utils.rs
@@ -14,10 +14,10 @@ use crate::{
     round_manager::VerifiedEvent,
     state_replication::StateComputer,
 };
+use aptos_channels::aptos_channel::Receiver;
 use aptos_consensus_types::common::Author;
 use aptos_infallible::Mutex;
 use aptos_types::{account_address::AccountAddress, validator_verifier::ValidatorVerifier};
-use channel::aptos_channel::Receiver;
 use futures::channel::mpsc::UnboundedReceiver;
 use std::sync::{atomic::AtomicU64, Arc};
 

--- a/consensus/src/experimental/tests/buffer_manager_tests.rs
+++ b/consensus/src/experimental/tests/buffer_manager_tests.rs
@@ -23,6 +23,7 @@ use crate::{
         RandomComputeResultStateComputer,
     },
 };
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_consensus_types::{
     block::block_test_utils::certificate_for_genesis, executed_block::ExecutedBlock,
     vote_proposal::VoteProposal,
@@ -42,7 +43,6 @@ use aptos_types::{
     validator_verifier::{random_validator_verifier, ValidatorVerifier},
     waypoint::Waypoint,
 };
-use channel::{aptos_channel, message_queues::QueueStyle};
 use futures::{channel::oneshot, FutureExt, SinkExt, StreamExt};
 use itertools::enumerate;
 use std::sync::Arc;
@@ -53,7 +53,7 @@ pub fn prepare_buffer_manager() -> (
     Sender<OrderedBlocks>,
     Sender<ResetRequest>,
     aptos_channel::Sender<AccountAddress, VerifiedEvent>,
-    channel::Receiver<Event<ConsensusMsg>>,
+    aptos_channels::Receiver<Event<ConsensusMsg>>,
     PipelinePhase<ExecutionPhase>,
     PipelinePhase<SigningPhase>,
     PipelinePhase<PersistingPhase>,
@@ -95,7 +95,7 @@ pub fn prepare_buffer_manager() -> (
         ConnectionRequestSender::new(connection_reqs_tx),
     );
 
-    let (self_loop_tx, self_loop_rx) = channel::new_test(1000);
+    let (self_loop_tx, self_loop_rx) = aptos_channels::new_test(1000);
     let network = NetworkSender::new(author, network_sender, self_loop_tx, validators.clone());
 
     let (msg_tx, msg_rx) =
@@ -153,7 +153,7 @@ pub fn launch_buffer_manager() -> (
     Sender<OrderedBlocks>,
     Sender<ResetRequest>,
     aptos_channel::Sender<AccountAddress, VerifiedEvent>,
-    channel::Receiver<Event<ConsensusMsg>>,
+    aptos_channels::Receiver<Event<ConsensusMsg>>,
     HashValue,
     Runtime,
     Vec<ValidatorSigner>,
@@ -196,7 +196,7 @@ pub fn launch_buffer_manager() -> (
 }
 
 async fn loopback_commit_vote(
-    self_loop_rx: &mut channel::Receiver<Event<ConsensusMsg>>,
+    self_loop_rx: &mut aptos_channels::Receiver<Event<ConsensusMsg>>,
     msg_tx: &aptos_channel::Sender<AccountAddress, VerifiedEvent>,
     verifier: &ValidatorVerifier,
 ) {

--- a/consensus/src/liveness/round_state.rs
+++ b/consensus/src/liveness/round_state.rs
@@ -151,7 +151,7 @@ pub struct RoundState {
     // Service for timer
     time_service: Arc<dyn TimeService>,
     // To send local timeout events to the subscriber (e.g., SMR)
-    timeout_sender: channel::Sender<Round>,
+    timeout_sender: aptos_channels::Sender<Round>,
     // Votes received fot the current round.
     pending_votes: PendingVotes,
     // Vote sent locally for the current round.
@@ -185,7 +185,7 @@ impl RoundState {
     pub fn new(
         time_interval: Box<dyn RoundTimeInterval>,
         time_service: Arc<dyn TimeService>,
-        timeout_sender: channel::Sender<Round>,
+        timeout_sender: aptos_channels::Sender<Round>,
     ) -> Self {
         // Our counters are initialized lazily, so they're not going to appear in
         // Prometheus if some conditions never happen. Invoking get() function enforces creation.

--- a/consensus/src/liveness/round_state_test.rs
+++ b/consensus/src/liveness/round_state_test.rs
@@ -82,10 +82,10 @@ fn test_round_event_generation() {
     );
 }
 
-fn make_round_state() -> (RoundState, channel::Receiver<Round>) {
+fn make_round_state() -> (RoundState, aptos_channels::Receiver<Round>) {
     let time_interval = Box::new(ExponentialTimeInterval::fixed(Duration::from_millis(2)));
     let simulated_time = SimulatedTimeService::auto_advance_until(Duration::from_millis(4));
-    let (timeout_tx, timeout_rx) = channel::new_test(1_024);
+    let (timeout_tx, timeout_rx) = aptos_channels::new_test(1_024);
     (
         RoundState::new(time_interval, Arc::new(simulated_time), timeout_tx),
         timeout_rx,

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -5,6 +5,7 @@
 
 use crate::counters;
 use anyhow::anyhow;
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::network_id::{NetworkId, PeerNetworkId};
 use aptos_consensus_types::{
     block_retrieval::{BlockRetrievalRequest, BlockRetrievalResponse},
@@ -31,7 +32,6 @@ use aptos_network::{
 };
 use aptos_types::{epoch_change::EpochChangeProof, PeerId};
 use async_trait::async_trait;
-use channel::{aptos_channel, message_queues::QueueStyle};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc, time::Duration};
 

--- a/consensus/src/recovery_manager.rs
+++ b/consensus/src/recovery_manager.rs
@@ -12,12 +12,12 @@ use crate::{
     state_replication::StateComputer,
 };
 use anyhow::{anyhow, ensure, Context, Result};
+use aptos_channels::aptos_channel;
 use aptos_consensus_types::{
     common::Author, proposal_msg::ProposalMsg, sync_info::SyncInfo, vote_msg::VoteMsg,
 };
 use aptos_logger::prelude::*;
 use aptos_types::{block_info::Round, epoch_state::EpochState};
-use channel::aptos_channel;
 use futures::{FutureExt, StreamExt};
 use futures_channel::oneshot;
 use std::{mem::Discriminant, process, sync::Arc};

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -23,6 +23,7 @@ use crate::{
     persistent_liveness_storage::PersistentLivenessStorage,
 };
 use anyhow::{bail, ensure, Context, Result};
+use aptos_channels::aptos_channel;
 use aptos_config::config::ConsensusConfig;
 use aptos_consensus_types::{
     block::Block,
@@ -44,7 +45,6 @@ use aptos_types::{
     epoch_state::EpochState, on_chain_config::OnChainConsensusConfig,
     validator_verifier::ValidatorVerifier,
 };
-use channel::aptos_channel;
 use fail::fail_point;
 use futures::{channel::oneshot, FutureExt, StreamExt};
 use serde::Serialize;

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -17,6 +17,7 @@ use crate::{
     test_utils::{EmptyStateComputer, MockPayloadManager, MockStorage},
     util::{mock_time_service::SimulatedTimeService, time_service::TimeService},
 };
+use aptos_channels::{self, aptos_channel, message_queues::QueueStyle};
 use aptos_config::config::ConsensusConfig;
 use aptos_consensus_types::proposal_msg::ProposalMsg;
 use aptos_infallible::Mutex;
@@ -35,7 +36,6 @@ use aptos_types::{
     validator_signer::ValidatorSigner,
     validator_verifier::ValidatorVerifier,
 };
-use channel::{self, aptos_channel, message_queues::QueueStyle};
 use futures::{channel::mpsc, executor::block_on};
 use once_cell::sync::Lazy;
 use std::{sync::Arc, time::Duration};
@@ -95,7 +95,7 @@ fn make_initial_epoch_change_proof(signer: &ValidatorSigner) -> EpochChangeProof
 fn create_round_state() -> RoundState {
     let base_timeout = std::time::Duration::new(60, 0);
     let time_interval = Box::new(ExponentialTimeInterval::fixed(base_timeout));
-    let (round_timeout_sender, _) = channel::new_test(1_024);
+    let (round_timeout_sender, _) = aptos_channels::new_test(1_024);
     let time_service = Arc::new(SimulatedTimeService::new());
     RoundState::new(time_interval, time_service, round_timeout_sender)
 }
@@ -124,7 +124,7 @@ fn create_node_for_fuzzing() -> RoundManager {
         PeerManagerRequestSender::new(network_reqs_tx),
         ConnectionRequestSender::new(connection_reqs_tx),
     );
-    let (self_sender, _self_receiver) = channel::new_test(8);
+    let (self_sender, _self_receiver) = aptos_channels::new_test(8);
 
     let epoch_state = EpochState {
         epoch: 1,

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -46,7 +46,7 @@ pub struct ExecutionProxy {
     executor: Arc<dyn BlockExecutorTrait>,
     txn_notifier: Arc<dyn TxnNotifier>,
     state_sync_notifier: Arc<dyn ConsensusNotificationSender>,
-    async_state_sync_notifier: channel::Sender<NotificationType>,
+    async_state_sync_notifier: aptos_channels::Sender<NotificationType>,
     validators: Mutex<Vec<AccountAddress>>,
     write_mutex: AsyncMutex<()>,
     payload_manager: Mutex<Option<Arc<PayloadManager>>>,
@@ -60,7 +60,7 @@ impl ExecutionProxy {
         handle: &tokio::runtime::Handle,
     ) -> Self {
         let (tx, mut rx) =
-            channel::new::<NotificationType>(10, &counters::PENDING_STATE_SYNC_NOTIFICATION);
+            aptos_channels::new::<NotificationType>(10, &counters::PENDING_STATE_SYNC_NOTIFICATION);
         let notifier = state_sync_notifier.clone();
         handle.spawn(async move {
             while let Some((callback, txns, reconfig_events)) = rx.next().await {

--- a/consensus/src/util/time_service.rs
+++ b/consensus/src/util/time_service.rs
@@ -57,7 +57,7 @@ pub struct SendTask<T>
 where
     T: Send + 'static,
 {
-    sender: Option<channel::Sender<T>>,
+    sender: Option<aptos_channels::Sender<T>>,
     message: Option<T>,
 }
 
@@ -66,7 +66,7 @@ where
     T: Send + 'static,
 {
     /// Makes new SendTask for given sender and message and wraps it to Box
-    pub fn make(sender: channel::Sender<T>, message: T) -> Box<dyn ScheduledTask> {
+    pub fn make(sender: aptos_channels::Sender<T>, message: T) -> Box<dyn ScheduledTask> {
         Box::new(SendTask {
             sender: Some(sender),
             message: Some(message),
@@ -132,7 +132,7 @@ async fn test_time_service_abort() {
     use futures::StreamExt;
 
     let time_service = ClockTimeService::new(tokio::runtime::Handle::current());
-    let (tx, mut rx) = channel::new_test(10);
+    let (tx, mut rx) = aptos_channels::new_test(10);
     let task1 = SendTask::make(tx.clone(), 1);
     let task2 = SendTask::make(tx.clone(), 2);
     let handle1 = time_service.run_after(Duration::from_millis(100), task1);

--- a/crates/channel/Cargo.toml
+++ b/crates/channel/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "channel"
+name = "aptos-channels"
 description = "An implementation of a channel with configurable QoS"
 version = "0.1.0"
 

--- a/crates/channel/tests/many-keys-stress-test.rs
+++ b/crates/channel/tests/many-keys-stress-test.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use channel::{aptos_channel, message_queues::QueueStyle};
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use futures::{executor::block_on, stream::StreamExt};
 use std::{
     io::{Cursor, Write},

--- a/crates/transaction-emitter/Cargo.toml
+++ b/crates/transaction-emitter/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "transaction-emitter"
+name = "aptos-transaction-emitter"
 description = "Aptos transaction emitter for testing"
 version = "0.0.0"
 

--- a/docker/build-rust-all.sh
+++ b/docker/build-rust-all.sh
@@ -21,7 +21,7 @@ cargo build --locked --profile=$PROFILE \
     -p aptos-openapi-spec-generator \
     -p aptos-telemetry-service \
     -p db-bootstrapper \
-    -p transaction-emitter \
+    -p aptos-transaction-emitter \
     "$@"
 
 # Build aptos-node separately
@@ -49,7 +49,7 @@ BINS=(
     db-bootstrapper
     db-restore
     forge
-    transaction-emitter
+    aptos-transaction-emitter
 )
 
 mkdir dist

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -154,7 +154,7 @@ COPY --link --from=builder /aptos/dist/db-restore /usr/local/bin/db-restore
 COPY --link --from=builder /aptos/dist/aptos /usr/local/bin/aptos
 COPY --link --from=builder /aptos/dist/aptos-openapi-spec-generator /usr/local/bin/aptos-openapi-spec-generator
 COPY --link --from=builder /aptos/dist/aptos-fn-check-client /usr/local/bin/aptos-fn-check-client
-COPY --link --from=builder /aptos/dist/transaction-emitter /usr/local/bin/transaction-emitter
+COPY --link --from=builder /aptos/dist/aptos-transaction-emitter /usr/local/bin/aptos-transaction-emitter
 
 ### Get Aptos Move releases for genesis ceremony
 RUN mkdir -p /aptos-framework/move

--- a/execution/db-bootstrapper/Cargo.toml
+++ b/execution/db-bootstrapper/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "db-bootstrapper"
+name = "aptos-db-bootstrapper"
 description = "Aptos DB-Bootstrapper"
 version = "0.1.0"
 

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "executor-benchmark"
+name = "aptos-executor-benchmark"
 description = "Aptos executor benchmark"
 version = "0.1.0"
 

--- a/execution/executor-benchmark/benches/executor_benchmark.rs
+++ b/execution/executor-benchmark/benches/executor_benchmark.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_executor_types::BlockExecutorTrait;
-use criterion::{criterion_group, criterion_main, measurement::Measurement, BatchSize, Criterion};
-use executor_benchmark::{
+use aptos_executor_benchmark::{
     init_db_and_executor, transaction_executor::TransactionExecutor,
     transaction_generator::TransactionGenerator,
 };
+use aptos_executor_types::BlockExecutorTrait;
+use criterion::{criterion_group, criterion_main, measurement::Measurement, BatchSize, Criterion};
 use std::sync::Arc;
 
 pub const NUM_ACCOUNTS: usize = 1000;

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -163,7 +163,7 @@ fn main() {
             num_accounts,
             init_account_balance,
         } => {
-            executor_benchmark::db_generator::run(
+            aptos_executor_benchmark::db_generator::run(
                 num_accounts,
                 init_account_balance,
                 opt.block_size,
@@ -177,7 +177,7 @@ fn main() {
             data_dir,
             checkpoint_dir,
         } => {
-            executor_benchmark::run_benchmark(
+            aptos_executor_benchmark::run_benchmark(
                 opt.block_size,
                 blocks,
                 data_dir,
@@ -192,7 +192,7 @@ fn main() {
             num_new_accounts,
             init_account_balance,
         } => {
-            executor_benchmark::add_accounts(
+            aptos_executor_benchmark::add_accounts(
                 num_new_accounts,
                 init_account_balance,
                 opt.block_size,

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-bounded-executor = { workspace = true }
+aptos-channels = { workspace = true }
 aptos-config = { workspace = true }
 aptos-consensus-types = { workspace = true }
 aptos-crypto = { workspace = true }
@@ -32,7 +33,6 @@ aptos-types = { workspace = true }
 aptos-vm-validator = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
-channel = { workspace = true }
 fail = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -14,6 +14,7 @@ use crate::{
         },
     },
 };
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::{
     config::{MempoolConfig, PeerRole, RoleType},
     network_id::{NetworkId, PeerNetworkId},
@@ -38,7 +39,6 @@ use aptos_network::{
 use aptos_types::{transaction::SignedTransaction, PeerId};
 use aptos_vm_validator::vm_validator::TransactionValidation;
 use async_trait::async_trait;
-use channel::{aptos_channel, message_queues::QueueStyle};
 use fail::fail_point;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -8,6 +8,7 @@ use crate::{
     MempoolClientSender, QuorumStoreRequest,
 };
 use anyhow::{format_err, Result};
+use aptos_channels::{self, aptos_channel, message_queues::QueueStyle};
 use aptos_config::{
     config::{NetworkConfig, NodeConfig},
     network_id::NetworkId,
@@ -29,7 +30,6 @@ use aptos_types::{
 use aptos_vm_validator::{
     mocks::mock_vm_validator::MockVMValidator, vm_validator::TransactionValidation,
 };
-use channel::{self, aptos_channel, message_queues::QueueStyle};
 use futures::channel::mpsc;
 use std::collections::HashMap;
 use std::{collections::HashSet, sync::Arc};

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     tests::common::TestTransaction,
 };
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::{
     config::{Identity, NodeConfig, PeerRole, RoleType},
     network_id::{NetworkContext, NetworkId, PeerNetworkId},
@@ -31,7 +32,6 @@ use aptos_storage_interface::mock::MockDbReaderWriter;
 use aptos_types::on_chain_config::OnChainConfigPayload;
 use aptos_types::{account_config::AccountSequenceInfo, PeerId};
 use aptos_vm_validator::mocks::mock_vm_validator::MockVMValidator;
-use channel::{aptos_channel, message_queues::QueueStyle};
 use enum_dispatch::enum_dispatch;
 use futures::{
     channel::mpsc::{self, unbounded, UnboundedReceiver},

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -10,6 +10,8 @@ use crate::{
     tests::common::TestTransaction,
     MempoolClientRequest, MempoolClientSender, QuorumStoreRequest,
 };
+use aptos_channels::aptos_channel;
+use aptos_channels::message_queues::QueueStyle;
 use aptos_config::{
     config::NodeConfig,
     network_id::{NetworkId, PeerNetworkId},
@@ -39,8 +41,6 @@ use aptos_types::{
     transaction::SignedTransaction,
 };
 use aptos_vm_validator::mocks::mock_vm_validator::MockVMValidator;
-use channel::aptos_channel;
-use channel::message_queues::QueueStyle;
 use futures::{channel::oneshot, SinkExt};
 use std::{
     collections::{HashMap, HashSet},

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-bitvec = { workspace = true }
+aptos-channels = { workspace = true }
 aptos-compression = { workspace = true }
 aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }
@@ -34,7 +35,6 @@ aptos-types = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
-channel = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 hex = { workspace = true }

--- a/network/builder/Cargo.toml
+++ b/network/builder/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+aptos-channels = { workspace = true }
 aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-event-notifications = { workspace = true }
@@ -26,7 +27,6 @@ aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
-channel = { workspace = true }
 futures = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -327,7 +327,7 @@ impl NetworkBuilder {
         self.network_context
     }
 
-    pub fn conn_mgr_reqs_tx(&self) -> Option<channel::Sender<ConnectivityRequest>> {
+    pub fn conn_mgr_reqs_tx(&self) -> Option<aptos_channels::Sender<ConnectivityRequest>> {
         self.connectivity_manager_builder
             .as_ref()
             .map(|conn_mgr_builder| conn_mgr_builder.conn_mgr_reqs_tx())

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -4,6 +4,7 @@
 //! Integration tests for validator_network.
 
 use crate::builder::NetworkBuilder;
+use aptos_channels::aptos_channel;
 use aptos_config::{
     config::{Peer, PeerRole, PeerSet, RoleType, NETWORK_CHANNEL_SIZE},
     network_id::{NetworkContext, NetworkId},
@@ -29,7 +30,6 @@ use aptos_network::{
 use aptos_time_service::TimeService;
 use aptos_types::{chain_id::ChainId, network_address::NetworkAddress, PeerId};
 use async_trait::async_trait;
-use channel::aptos_channel;
 use futures::{executor::block_on, StreamExt};
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};

--- a/network/discovery/Cargo.toml
+++ b/network/discovery/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-channels = { workspace = true }
 aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-event-notifications = { workspace = true }
@@ -25,7 +26,6 @@ aptos-short-hex-str = { workspace = true }
 aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
-channel = { workspace = true }
 futures = { workspace = true }
 once_cell = { workspace = true }
 serde_yaml = { workspace = true }

--- a/network/discovery/src/file.rs
+++ b/network/discovery/src/file.rs
@@ -57,6 +57,7 @@ fn load_file(path: &Path) -> Result<PeerSet, DiscoveryError> {
 mod tests {
     use super::*;
     use crate::DiscoveryChangeListener;
+    use aptos_channels::Receiver;
     use aptos_config::{
         config::{Peer, PeerRole},
         network_id::NetworkContext,
@@ -64,7 +65,6 @@ mod tests {
     use aptos_network::connectivity_manager::{ConnectivityRequest, DiscoverySource};
     use aptos_temppath::TempPath;
     use aptos_types::{network_address::NetworkAddress, PeerId};
-    use channel::Receiver;
     use futures::StreamExt;
     use std::{collections::HashSet, str::FromStr, sync::Arc};
     use tokio::time::sleep;
@@ -73,7 +73,7 @@ mod tests {
         let check_interval = Duration::from_millis(5);
         // TODO: Figure out why mock time doesn't work right
         let time_service = TimeService::real();
-        let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new(
+        let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = aptos_channels::new(
             1,
             &aptos_network::counters::PENDING_CONNECTIVITY_MANAGER_REQUESTS,
         );

--- a/network/discovery/src/lib.rs
+++ b/network/discovery/src/lib.rs
@@ -35,7 +35,7 @@ pub enum DiscoveryError {
 pub struct DiscoveryChangeListener {
     discovery_source: DiscoverySource,
     network_context: NetworkContext,
-    update_channel: channel::Sender<ConnectivityRequest>,
+    update_channel: aptos_channels::Sender<ConnectivityRequest>,
     source_stream: DiscoveryChangeStream,
 }
 
@@ -58,7 +58,7 @@ impl Stream for DiscoveryChangeStream {
 impl DiscoveryChangeListener {
     pub fn validator_set(
         network_context: NetworkContext,
-        update_channel: channel::Sender<ConnectivityRequest>,
+        update_channel: aptos_channels::Sender<ConnectivityRequest>,
         expected_pubkey: x25519::PublicKey,
         reconfig_events: ReconfigNotificationListener,
     ) -> Self {
@@ -77,7 +77,7 @@ impl DiscoveryChangeListener {
 
     pub fn file(
         network_context: NetworkContext,
-        update_channel: channel::Sender<ConnectivityRequest>,
+        update_channel: aptos_channels::Sender<ConnectivityRequest>,
         file_path: &Path,
         interval_duration: Duration,
         time_service: TimeService,

--- a/network/discovery/src/validator_set.rs
+++ b/network/discovery/src/validator_set.rs
@@ -153,6 +153,7 @@ fn extract_validator_set_updates(
 mod tests {
     use super::*;
     use crate::DiscoveryChangeListener;
+    use aptos_channels::{aptos_channel, message_queues::QueueStyle};
     use aptos_config::config::HANDSHAKE_VERSION;
     use aptos_crypto::{bls12381, x25519::PrivateKey, PrivateKey as PK, Uniform};
     use aptos_event_notifications::ReconfigNotification;
@@ -160,7 +161,6 @@ mod tests {
         network_address::NetworkAddress, on_chain_config::OnChainConfig,
         validator_config::ValidatorConfig, validator_info::ValidatorInfo, PeerId,
     };
-    use channel::{aptos_channel, message_queues::QueueStyle};
     use futures::executor::block_on;
     use rand::{rngs::StdRng, SeedableRng};
     use std::{collections::HashMap, sync::Arc, time::Instant};
@@ -180,7 +180,7 @@ mod tests {
         let peer_id = aptos_types::account_address::from_identity_public_key(pubkey);
 
         // Build up the Reconfig Listener
-        let (conn_mgr_reqs_tx, _rx) = channel::new_test(1);
+        let (conn_mgr_reqs_tx, _rx) = aptos_channels::new_test(1);
         let (mut reconfig_sender, reconfig_events) = aptos_channel::new(QueueStyle::LIFO, 1, None);
         let reconfig_listener = ReconfigNotificationListener {
             notification_receiver: reconfig_events,
@@ -235,7 +235,7 @@ mod tests {
         peer_id: PeerId,
         consensus_pubkey: bls12381::PublicKey,
         pubkey: x25519::PublicKey,
-        reconfig_tx: &mut channel::aptos_channel::Sender<(), ReconfigNotification>,
+        reconfig_tx: &mut aptos_channels::aptos_channel::Sender<(), ReconfigNotification>,
     ) {
         let validator_address =
             NetworkAddress::mock().append_prod_protos(pubkey, HANDSHAKE_VERSION);

--- a/network/peer-monitoring-service/client/Cargo.toml
+++ b/network/peer-monitoring-service/client/Cargo.toml
@@ -13,10 +13,10 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+aptos-channels = { workspace = true }
 aptos-config = { workspace = true }
 aptos-network = { workspace = true }
 aptos-peer-monitoring-service-types = { workspace = true }
 aptos-types = { workspace = true }
 async-trait = { workspace = true }
-channel = { workspace = true }
 thiserror = { workspace = true }

--- a/network/peer-monitoring-service/server/Cargo.toml
+++ b/network/peer-monitoring-service/server/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 aptos-bounded-executor = { workspace = true }
+aptos-channels = { workspace = true }
 aptos-config = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
@@ -23,7 +24,6 @@ aptos-peer-monitoring-service-types = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
-channel = { workspace = true }
 futures = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true }

--- a/network/peer-monitoring-service/server/src/network.rs
+++ b/network/peer-monitoring-service/server/src/network.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::metrics;
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::config::PeerMonitoringServiceConfig;
 use aptos_network::{
     peer_manager::{ConnectionNotification, PeerManagerNotification},
@@ -14,7 +15,6 @@ use aptos_peer_monitoring_service_types::{
 };
 use aptos_types::PeerId;
 use bytes::Bytes;
-use channel::{aptos_channel, message_queues::QueueStyle};
 use futures::{
     channel::oneshot,
     future,

--- a/network/peer-monitoring-service/server/src/tests.rs
+++ b/network/peer-monitoring-service/server/src/tests.rs
@@ -6,6 +6,7 @@
 use crate::{
     PeerMonitoringServiceNetworkEvents, PeerMonitoringServiceServer, PEER_MONITORING_SERVER_VERSION,
 };
+use aptos_channels::aptos_channel;
 use aptos_config::{
     config::{PeerMonitoringServiceConfig, PeerRole},
     network_id::{NetworkId, PeerNetworkId},
@@ -30,7 +31,6 @@ use aptos_peer_monitoring_service_types::{
     PeerMonitoringServiceRequest, PeerMonitoringServiceResponse, ServerProtocolVersionResponse,
 };
 use aptos_types::{network_address::NetworkAddress, PeerId};
-use channel::aptos_channel;
 use futures::channel::oneshot;
 use std::{
     collections::{hash_map::Entry, HashMap},

--- a/network/src/connectivity_manager/builder.rs
+++ b/network/src/connectivity_manager/builder.rs
@@ -17,7 +17,7 @@ pub type ConnectivityManagerService = ConnectivityManager<ExponentialBackoff>;
 
 pub struct ConnectivityManagerBuilder {
     connectivity_manager: Option<ConnectivityManagerService>,
-    conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
+    conn_mgr_reqs_tx: aptos_channels::Sender<ConnectivityRequest>,
 }
 
 impl ConnectivityManagerBuilder {
@@ -35,7 +35,7 @@ impl ConnectivityManagerBuilder {
         outbound_connection_limit: Option<usize>,
         mutual_authentication: bool,
     ) -> Self {
-        let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new(
+        let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = aptos_channels::new(
             channel_size,
             &counters::PENDING_CONNECTIVITY_MANAGER_REQUESTS,
         );
@@ -59,7 +59,7 @@ impl ConnectivityManagerBuilder {
         }
     }
 
-    pub fn conn_mgr_reqs_tx(&self) -> channel::Sender<ConnectivityRequest> {
+    pub fn conn_mgr_reqs_tx(&self) -> aptos_channels::Sender<ConnectivityRequest> {
         self.conn_mgr_reqs_tx.clone()
     }
 

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -96,7 +96,7 @@ pub struct ConnectivityManager<TBackoff> {
     /// Channel to receive notifications from PeerManager.
     connection_notifs_rx: conn_notifs_channel::Receiver,
     /// Channel over which we receive requests from other actors.
-    requests_rx: channel::Receiver<ConnectivityRequest>,
+    requests_rx: aptos_channels::Receiver<ConnectivityRequest>,
     /// Peers queued to be dialed, potentially with some delay. The dial can be canceled by
     /// sending over (or dropping) the associated oneshot sender.
     dial_queue: HashMap<PeerId, oneshot::Sender<()>>,
@@ -307,7 +307,7 @@ where
         seeds: PeerSet,
         connection_reqs_tx: ConnectionRequestSender,
         connection_notifs_rx: conn_notifs_channel::Receiver,
-        requests_rx: channel::Receiver<ConnectivityRequest>,
+        requests_rx: aptos_channels::Receiver<ConnectivityRequest>,
         connectivity_check_interval: Duration,
         backoff_strategy: TBackoff,
         max_delay: Duration,

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -7,12 +7,12 @@ use crate::{
     peer_manager::{conn_notifs_channel, ConnectionRequest},
     transport::ConnectionMetadata,
 };
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::config::{Peer, PeerRole, PeerSet, HANDSHAKE_VERSION};
 use aptos_crypto::{test_utils::TEST_SEED, x25519, Uniform};
 use aptos_logger::info;
 use aptos_time_service::{MockTimeService, TimeService};
 use aptos_types::{account_address::AccountAddress, network_address::NetworkAddress};
-use channel::{aptos_channel, message_queues::QueueStyle};
 use futures::{executor::block_on, future, SinkExt};
 use maplit::{hashmap, hashset};
 use rand::rngs::StdRng;
@@ -73,7 +73,7 @@ struct TestHarness {
     mock_time: MockTimeService,
     connection_reqs_rx: aptos_channel::Receiver<PeerId, ConnectionRequest>,
     connection_notifs_tx: conn_notifs_channel::Sender,
-    conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
+    conn_mgr_reqs_tx: aptos_channels::Sender<ConnectivityRequest>,
 }
 
 impl TestHarness {
@@ -83,7 +83,7 @@ impl TestHarness {
         let (connection_reqs_tx, connection_reqs_rx) =
             aptos_channel::new(QueueStyle::FIFO, 1, None);
         let (connection_notifs_tx, connection_notifs_rx) = conn_notifs_channel::new();
-        let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(0);
+        let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = aptos_channels::new_test(0);
         let trusted_peers = Arc::new(RwLock::new(HashMap::new()));
 
         let conn_mgr = ConnectivityManager::new(

--- a/network/src/peer/fuzzing.rs
+++ b/network/src/peer/fuzzing.rs
@@ -11,13 +11,13 @@ use crate::{
     testutils::fake_socket::ReadOnlyTestSocketVec,
     transport::{Connection, ConnectionId, ConnectionMetadata},
 };
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::{config::PeerRole, network_id::NetworkContext};
 use aptos_memsocket::MemorySocket;
 use aptos_netcore::transport::ConnectionOrigin;
 use aptos_proptest_helpers::ValueGenerator;
 use aptos_time_service::TimeService;
 use aptos_types::{network_address::NetworkAddress, PeerId};
-use channel::{aptos_channel, message_queues::QueueStyle};
 use futures::{executor::block_on, future, io::AsyncReadExt, sink::SinkExt, stream::StreamExt};
 use proptest::{arbitrary::any, collection::vec};
 use std::time::Duration;
@@ -87,7 +87,7 @@ pub fn fuzz(data: &[u8]) {
     );
     let connection = Connection { socket, metadata };
 
-    let (connection_notifs_tx, connection_notifs_rx) = channel::new_test(8);
+    let (connection_notifs_tx, connection_notifs_rx) = aptos_channels::new_test(8);
     let channel_size = 8;
 
     let (peer_reqs_tx, peer_reqs_rx) = aptos_channel::new(QueueStyle::FIFO, channel_size, None);

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -22,13 +22,13 @@ use crate::{
     transport::{Connection, ConnectionId, ConnectionMetadata},
     ProtocolId,
 };
+use aptos_channels::{self, aptos_channel, message_queues::QueueStyle};
 use aptos_config::{config::PeerRole, network_id::NetworkContext};
 use aptos_memsocket::MemorySocket;
 use aptos_netcore::transport::ConnectionOrigin;
 use aptos_time_service::{MockTimeService, TimeService};
 use aptos_types::{network_address::NetworkAddress, PeerId};
 use bytes::Bytes;
-use channel::{self, aptos_channel, message_queues::QueueStyle};
 use futures::{
     channel::oneshot,
     future::{self, FutureExt},
@@ -52,7 +52,7 @@ fn build_test_peer(
     Peer<MemorySocket>,
     PeerHandle,
     MemorySocket,
-    channel::Receiver<TransportNotification<MemorySocket>>,
+    aptos_channels::Receiver<TransportNotification<MemorySocket>>,
     aptos_channel::Receiver<ProtocolId, PeerNotification>,
 ) {
     let (a, b) = MemorySocket::new_pair();
@@ -70,7 +70,7 @@ fn build_test_peer(
         socket: a,
     };
 
-    let (connection_notifs_tx, connection_notifs_rx) = channel::new_test(1);
+    let (connection_notifs_tx, connection_notifs_rx) = aptos_channels::new_test(1);
     let (peer_reqs_tx, peer_reqs_rx) =
         aptos_channel::new(QueueStyle::FIFO, NETWORK_CHANNEL_SIZE, None);
     let (peer_notifs_tx, peer_notifs_rx) =
@@ -104,13 +104,13 @@ fn build_test_connected_peers(
     (
         Peer<MemorySocket>,
         PeerHandle,
-        channel::Receiver<TransportNotification<MemorySocket>>,
+        aptos_channels::Receiver<TransportNotification<MemorySocket>>,
         aptos_channel::Receiver<ProtocolId, PeerNotification>,
     ),
     (
         Peer<MemorySocket>,
         PeerHandle,
-        channel::Receiver<TransportNotification<MemorySocket>>,
+        aptos_channels::Receiver<TransportNotification<MemorySocket>>,
         aptos_channel::Receiver<ProtocolId, PeerNotification>,
     ),
 ) {
@@ -156,7 +156,7 @@ fn build_network_sink_stream(
 async fn assert_disconnected_event(
     peer_id: PeerId,
     reason: DisconnectReason,
-    connection_notifs_rx: &mut channel::Receiver<TransportNotification<MemorySocket>>,
+    connection_notifs_rx: &mut aptos_channels::Receiver<TransportNotification<MemorySocket>>,
 ) {
     match connection_notifs_rx.next().await {
         Some(TransportNotification::Disconnected(metadata, actual_reason)) => {

--- a/network/src/peer_manager/builder.rs
+++ b/network/src/peer_manager/builder.rs
@@ -14,6 +14,7 @@ use crate::{
     transport::{self, AptosNetTransport, Connection, APTOS_TCP_TRANSPORT},
     ProtocolId,
 };
+use aptos_channels::{self, aptos_channel, message_queues::QueueStyle};
 use aptos_config::{
     config::{PeerSet, RateLimitConfig, HANDSHAKE_VERSION},
     network_id::NetworkContext,
@@ -30,7 +31,6 @@ use aptos_netcore::transport::{
 use aptos_rate_limiter::rate_limit::TokenBucketRateLimiter;
 use aptos_time_service::TimeService;
 use aptos_types::{chain_id::ChainId, network_address::NetworkAddress, PeerId};
-use channel::{self, aptos_channel, message_queues::QueueStyle};
 use std::{clone::Clone, collections::HashMap, fmt::Debug, net::IpAddr, sync::Arc};
 use tokio::runtime::Handle;
 

--- a/network/src/peer_manager/conn_notifs_channel.rs
+++ b/network/src/peer_manager/conn_notifs_channel.rs
@@ -9,8 +9,8 @@
 //! and `conn_notifs_channel::Sender` which behave similarly to existing mpsc data structures.
 
 use crate::peer_manager::ConnectionNotification;
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_types::PeerId;
-use channel::{aptos_channel, message_queues::QueueStyle};
 
 pub type Sender = aptos_channel::Sender<PeerId, ConnectionNotification>;
 pub type Receiver = aptos_channel::Receiver<PeerId, ConnectionNotification>;

--- a/network/src/peer_manager/senders.rs
+++ b/network/src/peer_manager/senders.rs
@@ -8,9 +8,9 @@ use crate::{
     },
     ProtocolId,
 };
+use aptos_channels::{self, aptos_channel};
 use aptos_types::{network_address::NetworkAddress, PeerId};
 use bytes::Bytes;
-use channel::{self, aptos_channel};
 use futures::channel::oneshot;
 use std::time::Duration;
 

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -21,6 +21,7 @@ use crate::{
     ProtocolId,
 };
 use anyhow::anyhow;
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::{
     config::{PeerRole, MAX_INBOUND_CONNECTIONS},
     network_id::NetworkContext,
@@ -34,7 +35,6 @@ use aptos_rate_limiter::rate_limit::TokenBucketRateLimiter;
 use aptos_time_service::TimeService;
 use aptos_types::{network_address::NetworkAddress, PeerId};
 use bytes::Bytes;
-use channel::{aptos_channel, message_queues::QueueStyle};
 use futures::{channel::oneshot, io::AsyncWriteExt, stream::StreamExt};
 use std::{collections::HashMap, sync::Arc};
 use tokio::runtime::Handle;

--- a/network/src/peer_manager/transport.rs
+++ b/network/src/peer_manager/transport.rs
@@ -7,13 +7,13 @@ use crate::{
     transport::Connection,
 };
 use anyhow::format_err;
+use aptos_channels::{self};
 use aptos_config::network_id::NetworkContext;
 use aptos_logger::prelude::*;
 use aptos_netcore::transport::{ConnectionOrigin, Transport};
 use aptos_short_hex_str::AsShortHexStr;
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::{network_address::NetworkAddress, PeerId};
-use channel::{self};
 use futures::{
     channel::oneshot,
     future::{BoxFuture, FutureExt},
@@ -43,8 +43,8 @@ where
     /// [`Transport`] that is used to establish connections
     transport: TTransport,
     listener: Fuse<TTransport::Listener>,
-    transport_reqs_rx: channel::Receiver<TransportRequest>,
-    transport_notifs_tx: channel::Sender<TransportNotification<TSocket>>,
+    transport_reqs_rx: aptos_channels::Receiver<TransportRequest>,
+    transport_notifs_tx: aptos_channels::Sender<TransportNotification<TSocket>>,
 }
 
 impl<TTransport, TSocket> TransportHandler<TTransport, TSocket>
@@ -60,8 +60,8 @@ where
         time_service: TimeService,
         transport: TTransport,
         listen_addr: NetworkAddress,
-        transport_reqs_rx: channel::Receiver<TransportRequest>,
-        transport_notifs_tx: channel::Sender<TransportNotification<TSocket>>,
+        transport_reqs_rx: aptos_channels::Receiver<TransportRequest>,
+        transport_notifs_tx: aptos_channels::Sender<TransportNotification<TSocket>>,
     ) -> (Self, NetworkAddress) {
         let addr_string = format!("{}", listen_addr);
         let (listener, listen_addr) = transport

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -34,6 +34,7 @@ use crate::{
     },
     ProtocolId,
 };
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::network_id::{NetworkContext, PeerNetworkId};
 use aptos_logger::prelude::*;
 use aptos_short_hex_str::AsShortHexStr;
@@ -41,7 +42,6 @@ use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::PeerId;
 use async_trait::async_trait;
 use bytes::Bytes;
-use channel::{aptos_channel, message_queues::QueueStyle};
 use futures::{
     channel::oneshot,
     stream::{FuturesUnordered, StreamExt},

--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -14,8 +14,8 @@ use crate::{
     transport::ConnectionMetadata,
     ProtocolId,
 };
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_time_service::{MockTimeService, TimeService};
-use channel::{aptos_channel, message_queues::QueueStyle};
 use futures::{executor::block_on, future};
 
 const PING_INTERVAL: Duration = Duration::from_secs(1);

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -13,12 +13,12 @@ use crate::{
     transport::ConnectionMetadata,
     ProtocolId,
 };
+use aptos_channels::aptos_channel;
 use aptos_logger::prelude::*;
 use aptos_short_hex_str::AsShortHexStr;
 use aptos_types::{network_address::NetworkAddress, PeerId};
 use async_trait::async_trait;
 use bytes::Bytes;
-use channel::aptos_channel;
 use futures::{
     channel::oneshot,
     future,

--- a/network/src/protocols/rpc/mod.rs
+++ b/network/src/protocols/rpc/mod.rs
@@ -58,6 +58,7 @@ use crate::{
     ProtocolId,
 };
 use anyhow::anyhow;
+use aptos_channels::aptos_channel;
 use aptos_config::network_id::NetworkContext;
 use aptos_id_generator::{IdGenerator, U32IdGenerator};
 use aptos_logger::prelude::*;
@@ -65,7 +66,6 @@ use aptos_short_hex_str::AsShortHexStr;
 use aptos_time_service::{timeout, TimeService, TimeServiceTrait};
 use aptos_types::PeerId;
 use bytes::Bytes;
-use channel::aptos_channel;
 use error::RpcError;
 use futures::{
     channel::oneshot,
@@ -296,7 +296,7 @@ impl InboundRpcs {
     /// the outbound write queue.
     pub async fn send_outbound_response(
         &mut self,
-        write_reqs_tx: &mut channel::Sender<NetworkMessage>,
+        write_reqs_tx: &mut aptos_channels::Sender<NetworkMessage>,
         maybe_response: Result<RpcResponse, RpcError>,
     ) -> Result<(), RpcError> {
         let network_context = &self.network_context;
@@ -379,7 +379,7 @@ impl OutboundRpcs {
     pub async fn handle_outbound_request(
         &mut self,
         request: OutboundRpcRequest,
-        write_reqs_tx: &mut channel::Sender<NetworkMessage>,
+        write_reqs_tx: &mut aptos_channels::Sender<NetworkMessage>,
     ) -> Result<(), RpcError> {
         let network_context = &self.network_context;
         let peer_id = &self.remote_peer_id;

--- a/network/src/protocols/stream/mod.rs
+++ b/network/src/protocols/stream/mod.rs
@@ -3,8 +3,8 @@
 
 use crate::protocols::wire::messaging::v1::{MultiplexMessage, NetworkMessage};
 use anyhow::{bail, ensure};
+use aptos_channels::Sender;
 use aptos_id_generator::{IdGenerator, U32IdGenerator};
-use channel::Sender;
 use futures_util::SinkExt;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;

--- a/network/src/protocols/wire/messaging/v1/test.rs
+++ b/network/src/protocols/wire/messaging/v1/test.rs
@@ -236,8 +236,8 @@ proptest! {
 
         let mut message_tx = MultiplexMessageSink::new(socket_tx, 128, None);
         let message_rx = MultiplexMessageStream::new(socket_rx, 128, None);
-        let (stream_tx, stream_rx) = channel::new_test(1024);
-        let (mut msg_tx, msg_rx) = channel::new_test(1024);
+        let (stream_tx, stream_rx) = aptos_channels::new_test(1024);
+        let (mut msg_tx, msg_rx) = aptos_channels::new_test(1024);
         let mut outbound_stream = OutboundStream::new(128, 64 * 255, stream_tx);
         let mut inbound_stream = InboundStreamBuffer::new(255);
 

--- a/network/src/testutils/test_framework.rs
+++ b/network/src/testutils/test_framework.rs
@@ -10,11 +10,11 @@ use crate::{
         OutboundMessageReceiver,
     },
 };
+use aptos_channels::message_queues::QueueStyle;
 use aptos_config::{
     config::NodeConfig,
     network_id::{NetworkId, PeerNetworkId},
 };
-use channel::message_queues::QueueStyle;
 use std::{collections::HashMap, hash::Hash, sync::Arc, vec::Vec};
 
 /// A trait describing a test framework for a specific application
@@ -98,9 +98,9 @@ fn setup_network<NetworkSender: NewNetworkSender, NetworkEvents: NewNetworkEvent
 
 /// A generic FIFO Aptos channel
 fn aptos_channel<K: Eq + Hash + Clone, T>() -> (
-    channel::aptos_channel::Sender<K, T>,
-    channel::aptos_channel::Receiver<K, T>,
+    aptos_channels::aptos_channel::Sender<K, T>,
+    aptos_channels::aptos_channel::Receiver<K, T>,
 ) {
     static MAX_QUEUE_SIZE: usize = 8;
-    channel::aptos_channel::new(QueueStyle::FIFO, MAX_QUEUE_SIZE, None)
+    aptos_channels::aptos_channel::new(QueueStyle::FIFO, MAX_QUEUE_SIZE, None)
 }

--- a/network/src/testutils/test_node.rs
+++ b/network/src/testutils/test_node.rs
@@ -23,14 +23,14 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 /// A sender to a node to mock an inbound network message from [`PeerManager`]
 pub type InboundMessageSender =
-    channel::aptos_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>;
+    aptos_channels::aptos_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>;
 
 /// A sender to a node to mock an inbound connection from [`PeerManager`]
 pub type ConnectionUpdateSender = crate::peer_manager::conn_notifs_channel::Sender;
 
 /// A receiver to get outbound network messages to [`PeerManager`]
 pub type OutboundMessageReceiver =
-    channel::aptos_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>;
+    aptos_channels::aptos_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>;
 
 /// A connection handle describing the network for a node.
 ///

--- a/state-sync/aptos-data-client/Cargo.toml
+++ b/state-sync/aptos-data-client/Cargo.toml
@@ -34,11 +34,11 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+aptos-channels = { workspace = true }
 aptos-network = { workspace = true, features = ["fuzzing"] }
 aptos-storage-service-server = { workspace = true }
 aptos-time-service = { workspace = true, features = ["async", "testing"] }
 bcs = { workspace = true }
-channel = { workspace = true }
 claims = { workspace = true }
 maplit = { workspace = true }
 tokio = { workspace = true }

--- a/state-sync/aptos-data-client/src/aptosnet/tests.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/tests.rs
@@ -3,6 +3,7 @@
 
 use super::{AptosDataClient, AptosNetDataClient, DataSummaryPoller, Error};
 use crate::aptosnet::{poll_peer, state::calculate_optimal_chunk_sizes};
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::{
     config::{AptosDataClientConfig, BaseConfig, RoleType, StorageServiceConfig},
     network_id::{NetworkId, PeerNetworkId},
@@ -36,7 +37,6 @@ use aptos_types::{
     transaction::{TransactionListWithProof, Version},
     PeerId,
 };
-use channel::{aptos_channel, message_queues::QueueStyle};
 use claims::{assert_err, assert_matches, assert_none};
 use futures::StreamExt;
 use maplit::hashmap;

--- a/state-sync/inter-component/event-notifications/Cargo.toml
+++ b/state-sync/inter-component/event-notifications/Cargo.toml
@@ -13,13 +13,13 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+aptos-channels = { workspace = true }
 aptos-id-generator = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-state-view = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-types = { workspace = true }
 async-trait = { workspace = true }
-channel = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/state-sync/inter-component/event-notifications/src/lib.rs
+++ b/state-sync/inter-component/event-notifications/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_id_generator::{IdGenerator, U64IdGenerator};
 use aptos_infallible::RwLock;
 use aptos_state_view::account_with_state_view::AsAccountWithStateView;
@@ -17,7 +18,6 @@ use aptos_types::{
     on_chain_config::{ConfigID, OnChainConfigPayload},
     transaction::Version,
 };
-use channel::{aptos_channel, message_queues::QueueStyle};
 use futures::{channel::mpsc::SendError, stream::FusedStream, Stream};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -347,7 +347,7 @@ type SubscriptionId = u64;
 #[derive(Debug)]
 struct EventSubscription {
     pub event_buffer: Vec<ContractEvent>,
-    pub notification_sender: channel::aptos_channel::Sender<(), EventNotification>,
+    pub notification_sender: aptos_channels::aptos_channel::Sender<(), EventNotification>,
 }
 
 impl EventSubscription {
@@ -371,7 +371,7 @@ impl EventSubscription {
 /// corresponding notifications.
 #[derive(Debug)]
 struct ReconfigSubscription {
-    pub notification_sender: channel::aptos_channel::Sender<(), ReconfigNotification>,
+    pub notification_sender: aptos_channels::aptos_channel::Sender<(), ReconfigNotification>,
 }
 
 impl ReconfigSubscription {
@@ -414,7 +414,7 @@ pub type ReconfigNotificationListener = NotificationListener<ReconfigNotificatio
 /// The component responsible for listening to subscription notifications.
 #[derive(Debug)]
 pub struct NotificationListener<T> {
-    pub notification_receiver: channel::aptos_channel::Receiver<(), T>,
+    pub notification_receiver: aptos_channels::aptos_channel::Receiver<(), T>,
 }
 
 impl<T> Stream for NotificationListener<T> {

--- a/state-sync/state-sync-v2/data-streaming-service/Cargo.toml
+++ b/state-sync/state-sync-v2/data-streaming-service/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+aptos-channels = { workspace = true }
 aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-data-client = { workspace = true }
@@ -24,7 +25,6 @@ aptos-network = { workspace = true }
 aptos-short-hex-str = { workspace = true }
 aptos-types = { workspace = true }
 async-trait = { workspace = true }
-channel = { workspace = true }
 enum_dispatch = { workspace = true }
 futures = { workspace = true }
 once_cell = { workspace = true }

--- a/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
+++ b/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
@@ -40,6 +40,7 @@ tokio-stream = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+aptos-channels = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-db = { workspace = true }
 aptos-executor = { workspace = true }
@@ -54,7 +55,6 @@ aptos-vm = { workspace = true }
 aptos-vm-genesis = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
-channel = { workspace = true }
 claims = { workspace = true }
 mockall = { workspace = true }
 move-core-types = { workspace = true }

--- a/state-sync/storage-service/client/Cargo.toml
+++ b/state-sync/storage-service/client/Cargo.toml
@@ -13,10 +13,10 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+aptos-channels = { workspace = true }
 aptos-config = { workspace = true }
 aptos-network = { workspace = true }
 aptos-storage-service-types = { workspace = true }
 aptos-types = { workspace = true }
 async-trait = { workspace = true }
-channel = { workspace = true }
 thiserror = { workspace = true }

--- a/state-sync/storage-service/server/Cargo.toml
+++ b/state-sync/storage-service/server/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 aptos-bounded-executor = { workspace = true }
+aptos-channels = { workspace = true }
 aptos-config = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-logger = { workspace = true }
@@ -25,7 +26,6 @@ aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
-channel = { workspace = true }
 futures = { workspace = true }
 lru = { workspace = true }
 once_cell = { workspace = true }

--- a/state-sync/storage-service/server/src/network.rs
+++ b/state-sync/storage-service/server/src/network.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::metrics;
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::config::StorageServiceConfig;
 use aptos_network::{
     peer_manager::{ConnectionNotification, PeerManagerNotification},
@@ -13,7 +14,6 @@ use aptos_storage_service_types::responses::StorageServiceResponse;
 use aptos_storage_service_types::{Result, StorageServiceMessage};
 use aptos_types::PeerId;
 use bytes::Bytes;
-use channel::{aptos_channel, message_queues::QueueStyle};
 use futures::{
     channel::oneshot,
     future,

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -6,6 +6,7 @@
 use crate::{network::StorageServiceNetworkEvents, StorageReader, StorageServiceServer};
 use anyhow::{format_err, Result};
 use aptos_bitvec::BitVec;
+use aptos_channels::aptos_channel;
 use aptos_config::config::StorageServiceConfig;
 use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, SigningKey, Uniform};
 use aptos_logger::Level;
@@ -59,7 +60,6 @@ use aptos_types::{
     write_set::WriteSet,
     PeerId,
 };
-use channel::aptos_channel;
 use claims::{assert_matches, assert_none};
 use futures::channel::{oneshot, oneshot::Receiver};
 use mockall::{


### PR DESCRIPTION
### Description
This PR continues along the path of renaming various crates to use the new standard crate naming convention `aptos-*`.

### Test Plan
Existing test infrastructure.