### PR TITLE
[Aptos Framework] Update aptos_account::transfer to do implicit registering of APT if necessary

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/aptos_account.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_account.md
@@ -244,6 +244,11 @@ This would create the recipient account first, which also registers it to receiv
     <b>if</b> (!<a href="account.md#0x1_account_exists_at">account::exists_at</a>(<b>to</b>)) {
         <a href="aptos_account.md#0x1_aptos_account_create_account">create_account</a>(<b>to</b>)
     };
+    // Resource accounts can be created without registering them <b>to</b> receive APT.
+    // This conveniently does the registration <b>if</b> necessary.
+    <b>if</b> (!<a href="coin.md#0x1_coin_is_account_registered">coin::is_account_registered</a>&lt;AptosCoin&gt;(<b>to</b>)) {
+        <a href="coin.md#0x1_coin_register">coin::register</a>&lt;AptosCoin&gt;(&<a href="account.md#0x1_account_create_signer">account::create_signer</a>(<b>to</b>));
+    };
     <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;AptosCoin&gt;(source, <b>to</b>, amount)
 }
 </code></pre>

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -900,22 +900,6 @@ async fn test_block() {
     .await
     .unwrap_err();
 
-    // This one will fail (and skip estimation of gas)
-    transfer_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
-        private_key_1,
-        AccountAddress::ONE,
-        20,
-        Duration::from_secs(5),
-        None,
-        Some(100000),
-        Some(min_gas_price),
-    )
-    .await
-    .unwrap_err();
-
     // Test native stake pool and reset lockup support
     cli.fund_account(2, Some(1000000000000000)).await.unwrap();
     create_stake_pool_and_wait(


### PR DESCRIPTION
### Description

Resource accounts might not be registered to receive APT. aptos_account::transfer would error out for them. This updates aptos_account::transfer to implicitly register the recipient for APT if needed. 

A general side effect of implicit registration is that users can now send coins to reserved account - 0x1, 0x2, ..., 0xa. This is fine and in general a way to "burn" coins.

### Test Plan
Unit tests
