### PR TITLE
[Docs] Add small note about archival fullnodes.

### DIFF
--- a/developer-docs-site/docs/guides/state-sync.md
+++ b/developer-docs-site/docs/guides/state-sync.md
@@ -118,6 +118,21 @@ network delays that may occur when initializing slow network connections:
      max_connection_deadline_secs: 1000000 # Tolerate slow peer discovery & connections
 ```
 
+## Running Archival Nodes
+
+To operate an archival node, i.e., a fullnode that contains all blockchain data
+since the start of the blockchain's history (that is, genesis), you should:
+1. Run a fullnode and configure it to execute all transactions, or apply all transaction outputs (see above).
+Do not select fast syncing, as the fullnode will not contain all data since genesis.
+2. Disable the ledger pruner, as described in the [Data Pruning document](../guides/data-pruning#disabling-the-ledger-pruner).
+This will ensure that no data is pruned and the fullnode contains all data.
+
+:::caution Proceed with caution
+Running and maintaining archival nodes is likely to be expensive and slow
+as the amount of data being stored on the fullnode will continuously grow.
+:::
+
+
 ## Security implications and data integrity
 Each of the different syncing modes perform data integrity verifications to
 ensure that the data being synced to the node has been correctly produced
@@ -144,7 +159,7 @@ All of the syncing modes get their root of trust from the validator set
 and cryptographic signatures from those validators over the blockchain data.
 For more information about how this works, see the [state synchronization blogpost](https://medium.com/aptoslabs/the-evolution-of-state-sync-the-path-to-100k-transactions-per-second-with-sub-second-latency-at-52e25a2c6f10).
 
-## State sync architecture
+# State sync architecture
 
 The state synchronization component is comprised of four sub-components, each with a specific purpose:
 


### PR DESCRIPTION
### Description
This PR adds a small blurb about running an archival fullnode to the state synchronization page. Related to the issue here: https://github.com/aptos-labs/aptos-core/issues/6024

### Test Plan
Manual verification.