### PR TITLE
[cli] add aptos-db-tool cli to integration all commands about db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,6 +822,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-db-tool"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-backup-service",
+ "aptos-config",
+ "aptos-crypto",
+ "aptos-db",
+ "aptos-executor",
+ "aptos-executor-test-helpers",
+ "aptos-executor-types",
+ "aptos-infallible",
+ "aptos-jellyfish-merkle",
+ "aptos-logger",
+ "aptos-proptest-helpers",
+ "aptos-push-metrics",
+ "aptos-scratchpad",
+ "aptos-storage-interface",
+ "aptos-temppath",
+ "aptos-types",
+ "aptos-vm",
+ "async-trait",
+ "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
+ "bytes 1.2.1",
+ "clap 3.2.23",
+ "futures",
+ "itertools",
+ "move-binary-format",
+ "move-bytecode-verifier",
+ "num_cpus",
+ "once_cell",
+ "pin-project",
+ "proptest",
+ "rand 0.7.3",
+ "regex",
+ "reqwest",
+ "serde 1.0.149",
+ "serde_json",
+ "serde_yaml 0.8.26",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.3",
+ "warp",
+]
+
+[[package]]
 name = "aptos-debugger"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "api/openapi-spec-generator",
     "api/test-context",
     "api/types",
+    "aptos-db-tool",
     "aptos-move/aptos-aggregator",
     "aptos-move/aptos-debugger",
     "aptos-move/aptos-gas",
@@ -174,6 +175,7 @@ aptos-aggregator = { path = "aptos-move/aptos-aggregator" }
 aptos-api = { path = "api" }
 aptos-api-test-context = { path = "api/test-context" }
 aptos-api-types = { path = "api/types" }
+aptos-db-tool = { path = "aptos-db-tool" }
 aptos-backup-cli = { path = "storage/backup/backup-cli" }
 aptos-backup-service = { path = "storage/backup/backup-service" }
 aptos-bounded-executor = { path = "crates/bounded-executor" }

--- a/aptos-db-tool/Cargo.toml
+++ b/aptos-db-tool/Cargo.toml
@@ -1,0 +1,64 @@
+[package]
+name = "aptos-db-tool"
+version = "0.1.0"
+description = "Aptos DB Tool"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+aptos-config = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-db = { workspace = true }
+aptos-executor = { workspace = true }
+aptos-executor-test-helpers = { workspace = true }
+aptos-executor-types = { workspace = true }
+aptos-infallible = { workspace = true }
+aptos-jellyfish-merkle = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-push-metrics = { workspace = true }
+aptos-scratchpad = { workspace = true }
+aptos-storage-interface = { workspace = true }
+aptos-temppath = { workspace = true }
+aptos-types = { workspace = true }
+aptos-vm = { workspace = true }
+async-trait = { workspace = true }
+bcs = { workspace = true }
+bytes = { workspace = true }
+clap = { workspace = true }
+futures = { workspace = true }
+itertools = { workspace = true }
+move-binary-format = { workspace = true }
+move-bytecode-verifier = { workspace = true }
+num_cpus = { workspace = true }
+once_cell = { workspace = true }
+pin-project = { workspace = true }
+rand = { workspace = true }
+regex = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
+
+[dev-dependencies]
+aptos-backup-service = { workspace = true }
+aptos-config = { workspace = true }
+aptos-db = { workspace = true }
+aptos-executor-test-helpers = { workspace = true }
+aptos-proptest-helpers = { workspace = true }
+aptos-storage-interface = { workspace = true }
+proptest = { workspace = true }
+warp = { workspace = true }
+
+[features]
+fuzzing = ["aptos-db/fuzzing"]

--- a/aptos-db-tool/src/app.rs
+++ b/aptos-db-tool/src/app.rs
@@ -1,0 +1,68 @@
+use crate::commands::{
+    backup::{
+        self,
+        utils::{GlobalRestoreOpt, GlobalRestoreOptions},
+    },
+    backup_verified, bootstrapper, restore,
+};
+use anyhow::Result;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[clap(
+    name = "aptos-db-tool",
+    author="hgamiui9",
+    version="0.1.0",
+    about="A separate dev-oriented cli tool combine all the aptos db commands.",
+    long_about = None,
+    propagate_version = true
+)]
+pub struct Tool {
+    #[clap(value_parser)]
+    name: Option<String>,
+
+    #[clap(flatten)]
+    pub global: GlobalRestoreOpt,
+
+    #[clap(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    #[clap(about = "Ledger backup tool.")]
+    Backup {
+        #[clap(subcommand)]
+        command: backup::commands::Backup,
+    },
+
+    #[clap(about = "Verify aptos backup succeed or failed.")]
+    BackupVerified {
+        #[clap(flatten)]
+        command: backup_verified::commands::BackupVerified,
+    },
+
+    #[clap(about = "Bootstrap AptosDB from a backup.")]
+    Bootstrapper {
+        #[clap(flatten)]
+        command: bootstrapper::commands::Bootstrapper,
+    },
+
+    #[clap(about = "Restore the db from the backup files tool.")]
+    Restore {
+        #[clap(subcommand)]
+        command: restore::commands::Restore,
+    },
+}
+
+impl Tool {
+    pub async fn process(self, global_opt: GlobalRestoreOptions) -> Result<()> {
+        match &self.command {
+            Commands::Backup { command } => command.process().await,
+            Commands::Restore { command } => command.process(global_opt).await,
+            Commands::Bootstrapper { command } => command.process().await,
+            Commands::BackupVerified { command } => command.process().await,
+        }
+    }
+}

--- a/aptos-db-tool/src/commands/backup/backup_types/epoch_ending/backup.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/epoch_ending/backup.rs
@@ -1,0 +1,208 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    backup_types::epoch_ending::manifest::{EpochEndingBackup, EpochEndingChunk},
+    metadata::Metadata,
+    storage::{BackupHandleRef, BackupStorage, FileHandle, ShellSafeName},
+    utils::{
+        backup_service_client::BackupServiceClient, read_record_bytes::ReadRecordBytes,
+        should_cut_chunk, storage_ext::BackupStorageExt, GlobalBackupOpt,
+    },
+};
+use anyhow::{anyhow, ensure, Result};
+use aptos_logger::prelude::*;
+use aptos_types::{ledger_info::LedgerInfoWithSignatures, waypoint::Waypoint};
+use clap::Parser;
+use once_cell::sync::Lazy;
+use std::{convert::TryInto, str::FromStr, sync::Arc};
+use tokio::io::AsyncWriteExt;
+
+#[derive(Parser, Clone)]
+pub struct EpochEndingBackupOpt {
+    #[clap(long = "start-epoch", help = "First epoch to be backed up.")]
+    pub start_epoch: u64,
+
+    #[clap(
+        long = "end-epoch",
+        help = "Epoch before which epoch ending backup stops. Pass in the current open epoch to get all."
+    )]
+    pub end_epoch: u64,
+}
+
+pub struct EpochEndingBackupController {
+    start_epoch: u64,
+    end_epoch: u64,
+    max_chunk_size: usize,
+    client: Arc<BackupServiceClient>,
+    storage: Arc<dyn BackupStorage>,
+}
+
+impl EpochEndingBackupController {
+    pub fn new(
+        opt: EpochEndingBackupOpt,
+        global_opt: GlobalBackupOpt,
+        client: Arc<BackupServiceClient>,
+        storage: Arc<dyn BackupStorage>,
+    ) -> Self {
+        Self {
+            start_epoch: opt.start_epoch,
+            end_epoch: opt.end_epoch,
+            max_chunk_size: global_opt.max_chunk_size,
+            client,
+            storage,
+        }
+    }
+
+    pub async fn run(self) -> Result<FileHandle> {
+        info!(
+            "Epoch ending backup started, starting from epoch {start_epoch}, until epoch {end_epoch} (excluded).",
+            start_epoch = self.start_epoch,
+            end_epoch = self.end_epoch,
+        );
+        let ret = self
+            .run_impl()
+            .await
+            .map_err(|e| anyhow!("Epoch ending backup failed: {}", e))?;
+        info!("Epoch ending backup succeeded. Manifest: {}", ret);
+        Ok(ret)
+    }
+}
+
+impl EpochEndingBackupController {
+    async fn run_impl(self) -> Result<FileHandle> {
+        let backup_handle = self
+            .storage
+            .create_backup_with_random_suffix(&self.backup_name())
+            .await?;
+
+        let mut chunks = Vec::new();
+        let mut waypoints = Vec::new();
+        let mut chunk_bytes = Vec::new();
+
+        let mut ledger_infos_file = self
+            .client
+            .get_epoch_ending_ledger_infos(self.start_epoch, self.end_epoch)
+            .await?;
+        let mut current_epoch: u64 = self.start_epoch;
+        let mut chunk_first_epoch: u64 = self.start_epoch;
+
+        while let Some(record_bytes) = ledger_infos_file.read_record_bytes().await? {
+            if should_cut_chunk(&chunk_bytes, &record_bytes, self.max_chunk_size) {
+                let chunk = self
+                    .write_chunk(
+                        &backup_handle,
+                        &chunk_bytes,
+                        chunk_first_epoch,
+                        current_epoch - 1,
+                    )
+                    .await?;
+                chunks.push(chunk);
+                chunk_bytes = vec![];
+                chunk_first_epoch = current_epoch;
+            }
+
+            waypoints.push(Self::get_waypoint(&record_bytes, current_epoch)?);
+            chunk_bytes.extend((record_bytes.len() as u32).to_be_bytes());
+            chunk_bytes.extend(&record_bytes);
+            current_epoch += 1;
+        }
+
+        assert!(!chunk_bytes.is_empty());
+        assert_eq!(current_epoch, self.end_epoch);
+        let chunk = self
+            .write_chunk(
+                &backup_handle,
+                &chunk_bytes,
+                chunk_first_epoch,
+                current_epoch - 1,
+            )
+            .await?;
+        chunks.push(chunk);
+
+        self.write_manifest(&backup_handle, waypoints, chunks).await
+    }
+
+    fn backup_name(&self) -> String {
+        format!("epoch_ending_{}-", self.start_epoch)
+    }
+
+    fn manifest_name() -> &'static ShellSafeName {
+        static NAME: Lazy<ShellSafeName> =
+            Lazy::new(|| ShellSafeName::from_str("epoch_ending.manifest").unwrap());
+        &NAME
+    }
+
+    fn chunk_name(first_epoch: u64) -> ShellSafeName {
+        format!("{}-.chunk", first_epoch).try_into().unwrap()
+    }
+
+    fn get_waypoint(record: &[u8], epoch: u64) -> Result<Waypoint> {
+        let li: LedgerInfoWithSignatures = bcs::from_bytes(record)?;
+        ensure!(
+            li.ledger_info().epoch() == epoch,
+            "Epoch not expected. expected: {}, actual: {}.",
+            li.ledger_info().epoch(),
+            epoch,
+        );
+        Waypoint::new_epoch_boundary(li.ledger_info())
+    }
+
+    async fn write_chunk(
+        &self,
+        backup_handle: &BackupHandleRef,
+        chunk_bytes: &[u8],
+        first_epoch: u64,
+        last_epoch: u64,
+    ) -> Result<EpochEndingChunk> {
+        let (chunk_handle, mut chunk_file) = self
+            .storage
+            .create_for_write(backup_handle, &Self::chunk_name(first_epoch))
+            .await?;
+        chunk_file.write_all(chunk_bytes).await?;
+        chunk_file.shutdown().await?;
+        Ok(EpochEndingChunk {
+            first_epoch,
+            last_epoch,
+            ledger_infos: chunk_handle,
+        })
+    }
+
+    async fn write_manifest(
+        &self,
+        backup_handle: &BackupHandleRef,
+        waypoints: Vec<Waypoint>,
+        chunks: Vec<EpochEndingChunk>,
+    ) -> Result<FileHandle> {
+        let first_epoch = self.start_epoch;
+        let last_epoch = self.end_epoch - 1;
+
+        let manifest = EpochEndingBackup {
+            first_epoch,
+            last_epoch,
+            waypoints,
+            chunks,
+        };
+        let (manifest_handle, mut manifest_file) = self
+            .storage
+            .create_for_write(backup_handle, Self::manifest_name())
+            .await?;
+        manifest_file
+            .write_all(&serde_json::to_vec(&manifest)?)
+            .await?;
+        manifest_file.shutdown().await?;
+
+        let metadata = Metadata::new_epoch_ending_backup(
+            first_epoch,
+            last_epoch,
+            manifest.waypoints.first().expect("No waypoints.").version(),
+            manifest.waypoints.last().expect("No waypoints.").version(),
+            manifest_handle.clone(),
+        );
+
+        self.storage
+            .save_metadata_line(&metadata.name(), &metadata.to_text_line()?)
+            .await?;
+        Ok(manifest_handle)
+    }
+}

--- a/aptos-db-tool/src/commands/backup/backup_types/epoch_ending/manifest.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/epoch_ending/manifest.rs
@@ -1,0 +1,70 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{ensure, Result};
+use aptos_types::waypoint::Waypoint;
+use serde::{Deserialize, Serialize};
+
+use crate::commands::backup::storage::FileHandle;
+
+/// A chunk of an epoch ending backup manifest, representing the
+/// [`first_epoch`, `last_epoch`] range (right side inclusive).
+#[derive(Deserialize, Serialize)]
+pub struct EpochEndingChunk {
+    pub first_epoch: u64,
+    pub last_epoch: u64,
+    pub ledger_infos: FileHandle,
+}
+
+/// Epoch ending backup manifest, representing epoch ending information in the
+/// [`first_epoch`, `last_epoch`] range (right side inclusive).
+#[derive(Deserialize, Serialize)]
+pub struct EpochEndingBackup {
+    pub first_epoch: u64,
+    pub last_epoch: u64,
+    pub waypoints: Vec<Waypoint>,
+    pub chunks: Vec<EpochEndingChunk>,
+}
+
+impl EpochEndingBackup {
+    pub fn verify(&self) -> Result<()> {
+        // check number of waypoints
+        ensure!(
+            self.first_epoch <= self.last_epoch
+                && self.last_epoch - self.first_epoch + 1 == self.waypoints.len() as u64,
+            "Malformed manifest. first epoch: {}, last epoch {}, num waypoints {}",
+            self.first_epoch,
+            self.last_epoch,
+            self.waypoints.len(),
+        );
+
+        // check chunk ranges
+        ensure!(!self.chunks.is_empty(), "No chunks.");
+        let mut next_epoch = self.first_epoch;
+        for chunk in &self.chunks {
+            ensure!(
+                chunk.first_epoch == next_epoch,
+                "Chunk ranges not continuous. Expected first epoch: {}, actual: {}.",
+                next_epoch,
+                chunk.first_epoch,
+            );
+            ensure!(
+                chunk.last_epoch >= chunk.first_epoch,
+                "Chunk range invalid. [{}, {}]",
+                chunk.first_epoch,
+                chunk.last_epoch,
+            );
+            next_epoch = chunk.last_epoch + 1;
+        }
+
+        // check last epoch in chunk matches manifest
+        ensure!(
+            next_epoch - 1 == self.last_epoch, // okay to -1 because chunks is not empty.
+            "Last epoch in chunks: {}, in manifest: {}",
+            next_epoch - 1,
+            self.last_epoch,
+        );
+
+        Ok(())
+    }
+}

--- a/aptos-db-tool/src/commands/backup/backup_types/epoch_ending/mod.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/epoch_ending/mod.rs
@@ -1,0 +1,9 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod backup;
+pub mod manifest;
+pub mod restore;
+
+#[cfg(test)]
+pub mod tests;

--- a/aptos-db-tool/src/commands/backup/backup_types/epoch_ending/restore.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/epoch_ending/restore.rs
@@ -1,0 +1,415 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    backup_types::epoch_ending::manifest::EpochEndingBackup,
+    metrics::{
+        restore::{EPOCH_ENDING_EPOCH, EPOCH_ENDING_VERSION},
+        verify::{VERIFY_EPOCH_ENDING_EPOCH, VERIFY_EPOCH_ENDING_VERSION},
+    },
+    storage::{BackupStorage, FileHandle, FileHandleRef},
+    utils::{
+        read_record_bytes::ReadRecordBytes, storage_ext::BackupStorageExt, stream::StreamX,
+        GlobalRestoreOptions, RestoreRunMode,
+    },
+};
+use anyhow::{anyhow, ensure, Result};
+use aptos_logger::prelude::*;
+use aptos_types::{
+    epoch_change::Verifier,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    transaction::Version,
+    waypoint::Waypoint,
+};
+use clap::Parser;
+use futures::StreamExt;
+use std::{collections::HashMap, sync::Arc, time::Instant};
+
+#[derive(Parser, Clone)]
+pub struct EpochEndingRestoreOpt {
+    #[clap(long = "epoch-ending-manifest")]
+    pub manifest_handle: FileHandle,
+}
+
+pub struct EpochEndingRestoreController {
+    storage: Arc<dyn BackupStorage>,
+    run_mode: Arc<RestoreRunMode>,
+    manifest_handle: FileHandle,
+    target_version: Version,
+    trusted_waypoints: Arc<HashMap<Version, Waypoint>>,
+}
+
+impl EpochEndingRestoreController {
+    pub fn new(
+        opt: EpochEndingRestoreOpt,
+        global_opt: GlobalRestoreOptions,
+        storage: Arc<dyn BackupStorage>,
+    ) -> Self {
+        Self {
+            storage,
+            run_mode: global_opt.run_mode,
+            manifest_handle: opt.manifest_handle,
+            target_version: global_opt.target_version,
+            trusted_waypoints: global_opt.trusted_waypoints,
+        }
+    }
+
+    pub async fn preheat(self) -> PreheatedEpochEndingRestore {
+        PreheatedEpochEndingRestore {
+            preheat_result: self.preheat_impl().await,
+            controller: self,
+        }
+    }
+
+    pub async fn run(
+        self,
+        previous_epoch_ending_ledger_info: Option<&LedgerInfo>,
+    ) -> Result<Vec<LedgerInfo>> {
+        self.preheat()
+            .await
+            .run(previous_epoch_ending_ledger_info)
+            .await
+    }
+}
+
+impl EpochEndingRestoreController {
+    fn name(&self) -> String {
+        format!("epoch ending {}", self.run_mode.name())
+    }
+
+    async fn preheat_impl(&self) -> Result<EpochEndingRestorePreheatData> {
+        let manifest: EpochEndingBackup =
+            self.storage.load_json_file(&self.manifest_handle).await?;
+        manifest.verify()?;
+
+        let mut next_epoch = manifest.first_epoch;
+        let mut waypoint_iter = manifest.waypoints.iter();
+
+        let mut previous_li: Option<&LedgerInfoWithSignatures> = None;
+        let mut ledger_infos = Vec::new();
+
+        let mut past_target = false;
+        for chunk in &manifest.chunks {
+            if past_target {
+                break;
+            }
+
+            let lis = self.read_chunk(&chunk.ledger_infos).await?;
+            ensure!(
+                chunk.first_epoch + lis.len() as u64 == chunk.last_epoch + 1,
+                "Number of items in chunks doesn't match that in manifest. \
+                first_epoch: {}, last_epoch: {}, items in chunk: {}",
+                chunk.first_epoch,
+                chunk.last_epoch,
+                lis.len(),
+            );
+
+            for li in lis {
+                if li.ledger_info().version() > self.target_version {
+                    past_target = true;
+                    break;
+                }
+
+                ensure!(
+                    li.ledger_info().epoch() == next_epoch,
+                    "LedgerInfo epoch not expected. Expected: {}, actual: {}.",
+                    li.ledger_info().epoch(),
+                    next_epoch,
+                );
+                let wp_manifest = waypoint_iter.next().ok_or_else(|| {
+                    anyhow!("More LedgerInfo's found than waypoints in manifest.")
+                })?;
+                let wp_li = Waypoint::new_epoch_boundary(li.ledger_info())?;
+                ensure!(
+                    *wp_manifest == wp_li,
+                    "Waypoints don't match. In manifest: {}, In chunk: {}",
+                    wp_manifest,
+                    wp_li,
+                );
+                if let Some(wp_trusted) = self.trusted_waypoints.get(&wp_li.version()) {
+                    ensure!(
+                        *wp_trusted == wp_li,
+                        "Waypoints don't match. In backup: {}, trusted: {}",
+                        wp_li,
+                        wp_trusted,
+                    );
+                } else if let Some(pre_li) = previous_li {
+                    pre_li
+                        .ledger_info()
+                        .next_epoch_state()
+                        .ok_or_else(|| {
+                            anyhow!(
+                                "Next epoch state not found from LI at epoch {}.",
+                                pre_li.ledger_info().epoch()
+                            )
+                        })?
+                        .verify(&li)?;
+                }
+                ledger_infos.push(li);
+                previous_li = ledger_infos.last();
+                next_epoch += 1;
+            }
+        }
+
+        Ok(EpochEndingRestorePreheatData {
+            manifest,
+            ledger_infos,
+        })
+    }
+
+    async fn read_chunk(
+        &self,
+        file_handle: &FileHandleRef,
+    ) -> Result<Vec<LedgerInfoWithSignatures>> {
+        let mut file = self.storage.open_for_read(file_handle).await?;
+        let mut chunk = vec![];
+
+        while let Some(record_bytes) = file.read_record_bytes().await? {
+            chunk.push(bcs::from_bytes(&record_bytes)?);
+        }
+
+        Ok(chunk)
+    }
+}
+
+struct EpochEndingRestorePreheatData {
+    manifest: EpochEndingBackup,
+    ledger_infos: Vec<LedgerInfoWithSignatures>,
+}
+
+pub struct PreheatedEpochEndingRestore {
+    controller: EpochEndingRestoreController,
+    preheat_result: Result<EpochEndingRestorePreheatData>,
+}
+
+impl PreheatedEpochEndingRestore {
+    pub async fn run(
+        self,
+        previous_epoch_ending_ledger_info: Option<&LedgerInfo>,
+    ) -> Result<Vec<LedgerInfo>> {
+        let name = self.controller.name();
+        info!(
+            "{} started. Manifest: {}",
+            name, self.controller.manifest_handle
+        );
+        let res = self
+            .run_impl(previous_epoch_ending_ledger_info)
+            .await
+            .map_err(|e| anyhow!("{} failed: {}", name, e))?;
+        info!("{} succeeded.", name);
+        Ok(res)
+    }
+}
+
+impl PreheatedEpochEndingRestore {
+    async fn run_impl(
+        self,
+        previous_epoch_ending_ledger_info: Option<&LedgerInfo>,
+    ) -> Result<Vec<LedgerInfo>> {
+        let preheat_data = self
+            .preheat_result
+            .map_err(|e| anyhow!("Preheat failed: {}", e))?;
+
+        let first_li = preheat_data
+            .ledger_infos
+            .first()
+            .expect("Epoch ending backup can't be empty.");
+
+        if let Some(li) = previous_epoch_ending_ledger_info {
+            ensure!(
+                li.next_block_epoch() == preheat_data.manifest.first_epoch,
+                "Previous epoch ending LedgerInfo is not the one expected. \
+                My first epoch: {}, previous LedgerInfo next_block_epoch: {}",
+                preheat_data.manifest.first_epoch,
+                li.next_block_epoch(),
+            );
+            // Waypoint has been verified in preheat if it's trusted, otherwise try to check
+            // the signatures.
+            if self
+                .controller
+                .trusted_waypoints
+                .get(&first_li.ledger_info().version())
+                .is_none()
+            {
+                li.next_epoch_state()
+                    .ok_or_else(|| {
+                        anyhow!("Previous epoch ending LedgerInfo doesn't end an epoch")
+                    })?
+                    .verify(first_li)?;
+            }
+        }
+
+        let last_li = preheat_data
+            .ledger_infos
+            .last()
+            .expect("Verified not empty.")
+            .ledger_info();
+        match self.controller.run_mode.as_ref() {
+            RestoreRunMode::Restore { restore_handler } => {
+                restore_handler.save_ledger_infos(&preheat_data.ledger_infos)?;
+
+                EPOCH_ENDING_EPOCH.set(last_li.epoch() as i64);
+                EPOCH_ENDING_VERSION.set(last_li.version() as i64);
+            },
+            RestoreRunMode::Verify => {
+                VERIFY_EPOCH_ENDING_EPOCH.set(last_li.epoch() as i64);
+                VERIFY_EPOCH_ENDING_VERSION.set(last_li.version() as i64);
+            },
+        };
+
+        Ok(preheat_data
+            .ledger_infos
+            .into_iter()
+            .map(|x| x.ledger_info().clone())
+            .collect())
+    }
+}
+
+/// Represents a history of epoch changes since epoch 0.
+#[derive(Clone)]
+pub struct EpochHistory {
+    pub epoch_endings: Vec<LedgerInfo>,
+    pub trusted_waypoints: Arc<HashMap<Version, Waypoint>>,
+}
+
+impl EpochHistory {
+    pub fn verify_ledger_info(&self, li_with_sigs: &LedgerInfoWithSignatures) -> Result<()> {
+        let epoch = li_with_sigs.ledger_info().epoch();
+        ensure!(!self.epoch_endings.is_empty(), "Empty epoch history.",);
+        if epoch > self.epoch_endings.len() as u64 {
+            // TODO(aldenhu): fix this from upper level
+            warn!(
+                epoch = epoch,
+                epoch_history_until = self.epoch_endings.len(),
+                "Epoch is too new and can't be verified. Previous chunks are verified and node \
+                won't be able to start if this data is malicious."
+            );
+            return Ok(());
+        }
+        if epoch == 0 {
+            ensure!(
+                li_with_sigs.ledger_info() == &self.epoch_endings[0],
+                "Genesis epoch LedgerInfo info doesn't match.",
+            );
+        } else if let Some(wp_trusted) = self
+            .trusted_waypoints
+            .get(&li_with_sigs.ledger_info().version())
+        {
+            let wp_li = Waypoint::new_any(li_with_sigs.ledger_info());
+            ensure!(
+                *wp_trusted == wp_li,
+                "Waypoints don't match. In backup: {}, trusted: {}",
+                wp_li,
+                wp_trusted,
+            );
+        } else {
+            self.epoch_endings[epoch as usize - 1]
+                .next_epoch_state()
+                .ok_or_else(|| anyhow!("Shouldn't contain non- epoch bumping LIs."))?
+                .verify(li_with_sigs)?;
+        };
+        Ok(())
+    }
+}
+
+pub struct EpochHistoryRestoreController {
+    storage: Arc<dyn BackupStorage>,
+    manifest_handles: Vec<FileHandle>,
+    global_opt: GlobalRestoreOptions,
+}
+
+impl EpochHistoryRestoreController {
+    pub fn new(
+        manifest_handles: Vec<FileHandle>,
+        global_opt: GlobalRestoreOptions,
+        storage: Arc<dyn BackupStorage>,
+    ) -> Self {
+        Self {
+            storage,
+            manifest_handles,
+            global_opt,
+        }
+    }
+
+    pub async fn run(self) -> Result<EpochHistory> {
+        let name = self.name();
+        info!("{} started.", name,);
+        let res = self
+            .run_impl()
+            .await
+            .map_err(|e| anyhow!("{} failed: {}", name, e))?;
+        info!("{} succeeded.", name);
+        Ok(res)
+    }
+}
+
+impl EpochHistoryRestoreController {
+    fn name(&self) -> String {
+        format!("epoch history {}", self.global_opt.run_mode.name())
+    }
+
+    async fn run_impl(self) -> Result<EpochHistory> {
+        let timer = Instant::now();
+        if self.manifest_handles.is_empty() {
+            return Ok(EpochHistory {
+                epoch_endings: Vec::new(),
+                trusted_waypoints: Arc::new(HashMap::new()),
+            });
+        }
+
+        let futs_iter = self.manifest_handles.iter().map(|hdl| {
+            EpochEndingRestoreController::new(
+                EpochEndingRestoreOpt {
+                    manifest_handle: hdl.clone(),
+                },
+                self.global_opt.clone(),
+                self.storage.clone(),
+            )
+            .preheat()
+        });
+        let mut futs_stream = futures::stream::iter(futs_iter).buffered_x(
+            self.global_opt.concurrent_downloads * 2, /* buffer size */
+            self.global_opt.concurrent_downloads,     /* concurrency */
+        );
+
+        let mut next_epoch = 0u64;
+        let mut previous_li = None;
+        let mut epoch_endings = Vec::new();
+
+        while let Some(preheated_restore) = futs_stream.next().await {
+            let manifest_handle = preheated_restore.controller.manifest_handle.clone();
+            let lis = preheated_restore.run(previous_li).await?;
+            ensure!(
+                !lis.is_empty(),
+                "No epochs restored from {}",
+                manifest_handle,
+            );
+            for li in &lis {
+                ensure!(
+                    li.epoch() == next_epoch,
+                    "Restored LedgerInfo has epoch {}, expecting {}.",
+                    li.epoch(),
+                    next_epoch,
+                );
+                ensure!(
+                    li.ends_epoch(),
+                    "LedgerInfo is not one at an epoch ending. epoch: {}",
+                    li.epoch(),
+                );
+                next_epoch += 1;
+            }
+
+            epoch_endings.extend(lis);
+            previous_li = epoch_endings.last();
+        }
+
+        info!(
+            "Epoch history recovered in {:.2} seconds",
+            timer.elapsed().as_secs_f64()
+        );
+        Ok(EpochHistory {
+            epoch_endings,
+            trusted_waypoints: self.global_opt.trusted_waypoints.clone(),
+        })
+    }
+}

--- a/aptos-db-tool/src/commands/backup/backup_types/epoch_ending/tests.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/epoch_ending/tests.rs
@@ -1,0 +1,265 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    backup_types::epoch_ending::{
+        backup::{EpochEndingBackupController, EpochEndingBackupOpt},
+        restore::{
+            EpochEndingRestoreController, EpochEndingRestoreOpt, EpochHistoryRestoreController,
+        },
+    },
+    storage::{local_fs::LocalFs, BackupStorage},
+    utils::{
+        backup_service_client::BackupServiceClient, test_utils::tmp_db_with_random_content,
+        ConcurrentDownloadsOpt, GlobalBackupOpt, GlobalRestoreOpt, ReplayConcurrencyLevelOpt,
+        RocksdbOpt, TrustedWaypointOpt,
+    },
+};
+use aptos_backup_service::start_backup_service;
+use aptos_config::utils::get_available_port;
+use aptos_db::AptosDB;
+use aptos_storage_interface::DbReader;
+use aptos_temppath::TempPath;
+use aptos_types::{
+    aggregate_signature::AggregateSignature,
+    ledger_info::LedgerInfoWithSignatures,
+    proptest_types::{AccountInfoUniverse, LedgerInfoWithSignaturesGen},
+    waypoint::Waypoint,
+};
+use proptest::{collection::vec, prelude::*};
+use std::{
+    convert::TryInto,
+    io::Write,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
+use tokio::{runtime::Runtime, time::Duration};
+use warp::Filter;
+
+#[test]
+fn end_to_end() {
+    let (_src_db_dir, src_db, blocks) = tmp_db_with_random_content();
+    let tgt_db_dir = TempPath::new();
+    tgt_db_dir.create_as_dir().unwrap();
+
+    let backup_dir = TempPath::new();
+    backup_dir.create_as_dir().unwrap();
+    let store: Arc<dyn BackupStorage> = Arc::new(LocalFs::new(backup_dir.path().to_path_buf()));
+
+    let port = get_available_port();
+    let rt = start_backup_service(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+        src_db,
+    );
+    let client = Arc::new(BackupServiceClient::new(format!(
+        "http://localhost:{}",
+        port
+    )));
+
+    let latest_epoch = blocks.last().unwrap().1.ledger_info().next_block_epoch();
+    let target_version = blocks[blocks.len() / 2].1.ledger_info().version() + 1;
+    let manifest_handle = rt
+        .block_on(
+            EpochEndingBackupController::new(
+                EpochEndingBackupOpt {
+                    start_epoch: 0,
+                    end_epoch: latest_epoch,
+                },
+                GlobalBackupOpt {
+                    max_chunk_size: 1024,
+                },
+                client,
+                Arc::clone(&store),
+            )
+            .run(),
+        )
+        .unwrap();
+
+    rt.block_on(
+        EpochEndingRestoreController::new(
+            EpochEndingRestoreOpt { manifest_handle },
+            GlobalRestoreOpt {
+                db_dir: Some(tgt_db_dir.path().to_path_buf()),
+                dry_run: false,
+                target_version: Some(target_version),
+                trusted_waypoints: TrustedWaypointOpt::default(),
+                rocksdb_opt: RocksdbOpt::default(),
+                concurrent_downloads: ConcurrentDownloadsOpt::default(),
+                replay_concurrency_level: ReplayConcurrencyLevelOpt::default(),
+            }
+            .try_into()
+            .unwrap(),
+            store,
+        )
+        .run(None),
+    )
+    .unwrap();
+
+    let expected_ledger_infos = blocks
+        .into_iter()
+        .map(|(_, li)| li)
+        .filter(|li| li.ledger_info().ends_epoch() && li.ledger_info().version() <= target_version)
+        .collect::<Vec<_>>();
+    let target_version_next_block_epoch = expected_ledger_infos
+        .last()
+        .map(|li| li.ledger_info().next_block_epoch())
+        .unwrap_or(0);
+
+    let tgt_db = AptosDB::new_for_test(&tgt_db_dir);
+    assert_eq!(
+        tgt_db
+            .get_epoch_ending_ledger_infos(0, target_version_next_block_epoch)
+            .unwrap()
+            .ledger_info_with_sigs,
+        expected_ledger_infos,
+    );
+
+    rt.shutdown_timeout(Duration::from_secs(1));
+}
+
+prop_compose! {
+    fn arb_epoch_endings_with_trusted_waypoints()(
+        num_blocks in 1..10usize,
+    )(
+        mut universe in any_with::<AccountInfoUniverse>(3),
+        blocks in vec(
+            (
+                1..100usize, // block size
+                any::<LedgerInfoWithSignaturesGen>(),
+                any::<bool>(), // overwrite validator set
+                any::<bool>(), // trusted even if not overwriting validator set
+            ),
+            num_blocks
+        )
+    ) -> (Vec<LedgerInfoWithSignatures>, Vec<Waypoint>, bool) {
+        let mut should_fail_without_waypoints = false;
+        let mut res_lis = Vec::new();
+        let mut res_waypoints = Vec::new();
+        for (block_size, gen, overwrite, trusted) in blocks {
+            let mut li = gen.materialize(&mut universe, block_size);
+            if li.ledger_info().ends_epoch() {
+                if overwrite && li.ledger_info().epoch() != 0 {
+                    li = LedgerInfoWithSignatures::new(
+                        li.ledger_info().clone(),
+                        AggregateSignature::empty(),
+                    );
+                    should_fail_without_waypoints = true;
+                }
+                if overwrite || trusted {
+                    res_waypoints.push(Waypoint::new_epoch_boundary(li.ledger_info()).unwrap())
+                }
+                res_lis.push(li);
+
+            }
+        }
+        (res_lis, res_waypoints, should_fail_without_waypoints)
+    }
+}
+
+async fn mock_backup_service_get_epoch_ending_lis(lis: Vec<LedgerInfoWithSignatures>) -> u16 {
+    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+    let route = warp::path!("epoch_ending_ledger_infos" / usize / usize).map(move |start, end| {
+        let mut response = Vec::<u8>::new();
+        for li in &lis[start..end] {
+            let bytes = bcs::to_bytes(&li).unwrap();
+            let size_bytes = (bytes.len() as u32).to_be_bytes();
+            response.write_all(&size_bytes).unwrap();
+            response.write_all(&bytes).unwrap();
+        }
+        response
+    });
+    let (addr, svr) = warp::serve(route).bind_ephemeral(address);
+    tokio::spawn(svr);
+    addr.port()
+}
+
+async fn test_trusted_waypoints_impl(
+    lis: Vec<LedgerInfoWithSignatures>,
+    trusted_waypoints: Vec<Waypoint>,
+    should_fail_without: bool,
+) {
+    let backup_dir = TempPath::new();
+    backup_dir.create_as_dir().unwrap();
+    let store: Arc<dyn BackupStorage> = Arc::new(LocalFs::new(backup_dir.path().to_path_buf()));
+    let port = mock_backup_service_get_epoch_ending_lis(lis.clone()).await;
+    let client = Arc::new(BackupServiceClient::new(format!(
+        "http://localhost:{}",
+        port
+    )));
+
+    let mut manifests = Vec::new();
+    let mut start = 0;
+    while start < lis.len() {
+        let m = EpochEndingBackupController::new(
+            EpochEndingBackupOpt {
+                start_epoch: start as u64,
+                end_epoch: std::cmp::min(start + 2, lis.len()) as u64,
+            },
+            GlobalBackupOpt {
+                max_chunk_size: 1024,
+            },
+            client.clone(),
+            Arc::clone(&store),
+        )
+        .run()
+        .await
+        .unwrap();
+        manifests.push(m);
+        start += 2;
+    }
+
+    let res_without_waypoints = EpochHistoryRestoreController::new(
+        manifests.clone(),
+        GlobalRestoreOpt {
+            db_dir: None,
+            dry_run: true,
+            target_version: None,
+            trusted_waypoints: TrustedWaypointOpt::default(),
+            rocksdb_opt: RocksdbOpt::default(),
+            concurrent_downloads: ConcurrentDownloadsOpt::default(),
+            replay_concurrency_level: ReplayConcurrencyLevelOpt::default(),
+        }
+        .try_into()
+        .unwrap(),
+        Arc::clone(&store),
+    )
+    .run()
+    .await;
+    assert_eq!(should_fail_without, res_without_waypoints.is_err());
+
+    let restored = EpochHistoryRestoreController::new(
+        manifests,
+        GlobalRestoreOpt {
+            db_dir: None,
+            dry_run: true,
+            target_version: None,
+            trusted_waypoints: TrustedWaypointOpt {
+                trust_waypoint: trusted_waypoints,
+            },
+            rocksdb_opt: RocksdbOpt::default(),
+            concurrent_downloads: ConcurrentDownloadsOpt::default(),
+            replay_concurrency_level: ReplayConcurrencyLevelOpt::default(),
+        }
+        .try_into()
+        .unwrap(),
+        Arc::clone(&store),
+    )
+    .run()
+    .await
+    .unwrap();
+    assert_eq!(
+        lis.into_iter()
+            .map(|li| li.ledger_info().clone())
+            .collect::<Vec<_>>(),
+        restored.epoch_endings,
+    );
+}
+
+proptest! {
+    #[test]
+    fn trusted_waypoints(
+        (lis, trusted_waypoints, should_fail_without) in arb_epoch_endings_with_trusted_waypoints()
+    ) {
+        Runtime::new().unwrap().block_on(test_trusted_waypoints_impl(lis, trusted_waypoints, should_fail_without))
+    }
+}

--- a/aptos-db-tool/src/commands/backup/backup_types/mod.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/mod.rs
@@ -1,0 +1,9 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod epoch_ending;
+pub mod state_snapshot;
+pub mod transaction;
+
+#[cfg(test)]
+pub mod tests;

--- a/aptos-db-tool/src/commands/backup/backup_types/state_snapshot/backup.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/state_snapshot/backup.rs
@@ -1,0 +1,274 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    backup_types::state_snapshot::manifest::{StateSnapshotBackup, StateSnapshotChunk},
+    metadata::Metadata,
+    storage::{BackupHandleRef, BackupStorage, FileHandle, ShellSafeName},
+    utils::{
+        backup_service_client::BackupServiceClient, read_record_bytes::ReadRecordBytes,
+        should_cut_chunk, storage_ext::BackupStorageExt, GlobalBackupOpt,
+    },
+};
+use anyhow::{anyhow, Result};
+use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_logger::prelude::*;
+use aptos_types::{
+    ledger_info::LedgerInfoWithSignatures,
+    proof::TransactionInfoWithProof,
+    state_store::{state_key::StateKey, state_value::StateValue},
+    transaction::Version,
+};
+use bytes::Bytes;
+use clap::Parser;
+use once_cell::sync::Lazy;
+use std::{convert::TryInto, str::FromStr, sync::Arc};
+use tokio::{io::AsyncWriteExt, time::Instant};
+
+#[derive(Parser, Clone)]
+pub struct StateSnapshotBackupOpt {
+    #[clap(
+        long = "state-snapshot-epoch",
+        help = "Epoch at the end of which a state snapshot is to be taken."
+    )]
+    pub epoch: u64,
+}
+
+pub struct StateSnapshotBackupController {
+    epoch: u64,
+    version: Option<Version>, // initialize before using
+    max_chunk_size: usize,
+    client: Arc<BackupServiceClient>,
+    storage: Arc<dyn BackupStorage>,
+}
+
+impl StateSnapshotBackupController {
+    pub fn new(
+        opt: StateSnapshotBackupOpt,
+        global_opt: GlobalBackupOpt,
+        client: Arc<BackupServiceClient>,
+        storage: Arc<dyn BackupStorage>,
+    ) -> Self {
+        Self {
+            epoch: opt.epoch,
+            version: None,
+            max_chunk_size: global_opt.max_chunk_size,
+            client,
+            storage,
+        }
+    }
+
+    pub async fn run(self) -> Result<FileHandle> {
+        info!("State snapshot backup started, for epoch {}.", self.epoch);
+        let ret = self
+            .run_impl()
+            .await
+            .map_err(|e| anyhow!("State snapshot backup failed: {}", e))?;
+        info!("State snapshot backup succeeded. Manifest: {}", ret);
+        Ok(ret)
+    }
+
+    async fn run_impl(mut self) -> Result<FileHandle> {
+        self.version = Some(self.get_version_for_epoch_ending(self.epoch).await?);
+        let backup_handle = self
+            .storage
+            .create_backup_with_random_suffix(&self.backup_name())
+            .await?;
+
+        let mut chunks = vec![];
+
+        let mut state_snapshot_file = self.client.get_state_snapshot(self.version()).await?;
+        let mut prev_record_bytes = state_snapshot_file
+            .read_record_bytes()
+            .await?
+            .ok_or_else(|| anyhow!("State is empty."))?;
+        let mut chunk_bytes = (prev_record_bytes.len() as u32).to_be_bytes().to_vec();
+        chunk_bytes.extend(&prev_record_bytes);
+        let mut chunk_first_key = Self::parse_key(&prev_record_bytes)?;
+        let mut current_idx: usize = 0;
+        let mut chunk_first_idx: usize = 0;
+
+        let start = Instant::now();
+        while let Some(record_bytes) = state_snapshot_file.read_record_bytes().await? {
+            if should_cut_chunk(&chunk_bytes, &record_bytes, self.max_chunk_size) {
+                let chunk = self
+                    .write_chunk(
+                        &backup_handle,
+                        &chunk_bytes,
+                        chunk_first_idx,
+                        current_idx,
+                        chunk_first_key,
+                        Self::parse_key(&prev_record_bytes)?,
+                    )
+                    .await?;
+                chunks.push(chunk);
+                chunk_bytes = vec![];
+                chunk_first_idx = current_idx + 1;
+                chunk_first_key = Self::parse_key(&record_bytes)?;
+
+                info!(
+                    last_idx = current_idx,
+                    values_per_second =
+                        ((current_idx + 1) as f64 / start.elapsed().as_secs_f64()) as u64,
+                    "Chunk written."
+                );
+            }
+
+            current_idx += 1;
+            chunk_bytes.extend((record_bytes.len() as u32).to_be_bytes());
+            chunk_bytes.extend(&record_bytes);
+            prev_record_bytes = record_bytes;
+        }
+
+        assert!(!chunk_bytes.is_empty());
+        let chunk = self
+            .write_chunk(
+                &backup_handle,
+                &chunk_bytes,
+                chunk_first_idx,
+                current_idx,
+                chunk_first_key,
+                Self::parse_key(&prev_record_bytes)?,
+            )
+            .await?;
+        chunks.push(chunk);
+
+        self.write_manifest(&backup_handle, chunks).await
+    }
+}
+
+impl StateSnapshotBackupController {
+    fn version(&self) -> Version {
+        self.version.unwrap()
+    }
+
+    fn backup_name(&self) -> String {
+        format!("state_epoch_{}_ver_{}", self.epoch, self.version())
+    }
+
+    fn manifest_name() -> &'static ShellSafeName {
+        static NAME: Lazy<ShellSafeName> =
+            Lazy::new(|| ShellSafeName::from_str("state.manifest").unwrap());
+        &NAME
+    }
+
+    fn proof_name() -> &'static ShellSafeName {
+        static NAME: Lazy<ShellSafeName> =
+            Lazy::new(|| ShellSafeName::from_str("state.proof").unwrap());
+        &NAME
+    }
+
+    fn chunk_name(first_idx: usize) -> ShellSafeName {
+        format!("{}-.chunk", first_idx).try_into().unwrap()
+    }
+
+    fn chunk_proof_name(first_idx: usize, last_idx: usize) -> ShellSafeName {
+        format!("{}-{}.proof", first_idx, last_idx)
+            .try_into()
+            .unwrap()
+    }
+
+    fn parse_key(record: &Bytes) -> Result<HashValue> {
+        let (key, _): (StateKey, StateValue) = bcs::from_bytes(record)?;
+        Ok(key.hash())
+    }
+
+    async fn get_version_for_epoch_ending(&self, epoch: u64) -> Result<u64> {
+        let ledger_info: LedgerInfoWithSignatures = bcs::from_bytes(
+            self.client
+                .get_epoch_ending_ledger_infos(epoch, epoch + 1)
+                .await?
+                .read_record_bytes()
+                .await?
+                .ok_or_else(|| {
+                    anyhow!("Failed to get epoch ending ledger info for epoch {}", epoch)
+                })?
+                .as_ref(),
+        )?;
+        Ok(ledger_info.ledger_info().version())
+    }
+
+    async fn write_chunk(
+        &self,
+        backup_handle: &BackupHandleRef,
+        chunk_bytes: &[u8],
+        first_idx: usize,
+        last_idx: usize,
+        first_key: HashValue,
+        last_key: HashValue,
+    ) -> Result<StateSnapshotChunk> {
+        let (chunk_handle, mut chunk_file) = self
+            .storage
+            .create_for_write(backup_handle, &Self::chunk_name(first_idx))
+            .await?;
+        chunk_file.write_all(chunk_bytes).await?;
+        chunk_file.shutdown().await?;
+        let (proof_handle, mut proof_file) = self
+            .storage
+            .create_for_write(backup_handle, &Self::chunk_proof_name(first_idx, last_idx))
+            .await?;
+        tokio::io::copy(
+            &mut self
+                .client
+                .get_account_range_proof(last_key, self.version())
+                .await?,
+            &mut proof_file,
+        )
+        .await?;
+        proof_file.shutdown().await?;
+
+        Ok(StateSnapshotChunk {
+            first_idx,
+            last_idx,
+            first_key,
+            last_key,
+            blobs: chunk_handle,
+            proof: proof_handle,
+        })
+    }
+
+    async fn write_manifest(
+        &self,
+        backup_handle: &BackupHandleRef,
+        chunks: Vec<StateSnapshotChunk>,
+    ) -> Result<FileHandle> {
+        let proof_bytes = self.client.get_state_root_proof(self.version()).await?;
+        let (txn_info, _): (TransactionInfoWithProof, LedgerInfoWithSignatures) =
+            bcs::from_bytes(&proof_bytes)?;
+
+        let (proof_handle, mut proof_file) = self
+            .storage
+            .create_for_write(backup_handle, Self::proof_name())
+            .await?;
+        proof_file.write_all(&proof_bytes).await?;
+        proof_file.shutdown().await?;
+
+        let manifest = StateSnapshotBackup {
+            epoch: self.epoch,
+            version: self.version(),
+            root_hash: txn_info.transaction_info().ensure_state_checkpoint_hash()?,
+            chunks,
+            proof: proof_handle,
+        };
+
+        let (manifest_handle, mut manifest_file) = self
+            .storage
+            .create_for_write(backup_handle, Self::manifest_name())
+            .await?;
+        manifest_file
+            .write_all(&serde_json::to_vec(&manifest)?)
+            .await?;
+        manifest_file.shutdown().await?;
+
+        let metadata = Metadata::new_state_snapshot_backup(
+            self.epoch,
+            self.version(),
+            manifest_handle.clone(),
+        );
+        self.storage
+            .save_metadata_line(&metadata.name(), &metadata.to_text_line()?)
+            .await?;
+
+        Ok(manifest_handle)
+    }
+}

--- a/aptos-db-tool/src/commands/backup/backup_types/state_snapshot/manifest.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/state_snapshot/manifest.rs
@@ -1,0 +1,52 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_crypto::HashValue;
+use aptos_types::transaction::Version;
+use serde::{Deserialize, Serialize};
+
+use crate::commands::backup::storage::FileHandle;
+
+/// A chunk of a state snapshot manifest, representing accounts in the key range
+/// [`first_key`, `last_key`] (right side inclusive).
+#[derive(Deserialize, Serialize)]
+pub struct StateSnapshotChunk {
+    /// index of the first account in this chunk over all accounts.
+    pub first_idx: usize,
+    /// index of the last account in this chunk over all accounts.
+    pub last_idx: usize,
+    /// key of the first account in this chunk.
+    pub first_key: HashValue,
+    /// key of the last account in this chunk.
+    pub last_key: HashValue,
+    /// Repeated `len(record) + record` where `record` is BCS serialized tuple
+    /// `(key, state_value)`
+    pub blobs: FileHandle,
+    /// BCS serialized `SparseMerkleRangeProof` that proves this chunk adds up to the root hash
+    /// indicated in the backup (`StateSnapshotBackup::root_hash`).
+    pub proof: FileHandle,
+}
+
+/// State snapshot backup manifest, representing a complete state view at specified version.
+#[derive(Deserialize, Serialize)]
+pub struct StateSnapshotBackup {
+    /// Version at which this state snapshot is taken.
+    pub version: Version,
+    /// Epoch in which this state snapshot is taken.
+    pub epoch: u64,
+    /// Hash of the state tree root.
+    pub root_hash: HashValue,
+    /// All account blobs in chunks.
+    pub chunks: Vec<StateSnapshotChunk>,
+    /// BCS serialized
+    /// `Tuple(TransactionInfoWithProof, LedgerInfoWithSignatures)`.
+    ///   - The `TransactionInfoWithProof` is at `Version` above, and carries the same `root_hash`
+    /// above; It proves that at specified version the root hash is as specified in a chain
+    /// represented by the LedgerInfo below.
+    ///   - The signatures on the `LedgerInfoWithSignatures` has a version greater than or equal to
+    /// the version of this backup but is within the same epoch, so the signatures on it can be
+    /// verified by the validator set in the same epoch, which can be provided by an
+    /// `EpochStateBackup` recovered prior to this to the DB; Requiring it to be in the same epoch
+    /// limits the requirement on such `EpochStateBackup` to no older than the same epoch.
+    pub proof: FileHandle,
+}

--- a/aptos-db-tool/src/commands/backup/backup_types/state_snapshot/mod.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/state_snapshot/mod.rs
@@ -1,0 +1,9 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod backup;
+pub mod manifest;
+pub mod restore;
+
+#[cfg(test)]
+pub mod tests;

--- a/aptos-db-tool/src/commands/backup/backup_types/state_snapshot/restore.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/state_snapshot/restore.rs
@@ -1,0 +1,251 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    backup_types::{
+        epoch_ending::restore::EpochHistory, state_snapshot::manifest::StateSnapshotBackup,
+    },
+    metrics::{
+        restore::{
+            STATE_SNAPSHOT_LEAF_INDEX, STATE_SNAPSHOT_TARGET_LEAF_INDEX, STATE_SNAPSHOT_VERSION,
+        },
+        verify::{
+            VERIFY_STATE_SNAPSHOT_LEAF_INDEX, VERIFY_STATE_SNAPSHOT_TARGET_LEAF_INDEX,
+            VERIFY_STATE_SNAPSHOT_VERSION,
+        },
+        OTHER_TIMERS_SECONDS,
+    },
+    storage::{BackupStorage, FileHandle},
+    utils::{
+        read_record_bytes::ReadRecordBytes, storage_ext::BackupStorageExt, stream::StreamX,
+        GlobalRestoreOptions, RestoreRunMode,
+    },
+};
+use anyhow::{anyhow, ensure, Result};
+use aptos_infallible::Mutex;
+use aptos_logger::prelude::*;
+use aptos_storage_interface::StateSnapshotReceiver;
+use aptos_types::{
+    access_path::Path,
+    ledger_info::LedgerInfoWithSignatures,
+    proof::TransactionInfoWithProof,
+    state_store::{state_key::StateKey, state_value::StateValue},
+    transaction::Version,
+};
+use aptos_vm::move_vm_ext::verifier_config;
+use clap::Parser;
+use futures::{stream, TryStreamExt};
+use move_binary_format::CompiledModule;
+use move_bytecode_verifier::verify_module_with_config;
+use std::sync::Arc;
+use tokio::time::Instant;
+
+#[derive(Parser, Clone)]
+pub struct StateSnapshotRestoreOpt {
+    #[clap(long = "state-manifest")]
+    pub manifest_handle: FileHandle,
+    #[clap(long = "state-into-version")]
+    pub version: Version,
+    #[clap(long)]
+    pub validate_modules: bool,
+}
+
+pub struct StateSnapshotRestoreController {
+    storage: Arc<dyn BackupStorage>,
+    run_mode: Arc<RestoreRunMode>,
+    /// State snapshot restores to this version.
+    version: Version,
+    manifest_handle: FileHandle,
+    /// Global "target_version" for the entire restore process, if `version` is newer than this,
+    /// nothing will be done, otherwise, this has no effect.
+    target_version: Version,
+    epoch_history: Option<Arc<EpochHistory>>,
+    concurrent_downloads: usize,
+    validate_modules: bool,
+}
+
+impl StateSnapshotRestoreController {
+    pub fn new(
+        opt: StateSnapshotRestoreOpt,
+        global_opt: GlobalRestoreOptions,
+        storage: Arc<dyn BackupStorage>,
+        epoch_history: Option<Arc<EpochHistory>>,
+    ) -> Self {
+        Self {
+            storage,
+            run_mode: global_opt.run_mode,
+            version: opt.version,
+            manifest_handle: opt.manifest_handle,
+            target_version: global_opt.target_version,
+            epoch_history,
+            concurrent_downloads: global_opt.concurrent_downloads,
+            validate_modules: opt.validate_modules,
+        }
+    }
+
+    pub async fn run(self) -> Result<()> {
+        let name = self.name();
+        let start = Instant::now();
+        info!("{} started. Manifest: {}", name, self.manifest_handle);
+        self.run_impl()
+            .await
+            .map_err(|e| anyhow!("{} failed: {}", name, e))?;
+        info!(time = start.elapsed().as_secs(), "{} succeeded.", name);
+        Ok(())
+    }
+}
+
+impl StateSnapshotRestoreController {
+    fn name(&self) -> String {
+        format!("state snapshot {}", self.run_mode.name())
+    }
+
+    async fn run_impl(self) -> Result<()> {
+        if self.version > self.target_version {
+            warn!(
+                "Trying to restore state snapshot to version {}, which is newer than the target version {}, skipping.",
+                self.version,
+                self.target_version,
+            );
+            return Ok(());
+        }
+
+        let manifest: StateSnapshotBackup =
+            self.storage.load_json_file(&self.manifest_handle).await?;
+        let (txn_info_with_proof, li): (TransactionInfoWithProof, LedgerInfoWithSignatures) =
+            self.storage.load_bcs_file(&manifest.proof).await?;
+        txn_info_with_proof.verify(li.ledger_info(), manifest.version)?;
+        let state_root_hash = txn_info_with_proof
+            .transaction_info()
+            .ensure_state_checkpoint_hash()?;
+        ensure!(
+            state_root_hash == manifest.root_hash,
+            "Root hash mismatch with that in proof. root hash: {}, expected: {}",
+            manifest.root_hash,
+            state_root_hash,
+        );
+        if let Some(epoch_history) = self.epoch_history.as_ref() {
+            epoch_history.verify_ledger_info(&li)?;
+        }
+
+        let receiver = Arc::new(Mutex::new(Some(
+            self.run_mode
+                .get_state_restore_receiver(self.version, manifest.root_hash)?,
+        )));
+
+        let (ver_gauge, tgt_leaf_idx, leaf_idx) = if self.run_mode.is_verify() {
+            (
+                &VERIFY_STATE_SNAPSHOT_VERSION,
+                &VERIFY_STATE_SNAPSHOT_TARGET_LEAF_INDEX,
+                &VERIFY_STATE_SNAPSHOT_LEAF_INDEX,
+            )
+        } else {
+            (
+                &STATE_SNAPSHOT_VERSION,
+                &STATE_SNAPSHOT_TARGET_LEAF_INDEX,
+                &STATE_SNAPSHOT_LEAF_INDEX,
+            )
+        };
+
+        ver_gauge.set(self.version as i64);
+        tgt_leaf_idx.set(manifest.chunks.last().map_or(0, |c| c.last_idx as i64));
+        let total_chunks = manifest.chunks.len();
+
+        let resume_point_opt = receiver.lock().as_mut().unwrap().previous_key_hash()?;
+        let chunks = if let Some(resume_point) = resume_point_opt {
+            manifest
+                .chunks
+                .into_iter()
+                .skip_while(|chunk| chunk.last_key <= resume_point)
+                .collect()
+        } else {
+            manifest.chunks
+        };
+        if chunks.len() < total_chunks {
+            info!(
+                chunks_to_add = chunks.len(),
+                total_chunks = total_chunks,
+                "Resumed state snapshot restore."
+            )
+        };
+        let chunks_to_add = chunks.len();
+
+        let start_idx = chunks.first().map_or(0, |chunk| chunk.first_idx);
+
+        let storage = self.storage.clone();
+        let futs_iter = chunks.into_iter().enumerate().map(|(chunk_idx, chunk)| {
+            let storage = storage.clone();
+            async move {
+                tokio::spawn(async move {
+                    let blobs = Self::read_state_value(&storage, chunk.blobs.clone()).await?;
+                    let proof = storage.load_bcs_file(&chunk.proof).await?;
+                    Result::<_>::Ok((chunk_idx, chunk, blobs, proof))
+                })
+                .await?
+            }
+        });
+        let con = self.concurrent_downloads;
+        let mut futs_stream = stream::iter(futs_iter).buffered_x(con * 2, con);
+        let mut start = None;
+        while let Some((chunk_idx, chunk, blobs, proof)) = futs_stream.try_next().await? {
+            start = start.or_else(|| Some(Instant::now()));
+            let _timer = OTHER_TIMERS_SECONDS
+                .with_label_values(&["add_state_chunk"])
+                .start_timer();
+            let receiver = receiver.clone();
+            if self.validate_modules {
+                Self::validate_modules(&blobs);
+            }
+            tokio::task::spawn_blocking(move || {
+                receiver.lock().as_mut().unwrap().add_chunk(blobs, proof)
+            })
+            .await??;
+            leaf_idx.set(chunk.last_idx as i64);
+            info!(
+                chunk = chunk_idx,
+                chunks_to_add = chunks_to_add,
+                last_idx = chunk.last_idx,
+                values_per_second = ((chunk.last_idx + 1 - start_idx) as f64
+                    / start.as_ref().unwrap().elapsed().as_secs_f64())
+                    as u64,
+                "State chunk added.",
+            );
+        }
+
+        tokio::task::spawn_blocking(move || receiver.lock().take().unwrap().finish()).await??;
+        self.run_mode.finish();
+        Ok(())
+    }
+
+    fn validate_modules(blob: &[(StateKey, StateValue)]) {
+        let config = verifier_config(false);
+        for (key, value) in blob {
+            if let StateKey::AccessPath(p) = key {
+                if let Path::Code(module_id) = p.get_path() {
+                    if let Ok(module) = CompiledModule::deserialize(value.bytes()) {
+                        if let Err(err) = verify_module_with_config(&config, &module) {
+                            error!("Module {:?} failed validation: {:?}", module_id, err);
+                        }
+                    } else {
+                        error!("Module {:?} failed to deserialize", module_id);
+                    }
+                }
+            }
+        }
+    }
+
+    async fn read_state_value(
+        storage: &Arc<dyn BackupStorage>,
+        file_handle: FileHandle,
+    ) -> Result<Vec<(StateKey, StateValue)>> {
+        let mut file = storage.open_for_read(&file_handle).await?;
+
+        let mut chunk = vec![];
+
+        while let Some(record_bytes) = file.read_record_bytes().await? {
+            chunk.push(bcs::from_bytes(&record_bytes)?);
+        }
+
+        Ok(chunk)
+    }
+}

--- a/aptos-db-tool/src/commands/backup/backup_types/state_snapshot/tests.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/state_snapshot/tests.rs
@@ -1,0 +1,109 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    backup_types::state_snapshot::{
+        backup::{StateSnapshotBackupController, StateSnapshotBackupOpt},
+        restore::{StateSnapshotRestoreController, StateSnapshotRestoreOpt},
+    },
+    storage::{local_fs::LocalFs, BackupStorage},
+    utils::{
+        backup_service_client::BackupServiceClient,
+        test_utils::{start_local_backup_service, tmp_db_with_random_content},
+        ConcurrentDownloadsOpt, GlobalBackupOpt, GlobalRestoreOpt, ReplayConcurrencyLevelOpt,
+        RocksdbOpt, TrustedWaypointOpt,
+    },
+};
+use aptos_db::AptosDB;
+use aptos_storage_interface::DbReader;
+use aptos_temppath::TempPath;
+use std::{convert::TryInto, sync::Arc};
+use tokio::time::Duration;
+
+#[test]
+fn end_to_end() {
+    let (_src_db_dir, src_db, _blocks) = tmp_db_with_random_content();
+    let tgt_db_dir = TempPath::new();
+    tgt_db_dir.create_as_dir().unwrap();
+    let backup_dir = TempPath::new();
+    backup_dir.create_as_dir().unwrap();
+    let store: Arc<dyn BackupStorage> = Arc::new(LocalFs::new(backup_dir.path().to_path_buf()));
+
+    let epoch = src_db
+        .get_latest_ledger_info()
+        .unwrap()
+        .ledger_info()
+        .next_block_epoch()
+        - 1;
+    let latest_epoch_ending_li = src_db
+        .get_epoch_ending_ledger_infos(epoch, epoch + 1)
+        .unwrap()
+        .ledger_info_with_sigs
+        .pop()
+        .unwrap();
+    let version = latest_epoch_ending_li.ledger_info().version();
+    let state_root_hash = src_db
+        .get_transactions(version, 1, version, false)
+        .unwrap()
+        .proof
+        .transaction_infos
+        .pop()
+        .unwrap()
+        .state_checkpoint_hash()
+        .unwrap();
+
+    let (rt, port) = start_local_backup_service(src_db);
+    let client = Arc::new(BackupServiceClient::new(format!(
+        "http://localhost:{}",
+        port
+    )));
+    let manifest_handle = rt
+        .block_on(
+            StateSnapshotBackupController::new(
+                StateSnapshotBackupOpt { epoch },
+                GlobalBackupOpt {
+                    max_chunk_size: 500,
+                },
+                client,
+                Arc::clone(&store),
+            )
+            .run(),
+        )
+        .unwrap();
+
+    rt.block_on(
+        StateSnapshotRestoreController::new(
+            StateSnapshotRestoreOpt {
+                manifest_handle,
+                version,
+                validate_modules: false,
+            },
+            GlobalRestoreOpt {
+                dry_run: false,
+                db_dir: Some(tgt_db_dir.path().to_path_buf()),
+                target_version: None, // max
+                trusted_waypoints: TrustedWaypointOpt::default(),
+                rocksdb_opt: RocksdbOpt::default(),
+                concurrent_downloads: ConcurrentDownloadsOpt::default(),
+                replay_concurrency_level: ReplayConcurrencyLevelOpt::default(),
+            }
+            .try_into()
+            .unwrap(),
+            store,
+            None, /* epoch_history */
+        )
+        .run(),
+    )
+    .unwrap();
+
+    let tgt_db = AptosDB::new_readonly_for_test(&tgt_db_dir);
+    assert_eq!(
+        tgt_db
+            .get_state_snapshot_before(version + 1) // We cannot use get_latest_snapshot() because it searches backward from the latest txn_info version
+            .unwrap()
+            .unwrap(),
+        (version, state_root_hash)
+    );
+
+    rt.shutdown_timeout(Duration::from_secs(1));
+}

--- a/aptos-db-tool/src/commands/backup/backup_types/tests.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/tests.rs
@@ -1,0 +1,205 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    backup_types::{
+        state_snapshot::{
+            backup::{StateSnapshotBackupController, StateSnapshotBackupOpt},
+            restore::{StateSnapshotRestoreController, StateSnapshotRestoreOpt},
+        },
+        transaction::{
+            backup::{TransactionBackupController, TransactionBackupOpt},
+            restore::{TransactionRestoreController, TransactionRestoreOpt},
+        },
+    },
+    storage::{local_fs::LocalFs, BackupStorage},
+    utils::{
+        backup_service_client::BackupServiceClient, test_utils::start_local_backup_service,
+        ConcurrentDownloadsOpt, GlobalBackupOpt, GlobalRestoreOpt, GlobalRestoreOptions,
+        ReplayConcurrencyLevelOpt, RocksdbOpt, TrustedWaypointOpt,
+    },
+};
+use aptos_db::AptosDB;
+use aptos_executor_test_helpers::integration_test_impl::test_execution_with_storage_impl;
+use aptos_storage_interface::DbReader;
+use aptos_temppath::TempPath;
+use aptos_types::transaction::Version;
+use proptest::{prelude::*, sample::Index};
+use std::{convert::TryInto, sync::Arc};
+use tokio::time::Duration;
+
+#[derive(Debug)]
+struct TestData {
+    db: Arc<AptosDB>,
+    txn_start_ver: Version,
+    state_snapshot_epoch: Option<u64>,
+    state_snapshot_ver: Option<u64>,
+    target_ver: Version,
+}
+
+fn test_data_strategy() -> impl Strategy<Value = TestData> {
+    let db = test_execution_with_storage_impl();
+    let latest_ver = db.get_latest_version().unwrap();
+
+    let latest_epoch_state = db.get_latest_epoch_state().unwrap();
+    let epoch_ending_lis = db
+        .get_epoch_ending_ledger_infos(0, latest_epoch_state.epoch)
+        .unwrap()
+        .ledger_info_with_sigs;
+
+    any::<Index>()
+        .prop_flat_map(move |state_snapshot_index| {
+            let state_snapshot_epoch_li = state_snapshot_index.get(&epoch_ending_lis);
+            let state_snapshot_ver = state_snapshot_epoch_li.ledger_info().version();
+            let state_snapshot_epoch = state_snapshot_epoch_li.ledger_info().epoch();
+            (
+                0..=state_snapshot_ver,
+                prop_oneof![Just(Some(state_snapshot_epoch)), Just(None)],
+                Just(state_snapshot_ver),
+                state_snapshot_ver..=latest_ver,
+            )
+        })
+        .prop_map(
+            move |(txn_start_ver, state_snapshot_epoch, state_snapshot_ver, target_ver)| TestData {
+                db: Arc::clone(&db),
+                txn_start_ver,
+                state_snapshot_epoch,
+                state_snapshot_ver: state_snapshot_epoch.map(|_| state_snapshot_ver),
+                target_ver,
+            },
+        )
+}
+
+fn test_end_to_end_impl(d: TestData) {
+    let tgt_db_dir = TempPath::new();
+    tgt_db_dir.create_as_dir().unwrap();
+    let backup_dir = TempPath::new();
+    backup_dir.create_as_dir().unwrap();
+    let store: Arc<dyn BackupStorage> = Arc::new(LocalFs::new(backup_dir.path().to_path_buf()));
+    let (rt, port) = start_local_backup_service(Arc::clone(&d.db));
+    let client = Arc::new(BackupServiceClient::new(format!(
+        "http://localhost:{}",
+        port
+    )));
+    let num_txns_to_backup = d.target_ver - d.txn_start_ver + 1;
+
+    // Backup
+    let global_backup_opt = GlobalBackupOpt {
+        max_chunk_size: 2048,
+    };
+    let state_snapshot_manifest = d.state_snapshot_epoch.map(|epoch| {
+        rt.block_on(
+            StateSnapshotBackupController::new(
+                StateSnapshotBackupOpt { epoch },
+                global_backup_opt.clone(),
+                Arc::clone(&client),
+                Arc::clone(&store),
+            )
+            .run(),
+        )
+        .unwrap()
+    });
+    let txn_manifest = rt
+        .block_on(
+            TransactionBackupController::new(
+                TransactionBackupOpt {
+                    start_version: d.txn_start_ver,
+                    num_transactions: num_txns_to_backup as usize,
+                },
+                global_backup_opt,
+                Arc::clone(&client),
+                Arc::clone(&store),
+            )
+            .run(),
+        )
+        .unwrap();
+
+    // Restore
+    let global_restore_opt: GlobalRestoreOptions = GlobalRestoreOpt {
+        dry_run: false,
+        db_dir: Some(tgt_db_dir.path().to_path_buf()),
+        target_version: Some(d.target_ver),
+        trusted_waypoints: TrustedWaypointOpt::default(),
+        rocksdb_opt: RocksdbOpt::default(),
+        concurrent_downloads: ConcurrentDownloadsOpt::default(),
+        replay_concurrency_level: ReplayConcurrencyLevelOpt::default(),
+    }
+    .try_into()
+    .unwrap();
+    if let Some(version) = d.state_snapshot_ver {
+        rt.block_on(
+            StateSnapshotRestoreController::new(
+                StateSnapshotRestoreOpt {
+                    manifest_handle: state_snapshot_manifest.unwrap(),
+                    version,
+                    validate_modules: false,
+                },
+                global_restore_opt.clone(),
+                Arc::clone(&store),
+                None, /* epoch_history */
+            )
+            .run(),
+        )
+        .unwrap()
+    }
+    rt.block_on(
+        TransactionRestoreController::new(
+            TransactionRestoreOpt {
+                manifest_handle: txn_manifest,
+                replay_from_version: Some(
+                    d.state_snapshot_ver.unwrap_or(Version::max_value() - 1) + 1,
+                ),
+            },
+            global_restore_opt,
+            store,
+            None, /* epoch_history */
+            vec![],
+        )
+        .run(),
+    )
+    .unwrap();
+
+    // Check
+    let tgt_db = AptosDB::new_readonly_for_test(&tgt_db_dir);
+    assert_eq!(
+        d.db.get_transactions(
+            d.txn_start_ver,
+            num_txns_to_backup,
+            d.target_ver,
+            true /* fetch_events */
+        )
+        .unwrap(),
+        tgt_db
+            .get_transactions(
+                d.txn_start_ver,
+                num_txns_to_backup,
+                d.target_ver,
+                true /* fetch_events */
+            )
+            .unwrap()
+    );
+    if let Some(state_snapshot_ver) = d.state_snapshot_ver {
+        let first_replayed = state_snapshot_ver + 1;
+        let num_replayed = d.target_ver - state_snapshot_ver;
+        // Events recreated:
+        assert_eq!(
+            d.db.get_transactions(first_replayed, num_replayed, d.target_ver, true)
+                .unwrap(),
+            tgt_db
+                .get_transactions(first_replayed, num_replayed, d.target_ver, true)
+                .unwrap()
+        );
+    };
+
+    rt.shutdown_timeout(Duration::from_secs(1));
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10))]
+
+    #[test]
+    #[cfg_attr(feature = "consensus-only-perf-test", ignore)]
+    fn test_end_to_end(d in test_data_strategy()) {
+        test_end_to_end_impl(d)
+    }
+}

--- a/aptos-db-tool/src/commands/backup/backup_types/transaction/backup.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/transaction/backup.rs
@@ -1,0 +1,215 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    backup_types::transaction::manifest::{TransactionBackup, TransactionChunk},
+    metadata::Metadata,
+    storage::{BackupHandleRef, BackupStorage, FileHandle, ShellSafeName},
+    utils::{
+        backup_service_client::BackupServiceClient, read_record_bytes::ReadRecordBytes,
+        should_cut_chunk, storage_ext::BackupStorageExt, GlobalBackupOpt,
+    },
+};
+use anyhow::{anyhow, ensure, Result};
+use aptos_logger::prelude::*;
+use aptos_types::transaction::Version;
+use clap::Parser;
+use once_cell::sync::Lazy;
+use std::{convert::TryInto, str::FromStr, sync::Arc};
+use tokio::io::AsyncWriteExt;
+
+#[derive(Parser, Clone)]
+pub struct TransactionBackupOpt {
+    #[clap(long = "start-version", help = "First transaction to backup.")]
+    pub start_version: u64,
+
+    #[clap(long = "num_transactions", help = "Number of transactions to backup")]
+    pub num_transactions: usize,
+}
+
+pub struct TransactionBackupController {
+    start_version: u64,
+    num_transactions: usize,
+    max_chunk_size: usize,
+    client: Arc<BackupServiceClient>,
+    storage: Arc<dyn BackupStorage>,
+}
+
+impl TransactionBackupController {
+    pub fn new(
+        opt: TransactionBackupOpt,
+        global_opt: GlobalBackupOpt,
+        client: Arc<BackupServiceClient>,
+        storage: Arc<dyn BackupStorage>,
+    ) -> Self {
+        Self {
+            start_version: opt.start_version,
+            num_transactions: opt.num_transactions,
+            max_chunk_size: global_opt.max_chunk_size,
+            client,
+            storage,
+        }
+    }
+
+    pub async fn run(self) -> Result<FileHandle> {
+        info!(
+            "Transaction backup started, starting from version {}, for {} transactions in total.",
+            self.start_version, self.num_transactions,
+        );
+        let ret = self
+            .run_impl()
+            .await
+            .map_err(|e| anyhow!("Transaction backup failed: {}", e))?;
+        info!("Transaction backup succeeded. Manifest: {}", ret);
+        Ok(ret)
+    }
+}
+
+impl TransactionBackupController {
+    async fn run_impl(self) -> Result<FileHandle> {
+        let backup_handle = self
+            .storage
+            .create_backup_with_random_suffix(&self.backup_name())
+            .await?;
+
+        let mut chunks = Vec::new();
+        let mut chunk_bytes = Vec::new();
+
+        let mut transactions_file = self
+            .client
+            .get_transactions(self.start_version, self.num_transactions)
+            .await?;
+        let mut current_ver: u64 = self.start_version;
+        let mut chunk_first_ver: u64 = self.start_version;
+
+        while let Some(record_bytes) = transactions_file.read_record_bytes().await? {
+            if should_cut_chunk(&chunk_bytes, &record_bytes, self.max_chunk_size) {
+                let chunk = self
+                    .write_chunk(
+                        &backup_handle,
+                        &chunk_bytes,
+                        chunk_first_ver,
+                        current_ver - 1,
+                    )
+                    .await?;
+                chunks.push(chunk);
+                chunk_bytes = vec![];
+                chunk_first_ver = current_ver;
+            }
+
+            chunk_bytes.extend((record_bytes.len() as u32).to_be_bytes());
+            chunk_bytes.extend(&record_bytes);
+            current_ver += 1;
+        }
+
+        assert!(!chunk_bytes.is_empty());
+        let expected_next_version = self.start_version + self.num_transactions as u64;
+        ensure!(
+            current_ver == expected_next_version,
+            "Server did not return all transactions requested. Expecting last version {}, got {}",
+            expected_next_version,
+            current_ver,
+        );
+        let chunk = self
+            .write_chunk(
+                &backup_handle,
+                &chunk_bytes,
+                chunk_first_ver,
+                current_ver - 1,
+            )
+            .await?;
+        chunks.push(chunk);
+
+        self.write_manifest(&backup_handle, self.start_version, current_ver - 1, chunks)
+            .await
+    }
+
+    fn backup_name(&self) -> String {
+        format!("transaction_{}-", self.start_version)
+    }
+
+    fn manifest_name() -> &'static ShellSafeName {
+        static NAME: Lazy<ShellSafeName> =
+            Lazy::new(|| ShellSafeName::from_str("transaction.manifest").unwrap());
+        &NAME
+    }
+
+    fn chunk_name(first_ver: Version) -> ShellSafeName {
+        format!("{}-.chunk", first_ver).try_into().unwrap()
+    }
+
+    fn chunk_proof_name(first_ver: u64, last_ver: Version) -> ShellSafeName {
+        format!("{}-{}.proof", first_ver, last_ver)
+            .try_into()
+            .unwrap()
+    }
+
+    async fn write_chunk(
+        &self,
+        backup_handle: &BackupHandleRef,
+        chunk_bytes: &[u8],
+        first_version: u64,
+        last_version: u64,
+    ) -> Result<TransactionChunk> {
+        let (proof_handle, mut proof_file) = self
+            .storage
+            .create_for_write(
+                backup_handle,
+                &Self::chunk_proof_name(first_version, last_version),
+            )
+            .await?;
+        tokio::io::copy(
+            &mut self
+                .client
+                .get_transaction_range_proof(first_version, last_version)
+                .await?,
+            &mut proof_file,
+        )
+        .await?;
+        proof_file.shutdown().await?;
+
+        let (chunk_handle, mut chunk_file) = self
+            .storage
+            .create_for_write(backup_handle, &Self::chunk_name(first_version))
+            .await?;
+        chunk_file.write_all(chunk_bytes).await?;
+        chunk_file.shutdown().await?;
+
+        Ok(TransactionChunk {
+            first_version,
+            last_version,
+            transactions: chunk_handle,
+            proof: proof_handle,
+        })
+    }
+
+    async fn write_manifest(
+        &self,
+        backup_handle: &BackupHandleRef,
+        first_version: Version,
+        last_version: Version,
+        chunks: Vec<TransactionChunk>,
+    ) -> Result<FileHandle> {
+        let manifest = TransactionBackup {
+            first_version,
+            last_version,
+            chunks,
+        };
+        let (manifest_handle, mut manifest_file) = self
+            .storage
+            .create_for_write(backup_handle, Self::manifest_name())
+            .await?;
+        manifest_file
+            .write_all(&serde_json::to_vec(&manifest)?)
+            .await?;
+        manifest_file.shutdown().await?;
+
+        let metadata =
+            Metadata::new_transaction_backup(first_version, last_version, manifest_handle.clone());
+        self.storage
+            .save_metadata_line(&metadata.name(), &metadata.to_text_line()?)
+            .await?;
+
+        Ok(manifest_handle)
+    }
+}

--- a/aptos-db-tool/src/commands/backup/backup_types/transaction/manifest.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/transaction/manifest.rs
@@ -1,0 +1,76 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{ensure, Result};
+use aptos_types::transaction::Version;
+use serde::{Deserialize, Serialize};
+
+use crate::commands::backup::storage::FileHandle;
+
+/// A chunk of a transaction backup manifest to represent the
+/// [`first_version`, `last_version`] range (right side inclusive).
+#[derive(Clone, Deserialize, Serialize)]
+pub struct TransactionChunk {
+    pub first_version: Version,
+    pub last_version: Version,
+    /// Repeated `len(record) + record`, where `record` is BCS serialized tuple
+    /// `(Transaction, TransactionInfo)`
+    pub transactions: FileHandle,
+    /// BCS serialized `(TransactionAccumulatorRangeProof, LedgerInfoWithSignatures)`.
+    /// The `TransactionAccumulatorRangeProof` links the transactions to the
+    /// `LedgerInfoWithSignatures`, and the `LedgerInfoWithSignatures` can be verified by the
+    /// signatures it carries, against the validator set in the epoch. (Hence proper
+    /// `EpochEndingBackup` is needed for verification.)
+    pub proof: FileHandle,
+}
+
+/// Transaction backup manifest, representing transactions in the
+/// [`first_version`, `last_version`] range (right side inclusive).
+#[derive(Deserialize, Serialize)]
+pub struct TransactionBackup {
+    pub first_version: Version,
+    pub last_version: Version,
+    pub chunks: Vec<TransactionChunk>,
+}
+
+impl TransactionBackup {
+    pub fn verify(&self) -> Result<()> {
+        // check number of waypoints
+        ensure!(
+            self.first_version <= self.last_version,
+            "Bad version range: [{}, {}]",
+            self.first_version,
+            self.last_version,
+        );
+
+        // check chunk ranges
+        ensure!(!self.chunks.is_empty(), "No chunks.");
+
+        let mut next_version = self.first_version;
+        for chunk in &self.chunks {
+            ensure!(
+                chunk.first_version == next_version,
+                "Chunk ranges not continuous. Expected first version: {}, actual: {}.",
+                next_version,
+                chunk.first_version,
+            );
+            ensure!(
+                chunk.last_version >= chunk.first_version,
+                "Chunk range invalid. [{}, {}]",
+                chunk.first_version,
+                chunk.last_version,
+            );
+            next_version = chunk.last_version + 1;
+        }
+
+        // check last version in chunk matches manifest
+        ensure!(
+            next_version - 1 == self.last_version, // okay to -1 because chunks is not empty.
+            "Last version in chunks: {}, in manifest: {}",
+            next_version - 1,
+            self.last_version,
+        );
+
+        Ok(())
+    }
+}

--- a/aptos-db-tool/src/commands/backup/backup_types/transaction/mod.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/transaction/mod.rs
@@ -1,0 +1,9 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod backup;
+pub mod manifest;
+pub mod restore;
+
+#[cfg(test)]
+pub mod tests;

--- a/aptos-db-tool/src/commands/backup/backup_types/transaction/restore.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/transaction/restore.rs
@@ -1,0 +1,523 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    backup_types::{
+        epoch_ending::restore::EpochHistory,
+        transaction::manifest::{TransactionBackup, TransactionChunk},
+    },
+    metrics::{
+        restore::{TRANSACTION_REPLAY_VERSION, TRANSACTION_SAVE_VERSION},
+        verify::VERIFY_TRANSACTION_VERSION,
+        OTHER_TIMERS_SECONDS,
+    },
+    storage::{BackupStorage, FileHandle},
+    utils::{
+        error_notes::ErrorNotes,
+        read_record_bytes::ReadRecordBytes,
+        storage_ext::BackupStorageExt,
+        stream::{StreamX, TryStreamX},
+        GlobalRestoreOptions, RestoreRunMode,
+    },
+};
+use anyhow::{anyhow, ensure, Result};
+use aptos_db::backup::restore_handler::RestoreHandler;
+use aptos_executor::chunk_executor::ChunkExecutor;
+use aptos_executor_types::TransactionReplayer;
+use aptos_logger::prelude::*;
+use aptos_storage_interface::DbReaderWriter;
+use aptos_types::{
+    contract_event::ContractEvent,
+    ledger_info::LedgerInfoWithSignatures,
+    proof::{TransactionAccumulatorRangeProof, TransactionInfoListWithProof},
+    transaction::{Transaction, TransactionInfo, TransactionListWithProof, Version},
+    write_set::WriteSet,
+};
+use aptos_vm::AptosVM;
+use clap::Parser;
+use futures::{
+    future,
+    future::TryFutureExt,
+    stream,
+    stream::{Peekable, Stream, TryStreamExt},
+    StreamExt,
+};
+use itertools::{izip, Itertools};
+use std::{
+    cmp::{max, min},
+    collections::BTreeSet,
+    pin::Pin,
+    sync::Arc,
+    time::Instant,
+};
+use tokio::io::BufReader;
+
+const BATCH_SIZE: usize = if cfg!(test) { 2 } else { 10000 };
+
+#[derive(Parser, Clone)]
+pub struct TransactionRestoreOpt {
+    #[clap(long = "transaction-manifest")]
+    pub manifest_handle: FileHandle,
+    #[clap(
+        long = "replay-transactions-from-version",
+        help = "Transactions with this version and above will be replayed so state and events are \
+        gonna pop up. Requires state at the version right before this to exist, either by \
+        recovering a state snapshot, or previous transaction replay."
+    )]
+    pub replay_from_version: Option<Version>,
+}
+
+pub struct TransactionRestoreController {
+    inner: TransactionRestoreBatchController,
+}
+
+#[allow(dead_code)]
+struct LoadedChunk {
+    pub manifest: TransactionChunk,
+    pub txns: Vec<Transaction>,
+    pub txn_infos: Vec<TransactionInfo>,
+    pub event_vecs: Vec<Vec<ContractEvent>>,
+    pub write_sets: Vec<WriteSet>,
+    pub range_proof: TransactionAccumulatorRangeProof,
+    pub ledger_info: LedgerInfoWithSignatures,
+}
+
+impl LoadedChunk {
+    async fn load(
+        manifest: TransactionChunk,
+        storage: &Arc<dyn BackupStorage>,
+        epoch_history: Option<&Arc<EpochHistory>>,
+    ) -> Result<Self> {
+        let mut file = BufReader::new(storage.open_for_read(&manifest.transactions).await?);
+        let mut txns = Vec::new();
+        let mut txn_infos = Vec::new();
+        let mut event_vecs = Vec::new();
+        let mut write_sets = Vec::new();
+
+        while let Some(record_bytes) = file.read_record_bytes().await? {
+            let (txn, txn_info, events, write_set): (_, _, _, WriteSet) =
+                bcs::from_bytes(&record_bytes)?;
+            txns.push(txn);
+            txn_infos.push(txn_info);
+            event_vecs.push(events);
+            write_sets.push(write_set);
+        }
+
+        ensure!(
+            manifest.first_version + (txns.len() as Version) == manifest.last_version + 1,
+            "Number of items in chunks doesn't match that in manifest. first_version: {}, last_version: {}, items in chunk: {}",
+            manifest.first_version,
+            manifest.last_version,
+            txns.len(),
+        );
+
+        let (range_proof, ledger_info) = storage
+            .load_bcs_file::<(TransactionAccumulatorRangeProof, LedgerInfoWithSignatures)>(
+                &manifest.proof,
+            )
+            .await?;
+        if let Some(epoch_history) = epoch_history {
+            epoch_history.verify_ledger_info(&ledger_info)?;
+        }
+
+        // make a `TransactionListWithProof` to reuse its verification code.
+        let txn_list_with_proof = TransactionListWithProof::new(
+            txns,
+            Some(event_vecs),
+            Some(manifest.first_version),
+            TransactionInfoListWithProof::new(range_proof, txn_infos),
+        );
+        txn_list_with_proof.verify(ledger_info.ledger_info(), Some(manifest.first_version))?;
+        // and disassemble it to get things back.
+        let txns = txn_list_with_proof.transactions;
+        let range_proof = txn_list_with_proof
+            .proof
+            .ledger_info_to_transaction_infos_proof;
+        let txn_infos = txn_list_with_proof.proof.transaction_infos;
+        let event_vecs = txn_list_with_proof.events.expect("unknown to be Some.");
+
+        Ok(Self {
+            manifest,
+            txns,
+            txn_infos,
+            event_vecs,
+            range_proof,
+            ledger_info,
+            write_sets,
+        })
+    }
+}
+
+impl TransactionRestoreController {
+    pub fn new(
+        opt: TransactionRestoreOpt,
+        global_opt: GlobalRestoreOptions,
+        storage: Arc<dyn BackupStorage>,
+        epoch_history: Option<Arc<EpochHistory>>,
+        txns_to_skip: Vec<Version>,
+    ) -> Self {
+        let inner = TransactionRestoreBatchController::new(
+            global_opt,
+            storage,
+            vec![opt.manifest_handle],
+            opt.replay_from_version,
+            epoch_history,
+            txns_to_skip.into_iter().collect(),
+        );
+
+        Self { inner }
+    }
+
+    pub async fn run(self) -> Result<()> {
+        self.inner.run().await
+    }
+}
+
+impl TransactionRestoreController {}
+
+/// Takes a series of transaction backup manifests, preheat in parallel, then execute in order.
+pub struct TransactionRestoreBatchController {
+    global_opt: GlobalRestoreOptions,
+    storage: Arc<dyn BackupStorage>,
+    manifest_handles: Vec<FileHandle>,
+    replay_from_version: Option<Version>,
+    epoch_history: Option<Arc<EpochHistory>>,
+    txns_to_skip: Arc<BTreeSet<Version>>,
+}
+
+impl TransactionRestoreBatchController {
+    pub fn new(
+        global_opt: GlobalRestoreOptions,
+        storage: Arc<dyn BackupStorage>,
+        manifest_handles: Vec<FileHandle>,
+        replay_from_version: Option<Version>,
+        epoch_history: Option<Arc<EpochHistory>>,
+        txns_to_skip: Vec<Version>,
+    ) -> Self {
+        Self {
+            global_opt,
+            storage,
+            manifest_handles,
+            replay_from_version,
+            epoch_history,
+            txns_to_skip: Arc::new(txns_to_skip.into_iter().collect()),
+        }
+    }
+
+    pub async fn run(self) -> Result<()> {
+        let name = self.name();
+        info!("{} started.", name);
+        self.run_impl()
+            .await
+            .map_err(|e| anyhow!("{} failed: {}", name, e))?;
+        info!("{} succeeded.", name);
+        Ok(())
+    }
+
+    fn name(&self) -> String {
+        format!("transaction {}", self.global_opt.run_mode.name())
+    }
+
+    async fn run_impl(self) -> Result<()> {
+        if self.manifest_handles.is_empty() {
+            return Ok(());
+        }
+
+        let mut loaded_chunk_stream = self.loaded_chunk_stream();
+        let first_version = self
+            .confirm_or_save_frozen_subtrees(&mut loaded_chunk_stream)
+            .await?;
+
+        if let RestoreRunMode::Restore { restore_handler } = self.global_opt.run_mode.as_ref() {
+            AptosVM::set_concurrency_level_once(self.global_opt.replay_concurrency_level);
+            let txns_to_execute_stream = self
+                .save_before_replay_version(first_version, loaded_chunk_stream, restore_handler)
+                .await?;
+
+            if let Some(txns_to_execute_stream) = txns_to_execute_stream {
+                self.replay_transactions(restore_handler, txns_to_execute_stream)
+                    .await?;
+            }
+        } else {
+            Self::go_through_verified_chunks(loaded_chunk_stream, first_version).await?;
+        }
+        Ok(())
+    }
+
+    fn loaded_chunk_stream(&self) -> Peekable<impl Stream<Item = Result<LoadedChunk>>> {
+        let con = self.global_opt.concurrent_downloads;
+
+        let manifest_handle_stream = stream::iter(self.manifest_handles.clone().into_iter());
+
+        let storage = self.storage.clone();
+        let manifest_stream = manifest_handle_stream
+            .map(move |hdl| {
+                let storage = storage.clone();
+                async move { storage.load_json_file(&hdl).await.err_notes(&hdl) }
+            })
+            .buffered_x(con * 3, con)
+            .and_then(|m: TransactionBackup| future::ready(m.verify().map(|_| m)));
+
+        let target_version = self.global_opt.target_version;
+        let chunk_manifest_stream = manifest_stream
+            .map_ok(|m| stream::iter(m.chunks.into_iter().map(Result::<_>::Ok)))
+            .try_flatten()
+            .try_take_while(move |c| future::ready(Ok(c.first_version <= target_version)))
+            .scan(0, |last_chunk_last_version, chunk_res| {
+                let res = match &chunk_res {
+                    Ok(chunk) => {
+                        if *last_chunk_last_version != 0
+                            && chunk.first_version != *last_chunk_last_version + 1
+                        {
+                            Some(Err(anyhow!(
+                                "Chunk range not consecutive. expecting {}, got {}",
+                                *last_chunk_last_version + 1,
+                                chunk.first_version
+                            )))
+                        } else {
+                            *last_chunk_last_version = chunk.last_version;
+                            Some(chunk_res)
+                        }
+                    },
+                    Err(_) => Some(chunk_res),
+                };
+                future::ready(res)
+            });
+
+        let storage = self.storage.clone();
+        let epoch_history = self.epoch_history.clone();
+        chunk_manifest_stream
+            .and_then(move |chunk| {
+                let storage = storage.clone();
+                let epoch_history = epoch_history.clone();
+                future::ok(async move {
+                    tokio::task::spawn(async move {
+                        LoadedChunk::load(chunk, &storage, epoch_history.as_ref()).await
+                    })
+                    .err_into::<anyhow::Error>()
+                    .await
+                })
+            })
+            .try_buffered_x(con * 2, con)
+            .and_then(future::ready)
+            .peekable()
+    }
+
+    async fn confirm_or_save_frozen_subtrees(
+        &self,
+        loaded_chunk_stream: &mut Peekable<impl Unpin + Stream<Item = Result<LoadedChunk>>>,
+    ) -> Result<Version> {
+        let first_chunk = Pin::new(loaded_chunk_stream)
+            .peek()
+            .await
+            .ok_or_else(|| anyhow!("LoadedChunk stream is empty."))?
+            .as_ref()
+            .map_err(|e| anyhow!("Error: {}", e))?;
+
+        if let RestoreRunMode::Restore { restore_handler } = self.global_opt.run_mode.as_ref() {
+            restore_handler.confirm_or_save_frozen_subtrees(
+                first_chunk.manifest.first_version,
+                first_chunk.range_proof.left_siblings(),
+            )?;
+        }
+
+        Ok(first_chunk.manifest.first_version)
+    }
+
+    async fn save_before_replay_version(
+        &self,
+        global_first_version: Version,
+        loaded_chunk_stream: impl Stream<Item = Result<LoadedChunk>> + Unpin,
+        restore_handler: &RestoreHandler,
+    ) -> Result<
+        Option<
+            impl Stream<Item = Result<(Transaction, TransactionInfo, WriteSet, Vec<ContractEvent>)>>,
+        >,
+    > {
+        let next_expected_version = self
+            .global_opt
+            .run_mode
+            .get_next_expected_transaction_version()?;
+        let start = Instant::now();
+
+        let restore_handler_clone = restore_handler.clone();
+        // DB doesn't allow replaying anything before what's in DB already.
+        //
+        // TODO: notice that ideals we detect and avoid calling rh.save_transactions() for txns
+        //       before `first_to_replay` calculated below, but we don't deal with it for now,
+        //       because unlike replaying, that's allowed by the DB. Need to follow up later.
+        let first_to_replay = max(
+            self.replay_from_version.unwrap_or(Version::MAX),
+            next_expected_version,
+        );
+        let target_version = self.global_opt.target_version;
+
+        let mut txns_to_execute_stream = loaded_chunk_stream
+            .and_then(move |chunk| {
+                let restore_handler = restore_handler_clone.clone();
+                future::ok(async move {
+                    let LoadedChunk {
+                        manifest:
+                            TransactionChunk {
+                                first_version,
+                                mut last_version,
+                                transactions: _,
+                                proof: _,
+                            },
+                        mut txns,
+                        mut txn_infos,
+                        mut event_vecs,
+                        mut write_sets,
+                        range_proof: _,
+                        ledger_info: _,
+                    } = chunk;
+
+                    if target_version < last_version {
+                        let num_to_keep = (target_version - first_version + 1) as usize;
+                        txns.drain(num_to_keep..);
+                        txn_infos.drain(num_to_keep..);
+                        event_vecs.drain(num_to_keep..);
+                        write_sets.drain(num_to_keep..);
+                        last_version = target_version;
+                    }
+
+                    if first_version < first_to_replay {
+                        let num_to_save =
+                            (min(first_to_replay, last_version + 1) - first_version) as usize;
+                        let txns_to_save: Vec<_> = txns.drain(..num_to_save).collect();
+                        let txn_infos_to_save: Vec<_> = txn_infos.drain(..num_to_save).collect();
+                        let event_vecs_to_save: Vec<_> = event_vecs.drain(..num_to_save).collect();
+                        write_sets.drain(..num_to_save);
+
+                        tokio::task::spawn_blocking(move || {
+                            restore_handler.save_transactions(
+                                first_version,
+                                &txns_to_save,
+                                &txn_infos_to_save,
+                                &event_vecs_to_save,
+                            )
+                        })
+                        .await??;
+                        let last_saved = first_version + num_to_save as u64 - 1;
+                        TRANSACTION_SAVE_VERSION.set(last_saved as i64);
+                        info!(
+                            version = last_saved,
+                            accumulative_tps = (last_saved - global_first_version + 1) as f64
+                                / start.elapsed().as_secs_f64(),
+                            "Transactions saved."
+                        );
+                    }
+
+                    Ok(stream::iter(
+                        izip!(txns, txn_infos, write_sets, event_vecs)
+                            .into_iter()
+                            .map(Result::<_>::Ok),
+                    ))
+                })
+            })
+            .try_buffered_x(self.global_opt.concurrent_downloads, 1)
+            .try_flatten()
+            .peekable();
+
+        // Finish saving transactions that are not to be replayed.
+        let first_txn_to_replay = {
+            Pin::new(&mut txns_to_execute_stream)
+                .peek()
+                .await
+                .map(|res| res.as_ref().map_err(|e| anyhow!("Error: {}", e)))
+                .transpose()?
+                .map(|_| ())
+        };
+
+        Ok(first_txn_to_replay.map(|_| txns_to_execute_stream))
+    }
+
+    async fn replay_transactions(
+        &self,
+        restore_handler: &RestoreHandler,
+        txns_to_execute_stream: impl Stream<
+            Item = Result<(Transaction, TransactionInfo, WriteSet, Vec<ContractEvent>)>,
+        >,
+    ) -> Result<()> {
+        let first_version = self.replay_from_version.unwrap();
+        restore_handler.reset_state_store();
+        let replay_start = Instant::now();
+        let db = DbReaderWriter::from_arc(Arc::clone(&restore_handler.aptosdb));
+        let chunk_replayer = Arc::new(ChunkExecutor::<AptosVM>::new(db));
+
+        let db_commit_stream = txns_to_execute_stream
+            .try_chunks(BATCH_SIZE)
+            .err_into::<anyhow::Error>()
+            .map_ok(|chunk| {
+                let (txns, txn_infos, write_sets, events): (Vec<_>, Vec<_>, Vec<_>, Vec<_>) =
+                    chunk.into_iter().multiunzip();
+                let chunk_replayer = chunk_replayer.clone();
+                let txns_to_skip = self.txns_to_skip.clone();
+
+                async move {
+                    let _timer = OTHER_TIMERS_SECONDS
+                        .with_label_values(&["replay_txn_chunk"])
+                        .start_timer();
+                    tokio::task::spawn_blocking(move || {
+                        chunk_replayer.replay(txns, txn_infos, write_sets, events, txns_to_skip)
+                    })
+                    .err_into::<anyhow::Error>()
+                    .await
+                }
+            })
+            .try_buffered_x(self.global_opt.concurrent_downloads, 1)
+            .and_then(future::ready);
+
+        let total_replayed = db_commit_stream
+            .and_then(|()| {
+                let chunk_replayer = chunk_replayer.clone();
+                async move {
+                    let _timer = OTHER_TIMERS_SECONDS
+                        .with_label_values(&["commit_txn_chunk"])
+                        .start_timer();
+                    tokio::task::spawn_blocking(move || {
+                        let committed_chunk = chunk_replayer.commit()?;
+                        let v = committed_chunk.result_view.version().unwrap_or(0);
+                        let total_replayed = v - first_version + 1;
+                        TRANSACTION_REPLAY_VERSION.set(v as i64);
+                        info!(
+                            version = v,
+                            accumulative_tps =
+                                total_replayed as f64 / replay_start.elapsed().as_secs_f64(),
+                            "Transactions replayed."
+                        );
+                        Ok(v)
+                    })
+                    .await?
+                }
+            })
+            .try_fold(0, |_total, total| future::ok(total))
+            .await?;
+        info!(
+            total_replayed = total_replayed,
+            accumulative_tps = total_replayed as f64 / replay_start.elapsed().as_secs_f64(),
+            "Replay finished."
+        );
+        Ok(())
+    }
+
+    async fn go_through_verified_chunks(
+        loaded_chunk_stream: impl Stream<Item = Result<LoadedChunk>>,
+        first_version: Version,
+    ) -> Result<()> {
+        let start = Instant::now();
+        loaded_chunk_stream
+            .try_fold((), |(), chunk| {
+                let v = chunk.manifest.last_version;
+                VERIFY_TRANSACTION_VERSION.set(v as i64);
+                info!(
+                    version = v,
+                    accumulative_tps =
+                        (v - first_version + 1) as f64 / start.elapsed().as_secs_f64(),
+                    "Transactions verified."
+                );
+                future::ok(())
+            })
+            .await
+    }
+}

--- a/aptos-db-tool/src/commands/backup/backup_types/transaction/tests.rs
+++ b/aptos-db-tool/src/commands/backup/backup_types/transaction/tests.rs
@@ -1,0 +1,143 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    backup_types::transaction::{
+        backup::{TransactionBackupController, TransactionBackupOpt},
+        restore::{TransactionRestoreController, TransactionRestoreOpt},
+    },
+    storage::{local_fs::LocalFs, BackupStorage},
+    utils::{
+        backup_service_client::BackupServiceClient,
+        test_utils::{start_local_backup_service, tmp_db_with_random_content},
+        ConcurrentDownloadsOpt, GlobalBackupOpt, GlobalRestoreOpt, ReplayConcurrencyLevelOpt,
+        RocksdbOpt, TrustedWaypointOpt,
+    },
+};
+use aptos_db::AptosDB;
+use aptos_storage_interface::DbReader;
+use aptos_temppath::TempPath;
+use aptos_types::transaction::Version;
+use std::{convert::TryInto, mem::size_of, sync::Arc};
+use tokio::time::Duration;
+
+#[test]
+fn end_to_end() {
+    let (_src_db_dir, src_db, blocks) = tmp_db_with_random_content();
+    let tgt_db_dir = TempPath::new();
+    tgt_db_dir.create_as_dir().unwrap();
+    let backup_dir = TempPath::new();
+    backup_dir.create_as_dir().unwrap();
+    let store: Arc<dyn BackupStorage> = Arc::new(LocalFs::new(backup_dir.path().to_path_buf()));
+
+    let (rt, port) = start_local_backup_service(src_db);
+    let client = Arc::new(BackupServiceClient::new(format!(
+        "http://localhost:{}",
+        port
+    )));
+
+    let latest_version = blocks.last().unwrap().1.ledger_info().version();
+    let total_txns = blocks.iter().fold(0, |x, b| x + b.0.len());
+    assert_eq!(latest_version as usize + 1, total_txns);
+    let txns = blocks
+        .iter()
+        .flat_map(|(txns, _li)| txns)
+        .map(|txn_to_commit| txn_to_commit.transaction())
+        .collect::<Vec<_>>();
+    let max_chunk_size = txns
+        .iter()
+        .map(|t| bcs::to_bytes(t).unwrap().len())
+        .max()
+        .unwrap() // biggest txn
+        + 115 // size of a serialized TransactionInfo
+        + size_of::<u32>(); // record len header
+    let first_ver_to_backup = (total_txns / 4) as Version;
+    let num_txns_to_backup = total_txns - first_ver_to_backup as usize;
+    let target_version = first_ver_to_backup + total_txns as Version / 2;
+    let num_txns_to_restore = (target_version - first_ver_to_backup + 1) as usize;
+
+    let manifest_handle = rt
+        .block_on(
+            TransactionBackupController::new(
+                TransactionBackupOpt {
+                    start_version: first_ver_to_backup,
+                    num_transactions: num_txns_to_backup,
+                },
+                GlobalBackupOpt { max_chunk_size },
+                client,
+                Arc::clone(&store),
+            )
+            .run(),
+        )
+        .unwrap();
+
+    rt.block_on(
+        TransactionRestoreController::new(
+            TransactionRestoreOpt {
+                manifest_handle,
+                replay_from_version: None, // max
+            },
+            GlobalRestoreOpt {
+                dry_run: false,
+                db_dir: Some(tgt_db_dir.path().to_path_buf()),
+                target_version: Some(target_version),
+                trusted_waypoints: TrustedWaypointOpt::default(),
+                rocksdb_opt: RocksdbOpt::default(),
+                concurrent_downloads: ConcurrentDownloadsOpt::default(),
+                replay_concurrency_level: ReplayConcurrencyLevelOpt::default(),
+            }
+            .try_into()
+            .unwrap(),
+            store,
+            None, /* epoch_history */
+            vec![],
+        )
+        .run(),
+    )
+    .unwrap();
+
+    // We don't write down any ledger infos when recovering transactions. State-sync needs to take
+    // care of it before running consensus. The latest transactions are deemed "synced" instead of
+    // "committed" most likely.
+    let tgt_db = AptosDB::new_readonly_for_test(&tgt_db_dir);
+    assert_eq!(
+        tgt_db
+            .get_latest_transaction_info_option()
+            .unwrap()
+            .unwrap()
+            .0,
+        target_version,
+    );
+    let recovered_transactions = tgt_db
+        .get_transactions(
+            first_ver_to_backup,
+            num_txns_to_restore as u64,
+            target_version,
+            true, /* fetch_events */
+        )
+        .unwrap();
+
+    assert_eq!(
+        recovered_transactions.transactions,
+        txns.into_iter()
+            .skip(first_ver_to_backup as usize)
+            .take(num_txns_to_restore)
+            .cloned()
+            .collect::<Vec<_>>()
+    );
+
+    assert_eq!(
+        recovered_transactions.events.unwrap(),
+        blocks
+            .iter()
+            .flat_map(|(txns, _li)| {
+                txns.iter()
+                    .map(|txn_to_commit| txn_to_commit.events().to_vec())
+            })
+            .skip(first_ver_to_backup as usize)
+            .take(num_txns_to_restore)
+            .collect::<Vec<_>>()
+    );
+
+    rt.shutdown_timeout(Duration::from_secs(1));
+}

--- a/aptos-db-tool/src/commands/backup/commands.rs
+++ b/aptos-db-tool/src/commands/backup/commands.rs
@@ -1,0 +1,206 @@
+use anyhow::Result;
+use std::sync::Arc;
+
+use super::{
+    backup_types::{
+        epoch_ending::backup::{EpochEndingBackupController, EpochEndingBackupOpt},
+        state_snapshot::backup::{StateSnapshotBackupController, StateSnapshotBackupOpt},
+        transaction::backup::{TransactionBackupController, TransactionBackupOpt},
+    },
+    coordinators::backup::{BackupCoordinator, BackupCoordinatorOpt},
+    metadata::cache,
+    storage::StorageOpt,
+    utils::{
+        backup_service_client::{BackupServiceClient, BackupServiceClientOpt},
+        ConcurrentDownloadsOpt, GlobalBackupOpt,
+    },
+};
+use crate::commands::backup::metadata::cache::MetadataCacheOpt;
+use clap::{Parser, Subcommand};
+
+#[derive(Subcommand)]
+pub enum Backup {
+    #[clap(subcommand, about = "Manually run one shot commands.")]
+    OneShot(OneShotCommand),
+    #[clap(
+        subcommand,
+        about = "Long running process backing up the chain continuously."
+    )]
+    Coordinator(CoordinatorCommand),
+}
+
+#[derive(Subcommand)]
+pub enum OneShotCommand {
+    #[clap(
+        subcommand,
+        about = "Query the backup service builtin in the local node."
+    )]
+    Query(OneShotQueryType),
+    #[clap(about = "Do a one shot backup of either of the backup types.")]
+    Backup(OneShotBackupOpt),
+}
+
+#[derive(Parser, Clone)]
+pub enum OneShotQueryType {
+    #[clap(
+        about = "Queries the latest epoch, committed version and synced version of the local \
+        node, via the backup service within it."
+    )]
+    NodeState(OneShotQueryNodeStateOpt),
+    #[clap(
+        about = "Queries the latest epoch and versions of the existing backups in the storage."
+    )]
+    BackupStorageState(OneShotQueryBackupStorageStateOpt),
+}
+
+#[derive(Parser, Clone)]
+pub struct OneShotQueryNodeStateOpt {
+    #[clap(flatten)]
+    client: BackupServiceClientOpt,
+}
+
+#[derive(Parser, Clone)]
+pub struct OneShotQueryBackupStorageStateOpt {
+    #[clap(flatten)]
+    metadata_cache: MetadataCacheOpt,
+    #[clap(flatten)]
+    concurrent_downloads: ConcurrentDownloadsOpt,
+    #[clap(subcommand)]
+    storage: StorageOpt,
+}
+
+#[derive(Parser, Clone)]
+pub struct OneShotBackupOpt {
+    #[clap(flatten)]
+    global: GlobalBackupOpt,
+
+    #[clap(flatten)]
+    client: BackupServiceClientOpt,
+
+    #[clap(subcommand)]
+    backup_type: BackupType,
+}
+
+#[derive(Parser, Clone)]
+pub enum BackupType {
+    EpochEnding {
+        #[clap(flatten)]
+        opt: EpochEndingBackupOpt,
+        #[clap(subcommand)]
+        storage: StorageOpt,
+    },
+    StateSnapshot {
+        #[clap(flatten)]
+        opt: StateSnapshotBackupOpt,
+        #[clap(subcommand)]
+        storage: StorageOpt,
+    },
+    Transaction {
+        #[clap(flatten)]
+        opt: TransactionBackupOpt,
+        #[clap(subcommand)]
+        storage: StorageOpt,
+    },
+}
+
+#[derive(Parser)]
+pub enum CoordinatorCommand {
+    #[clap(
+        about = "Run the backup coordinator which backs up blockchain data continuously off \
+    a Aptos Node."
+    )]
+    Run(CoordinatorRunOpt),
+}
+
+#[derive(Parser, Clone)]
+pub struct CoordinatorRunOpt {
+    #[clap(flatten)]
+    global: GlobalBackupOpt,
+
+    #[clap(flatten)]
+    client: BackupServiceClientOpt,
+
+    #[clap(flatten)]
+    coordinator: BackupCoordinatorOpt,
+
+    #[clap(subcommand)]
+    storage: StorageOpt,
+}
+
+impl Backup {
+    pub async fn process(&self) -> Result<()> {
+        match self {
+            Backup::OneShot(one_shot_cmd) => match &one_shot_cmd {
+                OneShotCommand::Query(typ) => match &typ {
+                    OneShotQueryType::NodeState(opt) => {
+                        let client = BackupServiceClient::new_with_opt(opt.clone().client);
+                        if let Some(db_state) = client.get_db_state().await? {
+                            println!("{}", db_state)
+                        } else {
+                            println!("DB not bootstrapped.")
+                        }
+                    },
+                    OneShotQueryType::BackupStorageState(opt) => {
+                        let view = cache::sync_and_load(
+                            &opt.metadata_cache,
+                            opt.clone().storage.init_storage().await?,
+                            opt.concurrent_downloads.get(),
+                        )
+                        .await?;
+                        println!("{}", view.get_storage_state()?)
+                    },
+                },
+                OneShotCommand::Backup(opt) => {
+                    let client = Arc::new(BackupServiceClient::new_with_opt(opt.clone().client));
+                    let global_opt = opt.clone().global;
+
+                    match &opt.clone().backup_type {
+                        BackupType::EpochEnding { opt, storage } => {
+                            EpochEndingBackupController::new(
+                                opt.clone(),
+                                global_opt,
+                                client,
+                                storage.clone().init_storage().await?,
+                            )
+                            .run()
+                            .await?;
+                        },
+                        BackupType::StateSnapshot { opt, storage } => {
+                            StateSnapshotBackupController::new(
+                                opt.clone(),
+                                global_opt,
+                                client,
+                                storage.clone().init_storage().await?,
+                            )
+                            .run()
+                            .await?;
+                        },
+                        BackupType::Transaction { opt, storage } => {
+                            TransactionBackupController::new(
+                                opt.clone(),
+                                global_opt,
+                                client,
+                                storage.clone().init_storage().await?,
+                            )
+                            .run()
+                            .await?;
+                        },
+                    }
+                },
+            },
+            Backup::Coordinator(coordinator_cmd) => match &coordinator_cmd {
+                CoordinatorCommand::Run(opt) => {
+                    BackupCoordinator::new(
+                        opt.clone().coordinator,
+                        opt.clone().global,
+                        Arc::new(BackupServiceClient::new_with_opt(opt.clone().client)),
+                        opt.clone().storage.init_storage().await?,
+                    )
+                    .run()
+                    .await?;
+                },
+            },
+        }
+        Ok(())
+    }
+}

--- a/aptos-db-tool/src/commands/backup/coordinators/backup.rs
+++ b/aptos-db-tool/src/commands/backup/coordinators/backup.rs
@@ -1,0 +1,403 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    backup_types::{
+        epoch_ending::backup::{EpochEndingBackupController, EpochEndingBackupOpt},
+        state_snapshot::backup::{StateSnapshotBackupController, StateSnapshotBackupOpt},
+        transaction::backup::{TransactionBackupController, TransactionBackupOpt},
+    },
+    metadata,
+    metadata::cache::MetadataCacheOpt,
+    metrics::backup::{
+        EPOCH_ENDING_EPOCH, HEARTBEAT_TS, STATE_SNAPSHOT_EPOCH, TRANSACTION_VERSION,
+    },
+    storage::BackupStorage,
+    utils::{
+        backup_service_client::BackupServiceClient, unix_timestamp_sec, ConcurrentDownloadsOpt,
+        GlobalBackupOpt,
+    },
+};
+use anyhow::{anyhow, ensure, Result};
+use aptos_db::backup::backup_handler::DbState;
+use aptos_logger::prelude::*;
+use aptos_types::transaction::Version;
+use clap::Parser;
+use futures::{stream, Future, StreamExt};
+use std::{fmt::Debug, sync::Arc};
+use tokio::{
+    sync::watch,
+    time::{interval, Duration},
+};
+use tokio_stream::wrappers::IntervalStream;
+
+#[derive(Parser, Clone)]
+pub struct BackupCoordinatorOpt {
+    #[clap(flatten)]
+    pub metadata_cache_opt: MetadataCacheOpt,
+    // Defaulting to 1 to try to always have the latest state snapshot.
+    #[clap(
+        long,
+        default_value = "1",
+        help = "Frequency (in number of epochs) to take state snapshots at epoch ending versions. \
+        Adjacent epochs share much of the state, so it's inefficient storage-wise and bandwidth-wise \
+        to take it too frequently. However, a recent snapshot is obviously desirable if one intends \
+        to recover a snapshot and catch up with the chain by replaying transactions on top of it. \
+        Notice: If, while a snapshot is being taken, the chain advanced several epoch, past several \
+        new points where a snapshot is eligible according to this setting, we will skip those in the \
+        middle and take only at the newest epoch among them. For example, if the setting is 5, \
+        then the snapshots will be at at 0, 5, 10 ... If when the snapshot at 5 ends the chain \
+        is already at 19, then snapshot at 15 will be taken instead of at 10 (not at 18)."
+    )]
+    pub state_snapshot_interval_epochs: usize,
+    // Defaulting to 1M, which converts to a 20 minutes delay of a transaction showing up in a backup,
+    // from a 1K TPS chain, and a few minutes replay time.
+    #[clap(
+        long,
+        default_value = "1000000",
+        help = "The frequency (in transaction versions) to take an incremental transaction backup. \
+        Making a transaction backup every 10 Million versions will result in the latest transaction \
+        to appear in the backup potentially 10 Million versions later. If the net work is running \
+        at 1 thousand transactions per second, that is roughly 3 hours. On the other hand, if \
+        backups are too frequent and hence small, it slows down loading the backup metadata by too \
+        many small files. "
+    )]
+    pub transaction_batch_size: usize,
+    #[clap(flatten)]
+    pub concurrent_downloads: ConcurrentDownloadsOpt,
+}
+
+impl BackupCoordinatorOpt {
+    fn validate(&self) -> Result<()> {
+        ensure!(
+            self.state_snapshot_interval_epochs > 0 && self.transaction_batch_size > 0,
+            "Backup interval and batch size must be greater than 0."
+        );
+        Ok(())
+    }
+}
+
+pub struct BackupCoordinator {
+    client: Arc<BackupServiceClient>,
+    storage: Arc<dyn BackupStorage>,
+    global_opt: GlobalBackupOpt,
+    metadata_cache_opt: MetadataCacheOpt,
+    state_snapshot_interval_epochs: usize,
+    transaction_batch_size: usize,
+    concurrent_downloads: usize,
+}
+
+impl BackupCoordinator {
+    pub fn new(
+        opt: BackupCoordinatorOpt,
+        global_opt: GlobalBackupOpt,
+        client: Arc<BackupServiceClient>,
+        storage: Arc<dyn BackupStorage>,
+    ) -> Self {
+        opt.validate().unwrap();
+        Self {
+            client,
+            storage,
+            global_opt,
+            metadata_cache_opt: opt.metadata_cache_opt,
+            state_snapshot_interval_epochs: opt.state_snapshot_interval_epochs,
+            transaction_batch_size: opt.transaction_batch_size,
+            concurrent_downloads: opt.concurrent_downloads.get(),
+        }
+    }
+
+    pub async fn run(&self) -> Result<()> {
+        // Connect to both the local node and the backup storage.
+        let backup_state = metadata::cache::sync_and_load(
+            &self.metadata_cache_opt,
+            Arc::clone(&self.storage),
+            self.concurrent_downloads,
+        )
+        .await?
+        .get_storage_state()?;
+
+        // On new DbState retrieved:
+        // `watch_db_state` informs `backup_epoch_endings` via channel 1,
+        // and the latter informs the other backup type workers via channel 2, after epoch
+        // ending is properly backed up, if necessary. This way, the epoch ending LedgerInfo needed
+        // for proof verification is always available in the same backup storage.
+        let (tx1, rx1) = watch::channel::<Option<DbState>>(None);
+        let (tx2, rx2) = watch::channel::<Option<DbState>>(None);
+
+        // Schedule work streams.
+        let watch_db_state = IntervalStream::new(interval(Duration::from_secs(1)))
+            .then(|_| self.try_refresh_db_state(&tx1))
+            .boxed_local();
+
+        let backup_epoch_endings = self
+            .backup_work_stream(
+                backup_state.latest_epoch_ending_epoch,
+                &rx1,
+                |slf, last_epoch, db_state| {
+                    Self::backup_epoch_endings(slf, last_epoch, db_state, &tx2)
+                },
+            )
+            .boxed_local();
+        let backup_state_snapshots = self
+            .backup_work_stream(
+                backup_state.latest_state_snapshot_epoch,
+                &rx2,
+                Self::backup_state_snapshot,
+            )
+            .boxed_local();
+        let backup_transactions = self
+            .backup_work_stream(
+                backup_state.latest_transaction_version,
+                &rx2,
+                Self::backup_transactions,
+            )
+            .boxed_local();
+
+        info!("Backup coordinator started.");
+        let mut all_work = stream::select_all(vec![
+            watch_db_state,
+            backup_epoch_endings,
+            backup_state_snapshots,
+            backup_transactions,
+        ]);
+
+        loop {
+            all_work
+                .next()
+                .await
+                .ok_or_else(|| anyhow!("Must be a bug: we never returned None."))?
+        }
+    }
+}
+
+impl BackupCoordinator {
+    async fn try_refresh_db_state(&self, db_state_broadcast: &watch::Sender<Option<DbState>>) {
+        match self.client.get_db_state().await {
+            Ok(s) => {
+                HEARTBEAT_TS.set(unix_timestamp_sec());
+                if s.is_none() {
+                    warn!("DB not bootstrapped.");
+                } else {
+                    db_state_broadcast
+                        .send(s)
+                        .map_err(|e| anyhow!("Receivers should not be cancelled: {}", e))
+                        .unwrap()
+                }
+            },
+            Err(e) => warn!(
+                "Failed pulling DbState from local node: {}. Will keep trying.",
+                e
+            ),
+        };
+    }
+
+    async fn backup_epoch_endings(
+        &self,
+        mut last_epoch_ending_epoch_in_backup: Option<u64>,
+        db_state: DbState,
+        downstream_db_state_broadcaster: &watch::Sender<Option<DbState>>,
+    ) -> Result<Option<u64>> {
+        loop {
+            if let Some(epoch) = last_epoch_ending_epoch_in_backup {
+                EPOCH_ENDING_EPOCH.set(epoch as i64);
+            }
+            let (first, last) = get_batch_range(last_epoch_ending_epoch_in_backup, 1);
+
+            if db_state.epoch <= last {
+                // "<=" because `db_state.epoch` hasn't ended yet, wait for the next db_state update
+                break;
+            }
+
+            EpochEndingBackupController::new(
+                EpochEndingBackupOpt {
+                    start_epoch: first,
+                    end_epoch: last + 1,
+                },
+                self.global_opt.clone(),
+                Arc::clone(&self.client),
+                Arc::clone(&self.storage),
+            )
+            .run()
+            .await?;
+            last_epoch_ending_epoch_in_backup = Some(last)
+        }
+
+        downstream_db_state_broadcaster
+            .send(Some(db_state))
+            .map_err(|e| anyhow!("Receivers should not be cancelled: {}", e))
+            .unwrap();
+        Ok(last_epoch_ending_epoch_in_backup)
+    }
+
+    async fn backup_state_snapshot(
+        &self,
+        last_snapshot_epoch_in_backup: Option<Version>,
+        db_state: DbState,
+    ) -> Result<Option<Version>> {
+        if let Some(epoch) = last_snapshot_epoch_in_backup {
+            STATE_SNAPSHOT_EPOCH.set(epoch as i64);
+        }
+        let epoch = get_next_snapshot(
+            last_snapshot_epoch_in_backup,
+            db_state,
+            self.state_snapshot_interval_epochs,
+        );
+
+        // <= becuse db_state.epoch is still open
+        if db_state.epoch <= epoch {
+            // wait for the next db_state update
+            return Ok(last_snapshot_epoch_in_backup);
+        }
+
+        StateSnapshotBackupController::new(
+            StateSnapshotBackupOpt { epoch },
+            self.global_opt.clone(),
+            Arc::clone(&self.client),
+            Arc::clone(&self.storage),
+        )
+        .run()
+        .await?;
+
+        Ok(Some(epoch))
+    }
+
+    async fn backup_transactions(
+        &self,
+        mut last_transaction_version_in_backup: Option<Version>,
+        db_state: DbState,
+    ) -> Result<Option<u64>> {
+        loop {
+            if let Some(version) = last_transaction_version_in_backup {
+                TRANSACTION_VERSION.set(version as i64);
+            }
+            let (first, last) = get_batch_range(
+                last_transaction_version_in_backup,
+                self.transaction_batch_size,
+            );
+
+            if db_state.committed_version < last {
+                // wait for the next db_state update
+                return Ok(last_transaction_version_in_backup);
+            }
+
+            TransactionBackupController::new(
+                TransactionBackupOpt {
+                    start_version: first,
+                    num_transactions: (last + 1 - first) as usize,
+                },
+                self.global_opt.clone(),
+                Arc::clone(&self.client),
+                Arc::clone(&self.storage),
+            )
+            .run()
+            .await?;
+
+            last_transaction_version_in_backup = Some(last);
+        }
+    }
+
+    fn backup_work_stream<'a, S, W, Fut>(
+        &'a self,
+        initial_state: S,
+        db_state_rx: &'a watch::Receiver<Option<DbState>>,
+        worker: W,
+    ) -> impl StreamExt<Item = ()> + 'a
+    where
+        S: Copy + Debug + 'a,
+        W: Worker<'a, S, Fut> + Copy + 'a,
+        Fut: Future<Output = Result<S>> + 'a,
+    {
+        stream::unfold(
+            (initial_state, db_state_rx.clone()),
+            move |(s, mut rx)| async move {
+                rx.changed().await.unwrap();
+                let db_state = *rx.borrow();
+                if let Some(db_state) = db_state {
+                    let next_state = worker(self, s, db_state).await.unwrap_or_else(|e| {
+                        warn!("backup failed: {}. Keep trying with state {:?}.", e, s);
+                        s
+                    });
+                    Some(((), (next_state, rx)))
+                } else {
+                    // initial state
+                    Some(((), (s, rx)))
+                }
+            },
+        )
+    }
+}
+
+trait Worker<'a, S, Fut: Future<Output = Result<S>> + 'a>:
+    Fn(&'a BackupCoordinator, S, DbState) -> Fut
+{
+}
+
+impl<'a, T, S, Fut> Worker<'a, S, Fut> for T
+where
+    T: Fn(&'a BackupCoordinator, S, DbState) -> Fut,
+    Fut: Future<Output = Result<S>> + 'a,
+{
+}
+
+fn get_batch_range(last_in_backup: Option<u64>, batch_size: usize) -> (u64, u64) {
+    // say, 7 is already in backup, and we target batches of size 10, we will return (8, 10) in this
+    // case, so 8, 9, 10 will be in this batch, and next time the backup worker will pass in 10,
+    // and we will return (11, 20). The transaction 0 will be in it's own batch.
+    last_in_backup.map_or((0, 0), |n| {
+        let first = n + 1;
+        let batch = n / batch_size as u64 + 1;
+        let last = batch * batch_size as u64;
+        (first, last)
+    })
+}
+
+fn get_next_snapshot(last_in_backup: Option<u64>, db_state: DbState, interval: usize) -> u64 {
+    // We don't try to guarantee snapshots are taken at each applicable interval: when the backup
+    // progress can't keep up with the ledger growth, we favor timeliness over completeness.
+    // For example, with interval 100, when we finished taking a snapshot at version 700, if we
+    // found the latest version is already 1250, the next snapshot we take will be at 1200, not 800.
+
+    let next_for_storage = match last_in_backup {
+        Some(last) => (last / interval as u64 + 1) * interval as u64,
+        None => 0,
+    };
+
+    // Notice that db_state.epoch is not closed yet.
+    let last_for_db: u64 = db_state.epoch.saturating_sub(1) / interval as u64 * interval as u64;
+
+    std::cmp::max(next_for_storage, last_for_db)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::commands::backup::coordinators::backup::{get_batch_range, get_next_snapshot};
+    use aptos_db::backup::backup_handler::DbState;
+
+    #[test]
+    fn test_get_batch_range() {
+        assert_eq!(get_batch_range(None, 100), (0, 0));
+        assert_eq!(get_batch_range(Some(0), 100), (1, 100));
+        assert_eq!(get_batch_range(Some(100), 50), (101, 150));
+        assert_eq!(get_batch_range(Some(150), 100), (151, 200));
+        assert_eq!(get_batch_range(Some(200), 100), (201, 300));
+    }
+
+    #[test]
+    fn test_get_next_snapshot() {
+        let _state = |epoch| DbState {
+            epoch,
+            committed_version: 0,
+        };
+
+        assert_eq!(get_next_snapshot(None, _state(90), 100), 0);
+        assert_eq!(get_next_snapshot(Some(0), _state(90), 100), 100);
+        assert_eq!(get_next_snapshot(Some(0), _state(100), 100), 100);
+        assert_eq!(get_next_snapshot(Some(0), _state(101), 100), 100);
+        assert_eq!(get_next_snapshot(Some(0), _state(190), 100), 100);
+        // Notice that epoch 200 is not closed yet.
+        assert_eq!(get_next_snapshot(Some(0), _state(200), 100), 100);
+        assert_eq!(get_next_snapshot(Some(0), _state(201), 100), 200);
+        assert_eq!(get_next_snapshot(Some(0), _state(250), 100), 200);
+        assert_eq!(get_next_snapshot(Some(200), _state(250), 100), 300);
+    }
+}

--- a/aptos-db-tool/src/commands/backup/coordinators/mod.rs
+++ b/aptos-db-tool/src/commands/backup/coordinators/mod.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod backup;
+pub mod restore;
+pub mod verify;

--- a/aptos-db-tool/src/commands/backup/coordinators/restore.rs
+++ b/aptos-db-tool/src/commands/backup/coordinators/restore.rs
@@ -1,0 +1,223 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    backup_types::{
+        epoch_ending::restore::EpochHistoryRestoreController,
+        state_snapshot::restore::{StateSnapshotRestoreController, StateSnapshotRestoreOpt},
+        transaction::restore::TransactionRestoreBatchController,
+    },
+    metadata,
+    metadata::{cache::MetadataCacheOpt, TransactionBackupMeta},
+    metrics::restore::{
+        COORDINATOR_FAIL_TS, COORDINATOR_START_TS, COORDINATOR_SUCC_TS, COORDINATOR_TARGET_VERSION,
+    },
+    storage::BackupStorage,
+    utils::{unix_timestamp_sec, GlobalRestoreOptions},
+};
+use anyhow::{anyhow, bail, Result};
+use aptos_logger::prelude::*;
+use aptos_types::transaction::Version;
+use clap::Parser;
+use std::sync::Arc;
+
+#[derive(Parser, Clone)]
+pub struct RestoreCoordinatorOpt {
+    #[clap(flatten)]
+    pub metadata_cache_opt: MetadataCacheOpt,
+    #[clap(
+        long,
+        help = "Replay all transactions, don't try to use a state snapshot."
+    )]
+    pub replay_all: bool,
+    #[clap(
+        long,
+        help = "[default to only start ledger history after selected state snapshot] \
+        Ignore restoring the ledger history (transactions and events) before this version \
+        if possible, set 0 for full ledger history."
+    )]
+    pub ledger_history_start_version: Option<Version>,
+    #[clap(long, help = "Skip restoring epoch ending info, used for debugging.")]
+    pub skip_epoch_endings: bool,
+}
+
+pub struct RestoreCoordinator {
+    storage: Arc<dyn BackupStorage>,
+    global_opt: GlobalRestoreOptions,
+    metadata_cache_opt: MetadataCacheOpt,
+    replay_all: bool,
+    ledger_history_start_version: Option<Version>,
+    skip_epoch_endings: bool,
+}
+
+impl RestoreCoordinator {
+    pub fn new(
+        opt: RestoreCoordinatorOpt,
+        global_opt: GlobalRestoreOptions,
+        storage: Arc<dyn BackupStorage>,
+    ) -> Self {
+        Self {
+            storage,
+            global_opt,
+            metadata_cache_opt: opt.metadata_cache_opt,
+            replay_all: opt.replay_all,
+            ledger_history_start_version: opt.ledger_history_start_version,
+            skip_epoch_endings: opt.skip_epoch_endings,
+        }
+    }
+
+    pub async fn run(self) -> Result<()> {
+        info!("Restore coordinator started.");
+        COORDINATOR_START_TS.set(unix_timestamp_sec());
+
+        let ret = self.run_impl().await;
+
+        if let Err(e) = &ret {
+            error!(
+                error = ?e,
+                "Restore coordinator failed."
+            );
+            COORDINATOR_FAIL_TS.set(unix_timestamp_sec());
+        } else {
+            info!("Restore coordinator exiting with success.");
+            COORDINATOR_SUCC_TS.set(unix_timestamp_sec());
+        }
+
+        ret
+    }
+
+    async fn run_impl(mut self) -> Result<()> {
+        // N.b.
+        // The coordinator now focuses on doing one procedure, ignoring the combination of options
+        // supported before:
+        //   1. a most recent state snapshot before --target-version
+        //   2. a only transaction and its output, at the state snapshot version
+        //   3. the epoch history from 0 up until the latest closed epoch preceding the state
+        //      snapshot version.
+        // And it does so in a resume-able way.
+
+        if self.replay_all {
+            bail!("--replay--all not supported in this version.");
+        }
+        if self.ledger_history_start_version.is_some() {
+            bail!("--ledger-history-start-version not supported in this version.");
+        }
+
+        let metadata_view = metadata::cache::sync_and_load(
+            &self.metadata_cache_opt,
+            Arc::clone(&self.storage),
+            self.global_opt.concurrent_downloads,
+        )
+        .await?;
+
+        let next_txn_version = self
+            .global_opt
+            .run_mode
+            .get_next_expected_transaction_version()?;
+        if next_txn_version != 0 {
+            // DB is already in workable state
+            info!(
+                next_txn_version = next_txn_version,
+                "DB is ready to accept transactions, start the node to catch up with the chain. \
+                If the node is unable to catch up because the DB is too old, delete the data folder \
+                and bootstrap again.",
+            );
+            return Ok(());
+        }
+
+        let state_snapshot_backup =
+            if let Some(version) = self.global_opt.run_mode.get_in_progress_state_snapshot()? {
+                info!(
+                    version = version,
+                    "Found in progress state snapshot restore",
+                );
+                metadata_view.expect_state_snapshot(version)?
+            } else {
+                let max_txn_ver = metadata_view
+                    .max_transaction_version()?
+                    .ok_or_else(|| anyhow!("No transaction backup found."))?;
+                metadata_view
+                    .select_state_snapshot(std::cmp::min(self.target_version(), max_txn_ver))?
+                    .ok_or_else(|| anyhow!("No usable state snapshot."))?
+            };
+        let version = state_snapshot_backup.version;
+        self.global_opt.target_version = version;
+        let epoch_ending_backups = metadata_view.select_epoch_ending_backups(version)?;
+        let transaction_backup = metadata_view
+            .select_transaction_backups(version, version)?
+            .pop()
+            .unwrap();
+        COORDINATOR_TARGET_VERSION.set(version as i64);
+        info!(version = version, "Restore target decided.");
+
+        let epoch_history = if !self.skip_epoch_endings {
+            Some(Arc::new(
+                EpochHistoryRestoreController::new(
+                    epoch_ending_backups
+                        .into_iter()
+                        .map(|backup| backup.manifest)
+                        .collect(),
+                    self.global_opt.clone(),
+                    self.storage.clone(),
+                )
+                .run()
+                .await?,
+            ))
+        } else {
+            None
+        };
+
+        StateSnapshotRestoreController::new(
+            StateSnapshotRestoreOpt {
+                manifest_handle: state_snapshot_backup.manifest,
+                version,
+                validate_modules: false,
+            },
+            self.global_opt.clone(),
+            Arc::clone(&self.storage),
+            epoch_history.clone(),
+        )
+        .run()
+        .await?;
+
+        let txn_manifests = vec![transaction_backup.manifest];
+        TransactionRestoreBatchController::new(
+            self.global_opt,
+            self.storage,
+            txn_manifests,
+            None,
+            epoch_history,
+            vec![],
+        )
+        .run()
+        .await?;
+
+        Ok(())
+    }
+}
+
+impl RestoreCoordinator {
+    fn target_version(&self) -> Version {
+        self.global_opt.target_version
+    }
+
+    #[allow(dead_code)]
+    fn get_actual_target_version(
+        &self,
+        transaction_backups: &[TransactionBackupMeta],
+    ) -> Result<Version> {
+        if let Some(b) = transaction_backups.last() {
+            if b.last_version > self.target_version() {
+                Ok(self.target_version())
+            } else {
+                warn!(
+                    "Can't find transaction backup containing the target version, \
+                    will restore as much as possible"
+                );
+                Ok(b.last_version)
+            }
+        } else {
+            bail!("No transaction backup found.")
+        }
+    }
+}

--- a/aptos-db-tool/src/commands/backup/coordinators/verify.rs
+++ b/aptos-db-tool/src/commands/backup/coordinators/verify.rs
@@ -1,0 +1,127 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    backup_types::{
+        epoch_ending::restore::EpochHistoryRestoreController,
+        state_snapshot::restore::{StateSnapshotRestoreController, StateSnapshotRestoreOpt},
+        transaction::restore::TransactionRestoreBatchController,
+    },
+    metadata,
+    metadata::cache::MetadataCacheOpt,
+    metrics::verify::{
+        VERIFY_COORDINATOR_FAIL_TS, VERIFY_COORDINATOR_START_TS, VERIFY_COORDINATOR_SUCC_TS,
+    },
+    storage::BackupStorage,
+    utils::{unix_timestamp_sec, GlobalRestoreOptions, RestoreRunMode, TrustedWaypointOpt},
+};
+use anyhow::Result;
+use aptos_logger::prelude::*;
+use aptos_types::transaction::Version;
+use std::sync::Arc;
+
+pub struct VerifyCoordinator {
+    storage: Arc<dyn BackupStorage>,
+    metadata_cache_opt: MetadataCacheOpt,
+    trusted_waypoints_opt: TrustedWaypointOpt,
+    concurrent_downloads: usize,
+}
+
+impl VerifyCoordinator {
+    pub fn new(
+        storage: Arc<dyn BackupStorage>,
+        metadata_cache_opt: MetadataCacheOpt,
+        trusted_waypoints_opt: TrustedWaypointOpt,
+        concurrent_downloads: usize,
+    ) -> Result<Self> {
+        Ok(Self {
+            storage,
+            metadata_cache_opt,
+            trusted_waypoints_opt,
+            concurrent_downloads,
+        })
+    }
+
+    pub async fn run(self) -> Result<()> {
+        info!("Verify coordinator started.");
+        VERIFY_COORDINATOR_START_TS.set(unix_timestamp_sec());
+
+        let ret = self.run_impl().await;
+
+        if let Err(e) = &ret {
+            error!(
+                error = ?e,
+                "Verify coordinator failed."
+            );
+            VERIFY_COORDINATOR_FAIL_TS.set(unix_timestamp_sec());
+        } else {
+            info!("Verify coordinator exiting with success.");
+            VERIFY_COORDINATOR_SUCC_TS.set(unix_timestamp_sec());
+        }
+
+        ret
+    }
+
+    async fn run_impl(self) -> Result<()> {
+        let metadata_view = metadata::cache::sync_and_load(
+            &self.metadata_cache_opt,
+            Arc::clone(&self.storage),
+            self.concurrent_downloads,
+        )
+        .await?;
+        let ver_max = Version::max_value();
+        let state_snapshot = metadata_view.select_state_snapshot(ver_max)?;
+        let transactions = metadata_view.select_transaction_backups(0, ver_max)?;
+        let epoch_endings = metadata_view.select_epoch_ending_backups(ver_max)?;
+
+        let global_opt = GlobalRestoreOptions {
+            target_version: ver_max,
+            trusted_waypoints: Arc::new(self.trusted_waypoints_opt.verify()?),
+            run_mode: Arc::new(RestoreRunMode::Verify),
+            concurrent_downloads: self.concurrent_downloads,
+            replay_concurrency_level: 0, // won't replay, doesn't matter
+        };
+
+        let epoch_history = Arc::new(
+            EpochHistoryRestoreController::new(
+                epoch_endings
+                    .into_iter()
+                    .map(|backup| backup.manifest)
+                    .collect(),
+                global_opt.clone(),
+                self.storage.clone(),
+            )
+            .run()
+            .await?,
+        );
+
+        if let Some(backup) = state_snapshot {
+            StateSnapshotRestoreController::new(
+                StateSnapshotRestoreOpt {
+                    manifest_handle: backup.manifest,
+                    version: backup.version,
+                    validate_modules: false,
+                },
+                global_opt.clone(),
+                Arc::clone(&self.storage),
+                Some(Arc::clone(&epoch_history)),
+            )
+            .run()
+            .await?;
+        }
+
+        let txn_manifests = transactions.into_iter().map(|b| b.manifest).collect();
+        TransactionRestoreBatchController::new(
+            global_opt,
+            self.storage,
+            txn_manifests,
+            None, /* replay_from_version */
+            Some(epoch_history),
+            vec![],
+        )
+        .run()
+        .await?;
+
+        Ok(())
+    }
+}

--- a/aptos-db-tool/src/commands/backup/metadata/cache.rs
+++ b/aptos-db-tool/src/commands/backup/metadata/cache.rs
@@ -1,0 +1,231 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    metadata::{view::MetadataView, Metadata},
+    metrics::metadata::{NUM_META_DOWNLOAD, NUM_META_FILES, NUM_META_MISS},
+    storage::{BackupStorage, FileHandle},
+    utils::{error_notes::ErrorNotes, stream::StreamX},
+};
+use anyhow::{anyhow, Context, Result};
+use aptos_logger::prelude::*;
+use aptos_temppath::TempPath;
+use async_trait::async_trait;
+use clap::Parser;
+use futures::stream::poll_fn;
+use once_cell::sync::Lazy;
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    sync::Arc,
+    time::Instant,
+};
+use tokio::{
+    fs::{create_dir_all, read_dir, remove_file, OpenOptions},
+    io::{AsyncRead, AsyncReadExt},
+};
+use tokio_stream::StreamExt;
+
+static TEMP_METADATA_CACHE_DIR: Lazy<TempPath> = Lazy::new(|| {
+    let dir = TempPath::new();
+    dir.create_as_dir()
+        .expect("Temp metadata dir should create.");
+    dir
+});
+
+#[derive(Parser, Clone)]
+pub struct MetadataCacheOpt {
+    #[clap(
+        long = "metadata-cache-dir",
+        parse(from_os_str),
+        help = "Metadata cache dir. If specified and shared across runs, \
+        metadata files in cache won't be downloaded again from backup source, speeding up tool \
+        boot up significantly. Cache content can be messed up if used across the devnet, \
+        the testnet and the mainnet, hence it [Defaults to temporary dir]."
+    )]
+    dir: Option<PathBuf>,
+}
+
+impl MetadataCacheOpt {
+    // in cache we save things other than the cached files.
+    const SUB_DIR: &'static str = "cache";
+
+    fn cache_dir(&self) -> PathBuf {
+        self.dir
+            .clone()
+            .unwrap_or_else(|| TEMP_METADATA_CACHE_DIR.path().to_path_buf())
+            .join(Self::SUB_DIR)
+    }
+}
+
+/// Try to load the identity metadata, if not present, try to write one in.
+pub async fn initialize_identity(storage: &Arc<dyn BackupStorage>) -> Result<()> {
+    let metadata = Metadata::new_random_identity();
+    storage
+        .save_metadata_line(&metadata.name(), &metadata.to_text_line()?)
+        .await
+}
+
+/// Sync local cache folder with remote storage, and load all metadata entries from the cache.
+pub async fn sync_and_load(
+    opt: &MetadataCacheOpt,
+    storage: Arc<dyn BackupStorage>,
+    concurrent_downloads: usize,
+) -> Result<MetadataView> {
+    let timer = Instant::now();
+    let cache_dir = opt.cache_dir();
+    create_dir_all(&cache_dir).await.err_notes(&cache_dir)?; // create if not present already
+
+    // List cached metadata files.
+    let mut dir = read_dir(&cache_dir).await.err_notes(&cache_dir)?;
+    let local_entries = poll_fn(|ctx| {
+        ::std::task::Poll::Ready(match futures::ready!(dir.poll_next_entry(ctx)) {
+            Ok(Some(entry)) => Some(Ok(entry)),
+            Ok(None) => None,
+            Err(err) => Some(Err(err)),
+        })
+    })
+    .collect::<tokio::io::Result<Vec<_>>>()
+    .await?;
+    let local_hashes = local_entries
+        .iter()
+        .map(|e| {
+            e.file_name()
+                .into_string()
+                .map_err(|s| anyhow!("into_string() failed for file name {:?}", s))
+        })
+        .collect::<Result<HashSet<_>>>()?;
+
+    // List remote metadata files.
+    let mut remote_file_handles = storage.list_metadata_files().await?;
+    if remote_file_handles.is_empty() {
+        initialize_identity(&storage).await.context(
+            "\
+            Backup storage appears empty and failed to put in identity metadata, \
+            no point to go on. If you believe there is content in the backup, check authentication.\
+            ",
+        )?;
+        remote_file_handles = storage.list_metadata_files().await?;
+    }
+    let remote_file_handle_by_hash: HashMap<_, _> = remote_file_handles
+        .into_iter()
+        .map(|file_handle| (file_handle.file_handle_hash(), file_handle))
+        .collect();
+    let remote_hashes: HashSet<_> = remote_file_handle_by_hash.keys().cloned().collect();
+    info!("Metadata files listed.");
+    NUM_META_FILES.set(remote_hashes.len() as i64);
+
+    // Sync local cache with remote metadata files.
+    let stale_local_hashes = local_hashes.difference(&remote_hashes);
+    let new_remote_hashes = remote_hashes.difference(&local_hashes).collect::<Vec<_>>();
+    let up_to_date_local_hashes = local_hashes.intersection(&remote_hashes);
+
+    for h in stale_local_hashes {
+        let file = cache_dir.join(h);
+        remove_file(&file).await.err_notes(&file)?;
+        info!("Deleted stale metadata files in cache.");
+    }
+
+    let num_new_files = new_remote_hashes.len();
+    NUM_META_MISS.set(num_new_files as i64);
+    NUM_META_DOWNLOAD.set(0);
+    let futs = new_remote_hashes.iter().enumerate().map(|(i, h)| {
+        let fh_by_h_ref = &remote_file_handle_by_hash;
+        let storage_ref = &storage;
+        let cache_dir_ref = &cache_dir;
+
+        async move {
+            let file_handle = fh_by_h_ref.get(*h).expect("In map.");
+            let local_file = cache_dir_ref.join(*h);
+            let local_tmp_file = cache_dir_ref.join(format!(".{}", *h));
+            // download to tmp file ".xxxxxx"
+            tokio::io::copy(
+                &mut storage_ref
+                    .open_for_read(file_handle)
+                    .await
+                    .err_notes(file_handle)?,
+                &mut OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&local_tmp_file)
+                    .await
+                    .err_notes(&local_file)?,
+            )
+            .await?;
+            // rename to target file only if successful; stale tmp file caused by failure will be
+            // reclaimed on next run
+            tokio::fs::rename(local_tmp_file, local_file).await?;
+            info!(
+                file_handle = file_handle,
+                processed = i + 1,
+                total = num_new_files,
+                "Metadata file downloaded."
+            );
+            NUM_META_DOWNLOAD.inc();
+            Ok(())
+        }
+    });
+    futures::stream::iter(futs)
+        .buffered_x(
+            concurrent_downloads * 2, /* buffer size */
+            concurrent_downloads,     /* concurrency */
+        )
+        .collect::<Result<Vec<_>>>()
+        .await?;
+
+    info!("Loading all metadata files to memory.");
+    // Load metadata from synced cache files.
+    let mut metadata_vec = Vec::new();
+    for h in new_remote_hashes.into_iter().chain(up_to_date_local_hashes) {
+        let cached_file = cache_dir.join(h);
+        metadata_vec.extend(
+            OpenOptions::new()
+                .read(true)
+                .open(&cached_file)
+                .await
+                .err_notes(&cached_file)?
+                .load_metadata_lines()
+                .await
+                .err_notes(&cached_file)?
+                .into_iter(),
+        )
+    }
+    info!(
+        total_time = timer.elapsed().as_secs(),
+        "Metadata cache loaded.",
+    );
+    Ok(metadata_vec.into())
+}
+
+trait FileHandleHash {
+    fn file_handle_hash(&self) -> String;
+}
+
+impl FileHandleHash for FileHandle {
+    fn file_handle_hash(&self) -> String {
+        use std::hash::{Hash, Hasher};
+
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.hash(&mut hasher);
+        format!("{:x}", hasher.finish())
+    }
+}
+
+#[async_trait]
+trait LoadMetadataLines {
+    async fn load_metadata_lines(&mut self) -> Result<Vec<Metadata>>;
+}
+
+#[async_trait]
+impl<R: AsyncRead + Send + Unpin> LoadMetadataLines for R {
+    async fn load_metadata_lines(&mut self) -> Result<Vec<Metadata>> {
+        let mut buf = String::new();
+        self.read_to_string(&mut buf)
+            .await
+            .err_notes((file!(), line!(), &buf))?;
+        Ok(buf
+            .lines()
+            .map(serde_json::from_str::<Metadata>)
+            .collect::<Result<_, serde_json::error::Error>>()?)
+    }
+}

--- a/aptos-db-tool/src/commands/backup/metadata/mod.rs
+++ b/aptos-db-tool/src/commands/backup/metadata/mod.rs
@@ -1,0 +1,112 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod cache;
+pub mod view;
+
+use crate::commands::backup::storage::{FileHandle, ShellSafeName, TextLine};
+use anyhow::Result;
+use aptos_crypto::HashValue;
+use aptos_types::transaction::Version;
+use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
+
+#[derive(Deserialize, Serialize)]
+#[allow(clippy::enum_variant_names)] // to introduce: BackupperId, etc
+pub(crate) enum Metadata {
+    EpochEndingBackup(EpochEndingBackupMeta),
+    StateSnapshotBackup(StateSnapshotBackupMeta),
+    TransactionBackup(TransactionBackupMeta),
+    Identity(IdentityMeta),
+}
+
+impl Metadata {
+    pub fn new_epoch_ending_backup(
+        first_epoch: u64,
+        last_epoch: u64,
+        first_version: Version,
+        last_version: Version,
+        manifest: FileHandle,
+    ) -> Self {
+        Self::EpochEndingBackup(EpochEndingBackupMeta {
+            first_epoch,
+            last_epoch,
+            first_version,
+            last_version,
+            manifest,
+        })
+    }
+
+    pub fn new_state_snapshot_backup(epoch: u64, version: Version, manifest: FileHandle) -> Self {
+        Self::StateSnapshotBackup(StateSnapshotBackupMeta {
+            epoch,
+            version,
+            manifest,
+        })
+    }
+
+    pub fn new_transaction_backup(
+        first_version: Version,
+        last_version: Version,
+        manifest: FileHandle,
+    ) -> Self {
+        Self::TransactionBackup(TransactionBackupMeta {
+            first_version,
+            last_version,
+            manifest,
+        })
+    }
+
+    pub fn new_random_identity() -> Self {
+        Self::Identity(IdentityMeta {
+            id: HashValue::random(),
+        })
+    }
+
+    pub fn name(&self) -> ShellSafeName {
+        match self {
+            Self::EpochEndingBackup(e) => {
+                format!("epoch_ending_{}-{}.meta", e.first_epoch, e.last_epoch)
+            },
+            Self::StateSnapshotBackup(s) => format!("state_snapshot_ver_{}.meta", s.version),
+            Self::TransactionBackup(t) => {
+                format!("transaction_{}-{}.meta", t.first_version, t.last_version,)
+            },
+            Metadata::Identity(_) => "identity.meta".into(),
+        }
+        .try_into()
+        .unwrap()
+    }
+
+    pub fn to_text_line(&self) -> Result<TextLine> {
+        TextLine::new(&serde_json::to_string(self)?)
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+pub struct EpochEndingBackupMeta {
+    pub first_epoch: u64,
+    pub last_epoch: u64,
+    pub first_version: Version,
+    pub last_version: Version,
+    pub manifest: FileHandle,
+}
+
+#[derive(Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+pub struct StateSnapshotBackupMeta {
+    pub epoch: u64,
+    pub version: Version,
+    pub manifest: FileHandle,
+}
+
+#[derive(Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+pub struct TransactionBackupMeta {
+    pub first_version: Version,
+    pub last_version: Version,
+    pub manifest: FileHandle,
+}
+
+#[derive(Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+pub struct IdentityMeta {
+    pub id: HashValue,
+}

--- a/aptos-db-tool/src/commands/backup/metadata/view.rs
+++ b/aptos-db-tool/src/commands/backup/metadata/view.rs
@@ -1,0 +1,206 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::metadata::{
+    EpochEndingBackupMeta, IdentityMeta, Metadata, StateSnapshotBackupMeta, TransactionBackupMeta,
+};
+use anyhow::{anyhow, ensure, Result};
+use aptos_types::transaction::Version;
+use itertools::Itertools;
+use std::{fmt, str::FromStr};
+
+pub struct MetadataView {
+    epoch_ending_backups: Vec<EpochEndingBackupMeta>,
+    state_snapshot_backups: Vec<StateSnapshotBackupMeta>,
+    transaction_backups: Vec<TransactionBackupMeta>,
+    _identity: Option<IdentityMeta>,
+}
+
+impl MetadataView {
+    pub fn get_storage_state(&self) -> Result<BackupStorageState> {
+        let latest_epoch_ending_epoch =
+            self.epoch_ending_backups.iter().map(|e| e.last_epoch).max();
+        let latest_state_snapshot = self.select_state_snapshot(Version::MAX)?;
+        let (latest_state_snapshot_epoch, latest_state_snapshot_version) =
+            match latest_state_snapshot {
+                Some(snapshot) => (Some(snapshot.epoch), Some(snapshot.version)),
+                None => (None, None),
+            };
+        let latest_transaction_version = self
+            .transaction_backups
+            .iter()
+            .map(|t| t.last_version)
+            .max();
+
+        Ok(BackupStorageState {
+            latest_epoch_ending_epoch,
+            latest_state_snapshot_epoch,
+            latest_state_snapshot_version,
+            latest_transaction_version,
+        })
+    }
+
+    pub fn select_state_snapshot(
+        &self,
+        target_version: Version,
+    ) -> Result<Option<StateSnapshotBackupMeta>> {
+        Ok(self
+            .state_snapshot_backups
+            .iter()
+            .sorted()
+            .rev()
+            .find(|m| m.version <= target_version)
+            .map(Clone::clone))
+    }
+
+    pub fn expect_state_snapshot(&self, version: Version) -> Result<StateSnapshotBackupMeta> {
+        self.state_snapshot_backups
+            .iter()
+            .find(|m| m.version == version)
+            .map(Clone::clone)
+            .ok_or_else(|| anyhow!("State snapshot not found at version {}", version))
+    }
+
+    pub fn select_transaction_backups(
+        &self,
+        start_version: Version,
+        target_version: Version,
+    ) -> Result<Vec<TransactionBackupMeta>> {
+        // This can be more flexible, but for now we assume and check backups are continuous in
+        // range (which is always true when we backup from a single backup coordinator)
+        let mut next_ver = 0;
+        let mut res = Vec::new();
+        for backup in self.transaction_backups.iter().sorted() {
+            if backup.first_version > target_version {
+                break;
+            }
+            ensure!(
+                backup.first_version == next_ver,
+                "Transaction backup ranges not continuous, expecting version {}, got {}.",
+                next_ver,
+                backup.first_version,
+            );
+
+            if backup.last_version >= start_version {
+                res.push(backup.clone());
+            }
+
+            next_ver = backup.last_version + 1;
+        }
+
+        Ok(res)
+    }
+
+    pub fn max_transaction_version(&self) -> Result<Option<Version>> {
+        Ok(self
+            .transaction_backups
+            .iter()
+            .sorted()
+            .last()
+            .map(|backup| backup.last_version))
+    }
+
+    pub fn select_epoch_ending_backups(
+        &self,
+        target_version: Version,
+    ) -> Result<Vec<EpochEndingBackupMeta>> {
+        // This can be more flexible, but for now we assume and check backups are continuous in
+        // range (which is always true when we backup from a single backup coordinator)
+        let mut next_epoch = 0;
+        let mut res = Vec::new();
+        for backup in self.epoch_ending_backups.iter().sorted() {
+            if backup.first_version > target_version {
+                break;
+            }
+
+            ensure!(
+                backup.first_epoch == next_epoch,
+                "Epoch ending backup ranges not continuous, expecting epoch {}, got {}.",
+                next_epoch,
+                backup.first_epoch,
+            );
+            res.push(backup.clone());
+
+            next_epoch = backup.last_epoch + 1;
+        }
+
+        Ok(res)
+    }
+}
+
+impl From<Vec<Metadata>> for MetadataView {
+    fn from(metadata_vec: Vec<Metadata>) -> Self {
+        let mut epoch_ending_backups = Vec::new();
+        let mut state_snapshot_backups = Vec::new();
+        let mut transaction_backups = Vec::new();
+        let mut identity = None;
+
+        for meta in metadata_vec {
+            match meta {
+                Metadata::EpochEndingBackup(e) => epoch_ending_backups.push(e),
+                Metadata::StateSnapshotBackup(s) => state_snapshot_backups.push(s),
+                Metadata::TransactionBackup(t) => transaction_backups.push(t),
+                Metadata::Identity(i) => identity = Some(i),
+            }
+        }
+
+        Self {
+            epoch_ending_backups,
+            state_snapshot_backups,
+            transaction_backups,
+            _identity: identity,
+        }
+    }
+}
+
+pub struct BackupStorageState {
+    pub latest_epoch_ending_epoch: Option<u64>,
+    pub latest_state_snapshot_epoch: Option<u64>,
+    pub latest_state_snapshot_version: Option<Version>,
+    pub latest_transaction_version: Option<Version>,
+}
+
+impl fmt::Display for BackupStorageState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "latest_epoch_ending_epoch: {}, latest_state_snapshot_epoch: {}, latest_state_snapshot_version: {}, latest_transaction_version: {}",
+            self.latest_epoch_ending_epoch.as_ref().map_or("none".to_string(), u64::to_string),
+            self.latest_state_snapshot_epoch.as_ref().map_or("none".to_string(), u64::to_string),
+            self.latest_state_snapshot_version.as_ref().map_or("none".to_string(), Version::to_string),
+            self.latest_transaction_version.as_ref().map_or("none".to_string(), Version::to_string),
+        )
+    }
+}
+
+trait ParseOptionU64 {
+    fn parse_option_u64(&self) -> Result<Option<u64>>;
+}
+
+impl ParseOptionU64 for Option<regex::Match<'_>> {
+    fn parse_option_u64(&self) -> Result<Option<u64>> {
+        let m = self.ok_or_else(|| anyhow!("No match."))?;
+        if m.as_str() == "none" {
+            Ok(None)
+        } else {
+            Ok(Some(m.as_str().parse()?))
+        }
+    }
+}
+
+impl FromStr for BackupStorageState {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let captures = regex::Regex::new(
+            r"latest_epoch_ending_epoch: (none|\d+), latest_state_snapshot_epoch: (none|\d+), latest_state_snapshot_version: (none|\d+), latest_transaction_version: (none|\d+)",
+        )?.captures(s).ok_or_else(|| anyhow!("Not in BackupStorageState display format: {}", s))?;
+
+        Ok(Self {
+            latest_epoch_ending_epoch: captures.get(1).parse_option_u64()?,
+            latest_state_snapshot_epoch: captures.get(2).parse_option_u64()?,
+            latest_state_snapshot_version: captures.get(3).parse_option_u64()?,
+            latest_transaction_version: captures.get(4).parse_option_u64()?,
+        })
+    }
+}

--- a/aptos-db-tool/src/commands/backup/metrics/backup.rs
+++ b/aptos-db-tool/src/commands/backup/metrics/backup.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_push_metrics::{register_int_gauge, IntGauge};
+use once_cell::sync::Lazy;
+
+pub static HEARTBEAT_TS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_backup_coordinator_heartbeat_timestamp_s",
+        "Timestamp when the backup coordinator successfully updates state from the backup service."
+    )
+    .unwrap()
+});
+
+pub static EPOCH_ENDING_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_backup_coordinator_epoch_ending_epoch",
+        "Epoch of the latest epoch ending backed up."
+    )
+    .unwrap()
+});
+
+pub static STATE_SNAPSHOT_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_backup_coordinator_state_snapshot_epoch",
+        "The epoch at the end of which the latest state snapshot was taken."
+    )
+    .unwrap()
+});
+
+pub static TRANSACTION_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_backup_coordinator_transaction_version",
+        "Version of the latest transaction backed up."
+    )
+    .unwrap()
+});

--- a/aptos-db-tool/src/commands/backup/metrics/metadata.rs
+++ b/aptos-db-tool/src/commands/backup/metrics/metadata.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_push_metrics::{register_int_gauge, IntGauge};
+use once_cell::sync::Lazy;
+
+pub static NUM_META_FILES: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_backup_metadata_num_files",
+        "Number of metadata files in total."
+    )
+    .unwrap()
+});
+
+pub static NUM_META_MISS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_backup_metadata_num_file_cache_misses",
+        "Number of metadata files to download due to non-existence in local cache."
+    )
+    .unwrap()
+});
+
+pub static NUM_META_DOWNLOAD: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_backup_metadata_num_file_downloads",
+        "Number of metadata files to download due to non-existence in local cache."
+    )
+    .unwrap()
+});

--- a/aptos-db-tool/src/commands/backup/metrics/mod.rs
+++ b/aptos-db-tool/src/commands/backup/metrics/mod.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_push_metrics::{exponential_buckets, register_histogram_vec, HistogramVec};
+use once_cell::sync::Lazy;
+
+pub mod backup;
+pub mod metadata;
+pub mod restore;
+pub mod verify;
+
+pub static OTHER_TIMERS_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        // metric name
+        "aptos_backup_cli_other_timers_seconds",
+        // metric description
+        "Various timers for performance analysis.",
+        // metric labels (dimensions)
+        &["name"],
+        exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 22).unwrap(),
+    )
+    .unwrap()
+});

--- a/aptos-db-tool/src/commands/backup/metrics/restore.rs
+++ b/aptos-db-tool/src/commands/backup/metrics/restore.rs
@@ -1,0 +1,93 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_push_metrics::{register_int_gauge, IntGauge};
+use once_cell::sync::Lazy;
+
+pub static COORDINATOR_TARGET_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_restore_coordinator_target_version",
+        "The target version to restore to by the restore coordinator."
+    )
+    .unwrap()
+});
+
+pub static EPOCH_ENDING_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_restore_epoch_ending_epoch",
+        "Current epoch ending epoch being restored."
+    )
+    .unwrap()
+});
+
+pub static EPOCH_ENDING_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_restore_epoch_ending_version",
+        "Last version of the current epoch ending being restored."
+    )
+    .unwrap()
+});
+
+pub static STATE_SNAPSHOT_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_restore_state_snapshot_version",
+        "The version that a state snapshot restores to."
+    )
+    .unwrap()
+});
+
+pub static STATE_SNAPSHOT_TARGET_LEAF_INDEX: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_restore_state_snapshot_target_leaf_index",
+        "The biggest leaf index in state snapshot being restored (# of accounts - 1)."
+    )
+    .unwrap()
+});
+
+pub static STATE_SNAPSHOT_LEAF_INDEX: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_restore_state_snapshot_leaf_index",
+        "Current leaf index being restored."
+    )
+    .unwrap()
+});
+
+pub static TRANSACTION_SAVE_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_restore_transaction_save_version",
+        "Version of the transaction being restored without replaying."
+    )
+    .unwrap()
+});
+
+pub static TRANSACTION_REPLAY_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_restore_transaction_replay_version",
+        "Version of the transaction being replayed"
+    )
+    .unwrap()
+});
+
+pub static COORDINATOR_START_TS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_restore_coordinator_start_timestamp_s",
+        "Timestamp when the verify coordinator starts."
+    )
+    .unwrap()
+});
+
+pub static COORDINATOR_SUCC_TS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_restore_coordinator_succeed_timestamp_s",
+        "Timestamp when the verify coordinator fails."
+    )
+    .unwrap()
+});
+
+pub static COORDINATOR_FAIL_TS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_restore_coordinator_fail_timestamp_s",
+        "Timestamp when the verify coordinator fails."
+    )
+    .unwrap()
+});

--- a/aptos-db-tool/src/commands/backup/metrics/verify.rs
+++ b/aptos-db-tool/src/commands/backup/metrics/verify.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_push_metrics::{register_int_gauge, IntGauge};
+use once_cell::sync::Lazy;
+
+pub static VERIFY_EPOCH_ENDING_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_backup_verify_epoch_ending_epoch",
+        "Current epoch ending epoch being verified."
+    )
+    .unwrap()
+});
+
+pub static VERIFY_EPOCH_ENDING_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_backup_verify_epoch_ending_version",
+        "Last version of the current epoch ending being verified."
+    )
+    .unwrap()
+});
+
+pub static VERIFY_STATE_SNAPSHOT_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_backup_verify_state_snapshot_version",
+        "The version of the verified state snapshot."
+    )
+    .unwrap()
+});
+
+pub static VERIFY_STATE_SNAPSHOT_TARGET_LEAF_INDEX: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_backup_verify_state_snapshot_target_leaf_index",
+        "The biggest leaf index in state snapshot being verified (# of accounts - 1)."
+    )
+    .unwrap()
+});
+
+pub static VERIFY_STATE_SNAPSHOT_LEAF_INDEX: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_backup_verify_state_snapshot_leaf_index",
+        "Current leaf index being verified."
+    )
+    .unwrap()
+});
+
+pub static VERIFY_TRANSACTION_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_backup_verify_transaction_version",
+        "Version of the transaction being verified."
+    )
+    .unwrap()
+});
+
+pub static VERIFY_COORDINATOR_START_TS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_backup_verify_coordinator_start_timestamp_s",
+        "Timestamp when the verify coordinator starts."
+    )
+    .unwrap()
+});
+
+pub static VERIFY_COORDINATOR_SUCC_TS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_backup_verify_coordinator_succeed_timestamp_s",
+        "Timestamp when the verify coordinator fails."
+    )
+    .unwrap()
+});
+
+pub static VERIFY_COORDINATOR_FAIL_TS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_db_backup_verify_coordinator_fail_timestamp_s",
+        "Timestamp when the verify coordinator fails."
+    )
+    .unwrap()
+});

--- a/aptos-db-tool/src/commands/backup/mod.rs
+++ b/aptos-db-tool/src/commands/backup/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod backup_types;
+pub mod commands;
+pub mod coordinators;
+pub mod metadata;
+pub mod metrics;
+pub mod storage;
+pub mod utils;

--- a/aptos-db-tool/src/commands/backup/storage/command_adapter/command.rs
+++ b/aptos-db-tool/src/commands/backup/storage/command_adapter/command.rs
@@ -1,0 +1,225 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    storage::command_adapter::config::EnvVar, utils::error_notes::ErrorNotes,
+};
+use anyhow::{bail, ensure, Result};
+use aptos_logger::prelude::*;
+use futures::{
+    future::BoxFuture,
+    task::{Context, Poll},
+    Future, FutureExt,
+};
+use std::{
+    fmt::{Debug, Formatter},
+    process::Stdio,
+};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    macros::support::Pin,
+    process::{Child, ChildStdin, ChildStdout},
+};
+
+pub(super) struct Command {
+    cmd_str: String,
+    // API parameters, like $FILE_HANDLE for `open_for_read()`
+    param_env_vars: Vec<EnvVar>,
+    // Env vars defined in the config file.
+    config_env_vars: Vec<EnvVar>,
+}
+
+impl Command {
+    pub fn new(raw_cmd: &str, param_env_vars: Vec<EnvVar>, config_env_vars: Vec<EnvVar>) -> Self {
+        Self {
+            cmd_str: format!("set -o nounset -o errexit -o pipefail; {}", raw_cmd),
+            param_env_vars,
+            config_env_vars,
+        }
+    }
+
+    pub fn spawn(self) -> Result<SpawnedCommand> {
+        SpawnedCommand::spawn(self)
+    }
+}
+
+impl Debug for Command {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            r#""{}" with params [{}]"#,
+            self.cmd_str,
+            self.param_env_vars
+                .iter()
+                .map(|v| format!("{}={}", v.key, v.value))
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
+    }
+}
+
+pub(super) struct SpawnedCommand {
+    command: Command,
+    child: Child,
+}
+
+impl SpawnedCommand {
+    pub fn spawn(command: Command) -> Result<Self> {
+        debug!("Spawning {:?}", command);
+
+        let mut cmd = tokio::process::Command::new("bash");
+        cmd.args(["-c", &command.cmd_str]);
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+        for v in command
+            .config_env_vars
+            .iter()
+            .chain(command.param_env_vars.iter())
+        {
+            cmd.env(&v.key, &v.value);
+        }
+        let child = cmd.spawn().err_notes(&cmd)?;
+        ensure!(
+            child.stdin.is_some(),
+            "child.stdin is None. cmd: {:?}",
+            &command,
+        );
+        ensure!(
+            child.stdout.is_some(),
+            "child.stdout is None. cmd: {:?}",
+            &command,
+        );
+
+        Ok(Self { command, child })
+    }
+
+    pub fn stdout(&mut self) -> &mut ChildStdout {
+        self.child.stdout.as_mut().unwrap()
+    }
+
+    pub fn stdin(&mut self) -> &mut ChildStdin {
+        self.child.stdin.as_mut().unwrap()
+    }
+
+    pub fn into_data_source<'a>(self) -> ChildStdoutAsDataSource<'a> {
+        ChildStdoutAsDataSource::new(self)
+    }
+
+    pub fn into_data_sink<'a>(self) -> ChildStdinAsDataSink<'a> {
+        ChildStdinAsDataSink::new(self)
+    }
+
+    pub async fn join(self) -> Result<()> {
+        match self.child.wait_with_output().await {
+            Ok(output) => {
+                if output.status.success() {
+                    Ok(())
+                } else {
+                    bail!(
+                        "Command {:?} failed with exit status: {}",
+                        self.command,
+                        output.status
+                    )
+                }
+            },
+            Err(e) => bail!("Failed joining command {:?}: {}", self.command, e),
+        }
+    }
+}
+
+pub(super) struct ChildStdoutAsDataSource<'a> {
+    child: Option<SpawnedCommand>,
+    join_fut: Option<BoxFuture<'a, Result<()>>>,
+}
+
+impl<'a> ChildStdoutAsDataSource<'a> {
+    fn new(child: SpawnedCommand) -> Self {
+        Self {
+            child: Some(child),
+            join_fut: None,
+        }
+    }
+}
+
+impl<'a> AsyncRead for ChildStdoutAsDataSource<'a> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<::std::io::Result<()>> {
+        if self.child.is_some() {
+            let filled_before_poll = buf.filled().len();
+            let res = Pin::new(self.child.as_mut().unwrap().stdout()).poll_read(cx, buf);
+            match res {
+                Poll::Ready(Ok(())) if buf.filled().len() == filled_before_poll => {
+                    // hit EOF, start joining self.child
+                    self.join_fut = Some(self.child.take().unwrap().join().boxed());
+                },
+                _ => return res,
+            }
+        }
+
+        Pin::new(self.join_fut.as_mut().unwrap())
+            .poll(cx)
+            .map_err(|e| ::std::io::Error::new(::std::io::ErrorKind::Other, e))
+    }
+}
+
+pub(super) struct ChildStdinAsDataSink<'a> {
+    child: Option<SpawnedCommand>,
+    join_fut: Option<BoxFuture<'a, Result<()>>>,
+}
+
+impl<'a> ChildStdinAsDataSink<'a> {
+    fn new(child: SpawnedCommand) -> Self {
+        Self {
+            child: Some(child),
+            join_fut: None,
+        }
+    }
+}
+
+impl<'a> AsyncWrite for ChildStdinAsDataSink<'a> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, tokio::io::Error>> {
+        if self.join_fut.is_some() {
+            Poll::Ready(Err(tokio::io::ErrorKind::BrokenPipe.into()))
+        } else {
+            Pin::new(self.child.as_mut().unwrap().stdin()).poll_write(cx, buf)
+        }
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), tokio::io::Error>> {
+        if self.join_fut.is_some() {
+            Poll::Ready(Err(tokio::io::ErrorKind::BrokenPipe.into()))
+        } else {
+            Pin::new(self.child.as_mut().unwrap().stdin()).poll_flush(cx)
+        }
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), tokio::io::Error>> {
+        if self.join_fut.is_none() {
+            let res = Pin::new(self.child.as_mut().unwrap().stdin()).poll_shutdown(cx);
+            if let Poll::Ready(Ok(_)) = res {
+                // pipe shutdown successful
+                self.join_fut = Some(self.child.take().unwrap().join().boxed())
+            } else {
+                return res;
+            }
+        }
+
+        Pin::new(self.join_fut.as_mut().unwrap())
+            .poll(cx)
+            .map_err(|e| tokio::io::Error::new(tokio::io::ErrorKind::Other, e))
+    }
+}

--- a/aptos-db-tool/src/commands/backup/storage/command_adapter/config.rs
+++ b/aptos-db-tool/src/commands/backup/storage/command_adapter/config.rs
@@ -1,0 +1,94 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    storage::{BackupHandle, FileHandle},
+    utils::error_notes::ErrorNotes,
+};
+use anyhow::Result;
+use serde::Deserialize;
+use std::path::Path;
+use tokio::io::AsyncReadExt;
+
+#[derive(Clone, Deserialize)]
+pub struct EnvVar {
+    pub key: String,
+    pub value: String,
+}
+
+impl EnvVar {
+    pub fn backup_name(value: String) -> Self {
+        Self::new("BACKUP_NAME".to_string(), value)
+    }
+
+    pub fn file_name(value: String) -> Self {
+        Self::new("FILE_NAME".to_string(), value)
+    }
+
+    pub fn file_handle(value: FileHandle) -> Self {
+        Self::new("FILE_HANDLE".to_string(), value)
+    }
+
+    pub fn backup_handle(value: BackupHandle) -> Self {
+        Self::new("BACKUP_HANDLE".to_string(), value)
+    }
+
+    pub fn new(key: String, value: String) -> Self {
+        Self { key, value }
+    }
+}
+
+#[derive(Clone, Default, Deserialize)]
+pub struct Commands {
+    /// Command line to create backup.
+    /// input env vars:
+    ///     $BACKUP_NAME
+    /// expected output on stdout:
+    ///     BackupHandle, trailing newline is trimmed
+    pub create_backup: String,
+    /// Command line to open a file for writing.
+    /// input env vars:
+    ///     $BACKUP_HANDLE returned from the previous command
+    ///     $FILE_NAME
+    /// stdin will be fed with byte stream.
+    /// expected output on stdout:
+    ///     FileHandle, trailing newline
+    pub create_for_write: String,
+    /// Command line to open a file for reading.
+    /// input env vars:
+    ///     $FILE_NAME
+    /// expected stdout to stream out bytes of the file.
+    pub open_for_read: String,
+    /// Command line to save a line of metadata
+    /// input env vars:
+    ///     $FILE_NAME
+    /// stdin will be fed with a line of text with a trailing newline.
+    pub save_metadata_line: String,
+    /// Command line to list all existing metadata file handles.
+    /// expected stdout to stream out lines of file handles.
+    pub list_metadata_files: String,
+}
+
+#[derive(Clone, Default, Deserialize)]
+pub struct CommandAdapterConfig {
+    /// Command lines that implements `BackupStorage` APIs.
+    pub commands: Commands,
+    /// Additional environment variables to be set when command lines are spawned.
+    pub env_vars: Vec<EnvVar>,
+}
+
+impl CommandAdapterConfig {
+    pub async fn load_from_file(path: &Path) -> Result<Self> {
+        let path_str = path.to_str().unwrap_or_default();
+        let mut file = tokio::fs::File::open(path).await.err_notes(path_str)?;
+        let mut content = Vec::new();
+        file.read_to_end(&mut content).await.err_notes(path_str)?;
+
+        Ok(serde_yaml::from_slice(&content)?)
+    }
+
+    #[allow(dead_code)]
+    pub fn load_from_str(content: &str) -> Result<Self> {
+        Ok(serde_yaml::from_str(content)?)
+    }
+}

--- a/aptos-db-tool/src/commands/backup/storage/command_adapter/mod.rs
+++ b/aptos-db-tool/src/commands/backup/storage/command_adapter/mod.rs
@@ -1,0 +1,146 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+mod command;
+pub mod config;
+
+#[cfg(test)]
+mod tests;
+
+use crate::commands::backup::{
+    storage::{
+        command_adapter::{
+            command::Command,
+            config::{CommandAdapterConfig, EnvVar},
+        },
+        BackupHandle, BackupHandleRef, BackupStorage, FileHandle, FileHandleRef, ShellSafeName,
+        TextLine,
+    },
+    utils::error_notes::ErrorNotes,
+};
+use anyhow::Result;
+use async_trait::async_trait;
+use clap::Parser;
+use std::path::PathBuf;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+#[derive(Parser, Clone)]
+pub struct CommandAdapterOpt {
+    #[clap(
+        long = "config",
+        help = "Config file for the command adapter backup store."
+    )]
+    config: PathBuf,
+}
+
+/// A BackupStorage that delegates required APIs to configured command lines.
+/// see `CommandAdapterConfig`.
+pub struct CommandAdapter {
+    config: CommandAdapterConfig,
+}
+
+impl CommandAdapter {
+    pub fn new(config: CommandAdapterConfig) -> Self {
+        Self { config }
+    }
+
+    pub async fn new_with_opt(opt: CommandAdapterOpt) -> Result<Self> {
+        let config = CommandAdapterConfig::load_from_file(&opt.config).await?;
+
+        Ok(Self::new(config))
+    }
+
+    fn cmd(&self, cmd_str: &str, env_vars: Vec<EnvVar>) -> Command {
+        Command::new(cmd_str, env_vars, self.config.env_vars.clone())
+    }
+}
+
+#[async_trait]
+impl BackupStorage for CommandAdapter {
+    async fn create_backup(&self, name: &ShellSafeName) -> Result<BackupHandle> {
+        let mut child = self
+            .cmd(
+                &self.config.commands.create_backup,
+                vec![EnvVar::backup_name(name.to_string())],
+            )
+            .spawn()?;
+        let mut backup_handle = BackupHandle::new();
+        child
+            .stdout()
+            .read_to_string(&mut backup_handle)
+            .await
+            .err_notes((file!(), line!(), name))?;
+        child.join().await?;
+        backup_handle.truncate(backup_handle.trim_end().len());
+
+        Ok(backup_handle)
+    }
+
+    async fn create_for_write(
+        &self,
+        backup_handle: &BackupHandleRef,
+        name: &ShellSafeName,
+    ) -> Result<(FileHandle, Box<dyn AsyncWrite + Send + Unpin>)> {
+        let mut child = self
+            .cmd(
+                &self.config.commands.create_for_write,
+                vec![
+                    EnvVar::backup_handle(backup_handle.to_string()),
+                    EnvVar::file_name(name.to_string()),
+                ],
+            )
+            .spawn()?;
+        let mut file_handle = FileHandle::new();
+        child
+            .stdout()
+            .read_to_string(&mut file_handle)
+            .await
+            .err_notes(backup_handle)?;
+        file_handle.truncate(file_handle.trim_end().len());
+        Ok((file_handle, Box::new(child.into_data_sink())))
+    }
+
+    async fn open_for_read(
+        &self,
+        file_handle: &FileHandleRef,
+    ) -> Result<Box<dyn AsyncRead + Send + Unpin>> {
+        let child = self
+            .cmd(
+                &self.config.commands.open_for_read,
+                vec![EnvVar::file_handle(file_handle.to_string())],
+            )
+            .spawn()?;
+        Ok(Box::new(child.into_data_source()))
+    }
+
+    async fn save_metadata_line(&self, name: &ShellSafeName, content: &TextLine) -> Result<()> {
+        let mut child = self
+            .cmd(
+                &self.config.commands.save_metadata_line,
+                vec![EnvVar::file_name(name.to_string())],
+            )
+            .spawn()?;
+
+        child
+            .stdin()
+            .write_all(content.as_ref().as_bytes())
+            .await
+            .err_notes(name)?;
+        child.join().await?;
+        Ok(())
+    }
+
+    async fn list_metadata_files(&self) -> Result<Vec<FileHandle>> {
+        let child = self
+            .cmd(&self.config.commands.list_metadata_files, vec![])
+            .spawn()?;
+
+        let mut buf = FileHandle::new();
+        child
+            .into_data_source()
+            .read_to_string(&mut buf)
+            .await
+            .err_notes((file!(), line!(), &buf))?;
+        Ok(buf.lines().map(str::to_string).collect())
+    }
+}

--- a/aptos-db-tool/src/commands/backup/storage/command_adapter/sample_configs/azure.sample.yaml
+++ b/aptos-db-tool/src/commands/backup/storage/command_adapter/sample_configs/azure.sample.yaml
@@ -1,0 +1,33 @@
+env_vars:
+  - key: "ACCOUNT"
+    value: "aptos-backup"
+  - key: "CONTAINER"
+    value: "backup-1"
+  - key: "SUB_DIR"
+    value: "e1"
+  - key: "SAS"
+    value: "?a=blah&b=blah&c=blah"
+commands:
+  create_backup: |
+    # backup handle is the same with input backup name, output to stdout
+    echo "$BACKUP_NAME"
+  create_for_write: |
+    # file handle is the file name under the folder with the name of the backup handle
+    FILE_HANDLE="$BACKUP_HANDLE/$FILE_NAME"
+    # output file handle to stdout
+    echo "$FILE_HANDLE"
+    # close stdout
+    exec 1>&-
+    # route stdin to file handle
+    gzip -c | azcopy cp --from-to PipeBlob "https://$ACCOUNT.blob.core.windows.net/$CONTAINER/$SUB_DIR/$FILE_HANDLE$SAS" > /dev/null
+  open_for_read: |
+    # need to close stdin by "</dev/null" since azcopy gets confused about the direction of the pipe, even though we supply --from-to
+    # route file handle content to stdout
+    azcopy cp --from-to BlobPipe "https://$ACCOUNT.blob.core.windows.net/$CONTAINER/$SUB_DIR/$FILE_HANDLE$SAS" < /dev/null | gzip -cd
+  save_metadata_line: |
+    # save the line to a new file under the metadata folder
+    gzip -c | azcopy cp --from-to PipeBlob "https://$ACCOUNT.blob.core.windows.net/$SUBDIR/metadata/$FILE_NAME$SAS"
+  list_metadata_files: |
+    # list files under the metadata folder
+    (azcopy ls "https://$ACCOUNT.blob.core.windows.net/$CONTAINER/$SUB_DIR/metadata/$SAS" ||:) \
+    | sed -ne "s#; .*##;s#INFO: \(.*\.meta\)#metadata/\1#p"

--- a/aptos-db-tool/src/commands/backup/storage/command_adapter/sample_configs/gcp.sample.yaml
+++ b/aptos-db-tool/src/commands/backup/storage/command_adapter/sample_configs/gcp.sample.yaml
@@ -1,0 +1,28 @@
+env_vars:
+  - key: "BUCKET"
+    value: "aptos-backup/backup1"
+  - key: "SUB_DIR"
+    value: "e1"
+commands:
+  create_backup: |
+    # backup handle is the same with input backup name, output to stdout
+    echo "$BACKUP_NAME"
+  create_for_write: |
+    # file handle is the file name under the folder with the name of the backup handle
+    FILE_HANDLE="$BACKUP_HANDLE/$FILE_NAME"
+    # output file handle to stdout
+    echo "$FILE_HANDLE"
+    # close stdout
+    exec 1>&-
+    # route stdin to file handle
+    gzip -c | gsutil -q cp - "gs://$BUCKET/$SUB_DIR/$FILE_HANDLE" > /dev/null
+  open_for_read: |
+    # route file handle content to stdout
+    gsutil -q cp "gs://$BUCKET/$SUB_DIR/$FILE_HANDLE" - | gzip -cd
+  save_metadata_line: |
+    # save the line to a new file under the metadata folder
+    gzip -c | gsutil -q cp - "gs://$BUCKET/$SUB_DIR/metadata/$FILE_NAME"
+  list_metadata_files: |
+    # list files under the metadata folder
+    (gsutil -q ls gs://$BUCKET/$SUB_DIR/metadata/ ||:) \
+    | sed -ne "s#gs://.*/metadata/#metadata/#p"

--- a/aptos-db-tool/src/commands/backup/storage/command_adapter/sample_configs/local_folder.sample.yaml
+++ b/aptos-db-tool/src/commands/backup/storage/command_adapter/sample_configs/local_folder.sample.yaml
@@ -1,0 +1,10 @@
+env_vars:
+  - key: "FOLDER"
+    value: "/Users/runtianz/backup"
+
+commands:
+  create_backup: 'cd "$FOLDER" && mkdir $BACKUP_NAME && echo $BACKUP_NAME'
+  create_for_write: 'cd "$FOLDER" && cd "$BACKUP_HANDLE" && test ! -f $FILE_NAME && touch $FILE_NAME && echo $BACKUP_HANDLE/$FILE_NAME && exec >&- && gzip -c > $FILE_NAME'
+  open_for_read: 'cat "$FOLDER/$FILE_HANDLE" | gzip -cd'
+  save_metadata_line: 'cd "$FOLDER" && mkdir -p metadata && cd metadata && gzip -c > $FILE_NAME'
+  list_metadata_files: 'cd "$FOLDER" && (test -d metadata && cd metadata && ls -1 || exec) | while read f; do echo metadata/$f; done'

--- a/aptos-db-tool/src/commands/backup/storage/command_adapter/sample_configs/s3.sample.yaml
+++ b/aptos-db-tool/src/commands/backup/storage/command_adapter/sample_configs/s3.sample.yaml
@@ -1,0 +1,27 @@
+env_vars:
+  - key: "BUCKET"
+    value: "aptos-backup/backup1"
+  - key: "SUB_DIR"
+    value: "e1"
+commands:
+  create_backup: |
+    # backup handle is the same with input backup name, output to stdout
+    echo "$BACKUP_NAME"
+  create_for_write: |
+    # file handle is the file name under the folder with the name of the backup handle
+    FILE_HANDLE="$BACKUP_HANDLE/$FILE_NAME"
+    # output file handle to stdout
+    echo "$FILE_HANDLE"
+    # close stdout
+    exec 1>&-
+    # route stdin to file handle
+    gzip -c | aws s3 cp - "s3://$BUCKET/$SUB_DIR/$FILE_HANDLE"
+  open_for_read: |
+    # route file handle content to stdout
+    aws s3 cp "s3://$BUCKET/$SUB_DIR/$FILE_HANDLE" - | gzip -cd
+  save_metadata_line: |
+    # save the line to a new file under the metadata folder
+    gzip -c | aws s3 cp - "s3://$BUCKET/$SUB_DIR/metadata/$FILE_NAME"
+  list_metadata_files: |
+    # list files under the metadata folder
+    (aws s3 ls s3://$BUCKET/$SUB_DIR/metadata/ ||:) | sed -ne "s#.* \(.*\)#metadata/\1#p"

--- a/aptos-db-tool/src/commands/backup/storage/command_adapter/tests.rs
+++ b/aptos-db-tool/src/commands/backup/storage/command_adapter/tests.rs
@@ -1,0 +1,194 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::storage::test_util::{
+    arb_backups, arb_metadata_files, test_save_and_list_metadata_files_impl,
+    test_write_and_read_impl,
+};
+
+use super::{config::Commands, *};
+use aptos_temppath::TempPath;
+use futures::Future;
+use proptest::prelude::*;
+use std::str::FromStr;
+use tokio::runtime::Runtime;
+
+fn get_store(tmpdir: &TempPath) -> Box<dyn BackupStorage> {
+    tmpdir.create_as_dir().unwrap();
+    let config = CommandAdapterConfig::load_from_str(
+        &format!(r#"
+env_vars:
+  - key: "FOLDER"
+    value: "{}"
+
+commands:
+  create_backup: 'cd "$FOLDER" && mkdir $BACKUP_NAME && echo $BACKUP_NAME'
+  create_for_write: 'cd "$FOLDER" && cd "$BACKUP_HANDLE" && test ! -f $FILE_NAME && touch $FILE_NAME && echo $BACKUP_HANDLE/$FILE_NAME && exec >&- && cat > $FILE_NAME'
+  open_for_read: 'cat "$FOLDER/$FILE_HANDLE"'
+  save_metadata_line: 'cd "$FOLDER" && mkdir -p metadata && cd metadata && cat > $FILE_NAME'
+  list_metadata_files: 'cd "$FOLDER" && (test -d metadata && cd metadata && ls -1 || exec) | while read f; do echo metadata/$f; done'
+"#, tmpdir.path().to_str().unwrap()),
+    ).unwrap();
+
+    Box::new(CommandAdapter::new(config))
+}
+
+fn block_on<F: Future<Output = ()>>(f: F) {
+    Runtime::new().unwrap().block_on(f)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10))]
+
+    #[test]
+    fn test_write_and_read(
+        backups in arb_backups()
+    ) {
+        let tmpdir = TempPath::new();
+        block_on(test_write_and_read_impl(get_store(&tmpdir), backups));
+    }
+
+    #[test]
+    fn test_save_list_metadata_files(
+        input in arb_metadata_files(),
+    ) {
+        let tmpdir = TempPath::new();
+        block_on(test_save_and_list_metadata_files_impl(get_store(&tmpdir), input));
+    }
+}
+
+fn dummy_store(cmd: &str) -> CommandAdapter {
+    CommandAdapter::new(CommandAdapterConfig {
+        commands: Commands {
+            create_backup: cmd.to_string(),
+            create_for_write: cmd.to_string(),
+            open_for_read: cmd.to_string(),
+            save_metadata_line: cmd.to_string(),
+            list_metadata_files: cmd.to_string(),
+        },
+        env_vars: Vec::new(),
+    })
+}
+
+async fn assert_commands_error(cmd: &str) {
+    let name = ShellSafeName::from_str("name").unwrap();
+
+    let store = dummy_store(cmd);
+
+    // create_backup
+    assert!(store
+        .create_backup(&ShellSafeName::from_str("backup_name").unwrap())
+        .await
+        .is_err());
+
+    let handle = "handle";
+
+    // open_for_read
+    let mut buf = String::new();
+    assert!(store
+        .open_for_read(handle)
+        .await
+        .unwrap()
+        .read_to_string(&mut buf)
+        .await
+        .is_err());
+
+    // create_for_write
+    assert!(async {
+        let (_, mut file) = store.create_for_write(handle, &name).await?;
+        file.write_all(&[0; 1024]).await?;
+        file.shutdown().await?;
+        Result::<()>::Ok(())
+    }
+    .await
+    .is_err());
+
+    // save_metadata_line
+    assert!(store
+        .save_metadata_line(&name, &TextLine::new("1234").unwrap())
+        .await
+        .is_err());
+
+    // list_metadata_files
+    assert!(store.list_metadata_files().await.is_err());
+}
+
+async fn assert_commands_okay(cmd: &str) {
+    let handle = "handle";
+    let name = ShellSafeName::from_str("name").unwrap();
+
+    let store = dummy_store(cmd);
+
+    // create_backup
+    assert_eq!(&store.create_backup(&name).await.unwrap(), "okay");
+
+    // open_for_read
+    let mut buf = String::new();
+    store
+        .open_for_read(handle)
+        .await
+        .unwrap()
+        .read_to_string(&mut buf)
+        .await
+        .unwrap();
+    assert_eq!(&buf, "okay\n");
+
+    // create_for_write
+    let (out_handle, mut file) = store.create_for_write(handle, &name).await.unwrap();
+    assert_eq!(out_handle, "okay");
+    file.write_all(&[0; 1024]).await.unwrap();
+    file.shutdown().await.unwrap();
+
+    // save_metadata_line
+    store
+        .save_metadata_line(&name, &TextLine::new("1234").unwrap())
+        .await
+        .unwrap();
+
+    // list_metadata_files
+    assert_eq!(store.list_metadata_files().await.unwrap(), vec!["okay"])
+}
+
+#[test]
+fn test_unprocessed_error() {
+    block_on(assert_commands_error(
+        "echo okay; exec 1>&-; false; cat > /dev/null",
+    ));
+
+    // error processed
+    block_on(assert_commands_okay(
+        "echo okay; exec 1>&-; false && true; cat > /dev/null",
+    ));
+}
+
+#[test]
+fn test_unset_env_var() {
+    std::env::remove_var("MYVAR2343u2");
+    block_on(assert_commands_error(
+        "echo $MYVAR2343u2 > /dev/null; echo okay; exec 1>&-; cat > /dev/null",
+    ));
+
+    // variable set
+    std::env::set_var("MYVAR2343u2", "hehe");
+    block_on(assert_commands_okay(
+        "echo $MYVAR2343u2 > /dev/null; echo okay; exec 1>&-; cat > /dev/null",
+    ));
+}
+
+/// Make sure errors in pipe processing are not ignored.
+#[test]
+fn test_pipe_fail() {
+    // pipe fail on stdout processing
+    block_on(assert_commands_error(
+        "echo okay | (cat; false) | cat; exec 1>&-; cat | (cat; true) | cat > /dev/null",
+    ));
+    // pipe fail on stdin processing
+    block_on(assert_commands_error(
+        "echo okay | (cat; true) | cat; exec 1>&-; cat | (cat; false) | cat > /dev/null",
+    ));
+
+    // no error in pipelines
+    block_on(assert_commands_okay(
+        "echo okay | (cat; true) | cat; exec 1>&-; cat | (cat; true) | cat > /dev/null",
+    ));
+}

--- a/aptos-db-tool/src/commands/backup/storage/local_fs/mod.rs
+++ b/aptos-db-tool/src/commands/backup/storage/local_fs/mod.rs
@@ -1,0 +1,125 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod tests;
+
+use super::{BackupHandle, BackupHandleRef, FileHandle, FileHandleRef};
+use crate::commands::backup::{
+    storage::{BackupStorage, ShellSafeName, TextLine},
+    utils::{error_notes::ErrorNotes, path_exists, PathToString},
+};
+use anyhow::Result;
+use async_trait::async_trait;
+use clap::Parser;
+use std::path::{Path, PathBuf};
+use tokio::{
+    fs::{create_dir_all, read_dir, OpenOptions},
+    io::{AsyncRead, AsyncWrite, AsyncWriteExt},
+};
+
+#[derive(Parser, Clone)]
+pub struct LocalFsOpt {
+    #[clap(
+        long = "dir",
+        parse(from_os_str),
+        help = "Target local dir to hold backups."
+    )]
+    pub dir: PathBuf,
+}
+
+/// A storage backend that stores everything in a local directory.
+pub struct LocalFs {
+    /// The path where everything is stored.
+    dir: PathBuf,
+}
+
+impl LocalFs {
+    const METADATA_DIR: &'static str = "metadata";
+
+    pub fn new(dir: PathBuf) -> Self {
+        Self { dir }
+    }
+
+    pub fn new_with_opt(opt: LocalFsOpt) -> Self {
+        Self::new(opt.dir)
+    }
+
+    pub fn metadata_dir(&self) -> PathBuf {
+        self.dir.join(Self::METADATA_DIR)
+    }
+}
+
+#[async_trait]
+impl BackupStorage for LocalFs {
+    async fn create_backup(&self, name: &ShellSafeName) -> Result<BackupHandle> {
+        create_dir_all(self.dir.join(name.as_ref()))
+            .await
+            .err_notes(self.dir.join(name.as_ref()))?;
+        Ok(name.to_string())
+    }
+
+    async fn create_for_write(
+        &self,
+        backup_handle: &BackupHandleRef,
+        name: &ShellSafeName,
+    ) -> Result<(FileHandle, Box<dyn AsyncWrite + Send + Unpin>)> {
+        let file_handle = Path::new(backup_handle)
+            .join(name.as_ref())
+            .path_to_string()?;
+        let abs_path = self.dir.join(&file_handle).path_to_string()?;
+        let file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&abs_path)
+            .await
+            .err_notes(&abs_path)?;
+        Ok((file_handle, Box::new(file)))
+    }
+
+    async fn open_for_read(
+        &self,
+        file_handle: &FileHandleRef,
+    ) -> Result<Box<dyn AsyncRead + Send + Unpin>> {
+        let path = self.dir.join(file_handle);
+        let file = OpenOptions::new()
+            .read(true)
+            .open(&path)
+            .await
+            .err_notes(&path)?;
+        Ok(Box::new(file))
+    }
+
+    async fn save_metadata_line(&self, name: &ShellSafeName, content: &TextLine) -> Result<()> {
+        let dir = self.metadata_dir();
+        create_dir_all(&dir).await.err_notes(name)?; // in case not yet created
+
+        let path = dir.join(name.as_ref());
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .await
+            .err_notes(&path)?;
+        file.write_all(content.as_ref().as_bytes())
+            .await
+            .err_notes(&path)?;
+        file.shutdown().await.err_notes(&path)?;
+
+        Ok(())
+    }
+
+    async fn list_metadata_files(&self) -> Result<Vec<FileHandle>> {
+        let dir = self.metadata_dir();
+        let rel_path = Path::new(Self::METADATA_DIR);
+
+        let mut res = Vec::new();
+        if path_exists(&dir).await {
+            let mut entries = read_dir(&dir).await.err_notes(&dir)?;
+            while let Some(entry) = entries.next_entry().await.err_notes(&dir)? {
+                res.push(rel_path.join(entry.file_name()).path_to_string()?)
+            }
+        }
+        Ok(res)
+    }
+}

--- a/aptos-db-tool/src/commands/backup/storage/local_fs/tests.rs
+++ b/aptos-db-tool/src/commands/backup/storage/local_fs/tests.rs
@@ -1,0 +1,39 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::commands::backup::storage::test_util::{
+    arb_backups, arb_metadata_files, test_save_and_list_metadata_files_impl,
+    test_write_and_read_impl,
+};
+use aptos_temppath::TempPath;
+use proptest::prelude::*;
+use tokio::runtime::Runtime;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10))]
+
+    #[test]
+    fn test_write_and_read(
+        backups in arb_backups()
+    ) {
+        let tmpdir = TempPath::new();
+        tmpdir.create_as_dir().unwrap();
+        let store = LocalFs::new(tmpdir.path().to_path_buf());
+
+        let rt = Runtime::new().unwrap();
+        rt.block_on(test_write_and_read_impl(Box::new(store), backups));
+    }
+
+    #[test]
+    fn test_save_list_metadata_files(
+        input in arb_metadata_files(),
+    ) {
+        let tmpdir = TempPath::new();
+        tmpdir.create_as_dir().unwrap();
+        let store = LocalFs::new(tmpdir.path().to_path_buf());
+
+        let rt = Runtime::new().unwrap();
+        rt.block_on(test_save_and_list_metadata_files_impl(Box::new(store), input));
+    }
+}

--- a/aptos-db-tool/src/commands/backup/storage/mod.rs
+++ b/aptos-db-tool/src/commands/backup/storage/mod.rs
@@ -1,0 +1,190 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod command_adapter;
+pub mod local_fs;
+
+#[cfg(test)]
+mod test_util;
+#[cfg(test)]
+mod tests;
+
+use anyhow::{ensure, Result};
+use async_trait::async_trait;
+use clap::Parser;
+use command_adapter::{CommandAdapter, CommandAdapterOpt};
+use local_fs::{LocalFs, LocalFsOpt};
+use once_cell::sync::Lazy;
+#[cfg(test)]
+use proptest::prelude::*;
+use regex::Regex;
+#[cfg(test)]
+use std::convert::TryInto;
+use std::{convert::TryFrom, ops::Deref, str::FromStr, sync::Arc};
+use tokio::io::{AsyncRead, AsyncWrite};
+
+/// String returned by a specific storage implementation to identify a backup, probably a folder name
+/// which is exactly the same with the backup name we pass into `create_backup()`
+/// This is created and returned by the storage when `create_backup()`, passed back to the storage
+/// when `create_for_write()` and persisted nowhere (once a backup is created, files are referred to
+/// by `FileHandle`s).
+pub type BackupHandle = String;
+pub type BackupHandleRef = str;
+
+/// URI pointing to a file in a backup storage, like "s3:///bucket/path/file".
+/// These are created by the storage when `create_for_write()`, stored in manifests by the backup
+/// controller, and passed back to the storage when `open_for_read()` by the restore controller
+/// to retrieve a file referred to in the manifest.
+pub type FileHandle = String;
+pub type FileHandleRef = str;
+
+/// Through this, the backup controller promises to the storage the names passed to
+/// `create_backup()` and `create_for_write()` don't contain funny characters tricky to deal with
+/// in shell commands.
+/// Specifically, names follow the pattern "\A[a-zA-Z0-9][a-zA-Z0-9._-]{2,126}\z"
+#[cfg_attr(test, derive(Hash, Eq, PartialEq))]
+#[derive(Debug)]
+pub struct ShellSafeName(String);
+
+impl ShellSafeName {
+    const PATTERN: &'static str = r"\A[a-zA-Z0-9][a-zA-Z0-9._-]{2,126}\z";
+
+    fn sanitize(name: &str) -> Result<()> {
+        static RE: Lazy<Regex> = Lazy::new(|| Regex::new(ShellSafeName::PATTERN).unwrap());
+        ensure!(RE.is_match(name), "Illegal name: {}", name,);
+        Ok(())
+    }
+}
+
+impl TryFrom<String> for ShellSafeName {
+    type Error = anyhow::Error;
+
+    fn try_from(value: String) -> Result<Self> {
+        Self::sanitize(&value).map(|_| Self(value))
+    }
+}
+
+impl FromStr for ShellSafeName {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::sanitize(s).map(|_| Self(s.to_string()))
+    }
+}
+
+impl Deref for ShellSafeName {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<str> for ShellSafeName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+impl Arbitrary for ShellSafeName {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        (&ShellSafeName::PATTERN[2..(ShellSafeName::PATTERN.len() - 2)]) // remove \A and \z
+            .prop_map(|s| s.try_into().unwrap())
+            .boxed()
+    }
+}
+
+#[cfg_attr(test, derive(Debug, Hash, Eq, Ord, PartialEq, PartialOrd))]
+pub struct TextLine(String);
+
+impl TextLine {
+    pub fn new(value: &str) -> Result<Self> {
+        let newlines: &[_] = &['\n', '\r'];
+        ensure!(value.find(newlines).is_none(), "Newline not allowed.");
+        let mut ret = value.to_string();
+        ret.push('\n');
+        Ok(Self(ret))
+    }
+}
+
+impl AsRef<str> for TextLine {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+impl Arbitrary for TextLine {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        ("[^\r\n]{0,1024}")
+            .prop_map(|s| TextLine::new(&s).unwrap())
+            .boxed()
+    }
+}
+
+#[async_trait]
+pub trait BackupStorage: Send + Sync {
+    /// Hint that a bunch of files are gonna be created related to a backup identified by `name`,
+    /// which is unique to the content of the backup, i.e. it won't be the same name unless you are
+    /// backing up exactly the same thing.
+    /// Storage can choose to take actions like create a dedicated folder or do nothing.
+    /// Returns a string to identify this operation in potential succeeding file creation requests.
+    async fn create_backup(&self, name: &ShellSafeName) -> Result<BackupHandle>;
+    /// Ask to create a file for write, `backup_handle` was returned by `create_backup` to identify
+    /// the current backup.
+    async fn create_for_write(
+        &self,
+        backup_handle: &BackupHandleRef,
+        name: &ShellSafeName,
+    ) -> Result<(FileHandle, Box<dyn AsyncWrite + Send + Unpin>)>;
+    /// Open file for reading.
+    async fn open_for_read(
+        &self,
+        file_handle: &FileHandleRef,
+    ) -> Result<Box<dyn AsyncRead + Send + Unpin>>;
+    /// Asks to save a metadata entry. A metadata entry is one line of text.
+    /// The backup system doesn't expect a metadata entry to exclusively map to a single file
+    /// handle, or the same file handle when accessed later, so there's no need to return one. This
+    /// also means a local cache must download each metadata file from remote at least once, to
+    /// uncover potential storage glitch sooner.
+    /// Behavior on duplicated names is undefined, overwriting the content upon an existing name
+    /// is straightforward and acceptable.
+    /// See `list_metadata_files`.
+    async fn save_metadata_line(&self, name: &ShellSafeName, content: &TextLine) -> Result<()>;
+    /// The backup system always asks for all metadata files and cache and build index on top of
+    /// the content of them. This means:
+    ///   1. The storage is free to reorganise the metadata files, like combining multiple ones to
+    /// reduce fragmentation.
+    ///   2. But the cache does expect the content stays the same for a file handle, so when
+    /// reorganising metadata files, give them new unique names.
+    async fn list_metadata_files(&self) -> Result<Vec<FileHandle>>;
+}
+
+#[derive(Parser, Clone)]
+pub enum StorageOpt {
+    #[clap(about = "Select the LocalFs backup storage type, which is used mainly for tests.")]
+    LocalFs(LocalFsOpt),
+    #[clap(
+        about = "Select the CommandAdapter backup storage type, which reads shell commands with which \
+    it communicates with either a local file system or a remote cloud storage. Compression or other \
+    fitlers can be added as part of the commands. See a sample config here: \
+    https://github.com/aptos-labs/aptos-core/tree/main/storage/backup/backup-cli/src/storage/command_adapter/sample_configs/"
+    )]
+    CommandAdapter(CommandAdapterOpt),
+}
+
+impl StorageOpt {
+    pub async fn init_storage(self) -> Result<Arc<dyn BackupStorage>> {
+        Ok(match self {
+            StorageOpt::LocalFs(opt) => Arc::new(LocalFs::new_with_opt(opt)),
+            StorageOpt::CommandAdapter(opt) => Arc::new(CommandAdapter::new_with_opt(opt).await?),
+        })
+    }
+}

--- a/aptos-db-tool/src/commands/backup/storage/test_util.rs
+++ b/aptos-db-tool/src/commands/backup/storage/test_util.rs
@@ -1,0 +1,104 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::{
+    storage::{BackupStorage, ShellSafeName, TextLine},
+    utils::PathToString,
+};
+use anyhow::Result;
+use itertools::Itertools;
+use proptest::{
+    collection::{hash_map, vec},
+    prelude::*,
+};
+use std::{collections::HashMap, path::Path};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+fn to_file_name(backup_name: &str, file_name: &str) -> String {
+    Path::new(backup_name)
+        .join(file_name)
+        .path_to_string()
+        .unwrap()
+}
+
+pub async fn test_write_and_read_impl(
+    store: Box<dyn BackupStorage>,
+    backups: HashMap<ShellSafeName, HashMap<ShellSafeName, Vec<u8>>>,
+) {
+    for (backup_name, files) in &backups {
+        let backup_handle = store.create_backup(backup_name).await.unwrap();
+        assert_eq!(backup_handle, backup_name.as_ref());
+        for (name, content) in files {
+            let (handle, mut file) = store.create_for_write(&backup_handle, name).await.unwrap();
+            assert_eq!(handle, to_file_name(backup_name, name));
+            file.write_all(content).await.unwrap();
+            file.shutdown().await.unwrap();
+        }
+    }
+
+    for (backup_name, files) in &backups {
+        for (name, content) in files {
+            let handle = to_file_name(backup_name, name);
+            let mut file = store.open_for_read(&handle).await.unwrap();
+            let mut buf = Vec::new();
+            file.read_to_end(&mut buf).await.unwrap();
+            assert_eq!(content, &buf);
+        }
+    }
+}
+
+pub fn arb_backups(
+) -> impl Strategy<Value = HashMap<ShellSafeName, HashMap<ShellSafeName, Vec<u8>>>> {
+    hash_map(
+        any::<ShellSafeName>(), // backup_name
+        hash_map(
+            any::<ShellSafeName>(),    // file name
+            vec(any::<u8>(), 1..1000), // file content
+            1..10,
+        ),
+        1..10,
+    )
+}
+
+pub async fn test_save_and_list_metadata_files_impl(
+    store: Box<dyn BackupStorage>,
+    input: Vec<(ShellSafeName, TextLine)>,
+) {
+    for (name, content) in &input {
+        store.save_metadata_line(name, content).await.unwrap();
+    }
+
+    let mut read_back = Vec::new();
+    for file_handle in store.list_metadata_files().await.unwrap() {
+        let mut buf = String::new();
+        store
+            .open_for_read(&file_handle)
+            .await
+            .unwrap()
+            .read_to_string(&mut buf)
+            .await
+            .unwrap();
+        read_back.extend(
+            buf.lines()
+                .map(TextLine::new)
+                .collect::<Result<Vec<_>>>()
+                .unwrap()
+                .into_iter(),
+        )
+    }
+    read_back.sort();
+
+    let expected = input
+        .into_iter()
+        .map(|(_name, content)| content)
+        .sorted()
+        .collect::<Vec<_>>();
+
+    assert_eq!(read_back, expected)
+}
+
+pub fn arb_metadata_files() -> impl Strategy<Value = Vec<(ShellSafeName, TextLine)>> {
+    hash_map(any::<ShellSafeName>(), any::<TextLine>(), 0..10)
+        .prop_map(HashMap::into_iter)
+        .prop_map(Iterator::collect)
+}

--- a/aptos-db-tool/src/commands/backup/storage/tests.rs
+++ b/aptos-db-tool/src/commands/backup/storage/tests.rs
@@ -1,0 +1,19 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::storage::ShellSafeName;
+use std::str::FromStr;
+
+#[test]
+fn test_shell_safe_name() {
+    assert!(ShellSafeName::from_str(".hidden").is_err());
+    assert!(ShellSafeName::from_str(".").is_err());
+    assert!(ShellSafeName::from_str("..").is_err());
+    assert!(ShellSafeName::from_str("-m").is_err());
+    assert!(ShellSafeName::from_str("a b").is_err());
+    assert!(ShellSafeName::from_str("a\nb").is_err());
+    assert!(ShellSafeName::from_str("ab?").is_err());
+    assert!(ShellSafeName::from_str(&"x".repeat(128)).is_err());
+
+    assert!(ShellSafeName::from_str(&"x".repeat(127)).is_ok());
+}

--- a/aptos-db-tool/src/commands/backup/utils/backup_service_client.rs
+++ b/aptos-db-tool/src/commands/backup/utils/backup_service_client.rs
@@ -1,0 +1,124 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use super::error_notes::ErrorNotes;
+use anyhow::Result;
+use aptos_crypto::HashValue;
+use aptos_db::backup::backup_handler::DbState;
+use aptos_types::transaction::Version;
+use clap::Parser;
+use futures::TryStreamExt;
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio_util::compat::FuturesAsyncReadCompatExt;
+
+#[derive(Parser, Clone)]
+pub struct BackupServiceClientOpt {
+    #[clap(
+        long = "backup-service-address",
+        default_value = "http://localhost:6186",
+        help = "Backup service address. By default a Aptos Node runs the backup service serving \
+        on tcp port 6186 to localhost only."
+    )]
+    pub address: String,
+}
+
+pub struct BackupServiceClient {
+    address: String,
+    client: reqwest::Client,
+}
+
+impl BackupServiceClient {
+    pub fn new_with_opt(opt: BackupServiceClientOpt) -> Self {
+        Self::new(opt.address)
+    }
+
+    pub fn new(address: String) -> Self {
+        Self {
+            address,
+            client: reqwest::Client::builder()
+                .no_proxy()
+                .build()
+                .expect("Http client should build."),
+        }
+    }
+
+    async fn get(&self, path: &str) -> Result<impl AsyncRead> {
+        let url = format!("{}/{}", self.address, path);
+        Ok(self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .err_notes(&url)?
+            .error_for_status()
+            .err_notes(&url)?
+            .bytes_stream()
+            .map_err(|e| futures::io::Error::new(futures::io::ErrorKind::Other, e))
+            .into_async_read()
+            .compat())
+    }
+
+    pub async fn get_db_state(&self) -> Result<Option<DbState>> {
+        let mut buf = Vec::new();
+        self.get("db_state").await?.read_to_end(&mut buf).await?;
+        Ok(bcs::from_bytes(&buf)?)
+    }
+
+    pub async fn get_account_range_proof(
+        &self,
+        key: HashValue,
+        version: Version,
+    ) -> Result<impl AsyncRead> {
+        self.get(&format!("state_range_proof/{}/{:x}", version, key))
+            .await
+    }
+
+    pub async fn get_state_snapshot(&self, version: Version) -> Result<impl AsyncRead> {
+        self.get(&format!("state_snapshot/{}", version)).await
+    }
+
+    pub async fn get_state_root_proof(&self, version: Version) -> Result<Vec<u8>> {
+        let mut buf = Vec::new();
+        self.get(&format!("state_root_proof/{}", version))
+            .await?
+            .read_to_end(&mut buf)
+            .await?;
+        Ok(buf)
+    }
+
+    pub async fn get_epoch_ending_ledger_infos(
+        &self,
+        start_epoch: u64,
+        end_epoch: u64,
+    ) -> Result<impl AsyncRead> {
+        self.get(&format!(
+            "epoch_ending_ledger_infos/{}/{}",
+            start_epoch, end_epoch
+        ))
+        .await
+    }
+
+    pub async fn get_transactions(
+        &self,
+        start_version: Version,
+        num_transactions: usize,
+    ) -> Result<impl AsyncRead> {
+        self.get(&format!(
+            "transactions/{}/{}",
+            start_version, num_transactions
+        ))
+        .await
+    }
+
+    pub async fn get_transaction_range_proof(
+        &self,
+        first_version: Version,
+        last_version: Version,
+    ) -> Result<impl AsyncRead> {
+        self.get(&format!(
+            "transaction_range_proof/{}/{}",
+            first_version, last_version,
+        ))
+        .await
+    }
+}

--- a/aptos-db-tool/src/commands/backup/utils/error_notes.rs
+++ b/aptos-db-tool/src/commands/backup/utils/error_notes.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_logger::error;
+use std::fmt::{Debug, Display};
+
+pub(crate) trait ErrorNotes<T, E: Display, N: Debug> {
+    fn err_notes(self, notes: N) -> Result<T, E>;
+}
+
+impl<T, E: Display, N: Debug> ErrorNotes<T, E, N> for Result<T, E> {
+    fn err_notes(self, notes: N) -> Result<T, E> {
+        if let Err(e) = &self {
+            error!(error = %e, notes = ?notes, "Error raised, see notes.");
+        }
+        self
+    }
+}

--- a/aptos-db-tool/src/commands/backup/utils/mod.rs
+++ b/aptos-db-tool/src/commands/backup/utils/mod.rs
@@ -1,0 +1,378 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod backup_service_client;
+pub(crate) mod error_notes;
+pub mod read_record_bytes;
+pub mod storage_ext;
+pub(crate) mod stream;
+
+#[cfg(test)]
+pub mod test_utils;
+
+use anyhow::{anyhow, Result};
+use aptos_config::config::{
+    RocksdbConfig, RocksdbConfigs, BUFFERED_STATE_TARGET_ITEMS,
+    DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD, NO_OP_STORAGE_PRUNER_CONFIG,
+};
+use aptos_crypto::HashValue;
+use aptos_db::{
+    backup::restore_handler::RestoreHandler,
+    state_restore::{
+        StateSnapshotProgress, StateSnapshotRestore, StateValueBatch, StateValueWriter,
+    },
+    AptosDB, GetRestoreHandler,
+};
+use aptos_infallible::duration_since_epoch;
+use aptos_jellyfish_merkle::{NodeBatch, TreeWriter};
+use aptos_logger::info;
+use aptos_types::{
+    state_store::{
+        state_key::StateKey, state_storage_usage::StateStorageUsage, state_value::StateValue,
+    },
+    transaction::Version,
+    waypoint::Waypoint,
+};
+use clap::Parser;
+use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    mem::size_of,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use tokio::fs::metadata;
+
+#[derive(Clone, Parser)]
+pub struct GlobalBackupOpt {
+    // Defaults to 128MB, so concurrent chunk downloads won't take up too much memory.
+    #[clap(
+        long = "max-chunk-size",
+        default_value = "134217728",
+        help = "Maximum chunk file size in bytes."
+    )]
+    pub max_chunk_size: usize,
+}
+
+#[derive(Clone, Parser)]
+pub struct RocksdbOpt {
+    #[clap(long, default_value = "5000")]
+    ledger_db_max_open_files: i32,
+    #[clap(long, default_value = "1073741824")] // 1GB
+    ledger_db_max_total_wal_size: u64,
+    #[clap(long, default_value = "5000")]
+    state_merkle_db_max_open_files: i32,
+    #[clap(long, default_value = "1073741824")] // 1GB
+    state_merkle_db_max_total_wal_size: u64,
+    #[clap(long, default_value = "1000")]
+    index_db_max_open_files: i32,
+    #[clap(long, default_value = "1073741824")] // 1GB
+    index_db_max_total_wal_size: u64,
+    #[clap(long, default_value = "16")]
+    max_background_jobs: i32,
+}
+
+impl From<RocksdbOpt> for RocksdbConfigs {
+    fn from(opt: RocksdbOpt) -> Self {
+        Self {
+            ledger_db_config: RocksdbConfig {
+                max_open_files: opt.ledger_db_max_open_files,
+                max_total_wal_size: opt.ledger_db_max_total_wal_size,
+                max_background_jobs: opt.max_background_jobs,
+                ..Default::default()
+            },
+            state_merkle_db_config: RocksdbConfig {
+                max_open_files: opt.state_merkle_db_max_open_files,
+                max_total_wal_size: opt.state_merkle_db_max_total_wal_size,
+                max_background_jobs: opt.max_background_jobs,
+                ..Default::default()
+            },
+            index_db_config: RocksdbConfig {
+                max_open_files: opt.index_db_max_open_files,
+                max_total_wal_size: opt.index_db_max_total_wal_size,
+                max_background_jobs: opt.max_background_jobs,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl Default for RocksdbOpt {
+    fn default() -> Self {
+        Self::from_iter(vec!["exe"])
+    }
+}
+
+#[derive(Clone, Parser)]
+pub struct GlobalRestoreOpt {
+    #[clap(long, help = "Dry run without writing data to DB.")]
+    pub dry_run: bool,
+
+    #[clap(
+        long = "target-db-dir",
+        parse(from_os_str),
+        conflicts_with = "dry-run",
+        required_unless = "dry-run"
+    )]
+    pub db_dir: Option<PathBuf>,
+
+    #[clap(
+        long,
+        help = "Content newer than this version will not be recovered to DB, \
+        defaulting to the largest version possible, meaning recover everything in the backups."
+    )]
+    pub target_version: Option<Version>,
+
+    #[clap(flatten)]
+    pub trusted_waypoints: TrustedWaypointOpt,
+
+    #[clap(flatten)]
+    pub rocksdb_opt: RocksdbOpt,
+
+    #[clap(flatten)]
+    pub concurrent_downloads: ConcurrentDownloadsOpt,
+
+    #[clap(flatten)]
+    pub replay_concurrency_level: ReplayConcurrencyLevelOpt,
+}
+
+pub enum RestoreRunMode {
+    Restore { restore_handler: RestoreHandler },
+    Verify,
+}
+
+struct MockStore;
+
+impl TreeWriter<StateKey> for MockStore {
+    fn write_node_batch(&self, _node_batch: &NodeBatch<StateKey>) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl StateValueWriter<StateKey, StateValue> for MockStore {
+    fn write_kv_batch(
+        &self,
+        _version: Version,
+        _kv_batch: &StateValueBatch<StateKey, Option<StateValue>>,
+        _progress: StateSnapshotProgress,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn write_usage(&self, _version: Version, _usage: StateStorageUsage) -> Result<()> {
+        Ok(())
+    }
+
+    fn get_progress(&self, _version: Version) -> Result<Option<StateSnapshotProgress>> {
+        Ok(None)
+    }
+}
+
+impl RestoreRunMode {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Restore { restore_handler: _ } => "restore",
+            Self::Verify => "verify",
+        }
+    }
+
+    pub fn is_verify(&self) -> bool {
+        match self {
+            Self::Restore { restore_handler: _ } => false,
+            Self::Verify => true,
+        }
+    }
+
+    pub fn get_state_restore_receiver(
+        &self,
+        version: Version,
+        expected_root_hash: HashValue,
+    ) -> Result<StateSnapshotRestore<StateKey, StateValue>> {
+        match self {
+            Self::Restore { restore_handler } => {
+                restore_handler.get_state_restore_receiver(version, expected_root_hash)
+            },
+            Self::Verify => {
+                let mock_store = Arc::new(MockStore);
+                StateSnapshotRestore::new_overwrite(
+                    &mock_store,
+                    &mock_store,
+                    version,
+                    expected_root_hash,
+                )
+            },
+        }
+    }
+
+    pub fn finish(&self) {
+        match self {
+            Self::Restore { restore_handler } => {
+                restore_handler.reset_state_store();
+            },
+            Self::Verify => (),
+        }
+    }
+
+    pub fn get_next_expected_transaction_version(&self) -> Result<Version> {
+        match self {
+            RestoreRunMode::Restore { restore_handler } => {
+                restore_handler.get_next_expected_transaction_version()
+            },
+            RestoreRunMode::Verify => {
+                info!("This is a dry run. Assuming resuming point at version 0.");
+                Ok(0)
+            },
+        }
+    }
+
+    pub fn get_in_progress_state_snapshot(&self) -> Result<Option<Version>> {
+        match self {
+            RestoreRunMode::Restore { restore_handler } => {
+                restore_handler.get_in_progress_state_snapshot_version()
+            },
+            RestoreRunMode::Verify => Ok(None),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct GlobalRestoreOptions {
+    pub target_version: Version,
+    pub trusted_waypoints: Arc<HashMap<Version, Waypoint>>,
+    pub run_mode: Arc<RestoreRunMode>,
+    pub concurrent_downloads: usize,
+    pub replay_concurrency_level: usize,
+}
+
+impl TryFrom<GlobalRestoreOpt> for GlobalRestoreOptions {
+    type Error = anyhow::Error;
+
+    fn try_from(opt: GlobalRestoreOpt) -> Result<Self> {
+        let target_version = opt.target_version.unwrap_or(Version::max_value());
+        let concurrent_downloads = opt.concurrent_downloads.get();
+        let replay_concurrency_level = opt.replay_concurrency_level.get();
+        let run_mode = if let Some(db_dir) = &opt.db_dir {
+            let restore_handler = Arc::new(AptosDB::open(
+                db_dir,
+                false,                       /* read_only */
+                NO_OP_STORAGE_PRUNER_CONFIG, /* pruner config */
+                opt.rocksdb_opt.into(),
+                false,
+                BUFFERED_STATE_TARGET_ITEMS,
+                DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
+            )?)
+            .get_restore_handler();
+            RestoreRunMode::Restore { restore_handler }
+        } else {
+            RestoreRunMode::Verify
+        };
+        Ok(Self {
+            target_version,
+            trusted_waypoints: Arc::new(opt.trusted_waypoints.verify()?),
+            run_mode: Arc::new(run_mode),
+            concurrent_downloads,
+            replay_concurrency_level,
+        })
+    }
+}
+
+#[derive(Clone, Default, Parser)]
+pub struct TrustedWaypointOpt {
+    #[clap(
+        long,
+        help = "(multiple) When provided, an epoch ending LedgerInfo at the waypoint version will be \
+        checked against the hash in the waypoint, but signatures on it are NOT checked. \
+        Use this for two purposes: \
+        1. set the genesis or the latest waypoint to confirm the backup is compatible. \
+        2. set waypoints at versions where writeset transactions were used to overwrite the \
+        validator set, so that the signature check is skipped. \
+        N.B. LedgerInfos are verified only when restoring / verifying the epoch ending backups, \
+        i.e. they are NOT checked at all when doing one-shot restoring of the transaction \
+        and state backups."
+    )]
+    pub trust_waypoint: Vec<Waypoint>,
+}
+
+impl TrustedWaypointOpt {
+    pub fn verify(self) -> Result<HashMap<Version, Waypoint>> {
+        let mut trusted_waypoints = HashMap::new();
+        for w in self.trust_waypoint {
+            trusted_waypoints
+                .insert(w.version(), w)
+                .map_or(Ok(()), |w| {
+                    Err(anyhow!("Duplicated waypoints at version {}", w.version()))
+                })?;
+        }
+        Ok(trusted_waypoints)
+    }
+}
+
+#[derive(Clone, Copy, Default, Parser)]
+pub struct ConcurrentDownloadsOpt {
+    #[clap(
+        long,
+        help = "Number of concurrent downloads from the backup storage. This covers the initial \
+        metadata downloads as well. Speeds up remote backup access. [Defaults to number of CPUs]"
+    )]
+    concurrent_downloads: Option<usize>,
+}
+
+impl ConcurrentDownloadsOpt {
+    pub fn get(&self) -> usize {
+        let ret = self.concurrent_downloads.unwrap_or_else(num_cpus::get);
+        info!(
+            concurrent_downloads = ret,
+            "Determined concurrency level for downloading."
+        );
+        ret
+    }
+}
+
+#[derive(Clone, Copy, Default, Parser)]
+pub struct ReplayConcurrencyLevelOpt {
+    /// AptosVM::set_concurrency_level_once() is called with this
+    #[clap(
+        long,
+        help = "concurrency_level used by the transaction executor, applicable when replaying transactions \
+        after a state snapshot. [Defaults to number of CPUs]"
+    )]
+    replay_concurrency_level: Option<usize>,
+}
+
+impl ReplayConcurrencyLevelOpt {
+    pub fn get(&self) -> usize {
+        let ret = self.replay_concurrency_level.unwrap_or_else(num_cpus::get);
+        info!(
+            concurrency = ret,
+            "Determined concurrency level for transaction replaying."
+        );
+        ret
+    }
+}
+
+pub(crate) fn should_cut_chunk(chunk: &[u8], record: &[u8], max_chunk_size: usize) -> bool {
+    !chunk.is_empty() && chunk.len() + record.len() + size_of::<u32>() > max_chunk_size
+}
+
+// TODO: use Path::exists() when Rust 1.5 stabilizes.
+pub(crate) async fn path_exists(path: &Path) -> bool {
+    metadata(&path).await.is_ok()
+}
+
+pub(crate) trait PathToString {
+    fn path_to_string(&self) -> Result<String>;
+}
+
+impl<T: AsRef<Path>> PathToString for T {
+    fn path_to_string(&self) -> Result<String> {
+        self.as_ref()
+            .to_path_buf()
+            .into_os_string()
+            .into_string()
+            .map_err(|s| anyhow!("into_string failed for OsString '{:?}'", s))
+    }
+}
+
+pub(crate) fn unix_timestamp_sec() -> i64 {
+    duration_since_epoch().as_secs() as i64
+}

--- a/aptos-db-tool/src/commands/backup/utils/read_record_bytes.rs
+++ b/aptos-db-tool/src/commands/backup/utils/read_record_bytes.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use super::error_notes::ErrorNotes;
+use anyhow::{bail, Result};
+use async_trait::async_trait;
+use bytes::{Bytes, BytesMut};
+use std::convert::TryInto;
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+#[async_trait]
+pub trait ReadRecordBytes {
+    async fn read_full_buf_or_none(&mut self, buf: &mut BytesMut) -> Result<()>;
+    async fn read_record_bytes(&mut self) -> Result<Option<Bytes>>;
+}
+
+#[async_trait]
+impl<R: AsyncRead + Send + Unpin> ReadRecordBytes for R {
+    async fn read_full_buf_or_none(&mut self, buf: &mut BytesMut) -> Result<()> {
+        assert_eq!(buf.len(), 0);
+        let n_expected = buf.capacity();
+
+        loop {
+            let n_read = self.read_buf(buf).await.err_notes("")?;
+            let n_read_total = buf.len();
+            if n_read_total == n_expected {
+                return Ok(());
+            }
+            if n_read == 0 {
+                if n_read_total == 0 {
+                    return Ok(());
+                } else {
+                    bail!(
+                        "Hit EOF before filling the whole buffer, read {}, expected {}",
+                        n_read_total,
+                        n_expected
+                    );
+                }
+            }
+        }
+    }
+
+    async fn read_record_bytes(&mut self) -> Result<Option<Bytes>> {
+        // read record size
+        let mut size_buf = BytesMut::with_capacity(4);
+        self.read_full_buf_or_none(&mut size_buf).await?;
+        if size_buf.is_empty() {
+            return Ok(None);
+        }
+
+        // empty record
+        let record_size = u32::from_be_bytes(size_buf.as_ref().try_into()?) as usize;
+        if record_size == 0 {
+            return Ok(Some(Bytes::new()));
+        }
+
+        // read record
+        let mut record_buf = BytesMut::with_capacity(record_size);
+        self.read_full_buf_or_none(&mut record_buf).await?;
+        if record_buf.is_empty() {
+            bail!("Hit EOF when reading record.")
+        }
+
+        Ok(Some(record_buf.freeze()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::commands::backup::utils::read_record_bytes::ReadRecordBytes;
+    use tokio::runtime::Runtime;
+
+    #[test]
+    fn test_read_record_bytes() {
+        Runtime::new().unwrap().block_on(async {
+            let data = b"abc";
+            let size = (data.len() as u32).to_be_bytes();
+
+            let mut good_record = size.to_vec();
+            good_record.extend_from_slice(data);
+
+            assert_eq!(
+                good_record
+                    .as_slice()
+                    .read_record_bytes()
+                    .await
+                    .unwrap()
+                    .unwrap(),
+                &data[..],
+            );
+
+            let mut eof: &[u8] = &[];
+            assert!(eof.read_record_bytes().await.unwrap().is_none());
+
+            let mut empty = &0u32.to_be_bytes()[..];
+            assert_eq!(empty.read_record_bytes().await.unwrap().unwrap(), &[][..]);
+
+            let mut data_missing = &1u32.to_be_bytes()[..];
+            assert!(data_missing.read_record_bytes().await.is_err());
+
+            let mut bad_len = 10u32.to_be_bytes().to_vec();
+            bad_len.pop();
+            assert!(bad_len.as_slice().read_record_bytes().await.is_err());
+
+            let mut bad_data = 10u32.to_be_bytes().to_vec();
+            bad_data.push(0u8);
+            assert!(bad_data.as_slice().read_record_bytes().await.is_err());
+        })
+    }
+}

--- a/aptos-db-tool/src/commands/backup/utils/storage_ext.rs
+++ b/aptos-db-tool/src/commands/backup/utils/storage_ext.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::backup::storage::{BackupHandle, BackupStorage, FileHandleRef};
+use anyhow::Result;
+use async_trait::async_trait;
+use rand::random;
+use serde::de::DeserializeOwned;
+use std::{convert::TryInto, sync::Arc};
+use tokio::io::AsyncReadExt;
+
+#[async_trait]
+pub trait BackupStorageExt {
+    async fn read_all(&self, file_handle: &FileHandleRef) -> Result<Vec<u8>>;
+    async fn load_json_file<T: DeserializeOwned>(&self, file_handle: &FileHandleRef) -> Result<T>;
+    async fn load_bcs_file<T: DeserializeOwned>(&self, file_handle: &FileHandleRef) -> Result<T>;
+    /// Adds a random suffix ".XXXX" to the backup name, so a retry won't pass a same backup name to
+    /// the storage.
+    async fn create_backup_with_random_suffix(&self, name: &str) -> Result<BackupHandle>;
+}
+
+#[async_trait]
+impl BackupStorageExt for Arc<dyn BackupStorage> {
+    async fn read_all(&self, file_handle: &FileHandleRef) -> Result<Vec<u8>> {
+        let mut file = self.open_for_read(file_handle).await?;
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes).await?;
+        Ok(bytes)
+    }
+
+    async fn load_bcs_file<T: DeserializeOwned>(&self, file_handle: &FileHandleRef) -> Result<T> {
+        Ok(bcs::from_bytes(&self.read_all(file_handle).await?)?)
+    }
+
+    async fn load_json_file<T: DeserializeOwned>(&self, file_handle: &FileHandleRef) -> Result<T> {
+        Ok(serde_json::from_slice(&self.read_all(file_handle).await?)?)
+    }
+
+    async fn create_backup_with_random_suffix(&self, name: &str) -> Result<BackupHandle> {
+        self.create_backup(&format!("{}.{:04x}", name, random::<u16>()).try_into()?)
+            .await
+    }
+}

--- a/aptos-db-tool/src/commands/backup/utils/stream/buffered_x.rs
+++ b/aptos-db-tool/src/commands/backup/utils/stream/buffered_x.rs
@@ -1,0 +1,139 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+///! This is a copy of `futures::stream::buffered` from `futures 0.3.6`, except that it uses
+///! `FuturesOrderedX` which provides concurrency control. So we can buffer more results without
+///! too many futures driven at the same time.
+use futures::{
+    ready,
+    stream::Fuse,
+    task::{Context, Poll},
+    Future, Stream, StreamExt,
+};
+use pin_project::pin_project;
+use std::pin::Pin;
+
+use super::futures_ordered_x::FuturesOrderedX;
+
+#[pin_project]
+#[must_use = "streams do nothing unless polled"]
+pub struct BufferedX<St>
+where
+    St: Stream,
+    St::Item: Future,
+{
+    #[pin]
+    stream: Fuse<St>,
+    in_progress_queue: FuturesOrderedX<St::Item>,
+    max: usize,
+}
+
+impl<St> std::fmt::Debug for BufferedX<St>
+where
+    St: Stream + std::fmt::Debug,
+    St::Item: Future,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BufferedX")
+            .field("stream", &self.stream)
+            .field("in_progress_queue", &self.in_progress_queue)
+            .field("max", &self.max)
+            .finish()
+    }
+}
+
+impl<St> BufferedX<St>
+where
+    St: Stream,
+    St::Item: Future,
+{
+    pub(super) fn new(stream: St, n: usize, max_in_progress: usize) -> BufferedX<St> {
+        assert!(n > 0);
+
+        BufferedX {
+            stream: stream.fuse(),
+            in_progress_queue: FuturesOrderedX::new(max_in_progress),
+            max: n,
+        }
+    }
+}
+
+impl<St> Stream for BufferedX<St>
+where
+    St: Stream,
+    St::Item: Future,
+{
+    type Item = <St::Item as Future>::Output;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        // First up, try to spawn off as many futures as possible by filling up
+        // our queue of futures.
+        while this.in_progress_queue.len() < *this.max {
+            match this.stream.as_mut().poll_next(cx) {
+                Poll::Ready(Some(fut)) => this.in_progress_queue.push(fut),
+                Poll::Ready(None) | Poll::Pending => break,
+            }
+        }
+
+        // Attempt to pull the next value from the in_progress_queue
+        let res = this.in_progress_queue.poll_next_unpin(cx);
+        if let Some(val) = ready!(res) {
+            return Poll::Ready(Some(val));
+        }
+
+        // If more values are still coming from the stream, we're not done yet
+        if this.stream.is_done() {
+            Poll::Ready(None)
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let queue_len = self.in_progress_queue.len();
+        let (lower, upper) = self.stream.size_hint();
+        let lower = lower.saturating_add(queue_len);
+        let upper = match upper {
+            Some(x) => x.checked_add(queue_len),
+            None => None,
+        };
+        (lower, upper)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::StreamX;
+    use futures::StreamExt;
+    use proptest::{collection::vec, prelude::*};
+    use tokio::{runtime::Runtime, time::Duration};
+
+    proptest! {
+        #[test]
+        fn test_run(
+            sleeps_ms in vec(0u64..10, 0..100),
+            buffer_size in 1usize..100,
+            max_in_progress in 1usize..100,
+        ) {
+            let rt = Runtime::new().unwrap();
+            rt.block_on(async {
+                let num_sleeps = sleeps_ms.len();
+
+                let outputs = futures::stream::iter(
+                    sleeps_ms.into_iter().enumerate().map(|(n, sleep_ms)| async move {
+                        tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
+                        n
+                    })
+                ).buffered_x(buffer_size, max_in_progress)
+                .collect::<Vec<_>>().await;
+
+                assert_eq!(
+                    outputs,
+                    (0..num_sleeps).collect::<Vec<_>>()
+                );
+            });
+        }
+    }
+}

--- a/aptos-db-tool/src/commands/backup/utils/stream/futures_ordered_x.rs
+++ b/aptos-db-tool/src/commands/backup/utils/stream/futures_ordered_x.rs
@@ -1,0 +1,211 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+/// This is a copy of `futures::stream::futures_ordered` from `futures 0.3.6`, except that it uses
+/// `FuturesUnorderedX` which provides concurrency control. So we can manage more futures without
+/// too many activated at the same time.
+use futures::{
+    ready,
+    stream::{FusedStream, StreamExt},
+    task::{Context, Poll},
+    Future, Stream,
+};
+use pin_project::pin_project;
+use std::{
+    cmp::Ordering,
+    collections::{binary_heap::PeekMut, BinaryHeap},
+    pin::Pin,
+};
+
+use super::futures_unordered_x::FuturesUnorderedX;
+
+#[pin_project]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+#[derive(Debug)]
+struct OrderWrapper<T> {
+    #[pin]
+    data: T, // A future or a future's output
+    index: usize,
+}
+
+impl<T> PartialEq for OrderWrapper<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.index == other.index
+    }
+}
+
+impl<T> Eq for OrderWrapper<T> {}
+
+impl<T> PartialOrd for OrderWrapper<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> Ord for OrderWrapper<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // BinaryHeap is a max heap, so compare backwards here.
+        other.index.cmp(&self.index)
+    }
+}
+
+impl<T> Future for OrderWrapper<T>
+where
+    T: Future,
+{
+    type Output = OrderWrapper<T::Output>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let index = self.index;
+        self.project().data.poll(cx).map(|output| OrderWrapper {
+            data: output,
+            index,
+        })
+    }
+}
+
+#[must_use = "streams do nothing unless polled"]
+pub struct FuturesOrderedX<T: Future> {
+    in_progress_queue: FuturesUnorderedX<OrderWrapper<T>>,
+    queued_outputs: BinaryHeap<OrderWrapper<T::Output>>,
+    next_incoming_index: usize,
+    next_outgoing_index: usize,
+}
+
+impl<T: Future> Unpin for FuturesOrderedX<T> {}
+
+impl<Fut: Future> FuturesOrderedX<Fut> {
+    /// Constructs a new, empty `FuturesOrdered`
+    ///
+    /// The returned `FuturesOrdered` does not contain any futures and, in this
+    /// state, `FuturesOrdered::poll_next` will return `Poll::Ready(None)`.
+    pub fn new(max_in_progress: usize) -> FuturesOrderedX<Fut> {
+        FuturesOrderedX {
+            in_progress_queue: FuturesUnorderedX::new(max_in_progress),
+            queued_outputs: BinaryHeap::new(),
+            next_incoming_index: 0,
+            next_outgoing_index: 0,
+        }
+    }
+
+    /// Returns the number of futures contained in the queue.
+    ///
+    /// This represents the total number of in-flight futures, both
+    /// those currently processing and those that have completed but
+    /// which are waiting for earlier futures to complete.
+    pub fn len(&self) -> usize {
+        self.in_progress_queue.len() + self.queued_outputs.len()
+    }
+
+    /// Returns `true` if the queue contains no futures
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.in_progress_queue.is_empty() && self.queued_outputs.is_empty()
+    }
+
+    /// Push a future into the queue.
+    ///
+    /// This function submits the given future to the internal set for managing.
+    /// This function will not call `poll` on the submitted future. The caller
+    /// must ensure that `FuturesOrdered::poll` is called in order to receive
+    /// task notifications.
+    pub fn push(&mut self, future: Fut) {
+        let wrapped = OrderWrapper {
+            data: future,
+            index: self.next_incoming_index,
+        };
+        self.next_incoming_index += 1;
+        self.in_progress_queue.push(wrapped);
+    }
+}
+
+impl<Fut: Future> Stream for FuturesOrderedX<Fut> {
+    type Item = Fut::Output;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = &mut *self;
+
+        // Check to see if we've already received the next value
+        if let Some(next_output) = this.queued_outputs.peek_mut() {
+            if next_output.index == this.next_outgoing_index {
+                this.next_outgoing_index += 1;
+                return Poll::Ready(Some(PeekMut::pop(next_output).data));
+            }
+        }
+
+        loop {
+            match ready!(this.in_progress_queue.poll_next_unpin(cx)) {
+                Some(output) => {
+                    if output.index == this.next_outgoing_index {
+                        this.next_outgoing_index += 1;
+                        return Poll::Ready(Some(output.data));
+                    } else {
+                        this.queued_outputs.push(output)
+                    }
+                },
+                None => return Poll::Ready(None),
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl<Fut: Future> std::fmt::Debug for FuturesOrderedX<Fut> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FuturesOrderedX {{ ... }}")
+    }
+}
+
+impl<Fut: Future> FusedStream for FuturesOrderedX<Fut> {
+    fn is_terminated(&self) -> bool {
+        self.in_progress_queue.is_terminated() && self.queued_outputs.is_empty()
+    }
+}
+
+impl<Fut: Future> Extend<Fut> for FuturesOrderedX<Fut> {
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = Fut>,
+    {
+        for item in iter.into_iter() {
+            self.push(item);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FuturesOrderedX;
+    use futures::StreamExt;
+    use proptest::{collection::vec, prelude::*};
+    use tokio::{runtime::Runtime, time::Duration};
+
+    proptest! {
+        #[test]
+        fn test_run(
+            sleeps_ms in vec(0u64..10, 0..100),
+            max_in_progress in 1usize..100,
+        ) {
+            let rt = Runtime::new().unwrap();
+            rt.block_on(async {
+                let num_sleeps = sleeps_ms.len();
+                let mut futures = FuturesOrderedX::new(max_in_progress);
+                assert!(futures.is_empty());
+
+                futures.extend(sleeps_ms.into_iter().enumerate().map(|(n, sleep_ms)| async move {
+                        tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
+                        n
+                }));
+                assert!(num_sleeps > 0 || futures.is_empty());
+                assert_eq!(
+                    futures.collect::<Vec<_>>().await,
+                    (0..num_sleeps).collect::<Vec<_>>()
+                );
+            });
+        }
+    }
+}

--- a/aptos-db-tool/src/commands/backup/utils/stream/futures_unordered_x.rs
+++ b/aptos-db-tool/src/commands/backup/utils/stream/futures_unordered_x.rs
@@ -1,0 +1,187 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+/// This wraps around `futures::stream::futures_unorderd::FuturesUnordered` to provide similar
+/// functionality except that there's limit on concurrency. This allows us to manage more futures
+/// without activation too many of them at the same time.
+use futures::{
+    stream::{FusedStream, FuturesUnordered},
+    task::{Context, Poll},
+    Future, Stream, StreamExt,
+};
+use std::{collections::VecDeque, fmt::Debug, pin::Pin};
+
+#[must_use = "streams do nothing unless polled"]
+pub struct FuturesUnorderedX<T: Future> {
+    queued: VecDeque<T>,
+    in_progress: FuturesUnordered<T>,
+    queued_outputs: VecDeque<T::Output>,
+    max_in_progress: usize,
+}
+
+impl<T: Future> Unpin for FuturesUnorderedX<T> {}
+
+impl<Fut: Future> FuturesUnorderedX<Fut> {
+    /// Constructs a new, empty `FuturesOrderedX`
+    ///
+    /// The returned `FuturesOrderedX` does not contain any futures and, in this
+    /// state, `FuturesOrdered::poll_next` will return `Poll::Ready(None)`.
+    pub fn new(max_in_progress: usize) -> FuturesUnorderedX<Fut> {
+        assert!(max_in_progress > 0);
+        FuturesUnorderedX {
+            queued: VecDeque::new(),
+            in_progress: FuturesUnordered::new(),
+            queued_outputs: VecDeque::new(),
+            max_in_progress,
+        }
+    }
+
+    /// Returns the number of futures contained in the queue.
+    ///
+    /// This represents the total number of in-flight futures, including those whose outputs queued
+    /// for polling, those currently being processing and those in queued due to concurrency limit.
+    pub fn len(&self) -> usize {
+        self.queued.len() + self.in_progress.len() + self.queued_outputs.len()
+    }
+
+    /// Returns `true` if the queue contains no futures
+    pub fn is_empty(&self) -> bool {
+        self.queued.is_empty() && self.in_progress.is_empty() && self.queued_outputs.is_empty()
+    }
+
+    /// Push a future into the queue.
+    ///
+    /// This function submits the given future to the internal set for managing.
+    /// This function will not call `poll` on the submitted future. The caller
+    /// must ensure that `FuturesOrdered::poll` is called in order to receive
+    /// task notifications.
+    pub fn push(&mut self, future: Fut) {
+        if self.in_progress.len() < self.max_in_progress {
+            self.in_progress.push(future);
+        } else {
+            self.queued.push_back(future);
+        }
+    }
+}
+
+impl<Fut: Future> Stream for FuturesUnorderedX<Fut> {
+    type Item = Fut::Output;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Collect outputs from newly finished futures from the underlying `FuturesUnordered`.
+        while let Poll::Ready(Some(output)) = self.in_progress.poll_next_unpin(cx) {
+            self.queued_outputs.push_back(output);
+            // Concurrency is now below `self.max_in_progress`, kick off a queued one, if any.
+            if let Some(future) = self.queued.pop_front() {
+                self.in_progress.push(future)
+            }
+        }
+
+        if let Some(output) = self.queued_outputs.pop_front() {
+            Poll::Ready(Some(output))
+        } else if self.in_progress.is_empty() {
+            Poll::Ready(None)
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl<Fut: Future> Debug for FuturesUnorderedX<Fut> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FuturesOrderedX {{ ... }}")
+    }
+}
+
+impl<Fut: Future> FusedStream for FuturesUnorderedX<Fut> {
+    fn is_terminated(&self) -> bool {
+        self.in_progress.is_terminated() && self.queued_outputs.is_empty()
+    }
+}
+
+impl<Fut: Future> Extend<Fut> for FuturesUnorderedX<Fut> {
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = Fut>,
+    {
+        for item in iter.into_iter() {
+            self.push(item);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FuturesUnorderedX;
+    use futures::StreamExt;
+    use proptest::prelude::*;
+    use std::{
+        cmp::min,
+        sync::{
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+            Arc,
+        },
+    };
+    use tokio::{runtime::Runtime, time::Duration};
+
+    proptest! {
+        #[test]
+        fn test_run(
+            num_tasks in 0usize..100,
+            max_in_progress in 1usize..100,
+        ) {
+            const MAX_WAIT_MS: usize = 1000;
+
+            let rt = Runtime::new().unwrap();
+            rt.block_on(async {
+                let mut futures = FuturesUnorderedX::new(max_in_progress);
+                assert!(futures.is_empty());
+
+                let n_running = Arc::new(AtomicUsize::new(0));
+                let seen_max_concurrency = Arc::new(AtomicBool::new(false));
+
+                for n in 0..num_tasks {
+                    let n_running = n_running.clone();
+                    let seen_max_concurrency = seen_max_concurrency.clone();
+
+                    futures.push(async move {
+                        n_running.fetch_add(1, Ordering::Relaxed);
+
+                        for _ in 0..MAX_WAIT_MS {
+                            // yield
+                            tokio::time::sleep(Duration::from_millis(1)).await;
+                            if num_tasks < max_in_progress {
+                                break
+                            }
+                            if seen_max_concurrency.load(Ordering::Relaxed) {
+                                break
+                            }
+                            if n_running.load(Ordering::Relaxed) == max_in_progress {
+                                seen_max_concurrency.store(true, Ordering::Relaxed);
+                                break
+                            }
+                        }
+
+                        let r = n_running.fetch_sub(1, Ordering::SeqCst);
+                        assert!(r > 0 && r <= min(max_in_progress, num_tasks));
+                        n
+                    })
+                }
+
+                assert!(num_tasks > 0 || futures.is_empty());
+                let mut outputs = futures.collect::<Vec<_>>().await;
+                if max_in_progress <= num_tasks {
+                    assert!(seen_max_concurrency.load(Ordering::Relaxed));
+                }
+
+                outputs.sort_unstable();
+                assert_eq!(outputs, (0..num_tasks).collect::<Vec<_>>());
+            });
+        }
+    }
+}

--- a/aptos-db-tool/src/commands/backup/utils/stream/mod.rs
+++ b/aptos-db-tool/src/commands/backup/utils/stream/mod.rs
@@ -1,0 +1,35 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+mod buffered_x;
+mod futures_ordered_x;
+mod futures_unordered_x;
+mod try_buffered_x;
+
+use buffered_x::BufferedX;
+use futures::{Future, Stream, TryFuture, TryStream};
+use try_buffered_x::TryBufferedX;
+
+pub(crate) trait StreamX: Stream {
+    fn buffered_x(self, n: usize, max_in_progress: usize) -> BufferedX<Self>
+    where
+        Self::Item: Future,
+        Self: Sized,
+    {
+        BufferedX::new(self, n, max_in_progress)
+    }
+}
+
+impl<T: ?Sized> StreamX for T where T: Stream {}
+
+pub(crate) trait TryStreamX: TryStream {
+    fn try_buffered_x(self, n: usize, max_in_progress: usize) -> TryBufferedX<Self>
+    where
+        Self::Ok: TryFuture<Error = Self::Error>,
+        Self: Sized,
+    {
+        TryBufferedX::new(self, n, max_in_progress)
+    }
+}
+
+impl<T: ?Sized> TryStreamX for T where T: TryStream {}

--- a/aptos-db-tool/src/commands/backup/utils/stream/try_buffered_x.rs
+++ b/aptos-db-tool/src/commands/backup/utils/stream/try_buffered_x.rs
@@ -1,0 +1,114 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+///! This is a copy of `futures::try_stream::try_buffered` from `futures 0.3.16`, except that it uses
+///! `FuturesOrderedX` which provides concurrency control. So we can buffer more results without
+///! too many futures driven at the same time.
+use super::futures_ordered_x::FuturesOrderedX;
+use core::pin::Pin;
+use futures::{
+    future::{IntoFuture, TryFuture, TryFutureExt},
+    stream::{Fuse, IntoStream, Stream, StreamExt, TryStream},
+    task::{Context, Poll},
+    TryStreamExt,
+};
+use pin_project::pin_project;
+
+/// Stream for the [`try_buffered`](super::TryStreamExt::try_buffered) method.
+#[pin_project]
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct TryBufferedX<St>
+where
+    St: TryStream,
+    St::Ok: TryFuture,
+{
+    #[pin]
+    stream: Fuse<IntoStream<St>>,
+    in_progress_queue: FuturesOrderedX<IntoFuture<St::Ok>>,
+    max: usize,
+}
+
+impl<St> TryBufferedX<St>
+where
+    St: TryStream,
+    St::Ok: TryFuture,
+{
+    pub(super) fn new(stream: St, n: usize, max_in_progress: usize) -> Self {
+        Self {
+            stream: stream.into_stream().fuse(),
+            in_progress_queue: FuturesOrderedX::new(max_in_progress),
+            max: n,
+        }
+    }
+}
+
+impl<St> Stream for TryBufferedX<St>
+where
+    St: TryStream,
+    St::Ok: TryFuture<Error = St::Error>,
+{
+    type Item = Result<<St::Ok as TryFuture>::Ok, St::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        // First up, try to spawn off as many futures as possible by filling up
+        // our queue of futures. Propagate errors from the stream immediately.
+        while this.in_progress_queue.len() < *this.max {
+            match this.stream.as_mut().poll_next(cx)? {
+                Poll::Ready(Some(fut)) => this.in_progress_queue.push(fut.into_future()),
+                Poll::Ready(None) | Poll::Pending => break,
+            }
+        }
+
+        // Attempt to pull the next value from the in_progress_queue
+        match this.in_progress_queue.poll_next_unpin(cx) {
+            x @ Poll::Pending | x @ Poll::Ready(Some(_)) => return x,
+            Poll::Ready(None) => {},
+        }
+
+        // If more values are still coming from the stream, we're not done yet
+        if this.stream.is_done() {
+            Poll::Ready(None)
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::TryStreamX;
+    use anyhow::Result;
+    use futures::stream::TryStreamExt;
+    use proptest::{collection::vec, prelude::*};
+    use tokio::{runtime::Runtime, time::Duration};
+
+    proptest! {
+        #[test]
+        fn test_run(
+            sleeps_ms in vec(0u64..10, 0..100),
+            buffer_size in 1usize..100,
+            max_in_progress in 1usize..100,
+        ) {
+            let rt = Runtime::new().unwrap();
+            rt.block_on(async {
+                let num_sleeps = sleeps_ms.len();
+
+                let outputs = futures::stream::iter(
+                    sleeps_ms.into_iter().enumerate().map(|(n, sleep_ms)| Ok(async move {
+                        tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
+                        Result::<_>::Ok(n)
+                    }))
+                ).try_buffered_x(buffer_size, max_in_progress)
+                .try_collect::<Vec<_>>().await.unwrap();
+
+                assert_eq!(
+                    outputs,
+                    (0..num_sleeps).collect::<Vec<_>>()
+                );
+            });
+        }
+    }
+}

--- a/aptos-db-tool/src/commands/backup/utils/test_utils.rs
+++ b/aptos-db-tool/src/commands/backup/utils/test_utils.rs
@@ -1,0 +1,61 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_backup_service::start_backup_service;
+use aptos_config::utils::get_available_port;
+use aptos_db::{
+    test_helper::{arb_blocks_to_commit, update_in_memory_state},
+    AptosDB,
+};
+use aptos_proptest_helpers::ValueGenerator;
+use aptos_storage_interface::DbWriter;
+use aptos_temppath::TempPath;
+use aptos_types::{
+    ledger_info::LedgerInfoWithSignatures,
+    transaction::{TransactionToCommit, Version},
+};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
+use tokio::runtime::Runtime;
+
+pub fn tmp_db_empty() -> (TempPath, Arc<AptosDB>) {
+    let tmpdir = TempPath::new();
+    let db = Arc::new(AptosDB::new_for_test(&tmpdir));
+
+    (tmpdir, db)
+}
+
+pub fn tmp_db_with_random_content() -> (
+    TempPath,
+    Arc<AptosDB>,
+    Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>,
+) {
+    let (tmpdir, db) = tmp_db_empty();
+    let mut cur_ver: Version = 0;
+    let mut in_memory_state = db.buffered_state().lock().current_state().clone();
+    let _ancestor = in_memory_state.base.clone();
+    let blocks = ValueGenerator::new().generate(arb_blocks_to_commit());
+    for (txns_to_commit, ledger_info_with_sigs) in &blocks {
+        update_in_memory_state(&mut in_memory_state, txns_to_commit.as_slice());
+        db.save_transactions(
+            txns_to_commit,
+            cur_ver, /* first_version */
+            cur_ver.checked_sub(1),
+            Some(ledger_info_with_sigs),
+            true, /* sync_commit */
+            in_memory_state.clone(),
+        )
+        .unwrap();
+        cur_ver += txns_to_commit.len() as u64;
+    }
+
+    (tmpdir, db, blocks)
+}
+
+pub fn start_local_backup_service(db: Arc<AptosDB>) -> (Runtime, u16) {
+    let port = get_available_port();
+    let rt = start_backup_service(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port), db);
+    (rt, port)
+}

--- a/aptos-db-tool/src/commands/backup_verified/commands.rs
+++ b/aptos-db-tool/src/commands/backup_verified/commands.rs
@@ -1,0 +1,35 @@
+use anyhow::Result;
+use clap::Parser;
+
+use crate::commands::backup::{
+    coordinators::verify::VerifyCoordinator,
+    metadata::cache::MetadataCacheOpt,
+    storage::StorageOpt,
+    utils::{ConcurrentDownloadsOpt, TrustedWaypointOpt},
+};
+
+#[derive(Parser, Clone)]
+#[clap(about = "Verify aptos backup succeed or failed")]
+pub struct BackupVerified {
+    #[clap(flatten)]
+    metadata_cache_opt: MetadataCacheOpt,
+    #[clap(flatten)]
+    trusted_waypoints_opt: TrustedWaypointOpt,
+    #[clap(subcommand)]
+    storage: StorageOpt,
+    #[clap(flatten)]
+    concurrent_downloads: ConcurrentDownloadsOpt,
+}
+
+impl BackupVerified {
+    pub async fn process(&self) -> Result<()> {
+        VerifyCoordinator::new(
+            self.storage.clone().init_storage().await?,
+            self.metadata_cache_opt.clone(),
+            self.trusted_waypoints_opt.clone(),
+            self.concurrent_downloads.get(),
+        )?
+        .run()
+        .await
+    }
+}

--- a/aptos-db-tool/src/commands/backup_verified/mod.rs
+++ b/aptos-db-tool/src/commands/backup_verified/mod.rs
@@ -1,0 +1,1 @@
+pub mod commands;

--- a/aptos-db-tool/src/commands/bootstrapper/commands.rs
+++ b/aptos-db-tool/src/commands/bootstrapper/commands.rs
@@ -1,0 +1,74 @@
+use std::{path::PathBuf, sync::Arc};
+
+use clap::Parser;
+
+use anyhow::Result;
+
+use crate::commands::backup::{
+    coordinators::restore::{RestoreCoordinator, RestoreCoordinatorOpt},
+    metadata::cache::MetadataCacheOpt,
+    storage::command_adapter::{config::CommandAdapterConfig, CommandAdapter},
+    utils::{ConcurrentDownloadsOpt, GlobalRestoreOpt, ReplayConcurrencyLevelOpt, RocksdbOpt},
+};
+///
+///
+/// Enables users to load from a backup to catch their node's DB up to a known state.
+#[derive(Parser, Clone)]
+#[clap(about = "Bootstrap AptosDB from a backup")]
+pub struct Bootstrapper {
+    /// Config file for the source backup
+    ///
+    /// This file configures if we should use local files or cloud storage, and how to access
+    /// the backup.
+    #[clap(long, parse(from_os_str))]
+    config_path: PathBuf,
+
+    /// Target database directory
+    ///
+    /// The directory to create the AptosDB with snapshots and transactions from the backup.
+    /// The data folder can later be used to start an Aptos node. e.g. /opt/aptos/data/db
+    #[clap(long = "target-db-dir", parse(from_os_str))]
+    pub db_dir: PathBuf,
+
+    #[clap(flatten)]
+    pub metadata_cache_opt: MetadataCacheOpt,
+
+    #[clap(flatten)]
+    pub concurrent_downloads: ConcurrentDownloadsOpt,
+
+    #[clap(flatten)]
+    pub replay_concurrency_level: ReplayConcurrencyLevelOpt,
+}
+
+impl Bootstrapper {
+    pub async fn process(&self) -> Result<()> {
+        let opt = RestoreCoordinatorOpt {
+            metadata_cache_opt: self.metadata_cache_opt.clone(),
+            replay_all: false,
+            ledger_history_start_version: None,
+            skip_epoch_endings: false,
+        };
+        let global_opt = GlobalRestoreOpt {
+            dry_run: false,
+            db_dir: Some(self.db_dir.clone()),
+            target_version: None,
+            trusted_waypoints: Default::default(),
+            rocksdb_opt: RocksdbOpt::default(),
+            concurrent_downloads: self.concurrent_downloads,
+            replay_concurrency_level: self.replay_concurrency_level,
+        }
+        .try_into()?;
+        let storage = Arc::new(CommandAdapter::new(
+            CommandAdapterConfig::load_from_file(&self.config_path).await?,
+        ));
+
+        tokio::task::spawn_blocking(|| {
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            runtime.block_on(RestoreCoordinator::new(opt, global_opt, storage).run())
+        })
+        .await
+        .unwrap()?;
+
+        Ok(())
+    }
+}

--- a/aptos-db-tool/src/commands/bootstrapper/mod.rs
+++ b/aptos-db-tool/src/commands/bootstrapper/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod commands;

--- a/aptos-db-tool/src/commands/mod.rs
+++ b/aptos-db-tool/src/commands/mod.rs
@@ -1,0 +1,7 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod backup;
+pub mod backup_verified;
+pub mod bootstrapper;
+pub mod restore;

--- a/aptos-db-tool/src/commands/restore/commands.rs
+++ b/aptos-db-tool/src/commands/restore/commands.rs
@@ -1,0 +1,88 @@
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::commands::backup::{
+    backup_types::{
+        epoch_ending::restore::{EpochEndingRestoreController, EpochEndingRestoreOpt},
+        state_snapshot::restore::{StateSnapshotRestoreController, StateSnapshotRestoreOpt},
+        transaction::restore::{TransactionRestoreController, TransactionRestoreOpt},
+    },
+    coordinators::restore::{RestoreCoordinator, RestoreCoordinatorOpt},
+    storage::StorageOpt,
+    utils::GlobalRestoreOptions,
+};
+
+#[derive(Subcommand)]
+pub enum Restore {
+    EpochEnding {
+        #[clap(flatten)]
+        opt: EpochEndingRestoreOpt,
+        #[clap(subcommand)]
+        storage: StorageOpt,
+    },
+    StateSnapshot {
+        #[clap(flatten)]
+        opt: StateSnapshotRestoreOpt,
+        #[clap(subcommand)]
+        storage: StorageOpt,
+    },
+    Transaction {
+        #[clap(flatten)]
+        opt: TransactionRestoreOpt,
+        #[clap(subcommand)]
+        storage: StorageOpt,
+    },
+    Auto {
+        #[clap(flatten)]
+        opt: RestoreCoordinatorOpt,
+        #[clap(subcommand)]
+        storage: StorageOpt,
+    },
+}
+
+impl Restore {
+    pub async fn process(&self, global_opt: GlobalRestoreOptions) -> Result<()> {
+        match self {
+            Restore::EpochEnding { opt, storage } => {
+                EpochEndingRestoreController::new(
+                    opt.clone(),
+                    global_opt,
+                    storage.clone().init_storage().await?,
+                )
+                .run(None)
+                .await?;
+            },
+            Restore::StateSnapshot { opt, storage } => {
+                StateSnapshotRestoreController::new(
+                    opt.clone(),
+                    global_opt,
+                    storage.clone().init_storage().await?,
+                    None, /* epoch_history */
+                )
+                .run()
+                .await?;
+            },
+            Restore::Transaction { opt, storage } => {
+                TransactionRestoreController::new(
+                    opt.clone(),
+                    global_opt,
+                    storage.clone().init_storage().await?,
+                    None, /* epoch_history */
+                    vec![],
+                )
+                .run()
+                .await?;
+            },
+            Restore::Auto { opt, storage } => {
+                RestoreCoordinator::new(
+                    opt.clone(),
+                    global_opt,
+                    storage.clone().init_storage().await?,
+                )
+                .run()
+                .await?;
+            },
+        }
+        Ok(())
+    }
+}

--- a/aptos-db-tool/src/commands/restore/mod.rs
+++ b/aptos-db-tool/src/commands/restore/mod.rs
@@ -1,0 +1,1 @@
+pub mod commands;

--- a/aptos-db-tool/src/lib.rs
+++ b/aptos-db-tool/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod commands;

--- a/aptos-db-tool/src/main.rs
+++ b/aptos-db-tool/src/main.rs
@@ -1,0 +1,19 @@
+mod app;
+use anyhow::Result;
+use aptos_logger::{error, Level, Logger};
+use clap::Parser;
+use commands::backup::utils::GlobalRestoreOptions;
+mod commands;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    Logger::new().level(Level::Info).init();
+    let tool = app::Tool::from_args();
+
+    let global_opt: GlobalRestoreOptions = tool.global.clone().try_into()?;
+
+    tool.process(global_opt).await.map_err(|e| {
+        error!("main_impl() failed: {}", e);
+        e
+    })
+}


### PR DESCRIPTION
#2836 

### Description
1. Make a new crate that merges all 3 of these tools into one tool, named aptos-db-tool and have subcommands.
2. Change the build to only build and use this new tool.
3. Change all usages and references to these original tools to the new tool.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
The same as origin cmds about aptos db.
