### PR TITLE
Add ability to self update to aptos CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "reqwest",
+ "self_update",
  "serde 1.0.149",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -932,7 +933,7 @@ dependencies = [
  "aptos-vm",
  "chrono",
  "criterion",
- "indicatif",
+ "indicatif 0.15.0",
  "itertools",
  "jemallocator",
  "num_cpus",
@@ -5609,8 +5610,20 @@ checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
 dependencies = [
  "console",
  "lazy_static 1.4.0",
- "number_prefix",
+ "number_prefix 0.3.0",
  "regex",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
+dependencies = [
+ "console",
+ "number_prefix 0.4.0",
+ "portable-atomic",
+ "unicode-width",
 ]
 
 [[package]]
@@ -7286,6 +7299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7844,6 +7863,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8178,6 +8203,15 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quote"
@@ -8820,6 +8854,24 @@ checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "self_update"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b28d58e73c427061f46c801176f54349be3c1a2818cf549e1d9bcac37eef7bca"
+dependencies = [
+ "hyper",
+ "indicatif 0.17.3",
+ "log",
+ "quick-xml",
+ "regex",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tempfile",
+ "zip",
 ]
 
 [[package]]
@@ -10808,6 +10860,19 @@ dependencies = [
  "quote 1.0.21",
  "syn 1.0.105",
  "synstructure",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "time 0.3.13",
 ]
 
 [[package]]

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -61,6 +61,7 @@ move-vm-runtime = { workspace = true, features = [ "testing" ] }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
+self_update = { version = "0.34.0", features = ["archive-zip", "compression-zip-deflate"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -14,6 +14,7 @@ pub mod op;
 pub mod stake;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod test;
+pub mod update;
 
 use crate::common::{
     types::{CliCommand, CliResult, CliTypedResult},
@@ -45,6 +46,7 @@ pub enum Tool {
     Node(node::NodeTool),
     #[clap(subcommand)]
     Stake(stake::StakeTool),
+    Update(update::UpdateTool),
 }
 
 impl Tool {
@@ -62,6 +64,7 @@ impl Tool {
             Move(tool) => tool.execute().await,
             Node(tool) => tool.execute().await,
             Stake(tool) => tool.execute().await,
+            Update(tool) => tool.execute_serialized().await,
         }
     }
 }

--- a/crates/aptos/src/update/helpers.rs
+++ b/crates/aptos/src/update/helpers.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Context, Result};
+use self_update::{backends::github::Update, cargo_crate_version, version::bump_is_greater};
+
+pub struct UpdateRequiredInfo {
+    pub update_required: bool,
+    pub current_version: String,
+    pub latest_version: String,
+    pub latest_version_tag: String,
+}
+
+/// Return information about whether an update is required.
+pub fn check_if_update_required(repo_owner: &str, repo_name: &str) -> Result<UpdateRequiredInfo> {
+    // Build a configuration for determining the latest release.
+    let config = Update::configure()
+        .repo_owner(repo_owner)
+        .repo_name(repo_name)
+        .bin_name("aptos")
+        .current_version(cargo_crate_version!())
+        .build()
+        .map_err(|e| anyhow!("Failed to build self-update configuration: {:#}", e))?;
+
+    // Get information about the latest release.
+    let latest_release = config
+        .get_latest_release()
+        .map_err(|e| anyhow!("Failed to lookup latest release: {:#}", e))?;
+    let latest_version_tag = latest_release.version;
+    let latest_version = latest_version_tag.split("-v").last().unwrap();
+
+    // Return early if we're up to date already.
+    let current_version = config.current_version();
+    let update_required = bump_is_greater(&current_version, latest_version)
+        .context("Failed to compare current and latest CLI versions")?;
+
+    Ok(UpdateRequiredInfo {
+        update_required,
+        current_version,
+        latest_version: latest_version.to_string(),
+        latest_version_tag,
+    })
+}
+
+pub enum InstallationMethod {
+    Source,
+    Homebrew,
+    Other,
+}
+
+impl InstallationMethod {
+    pub fn from_env() -> Result<Self> {
+        // Determine update instructions based on what we detect about the installation.
+        let exe_path = std::env::current_exe()?;
+        let installation_method = if exe_path.to_string_lossy().contains("brew") {
+            InstallationMethod::Homebrew
+        } else if exe_path.to_string_lossy().contains("target") {
+            InstallationMethod::Source
+        } else {
+            InstallationMethod::Other
+        };
+        Ok(installation_method)
+    }
+}

--- a/crates/aptos/src/update/mod.rs
+++ b/crates/aptos/src/update/mod.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+mod helpers;
+mod tool;
+
+use helpers::check_if_update_required;
+pub use tool::UpdateTool;

--- a/crates/aptos/src/update/tool.rs
+++ b/crates/aptos/src/update/tool.rs
@@ -1,0 +1,135 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{check_if_update_required, helpers::InstallationMethod};
+use crate::common::{
+    types::{CliCommand, CliTypedResult},
+    utils::cli_build_information,
+};
+use anyhow::{anyhow, Context};
+use aptos_build_info::BUILD_OS;
+use async_trait::async_trait;
+use clap::Parser;
+use self_update::{backends::github::Update, cargo_crate_version, Status};
+use std::process::Command;
+
+/// Update the CLI itself
+///
+/// This can be used to update the CLI to the latest version. This is useful if you
+/// installed the CLI via the install script / by downloading the binary directly.
+#[derive(Debug, Parser)]
+pub struct UpdateTool {
+    /// The owner of the repo to download the binary from.
+    #[clap(long, default_value = "aptos-labs")]
+    repo_owner: String,
+
+    /// The name of the repo to download the binary from.
+    #[clap(long, default_value = "aptos-core")]
+    repo_name: String,
+}
+
+impl UpdateTool {
+    // Out of the box this crate assumes that you have releases named a specific way
+    // with the crate name, version, and target triple in a specific format. We don't
+    // do this with our releases, we have other GitHub releases beyond just the CLI,
+    // and we don't build for all major target triples, so we have to do some of the
+    // work ourselves first to figure out what the latest version of the CLI is and
+    // which binary to download based on the current OS. Then we can plug that into
+    // the library which takes care of the rest.
+    fn update(&self) -> CliTypedResult<String> {
+        let installation_method =
+            InstallationMethod::from_env().context("Failed to determine installation method")?;
+        match installation_method {
+            InstallationMethod::Source => {
+                return Err(
+                    anyhow!("Detected this CLI was built from source, refusing to update").into(),
+                );
+            },
+            InstallationMethod::Homebrew => {
+                return Err(anyhow!(
+                    "Detected this CLI comes from homebrew, use `brew upgrade aptos` instead"
+                )
+                .into());
+            },
+            InstallationMethod::Other => {},
+        }
+
+        let info = check_if_update_required(&self.repo_owner, &self.repo_name)?;
+        if !info.update_required {
+            return Ok(format!("CLI already up to date (v{})", info.latest_version));
+        }
+
+        // Determine the target we should download. This is necessary because we don't
+        // name our binary releases using the target triples nor do we build specifically
+        // for all major triples, so we have to generalize to one of the binaries we do
+        // happen to build. We figure this out based on what system the CLI was built on.
+        let build_info = cli_build_information();
+        let target = match build_info.get(BUILD_OS).context("Failed to determine build info of current CLI")?.as_str() {
+            "linux-x86_64" => {
+                // In the case of Linux, which build to use depends on the OpenSSL
+                // library on the host machine. So we try to determine that here.
+                let output = Command::new("openssl")
+                .args(["version"])
+                .output();
+                let version = match output {
+                    Ok(output) => {
+                        let stdout = String::from_utf8(output.stdout).unwrap();
+                        stdout.split_whitespace().collect::<Vec<&str>>()[1].to_string()
+                    },
+                    Err(e) => {
+                        println!("Failed to determine OpenSSL version, assuming an older version: {:#}", e);
+                        "1.0.0".to_string()
+                    }
+                };
+                if version.starts_with('3') {
+                    "Ubuntu-22.04-x86_64"
+                } else {
+                    "Ubuntu-x86_64"
+                }
+            },
+            "macos-x86_64" => "MacOSX-x86_64",
+            "windows-x86_64" => "Windows-x86_64",
+            wildcard => return Err(anyhow!("Self-updating is not supported on your OS right now, please download the binary manually: {}", wildcard).into()),
+        };
+
+        // Build a new configuration that will direct the library to download the
+        // binary with the target version tag and target that we determined above.
+        let config = Update::configure()
+            .repo_owner("aptos-labs")
+            .repo_name("aptos-core")
+            .bin_name("aptos")
+            .current_version(cargo_crate_version!())
+            .target_version_tag(&info.latest_version_tag)
+            .target(target)
+            .build()
+            .map_err(|e| anyhow!("Failed to build self-update configuration: {:#}", e))?;
+
+        // Update the binary.
+        let result = config
+            .update()
+            .map_err(|e| anyhow!("Failed to update Aptos CLI: {:#}", e))?;
+
+        let message = match result {
+            Status::UpToDate(_) => panic!("We should have caught this already"),
+            Status::Updated(_) => format!(
+                "Successfully updated from v{} to v{}",
+                info.current_version, info.latest_version
+            ),
+        };
+
+        Ok(message)
+    }
+}
+
+#[async_trait]
+impl CliCommand<String> for UpdateTool {
+    fn command_name(&self) -> &'static str {
+        "Update"
+    }
+
+    async fn execute(self) -> CliTypedResult<String> {
+        tokio::task::spawn_blocking(move || self.update())
+            .await
+            .context("Failed to self-update Aptos CLI")?
+    }
+}


### PR DESCRIPTION
## Description
This adds to the CLI the ability to update itself.

### Test Plan
First, I changed the version of the CLI in Cargo.toml from 1.0.4 to 1.0.3 to make the CLI think it needs to update itself:
```
$ cargo build-p aptos
$ mv target/debug/aptos /tmp/aptos
$ /tmp/aptos --version
aptos 1.0.3
```

Next, run the self update subcommand:
```
$ /tmp/aptos -- update
Checking target-arch... MacOSX-x86_64
Checking current version... v1.0.3
Looking for tag: aptos-cli-v1.0.4

aptos release status:
  * Current exe: "/Users/dport/a/core/target/debug/aptos"
  * New exe release: "aptos-cli-1.0.4-MacOSX-x86_64.zip"
  * New exe download url: "https://api.github.com/repos/aptos-labs/aptos-core/releases/assets/91367154"

The new release will be downloaded/extracted and the existing binary will be replaced.
Do you want to continue? [Y/n] y
Downloading...
Extracting archive... Done
Replacing binary file... Done
{
  "Result": "Successfully updated from v1.0.3 to v1.0.4"
}
```

Confirm that the CLI has updated:
```
$ /tmp/aptos --version
aptos 1.0.4
```

I ran this test successfully on the following systems:
- MacOS (ARM)
- Arch (x86_64)
- Windows (NT) (x86_64)
- Ubuntu 22 (x86_64)
- Windows (WSL, Ubuntu 22)