### PR TITLE
[backup] fix that db-restore can create db will missing LedgerInfos at the tail of history

### DIFF
--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -643,7 +643,7 @@ impl TestContext {
             .context
             .get_latest_ledger_info_with_signatures()
             .unwrap();
-        let epoch = parent.ledger_info().epoch();
+        let epoch = parent.ledger_info().next_block_epoch();
         let version = parent.ledger_info().version() + (block_size as u64);
         let info = LedgerInfo::new(
             BlockInfo::new(

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -118,7 +118,7 @@ fn gen_ledger_info(
 ) -> LedgerInfoWithSignatures {
     let ledger_info = LedgerInfo::new(
         BlockInfo::new(
-            1,
+            0,
             0,
             commit_block_id,
             root_hash,

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1634,6 +1634,16 @@ impl DbWriter for AptosDB {
                     new_root_hash,
                     expected_root_hash,
                 );
+                let current_epoch = self
+                    .ledger_store
+                    .get_latest_ledger_info_option()
+                    .map_or(0, |li| li.ledger_info().next_block_epoch());
+                ensure!(
+                    x.ledger_info().epoch() == current_epoch,
+                    "Gap in epoch history. Trying to put in LedgerInfo in epoch: {}, current epoch: {}",
+                    x.ledger_info().epoch(),
+                    current_epoch,
+                );
 
                 self.ledger_store.put_ledger_info(x, &batch)?;
             }

--- a/storage/aptosdb/src/utils/iterators.rs
+++ b/storage/aptosdb/src/utils/iterators.rs
@@ -287,7 +287,12 @@ impl<'a> EpochEndingLedgerInfoIter<'a> {
                 if !li.ledger_info().ends_epoch() {
                     None
                 } else {
-                    ensure!(epoch == self.next_epoch, "Epochs are not consecutive.");
+                    ensure!(
+                        epoch == self.next_epoch,
+                        "Epochs are not consecutive. expecting: {}, got: {}",
+                        self.next_epoch,
+                        epoch,
+                    );
                     self.next_epoch += 1;
                     Some(li)
                 }

--- a/storage/backup/backup-cli/src/coordinators/restore.rs
+++ b/storage/backup/backup-cli/src/coordinators/restore.rs
@@ -86,7 +86,7 @@ impl RestoreCoordinator {
         ret
     }
 
-    async fn run_impl(self) -> Result<()> {
+    async fn run_impl(mut self) -> Result<()> {
         // N.b.
         // The coordinator now focuses on doing one procedure, ignoring the combination of options
         // supported before:
@@ -141,6 +141,7 @@ impl RestoreCoordinator {
                     .ok_or_else(|| anyhow!("No usable state snapshot."))?
             };
         let version = state_snapshot_backup.version;
+        self.global_opt.target_version = version;
         let epoch_ending_backups = metadata_view.select_epoch_ending_backups(version)?;
         let transaction_backup = metadata_view
             .select_transaction_backups(version, version)?
@@ -184,7 +185,7 @@ impl RestoreCoordinator {
             self.global_opt,
             self.storage,
             txn_manifests,
-            Some(version + 1),
+            None,
             epoch_history,
             vec![],
         )

--- a/storage/backup/backup-cli/src/coordinators/restore.rs
+++ b/storage/backup/backup-cli/src/coordinators/restore.rs
@@ -90,7 +90,7 @@ impl RestoreCoordinator {
         // N.b.
         // The coordinator now focuses on doing one procedure, ignoring the combination of options
         // supported before:
-        //   1. a most recent state snapshot
+        //   1. a most recent state snapshot before --target-version
         //   2. a only transaction and its output, at the state snapshot version
         //   3. the epoch history from 0 up until the latest closed epoch preceding the state
         //      snapshot version.

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     smoke_test_environment::{new_local_swarm_with_aptos, SwarmBuilder},
-    test_utils::{create_and_fund_account, transfer_and_reconfig, transfer_coins},
+    test_utils::{create_and_fund_account, transfer_and_maybe_reconfig, transfer_coins},
 };
 use aptos_config::config::{BootstrappingMode, ContinuousSyncingMode, NodeConfig};
 use aptos_forge::{LocalSwarm, Node, NodeExt, Swarm, SwarmExt};
@@ -760,7 +760,7 @@ async fn execute_transactions(
 
     let transaction_factory = swarm.chain_info().transaction_factory();
     if execute_epoch_changes {
-        transfer_and_reconfig(
+        transfer_and_maybe_reconfig(
             client,
             &transaction_factory,
             swarm.chain_info().root_account,

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -45,7 +45,7 @@ pub async fn transfer_coins(
     txn
 }
 
-pub async fn transfer_and_reconfig(
+pub async fn transfer_and_maybe_reconfig(
     client: &RestClient,
     transaction_factory: &TransactionFactory,
     root_account: &mut LocalAccount,


### PR DESCRIPTION
### Description

At lower traffic, we enlarged the number of txns in each txn backup, hence it's likely that one txn backup now crosses multiple epoch boundaries, which exposes a bad edge case of the `db-restore auto` command where there are epoch endings in the txn backup after the state snapshot version selected -- and those epoch ending are missing in the restored DB.

The fix is (according to the latest spirit of the tool), we don't replay additional txns after the recovered state snapshot.

smoke-test is updated to verify the breakage (with added checks in the code) and the fix.

### Test Plan

smoke-test updated
