### PR TITLE
[CLI] Fix file format flag for governance proposal generator

### DIFF
--- a/aptos-move/framework/src/aptos.rs
+++ b/aptos-move/framework/src/aptos.rs
@@ -115,6 +115,7 @@ impl ReleaseTarget {
                     references_file: Some("doc_template/references.md".to_string()),
                 }),
                 skip_fetch_latest_git_deps: false,
+                bytecode_version: None,
             },
             packages: packages.iter().map(|(path, _)| path.to_owned()).collect(),
             rust_bindings: packages

--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -57,6 +57,7 @@ pub struct BuildOptions {
     pub docgen_options: Option<DocgenOptions>,
     #[clap(long)]
     pub skip_fetch_latest_git_deps: bool,
+    pub bytecode_version: Option<u32>,
 }
 
 // Because named_addresses has no parser, we can't use clap's default impl. This must be aligned
@@ -75,6 +76,7 @@ impl Default for BuildOptions {
             // This is false by default, because it could accidentally pull new dependencies
             // while in a test (and cause some havoc)
             skip_fetch_latest_git_deps: false,
+            bytecode_version: None,
         }
     }
 }
@@ -208,7 +210,11 @@ impl BuiltPackage {
     pub fn extract_code(&self) -> Vec<Vec<u8>> {
         self.package
             .root_modules()
-            .map(|unit_with_source| unit_with_source.unit.serialize(None))
+            .map(|unit_with_source| {
+                unit_with_source
+                    .unit
+                    .serialize(self.options.bytecode_version)
+            })
             .collect()
     }
 
@@ -240,7 +246,11 @@ impl BuiltPackage {
     pub fn extract_script_code(&self) -> Vec<Vec<u8>> {
         self.package
             .scripts()
-            .map(|unit_with_source| unit_with_source.unit.serialize(None))
+            .map(|unit_with_source| {
+                unit_with_source
+                    .unit
+                    .serialize(self.options.bytecode_version)
+            })
             .collect()
     }
 

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -767,10 +767,11 @@ impl CliCommand<()> for GenerateUpgradeProposal {
             next_execution_hash,
         } = self;
         let package_path = move_options.get_package_path()?;
-        let options = included_artifacts.build_options(
+        let mut options = included_artifacts.build_options(
             move_options.skip_fetch_latest_git_deps,
             move_options.named_addresses(),
         );
+        options.bytecode_version = move_options.bytecode_version;
         let package = BuiltPackage::build(package_path, options)?;
         let release = ReleasePackage::new(package)?;
 

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -481,6 +481,7 @@ impl CliCommand<&'static str> for DocumentPackage {
             named_addresses: move_options.named_addresses(),
             docgen_options: Some(docgen_options),
             skip_fetch_latest_git_deps: move_options.skip_fetch_latest_git_deps,
+            bytecode_version: move_options.bytecode_version,
         };
         BuiltPackage::build(move_options.get_package_path()?, build_options)?;
         Ok("succeeded")


### PR DESCRIPTION
### Description

Right now the aptos cli didn't forward the file format flag to the release bundle generator, causing the cli to always emit the modules with the latest version of file format.

### Test Plan

Manually inspected the generated module to make sure the major version is as expected.
