### PR TITLE
Add txn emitter phases and generic configuration

### DIFF
--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -73,17 +73,20 @@ pub struct ClusterArgs {
     pub coin_source_args: CoinSourceArgs,
 }
 
-#[derive(Debug, Clone, Copy, ArgEnum, Deserialize, Parser, Serialize)]
-pub enum TransactionType {
-    P2P,
+#[derive(Debug, Copy, Clone, ArgEnum, Deserialize, Parser, Serialize)]
+pub enum TransactionTypeArg {
+    CoinTransfer,
     AccountGeneration,
+    AccountGenerationLargePool,
     NftMintAndTransfer,
     PublishPackage,
+    CustomFunctionLargeModuleWorkingSet,
+    CreateNewResource,
 }
 
-impl Default for TransactionType {
+impl Default for TransactionTypeArg {
     fn default() -> Self {
-        TransactionType::P2P
+        TransactionTypeArg::CoinTransfer
     }
 }
 
@@ -118,14 +121,17 @@ pub struct EmitArgs {
     #[clap(
         long,
         arg_enum,
-        default_value = "p2p",
+        default_value = "coin-transfer",
         min_values = 1,
         ignore_case = true
     )]
-    pub transaction_type: Vec<TransactionType>,
+    pub transaction_type: Vec<TransactionTypeArg>,
 
     #[clap(long, min_values = 0)]
-    pub transaction_type_weights: Vec<usize>,
+    pub transaction_weights: Vec<usize>,
+
+    #[clap(long, min_values = 0)]
+    pub transaction_phases: Vec<usize>,
 
     #[clap(long)]
     pub expected_max_txns: Option<u64>,
@@ -136,6 +142,10 @@ pub struct EmitArgs {
     #[clap(long)]
     pub max_transactions_per_account: Option<usize>,
 
+    // In cases you want to run txn emitter from multiple machines,
+    // and want to make sure that initialization succeeds
+    // (account minting and txn-specific initialization), before the
+    // loadtest puts significant load, you can add a delay here.
     #[clap(long)]
     pub delay_after_minting: Option<u64>,
 }

--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    emitter::{MINT_GAS_FEE_MULTIPLIER, SEND_AMOUNT},
-    transaction_generator::TransactionExecutor,
+    emitter::MINT_GAS_FEE_MULTIPLIER,
+    transaction_generator::{TransactionExecutor, SEND_AMOUNT},
     EmitJobRequest, EmitModeParams,
 };
 use anyhow::{anyhow, format_err, Context, Result};

--- a/crates/transaction-emitter-lib/src/lib.rs
+++ b/crates/transaction-emitter-lib/src/lib.rs
@@ -11,12 +11,13 @@ mod transaction_generator;
 mod wrappers;
 
 // These are the top level things you should need to run the emitter.
-pub use args::{ClusterArgs, CoinSourceArgs, EmitArgs, TransactionType};
+pub use args::{ClusterArgs, CoinSourceArgs, EmitArgs, TransactionTypeArg};
 // We export these if you want finer grained control.
 pub use cluster::Cluster;
 pub use emitter::{
     query_sequence_number, query_sequence_numbers,
     stats::{TxnStats, TxnStatsRate},
-    EmitJob, EmitJobMode, EmitJobRequest, EmitModeParams, TxnEmitter,
+    EmitJob, EmitJobMode, EmitJobRequest, EmitModeParams, TransactionType, TxnEmitter,
 };
+pub use transaction_generator::EntryPoints;
 pub use wrappers::{emit_transactions, emit_transactions_with_cluster};

--- a/crates/transaction-emitter-lib/src/transaction_generator/mod.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/mod.rs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use aptos_infallible::RwLock;
 use aptos_sdk::{
     move_types::account_address::AccountAddress,
+    transaction_builder::TransactionFactory,
     types::{transaction::SignedTransaction, LocalAccount},
 };
 use async_trait::async_trait;
-use std::sync::atomic::AtomicUsize;
+use std::sync::{atomic::AtomicUsize, Arc};
 
 pub mod account_generator;
 pub mod call_custom_modules;
@@ -16,7 +18,17 @@ pub mod p2p_transaction_generator;
 pub mod publish_modules;
 mod publishing;
 pub mod transaction_mix_generator;
+use self::{
+    account_generator::AccountGeneratorCreator, call_custom_modules::CallCustomModulesCreator,
+    nft_mint_and_transfer::NFTMintAndTransferGeneratorCreator,
+    p2p_transaction_generator::P2PTransactionGeneratorCreator,
+    publish_modules::PublishPackageCreator,
+    transaction_mix_generator::PhasedTxnMixGeneratorCreator,
+};
+use crate::{emitter::stats::DynamicStatsTracking, TransactionType};
 pub use publishing::module_simple::EntryPoints;
+
+pub const SEND_AMOUNT: u64 = 1;
 
 pub trait TransactionGenerator: Sync + Send {
     fn generate_transactions(
@@ -44,4 +56,90 @@ pub trait TransactionExecutor: Sync + Send {
         txns: &[SignedTransaction],
         failure_counter: &AtomicUsize,
     ) -> Result<()>;
+}
+
+pub async fn create_txn_generator_creator(
+    transaction_mix_per_phase: &[Vec<(TransactionType, usize)>],
+    num_workers: usize,
+    all_accounts: &mut [LocalAccount],
+    txn_executor: &dyn TransactionExecutor,
+    txn_factory: &TransactionFactory,
+    stats: Arc<DynamicStatsTracking>,
+) -> Box<dyn TransactionGeneratorCreator> {
+    let all_addresses = Arc::new(RwLock::new(
+        all_accounts.iter().map(|d| d.address()).collect::<Vec<_>>(),
+    ));
+    let accounts_pool = Arc::new(RwLock::new(Vec::new()));
+
+    let mut txn_generator_creator_mix_per_phase: Vec<
+        Vec<(Box<dyn TransactionGeneratorCreator>, usize)>,
+    > = Vec::new();
+
+    for transaction_mix in transaction_mix_per_phase {
+        let mut txn_generator_creator_mix: Vec<(Box<dyn TransactionGeneratorCreator>, usize)> =
+            Vec::new();
+        for (transaction_type, weight) in transaction_mix {
+            let txn_generator_creator: Box<dyn TransactionGeneratorCreator> = match transaction_type
+            {
+                TransactionType::CoinTransfer {
+                    invalid_transaction_ratio,
+                } => Box::new(P2PTransactionGeneratorCreator::new(
+                    txn_factory.clone(),
+                    SEND_AMOUNT,
+                    all_addresses.clone(),
+                    *invalid_transaction_ratio,
+                )),
+                TransactionType::AccountGeneration {
+                    add_created_accounts_to_pool,
+                    max_account_working_set,
+                    creation_balance,
+                } => Box::new(AccountGeneratorCreator::new(
+                    txn_factory.clone(),
+                    all_addresses.clone(),
+                    accounts_pool.clone(),
+                    *add_created_accounts_to_pool,
+                    *max_account_working_set,
+                    *creation_balance,
+                )),
+                TransactionType::NftMintAndTransfer => Box::new(
+                    NFTMintAndTransferGeneratorCreator::new(
+                        txn_factory.clone(),
+                        all_accounts.get_mut(0).unwrap(),
+                        txn_executor,
+                        num_workers,
+                    )
+                    .await,
+                ),
+                TransactionType::PublishPackage => {
+                    Box::new(PublishPackageCreator::new(txn_factory.clone()))
+                },
+                TransactionType::CallCustomModules {
+                    entry_point,
+                    num_modules,
+                    use_account_pool,
+                } => Box::new(
+                    CallCustomModulesCreator::new(
+                        txn_factory.clone(),
+                        all_accounts,
+                        txn_executor,
+                        if *use_account_pool {
+                            Some(accounts_pool.clone())
+                        } else {
+                            None
+                        },
+                        *entry_point,
+                        *num_modules,
+                    )
+                    .await,
+                ),
+            };
+            txn_generator_creator_mix.push((txn_generator_creator, *weight));
+        }
+        txn_generator_creator_mix_per_phase.push(txn_generator_creator_mix)
+    }
+
+    Box::new(PhasedTxnMixGeneratorCreator::new(
+        txn_generator_creator_mix_per_phase,
+        stats,
+    ))
 }

--- a/crates/transaction-emitter-lib/src/transaction_generator/transaction_mix_generator.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/transaction_mix_generator.rs
@@ -1,68 +1,104 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
-use crate::transaction_generator::{TransactionGenerator, TransactionGeneratorCreator};
+use crate::{
+    emitter::stats::DynamicStatsTracking,
+    transaction_generator::{TransactionGenerator, TransactionGeneratorCreator},
+};
 use aptos_sdk::types::{transaction::SignedTransaction, LocalAccount};
 use async_trait::async_trait;
 use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::sync::Arc;
 
-pub struct TxnMixGenerator {
+pub struct PhasedTxnMixGenerator {
     rng: StdRng,
-    txn_mix: Vec<(Box<dyn TransactionGenerator>, usize)>,
-    total_weight: usize,
+    // for each phase, list of transaction mixes.
+    txn_mix_per_phase: Vec<Vec<(Box<dyn TransactionGenerator>, usize)>>,
+    total_weight_per_phase: Vec<usize>,
+    phase: Arc<DynamicStatsTracking>,
 }
 
-impl TxnMixGenerator {
-    pub fn new(rng: StdRng, txn_mix: Vec<(Box<dyn TransactionGenerator>, usize)>) -> Self {
-        let total_weight = txn_mix.iter().map(|(_, weight)| weight).sum();
+impl PhasedTxnMixGenerator {
+    pub fn new(
+        rng: StdRng,
+        txn_mix_per_phase: Vec<Vec<(Box<dyn TransactionGenerator>, usize)>>,
+        phase: Arc<DynamicStatsTracking>,
+    ) -> Self {
+        let total_weight_per_phase = txn_mix_per_phase
+            .iter()
+            .map(|txn_mix| txn_mix.iter().map(|(_, weight)| weight).sum())
+            .collect();
         Self {
             rng,
-            txn_mix,
-            total_weight,
+            txn_mix_per_phase,
+            total_weight_per_phase,
+            phase,
         }
     }
 }
 
-impl TransactionGenerator for TxnMixGenerator {
+impl TransactionGenerator for PhasedTxnMixGenerator {
     fn generate_transactions(
         &mut self,
         accounts: Vec<&mut LocalAccount>,
         transactions_per_account: usize,
     ) -> Vec<SignedTransaction> {
-        let mut picked = self.rng.gen_range(0, self.total_weight);
-        for (gen, weight) in &mut self.txn_mix {
+        let phase = if self.txn_mix_per_phase.len() == 1 {
+            // when only single txn_mix is passed, use it for all phases, for simplicity
+            0
+        } else {
+            self.phase.get_cur_phase()
+        };
+
+        let mut picked = self.rng.gen_range(0, self.total_weight_per_phase[phase]);
+        for (gen, weight) in &mut self.txn_mix_per_phase[phase] {
             if picked < *weight {
                 return gen.generate_transactions(accounts, transactions_per_account);
             }
             picked -= *weight;
         }
         panic!(
-            "Picked {} out of {}, couldn't find correct generator",
-            picked, self.total_weight
+            "Picked {} out of {}, at phase {}, couldn't find correct generator",
+            picked, self.total_weight_per_phase[phase], phase,
         );
     }
 }
 
-pub struct TxnMixGeneratorCreator {
-    txn_mix_creators: Vec<(Box<dyn TransactionGeneratorCreator>, usize)>,
+pub struct PhasedTxnMixGeneratorCreator {
+    txn_mix_per_phase_creators: Vec<Vec<(Box<dyn TransactionGeneratorCreator>, usize)>>,
+    phase: Arc<DynamicStatsTracking>,
 }
 
-impl TxnMixGeneratorCreator {
-    pub fn new(txn_mix_creators: Vec<(Box<dyn TransactionGeneratorCreator>, usize)>) -> Self {
-        Self { txn_mix_creators }
+impl PhasedTxnMixGeneratorCreator {
+    pub fn new(
+        txn_mix_per_phase_creators: Vec<Vec<(Box<dyn TransactionGeneratorCreator>, usize)>>,
+        phase: Arc<DynamicStatsTracking>,
+    ) -> Self {
+        Self {
+            txn_mix_per_phase_creators,
+            phase,
+        }
     }
 }
 
 #[async_trait]
-impl TransactionGeneratorCreator for TxnMixGeneratorCreator {
+impl TransactionGeneratorCreator for PhasedTxnMixGeneratorCreator {
     async fn create_transaction_generator(&mut self) -> Box<dyn TransactionGenerator> {
-        let mut txn_mix = Vec::<(Box<dyn TransactionGenerator>, usize)>::new();
-        for (generator_creator, weight) in self.txn_mix_creators.iter_mut() {
-            txn_mix.push((
-                generator_creator.create_transaction_generator().await,
-                *weight,
-            ));
+        let mut txn_mix_per_phase = Vec::<Vec<(Box<dyn TransactionGenerator>, usize)>>::new();
+        for txn_mix_creators in self.txn_mix_per_phase_creators.iter_mut() {
+            let mut txn_mix = Vec::<(Box<dyn TransactionGenerator>, usize)>::new();
+            for (generator_creator, weight) in txn_mix_creators.iter_mut() {
+                txn_mix.push((
+                    generator_creator.create_transaction_generator().await,
+                    *weight,
+                ));
+            }
+            txn_mix_per_phase.push(txn_mix);
         }
 
-        Box::new(TxnMixGenerator::new(StdRng::from_entropy(), txn_mix))
+        Box::new(PhasedTxnMixGenerator::new(
+            StdRng::from_entropy(),
+            txn_mix_per_phase,
+            self.phase.clone(),
+        ))
     }
 }

--- a/terraform/helm/node-health-checker/files/nhc_baseline_fullnode.yaml
+++ b/terraform/helm/node-health-checker/files/nhc_baseline_fullnode.yaml
@@ -44,7 +44,7 @@ evaluator_args:
       txn_expiration_time_secs: 30
       duration: 10
       invalid_tx: 0
-      transaction_type: P2P
+      transaction_type: coin_transfer
     mint_args:
       mint_key:
         key: {{ .Values.node_health_checker.mint_key }}

--- a/testsuite/smoke-test/src/consensus/consensus_only.rs
+++ b/testsuite/smoke-test/src/consensus/consensus_only.rs
@@ -18,10 +18,10 @@ async fn test_consensus_only_with_txn_emitter() {
         &all_validators,
         Duration::from_secs(10),
         1,
-        vec![
-            (TransactionType::P2P, 70),
-            (TransactionType::AccountGeneration, 20),
-        ],
+        vec![vec![
+            (TransactionType::default_coin_transfer(), 70),
+            (TransactionType::default_account_generation(), 20),
+        ]],
     )
     .await
     .unwrap();

--- a/testsuite/smoke-test/src/txn_emitter.rs
+++ b/testsuite/smoke-test/src/txn_emitter.rs
@@ -4,7 +4,8 @@
 use crate::smoke_test_environment::new_local_swarm_with_aptos;
 use anyhow::ensure;
 use aptos_forge::{
-    EmitJobMode, EmitJobRequest, NodeExt, Result, Swarm, TransactionType, TxnEmitter, TxnStats,
+    EmitJobMode, EmitJobRequest, EntryPoints, NodeExt, Result, Swarm, TransactionType, TxnEmitter,
+    TxnStats,
 };
 use aptos_sdk::{transaction_builder::TransactionFactory, types::PeerId};
 use rand::{rngs::OsRng, SeedableRng};
@@ -15,7 +16,7 @@ pub async fn generate_traffic(
     nodes: &[PeerId],
     duration: Duration,
     gas_price: u64,
-    txn_mix: Vec<(TransactionType, usize)>,
+    transaction_mix_per_phase: Vec<Vec<(TransactionType, usize)>>,
 ) -> Result<TxnStats> {
     ensure!(gas_price > 0, "gas_price is required to be non zero");
     let rng = SeedableRng::from_rng(OsRng)?;
@@ -27,12 +28,12 @@ pub async fn generate_traffic(
     let mut emit_job_request = EmitJobRequest::default();
     let chain_info = swarm.chain_info();
     let transaction_factory = TransactionFactory::new(chain_info.chain_id).with_gas_unit_price(1);
-    let mut emitter = TxnEmitter::new(transaction_factory, rng);
+    let emitter = TxnEmitter::new(transaction_factory, rng);
 
     emit_job_request = emit_job_request
         .rest_clients(validator_clients)
         .gas_price(gas_price)
-        .transaction_mix(txn_mix)
+        .transaction_mix_per_phase(transaction_mix_per_phase)
         .mode(EmitJobMode::ConstTps { tps: 20 });
     emitter
         .emit_txn_for_with_stats(chain_info.root_account, emit_job_request, duration, 3)
@@ -49,15 +50,38 @@ async fn test_txn_emmitter() {
     let txn_stat = generate_traffic(
         &mut swarm,
         &all_validators,
-        Duration::from_secs(10),
+        Duration::from_secs(20),
         1,
         vec![
-            (TransactionType::P2P, 60),
-            (TransactionType::AccountGeneration, 20),
-            // commenting this out given it consistently fails smoke test
-            // and it seems to be called only from `test_txn_emmitter`
-            // (TransactionType::NftMintAndTransfer, 10),
-            (TransactionType::PublishPackage, 30),
+            vec![(
+                TransactionType::AccountGeneration {
+                    add_created_accounts_to_pool: true,
+                    max_account_working_set: 1_000_000,
+                    creation_balance: 1_000_000,
+                },
+                20,
+            )],
+            vec![
+                (TransactionType::default_coin_transfer(), 20),
+                // // commenting this out given it consistently fails smoke test
+                // // and it seems to be called only from `test_txn_emmitter`
+                // (TransactionType::NftMintAndTransfer, 20),
+                (TransactionType::PublishPackage, 20),
+            ],
+            vec![
+                (TransactionType::default_call_different_modules(), 20),
+                (
+                    TransactionType::CallCustomModules {
+                        entry_point: EntryPoints::MakeOrChange {
+                            string_length: Some(0),
+                            data_length: Some(64),
+                        },
+                        num_modules: 1,
+                        use_account_pool: true,
+                    },
+                    20,
+                ),
+            ],
         ],
     )
     .await

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -87,7 +87,7 @@ pub fn generate_traffic(
 ) -> Result<TxnStats> {
     let emit_job_request = ctx.emit_job.clone();
     let rng = SeedableRng::from_rng(ctx.core().rng())?;
-    let (mut emitter, emit_job_request) =
+    let (emitter, emit_job_request) =
         create_emitter_and_request(ctx.swarm(), emit_job_request, nodes, rng)?;
 
     let rt = traffic_emitter_runtime()?;
@@ -211,13 +211,24 @@ impl dyn NetworkLoadTest {
             .swarm()
             .get_clients_for_peers(&nodes_to_send_load_to, Duration::from_secs(10));
 
+        let mut stats_tracking_phases = emit_job_request.get_num_phases();
+        assert!(stats_tracking_phases > 0 && stats_tracking_phases != 2);
+        if stats_tracking_phases == 1 {
+            stats_tracking_phases = 3;
+        }
+
         let job = rt
-            .block_on(emitter.start_job(ctx.swarm().chain_info().root_account, emit_job_request, 3))
+            .block_on(emitter.start_job(
+                ctx.swarm().chain_info().root_account,
+                emit_job_request,
+                stats_tracking_phases,
+            ))
             .context("start emitter job")?;
 
         let warmup_duration = duration.mul_f32(warmup_duration_fraction);
         let cooldown_duration = duration.mul_f32(cooldown_duration_fraction);
         let test_duration = duration - warmup_duration - cooldown_duration;
+        let phase_duration = test_duration.div_f32((stats_tracking_phases - 2) as f32);
         info!("Starting emitting txns for {}s", duration.as_secs());
 
         std::thread::sleep(warmup_duration);
@@ -233,11 +244,24 @@ impl dyn NetworkLoadTest {
             .map(|s| s.version - 2 * s.block_height)
             .max();
 
-        job.start_next_phase();
-
+        let mut actual_phase_durations = Vec::new();
         let test_start = Instant::now();
-        self.test(ctx.swarm(), test_duration)
-            .context("test NetworkLoadTest")?;
+        for i in 0..stats_tracking_phases - 2 {
+            job.start_next_phase();
+
+            if i > 0 {
+                info!(
+                    "Starting test phase {} out of {}",
+                    i,
+                    stats_tracking_phases - 2,
+                );
+            }
+            let phase_start = Instant::now();
+
+            self.test(ctx.swarm(), phase_duration)
+                .context("test NetworkLoadTest")?;
+            actual_phase_durations.push(phase_start.elapsed());
+        }
         let actual_test_duration = test_start.elapsed();
         info!(
             "{}s test finished after {}s",
@@ -271,8 +295,25 @@ impl dyn NetworkLoadTest {
 
         info!("Stopped job");
         info!("Warmup stats: {}", txn_stats[0].rate(warmup_duration));
-        info!("Test stats: {}", txn_stats[1].rate(actual_test_duration));
-        info!("Cooldown stats: {}", txn_stats[2].rate(cooldown_duration));
+
+        let mut stats: Option<TxnStats> = None;
+        for i in 0..stats_tracking_phases - 2 {
+            let cur = &txn_stats[1 + i];
+            info!(
+                "Test stats [test phase {}]: {}",
+                i,
+                cur.rate(actual_phase_durations[i])
+            );
+            stats = if let Some(previous) = stats {
+                Some(&previous + cur)
+            } else {
+                Some(cur.clone())
+            };
+        }
+        info!(
+            "Cooldown stats: {}",
+            txn_stats.last().unwrap().rate(cooldown_duration)
+        );
 
         let ledger_transactions = if let Some(end_t) = max_end_ledger_transactions {
             if let Some(start_t) = max_start_ledger_transactions {
@@ -283,10 +324,6 @@ impl dyn NetworkLoadTest {
         } else {
             0
         };
-        Ok((
-            txn_stats.into_iter().nth(1).unwrap(),
-            actual_test_duration,
-            ledger_transactions,
-        ))
+        Ok((stats.unwrap(), actual_test_duration, ledger_transactions))
     }
 }

--- a/testsuite/testcases/src/two_traffics_test.rs
+++ b/testsuite/testcases/src/two_traffics_test.rs
@@ -42,7 +42,7 @@ impl NetworkLoadTest for TwoTrafficsTest {
         let nodes_to_send_load_to = LoadDestination::AllFullnodes.get_destination_nodes(swarm);
         let rng = ::rand::rngs::StdRng::from_seed(OsRng.gen());
 
-        let (mut emitter, emit_job_request) = create_emitter_and_request(
+        let (emitter, emit_job_request) = create_emitter_and_request(
             swarm,
             EmitJobRequest::default()
                 .mode(EmitJobMode::ConstTps {


### PR DESCRIPTION
### Description

Make transaction emitter configuration more powerful:

- Transactions are now parametrized enums, and each contains flags relevant for it.
- additionally add phases support, so that we can run first one workload, then second. This way we can first create bunch of accounts, and then do something with them in the second phase.

### Test Plan
run on forge and through txn emitter