### PR TITLE
[move-vm] Reset verifier config to none

### DIFF
--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -114,8 +114,8 @@ pub fn verifier_config(_treat_friend_as_private: bool) -> VerifierConfig {
         max_type_nodes: Some(256),
         max_dependency_depth: Some(256),
         max_push_size: Some(10000),
-        max_struct_definitions: Some(200),
-        max_fields_in_struct: Some(30),
-        max_function_definitions: Some(1000),
+        max_struct_definitions: None,
+        max_fields_in_struct: None,
+        max_function_definitions: None,
     }
 }


### PR DESCRIPTION
### Description

As we did for aptos-node-v1.2.0 in #6181 , set the values for the new limits to be None.

### Test Plan
NA
