### PR TITLE
[State Sync] Add a config flag around auto-bootstrapping.

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -285,6 +285,10 @@ where
         template.execution.num_proof_reading_threads = 1;
         template.peer_monitoring_service.max_concurrent_requests = 1;
         template.mempool.shared_mempool_max_concurrent_inbound_syncs = 1;
+        template
+            .state_sync
+            .state_sync_driver
+            .enable_auto_bootstrapping = true;
 
         let validator_network = template.validator_network.as_mut().unwrap();
         validator_network.max_concurrent_network_reqs = 1;

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -68,9 +68,10 @@ pub struct StateSyncDriverConfig {
     pub bootstrapping_mode: BootstrappingMode, // The mode by which to bootstrap
     pub commit_notification_timeout_ms: u64, // The max time taken to process a commit notification
     pub continuous_syncing_mode: ContinuousSyncingMode, // The mode by which to sync after bootstrapping
+    pub enable_auto_bootstrapping: bool, // Enable auto-bootstrapping if no peers are found after `max_connection_deadline_secs`
     pub fallback_to_output_syncing_secs: u64, // The duration to fallback to output syncing after an execution failure
     pub progress_check_interval_ms: u64, // The interval (ms) at which to check state sync progress
-    pub max_connection_deadline_secs: u64, // The max time (secs) to wait for connections from peers
+    pub max_connection_deadline_secs: u64, // The max time (secs) to wait for connections from peers before auto-bootstrapping
     pub max_consecutive_stream_notifications: u64, // The max number of notifications to process per driver loop
     pub max_num_stream_timeouts: u64, // The max number of stream timeouts allowed before termination
     pub max_pending_data_chunks: u64, // The max number of data chunks pending execution or commit
@@ -86,6 +87,7 @@ impl Default for StateSyncDriverConfig {
             bootstrapping_mode: BootstrappingMode::ApplyTransactionOutputsFromGenesis,
             commit_notification_timeout_ms: 5000,
             continuous_syncing_mode: ContinuousSyncingMode::ApplyTransactionOutputs,
+            enable_auto_bootstrapping: false,
             fallback_to_output_syncing_secs: 180, // 3 minutes
             progress_check_interval_ms: 100,
             max_connection_deadline_secs: 10,

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
@@ -523,6 +523,7 @@ impl<
     async fn check_auto_bootstrapping(&mut self) {
         if !self.bootstrapper.is_bootstrapped()
             && self.is_validator()
+            && self.driver_configuration.config.enable_auto_bootstrapping
             && self.driver_configuration.waypoint.version() == 0
         {
             if let Some(start_time) = self.start_time {

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
@@ -244,6 +244,10 @@ async fn create_validator_driver(
 ) {
     let mut node_config = NodeConfig::default();
     node_config.base.role = RoleType::Validator;
+    node_config
+        .state_sync
+        .state_sync_driver
+        .enable_auto_bootstrapping = true;
 
     create_driver_for_tests(node_config, Waypoint::default(), event_key_subscriptions).await
 }

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -145,6 +145,10 @@ impl LocalSwarm {
                         config
                             .state_sync
                             .state_sync_driver
+                            .enable_auto_bootstrapping = true;
+                        config
+                            .state_sync
+                            .state_sync_driver
                             .max_connection_deadline_secs = 1;
                     }
 

--- a/testsuite/smoke-test/src/consensus/consensus_fault_tolerance.rs
+++ b/testsuite/smoke-test/src/consensus/consensus_fault_tolerance.rs
@@ -35,6 +35,10 @@ pub async fn create_swarm(num_nodes: usize, max_block_txns: u64) -> LocalSwarm {
             config
                 .state_sync
                 .state_sync_driver
+                .enable_auto_bootstrapping = true;
+            config
+                .state_sync
+                .state_sync_driver
                 .max_connection_deadline_secs = 3;
         }))
         .build()


### PR DESCRIPTION
### Description
This PR adds a simple config flag around auto-bootstrapping to disable it in production (because it's only really useful for testing environments), i.e., auto-bootstrapping only happens if a node is a validator, it has no peer connections for a sustained period of time, and the waypoint version is genesis. In a production environment, we don't want auto-boostrapping because the node should always have peers.

### Test Plan
Existing test infrastructure.