### PR TITLE
enable cryptography features and type_info::chain_id() feature in Move

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -19,7 +19,11 @@ pub struct Features {
 pub enum FeatureFlag {
     CodeDependencyCheck,
     TreatFriendAsPrivate,
+    Sha512AndRipeMd160Natives,
+    AptosStdChainIdNatives,
     VMBinaryFormatV6,
+    MultiEd25519PkValidateV2Natives,
+    Blake2b256Native,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -93,7 +97,15 @@ impl From<FeatureFlag> for AptosFeatureFlag {
         match f {
             FeatureFlag::CodeDependencyCheck => AptosFeatureFlag::CODE_DEPENDENCY_CHECK,
             FeatureFlag::TreatFriendAsPrivate => AptosFeatureFlag::TREAT_FRIEND_AS_PRIVATE,
+            FeatureFlag::Sha512AndRipeMd160Natives => {
+                AptosFeatureFlag::SHA_512_AND_RIPEMD_160_NATIVES
+            },
+            FeatureFlag::AptosStdChainIdNatives => AptosFeatureFlag::APTOS_STD_CHAIN_ID_NATIVES,
             FeatureFlag::VMBinaryFormatV6 => AptosFeatureFlag::VM_BINARY_FORMAT_V6,
+            FeatureFlag::MultiEd25519PkValidateV2Natives => {
+                AptosFeatureFlag::MULTI_ED25519_PK_VALIDATE_V2_NATIVES
+            },
+            FeatureFlag::Blake2b256Native => AptosFeatureFlag::BLAKE2B_256_NATIVE,
         }
     }
 }
@@ -104,7 +116,15 @@ impl From<AptosFeatureFlag> for FeatureFlag {
         match f {
             AptosFeatureFlag::CODE_DEPENDENCY_CHECK => FeatureFlag::CodeDependencyCheck,
             AptosFeatureFlag::TREAT_FRIEND_AS_PRIVATE => FeatureFlag::TreatFriendAsPrivate,
+            AptosFeatureFlag::SHA_512_AND_RIPEMD_160_NATIVES => {
+                FeatureFlag::Sha512AndRipeMd160Natives
+            },
+            AptosFeatureFlag::APTOS_STD_CHAIN_ID_NATIVES => FeatureFlag::AptosStdChainIdNatives,
             AptosFeatureFlag::VM_BINARY_FORMAT_V6 => FeatureFlag::VMBinaryFormatV6,
+            AptosFeatureFlag::MULTI_ED25519_PK_VALIDATE_V2_NATIVES => {
+                FeatureFlag::MultiEd25519PkValidateV2Natives
+            },
+            AptosFeatureFlag::BLAKE2B_256_NATIVE => FeatureFlag::Blake2b256Native,
         }
     }
 }

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -399,7 +399,15 @@ fn initialize(
 }
 
 fn initialize_features(session: &mut SessionExt<impl MoveResolver>) {
-    let features: Vec<u64> = vec![1, 2, 5];
+    let features: Vec<u64> = vec![
+        FeatureFlag::CODE_DEPENDENCY_CHECK as u64,
+        FeatureFlag::TREAT_FRIEND_AS_PRIVATE as u64,
+        FeatureFlag::SHA_512_AND_RIPEMD_160_NATIVES as u64,
+        FeatureFlag::APTOS_STD_CHAIN_ID_NATIVES as u64,
+        FeatureFlag::VM_BINARY_FORMAT_V6 as u64,
+        FeatureFlag::MULTI_ED25519_PK_VALIDATE_V2_NATIVES as u64,
+        FeatureFlag::BLAKE2B_256_NATIVE as u64,
+    ];
 
     let mut serialized_values = serialize_values(&vec![MoveValue::Signer(CORE_CODE_ADDRESS)]);
     serialized_values.push(bcs::to_bytes(&features).unwrap());

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -10,7 +10,12 @@ use serde::{Deserialize, Serialize};
 pub enum FeatureFlag {
     CODE_DEPENDENCY_CHECK = 1,
     TREAT_FRIEND_AS_PRIVATE = 2,
+    SHA_512_AND_RIPEMD_160_NATIVES = 3,
+    APTOS_STD_CHAIN_ID_NATIVES = 4,
     VM_BINARY_FORMAT_V6 = 5,
+    //COLLECT_AND_DISTRIBUTE_GAS_FEES = 6,
+    MULTI_ED25519_PK_VALIDATE_V2_NATIVES = 7,
+    BLAKE2B_256_NATIVE = 8,
 }
 
 /// Representation of features on chain as a bitset.


### PR DESCRIPTION
### Description

Enables a few cryptography related feature flags:

 - SHA2-512, SHA3-512 and RIPEMD-160 hash functions
 - `aptos_stdlib::type_info::chain_id()` native
 - A new V2 MultiEd25519 PK validation native
 - Blake2b-256 hash function

@davidiw told me these were never enabled :'-(

### Test Plan

Test in production.
