### PR TITLE
[helm/docker] enable pyroscope profiling on forge

### DIFF
--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -305,6 +305,9 @@ RUN apt-get update && apt-get install -y \
     valgrind \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
+# Install pyroscope for profiling
+RUN curl https://dl.pyroscope.io/release/pyroscope_0.36.0_amd64.deb --output pyroscope_0.36.0_amd64.deb && apt-get install ./pyroscope_0.36.0_amd64.deb
+
 ### Because build machine perf might not match run machine perf, we have to symlink
 ### Even if version slightly off, still mostly works
 RUN ln -sf /usr/bin/perf_* /usr/bin/perf
@@ -313,11 +316,11 @@ RUN echo "deb http://deb.debian.org/debian sid main contrib non-free" >> /etc/ap
 RUN echo "deb-src http://deb.debian.org/debian sid main contrib non-free" >> /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y \
-		arping bison clang-format cmake dh-python \
-		dpkg-dev pkg-kde-tools ethtool flex inetutils-ping iperf \
-		libbpf-dev libclang-11-dev libclang-cpp-dev libedit-dev libelf-dev \
-		libfl-dev libzip-dev linux-libc-dev llvm-11-dev libluajit-5.1-dev \
-		luajit python3-netaddr python3-pyroute2 python3-distutils python3 \
+    arping bison clang-format cmake dh-python \
+    dpkg-dev pkg-kde-tools ethtool flex inetutils-ping iperf \
+    libbpf-dev libclang-11-dev libclang-cpp-dev libedit-dev libelf-dev \
+    libfl-dev libzip-dev linux-libc-dev llvm-11-dev libluajit-5.1-dev \
+    luajit python3-netaddr python3-pyroute2 python3-distutils python3 \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN git clone https://github.com/aptos-labs/bcc.git

--- a/terraform/aptos-node/aws/kubernetes.tf
+++ b/terraform/aptos-node/aws/kubernetes.tf
@@ -125,9 +125,9 @@ locals {
     numFullnodeGroups = var.num_fullnode_groups
     imageTag          = var.image_tag
     chain = {
-      era        = var.era
-      chain_id   = var.chain_id
-      chain_name = var.chain_name
+      era      = var.era
+      chain_id = var.chain_id
+      name     = var.chain_name
     }
     validator = {
       name = var.validator_name
@@ -184,11 +184,11 @@ resource "helm_release" "validator" {
   max_history = 5
   wait        = false
 
-  lifecycle {
-    ignore_changes = [
-      values,
-    ]
-  }
+  # lifecycle {
+  #   ignore_changes = [
+  #     values,
+  #   ]
+  # }
 
   values = [
     local.helm_values,

--- a/terraform/aptos-node/azure/kubernetes.tf
+++ b/terraform/aptos-node/azure/kubernetes.tf
@@ -31,9 +31,9 @@ resource "helm_release" "validator" {
     jsonencode({
       imageTag = var.image_tag
       chain = {
-        era        = var.era
-        chain_id   = var.chain_id
-        chain_name = var.chain_name
+        era      = var.era
+        chain_id = var.chain_id
+        name     = var.chain_name
       }
       validator = {
         name = var.validator_name

--- a/terraform/aptos-node/gcp/kubernetes.tf
+++ b/terraform/aptos-node/gcp/kubernetes.tf
@@ -52,9 +52,9 @@ resource "helm_release" "validator" {
     jsonencode({
       imageTag = var.image_tag
       chain = {
-        era        = var.era
-        chain_id   = var.chain_id
-        chain_name = var.chain_name
+        era      = var.era
+        chain_id = var.chain_id
+        name     = var.chain_name
       }
       validator = {
         name = var.validator_name

--- a/terraform/helm/aptos-node/templates/fullnode.yaml
+++ b/terraform/helm/aptos-node/templates/fullnode.yaml
@@ -77,7 +77,20 @@ spec:
       - name: fullnode
         image: {{ $.Values.validator.image.repo }}:{{ $.Values.validator.image.tag | default $.Values.imageTag }}
         imagePullPolicy: {{ $.Values.validator.image.pullPolicy }}
+        {{- if not $.Values.pyroscope.enabled }}
         command: ["/usr/local/bin/aptos-node", "-f", "/opt/aptos/etc/fullnode.yaml"]
+        {{- else }}
+        command: ["/bin/bash", "-c"]
+        args:
+        - |
+          set -e
+          export PYROSCOPE_APPLICATION_NAME="aptos-node{namespace=${KUBERNETES_NAMESPACE},pod_name=${KUBERNETES_POD_NAME},chain_name={{ $.Values.chain.chain_name | default $.Values.chain.name }}}"
+          # to wrap an existing program and profile it
+          # TODO: this does not seem to work yet
+          # pyroscope exec /usr/local/bin/aptos-node -f /opt/aptos/etc/fullnode.yaml
+          # to profile the entire system
+          pyroscope ebpf & /usr/local/bin/aptos-node -f /opt/aptos/etc/fullnode.yaml
+        {{- end }}
       {{- with $.Values.fullnode }}
         resources:
           {{- toYaml .resources | nindent 10 }}
@@ -92,8 +105,33 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: RUST_BACKTRACE
           value: "0"
+        {{- if $.Values.pyroscope.enabled }}
+        - name: PYROSCOPE_SERVER_ADDRESS
+          valueFrom:
+            secretKeyRef:
+              name: {{ $.Values.pyroscope.secretName }}
+              key: PYROSCOPE_SERVER_ADDRESS
+        - name: PYROSCOPE_AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ $.Values.pyroscope.secretName }}
+              key: PYROSCOPE_AUTH_TOKEN
+        - name: PYROSCOPE_SPY_NAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ $.Values.pyroscope.secretName }}
+              key: PYROSCOPE_SPY_NAME
+        - name: PYROSCOPE_SAMPLE_RATE
+          value: "24"
+        - name: PYROSCOPE_LOG_LEVEL
+          value: error
+        {{- end }}
       {{- end }}
         volumeMounts:
         - name: aptos-config

--- a/terraform/helm/aptos-node/templates/validator.yaml
+++ b/terraform/helm/aptos-node/templates/validator.yaml
@@ -82,7 +82,20 @@ spec:
         image: {{ $.Values.validator.image.repo }}:{{ $.Values.validator.image.tag | default $.Values.imageTag }}
       {{- with $.Values.validator }}
         imagePullPolicy: {{ .image.pullPolicy }}
+        {{- if not $.Values.pyroscope.enabled }}
         command: ["/usr/local/bin/aptos-node", "-f", "/opt/aptos/etc/validator.yaml"]
+        {{- else }}
+        command: ["/bin/bash", "-c"]
+        args:
+        - |
+          set -e
+          export PYROSCOPE_APPLICATION_NAME="aptos-node{namespace=${KUBERNETES_NAMESPACE},pod_name=${KUBERNETES_POD_NAME},chain_name={{ $.Values.chain.chain_name | default $.Values.chain.name }}}"
+          # to wrap an existing program and profile it
+          # TODO: this does not seem to work yet
+          # pyroscope exec /usr/local/bin/aptos-node -f /opt/aptos/etc/validator.yaml
+          # to profile the entire system
+          pyroscope ebpf & /usr/local/bin/aptos-node -f /opt/aptos/etc/validator.yaml
+        {{- end }}
         resources:
           {{- toYaml .resources | nindent 10 }}
         env:
@@ -96,8 +109,33 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: RUST_BACKTRACE
           value: "0"
+        {{- if $.Values.pyroscope.enabled }}
+        - name: PYROSCOPE_SERVER_ADDRESS
+          valueFrom:
+            secretKeyRef:
+              name: {{ $.Values.pyroscope.secretName }}
+              key: PYROSCOPE_SERVER_ADDRESS
+        - name: PYROSCOPE_AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ $.Values.pyroscope.secretName }}
+              key: PYROSCOPE_AUTH_TOKEN
+        - name: PYROSCOPE_SPY_NAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ $.Values.pyroscope.secretName }}
+              key: PYROSCOPE_SPY_NAME
+        - name: PYROSCOPE_SAMPLE_RATE
+          value: "24"
+        - name: PYROSCOPE_LOG_LEVEL
+          value: error
+        {{- end }}
       {{- end }}
         volumeMounts:
         - name: aptos-config

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -178,5 +178,14 @@ podSecurityPolicy: true
 # -- Load test-data for starting a test network
 loadTestGenesis: false
 
+# -- TEST ONLY: Enable running as root for profiling
+enablePrivilegedMode: false
+
+pyroscope:
+  # -- Enable Pyroscope profiling
+  enabled: false
+  # -- Secret which contains the Pyroscope API key and other configuration
+  secretName: pyroscope
+
 # Additional labels
 labels:

--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -104,6 +104,7 @@ GRAFANA_BASE_URL = (
     "https://o11y.aptosdev.com/grafana/d/overview/overview?orgId=1&refresh=10s&"
     "var-Datasource=VictoriaMetrics%20Global"
 )
+PYROSCOPE_BASE_URL = "https://pyroscope.o11y.aptosdev.com"
 
 # helm chart default override values
 HELM_CHARTS = ["aptos-node", "aptos-genesis"]
@@ -465,6 +466,13 @@ def get_humio_logs_link(
     )
 
 
+def get_pyroscope_profiling_link(
+    forge_namespace: str,
+) -> str:
+    """Get a link to the pyroscope profiling for a given test run in a given namespace. Note that there is no time filtering yet"""
+    return f'{PYROSCOPE_BASE_URL}/?query=aptos-node.cpu%7Bnamespace%3D"{forge_namespace}"%7D&from=now-24h'
+
+
 def format_github_info(context: ForgeContext) -> str:
     if not context.github_job_url:
         return ""
@@ -499,6 +507,7 @@ def format_pre_comment(context: ForgeContext) -> str:
         context.forge_namespace,
         True,
     )
+    pyroscope_profiling_link = get_pyroscope_profiling_link(context.forge_namespace)
 
     return (
         textwrap.dedent(
@@ -506,6 +515,7 @@ def format_pre_comment(context: ForgeContext) -> str:
             ### Forge is running suite `{context.forge_test_suite}` on {get_testsuite_images(context)}
             * [Grafana dashboard (auto-refresh)]({dashboard_link})
             * [Humio Logs]({humio_logs_link})
+            * [Pyroscope Profiling]({pyroscope_profiling_link})
             """
         ).lstrip()
         + format_github_info(context)
@@ -522,6 +532,7 @@ def format_comment(context: ForgeContext, result: ForgeResult) -> str:
         context.forge_namespace,
         (result.start_time, result.end_time),
     )
+    pyroscope_profiling_link = get_pyroscope_profiling_link(context.forge_namespace)
 
     if result.state == ForgeState.PASS:
         forge_comment_header = f"### :white_check_mark: Forge suite `{context.forge_test_suite}` success on {get_testsuite_images(context)}"
@@ -545,6 +556,7 @@ def format_comment(context: ForgeContext, result: ForgeResult) -> str:
         ```
         * [Grafana dashboard]({dashboard_link})
         * [Humio Logs]({humio_logs_link})
+        * [Pyroscope Profiling]({pyroscope_profiling_link})
         """
         )
         + format_github_info(context)

--- a/testsuite/forge/src/backend/k8s/cluster_helper.rs
+++ b/testsuite/forge/src/backend/k8s/cluster_helper.rs
@@ -3,21 +3,21 @@
 
 use crate::{
     get_fullnodes, get_validators, k8s_wait_genesis_strategy, k8s_wait_nodes_strategy,
-    nodes_healthcheck, wait_stateful_set, Create, GenesisConfigFn, K8sApi, K8sNode, NodeConfigFn,
-    Result, APTOS_NODE_HELM_CHART_PATH, APTOS_NODE_HELM_RELEASE_NAME, DEFAULT_ROOT_KEY,
-    FORGE_KEY_SEED, FULLNODE_HAPROXY_SERVICE_SUFFIX, FULLNODE_SERVICE_SUFFIX,
+    nodes_healthcheck, wait_stateful_set, Create, GenesisConfigFn, Get, K8sApi, K8sNode,
+    NodeConfigFn, Result, APTOS_NODE_HELM_CHART_PATH, APTOS_NODE_HELM_RELEASE_NAME,
+    DEFAULT_ROOT_KEY, FORGE_KEY_SEED, FULLNODE_HAPROXY_SERVICE_SUFFIX, FULLNODE_SERVICE_SUFFIX,
     GENESIS_HELM_CHART_PATH, GENESIS_HELM_RELEASE_NAME, HELM_BIN, KUBECTL_BIN,
     MANAGEMENT_CONFIGMAP_PREFIX, NAMESPACE_CLEANUP_THRESHOLD_SECS, POD_CLEANUP_THRESHOLD_SECS,
     VALIDATOR_HAPROXY_SERVICE_SUFFIX, VALIDATOR_SERVICE_SUFFIX,
 };
 use again::RetryPolicy;
 use anyhow::{anyhow, bail, format_err};
-use aptos_logger::info;
+use aptos_logger::{info, warn};
 use aptos_sdk::types::PeerId;
 use k8s_openapi::api::{
     apps::v1::{Deployment, StatefulSet},
     batch::{v1::Job, v1beta1::CronJob},
-    core::v1::{ConfigMap, Namespace, PersistentVolume, PersistentVolumeClaim, Pod},
+    core::v1::{ConfigMap, Namespace, PersistentVolume, PersistentVolumeClaim, Pod, Secret},
 };
 use kube::{
     api::{Api, DeleteParams, ListParams, Meta, ObjectMeta, Patch, PatchParams, PostParams},
@@ -801,6 +801,54 @@ async fn create_namespace(
                 &kube_namespace_name, api_err
             )));
         }
+    }
+    Ok(())
+}
+
+pub async fn create_pyroscope_secret(kube_namespace: String) -> Result<()> {
+    let kube_client = create_k8s_client().await;
+    let kube_namespace_name = kube_namespace.clone();
+    let default_secrets_api = Arc::new(K8sApi::<Secret>::from_client(
+        kube_client.clone(),
+        Some("default".to_string()),
+    ));
+    let namespace_secrets_api = Arc::new(K8sApi::<Secret>::from_client(
+        kube_client.clone(),
+        Some(kube_namespace_name.to_string()),
+    ));
+    // load in the secret from namespace and copy it to the new namespace
+    if let secret = default_secrets_api.get("pyroscope").await? {
+        info!("Secret pyroscope exists, continuing with it");
+        let pyroscope_secret_data = secret.data.clone();
+        let namespaced_pyroscope_secret = Secret {
+            metadata: ObjectMeta {
+                name: Some("pyroscope".to_string()),
+                ..ObjectMeta::default()
+            },
+            data: pyroscope_secret_data,
+            string_data: None,
+            type_: None,
+        };
+        if let Err(KubeError::Api(api_err)) = namespace_secrets_api
+            .create(&PostParams::default(), &namespaced_pyroscope_secret)
+            .await
+        {
+            if api_err.code == 409 {
+                info!(
+                    "Secret pyroscope already exists in namespace {}, continuing with it",
+                    &kube_namespace_name
+                );
+            } else {
+                return Err(format_err!(
+                    "Failed to create secret pyroscope in namespace {}: {:?}",
+                    &kube_namespace_name,
+                    api_err
+                ));
+            }
+        }
+    } else {
+        warn!("Secret pyroscope does not exist. This test run will not be profiled");
+        // do not exit with an error, but throw a warning
     }
     Ok(())
 }

--- a/testsuite/forge/src/backend/k8s/helm-values/aptos-node-default-values.yaml
+++ b/testsuite/forge/src/backend/k8s/helm-values/aptos-node-default-values.yaml
@@ -34,3 +34,8 @@ service:
 
 # always assume we're spinning up a testnet and doing genesis rather than using the single validator test mode
 loadTestGenesis: false
+# always run forge in privileged mode for extra testing capability
+enablePrivilegedMode: true
+# always run forge with profiling enabled
+pyroscope:
+  enabled: true

--- a/testsuite/forge/src/backend/k8s/mod.rs
+++ b/testsuite/forge/src/backend/k8s/mod.rs
@@ -130,6 +130,8 @@ impl Factory for K8sFactory {
             // create the forge-management configmap before installing anything
             create_management_configmap(self.kube_namespace.clone(), self.keep, cleanup_duration)
                 .await?;
+            // create a secret to access pyroscope
+            create_pyroscope_secret(self.kube_namespace.clone()).await?;
             if let Some(existing_db_tag) = existing_db_tag {
                 // TODO(prod-eng): For now we are managing PVs out of forge, and bind them manually
                 // with the volume. Going forward we should consider automate this process.


### PR DESCRIPTION
### Description

Installs `pyroscope` on each of the `validator-testing` images and wraps the `aptos-node` binary exec call with it. A few tweaks to get this to work:
* Always run Forge as privileged
* Each cluster needs a secret to connect to pyroscope. For Forge, we guarantee it in the `default` namespace, and then it is copied over to the test namespace. Otherwise, it can be configured.
* Forge copies the pyroscope secret from a known location (`default` namespace) to its own testing namespace so all validators/fullnodes can be profiled individually
* The pyroscope app will be named `aptos-node.${NAMESPACE}.${POD_NAME}`, such as `aptos-node.forge-e2e-pr-6083.aptos-node-7-validator-0`


### Test Plan

Run Forge and check the pretty stuff

<!-- Please provide us with clear details for verifying that your changes work. -->
