### PR TITLE
[indexer grpc][4/n] Indexer grpc data service 0.1

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -61,7 +61,6 @@ jobs:
             # on pull_request, this will default to null and the following "checkout" step will use the PR's base branch
             echo "BRANCH=${{ inputs.GIT_SHA }}" >> $GITHUB_OUTPUT
           fi
-
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ steps.determine-test-branch.outputs.BRANCH }}

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -61,6 +61,7 @@ jobs:
             # on pull_request, this will default to null and the following "checkout" step will use the PR's base branch
             echo "BRANCH=${{ inputs.GIT_SHA }}" >> $GITHUB_OUTPUT
           fi
+
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ steps.determine-test-branch.outputs.BRANCH }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,6 +1406,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-crash-handler",
+ "aptos-indexer-grpc-utils",
  "aptos-logger",
  "aptos-moving-average",
  "aptos-protos",
@@ -1423,6 +1424,29 @@ dependencies = [
  "serde_yaml 0.8.26",
  "tokio",
  "tonic",
+ "warp",
+]
+
+[[package]]
+name = "aptos-indexer-grpc-data-service"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-crash-handler",
+ "aptos-indexer-grpc-utils",
+ "aptos-logger",
+ "aptos-moving-average",
+ "aptos-protos",
+ "aptos-runtimes",
+ "cloud-storage",
+ "futures",
+ "prost",
+ "redis",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "uuid",
  "warp",
 ]
 
@@ -1506,6 +1530,7 @@ dependencies = [
  "anyhow",
  "cloud-storage",
  "futures-util",
+ "redis",
  "serde 1.0.149",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ members = [
     "crates/transaction-emitter",
     "crates/transaction-emitter-lib",
     "ecosystem/indexer-grpc/indexer-grpc-cache-worker",
+    "ecosystem/indexer-grpc/indexer-grpc-data-service",
     "ecosystem/indexer-grpc/indexer-grpc-file-store",
     "ecosystem/indexer-grpc/indexer-grpc-fullnode",
     "ecosystem/indexer-grpc/indexer-grpc-utils",
@@ -219,6 +220,7 @@ aptos-global-constants = { path = "config/global-constants" }
 aptos-id-generator = { path = "crates/aptos-id-generator" }
 aptos-indexer = { path = "crates/indexer" }
 aptos-indexer-grpc-cache-worker = { path = "ecosystem/indexer-grpc/indexer-grpc-cache-worker" }
+aptos-indexer-grpc-data-service = { path = "ecosystem/indexer-grpc/indexer-grpc-data-service" }
 aptos-indexer-grpc-file-store = { path = "ecosystem/indexer-grpc/indexer-grpc-file-store" }
 aptos-indexer-grpc-fullnode = { path = "ecosystem/indexer-grpc/indexer-grpc-fullnode" }
 aptos-indexer-grpc-utils = { path = "ecosystem/indexer-grpc/indexer-grpc-utils" }
@@ -321,7 +323,7 @@ clap = { version = "3.2.17", features = ["derive", "env", "suggestions"] }
 clap_complete = "3.2.3"
 cloud-storage = { version = "0.11.1", features = ["global-client"] }
 codespan-reporting = "0.11.1"
-console-subscriber = "0.1.8"
+console-subscriber = "0.1.6"
 const_format = "0.2.26"
 criterion = "0.3.5"
 criterion-cpu-time = "0.1.0"
@@ -331,7 +333,6 @@ crossbeam-queue = "0.3.5"
 curve25519-dalek = "3"
 dashmap = "5.2.0"
 datatest-stable = "0.1.1"
-deadpool-redis = "0.8.0"
 debug-ignore = { version = "1.0.3", features = ["serde"] }
 derivative = "2.2.0"
 diesel = { version = "2.0.0", features = ["chrono", "postgres", "r2d2", "numeric", "serde_json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -323,7 +323,7 @@ clap = { version = "3.2.17", features = ["derive", "env", "suggestions"] }
 clap_complete = "3.2.3"
 cloud-storage = { version = "0.11.1", features = ["global-client"] }
 codespan-reporting = "0.11.1"
-console-subscriber = "0.1.6"
+console-subscriber = "0.1.8"
 const_format = "0.2.26"
 criterion = "0.3.5"
 criterion-cpu-time = "0.1.0"

--- a/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/worker.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/worker.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{create_grpc_client, get_ttl_in_seconds, IndexerGrpcCacheWorkerConfig};
+use aptos_indexer_grpc_utils::update_cache_latest_version;
 use aptos_logger::{error, info};
 use aptos_moving_average::MovingAverage;
 use aptos_protos::datastream::v1::{
@@ -38,6 +39,14 @@ impl Worker {
     pub async fn run(&mut self) {
         // Re-connect if lost.
         // TODO: Add a restart from file store.
+        // TODO: fix the chain id verification.
+        let mut conn = self.redis_client.get_connection().unwrap();
+        let chain_id_exists: bool = conn.exists("chain_id").unwrap();
+        if !chain_id_exists {
+            conn.set::<&str, u32, ()>("chain_id", self.chain_id)
+                .unwrap();
+        }
+
         loop {
             let conn = self.redis_client.get_connection().unwrap();
             let mut rpc_client = create_grpc_client(self.grpc_address.clone()).await;
@@ -64,7 +73,7 @@ impl Worker {
     /// Function to process streaming response from datastream.
     /// It accepts a starting version, a response stream, and a function to process each transaction.
     pub(crate) async fn process_streaming_response(
-        &self,
+        &mut self,
         starting_version: u64,
         mut resp_stream: impl futures_core::Stream<Item = Result<RawDatastreamResponse, tonic::Status>>
             + std::marker::Unpin,
@@ -143,7 +152,10 @@ impl Worker {
                         )
                         .unwrap();
                     }
-
+                    update_cache_latest_version(&mut conn, batch_end_version)
+                        .await
+                        .expect("Update cache latest version failed.");
+                    self.current_version = batch_end_version;
                     ma.tick_now(transaction_len as u64);
                     transaction_count += transaction_len as u64;
                     info!(

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "aptos-indexer-grpc-cache-worker"
-description = "Indexer gRPC worker to collect on-chain data from node gRPC and push to cache."
+name = "aptos-indexer-grpc-data-service"
+description = "Aptos Indexer gRPC data service to serve the cached indexer data."
 version = "0.1.0"
 
 # Workspace inherited keys
@@ -20,17 +20,13 @@ aptos-logger = { workspace = true }
 aptos-moving-average = { workspace = true }
 aptos-protos = { workspace = true }
 aptos-runtimes = { workspace = true }
-async-trait = { workspace = true }
-backoff = { workspace = true }
-clap = { workspace = true }
+cloud-storage = { workspace = true }
 futures = { workspace = true }
-futures-core = { workspace = true }
-once_cell = { workspace = true }
+prost = { workspace = true }
 redis = { workspace = true }
-redis-test = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tonic = { workspace = true }
+uuid = { workspace = true }
 warp = { workspace = true }

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/README.md
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/README.md
@@ -1,0 +1,20 @@
+# Indexer GRPC data service
+
+Indexer GRPC data service fetches data from both cache and file store.
+
+## How to run it.
+
+* service account json with write access to bucket `{FILE_STORE_BUCKET_NAME}-{CHAIN_NAME}`, e.g., with name `xxx.json`.
+  
+* Command-line to run:
+
+```bash
+SERVICE_ACCOUNT=xxx.json \
+REDIS_ADDRESS=127.0.0.1 \
+CHAIN_NAME=devnet \
+GRPC_ADDRESS=0.0.0.0:50052 \
+FILE_STORE_BUCKET_NAME=indexer-grpc-file-store \
+FILE_STORE_BLOB_FOLDER_NAME=blobs \
+HEALTH_CHECK_PORT=8083 \
+cargo run --release
+```

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/lib.rs
@@ -1,0 +1,10 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+pub mod service;
+
+pub fn get_grpc_address() -> String {
+    std::env::var("GRPC_ADDRESS").expect("GRPC_ADDRESS not set")
+}

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/main.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/main.rs
@@ -1,0 +1,51 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_indexer_grpc_data_service::{get_grpc_address, service::DatastreamServer};
+use aptos_indexer_grpc_utils::get_health_check_port;
+use aptos_protos::datastream::v1::indexer_stream_server::IndexerStreamServer;
+use std::{
+    net::ToSocketAddrs,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+use tonic::transport::Server;
+use warp::Filter;
+
+fn main() {
+    aptos_logger::Logger::new().init();
+    aptos_crash_handler::setup_panic_handler();
+
+    let runtime = aptos_runtimes::spawn_named_runtime("indexerdata".to_string(), None);
+    // Start serving.
+    runtime.spawn(async move {
+        let server = DatastreamServer::new();
+        Server::builder()
+            .add_service(IndexerStreamServer::new(server))
+            .serve(
+                get_grpc_address()
+                    .to_socket_addrs()
+                    .unwrap()
+                    .next()
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+    });
+
+    // Start liveness and readiness probes.
+    runtime.spawn(async move {
+        let readiness = warp::path("readiness")
+            .map(move || warp::reply::with_status("ready", warp::http::StatusCode::OK));
+        warp::serve(readiness)
+            .run(([0, 0, 0, 0], get_health_check_port()))
+            .await;
+    });
+
+    let term = Arc::new(AtomicBool::new(false));
+    while !term.load(Ordering::Acquire) {
+        std::thread::park();
+    }
+}

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
@@ -1,0 +1,158 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_indexer_grpc_utils::{
+    get_cache_coverage_status, get_cache_transactions, get_file_store_bucket_name,
+    get_redis_address,
+    storage::{generate_blob_name, TransactionsBlob, BLOB_TRANSACTION_CHUNK_SIZE},
+    CacheCoverageStatus,
+};
+use aptos_logger::{info, warn};
+use aptos_moving_average::MovingAverage;
+use aptos_protos::datastream::v1::{
+    indexer_stream_server::IndexerStream,
+    raw_datastream_response::Response as DatastreamProtoResponse, RawDatastreamRequest,
+    RawDatastreamResponse, TransactionOutput, TransactionsOutput,
+};
+use cloud_storage::Object;
+use futures::Stream;
+use redis::{Client, Commands};
+use std::{pin::Pin, thread::sleep, time::Duration};
+use tokio::sync::mpsc::{self, error::TrySendError};
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+use uuid::Uuid;
+
+type ResponseStream = Pin<Box<dyn Stream<Item = Result<RawDatastreamResponse, Status>> + Send>>;
+
+pub struct DatastreamServer {
+    pub redis_client: Client,
+}
+
+impl DatastreamServer {
+    pub fn new() -> Self {
+        Self {
+            redis_client: Client::open(format!("redis://{}", get_redis_address())).unwrap(),
+        }
+    }
+}
+
+impl Default for DatastreamServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// DatastreamServer handles the raw datastream requests from cache and file store.
+#[tonic::async_trait]
+impl IndexerStream for DatastreamServer {
+    type RawDatastreamStream = ResponseStream;
+
+    async fn raw_datastream(
+        &self,
+        req: Request<RawDatastreamRequest>,
+    ) -> Result<Response<Self::RawDatastreamStream>, Status> {
+        let (tx, rx) = mpsc::channel(10000);
+
+        let mut conn = self.redis_client.get_connection().unwrap();
+
+        let req = req.into_inner();
+        // Round the version to the nearest STORAGE_BLOB_SIZE.
+        let mut current_version =
+            req.starting_version / BLOB_TRANSACTION_CHUNK_SIZE * BLOB_TRANSACTION_CHUNK_SIZE;
+
+        tokio::spawn(async move {
+            let mut ma = MovingAverage::new(10_000);
+            let request_id = Uuid::new_v4().to_string();
+            let chain_id = conn
+                .get("chain_id")
+                .expect("[Indexer Data] Failed to get chain id.");
+            let bucket_name = get_file_store_bucket_name();
+            loop {
+                // Check if the receiver is closed.
+                if tx.is_closed() {
+                    break;
+                }
+
+                // Get the cache coverage status.
+                //  1. If the cache coverage status is CacheHit, it'll fetch the data from the cache.
+                //  2. If the cache coverage status is CacheEvicted, it'll fetch the data from the file store.
+                //  3. If the cache coverage status is DataNotReady, it'll wait and retry.
+                let cache_coverage_status = get_cache_coverage_status(&mut conn, current_version)
+                    .await
+                    .expect("[Indexer Data] Failed to get cache coverage status.");
+
+                let encoded_proto_data_vec = match cache_coverage_status {
+                    CacheCoverageStatus::CacheEvicted => {
+                        // Read from file store.
+                        let blob_file =
+                            Object::download(&bucket_name, &generate_blob_name(current_version))
+                                .await
+                                .expect("[indexer gcs] Failed to get file store metadata.");
+                        let blob: TransactionsBlob = serde_json::from_slice(&blob_file)
+                            .expect("[indexer gcs] Failed to deserialize blob.");
+                        blob.transactions
+                    },
+
+                    CacheCoverageStatus::DataNotReady => {
+                        sleep(Duration::from_millis(1000));
+                        continue;
+                    },
+                    CacheCoverageStatus::CacheHit => {
+                        get_cache_transactions(&mut conn, current_version)
+                            .await
+                            .expect("[Indexer Data] Failed to get cache transactions.")
+                    },
+                };
+
+                let item = RawDatastreamResponse {
+                    response: Some(DatastreamProtoResponse::Data(TransactionsOutput {
+                        transactions: encoded_proto_data_vec
+                            .iter()
+                            .enumerate()
+                            .map(|(i, e)| TransactionOutput {
+                                encoded_proto_data: e.clone(),
+                                version: current_version + i as u64,
+                                ..TransactionOutput::default()
+                            })
+                            .collect(),
+                    })),
+                    chain_id,
+                };
+                match tx.try_send(Result::<_, Status>::Ok(item.clone())) {
+                    Ok(_) => {},
+                    Err(TrySendError::Full(_)) => {
+                        warn!(
+                            request_id = request_id.as_str(),
+                            "[Indexer Data] Receiver is full; retrying."
+                        );
+                        std::thread::sleep(Duration::from_secs(1));
+                        continue;
+                    },
+                    Err(TrySendError::Closed(_)) => {
+                        warn!(
+                            request_id = request_id.as_str(),
+                            "[Indexer Data] Receiver is closed; exiting."
+                        );
+                        break;
+                    },
+                }
+                current_version += BLOB_TRANSACTION_CHUNK_SIZE;
+                ma.tick_now(BLOB_TRANSACTION_CHUNK_SIZE);
+                info!(
+                    request_id = request_id.as_str(),
+                    current_version = current_version,
+                    batch_size = BLOB_TRANSACTION_CHUNK_SIZE,
+                    tps = (ma.avg() * 1000.0) as u64,
+                    "[Indexer Data] Sending batch."
+                );
+            }
+            info!("[Indexer Data] Client disconnected.");
+        });
+
+        let output_stream = ReceiverStream::new(rx);
+        Ok(Response::new(
+            Box::pin(output_stream) as Self::RawDatastreamStream
+        ))
+    }
+}

--- a/ecosystem/indexer-grpc/indexer-grpc-file-store/src/processor.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-file-store/src/processor.rs
@@ -4,23 +4,14 @@
 use aptos_indexer_grpc_utils::{
     get_file_store_bucket_name,
     storage::{
-        generate_blob_name, get_file_store_metadata, upload_file_store_metadata,
+        generate_blob_name, get_file_store_metadata, upload_file_store_metadata, TransactionsBlob,
         BLOB_TRANSACTION_CHUNK_SIZE,
     },
 };
 use aptos_moving_average::MovingAverage;
 use cloud_storage::Object;
 use redis::{Client, Commands};
-use serde::{Deserialize, Serialize};
 use std::{thread::sleep, time::Duration};
-
-#[derive(Serialize, Deserialize)]
-struct TransactionsBlob {
-    /// The version of the first transaction in the blob.
-    pub starting_version: u64,
-    /// The transactions in the blob.
-    pub transactions: Vec<String>,
-}
 
 pub struct Processor {
     pub redis_client: Client,

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2021"
 anyhow = { workspace = true }
 cloud-storage = { workspace = true }
 futures-util = { workspace = true }
+redis = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/lib.rs
@@ -60,7 +60,9 @@ pub async fn get_cache_coverage_status(
         Err(err) => return Err(err.into()),
     };
 
-    let request_batch_upper_bound = requested_version.checked_add(BLOB_STORAGE_SIZE).expect("Version boundary calculation overflows.");
+    let request_batch_upper_bound = requested_version
+        .checked_add(BLOB_STORAGE_SIZE)
+        .expect("Version boundary calculation overflows.");
     // Estimated cache lower bound is the latest version minus the cache size estimation; default to
     // 0.
     let estimated_cache_lower_bound = latest_version.saturating_sub(CACHE_SIZE_ESTIMATION);

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/lib.rs
@@ -1,10 +1,26 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use redis::Commands;
+
 pub mod storage;
 
 pub const CACHE_KEY_CHAIN_ID: &str = "chain_id";
+const CACHE_LATEST_VERSION: &str = "latest_version";
+
+const CACHE_SIZE_ESTIMATION: u64 = 10_000_000_u64;
+
 pub const BLOB_STORAGE_SIZE: u64 = 1_000;
+
+// This is an Enum to indicate the cache status of the requested version.
+pub enum CacheCoverageStatus {
+    // Requested version is not processed by cache worker yet.
+    DataNotReady,
+    // Requested version is cached.
+    CacheHit,
+    // Requested version is evicted from cache.
+    CacheEvicted,
+}
 
 /// Get redis address from env variable.
 #[inline]
@@ -23,4 +39,51 @@ pub fn get_file_store_bucket_name() -> String {
 #[inline]
 pub fn get_health_check_port() -> u16 {
     std::env::var("HEALTH_CHECK_PORT").map_or_else(|_| 8080, |v| v.parse::<u16>().unwrap())
+}
+
+pub async fn update_cache_latest_version(
+    conn: &mut impl redis::ConnectionLike,
+    latest_version: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    conn.set(CACHE_LATEST_VERSION, latest_version)
+        .map_err(|e| e.into())
+}
+
+// This function is used to check the cache status of the requested version.
+// The CacheEvicted is only an estimation from current latest version.
+pub async fn get_cache_coverage_status(
+    conn: &mut impl redis::ConnectionLike,
+    requested_version: u64,
+) -> Result<CacheCoverageStatus, Box<dyn std::error::Error>> {
+    let latest_version: u64 = match conn.get(CACHE_LATEST_VERSION) {
+        Ok(v) => v,
+        Err(err) => return Err(err.into()),
+    };
+
+    let request_batch_upper_bound = requested_version + BLOB_STORAGE_SIZE;
+    // Estimated cache lower bound is the latest version minus the cache size estimation; default to
+    // 0.
+    let estimated_cache_lower_bound =
+        std::cmp::max(latest_version, CACHE_SIZE_ESTIMATION) - CACHE_SIZE_ESTIMATION;
+    if request_batch_upper_bound > latest_version {
+        // The cache should contain [requested_version, requested_version + BLOB_STORAGE_SIZE),
+        // if upper bound is not covered, then the data is not ready.
+        Ok(CacheCoverageStatus::DataNotReady)
+    } else if estimated_cache_lower_bound < requested_version {
+        // If request version lower bound is smaller than latest version, it means the data is evicted.
+        Ok(CacheCoverageStatus::CacheEvicted)
+    } else {
+        Ok(CacheCoverageStatus::CacheHit)
+    }
+}
+
+pub async fn get_cache_transactions(
+    conn: &mut impl redis::ConnectionLike,
+    requested_version: u64,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let versions = (requested_version..requested_version + BLOB_STORAGE_SIZE)
+        .into_iter()
+        .map(|e| e.to_string())
+        .collect::<Vec<String>>();
+    conn.mget(versions).map_err(|e| e.into())
 }


### PR DESCRIPTION
### Description

* Context
[Design doc](https://docs.google.com/document/d/1E3J1qVwrpVWuRaJL-aAzq5fh5W-9ecbFf5e7GfQhs7E/edit#heading=h.562elfcgz0d3)

* Content
This PR creates a data service that fetch data from cache and file store if cache is not available. 

  * If cache is not ready, wait for 1 sec and retry;
  * If connection is closed, retry;

**Open item**
* Should verify the chain id for each batch for verification purpose;
* Add back-pressure to the streaming in case of server OOM;
* Metrics
* Use YAML file instead of env var.
* Staleness check, including stale file store/cache/data service: for internal ones(file store/cache), emit metrics/alerts;
for external ones(data service), notify them with RPC status.


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Run
```
REDIS_ADDRESS=127.0.0.1 \
CHAIN_NAME=devnet \
GRPC_ADDRESS=0.0.0.0:50052 \
FILE_STORE_BUCKET_NAME=indexer-grpc-file-store \
FILE_STORE_BLOB_FOLDER_NAME=blobs \
HEALTH_CHECK_PORT=8083 \
CHAIN_NAME=devnet \
cargo run --release
```

Result:

Client side(python script):

![image](https://user-images.githubusercontent.com/112209412/217982645-e2c79950-e8c0-4843-b318-d6cde0e412f2.png)


Server side(data service):

![image](https://user-images.githubusercontent.com/112209412/217982719-4acd1b0b-ced0-4773-8240-09bd55f8b526.png)


