### PR TITLE
Add generic CallCustomModule transaction generator

### DIFF
--- a/crates/transaction-emitter-lib/src/transaction_generator/account_generator.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/account_generator.rs
@@ -9,8 +9,7 @@ use aptos_sdk::{
     types::{transaction::SignedTransaction, LocalAccount},
 };
 use async_trait::async_trait;
-use rand::{prelude::StdRng, Rng};
-use rand_core::{OsRng, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{sync::Arc, time::Duration};
 
 pub struct AccountGenerator {
@@ -129,9 +128,9 @@ impl AccountGeneratorCreator {
 
 #[async_trait]
 impl TransactionGeneratorCreator for AccountGeneratorCreator {
-    async fn create_transaction_generator(&self) -> Box<dyn TransactionGenerator> {
+    async fn create_transaction_generator(&mut self) -> Box<dyn TransactionGenerator> {
         Box::new(AccountGenerator::new(
-            StdRng::from_seed(OsRng.gen()),
+            StdRng::from_entropy(),
             self.txn_factory.clone(),
             self.all_addresses.clone(),
             self.add_created_accounts_to_pool,

--- a/crates/transaction-emitter-lib/src/transaction_generator/call_custom_modules.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/call_custom_modules.rs
@@ -1,0 +1,147 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    publishing::{module_simple::EntryPoints, publish_util::Package},
+    TransactionExecutor,
+};
+use crate::transaction_generator::{
+    publishing::publish_util::PackageHandler, TransactionGenerator, TransactionGeneratorCreator,
+};
+use aptos_infallible::RwLock;
+use aptos_logger::{info, sample, sample::SampleRate, warn};
+use aptos_sdk::{
+    transaction_builder::TransactionFactory,
+    types::{transaction::SignedTransaction, LocalAccount},
+};
+use async_trait::async_trait;
+use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+use std::{sync::Arc, time::Duration};
+
+pub struct CallCustomModulesGenerator {
+    rng: StdRng,
+    txn_factory: TransactionFactory,
+    packages: Arc<Vec<Package>>,
+    accounts_pool: Option<Arc<RwLock<Vec<LocalAccount>>>>,
+    entry_point: EntryPoints,
+}
+
+impl CallCustomModulesGenerator {
+    pub fn new(
+        rng: StdRng,
+        txn_factory: TransactionFactory,
+        packages: Arc<Vec<Package>>,
+        accounts_pool: Option<Arc<RwLock<Vec<LocalAccount>>>>,
+        entry_point: EntryPoints,
+    ) -> Self {
+        Self {
+            rng,
+            txn_factory,
+            packages,
+            accounts_pool,
+            entry_point,
+        }
+    }
+}
+
+#[async_trait]
+impl TransactionGenerator for CallCustomModulesGenerator {
+    fn generate_transactions(
+        &mut self,
+        accounts: Vec<&mut LocalAccount>,
+        transactions_per_account: usize,
+    ) -> Vec<SignedTransaction> {
+        let needed = accounts.len() * transactions_per_account;
+        let mut requests = Vec::with_capacity(needed);
+
+        let mut accounts_to_burn = if let Some(accounts_pool_lock) = &self.accounts_pool {
+            let mut accounts_pool = accounts_pool_lock.write();
+            let num_in_pool = accounts_pool.len();
+            if num_in_pool < needed {
+                sample!(
+                    SampleRate::Duration(Duration::from_secs(10)),
+                    warn!("Cannot fetch enough accounts from pool, left in pool {}, needed {}", num_in_pool, needed);
+                );
+                return Vec::new();
+            }
+            accounts_pool
+                .drain((num_in_pool - needed)..)
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+
+        for account in accounts {
+            for _ in 0..transactions_per_account {
+                let mut next_to_burn = accounts_to_burn.pop();
+                let request = self
+                    .packages
+                    .choose(&mut self.rng)
+                    .unwrap()
+                    .use_specific_transaction(
+                        self.entry_point,
+                        next_to_burn.as_mut().unwrap_or(account),
+                        &self.txn_factory,
+                        Some(&mut self.rng),
+                        None,
+                    );
+                requests.push(request);
+            }
+        }
+        requests
+    }
+}
+
+pub struct CallCustomModulesCreator {
+    txn_factory: TransactionFactory,
+    packages: Arc<Vec<Package>>,
+    accounts_pool: Option<Arc<RwLock<Vec<LocalAccount>>>>,
+    entry_point: EntryPoints,
+}
+
+impl CallCustomModulesCreator {
+    #[allow(dead_code)]
+    pub async fn new(
+        txn_factory: TransactionFactory,
+        accounts: &mut [LocalAccount],
+        txn_executor: &dyn TransactionExecutor,
+        accounts_pool: Option<Arc<RwLock<Vec<LocalAccount>>>>,
+        entry_point: EntryPoints,
+        num_modules: usize,
+    ) -> Self {
+        let mut rng = StdRng::from_entropy();
+        assert!(accounts.len() >= num_modules);
+        let mut requests = Vec::with_capacity(accounts.len());
+        let mut package_handler = PackageHandler::new();
+        let mut packages = Vec::new();
+        for account in accounts.iter_mut().take(num_modules) {
+            let package = package_handler.pick_package(&mut rng, account);
+            let txn = package.publish_transaction(account, &txn_factory);
+            requests.push(txn);
+            packages.push(package);
+        }
+        info!("Publishing {} packages", requests.len());
+        txn_executor.execute_transactions(&requests).await.unwrap();
+        info!("Done publishing {} packages", requests.len());
+
+        Self {
+            txn_factory,
+            packages: Arc::new(packages),
+            accounts_pool,
+            entry_point,
+        }
+    }
+}
+
+#[async_trait]
+impl TransactionGeneratorCreator for CallCustomModulesCreator {
+    async fn create_transaction_generator(&mut self) -> Box<dyn TransactionGenerator> {
+        Box::new(CallCustomModulesGenerator::new(
+            StdRng::from_entropy(),
+            self.txn_factory.clone(),
+            self.packages.clone(),
+            self.accounts_pool.clone(),
+            self.entry_point,
+        ))
+    }
+}

--- a/crates/transaction-emitter-lib/src/transaction_generator/mod.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/mod.rs
@@ -1,15 +1,18 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
 use aptos_sdk::types::{transaction::SignedTransaction, LocalAccount};
 use async_trait::async_trait;
 
 pub mod account_generator;
+pub mod call_custom_modules;
 pub mod nft_mint_and_transfer;
 pub mod p2p_transaction_generator;
 pub mod publish_modules;
 mod publishing;
 pub mod transaction_mix_generator;
+pub use publishing::module_simple::EntryPoints;
 
 pub trait TransactionGenerator: Sync + Send {
     fn generate_transactions(
@@ -21,5 +24,10 @@ pub trait TransactionGenerator: Sync + Send {
 
 #[async_trait]
 pub trait TransactionGeneratorCreator: Sync + Send {
-    async fn create_transaction_generator(&self) -> Box<dyn TransactionGenerator>;
+    async fn create_transaction_generator(&mut self) -> Box<dyn TransactionGenerator>;
+}
+
+#[async_trait]
+pub trait TransactionExecutor: Sync + Send {
+    async fn execute_transactions(&self, txns: &[SignedTransaction]) -> Result<()>;
 }

--- a/crates/transaction-emitter-lib/src/transaction_generator/nft_mint_and_transfer.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/nft_mint_and_transfer.rs
@@ -1,27 +1,26 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use super::TransactionExecutor;
 use crate::{
-    emitter::{account_minter::create_and_fund_account_request, RETRY_POLICY},
+    emitter::account_minter::create_and_fund_account_request,
     transaction_generator::{TransactionGenerator, TransactionGeneratorCreator},
 };
-use aptos_infallible::Mutex;
-use aptos_logger::{info, warn};
-use aptos_rest_client::Client as RestClient;
+use aptos_logger::info;
 use aptos_sdk::{
     transaction_builder::{aptos_stdlib::aptos_token_stdlib, TransactionFactory},
     types::{account_address::AccountAddress, transaction::SignedTransaction, LocalAccount},
 };
 use async_trait::async_trait;
-use rand::{rngs::StdRng, thread_rng};
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use rand::{rngs::StdRng, thread_rng, SeedableRng};
+use std::collections::HashMap;
 
 const INITIAL_NFT_BALANCE: u64 = 50_000;
 
 pub struct NFTMintAndTransfer {
     txn_factory: TransactionFactory,
     creator_address: AccountAddress,
-    faucet_account: LocalAccount,
+    distribution_account: LocalAccount,
     collection_name: Vec<u8>,
     token_name: Vec<u8>,
     account_funded: HashMap<AccountAddress, bool>,
@@ -30,27 +29,14 @@ pub struct NFTMintAndTransfer {
 impl NFTMintAndTransfer {
     pub async fn new(
         txn_factory: TransactionFactory,
-        creator_account: Arc<Mutex<LocalAccount>>,
+        creator_address: AccountAddress,
+        distribution_account: LocalAccount,
         collection_name: Vec<u8>,
         token_name: Vec<u8>,
-        rest_client: &RestClient,
     ) -> Self {
-        let creator_address = creator_account.lock().address();
-        let faucet_account = LocalAccount::generate(&mut thread_rng());
-        let fund_faucet_account_txn = create_nft_transfer_request(
-            &mut creator_account.lock(),
-            &faucet_account,
-            creator_address,
-            &collection_name,
-            &token_name,
-            &txn_factory,
-            1_000_000_000,
-        );
-        submit_retry_and_wait(rest_client, &fund_faucet_account_txn).await;
-
         Self {
             txn_factory,
-            faucet_account,
+            distribution_account,
             creator_address,
             collection_name,
             token_name,
@@ -77,7 +63,7 @@ impl TransactionGenerator for NFTMintAndTransfer {
                     if account_funded {
                         create_nft_transfer_request(
                             account,
-                            &self.faucet_account,
+                            &self.distribution_account,
                             self.creator_address,
                             &self.collection_name,
                             &self.token_name,
@@ -90,7 +76,7 @@ impl TransactionGenerator for NFTMintAndTransfer {
                         )
                     } else {
                         create_nft_transfer_request(
-                            &mut self.faucet_account,
+                            &mut self.distribution_account,
                             account,
                             self.creator_address,
                             &self.collection_name,
@@ -112,55 +98,14 @@ impl TransactionGenerator for NFTMintAndTransfer {
     }
 }
 
-async fn submit_retry_and_wait(rest_client: &RestClient, txn: &SignedTransaction) {
-    let submit_result = RETRY_POLICY
-        .retry(move || rest_client.submit_bcs(txn))
-        .await;
-    if let Err(e) = submit_result {
-        warn!("Failed submitting transaction {:?} with {:?}", txn, e);
-    }
-    // if submission timeouts, it might still get committed:
-    RETRY_POLICY
-        .retry(move || {
-            rest_client.wait_for_transaction_by_hash_bcs(
-                txn.clone().committed_hash(),
-                txn.expiration_timestamp_secs(),
-                Some(Duration::from_secs(120)),
-                None,
-            )
-        })
-        .await
-        .unwrap();
-}
-
 pub async fn initialize_nft_collection(
-    rest_client: &RestClient,
+    txn_executor: &dyn TransactionExecutor,
     root_account: &mut LocalAccount,
     creator_account: &mut LocalAccount,
     txn_factory: &TransactionFactory,
     collection_name: &[u8],
     token_name: &[u8],
 ) {
-    // resync root account sequence number
-    match rest_client.get_account(root_account.address()).await {
-        Ok(result) => {
-            let account = result.into_inner();
-            if root_account.sequence_number() < account.sequence_number {
-                warn!(
-                    "Root account sequence number got out of sync: remotely {}, locally {}",
-                    account.sequence_number,
-                    root_account.sequence_number_mut()
-                );
-                *root_account.sequence_number_mut() = account.sequence_number;
-            }
-        },
-        Err(e) => warn!(
-            "[{}] Couldn't check account sequence number due to {:?}",
-            rest_client.path_prefix_string(),
-            e
-        ),
-    }
-
     // Create and mint the owner account first
     let create_account_txn = create_and_fund_account_request(
         root_account,
@@ -169,23 +114,28 @@ pub async fn initialize_nft_collection(
         txn_factory,
     );
 
-    submit_retry_and_wait(rest_client, &create_account_txn).await;
-
-    info!("create_account_txn complete");
+    txn_executor
+        .execute_transactions(&[create_account_txn])
+        .await
+        .unwrap();
 
     let collection_txn =
         create_nft_collection_request(creator_account, collection_name, txn_factory);
 
-    submit_retry_and_wait(rest_client, &collection_txn).await;
-
-    info!("collection_txn complete");
+    txn_executor
+        .execute_transactions(&[collection_txn])
+        .await
+        .unwrap();
 
     let token_txn =
         create_nft_token_request(creator_account, collection_name, token_name, txn_factory);
 
-    submit_retry_and_wait(rest_client, &token_txn).await;
+    txn_executor
+        .execute_transactions(&[token_txn])
+        .await
+        .unwrap();
 
-    info!("token_txn complete");
+    info!("initialize_nft_collection complete");
 }
 
 pub fn create_nft_collection_request(
@@ -252,24 +202,26 @@ pub fn create_nft_transfer_request(
 
 pub struct NFTMintAndTransferGeneratorCreator {
     txn_factory: TransactionFactory,
-    creator_account: Arc<Mutex<LocalAccount>>,
+    creator_address: AccountAddress,
+    distribution_accounts: Vec<LocalAccount>,
     collection_name: Vec<u8>,
     token_name: Vec<u8>,
-    rest_client: RestClient,
 }
 
 impl NFTMintAndTransferGeneratorCreator {
     pub async fn new(
-        mut rng: StdRng,
         txn_factory: TransactionFactory,
         root_account: &mut LocalAccount,
-        rest_client: RestClient,
+        txn_executor: &dyn TransactionExecutor,
+        num_workers: usize,
     ) -> Self {
+        let mut rng = StdRng::from_entropy();
         let mut creator_account = LocalAccount::generate(&mut rng);
+        let creator_address = creator_account.address();
         let collection_name = "collection name".to_owned().into_bytes();
         let token_name = "token name".to_owned().into_bytes();
         initialize_nft_collection(
-            &rest_client,
+            txn_executor,
             root_account,
             &mut creator_account,
             &txn_factory,
@@ -277,26 +229,51 @@ impl NFTMintAndTransferGeneratorCreator {
             &token_name,
         )
         .await;
+
+        let mut distribution_accounts = Vec::new();
+        let mut txns = Vec::new();
+
+        for _ in 0..num_workers {
+            let distribution_account = LocalAccount::generate(&mut thread_rng());
+            txns.push(create_nft_transfer_request(
+                &mut creator_account,
+                &distribution_account,
+                creator_address,
+                &collection_name,
+                &token_name,
+                &txn_factory,
+                1_000_000_000,
+            ));
+            distribution_accounts.push(distribution_account);
+        }
+
+        info!("Creating {} NFTs", txns.len());
+        // per account limit is 100
+        for chunk in txns.chunks(100) {
+            txn_executor.execute_transactions(chunk).await.unwrap();
+        }
+        info!("Done creating {} NFTs", txns.len());
+
         Self {
             txn_factory,
-            creator_account: Arc::new(Mutex::new(creator_account)),
+            creator_address,
+            distribution_accounts,
             collection_name,
             token_name,
-            rest_client,
         }
     }
 }
 
 #[async_trait]
 impl TransactionGeneratorCreator for NFTMintAndTransferGeneratorCreator {
-    async fn create_transaction_generator(&self) -> Box<dyn TransactionGenerator> {
+    async fn create_transaction_generator(&mut self) -> Box<dyn TransactionGenerator> {
         Box::new(
             NFTMintAndTransfer::new(
                 self.txn_factory.clone(),
-                self.creator_account.clone(),
+                self.creator_address,
+                self.distribution_accounts.pop().unwrap(),
                 self.collection_name.clone(),
                 self.token_name.clone(),
-                &self.rest_client,
             )
             .await,
         )

--- a/crates/transaction-emitter-lib/src/transaction_generator/p2p_transaction_generator.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/p2p_transaction_generator.rs
@@ -10,10 +10,10 @@ use aptos_sdk::{
 use async_trait::async_trait;
 use rand::{
     distributions::{Distribution, Standard},
-    prelude::{SliceRandom, StdRng},
-    Rng,
+    prelude::SliceRandom,
+    rngs::StdRng,
+    Rng, RngCore, SeedableRng,
 };
-use rand_core::RngCore;
 use std::{cmp::max, sync::Arc};
 
 pub struct P2PTransactionGenerator {
@@ -22,7 +22,6 @@ pub struct P2PTransactionGenerator {
     txn_factory: TransactionFactory,
     all_addresses: Arc<RwLock<Vec<AccountAddress>>>,
     invalid_transaction_ratio: usize,
-    gas_price: u64,
 }
 
 impl P2PTransactionGenerator {
@@ -32,7 +31,6 @@ impl P2PTransactionGenerator {
         txn_factory: TransactionFactory,
         all_addresses: Arc<RwLock<Vec<AccountAddress>>>,
         invalid_transaction_ratio: usize,
-        gas_price: u64,
     ) -> Self {
         Self {
             rng,
@@ -40,7 +38,6 @@ impl P2PTransactionGenerator {
             txn_factory,
             all_addresses,
             invalid_transaction_ratio,
-            gas_price,
         }
     }
 
@@ -50,12 +47,9 @@ impl P2PTransactionGenerator {
         to: &AccountAddress,
         num_coins: u64,
         txn_factory: &TransactionFactory,
-        gas_price: u64,
     ) -> SignedTransaction {
         from.sign_with_transaction_builder(
-            txn_factory
-                .payload(aptos_stdlib::aptos_coin_transfer(*to, num_coins))
-                .gas_unit_price(gas_price),
+            txn_factory.payload(aptos_stdlib::aptos_coin_transfer(*to, num_coins)),
         )
     }
 
@@ -71,40 +65,26 @@ impl P2PTransactionGenerator {
         match Standard.sample(rng) {
             InvalidTransactionType::ChainId => {
                 let txn_factory = &self.txn_factory.clone().with_chain_id(ChainId::new(255));
-                self.gen_single_txn(
-                    sender,
-                    receiver,
-                    self.send_amount,
-                    txn_factory,
-                    self.gas_price,
-                )
+                self.gen_single_txn(sender, receiver, self.send_amount, txn_factory)
             },
             InvalidTransactionType::Sender => self.gen_single_txn(
                 &mut invalid_account,
                 receiver,
                 self.send_amount,
                 &self.txn_factory,
-                self.gas_price,
             ),
             InvalidTransactionType::Receiver => self.gen_single_txn(
                 sender,
                 &invalid_address,
                 self.send_amount,
                 &self.txn_factory,
-                self.gas_price,
             ),
             InvalidTransactionType::Duplication => {
                 // if this is the first tx, default to generate invalid tx with wrong chain id
                 // otherwise, make a duplication of an exist valid tx
                 if reqs.is_empty() {
                     let txn_factory = &self.txn_factory.clone().with_chain_id(ChainId::new(255));
-                    self.gen_single_txn(
-                        sender,
-                        receiver,
-                        self.send_amount,
-                        txn_factory,
-                        self.gas_price,
-                    )
+                    self.gen_single_txn(sender, receiver, self.send_amount, txn_factory)
                 } else {
                     let random_index = rng.gen_range(0, reqs.len());
                     reqs[random_index].clone()
@@ -168,13 +148,7 @@ impl TransactionGenerator for P2PTransactionGenerator {
                 let receiver = receivers.get(i).expect("all_addresses can't be empty");
                 let request = if num_valid_tx > 0 {
                     num_valid_tx -= 1;
-                    self.gen_single_txn(
-                        sender,
-                        receiver,
-                        self.send_amount,
-                        &self.txn_factory,
-                        self.gas_price,
-                    )
+                    self.gen_single_txn(sender, receiver, self.send_amount, &self.txn_factory)
                 } else {
                     self.generate_invalid_transaction(
                         &mut self.rng.clone(),
@@ -191,44 +165,37 @@ impl TransactionGenerator for P2PTransactionGenerator {
 }
 
 pub struct P2PTransactionGeneratorCreator {
-    rng: StdRng,
     txn_factory: TransactionFactory,
     amount: u64,
     all_addresses: Arc<RwLock<Vec<AccountAddress>>>,
     invalid_transaction_ratio: usize,
-    gas_price: u64,
 }
 
 impl P2PTransactionGeneratorCreator {
     pub fn new(
-        rng: StdRng,
         txn_factory: TransactionFactory,
         amount: u64,
         all_addresses: Arc<RwLock<Vec<AccountAddress>>>,
         invalid_transaction_ratio: usize,
-        gas_price: u64,
     ) -> Self {
         Self {
-            rng,
             txn_factory,
             amount,
             all_addresses,
             invalid_transaction_ratio,
-            gas_price,
         }
     }
 }
 
 #[async_trait]
 impl TransactionGeneratorCreator for P2PTransactionGeneratorCreator {
-    async fn create_transaction_generator(&self) -> Box<dyn TransactionGenerator> {
+    async fn create_transaction_generator(&mut self) -> Box<dyn TransactionGenerator> {
         Box::new(P2PTransactionGenerator::new(
-            self.rng.clone(),
+            StdRng::from_entropy(),
             self.amount,
             self.txn_factory.clone(),
             self.all_addresses.clone(),
             self.invalid_transaction_ratio,
-            self.gas_price,
         ))
     }
 }

--- a/crates/transaction-emitter-lib/src/transaction_generator/publish_modules.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/publish_modules.rs
@@ -9,7 +9,7 @@ use aptos_sdk::{
     types::{transaction::SignedTransaction, LocalAccount},
 };
 use async_trait::async_trait;
-use rand::rngs::StdRng;
+use rand::{rngs::StdRng, SeedableRng};
 use std::sync::Arc;
 
 #[allow(dead_code)]
@@ -17,7 +17,6 @@ pub struct PublishPackageGenerator {
     rng: StdRng,
     package_handler: Arc<RwLock<PackageHandler>>,
     txn_factory: TransactionFactory,
-    gas_price: u64,
 }
 
 impl PublishPackageGenerator {
@@ -25,13 +24,11 @@ impl PublishPackageGenerator {
         rng: StdRng,
         package_handler: Arc<RwLock<PackageHandler>>,
         txn_factory: TransactionFactory,
-        gas_price: u64,
     ) -> Self {
         Self {
             rng,
             package_handler,
             txn_factory,
-            gas_price,
         }
     }
 }
@@ -55,12 +52,8 @@ impl TransactionGenerator for PublishPackageGenerator {
             // use module published
             // for _ in 1..transactions_per_account - 1 {
             for _ in 1..transactions_per_account {
-                let request = package.use_transaction(
-                    &mut self.rng,
-                    account,
-                    &self.txn_factory,
-                    self.gas_price,
-                );
+                let request =
+                    package.use_random_transaction(&mut self.rng, account, &self.txn_factory);
                 requests.push(request);
             }
             // republish
@@ -76,31 +69,26 @@ impl TransactionGenerator for PublishPackageGenerator {
 }
 
 pub struct PublishPackageCreator {
-    rng: StdRng,
     txn_factory: TransactionFactory,
     package_handler: Arc<RwLock<PackageHandler>>,
-    gas_price: u64,
 }
 
 impl PublishPackageCreator {
-    pub fn new(rng: StdRng, txn_factory: TransactionFactory, gas_price: u64) -> Self {
+    pub fn new(txn_factory: TransactionFactory) -> Self {
         Self {
-            rng,
             txn_factory,
             package_handler: Arc::new(RwLock::new(PackageHandler::new())),
-            gas_price,
         }
     }
 }
 
 #[async_trait]
 impl TransactionGeneratorCreator for PublishPackageCreator {
-    async fn create_transaction_generator(&self) -> Box<dyn TransactionGenerator> {
+    async fn create_transaction_generator(&mut self) -> Box<dyn TransactionGenerator> {
         Box::new(PublishPackageGenerator::new(
-            self.rng.clone(),
+            StdRng::from_entropy(),
             self.package_handler.clone(),
             self.txn_factory.clone(),
-            self.gas_price,
         ))
     }
 }

--- a/crates/transaction-emitter-lib/src/transaction_generator/publishing/module_simple.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/publishing/module_simple.rs
@@ -16,7 +16,7 @@ use move_binary_format::{
     file_format::{FunctionHandleIndex, IdentifierIndex, SignatureToken},
     CompiledModule,
 };
-use rand::{distributions::Alphanumeric, prelude::StdRng, Rng};
+use rand::{distributions::Alphanumeric, prelude::StdRng, seq::SliceRandom, Rng};
 use rand_core::RngCore;
 
 //
@@ -100,129 +100,174 @@ pub fn scramble(module: &mut CompiledModule, fn_count: usize, rng: &mut StdRng) 
 //
 // List of entry points to expose
 //
-enum EntryPoints {
+// More info in the Simple.move
+#[derive(Debug, Copy, Clone)]
+pub enum EntryPoints {
     // 0 args
-    Nop = 0,
-    Step = 1,
-    GetCounter = 2,
-    ResetData = 3,
-    Double = 4,
-    Half = 5,
+    /// Empty (NoOp) function
+    Nop,
+    /// Increment global resource - COUNTER_STEP
+    Step,
+    /// Fetch global resource - COUNTER_STEP
+    GetCounter,
+    /// Reset resource `Resource`
+    ResetData,
+    /// Double the size of `Resource`
+    Double,
+    /// Half the size of `Resource`
+    Half,
     // 1 arg
-    Loopy = 6,
-    GetFromRandomConst = 7,
-    SetId = 8,
-    SetName = 9,
+    /// run a for loop
+    Loopy {
+        loop_count: Option<u64>,
+    },
+    /// Return value from constant array (RANDOM)
+    GetFromConst {
+        const_idx: Option<u64>,
+    },
+    /// Set the `Resource.id`
+    SetId,
+    /// Set the `Resource.name`
+    SetName,
     // 2 args
     // next 2 functions, second arg must be existing account address with data
-    Maximize = 10,
-    Minimize = 11,
+    // Sets `Resource` to the max from two addresses
+    Maximize,
+    // Sets `Resource` to the min from two addresses
+    Minimize,
     // 3 args
-    MakeOrChange = 12,
+    /// Explicitly change Resource
+    MakeOrChange {
+        string_length: Option<usize>,
+        data_length: Option<usize>,
+    },
 }
 
-const ENTRY_POINTS_START: u8 = EntryPoints::Nop as u8;
-const ENTRY_POINTS_END: u8 = EntryPoints::MakeOrChange as u8;
-const ZERO_ARG_ENTRY_POINTS_START: u8 = EntryPoints::Nop as u8;
-const ZERO_ARG_ENTRY_POINTS_END: u8 = EntryPoints::Half as u8;
-const ONE_ARG_ENTRY_POINTS_START: u8 = EntryPoints::Loopy as u8;
-const ONE_ARG_ENTRY_POINTS_END: u8 = EntryPoints::SetName as u8;
-const TWO_ARG_ENTRY_POINTS_START: u8 = EntryPoints::Maximize as u8;
-const TWO_ARG_ENTRY_POINTS_END: u8 = EntryPoints::Minimize as u8;
-const THREE_ARG_ENTRY_POINTS_START: u8 = EntryPoints::MakeOrChange as u8;
-const THREE_ARG_ENTRY_POINTS_END: u8 = EntryPoints::MakeOrChange as u8;
-
-impl TryFrom<u8> for EntryPoints {
-    type Error = &'static str;
-
-    fn try_from(val: u8) -> Result<EntryPoints, &'static str> {
-        match val {
-            0 => Ok(EntryPoints::Nop),
-            1 => Ok(EntryPoints::Step),
-            2 => Ok(EntryPoints::GetCounter),
-            3 => Ok(EntryPoints::ResetData),
-            4 => Ok(EntryPoints::Double),
-            5 => Ok(EntryPoints::Half),
-            6 => Ok(EntryPoints::Loopy),
-            7 => Ok(EntryPoints::GetFromRandomConst),
-            8 => Ok(EntryPoints::SetId),
-            9 => Ok(EntryPoints::SetName),
-            10 => Ok(EntryPoints::Maximize),
-            11 => Ok(EntryPoints::Minimize),
-            12 => Ok(EntryPoints::MakeOrChange),
-            _ => Err("Value out of range for EntryPoints"),
+impl EntryPoints {
+    pub fn create_payload(
+        &self,
+        module_id: ModuleId,
+        rng: Option<&mut StdRng>,
+        other: Option<AccountAddress>,
+    ) -> TransactionPayload {
+        match self {
+            // 0 args
+            EntryPoints::Nop => get_payload_void(module_id, ident_str!("nop").to_owned()),
+            EntryPoints::Step => get_payload_void(module_id, ident_str!("step").to_owned()),
+            EntryPoints::GetCounter => {
+                get_payload_void(module_id, ident_str!("get_counter").to_owned())
+            },
+            EntryPoints::ResetData => {
+                get_payload_void(module_id, ident_str!("reset_data").to_owned())
+            },
+            EntryPoints::Double => get_payload_void(module_id, ident_str!("double").to_owned()),
+            EntryPoints::Half => get_payload_void(module_id, ident_str!("half").to_owned()),
+            // 1 arg
+            EntryPoints::Loopy { loop_count } => loopy(
+                module_id,
+                loop_count
+                    .unwrap_or_else(|| rng.expect("Must provide RNG").gen_range(0u64, 1000u64)),
+            ),
+            EntryPoints::GetFromConst { const_idx } => get_from_random_const(
+                module_id,
+                const_idx.unwrap_or_else(
+                    // TODO: get a value in range for the const array in Simple.move
+                    || rng.expect("Must provide RNG").gen_range(0u64, 1u64),
+                ),
+            ),
+            EntryPoints::SetId => set_id(rng.expect("Must provide RNG"), module_id),
+            EntryPoints::SetName => set_name(rng.expect("Must provide RNG"), module_id),
+            // 2 args, second arg existing account address with data
+            EntryPoints::Maximize => maximize(module_id, other.expect("Must provide other")),
+            EntryPoints::Minimize => minimize(module_id, other.expect("Must provide other")),
+            // 3 args
+            EntryPoints::MakeOrChange {
+                string_length,
+                data_length,
+            } => {
+                let rng = rng.expect("Must provide RNG");
+                let str_len = string_length.unwrap_or_else(|| rng.gen_range(0usize, 100usize));
+                let data_len = data_length.unwrap_or_else(|| rng.gen_range(0usize, 1000usize));
+                make_or_change(rng, module_id, str_len, data_len)
+            },
         }
     }
 }
 
-fn call_function(
-    fun_idx: u8,
-    rng: &mut StdRng,
-    module_id: ModuleId,
-    other: Option<AccountAddress>,
-) -> TransactionPayload {
-    match EntryPoints::try_from(fun_idx).expect("Must pick a function in range, bogus id generated")
-    {
-        // 0 args
-        EntryPoints::Nop => get_payload_void(module_id, ident_str!("nop").to_owned()),
-        EntryPoints::Step => get_payload_void(module_id, ident_str!("step").to_owned()),
-        EntryPoints::GetCounter => {
-            get_payload_void(module_id, ident_str!("get_counter").to_owned())
-        },
-        EntryPoints::ResetData => get_payload_void(module_id, ident_str!("reset_data").to_owned()),
-        EntryPoints::Double => get_payload_void(module_id, ident_str!("double").to_owned()),
-        EntryPoints::Half => get_payload_void(module_id, ident_str!("half").to_owned()),
-        // 1 arg
-        EntryPoints::Loopy => loopy(rng, module_id),
-        EntryPoints::GetFromRandomConst => get_from_random_const(rng, module_id),
-        EntryPoints::SetId => set_id(rng, module_id),
-        EntryPoints::SetName => set_name(rng, module_id),
-        // 2 args, second arg existing account address with data
-        EntryPoints::Maximize => maximize(module_id, other.expect("Must provide other")),
-        EntryPoints::Minimize => minimize(module_id, other.expect("Must provide other")),
-        // 3 args
-        EntryPoints::MakeOrChange => make_or_change(rng, module_id),
-    }
-}
-
-pub fn any_function(
-    rng: &mut StdRng,
-    module_id: ModuleId,
-    other: Option<AccountAddress>,
-) -> TransactionPayload {
-    let fun_idx = rng.gen_range(ENTRY_POINTS_START, ENTRY_POINTS_END + 1);
-    call_function(fun_idx, rng, module_id, other)
-}
+const ZERO_ARG_ENTRY_POINTS: &[EntryPoints; 6] = &[
+    EntryPoints::Nop,
+    EntryPoints::Step,
+    EntryPoints::GetCounter,
+    EntryPoints::ResetData,
+    EntryPoints::Double,
+    EntryPoints::Half,
+];
+const ONE_ARG_ENTRY_POINTS: &[EntryPoints; 4] = &[
+    EntryPoints::Loopy { loop_count: None },
+    EntryPoints::GetFromConst { const_idx: None },
+    EntryPoints::SetId,
+    EntryPoints::SetName,
+];
+const SIMPLE_ENTRY_POINTS: &[EntryPoints; 9] = &[
+    EntryPoints::Nop,
+    EntryPoints::Step,
+    EntryPoints::GetCounter,
+    EntryPoints::ResetData,
+    EntryPoints::Double,
+    EntryPoints::Half,
+    EntryPoints::Loopy { loop_count: None },
+    EntryPoints::GetFromConst { const_idx: None },
+    EntryPoints::SetId,
+];
+const GEN_ENTRY_POINTS: &[EntryPoints; 11] = &[
+    EntryPoints::Nop,
+    EntryPoints::Step,
+    EntryPoints::GetCounter,
+    EntryPoints::ResetData,
+    EntryPoints::Double,
+    EntryPoints::Half,
+    EntryPoints::Loopy { loop_count: None },
+    EntryPoints::GetFromConst { const_idx: None },
+    EntryPoints::SetId,
+    EntryPoints::SetName,
+    EntryPoints::MakeOrChange {
+        string_length: None,
+        data_length: None,
+    },
+];
 
 pub fn rand_simple_function(rng: &mut StdRng, module_id: ModuleId) -> TransactionPayload {
-    let fun_idx = rng.gen_range(ZERO_ARG_ENTRY_POINTS_START, EntryPoints::SetName as u8);
-    call_function(fun_idx, rng, module_id, None)
+    SIMPLE_ENTRY_POINTS
+        .choose(rng)
+        .unwrap()
+        .create_payload(module_id, Some(rng), None)
 }
 
 pub fn zero_args_function(rng: &mut StdRng, module_id: ModuleId) -> TransactionPayload {
-    let fun_idx = rng.gen_range(ZERO_ARG_ENTRY_POINTS_START, ZERO_ARG_ENTRY_POINTS_END + 1);
-    call_function(fun_idx, rng, module_id, None)
+    ZERO_ARG_ENTRY_POINTS
+        .choose(rng)
+        .unwrap()
+        .create_payload(module_id, Some(rng), None)
 }
 
 pub fn rand_gen_function(rng: &mut StdRng, module_id: ModuleId) -> TransactionPayload {
-    let fun_idx = rng.gen_range(ZERO_ARG_ENTRY_POINTS_START, ONE_ARG_ENTRY_POINTS_END + 1);
-    call_function(fun_idx, rng, module_id, None)
+    GEN_ENTRY_POINTS
+        .choose(rng)
+        .unwrap()
+        .create_payload(module_id, Some(rng), None)
 }
 
 //
 // Entry points payload
 //
 
-fn loopy(rng: &mut StdRng, module_id: ModuleId) -> TransactionPayload {
-    let count = rng.gen_range(0u64, 1000u64);
+fn loopy(module_id: ModuleId, count: u64) -> TransactionPayload {
     get_payload(module_id, ident_str!("loopy").to_owned(), vec![
         bcs::to_bytes(&count).unwrap(),
     ])
 }
 
-fn get_from_random_const(rng: &mut StdRng, module_id: ModuleId) -> TransactionPayload {
-    // TODO: get a value in range for the const array in Simple.move
-    let idx = rng.gen_range(0u64, 1u64);
+fn get_from_random_const(module_id: ModuleId, idx: u64) -> TransactionPayload {
     get_payload(
         module_id,
         ident_str!("get_from_random_const").to_owned(),
@@ -261,16 +306,19 @@ fn minimize(module_id: ModuleId, other: AccountAddress) -> TransactionPayload {
     ])
 }
 
-fn make_or_change(rng: &mut StdRng, module_id: ModuleId) -> TransactionPayload {
+fn make_or_change(
+    rng: &mut StdRng,
+    module_id: ModuleId,
+    str_len: usize,
+    data_len: usize,
+) -> TransactionPayload {
     let id: u64 = rng.gen();
-    let len = rng.gen_range(0usize, 100usize);
     let name: String = rng
         .sample_iter(&Alphanumeric)
-        .take(len)
+        .take(str_len)
         .map(char::from)
         .collect();
-    let len = rng.gen_range(0usize, 1000usize);
-    let mut bytes = Vec::<u8>::with_capacity(len);
+    let mut bytes = Vec::<u8>::with_capacity(data_len);
     rng.fill_bytes(&mut bytes);
     get_payload(module_id, ident_str!("make_or_change").to_owned(), vec![
         bcs::to_bytes(&id).unwrap(),

--- a/crates/transaction-emitter-lib/src/transaction_generator/publishing/publish_util.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/publishing/publish_util.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use super::module_simple::EntryPoints;
 use crate::transaction_generator::publishing::module_simple;
 use aptos_framework::natives::code::PackageMetadata;
 use aptos_sdk::{
@@ -146,21 +147,35 @@ impl Package {
     }
 
     // Return a transaction to use the current package
-    pub fn use_transaction(
+    pub fn use_random_transaction(
         &self,
         rng: &mut StdRng,
         account: &mut LocalAccount,
         txn_factory: &TransactionFactory,
-        gas_price: u64,
     ) -> SignedTransaction {
         match self {
             Self::Simple(modules, _) => {
                 let module_id = modules[0].self_id();
                 // let payload = module_simple::rand_gen_function(rng, module_id);
                 let payload = module_simple::rand_simple_function(rng, module_id);
-                account.sign_with_transaction_builder(
-                    txn_factory.payload(payload).gas_unit_price(gas_price),
-                )
+                account.sign_with_transaction_builder(txn_factory.payload(payload))
+            },
+        }
+    }
+
+    pub fn use_specific_transaction(
+        &self,
+        fun: EntryPoints,
+        account: &mut LocalAccount,
+        txn_factory: &TransactionFactory,
+        rng: Option<&mut StdRng>,
+        other: Option<AccountAddress>,
+    ) -> SignedTransaction {
+        match self {
+            Self::Simple(modules, _) => {
+                let module_id = modules[0].self_id();
+                let payload = fun.create_payload(module_id, rng, other);
+                account.sign_with_transaction_builder(txn_factory.payload(payload))
             },
         }
     }

--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -9,8 +9,7 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use aptos_sdk::transaction_builder::TransactionFactory;
-use rand::{rngs::StdRng, Rng};
-use rand_core::{OsRng, SeedableRng};
+use rand::{rngs::StdRng, SeedableRng};
 use std::time::Duration;
 
 pub async fn emit_transactions(
@@ -37,7 +36,7 @@ pub async fn emit_transactions_with_cluster(
         TransactionFactory::new(cluster.chain_id)
             .with_transaction_expiration_time(args.txn_expiration_time_secs)
             .with_gas_unit_price(aptos_global_constants::GAS_UNIT_PRICE),
-        StdRng::from_seed(OsRng.gen()),
+        StdRng::from_entropy(),
     );
 
     let transaction_mix = if args.transaction_type_weights.is_empty() {

--- a/crates/transaction-emitter/src/diag.rs
+++ b/crates/transaction-emitter/src/diag.rs
@@ -6,8 +6,7 @@ use aptos_sdk::transaction_builder::TransactionFactory;
 use aptos_transaction_emitter_lib::{query_sequence_number, Cluster, TxnEmitter};
 use futures::future::join_all;
 use itertools::zip;
-use rand::{rngs::StdRng, Rng, SeedableRng};
-use rand_core::OsRng;
+use rand::{rngs::StdRng, SeedableRng};
 use std::{
     cmp::min,
     time::{Duration, Instant},
@@ -19,7 +18,7 @@ pub async fn diag(cluster: &Cluster) -> Result<()> {
     let emitter = TxnEmitter::new(
         TransactionFactory::new(cluster.chain_id)
             .with_gas_unit_price(aptos_global_constants::GAS_UNIT_PRICE),
-        StdRng::from_seed(OsRng.gen()),
+        StdRng::from_entropy(),
     );
     let coin_source_account_address = coin_source_account.address();
     let instances: Vec<_> = cluster.all_instances().collect();


### PR DESCRIPTION
### Description

Build on top of @dariorussi PR for publishing modules, this adds a generic way to issue transaction from that module (but not load test the module publishing, working set of modules is created in the initialization stage)

Also created TransactionExecutor to wrap submitting and rertrying on the transactions in parallel, and fixed/sped up NFT txn generator with it.


Next PR in the stack will test out using this
