### PR TITLE
[crash-handler] Ignore crashed from verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,7 @@ version = "0.1.0"
 dependencies = [
  "aptos-logger",
  "backtrace",
+ "move-core-types",
  "serde 1.0.149",
  "toml",
 ]
@@ -3477,7 +3478,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -6341,7 +6342,7 @@ checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6358,7 +6359,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
@@ -6374,12 +6375,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6394,7 +6395,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6406,9 +6407,10 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
+ "fail 0.4.0",
  "move-binary-format",
  "move-borrow-graph",
  "move-core-types",
@@ -6418,7 +6420,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -6435,7 +6437,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6481,7 +6483,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "difference",
@@ -6498,7 +6500,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6527,7 +6529,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
@@ -6549,7 +6551,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6569,7 +6571,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -6587,7 +6589,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6605,7 +6607,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6619,7 +6621,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6638,7 +6640,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6657,7 +6659,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "hex",
@@ -6670,7 +6672,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "hex",
@@ -6684,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6710,7 +6712,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6746,7 +6748,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6783,7 +6785,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6811,7 +6813,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6822,7 +6824,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6837,7 +6839,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -6864,7 +6866,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -6882,7 +6884,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "hex",
@@ -6905,7 +6907,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "once_cell",
  "serde 1.0.149",
@@ -6914,7 +6916,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6931,7 +6933,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -6963,7 +6965,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "better_any",
@@ -6994,7 +6996,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -7011,7 +7013,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7025,7 +7027,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-binary-format",
@@ -8344,7 +8346,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -8359,7 +8361,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=2336fe284b6db095e8f0a7ce5850ee165b3816fe#2336fe284b6db095e8f0a7ce5850ee165b3816fe"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -456,34 +456,34 @@ x25519-dalek = "1.2.0"
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES
-move-abigen = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-cli = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-compiler ={ git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0", features = ["address32"] }
-move-docgen = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-model = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-package = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-prover = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0", features = ["table-extension"] }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0", features = ["lazy_natives"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0", features = ["table-extension"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-cli = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-compiler ={ git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe", features = ["address32"] }
+move-docgen = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-model = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-package = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-prover = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe", features = ["table-extension"] }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe", features = ["lazy_natives"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe", features = ["table-extension"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+read-write-set = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "2336fe284b6db095e8f0a7ce5850ee165b3816fe" }
 # END MOVE DEPENDENCIES
 
 [profile.release]

--- a/aptos-move/aptos-vm-profiling/src/profile_aptos_vm.rs
+++ b/aptos-move/aptos-vm-profiling/src/profile_aptos_vm.rs
@@ -28,8 +28,8 @@ fn run_aptos_p2p() -> Result<()> {
 
     let genesis_blob = bcs::to_bytes(GENESIS_CHANGE_SET_HEAD.write_set())?;
 
-    let log_path = Path::join(*PATH_CRATE_ROOT, "p2p.log");
-    let annotation_path = Path::join(*PATH_CRATE_ROOT, "p2p.txt");
+    let log_path = Path::join(&PATH_CRATE_ROOT, "p2p.log");
+    let annotation_path = Path::join(&PATH_CRATE_ROOT, "p2p.txt");
 
     crate::valgrind::profile_with_valgrind(
         [&*PATH_BIN_RUN_APTOS_P2P],

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -104,16 +104,18 @@ impl Deref for MoveVmExt {
     }
 }
 
-pub fn verifier_config(treat_friend_as_private: bool) -> VerifierConfig {
+pub fn verifier_config(_treat_friend_as_private: bool) -> VerifierConfig {
     VerifierConfig {
         max_loop_depth: Some(5),
-        treat_friend_as_private,
         max_generic_instantiation_length: Some(32),
         max_function_parameters: Some(128),
         max_basic_blocks: Some(1024),
         max_value_stack_size: 1024,
         max_type_nodes: Some(256),
-        max_dependency_depth: 256,
+        max_dependency_depth: Some(256),
         max_push_size: Some(10000),
+        max_struct_definitions: Some(200),
+        max_fields_in_struct: Some(30),
+        max_function_definitions: Some(1000),
     }
 }

--- a/crates/crash-handler/Cargo.toml
+++ b/crates/crash-handler/Cargo.toml
@@ -15,6 +15,6 @@ rust-version = { workspace = true }
 [dependencies]
 aptos-logger = { workspace = true }
 backtrace = { workspace = true }
+move-core-types = { workspace = true }
 serde = { workspace = true }
 toml = { workspace = true }
-

--- a/crates/crash-handler/src/lib.rs
+++ b/crates/crash-handler/src/lib.rs
@@ -5,6 +5,7 @@
 
 use aptos_logger::prelude::*;
 use backtrace::Backtrace;
+use move_core_types::state::{self, VMState};
 use serde::Serialize;
 use std::{
     panic::{self, PanicInfo},
@@ -43,6 +44,14 @@ fn handle_panic(panic_info: &PanicInfo<'_>) {
 
     // Wait till the logs have been flushed
     aptos_logger::flush();
+
+    // Do not kill the process if the panics happened at move-bytecode-verifier.
+    // This is safe because the `state::get_state()` uses a thread_local for storing states. Thus the state can only be mutated to VERIFIER by the thread that's running the bytecode verifier.
+    //
+    // TODO: once `can_unwind` is stable, we should assert it. See https://github.com/rust-lang/rust/issues/92988.
+    if state::get_state() == VMState::VERIFIER {
+        return;
+    }
 
     // Kill the process
     process::exit(12);


### PR DESCRIPTION
### Description

Update the commit hash for Move repo and made crash handler skip the error coming from move-bytecode-verifer.

### Test Plan
Had a one-off rust test to make sure the rust thread_local primitive will behave as expected. We've already test the panic behavior in https://github.com/move-language/move/pull/750
