### PR TITLE
[Consensus] Add metrics for per peer consensus participation

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -346,6 +346,16 @@ pub static NUM_BLOCKS_IN_TREE: Lazy<IntGauge> = Lazy::new(|| {
 });
 
 /// Counter for the number of blocks in the pipeline broken down by stage.
+pub static CONSENSUS_PARTICIPATION_STATUS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_consensus_participation_status",
+        "Counter for consensus participation status, 0 means no participation and 1 otherwise",
+        &["peer_id"]
+    )
+    .unwrap()
+});
+
+/// Counter for the number of blocks in the pipeline broken down by stage.
 pub static NUM_BLOCKS_IN_PIPELINE: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "aptos_consensus_num_blocks_in_pipeline",

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -7,7 +7,8 @@ use crate::{
         CHAIN_HEALTH_REPUTATION_PARTICIPATING_VOTING_POWER_FRACTION,
         CHAIN_HEALTH_TOTAL_NUM_VALIDATORS, CHAIN_HEALTH_TOTAL_VOTING_POWER,
         CHAIN_HEALTH_WINDOW_SIZES, COMMITTED_PROPOSALS_IN_WINDOW, COMMITTED_VOTES_IN_WINDOW,
-        FAILED_PROPOSALS_IN_WINDOW, LEADER_REPUTATION_ROUND_HISTORY_SIZE,
+        CONSENSUS_PARTICIPATION_STATUS, FAILED_PROPOSALS_IN_WINDOW,
+        LEADER_REPUTATION_ROUND_HISTORY_SIZE,
     },
     liveness::proposer_election::{choose_index, ProposerElection},
 };
@@ -629,6 +630,18 @@ impl LeaderReputation {
                     .filter(|(c, _vp)| participants.contains(c))
                     .map(|(_c, vp)| *vp as f64)
                     .sum();
+
+                candidates.iter().for_each(|x| {
+                    if participants.contains(x) {
+                        CONSENSUS_PARTICIPATION_STATUS
+                            .with_label_values(&[&x.to_string()])
+                            .set(0_i64)
+                    } else {
+                        CONSENSUS_PARTICIPATION_STATUS
+                            .with_label_values(&[&x.to_string()])
+                            .set(1_i64)
+                    }
+                });
 
                 CHAIN_HEALTH_PARTICIPATING_VOTING_POWER[counter_index]
                     .set(participating_voting_power);

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -25,6 +25,7 @@ use aptos_types::{
     epoch_state::EpochState,
 };
 use std::{
+    cmp::max,
     collections::{HashMap, HashSet},
     convert::TryFrom,
     sync::Arc,
@@ -631,17 +632,20 @@ impl LeaderReputation {
                     .map(|(_c, vp)| *vp as f64)
                     .sum();
 
-                candidates.iter().for_each(|x| {
-                    if participants.contains(x) {
-                        CONSENSUS_PARTICIPATION_STATUS
-                            .with_label_values(&[&x.to_string()])
-                            .set(0_i64)
-                    } else {
-                        CONSENSUS_PARTICIPATION_STATUS
-                            .with_label_values(&[&x.to_string()])
-                            .set(1_i64)
-                    }
-                });
+                if counter_index == max(CHAIN_HEALTH_WINDOW_SIZES.len() - 2, 0) {
+                    // Only emit this for the for one window value. Currently it is set to 100
+                    candidates.iter().for_each(|x| {
+                        if participants.contains(x) {
+                            CONSENSUS_PARTICIPATION_STATUS
+                                .with_label_values(&[&x.to_string()])
+                                .set(0_i64)
+                        } else {
+                            CONSENSUS_PARTICIPATION_STATUS
+                                .with_label_values(&[&x.to_string()])
+                                .set(1_i64)
+                        }
+                    });
+                }
 
                 CHAIN_HEALTH_PARTICIPATING_VOTING_POWER[counter_index]
                     .set(participating_voting_power);

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -633,16 +633,16 @@ impl LeaderReputation {
                     .sum();
 
                 if counter_index == max(CHAIN_HEALTH_WINDOW_SIZES.len() - 2, 0) {
-                    // Only emit this for the for one window value. Currently it is set to 100
+                    // Only emit this for one window value. Currently defaults to 100
                     candidates.iter().for_each(|x| {
                         if participants.contains(x) {
                             CONSENSUS_PARTICIPATION_STATUS
                                 .with_label_values(&[&x.to_string()])
-                                .set(0_i64)
+                                .set(1_i64)
                         } else {
                             CONSENSUS_PARTICIPATION_STATUS
                                 .with_label_values(&[&x.to_string()])
-                                .set(1_i64)
+                                .set(0_i64)
                         }
                     });
                 }


### PR DESCRIPTION
### Description

PR adds metrics to emit status for each peer for consensus participation. This metric is emitted from each peer - so even if at least one node in the network is up, we will continue getting this data. The downside however is that the O(N2) number of series are emitted but this is okay because we don't have more than 100 nodes in testnet or mainnet. 

### Test Plan
Run UTs
