### PR TITLE
[Dockerfile] Pin llvm and clang dependency version in validator-testing image

### DIFF
--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -315,8 +315,8 @@ RUN echo "deb-src http://deb.debian.org/debian sid main contrib non-free" >> /et
 RUN apt-get update && apt-get install -y \
 		arping bison clang-format cmake dh-python \
 		dpkg-dev pkg-kde-tools ethtool flex inetutils-ping iperf \
-		libbpf-dev libclang-dev libclang-cpp-dev libedit-dev libelf-dev \
-		libfl-dev libzip-dev linux-libc-dev llvm-dev libluajit-5.1-dev \
+		libbpf-dev libclang-11-dev libclang-cpp-dev libedit-dev libelf-dev \
+		libfl-dev libzip-dev linux-libc-dev llvm-11-dev libluajit-5.1-dev \
 		luajit python3-netaddr python3-pyroute2 python3-distutils python3 \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 


### PR DESCRIPTION
### Description

We use `sid` unstable apt package sources in validator-testing image and install certain packages without version pinning. As a result, clang and llvm got updated to v14 recently, which breaks bcc which depends on v11. 

This PR pins the version fro clang and llvm to v11. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Wait for CICD.
