### PR TITLE
[docs] add a note on dangling volumes after changing era

### DIFF
--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-aws.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-aws.md
@@ -5,14 +5,14 @@ slug: "run-validator-node-using-aws"
 
 # On AWS
 
-This is a step-by-step guide to install an Aptos node on AWS. Follow these steps to configure a validator node and a validator fullnode on separate machines. 
+This is a step-by-step guide to install an Aptos node on Amazon Web Services (AWS). Follow these steps to configure a validator node and a validator fullnode on separate machines. 
 
-:::danger Did you set up your AWS account?
+:::caution Did you set up your AWS account?
 This guide assumes that you already have AWS account setup.
 :::
 
 :::danger Do you have stale volumes after bumping your deployment's era?
-`era` is a concept relevant only to kubernetes deployments of an Aptos Node. Changing the `era` provides an easy way to wipe your deployment's state. However, this may lead to dangling persistent volumes, which must be cleaned up manually.
+`era` is a concept relevant only to Kubernetes deployments of an Aptos node. Changing the `era` provides an easy way to wipe your deployment's state. However, this may lead to dangling persistent volumes on validator fullnodes. Confirm the existence of these volumes with `kubectl get pvc` and delete them manually to minimize costs.
 :::
 
 ## Before you proceed

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-aws.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-aws.md
@@ -7,6 +7,14 @@ slug: "run-validator-node-using-aws"
 
 This is a step-by-step guide to install an Aptos node on AWS. Follow these steps to configure a validator node and a validator fullnode on separate machines. 
 
+:::danger Did you set up your AWS account?
+This guide assumes that you already have AWS account setup.
+:::
+
+:::danger Do you have stale volumes after bumping your deployment's era?
+`era` is a concept relevant only to kubernetes deployments of an Aptos Node. Changing the `era` provides an easy way to wipe your deployment's state. However, this may lead to dangling persistent volumes, which must be cleaned up manually.
+:::
+
 ## Before you proceed
 
 Make sure you complete these prerequisite steps before you proceed:

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-azure.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-azure.md
@@ -11,6 +11,10 @@ This is a step-by-step guide to install an Aptos node on Azure. Follow these ste
 This guide assumes that you already have Azure account setup.
 :::
 
+:::danger Do you have stale volumes after bumping your deployment's era?
+`era` is a concept relevant only to kubernetes deployments of an Aptos Node. Changing the `era` provides an easy way to wipe your deployment's state. However, this may lead to dangling persistent volumes, which must be cleaned up manually.
+:::
+
 ## Before you proceed
 
 Make sure you complete these prerequisite steps before you proceed:

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-azure.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-azure.md
@@ -5,20 +5,21 @@ slug: "run-validator-node-using-azure"
 
 # On Azure
 
-This is a step-by-step guide to install an Aptos node on Azure. Follow these steps to configure a validator node and a validator fullnode on separate machines. 
+This is a step-by-step guide to install an Aptos node on Microsoft Azure. Follow these steps to configure a validator node and a validator fullnode on separate machines. 
 
-:::danger Did you set up your Azure account?
+:::caution Did you set up your Azure account?
 This guide assumes that you already have Azure account setup.
 :::
 
 :::danger Do you have stale volumes after bumping your deployment's era?
-`era` is a concept relevant only to kubernetes deployments of an Aptos Node. Changing the `era` provides an easy way to wipe your deployment's state. However, this may lead to dangling persistent volumes, which must be cleaned up manually.
+`era` is a concept relevant only to Kubernetes deployments of an Aptos node. Changing the `era` provides an easy way to wipe your deployment's state. However, this may lead to dangling persistent volumes on validator fullnodes. Confirm the existence of these volumes with `kubectl get pvc` and delete them manually to minimize costs.
 :::
 
 ## Before you proceed
 
 Make sure you complete these prerequisite steps before you proceed:
 
+- **Azure account**: https://azure.microsoft.com/
 - **Aptos CLI**: https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli
 - **Terraform 1.2.4**: https://www.terraform.io/downloads.html
 - **Kubernetes CLI**: https://kubernetes.io/docs/tasks/tools/

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-gcp.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-gcp.md
@@ -7,8 +7,12 @@ slug: "run-validator-node-using-gcp"
 
 This is a step-by-step guide to install an Aptos node on Google GCP. Follow these steps to configure a validator node and a validator fullnode on separate machines. 
 
-:::danger Did you set up your GCP account and created a project?
+:::danger Did you set up your GCP account and create a project?
 This guide assumes you already have GCP account setup, and have created a new project for deploying Aptos node. If you are not familiar with GCP (Google Cloud Platform), checkout this [Prerequisites section](https://aptos.dev/tutorials/run-a-fullnode-on-gcp#prerequisites) for GCP account setup.
+:::
+
+:::danger Do you have stale volumes after bumping your deployment's era?
+`era` is a concept relevant only to kubernetes deployments of an Aptos Node. Changing the `era` provides an easy way to wipe your deployment's state. However, this may lead to dangling persistent volumes, which must be cleaned up manually.
 :::
 
 ## Before you proceed

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-gcp.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-gcp.md
@@ -7,17 +7,18 @@ slug: "run-validator-node-using-gcp"
 
 This is a step-by-step guide to install an Aptos node on Google GCP. Follow these steps to configure a validator node and a validator fullnode on separate machines. 
 
-:::danger Did you set up your GCP account and create a project?
-This guide assumes you already have GCP account setup, and have created a new project for deploying Aptos node. If you are not familiar with GCP (Google Cloud Platform), checkout this [Prerequisites section](https://aptos.dev/tutorials/run-a-fullnode-on-gcp#prerequisites) for GCP account setup.
+:::caution Did you set up your GCP account and create a project?
+This guide assumes you already have a Google Cloud Platform (GCP) account setup, and have created a new project for deploying Aptos node. If you are not familiar with GCP (Google Cloud Platform), checkout this [Prerequisites section](https://aptos.dev/tutorials/run-a-fullnode-on-gcp#prerequisites) for GCP account setup.
 :::
 
 :::danger Do you have stale volumes after bumping your deployment's era?
-`era` is a concept relevant only to kubernetes deployments of an Aptos Node. Changing the `era` provides an easy way to wipe your deployment's state. However, this may lead to dangling persistent volumes, which must be cleaned up manually.
+`era` is a concept relevant only to Kubernetes deployments of an Aptos node. Changing the `era` provides an easy way to wipe your deployment's state. However, this may lead to dangling persistent volumes on validator fullnodes. Confirm the existence of these volumes with `kubectl get pvc` and delete them manually to minimize costs.
 :::
 
 ## Before you proceed
 
-Make sure the following are installed on your local computer:
+Make sure the following are setup for your environment:
+  - **GCP account**: hhttps://cloud.google.com/
   - **Aptos CLI**: https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli
   - **Terraform 1.2.4**: https://www.terraform.io/downloads.html
   - **Kubernetes CLI**: https://kubernetes.io/docs/tasks/tools/


### PR DESCRIPTION
### Description

This is relevant to https://github.com/aptos-labs/aptos-core/issues/5508. While it's not recommended/common for node operators to be wiping their storage, this doc change clarifies a quirk with our k8s setup.

If operators wipe their storage on k8s changing the `era`, they must also check if there are any dangling volumes from previous eras and delete them accordingly. Otherwise, their costs might stack up.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
