### PR TITLE
[State Sync] Bump fallback time from 2 minutes to 3 minutes.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -86,7 +86,7 @@ impl Default for StateSyncDriverConfig {
             bootstrapping_mode: BootstrappingMode::ApplyTransactionOutputsFromGenesis,
             commit_notification_timeout_ms: 5000,
             continuous_syncing_mode: ContinuousSyncingMode::ApplyTransactionOutputs,
-            fallback_to_output_syncing_secs: 120, // 2 minutes
+            fallback_to_output_syncing_secs: 180, // 3 minutes
             progress_check_interval_ms: 100,
             max_connection_deadline_secs: 10,
             max_consecutive_stream_notifications: 10,


### PR DESCRIPTION
### Description
This PR bumps the fallback time in intelligent syncing mode from 2 minutes to 3 minutes.

### Test Plan
Existing test infrastructure.