### PR TITLE
hotfix: remove rust_demangler cp from docker build due it breaking build

### DIFF
--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -314,7 +314,8 @@ RUN cmake ..
 RUN make
 RUN make install
 WORKDIR ..
-RUN cp -r rust_demangler /usr/lib/python3/dist-packages/rust_demangler
+# commenting out rust_demangler cp in testnet branch due to it breaking build for not yet understood reason
+# RUN cp -r rust_demangler /usr/lib/python3/dist-packages/rust_demangler
 
 # Capture backtrace on error
 ENV RUST_BACKTRACE 1


### PR DESCRIPTION
Quick fix to docker build on testnet branch.

context: https://aptos-org.slack.com/archives/C037JDQJAQG/p1673649882442679?thread_ts=1673639771.403529&cid=C037JDQJAQG
