### PR TITLE
[Gas] Correct the gas schedule version for a recently added native function

### DIFF
--- a/aptos-move/aptos-gas/src/aptos_framework.rs
+++ b/aptos-move/aptos-gas/src/aptos_framework.rs
@@ -92,8 +92,8 @@ crate::natives::define_gas_parameters_for_natives!(GasParameters, "aptos_framewo
     // Using SHA2-256's cost
     [.hash.ripemd160.base, { 4.. => "hash.ripemd160.base" }, 3000],
     [.hash.ripemd160.per_byte, { 4.. => "hash.ripemd160.per_byte" }, 50],
-    [.hash.blake2b_256.base, { 6.. => "hash.blake2b_256.base" }, 1750],
-    [.hash.blake2b_256.per_byte, { 6.. => "hash.blake2b_256.per_byte" }, 15],
+    [.hash.blake2b_256.base, { 5.. => "hash.blake2b_256.base" }, 1750],
+    [.hash.blake2b_256.per_byte, { 5.. => "hash.blake2b_256.per_byte" }, 15],
 
     [.util.from_bytes.base, "util.from_bytes.base", 300 * MUL],
     [.util.from_bytes.per_byte, "util.from_bytes.per_byte", 5 * MUL],

--- a/aptos-move/aptos-gas/src/aptos_framework.rs
+++ b/aptos-move/aptos-gas/src/aptos_framework.rs
@@ -92,8 +92,8 @@ crate::natives::define_gas_parameters_for_natives!(GasParameters, "aptos_framewo
     // Using SHA2-256's cost
     [.hash.ripemd160.base, { 4.. => "hash.ripemd160.base" }, 3000],
     [.hash.ripemd160.per_byte, { 4.. => "hash.ripemd160.per_byte" }, 50],
-    [.hash.blake2b_256.base, { 4.. => "hash.blake2b_256.base" }, 1750],
-    [.hash.blake2b_256.per_byte, { 4.. => "hash.blake2b_256.per_byte" }, 15],
+    [.hash.blake2b_256.base, { 6.. => "hash.blake2b_256.base" }, 1750],
+    [.hash.blake2b_256.per_byte, { 6.. => "hash.blake2b_256.per_byte" }, 15],
 
     [.util.from_bytes.base, "util.from_bytes.base", 300 * MUL],
     [.util.from_bytes.per_byte, "util.from_bytes.per_byte", 5 * MUL],

--- a/aptos-move/aptos-gas/src/gas_meter.rs
+++ b/aptos-move/aptos-gas/src/gas_meter.rs
@@ -48,7 +48,7 @@ use std::collections::BTreeMap;
 //       global operations.
 // - V1
 //   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = 6;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = 5;
 
 pub(crate) const EXECUTION_GAS_MULTIPLIER: u64 = 20;
 

--- a/aptos-move/aptos-gas/src/gas_meter.rs
+++ b/aptos-move/aptos-gas/src/gas_meter.rs
@@ -28,6 +28,8 @@ use move_vm_types::{
 use std::collections::BTreeMap;
 
 // Change log:
+// - V6
+//   - Added a new native function - blake2b_256.
 // - V5
 //   - u16, u32, u256
 //   - free_write_bytes_quota
@@ -46,7 +48,7 @@ use std::collections::BTreeMap;
 //       global operations.
 // - V1
 //   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = 5;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = 6;
 
 pub(crate) const EXECUTION_GAS_MULTIPLIER: u64 = 20;
 

--- a/aptos-move/aptos-gas/src/gas_meter.rs
+++ b/aptos-move/aptos-gas/src/gas_meter.rs
@@ -28,9 +28,8 @@ use move_vm_types::{
 use std::collections::BTreeMap;
 
 // Change log:
-// - V6
-//   - Added a new native function - blake2b_256.
 // - V5
+//   - Added a new native function - blake2b_256.
 //   - u16, u32, u256
 //   - free_write_bytes_quota
 //   - configurable ChangeSetConfigs


### PR DESCRIPTION
### Description
The gas version there is wrong. New native functions added should use the next gas version. The new hash native function added in that commit uses an existing gas version (4) while the current latest version is 5 - https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/aptos-gas/src/gas_meter.rs#L49

### Test Plan
Compat test
