### PR TITLE
[TS SDK] use getAccountResource in checkBalance

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 
 - Export classes from property_map_serde
 - User can specify token string property type using "string", "String" or "0x1::string::String" to serde the string token property on-chain
+- Use `getAccountResource` to replace `getAccountResources` in `CoinClient#checkBalance`, which can reduce network load.
 
 ## 1.4.0 (2022-11-30)
 

--- a/ecosystem/typescript/sdk/src/coin_client.ts
+++ b/ecosystem/typescript/sdk/src/coin_client.ts
@@ -97,8 +97,7 @@ export class CoinClient {
     const coinType = extraArgs?.coinType ?? APTOS_COIN;
     const typeTag = `0x1::coin::CoinStore<${coinType}>`;
     const address = getAddressFromAccountOrAddress(account);
-    const resources = await this.aptosClient.getAccountResources(address);
-    const accountResource = resources.find((r) => r.type === typeTag);
-    return BigInt((accountResource!.data as any).coin.value);
+    const accountResource = await this.aptosClient.getAccountResource(address, typeTag);
+    return BigInt((accountResource.data as any).coin.value);
   } // <:!:checkBalance
 }


### PR DESCRIPTION
### Description
Use `getAccountResource` to replace `getAccountResources` in `CoinClient#checkBalance`, which can reduce network load.

### Test Plan

```
pnpm test
```