### PR TITLE
Use larger gas fee for minting

### DIFF
--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -132,6 +132,9 @@ pub struct EmitArgs {
 
     #[clap(long)]
     pub expected_gas_per_txn: Option<u64>,
+
+    #[clap(long)]
+    pub max_transactions_per_account: Option<usize>,
 }
 
 fn parse_target(target: &str) -> Result<Url> {

--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    emitter::{wait_for_single_account_sequence, RETRY_POLICY, SEND_AMOUNT},
+    emitter::{wait_for_single_account_sequence, RETRY_POLICY, SEND_AMOUNT, MINT_GAS_FEE_MULTIPLIER},
     query_sequence_number, EmitJobRequest, EmitModeParams,
 };
 use anyhow::{anyhow, format_err, Context, Result};
@@ -86,12 +86,12 @@ impl<'t> AccountMinter<'t> {
         let coins_per_seed_account = (expected_children_per_seed_account as u64)
             .checked_mul(coins_per_account + req.expected_gas_per_txn)
             .unwrap()
-            .checked_add(aptos_global_constants::MAX_GAS_AMOUNT * req.gas_price)
+            .checked_add(aptos_global_constants::MAX_GAS_AMOUNT * req.gas_price * MINT_GAS_FEE_MULTIPLIER)
             .unwrap();
         let coins_for_source = coins_per_seed_account
             .checked_mul(expected_num_seed_accounts as u64)
             .unwrap()
-            .checked_add(aptos_global_constants::MAX_GAS_AMOUNT * req.gas_price)
+            .checked_add(aptos_global_constants::MAX_GAS_AMOUNT * req.gas_price * MINT_GAS_FEE_MULTIPLIER)
             .unwrap();
         info!(
             "Account creation plan created for {} accounts with {} balance each.",

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -51,6 +51,7 @@ use tokio::{runtime::Handle, task::JoinHandle, time};
 // Max is 100k TPS for a full day.
 const MAX_TXNS: u64 = 100_000_000_000;
 const SEND_AMOUNT: u64 = 1;
+const MINT_GAS_FEE_MULTIPLIER: u64 = 10;
 
 // This retry policy is used for important client calls necessary for setting
 // up the test (e.g. account creation) and collecting its results (e.g. checking
@@ -122,6 +123,8 @@ pub struct EmitJobRequest {
     max_account_working_set: usize,
 
     txn_expiration_time_secs: u64,
+    max_transactions_per_account: usize,
+
     expected_max_txns: u64,
     expected_gas_per_txn: u64,
     prompt_before_spending: bool,
@@ -142,6 +145,7 @@ impl Default for EmitJobRequest {
             add_created_accounts_to_pool: true,
             max_account_working_set: 1_000_000,
             txn_expiration_time_secs: 60,
+            max_transactions_per_account: 20,
             expected_max_txns: MAX_TXNS,
             expected_gas_per_txn: aptos_global_constants::MAX_GAS_AMOUNT,
             prompt_before_spending: false,
@@ -219,6 +223,11 @@ impl EmitJobRequest {
         self
     }
 
+    pub fn max_transactions_per_account(mut self, max_transactions_per_account: usize) -> Self {
+        self.max_transactions_per_account = max_transactions_per_account;
+        self
+    }
+
     pub fn calculate_mode_params(&self) -> EmitModeParams {
         let clients_count = self.rest_clients.len();
 
@@ -227,7 +236,7 @@ impl EmitJobRequest {
                 // The target mempool backlog is set to be 3x of the target TPS because of the on an average,
                 // we can ~3 blocks in consensus queue. As long as we have 3x the target TPS as backlog,
                 // it should be enough to produce the target TPS.
-                let transactions_per_account = 20;
+                let transactions_per_account = self.max_transactions_per_account;
                 let num_workers_per_endpoint = max(
                     mempool_backlog / (clients_count * transactions_per_account),
                     1,
@@ -277,7 +286,7 @@ impl EmitJobRequest {
                 // In case we set a very low TPS, we need to still be able to spread out
                 // transactions, at least to the seconds granularity, so we reduce transactions_per_account
                 // if needed.
-                let transactions_per_account = min(20, tps);
+                let transactions_per_account = min(self.max_transactions_per_account, tps);
                 assert!(
                     transactions_per_account > 0,
                     "TPS ({}) needs to be larger than 0",
@@ -415,7 +424,7 @@ impl TxnEmitter {
             .with_gas_unit_price(req.gas_price);
 
         let mut account_minter =
-            AccountMinter::new(root_account, txn_factory.clone(), self.rng.clone());
+            AccountMinter::new(root_account, txn_factory.clone().with_gas_unit_price(req.gas_price * MINT_GAS_FEE_MULTIPLIER), self.rng.clone());
         let mut new_accounts = account_minter
             .create_accounts(&req, &mode_params, num_accounts)
             .await?;

--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -65,6 +65,9 @@ pub async fn emit_transactions_with_cluster(
     if reuse_accounts {
         emit_job_request = emit_job_request.reuse_accounts();
     }
+    if let Some(max_transactions_per_account) = args.max_transactions_per_account {
+        emit_job_request = emit_job_request.max_transactions_per_account(max_transactions_per_account);
+    }
     if let Some(expected_max_txns) = args.expected_max_txns {
         emit_job_request = emit_job_request.expected_max_txns(expected_max_txns);
     }


### PR DESCRIPTION
- increase batches to 100 transactions, to reduce number of accounts needed for large jobs.
- use larger gas fee for minting, to help with cases when multiple txn emitters are running
