### PR TITLE
[helm][vector-log-agent] fix k8s log drop issue

### DIFF
--- a/terraform/helm/vector-log-agent/files/vector-config.yaml
+++ b/terraform/helm/vector-log-agent/files/vector-config.yaml
@@ -8,6 +8,10 @@ api:
 sources:
   kubernetes_logs:
     type: kubernetes_logs
+    # Resolves https://github.com/vectordotdev/vector/issues/12014
+    max_line_bytes: 16777216
+    max_read_bytes: 16777216
+    glob_minimum_cooldown_ms: 1000
     pod_annotation_fields:
       pod_annotations: kubernetes.annotations
       pod_labels: kubernetes.labels

--- a/terraform/helm/vector-log-agent/values.yaml
+++ b/terraform/helm/vector-log-agent/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: timberio/vector
   pullPolicy: IfNotPresent
-  tag: "0.24.X-distroless-libc"
+  tag: "0.25.X-distroless-libc"
 
 
 # -- Choose any (you can choose multiple) logging sinks supported by vector as found here https://vector.dev/docs/reference/configuration/sinks/


### PR DESCRIPTION
### Description

The issue is described in https://github.com/vectordotdev/vector/issues/12014

Redeploy shows logs coming back in, but that's expected even without the fix. We can monitor the log volume over the next few days.

<!-- Please provide us with clear details for verifying that your changes work. -->
