### PR TITLE
[cargo] Change stack size to 8MB on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,3 +16,16 @@ rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes", "-C", 
 
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["--cfg", "tokio_unstable", "-C", "link-arg=-fuse-ld=lld", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes"]
+
+# 64 bit MSVC
+[target.x86_64-pc-windows-msvc]
+rustflags = [
+  "--cfg",
+  "tokio_unstable",
+  "-C",
+  "force-frame-pointers=yes",
+  "-C",
+  "force-unwind-tables=yes",
+  "-C",
+  "link-arg=/STACK:8000000" # Set stack to 8 MB
+]


### PR DESCRIPTION
### Description
The linker has to be set for the stack size in Windows, and by default it's set to 1MB, which is too small for the Move compiler.  More info
here: https://users.rust-lang.org/t/stack-overflow-when-compiling-on-windows-10/50818/6

### Test Plan
Ran with a Windows VM, didn't get any out of memory errors

### Related issue
https://github.com/aptos-labs/aptos-core/issues/5474
