### PR TITLE
[block-executor] Fix missing lifetime

### DIFF
--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -160,7 +160,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
         base_view: &'a S,
         map: &'a MVHashMapView<'a, T::Key, T::Value>,
         txn_idx: TxnIndex,
-    ) -> LatestView<T, S> {
+    ) -> LatestView<'a, T, S> {
         LatestView {
             base_view,
             latest_view: ViewMapKind::MultiVersion(map),
@@ -172,7 +172,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
         base_view: &'a S,
         map: &'a BTreeMap<T::Key, T::Value>,
         txn_idx: TxnIndex,
-    ) -> LatestView<T, S> {
+    ) -> LatestView<'a, T, S> {
         LatestView {
             base_view,
             latest_view: ViewMapKind::BTree(map),


### PR DESCRIPTION
### Description
This fails to build on Windows (but not on Mac) for some reason, unsure why it's skipped elsewhere.

### Test Plan
cargo build now passes on windows instead of failing 

The error prior to fixing it:
```
error[E0106]: missing lifetime specifier
   --> aptos-move\block-executor\src\view.rs:175:20
    |
172 |         base_view: &'a S,
    |                    -----
173 |         map: &'a BTreeMap<T::Key, T::Value>,
    |              ------------------------------
174 |         txn_idx: TxnIndex,
175 |     ) -> LatestView<T, S> {
    |                    ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
help: consider using the `'a` lifetime
    |
175 |     ) -> LatestView<'a, T, S> {
    |                     +++

```
