### PR TITLE
[aptos-cli] Update to 1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "aptos-backup-cli",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "1.0.1"
+version = "1.0.2"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
### Description
Need to update CLI, due to compiler change causing errors on tests.

See: https://github.com/aptos-labs/aptos-core/issues/5867

### Test Plan
Tested manually to build

Old release:
```
aptos move test --named-addresses hello_blockchain=default --package-dir aptos-move/move-examples/hello_blockchain
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING Examples
error[E03002]: unbound module
    ┌─ aptos-move/move-examples/hello_blockchain/../../framework/aptos-framework/sources/coin.move:950:57
    │
950 │     #[expected_failure(abort_code = 0x50003, location = aptos_framework::system_addresses)]
    │                                                         ^^^^^^^^^^^^^^^ Unbound module alias 'aptos_framework'

error[E03002]: unbound module
    ┌─ aptos-move/move-examples/hello_blockchain/../../framework/aptos-framework/sources/coin.move:974:57
    │
974 │     #[expected_failure(abort_code = 0x20001, location = aptos_framework::aggregator)]
    │                                                         ^^^^^^^^^^^^^^^ Unbound module alias 'aptos_framework'

error[E03002]: unbound module
    ┌─ aptos-move/move-examples/hello_blockchain/../../framework/aptos-framework/sources/coin.move:988:57
    │
988 │     #[expected_failure(abort_code = 0x5000B, location = aptos_framework::coin)]
    │                                                         ^^^^^^^^^^^^^^^ Unbound module alias 'aptos_framework'
...
```

New version:
```
aptos move test --named-addresses hello_blockchain=default -
-package-dir aptos-move/move-examples/hello_blockchain
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING Examples
Running Move unit tests
[ PASS    ] 0xb6dbf76636021a840c64da0ca6aa94297b4ead015f7398521f57347f68364898::message::sender_can_set_message
[ PASS    ] 0xb6dbf76636021a840c64da0ca6aa94297b4ead015f7398521f57347f68364898::message_tests::sender_can_set_message
Test result: OK. Total tests: 2; passed: 2; failed: 0
{
  "Result": "Success"
}
```
