### PR TITLE
Some codes cleanup for aptos-node & config

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -198,7 +198,7 @@ pub fn setup_test_environment_and_start_node<R>(
     rng: R,
 ) -> anyhow::Result<()>
 where
-    R: ::rand::RngCore + ::rand::CryptoRng,
+    R: rand::RngCore + rand::CryptoRng,
 {
     // If there wasn't a test directory specified, create a temporary one
     let test_dir =
@@ -235,7 +235,7 @@ where
 
         // Write the mint key to disk
         let serialized_keys = bcs::to_bytes(&root_key)?;
-        let mut key_file = std::fs::File::create(&aptos_root_key_path)?;
+        let mut key_file = fs::File::create(&aptos_root_key_path)?;
         key_file.write_all(&serialized_keys)?;
 
         // Build a waypoint file so that clients / docker can grab it easily

--- a/aptos-node/src/services.rs
+++ b/aptos-node/src/services.rs
@@ -22,7 +22,7 @@ const AC_SMP_CHANNEL_BUFFER_SIZE: usize = 1_024;
 const INTRA_NODE_CHANNEL_BUFFER_SIZE: usize = 1;
 
 /// Bootstraps the API and the indexer. Returns the Mempool client
-/// recevier, and both the api and indexer runtimes.
+/// receiver, and both the api and indexer runtimes.
 pub fn bootstrap_api_and_indexer(
     node_config: &NodeConfig,
     aptos_db: Arc<dyn DbReader>,
@@ -98,11 +98,11 @@ pub fn start_mempool_runtime_and_get_consensus_sender(
     // Destruct the mempool network handle.
     // TODO: the bootstrap method should be refactored to avoid using large tuples.
     let mut deconstructed_network_handles = vec![];
-    for appplication_network_handle in mempool_network_handles {
+    for application_network_handle in mempool_network_handles {
         deconstructed_network_handles.push((
-            appplication_network_handle.network_id,
-            appplication_network_handle.network_sender,
-            appplication_network_handle.network_events,
+            application_network_handle.network_id,
+            application_network_handle.network_sender,
+            application_network_handle.network_events,
         ))
     }
 

--- a/config/src/config/logger_config.rs
+++ b/config/src/config/logger_config.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct LoggerConfig {
-    // channel size for the asychronous channel for node logging.
+    // channel size for the asynchronous channel for node logging.
     pub chan_size: usize,
     // Enables backtraces on error logs
     pub enable_backtrace: bool,

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -588,13 +588,12 @@ mod test {
     }
 
     #[test]
-    // TODO(joshlind): once the 'matches' crate becomes stable, clean this test up!
     fn verify_parse_role_error_on_invalid_role() {
         let invalid_role_type = "this is not a valid role type";
-        match RoleType::from_str(invalid_role_type) {
-            Err(ParseRoleError(_)) => { /* the expected error was thrown! */ },
-            _ => panic!("A ParseRoleError should have been thrown on the invalid role type!"),
-        }
+        assert!(matches!(
+            RoleType::from_str(invalid_role_type),
+            Err(ParseRoleError(_))
+        ));
     }
 
     #[test]
@@ -606,5 +605,16 @@ mod test {
         let contents = std::include_str!("test_data/safety_rules.yaml");
         SafetyRulesConfig::parse(contents)
             .unwrap_or_else(|e| panic!("Error in safety_rules.yaml: {}", e));
+    }
+
+    #[test]
+    fn validate_invalid_network_id() {
+        let mut config = NodeConfig::default_for_public_full_node();
+        let network = config.full_node_networks.iter_mut().next().unwrap();
+        network.network_id = NetworkId::Validator;
+        assert!(matches!(
+            config.validate_network_configs(),
+            Err(Error::InvariantViolation(_))
+        ));
     }
 }

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -7,7 +7,7 @@ use aptos_types::{waypoint::Waypoint, PeerId};
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     fmt, fs,
     fs::File,
     io::{Read, Write},
@@ -398,22 +398,12 @@ impl NodeConfig {
             )?;
         }
 
-        let mut network_ids = HashSet::new();
         if let Some(network) = &mut self.validator_network {
             network.load_validator_network()?;
             network.mutual_authentication = true; // This should always be the default for validators
-            network_ids.insert(network.network_id);
         }
         for network in &mut self.full_node_networks {
             network.load_fullnode_network()?;
-
-            // Check a validator network is not included in a list of full-node networks
-            let network_id = network.network_id;
-            invariant(
-                !matches!(network_id, NetworkId::Validator),
-                "Included a validator network in full_node_networks".into(),
-            )?;
-            network_ids.insert(network_id);
         }
         Ok(self)
     }

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -262,15 +262,12 @@ impl NetworkConfig {
             Identity::None => {
                 let mut rng = StdRng::from_seed(OsRng.gen());
                 let key = x25519::PrivateKey::generate(&mut rng);
-                let peer_id =
-                    aptos_types::account_address::from_identity_public_key(key.public_key());
+                let peer_id = from_identity_public_key(key.public_key());
                 self.identity = Identity::from_config(key, peer_id);
             },
             Identity::FromConfig(config) => {
-                let peer_id =
-                    aptos_types::account_address::from_identity_public_key(config.key.public_key());
                 if config.peer_id == PeerId::ZERO {
-                    config.peer_id = peer_id;
+                    config.peer_id = from_identity_public_key(config.key.public_key());
                 }
             },
             Identity::FromFile(_) => (),

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -269,7 +269,7 @@ mod test {
     use crate::config::PrunerConfig;
 
     #[test]
-    pub fn tset_default_prune_window() {
+    pub fn test_default_prune_window() {
         // Not that these can't be changed, but think twice -- make them safe for mainnet
 
         let config = PrunerConfig::default();


### PR DESCRIPTION
### Description
Mainly fixing typo for aptos-node and config package

A short explanation for `config/src/config/mod.rs`
1. `network.load_fullnode_network` will check whether it is a `validator`, so the `invariant` check is not needed.
2. Add each `network_id` to the `network_ids` seems to be useless.


### Test Plan
cargo test

