### PR TITLE
[Forge] Reduce the TPS requirement from 6000 to 5500

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -903,7 +903,7 @@ fn land_blocking_test_suite(duration: Duration) -> ForgeConfig<'static> {
             SuccessCriteria::new(if duration.as_secs() > 1200 {
                 5000
             } else {
-                6000
+                5500
             })
             .add_no_restarts()
             .add_wait_for_catchup_s(


### PR DESCRIPTION
### Description

There has been some flakiness found in forge performance - reducing it temporarily to reduce the noise. We will increase it as we land single-node performance improvement items in next few months. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
