### PR TITLE
[cli] fix errors caused by mishandling of bytecode version

### DIFF
--- a/aptos-move/framework/src/aptos.rs
+++ b/aptos-move/framework/src/aptos.rs
@@ -115,6 +115,7 @@ impl ReleaseTarget {
                     references_file: Some("doc_template/references.md".to_string()),
                 }),
                 skip_fetch_latest_git_deps: false,
+                bytecode_version: None,
             },
             packages: packages.iter().map(|(path, _)| path.to_owned()).collect(),
             rust_bindings: packages

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -949,6 +949,10 @@ impl MovePackageDir {
             .collect()
     }
 
+    pub fn bytecode_version_or_detault(&self) -> u32 {
+        self.bytecode_version.unwrap_or(5)
+    }
+
     pub fn add_named_address(&mut self, key: String, value: String) {
         self.named_addresses
             .insert(key, AccountAddressWrapper::from_str(&value).unwrap());

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -304,6 +304,7 @@ impl CliCommand<Vec<String>> for CompilePackage {
                 .build_options(
                     self.move_options.skip_fetch_latest_git_deps,
                     self.move_options.named_addresses(),
+                    self.move_options.bytecode_version_or_detault(),
                 )
         };
         let pack = BuiltPackage::build(self.move_options.get_package_path()?, build_options)
@@ -481,6 +482,7 @@ impl CliCommand<&'static str> for DocumentPackage {
             named_addresses: move_options.named_addresses(),
             docgen_options: Some(docgen_options),
             skip_fetch_latest_git_deps: move_options.skip_fetch_latest_git_deps,
+            bytecode_version: Some(move_options.bytecode_version_or_detault()),
         };
         BuiltPackage::build(move_options.get_package_path()?, build_options)?;
         Ok("succeeded")
@@ -554,6 +556,7 @@ impl IncludedArtifacts {
         self,
         skip_fetch_latest_git_deps: bool,
         named_addresses: BTreeMap<String, AccountAddress>,
+        bytecode_version: u32,
     ) -> BuildOptions {
         use IncludedArtifacts::*;
         match self {
@@ -565,6 +568,7 @@ impl IncludedArtifacts {
                 with_error_map: true,
                 named_addresses,
                 skip_fetch_latest_git_deps,
+                bytecode_version: Some(bytecode_version),
                 ..BuildOptions::default()
             },
             Sparse => BuildOptions {
@@ -574,6 +578,7 @@ impl IncludedArtifacts {
                 with_error_map: true,
                 named_addresses,
                 skip_fetch_latest_git_deps,
+                bytecode_version: Some(bytecode_version),
                 ..BuildOptions::default()
             },
             All => BuildOptions {
@@ -583,6 +588,7 @@ impl IncludedArtifacts {
                 with_error_map: true,
                 named_addresses,
                 skip_fetch_latest_git_deps,
+                bytecode_version: Some(bytecode_version),
                 ..BuildOptions::default()
             },
         }
@@ -609,6 +615,7 @@ impl CliCommand<TransactionSummary> for PublishPackage {
         let options = included_artifacts_args.included_artifacts.build_options(
             move_options.skip_fetch_latest_git_deps,
             move_options.named_addresses(),
+            move_options.bytecode_version_or_detault(),
         );
         let package = BuiltPackage::build(package_path, options)?;
         let compiled_units = package.extract_code();
@@ -695,6 +702,7 @@ impl CliCommand<TransactionSummary> for CreateResourceAccountAndPublishPackage {
         let options = included_artifacts_args.included_artifacts.build_options(
             move_options.skip_fetch_latest_git_deps,
             move_options.named_addresses(),
+            move_options.bytecode_version_or_detault(),
         );
         let package = BuiltPackage::build(package_path, options)?;
         let compiled_units = package.extract_code();
@@ -819,9 +827,11 @@ impl CliCommand<&'static str> for VerifyPackage {
         // First build the package locally to get the package metadata
         let build_options = BuildOptions {
             install_dir: self.move_options.output_dir.clone(),
+            bytecode_version: Some(self.move_options.bytecode_version_or_detault()),
             ..self.included_artifacts.build_options(
                 self.move_options.skip_fetch_latest_git_deps,
                 self.move_options.named_addresses(),
+                self.move_options.bytecode_version_or_detault(),
             )
         };
         let pack = BuiltPackage::build(self.move_options.get_package_path()?, build_options)

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -928,6 +928,7 @@ impl CliTestFramework {
                     framework_local_dir: Some(Self::aptos_framework_dir()),
                     skip_fetch_latest_git_deps: false,
                 },
+                bytecode_version: None,
             },
             args: Vec::new(),
             type_args: Vec::new(),


### PR DESCRIPTION
The CLI & the underlying BuiiltPackage didn't handle bytecode version correctly. This gets them fixed.