### PR TITLE
[framework] fix breakage in compile-time compatability

### DIFF
--- a/aptos-move/framework/src/extended_checks.rs
+++ b/aptos-move/framework/src/extended_checks.rs
@@ -132,10 +132,10 @@ impl<'a> ExtendedChecker<'a> {
         use Type::*;
         match ty {
             Primitive(_) | TypeParameter(_) => {
-                // Any primitive type allowed, any parameter expected to instantiate with primitive
+                // Any primitive type is allowed
             },
-            Reference(false, bt) if matches!(bt.as_ref(), Primitive(PrimitiveType::Signer)) => {
-                // Reference to signer allowed
+            Reference(false, bt) if matches!(bt.as_ref(), Primitive(_)) => {
+                // Any reference to a primitive is allowed
             },
             Vector(ety) => {
                 // Vectors are allowed if element type is allowed


### PR DESCRIPTION
we have historically not restricted references in entry functions and it can make a lot of sense to actually have public entry which may take a reference from another space within move

this returns back to the more permissive state

note: there are examples on mainnet, where this would require the authors to build with an older compiler.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
