### PR TITLE
[Network] Add simple cache to PeersAndMetadata.

### DIFF
--- a/crates/aptos-bitvec/src/lib.rs
+++ b/crates/aptos-bitvec/src/lib.rs
@@ -63,7 +63,7 @@ const MAX_BUCKETS: usize = 8192;
 /// assert!(intersection.is_set(2));
 /// assert_eq!(false, intersection.is_set(3));
 /// ```
-#[derive(Clone, Default, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Default, Debug, Eq, Hash, PartialEq, Serialize)]
 pub struct BitVec {
     #[serde(with = "serde_bytes")]
     inner: Vec<u8>,

--- a/network/src/application/interface.rs
+++ b/network/src/application/interface.rs
@@ -119,6 +119,8 @@ impl<Message: NetworkMessageTrait + Clone> NetworkClient<Message> {
         peer: &PeerNetworkId,
         preferred_protocols: &[ProtocolId],
     ) -> Result<ProtocolId, Error> {
+        // TODO: we need to provide a caching mechanism to avoid recomputing this!
+
         let protocols_supported_by_peer = self.get_supported_protocols(peer)?;
         for protocol in preferred_protocols {
             if protocols_supported_by_peer.contains(*protocol) {

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -199,7 +199,7 @@ impl fmt::Display for ProtocolId {
 /// These sets are sent over-the-wire in the initial [`HandshakeMsg`] to other
 /// AptosNet peers in order to negotiate the set of common supported protocols for
 /// use on a new AptosNet connection.
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct ProtocolIdSet(aptos_bitvec::BitVec);
 


### PR DESCRIPTION
Note: most of this PR is new unit tests.

### Description
This PR adds a simple cache to the `PeersAndMetadata` struct to cache results from the `get_connected_supported_peers()` method. This method is expected to be called very frequently from applications (e.g., state sync, mempool, etc.) and returns the connected and supported peers for the given protocol set. Thus, we cache the results to avoid performing redundant computations. Each time peers and metadata is internally updated (e.g., by the network code when a new peer connects to the node, or disconnects from the node), the cache is invalidated and reconstructed lazily.

### Test Plan
New unit tests and the existing test infrastructure.