### PR TITLE
Updating homebrew docs and formula

### DIFF
--- a/crates/aptos/homebrew/README.md
+++ b/crates/aptos/homebrew/README.md
@@ -135,7 +135,7 @@ going forward, we would modify the formula slightly. See the comments below for 
   # above and build the binary without rustup as a dependency
   #
   # Uses build_cli_release.sh for creating the compiled binaries.
-  # This drastically reduces their size (ie. 2.2gb on Linux for release
+  # This drastically reduces their size (ie. 2.2 GB on Linux for release
   # build becomes 40 MB when run with opt-level = "z", strip, lto, etc).
   # See cargo.toml [profile.cli] section for more details
   def install

--- a/crates/aptos/homebrew/README.md
+++ b/crates/aptos/homebrew/README.md
@@ -6,6 +6,7 @@ The [Aptos command line interface (CLI)](https://aptos.dev/cli-tools/aptos-cli-t
 
 - [Formula in Homebrew GitHub](https://github.com/Homebrew/homebrew-core/blob/master/Formula/aptos.rb)
 - [Aptos 1.0.3 New Formula PR for GitHub](https://github.com/Homebrew/homebrew-core/pull/119832)
+- [Aptos Formula Fix PR to use build_cli_release.sh](https://github.com/Homebrew/homebrew-core/pull/120051)
 
 ### Getting started
 Copy the `aptos.rb` file to your `homebrew` `formula` directory. For example, on macOS with an M1, this will likely be:
@@ -121,7 +122,7 @@ going forward, we would modify the formula slightly. See the comments below for 
 
   on_linux do
     depends_on "pkg-config" => :build
-    # Might need to use "openssl@1.1", let's see https://docs.rs/openssl/latest/openssl/#automatic
+    depends_on "zip" => :build
     depends_on "openssl@3"
     depends_on "systemd"
   end
@@ -132,12 +133,17 @@ going forward, we would modify the formula slightly. See the comments below for 
   # toolchain, we can remove the use of rustup-init, replacing it with a 
   # depends_on "rust" => :build
   # above and build the binary without rustup as a dependency
+  #
+  # Uses build_cli_release.sh for creating the compiled binaries.
+  # This drastically reduces their size (ie. 2.2gb on Linux for release
+  # build becomes 40 MB when run with opt-level = "z", strip, lto, etc).
+  # See cargo.toml [profile.cli] section for more details
   def install
     system "#{Formula["rustup-init"].bin}/rustup-init",
       "-qy", "--no-modify-path", "--default-toolchain", "1.64"
     ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
-    system "cargo", "install", *std_cargo_args(path: "crates/aptos")
-    bin.install "target/release/aptos"
+    system "./scripts/cli/build_cli_release.sh", "homebrew"
+    bin.install "target/cli/aptos"
   end
 ```
 

--- a/crates/aptos/homebrew/aptos.rb
+++ b/crates/aptos/homebrew/aptos.rb
@@ -16,6 +16,7 @@ class Aptos < Formula
 
   on_linux do
     depends_on "pkg-config" => :build
+    depends_on "zip" => :build
     depends_on "openssl@3"
     depends_on "systemd"
   end
@@ -24,8 +25,8 @@ class Aptos < Formula
     system "#{Formula["rustup-init"].bin}/rustup-init",
       "-qy", "--no-modify-path", "--default-toolchain", "1.64"
     ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
-    system "cargo", "install", *std_cargo_args(path: "crates/aptos")
-    bin.install "target/release/aptos"
+    system "./scripts/cli/build_cli_release.sh", "homebrew"
+    bin.install "target/cli/aptos"
   end
 
   test do


### PR DESCRIPTION
### Description
Docs and Formula were updated to use cli release bash script. This dramatically reduces the binary size for release builds that are stored on homebrew and makes them in-line with the compiled binaries on the releases tab of aptos-core. 

### Test Plan
Running e2e tests yields

```bash
2023-01-10 18:34:40,206 - INFO - Running aptos CLI local testnet from image: aptoslabs/tools:devnet
2023-01-10 18:34:40,206 - INFO - Waiting for node and faucet APIs for aptos-tools-devnet to come up
2023-01-10 18:34:56,387 - INFO - Node and faucet APIs for aptos-tools-devnet came up
2023-01-10 18:34:56,394 - INFO - Running test: test_init
2023-01-10 18:34:57,804 - INFO - Test passed: test_init
2023-01-10 18:34:57,806 - INFO - Running test: test_account_fund_with_faucet
2023-01-10 18:34:59,416 - INFO - Test passed: test_account_fund_with_faucet
2023-01-10 18:34:59,421 - INFO - Running test: test_account_create
2023-01-10 18:35:01,334 - INFO - Test passed: test_account_create
2023-01-10 18:35:01,338 - INFO - Stopping container: aptos-tools-devnet
2023-01-10 18:35:01,559 - INFO - Stopped container: aptos-tools-devnet
2023-01-10 18:35:01,560 - INFO - These tests passed:
2023-01-10 18:35:01,560 - INFO - test_init
2023-01-10 18:35:01,560 - INFO - test_account_fund_with_faucet
2023-01-10 18:35:01,560 - INFO - test_account_create
2023-01-10 18:35:01,561 - INFO - All tests passed!
```
