### PR TITLE
[Parallel Execution] Counter for dependency waits

### DIFF
--- a/aptos-move/block-executor/src/counters.rs
+++ b/aptos-move/block-executor/src/counters.rs
@@ -13,11 +13,21 @@ pub static MODULE_PUBLISHING_FALLBACK_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Count of speculative transaction re-executions due to a failed validation .
+/// Count of speculative transaction re-executions due to a failed validation.
 pub static SPECULATIVE_ABORT_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
         "aptos_execution_speculative_abort_count",
         "Number of speculative aborts in parallel execution (leading to re-execution)"
+    )
+    .unwrap()
+});
+
+/// Count of times a transaction got suspended due to an estimated r/w dependency.
+pub static DEPENDENCY_SUSPEND_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_execution_dependency_suspend_count",
+        "Count write estimates encountered when reading in parallel execution \
+        (typically leading to a suspension / waiting)"
     )
     .unwrap()
 });

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -105,6 +105,7 @@ impl<
                     // `self.txn_idx` estimated to depend on a write from `dep_idx`.
                     match self.scheduler.wait_for_dependency(self.txn_idx, dep_idx) {
                         Some(dep_condition) => {
+                            counters::DEPENDENCY_SUSPEND_COUNT.inc();
                             // Wait on a condition variable corresponding to the encountered
                             // read dependency. Once the dep_idx finishes re-execution, scheduler
                             // will mark the dependency as resolved, and then the txn_idx will be


### PR DESCRIPTION
Add a counter for monitoring, e.g. with more threads should observe more aborts and dependency waits, and actually dependency waits are saving aborts, so good complementary metric to the number of speculative aborts.