### PR TITLE
Add merge_and_return_zero_coin function on coin.move for gas optimize reason.

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -473,13 +473,12 @@ module aptos_framework::coin {
     /// Same as be merge function but it return zero source coin for gas fee optimize reason if
     /// you got a situation that you need merge Coin<CoinType> then you also need zero value Coin<CoinType>,
     /// for example to feed zero coin to an Uniswap V2 type AMM DEX for doing a swap action.
-    public fun merge_and_return_zero_coin<CoinType>(dst_coin: &mut Coin<CoinType>, source_coin: Coin<CoinType>) : Coin<CoinType> {
+    public fun merge_and_return_zero_coin<CoinType>(dst_coin: &mut Coin<CoinType>, source_coin: &mut Coin<CoinType>) {
         spec {
             assume dst_coin.value + source_coin.value <= MAX_U64;
         };
         dst_coin.value = dst_coin.value + source_coin.value;
         source_coin.value = 0;
-        source_coin
     }
 
     /// Mint new `Coin` with capability.
@@ -816,8 +815,8 @@ module aptos_framework::coin {
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&source, 1, true);
         let coin_a = mint<FakeMoney>(100, &mint_cap);
         let coin_b = mint<FakeMoney>(200, &mint_cap);
-        let zero_coin = merge_and_return_zero_coin(&mut coin_b, coin_a);
-        destroy_zero(zero_coin);
+        merge_and_return_zero_coin(&mut coin_b, &mut coin_a);
+        destroy_zero(coin_a);
         assert!(value(&coin_b) == 300, 0);
         burn(coin_b, &burn_cap);
 

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -819,6 +819,7 @@ module aptos_framework::coin {
         let zero_coin = merge_and_return_zero_coin(&mut coin_b, coin_a);
         destroy_zero(zero_coin);
         assert!(value(&coin_b) == 300, 0);
+        burn(coin_b, &burn_cap);
 
         move_to(&source, FakeMoneyCapabilities {
             burn_cap,

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -470,6 +470,18 @@ module aptos_framework::coin {
         let Coin { value: _ } = source_coin;
     }
 
+    /// Same as be merge function but it return zero source coin for gas fee optimize reason if
+    /// you got a situation that you need merge Coin<CoinType> then you also need zero value Coin<CoinType>,
+    /// for example to feed zero coin to an Uniswap V2 type AMM DEX for doing a swap action.
+    public fun merge_and_return_zero_coin<CoinType>(dst_coin: &mut Coin<CoinType>, source_coin: Coin<CoinType>) : Coin<CoinType> {
+        spec {
+            assume dst_coin.value + source_coin.value <= MAX_U64;
+        };
+        dst_coin.value = dst_coin.value + source_coin.value;
+        source_coin.value = 0;
+        source_coin
+    }
+
     /// Mint new `Coin` with capability.
     /// The capability `_cap` should be passed as reference to `MintCapability<CoinType>`.
     /// Returns minted `Coin`.

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -809,6 +809,25 @@ module aptos_framework::coin {
     }
 
     #[test(source = @0x1)]
+    public fun test_merge_and_return_zero_coin(
+        source: signer,
+    ) acquires CoinInfo {
+        account::create_account_for_test(signer::address_of(&source));
+        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&source, 1, true);
+        let coin_a = mint<FakeMoney>(100, &mint_cap);
+        let coin_b = mint<FakeMoney>(200, &mint_cap);
+        let zero_coin = merge_and_return_zero_coin(&mut coin_b, coin_a);
+        destroy_zero(zero_coin);
+        assert!(value(&coin_b) == 300, 0);
+
+        move_to(&source, FakeMoneyCapabilities {
+            burn_cap,
+            freeze_cap,
+            mint_cap,
+        });
+    }
+
+    #[test(source = @0x1)]
     public entry fun test_extract(
         source: signer,
     ) acquires CoinInfo, CoinStore {

--- a/aptos-move/framework/aptos-framework/sources/coin.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.spec.move
@@ -215,7 +215,7 @@ spec aptos_framework::coin {
         ensures dst_coin.value == old(dst_coin.value) + source_coin.value;
     }
 
-    spec merge_and_return_zero_coin<CoinType>(dst_coin: &mut Coin<CoinType>, source_coin: Coin<CoinType>) : Coin<CoinType> {
+    spec merge_and_return_zero_coin<CoinType>(dst_coin: &mut Coin<CoinType>, source_coin: &mut Coin<CoinType>) {
         ensures dst_coin.value == old(dst_coin.value) + source_coin.value;
         ensures source_coin.value == 0;
     }

--- a/aptos-move/framework/aptos-framework/sources/coin.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.spec.move
@@ -215,6 +215,11 @@ spec aptos_framework::coin {
         ensures dst_coin.value == old(dst_coin.value) + source_coin.value;
     }
 
+    spec merge_and_return_zero_coin<CoinType>(dst_coin: &mut Coin<CoinType>, source_coin: Coin<CoinType>) : Coin<CoinType> {
+        ensures dst_coin.value == old(dst_coin.value) + source_coin.value;
+        ensures source_coin.value == 0;
+    }
+
     /// An account can only be registered once.
     /// Updating `Account.guid_creation_num` will not overflow.
     spec register<CoinType>(account: &signer) {


### PR DESCRIPTION
… reason.

### Description
Could we have this? so some dapps I think it could use this function to avoid destroy coin then create coin again for gas optimizing. Please let me know if there has something wrong.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
I wrote the spec for verify propose, it should be right, what test plan should I did?

--------
Honestly, if you want less gas fee on Move Contract, you have to write the contract like assembly language and exploit gas meter rule.