### PR TITLE
[Network] Adding AptosPerf Client

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -122,7 +122,7 @@ jobs:
       - uses: taiki-e/install-action@v1.5.6
         with:
           tool: nextest
-      - run: cargo nextest run --profile ci --locked --workspace --exclude smoke-test --exclude aptos-testcases --retries 3 --no-fail-fast
+      - run: RUST_MIN_STACK=4194304 cargo nextest run --profile ci --locked --workspace --exclude smoke-test --exclude aptos-testcases --retries 3 --no-fail-fast
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,8 +1621,10 @@ dependencies = [
  "aptos-time-service",
  "aptos-types",
  "async-trait",
+ "axum",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "bytes 1.2.1",
+ "dashmap",
  "futures",
  "futures-util",
  "hex",
@@ -3074,43 +3076,12 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e3356844c4d6a6d6467b8da2cffb4a2820be256f50a3a386c9d152bab31043"
-dependencies = [
- "async-trait",
- "axum-core 0.2.8",
- "bitflags",
- "bytes 1.2.1",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "itoa 1.0.3",
- "matchit 0.5.0",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde 1.0.149",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
 dependencies = [
  "async-trait",
- "axum-core 0.3.0",
+ "axum-core",
  "bitflags",
  "bytes 1.2.1",
  "futures-util",
@@ -3118,32 +3089,20 @@ dependencies = [
  "http-body",
  "hyper",
  "itoa 1.0.3",
- "matchit 0.7.0",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
  "serde 1.0.149",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower",
  "tower-http",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f0c0a60006f2a293d82d571f635042a72edf927539b7685bd62d361963839b"
-dependencies = [
- "async-trait",
- "bytes 1.2.1",
- "futures-util",
- "http",
- "http-body",
- "mime",
  "tower-layer",
  "tower-service",
 ]
@@ -3169,7 +3128,7 @@ dependencies = [
 name = "axum-test"
 version = "0.1.0"
 dependencies = [
- "axum 0.5.16",
+ "axum",
  "tokio",
 ]
 
@@ -5298,9 +5257,9 @@ checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "httparse"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
@@ -5359,9 +5318,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
  "bytes 1.2.1",
  "futures-channel",
@@ -6149,12 +6108,6 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
-name = "matchit"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "matchit"
@@ -8921,6 +8874,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b04f22b563c91331a10074bda3dd5492e3cc39d56bd557e91c0af42b6c7341"
+dependencies = [
+ "serde 1.0.149",
+]
+
+[[package]]
 name = "serde_regex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9243,9 +9205,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -9825,7 +9787,7 @@ checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.6.1",
+ "axum",
  "base64 0.13.0",
  "bytes 1.2.1",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,7 +287,7 @@ assert_approx_eq = "1.1.0"
 assert_unordered = "0.1.1"
 async-stream = "0.3"
 async-trait = "0.1.53"
-axum = "0.5.16"
+axum = "0.6.1"
 base64 = "0.13.0"
 backtrace = "0.3.58"
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
@@ -345,7 +345,7 @@ hkdf = "0.10.0"
 hostname = "0.3.1"
 http = "0.2.3"
 httpmock = "0.6"
-hyper = { version = "0.14.18", features = ["full"] }
+hyper = { version = "0.14.23", features = ["full"] }
 hyper-tls = "0.5.0"
 include_dir = { version = "0.7.2", features = ["glob"] }
 indicatif = "0.15.0"

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -434,10 +434,12 @@ impl NodeConfig {
 
         if let Some(network) = self.validator_network.as_mut() {
             network.listen_address = crate::utils::get_available_port_in_multiaddr(true);
+            network.randomize_ports();
         }
 
         for network in self.full_node_networks.iter_mut() {
             network.listen_address = crate::utils::get_available_port_in_multiaddr(true);
+            network.randomize_ports();
         }
     }
 

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -54,6 +54,7 @@ pub const INBOUND_TCP_RX_BUFFER_SIZE: u32 = 3 * 1024 * 1024; // 3MB ~6MB/s with 
 pub const INBOUND_TCP_TX_BUFFER_SIZE: u32 = 512 * 1024; // 1MB use a bigger spoon
 pub const OUTBOUND_TCP_RX_BUFFER_SIZE: u32 = 3 * 1024 * 1024; // 3MB ~6MB/s with 500ms latency
 pub const OUTBOUND_TCP_TX_BUFFER_SIZE: u32 = 1024 * 1024; // 1MB use a bigger spoon
+pub const ENABLE_APTOS_NETPERF_CLIENT: bool = true;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -80,6 +81,7 @@ pub struct NetworkConfig {
     // Select this to enforce that both peers should authenticate each other, otherwise
     // authentication only occurs for outgoing connections.
     pub mutual_authentication: bool,
+    pub enable_netperf_client: bool,
     pub network_id: NetworkId,
     pub runtime_threads: Option<usize>,
     pub inbound_rx_buffer_size_bytes: Option<u32>,
@@ -129,6 +131,7 @@ impl NetworkConfig {
             identity: Identity::None,
             listen_address: "/ip4/0.0.0.0/tcp/6180".parse().unwrap(),
             mutual_authentication,
+            enable_netperf_client: ENABLE_APTOS_NETPERF_CLIENT,
             network_id,
             runtime_threads: None,
             seed_addrs: HashMap::new(),

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -55,7 +55,7 @@ pub const INBOUND_TCP_TX_BUFFER_SIZE: u32 = 512 * 1024; // 1MB use a bigger spoo
 pub const OUTBOUND_TCP_RX_BUFFER_SIZE: u32 = 3 * 1024 * 1024; // 3MB ~6MB/s with 500ms latency
 pub const OUTBOUND_TCP_TX_BUFFER_SIZE: u32 = 1024 * 1024; // 1MB use a bigger spoon
 pub const ENABLE_APTOS_NETPERF_CLIENT: bool = true;
-pub const DEFAULT_APTOS_NETPERF_CLIENT_PORT: u16 = 9107;
+pub const DEFAULT_APTOS_NETPERF_CLIENT_PORT: u16 = 9105;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -184,7 +184,7 @@ impl NetworkSender {
         // Broadcast message over direct-send to all other validators.
         if let Err(err) = self
             .consensus_network_client
-            .send_to_many(other_validators.into_iter(), msg)
+            .send_to_many(other_validators.into_iter(), &msg)
         {
             warn!(error = ?err, "Error broadcasting message");
         }

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -149,7 +149,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusMsg>> ConsensusNetworkClient
     pub fn send_to_many(
         &self,
         peers: impl Iterator<Item = PeerId>,
-        message: ConsensusMsg,
+        message: &ConsensusMsg,
     ) -> Result<(), Error> {
         let peer_network_ids: Vec<PeerNetworkId> = peers
             .map(|peer| self.get_peer_network_id_for_peer(peer))

--- a/consensus/src/payload_manager.rs
+++ b/consensus/src/payload_manager.rs
@@ -18,6 +18,7 @@ use tokio::sync::oneshot;
 
 /// Responsible to extract the transactions out of the payload and notify QuorumStore about commits.
 /// If QuorumStore is enabled, has to ask BatchReader for the transaction behind the proofs of availability in the payload.
+#[allow(dead_code)]
 pub enum PayloadManager {
     DirectMempool,
     InQuorumStore(BatchReader, Mutex<Sender<PayloadRequest>>),

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -37,10 +37,12 @@ type NotificationType = (
     Vec<ContractEvent>,
 );
 
+#[allow(dead_code)]
 type CommitType = (u64, Round, Vec<Payload>);
 
 /// Basic communication with the Execution module;
 /// implements StateComputer traits.
+#[allow(dead_code)]
 pub struct ExecutionProxy {
     executor: Arc<dyn BlockExecutorTrait>,
     txn_notifier: Arc<dyn TxnNotifier>,

--- a/crates/aptos-compression/src/metrics.rs
+++ b/crates/aptos-compression/src/metrics.rs
@@ -20,6 +20,7 @@ pub enum CompressionClient {
     Consensus,
     Mempool,
     StateSync,
+    NetPerf,
 }
 
 impl CompressionClient {
@@ -29,6 +30,7 @@ impl CompressionClient {
             Self::Consensus => "consensus",
             Self::Mempool => "mempool",
             Self::StateSync => "state_sync",
+            Self::NetPerf => "netperf",
         }
     }
 }

--- a/crates/channel/src/message_queues.rs
+++ b/crates/channel/src/message_queues.rs
@@ -123,6 +123,7 @@ impl<K: Eq + Hash + Clone, T> PerKeyQueue<K, T> {
             // For example, many of our queues have a max capacity of 1024. To
             // handle a single rpc from a transient peer, we would end up
             // allocating ~ 96 b * 1024 ~ 64 Kib per queue.
+            //TODO: Reconsider this. Maybe true for VFN but not Validators
             .or_insert_with(|| VecDeque::with_capacity(1));
 
         // Add the key to our round-robin queue if it's not already there

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -33,8 +33,10 @@ aptos-short-hex-str = { workspace = true }
 aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
 async-trait = { workspace = true }
+axum = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
+dashmap = {worksapce = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 hex = { workspace = true }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -36,7 +36,7 @@ async-trait = { workspace = true }
 axum = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
-dashmap = {worksapce = true }
+dashmap = { worksapce = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 hex = { workspace = true }

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -24,7 +24,6 @@ use aptos_infallible::RwLock;
 use aptos_logger::prelude::*;
 use aptos_netcore::transport::tcp::TCPBufferCfg;
 use aptos_network::application::netperf::builder::NetPerfBuilder;
-use aptos_network::protocols::wire::handshake::v1::ProtocolId::NetPerfDirectSendCompressed;
 use aptos_network::{
     application::netperf::NetPerf,
     application::storage::PeerMetadataStorage,
@@ -447,7 +446,7 @@ impl NetworkBuilder {
 
     /// Add a Aptos NetPerf to the network.
     fn add_network_perf(&mut self, netperf_port: u16) -> &mut Self {
-        let (netperf_tx, netperf_rx) = self.add_p2p_service(&NetPerf::network_endpoint_config());
+        let (netperf_tx, netperf_rx) = self.add_client_and_service(&NetPerf::network_endpoint_config());
         self.netperf_builder = Some(NetPerfBuilder::new(
             self.network_context(),
             self.peer_metadata_storage.clone(),

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -23,10 +23,11 @@ use aptos_event_notifications::{EventSubscriptionService, ReconfigNotificationLi
 use aptos_infallible::RwLock;
 use aptos_logger::prelude::*;
 use aptos_netcore::transport::tcp::TCPBufferCfg;
-use aptos_network::application::netperf::builder::NetPerfBuilder;
 use aptos_network::{
-    application::netperf::NetPerf,
-    application::storage::PeerMetadataStorage,
+    application::{
+        netperf::{builder::NetPerfBuilder, NetPerf},
+        storage::PeerMetadataStorage,
+    },
     connectivity_manager::{builder::ConnectivityManagerBuilder, ConnectivityRequest},
     constants::MAX_MESSAGE_SIZE,
     logging::NetworkSchema,
@@ -446,7 +447,8 @@ impl NetworkBuilder {
 
     /// Add a Aptos NetPerf to the network.
     fn add_network_perf(&mut self, netperf_port: u16) -> &mut Self {
-        let (netperf_tx, netperf_rx) = self.add_client_and_service(&NetPerf::network_endpoint_config());
+        let (netperf_tx, netperf_rx) =
+            self.add_client_and_service(&NetPerf::network_endpoint_config());
         self.netperf_builder = Some(NetPerfBuilder::new(
             self.network_context(),
             self.peer_metadata_storage.clone(),

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -231,8 +231,8 @@ impl NetworkBuilder {
             config.ping_failures_tolerated,
         );
 
-        if config.enable_netperf_client == true {
-            network_builder.add_network_perf();
+        if let Some(netperf_port) = config.netperf_client_port {
+            network_builder.add_network_perf(netperf_port);
         }
 
         // Always add a connectivity manager to keep track of known peers
@@ -325,11 +325,13 @@ impl NetworkBuilder {
         }
 
         if let Some(netperf_builder) = self.netperf_builder.as_mut() {
-            netperf_builder.start(executor);
-            debug!(
-                NetworkSchema::new(&self.network_context),
-                "{} Started Aptos NetPerf", self.network_context
-            );
+            if self.network_context.role() == RoleType::Validator {
+                netperf_builder.start(executor);
+                debug!(
+                    NetworkSchema::new(&self.network_context),
+                    "{} Started Aptos NetPerf", self.network_context
+                );
+            }
         }
 
         if let Some(discovery_listeners) = self.discovery_listeners.take() {
@@ -444,13 +446,14 @@ impl NetworkBuilder {
     }
 
     /// Add a Aptos NetPerf to the network.
-    fn add_network_perf(&mut self) -> &mut Self {
+    fn add_network_perf(&mut self, netperf_port: u16) -> &mut Self {
         let (netperf_tx, netperf_rx) = self.add_p2p_service(&NetPerf::network_endpoint_config());
         self.netperf_builder = Some(NetPerfBuilder::new(
             self.network_context(),
             self.peer_metadata_storage.clone(),
             Arc::new(netperf_tx),
             netperf_rx,
+            netperf_port,
         ));
         debug!(
             NetworkSchema::new(&self.network_context),

--- a/network/src/application/interface.rs
+++ b/network/src/application/interface.rs
@@ -48,7 +48,7 @@ pub trait NetworkClientInterface<Message: NetworkMessageTrait>: Clone + Send + S
 
     /// Sends the given message to each peer in the specified peer list.
     /// Note: this method does not guarantee message delivery or handle responses.
-    fn send_to_peers(&self, _message: Message, _peers: &[PeerNetworkId]) -> Result<(), Error>;
+    fn send_to_peers(&self, _message: &Message, _peers: &[PeerNetworkId]) -> Result<(), Error>;
 
     /// Sends the given message to the specified peer with the corresponding
     /// timeout. Awaits a response from the peer, or hits the timeout
@@ -153,7 +153,7 @@ impl<Message: NetworkMessageTrait> NetworkClientInterface<Message> for NetworkCl
         Ok(network_sender.send_to(peer.peer_id(), direct_send_protocol_id, message)?)
     }
 
-    fn send_to_peers(&self, message: Message, peers: &[PeerNetworkId]) -> Result<(), Error> {
+    fn send_to_peers(&self, message: &Message, peers: &[PeerNetworkId]) -> Result<(), Error> {
         // Sort peers by protocol
         let mut peers_per_protocol = HashMap::new();
         let mut peers_without_a_protocol = vec![];
@@ -188,7 +188,7 @@ impl<Message: NetworkMessageTrait> NetworkClientInterface<Message> for NetworkCl
             {
                 let network_sender = self.get_sender_for_network_id(&network_id)?;
                 let peer_ids = peers.map(|peer_network_id| peer_network_id.peer_id());
-                network_sender.send_to_many(peer_ids, protocol_id, message.clone())?;
+                network_sender.send_to_many(peer_ids, protocol_id, message)?;
             }
         }
         Ok(())

--- a/network/src/application/mod.rs
+++ b/network/src/application/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod error;
 pub mod interface;
+pub mod netperf;
 pub mod storage;
 pub mod types;
 

--- a/network/src/application/netperf/builder.rs
+++ b/network/src/application/netperf/builder.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    application::netperf::{
+use crate::application::{
+    netperf::{
         interface::{NetPerfNetworkEvents, NetPerfNetworkSender},
         NetPerf,
     },
-    application::storage::PeerMetadataStorage,
+    storage::PeerMetadataStorage,
 };
 use aptos_config::network_id::NetworkContext;
 use aptos_logger::prelude::*;

--- a/network/src/application/netperf/builder.rs
+++ b/network/src/application/netperf/builder.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    application::netperf::{
+        interface::{NetPerfNetworkEvents, NetPerfNetworkSender},
+        NetPerf,
+    },
+    application::storage::PeerMetadataStorage,
+};
+use aptos_config::network_id::NetworkContext;
+use aptos_logger::prelude::*;
+use std::sync::Arc;
+use tokio::runtime::Handle;
+
+pub struct NetPerfBuilder {
+    service: Option<NetPerf>,
+}
+
+impl NetPerfBuilder {
+    pub fn new(
+        network_context: NetworkContext,
+        peer_metadata_storage: Arc<PeerMetadataStorage>,
+        network_tx: Arc<NetPerfNetworkSender>,
+        network_rx: NetPerfNetworkEvents,
+    ) -> Self {
+        let service = NetPerf::new(
+            network_context,
+            peer_metadata_storage,
+            network_tx,
+            network_rx,
+        );
+        Self {
+            service: Some(service),
+        }
+    }
+
+    pub fn start(&mut self, executor: &Handle) {
+        if let Some(service) = self.service.take() {
+            spawn_named!("[Network] NetPerf", executor, service.start());
+        }
+    }
+}

--- a/network/src/application/netperf/builder.rs
+++ b/network/src/application/netperf/builder.rs
@@ -23,12 +23,14 @@ impl NetPerfBuilder {
         peer_metadata_storage: Arc<PeerMetadataStorage>,
         network_tx: Arc<NetPerfNetworkSender>,
         network_rx: NetPerfNetworkEvents,
+        netperf_port: u16,
     ) -> Self {
         let service = NetPerf::new(
             network_context,
             peer_metadata_storage,
             network_tx,
             network_rx,
+            netperf_port,
         );
         Self {
             service: Some(service),

--- a/network/src/application/netperf/interface.rs
+++ b/network/src/application/netperf/interface.rs
@@ -30,7 +30,16 @@ pub enum NetPerfMsg {
 /// `NetPerfMsg` types. `NetPerfNetworkEvents` is a thin wrapper
 /// around an `channel::Receiver<PeerManagerNotification>`.
 pub type NetPerfNetworkEvents = NetworkEvents<NetPerfMsg>;
+/*
+impl Stream for HealthCheckNetworkInterface {
+    type Item = Event<HealthCheckerMsg>;
 
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.get_mut().receiver).poll_next(cx)
+    }
+}
+
+ */
 /// The interface from NetPerf to Networking layer.
 ///
 /// This is a thin wrapper around a `NetworkSender<NetPerfMsg>`, so it is

--- a/network/src/application/netperf/interface.rs
+++ b/network/src/application/netperf/interface.rs
@@ -1,13 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 //
-use crate::{
-    protocols::{
-        network::{
-            NetworkEvents, NetworkSender,
-        },
-    },
-};
+use crate::protocols::network::{NetworkEvents, NetworkSender};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -16,8 +10,11 @@ pub struct NetPerfPayload {
 }
 
 impl NetPerfPayload {
-    pub fn new(len :usize) -> Self {
-        let v = Vec::with_capacity(len);
+    pub fn new(len: usize) -> Self {
+        let mut v = Vec::with_capacity(len);
+        unsafe {
+            v.set_len(len);
+        }
         NetPerfPayload { byte: v }
     }
 }

--- a/network/src/application/netperf/interface.rs
+++ b/network/src/application/netperf/interface.rs
@@ -2,20 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 use crate::{
-    application::interface::NetworkInterface,
-    constants::NETWORK_CHANNEL_SIZE,
-    counters,
-    error::NetworkError,
-    logging::NetworkSchema,
-    peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::{
         network::{
-            AppConfig, ApplicationNetworkSender, Event, NetworkEvents, NetworkSender,
-            NewNetworkSender,
+            NetworkEvents, NetworkSender,
         },
-        rpc::error::RpcError,
     },
-    ProtocolId,
 };
 use serde::{Deserialize, Serialize};
 

--- a/network/src/application/netperf/interface.rs
+++ b/network/src/application/netperf/interface.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+//
+use crate::{
+    application::interface::NetworkInterface,
+    constants::NETWORK_CHANNEL_SIZE,
+    counters,
+    error::NetworkError,
+    logging::NetworkSchema,
+    peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
+    protocols::{
+        network::{
+            AppConfig, ApplicationNetworkSender, Event, NetworkEvents, NetworkSender,
+            NewNetworkSender,
+        },
+        rpc::error::RpcError,
+    },
+    ProtocolId,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum NetPerfMsg {
+    BlockOfBytes64K,
+}
+/// The interface from Network to NetPerf layer.
+///
+/// `NetPerfNetworkEvents` is a `Stream` of `PeerManagerNotification` where the
+/// raw `Bytes` rpc messages are deserialized into
+/// `NetPerfMsg` types. `NetPerfNetworkEvents` is a thin wrapper
+/// around an `channel::Receiver<PeerManagerNotification>`.
+pub type NetPerfNetworkEvents = NetworkEvents<NetPerfMsg>;
+
+/// The interface from NetPerf to Networking layer.
+///
+/// This is a thin wrapper around a `NetworkSender<NetPerfMsg>`, so it is
+/// easy to clone and send off to a separate task. For example, the rpc requests
+/// return Futures that encapsulate the whole flow, from sending the request to
+/// remote, to finally receiving the response and deserializing. It therefore
+/// makes the most sense to make the rpc call on a separate async task, which
+/// requires the `NetPerfNetworkSender` to be `Clone` and `Send`.
+pub type NetPerfNetworkSender = NetworkSender<NetPerfMsg>;

--- a/network/src/application/netperf/interface.rs
+++ b/network/src/application/netperf/interface.rs
@@ -10,10 +10,11 @@ pub struct NetPerfPayload {
 }
 
 impl NetPerfPayload {
-    pub fn new(len: usize) -> Self {
+    pub fn new(mut len: usize) -> Self {
         let mut v = Vec::with_capacity(len);
-        unsafe {
-            v.set_len(len);
+        while len > 0 {
+            v.push(0);
+            len -= 1;
         }
         NetPerfPayload { byte: v }
     }
@@ -30,16 +31,7 @@ pub enum NetPerfMsg {
 /// `NetPerfMsg` types. `NetPerfNetworkEvents` is a thin wrapper
 /// around an `channel::Receiver<PeerManagerNotification>`.
 pub type NetPerfNetworkEvents = NetworkEvents<NetPerfMsg>;
-/*
-impl Stream for HealthCheckNetworkInterface {
-    type Item = Event<HealthCheckerMsg>;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.get_mut().receiver).poll_next(cx)
-    }
-}
-
- */
 /// The interface from NetPerf to Networking layer.
 ///
 /// This is a thin wrapper around a `NetworkSender<NetPerfMsg>`, so it is

--- a/network/src/application/netperf/interface.rs
+++ b/network/src/application/netperf/interface.rs
@@ -20,8 +20,20 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct NetPerfPayload {
+    byte: Vec<u8>,
+}
+
+impl NetPerfPayload {
+    pub fn new(len :usize) -> Self {
+        let v = Vec::with_capacity(len);
+        NetPerfPayload { byte: v }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum NetPerfMsg {
-    BlockOfBytes64K,
+    BlockOfBytes(NetPerfPayload),
 }
 /// The interface from Network to NetPerf layer.
 ///

--- a/network/src/application/netperf/mod.rs
+++ b/network/src/application/netperf/mod.rs
@@ -146,10 +146,13 @@ impl NetPerf {
                                 &metadata.remote_peer_id
                             );
                         }
-                        Event::Message(peer_id, msg) =>  {
+                        Event::Message(_peer_id, msg) =>  {
                             match msg {
-                                NetPerfMsg::BlockOfBytes(bytes) => {}
-                                _ => {}
+                                NetPerfMsg::BlockOfBytes(_bytes) => {
+                                    /* maybe add dedicated counters? but network_application_{out/in}bound_traffic
+                                     * seems to have us coverred
+                                     * */
+                                }
 
                             }
 
@@ -276,8 +279,10 @@ async fn netperf_broadcast(state: NetPerfState) {
     let msg = NetPerfMsg::BlockOfBytes(NetPerfPayload::new(64 * 1024));
 
     loop {
-        /* TODO(AlexM): Better Fine grained controll with send_to.
-         * Its interesting to see which of the validr queus gets full.
+        /* TODO(AlexM):
+         * 1. Fine grained controll with send_to.
+         *    Its interesting to see which of the validator queus gets filled.
+         * 2. msg.clone() is a disaster
          * */
         let rc = state.sender.send_to_many(
             state.peer_list.iter().map(|entry| entry.key().to_owned()),
@@ -287,6 +292,10 @@ async fn netperf_broadcast(state: NetPerfState) {
         if let Err(_) = rc {
             should_yield = true
         } //else update peer counters
+          /* maybe add dedicated counters? but network_application_{out/in}bound_traffic
+           * seems to have us coverred
+           * */
+
         if should_yield == true {
             break;
         }

--- a/network/src/application/netperf/mod.rs
+++ b/network/src/application/netperf/mod.rs
@@ -1,0 +1,66 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+//! Network Load Generator
+//!
+//! NetPerf is used to stress the network layer to gouge potential performance capabilities
+//! and simplify network-related performance profiling and debugging
+//!
+
+use crate::application::storage::PeerMetadataStorage;
+use crate::{
+    application::netperf::interface::{NetPerfNetworkEvents, NetPerfNetworkSender},
+    constants::NETWORK_CHANNEL_SIZE,
+    counters,
+    error::NetworkError,
+    logging::NetworkSchema,
+    peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
+    protocols::{
+        network::{
+            AppConfig, ApplicationNetworkSender, Event, NetworkEvents, NetworkSender,
+            NewNetworkSender,
+        },
+        rpc::error::RpcError,
+    },
+    ProtocolId,
+};
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
+use aptos_config::network_id::{NetworkContext, PeerNetworkId};
+use std::sync::Arc;
+
+pub mod builder;
+mod interface;
+
+//Interface End
+pub struct NetPerf {
+    network_context: NetworkContext,
+    peers: Arc<PeerMetadataStorage>,
+    sender: Arc<NetPerfNetworkSender>,
+    events: NetPerfNetworkEvents,
+}
+
+impl NetPerf {
+    pub fn new(
+        network_context: NetworkContext,
+        peers: Arc<PeerMetadataStorage>,
+        sender: Arc<NetPerfNetworkSender>,
+        events: NetPerfNetworkEvents,
+    ) -> Self {
+        NetPerf {
+            network_context,
+            peers,
+            sender,
+            events,
+        }
+    }
+
+    /// Configuration for the network endpoints to support NetPerf.
+    pub fn network_endpoint_config() -> AppConfig {
+        AppConfig::p2p(
+            [ProtocolId::NetPerfRpcCompressed],
+            aptos_channel::Config::new(NETWORK_CHANNEL_SIZE).queue_style(QueueStyle::LIFO),
+        )
+    }
+
+    pub async fn start(mut self) {}
+}

--- a/network/src/application/netperf/mod.rs
+++ b/network/src/application/netperf/mod.rs
@@ -118,7 +118,8 @@ impl NetPerf {
 
     async fn start(mut self) {
         let port = preferred_axum_port(self.netperf_port);
-        let (tx, rx) = tokio::sync::mpsc::channel::<NetPerfCommands>(NETPERF_COMMAND_CHANNEL_SIZE);
+        let (tx, mut rx) =
+            tokio::sync::mpsc::channel::<NetPerfCommands>(NETPERF_COMMAND_CHANNEL_SIZE);
 
         info!(
             NetworkSchema::new(&self.network_context),
@@ -286,7 +287,7 @@ async fn netperf_comp_handler(state: NetPerfState, mut rx: Receiver<NetPerfComma
                     None => break,
                 }
             }
-            _res = rpc_handlers.select_next_some() => {}
+            _res = rpc_handlers.select_next_some() => {break}
         }
     }
 }

--- a/network/src/application/netperf/mod.rs
+++ b/network/src/application/netperf/mod.rs
@@ -118,7 +118,7 @@ impl NetPerf {
 
     async fn start(mut self) {
         let port = preferred_axum_port(self.netperf_port);
-        let (tx, rx) = tokio::sync::mpsc::channel::<NetPerfCommands>(NETPERF_COMMAND_CHANNEL_SIZE);
+        let (tx, _rx) = tokio::sync::mpsc::channel::<NetPerfCommands>(NETPERF_COMMAND_CHANNEL_SIZE);
 
         info!(
             NetworkSchema::new(&self.network_context),
@@ -128,10 +128,6 @@ impl NetPerf {
         spawn_named!(
             "NetPerf Axum",
             start_axum(self.net_perf_state(tx.clone()), port)
-        );
-        spawn_named!(
-            "NetPerf EventHandler",
-            netperf_comp_handler(self.net_perf_state(tx.clone()), rx)
         );
 
         loop {
@@ -262,6 +258,7 @@ async fn parse_query(
     StatusCode::OK
 }
 
+#[allow(dead_code)]
 async fn netperf_comp_handler(state: NetPerfState, mut rx: Receiver<NetPerfCommands>) {
     let mut rpc_handlers = FuturesUnordered::new();
 

--- a/network/src/application/netperf/mod.rs
+++ b/network/src/application/netperf/mod.rs
@@ -296,6 +296,26 @@ async fn netperf_comp_handler(state: NetPerfState, mut rx: Receiver<NetPerfComma
     }
 }
 
+fn loop_body(state: &NetPerfState, msg: &NetPerfMsg) -> bool {
+    /* TODO(AlexM):
+ * 1. Fine grained control with send_to.
+ *    Its interesting to see which of the validator queus gets filled.
+ * 2. msg.clone() is a disaster
+ * */
+    let rc = state.sender.send_to_many(
+        state.peer_list.iter().map(|entry| entry.key().to_owned()),
+        ProtocolId::NetPerfDirectSendCompressed,
+        msg.clone(),
+    );
+    if rc.is_err() {
+        true
+    } else {
+        /* maybe add dedicated pep-peer counters? but network_application_{out/in}bound_traffic
+       * seems to have us covered
+       * */
+        false
+    }
+}
 async fn netperf_broadcast(state: NetPerfState, size: usize, duration: Duration) {
     let mut should_yield = false;
     let msg = NetPerfMsg::BlockOfBytes(NetPerfPayload::new(size));
@@ -312,24 +332,8 @@ async fn netperf_broadcast(state: NetPerfState, size: usize, duration: Duration)
 
     info!("Broadcast loop starting");
     loop {
-        /* TODO(AlexM):
-         * 1. Fine grained control with send_to.
-         *    Its interesting to see which of the validator queus gets filled.
-         * 2. msg.clone() is a disaster
-         * */
-        let rc = state.sender.send_to_many(
-            state.peer_list.iter().map(|entry| entry.key().to_owned()),
-            ProtocolId::NetPerfDirectSendCompressed,
-            msg.clone(),
-        );
-        if rc.is_err() {
-            should_yield = true;
-        } else {
-            /* maybe add dedicated pep-peer counters? but network_application_{out/in}bound_traffic
-           * seems to have us covered
-           * */
-            sent += 1;
-        }
+
+        should_yield = loop_body(&state, &msg);
 
         if done.load(std::sync::atomic::Ordering::Relaxed) {
             break;
@@ -337,7 +341,8 @@ async fn netperf_broadcast(state: NetPerfState, size: usize, duration: Duration)
         if should_yield {
             yield_count += 1;
             tokio::task::yield_now().await;
-            should_yield = false;
+        } else {
+            sent += 1;
         }
     }
     info!(

--- a/network/src/application/netperf/mod.rs
+++ b/network/src/application/netperf/mod.rs
@@ -118,8 +118,7 @@ impl NetPerf {
 
     async fn start(mut self) {
         let port = preferred_axum_port(self.netperf_port);
-        let (tx, mut rx) =
-            tokio::sync::mpsc::channel::<NetPerfCommands>(NETPERF_COMMAND_CHANNEL_SIZE);
+        let (tx, rx) = tokio::sync::mpsc::channel::<NetPerfCommands>(NETPERF_COMMAND_CHANNEL_SIZE);
 
         info!(
             NetworkSchema::new(&self.network_context),

--- a/network/src/application/netperf/mod.rs
+++ b/network/src/application/netperf/mod.rs
@@ -8,6 +8,7 @@
 //!
 
 use crate::application::storage::PeerMetadataStorage;
+use crate::transport::ConnectionMetadata;
 use crate::{
     application::netperf::interface::{NetPerfNetworkEvents, NetPerfNetworkSender},
     constants::NETWORK_CHANNEL_SIZE,
@@ -26,17 +27,47 @@ use crate::{
 };
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::network_id::{NetworkContext, PeerNetworkId};
+use aptos_logger::prelude::*;
+use aptos_types::account_address::AccountAddress;
+use aptos_types::PeerId;
+use axum::{
+    extract::Query,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Extension, Json, Router,
+};
+use dashmap::DashMap;
+use futures::StreamExt;
+use serde::Serialize;
+use std::fs::OpenOptions;
 use std::sync::Arc;
 
 pub mod builder;
 mod interface;
 
-//Interface End
 pub struct NetPerf {
     network_context: NetworkContext,
     peers: Arc<PeerMetadataStorage>,
+    peer_list: Arc<DashMap<PeerId, PeerNetPerfStat>>, //with capacity and hasher
     sender: Arc<NetPerfNetworkSender>,
     events: NetPerfNetworkEvents,
+    netperf_port: u16,
+}
+
+struct PeerNetPerfStat {}
+
+impl PeerNetPerfStat {
+    pub fn new(_md: ConnectionMetadata) -> Self {
+        PeerNetPerfStat {}
+    }
+}
+
+#[derive(Clone)]
+struct NetPerfState {
+    peers: Arc<PeerMetadataStorage>, //TODO: DO I need this?
+    peer_list: Arc<DashMap<PeerId, PeerNetPerfStat>>, //with capacity and hasher
+    sender: Arc<NetPerfNetworkSender>,
 }
 
 impl NetPerf {
@@ -45,12 +76,15 @@ impl NetPerf {
         peers: Arc<PeerMetadataStorage>,
         sender: Arc<NetPerfNetworkSender>,
         events: NetPerfNetworkEvents,
+        netperf_port: u16,
     ) -> Self {
         NetPerf {
             network_context,
             peers,
+            peer_list: Arc::new(DashMap::with_capacity(128)),
             sender,
             events,
+            netperf_port,
         }
     }
 
@@ -62,5 +96,124 @@ impl NetPerf {
         )
     }
 
-    pub async fn start(mut self) {}
+    fn net_perf_state(&self) -> NetPerfState {
+        NetPerfState {
+            peers: self.peers.clone(),
+            sender: self.sender.clone(),
+            peer_list: self.peer_list.clone(),
+        }
+    }
+
+    async fn start(mut self) {
+        let port = preferred_axum_port(self.netperf_port);
+        info!(
+            NetworkSchema::new(&self.network_context),
+            "{} NetPerf Event Listener started", self.network_context,
+        );
+
+        spawn_named!("NetPerf Axum", start_axum(self.net_perf_state(), port));
+
+        loop {
+            futures::select! {
+                maybe_event = self.events.next() => {
+                    // Shutdown the NetPerf when this network instance shuts
+                    // down. This happens when the `PeerManager` drops.
+                    let event = match maybe_event {
+                        Some(event) => event,
+                        None => break,
+                    };
+
+                    match event {
+                        Event::NewPeer(metadata) => {
+                            self.peer_list.insert(
+                                metadata.remote_peer_id,
+                                PeerNetPerfStat::new(metadata)
+                            );
+                        }
+                        Event::LostPeer(metadata) => {
+                            self.peer_list.remove(
+                                &metadata.remote_peer_id
+                            );
+                        }
+                        _ => {/* Currently ignore all*/}
+                    }
+                }
+            }
+        }
+        warn!(
+            NetworkSchema::new(&self.network_context),
+            "{} NetPerf event listener terminated", self.network_context
+        );
+    }
+}
+
+fn preferred_axum_port(netperf_port: u16) -> u16 {
+    if netperf_port != 9107 {
+        let _ = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open("/tmp/9107.tmp");
+
+        let _ = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(format!("/tmp/{}.tmp", netperf_port));
+    }
+    return netperf_port;
+}
+
+async fn start_axum(state: NetPerfState, netperf_port: u16) {
+    let app = Router::new()
+        .route("/", get(usage_handler))
+        .route("/peers", get(get_peers).layer(Extension(state.clone())))
+        .route(
+            "/command",
+            post(parse_query).layer(Extension(state.clone())),
+        );
+
+    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], netperf_port));
+
+    // run it with hyper on netperf_port
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+async fn usage_handler() -> &'static str {
+    "Usage: curl 127.0.0.01:9107/peers"
+}
+
+#[derive(Serialize)]
+struct PeerList {
+    len: usize,
+    peers: Vec<PeerId>,
+}
+
+impl PeerList {
+    pub fn new(len: usize) -> Self {
+        PeerList {
+            len,
+            peers: Vec::with_capacity(len),
+        }
+    }
+}
+
+async fn get_peers(Extension(state): Extension<NetPerfState>) -> Json<PeerList> {
+    let mut out = PeerList::new(state.peer_list.len());
+
+    let connected = state.peer_list.iter();
+
+    for peer in connected {
+        out.peers.push(peer.key().to_owned());
+    }
+
+    Json(out)
+}
+
+async fn parse_query(
+    Extension(state): Extension<NetPerfState>,
+    Query(params): Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    StatusCode::OK
 }

--- a/network/src/application/netperf/mod.rs
+++ b/network/src/application/netperf/mod.rs
@@ -10,7 +10,7 @@
 use crate::application::storage::PeerMetadataStorage;
 use crate::transport::ConnectionMetadata;
 use crate::{
-    application::netperf::interface::{NetPerfNetworkEvents, NetPerfNetworkSender},
+    application::netperf::interface::{NetPerfMsg::*, NetPerfNetworkEvents, NetPerfNetworkSender, NetPerfPayload},
     constants::NETWORK_CHANNEL_SIZE,
     counters,
     error::NetworkError,
@@ -29,6 +29,7 @@ use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::network_id::{NetworkContext, PeerNetworkId};
 use aptos_logger::prelude::*;
 use aptos_types::account_address::AccountAddress;
+use aptos_types::network_address::ParseError::NetworkLayerMissing;
 use aptos_types::PeerId;
 use axum::{
     extract::Query,
@@ -39,12 +40,18 @@ use axum::{
 };
 use dashmap::DashMap;
 use futures::StreamExt;
+use futures_util::stream::FuturesUnordered;
 use serde::Serialize;
 use std::fs::OpenOptions;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
+use tokio::spawn;
+use tokio::sync::mpsc::{Receiver, Sender};
+use crate::application::netperf::interface::NetPerfMsg;
 
 pub mod builder;
 mod interface;
+
+const NETPERF_COMMAND_CHANNEL_SIZE: usize = 1024;
 
 pub struct NetPerf {
     network_context: NetworkContext,
@@ -68,6 +75,7 @@ struct NetPerfState {
     peers: Arc<PeerMetadataStorage>, //TODO: DO I need this?
     peer_list: Arc<DashMap<PeerId, PeerNetPerfStat>>, //with capacity and hasher
     sender: Arc<NetPerfNetworkSender>,
+    tx: Sender<NetPerfCommands>,
 }
 
 impl NetPerf {
@@ -91,27 +99,38 @@ impl NetPerf {
     /// Configuration for the network endpoints to support NetPerf.
     pub fn network_endpoint_config() -> AppConfig {
         AppConfig::p2p(
-            [ProtocolId::NetPerfRpcCompressed],
-            aptos_channel::Config::new(NETWORK_CHANNEL_SIZE).queue_style(QueueStyle::LIFO),
+            [ProtocolId::NetPerfDirectSendCompressed, ProtocolId::NetPerfRpcCompressed],
+            aptos_channel::Config::new(NETWORK_CHANNEL_SIZE).queue_style(QueueStyle::FIFO),
         )
     }
 
-    fn net_perf_state(&self) -> NetPerfState {
+    fn net_perf_state(&self, sender: Sender<NetPerfCommands>) -> NetPerfState {
         NetPerfState {
             peers: self.peers.clone(),
             sender: self.sender.clone(),
             peer_list: self.peer_list.clone(),
+            tx: sender,
         }
     }
 
     async fn start(mut self) {
         let port = preferred_axum_port(self.netperf_port);
+        let (tx, mut rx) =
+            tokio::sync::mpsc::channel::<NetPerfCommands>(NETPERF_COMMAND_CHANNEL_SIZE);
+
         info!(
             NetworkSchema::new(&self.network_context),
             "{} NetPerf Event Listener started", self.network_context,
         );
 
-        spawn_named!("NetPerf Axum", start_axum(self.net_perf_state(), port));
+        spawn_named!(
+            "NetPerf Axum",
+            start_axum(self.net_perf_state(tx.clone()), port)
+        );
+        spawn_named!(
+            "NetPerf EventHandler",
+            netperf_comp_handler(self.net_perf_state(tx.clone()), rx)
+        );
 
         loop {
             futures::select! {
@@ -145,6 +164,10 @@ impl NetPerf {
             "{} NetPerf event listener terminated", self.network_context
         );
     }
+}
+#[derive(Clone)]
+enum NetPerfCommands {
+    Broadcast,
 }
 
 fn preferred_axum_port(netperf_port: u16) -> u16 {
@@ -215,5 +238,48 @@ async fn parse_query(
     Extension(state): Extension<NetPerfState>,
     Query(params): Query<std::collections::HashMap<String, String>>,
 ) -> impl IntoResponse {
+    spawn_named!("[NetPerf] Broadcast Task", netperf_broadcast(state.clone()));
+
     StatusCode::OK
+}
+
+async fn netperf_comp_handler(state: NetPerfState, mut rx: Receiver<NetPerfCommands>) {
+    let mut rpc_handlers = FuturesUnordered::new();
+
+    loop {
+        tokio::select! {
+            opt_cmd = rx.recv() => {
+                match opt_cmd {
+                    Some(cmd) => {
+                        let msg = NetPerfMsg::BlockOfBytes(NetPerfPayload::new(64 * 1024));
+
+                        for peer in state.peer_list.iter() {
+                            //TODO(AlexM): Yet another Alloc + Copy OPs.
+                            // Best use Refs - Just ARC
+                            rpc_handlers.push(state.sender.send_rpc(
+                                peer.key().to_owned(),
+                                ProtocolId::NetPerfRpcCompressed,
+                                msg.clone(),
+                                Duration::from_secs(5),
+                            ));
+                        }
+                    }
+                    None => break,
+                }
+            }
+            res = rpc_handlers.select_next_some() => {}
+        }
+    }
+}
+
+async fn netperf_broadcast(state: NetPerfState) {
+    let msg = NetPerfMsg::BlockOfBytes(NetPerfPayload::new(64 * 1024));
+
+    for peer in state.peer_list.iter() {
+        state.sender.send_to(
+            peer.key().to_owned(),
+            ProtocolId::NetPerfDirectSendCompressed,
+            msg.clone(),
+        );
+    }
 }

--- a/network/src/application/netperf/mod.rs
+++ b/network/src/application/netperf/mod.rs
@@ -14,6 +14,7 @@ use crate::transport::ConnectionMetadata;
 use crate::{
     application::netperf::interface::{NetPerfNetworkEvents, NetPerfNetworkSender, NetPerfPayload},
     constants::NETWORK_CHANNEL_SIZE,
+    counters,
     logging::NetworkSchema,
     protocols::network::Event,
     ProtocolId,
@@ -62,7 +63,7 @@ impl PeerNetPerfStat {
 #[allow(dead_code)]
 #[derive(Clone)]
 struct NetPerfState {
-    peers: Arc<PeerMetadataStorage>, //TODO: DO I need this?
+    peers: Arc<PeerMetadataStorage>,
     peer_list: Arc<DashMap<PeerId, PeerNetPerfStat>>, //with capacity and hasher
     sender: Arc<NetPerfNetworkSender>,
     tx: Sender<NetPerfCommands>,
@@ -93,7 +94,9 @@ impl NetPerf {
                 ProtocolId::NetPerfDirectSendCompressed,
                 ProtocolId::NetPerfRpcCompressed,
             ],
-            aptos_channel::Config::new(NETWORK_CHANNEL_SIZE).queue_style(QueueStyle::FIFO),
+            aptos_channel::Config::new(NETWORK_CHANNEL_SIZE)
+                .queue_style(QueueStyle::FIFO)
+                .counters(&counters::PENDING_NET_PERF_NETWORK_EVENTS),
         )
     }
 

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -156,11 +156,13 @@ pub static APTOS_NETWORK_DISCOVERY_NOTES: Lazy<IntGaugeVec> = Lazy::new(|| {
 });
 
 pub static APTOS_NETWORK_RPC_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "aptos_network_rpc_messages",
-        "Number of RPC messages",
-        &["role_type", "network_id", "peer_id", "type", "state"]
-    )
+    register_int_counter_vec!("aptos_network_rpc_messages", "Number of RPC messages", &[
+        "role_type",
+        "network_id",
+        "peer_id",
+        "type",
+        "state"
+    ])
     .unwrap()
 });
 

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -156,13 +156,11 @@ pub static APTOS_NETWORK_DISCOVERY_NOTES: Lazy<IntGaugeVec> = Lazy::new(|| {
 });
 
 pub static APTOS_NETWORK_RPC_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!("aptos_network_rpc_messages", "Number of RPC messages", &[
-        "role_type",
-        "network_id",
-        "peer_id",
-        "type",
-        "state"
-    ])
+    register_int_counter_vec!(
+        "aptos_network_rpc_messages",
+        "Number of RPC messages",
+        &["role_type", "network_id", "peer_id", "type", "state"]
+    )
     .unwrap()
 });
 
@@ -321,6 +319,16 @@ pub static PENDING_NETWORK_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_network_pending_requests",
         "Number of pending outbound network requests by state",
+        &["state"]
+    )
+    .unwrap()
+});
+
+/// Counter of pending network events to Health Checker.
+pub static PENDING_NET_PERF_NETWORK_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_network_pending_netperf_events",
+        "Number of pending netperf events by state",
         &["state"]
     )
     .unwrap()

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -338,6 +338,7 @@ impl<TMessage: Message> NetworkSender<TMessage> {
         timeout: Duration,
     ) -> Result<TMessage, RpcError> {
         // serialize request
+        //TODO(AlexM): In Bcast next line repeats 100 Times, ergo, Bcast should be a Network function.
         let req_data = protocol.to_bytes(&req_msg)?.into();
         let res_data = self
             .peer_mgr_reqs_tx

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -318,10 +318,10 @@ impl<TMessage: Message> NetworkSender<TMessage> {
         &self,
         recipients: impl Iterator<Item = PeerId>,
         protocol: ProtocolId,
-        message: TMessage,
+        message: &TMessage,
     ) -> Result<(), NetworkError> {
         // Serialize message.
-        let mdata = protocol.to_bytes(&message)?.into();
+        let mdata = protocol.to_bytes(message)?.into();
         self.peer_mgr_reqs_tx
             .send_to_many(recipients, protocol, mdata)?;
         Ok(())

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -57,6 +57,8 @@ pub enum ProtocolId {
     PeerMonitoringServiceRpc = 10,
     ConsensusRpcCompressed = 11,
     ConsensusDirectSendCompressed = 12,
+    NetPerfRpcCompressed = 13,
+    NetPerfDirectSendCompressed = 14,
 }
 
 /// The encoding types for Protocols
@@ -83,6 +85,8 @@ impl ProtocolId {
             PeerMonitoringServiceRpc => "PeerMonitoringServiceRpc",
             ConsensusRpcCompressed => "ConsensusRpcCompressed",
             ConsensusDirectSendCompressed => "ConsensusDirectSendCompressed",
+            NetPerfRpcCompressed => "NetPerfRpcCompressed",
+            NetPerfDirectSendCompressed => "NetPerfDirectSendCompressed",
         }
     }
 
@@ -101,6 +105,8 @@ impl ProtocolId {
             ProtocolId::PeerMonitoringServiceRpc,
             ProtocolId::ConsensusRpcCompressed,
             ProtocolId::ConsensusDirectSendCompressed,
+            ProtocolId::NetPerfRpcCompressed,
+            ProtocolId::NetPerfDirectSendCompressed,
         ]
     }
 
@@ -109,6 +115,9 @@ impl ProtocolId {
         match self {
             ProtocolId::ConsensusDirectSendJson | ProtocolId::ConsensusRpcJson => Encoding::Json,
             ProtocolId::ConsensusDirectSendCompressed | ProtocolId::ConsensusRpcCompressed => {
+                Encoding::CompressedBcs(RECURSION_LIMIT)
+            },
+            ProtocolId::NetPerfDirectSendCompressed | ProtocolId::NetPerfRpcCompressed => {
                 Encoding::CompressedBcs(RECURSION_LIMIT)
             },
             ProtocolId::MempoolDirectSend => Encoding::CompressedBcs(USER_INPUT_RECURSION_LIMIT),

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -133,6 +133,7 @@ impl ProtocolId {
                 CompressionClient::Consensus
             },
             ProtocolId::MempoolDirectSend => CompressionClient::Mempool,
+            ProtocolId::NetPerfDirectSendCompressed => CompressionClient::NetPerf,
             protocol_id => unreachable!(
                 "The given protocol ({:?}) should not be using compression!",
                 protocol_id

--- a/testsuite/generate-format/tests/staged/network.yaml
+++ b/testsuite/generate-format/tests/staged/network.yaml
@@ -152,6 +152,10 @@ ProtocolId:
       ConsensusRpcCompressed: UNIT
     12:
       ConsensusDirectSendCompressed: UNIT
+    13:
+      NetPerfRpcCompressed: UNIT
+    14:
+      NetPerfDirectSendCompressed: UNIT
 ProtocolIdSet:
   NEWTYPESTRUCT:
     TYPENAME: BitVec

--- a/testsuite/smoke-test/src/network.rs
+++ b/testsuite/smoke-test/src/network.rs
@@ -99,6 +99,7 @@ async fn test_netperf_client() {
     while std::path::Path::new("/tmp/9107.tmp").exists() {
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
+    panic!("Showme the logs\n");
 }
 
 #[tokio::test]

--- a/testsuite/smoke-test/src/network.rs
+++ b/testsuite/smoke-test/src/network.rs
@@ -24,7 +24,7 @@ use std::{
 
 #[ignore]
 #[tokio::test]
-async fn test_netperfclient() {
+async fn test_netperf_client() {
     let mut swarm = new_local_swarm_with_aptos(5).await;
     let version = swarm.versions().max().unwrap();
     let validator_peer_id = swarm.validators().next().unwrap().peer_id();

--- a/testsuite/smoke-test/src/network.rs
+++ b/testsuite/smoke-test/src/network.rs
@@ -24,7 +24,7 @@ use std::{
 
 #[tokio::test]
 async fn test_connection_limiting() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = new_local_swarm_with_aptos(5).await;
     let version = swarm.versions().max().unwrap();
     let validator_peer_id = swarm.validators().next().unwrap().peer_id();
 
@@ -130,6 +130,9 @@ async fn test_connection_limiting() {
             .unwrap()
             .unwrap_or(0)
     );
+    while std::path::Path::new("/tmp/9107.tmp").exists() {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
This PR adds a new client on top of the Aptos Network stack. 
The motivation is dual:
1. Ease Network Stack Profiling
2. Ease testing for new changes e.g., Crypto Broadcast.