### PR TITLE
[Parallel Executor] Remove unnecessary Sync trait for MVHashMapView

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -63,6 +63,7 @@ use std::{
     cmp::min,
     collections::{BTreeMap, BTreeSet},
     convert::{AsMut, AsRef},
+    marker::Sync,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -273,7 +274,7 @@ impl AptosVM {
         let delta_write_set_mut = user_txn_change_set_ext
             .delta_change_set()
             .clone()
-            .try_into_write_set_mut(&storage)
+            .try_into_write_set_mut(storage)
             .expect("something terrible happened when applying aggregator deltas");
         let delta_write_set = delta_write_set_mut
             .freeze()
@@ -1036,7 +1037,7 @@ impl VMExecutor for AptosVM {
     /// transaction output.
     fn execute_block(
         transactions: Vec<Transaction>,
-        state_view: &impl StateView,
+        state_view: &(impl StateView + Sync),
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         fail_point!("move_adapter::execute_block", |_| {
             Err(VMStatus::Error(

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -128,7 +128,7 @@ impl BlockAptosVM {
             .collect()
     }
 
-    pub fn execute_block<S: StateView>(
+    pub fn execute_block<S: StateView + Sync>(
         transactions: Vec<Transaction>,
         state_view: &S,
         concurrency_level: usize,

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -23,7 +23,7 @@ pub(crate) struct AptosExecutorTask<'a, S> {
     base_view: &'a S,
 }
 
-impl<'a, S: 'a + StateView> ExecutorTask for AptosExecutorTask<'a, S> {
+impl<'a, S: 'a + StateView + Sync> ExecutorTask for AptosExecutorTask<'a, S> {
     type Argument = &'a S;
     type Error = VMStatus;
     type Output = AptosTransactionOutput;

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -133,6 +133,7 @@ use move_core_types::{
     account_address::AccountAddress,
     language_storage::{ResourceKey, StructTag},
 };
+use std::marker::Sync;
 
 /// This trait describes the VM's validation interfaces.
 pub trait VMValidator {
@@ -154,7 +155,7 @@ pub trait VMExecutor: Send + Sync {
     /// Executes a block of transactions and returns output for each one of them.
     fn execute_block(
         transactions: Vec<Transaction>,
-        state_view: &impl StateView,
+        state_view: &(impl StateView + Sync),
     ) -> Result<Vec<TransactionOutput>, VMStatus>;
 }
 

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -35,7 +35,7 @@ impl<T, E, S> BlockExecutor<T, E, S>
 where
     T: Transaction,
     E: ExecutorTask<Txn = T>,
-    S: TStateView<Key = T::Key>,
+    S: TStateView<Key = T::Key> + Sync,
 {
     /// The caller needs to ensure that concurrency_level > 1 (0 is illegal and 1 should
     /// be handled by sequential execution) and that concurrency_level <= num_cpus.

--- a/storage/state-view/src/lib.rs
+++ b/storage/state-view/src/lib.rs
@@ -21,7 +21,7 @@ pub mod account_with_state_view;
 /// `StateView` is a trait that defines a read-only snapshot of the global state. It is passed to
 /// the VM for transaction execution, during which the VM is guaranteed to read anything at the
 /// given state.
-pub trait TStateView: Sync {
+pub trait TStateView {
     type Key;
 
     /// For logging and debugging purpose, identifies what this view is for.
@@ -58,7 +58,7 @@ pub enum StateViewId {
 
 impl<R, S, K> TStateView for R
 where
-    R: Deref<Target = S> + Sync,
+    R: Deref<Target = S>,
     S: TStateView<Key = K>,
 {
     type Key = K;


### PR DESCRIPTION
Unnecessary mutexes I hate, they are evil.

But seriously, it goes beyond unnecessary mutex - per session view should be single threaded, and with multi-versioned code there will be more things to track than just the reads, and wrapping all of them in extra Sync-things is disgusting.

Using RefCell for interior mutability, as having general stateview trait have mut& self for reading would have been ugly.

This unnecessary mutex has been there for years, but we couldn't get rid of it. Finally, after rounds of recent stateview/aptos-vm/wrapper refactorings, it's now possible.

Anyway, now I'm wasting your (whoever's reading) time, the diff is tiny, please just look there instead 👯 