### PR TITLE
[move-vm] Generalize metadata for attribute parameters

### DIFF
--- a/aptos-move/aptos-vm/src/verifier/view_function.rs
+++ b/aptos-move/aptos-vm/src/verifier/view_function.rs
@@ -23,7 +23,7 @@ pub(crate) fn validate_view_function<S: MoveResolverExt>(
     let is_view = if let Some(data) = module_metadata {
         data.fun_attributes
             .get(fun_name.as_str())
-            .map(|attrs| attrs.contains(&KnownAttribute::ViewFunction))
+            .map(|attrs| attrs.contains(&KnownAttribute::view_function()))
             .unwrap_or_default()
     } else {
         false

--- a/aptos-move/framework/src/extended_checks.rs
+++ b/aptos-move/framework/src/extended_checks.rs
@@ -182,7 +182,7 @@ impl<'a> ExtendedChecker<'a> {
                 .fun_attributes
                 .entry(fun.get_simple_name_string().to_string())
                 .or_default()
-                .push(KnownAttribute::ViewFunction);
+                .push(KnownAttribute::view_function());
         }
     }
 }

--- a/aptos-move/framework/src/module_metadata.rs
+++ b/aptos-move/framework/src/module_metadata.rs
@@ -43,8 +43,28 @@ pub struct RuntimeModuleMetadataV1 {
 
 /// Enumeration of known attributes
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub enum KnownAttribute {
+pub struct KnownAttribute {
+    kind: KnownAttributeKind,
+    args: Vec<String>,
+}
+
+/// Enumeration of known attributes
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum KnownAttributeKind {
     ViewFunction = 1,
+}
+
+impl KnownAttribute {
+    pub fn view_function() -> Self {
+        Self {
+            kind: KnownAttributeKind::ViewFunction,
+            args: vec![],
+        }
+    }
+
+    pub fn is_view_function(&self) -> bool {
+        self.kind == KnownAttributeKind::ViewFunction
+    }
 }
 
 /// Extract metadata from the VM, upgrading V0 to V1 representation as needed


### PR DESCRIPTION
This generalizes metadata stored in the bytecode for attributes to allow parameters, as in `#[storage_group(group)]`. This was added recently for `#[view]` but did not support parameters. Folding this into current release will avoid breaking changes later.

