### PR TITLE
Add Aptos Docs GitHub project to Aptos.dev home page

### DIFF
--- a/developer-docs-site/docs/index.md
+++ b/developer-docs-site/docs/index.md
@@ -138,7 +138,7 @@ Please remember, community managers will never message or DM you first, and they
 
 Want to join a great team working on amazing world-scale problems? Take a look at [active roles](https://aptoslabs.com/careers) on [AptosLabs.com](https://www.aptoslabs.com/) and come build with us! Or [create a pull request](https://github.com/aptos-labs/aptos-core/pulls) to make updates and [file issues](https://github.com/aptos-labs/aptos-core/issues) to report problems.
 
-We welcome your own [contributions](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) to the Aptos blockchain and this site! In fact, every contributor to Aptos.dev is listed as an *author* on the pages they edit and update. See the *Authors* list at the bottom for an example.
+We welcome your own [contributions](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) to the Aptos blockchain and this site! In fact, every contributor to Aptos.dev is listed as an *author* on the pages they edit and update. See the *Authors* list at the bottom for an example. See the [Aptos Docs](https://github.com/orgs/aptos-labs/projects/14/views/1) project for open issues by status.
 
 Simply click *Edit this page* at the bottom of any location to go to the source and trigger editing there. The contents are in [Markdown](https://www.markdownguide.org/basic-syntax/) format. When ready, [start a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) with your changes. We will get back to you shortly.
 


### PR DESCRIPTION
### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
