### PR TITLE
Update dev_setup.sh

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -628,7 +628,7 @@ function install_nodejs {
 }
 
 function install_pnpm {
-    curl -fsSL https://get.pnpm.io/install.sh | "${PRE_COMMAND[@]}" env PNPM_VERSION=7.14.2 bash -
+    curl -fsSL https://get.pnpm.io/install.sh | "${PRE_COMMAND[@]}" env PNPM_VERSION=7.14.2 SHELL="$(which bash)" bash -
 }
 
 function install_python3 {


### PR DESCRIPTION
Change command for installing pnpm.

### Description
```
Password:
==> Extracting pnpm binaries 7.14.2
Copying pnpm CLI from /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.qP7xV27b/pnpm to /Users/jiwon/Library/pnpm/pnpm
 ERR_PNPM_UNSUPPORTED_SHELL  Can't setup configuration for "sh" shell. Supported shell languages are bash, zsh, and fish.
Install Error!
```

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
```
==> Extracting pnpm binaries 7.14.2
Copying pnpm CLI from /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.WQxdq0fU/pnpm to ~/pnpm/pnpm
Created ~/.bashrc

Next configuration changes were made:
export PNPM_HOME="~/pnpm"
export PATH="$PNPM_HOME:$PATH"
```

I refer this [issue](https://github.com/pnpm/pnpm/issues/3319).
Since `dev_setup.sh` doesn't work, I could not follow a instruction below.
![image](https://user-images.githubusercontent.com/48719289/208399055-34e3e878-6e2b-41a8-8636-6385e682916b.png)
