### PR TITLE
[CI] Adjust machine type used for verify module

### DIFF
--- a/.github/workflows/verify-on-chain-modules-mainnet.yaml
+++ b/.github/workflows/verify-on-chain-modules-mainnet.yaml
@@ -22,7 +22,7 @@ env:
 jobs:
   replay-transactions:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: high-perf-docker-with-local-ssd
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:

--- a/.github/workflows/verify-on-chain-modules-testnet.yaml
+++ b/.github/workflows/verify-on-chain-modules-testnet.yaml
@@ -22,7 +22,7 @@ env:
 jobs:
   replay-transactions:
     timeout-minutes: 720
-    runs-on: ubuntu-latest
+    runs-on: high-perf-docker-with-local-ssd
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:


### PR DESCRIPTION
### Description

Adjust the machine type for verify module task. The previous machine don't have enough memory and would OOM after a few minutes of execution.

### Test Plan

Manually trigger the job.
