### PR TITLE
[Parallel Executor] Block executor output and mvhashmap/resolver refactoring

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,7 +21,8 @@
 /aptos-move/framework/aptos-token @areshand
 /aptos-move/framework/src/natives/cryptography/ @alinush
 /aptos-move/framework/src/natives/aggregator_natives/ @georgemitenkov @gelash @zekun000
-/aptos-move/block-executor/ @gelash @zekun000 @sasha8
+/aptos-move/block-executor/ @gelash @zekun000 @sasha8 @danielxiangzl
+/aptos-move/mvhashmap/ @gelash @runtian-zhou @sasha8 @danielxiangzl
 /aptos-move/vm-genesis/ @davidiw @movekevin
 
 # Owner for aptos node (just to prevent things from becoming out of hand, again :D)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "anyhow",
  "aptos-aggregator",
  "aptos-infallible",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-mvhashmap",
  "aptos-state-view",
@@ -1575,6 +1576,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
+ "aptos-infallible",
  "aptos-types",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "crossbeam",

--- a/aptos-move/block-executor/Cargo.toml
+++ b/aptos-move/block-executor/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 aptos-aggregator = { workspace = true }
 aptos-infallible = { workspace = true }
+aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-mvhashmap = { workspace = true }
 aptos-state-view = { workspace = true }

--- a/aptos-move/block-executor/src/output_delta_resolver.rs
+++ b/aptos-move/block-executor/src/output_delta_resolver.rs
@@ -1,42 +1,37 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::view::ResolvedData;
+use crate::{executor::RAYON_EXEC_POOL, task::Transaction};
 use aptos_aggregator::delta_change_set::{deserialize, serialize};
 use aptos_mvhashmap::{EntryCell, MVHashMap};
+use aptos_state_view::TStateView;
 use aptos_types::write_set::{TransactionWrite, WriteOp};
-use std::{hash::Hash, thread::spawn};
 
-pub struct OutputDeltaResolver<K, V> {
-    versioned_outputs: MVHashMap<K, V>,
+pub(crate) struct OutputDeltaResolver<T: Transaction> {
+    versioned_outputs: MVHashMap<T::Key, T::Value>,
 }
 
-impl<K: Hash + Clone + Eq + Send + 'static, V: TransactionWrite + Send + Sync + 'static>
-    OutputDeltaResolver<K, V>
-{
-    pub fn new(versioned_outputs: MVHashMap<K, V>) -> Self {
+impl<T: Transaction> OutputDeltaResolver<T> {
+    pub fn new(versioned_outputs: MVHashMap<T::Key, T::Value>) -> Self {
         Self { versioned_outputs }
     }
 
     /// Takes Self, vector of all involved aggregator keys (each with at least one
     /// delta to resolve in the output), resolved values from storage for each key,
     /// and blocksize, and returns a Vec of materialized deltas per transaction index.
-    pub fn resolve(
+    pub(crate) fn resolve(
         self,
-        aggregator_keys: Vec<(K, anyhow::Result<ResolvedData>)>,
+        base_view: &impl TStateView<Key = T::Key>,
         block_size: usize,
-    ) -> Vec<Vec<(K, WriteOp)>> {
-        let mut ret: Vec<Vec<(K, WriteOp)>> = (0..block_size).map(|_| Vec::new()).collect();
+    ) -> Vec<Vec<(T::Key, WriteOp)>> {
+        let mut ret: Vec<Vec<(T::Key, WriteOp)>> = vec![vec![]; block_size];
 
         // TODO: with more deltas, re-use executor threads and process in parallel.
-        for (key, storage_val) in aggregator_keys.into_iter() {
-            let mut latest_value: Option<u128> = match storage_val
+        for key in self.versioned_outputs.aggregator_keys() {
+            let mut latest_value: Option<u128> = base_view
+                .get_state_value(&key)
                 .ok() // Was anything found in storage
-                .map(|value| value.map(|bytes| deserialize(&bytes)))
-            {
-                None => None,
-                Some(v) => v,
-            };
+                .and_then(|value| value.map(|bytes| deserialize(&bytes)));
 
             let indexed_entries = self
                 .versioned_outputs
@@ -66,7 +61,7 @@ impl<K: Hash + Clone + Eq + Send + 'static, V: TransactionWrite + Send + Sync + 
             }
         }
 
-        spawn(move || drop(self));
+        RAYON_EXEC_POOL.spawn(move || drop(self));
 
         ret
     }

--- a/aptos-move/block-executor/src/proptest_types/bencher.rs
+++ b/aptos-move/block-executor/src/proptest_types/bencher.rs
@@ -118,7 +118,7 @@ where
             EmptyDataView<KeyType<K>, ValueType<V>>,
         >::new(num_cpus::get())
         .execute_transactions_parallel((), &self.transactions, &data_view)
-        .map(|(res, _)| res);
+        .map(|zipped| zipped.into_iter().map(|(res, _)| res).collect());
 
         self.expected_output.assert_output(&output);
     }

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -6,10 +6,9 @@ use crate::{
     executor::BlockExecutor,
     proptest_types::types::{
         DeltaDataView, EmptyDataView, ExpectedOutput, KeyType, Task, Transaction, TransactionGen,
-        TransactionGenParams, ValueType, STORAGE_AGGREGATOR_VALUE,
+        TransactionGenParams, ValueType,
     },
 };
-use aptos_aggregator::delta_change_set::serialize;
 use claims::assert_ok;
 use num_cpus;
 use proptest::{
@@ -57,7 +56,7 @@ fn run_transactions<K, V>(
             EmptyDataView<KeyType<K>, ValueType<V>>,
         >::new(num_cpus::get())
         .execute_transactions_parallel((), &transactions, &data_view)
-        .map(|(res, _)| res);
+        .map(|zipped| zipped.into_iter().map(|(res, _)| res).collect());
 
         if module_access.0 && module_access.1 {
             assert_eq!(output.unwrap_err(), Error::ModulePathReadWrite);
@@ -166,9 +165,10 @@ fn deltas_writes_mixed() {
     .expect("creating a new value should succeed")
     .current();
 
+    // Do not allow deletions as resolver can't apply delta to a deleted aggregator.
     let transactions: Vec<_> = transaction_gen
         .into_iter()
-        .map(|txn_gen| txn_gen.materialize_with_deltas(&universe, 15, true))
+        .map(|txn_gen| txn_gen.materialize_with_deltas(&universe, 15, false))
         .collect();
 
     let data_view = DeltaDataView::<KeyType<[u8; 32]>, ValueType<[u8; 32]>> {
@@ -182,7 +182,7 @@ fn deltas_writes_mixed() {
             DeltaDataView<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
         >::new(num_cpus::get())
         .execute_transactions_parallel((), &transactions, &data_view)
-        .map(|(res, _)| res);
+        .map(|zipped| zipped.into_iter().map(|(res, _)| res).collect());
 
         let baseline = ExpectedOutput::generate_baseline(&transactions, None);
         baseline.assert_output(&output);
@@ -217,25 +217,15 @@ fn deltas_resolver() {
         .collect();
 
     for _ in 0..20 {
-        let output = BlockExecutor::<
+        let (output, resolved) = BlockExecutor::<
             Transaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             Task<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             DeltaDataView<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
         >::new(num_cpus::get())
-        .execute_transactions_parallel((), &transactions, &data_view);
-
-        let (output, delta_resolver) = output.unwrap();
-        let resolved = delta_resolver.resolve(
-            (15..50)
-                .map(|i| {
-                    (
-                        KeyType(universe[i], false),
-                        Ok(Some(serialize(&STORAGE_AGGREGATOR_VALUE))),
-                    )
-                })
-                .collect(),
-            num_txns,
-        );
+        .execute_transactions_parallel((), &transactions, &data_view)
+        .unwrap()
+        .into_iter()
+        .unzip();
 
         let baseline = ExpectedOutput::generate_baseline(&transactions, Some(resolved));
         baseline.assert_output(&Ok(output));
@@ -405,8 +395,7 @@ fn publishing_fixed_params() {
             Task<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             DeltaDataView<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
         >::new(num_cpus::get())
-        .execute_transactions_parallel((), &transactions, &data_view)
-        .map(|(res, _)| res);
+        .execute_transactions_parallel((), &transactions, &data_view);
 
         assert_eq!(output.unwrap_err(), Error::ModulePathReadWrite);
     }

--- a/aptos-move/block-executor/src/scheduler.rs
+++ b/aptos-move/block-executor/src/scheduler.rs
@@ -156,11 +156,6 @@ impl Scheduler {
         }
     }
 
-    /// Return the number of transactions to be executed from the block.
-    pub fn num_txn_to_execute(&self) -> usize {
-        self.num_txns
-    }
-
     /// Try to abort version = (txn_idx, incarnation), called upon validation failure.
     /// When the invocation manages to update the status of the transaction, it changes
     /// Executed(incarnation) => Aborting(incarnation), it returns true. Otherwise,

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -59,7 +59,7 @@ pub trait ExecutorTask: Sync {
     type Output: TransactionOutput<Txn = Self::Txn> + 'static;
 
     /// Type of error when the executor failed to process a transaction and needs to abort.
-    type Error: Clone + Send + Sync + 'static;
+    type Error: Clone + Send + Sync + Eq + 'static;
 
     /// Type to intialize the single thread transaction executor. Copy and Sync are required because
     /// we will create an instance of executor on each individual thread.
@@ -78,7 +78,7 @@ pub trait ExecutorTask: Sync {
     ) -> ExecutionStatus<Self::Output, Self::Error>;
 }
 
-/// Trait for execution result of a transaction.
+/// Trait for execution result of a single transaction.
 pub trait TransactionOutput: Send + Sync {
     /// Type of transaction and its associated key and value.
     type Txn: Transaction;

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -29,7 +29,7 @@ where
     let output =
         BlockExecutor::<Transaction<K, V>, Task<K, V>, DeltaDataView<K, V>>::new(num_cpus::get())
             .execute_transactions_parallel((), &transactions, &data_view)
-            .map(|(res, _)| res);
+            .map(|zipped| zipped.into_iter().map(|(res, _)| res).collect());
 
     let baseline = ExpectedOutput::generate_baseline(&transactions, None);
 

--- a/aptos-move/mvhashmap/Cargo.toml
+++ b/aptos-move/mvhashmap/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-aggregator = { workspace = true }
+aptos-infallible = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
 crossbeam = { workspace = true }

--- a/aptos-move/mvhashmap/src/lib.rs
+++ b/aptos-move/mvhashmap/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_aggregator::{delta_change_set::DeltaOp, transaction::AggregatorValue};
+use aptos_infallible::Mutex;
 use aptos_types::write_set::TransactionWrite;
 use crossbeam::utils::CachePadded;
 use dashmap::DashMap;
@@ -69,6 +70,28 @@ impl<V> Entry<V> {
     }
 }
 
+pub(crate) struct VersionedValue<V> {
+    pub(crate) versioned_map: BTreeMap<TxnIndex, CachePadded<Entry<V>>>,
+    // Note: this can cache base (storage) value in Option<u128> to facilitate
+    // aggregator validation & reading in the future, if needed.
+    pub(crate) contains_delta: bool,
+}
+
+impl<V: TransactionWrite> VersionedValue<V> {
+    pub fn new() -> Self {
+        Self {
+            versioned_map: BTreeMap::new(),
+            contains_delta: false,
+        }
+    }
+}
+
+impl<V: TransactionWrite> Default for VersionedValue<V> {
+    fn default() -> Self {
+        VersionedValue::new()
+    }
+}
+
 /// Main multi-version data-structure used by threads to read/write during parallel
 /// execution. Maps each access path to an interal BTreeMap that contains the indices
 /// of transactions that write at the given access path alongside the corresponding
@@ -78,7 +101,8 @@ impl<V> Entry<V> {
 /// given key, it holds exclusive access and doesn't need to explicitly synchronize
 /// with other reader/writers.
 pub struct MVHashMap<K, V> {
-    data: DashMap<K, BTreeMap<TxnIndex, CachePadded<Entry<V>>>>,
+    data: DashMap<K, VersionedValue<V>>,
+    delta_keys: Mutex<Vec<K>>,
 }
 
 /// Returned as Err(..) when failed to read from the multi-version data-structure.
@@ -106,18 +130,25 @@ pub enum MVHashMapOutput<V> {
     Version(Version, Arc<V>),
 }
 
-pub type Result<V> = anyhow::Result<MVHashMapOutput<V>, MVHashMapError>;
-
 impl<K: Hash + Clone + Eq, V: TransactionWrite> MVHashMap<K, V> {
     pub fn new() -> MVHashMap<K, V> {
         MVHashMap {
             data: DashMap::new(),
+            delta_keys: Mutex::new(Vec::new()),
         }
     }
 
     /// For processing outputs - removes the BTreeMap from the MVHashMap.
     pub fn entry_map_for_key(&self, key: &K) -> Option<BTreeMap<TxnIndex, CachePadded<Entry<V>>>> {
-        self.data.remove(key).map(|(_, tree)| tree)
+        self.data
+            .remove(key)
+            .map(|(_, v)| v)
+            .map(|p| p.versioned_map)
+    }
+
+    /// Returns the list of keys that had an associated delta entry at any prior point.
+    pub fn aggregator_keys(&self) -> Vec<K> {
+        std::mem::take(&mut self.delta_keys.lock())
     }
 
     /// Add a write of versioned data at a specified key. If the entry is overwritten, asserts
@@ -125,8 +156,8 @@ impl<K: Hash + Clone + Eq, V: TransactionWrite> MVHashMap<K, V> {
     pub fn add_write(&self, key: &K, version: Version, data: V) {
         let (txn_idx, incarnation) = version;
 
-        let mut map = self.data.entry(key.clone()).or_default();
-        let prev_entry = map.insert(
+        let mut v = self.data.entry(key.clone()).or_default();
+        let prev_entry = v.versioned_map.insert(
             txn_idx,
             CachePadded::new(Entry::new_write_from(FLAG_DONE, incarnation, data)),
         );
@@ -143,18 +174,24 @@ impl<K: Hash + Clone + Eq, V: TransactionWrite> MVHashMap<K, V> {
 
     /// Add a delta at a specified key.
     pub fn add_delta(&self, key: &K, txn_idx: usize, delta: DeltaOp) {
-        let mut map = self.data.entry(key.clone()).or_default();
-        map.insert(
+        let mut v = self.data.entry(key.clone()).or_default();
+        v.versioned_map.insert(
             txn_idx,
             CachePadded::new(Entry::new_delta_from(FLAG_DONE, delta)),
         );
+
+        if !v.contains_delta {
+            v.contains_delta = true;
+            self.delta_keys.lock().push(key.clone());
+        }
     }
 
     /// Mark an entry from transaction 'txn_idx' at access path 'key' as an estimated write
     /// (for future incarnation). Will panic if the entry is not in the data-structure.
     pub fn mark_estimate(&self, key: &K, txn_idx: TxnIndex) {
-        let map = self.data.get(key).expect("Path must exist");
-        map.get(&txn_idx)
+        let v = self.data.get(key).expect("Path must exist");
+        v.versioned_map
+            .get(&txn_idx)
             .expect("Entry by txn must exist")
             .mark_estimate();
     }
@@ -163,23 +200,27 @@ impl<K: Hash + Clone + Eq, V: TransactionWrite> MVHashMap<K, V> {
     /// if the access path has never been written before.
     pub fn delete(&self, key: &K, txn_idx: TxnIndex) {
         // TODO: investigate logical deletion.
-        let mut map = self.data.get_mut(key).expect("Path must exist");
-        map.remove(&txn_idx);
+        let mut v = self.data.get_mut(key).expect("Path must exist");
+        v.versioned_map.remove(&txn_idx);
     }
 
     /// Read entry from transaction 'txn_idx' at access path 'key'.
-    pub fn read(&self, key: &K, txn_idx: TxnIndex) -> Result<V> {
+    pub fn read(
+        &self,
+        key: &K,
+        txn_idx: TxnIndex,
+    ) -> anyhow::Result<MVHashMapOutput<V>, MVHashMapError> {
         use MVHashMapError::*;
         use MVHashMapOutput::*;
 
         match self.data.get(key) {
-            Some(tree) => {
-                let mut iter = tree.range(0..txn_idx);
+            Some(v) => {
+                let mut iter = v.versioned_map.range(0..txn_idx);
 
                 // If read encounters a delta, it must traverse the block of transactions
                 // (top-down) until it encounters a write or reaches the end of the block.
                 // During traversal, all aggregator deltas have to be accumulated together.
-                let mut accumulator: Option<DeltaOp> = None;
+                let mut accumulator: Option<Result<DeltaOp, ()>> = None;
                 while let Some((idx, entry)) = iter.next_back() {
                     let flag = entry.flag();
 
@@ -207,30 +248,37 @@ impl<K: Hash + Clone + Eq, V: TransactionWrite> MVHashMap<K, V> {
 
                             if maybe_value.is_none() {
                                 // Resolve to the write if the WriteOp was deletion
-                                // (MoveVM will observe 'deletion').
+                                // (MoveVM will observe 'deletion'). This takes precedence
+                                // over any speculative delta accumulation errors on top.
                                 let write_version = (*idx, *incarnation);
                                 return Ok(Version(write_version, data.clone()));
                             }
-
-                            return accumulator
-                                .apply_to(maybe_value.unwrap().into())
-                                .map_err(|_| DeltaApplicationFailure)
-                                .map(|result| Resolved(result));
+                            return accumulator.map_err(|_| DeltaApplicationFailure).and_then(
+                                |a| {
+                                    // Apply accumulated delta to resolve the aggregator value.
+                                    a.apply_to(maybe_value.unwrap().into())
+                                        .map(|result| Resolved(result))
+                                        .map_err(|_| DeltaApplicationFailure)
+                                },
+                            );
                         },
                         (EntryCell::Delta(delta), Some(accumulator)) => {
-                            // Read hit a delta during traversing the
-                            // block and aggregating other deltas. Merge
-                            // two deltas together. If Delta application
-                            // fails, we return a corresponding error, so that
-                            // the speculative execution can also fail.
-                            accumulator
-                                .merge_onto(*delta)
-                                .map_err(|_| DeltaApplicationFailure)?;
+                            *accumulator = accumulator.and_then(|mut a| {
+                                // Read hit a delta during traversing the block and aggregating
+                                // other deltas. Merge two deltas together. If Delta application
+                                // fails, we record an error, but continue processing (to e.g.
+                                // account for the case when the aggregator was deleted).
+                                if a.merge_onto(*delta).is_err() {
+                                    Err(())
+                                } else {
+                                    Ok(a)
+                                }
+                            });
                         },
                         (EntryCell::Delta(delta), None) => {
                             // Read hit a delta and must start accumulating.
                             // Initialize the accumulator and continue traversal.
-                            accumulator = Some(*delta)
+                            accumulator = Some(Ok(*delta))
                         },
                     }
                 }
@@ -239,7 +287,8 @@ impl<K: Hash + Clone + Eq, V: TransactionWrite> MVHashMap<K, V> {
                 // deltas the actual written value has not been seen yet (i.e.
                 // it is not added as an entry to the data-structure).
                 match accumulator {
-                    Some(accumulator) => Err(Unresolved(accumulator)),
+                    Some(Ok(accumulator)) => Err(Unresolved(accumulator)),
+                    Some(Err(_)) => Err(DeltaApplicationFailure),
                     None => Err(NotFound),
                 }
             },


### PR DESCRIPTION
Another follow-up in the ongoing refactoring stream:
(1) Get rid of ugly process_parallel/sequential_output dispatching.
(2) MVHashMap improvements: 
- track aggregator paths (paths that have had a delta)
- fix the error precedence over delta aggregation. not relevant to the current limited (e.g. total supply) uses, but still.
(3) Make delta resolution an internal implementation detail of block executor
- use the MVHashMap records to avoid traversing all outputs sequentially to find delta paths

In the future, we will do output (& delta, final logging) resolution in parallel by post-processing tasks after we have the rolling commit (@danielxiangzl), but most of the improvements in this PR are useful regardless.
The next follow-up on block-executor will be refactoring prop-tests and adding more aggregator tests (including for sequential execution).
The next follow-up for aptos-vm will be logging (removing circular dependencies w. block-executor, only logging final execution logs & knowing the txn versions)
