### PR TITLE
[State sync] Add client-side of new state syncing mode.

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -433,6 +433,7 @@ fn create_state_sync_runtimes<M: MempoolNotificationSender + 'static>(
         event_subscription_service,
         aptos_data_client,
         streaming_service_client,
+        TimeService::real(),
     );
 
     // Create and return the new state sync handle

--- a/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
@@ -43,6 +43,8 @@ pub enum DataClientRequest {
     StateValuesWithProof(StateValuesWithProofRequest),
     TransactionsWithProof(TransactionsWithProofRequest),
     TransactionOutputsWithProof(TransactionOutputsWithProofRequest),
+    NewTransactionsOrOutputsWithProof(NewTransactionsOrOutputsWithProofRequest),
+    TransactionsOrOutputsWithProof(TransactionsOrOutputsWithProofRequest),
 }
 
 impl DataClientRequest {
@@ -56,6 +58,8 @@ impl DataClientRequest {
             Self::StateValuesWithProof(_) => "state_values_with_proof",
             Self::TransactionsWithProof(_) => "transactions_with_proof",
             Self::TransactionOutputsWithProof(_) => "transaction_outputs_with_proof",
+            Self::NewTransactionsOrOutputsWithProof(_) => "new_transactions_or_outputs_with_proof",
+            Self::TransactionsOrOutputsWithProof(_) => "transactions_or_outputs_with_proof",
         }
     }
 }
@@ -78,6 +82,14 @@ pub struct EpochEndingLedgerInfosRequest {
 /// A client request for fetching new transactions with proofs.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NewTransactionsWithProofRequest {
+    pub known_version: Version,
+    pub known_epoch: Epoch,
+    pub include_events: bool,
+}
+
+/// A client request for fetching new transactions or outputs with proofs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NewTransactionsOrOutputsWithProofRequest {
     pub known_version: Version,
     pub known_epoch: Epoch,
     pub include_events: bool,
@@ -111,6 +123,15 @@ pub struct TransactionOutputsWithProofRequest {
     pub start_version: Version,
     pub end_version: Version,
     pub proof_version: Version,
+}
+
+/// A client request for fetching transaction or outputs with proofs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TransactionsOrOutputsWithProofRequest {
+    pub start_version: Version,
+    pub end_version: Version,
+    pub proof_version: Version,
+    pub include_events: bool,
 }
 
 /// A pending client response where data has been requested from the

--- a/state-sync/state-sync-v2/data-streaming-service/src/streaming_client.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/streaming_client.rs
@@ -68,6 +68,18 @@ pub trait DataStreamingClient {
         include_events: bool,
     ) -> Result<DataStreamListener, Error>;
 
+    /// Fetches all transactions or outputs with proofs from `start_version` to
+    /// `end_version` (inclusive) at the specified `proof_version`. If
+    /// `include_events` is true, events are also included in the proofs for
+    /// transaction notifications.
+    async fn get_all_transactions_or_outputs(
+        &self,
+        start_version: Version,
+        end_version: Version,
+        proof_version: Version,
+        include_events: bool,
+    ) -> Result<DataStreamListener, Error>;
+
     /// Continuously streams transaction outputs with proofs as the blockchain
     /// grows. The stream starts at `known_version + 1` (inclusive) and
     /// `known_epoch`, where the `known_epoch` is expected to be the epoch
@@ -98,6 +110,27 @@ pub trait DataStreamingClient {
     /// Note: if a `target` is provided, the stream will terminate once it reaches
     /// the target. Otherwise, it will continue indefinitely.
     async fn continuously_stream_transactions(
+        &self,
+        start_version: Version,
+        start_epoch: Epoch,
+        include_events: bool,
+        target: Option<LedgerInfoWithSignatures>,
+    ) -> Result<DataStreamListener, Error>;
+
+    /// Continuously streams transactions or outputs with proofs as the blockchain
+    /// grows. The stream starts at `known_version + 1` (inclusive) and
+    /// `known_epoch`, where the `known_epoch` is expected to be the epoch
+    /// that contains `known_version + 1`, i.e., any epoch change at
+    /// `known_version` must be noted by the client.
+    /// Transaction or output proof versions are tied to ledger infos within the
+    /// same epoch, otherwise epoch ending ledger infos will signify epoch changes.
+    ///
+    /// If `include_events` is true, events are also included in the proofs when
+    /// receiving transaction notifications.
+    ///
+    /// Note: if a `target` is provided, the stream will terminate once it reaches
+    /// the target. Otherwise, it will continue indefinitely.
+    async fn continuously_stream_transactions_or_outputs(
         &self,
         start_version: Version,
         start_epoch: Epoch,
@@ -138,8 +171,10 @@ pub enum StreamRequest {
     GetAllStates(GetAllStatesRequest),
     GetAllTransactions(GetAllTransactionsRequest),
     GetAllTransactionOutputs(GetAllTransactionOutputsRequest),
+    GetAllTransactionsOrOutputs(GetAllTransactionsOrOutputsRequest),
     ContinuouslyStreamTransactions(ContinuouslyStreamTransactionsRequest),
     ContinuouslyStreamTransactionOutputs(ContinuouslyStreamTransactionOutputsRequest),
+    ContinuouslyStreamTransactionsOrOutputs(ContinuouslyStreamTransactionsOrOutputsRequest),
     TerminateStream(TerminateStreamRequest),
 }
 
@@ -151,9 +186,13 @@ impl StreamRequest {
             Self::GetAllStates(_) => "get_all_states",
             Self::GetAllTransactions(_) => "get_all_transactions",
             Self::GetAllTransactionOutputs(_) => "get_all_transaction_outputs",
+            Self::GetAllTransactionsOrOutputs(_) => "get_all_transactions_or_outputs",
             Self::ContinuouslyStreamTransactions(_) => "continuously_stream_transactions",
             Self::ContinuouslyStreamTransactionOutputs(_) => {
                 "continuously_stream_transaction_outputs"
+            }
+            Self::ContinuouslyStreamTransactionsOrOutputs(_) => {
+                "continuously_stream_transactions_or_outputs"
             }
             Self::TerminateStream(_) => "terminate_stream",
         }
@@ -190,6 +229,15 @@ pub struct GetAllTransactionOutputsRequest {
     pub proof_version: Version,
 }
 
+/// A client request for fetching all transactions or outputs with proofs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetAllTransactionsOrOutputsRequest {
+    pub start_version: Version,
+    pub end_version: Version,
+    pub proof_version: Version,
+    pub include_events: bool,
+}
+
 /// A client request for continuously streaming transactions with proofs
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContinuouslyStreamTransactionsRequest {
@@ -204,6 +252,15 @@ pub struct ContinuouslyStreamTransactionsRequest {
 pub struct ContinuouslyStreamTransactionOutputsRequest {
     pub known_version: Version,
     pub known_epoch: Epoch,
+    pub target: Option<LedgerInfoWithSignatures>,
+}
+
+/// A client request for continuously streaming transactions or outputs with proofs
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContinuouslyStreamTransactionsOrOutputsRequest {
+    pub known_version: Version,
+    pub known_epoch: Epoch,
+    pub include_events: bool,
     pub target: Option<LedgerInfoWithSignatures>,
 }
 
@@ -329,6 +386,23 @@ impl DataStreamingClient for StreamingServiceClient {
         self.send_request_and_await_response(client_request).await
     }
 
+    async fn get_all_transactions_or_outputs(
+        &self,
+        start_version: u64,
+        end_version: u64,
+        proof_version: u64,
+        include_events: bool,
+    ) -> Result<DataStreamListener, Error> {
+        let client_request =
+            StreamRequest::GetAllTransactionsOrOutputs(GetAllTransactionsOrOutputsRequest {
+                start_version,
+                end_version,
+                proof_version,
+                include_events,
+            });
+        self.send_request_and_await_response(client_request).await
+    }
+
     async fn continuously_stream_transaction_outputs(
         &self,
         known_version: u64,
@@ -359,6 +433,24 @@ impl DataStreamingClient for StreamingServiceClient {
                 include_events,
                 target,
             });
+        self.send_request_and_await_response(client_request).await
+    }
+
+    async fn continuously_stream_transactions_or_outputs(
+        &self,
+        known_version: u64,
+        known_epoch: u64,
+        include_events: bool,
+        target: Option<LedgerInfoWithSignatures>,
+    ) -> Result<DataStreamListener, Error> {
+        let client_request = StreamRequest::ContinuouslyStreamTransactionsOrOutputs(
+            ContinuouslyStreamTransactionsOrOutputsRequest {
+                known_version,
+                known_epoch,
+                include_events,
+                target,
+            },
+        );
         self.send_request_and_await_response(client_request).await
     }
 

--- a/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
+++ b/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
@@ -28,6 +28,7 @@ aptos-metrics-core = { workspace = true }
 aptos-schemadb = { workspace = true }
 aptos-scratchpad = { workspace = true }
 aptos-storage-interface = { workspace = true }
+aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
@@ -20,6 +20,7 @@ use aptos_executor_types::ChunkExecutorTrait;
 use aptos_infallible::Mutex;
 use aptos_mempool_notifications::MempoolNotificationSender;
 use aptos_storage_interface::DbReaderWriter;
+use aptos_time_service::TimeService;
 use aptos_types::{move_resource::MoveStorage, waypoint::Waypoint};
 use futures::{channel::mpsc, executor::block_on};
 use std::sync::{
@@ -52,6 +53,7 @@ impl DriverFactory {
         mut event_subscription_service: EventSubscriptionService,
         aptos_data_client: AptosNetDataClient,
         streaming_service_client: StreamingServiceClient,
+        time_service: TimeService,
     ) -> Self {
         // Notify subscribers of the initial on-chain config values
         match (&*storage.reader).fetch_latest_state_checkpoint_version() {
@@ -133,6 +135,7 @@ impl DriverFactory {
             aptos_data_client,
             streaming_service_client,
             storage.reader,
+            time_service,
         );
 
         // Spawn the driver

--- a/state-sync/state-sync-v2/state-sync-driver/src/metrics.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/metrics.rs
@@ -72,7 +72,7 @@ pub static BOOTSTRAPPER_ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Counter for state sync continuous syncer errors
+/// Gauge for state sync continuous syncer fallback mode
 pub static CONTINUOUS_SYNCER_ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_state_sync_continuous_syncer_errors",
@@ -87,6 +87,16 @@ pub static DRIVER_COUNTERS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_state_sync_driver_counters",
         "Counters related to the state sync driver",
+        &["label"]
+    )
+    .unwrap()
+});
+
+/// Gauge for state sync bootstrapper fallback mode
+pub static DRIVER_FALLBACK_MODE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_state_sync_driver_fallback_mode",
+        "Gauges related to the driver fallback mode",
         &["label"]
     )
     .unwrap()

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/bootstrapper.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::utils::OutputFallbackHandler;
 use crate::{
     bootstrapper::{Bootstrapper, GENESIS_TRANSACTION_VERSION},
     driver::DriverConfiguration,
@@ -20,10 +21,12 @@ use crate::{
 };
 use aptos_config::config::BootstrappingMode;
 use aptos_data_client::GlobalDataSummary;
+use aptos_data_streaming_service::data_notification::NotificationId;
 use aptos_data_streaming_service::{
     data_notification::{DataNotification, DataPayload},
     streaming_client::{NotificationAndFeedback, NotificationFeedback},
 };
+use aptos_time_service::TimeService;
 use aptos_types::{
     transaction::{TransactionOutputListWithProof, Version},
     waypoint::Waypoint,
@@ -32,6 +35,7 @@ use claims::{assert_matches, assert_none, assert_ok};
 use futures::{channel::oneshot, FutureExt, SinkExt};
 use mockall::{predicate::eq, Sequence};
 use std::sync::Arc;
+use std::time::Duration;
 
 #[tokio::test]
 async fn test_bootstrap_genesis_waypoint() {
@@ -42,7 +46,8 @@ async fn test_bootstrap_genesis_waypoint() {
     let mock_streaming_client = create_mock_streaming_client();
 
     // Create the bootstrapper and verify it's not yet bootstrapped
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
+    let (mut bootstrapper, _) =
+        create_bootstrapper(driver_configuration, mock_streaming_client, None, true);
     assert!(!bootstrapper.is_bootstrapped());
 
     // Subscribe to a bootstrapped notification
@@ -78,7 +83,8 @@ async fn test_bootstrap_immediate_notification() {
     let mock_streaming_client = create_mock_streaming_client();
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
+    let (mut bootstrapper, _) =
+        create_bootstrapper(driver_configuration, mock_streaming_client, None, true);
 
     // Create a global data summary where only epoch 0 has ended
     let global_data_summary = create_global_summary(0);
@@ -112,7 +118,8 @@ async fn test_bootstrap_no_notification() {
         .return_once(move |_| Ok(data_stream_listener));
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
+    let (mut bootstrapper, _) =
+        create_bootstrapper(driver_configuration, mock_streaming_client, None, true);
 
     // Create a global data summary where epoch 0 and 1 have ended
     let global_data_summary = create_global_summary(1);
@@ -160,7 +167,8 @@ async fn test_critical_timeout() {
         .return_const(Ok(()));
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
+    let (mut bootstrapper, _) =
+        create_bootstrapper(driver_configuration, mock_streaming_client, None, true);
 
     // Create a global data summary where epoch 0 and 1 have ended
     let global_data_summary = create_global_summary(1);
@@ -237,7 +245,8 @@ async fn test_data_stream_state_values() {
         .return_const(Ok(()));
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
+    let (mut bootstrapper, _) =
+        create_bootstrapper(driver_configuration, mock_streaming_client, None, true);
 
     // Insert an epoch ending ledger info into the verified states of the bootstrapper
     manipulate_verified_epoch_states(&mut bootstrapper, true, true, Some(highest_version));
@@ -308,7 +317,8 @@ async fn test_data_stream_transactions() {
         .return_const(Ok(()));
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
+    let (mut bootstrapper, _) =
+        create_bootstrapper(driver_configuration, mock_streaming_client, None, true);
 
     // Insert an epoch ending ledger info into the verified states of the bootstrapper
     manipulate_verified_epoch_states(&mut bootstrapper, true, true, Some(highest_version));
@@ -379,7 +389,8 @@ async fn test_data_stream_transaction_outputs() {
         .return_const(Ok(()));
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
+    let (mut bootstrapper, _) =
+        create_bootstrapper(driver_configuration, mock_streaming_client, None, true);
 
     // Insert an epoch ending ledger info into the verified states of the bootstrapper
     manipulate_verified_epoch_states(&mut bootstrapper, true, true, Some(highest_version));
@@ -415,6 +426,195 @@ async fn test_data_stream_transaction_outputs() {
 }
 
 #[tokio::test]
+async fn test_data_stream_transactions_or_outputs() {
+    // Create test data
+    let notification_id = 0;
+    let highest_version = 9998765;
+    let highest_ledger_info = create_random_epoch_ending_ledger_info(highest_version, 1);
+
+    // Create a driver configuration with a genesis waypoint and transaction or output syncing
+    let mut driver_configuration = create_full_node_driver_configuration();
+    driver_configuration.config.bootstrapping_mode = BootstrappingMode::ExecuteOrApplyFromGenesis;
+
+    // Create the mock streaming client
+    let mut mock_streaming_client = create_mock_streaming_client();
+    let mut expectation_sequence = Sequence::new();
+    let (mut notification_sender_1, data_stream_listener_1) = create_data_stream_listener();
+    let (_notification_sender_2, data_stream_listener_2) = create_data_stream_listener();
+    let data_stream_id_1 = data_stream_listener_1.data_stream_id;
+    for data_stream_listener in [data_stream_listener_1, data_stream_listener_2] {
+        mock_streaming_client
+            .expect_get_all_transactions_or_outputs()
+            .times(1)
+            .with(eq(1), eq(highest_version), eq(highest_version), eq(false))
+            .return_once(move |_, _, _, _| Ok(data_stream_listener))
+            .in_sequence(&mut expectation_sequence);
+    }
+    mock_streaming_client
+        .expect_terminate_stream_with_feedback()
+        .with(
+            eq(data_stream_id_1),
+            eq(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::InvalidPayloadData,
+            ))),
+        )
+        .return_const(Ok(()));
+
+    // Create the bootstrapper
+    let (mut bootstrapper, _) =
+        create_bootstrapper(driver_configuration, mock_streaming_client, None, true);
+
+    // Insert an epoch ending ledger info into the verified states of the bootstrapper
+    manipulate_verified_epoch_states(&mut bootstrapper, true, true, Some(highest_version));
+
+    // Create a global data summary
+    let mut global_data_summary = create_global_summary(1);
+    global_data_summary.advertised_data.synced_ledger_infos = vec![highest_ledger_info.clone()];
+
+    // Drive progress to initialize the transaction output stream
+    drive_progress(&mut bootstrapper, &global_data_summary, false)
+        .await
+        .unwrap();
+
+    // Send an invalid output along the stream
+    let data_notification = DataNotification {
+        notification_id,
+        data_payload: DataPayload::EpochEndingLedgerInfos(vec![create_epoch_ending_ledger_info()]),
+    };
+    notification_sender_1.send(data_notification).await.unwrap();
+
+    // Drive progress again and ensure we get an invalid payload error
+    let error = drive_progress(&mut bootstrapper, &global_data_summary, false)
+        .await
+        .unwrap_err();
+    assert_matches!(error, Error::InvalidPayload(_));
+
+    // Drive progress to initialize the transaction output stream
+    drive_progress(&mut bootstrapper, &global_data_summary, false)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_data_stream_transactions_or_outputs_fallback() {
+    // Create test data
+    let notification_id = 1;
+    let highest_version = 9998765;
+    let highest_ledger_info = create_random_epoch_ending_ledger_info(highest_version, 1);
+
+    // Create a driver configuration with a genesis waypoint and transaction or output syncing
+    let mut driver_configuration = create_full_node_driver_configuration();
+    driver_configuration.config.bootstrapping_mode = BootstrappingMode::ExecuteOrApplyFromGenesis;
+
+    // Create the mock streaming client
+    let mut mock_streaming_client = create_mock_streaming_client();
+
+    // Set expectations for stream creations and terminations
+    let mut expectation_sequence = Sequence::new();
+    let (_notification_sender_1, data_stream_listener_1) = create_data_stream_listener();
+    let data_stream_id_1 = data_stream_listener_1.data_stream_id;
+    let (_notification_sender_2, data_stream_listener_2) = create_data_stream_listener();
+    let data_stream_id_2 = data_stream_listener_2.data_stream_id;
+    let (_notification_sender_3, data_stream_listener_3) = create_data_stream_listener();
+    mock_streaming_client
+        .expect_get_all_transactions_or_outputs()
+        .times(1)
+        .with(eq(1), eq(highest_version), eq(highest_version), eq(false))
+        .return_once(move |_, _, _, _| Ok(data_stream_listener_1))
+        .in_sequence(&mut expectation_sequence);
+    mock_streaming_client
+        .expect_terminate_stream_with_feedback()
+        .times(1)
+        .with(
+            eq(data_stream_id_1),
+            eq(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::PayloadProofFailed,
+            ))),
+        )
+        .return_const(Ok(()))
+        .in_sequence(&mut expectation_sequence);
+    mock_streaming_client
+        .expect_get_all_transaction_outputs()
+        .times(1)
+        .with(eq(1), eq(highest_version), eq(highest_version))
+        .return_once(move |_, _, _| Ok(data_stream_listener_2));
+    mock_streaming_client
+        .expect_terminate_stream_with_feedback()
+        .times(1)
+        .with(
+            eq(data_stream_id_2),
+            eq(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::InvalidPayloadData,
+            ))),
+        )
+        .return_const(Ok(()))
+        .in_sequence(&mut expectation_sequence);
+    mock_streaming_client
+        .expect_get_all_transactions_or_outputs()
+        .with(eq(1), eq(highest_version), eq(highest_version), eq(false))
+        .return_once(move |_, _, _, _| Ok(data_stream_listener_3));
+
+    // Create the bootstrapper
+    let time_service = TimeService::mock();
+    let (mut bootstrapper, mut output_fallback_handler) = create_bootstrapper(
+        driver_configuration.clone(),
+        mock_streaming_client,
+        Some(time_service.clone()),
+        true,
+    );
+    assert!(!output_fallback_handler.in_fallback_mode());
+
+    // Insert an epoch ending ledger info into the verified states of the bootstrapper
+    manipulate_verified_epoch_states(&mut bootstrapper, true, true, Some(highest_version));
+
+    // Create a global data summary
+    let mut global_data_summary = create_global_summary(1);
+    global_data_summary.advertised_data.synced_ledger_infos = vec![highest_ledger_info.clone()];
+
+    // Drive progress to initialize the first transaction output stream
+    drive_progress(&mut bootstrapper, &global_data_summary, false)
+        .await
+        .unwrap();
+
+    // Send a storage synchronizer error to the bootstrapper so that it falls back
+    // to output syncing and drive progress for the new stream type.
+    handle_storage_synchronizer_error(
+        &mut bootstrapper,
+        notification_id,
+        NotificationFeedback::PayloadProofFailed,
+    )
+    .await;
+    drive_progress(&mut bootstrapper, &global_data_summary, false)
+        .await
+        .unwrap();
+    assert!(output_fallback_handler.in_fallback_mode());
+
+    // Elapse enough time so that fallback mode is now disabled
+    time_service
+        .into_mock()
+        .advance_async(Duration::from_secs(
+            driver_configuration.config.fallback_to_output_syncing_secs,
+        ))
+        .await;
+
+    // Send another storage synchronizer error to the bootstrapper and drive progress
+    // so that a regular stream is created.
+    handle_storage_synchronizer_error(
+        &mut bootstrapper,
+        notification_id,
+        NotificationFeedback::InvalidPayloadData,
+    )
+    .await;
+    drive_progress(&mut bootstrapper, &global_data_summary, false)
+        .await
+        .unwrap();
+    assert!(!output_fallback_handler.in_fallback_mode());
+}
+
+#[tokio::test]
 async fn test_fetch_epoch_ending_ledger_infos() {
     // Create a driver configuration with a genesis waypoint and a stream timeout of 1 second
     let mut driver_configuration = create_full_node_driver_configuration();
@@ -429,7 +629,8 @@ async fn test_fetch_epoch_ending_ledger_infos() {
         .return_once(move |_| Ok(data_stream_listener));
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
+    let (mut bootstrapper, _) =
+        create_bootstrapper(driver_configuration, mock_streaming_client, None, true);
 
     // Set the waypoint as already having been verified (but no fetched ledger infos)
     manipulate_verified_epoch_states(&mut bootstrapper, false, true, None);
@@ -847,7 +1048,8 @@ async fn test_waypoint_mismatch() {
         .return_const(Ok(()));
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
+    let (mut bootstrapper, _) =
+        create_bootstrapper(driver_configuration, mock_streaming_client, None, true);
 
     // Create a global data summary up to the waypoint
     let mut global_data_summary = create_global_summary(waypoint_epoch);
@@ -891,7 +1093,8 @@ async fn test_waypoint_must_be_verified() {
         .return_once(move |_| Ok(data_stream_listener));
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
+    let (mut bootstrapper, _) =
+        create_bootstrapper(driver_configuration, mock_streaming_client, None, true);
 
     // Set fetched ledger infos to true but the waypoint is still not verified
     manipulate_verified_epoch_states(&mut bootstrapper, true, false, None);
@@ -923,7 +1126,8 @@ async fn test_waypoint_satisfiable() {
     let mock_streaming_client = create_mock_streaming_client();
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
+    let (mut bootstrapper, _) =
+        create_bootstrapper(driver_configuration, mock_streaming_client, None, true);
 
     // Create an empty global data summary
     let mut global_data_summary = GlobalDataSummary::empty();
@@ -949,8 +1153,12 @@ async fn test_waypoint_satisfiable() {
 fn create_bootstrapper(
     driver_configuration: DriverConfiguration,
     mock_streaming_client: MockStreamingClient,
+    time_service: Option<TimeService>,
     expect_reset_executor: bool,
-) -> Bootstrapper<MockMetadataStorage, MockStorageSynchronizer, MockStreamingClient> {
+) -> (
+    Bootstrapper<MockMetadataStorage, MockStorageSynchronizer, MockStreamingClient>,
+    OutputFallbackHandler,
+) {
     // Initialize the logger for tests
     aptos_logger::Logger::init_for_testing();
 
@@ -975,13 +1183,22 @@ fn create_bootstrapper(
         .expect_get_latest_transaction_info_option()
         .returning(|| Ok(Some((0, create_transaction_info()))));
 
-    Bootstrapper::new(
+    // Create the output fallback handler
+    let time_service = time_service.unwrap_or_else(TimeService::mock);
+    let output_fallback_handler =
+        OutputFallbackHandler::new(driver_configuration.clone(), time_service);
+
+    // Create the bootstrapper
+    let bootstrapper = Bootstrapper::new(
         driver_configuration,
         metadata_storage,
+        output_fallback_handler.clone(),
         mock_streaming_client,
         Arc::new(mock_database_reader),
         mock_storage_synchronizer,
-    )
+    );
+
+    (bootstrapper, output_fallback_handler)
 }
 
 /// Creates a bootstrapper for testing with a mock metadata storage
@@ -1010,9 +1227,14 @@ fn create_bootstrapper_with_storage(
         .expect_get_latest_transaction_info_option()
         .returning(move || Ok(Some((latest_synced_version, create_transaction_info()))));
 
+    // Create the output fallback handler
+    let output_fallback_handler =
+        OutputFallbackHandler::new(driver_configuration.clone(), TimeService::mock());
+
     Bootstrapper::new(
         driver_configuration,
         mock_metadata_storage,
+        output_fallback_handler,
         mock_streaming_client,
         Arc::new(mock_database_reader),
         mock_storage_synchronizer,
@@ -1077,4 +1299,23 @@ fn manipulate_verified_epoch_states(
 /// Verifies that the receiver gets a successful notification
 fn verify_bootstrap_notification(notification_receiver: oneshot::Receiver<Result<(), Error>>) {
     assert_ok!(notification_receiver.now_or_never().unwrap().unwrap());
+}
+
+/// Handles the given storage synchronizer error for the bootstrapper
+async fn handle_storage_synchronizer_error(
+    bootstrapper: &mut Bootstrapper<
+        MockMetadataStorage,
+        MockStorageSynchronizer,
+        MockStreamingClient,
+    >,
+    notification_id: NotificationId,
+    notification_feedback: NotificationFeedback,
+) {
+    bootstrapper
+        .handle_storage_synchronizer_error(NotificationAndFeedback::new(
+            notification_id,
+            notification_feedback,
+        ))
+        .await
+        .unwrap();
 }

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
@@ -9,6 +9,7 @@ use crate::{
         verify_mempool_and_event_notification,
     },
 };
+use aptos_config::config::StateSyncDriverConfig;
 use aptos_config::config::{NodeConfig, RoleType};
 use aptos_consensus_notifications::{ConsensusNotificationSender, ConsensusNotifier};
 use aptos_data_client::aptosnet::AptosNetDataClient;
@@ -34,6 +35,7 @@ use aptos_types::{
 use aptos_vm::AptosVM;
 use claims::{assert_err, assert_none};
 use futures::{FutureExt, StreamExt};
+use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 
 // TODO(joshlind): extend these tests to cover more functionality!
@@ -41,17 +43,37 @@ use std::{collections::HashMap, sync::Arc};
 #[tokio::test(flavor = "multi_thread")]
 async fn test_auto_bootstrapping() {
     // Create a driver for a validator with a waypoint at version 0
-    let (validator_driver, _, _, _, _) = create_validator_driver(None).await;
+    let (validator_driver, consensus_notifier, _, _, _, time_service) =
+        create_validator_driver(None).await;
+
+    // Spawn a driver client that's blocked on bootstrapping
+    let driver_client = validator_driver.create_driver_client();
+    let join_handle = tokio::spawn(async move {
+        driver_client.notify_once_bootstrapped().await.unwrap();
+    });
+
+    // Verify auto-bootstrapping hasn't happened yet
+    let result = consensus_notifier
+        .sync_to_target(create_ledger_info_at_version(0))
+        .await;
+    assert_err!(result);
+
+    // Elapse enough time on the time service for auto-bootstrapping
+    time_service
+        .into_mock()
+        .advance_async(Duration::from_secs(
+            StateSyncDriverConfig::default().max_connection_deadline_secs,
+        ))
+        .await;
 
     // Wait until the validator is bootstrapped (auto-bootstrapping should occur)
-    let driver_client = validator_driver.create_driver_client();
-    driver_client.notify_once_bootstrapped().await.unwrap();
+    join_handle.await.unwrap();
 }
 
 #[tokio::test]
 async fn test_consensus_commit_notification() {
     // Create a driver for a full node
-    let (_full_node_driver, consensus_notifier, _, _, _) = create_full_node_driver(None).await;
+    let (_full_node_driver, consensus_notifier, _, _, _, _) = create_full_node_driver(None).await;
 
     // Verify that full nodes can't process commit notifications
     let result = consensus_notifier
@@ -60,7 +82,7 @@ async fn test_consensus_commit_notification() {
     assert_err!(result);
 
     // Create a driver for a validator with a waypoint at version 0
-    let (_validator_driver, consensus_notifier, _, _, _) = create_validator_driver(None).await;
+    let (_validator_driver, consensus_notifier, _, _, _, _) = create_validator_driver(None).await;
 
     // Send a new commit notification and verify the node isn't bootstrapped
     let result = consensus_notifier
@@ -69,12 +91,26 @@ async fn test_consensus_commit_notification() {
     assert_err!(result);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_mempool_commit_notifications() {
     // Create a driver for a validator with a waypoint at version 0
     let subscription_event_key = EventKey::random();
-    let (validator_driver, consensus_notifier, mut mempool_listener, _, mut event_listener) =
-        create_validator_driver(Some(vec![subscription_event_key])).await;
+    let (
+        validator_driver,
+        consensus_notifier,
+        mut mempool_listener,
+        _,
+        mut event_listener,
+        time_service,
+    ) = create_validator_driver(Some(vec![subscription_event_key])).await;
+
+    // Elapse enough time on the time service for auto-bootstrapping
+    time_service
+        .into_mock()
+        .advance_async(Duration::from_secs(
+            StateSyncDriverConfig::default().max_connection_deadline_secs,
+        ))
+        .await;
 
     // Wait until the validator is bootstrapped
     let driver_client = validator_driver.create_driver_client();
@@ -110,11 +146,25 @@ async fn test_mempool_commit_notifications() {
     join_handle.await.unwrap();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_reconfiguration_notifications() {
     // Create a driver for a validator with a waypoint at version 0
-    let (validator_driver, consensus_notifier, mut mempool_listener, mut reconfig_listener, _) =
-        create_validator_driver(None).await;
+    let (
+        validator_driver,
+        consensus_notifier,
+        mut mempool_listener,
+        mut reconfig_listener,
+        _,
+        time_service,
+    ) = create_validator_driver(None).await;
+
+    // Elapse enough time on the time service for auto-bootstrapping
+    time_service
+        .into_mock()
+        .advance_async(Duration::from_secs(
+            StateSyncDriverConfig::default().max_connection_deadline_secs,
+        ))
+        .await;
 
     // Wait until the validator is bootstrapped
     let driver_client = validator_driver.create_driver_client();
@@ -163,7 +213,7 @@ async fn test_reconfiguration_notifications() {
 #[tokio::test]
 async fn test_consensus_sync_request() {
     // Create a driver for a full node
-    let (_full_node_driver, consensus_notifier, _, _, _) = create_full_node_driver(None).await;
+    let (_full_node_driver, consensus_notifier, _, _, _, _) = create_full_node_driver(None).await;
 
     // Verify that full nodes can't process sync requests
     let result = consensus_notifier
@@ -172,7 +222,7 @@ async fn test_consensus_sync_request() {
     assert_err!(result);
 
     // Create a driver for a validator with a waypoint at version 0
-    let (_validator_driver, consensus_notifier, _, _, _) = create_validator_driver(None).await;
+    let (_validator_driver, consensus_notifier, _, _, _, _) = create_validator_driver(None).await;
 
     // Send a new sync request and verify the node isn't bootstrapped
     let result = consensus_notifier
@@ -190,6 +240,7 @@ async fn create_validator_driver(
     MempoolNotificationListener,
     ReconfigNotificationListener,
     EventNotificationListener,
+    TimeService,
 ) {
     let mut node_config = NodeConfig::default();
     node_config.base.role = RoleType::Validator;
@@ -206,6 +257,7 @@ async fn create_full_node_driver(
     MempoolNotificationListener,
     ReconfigNotificationListener,
     EventNotificationListener,
+    TimeService,
 ) {
     let mut node_config = NodeConfig::default();
     node_config.base.role = RoleType::FullNode;
@@ -224,6 +276,7 @@ async fn create_driver_for_tests(
     MempoolNotificationListener,
     ReconfigNotificationListener,
     EventNotificationListener,
+    TimeService,
 ) {
     // Create test aptos database
     let db_path = aptos_temppath::TempPath::new();
@@ -262,6 +315,7 @@ async fn create_driver_for_tests(
     let (streaming_service_client, _) = new_streaming_service_client_listener_pair();
 
     // Create a test aptos data client
+    let time_service = TimeService::mock();
     let network_client = StorageServiceClient::new(
         MultiNetworkSender::new(HashMap::new()),
         PeerMetadataStorage::new(&[]),
@@ -270,7 +324,7 @@ async fn create_driver_for_tests(
         node_config.state_sync.aptos_data_client,
         node_config.base.clone(),
         node_config.state_sync.storage_service,
-        TimeService::mock(),
+        time_service.clone(),
         network_client,
         None,
     );
@@ -291,6 +345,7 @@ async fn create_driver_for_tests(
         event_subscription_service,
         aptos_data_client,
         streaming_service_client,
+        time_service.clone(),
     );
 
     // The driver will notify reconfiguration subscribers of the initial configs.
@@ -303,5 +358,6 @@ async fn create_driver_for_tests(
         mempool_listener,
         reconfiguration_subscriber,
         event_subscriber,
+        time_service,
     )
 }

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver_factory.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver_factory.rs
@@ -94,6 +94,7 @@ fn test_new_initialized_configs() {
         event_subscription_service,
         aptos_data_client,
         streaming_service_client,
+        TimeService::mock(),
     );
 
     // Verify the initial configs were notified

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -377,6 +377,14 @@ mock! {
             include_events: bool,
         ) -> Result<DataStreamListener, aptos_data_streaming_service::error::Error>;
 
+        async fn get_all_transactions_or_outputs(
+            &self,
+            start_version: Version,
+            end_version: Version,
+            proof_version: Version,
+            include_events: bool,
+        ) -> Result<DataStreamListener, aptos_data_streaming_service::error::Error>;
+
         async fn continuously_stream_transaction_outputs(
             &self,
             start_version: Version,
@@ -385,6 +393,14 @@ mock! {
         ) -> Result<DataStreamListener, aptos_data_streaming_service::error::Error>;
 
         async fn continuously_stream_transactions(
+            &self,
+            start_version: Version,
+            start_epoch: Epoch,
+            include_events: bool,
+            target: Option<LedgerInfoWithSignatures>,
+        ) -> Result<DataStreamListener, aptos_data_streaming_service::error::Error>;
+
+        async fn continuously_stream_transactions_or_outputs(
             &self,
             start_version: Version,
             start_epoch: Epoch,

--- a/state-sync/state-sync-v2/state-sync-driver/src/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/utils.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::driver::DriverConfiguration;
+use crate::storage_synchronizer::StorageSynchronizerInterface;
 use crate::{
     error::Error,
     logging::{LogEntry, LogSchema},
@@ -9,6 +11,7 @@ use crate::{
         CommitNotification, CommittedTransactions, MempoolNotificationHandler,
     },
 };
+use aptos_data_streaming_service::data_notification::NotificationId;
 use aptos_data_streaming_service::data_stream::DataStreamId;
 use aptos_data_streaming_service::streaming_client::NotificationAndFeedback;
 use aptos_data_streaming_service::{
@@ -20,11 +23,15 @@ use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_mempool_notifications::MempoolNotificationSender;
 use aptos_storage_interface::DbReader;
+use aptos_time_service::TimeService;
+use aptos_time_service::TimeServiceTrait;
+use aptos_types::transaction::{TransactionListWithProof, TransactionOutputListWithProof};
 use aptos_types::{
     epoch_change::Verifier, epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
     transaction::Version,
 };
 use futures::StreamExt;
+use std::time::Instant;
 use std::{sync::Arc, time::Duration};
 use tokio::time::timeout;
 
@@ -99,6 +106,88 @@ impl SpeculativeStreamState {
             .map_err(|error| {
                 Error::VerificationError(format!("Ledger info failed verification: {:?}", error))
             })
+    }
+}
+
+/// A simple struct that holds all information relevant for managing
+/// fallback behaviour to output syncing.
+#[derive(Clone)]
+pub struct OutputFallbackHandler {
+    // The configuration for the state sync driver
+    driver_configuration: DriverConfiguration,
+
+    // The most recent time at which we fell back to output syncing
+    fallback_start_time: Arc<Mutex<Option<Instant>>>,
+
+    // The time service
+    time_service: TimeService,
+}
+
+impl OutputFallbackHandler {
+    pub fn new(driver_configuration: DriverConfiguration, time_service: TimeService) -> Self {
+        let fallback_start_time = Arc::new(Mutex::new(None));
+        Self {
+            driver_configuration,
+            fallback_start_time,
+            time_service,
+        }
+    }
+
+    /// Initiates a fallback to output syncing (if we haven't already)
+    pub fn fallback_to_outputs(&mut self) {
+        if self.fallback_start_time.lock().is_none() {
+            self.set_fallback_start_time(self.time_service.now());
+            info!(LogSchema::new(LogEntry::Driver).message(&format!(
+                "Falling back to output syncing for at least {:?} seconds!",
+                self.get_fallback_duration().as_secs()
+            )));
+        }
+    }
+
+    /// Returns true iff we're currently in fallback mode
+    pub fn in_fallback_mode(&mut self) -> bool {
+        let fallback_start_time = self.fallback_start_time.lock().take();
+        if let Some(fallback_start_time) = fallback_start_time {
+            if let Some(fallback_deadline) =
+                fallback_start_time.checked_add(self.get_fallback_duration())
+            {
+                // Check if we elapsed the max fallback duration
+                if self.time_service.now() >= fallback_deadline {
+                    info!(LogSchema::new(LogEntry::AutoBootstrapping)
+                        .message("Passed the output fallback deadline! Disabling fallback mode!"));
+                    false
+                } else {
+                    // Reinsert the fallback deadline (not enough time has passed)
+                    self.set_fallback_start_time(fallback_start_time);
+                    true
+                }
+            } else {
+                warn!(LogSchema::new(LogEntry::Driver)
+                    .message("The fallback deadline overflowed! Disabling fallback mode!"));
+                false
+            }
+        } else {
+            false
+        }
+    }
+
+    /// Returns the fallback duration as defined by the config
+    fn get_fallback_duration(&self) -> Duration {
+        Duration::from_secs(
+            self.driver_configuration
+                .config
+                .fallback_to_output_syncing_secs,
+        )
+    }
+
+    /// Sets the fallback start time internally
+    fn set_fallback_start_time(&mut self, fallback_start_time: Instant) {
+        if let Some(old_start_time) = self.fallback_start_time.lock().replace(fallback_start_time) {
+            warn!(LogSchema::new(LogEntry::Driver).message(&format!(
+                "Overwrote the old fallback start time ({:?}) with the new one ({:?})!",
+                old_start_time, fallback_start_time
+            )));
+        }
     }
 }
 
@@ -277,4 +366,48 @@ pub fn update_new_epoch_metrics() {
         metrics::StorageSynchronizerOperations::SyncedEpoch.get_label(),
         1,
     );
+}
+
+/// Executes the given list of transactions and
+/// returns the number of transactions in the list.
+pub async fn execute_transactions<StorageSyncer: StorageSynchronizerInterface + Clone>(
+    mut storage_synchronizer: StorageSyncer,
+    notification_id: NotificationId,
+    proof_ledger_info: LedgerInfoWithSignatures,
+    end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
+    transaction_list_with_proof: TransactionListWithProof,
+) -> Result<usize, Error> {
+    let num_transactions = transaction_list_with_proof.transactions.len();
+    storage_synchronizer
+        .execute_transactions(
+            notification_id,
+            transaction_list_with_proof,
+            proof_ledger_info,
+            end_of_epoch_ledger_info,
+        )
+        .await?;
+    Ok(num_transactions)
+}
+
+/// Applies the given list of transaction outputs and
+/// returns the number of outputs in the list.
+pub async fn apply_transaction_outputs<StorageSyncer: StorageSynchronizerInterface + Clone>(
+    mut storage_synchronizer: StorageSyncer,
+    notification_id: NotificationId,
+    proof_ledger_info: LedgerInfoWithSignatures,
+    end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
+    transaction_outputs_with_proof: TransactionOutputListWithProof,
+) -> Result<usize, Error> {
+    let num_transaction_outputs = transaction_outputs_with_proof
+        .transactions_and_outputs
+        .len();
+    storage_synchronizer
+        .apply_transaction_outputs(
+            notification_id,
+            transaction_outputs_with_proof,
+            proof_ledger_info,
+            end_of_epoch_ledger_info,
+        )
+        .await?;
+    Ok(num_transaction_outputs)
 }

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -1594,6 +1594,7 @@ async fn test_get_transactions_or_outputs_with_proof_chunk_limit() {
         // Create test data
         let max_output_chunk_size =
             StorageServiceConfig::default().max_transaction_output_chunk_size;
+        let max_transaction_chunk_size = StorageServiceConfig::default().max_transaction_chunk_size;
         let chunk_size = max_output_chunk_size * 10; // Set a chunk request larger than the max
         let start_version = 0;
         let end_version = start_version + max_output_chunk_size - 1;
@@ -1616,7 +1617,7 @@ async fn test_get_transactions_or_outputs_with_proof_chunk_limit() {
             expect_get_transactions(
                 &mut db_reader,
                 start_version,
-                max_output_chunk_size,
+                max_transaction_chunk_size,
                 proof_version,
                 false,
                 transaction_list_with_proof.clone(),

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -118,6 +118,70 @@ async fn test_full_node_bootstrap_outputs_exponential_backoff() {
 }
 
 #[tokio::test]
+async fn test_full_node_bootstrap_transactions_or_outputs() {
+    // Create a validator swarm of 1 validator node with a small network limit
+    let mut swarm = SwarmBuilder::new_local(1)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
+            config.state_sync.storage_service.max_network_chunk_bytes = 5 * 1024;
+        }))
+        .build()
+        .await;
+
+    // Create a fullnode config that uses transactions or outputs to sync
+    let mut vfn_config = NodeConfig::default_for_validator_full_node();
+    vfn_config.state_sync.state_sync_driver.bootstrapping_mode =
+        BootstrappingMode::ExecuteOrApplyFromGenesis;
+    vfn_config
+        .state_sync
+        .state_sync_driver
+        .continuous_syncing_mode = ContinuousSyncingMode::ExecuteTransactionsOrApplyOutputs;
+    vfn_config
+        .state_sync
+        .aptos_data_client
+        .max_num_output_reductions = 1;
+    vfn_config.state_sync.aptos_data_client.response_timeout_ms = 1;
+
+    // Create the fullnode
+    let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
+
+    // Test the ability of the fullnode to sync
+    test_full_node_sync(vfn_peer_id, &mut swarm, true).await;
+}
+
+#[tokio::test]
+async fn test_full_node_bootstrap_snapshot_transactions_or_outputs() {
+    // Create a validator swarm of 1 validator node with a small network limit
+    let mut swarm = SwarmBuilder::new_local(1)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
+            config.state_sync.storage_service.max_network_chunk_bytes = 300 * 1024;
+        }))
+        .build()
+        .await;
+
+    // Create a fullnode config that uses snapshot syncing and transactions or outputs
+    let mut vfn_config = NodeConfig::default_for_validator_full_node();
+    vfn_config.state_sync.state_sync_driver.bootstrapping_mode =
+        BootstrappingMode::DownloadLatestStates;
+    vfn_config
+        .state_sync
+        .state_sync_driver
+        .continuous_syncing_mode = ContinuousSyncingMode::ExecuteTransactionsOrApplyOutputs;
+    vfn_config
+        .state_sync
+        .aptos_data_client
+        .max_num_output_reductions = 2;
+    vfn_config.state_sync.aptos_data_client.response_timeout_ms = 1;
+
+    // Create the fullnode
+    let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
+
+    // Test the ability of the fullnode to sync
+    test_full_node_sync(vfn_peer_id, &mut swarm, true).await;
+}
+
+#[tokio::test]
 async fn test_full_node_bootstrap_transactions() {
     // Create a validator swarm of 1 validator node
     let mut swarm = new_local_swarm_with_aptos(1).await;
@@ -408,6 +472,30 @@ async fn test_validator_bootstrap_transactions() {
                 BootstrappingMode::ExecuteTransactionsFromGenesis;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
                 ContinuousSyncingMode::ExecuteTransactions;
+        }))
+        .build()
+        .await;
+
+    // Test the ability of the validators to sync
+    test_validator_sync(&mut swarm, 1).await;
+}
+
+#[tokio::test]
+async fn test_validator_bootstrap_transactions_or_outputs() {
+    // Create a swarm of 4 validators using transaction or output syncing
+    let mut swarm = SwarmBuilder::new_local(4)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
+            config.state_sync.state_sync_driver.bootstrapping_mode =
+                BootstrappingMode::ExecuteOrApplyFromGenesis;
+            config.state_sync.state_sync_driver.continuous_syncing_mode =
+                ContinuousSyncingMode::ExecuteTransactionsOrApplyOutputs;
+            config.state_sync.storage_service.max_network_chunk_bytes = 10 * 1024;
+            config
+                .state_sync
+                .aptos_data_client
+                .max_num_output_reductions = 1;
+            config.state_sync.aptos_data_client.response_timeout_ms = 1;
         }))
         .build()
         .await;


### PR DESCRIPTION
Note: Over 1k lines of this PR are just new tests. The rest is boring boilerplate for supporting client-side data requests and a new syncing mode.

### Description
This PR adds the client-side implementation of the new semi-intelligent [syncing mode](https://github.com/aptos-labs/aptos-core/pull/5742) that switches between output application and transaction execution depending on whichever is faster. To achieve this, we:
1. Add a new set of state sync modes to fetch transactions or outputs.
2. Add all the boilerplate for the new state sync modes to fetch the correct data from the server (e.g., via data streams).
3. Set the maximum transaction output chunk size to be 1k (from 2k). Based on data in mainnet, this is more optimal as it results in fewer pre-fetcher misses.
4. Add a new fallback mechanism to the semi-intelligent state syncing modes. Specifically, if state sync tries to execute transactions that are no longer compatible, it switches to output syncing for 2 minutes to get past the problematic transactions. This is to the handle the worst case and should hopefully only ever happen in rare circumstances.
5. Adds a bunch of new tests around the driver (i.e., bootstrapper and continuous syncer), data streaming service and aptos data client. Smoke tests are also added.

### Test Plan
New unit tests and smoke tests!