### PR TITLE
[State Sync] Remove unnecessary panics and expects.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -119,11 +119,11 @@ impl Default for StorageServiceConfig {
     fn default() -> Self {
         Self {
             max_concurrent_requests: 4000,
-            max_epoch_chunk_size: 100,
+            max_epoch_chunk_size: 200,
             max_lru_cache_size: 500, // At ~0.6MiB per chunk, this should take no more than 0.5GiB
             max_network_channel_size: 4000,
             max_network_chunk_bytes: MAX_MESSAGE_SIZE as u64,
-            max_state_chunk_size: 2000,
+            max_state_chunk_size: 4000,
             max_subscription_period_ms: 5000,
             max_transaction_chunk_size: 2000,
             max_transaction_output_chunk_size: 1000,

--- a/state-sync/inter-component/event-notifications/src/lib.rs
+++ b/state-sync/inter-component/event-notifications/src/lib.rs
@@ -132,10 +132,10 @@ impl EventSubscriptionService {
             .subscription_id_to_event_subscription
             .insert(subscription_id, event_subscription)
         {
-            panic!(
+            return Err(Error::UnexpectedErrorEncountered(format!(
                 "Duplicate event subscription found! This should not occur! ID: {}, subscription: {:?}",
                 subscription_id, old_subscription
-            );
+            )));
         }
 
         // Update the event key subscriptions to include the new subscription
@@ -174,10 +174,10 @@ impl EventSubscriptionService {
             .reconfig_subscriptions
             .insert(subscription_id, reconfig_subscription)
         {
-            panic!(
+            return Err(Error::UnexpectedErrorEncountered(format!(
                 "Duplicate reconfiguration subscription found! This should not occur! ID: {}, subscription: {:?}",
                 subscription_id, old_subscription
-            );
+            )));
         }
 
         Ok(ReconfigNotificationListener {
@@ -273,10 +273,9 @@ impl EventSubscriptionService {
                 .fetch_config_by_version(*config_id, version)
             {
                 if let Some(old_entry) = config_id_to_config.insert(*config_id, config.clone()) {
-                    panic!(
+                    return Err(Error::UnexpectedErrorEncountered(format!(
                         "Unexpected config values for duplicate config id found! Key: {}, Value: {:?}!",
-                        config_id, old_entry
-                    );
+                        config_id, old_entry)));
                 }
             }
         }


### PR DESCRIPTION
### Description
This PR removes unnecessary panics and expects from the state sync code. While all of these instances should never be exploitable in practice, converting them to errors is safer :)

Note: this PR also increases the default `max_epoch_chunk_size` and `max_state_chunk_size`. Experimentation on `mainnet` shows that we can increase these without incurring network truncation.

### Test Plan
Existing test infrastructure.