### PR TITLE
[Network] Clean up uses of LockingHashmap and the health checker.

### DIFF
--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -18,11 +18,11 @@ use aptos_config::{
     config::{MempoolConfig, PeerRole, RoleType},
     network_id::PeerNetworkId,
 };
-use aptos_infallible::Mutex;
+use aptos_infallible::{Mutex, RwLock};
 use aptos_logger::prelude::*;
 use aptos_netcore::transport::ConnectionOrigin;
 use aptos_network::{
-    application::{error::Error, interface::NetworkClientInterface, storage::LockingHashMap},
+    application::{error::Error, interface::NetworkClientInterface},
     transport::ConnectionMetadata,
 };
 use aptos_types::{transaction::SignedTransaction, PeerId};
@@ -32,7 +32,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
-    collections::{hash_map::RandomState, BTreeMap, BTreeSet},
+    collections::{hash_map::RandomState, BTreeMap, BTreeSet, HashMap},
     hash::{BuildHasher, Hasher},
     ops::Add,
     sync::Arc,
@@ -79,7 +79,7 @@ pub enum BroadcastError {
 #[derive(Clone, Debug)]
 pub(crate) struct MempoolNetworkInterface<NetworkClient> {
     network_client: NetworkClient,
-    sync_states: Arc<LockingHashMap<PeerNetworkId, PeerSyncState>>,
+    sync_states: Arc<RwLock<HashMap<PeerNetworkId, PeerSyncState>>>,
     prioritized_peers: Arc<Mutex<Vec<PeerNetworkId>>>,
     role: RoleType,
     mempool_config: MempoolConfig,
@@ -94,7 +94,7 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
     ) -> MempoolNetworkInterface<NetworkClient> {
         Self {
             network_client,
-            sync_states: Arc::new(LockingHashMap::new()),
+            sync_states: Arc::new(RwLock::new(HashMap::new())),
             prioritized_peers: Arc::new(Mutex::new(Vec::new())),
             role,
             mempool_config,
@@ -104,7 +104,7 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
 
     /// Add a peer to sync states, and returns `false` if the peer already is in storage
     pub fn add_peer(&self, peer: PeerNetworkId, metadata: ConnectionMetadata) -> bool {
-        let mut sync_states = self.sync_states.write_lock();
+        let mut sync_states = self.sync_states.write();
         let is_new_peer = !sync_states.contains_key(&peer);
         if self.is_upstream_peer(&peer, Some(&metadata)) {
             // If we have a new peer, let's insert new data, otherwise, let's just update the current state
@@ -128,7 +128,7 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
     /// Disables a peer if it can be restarted, otherwise removes it
     pub fn disable_peer(&self, peer: PeerNetworkId) {
         // All other nodes have their state immediately restarted anyways, so let's free them
-        if self.sync_states.write_lock().remove(&peer).is_some() {
+        if self.sync_states.write().remove(&peer).is_some() {
             counters::active_upstream_peers(&peer.network_id()).dec();
         }
 
@@ -144,8 +144,8 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
 
         // Retrieve just what's needed for the peer ordering
         let peers: Vec<_> = {
-            let peer_states = self.sync_states.read_all();
-            peer_states
+            self.sync_states
+                .read()
                 .iter()
                 .map(|(peer, state)| (*peer, state.metadata.role))
                 .collect()
@@ -193,7 +193,7 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
         backoff: bool,
         timestamp: SystemTime,
     ) {
-        let mut sync_states = self.sync_states.write_lock();
+        let mut sync_states = self.sync_states.write();
 
         let sync_state = if let Some(state) = sync_states.get_mut(&peer) {
             state
@@ -245,7 +245,7 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
     }
 
     pub fn is_backoff_mode(&self, peer: &PeerNetworkId) -> bool {
-        if let Some(state) = self.sync_states.write_lock().get(peer) {
+        if let Some(state) = self.sync_states.write().get(peer) {
             state.broadcast_info.backoff_mode
         } else {
             // If we don't have sync state, we shouldn't backoff
@@ -280,7 +280,7 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
         scheduled_backoff: bool,
         smp: &mut SharedMempool<NetworkClient, TransactionValidator>,
     ) -> Result<(MultiBatchId, Vec<SignedTransaction>, Option<&str>), BroadcastError> {
-        let mut sync_states = self.sync_states.write_lock();
+        let mut sync_states = self.sync_states.write();
         // If we don't have any info about the node, we shouldn't broadcast to it
         let state = sync_states
             .get_mut(&peer)
@@ -416,7 +416,7 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
         batch_id: MultiBatchId,
         send_time: SystemTime,
     ) -> Result<usize, BroadcastError> {
-        let mut sync_states = self.sync_states.write_lock();
+        let mut sync_states = self.sync_states.write();
         let state = sync_states
             .get_mut(&peer)
             .ok_or(BroadcastError::PeerNotFound(peer))?;
@@ -478,7 +478,7 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
     }
 
     pub fn sync_states_exists(&self, peer: &PeerNetworkId) -> bool {
-        self.sync_states.read(peer).is_some()
+        self.sync_states.read().get(peer).is_some()
     }
 }
 

--- a/network/peer-monitoring-service/server/src/tests.rs
+++ b/network/peer-monitoring-service/server/src/tests.rs
@@ -16,7 +16,7 @@ use aptos_netcore::transport::ConnectionOrigin;
 use aptos_network::{
     application::{
         storage::PeerMetadataStorage,
-        types::{PeerError, PeerInfo, PeerState},
+        types::{PeerInfo, PeerState},
     },
     peer_manager::PeerManagerNotification,
     protocols::{
@@ -32,11 +32,7 @@ use aptos_peer_monitoring_service_types::{
 };
 use aptos_types::{network_address::NetworkAddress, PeerId};
 use futures::channel::oneshot;
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    str::FromStr,
-    sync::Arc,
-};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 #[tokio::test]
 async fn test_get_server_protocol_version() {
@@ -103,13 +99,7 @@ async fn test_get_connected_peers() {
 
     // Disconnect the peer
     peer_metadata_storage
-        .write(peer_network_id, |entry| match entry {
-            Entry::Vacant(..) => Err(PeerError::NotFound),
-            Entry::Occupied(inner) => {
-                inner.get_mut().status = PeerState::Disconnected;
-                Ok(())
-            },
-        })
+        .update_peer_state(peer_network_id, PeerState::Disconnected)
         .unwrap();
 
     // Process a request to fetch the connected peers

--- a/network/src/testutils/test_node.rs
+++ b/network/src/testutils/test_node.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    application::{
-        storage::PeerMetadataStorage,
-        types::{PeerError, PeerState},
-    },
+    application::{storage::PeerMetadataStorage, types::PeerState},
     peer_manager::{ConnectionNotification, PeerManagerNotification, PeerManagerRequest},
     protocols::{
         direct_send::Message,
@@ -22,11 +19,7 @@ use aptos_netcore::transport::ConnectionOrigin;
 use aptos_types::PeerId;
 use async_trait::async_trait;
 use futures::StreamExt;
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 /// A sender to a node to mock an inbound network message from [`PeerManager`]
 pub type InboundMessageSender =
@@ -90,13 +83,7 @@ impl InboundNetworkHandle {
         // Set the state of the peer as disconnected
         let peer_network_id = PeerNetworkId::new(network_id, conn_metadata.remote_peer_id);
         self.peer_metadata_storage
-            .write(peer_network_id, |entry| match entry {
-                Entry::Vacant(..) => Err(PeerError::NotFound),
-                Entry::Occupied(inner) => {
-                    inner.get_mut().status = PeerState::Disconnected;
-                    Ok(())
-                },
-            })
+            .update_peer_state(peer_network_id, PeerState::Disconnected)
             .unwrap();
 
         // Push the notification of the lost peer

--- a/state-sync/aptos-data-client/src/aptosnet/tests.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/tests.rs
@@ -43,7 +43,7 @@ use aptos_types::{
 use claims::{assert_err, assert_matches, assert_none};
 use futures::StreamExt;
 use maplit::hashmap;
-use std::{collections::hash_map::Entry, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 fn mock_ledger_info(version: Version) -> LedgerInfoWithSignatures {
     LedgerInfoWithSignatures::new(
@@ -184,13 +184,7 @@ impl MockNetwork {
     /// Updates the state of the given peer
     fn update_peer_state(&mut self, peer: PeerNetworkId, state: PeerState) {
         self.peer_metadata_storage
-            .write(peer, |entry| match entry {
-                Entry::Vacant(..) => panic!("Peer must exist!"),
-                Entry::Occupied(inner) => {
-                    inner.get_mut().status = state;
-                    Ok(())
-                },
-            })
+            .update_peer_state(peer, state)
             .unwrap();
     }
 


### PR DESCRIPTION
Note: this PR doesn't make any logical changes (only refactors).

### Description

This PR makes the following small refactors to the networking code:
1. Removes `LockingHashMap<T>` and all uses from the code. `LockingHashMap` is a simple wrapper around a `RwLock<HashMap<T>>`. While nice in theory, it has the following practical downsides: (i) it still has to expose the write lock to clients, which leaks abstractions; (ii) it performs unnecessary data copying (e.g., where a simple iterator through the hashmap would be cheaper than copying the entire map and returning it); and (iii) it results in another layer of indirection for calling code. Given that we're wanting to do some major cleanups to the code and reduce complexity, it seems cleaner to remove this entirely.
2. Cleans up some of the health checker network interface code. Specifically, we add a few methods to the interface so that the health checker code reads more clearly. Nothing should really change here other than readability.

Once this PR lands, I'll have another PR sent out that rebrands the entire `PeerMetadataStorage`. Note: I originally included that PR in this, but it became too big, so it seems simpler to break things up like this.

### Test Plan
Existing test infrastructure.