### PR TITLE
[mempool] Wait until max block size or quorum_store_poll_count is reached

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -36,9 +36,10 @@ pub struct ConsensusConfig {
     // Decides how long the leader waits before proposing empty block if there's no txns in mempool
     // the period = (poll_count - 1) * 30ms
     pub quorum_store_poll_count: u64,
+    pub quorum_store_create_empty_blocks_for_pending_ordering: bool,
+    pub quorum_store_create_partial_blocks_before_poll_ends: bool,
     pub intra_consensus_channel_buffer_size: usize,
     pub quorum_store_configs: QuorumStoreConfig,
-
     // Used to decide if backoff is needed.
     // must match one of the CHAIN_HEALTH_WINDOW_SIZES values.
     pub window_for_chain_health: usize,
@@ -80,7 +81,9 @@ impl Default for ConsensusConfig {
             sync_only: false,
             channel_size: 30, // hard-coded
             quorum_store_pull_timeout_ms: 1000,
-            quorum_store_poll_count: 10,
+            quorum_store_poll_count: 15,
+            quorum_store_create_empty_blocks_for_pending_ordering: true,
+            quorum_store_create_partial_blocks_before_poll_ends: true,
             intra_consensus_channel_buffer_size: 10,
             quorum_store_configs: QuorumStoreConfig::default(),
 

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -36,8 +36,20 @@ pub struct ConsensusConfig {
     // Decides how long the leader waits before proposing empty block if there's no txns in mempool
     // the period = (poll_count - 1) * 30ms
     pub quorum_store_poll_count: u64,
-    pub quorum_store_create_empty_blocks_for_pending_ordering: bool,
-    pub quorum_store_create_partial_blocks_before_poll_ends: bool,
+    // Whether to create partial blocks when few transactions exist, or empty blocks when there is
+    // pending ordering, or to wait for quorum_store_poll_count * 30ms to collect transactions for a block
+    //
+    // It is more efficient to execute larger blocks, as it creates less overhead. On the other hand
+    // waiting increases latency (unless we are under high load that added waiting latency
+    // is compensated by faster execution time). So we want to balance the two, by waiting only
+    // when we are saturating the execution pipeline:
+    // - if there are more pending blocks then usual in the execution pipeline,
+    //   block is going to wait there anyways, so we can wait to create a bigger/more efificent block
+    // - in case our node is faster than others, and we don't have many pending blocks,
+    //   but we still see very large recent (pending) blocks, we know that there is demand
+    //   and others are creating large blocks, so we can wait as well.
+    pub wait_for_full_blocks_above_pending_blocks: usize,
+    pub wait_for_full_blocks_above_recent_fill_threshold: f32,
     pub intra_consensus_channel_buffer_size: usize,
     pub quorum_store_configs: QuorumStoreConfig,
     // Used to decide if backoff is needed.
@@ -81,9 +93,12 @@ impl Default for ConsensusConfig {
             sync_only: false,
             channel_size: 30, // hard-coded
             quorum_store_pull_timeout_ms: 1000,
-            quorum_store_poll_count: 15,
-            quorum_store_create_empty_blocks_for_pending_ordering: true,
-            quorum_store_create_partial_blocks_before_poll_ends: true,
+            quorum_store_poll_count: 10,
+            // disable wait_for_full until fully tested
+            // We never go above 20-30 pending blocks, so this disables it
+            wait_for_full_blocks_above_pending_blocks: 100,
+            // Max is 1, so 1.1 disables it.
+            wait_for_full_blocks_above_recent_fill_threshold: 1.1,
             intra_consensus_channel_buffer_size: 10,
             quorum_store_configs: QuorumStoreConfig::default(),
 

--- a/consensus/consensus-types/src/request_response.rs
+++ b/consensus/consensus-types/src/request_response.rs
@@ -18,6 +18,8 @@ pub enum GetPayloadCommand {
         u64,
         // max byte size
         u64,
+        // return non full
+        bool,
         // block payloads to exclude from the requested block
         PayloadFilter,
         // callback to respond to
@@ -28,11 +30,11 @@ pub enum GetPayloadCommand {
 impl fmt::Display for GetPayloadCommand {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            GetPayloadCommand::GetPayloadRequest(round, max_txns, max_bytes, excluded, _) => {
+            GetPayloadCommand::GetPayloadRequest(round, max_txns, max_bytes, return_non_full, excluded, _) => {
                 write!(
                     f,
-                    "GetPayloadRequest [round: {}, max_txns: {}, max_bytes: {} excluded: {}]",
-                    round, max_txns, max_bytes, excluded
+                    "GetPayloadRequest [round: {}, max_txns: {}, max_bytes: {}, return_non_full: {},  excluded: {}]",
+                    round, max_txns, max_bytes, return_non_full, excluded
                 )
             },
         }

--- a/consensus/consensus-types/src/request_response.rs
+++ b/consensus/consensus-types/src/request_response.rs
@@ -30,7 +30,14 @@ pub enum GetPayloadCommand {
 impl fmt::Display for GetPayloadCommand {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            GetPayloadCommand::GetPayloadRequest(round, max_txns, max_bytes, return_non_full, excluded, _) => {
+            GetPayloadCommand::GetPayloadRequest(
+                round,
+                max_txns,
+                max_bytes,
+                return_non_full,
+                excluded,
+                _,
+            ) => {
                 write!(
                     f,
                     "GetPayloadRequest [round: {}, max_txns: {}, max_bytes: {}, return_non_full: {},  excluded: {}]",

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -195,6 +195,24 @@ pub static CHAIN_HEALTH_BACKOFF_TRIGGERED: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+/// How many pending blocks are there, when we make a proposal
+pub static PROPOSER_PENDING_BLOCKS_COUNT: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_proposer_pending_blocks_count",
+        "How many pending blocks are there, when we make a proposal",
+    )
+    .unwrap()
+});
+
+/// How full is a largest pending block, as a fraction of max len/bytes (between 0 and 1)
+pub static PROPOSER_PENDING_BLOCKS_FILL_FRACTION: Lazy<Gauge> = Lazy::new(|| {
+    register_gauge!(
+        "aptos_proposer_pending_blocks_fill_fraction",
+        "How full is a largest recent pending block, as a fraction of max len/bytes (between 0 and 1)",
+    )
+    .unwrap()
+});
+
 /// Next set of counters are computed at leader election time, with some delay.
 
 /// Current voting power fraction that participated in consensus

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -665,6 +665,8 @@ impl EpochManager {
             consensus_to_quorum_store_tx,
             self.config.quorum_store_poll_count, // TODO: consider moving it to a quorum store config in later PRs.
             self.config.quorum_store_pull_timeout_ms,
+            self.config.quorum_store_create_empty_blocks_for_pending_ordering,
+            self.config.quorum_store_create_partial_blocks_before_poll_ends,
         );
         self.commit_state_computer.new_epoch(
             &epoch_state,

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -665,8 +665,8 @@ impl EpochManager {
             consensus_to_quorum_store_tx,
             self.config.quorum_store_poll_count, // TODO: consider moving it to a quorum store config in later PRs.
             self.config.quorum_store_pull_timeout_ms,
-            self.config.quorum_store_create_empty_blocks_for_pending_ordering,
-            self.config.quorum_store_create_partial_blocks_before_poll_ends,
+            self.config.wait_for_full_blocks_above_recent_fill_threshold,
+            self.config.wait_for_full_blocks_above_pending_blocks,
         );
         self.commit_state_computer.new_epoch(
             &epoch_state,

--- a/consensus/src/liveness/proposal_generator.rs
+++ b/consensus/src/liveness/proposal_generator.rs
@@ -6,8 +6,13 @@ use super::{
     proposer_election::ProposerElection, unequivocal_proposer_election::UnequivocalProposerElection,
 };
 use crate::{
-    block_storage::BlockReader, counters::CHAIN_HEALTH_BACKOFF_TRIGGERED,
-    state_replication::PayloadClient, util::time_service::TimeService,
+    block_storage::BlockReader,
+    counters::{
+        CHAIN_HEALTH_BACKOFF_TRIGGERED, PROPOSER_PENDING_BLOCKS_COUNT,
+        PROPOSER_PENDING_BLOCKS_FILL_FRACTION,
+    },
+    state_replication::PayloadClient,
+    util::time_service::TimeService,
 };
 use anyhow::{bail, ensure, format_err, Context};
 use aptos_config::config::ChainHealthBackoffValues;
@@ -250,6 +255,20 @@ impl ProposalGenerator {
                 (self.max_block_txns, self.max_block_bytes)
             };
 
+            let max_pending_block_len = pending_blocks
+                .iter()
+                .map(|block| block.payload().map_or(0, |p| p.len()))
+                .max()
+                .unwrap_or(0);
+            let max_pending_block_bytes = pending_blocks
+                .iter()
+                .map(|block| block.payload().map_or(0, |p| p.size()))
+                .max()
+                .unwrap_or(0);
+            let max_fill_fraction = (max_pending_block_len as f32 / self.max_block_txns as f32)
+                .max(max_pending_block_bytes as f32 / self.max_block_bytes as f32);
+            PROPOSER_PENDING_BLOCKS_COUNT.set(pending_blocks.len() as i64);
+            PROPOSER_PENDING_BLOCKS_FILL_FRACTION.set(max_fill_fraction as f64);
             let payload = self
                 .payload_client
                 .pull_payload(
@@ -259,6 +278,8 @@ impl ProposalGenerator {
                     payload_filter,
                     wait_callback,
                     pending_ordering,
+                    pending_blocks.len(),
+                    max_fill_fraction,
                 )
                 .await
                 .context("Fail to retrieve payload")?;

--- a/consensus/src/payload_client.rs
+++ b/consensus/src/payload_client.rs
@@ -25,8 +25,8 @@ pub struct QuorumStoreClient {
     poll_count: u64,
     /// Timeout for consensus to pull transactions from quorum store and get a response (in milliseconds)
     pull_timeout_ms: u64,
-    create_empty_blocks_for_pending_ordering: bool,
-    create_partial_blocks_before_poll_ends: bool,
+    wait_for_full_blocks_above_recent_fill_threshold: f32,
+    wait_for_full_blocks_above_pending_blocks: usize,
 }
 
 impl QuorumStoreClient {
@@ -34,8 +34,8 @@ impl QuorumStoreClient {
         consensus_to_quorum_store_sender: mpsc::Sender<GetPayloadCommand>,
         poll_count: u64,
         pull_timeout_ms: u64,
-        create_empty_blocks_for_pending_ordering: bool,
-        create_partial_blocks_before_poll_ends: bool,
+        wait_for_full_blocks_above_recent_fill_threshold: f32,
+        wait_for_full_blocks_above_pending_blocks: usize,
     ) -> Self {
         assert!(
             poll_count > 0,
@@ -45,8 +45,8 @@ impl QuorumStoreClient {
             consensus_to_quorum_store_sender,
             poll_count,
             pull_timeout_ms,
-            create_empty_blocks_for_pending_ordering, 
-            create_partial_blocks_before_poll_ends,
+            wait_for_full_blocks_above_recent_fill_threshold,
+            wait_for_full_blocks_above_pending_blocks,
         }
     }
 
@@ -97,9 +97,13 @@ impl PayloadClient for QuorumStoreClient {
         exclude_payloads: PayloadFilter,
         wait_callback: BoxFuture<'static, ()>,
         pending_ordering: bool,
+        pending_uncommitted_blocks: usize,
+        recent_max_fill_fraction: f32,
     ) -> Result<Payload, QuorumStoreError> {
-        let return_empty = pending_ordering && self.create_empty_blocks_for_pending_ordering;
-        let return_non_full = self.create_partial_blocks_before_poll_ends;
+        let return_non_full = recent_max_fill_fraction
+            < self.wait_for_full_blocks_above_recent_fill_threshold
+            && pending_uncommitted_blocks < self.wait_for_full_blocks_above_pending_blocks;
+        let return_empty = pending_ordering && return_non_full;
 
         fail_point!("consensus::pull_payload", |_| {
             Err(anyhow::anyhow!("Injected error in pull_payload").into())

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -114,6 +114,9 @@ impl BatchGenerator {
             .pull_internal(
                 max_count,
                 self.config.mempool_txn_pull_max_bytes,
+                // allow creating non-full fragments
+                // is this a good place to disable fragments actually?
+                true,
                 exclude_txns,
             )
             .await

--- a/consensus/src/quorum_store/direct_mempool_quorum_store.rs
+++ b/consensus/src/quorum_store/direct_mempool_quorum_store.rs
@@ -138,8 +138,14 @@ impl DirectMempoolQuorumStore {
                 payload_filter,
                 callback,
             ) => {
-                self.handle_block_request(max_txns, max_bytes, return_non_full, payload_filter, callback)
-                    .await;
+                self.handle_block_request(
+                    max_txns,
+                    max_bytes,
+                    return_non_full,
+                    payload_filter,
+                    callback,
+                )
+                .await;
             },
         }
     }

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -76,7 +76,7 @@ impl ProofManager {
     pub(crate) fn handle_proposal_request(&mut self, msg: GetPayloadCommand) {
         match msg {
             // TODO: check what max_txns consensus is using
-            GetPayloadCommand::GetPayloadRequest(round, max_txns, max_bytes, filter, callback) => {
+            GetPayloadCommand::GetPayloadRequest(round, max_txns, max_bytes, return_non_full, filter, callback) => {
                 // TODO: Pass along to batch_store
                 let excluded_proofs: HashSet<HashValue> = match filter {
                     PayloadFilter::Empty => HashSet::new(),
@@ -91,6 +91,7 @@ impl ProofManager {
                     LogicalTime::new(self.latest_logical_time.epoch(), round),
                     max_txns,
                     max_bytes,
+                    return_non_full,
                 );
                 self.remaining_total_txn_num = self
                     .proofs_for_consensus

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -76,7 +76,14 @@ impl ProofManager {
     pub(crate) fn handle_proposal_request(&mut self, msg: GetPayloadCommand) {
         match msg {
             // TODO: check what max_txns consensus is using
-            GetPayloadCommand::GetPayloadRequest(round, max_txns, max_bytes, return_non_full, filter, callback) => {
+            GetPayloadCommand::GetPayloadRequest(
+                round,
+                max_txns,
+                max_bytes,
+                return_non_full,
+                filter,
+                callback,
+            ) => {
                 // TODO: Pass along to batch_store
                 let excluded_proofs: HashSet<HashValue> = match filter {
                     PayloadFilter::Empty => HashSet::new(),

--- a/consensus/src/quorum_store/tests/batch_generator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_generator_test.rs
@@ -26,6 +26,7 @@ async fn queue_mempool_batch_response(
     if let QuorumStoreRequest::GetBatchRequest(
         _max_batch_size,
         _max_bytes,
+        _return_non_full,
         exclude_txns,
         callback,
     ) = timeout(

--- a/consensus/src/quorum_store/tests/direct_mempool_quorum_store_test.rs
+++ b/consensus/src/quorum_store/tests/direct_mempool_quorum_store_test.rs
@@ -33,6 +33,7 @@ async fn test_block_request_no_txns() {
             1,
             100,
             1000,
+            true,
             PayloadFilter::DirectMempool(vec![]),
             consensus_callback,
         ))
@@ -41,6 +42,7 @@ async fn test_block_request_no_txns() {
     if let QuorumStoreRequest::GetBatchRequest(
         _max_batch_size,
         _max_bytes,
+        _return_non_full,
         _exclude_txns,
         callback,
     ) = timeout(

--- a/consensus/src/quorum_store/tests/proof_manager_test.rs
+++ b/consensus/src/quorum_store/tests/proof_manager_test.rs
@@ -28,6 +28,7 @@ async fn test_block_request() {
         1,
         100,
         1000000,
+        true,
         PayloadFilter::InQuorumStore(HashSet::new()),
         callback_tx,
     );

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -13,7 +13,7 @@ use aptos_consensus_types::{
     proof_of_store::{LogicalTime, ProofOfStore},
 };
 use aptos_crypto::HashValue;
-use aptos_logger::debug;
+use aptos_logger::{debug, info};
 use aptos_mempool::{QuorumStoreRequest, QuorumStoreResponse};
 use aptos_types::transaction::SignedTransaction;
 use chrono::Utc;
@@ -187,10 +187,11 @@ impl MempoolProxy {
         &self,
         max_items: u64,
         max_bytes: u64,
+        return_non_full: bool,
         exclude_txns: Vec<TransactionSummary>,
     ) -> Result<Vec<SignedTransaction>, anyhow::Error> {
         let (callback, callback_rcv) = oneshot::channel();
-        let msg = QuorumStoreRequest::GetBatchRequest(max_items, max_bytes, exclude_txns, callback);
+        let msg = QuorumStoreRequest::GetBatchRequest(max_items, max_bytes, return_non_full, exclude_txns, callback);
         self.mempool_tx
             .clone()
             .try_send(msg)
@@ -266,6 +267,7 @@ impl ProofQueue {
         current_time: LogicalTime,
         max_txns: u64,
         max_bytes: u64,
+        return_non_full: bool,
     ) -> Vec<ProofOfStore> {
         let num_expired = self
             .digest_queue
@@ -294,6 +296,9 @@ impl ProofQueue {
         let mut ret = Vec::new();
         let mut cur_bytes = 0;
         let mut cur_txns = 0;
+        let initial_size = self.digest_queue.len();
+        let mut size = self.digest_queue.len();
+        let mut full = false;
 
         for (digest, expiration) in self
             .digest_queue
@@ -311,6 +316,7 @@ impl ProofQueue {
                     cur_txns += proof.info().num_txns;
                     if cur_bytes > max_bytes || cur_txns > max_txns {
                         // Exceeded the limit for requested bytes or number of transactions.
+                        full = true;
                         break;
                     }
                     ret.push(proof.clone());
@@ -326,13 +332,29 @@ impl ProofQueue {
                     }
                 }
             }
+            size = size - 1;
         }
-        counters::EXPIRED_PROOFS_WHEN_PULL.observe(num_expired_but_not_committed as f64);
-        counters::BLOCK_SIZE_WHEN_PULL.observe(cur_txns as f64);
-        counters::BLOCK_BYTES_WHEN_PULL.observe(cur_bytes as f64);
-        counters::PROOF_SIZE_WHEN_PULL.observe(ret.len() as f64);
+        info!(
+            // before non full check
+            byte_size = cur_bytes,
+            block_size = cur_txns,
+            batch_count = ret,
+            remaining_proof_num = size,
+            initial_remaining_proof_num = initial_size,
+            full = full,
+            return_non_full = return_non_full,
+            "Pull payloads from QuorumStore: internal"
+        );
 
-        ret
+        if full || return_non_full {
+            counters::EXPIRED_PROOFS_WHEN_PULL.observe(num_expired_but_not_committed as f64);
+            counters::BLOCK_SIZE_WHEN_PULL.observe(cur_txns as f64);
+            counters::BLOCK_BYTES_WHEN_PULL.observe(cur_bytes as f64);
+            counters::PROOF_SIZE_WHEN_PULL.observe(ret.len() as f64);    
+            ret
+        } else {
+            Vec::new()
+        }
     }
 
     pub(crate) fn num_total_txns(&mut self, current_time: LogicalTime) -> u64 {

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -191,7 +191,13 @@ impl MempoolProxy {
         exclude_txns: Vec<TransactionSummary>,
     ) -> Result<Vec<SignedTransaction>, anyhow::Error> {
         let (callback, callback_rcv) = oneshot::channel();
-        let msg = QuorumStoreRequest::GetBatchRequest(max_items, max_bytes, return_non_full, exclude_txns, callback);
+        let msg = QuorumStoreRequest::GetBatchRequest(
+            max_items,
+            max_bytes,
+            return_non_full,
+            exclude_txns,
+            callback,
+        );
         self.mempool_tx
             .clone()
             .try_send(msg)
@@ -332,7 +338,7 @@ impl ProofQueue {
                     }
                 }
             }
-            size = size - 1;
+            size -= 1;
         }
         info!(
             // before non full check
@@ -350,7 +356,7 @@ impl ProofQueue {
             counters::EXPIRED_PROOFS_WHEN_PULL.observe(num_expired_but_not_committed as f64);
             counters::BLOCK_SIZE_WHEN_PULL.observe(cur_txns as f64);
             counters::BLOCK_BYTES_WHEN_PULL.observe(cur_bytes as f64);
-            counters::PROOF_SIZE_WHEN_PULL.observe(ret.len() as f64);    
+            counters::PROOF_SIZE_WHEN_PULL.observe(ret.len() as f64);
             ret
         } else {
             Vec::new()

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -32,6 +32,8 @@ pub trait PayloadClient: Send + Sync {
         exclude: PayloadFilter,
         wait_callback: BoxFuture<'static, ()>,
         pending_ordering: bool,
+        pending_uncommitted_blocks: usize,
+        recent_max_fill_fraction: f32,
     ) -> Result<Payload, QuorumStoreError>;
 
     fn trace_payloads(&self) {}

--- a/consensus/src/test_utils/mock_payload_manager.rs
+++ b/consensus/src/test_utils/mock_payload_manager.rs
@@ -26,7 +26,7 @@ pub struct MockPayloadManager {
 impl MockPayloadManager {
     pub fn new(consensus_to_quorum_store_sender: Option<mpsc::Sender<GetPayloadCommand>>) -> Self {
         let quorum_store_client =
-            consensus_to_quorum_store_sender.map(|s| QuorumStoreClient::new(s, 1, 1));
+            consensus_to_quorum_store_sender.map(|s| QuorumStoreClient::new(s, 1, 1, false, false));
         Self {
             _quorum_store_client: quorum_store_client,
         }

--- a/consensus/src/test_utils/mock_payload_manager.rs
+++ b/consensus/src/test_utils/mock_payload_manager.rs
@@ -26,7 +26,7 @@ pub struct MockPayloadManager {
 impl MockPayloadManager {
     pub fn new(consensus_to_quorum_store_sender: Option<mpsc::Sender<GetPayloadCommand>>) -> Self {
         let quorum_store_client =
-            consensus_to_quorum_store_sender.map(|s| QuorumStoreClient::new(s, 1, 1, false, false));
+            consensus_to_quorum_store_sender.map(|s| QuorumStoreClient::new(s, 1, 1, 1.1, 100));
         Self {
             _quorum_store_client: quorum_store_client,
         }
@@ -58,6 +58,8 @@ impl PayloadClient for MockPayloadManager {
         _exclude: PayloadFilter,
         _wait_callback: BoxFuture<'static, ()>,
         _pending_ordering: bool,
+        _pending_uncommitted_blocks: usize,
+        _recent_fill_fraction: f32,
     ) -> Result<Payload, QuorumStoreError> {
         // generate 1k txn is too slow with coverage instrumentation
         Ok(random_payload(10))

--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -77,37 +77,45 @@ impl<'t> AccountMinter<'t> {
         let txn_factory = self.txn_factory.clone();
         let expected_children_per_seed_account =
             (num_accounts + expected_num_seed_accounts - 1) / expected_num_seed_accounts;
-        let coins_per_seed_account = (expected_children_per_seed_account as u64)
-            .checked_mul(
-                coins_per_account
-                    + req.max_gas_per_txn * req.gas_price * req.init_gas_price_multiplier,
-            )
-            .unwrap()
-            .checked_add(req.max_gas_per_txn * req.gas_price * req.init_gas_price_multiplier)
-            .unwrap();
-        println!("{:?}", req);
-        println!(">>> coins_per_seed_account {}", coins_per_seed_account);
-        println!(
-            ">>> expected_num_seed_accounts {}",
-            expected_num_seed_accounts
-        );
-        let coins_for_source = coins_per_seed_account
-            .checked_mul(expected_num_seed_accounts as u64)
-            .unwrap()
-            .checked_add(req.max_gas_per_txn * req.gas_price * req.init_gas_price_multiplier)
-            .unwrap();
         info!(
             "Account creation plan created for {} accounts with {} balance each.",
             num_accounts, coins_per_account
         );
         info!(
-            "    through {} seed accounts with {} each, each to fund {} accounts",
-            expected_num_seed_accounts, coins_per_seed_account, expected_children_per_seed_account,
-        );
-        info!(
             "    because of expecting {} txns and {} gas at {} gas price for each ",
             req.expected_max_txns, req.expected_gas_per_txn, req.gas_price,
         );
+        let coins_per_seed_account = (expected_children_per_seed_account as u64)
+            .checked_mul(
+                coins_per_account
+                    + req.max_gas_per_txn * req.gas_price * req.init_gas_price_multiplier,
+            )
+            .unwrap_or_else(|| {
+                panic!(
+                    "coins_per_seed_account exceeds u64: {} * ({} + {} * {} * {})",
+                    expected_children_per_seed_account,
+                    coins_per_account,
+                    req.max_gas_per_txn,
+                    req.gas_price,
+                    req.init_gas_price_multiplier
+                )
+            })
+            .checked_add(req.max_gas_per_txn * req.gas_price * req.init_gas_price_multiplier)
+            .unwrap();
+        info!(
+            "    through {} seed accounts with {} each, each to fund {} accounts",
+            expected_num_seed_accounts, coins_per_seed_account, expected_children_per_seed_account,
+        );
+        let coins_for_source = coins_per_seed_account
+            .checked_mul(expected_num_seed_accounts as u64)
+            .unwrap_or_else(|| {
+                panic!(
+                    "coins_for_source exceeds u64: {} * {}",
+                    coins_per_seed_account, expected_num_seed_accounts
+                )
+            })
+            .checked_add(req.max_gas_per_txn * req.gas_price * req.init_gas_price_multiplier)
+            .unwrap();
 
         if req.mint_to_root {
             self.mint_to_root(txn_executor, coins_for_source).await?;

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -40,8 +40,8 @@ use std::{
 };
 use tokio::{runtime::Handle, task::JoinHandle, time};
 
-// Max is 100k TPS for a full day.
-const MAX_TXNS: u64 = 10_000_000_000;
+// Max is 100k TPS for 3 hours
+const MAX_TXNS: u64 = 1_000_000_000;
 
 const MAX_RETRIES: usize = 6;
 

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -165,6 +165,7 @@ impl Mempool {
         &self,
         max_txns: u64,
         max_bytes: u64,
+        return_non_full: bool,
         mut seen: HashSet<TxnPointer>,
     ) -> Vec<SignedTransaction> {
         let mut result = vec![];
@@ -214,12 +215,14 @@ impl Mempool {
         }
         let result_size = result.len();
         let mut block = Vec::with_capacity(result_size);
+        let mut full_bytes = false;
         for (address, seq) in result {
             if let Some((txn, ranking_score)) =
                 self.transactions.get_with_ranking_score(&address, seq)
             {
                 let txn_size = txn.raw_txn_bytes_len();
                 if total_bytes + txn_size > max_bytes as usize {
+                    full_bytes = true;
                     break;
                 }
                 total_bytes += txn_size;
@@ -233,14 +236,21 @@ impl Mempool {
             }
         }
 
+        if !return_non_full && !full_bytes && (block.len() as u64) < max_txns {
+            block.clear();
+        }
+
         debug!(
             LogSchema::new(LogEntry::GetBlock),
             seen_consensus = seen_size,
             walked = txn_walked,
             seen_after = seen.len(),
+            // before size and non full check
             result_size = result_size,
-            block_size = block.len(),
+            // before non full check
             byte_size = total_bytes,
+            block_size = block.len(),
+            return_non_full = return_non_full,
         );
 
         counters::mempool_service_transactions(counters::GET_BLOCK_LABEL, block.len());

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -236,10 +236,6 @@ impl Mempool {
             }
         }
 
-        if !return_non_full && !full_bytes && (block.len() as u64) < max_txns {
-            block.clear();
-        }
-
         debug!(
             LogSchema::new(LogEntry::GetBlock),
             seen_consensus = seen_size,
@@ -252,6 +248,10 @@ impl Mempool {
             block_size = block.len(),
             return_non_full = return_non_full,
         );
+
+        if !return_non_full && !full_bytes && (block.len() as u64) < max_txns {
+            block.clear();
+        }
 
         counters::mempool_service_transactions(counters::GET_BLOCK_LABEL, block.len());
         counters::MEMPOOL_SERVICE_BYTES_GET_BLOCK.observe(total_bytes as f64);

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -446,7 +446,13 @@ pub(crate) fn process_quorum_store_request<NetworkClient, TransactionValidator>(
     let start_time = Instant::now();
 
     let (resp, callback, counter_label) = match req {
-        QuorumStoreRequest::GetBatchRequest(max_txns, max_bytes, transactions, callback) => {
+        QuorumStoreRequest::GetBatchRequest(
+            max_txns,
+            max_bytes,
+            return_non_full,
+            transactions,
+            callback,
+        ) => {
             let exclude_transactions: HashSet<TxnPointer> = transactions
                 .iter()
                 .map(|txn| (txn.sender, txn.sequence_number))
@@ -476,7 +482,8 @@ pub(crate) fn process_quorum_store_request<NetworkClient, TransactionValidator>(
                     counters::GET_BLOCK_GET_BATCH_LABEL,
                     counters::REQUEST_SUCCESS_LABEL,
                 );
-                txns = mempool.get_batch(max_txns, max_bytes, exclude_transactions);
+                txns =
+                    mempool.get_batch(max_txns, max_bytes, return_non_full, exclude_transactions);
             }
 
             // mempool_service_transactions is logged inside get_batch

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -165,6 +165,8 @@ pub enum QuorumStoreRequest {
         u64,
         // max byte size
         u64,
+        // return non full
+        bool,
         // transactions to exclude from the requested batch
         Vec<TransactionSummary>,
         // callback to respond to
@@ -183,11 +185,18 @@ pub enum QuorumStoreRequest {
 impl fmt::Display for QuorumStoreRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let payload = match self {
-            QuorumStoreRequest::GetBatchRequest(max_txns, max_bytes, excluded_txns, _) => {
+            QuorumStoreRequest::GetBatchRequest(
+                max_txns,
+                max_bytes,
+                return_non_full,
+                excluded_txns,
+                _,
+            ) => {
                 format!(
-                    "GetBatchRequest [max_txns: {}, max_bytes: {}, excluded_txns_length: {}]",
+                    "GetBatchRequest [max_txns: {}, max_bytes: {}, return_non_full: {}, excluded_txns_length: {}]",
                     max_txns,
                     max_bytes,
+                    return_non_full,
                     excluded_txns.len()
                 )
             },

--- a/mempool/src/tests/common.rs
+++ b/mempool/src/tests/common.rs
@@ -170,7 +170,7 @@ impl ConsensusMock {
         max_txns: u64,
         max_bytes: u64,
     ) -> Vec<SignedTransaction> {
-        let block = mempool.get_batch(max_txns, max_bytes, self.0.clone());
+        let block = mempool.get_batch(max_txns, max_bytes, true, self.0.clone());
         self.0 = self
             .0
             .union(

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -251,7 +251,7 @@ fn test_system_ttl() {
 
     // GC routine should clear transaction from first insert but keep last one.
     mempool.gc();
-    let batch = mempool.get_batch(1, 1024, HashSet::new());
+    let batch = mempool.get_batch(1, 1024, true, HashSet::new());
     assert_eq!(vec![transaction.make_signed_transaction()], batch);
 }
 
@@ -263,11 +263,11 @@ fn test_commit_callback() {
     let txns = add_txns_to_mempool(&mut pool, vec![TestTransaction::new(1, 6, 1)]);
 
     // Check that pool is empty.
-    assert!(pool.get_batch(1, 1024, HashSet::new()).is_empty());
+    assert!(pool.get_batch(1, 1024, true, HashSet::new()).is_empty());
     // Transaction 5 got back from consensus.
     pool.commit_transaction(&TestTransaction::get_address(1), 5);
     // Verify that we can execute transaction 6.
-    assert_eq!(pool.get_batch(1, 1024, HashSet::new())[0], txns[0]);
+    assert_eq!(pool.get_batch(1, 1024, true, HashSet::new())[0], txns[0]);
 }
 
 #[test]
@@ -556,7 +556,7 @@ fn test_parking_lot_eviction() {
     }
     // Make sure that we have correct txns in Mempool.
     let mut txns: Vec<_> = pool
-        .get_batch(5, 5120, HashSet::new())
+        .get_batch(5, 5120, true, HashSet::new())
         .iter()
         .map(SignedTransaction::sequence_number)
         .collect();
@@ -585,7 +585,7 @@ fn test_parking_lot_evict_only_for_ready_txn_insertion() {
 
     // Make sure that we have correct txns in Mempool.
     let mut txns: Vec<_> = pool
-        .get_batch(5, 5120, HashSet::new())
+        .get_batch(5, 5120, true, HashSet::new())
         .iter()
         .map(SignedTransaction::sequence_number)
         .collect();
@@ -621,7 +621,7 @@ fn test_gc_ready_transaction() {
     pool.gc_by_expiration_time(Duration::from_secs(1));
 
     // Make sure txns 2 and 3 became not ready and we can't read them from any API.
-    let block = pool.get_batch(1, 1024, HashSet::new());
+    let block = pool.get_batch(1, 1024, true, HashSet::new());
     assert_eq!(block.len(), 1);
     assert_eq!(block[0].sequence_number(), 0);
 
@@ -646,7 +646,7 @@ fn test_clean_stuck_transactions() {
     let db_sequence_number = 10;
     let txn = TestTransaction::new(0, db_sequence_number, 1).make_signed_transaction();
     pool.add_txn(txn, 1, db_sequence_number, TimelineState::NotReady);
-    let block = pool.get_batch(1, 1024, HashSet::new());
+    let block = pool.get_batch(1, 1024, true, HashSet::new());
     assert_eq!(block.len(), 1);
     assert_eq!(block[0].sequence_number(), 10);
 }
@@ -699,11 +699,11 @@ fn test_bytes_limit() {
     for seq in 0..100 {
         add_txn(&mut pool, TestTransaction::new(1, seq, 1)).unwrap();
     }
-    let get_all = pool.get_batch(100, 100 * 1024, HashSet::new());
+    let get_all = pool.get_batch(100, 100 * 1024, true, HashSet::new());
     assert_eq!(get_all.len(), 100);
     let txn_size = get_all[0].raw_txn_bytes_len() as u64;
     let limit = 10;
-    let hit_limit = pool.get_batch(100, txn_size * limit, HashSet::new());
+    let hit_limit = pool.get_batch(100, txn_size * limit, true, HashSet::new());
     assert_eq!(hit_limit.len(), limit as usize);
 }
 
@@ -746,6 +746,23 @@ fn test_sequence_number_behavior_at_capacity() {
     add_txn(&mut pool, TestTransaction::new(2, 0, 1)).unwrap();
     pool.commit_transaction(&TestTransaction::get_address(2), 0);
 
-    let batch = pool.get_batch(10, 10240, HashSet::new());
+    let batch = pool.get_batch(10, 10240, true, HashSet::new());
+    assert_eq!(batch.len(), 1);
+}
+
+#[test]
+fn test_not_return_non_full() {
+    let mut config = NodeConfig::random();
+    config.mempool.capacity = 2;
+    let mut pool = CoreMempool::new(&config);
+    add_txn(&mut pool, TestTransaction::new(0, 0, 1)).unwrap();
+
+    let batch = pool.get_batch(10, 10240, true, HashSet::new());
+    assert_eq!(batch.len(), 1);
+
+    let batch = pool.get_batch(10, 10240, false, HashSet::new());
+    assert_eq!(batch.len(), 0);
+
+    let batch = pool.get_batch(1, 10240, false, HashSet::new());
     assert_eq!(batch.len(), 1);
 }

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -183,7 +183,7 @@ impl MockSharedMempool {
     pub fn get_txns(&self, size: u64) -> Vec<SignedTransaction> {
         let pool = self.mempool.lock();
         // assume txn size is less than 100kb
-        pool.get_batch(size, size * 102400, HashSet::new())
+        pool.get_batch(size, size * 102400, true, HashSet::new())
     }
 
     pub fn remove_txn(&self, txn: &SignedTransaction) {

--- a/mempool/src/tests/multi_node_test.rs
+++ b/mempool/src/tests/multi_node_test.rs
@@ -367,6 +367,7 @@ impl TestHarness {
                             let block = self.node(sender_id).mempool().get_batch(
                                 100,
                                 102400,
+                                true,
                                 HashSet::new(),
                             );
                             for txn in transactions.iter() {

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -169,7 +169,10 @@ impl MempoolNode {
     /// Asynchronously waits for up to 1 second for txns to appear in mempool
     pub async fn wait_on_txns_in_mempool(&self, txns: &[TestTransaction]) {
         for _ in 0..10 {
-            let block = self.mempool.lock().get_batch(100, 102400, HashSet::new());
+            let block = self
+                .mempool
+                .lock()
+                .get_batch(100, 102400, true, HashSet::new());
 
             if block_contains_all_transactions(&block, txns) {
                 break;
@@ -219,7 +222,10 @@ impl MempoolNode {
         txns: &[TestTransaction],
         condition: Condition,
     ) -> Result<(), (Vec<(AccountAddress, u64)>, Vec<(AccountAddress, u64)>)> {
-        let block = self.mempool.lock().get_batch(100, 102400, HashSet::new());
+        let block = self
+            .mempool
+            .lock()
+            .get_batch(100, 102400, true, HashSet::new());
         if !condition(&block, txns) {
             let actual: Vec<_> = block
                 .iter()


### PR DESCRIPTION
Adding two new flags, to improve blockchain performance.

   // Whether to create partial blocks when few transactions exist, or empty blocks when there is
    // pending ordering, or to wait for quorum_store_poll_count * 30ms to collect transactions for a block
    //
    // It is more efficient to execute larger blocks, as it creates less overhead. On the other hand
    // waiting increases latency (unless we are under high load that added waiting latency
    // is compensated by faster execution time). So we want to balance the two, by waiting only
    // when we are saturating the execution pipeline:
    // - if there are more pending blocks then usual in the execution pipeline,
    //   block is going to wait there anyways, so we can wait to create a bigger/more efificent block
    // - in case our node is faster than others, and we don't have many pending blocks,
    //   but we still see very large recent (pending) blocks, we know that there is demand
    //   and others are creating large blocks, so we can wait as well.