### PR TITLE
[aptos-move-package] Sort modules in packages by name

### DIFF
--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -274,7 +274,7 @@ impl MoveHarness {
             .expect("building package must succeed");
         let code = package.extract_code();
         let mut metadata = package
-            .extract_metadata()
+            .extract_metadata(true)
             .expect("extracting package metadata must succeed");
         patch_metadata(&mut metadata);
         self.create_transaction_payload(

--- a/aptos-move/e2e-move-tests/src/tests/attributes.rs
+++ b/aptos-move/e2e-move-tests/src/tests/attributes.rs
@@ -119,7 +119,7 @@ fn test_bad_fun_attribute_in_compiled_module() {
     compiled_module.metadata = vec![metadata];
     compiled_module.serialize(&mut code).unwrap();
     let metadata = package
-        .extract_metadata()
+        .extract_metadata(true)
         .expect("extracting package metadata must succeed");
     let result = h.run_transaction_payload(
         &account,
@@ -179,7 +179,7 @@ fn test_bad_view_attribute_in_compiled_module() {
     let mut code = vec![];
     compiled_module.serialize(&mut code).unwrap();
     let metadata = package
-        .extract_metadata()
+        .extract_metadata(true)
         .expect("extracting package metadata must succeed");
     let result = h.run_transaction_payload(
         &account,

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.rs
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.rs
@@ -229,7 +229,7 @@ fn code_publishing_using_resource_account() {
 
     let code = package.extract_code();
     let metadata = package
-        .extract_metadata()
+        .extract_metadata(true)
         .expect("extracting package metadata must succeed");
     let bcs_metadata = bcs::to_bytes(&metadata).expect("PackageMetadata has BCS");
 

--- a/aptos-move/e2e-move-tests/src/tests/generate_upgrade_script.rs
+++ b/aptos-move/e2e-move-tests/src/tests/generate_upgrade_script.rs
@@ -38,6 +38,7 @@ module 0x{}::test {{
 
     let upgrade_release = ReleasePackage::new(
         BuiltPackage::build(upgrade_dir.path().to_path_buf(), BuildOptions::default()).unwrap(),
+        true,
     )
     .unwrap();
 

--- a/aptos-move/e2e-move-tests/src/tests/mint_nft.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mint_nft.rs
@@ -69,7 +69,7 @@ fn mint_nft_e2e() {
 
     let code = package.extract_code();
     let metadata = package
-        .extract_metadata()
+        .extract_metadata(true)
         .expect("extracting package metadata must succeed");
 
     // create the resource account and publish the module under the resource account's address

--- a/aptos-move/e2e-move-tests/src/tests/simple_defi.rs
+++ b/aptos-move/e2e-move-tests/src/tests/simple_defi.rs
@@ -44,7 +44,7 @@ fn exchange_e2e_test() {
     .expect("building package must succeed");
     let code = package.extract_code();
     let metadata = package
-        .extract_metadata()
+        .extract_metadata(true)
         .expect("extracting package metadata must succeed");
 
     // create the resource account and publish the code under the resource account's address

--- a/aptos-move/framework/src/aptos.rs
+++ b/aptos-move/framework/src/aptos.rs
@@ -131,6 +131,7 @@ impl ReleaseTarget {
                 // Place in current directory
                 PathBuf::from(self.file_name())
             },
+            sort_modules: false,
         }
     }
 

--- a/aptos-move/framework/src/release_builder.rs
+++ b/aptos-move/framework/src/release_builder.rs
@@ -31,6 +31,9 @@ pub struct ReleaseOptions {
     /// The path to the file where to place the release bundle.
     #[clap(long, default_value = "head.mrb", parse(from_os_str))]
     pub output: PathBuf,
+    /// Sort the modules by name
+    #[clap(long)]
+    pub sort_modules: bool,
 }
 
 impl ReleaseOptions {
@@ -42,6 +45,7 @@ impl ReleaseOptions {
             packages,
             rust_bindings,
             output,
+            sort_modules,
         } = self;
         let mut released_packages = vec![];
         let mut source_paths = vec![];
@@ -54,7 +58,7 @@ impl ReleaseOptions {
                     .ok_or_else(|| anyhow!("abis not available, can't generate sdk"))?;
                 Self::generate_rust_bindings(&abis, &PathBuf::from(rust_binding_path))?;
             }
-            let released = ReleasePackage::new(built)?;
+            let released = ReleasePackage::new(built, sort_modules)?;
             let size = bcs::to_bytes(&released)?.len();
             println!(
                 "Including package `{}` size {}k",

--- a/aptos-move/framework/src/release_bundle.rs
+++ b/aptos-move/framework/src/release_bundle.rs
@@ -104,9 +104,9 @@ impl ReleaseBundle {
 
 impl ReleasePackage {
     /// Creates a new released package.
-    pub fn new(package: BuiltPackage) -> anyhow::Result<Self> {
+    pub fn new(package: BuiltPackage, sort_modules: bool) -> anyhow::Result<Self> {
         // TODO: remove poliocy and put it into toml
-        let metadata = package.extract_metadata()?;
+        let metadata = package.extract_metadata(sort_modules)?;
         Ok(ReleasePackage {
             metadata,
             code: package.extract_code(),

--- a/crates/aptos/src/move_tool/stored_package.rs
+++ b/crates/aptos/src/move_tool/stored_package.rs
@@ -175,12 +175,6 @@ impl<'a> CachedPackageMetadata<'a> {
                 package_metadata.upgrade_policy,
                 self_metadata.upgrade_policy
             )
-        } else if self_metadata.upgrade_number != package_metadata.upgrade_number {
-            bail!(
-                "Upgrade number doesn't match {:?} : {:?}",
-                package_metadata.upgrade_number,
-                self_metadata.upgrade_number
-            )
         } else if self_metadata.extension != package_metadata.extension {
             bail!(
                 "Extensions doesn't match {:?} : {:?}",

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -810,6 +810,7 @@ impl CliTestFramework {
             save_metadata: false,
             included_artifacts_args: IncludedArtifactsArgs {
                 included_artifacts: included_artifacts.unwrap_or(IncludedArtifacts::Sparse),
+                sort_modules: true,
             },
         }
         .execute()
@@ -844,6 +845,7 @@ impl CliTestFramework {
             override_size_check: false,
             included_artifacts_args: IncludedArtifactsArgs {
                 included_artifacts: included_artifacts.unwrap_or(IncludedArtifacts::Sparse),
+                sort_modules: true,
             },
         }
         .execute()

--- a/testsuite/module-publish/src/main.rs
+++ b/testsuite/module-publish/src/main.rs
@@ -102,7 +102,7 @@ fn write_pacakge_simple(file: &mut File) {
     let package =
         BuiltPackage::build(path, BuildOptions::default()).expect("building package must succeed");
     let code = package.extract_code();
-    let package_metadata = package.extract_metadata().expect("Metadata must exist");
+    let package_metadata = package.extract_metadata(true).expect("Metadata must exist");
     let metadata = bcs::to_bytes(&package_metadata).expect("Metadata must serialize");
 
     // write out package metadata

--- a/testsuite/smoke-test/src/aptos/move_test_helpers.rs
+++ b/testsuite/smoke-test/src/aptos/move_test_helpers.rs
@@ -16,7 +16,7 @@ pub async fn publish_package(
 ) -> Result<TransactionFactory> {
     let package = BuiltPackage::build(move_dir, BuildOptions::default())?;
     let blobs = package.extract_code();
-    let metadata = package.extract_metadata()?;
+    let metadata = package.extract_metadata(true)?;
     let payload = aptos_cached_packages::aptos_stdlib::code_publish_package_txn(
         bcs::to_bytes(&metadata).expect("PackageMetadata has BCS"),
         blobs,


### PR DESCRIPTION
### Description
This allows users to easily tell which order they need to upload their modules in a package, and helps readability.  A flag is used to turn on this new feature for backwards compatibility when verifying packages.

### Test Plan
```
 ./target/debug/aptos move compile --save-metadata --package-dir aptos-move/framework/aptos-framework --named-addresses hello_blockchain=default
Compiling, may take a little while to download git dependencies...
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING AptosFramework
{
  "Result": [
    "0000000000000000000000000000000000000000000000000000000000000001::account",
    "0000000000000000000000000000000000000000000000000000000000000001::aggregator",
    "0000000000000000000000000000000000000000000000000000000000000001::aggregator_factory",
    "0000000000000000000000000000000000000000000000000000000000000001::aptos_account",
    "0000000000000000000000000000000000000000000000000000000000000001::aptos_coin",
    "0000000000000000000000000000000000000000000000000000000000000001::aptos_governance",
    "0000000000000000000000000000000000000000000000000000000000000001::block",
    "0000000000000000000000000000000000000000000000000000000000000001::chain_id",
    "0000000000000000000000000000000000000000000000000000000000000001::chain_status",
    "0000000000000000000000000000000000000000000000000000000000000001::code",
    "0000000000000000000000000000000000000000000000000000000000000001::coin",
    "0000000000000000000000000000000000000000000000000000000000000001::consensus_config",
    "0000000000000000000000000000000000000000000000000000000000000001::event",
    "0000000000000000000000000000000000000000000000000000000000000001::gas_schedule",
    "0000000000000000000000000000000000000000000000000000000000000001::genesis",
    "0000000000000000000000000000000000000000000000000000000000000001::governance_proposal",
    "0000000000000000000000000000000000000000000000000000000000000001::guid",
    "0000000000000000000000000000000000000000000000000000000000000001::managed_coin",
    "0000000000000000000000000000000000000000000000000000000000000001::optional_aggregator",
    "0000000000000000000000000000000000000000000000000000000000000001::reconfiguration",
    "0000000000000000000000000000000000000000000000000000000000000001::resource_account",
    "0000000000000000000000000000000000000000000000000000000000000001::stake",
    "0000000000000000000000000000000000000000000000000000000000000001::staking_config",
    "0000000000000000000000000000000000000000000000000000000000000001::staking_contract",
    "0000000000000000000000000000000000000000000000000000000000000001::staking_proxy",
    "0000000000000000000000000000000000000000000000000000000000000001::state_storage",
    "0000000000000000000000000000000000000000000000000000000000000001::storage_gas",
    "0000000000000000000000000000000000000000000000000000000000000001::system_addresses",
    "0000000000000000000000000000000000000000000000000000000000000001::timestamp",
    "0000000000000000000000000000000000000000000000000000000000000001::transaction_context",
    "0000000000000000000000000000000000000000000000000000000000000001::transaction_fee",
    "0000000000000000000000000000000000000000000000000000000000000001::transaction_validation",
    "0000000000000000000000000000000000000000000000000000000000000001::util",
    "0000000000000000000000000000000000000000000000000000000000000001::version",
    "0000000000000000000000000000000000000000000000000000000000000001::vesting",
    "0000000000000000000000000000000000000000000000000000000000000001::voting"
  ]
}
```

I also manually verified the BCS metadata file to have the ordered modules