### PR TITLE
Update commit hash from aptos-v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,7 +3389,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -6235,7 +6235,7 @@ checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6252,7 +6252,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
@@ -6268,12 +6268,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6288,7 +6288,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6300,7 +6300,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6312,7 +6312,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -6329,7 +6329,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6375,7 +6375,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "difference",
@@ -6392,7 +6392,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6421,7 +6421,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6463,7 +6463,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -6481,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6499,7 +6499,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6513,7 +6513,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6532,7 +6532,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6551,7 +6551,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "hex",
@@ -6564,7 +6564,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "hex",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6604,7 +6604,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6640,7 +6640,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6677,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6705,7 +6705,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6716,7 +6716,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6731,7 +6731,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -6758,7 +6758,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -6776,7 +6776,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "hex",
@@ -6799,7 +6799,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "once_cell",
  "serde 1.0.149",
@@ -6808,7 +6808,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6825,7 +6825,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -6857,7 +6857,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "better_any",
@@ -6888,7 +6888,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -6905,7 +6905,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6919,7 +6919,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-binary-format",
@@ -8233,7 +8233,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -8248,7 +8248,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=81d19fce20d73675b7ac129abe6b6797513cc8d0#81d19fce20d73675b7ac129abe6b6797513cc8d0"
+source = "git+https://github.com/move-language/move?rev=318fe9b3314d88aabc3fe641033dad06aaee7c14#318fe9b3314d88aabc3fe641033dad06aaee7c14"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -448,34 +448,34 @@ x25519-dalek = "1.2.0"
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES
-move-abigen = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-cli = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-compiler ={ git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0", features = ["address32"] }
-move-docgen = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-model = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-package = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-prover = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0", features = ["table-extension"] }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0", features = ["lazy_natives"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0", features = ["table-extension"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "81d19fce20d73675b7ac129abe6b6797513cc8d0" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-cli = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-compiler ={ git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14", features = ["address32"] }
+move-docgen = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-model = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-package = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-prover = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14", features = ["table-extension"] }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14", features = ["lazy_natives"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14", features = ["table-extension"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+read-write-set = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "318fe9b3314d88aabc3fe641033dad06aaee7c14" }
 # END MOVE DEPENDENCIES
 
 [profile.release]

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -103,16 +103,18 @@ impl Deref for MoveVmExt {
     }
 }
 
-pub fn verifier_config(treat_friend_as_private: bool) -> VerifierConfig {
+pub fn verifier_config(_treat_friend_as_private: bool) -> VerifierConfig {
     VerifierConfig {
         max_loop_depth: Some(5),
-        treat_friend_as_private,
         max_generic_instantiation_length: Some(32),
         max_function_parameters: Some(128),
         max_basic_blocks: Some(1024),
         max_value_stack_size: 1024,
         max_type_nodes: Some(256),
-        max_dependency_depth: 256,
+        max_dependency_depth: Some(256),
         max_push_size: Some(10000),
+        max_struct_definitions: Some(200),
+        max_fields_in_struct: Some(30),
+        max_function_definitions: Some(1000),
     }
 }

--- a/crates/indexer/src/util.rs
+++ b/crates/indexer/src/util.rs
@@ -168,11 +168,9 @@ mod tests {
 
     #[test]
     fn test_parse_timestamp() {
-        let current_year = chrono::offset::Utc::now().year();
-
         let ts = parse_timestamp(1649560602763949, 1);
         assert_eq!(ts.timestamp(), 1649560602);
-        assert_eq!(ts.year(), current_year);
+        assert_eq!(ts.year(), 2022);
 
         let ts2 = parse_timestamp_secs(600000000000000, 2);
         assert_eq!(ts2.year(), 9999);


### PR DESCRIPTION
### Description

This updates the commit hash from the [aptos-v1.2.0](https://github.com/move-language/move/commit/318fe9b3314d88aabc3fe641033dad06aaee7c14) branch
