### PR TITLE
Revert "[crypto+move] add support for Blake2b-256 in Move"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,8 +626,6 @@ dependencies = [
  "aptos-crypto-derive",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "bitvec 0.19.6",
- "blake2",
- "blake2-rfc",
  "blst",
  "byteorder",
  "bytes 1.2.1",
@@ -1135,7 +1133,6 @@ dependencies = [
  "base64 0.13.0",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "better_any",
- "blake2-rfc",
  "claims",
  "clap 3.2.17",
  "codespan-reporting",
@@ -2809,15 +2806,6 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
-
-[[package]]
-name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
@@ -3317,25 +3305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest 0.10.5",
-]
-
-[[package]]
-name = "blake2-rfc"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
-dependencies = [
- "arrayvec 0.4.12",
- "constant_time_eq",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3794,12 +3763,6 @@ dependencies = [
  "quote 1.0.21",
  "unicode-xid 0.2.3",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "convert_case"
@@ -7045,12 +7008,6 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
-
-[[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,8 +291,6 @@ bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594
 better_any = "0.1.1"
 bigdecimal = { version = "0.3.0", features = ["serde"] }
 bitvec = "0.19.4"
-blake2 = "0.10.4"
-blake2-rfc = "0.2.18"
 blst = "0.3.7"
 byteorder = "1.4.3"
 bytes = "1.1.0"

--- a/aptos-move/aptos-gas/src/aptos_framework.rs
+++ b/aptos-move/aptos-gas/src/aptos_framework.rs
@@ -92,8 +92,6 @@ crate::natives::define_gas_parameters_for_natives!(GasParameters, "aptos_framewo
     // Using SHA2-256's cost
     [.hash.ripemd160.base, { 4.. => "hash.ripemd160.base" }, 3000],
     [.hash.ripemd160.per_byte, { 4.. => "hash.ripemd160.per_byte" }, 50],
-    [.hash.blake2b_256.base, { 4.. => "hash.blake2b_256.base" }, 1750],
-    [.hash.blake2b_256.per_byte, { 4.. => "hash.blake2b_256.per_byte" }, 15],
 
     [.util.from_bytes.base, "util.from_bytes.base", 300 * MUL],
     [.util.from_bytes.per_byte, "util.from_bytes.per_byte", 5 * MUL],

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib/sources/configs/features.move
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib/sources/configs/features.move
@@ -100,17 +100,6 @@ module std::features {
         is_enabled(MULTI_ED25519_PK_VALIDATE_V2_NATIVES)
     }
 
-    /// Whether the new BLAKE2B-256 hash function native is enabled.
-    /// This is needed because of the introduction of new native function(s).
-    /// Lifetime: transient
-    const BLAKE2B_256_NATIVE: u64 = 8;
-
-    public fun get_blake2b_256_feature(): u64 { BLAKE2B_256_NATIVE }
-
-    public fun blake2b_256_enabled(): bool acquires Features {
-        is_enabled(BLAKE2B_256_NATIVE)
-    }
-
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -23,7 +23,6 @@ aptos-types = { workspace = true }
 base64 = { workspace = true }
 bcs = { workspace = true }
 better_any = { workspace = true }
-blake2-rfc = { workspace = true }
 clap = { workspace = true }
 codespan-reporting = { workspace = true }
 curve25519-dalek = { workspace = true }

--- a/aptos-move/framework/aptos-stdlib/doc/hash.md
+++ b/aptos-move/framework/aptos-stdlib/doc/hash.md
@@ -20,11 +20,9 @@ Non-cryptograhic hashes:
 -  [Function `sha2_512`](#0x1_aptos_hash_sha2_512)
 -  [Function `sha3_512`](#0x1_aptos_hash_sha3_512)
 -  [Function `ripemd160`](#0x1_aptos_hash_ripemd160)
--  [Function `blake2b_256`](#0x1_aptos_hash_blake2b_256)
 -  [Function `sha2_512_internal`](#0x1_aptos_hash_sha2_512_internal)
 -  [Function `sha3_512_internal`](#0x1_aptos_hash_sha3_512_internal)
 -  [Function `ripemd160_internal`](#0x1_aptos_hash_ripemd160_internal)
--  [Function `blake2b_256_internal`](#0x1_aptos_hash_blake2b_256_internal)
 -  [Specification](#@Specification_1)
     -  [Function `sip_hash`](#@Specification_1_sip_hash)
     -  [Function `sip_hash_from_value`](#@Specification_1_sip_hash_from_value)
@@ -32,7 +30,6 @@ Non-cryptograhic hashes:
     -  [Function `sha2_512`](#@Specification_1_sha2_512)
     -  [Function `sha3_512`](#@Specification_1_sha3_512)
     -  [Function `ripemd160`](#@Specification_1_ripemd160)
-    -  [Function `blake2b_256`](#@Specification_1_blake2b_256)
     -  [Function `sha2_512_internal`](#@Specification_1_sha2_512_internal)
     -  [Function `sha3_512_internal`](#@Specification_1_sha3_512_internal)
     -  [Function `ripemd160_internal`](#@Specification_1_ripemd160_internal)
@@ -223,35 +220,6 @@ hashes will, with high probability, find a collision x_1 != x_2 such that RIPEMD
 
 </details>
 
-<a name="0x1_aptos_hash_blake2b_256"></a>
-
-## Function `blake2b_256`
-
-Returns the BLAKE2B-256 hash of <code>bytes</code>.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_blake2b_256">blake2b_256</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_blake2b_256">blake2b_256</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>if</b>(!<a href="../../move-stdlib/doc/features.md#0x1_features_blake2b_256_enabled">features::blake2b_256_enabled</a>()) {
-        <b>abort</b>(std::error::invalid_state(<a href="hash.md#0x1_aptos_hash_E_NATIVE_FUN_NOT_AVAILABLE">E_NATIVE_FUN_NOT_AVAILABLE</a>))
-    };
-
-    <a href="hash.md#0x1_aptos_hash_blake2b_256_internal">blake2b_256_internal</a>(bytes)
-}
-</code></pre>
-
-
-
-</details>
-
 <a name="0x1_aptos_hash_sha2_512_internal"></a>
 
 ## Function `sha2_512_internal`
@@ -318,29 +286,6 @@ hashes will, with high probability, find a collision x_1 != x_2 such that RIPEMD
 
 
 <pre><code><b>native</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_ripemd160_internal">ripemd160_internal</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
-</code></pre>
-
-
-
-</details>
-
-<a name="0x1_aptos_hash_blake2b_256_internal"></a>
-
-## Function `blake2b_256_internal`
-
-Returns the BLAKE2B-256 hash of <code>bytes</code>.
-
-
-<pre><code><b>fun</b> <a href="hash.md#0x1_aptos_hash_blake2b_256_internal">blake2b_256_internal</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>native</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_blake2b_256_internal">blake2b_256_internal</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
 </code></pre>
 
 
@@ -514,22 +459,6 @@ Returns the BLAKE2B-256 hash of <code>bytes</code>.
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> !<a href="../../move-stdlib/doc/features.md#0x1_features_spec_is_enabled">features::spec_is_enabled</a>(<a href="../../move-stdlib/doc/features.md#0x1_features_SHA_512_AND_RIPEMD_160_NATIVES">features::SHA_512_AND_RIPEMD_160_NATIVES</a>);
 <b>ensures</b> result == <a href="hash.md#0x1_aptos_hash_spec_ripemd160_internal">spec_ripemd160_internal</a>(bytes);
-</code></pre>
-
-
-
-<a name="@Specification_1_blake2b_256"></a>
-
-### Function `blake2b_256`
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_blake2b_256">blake2b_256</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-
-<pre><code><b>pragma</b> opaque;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/sources/hash.move
+++ b/aptos-move/framework/aptos-stdlib/sources/hash.move
@@ -65,15 +65,6 @@ module aptos_std::aptos_hash {
         ripemd160_internal(bytes)
     }
 
-    /// Returns the BLAKE2B-256 hash of `bytes`.
-    public fun blake2b_256(bytes: vector<u8>): vector<u8> {
-        if(!features::blake2b_256_enabled()) {
-            abort(std::error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE))
-        };
-
-        blake2b_256_internal(bytes)
-    }
-
     //
     // Private native functions
     //
@@ -90,9 +81,6 @@ module aptos_std::aptos_hash {
     /// WARNING: Only 80-bit security is provided by this function. This means an adversary who can compute roughly 2^80
     /// hashes will, with high probability, find a collision x_1 != x_2 such that RIPEMD-160(x_1) = RIPEMD-160(x_2).
     native fun ripemd160_internal(bytes: vector<u8>): vector<u8>;
-
-    /// Returns the BLAKE2B-256 hash of `bytes`.
-    native fun blake2b_256_internal(bytes: vector<u8>): vector<u8>;
 
     //
     // Testing
@@ -197,53 +185,6 @@ module aptos_std::aptos_hash {
             let input = *std::vector::borrow(&inputs, i);
             let hash_expected = *std::vector::borrow(&outputs, i);
             let hash = ripemd160(input);
-
-            assert!(hash_expected == hash, 1);
-
-            i = i + 1;
-        };
-    }
-
-    #[test(fx = @aptos_std)]
-    #[expected_failure(abort_code = 196609, location = Self)]
-    fun blake2b_256_aborts(fx: signer) {
-        // We disable the feature to make sure the `blake2b_256` call aborts
-        features::change_feature_flags(&fx, vector[], vector[features::get_blake2b_256_feature()]);
-
-        blake2b_256(b"This will abort");
-    }
-
-    #[test(fx = @aptos_std)]
-    fun blake2b_256_test(fx: signer) {
-        // We need to enable the feature in order for the native call to be allowed.
-        features::change_feature_flags(&fx, vector[features::get_blake2b_256_feature()], vector[]);
-        let inputs = vector[
-        b"",
-        b"testing",
-        b"testing again", // empty message doesn't yield an output on the online generator
-        ];
-
-        // From https://www.toolkitbay.com/tkb/tool/BLAKE2b_256.
-        //
-        // For computing the hash of an empty string, we use the following Python3 script:
-        // ```
-        //   #!/usr/bin/python3
-        //
-        //   import hashlib
-        //
-        //   print(hashlib.blake2b(b'', digest_size=32).hexdigest());
-        // ```
-        let outputs = vector[
-        x"0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
-        x"99397ff32ae348b8b6536d5c213f343d7e9fdeaa10e8a23a9f90ab21a1658565",
-        x"1deab5a4eb7481453ca9b29e1f7c4be8ba44de4faeeafdf173b310cbaecfc84c",
-        ];
-
-        let i = 0;
-        while (i < std::vector::length(&inputs)) {
-            let input = *std::vector::borrow(&inputs, i);
-            let hash_expected = *std::vector::borrow(&outputs, i);
-            let hash = blake2b_256(input);
 
             assert!(hash_expected == hash, 1);
 

--- a/aptos-move/framework/aptos-stdlib/sources/hash.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/hash.spec.move
@@ -77,9 +77,4 @@ spec aptos_std::aptos_hash {
         ensures result == spec_ripemd160_internal(bytes);
     }
 
-    spec blake2b_256 {
-        // TODO: temporary mockup.
-        pragma opaque;
-    }
-
 }

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -21,8 +21,6 @@ the Move stdlib, the Aptos stdlib, and the Aptos framework.
 -  [Function `collect_and_distribute_gas_fees`](#0x1_features_collect_and_distribute_gas_fees)
 -  [Function `multi_ed25519_pk_validate_v2_feature`](#0x1_features_multi_ed25519_pk_validate_v2_feature)
 -  [Function `multi_ed25519_pk_validate_v2_enabled`](#0x1_features_multi_ed25519_pk_validate_v2_enabled)
--  [Function `get_blake2b_256_feature`](#0x1_features_get_blake2b_256_feature)
--  [Function `blake2b_256_enabled`](#0x1_features_blake2b_256_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `is_enabled`](#0x1_features_is_enabled)
 -  [Function `set`](#0x1_features_set)
@@ -82,18 +80,6 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_APTOS_STD_CHAIN_ID_NATIVES">APTOS_STD_CHAIN_ID_NATIVES</a>: u64 = 4;
-</code></pre>
-
-
-
-<a name="0x1_features_BLAKE2B_256_NATIVE"></a>
-
-Whether the new BLAKE2B-256 hash function native is enabled.
-This is needed because of the introduction of new native function(s).
-Lifetime: transient
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_BLAKE2B_256_NATIVE">BLAKE2B_256_NATIVE</a>: u64 = 8;
 </code></pre>
 
 
@@ -449,52 +435,6 @@ Lifetime: transient
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_multi_ed25519_pk_validate_v2_enabled">multi_ed25519_pk_validate_v2_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_MULTI_ED25519_PK_VALIDATE_V2_NATIVES">MULTI_ED25519_PK_VALIDATE_V2_NATIVES</a>)
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x1_features_get_blake2b_256_feature"></a>
-
-## Function `get_blake2b_256_feature`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_blake2b_256_feature">get_blake2b_256_feature</a>(): u64
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_blake2b_256_feature">get_blake2b_256_feature</a>(): u64 { <a href="features.md#0x1_features_BLAKE2B_256_NATIVE">BLAKE2B_256_NATIVE</a> }
-</code></pre>
-
-
-
-</details>
-
-<a name="0x1_features_blake2b_256_enabled"></a>
-
-## Function `blake2b_256_enabled`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_blake2b_256_enabled">blake2b_256_enabled</a>(): bool
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_blake2b_256_enabled">blake2b_256_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
-    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_BLAKE2B_256_NATIVE">BLAKE2B_256_NATIVE</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -100,17 +100,6 @@ module std::features {
         is_enabled(MULTI_ED25519_PK_VALIDATE_V2_NATIVES)
     }
 
-    /// Whether the new BLAKE2B-256 hash function native is enabled.
-    /// This is needed because of the introduction of new native function(s).
-    /// Lifetime: transient
-    const BLAKE2B_256_NATIVE: u64 = 8;
-
-    public fun get_blake2b_256_feature(): u64 { BLAKE2B_256_NATIVE }
-
-    public fun blake2b_256_enabled(): bool acquires Features {
-        is_enabled(BLAKE2B_256_NATIVE)
-    }
-
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/framework/src/natives/hash.rs
+++ b/aptos-move/framework/src/natives/hash.rs
@@ -9,7 +9,7 @@ use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
 use move_vm_types::{
     loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
 };
-use ripemd::Digest as RipemdDigest;
+use ripemd::Digest as OtherDigest;
 use sha2::Digest;
 use smallvec::smallvec;
 use std::{collections::VecDeque, hash::Hasher};
@@ -129,32 +129,6 @@ fn native_sha3_512(
 }
 
 #[derive(Debug, Clone)]
-pub struct Blake2B256HashGasParameters {
-    pub base: InternalGas,
-    pub per_byte: InternalGasPerByte,
-}
-
-fn native_blake2b_256(
-    gas_params: &Blake2B256HashGasParameters,
-    _context: &mut NativeContext,
-    mut _ty_args: Vec<Type>,
-    mut args: VecDeque<Value>,
-) -> PartialVMResult<NativeResult> {
-    debug_assert!(_ty_args.is_empty());
-    debug_assert!(args.len() == 1);
-
-    let bytes = pop_arg!(args, Vec<u8>);
-
-    let cost = gas_params.base + gas_params.per_byte * NumBytes::new(bytes.len() as u64);
-
-    let output = blake2_rfc::blake2b::blake2b(32, &[], &bytes)
-        .as_bytes()
-        .to_vec();
-
-    Ok(NativeResult::ok(cost, smallvec![Value::vector_u8(output)]))
-}
-
-#[derive(Debug, Clone)]
 pub struct Ripemd160HashGasParameters {
     pub base: InternalGas,
     pub per_byte: InternalGasPerByte,
@@ -191,7 +165,6 @@ pub struct GasParameters {
     pub sha2_512: Sha2_512HashGasParameters,
     pub sha3_512: Sha3_512HashGasParameters,
     pub ripemd160: Ripemd160HashGasParameters,
-    pub blake2b_256: Blake2B256HashGasParameters,
 }
 
 pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
@@ -215,10 +188,6 @@ pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, Nati
         (
             "ripemd160_internal",
             make_native_from_func(gas_params.ripemd160, native_ripemd160),
-        ),
-        (
-            "blake2b_256_internal",
-            make_native_from_func(gas_params.blake2b_256, native_blake2b_256),
         ),
     ];
 

--- a/aptos-move/framework/src/natives/mod.rs
+++ b/aptos-move/framework/src/natives/mod.rs
@@ -130,10 +130,6 @@ impl GasParameters {
                     base: 0.into(),
                     per_byte: 0.into(),
                 },
-                blake2b_256: hash::Blake2B256HashGasParameters {
-                    base: 0.into(),
-                    per_byte: 0.into(),
-                },
             },
             type_info: type_info::GasParameters {
                 type_of: type_info::TypeOfGasParameters {

--- a/crates/aptos-crypto/Cargo.toml
+++ b/crates/aptos-crypto/Cargo.toml
@@ -42,8 +42,6 @@ x25519-dalek = { workspace = true }
 
 [dev-dependencies]
 bitvec = { workspace = true }
-blake2 = { workspace = true }
-blake2-rfc = { workspace = true }
 byteorder = { workspace = true }
 criterion = { workspace = true }
 proptest = { workspace = true }

--- a/crates/aptos-crypto/benches/hash.rs
+++ b/crates/aptos-crypto/benches/hash.rs
@@ -4,8 +4,6 @@
 #[macro_use]
 extern crate criterion;
 
-use blake2::digest::{Update, VariableOutput};
-use blake2::Blake2bVar;
 use criterion::{
     measurement::Measurement, AxisScale, BenchmarkGroup, BenchmarkId, Criterion, PlotConfiguration,
     Throughput,
@@ -16,7 +14,6 @@ use std::ptr::null;
 
 use aptos_crypto::bls12381::DST_BLS_SIG_IN_G2_WITH_POP;
 use aptos_crypto::test_utils::random_bytes;
-use blake2_rfc::blake2b::Blake2b;
 use sha2::{Sha256, Sha512};
 use tiny_keccak::{Hasher as KeccakHasher, Keccak};
 
@@ -44,8 +41,6 @@ fn bench_group(c: &mut Criterion) {
         hash_to_g1(&mut group, n, DST_BLS_SIG_IN_G2_WITH_POP);
         hash_to_g2(&mut group, n, DST_BLS_SIG_IN_G2_WITH_POP);
         keccak256(&mut group, n);
-        blake2_blake2b_256(&mut group, n);
-        blake2_rfc_blake2b_256(&mut group, n);
     }
 
     group.finish();
@@ -202,52 +197,6 @@ pub fn hash_to_g2<M: Measurement>(g: &mut BenchmarkGroup<M>, n: usize, dst: &[u8
             },
         )
     });
-}
-
-fn blake2_blake2b_256<M: Measurement>(g: &mut BenchmarkGroup<M>, n: usize) {
-    let mut rng = thread_rng();
-
-    g.throughput(Throughput::Bytes(n as u64));
-
-    g.bench_function(BenchmarkId::new("blake2b-256/crate-blake2", n), move |b| {
-        b.iter_with_setup(
-            || random_bytes(&mut rng, n),
-            |bytes| {
-                assert_eq!(bytes.len(), n);
-
-                let mut hasher = Blake2bVar::new(32).unwrap();
-                hasher.update(&bytes);
-                let mut output = vec![0u8; 32];
-                hasher.finalize_variable(&mut output).unwrap();
-
-                assert_eq!(output.as_slice().len(), 32);
-            },
-        )
-    });
-}
-
-fn blake2_rfc_blake2b_256<M: Measurement>(g: &mut BenchmarkGroup<M>, n: usize) {
-    let mut rng = thread_rng();
-
-    g.throughput(Throughput::Bytes(n as u64));
-
-    g.bench_function(
-        BenchmarkId::new("blake2b-256/crate-blake2-rfc", n),
-        move |b| {
-            b.iter_with_setup(
-                || random_bytes(&mut rng, n),
-                |bytes| {
-                    assert_eq!(bytes.len(), n);
-
-                    // Using the state context.
-                    let mut context = Blake2b::new(32);
-                    context.update(&bytes);
-                    let hash = context.finalize();
-                    assert_eq!(hash.as_bytes().len(), 32);
-                },
-            )
-        },
-    );
 }
 
 criterion_group!(


### PR DESCRIPTION
Reverts aptos-labs/aptos-core#5436 as it broke compatibility. The gas version there is wrong. New native functions added should use the next gas version. The new hash native function added in that commit uses an existing gas version (4) while the current latest version is 5 - https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/aptos-gas/src/gas_meter.rs#L49