### PR TITLE
[DONOTLAND] Repro of stack overflow in unit tests due to too large RootInfo

### DIFF
--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -170,7 +170,7 @@ impl BlockStore {
         back_pressure_limit: Round,
         payload_manager: Arc<PayloadManager>,
     ) -> Self {
-        let RootInfo(root_block, root_qc, root_ordered_cert, root_commit_cert) = root;
+        let RootInfo(root_block, root_qc, root_ordered_cert, root_commit_cert, _) = root;
 
         //verify root is correct
         assert!(

--- a/consensus/src/persistent_liveness_storage.rs
+++ b/consensus/src/persistent_liveness_storage.rs
@@ -53,7 +53,13 @@ pub trait PersistentLivenessStorage: Send + Sync {
 }
 
 #[derive(Clone)]
-pub struct RootInfo(pub Block, pub QuorumCert, pub QuorumCert, pub QuorumCert);
+pub struct RootInfo(
+    pub Block,
+    pub QuorumCert,
+    pub QuorumCert,
+    pub QuorumCert,
+    pub Block,
+);
 
 /// LedgerRecoveryData is a subset of RecoveryData that we can get solely from ledger info.
 #[derive(Clone)]
@@ -130,11 +136,13 @@ impl LedgerRecoveryData {
             .create_merged_with_executed_state(latest_ledger_info_sig)
             .expect("Inconsistent commit proof and evaluation decision, cannot commit block");
 
+        let extra_info = root_block.clone();
         Ok(RootInfo(
             root_block,
             root_quorum_cert,
             root_ordered_cert,
             root_commit_cert,
+            extra_info,
         ))
     }
 }


### PR DESCRIPTION
### Description

Run `cargo test --package aptos-consensus sync_on_partial_newer_sync_info`.
And see `thread 'round_manager::round_manager_test::sync_on_partial_newer_sync_info' has overflowed its stack
fatal runtime error: stack overflow`

This is due to the `RootInfo` being returned in `find_root`

Note, this does not show up in the release build, i.e., no stack overflow with `cargo test --release --package aptos-consensus sync_on_partial_newer_sync_info`

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
