### PR TITLE
[metadata] Only generate V1 module metadata if file format v>=6

### DIFF
--- a/aptos-move/framework/src/module_metadata.rs
+++ b/aptos-move/framework/src/module_metadata.rs
@@ -9,6 +9,9 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+/// The minimal file format version from which the V1 metadata is supported
+pub const METADATA_V1_MIN_FILE_FORMAT_VERSION: u32 = 6;
+
 /// The keys used to identify the metadata in the metadata section of the module bytecode.
 /// This is more or less arbitrary, besides we should use some unique key to identify
 /// Aptos specific metadata (`aptos::` here).
@@ -100,6 +103,14 @@ impl RuntimeModuleMetadata {
         RuntimeModuleMetadataV1 {
             error_map: self.error_map,
             ..RuntimeModuleMetadataV1::default()
+        }
+    }
+}
+
+impl RuntimeModuleMetadataV1 {
+    pub fn downgrade(self) -> RuntimeModuleMetadata {
+        RuntimeModuleMetadata {
+            error_map: self.error_map,
         }
     }
 }


### PR DESCRIPTION
This allows the CLI to operate with older networks. Notice this also means that by default, view functions do not work unless one uses the option `--bytecote-version 6`. 