### PR TITLE
[TS SDK] Add types field to avoid any type error on ESM projects

### DIFF
--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
### Description

There's an error message below when I use aptos sdk in ESM project.
> There are types at '/node_modules/aptos/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'aptos' library may need to update its package.json or typings.

So I added types field to exports.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

tests are passing