### PR TITLE
Add CI for running Aptos CLI test suite

### DIFF
--- a/.github/workflows/cli-e2e-tests.yaml
+++ b/.github/workflows/cli-e2e-tests.yaml
@@ -1,0 +1,66 @@
+name: "Run Aptos CLI E2E tests"
+on:
+  # This is called from within the docker-build-test.yaml workflow since we depend
+  # on the build of the image of the CLI we're testing having been built before this
+  # workflow runs. You can see in the invocation of the test suite that we pass in
+  # the image repo we just built and pushed the tools image to and the git SHA1 of
+  # the commit / PR that triggered this workflow.
+  workflow_call:
+    inputs:
+      GIT_SHA:
+        required: true
+        type: string
+        description: Use this to override the git SHA1, branch name (e.g. devnet) or tag
+
+jobs:
+  # Run the Aptos CLI examples. We run the CLI on this commit / PR against a
+  # local testnet using the devnet, testnet, and mainnet branches. This way
+  # we ensure that the Aptos CLI works with all 3 prod networks, at least
+  # based on the tests in the test suite.
+  run-cli-tests:
+    runs-on: high-perf-docker
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+
+      # Run CLI tests against local testnet built from devnet branch.
+      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
+        name: devnet-tests
+        with:
+          max_attempts: 5
+          timeout_minutes: 20
+          command: cd ./crates/aptos/e2e && python main.py -d --base-network devnet --image-repo-with-project ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }} --test-cli-tag ${{ inputs.GIT_SHA }} --working-directory ${{ runner.temp }}/aptos-e2e-tests-devnet
+
+      # Run CLI tests against local testnet built from testnet branch.
+      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
+        name: testnet-tests
+        with:
+          max_attempts: 5
+          timeout_minutes: 20
+          command: cd ./crates/aptos/e2e && python main.py -d --base-network testnet --image-repo-with-project ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }} --test-cli-tag ${{ inputs.GIT_SHA }} --working-directory ${{ runner.temp }}/aptos-e2e-tests-testnet
+
+      # Run CLI tests against local testnet built from mainnet branch.
+      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
+        name: mainnet-tests
+        with:
+          max_attempts: 5
+          timeout_minutes: 20
+          command: cd ./crates/aptos/e2e && python main.py -d --base-network mainnet --image-repo-with-project ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }} --test-cli-tag ${{ inputs.GIT_SHA }} --working-directory ${{ runner.temp }}/aptos-e2e-tests-mainnet
+
+      - name: Print local testnet logs on failure
+        if: ${{ failure() }}
+        working-directory: docker/compose/validator-testnet
+        run: docker logs aptos-tools-devnet && docker logs aptos-tools-testnet && docker logs aptos-tools-mainnet

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -180,6 +180,20 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
 
+  cli-e2e-tests:
+    needs: [rust-images, determine-docker-build-metadata]
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'CICD:skip-sdk-integration-test') && (
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+      github.event.pull_request.auto_merge != null) ||
+      contains(github.event.pull_request.body, '#e2e')
+    uses: ./.github/workflows/cli-e2e-tests.yaml
+    secrets: inherit
+    with:
+      GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+
   forge-e2e-test:
     needs:
       [rust-images, rust-images-failpoints, determine-docker-build-metadata]

--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -16,7 +16,7 @@
 
 name: "API + TS SDK CI"
 on:
-  # This is called from within the build-images.yaml workflow since we depend
+  # This is called from within the docker-build-test.yaml workflow since we depend
   # on the images having been built before this workflow runs.
   workflow_call:
     inputs:

--- a/crates/aptos/e2e/cases/init.py
+++ b/crates/aptos/e2e/cases/init.py
@@ -1,6 +1,10 @@
 # Copyright © Aptos Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
+from cases.shared import TestError
+
 
 def test_init(run_helper):
     run_helper.run_command(
@@ -8,3 +12,10 @@ def test_init(run_helper):
         ["aptos", "init", "--assume-yes", "--network", "local"],
         input="\n",
     )
+    config_path = os.path.join(
+        run_helper.host_working_directory, ".aptos", "config.yaml"
+    )
+    if not os.path.exists(config_path):
+        raise TestError(
+            f"{config_path} not found (in host working dir) after running aptos init"
+        )

--- a/crates/aptos/e2e/cases/shared.py
+++ b/crates/aptos/e2e/cases/shared.py
@@ -1,0 +1,9 @@
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+# Exception to use when a test fails, for the CLI did something unexpected,
+# an expected output was missing, etc.
+#
+# For errors with the framework itself, use RuntimeError.
+class TestError(Exception):
+    pass

--- a/crates/aptos/e2e/common.py
+++ b/crates/aptos/e2e/common.py
@@ -1,9 +1,9 @@
 # Copyright © Aptos Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from dataclasses import dataclass
 from enum import Enum
-
 
 NODE_PORT = 8080
 FAUCET_PORT = 8081
@@ -31,3 +31,14 @@ ACCOUNT_ONE = AccountInfo(
     public_key="0x25caf00522e4d4664ec0a27166a69e8a32b5078959d0fc398da70d40d2893e8f",
     account_address="0x585fc9f0f0c54183b039ffc770ca282ebd87307916c215a3e692f2f8e4305e82",
 )
+
+
+def build_image_name(image_repo_with_project: str, tag: str):
+    return f"{image_repo_with_project}/tools:{tag}"
+
+
+def recursive_chmod(path, perms):
+    for dirpath, _, filenames in os.walk(path):
+        os.chmod(dirpath, perms)
+        for filename in filenames:
+            os.chmod(os.path.join(dirpath, filename), perms)

--- a/crates/aptos/e2e/local_testnet.py
+++ b/crates/aptos/e2e/local_testnet.py
@@ -6,17 +6,16 @@
 import logging
 import subprocess
 import time
-
 from urllib.request import urlopen
 
-from common import FAUCET_PORT, NODE_PORT, Network
+from common import FAUCET_PORT, NODE_PORT, Network, build_image_name
 
 LOG = logging.getLogger(__name__)
 
 # Run a local testnet in a docker container. We choose to detach here and we'll
 # stop running it later using the container name.
-def run_node(network: Network, image_repo: str):
-    image_name = build_image_name(network, image_repo)
+def run_node(network: Network, image_repo_with_project: str):
+    image_name = build_image_name(image_repo_with_project, network)
     container_name = f"aptos-tools-{network}"
     LOG.info(f"Trying to run aptos CLI local testnet from image: {image_name}")
 
@@ -32,7 +31,8 @@ def run_node(network: Network, image_repo: str):
         [
             "docker",
             "run",
-            "--rm",
+            "--pull",
+            "always",
             "--detach",
             "--name",
             container_name,
@@ -81,7 +81,3 @@ def wait_for_startup(container_name: str, timeout: int):
             count += 1
             time.sleep(1)
     LOG.info(f"Node and faucet APIs for {container_name} came up")
-
-
-def build_image_name(network: Network, image_repo: str):
-    return f"{image_repo}aptoslabs/tools:{network}"

--- a/crates/aptos/e2e/test_helpers.py
+++ b/crates/aptos/e2e/test_helpers.py
@@ -7,10 +7,10 @@ import pathlib
 import subprocess
 import traceback
 import typing
-
+from contextlib import contextmanager
 from dataclasses import dataclass
 
-from common import AccountInfo
+from common import AccountInfo, build_image_name, recursive_chmod
 
 LOG = logging.getLogger(__name__)
 
@@ -21,26 +21,29 @@ WORKING_DIR_IN_CONTAINER = "/tmp"
 @dataclass
 class RunHelper:
     host_working_directory: str
-    image_repo: str
+    image_repo_with_project: str
     image_tag: str
     cli_path: str
     passed_tests: typing.List[str]
     failed_tests: typing.List[str]
+    volume_name: str
 
-    def __init__(self, host_working_directory, image_repo, image_tag, cli_path):
+    def __init__(
+        self, host_working_directory, image_repo_with_project, image_tag, cli_path
+    ):
         if image_tag and cli_path:
             raise RuntimeError("Cannot specify both image_tag and cli_path")
         if not (image_tag or cli_path):
             raise RuntimeError("Must specify one of image_tag and cli_path")
         self.host_working_directory = host_working_directory
-        self.image_repo = image_repo
+        self.image_repo_with_project = image_repo_with_project
         self.image_tag = image_tag
         self.cli_path = cli_path
         self.passed_tests = []
         self.failed_tests = []
 
     def build_image_name(self):
-        return f"{self.image_repo}aptoslabs/tools:{self.image_tag}"
+        return build_image_name(self.image_repo_with_project, self.image_tag)
 
     # This function lets you pass call the CLI like you would normally, but really it is
     # calling the CLI in a docker container and mounting the host working directory such
@@ -54,6 +57,10 @@ class RunHelper:
             full_command = [
                 "docker",
                 "run",
+                # For why we have to set --user, see here:
+                # https://github.com/community/community/discussions/44243
+                "--user",
+                f"{os.getuid()}:{os.getgid()}",
                 "--rm",
                 "--network",
                 "host",
@@ -128,7 +135,9 @@ class RunHelper:
     # set, in which case we ensure the file is there.
     def prepare(self):
         if self.image_tag:
-            command = ["docker", "pull", self.build_image_name()]
+            image_name = self.build_image_name()
+            LOG.info(f"Pre-pulling image for CLI we're testing: {image_name}")
+            command = ["docker", "pull", image_name]
             LOG.debug(f"Running command: {command}")
             output = subprocess.check_output(command)
             LOG.debug(f"Output: {output}")


### PR DESCRIPTION
### Description
In https://github.com/aptos-labs/aptos-core/pull/5946 I added a framework for running CLI tests. This PR configures CI to run those tests. The policy of when it runs is the same as sdk-release.yaml.

### Test Plan
Check CI.
