### PR TITLE
[API] avoid API failure for table item deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,7 @@ dependencies = [
  "anyhow",
  "aptos-config",
  "aptos-crypto",
+ "aptos-logger",
  "aptos-openapi",
  "aptos-storage-interface",
  "aptos-types",

--- a/api/types/Cargo.toml
+++ b/api/types/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }
+aptos-logger = { workspace = true }
 aptos-openapi = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-types = { workspace = true }

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -329,7 +329,7 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
             Ok(ti) => ti,
             Err(_) => {
                 aptos_logger::warn!(
-                    "Table info not found for handle {:?}, can't decode table item",
+                    "Table info not found for handle {:?}, can't decode table item. OK for simulation",
                     handle
                 );
                 return Ok(None); // if table item not found return None anyway to avoid crash
@@ -358,7 +358,7 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
             Ok(ti) => ti,
             Err(_) => {
                 aptos_logger::warn!(
-                    "Table info not found for handle {:?}, can't decode table item",
+                    "Table info not found for handle {:?}, can't decode table item. OK for simulation",
                     handle
                 );
                 return Ok(None); // if table item not found return None anyway to avoid crash

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -327,7 +327,13 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
         }
         let table_info = match self.db.get_table_info(handle) {
             Ok(ti) => ti,
-            Err(_) => return Ok(None), // if table item not found return None anyway to avoid crash
+            Err(_) => {
+                aptos_logger::error!(
+                    "Table info not found for handle {:?}, can't decode table item",
+                    handle
+                );
+                return Ok(None); // if table item not found return None anyway to avoid crash
+            },
         };
         let key = self.try_into_move_value(&table_info.key_type, key)?;
         let value = self.try_into_move_value(&table_info.value_type, value)?;
@@ -350,7 +356,13 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
         }
         let table_info = match self.db.get_table_info(handle) {
             Ok(ti) => ti,
-            Err(_) => return Ok(None), // if table item not found return None anyway to avoid crash
+            Err(_) => {
+                aptos_logger::error!(
+                    "Table info not found for handle {:?}, can't decode table item",
+                    handle
+                );
+                return Ok(None); // if table item not found return None anyway to avoid crash
+            },
         };
         let key = self.try_into_move_value(&table_info.key_type, key)?;
 

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -325,7 +325,10 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
         if !self.db.indexer_enabled() {
             return Ok(None);
         }
-        let table_info = self.db.get_table_info(handle).unwrap();
+        let table_info = match self.db.get_table_info(handle) {
+            Ok(ti) => ti,
+            Err(_) => return Ok(None), // if table item not found return None anyway to avoid crash
+        };
         let key = self.try_into_move_value(&table_info.key_type, key)?;
         let value = self.try_into_move_value(&table_info.value_type, value)?;
 
@@ -345,7 +348,10 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
         if !self.db.indexer_enabled() {
             return Ok(None);
         }
-        let table_info = self.db.get_table_info(handle).unwrap();
+        let table_info = match self.db.get_table_info(handle) {
+            Ok(ti) => ti,
+            Err(_) => return Ok(None), // if table item not found return None anyway to avoid crash
+        };
         let key = self.try_into_move_value(&table_info.key_type, key)?;
 
         Ok(Some(DeletedTableData {

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -328,7 +328,7 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
         let table_info = match self.db.get_table_info(handle) {
             Ok(ti) => ti,
             Err(_) => {
-                aptos_logger::error!(
+                aptos_logger::warn!(
                     "Table info not found for handle {:?}, can't decode table item",
                     handle
                 );
@@ -357,7 +357,7 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
         let table_info = match self.db.get_table_info(handle) {
             Ok(ti) => ti,
             Err(_) => {
-                aptos_logger::error!(
+                aptos_logger::warn!(
                     "Table info not found for handle {:?}, can't decode table item",
                     handle
                 );


### PR DESCRIPTION
### Description
Currently if the internal indexer is turned on, parsing tables would cause panics if the handle cannot be found in that internal indexer. This generally is the desired behavior but there is an edge case when we try to simulate a transaction. The table "created" does not get into the internal indexer (since it's not actually created) but when the API is queried, it expects the table to be in the internal indexer, hence the crash. 

The fix is to send a warning when internal indexer cannot find a table handle instead of crashing. 

### Test Plan
Manual testing. 
