### PR TITLE
[Aptos Framework][Vesting] Pay out the accumulated rewards relatively to vesting's remaining grant instead of staking contract's principal

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/vesting.md
+++ b/aptos-move/framework/aptos-framework/doc/vesting.md
@@ -1431,8 +1431,12 @@ Unlock any accumulated rewards.
     <a href="vesting.md#0x1_vesting_assert_active_vesting_contract">assert_active_vesting_contract</a>(contract_address);
 
     <b>let</b> vesting_contract = <b>borrow_global_mut</b>&lt;<a href="vesting.md#0x1_vesting_VestingContract">VestingContract</a>&gt;(contract_address);
-    <b>let</b> contract_signer = &<a href="vesting.md#0x1_vesting_get_vesting_account_signer_internal">get_vesting_account_signer_internal</a>(vesting_contract);
-    <a href="staking_contract.md#0x1_staking_contract_unlock_rewards">staking_contract::unlock_rewards</a>(contract_signer, vesting_contract.staking.operator);
+    <b>let</b> operator = vesting_contract.staking.operator;
+    <b>let</b> (total_active_stake, _, commission_amount) =
+        <a href="staking_contract.md#0x1_staking_contract_staking_contract_amounts">staking_contract::staking_contract_amounts</a>(contract_address, operator);
+    // Accumulated rewards, excluding unpaid commission, that entirely belongs <b>to</b> the shareholders.
+    <b>let</b> accumulated_rewards = total_active_stake - vesting_contract.remaining_grant - commission_amount;
+    <a href="vesting.md#0x1_vesting_unlock_stake">unlock_stake</a>(vesting_contract, accumulated_rewards);
 }
 </code></pre>
 


### PR DESCRIPTION
### Description

This is a bug in the outstanding rewards calculation of the vesting contract. Every time staking_contract::request_commission is called, it updates the principal to the total active stake - commission paid out. Since the vesting contract relies on this staking contract's principal to calculate accumulated rewards (to be sent out to shareholders), request_commission, when call before vesting::unlock_rewards, effectively locks up this accumulated rewards for the vesting contract's entire vesting schedule.

The correct accumulated rewards calculation for vesting::unlock_rewards should use the vesting contract's remaining grant as the base to get the actual amount of accumulated rewards so far.

### Test Plan
A newly added unit test that succeeds with the fix but fails otherwise.
