### PR TITLE
[gha] run forge once a day, continuous forge twice a day

### DIFF
--- a/.github/workflows/continuous-e2e-account-creation-test.yaml
+++ b/.github/workflows/continuous-e2e-account-creation-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   ### Please remember to use different namespace for different tests

--- a/.github/workflows/continuous-e2e-changing-working-quorum-test copy.yaml
+++ b/.github/workflows/continuous-e2e-changing-working-quorum-test copy.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   ### Please remember to use different namespace for different tests

--- a/.github/workflows/continuous-e2e-changing-working-quorum-test-high-load.yaml
+++ b/.github/workflows/continuous-e2e-changing-working-quorum-test-high-load.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   ### Please remember to use different namespace for different tests

--- a/.github/workflows/continuous-e2e-compat-test.yaml
+++ b/.github/workflows/continuous-e2e-compat-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   run-forge-compat:

--- a/.github/workflows/continuous-e2e-consensus-stress-test.yaml
+++ b/.github/workflows/continuous-e2e-consensus-stress-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   ### Please remember to use different namespace for different tests

--- a/.github/workflows/continuous-e2e-different-node-speed-and-reliability-test.yaml
+++ b/.github/workflows/continuous-e2e-different-node-speed-and-reliability-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   ### Please remember to use different namespace for different tests

--- a/.github/workflows/continuous-e2e-forge-continuous.yaml
+++ b/.github/workflows/continuous-e2e-forge-continuous.yaml
@@ -2,7 +2,7 @@ name: "Forge Continuous"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 9,3 * * *"
   pull_request:
     paths:
       - ".github/workflows/forge-continuous.yaml"

--- a/.github/workflows/continuous-e2e-full-node-reboot-stress-test.yaml
+++ b/.github/workflows/continuous-e2e-full-node-reboot-stress-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   run-forge-fullnode-reboot-stress-test:

--- a/.github/workflows/continuous-e2e-graceful-overload-test.yaml
+++ b/.github/workflows/continuous-e2e-graceful-overload-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   ### Please remember to use different namespace for different tests

--- a/.github/workflows/continuous-e2e-haproxy-test.yaml
+++ b/.github/workflows/continuous-e2e-haproxy-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   run-forge-haproxy:

--- a/.github/workflows/continuous-e2e-network-latency-test.yaml
+++ b/.github/workflows/continuous-e2e-network-latency-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   # Test under sub optimal circumstances (network delay)

--- a/.github/workflows/continuous-e2e-network-latency-with-different-node-speed-test.yaml
+++ b/.github/workflows/continuous-e2e-network-latency-with-different-node-speed-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   # Test under sub optimal circumstances (network delay and different node processing speed)

--- a/.github/workflows/continuous-e2e-network-partition-test.yaml
+++ b/.github/workflows/continuous-e2e-network-partition-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   run-forge-network-partition-test:

--- a/.github/workflows/continuous-e2e-nft-mint-test.yaml
+++ b/.github/workflows/continuous-e2e-nft-mint-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   ### Please remember to use different namespace for different tests

--- a/.github/workflows/continuous-e2e-performance-test.yaml
+++ b/.github/workflows/continuous-e2e-performance-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   ### Please remember to use different namespace for different tests

--- a/.github/workflows/continuous-e2e-release-test.yaml
+++ b/.github/workflows/continuous-e2e-release-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
   pull_request:
     paths:
       - ".github/workflows/run-forge.yaml"

--- a/.github/workflows/continuous-e2e-single-vfn-test.yaml
+++ b/.github/workflows/continuous-e2e-single-vfn-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   # Test transaction processing throughput at a single VFN

--- a/.github/workflows/continuous-e2e-state-sync-failures-catching-up-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-failures-catching-up-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   run-forge-state-sync-failures-catching-up-test:

--- a/.github/workflows/continuous-e2e-state-sync-perf-fullnode-apply-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-perf-fullnode-apply-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   # Performance test in an optimal setting

--- a/.github/workflows/continuous-e2e-state-sync-perf-fullnode-execute-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-perf-fullnode-execute-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   # Performance test in an optimal setting

--- a/.github/workflows/continuous-e2e-state-sync-perf-fullnode-fast-sync-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-perf-fullnode-fast-sync-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   # Performance test in an optimal setting

--- a/.github/workflows/continuous-e2e-state-sync-perf-validator-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-perf-validator-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   # Performance test in an optimal setting

--- a/.github/workflows/continuous-e2e-state-sync-slow-processing-catching-up-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-slow-processing-catching-up-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   run-forge-state-sync-slow-processing-catching-up-test:

--- a/.github/workflows/continuous-e2e-twin-validator-test.yaml
+++ b/.github/workflows/continuous-e2e-twin-validator-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   run-forge-twin-validator-test:

--- a/.github/workflows/continuous-e2e-validator-reboot-stress-test.yaml
+++ b/.github/workflows/continuous-e2e-validator-reboot-stress-test.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "0 9 * * *"
 
 jobs:
   run-forge-validator-reboot-stress-test:


### PR DESCRIPTION
### Description

9am forge test runs
continuous suite runs 9am, 3pm

tune down test intervals for the holidays to reflect lower commit rate

also rename some files so forge tests are easier to find in `.github`. They are all prefixed `continuous-e2e-*` now

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
