### PR TITLE
Add current_table_items and event index. Also clean up some code in default_processor

### DIFF
--- a/crates/indexer/migrations/2022-12-29-222902_curr_table_items/down.sql
+++ b/crates/indexer/migrations/2022-12-29-222902_curr_table_items/down.sql
@@ -1,2 +1,7 @@
 -- This file should undo anything in `up.sql`
+DROP VIEW IF EXISTS current_table_items_view;
+DROP INDEX IF EXISTS cti_insat_index;
+DROP TABLE IF EXISTS current_table_items;
 ALTER TABLE events DROP COLUMN IF EXISTS event_index;
+ALTER TABLE token_activities DROP COLUMN IF EXISTS event_index;
+ALTER TABLE coin_activities DROP COLUMN IF EXISTS event_index;

--- a/crates/indexer/migrations/2022-12-29-222902_curr_table_items/down.sql
+++ b/crates/indexer/migrations/2022-12-29-222902_curr_table_items/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE events DROP COLUMN IF EXISTS event_index;

--- a/crates/indexer/migrations/2022-12-29-222902_curr_table_items/up.sql
+++ b/crates/indexer/migrations/2022-12-29-222902_curr_table_items/up.sql
@@ -1,3 +1,35 @@
 -- Your SQL goes here
+CREATE TABLE current_table_items (
+  table_handle VARCHAR(66) NOT NULL,
+  -- Hash of the key for pk since key is unbounded
+  key_hash VARCHAR(64) NOT NULL,
+  key text NOT NULL,
+  decoded_key jsonb NOT NULL,
+  decoded_value jsonb,
+  is_deleted BOOLEAN NOT NULL,
+  latest_transaction_version BIGINT NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  -- Constraints
+  PRIMARY KEY (
+    table_handle,
+    key_hash
+  )
+);
+CREATE INDEX cti_insat_index ON current_table_items (inserted_at);
+-- Create view to avoid large jsonb in bigquery
+CREATE VIEW current_table_items_view AS
+SELECT "key",
+  table_handle,
+  key_hash,
+  decoded_key#>>'{}' AS json_decoded_key,
+  decoded_value#>>'{}' AS json_decoded_value,
+  is_deleted,
+  latest_transaction_version,
+  inserted_at
+FROM current_table_items;
 ALTER TABLE events
+ADD COLUMN event_index BIGINT;
+ALTER TABLE token_activities
+ADD COLUMN event_index BIGINT;
+ALTER TABLE coin_activities
 ADD COLUMN event_index BIGINT;

--- a/crates/indexer/migrations/2022-12-29-222902_curr_table_items/up.sql
+++ b/crates/indexer/migrations/2022-12-29-222902_curr_table_items/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+ALTER TABLE events
+ADD COLUMN event_index BIGINT;

--- a/crates/indexer/migrations/2022-12-29-222902_curr_table_items/up.sql
+++ b/crates/indexer/migrations/2022-12-29-222902_curr_table_items/up.sql
@@ -7,7 +7,7 @@ CREATE TABLE current_table_items (
   decoded_key jsonb NOT NULL,
   decoded_value jsonb,
   is_deleted BOOLEAN NOT NULL,
-  latest_transaction_version BIGINT NOT NULL,
+  last_transaction_version BIGINT NOT NULL,
   inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
   -- Constraints
   PRIMARY KEY (
@@ -24,7 +24,7 @@ SELECT "key",
   decoded_key#>>'{}' AS json_decoded_key,
   decoded_value#>>'{}' AS json_decoded_value,
   is_deleted,
-  latest_transaction_version,
+  last_transaction_version,
   inserted_at
 FROM current_table_items;
 ALTER TABLE events

--- a/crates/indexer/src/models/coin_models/coin_activities.rs
+++ b/crates/indexer/src/models/coin_models/coin_activities.rs
@@ -190,8 +190,7 @@ impl CoinActivity {
                     &entry_function_id_str,
                     txn_timestamp,
                     index as i64,
-                )),
-                None => {},
+                ));
             };
         }
         (

--- a/crates/indexer/src/models/coin_models/coin_activities.rs
+++ b/crates/indexer/src/models/coin_models/coin_activities.rs
@@ -28,6 +28,7 @@ use std::collections::HashMap;
 const GAS_FEE_EVENT: &str = "0x1::aptos_coin::GasFeeEvent";
 // We will never have a negative number on chain so this will avoid collision in postgres
 const BURN_GAS_EVENT_CREATION_NUM: i64 = -1;
+const BURN_GAS_EVENT_INDEX: i64 = -1;
 const MAX_ENTRY_FUNCTION_LENGTH: usize = 100;
 
 type OwnerAddress = String;
@@ -58,6 +59,7 @@ pub struct CoinActivity {
     pub entry_function_id_str: Option<String>,
     pub block_height: i64,
     pub transaction_timestamp: chrono::NaiveDateTime,
+    pub event_index: Option<i64>,
 }
 
 impl CoinActivity {
@@ -173,7 +175,7 @@ impl CoinActivity {
                 all_coin_supply.push(coin_supply);
             }
         }
-        for event in events {
+        for (index, event) in events.iter().enumerate() {
             let event_type = event.typ.to_string();
             if let Some(parsed_event) =
                 CoinEvent::from_event(event_type.as_str(), &event.data, txn_version).unwrap()
@@ -187,8 +189,10 @@ impl CoinActivity {
                     txn_info.block_height.unwrap().0 as i64,
                     &entry_function_id_str,
                     txn_timestamp,
-                ))
-            }
+                    index as i64,
+                )),
+                None => {},
+            };
         }
         (
             coin_activities,
@@ -208,6 +212,7 @@ impl CoinActivity {
         block_height: i64,
         entry_function_id_str: &Option<String>,
         transaction_timestamp: chrono::NaiveDateTime,
+        event_index: i64,
     ) -> Self {
         let amount = match coin_event {
             CoinEvent::WithdrawCoinEvent(inner) => inner.amount.clone(),
@@ -241,6 +246,7 @@ impl CoinActivity {
             entry_function_id_str: entry_function_id_str.clone(),
             block_height,
             transaction_timestamp,
+            event_index: Some(event_index),
         }
     }
 
@@ -269,6 +275,7 @@ impl CoinActivity {
             entry_function_id_str: entry_function_id_str.clone(),
             block_height: txn_info.block_height.unwrap().0 as i64,
             transaction_timestamp,
+            event_index: Some(BURN_GAS_EVENT_INDEX),
         }
     }
 }

--- a/crates/indexer/src/models/events.rs
+++ b/crates/indexer/src/models/events.rs
@@ -19,6 +19,7 @@ pub struct Event {
     pub transaction_block_height: i64,
     pub type_: String,
     pub data: serde_json::Value,
+    pub event_index: Option<i64>,
 }
 
 /// Need a separate struct for queryable because we don't want to define the inserted_at column (letting DB fill)
@@ -35,6 +36,7 @@ pub struct EventQuery {
     pub type_: String,
     pub data: serde_json::Value,
     pub inserted_at: chrono::NaiveDateTime,
+    pub event_index: Option<i64>,
 }
 
 impl Event {
@@ -42,6 +44,7 @@ impl Event {
         event: &APIEvent,
         transaction_version: i64,
         transaction_block_height: i64,
+        event_index: i64,
     ) -> Self {
         Event {
             account_address: standardize_address(&event.guid.account_address.to_string()),
@@ -51,6 +54,7 @@ impl Event {
             transaction_block_height,
             type_: event.typ.to_string(),
             data: event.data.clone(),
+            event_index: Some(event_index),
         }
     }
 
@@ -61,7 +65,15 @@ impl Event {
     ) -> Vec<Self> {
         events
             .iter()
-            .map(|event| Self::from_event(event, transaction_version, transaction_block_height))
+            .enumerate()
+            .map(|(index, event)| {
+                Self::from_event(
+                    event,
+                    transaction_version,
+                    transaction_block_height,
+                    index as i64,
+                )
+            })
             .collect::<Vec<EventModel>>()
     }
 }

--- a/crates/indexer/src/models/move_tables.rs
+++ b/crates/indexer/src/models/move_tables.rs
@@ -3,12 +3,28 @@
 #![allow(clippy::extra_unused_lifetimes)]
 use crate::{
     models::transactions::Transaction,
-    schema::{table_items, table_metadatas},
-    util::standardize_address,
+    schema::{current_table_items, table_items, table_metadatas},
+    util::{hash_str, standardize_address},
 };
 use aptos_api_types::{DeleteTableItem, WriteTableItem};
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(
+    table_handle,
+    key_hash
+))]
+#[diesel(table_name = current_table_items)]
+pub struct CurrentTableItem {
+    pub table_handle: String,
+    pub key_hash: String,
+    pub key: String,
+    pub decoded_key: serde_json::Value,
+    pub decoded_value: Option<serde_json::Value>,
+    pub latest_transaction_version: i64,
+    pub is_deleted: bool,
+}
 
 #[derive(
     Associations, Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize,
@@ -42,17 +58,28 @@ impl TableItem {
         write_set_change_index: i64,
         transaction_version: i64,
         transaction_block_height: i64,
-    ) -> Self {
-        Self {
-            transaction_version,
-            write_set_change_index,
-            transaction_block_height,
-            key: write_table_item.key.to_string(),
-            table_handle: standardize_address(&write_table_item.handle.to_string()),
-            decoded_key: write_table_item.data.as_ref().unwrap().key.clone(),
-            decoded_value: Some(write_table_item.data.as_ref().unwrap().value.clone()),
-            is_deleted: false,
-        }
+    ) -> (Self, CurrentTableItem) {
+        (
+            Self {
+                transaction_version,
+                write_set_change_index,
+                transaction_block_height,
+                key: write_table_item.key.to_string(),
+                table_handle: standardize_address(&write_table_item.handle.to_string()),
+                decoded_key: write_table_item.data.as_ref().unwrap().key.clone(),
+                decoded_value: Some(write_table_item.data.as_ref().unwrap().value.clone()),
+                is_deleted: false,
+            },
+            CurrentTableItem {
+                table_handle: standardize_address(&write_table_item.handle.to_string()),
+                key_hash: hash_str(&write_table_item.key.to_string()),
+                key: write_table_item.key.to_string(),
+                decoded_key: write_table_item.data.as_ref().unwrap().key.clone(),
+                decoded_value: Some(write_table_item.data.as_ref().unwrap().value.clone()),
+                latest_transaction_version: transaction_version,
+                is_deleted: false,
+            },
+        )
     }
 
     pub fn from_delete_table_item(
@@ -60,27 +87,39 @@ impl TableItem {
         write_set_change_index: i64,
         transaction_version: i64,
         transaction_block_height: i64,
-    ) -> Self {
-        Self {
-            transaction_version,
-            write_set_change_index,
-            transaction_block_height,
-            key: delete_table_item.key.to_string(),
-            table_handle: standardize_address(&delete_table_item.handle.to_string()),
-            decoded_key: delete_table_item
-                .data
-                .as_ref()
-                .unwrap_or_else(|| {
-                    panic!(
-                        "Could not extract data from DeletedTableItem '{:?}'",
-                        delete_table_item
-                    )
-                })
-                .key
-                .clone(),
-            decoded_value: None,
-            is_deleted: true,
-        }
+    ) -> (Self, CurrentTableItem) {
+        let decoded_key = delete_table_item
+            .data
+            .as_ref()
+            .unwrap_or_else(|| {
+                panic!(
+                    "Could not extract data from DeletedTableItem '{:?}'",
+                    delete_table_item
+                )
+            })
+            .key
+            .clone();
+        (
+            Self {
+                transaction_version,
+                write_set_change_index,
+                transaction_block_height,
+                key: delete_table_item.key.to_string(),
+                table_handle: standardize_address(&delete_table_item.handle.to_string()),
+                decoded_key: decoded_key.clone(),
+                decoded_value: None,
+                is_deleted: true,
+            },
+            CurrentTableItem {
+                table_handle: standardize_address(&delete_table_item.handle.to_string()),
+                key_hash: hash_str(&delete_table_item.key.to_string()),
+                key: delete_table_item.key.to_string(),
+                decoded_key,
+                decoded_value: None,
+                latest_transaction_version: transaction_version,
+                is_deleted: false,
+            },
+        )
     }
 }
 

--- a/crates/indexer/src/models/move_tables.rs
+++ b/crates/indexer/src/models/move_tables.rs
@@ -11,10 +11,7 @@ use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
-#[diesel(primary_key(
-    table_handle,
-    key_hash
-))]
+#[diesel(primary_key(table_handle, key_hash))]
 #[diesel(table_name = current_table_items)]
 pub struct CurrentTableItem {
     pub table_handle: String,
@@ -22,7 +19,7 @@ pub struct CurrentTableItem {
     pub key: String,
     pub decoded_key: serde_json::Value,
     pub decoded_value: Option<serde_json::Value>,
-    pub latest_transaction_version: i64,
+    pub last_transaction_version: i64,
     pub is_deleted: bool,
 }
 
@@ -76,7 +73,7 @@ impl TableItem {
                 key: write_table_item.key.to_string(),
                 decoded_key: write_table_item.data.as_ref().unwrap().key.clone(),
                 decoded_value: Some(write_table_item.data.as_ref().unwrap().value.clone()),
-                latest_transaction_version: transaction_version,
+                last_transaction_version: transaction_version,
                 is_deleted: false,
             },
         )
@@ -116,8 +113,8 @@ impl TableItem {
                 key: delete_table_item.key.to_string(),
                 decoded_key,
                 decoded_value: None,
-                latest_transaction_version: transaction_version,
-                is_deleted: false,
+                last_transaction_version: transaction_version,
+                is_deleted: true,
             },
         )
     }

--- a/crates/indexer/src/models/token_models/token_activities.rs
+++ b/crates/indexer/src/models/token_models/token_activities.rs
@@ -41,6 +41,7 @@ pub struct TokenActivity {
     pub coin_amount: Option<BigDecimal>,
     pub collection_data_id_hash: String,
     pub transaction_timestamp: chrono::NaiveDateTime,
+    pub event_index: Option<i64>,
 }
 
 /// A simplified TokenActivity (excluded common fields) to reduce code duplication
@@ -58,7 +59,7 @@ impl TokenActivity {
     pub fn from_transaction(transaction: &APITransaction) -> Vec<Self> {
         let mut token_activities = vec![];
         if let APITransaction::UserTransaction(user_txn) = transaction {
-            for event in &user_txn.events {
+            for (index, event) in user_txn.events.iter().enumerate() {
                 let txn_version = user_txn.info.version.0 as i64;
                 let event_type = event.typ.to_string();
                 if let Some(token_event) =
@@ -70,6 +71,7 @@ impl TokenActivity {
                         &token_event,
                         txn_version,
                         parse_timestamp(user_txn.timestamp.0, txn_version),
+                        index as i64,
                     ))
                 }
             }
@@ -83,6 +85,7 @@ impl TokenActivity {
         token_event: &TokenEvent,
         txn_version: i64,
         txn_timestamp: chrono::NaiveDateTime,
+        event_index: i64,
     ) -> Self {
         let event_account_address = standardize_address(&event.guid.account_address.to_string());
         let event_creation_number = event.guid.creation_number.0 as i64;
@@ -180,6 +183,7 @@ impl TokenActivity {
             coin_type: token_activity_helper.coin_type,
             coin_amount: token_activity_helper.coin_amount,
             transaction_timestamp: txn_timestamp,
+            event_index: Some(event_index),
         }
     }
 }

--- a/crates/indexer/src/models/write_set_changes.rs
+++ b/crates/indexer/src/models/write_set_changes.rs
@@ -4,7 +4,7 @@
 use super::{
     move_modules::MoveModule,
     move_resources::MoveResource,
-    move_tables::{TableItem, TableMetadata},
+    move_tables::{CurrentTableItem, TableItem, TableMetadata},
     transactions::TransactionQuery,
 };
 use crate::{
@@ -115,44 +115,48 @@ impl WriteSetChange {
                     transaction_block_height,
                 )),
             ),
-            APIWriteSetChange::WriteTableItem(table_item) => (
-                Self {
-                    transaction_version,
-                    hash: table_item.state_key_hash.clone(),
-                    transaction_block_height,
-                    type_,
-                    address: String::default(),
+            APIWriteSetChange::WriteTableItem(table_item) => {
+                let (ti, cti) = TableItem::from_write_table_item(
+                    table_item,
                     index,
-                },
-                WriteSetChangeDetail::Table(
-                    TableItem::from_write_table_item(
-                        table_item,
-                        index,
-                        transaction_version,
-                        transaction_block_height,
-                    ),
-                    Some(TableMetadata::from_write_table_item(table_item)),
-                ),
-            ),
-            APIWriteSetChange::DeleteTableItem(table_item) => (
-                Self {
                     transaction_version,
-                    hash: table_item.state_key_hash.clone(),
                     transaction_block_height,
-                    type_,
-                    address: String::default(),
-                    index,
-                },
-                WriteSetChangeDetail::Table(
-                    TableItem::from_delete_table_item(
-                        table_item,
-                        index,
+                );
+                (
+                    Self {
                         transaction_version,
+                        hash: table_item.state_key_hash.clone(),
                         transaction_block_height,
+                        type_,
+                        address: String::default(),
+                        index,
+                    },
+                    WriteSetChangeDetail::Table(
+                        ti,
+                        cti,
+                        Some(TableMetadata::from_write_table_item(table_item)),
                     ),
-                    None,
-                ),
-            ),
+                )
+            },
+            APIWriteSetChange::DeleteTableItem(table_item) => {
+                let (ti, cti) = TableItem::from_delete_table_item(
+                    table_item,
+                    index,
+                    transaction_version,
+                    transaction_block_height,
+                );
+                (
+                    Self {
+                        transaction_version,
+                        hash: table_item.state_key_hash.clone(),
+                        transaction_block_height,
+                        type_,
+                        address: String::default(),
+                        index,
+                    },
+                    WriteSetChangeDetail::Table(ti, cti, None),
+                )
+            },
         }
     }
 
@@ -193,7 +197,7 @@ impl WriteSetChange {
 pub enum WriteSetChangeDetail {
     Module(MoveModule),
     Resource(MoveResource),
-    Table(TableItem, Option<TableMetadata>),
+    Table(TableItem, CurrentTableItem, Option<TableMetadata>),
 }
 
 // Prevent conflicts with other things named `WriteSetChange`

--- a/crates/indexer/src/processors/coin_processor.rs
+++ b/crates/indexer/src/processors/coin_processor.rs
@@ -132,7 +132,11 @@ fn insert_coin_activities(
                     event_creation_number,
                     event_sequence_number,
                 ))
-                .do_nothing(),
+                .do_update()
+                .set((
+                    inserted_at.eq(excluded(inserted_at)),
+                    event_index.eq(excluded(event_index)),
+                )),
             None,
         )?;
     }

--- a/crates/indexer/src/processors/default_processor.rs
+++ b/crates/indexer/src/processors/default_processor.rs
@@ -14,7 +14,7 @@ use crate::{
         events::EventModel,
         move_modules::MoveModule,
         move_resources::MoveResource,
-        move_tables::{TableItem, TableMetadata},
+        move_tables::{CurrentTableItem, TableItem, TableMetadata},
         signatures::Signature,
         transactions::{TransactionDetail, TransactionModel},
         user_transactions::UserTransactionModel,
@@ -26,7 +26,7 @@ use aptos_api_types::Transaction;
 use async_trait::async_trait;
 use diesel::{result::Error, PgConnection};
 use field_count::FieldCount;
-use std::fmt::Debug;
+use std::{collections::HashMap, fmt::Debug};
 
 pub const NAME: &str = "default_processor";
 pub struct DefaultTransactionProcessor {
@@ -50,16 +50,57 @@ impl Debug for DefaultTransactionProcessor {
     }
 }
 
+fn insert_to_db_impl(
+    conn: &mut PgConnection,
+    txns: &[TransactionModel],
+    txn_details: (
+        &[UserTransactionModel],
+        &[Signature],
+        &[BlockMetadataTransactionModel],
+    ),
+    events: &[EventModel],
+    wscs: &[WriteSetChangeModel],
+    wsc_details: (
+        &[MoveModule],
+        &[MoveResource],
+        &[TableItem],
+        &[TableMetadata],
+    ),
+) -> Result<(), diesel::result::Error> {
+    let (user_transactions, signatures, block_metadata_transactions) = txn_details;
+    let (move_modules, move_resources, table_items, table_metadata) = wsc_details;
+    insert_transactions(conn, txns)?;
+    insert_user_transactions(conn, user_transactions)?;
+    insert_signatures(conn, signatures)?;
+    insert_block_metadata_transactions(conn, block_metadata_transactions)?;
+    insert_events(conn, events)?;
+    insert_write_set_changes(conn, wscs)?;
+    insert_move_modules(conn, move_modules)?;
+    insert_move_resources(conn, move_resources)?;
+    insert_table_items(conn, table_items)?;
+    insert_table_metadata(conn, table_metadata)?;
+    Ok(())
+}
+
 fn insert_to_db(
     conn: &mut PgPoolConnection,
     name: &'static str,
     start_version: u64,
     end_version: u64,
     txns: Vec<TransactionModel>,
-    txn_details: Vec<TransactionDetail>,
+    txn_details: (
+        Vec<UserTransactionModel>,
+        Vec<Signature>,
+        Vec<BlockMetadataTransactionModel>,
+    ),
     events: Vec<EventModel>,
     wscs: Vec<WriteSetChangeModel>,
-    wsc_details: Vec<WriteSetChangeDetail>,
+    wsc_details: (
+        Vec<MoveModule>,
+        Vec<MoveResource>,
+        Vec<TableItem>,
+        Vec<TableMetadata>,
+    ),
 ) -> Result<(), diesel::result::Error> {
     aptos_logger::trace!(
         name = name,
@@ -67,55 +108,79 @@ fn insert_to_db(
         end_version = end_version,
         "Inserting to db",
     );
+    let (user_transactions, signatures, block_metadata_transactions) = txn_details;
+    let (move_modules, move_resources, table_items, table_metadata) = wsc_details;
     match conn
         .build_transaction()
         .read_write()
         .run::<_, Error, _>(|pg_conn| {
-            insert_transactions(pg_conn, &txns)?;
-            insert_user_transactions_w_sigs(pg_conn, &txn_details)?;
-            insert_block_metadata_transactions(pg_conn, &txn_details)?;
-            insert_events(pg_conn, &events)?;
-            insert_write_set_changes(pg_conn, &wscs)?;
-            insert_move_modules(pg_conn, &wsc_details)?;
-            insert_move_resources(pg_conn, &wsc_details)?;
-            insert_table_data(pg_conn, &wsc_details)?;
-            Ok(())
+            insert_to_db_impl(
+                pg_conn,
+                &txns,
+                (
+                    &user_transactions,
+                    &signatures,
+                    &block_metadata_transactions,
+                ),
+                &events,
+                &wscs,
+                (
+                    &move_modules,
+                    &move_resources,
+                    &table_items,
+                    &table_metadata,
+                ),
+            )
         }) {
         Ok(_) => Ok(()),
-        Err(_) => conn
-            .build_transaction()
-            .read_write()
-            .run::<_, Error, _>(|pg_conn| {
-                let txns = clean_data_for_db(txns, true);
-                let txn_details = clean_data_for_db(txn_details, true);
-                let events = clean_data_for_db(events, true);
-                let wscs = clean_data_for_db(wscs, true);
-                let wsc_details = clean_data_for_db(wsc_details, true);
+        Err(_) => {
+            let txns = clean_data_for_db(txns, true);
+            let user_transactions = clean_data_for_db(user_transactions, true);
+            let signatures = clean_data_for_db(signatures, true);
+            let block_metadata_transactions = clean_data_for_db(block_metadata_transactions, true);
+            let events = clean_data_for_db(events, true);
+            let wscs = clean_data_for_db(wscs, true);
+            let move_modules = clean_data_for_db(move_modules, true);
+            let move_resources = clean_data_for_db(move_resources, true);
+            let table_items = clean_data_for_db(table_items, true);
+            let table_metadata = clean_data_for_db(table_metadata, true);
 
-                insert_transactions(pg_conn, &txns)?;
-                insert_user_transactions_w_sigs(pg_conn, &txn_details)?;
-                insert_block_metadata_transactions(pg_conn, &txn_details)?;
-                insert_events(pg_conn, &events)?;
-                insert_write_set_changes(pg_conn, &wscs)?;
-                insert_move_modules(pg_conn, &wsc_details)?;
-                insert_move_resources(pg_conn, &wsc_details)?;
-                insert_table_data(pg_conn, &wsc_details)?;
-                Ok(())
-            }),
+            conn.build_transaction()
+                .read_write()
+                .run::<_, Error, _>(|pg_conn| {
+                    insert_to_db_impl(
+                        pg_conn,
+                        &txns,
+                        (
+                            &user_transactions,
+                            &signatures,
+                            &block_metadata_transactions,
+                        ),
+                        &events,
+                        &wscs,
+                        (
+                            &move_modules,
+                            &move_resources,
+                            &table_items,
+                            &table_metadata,
+                        ),
+                    )
+                })
+        },
     }
 }
 
 fn insert_transactions(
     conn: &mut PgConnection,
-    txns: &[TransactionModel],
+    items_to_insert: &[TransactionModel],
 ) -> Result<(), diesel::result::Error> {
     use schema::transactions::dsl::*;
-    let chunks = get_chunks(txns.len(), TransactionModel::field_count());
+    let chunks = get_chunks(items_to_insert.len(), TransactionModel::field_count());
     for (start_ind, end_ind) in chunks {
         execute_with_better_error(
             conn,
             diesel::insert_into(schema::transactions::table)
-                .values(&txns[start_ind..end_ind])
+                .values(&items_to_insert[start_ind..end_ind])
                 .on_conflict(version)
                 .do_nothing(),
             None,
@@ -124,44 +189,41 @@ fn insert_transactions(
     Ok(())
 }
 
-fn insert_user_transactions_w_sigs(
+fn insert_user_transactions(
     conn: &mut PgConnection,
-    txn_details: &[TransactionDetail],
+    items_to_insert: &[UserTransactionModel],
 ) -> Result<(), diesel::result::Error> {
-    use schema::{signatures::dsl as sig_schema, user_transactions::dsl as ut_schema};
-    let mut all_signatures = vec![];
-    let mut all_user_transactions = vec![];
-    for detail in txn_details {
-        if let TransactionDetail::User(user_txn, sigs) = detail {
-            all_signatures.append(&mut sigs.clone());
-            all_user_transactions.push(user_txn.clone());
-        }
-    }
-    let chunks = get_chunks(
-        all_user_transactions.len(),
-        UserTransactionModel::field_count(),
-    );
+    use schema::user_transactions::dsl::*;
+    let chunks = get_chunks(items_to_insert.len(), UserTransactionModel::field_count());
     for (start_ind, end_ind) in chunks {
         execute_with_better_error(
             conn,
             diesel::insert_into(schema::user_transactions::table)
-                .values(&all_user_transactions[start_ind..end_ind])
-                .on_conflict(ut_schema::version)
+                .values(&items_to_insert[start_ind..end_ind])
+                .on_conflict(version)
                 .do_nothing(),
             None,
         )?;
     }
-    let chunks = get_chunks(all_signatures.len(), Signature::field_count());
+    Ok(())
+}
+
+fn insert_signatures(
+    conn: &mut PgConnection,
+    items_to_insert: &[Signature],
+) -> Result<(), diesel::result::Error> {
+    use schema::signatures::dsl::*;
+    let chunks = get_chunks(items_to_insert.len(), Signature::field_count());
     for (start_ind, end_ind) in chunks {
         execute_with_better_error(
             conn,
             diesel::insert_into(schema::signatures::table)
-                .values(&all_signatures[start_ind..end_ind])
+                .values(&items_to_insert[start_ind..end_ind])
                 .on_conflict((
-                    sig_schema::transaction_version,
-                    sig_schema::multi_agent_index,
-                    sig_schema::multi_sig_index,
-                    sig_schema::is_sender_primary,
+                    transaction_version,
+                    multi_agent_index,
+                    multi_sig_index,
+                    is_sender_primary,
                 ))
                 .do_nothing(),
             None,
@@ -172,24 +234,18 @@ fn insert_user_transactions_w_sigs(
 
 fn insert_block_metadata_transactions(
     conn: &mut PgConnection,
-    txn_details: &[TransactionDetail],
+    items_to_insert: &[BlockMetadataTransactionModel],
 ) -> Result<(), diesel::result::Error> {
     use schema::block_metadata_transactions::dsl::*;
-
-    let bmt = txn_details
-        .iter()
-        .filter_map(|detail| match detail {
-            TransactionDetail::BlockMetadata(bmt) => Some(bmt.clone()),
-            _ => None,
-        })
-        .collect::<Vec<BlockMetadataTransactionModel>>();
-
-    let chunks = get_chunks(bmt.len(), BlockMetadataTransactionModel::field_count());
+    let chunks = get_chunks(
+        items_to_insert.len(),
+        BlockMetadataTransactionModel::field_count(),
+    );
     for (start_ind, end_ind) in chunks {
         execute_with_better_error(
             conn,
             diesel::insert_into(schema::block_metadata_transactions::table)
-                .values(&bmt[start_ind..end_ind])
+                .values(&items_to_insert[start_ind..end_ind])
                 .on_conflict(version)
                 .do_nothing(),
             None,
@@ -198,16 +254,17 @@ fn insert_block_metadata_transactions(
     Ok(())
 }
 
-fn insert_events(conn: &mut PgConnection, ev: &[EventModel]) -> Result<(), diesel::result::Error> {
+fn insert_events(
+    conn: &mut PgConnection,
+    items_to_insert: &[EventModel],
+) -> Result<(), diesel::result::Error> {
     use schema::events::dsl::*;
-
-    let chunks = get_chunks(ev.len(), EventModel::field_count());
-
+    let chunks = get_chunks(items_to_insert.len(), EventModel::field_count());
     for (start_ind, end_ind) in chunks {
         execute_with_better_error(
             conn,
             diesel::insert_into(schema::events::table)
-                .values(&ev[start_ind..end_ind])
+                .values(&items_to_insert[start_ind..end_ind])
                 .on_conflict((account_address, creation_number, sequence_number))
                 .do_nothing(),
             None,
@@ -218,17 +275,15 @@ fn insert_events(conn: &mut PgConnection, ev: &[EventModel]) -> Result<(), diese
 
 fn insert_write_set_changes(
     conn: &mut PgConnection,
-    wscs: &[WriteSetChangeModel],
+    items_to_insert: &[WriteSetChangeModel],
 ) -> Result<(), diesel::result::Error> {
     use schema::write_set_changes::dsl::*;
-
-    let chunks = get_chunks(wscs.len(), WriteSetChangeModel::field_count());
-
+    let chunks = get_chunks(items_to_insert.len(), WriteSetChangeModel::field_count());
     for (start_ind, end_ind) in chunks {
         execute_with_better_error(
             conn,
             diesel::insert_into(schema::write_set_changes::table)
-                .values(&wscs[start_ind..end_ind])
+                .values(&items_to_insert[start_ind..end_ind])
                 .on_conflict((transaction_version, index))
                 .do_nothing(),
             None,
@@ -239,24 +294,15 @@ fn insert_write_set_changes(
 
 fn insert_move_modules(
     conn: &mut PgConnection,
-    wsc_details: &[WriteSetChangeDetail],
+    items_to_insert: &[MoveModule],
 ) -> Result<(), diesel::result::Error> {
     use schema::move_modules::dsl::*;
-
-    let modules = wsc_details
-        .iter()
-        .filter_map(|detail| match detail {
-            WriteSetChangeDetail::Module(module) => Some(module.clone()),
-            _ => None,
-        })
-        .collect::<Vec<MoveModule>>();
-
-    let chunks = get_chunks(modules.len(), MoveModule::field_count());
+    let chunks = get_chunks(items_to_insert.len(), MoveModule::field_count());
     for (start_ind, end_ind) in chunks {
         execute_with_better_error(
             conn,
             diesel::insert_into(schema::move_modules::table)
-                .values(&modules[start_ind..end_ind])
+                .values(&items_to_insert[start_ind..end_ind])
                 .on_conflict((transaction_version, write_set_change_index))
                 .do_nothing(),
             None,
@@ -267,24 +313,15 @@ fn insert_move_modules(
 
 fn insert_move_resources(
     conn: &mut PgConnection,
-    wsc_details: &[WriteSetChangeDetail],
+    items_to_insert: &[MoveResource],
 ) -> Result<(), diesel::result::Error> {
     use schema::move_resources::dsl::*;
-
-    let resources = wsc_details
-        .iter()
-        .filter_map(|detail| match detail {
-            WriteSetChangeDetail::Resource(resource) => Some(resource.clone()),
-            _ => None,
-        })
-        .collect::<Vec<MoveResource>>();
-
-    let chunks = get_chunks(resources.len(), MoveResource::field_count());
+    let chunks = get_chunks(items_to_insert.len(), MoveResource::field_count());
     for (start_ind, end_ind) in chunks {
         execute_with_better_error(
             conn,
             diesel::insert_into(schema::move_resources::table)
-                .values(&resources[start_ind..end_ind])
+                .values(&items_to_insert[start_ind..end_ind])
                 .on_conflict((transaction_version, write_set_change_index))
                 .do_nothing(),
             None,
@@ -293,49 +330,37 @@ fn insert_move_resources(
     Ok(())
 }
 
-/// This will insert all table data within each transaction within a block
-fn insert_table_data(
+fn insert_table_items(
     conn: &mut PgConnection,
-    wsc_details: &[WriteSetChangeDetail],
+    items_to_insert: &[TableItem],
 ) -> Result<(), diesel::result::Error> {
-    use schema::{table_items::dsl as ti, table_metadatas::dsl as tm};
-
-    let (items, metadata): (Vec<TableItem>, Vec<Option<TableMetadata>>) = wsc_details
-        .iter()
-        .filter_map(|detail| match detail {
-            WriteSetChangeDetail::Table(table_item, table_metadata) => {
-                Some((table_item.clone(), table_metadata.clone()))
-            },
-            _ => None,
-        })
-        .collect::<Vec<(TableItem, Option<TableMetadata>)>>()
-        .into_iter()
-        .unzip();
-    let mut metadata_nonnull = metadata
-        .iter()
-        .filter_map(|x| x.clone())
-        .collect::<Vec<TableMetadata>>();
-    metadata_nonnull.dedup_by(|a, b| a.handle == b.handle);
-    metadata_nonnull.sort_by(|a, b| a.handle.cmp(&b.handle));
-
-    let chunks = get_chunks(items.len(), TableItem::field_count());
+    use schema::table_items::dsl::*;
+    let chunks = get_chunks(items_to_insert.len(), TableItem::field_count());
     for (start_ind, end_ind) in chunks {
         execute_with_better_error(
             conn,
             diesel::insert_into(schema::table_items::table)
-                .values(&items[start_ind..end_ind])
-                .on_conflict((ti::transaction_version, ti::write_set_change_index))
+                .values(&items_to_insert[start_ind..end_ind])
+                .on_conflict((transaction_version, write_set_change_index))
                 .do_nothing(),
             None,
         )?;
     }
-    let chunks = get_chunks(metadata_nonnull.len(), TableMetadata::field_count());
+    Ok(())
+}
+
+fn insert_table_metadata(
+    conn: &mut PgConnection,
+    items_to_insert: &[TableMetadata],
+) -> Result<(), diesel::result::Error> {
+    use schema::table_metadatas::dsl::*;
+    let chunks = get_chunks(items_to_insert.len(), TableMetadata::field_count());
     for (start_ind, end_ind) in chunks {
         execute_with_better_error(
             conn,
             diesel::insert_into(schema::table_metadatas::table)
-                .values(&metadata_nonnull[start_ind..end_ind])
-                .on_conflict(tm::handle)
+                .values(&items_to_insert[start_ind..end_ind])
+                .on_conflict(handle)
                 .do_nothing(),
             None,
         )?;
@@ -355,8 +380,56 @@ impl TransactionProcessor for DefaultTransactionProcessor {
         start_version: u64,
         end_version: u64,
     ) -> Result<ProcessingResult, TransactionProcessingError> {
-        let (txns, user_txns, bm_txns, events, write_set_changes) =
+        let (txns, txn_details, events, write_set_changes, wsc_details) =
             TransactionModel::from_transactions(&transactions);
+
+        let mut signatures = vec![];
+        let mut user_transactions = vec![];
+        let mut block_metadata_transactions = vec![];
+        for detail in txn_details {
+            match detail {
+                TransactionDetail::User(user_txn, sigs) => {
+                    signatures.append(&mut sigs.clone());
+                    user_transactions.push(user_txn.clone());
+                },
+                TransactionDetail::BlockMetadata(bmt) => {
+                    block_metadata_transactions.push(bmt.clone())
+                },
+            }
+        }
+        let mut move_modules = vec![];
+        let mut move_resources = vec![];
+        let mut table_items = vec![];
+        let mut current_table_items = HashMap::new();
+        let mut table_metadata = HashMap::new();
+        for detail in wsc_details {
+            match detail {
+                WriteSetChangeDetail::Module(module) => move_modules.push(module.clone()),
+                WriteSetChangeDetail::Resource(resource) => move_resources.push(resource.clone()),
+                WriteSetChangeDetail::Table(item, current_item, metadata) => {
+                    table_items.push(item.clone());
+                    current_table_items.insert(
+                        (
+                            current_item.table_handle.clone(),
+                            current_item.key_hash.clone(),
+                        ),
+                        current_item.clone(),
+                    );
+                    if let Some(meta) = metadata {
+                        table_metadata.insert(meta.handle.clone(), meta.clone());
+                    }
+                },
+            }
+        }
+        // Getting list of values and sorting by pk in order to avoid postgres deadlock since we're doing multi threaded db writes
+        let mut current_table_items = current_table_items
+            .into_values()
+            .collect::<Vec<CurrentTableItem>>();
+        let mut table_metadata = table_metadata.into_values().collect::<Vec<TableMetadata>>();
+        // Sort by PK
+        current_table_items
+            .sort_by(|a, b| (&a.table_handle, &a.key_hash).cmp(&(&b.table_handle, &b.key_hash)));
+        table_metadata.sort_by(|a, b| a.handle.cmp(&b.handle));
 
         let mut conn = self.get_conn();
         let tx_result = insert_to_db(
@@ -365,10 +438,10 @@ impl TransactionProcessor for DefaultTransactionProcessor {
             start_version,
             end_version,
             txns,
-            user_txns,
-            bm_txns,
+            (user_transactions, signatures, block_metadata_transactions),
             events,
             write_set_changes,
+            (move_modules, move_resources, table_items, table_metadata),
         );
         match tx_result {
             Ok(_) => Ok(ProcessingResult::new(

--- a/crates/indexer/src/processors/token_processor.rs
+++ b/crates/indexer/src/processors/token_processor.rs
@@ -393,7 +393,11 @@ fn insert_token_activities(
                     event_creation_number,
                     event_sequence_number,
                 ))
-                .do_nothing(),
+                .do_update()
+                .set((
+                    inserted_at.eq(excluded(inserted_at)),
+                    event_index.eq(excluded(event_index)),
+                )),
             None,
         )?;
     }

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -34,6 +34,7 @@ diesel::table! {
         block_height -> Int8,
         transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
+        event_index -> Nullable<Int8>,
     }
 }
 
@@ -149,6 +150,19 @@ diesel::table! {
 }
 
 diesel::table! {
+    current_table_items (table_handle, key_hash) {
+        table_handle -> Varchar,
+        key_hash -> Varchar,
+        key -> Text,
+        decoded_key -> Jsonb,
+        decoded_value -> Nullable<Jsonb>,
+        is_deleted -> Bool,
+        latest_transaction_version -> Int8,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     current_token_datas (token_data_id_hash) {
         token_data_id_hash -> Varchar,
         creator_address -> Varchar,
@@ -222,6 +236,7 @@ diesel::table! {
         type_ -> Text,
         data -> Jsonb,
         inserted_at -> Timestamp,
+        event_index -> Nullable<Int8>,
     }
 }
 
@@ -364,6 +379,7 @@ diesel::table! {
         coin_amount -> Nullable<Numeric>,
         inserted_at -> Timestamp,
         transaction_timestamp -> Timestamp,
+        event_index -> Nullable<Int8>,
     }
 }
 
@@ -490,6 +506,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     current_coin_balances,
     current_collection_datas,
     current_staking_pool_voter,
+    current_table_items,
     current_token_datas,
     current_token_ownerships,
     current_token_pending_claims,

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -157,7 +157,7 @@ diesel::table! {
         decoded_key -> Jsonb,
         decoded_value -> Nullable<Jsonb>,
         is_deleted -> Bool,
-        latest_transaction_version -> Int8,
+        last_transaction_version -> Int8,
         inserted_at -> Timestamp,
     }
 }


### PR DESCRIPTION
### Description
* Added current_table_items table to be exposed via graphql
* Added event_index in several tables: events, token_activities, and coin_activities. This index represents the order in which the event is logged so sorting by transaction_version and event_index will be the best way to display events in the correct ordering moving forward. 

### Test Plan
Tested in devnet and testnet

current_table_items
<img width="1494" alt="image" src="https://user-images.githubusercontent.com/11738325/210481035-2edc47bd-273f-4e14-a255-dd3d859ed216.png">

events
<img width="959" alt="image" src="https://user-images.githubusercontent.com/11738325/210481060-3f8f8a0b-422f-4990-b7f8-edbe0b734cc3.png">

token_activities
<img width="829" alt="image" src="https://user-images.githubusercontent.com/11738325/210481091-157be3bf-908b-43a6-8b0d-24d274142af6.png">

coin_activities
<img width="1188" alt="image" src="https://user-images.githubusercontent.com/11738325/210481104-fef9cb4b-7cb8-4dfc-8589-2bfca355e8c7.png">

