### PR TITLE
Remove trailing slash from URL path if it exists.

### DIFF
--- a/developer-docs-site/src/theme/DocItem/Footer/index.js
+++ b/developer-docs-site/src/theme/DocItem/Footer/index.js
@@ -34,7 +34,9 @@ const Contributors = ({ contributors }) => {
 
 export default function FooterWrapper(props) {
   const location = useLocation();
-  const contributors = CONTRIBUTORS[location.pathname];
+  let urlPath = location.pathname;
+  if (urlPath.endsWith("/")) urlPath = urlPath.substring(0, urlPath.length - 1);
+  const contributors = CONTRIBUTORS[urlPath];
   return (
     <>
       <Footer {...props} />


### PR DESCRIPTION
### Description

The trailing slash (which sometimes gets added on initial page load) caused the authors not to be found.

### Test Plan
Tested that both https://deploy-preview-6094--aptos-developer-docs.netlify.app/nodes/local-testnet/local-testnet-index/ and https://deploy-preview-6094--aptos-developer-docs.netlify.app/nodes/local-testnet/local-testnet-index work correctly.