### PR TITLE
[gas] fix incorrect gas feature version for hash.blake2b_256

### DIFF
--- a/aptos-move/aptos-gas/src/aptos_framework.rs
+++ b/aptos-move/aptos-gas/src/aptos_framework.rs
@@ -92,8 +92,8 @@ crate::natives::define_gas_parameters_for_natives!(GasParameters, "aptos_framewo
     // Using SHA2-256's cost
     [.hash.ripemd160.base, { 4.. => "hash.ripemd160.base" }, 3000],
     [.hash.ripemd160.per_byte, { 4.. => "hash.ripemd160.per_byte" }, 50],
-    [.hash.blake2b_256.base, { 5.. => "hash.blake2b_256.base" }, 1750],
-    [.hash.blake2b_256.per_byte, { 5.. => "hash.blake2b_256.per_byte" }, 15],
+    [.hash.blake2b_256.base, { 6.. => "hash.blake2b_256.base" }, 1750],
+    [.hash.blake2b_256.per_byte, { 6.. => "hash.blake2b_256.per_byte" }, 15],
 
     [.util.from_bytes.base, "util.from_bytes.base", 300 * MUL],
     [.util.from_bytes.per_byte, "util.from_bytes.per_byte", 5 * MUL],

--- a/aptos-move/aptos-gas/src/gas_meter.rs
+++ b/aptos-move/aptos-gas/src/gas_meter.rs
@@ -27,8 +27,9 @@ use move_vm_types::{
 use std::collections::BTreeMap;
 
 // Change log:
-// - V5
+// - V6
 //   - Added a new native function - blake2b_256.
+// - V5
 //   - u16, u32, u256
 //   - free_write_bytes_quota
 //   - configurable ChangeSetConfigs
@@ -46,7 +47,7 @@ use std::collections::BTreeMap;
 //       global operations.
 // - V1
 //   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = 5;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = 6;
 
 pub(crate) const EXECUTION_GAS_MULTIPLIER: u64 = 20;
 


### PR DESCRIPTION
There was a previous attempt (https://github.com/aptos-labs/aptos-core/commit/57294de2ce700faefaff508373eb181de52dbdc3) to fix the incorrect gas feature version for this native function, but even that number was too low.