### PR TITLE
[aptos-debugger] Implement the CLI interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,12 +831,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-gas",
+ "aptos-logger",
  "aptos-resource-viewer",
  "aptos-rest-client",
  "aptos-state-view",
  "aptos-types",
  "aptos-validator-interface",
  "aptos-vm",
+ "clap 3.2.23",
  "move-binary-format",
  "move-cli",
  "move-compiler",
@@ -845,6 +847,8 @@ dependencies = [
  "move-table-extension",
  "move-vm-runtime",
  "move-vm-test-utils",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -2651,6 +2655,7 @@ dependencies = [
  "aptos-storage-interface",
  "aptos-types",
  "async-trait",
+ "lru",
  "move-binary-format",
  "tokio",
 ]

--- a/aptos-move/aptos-debugger/Cargo.toml
+++ b/aptos-move/aptos-debugger/Cargo.toml
@@ -12,12 +12,14 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 aptos-gas = { workspace = true }
+aptos-logger = { workspace = true }
 aptos-resource-viewer = { workspace = true }
 aptos-rest-client = { workspace = true }
 aptos-state-view = { workspace = true }
 aptos-types = { workspace = true }
 aptos-validator-interface = { workspace = true }
 aptos-vm = { workspace = true }
+clap = { workspace = true }
 move-binary-format = { workspace = true }
 move-cli = { workspace = true }
 move-compiler = { workspace = true }
@@ -26,3 +28,5 @@ move-resource-viewer = { workspace = true }
 move-table-extension = { workspace = true }
 move-vm-runtime = { workspace = true }
 move-vm-test-utils = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }

--- a/aptos-move/aptos-debugger/src/lib.rs
+++ b/aptos-move/aptos-debugger/src/lib.rs
@@ -62,6 +62,8 @@ impl AptosDebugger {
             .debugger
             .get_committed_transactions(begin, limit)
             .await?;
+
+        println!("{:#?}", txns);
         let mut ret = vec![];
         while limit != 0 {
             println!(

--- a/aptos-move/aptos-debugger/src/lib.rs
+++ b/aptos-move/aptos-debugger/src/lib.rs
@@ -63,7 +63,6 @@ impl AptosDebugger {
             .get_committed_transactions(begin, limit)
             .await?;
 
-        println!("{:#?}", txns);
         let mut ret = vec![];
         while limit != 0 {
             println!(

--- a/aptos-move/aptos-debugger/src/main.rs
+++ b/aptos-move/aptos-debugger/src/main.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use aptos_debugger::AptosDebugger;
+use aptos_rest_client::Client;
+use aptos_vm::AptosVM;
+use clap::{Subcommand, Parser};
+use url::Url;
+use std::path::PathBuf;
+
+
+#[derive(Subcommand)]
+pub enum Target {
+    /// Use full node's rest api as query endpoint.
+    Rest { endpoint: String },
+    /// Use a local db instance to serve as query endpoint.
+    DB { path: PathBuf },
+}
+#[derive(Parser)]
+pub struct Argument {
+    #[clap(subcommand)]
+    target: Target,
+
+    #[clap(long)]
+    begin_version: u64,
+
+    #[clap(long)]
+    limit: u64,
+
+    #[clap(long, default_value = "1")]
+    concurrency_level: usize,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    aptos_logger::Logger::new().init();
+    let args = Argument::parse();
+    AptosVM::set_concurrency_level_once(args.concurrency_level);
+
+    let debugger = match args.target {
+         Target::Rest { endpoint } => AptosDebugger::rest_client(Client::new(Url::parse(&endpoint)?))?,
+         Target::DB { path } => AptosDebugger::db(path)?,
+    };
+
+    println!(
+        "{:#?}",
+        debugger
+            .execute_past_transactions(args.begin_version, args.limit)
+            .await?
+    );
+
+    Ok(())
+}

--- a/aptos-move/aptos-debugger/src/main.rs
+++ b/aptos-move/aptos-debugger/src/main.rs
@@ -5,10 +5,9 @@ use anyhow::Result;
 use aptos_debugger::AptosDebugger;
 use aptos_rest_client::Client;
 use aptos_vm::AptosVM;
-use clap::{Subcommand, Parser};
-use url::Url;
+use clap::{Parser, Subcommand};
 use std::path::PathBuf;
-
+use url::Url;
 
 #[derive(Subcommand)]
 pub enum Target {
@@ -39,8 +38,10 @@ async fn main() -> Result<()> {
     AptosVM::set_concurrency_level_once(args.concurrency_level);
 
     let debugger = match args.target {
-         Target::Rest { endpoint } => AptosDebugger::rest_client(Client::new(Url::parse(&endpoint)?))?,
-         Target::DB { path } => AptosDebugger::db(path)?,
+        Target::Rest { endpoint } => {
+            AptosDebugger::rest_client(Client::new(Url::parse(&endpoint)?))?
+        },
+        Target::DB { path } => AptosDebugger::db(path)?,
     };
 
     println!(

--- a/aptos-move/aptos-validator-interface/Cargo.toml
+++ b/aptos-move/aptos-validator-interface/Cargo.toml
@@ -22,5 +22,6 @@ aptos-state-view = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-types = { workspace = true }
 async-trait = { workspace = true }
+lru = { workspace = true }
 move-binary-format = { workspace = true }
 tokio = { workspace = true }

--- a/aptos-move/aptos-validator-interface/src/lib.rs
+++ b/aptos-move/aptos-validator-interface/src/lib.rs
@@ -142,6 +142,7 @@ async fn handler_thread<'a>(
         if let Some(val) = cache.lock().unwrap().get(&(key.clone(), version)) {
             sender.send(val.clone()).unwrap();
         } else {
+            assert!(version > 0, "Expecting a non-genesis version");
             let db = db.clone();
             let cache = cache.clone();
             tokio::spawn(async move {

--- a/aptos-move/aptos-validator-interface/src/lib.rs
+++ b/aptos-move/aptos-validator-interface/src/lib.rs
@@ -18,11 +18,9 @@ use aptos_types::{
     },
     transaction::{Transaction, Version},
 };
+use lru::LruCache;
 use move_binary_format::file_format::CompiledModule;
-use std::sync::{
-    mpsc::{channel, Receiver, Sender},
-    Arc, Mutex,
-};
+use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 // TODO(skedia) Clean up this interfact to remove account specific logic and move to state store
@@ -115,36 +113,57 @@ pub trait AptosValidatorInterface: Sync {
 }
 
 pub struct DebuggerStateView {
-    query_sender: Mutex<UnboundedSender<(StateKey, Version)>>,
-    query_receiver: Mutex<Receiver<Result<Option<StateValue>>>>,
+    query_sender:
+        Mutex<UnboundedSender<(StateKey, Version, std::sync::mpsc::Sender<Option<Vec<u8>>>)>>,
     version: Version,
 }
 
 async fn handler_thread<'a>(
     db: Arc<dyn AptosValidatorInterface + Send>,
-    mut thread_receiver: UnboundedReceiver<(StateKey, Version)>,
-    thread_sender: Sender<Result<Option<StateValue>>>,
+    mut thread_receiver: UnboundedReceiver<(
+        StateKey,
+        Version,
+        std::sync::mpsc::Sender<Option<Vec<u8>>>,
+    )>,
 ) {
+    const M: usize = 1024 * 1024;
+    let cache = Arc::new(Mutex::new(
+        LruCache::<(StateKey, Version), Option<Vec<u8>>>::new(M),
+    ));
+
     loop {
-        let (key, version) = if let Some((key, version)) = thread_receiver.recv().await {
-            (key, version)
+        let (key, version, sender) =
+            if let Some((key, version, sender)) = thread_receiver.recv().await {
+                (key, version, sender)
+            } else {
+                break;
+            };
+
+        if let Some(val) = cache.lock().unwrap().get(&(key.clone(), version)) {
+            sender.send(val.clone()).unwrap();
         } else {
-            break;
-        };
-        let val = db.get_state_value_by_version(&key, version - 1).await;
-        thread_sender.send(val).unwrap();
+            let db = db.clone();
+            let cache = cache.clone();
+            tokio::spawn(async move {
+                let val = db
+                    .get_state_value_by_version(&key, version - 1)
+                    .await
+                    .ok()
+                    .and_then(|v| v.map(|s| s.into_bytes()));
+                cache.lock().unwrap().put((key, version), val.clone());
+                sender.send(val)
+            });
+        }
     }
 }
 
 impl DebuggerStateView {
     pub fn new(db: Arc<dyn AptosValidatorInterface + Send>, version: Version) -> Self {
         let (query_sender, thread_receiver) = unbounded_channel();
-        let (thread_sender, query_receiver) = channel();
 
-        tokio::spawn(async move { handler_thread(db, thread_receiver, thread_sender).await });
+        tokio::spawn(async move { handler_thread(db, thread_receiver).await });
         Self {
             query_sender: Mutex::new(query_sender),
-            query_receiver: Mutex::new(query_receiver),
             version,
         }
     }
@@ -154,18 +173,12 @@ impl DebuggerStateView {
         state_key: &StateKey,
         version: Version,
     ) -> Result<Option<Vec<u8>>> {
-        self.query_sender
-            .lock()
-            .unwrap()
-            .send((state_key.clone(), version))
+        let (tx, rx) = std::sync::mpsc::channel();
+        let query_handler_locked = self.query_sender.lock().unwrap();
+        query_handler_locked
+            .send((state_key.clone(), version, tx))
             .unwrap();
-        Ok(self
-            .query_receiver
-            .lock()
-            .unwrap()
-            .recv()?
-            .ok()
-            .and_then(|v| v.map(|s| s.into_bytes())))
+        Ok(rx.recv()?)
     }
 }
 

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -1099,6 +1099,19 @@ impl Client {
         self.get_bcs(url).await
     }
 
+    pub async fn get_account_module_bcs_at_version(
+        &self,
+        address: AccountAddress,
+        module_name: &str,
+        version: u64,
+    ) -> AptosResult<Response<bytes::Bytes>> {
+        let url = self.build_path(&format!(
+            "accounts/{}/module/{}?ledger_version={}",
+            address, module_name, version
+        ))?;
+        self.get_bcs(url).await
+    }
+
     pub async fn get_account_events(
         &self,
         address: AccountAddress,


### PR DESCRIPTION
### Description

Implemented a CLI tool to spawn an aptos vm and re-execute transactions locally providing an remote endpoint. The cli was built on top of `aptos-validator-interface` crate, which implements a `StateView` trait for the json-rpc/db endpoint so that aptos-vm can use either one of those to execute transactions.

This PR also includes a few optimizations and bug fixes to  `aptos-validator-interface`:
1. Added a LRU cache to optimize the query performance
2. Fixed the locking issue when serving concurrent readers.
3. Fixed the bad module fetching logic for rest api endpoint.
4. Add batching logic for the rest endpoint in order to execute a bigger chunk when needed.

### Test Plan

In order to try out the tool:

For replaying with local db instance, run `cargo run -p aptos-debugger -- --begin-version <VERSION_TO_REPLAY> --limit <NUM_TXNS_TO_REPLAY> db <PATH_TO_LOCAL_DB>`

For replaying with remote full node endpoint, run `cargo run -p aptos-debugger -- --begin-version <VERSION_TO_REPLAY> --limit <NUM_TXNS_TO_REPLAY> rest <PATH_TO_FULL_NODE_ENDPOINT>`

e.g: `cargo run -p aptos-debugger -- --begin-version 414263742 --limit 1 rest https://testnet.aptoslabs.com/v1`
