### PR TITLE
[tf] manage_via_tf triggers chart_sha1

### DIFF
--- a/terraform/aptos-node-testnet/main.tf
+++ b/terraform/aptos-node-testnet/main.tf
@@ -94,12 +94,6 @@ provider "kubernetes" {
 
 locals {
   genesis_helm_chart_path = "${path.module}/../helm/genesis"
-
-  # these values are the most likely to be changed by the user and may be managed by terraform to trigger re-deployment
-  genesis_helm_values_managed = {
-    "imageTag"  = var.image_tag
-    "chain.era" = var.era
-  }
 }
 
 
@@ -108,12 +102,6 @@ resource "helm_release" "genesis" {
   chart       = local.genesis_helm_chart_path
   max_history = 5
   wait        = false
-
-  lifecycle {
-    ignore_changes = [
-      values,
-    ]
-  }
 
   values = [
     jsonencode({
@@ -141,16 +129,11 @@ resource "helm_release" "genesis" {
   ]
 
   dynamic "set" {
-    for_each = var.manage_via_tf ? local.genesis_helm_values_managed : {}
+    for_each = var.manage_via_tf ? toset([""]) : toset([])
     content {
-      name  = set.key
-      value = set.value
+      # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
+      name  = "chart_sha1"
+      value = sha1(join("", [for f in fileset(local.genesis_helm_chart_path, "**") : filesha1("${local.genesis_helm_chart_path}/${f}")]))
     }
-  }
-
-  # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
-  set {
-    name  = "chart_sha1"
-    value = sha1(join("", [for f in fileset(local.genesis_helm_chart_path, "**") : filesha1("${local.genesis_helm_chart_path}/${f}")]))
   }
 }

--- a/terraform/aptos-node-testnet/main.tf
+++ b/terraform/aptos-node-testnet/main.tf
@@ -46,7 +46,7 @@ module "validator" {
   chain_id       = local.chain_id
   era            = var.era
   chain_name     = local.chain_name
-  image_tag      = var.image_tag
+  image_tag      = var.validator_image_tag != "" ? var.validator_image_tag : var.image_tag
   validator_name = "aptos-node"
 
   validator_storage_class = var.validator_storage_class

--- a/terraform/aptos-node-testnet/variables.tf
+++ b/terraform/aptos-node-testnet/variables.tf
@@ -83,8 +83,13 @@ variable "chain_name" {
 }
 
 variable "image_tag" {
-  description = "Docker image tag for Aptos node"
+  description = "Docker image tag for all Aptos workloads, including validators, fullnodes, backup, restore, genesis, and other tooling"
   default     = "devnet"
+}
+
+variable "validator_image_tag" {
+  description = "Docker image tag for validators and fullnodes. If set, overrides var.image_tag for those nodes"
+  default     = ""
 }
 
 ### Helm values

--- a/terraform/aptos-node/aws/kubernetes.tf
+++ b/terraform/aptos-node/aws/kubernetes.tf
@@ -169,12 +169,6 @@ locals {
 
   # override the helm release name if an override exists, otherwise adopt the workspace name
   helm_release_name = var.helm_release_name_override != "" ? var.helm_release_name_override : local.workspace_name
-
-  # these values are the most likely to be changed by the user and may be managed by terraform to trigger re-deployment
-  helm_values_managed = {
-    "imageTag"  = var.image_tag
-    "chain.era" = var.era
-  }
 }
 
 resource "helm_release" "validator" {
@@ -184,12 +178,6 @@ resource "helm_release" "validator" {
   max_history = 5
   wait        = false
 
-  # lifecycle {
-  #   ignore_changes = [
-  #     values,
-  #   ]
-  # }
-
   values = [
     local.helm_values,
     var.helm_values_file != "" ? file(var.helm_values_file) : "{}",
@@ -197,17 +185,12 @@ resource "helm_release" "validator" {
   ]
 
   dynamic "set" {
-    for_each = var.manage_via_tf ? local.helm_values_managed : {}
+    for_each = var.manage_via_tf ? toset([""]) : toset([])
     content {
-      name  = set.key
-      value = set.value
+      # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
+      name  = "chart_sha1"
+      value = sha1(join("", [for f in fileset(local.aptos_node_helm_chart_path, "**") : filesha1("${local.aptos_node_helm_chart_path}/${f}")]))
     }
-  }
-
-  # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
-  set {
-    name  = "chart_sha1"
-    value = sha1(join("", [for f in fileset(local.aptos_node_helm_chart_path, "**") : filesha1("${local.aptos_node_helm_chart_path}/${f}")]))
   }
 }
 

--- a/terraform/aptos-node/gcp/kubernetes.tf
+++ b/terraform/aptos-node/gcp/kubernetes.tf
@@ -28,12 +28,6 @@ locals {
   monitoring_helm_chart_path = "${path.module}/../../helm/monitoring"
   logger_helm_chart_path     = "${path.module}/../../helm/logger"
   aptos_node_helm_chart_path = var.helm_chart != "" ? var.helm_chart : "${path.module}/../../helm/aptos-node"
-
-  # these values are the most likely to be changed by the user and may be managed by terraform to trigger re-deployment
-  helm_values_managed = {
-    "imageTag"  = var.image_tag
-    "chain.era" = var.era
-  }
 }
 
 resource "helm_release" "validator" {
@@ -41,12 +35,6 @@ resource "helm_release" "validator" {
   chart       = local.aptos_node_helm_chart_path
   max_history = 5
   wait        = false
-
-  lifecycle {
-    ignore_changes = [
-      values,
-    ]
-  }
 
   values = [
     jsonencode({
@@ -89,17 +77,12 @@ resource "helm_release" "validator" {
   ]
 
   dynamic "set" {
-    for_each = var.manage_via_tf ? local.helm_values_managed : {}
+    for_each = var.manage_via_tf ? toset([""]) : toset([])
     content {
-      name  = set.key
-      value = set.value
+      # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
+      name  = "chart_sha1"
+      value = sha1(join("", [for f in fileset(local.aptos_node_helm_chart_path, "**") : filesha1("${local.aptos_node_helm_chart_path}/${f}")]))
     }
-  }
-
-  # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
-  set {
-    name  = "chart_sha1"
-    value = sha1(join("", [for f in fileset(local.aptos_node_helm_chart_path, "**") : filesha1("${local.aptos_node_helm_chart_path}/${f}")]))
   }
 }
 


### PR DESCRIPTION
### Description

Change the functionality of `var.manage_via_tf` to still trigger helm updates when relevant TF variables are updated. It now only toggles the inclusion of the `chart_sha1` helm value that we use to force helm chart update.

If any of the built-in/derived or user-specified helm values change, the `helm_release` resource will be updated. All these changes should be either (1) rare or (2) user-triggered

Bonus: `var.validator_image_tag` lets you specify image tags for validator/fullnode workloads separately from `var.image_tag`, e.g. to use `var.validator_image_tag = performance_<REV>`, and `var.image_tag = <REV>`

### Test Plan

Apply some different scenarios we expect testnet operators to be in:
* update `var.chain_id`
* update `var.image_tag`
* update `var.era`
* update `var.num_validators`
* update `var.manage_via_tf`
* update any of the user-provided helm values

<!-- Please provide us with clear details for verifying that your changes work. -->
