### PR TITLE
[Aptos Runtimes] Add a small crate that spawns named runtimes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-metrics-core",
  "aptos-proptest-helpers",
+ "aptos-runtimes",
  "aptos-sdk",
  "aptos-state-view",
  "aptos-storage-interface",
@@ -381,6 +382,7 @@ dependencies = [
  "aptos-db",
  "aptos-logger",
  "aptos-metrics-core",
+ "aptos-runtimes",
  "aptos-storage-interface",
  "aptos-temppath",
  "aptos-types",
@@ -536,6 +538,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-metrics-core",
  "aptos-network",
+ "aptos-runtimes",
  "aptos-safety-rules",
  "aptos-schemadb",
  "aptos-secure-storage",
@@ -576,6 +579,7 @@ name = "aptos-consensus-notifications"
 version = "0.1.0"
 dependencies = [
  "aptos-crypto",
+ "aptos-runtimes",
  "aptos-types",
  "async-trait",
  "claims",
@@ -1314,6 +1318,7 @@ dependencies = [
  "aptos-logger",
  "aptos-mempool",
  "aptos-metrics-core",
+ "aptos-runtimes",
  "aptos-storage-interface",
  "aptos-types",
  "aptos-vm",
@@ -1353,6 +1358,7 @@ dependencies = [
  "aptos-infallible",
  "aptos-logger",
  "aptos-metrics-core",
+ "aptos-runtimes",
  "aptos-telemetry",
  "assert_approx_eq",
  "futures",
@@ -1487,6 +1493,7 @@ dependencies = [
  "aptos-netcore",
  "aptos-network",
  "aptos-proptest-helpers",
+ "aptos-runtimes",
  "aptos-short-hex-str",
  "aptos-storage-interface",
  "aptos-types",
@@ -1513,6 +1520,7 @@ name = "aptos-mempool-notifications"
 version = "0.1.0"
 dependencies = [
  "aptos-crypto",
+ "aptos-runtimes",
  "aptos-types",
  "async-trait",
  "claims",
@@ -1733,6 +1741,7 @@ dependencies = [
  "aptos-mempool-notifications",
  "aptos-network",
  "aptos-network-builder",
+ "aptos-runtimes",
  "aptos-secure-storage",
  "aptos-state-sync-driver",
  "aptos-state-view",
@@ -2019,6 +2028,7 @@ dependencies = [
  "aptos-logger",
  "aptos-node",
  "aptos-rest-client",
+ "aptos-runtimes",
  "aptos-sdk",
  "aptos-types",
  "aptos-warp-webserver",
@@ -2053,6 +2063,13 @@ dependencies = [
  "serde_json",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "aptos-runtimes"
+version = "0.1.0"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]
@@ -2230,6 +2247,7 @@ dependencies = [
  "aptos-mempool-notifications",
  "aptos-metrics-core",
  "aptos-network",
+ "aptos-runtimes",
  "aptos-schemadb",
  "aptos-scratchpad",
  "aptos-storage-interface",
@@ -2367,6 +2385,7 @@ dependencies = [
  "aptos-metrics-core",
  "aptos-network",
  "aptos-node-resource-metrics",
+ "aptos-runtimes",
  "aptos-state-sync-driver",
  "aptos-telemetry-service",
  "aptos-types",
@@ -2454,6 +2473,7 @@ dependencies = [
  "aptos-logger",
  "aptos-move-examples",
  "aptos-rest-client",
+ "aptos-runtimes",
  "aptos-sdk",
  "aptos-types",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ members = [
     "crates/aptos-retrier",
     "crates/aptos-rosetta",
     "crates/aptos-rosetta-cli",
+    "crates/aptos-runtimes",
     "crates/aptos-telemetry",
     "crates/aptos-telemetry-service",
     "crates/aptos-temppath",
@@ -244,6 +245,7 @@ aptos-rest-client = { path = "crates/aptos-rest-client" }
 aptos-retrier = { path = "crates/aptos-retrier" }
 aptos-rocksdb-options = { path = "storage/rocksdb-options" }
 aptos-rosetta = { path = "crates/aptos-rosetta" }
+aptos-runtimes = { path = "crates/aptos-runtimes" }
 aptos-safety-rules = { path = "consensus/safety-rules" }
 aptos-schemadb = { path = "storage/schemadb" }
 aptos-scratchpad = { path = "storage/scratchpad" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -22,6 +22,7 @@ aptos-gas = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-mempool = { workspace = true }
 aptos-metrics-core = { workspace = true }
+aptos-runtimes = { workspace = true }
 aptos-state-view = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-types = { workspace = true }

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -39,6 +39,7 @@ aptos-mempool = { workspace = true }
 aptos-mempool-notifications = { workspace = true }
 aptos-network = { workspace = true }
 aptos-network-builder = { workspace = true }
+aptos-runtimes = { workspace = true }
 aptos-secure-storage = { workspace = true }
 aptos-state-sync-driver = { workspace = true }
 aptos-state-view = { workspace = true }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -29,6 +29,7 @@ aptos-logger = { workspace = true }
 aptos-mempool = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-network = { workspace = true }
+aptos-runtimes = { workspace = true }
 aptos-safety-rules = { workspace = true }
 aptos-schemadb = { workspace = true }
 aptos-secure-storage = { workspace = true }

--- a/consensus/src/test_utils/mod.rs
+++ b/consensus/src/test_utils/mod.rs
@@ -199,11 +199,7 @@ pub fn consensus_runtime() -> runtime::Runtime {
         ::aptos_logger::Logger::new().level(Level::Debug).init();
     }
 
-    runtime::Builder::new_multi_thread()
-        .enable_all()
-        .disable_lifo_slot()
-        .build()
-        .expect("Failed to create Tokio runtime!")
+    aptos_runtimes::spawn_named_runtime("consensus".into(), None)
 }
 
 pub fn timed_block_on<F>(runtime: &runtime::Runtime, f: F) -> <F as Future>::Output

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -46,7 +46,7 @@ use aptos_types::{
 use futures::{channel::mpsc, StreamExt};
 use maplit::hashmap;
 use std::{collections::HashMap, iter::FromIterator, sync::Arc};
-use tokio::runtime::{Builder, Runtime};
+use tokio::runtime::Runtime;
 
 /// Auxiliary struct that is preparing SMR for the test
 pub struct SMRNode {
@@ -123,16 +123,8 @@ impl SMRNode {
             })
             .unwrap();
 
-        let runtime = Builder::new_multi_thread()
-            .thread_name(format!(
-                "{}-node-{}",
-                twin_id.id,
-                std::thread::current().name().unwrap_or("")
-            ))
-            .disable_lifo_slot()
-            .enable_all()
-            .build()
-            .unwrap();
+        let thread_name = format!("twin-{}", twin_id.id,);
+        let runtime = aptos_runtimes::spawn_named_runtime(thread_name, None);
 
         let time_service = Arc::new(ClockTimeService::new(runtime.handle().clone()));
 

--- a/crates/aptos-rosetta/Cargo.toml
+++ b/crates/aptos-rosetta/Cargo.toml
@@ -21,6 +21,7 @@ aptos-global-constants = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-node = { workspace = true }
 aptos-rest-client = { workspace = true }
+aptos-runtimes = { workspace = true }
 aptos-sdk = { workspace = true }
 aptos-types = { workspace = true }
 aptos-warp-webserver = { workspace = true }

--- a/crates/aptos-rosetta/src/lib.rs
+++ b/crates/aptos-rosetta/src/lib.rs
@@ -15,14 +15,7 @@ use aptos_config::config::ApiConfig;
 use aptos_logger::{debug, warn};
 use aptos_types::{account_address::AccountAddress, chain_id::ChainId};
 use aptos_warp_webserver::{logger, Error, WebServer};
-use std::{
-    collections::BTreeMap,
-    convert::Infallible,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
-};
+use std::{collections::BTreeMap, convert::Infallible, sync::Arc};
 use tokio::task::JoinHandle;
 use warp::{
     http::{HeaderValue, Method, StatusCode},
@@ -121,16 +114,7 @@ pub fn bootstrap(
     rest_client: Option<aptos_rest_client::Client>,
     owner_addresses: Vec<AccountAddress>,
 ) -> anyhow::Result<tokio::runtime::Runtime> {
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .thread_name_fn(|| {
-            static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-            let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-            format!("rosetta-{}", id)
-        })
-        .disable_lifo_slot()
-        .enable_all()
-        .build()
-        .expect("[rosetta] failed to create runtime");
+    let runtime = aptos_runtimes::spawn_named_runtime("rosetta".into(), None);
 
     debug!("Starting up Rosetta server with {:?}", api_config);
 

--- a/crates/aptos-runtimes/Cargo.toml
+++ b/crates/aptos-runtimes/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "aptos-runtimes"
+description = "Simple runtime spawning utilities"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+tokio = { workspace = true }

--- a/crates/aptos-runtimes/src/lib.rs
+++ b/crates/aptos-runtimes/src/lib.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::runtime::{Builder, Runtime};
+
+/// The max thread name length before the name will be truncated
+/// when it's displayed. Note: the max display length is 15, but
+/// we need to leave space for the thread IDs.
+const MAX_THREAD_NAME_LENGTH: usize = 12;
+
+/// Returns a tokio runtime with named threads.
+/// This is useful for tracking threads when debugging.
+pub fn spawn_named_runtime(thread_name: String, num_worker_threads: Option<usize>) -> Runtime {
+    // Verify the given name has an appropriate length
+    if thread_name.len() > MAX_THREAD_NAME_LENGTH {
+        panic!(
+            "The given runtime thread name is too long! Max length: {}, given name: {}",
+            MAX_THREAD_NAME_LENGTH, thread_name
+        );
+    }
+
+    // Create the runtime builder
+    let atomic_id = AtomicUsize::new(0);
+    let thread_name_clone = thread_name.clone();
+    let mut builder = Builder::new_multi_thread();
+    builder
+        .thread_name_fn(move || {
+            let id = atomic_id.fetch_add(1, Ordering::SeqCst);
+            format!("{}-{}", thread_name_clone, id)
+        })
+        .disable_lifo_slot()
+        .enable_all();
+    if let Some(num_worker_threads) = num_worker_threads {
+        builder.worker_threads(num_worker_threads);
+    }
+
+    // Spawn and return the runtime
+    builder.build().unwrap_or_else(|error| {
+        panic!(
+            "Failed to spawn named runtime! Name: {:?}, Error: {:?}",
+            thread_name, error
+        )
+    })
+}

--- a/crates/aptos-telemetry/Cargo.toml
+++ b/crates/aptos-telemetry/Cargo.toml
@@ -25,6 +25,7 @@ aptos-mempool = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-network = { workspace = true }
 aptos-node-resource-metrics = { workspace = true }
+aptos-runtimes = { workspace = true }
 aptos-state-sync-driver = { workspace = true }
 aptos-telemetry-service = { workspace = true }
 aptos-types = { workspace = true }

--- a/crates/aptos-telemetry/src/service.rs
+++ b/crates/aptos-telemetry/src/service.rs
@@ -25,14 +25,9 @@ use std::{
     collections::BTreeMap,
     env,
     future::Future,
-    sync::atomic::{AtomicUsize, Ordering},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
-use tokio::{
-    runtime::{Builder, Runtime},
-    task::JoinHandle,
-    time,
-};
+use tokio::{runtime::Runtime, task::JoinHandle, time};
 use uuid::Uuid;
 
 // The chain ID key
@@ -119,17 +114,7 @@ pub fn start_telemetry_service(
     }
 
     // Create the telemetry runtime
-    let telemetry_runtime = Builder::new_multi_thread()
-        .thread_name_fn(|| {
-            static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-            let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-            format!("telemetry-{}", id)
-        })
-        .disable_lifo_slot()
-        .enable_all()
-        .build()
-        .expect("Failed to create the Aptos Telemetry runtime!");
-
+    let telemetry_runtime = aptos_runtimes::spawn_named_runtime("telemetry".into(), None);
     telemetry_runtime.handle().spawn(spawn_telemetry_service(
         node_config,
         chain_id,

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -21,6 +21,7 @@ aptos-config = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-mempool = { workspace = true }
 aptos-metrics-core = { workspace = true }
+aptos-runtimes = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }

--- a/crates/indexer/src/runtime.rs
+++ b/crates/indexer/src/runtime.rs
@@ -20,7 +20,7 @@ use aptos_mempool::MempoolClientSender;
 use aptos_storage_interface::DbReader;
 use aptos_types::chain_id::ChainId;
 use std::{collections::VecDeque, sync::Arc};
-use tokio::runtime::{Builder, Runtime};
+use tokio::runtime::Runtime;
 
 pub struct MovingAverage {
     window_millis: u64,
@@ -84,12 +84,7 @@ pub fn bootstrap(
         return None;
     }
 
-    let runtime = Builder::new_multi_thread()
-        .thread_name("indexer")
-        .disable_lifo_slot()
-        .enable_all()
-        .build()
-        .expect("[indexer] failed to create runtime");
+    let runtime = aptos_runtimes::spawn_named_runtime("indexer".into(), None);
 
     let indexer_config = config.indexer.clone();
     let node_config = config.clone();

--- a/crates/inspection-service/Cargo.toml
+++ b/crates/inspection-service/Cargo.toml
@@ -19,6 +19,7 @@ aptos-config = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
+aptos-runtimes = { workspace = true }
 aptos-telemetry = { workspace = true }
 futures = { workspace = true }
 hyper = { workspace = true }

--- a/crates/inspection-service/src/inspection_service.rs
+++ b/crates/inspection-service/src/inspection_service.rs
@@ -18,7 +18,6 @@ use std::{
     net::{SocketAddr, ToSocketAddrs},
     thread,
 };
-use tokio::runtime;
 
 // The message displayed when the endpoint is disabled.
 const DISABLED_ENDPOINT_MESSAGE: &str =
@@ -167,12 +166,7 @@ pub fn start_inspection_service(node_config: NodeConfig) {
             }
         });
 
-        let runtime = runtime::Builder::new_current_thread()
-            .thread_name("inspection")
-            .enable_io()
-            .disable_lifo_slot()
-            .build()
-            .unwrap();
+        let runtime = aptos_runtimes::spawn_named_runtime("inspection".into(), None);
         runtime
             .block_on(async {
                 let server = Server::bind(&addr).serve(make_service);

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -27,6 +27,7 @@ aptos-metrics-core = { workspace = true }
 aptos-netcore = { workspace = true }
 aptos-network = { workspace = true }
 aptos-proptest-helpers = { workspace = true, optional = true }
+aptos-runtimes = { workspace = true }
 aptos-short-hex-str = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-types = { workspace = true }

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -34,7 +34,7 @@ use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
 };
-use tokio::runtime::{Builder, Handle, Runtime};
+use tokio::runtime::{Handle, Runtime};
 
 /// Mock of a running instance of shared mempool.
 pub struct MockSharedMempool {
@@ -51,12 +51,7 @@ impl MockSharedMempool {
     /// Returns the runtime on which the shared mempool is running
     /// and the channel through which shared mempool receives client events.
     pub fn new() -> Self {
-        let runtime = Builder::new_multi_thread()
-            .thread_name("mock-shared-mem")
-            .disable_lifo_slot()
-            .enable_all()
-            .build()
-            .expect("[mock shared mempool] failed to create runtime");
+        let runtime = aptos_runtimes::spawn_named_runtime("shared-mem".into(), None);
         let (ac_client, mempool, quorum_store_sender, mempool_notifier) = Self::start(
             runtime.handle(),
             &DbReaderWriter::new(MockDbReaderWriter),

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -41,7 +41,7 @@ use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
 };
-use tokio::runtime::{Builder, Runtime};
+use tokio::runtime::Runtime;
 
 type MempoolNetworkHandle = (
     NetworkId,
@@ -581,12 +581,7 @@ fn start_node_mempool(
             on_chain_configs: OnChainConfigPayload::new(1, Arc::new(HashMap::new())),
         })
         .unwrap();
-    let runtime = Builder::new_multi_thread()
-        .thread_name("shared-mem")
-        .disable_lifo_slot()
-        .enable_all()
-        .build()
-        .expect("[shared mempool] failed to create runtime");
+    let runtime = aptos_runtimes::spawn_named_runtime("shared-mem".into(), None);
     start_shared_mempool(
         runtime.handle(),
         &config,

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -10,7 +10,6 @@ use aptos_consensus_types::common::RejectedTransactionSummary;
 use aptos_mempool_notifications::MempoolNotificationSender;
 use aptos_types::transaction::Transaction;
 use futures::{channel::oneshot, executor::block_on, sink::SinkExt};
-use tokio::runtime::Builder;
 
 #[test]
 fn test_consensus_events_rejected_txns() {
@@ -56,11 +55,7 @@ fn test_consensus_events_rejected_txns() {
 #[test]
 fn test_mempool_notify_committed_txns() {
     // Create runtime for the mempool notifier and listener
-    let runtime = Builder::new_multi_thread()
-        .disable_lifo_slot()
-        .enable_all()
-        .build()
-        .unwrap();
+    let runtime = aptos_runtimes::spawn_named_runtime("shared-mem".into(), None);
     let _enter = runtime.enter();
 
     // Create a new mempool notifier, listener and shared mempool

--- a/state-sync/inter-component/consensus-notifications/Cargo.toml
+++ b/state-sync/inter-component/consensus-notifications/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 aptos-crypto = { workspace = true }
+aptos-runtimes = { workspace = true }
 aptos-types = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }

--- a/state-sync/inter-component/consensus-notifications/src/lib.rs
+++ b/state-sync/inter-component/consensus-notifications/src/lib.rs
@@ -286,7 +286,7 @@ mod tests {
     use futures::{executor::block_on, FutureExt, StreamExt};
     use move_core_types::language_storage::TypeTag;
     use std::time::Duration;
-    use tokio::runtime::{Builder, Runtime};
+    use tokio::runtime::Runtime;
 
     const CONSENSUS_NOTIFICATION_TIMEOUT: u64 = 1000;
 
@@ -454,10 +454,6 @@ mod tests {
     }
 
     fn create_runtime() -> Runtime {
-        Builder::new_multi_thread()
-            .disable_lifo_slot()
-            .enable_all()
-            .build()
-            .unwrap()
+        aptos_runtimes::spawn_named_runtime("test".into(), None)
     }
 }

--- a/state-sync/inter-component/mempool-notifications/Cargo.toml
+++ b/state-sync/inter-component/mempool-notifications/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+aptos-runtimes = { workspace = true }
 aptos-types = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }

--- a/state-sync/inter-component/mempool-notifications/src/lib.rs
+++ b/state-sync/inter-component/mempool-notifications/src/lib.rs
@@ -226,7 +226,7 @@ mod tests {
     };
     use claims::{assert_matches, assert_ok};
     use futures::{executor::block_on, FutureExt, StreamExt};
-    use tokio::runtime::{Builder, Runtime};
+    use tokio::runtime::Runtime;
 
     #[test]
     fn test_mempool_not_listening() {
@@ -394,10 +394,6 @@ mod tests {
     }
 
     fn create_runtime() -> Runtime {
-        Builder::new_multi_thread()
-            .disable_lifo_slot()
-            .enable_all()
-            .build()
-            .unwrap()
+        aptos_runtimes::spawn_named_runtime("test".into(), None)
     }
 }

--- a/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
+++ b/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
@@ -25,6 +25,7 @@ aptos-infallible = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-mempool-notifications = { workspace = true }
 aptos-metrics-core = { workspace = true }
+aptos-runtimes = { workspace = true }
 aptos-schemadb = { workspace = true }
 aptos-scratchpad = { workspace = true }
 aptos-storage-interface = { workspace = true }

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
@@ -23,11 +23,8 @@ use aptos_storage_interface::DbReaderWriter;
 use aptos_time_service::TimeService;
 use aptos_types::{move_resource::MoveStorage, waypoint::Waypoint};
 use futures::{channel::mpsc, executor::block_on};
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc,
-};
-use tokio::runtime::{Builder, Runtime};
+use std::sync::Arc;
+use tokio::runtime::Runtime;
 
 /// Creates a new state sync driver and client
 pub struct DriverFactory {
@@ -84,18 +81,8 @@ impl DriverFactory {
 
         // Create a new runtime (if required)
         let driver_runtime = if create_runtime {
-            Some(
-                Builder::new_multi_thread()
-                    .thread_name_fn(|| {
-                        static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-                        let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-                        format!("sync-driver-{}", id)
-                    })
-                    .disable_lifo_slot()
-                    .enable_all()
-                    .build()
-                    .expect("Failed to create state sync v2 driver runtime!"),
-            )
+            let runtime = aptos_runtimes::spawn_named_runtime("sync-driver".into(), None);
+            Some(runtime)
         } else {
             None
         };

--- a/storage/backup/backup-service/Cargo.toml
+++ b/storage/backup/backup-service/Cargo.toml
@@ -18,6 +18,7 @@ aptos-crypto = { workspace = true }
 aptos-db = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
+aptos-runtimes = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }

--- a/testsuite/smoke-test/src/txn_emitter.rs
+++ b/testsuite/smoke-test/src/txn_emitter.rs
@@ -9,7 +9,6 @@ use aptos_forge::{
 use aptos_sdk::{transaction_builder::TransactionFactory, types::PeerId};
 use rand::{rngs::OsRng, SeedableRng};
 use std::time::Duration;
-use tokio::runtime::Builder;
 
 pub async fn generate_traffic(
     swarm: &mut dyn Swarm,
@@ -18,9 +17,6 @@ pub async fn generate_traffic(
     gas_price: u64,
 ) -> Result<TxnStats> {
     ensure!(gas_price > 0, "gas_price is required to be non zero");
-    let mut runtime_builder = Builder::new_multi_thread();
-    runtime_builder.disable_lifo_slot().enable_all();
-    runtime_builder.worker_threads(64);
     let rng = SeedableRng::from_rng(OsRng)?;
     let validator_clients = swarm
         .validators()

--- a/testsuite/testcases/Cargo.toml
+++ b/testsuite/testcases/Cargo.toml
@@ -22,6 +22,7 @@ aptos-keygen = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-move-examples = { workspace = true }
 aptos-rest-client = { workspace = true }
+aptos-runtimes = { workspace = true }
 aptos-sdk = { workspace = true }
 aptos-types = { workspace = true }
 futures = { workspace = true }

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -20,7 +20,7 @@ pub mod two_traffics_test;
 pub mod validator_join_leave_test;
 pub mod validator_reboot_stress_test;
 
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use aptos_forge::{
     EmitJobRequest, NetworkContext, NetworkTest, NodeExt, Result, Swarm, SwarmExt, Test,
     TxnEmitter, TxnStats, Version,
@@ -30,7 +30,7 @@ use aptos_sdk::{transaction_builder::TransactionFactory, types::PeerId};
 use futures::future::join_all;
 use rand::{rngs::StdRng, SeedableRng};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-use tokio::runtime::{Builder, Runtime};
+use tokio::runtime::Runtime;
 
 const WARMUP_DURATION_FRACTION: f32 = 0.07;
 const COOLDOWN_DURATION_FRACTION: f32 = 0.04;
@@ -76,12 +76,8 @@ pub fn create_emitter_and_request(
 }
 
 pub fn traffic_emitter_runtime() -> Result<Runtime> {
-    let mut runtime_builder = Builder::new_multi_thread();
-    runtime_builder.disable_lifo_slot().enable_all();
-    runtime_builder.worker_threads(64);
-    runtime_builder
-        .build()
-        .map_err(|err| anyhow!("Failed to start runtime for transaction emitter. {}", err))
+    let runtime = aptos_runtimes::spawn_named_runtime("emitter".into(), Some(64));
+    Ok(runtime)
 }
 
 pub fn generate_traffic(


### PR DESCRIPTION
### Description
This PR adds a new crate that provides a simple utility for spawning tokio runtimes with named threads. We're currently doing this all over the place, so it make sense to unify it into a single location to reduce the duplication.

Note: in the ideal case we wouldn't need to introduce a new crate for this, but there's too many dependencies, so we're running into circular dependencies. A new crate seems okay for now.

### Test Plan
Existing test infrastructure.