### PR TITLE
Add framework for CLI tests

### DIFF
--- a/crates/aptos/e2e/README.md
+++ b/crates/aptos/e2e/README.md
@@ -1,0 +1,6 @@
+# CLI test suite
+
+This directory contains Python code to help with running the CLI test suite. For usage instructions, try this:
+```
+python3 main.py -h
+```

--- a/crates/aptos/e2e/cases/account.py
+++ b/crates/aptos/e2e/cases/account.py
@@ -1,0 +1,32 @@
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+
+from common import ACCOUNT_ONE
+
+
+def test_account_fund_with_faucet(run_helper):
+    run_helper.run_command(
+        "test_account_fund_with_faucet",
+        [
+            "aptos",
+            "account",
+            "fund-with-faucet",
+            "--account",
+            run_helper.get_account_info().account_address,
+        ],
+    )
+
+
+def test_account_create(run_helper):
+    run_helper.run_command(
+        "test_account_create",
+        [
+            "aptos",
+            "account",
+            "create",
+            "--account",
+            ACCOUNT_ONE.account_address,
+            "--assume-yes",
+        ],
+    )

--- a/crates/aptos/e2e/cases/init.py
+++ b/crates/aptos/e2e/cases/init.py
@@ -1,0 +1,10 @@
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+
+def test_init(run_helper):
+    run_helper.run_command(
+        "test_init",
+        ["aptos", "init", "--assume-yes", "--network", "local"],
+        input="\n",
+    )

--- a/crates/aptos/e2e/common.py
+++ b/crates/aptos/e2e/common.py
@@ -1,0 +1,33 @@
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+NODE_PORT = 8080
+FAUCET_PORT = 8081
+
+
+class Network(Enum):
+    DEVNET = "devnet"
+    TESTNET = "testnet"
+    MAINNET = "mainnet"
+
+    def __str__(self):
+        return self.value
+
+
+# Information for some accounts we use for testing.
+@dataclass
+class AccountInfo:
+    private_key: str
+    public_key: str
+    account_address: str
+
+
+ACCOUNT_ONE = AccountInfo(
+    private_key="0x37368b46ce665362562c6d1d4ec01a08c8644c488690df5a17e13ba163e20221",
+    public_key="0x25caf00522e4d4664ec0a27166a69e8a32b5078959d0fc398da70d40d2893e8f",
+    account_address="0x585fc9f0f0c54183b039ffc770ca282ebd87307916c215a3e692f2f8e4305e82",
+)

--- a/crates/aptos/e2e/local_testnet.py
+++ b/crates/aptos/e2e/local_testnet.py
@@ -1,0 +1,87 @@
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+# This file contains functions for running the local testnet.
+
+import logging
+import subprocess
+import time
+
+from urllib.request import urlopen
+
+from common import FAUCET_PORT, NODE_PORT, Network
+
+LOG = logging.getLogger(__name__)
+
+# Run a local testnet in a docker container. We choose to detach here and we'll
+# stop running it later using the container name.
+def run_node(network: Network, image_repo: str):
+    image_name = build_image_name(network, image_repo)
+    container_name = f"aptos-tools-{network}"
+    LOG.info(f"Trying to run aptos CLI local testnet from image: {image_name}")
+
+    # First delete the existing container if there is one with the same name.
+    subprocess.run(
+        ["docker", "rm", "-f", container_name],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    # Run the container.
+    subprocess.check_output(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--detach",
+            "--name",
+            container_name,
+            "-p",
+            f"{NODE_PORT}:{NODE_PORT}",
+            "-p",
+            f"{FAUCET_PORT}:{FAUCET_PORT}",
+            image_name,
+            "aptos",
+            "node",
+            "run-local-testnet",
+            "--with-faucet",
+        ],
+    )
+    LOG.info(f"Running aptos CLI local testnet from image: {image_name}")
+    return container_name
+
+
+# Stop running the detached node.
+def stop_node(container_name: str):
+    LOG.info(f"Stopping container: {container_name}")
+    subprocess.check_output(["docker", "stop", container_name])
+    LOG.info(f"Stopped container: {container_name}")
+
+
+# Query the node and faucet APIs until they start up or we timeout.
+def wait_for_startup(container_name: str, timeout: int):
+    LOG.info(f"Waiting for node and faucet APIs for {container_name} to come up")
+    count = 0
+    api_response = None
+    faucet_response = None
+    while True:
+        try:
+            api_response = urlopen(f"http://127.0.0.1:{NODE_PORT}/v1")
+            faucet_response = urlopen(f"http://127.0.0.1:{FAUCET_PORT}/health")
+            if api_response.status != 200 or faucet_response.status != 200:
+                raise RuntimeError(
+                    f"API or faucet not ready. API response: {api_response}. "
+                    f"Faucet response: {faucet_response}"
+                )
+            break
+        except Exception:
+            if count >= timeout:
+                LOG.error(f"Timeout while waiting for node / faucet to come up")
+                raise
+            count += 1
+            time.sleep(1)
+    LOG.info(f"Node and faucet APIs for {container_name} came up")
+
+
+def build_image_name(network: Network, image_repo: str):
+    return f"{image_repo}aptoslabs/tools:{network}"

--- a/crates/aptos/e2e/main.py
+++ b/crates/aptos/e2e/main.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This script is how we orchestrate running a local testnet and then running CLI tests against it. There are two different CLIs used for this:
+
+1. Base: For running the local testnet. This is what the --base-network flag and all other flags starting with --base are for.
+2. Test: The CLI that we're testing. This is what the --test-cli-tag / --test-cli-path and all other flags starting with --test are for.
+
+Example (testing CLI in image):
+  python3 main.py --base-network testnet --test-cli-tag mainnet_0431e2251d0b42920d89a52c63439f7b9eda6ac3
+
+Example (testing locally built CLI binary):
+  python3 main.py --base-network devnet --test-cli-path ~/aptos-core/target/release/aptos
+
+This means, run the CLI test suite using a CLI built from mainnet_0431e2251d0b42920d89a52c63439f7b9eda6ac3 against a local testnet built from the testnet branch of aptos-core.
+
+When the test suite is complete, it will tell you which tests passed and which failed. To further debug a failed test, you can check the output in --working-directory, there will be files for each test containing the command run, stdout, stderr, and any exception.
+"""
+
+import argparse
+import logging
+import pathlib
+import shutil
+import sys
+
+from cases.account import test_account_create, test_account_fund_with_faucet
+from cases.init import test_init
+from common import Network
+from test_helpers import RunHelper
+from local_testnet import run_node, stop_node, wait_for_startup
+
+logging.basicConfig(
+    stream=sys.stderr,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    level=logging.INFO,
+)
+
+LOG = logging.getLogger(__name__)
+
+
+def parse_args():
+    # You'll notice there are two argument "prefixes", base and test. These refer to
+    # cases 1 and 2 in the top-level comment.
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=__doc__,
+    )
+    parser.add_argument("-d", "--debug", action="store_true")
+    parser.add_argument(
+        "--image-repo",
+        help="What docker image repo to use for the local testnet. By default we use Docker Hub.",
+    )
+    parser.add_argument(
+        "--base-network",
+        required=True,
+        type=Network,
+        choices=list(Network),
+        help="What branch the Aptos CLI used for the local testnet should be built from",
+    )
+    parser.add_argument(
+        "--base-startup-timeout",
+        type=int,
+        default=30,
+        help="Timeout in seconds for waiting for node and faucet to start up",
+    )
+    test_cli_args = parser.add_mutually_exclusive_group(required=True)
+    test_cli_args.add_argument(
+        "--test-cli-tag",
+        help="The image tag for the CLI we want to test, e.g. mainnet_0431e2251d0b42920d89a52c63439f7b9eda6ac3",
+    )
+    test_cli_args.add_argument(
+        "--test-cli-path",
+        help="Path to CLI binary we want to test, e.g. /home/dport/aptos-core/target/release/aptos",
+    )
+    parser.add_argument(
+        "--working-directory",
+        default="/tmp/aptos-cli-tests",
+        help="Where we'll run CLI commands from (in the host system). Default: %(default)s",
+    )
+    args = parser.parse_args()
+    args.image_repo = args.image_repo or ""
+    return args
+
+
+def run_tests(run_helper):
+    # Run init tests. We run these first to set up the CLI.
+    test_init(run_helper)
+
+    # Run account tests.
+    test_account_fund_with_faucet(run_helper)
+    test_account_create(run_helper)
+
+
+def main():
+    args = parse_args()
+
+    if args.debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+        LOG.debug("Debug logging enabled")
+    else:
+        logging.getLogger().setLevel(logging.INFO)
+
+    # Run a node + faucet and wait for them to start up.
+    container_name = run_node(args.base_network, args.image_repo)
+    wait_for_startup(container_name, args.base_startup_timeout)
+
+    # Create the dir the test CLI will run from.
+    shutil.rmtree(args.working_directory, ignore_errors=True)
+    pathlib.Path(args.working_directory).mkdir(parents=True, exist_ok=True)
+
+    # Build the RunHelper object.
+    run_helper = RunHelper(
+        host_working_directory=args.working_directory,
+        image_repo=args.image_repo,
+        image_tag=args.test_cli_tag,
+        cli_path=args.test_cli_path,
+    )
+
+    # Prepare the run helper. This ensures in advance that everything needed is there.
+    run_helper.prepare()
+
+    # Run tests.
+    run_tests(run_helper)
+
+    # Stop the node + faucet.
+    stop_node(container_name)
+
+    if run_helper.passed_tests:
+        LOG.info("These tests passed:")
+        for test_name in run_helper.passed_tests:
+            LOG.info(test_name)
+
+    if run_helper.failed_tests:
+        LOG.error("These tests failed:")
+        for test_name in run_helper.failed_tests:
+            LOG.error(test_name)
+        return False
+
+    LOG.info("All tests passed!")
+    return True
+
+
+if __name__ == "__main__":
+    if main():
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/crates/aptos/e2e/test_helpers.py
+++ b/crates/aptos/e2e/test_helpers.py
@@ -1,0 +1,161 @@
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import os
+import pathlib
+import subprocess
+import traceback
+import typing
+
+from dataclasses import dataclass
+
+from common import AccountInfo
+
+LOG = logging.getLogger(__name__)
+
+WORKING_DIR_IN_CONTAINER = "/tmp"
+
+# We pass this class into all test functions to help with calling the CLI,
+# collecting output, and accessing common info.
+@dataclass
+class RunHelper:
+    host_working_directory: str
+    image_repo: str
+    image_tag: str
+    cli_path: str
+    passed_tests: typing.List[str]
+    failed_tests: typing.List[str]
+
+    def __init__(self, host_working_directory, image_repo, image_tag, cli_path):
+        if image_tag and cli_path:
+            raise RuntimeError("Cannot specify both image_tag and cli_path")
+        if not (image_tag or cli_path):
+            raise RuntimeError("Must specify one of image_tag and cli_path")
+        self.host_working_directory = host_working_directory
+        self.image_repo = image_repo
+        self.image_tag = image_tag
+        self.cli_path = cli_path
+        self.passed_tests = []
+        self.failed_tests = []
+
+    def build_image_name(self):
+        return f"{self.image_repo}aptoslabs/tools:{self.image_tag}"
+
+    # This function lets you pass call the CLI like you would normally, but really it is
+    # calling the CLI in a docker container and mounting the host working directory such
+    # that the container will write it results out to that directory. That way the CLI
+    # state / configuration is preserved between test cases.
+    def run_command(self, test_name, command, *args, **kwargs):
+        LOG.info(f"Running test: {test_name}")
+
+        # Build command.
+        if self.image_tag:
+            full_command = [
+                "docker",
+                "run",
+                "--rm",
+                "--network",
+                "host",
+                "-i",
+                "-v",
+                f"{self.host_working_directory}:{WORKING_DIR_IN_CONTAINER}",
+                "--workdir",
+                WORKING_DIR_IN_CONTAINER,
+                self.build_image_name(),
+            ] + command
+        else:
+            full_command = [self.cli_path] + command[1:]
+        LOG.debug(f"Running command: {full_command}")
+
+        # Create the output directory if necessary.
+        out_path = os.path.join(self.host_working_directory, "out")
+        pathlib.Path(out_path).mkdir(exist_ok=True)
+
+        # Write the command we're going to run to file.
+        with open(os.path.join(out_path, f"{test_name}.command"), "w") as f:
+            f.write(" ".join(command))
+
+        # Run command.
+        try:
+            # If we're using a local CLI, set the working directory for subprocess.run.
+            if self.cli_path:
+                kwargs["cwd"] = self.host_working_directory
+            result = subprocess.run(
+                full_command,
+                *args,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                universal_newlines=True,
+                **kwargs,
+            )
+            LOG.info(f"Test passed: {test_name}")
+            self.passed_tests.append(test_name)
+
+            out = result
+        except Exception as e:
+            LOG.warn(f"Test failed: {test_name}")
+            self.failed_tests.append(test_name)
+
+            # Write the exception to file.
+            with open(os.path.join(out_path, f"{test_name}.exception"), "w") as f:
+                f.write(
+                    "".join(
+                        traceback.format_exception(
+                            etype=type(e), value=e, tb=e.__traceback__
+                        )
+                    )
+                )
+
+            # Fortunately the result and exception of subprocess.run both have the
+            # stdout and stderr attributes on them.
+            out = e
+
+        LOG.debug(f"Stdout: {out.stdout}")
+        LOG.debug(f"Stderr: {out.stderr}")
+
+        # Write stdout and stderr to file.
+        with open(os.path.join(out_path, f"{test_name}.stdout"), "w") as f:
+            f.write(out.stdout)
+        with open(os.path.join(out_path, f"{test_name}.stderr"), "w") as f:
+            f.write(out.stderr)
+
+        return out
+
+    # If image_Tag is set, pull the test CLI image. We don't technically have to do
+    # this separately but it makes the steps clearer. Otherwise, cli_path must be
+    # set, in which case we ensure the file is there.
+    def prepare(self):
+        if self.image_tag:
+            command = ["docker", "pull", self.build_image_name()]
+            LOG.debug(f"Running command: {command}")
+            output = subprocess.check_output(command)
+            LOG.debug(f"Output: {output}")
+        else:
+            if not os.path.isfile(self.cli_path):
+                raise RuntimeError(f"CLI not found at path: {self.cli_path}")
+
+    # Get the account info of the account created by test_init.
+    def get_account_info(self):
+        path = os.path.join(self.host_working_directory, ".aptos", "config.yaml")
+        with open(path) as f:
+            content = f.read().splitlines()
+        # To avoid using external deps we parse the file manually.
+        private_key = None
+        public_key = None
+        account_address = None
+        for line in content:
+            if "private_key: " in line:
+                private_key = line.split("private_key: ")[1].replace('"', "")
+            if "public_key: " in line:
+                public_key = line.split("public_key: ")[1].replace('"', "")
+            if "account: " in line:
+                account_address = line.split("account: ")[1].replace('"', "")
+        if not private_key or not public_key or not account_address:
+            raise RuntimeError(f"Failed to parse {path} to get account info")
+        return AccountInfo(
+            private_key=private_key,
+            public_key=public_key,
+            account_address=account_address,
+        )


### PR DESCRIPTION
## Description
This PR adds a framework for running aptos CLI tests and a few tests to boot. See the comment in main.py for more information on how this works.

This is pretty custom, we could look at using some existing framework if anyone has something to suggest.

### Test Plan
```
python3 main.py -d --base-network mainnet --test-cli-tag mainnet_0431e2251d0b42920d89a52c63439f7b9eda6ac3
```
This will result in output like this:
```
$ ls -1aR /tmp/aptos-cli-tests
.
..
.aptos
out

/tmp/aptos-cli-tests/.aptos:
.
..
config.yaml

/tmp/aptos-cli-tests/out:
.
..
test_account_create.command
test_account_create.stderr
test_account_create.stdout
test_account_fund_with_faucet.command
test_account_fund_with_faucet.stderr
test_account_fund_with_faucet.stdout
test_init.command
test_init.stderr
test_init.stdout
```

I also tested the local CLI case (as opposed to the above where it uses the CLI from an image).