### PR TITLE
rust-sdk-builder: default to using local types

### DIFF
--- a/aptos-move/aptos-sdk-builder/src/main.rs
+++ b/aptos-move/aptos-sdk-builder/src/main.rs
@@ -72,7 +72,7 @@ fn main() {
             let mut out = stdout.lock();
             match options.language {
                 Language::Rust => {
-                    aptos_sdk_builder::rust::output(&mut out, &abis, /* local types */ false)
+                    aptos_sdk_builder::rust::output(&mut out, &abis, /* local types */ true)
                         .unwrap()
                 }
                 Language::Go => {


### PR DESCRIPTION
Addresses part of the issues mentioned in https://github.com/aptos-labs/aptos-core/issues/5986#issuecomment-1363427483 by defaulting to `local_types` generation.