### PR TITLE
[aptos-vm] Guard usage of new metadata by VM_BINARY_FORMNAT_V6 feature fkag

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -517,7 +517,11 @@ impl AptosVMImpl {
         &self,
         module: &ModuleId,
     ) -> Option<RuntimeModuleMetadataV1> {
-        aptos_framework::get_vm_metadata(&self.move_vm, module.clone())
+        if self.features.is_enabled(FeatureFlag::VM_BINARY_FORMAT_V6) {
+            aptos_framework::get_vm_metadata(&self.move_vm, module.clone())
+        } else {
+            aptos_framework::get_vm_metadata_v0(&self.move_vm, module.clone())
+        }
     }
 
     pub fn new_session<'r, R: MoveResolverExt>(

--- a/aptos-move/framework/src/module_metadata.rs
+++ b/aptos-move/framework/src/module_metadata.rs
@@ -85,6 +85,16 @@ pub fn get_vm_metadata(vm: &MoveVM, module_id: ModuleId) -> Option<RuntimeModule
     }
 }
 
+/// Extract metadata from the VM, legacy V0 format upgraded to V1
+pub fn get_vm_metadata_v0(vm: &MoveVM, module_id: ModuleId) -> Option<RuntimeModuleMetadataV1> {
+    if let Some(data) = vm.get_module_metadata(module_id, &APTOS_METADATA_KEY) {
+        let data_v0 = bcs::from_bytes::<RuntimeModuleMetadata>(&data.value).ok()?;
+        Some(data_v0.upgrade())
+    } else {
+        None
+    }
+}
+
 /// Extract metadata from a compiled module, upgrading V0 to V1 representation as needed.
 pub fn get_module_metadata(module: &CompiledModule) -> Option<RuntimeModuleMetadataV1> {
     if let Some(data) = find_metadata(module, &APTOS_METADATA_KEY_V1) {


### PR DESCRIPTION
This feature flag seems to guard also usage of u256.
