### PR TITLE
[CLI][Staking] Add support for withdrawing from a staking contract

### DIFF
--- a/crates/aptos/src/stake/mod.rs
+++ b/crates/aptos/src/stake/mod.rs
@@ -184,7 +184,9 @@ impl CliCommand<Vec<TransactionSummary>> for UnlockStake {
 /// Before calling `WithdrawStake`, `UnlockStake` must be called first.
 #[derive(Parser)]
 pub struct WithdrawStake {
-    /// Amount of Octas (10^-8 APT) to withdraw
+    /// Amount of Octas (10^-8 APT) to withdraw.
+    /// This only applies to stake pools owned directly by the owner account, instead of via
+    /// a staking contract. In the latter case, when withdrawal is issued, all coins are distributed
     #[clap(long)]
     pub amount: u64,
 
@@ -193,16 +195,51 @@ pub struct WithdrawStake {
 }
 
 #[async_trait]
-impl CliCommand<TransactionSummary> for WithdrawStake {
+impl CliCommand<Vec<TransactionSummary>> for WithdrawStake {
     fn command_name(&self) -> &'static str {
         "WithdrawStake"
     }
 
-    async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
-        self.node_op_options
-            .submit_transaction(aptos_stdlib::stake_withdraw(self.amount))
-            .await
-            .map(|inner| inner.into())
+    async fn execute(mut self) -> CliTypedResult<Vec<TransactionSummary>> {
+        let client = self
+            .node_op_options
+            .rest_options
+            .client(&self.node_op_options.profile_options)?;
+        let amount = self.amount;
+        let owner_address = self.node_op_options.sender_address()?;
+        let mut transaction_summaries: Vec<TransactionSummary> = vec![];
+
+        let stake_pool_results = get_stake_pools(&client, owner_address).await?;
+        for stake_pool in stake_pool_results {
+            match stake_pool.pool_type {
+                StakePoolType::Direct => {
+                    transaction_summaries.push(
+                        self.node_op_options
+                            .submit_transaction(aptos_stdlib::stake_withdraw(amount))
+                            .await
+                            .map(|inner| inner.into())?,
+                    );
+                },
+                StakePoolType::StakingContract => {
+                    transaction_summaries.push(
+                        self.node_op_options
+                            .submit_transaction(aptos_stdlib::staking_contract_distribute(
+                                owner_address,
+                                stake_pool.operator_address,
+                            ))
+                            .await
+                            .map(|inner| inner.into())?,
+                    );
+                },
+                StakePoolType::Vesting => {
+                    return Err(CliError::UnexpectedError(
+                        "Stake withdrawal from vesting contract should use distribute-vested-coins"
+                            .into(),
+                    ))
+                },
+            }
+        }
+        Ok(transaction_summaries)
     }
 }
 

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -413,7 +413,7 @@ impl CliTestFramework {
         &self,
         index: usize,
         amount: u64,
-    ) -> CliTypedResult<TransactionSummary> {
+    ) -> CliTypedResult<Vec<TransactionSummary>> {
         WithdrawStake {
             node_op_options: self.transaction_options(index, None),
             amount,

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -1005,7 +1005,8 @@ async fn test_join_and_leave_validator() {
     gas_used += get_gas(
         cli.withdraw_stake(validator_cli_index, withdraw_stake)
             .await
-            .unwrap(),
+            .unwrap()
+            .remove(0),
     );
 
     cli.assert_account_balance_now(


### PR DESCRIPTION
### Description
aptos stake withdraw-stake currently only supports the classic stake contract, and not staking_contract (where operator and commission are involved).

### Test Plan
Unit and manual tests
