### PR TITLE
[docs] Update GCP to 1.3.6 Terraform

### DIFF
--- a/developer-docs-site/docs/nodes/full-node/run-a-fullnode-on-gcp.md
+++ b/developer-docs-site/docs/nodes/full-node/run-a-fullnode-on-gcp.md
@@ -19,7 +19,7 @@ The following packages are pre-installed with Cloud Shell. **Make sure to review
 
 However, if you are running the installation from your laptop or another machine, you need to install:
 
-* Terraform 1.1.7: https://www.terraform.io/downloads.html
+* Terraform 1.3.6: https://www.terraform.io/downloads.html
 * Kubernetes cli: https://kubernetes.io/docs/tasks/tools/
 * Google Cloud cli: https://cloud.google.com/sdk/docs/install-sdk
 
@@ -103,7 +103,7 @@ Example content for `main.tf`:
 
   ```rust
   terraform {
-    required_version = "~> 1.2.0"
+    required_version = "~> 1.3.6"
     backend "gcs" {
       bucket = "BUCKET_NAME" # bucket name created in step 2
       prefix = "state/fullnode"

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-aws.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-aws.md
@@ -22,7 +22,7 @@ Make sure you complete these prerequisite steps before you proceed:
 1. Set up your AWS account. 
 2. Make sure the following are installed on your local computer:
    - **Aptos CLI**: https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli
-   - **Terraform 1.2.4**: https://www.terraform.io/downloads.html
+   - **Terraform 1.3.6**: https://www.terraform.io/downloads.html
    - **Kubernetes CLI**: https://kubernetes.io/docs/tasks/tools/
    - **AWS CLI**: https://aws.amazon.com/cli/
 
@@ -69,7 +69,7 @@ Follow the below instructions **twice**, i.e., first on one machine to run a val
 
     ```
     terraform {
-      required_version = "~> 1.2.0"
+      required_version = "~> 1.3.6"
       backend "s3" {
         bucket = "terraform.aptos-node"
         key    = "state/aptos-node"

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-azure.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-azure.md
@@ -21,7 +21,7 @@ Make sure you complete these prerequisite steps before you proceed:
 
 - **Azure account**: https://azure.microsoft.com/
 - **Aptos CLI**: https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli
-- **Terraform 1.2.4**: https://www.terraform.io/downloads.html
+- **Terraform 1.3.6**: https://www.terraform.io/downloads.html
 - **Kubernetes CLI**: https://kubernetes.io/docs/tasks/tools/
 - **Azure CLI**: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
 
@@ -69,7 +69,7 @@ Follow the below instructions **twice**, i.e., first on one machine to run a val
 
   ```
   terraform {
-    required_version = "~> 1.2.0"
+    required_version = "~> 1.3.6"
     backend "azurerm" {
       resource_group_name  = <resource group name>
       storage_account_name = <storage account name>

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-gcp.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-gcp.md
@@ -20,7 +20,7 @@ This guide assumes you already have a Google Cloud Platform (GCP) account setup,
 Make sure the following are setup for your environment:
   - **GCP account**: hhttps://cloud.google.com/
   - **Aptos CLI**: https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli
-  - **Terraform 1.2.4**: https://www.terraform.io/downloads.html
+  - **Terraform 1.3.6**: https://www.terraform.io/downloads.html
   - **Kubernetes CLI**: https://kubernetes.io/docs/tasks/tools/
   - **Google Cloud CLI**: https://cloud.google.com/sdk/docs/install-sdk
 
@@ -65,7 +65,7 @@ Follow the below instructions **twice**, i.e., first on one machine to run a val
 4. Modify `main.tf` file to configure Terraform, and create fullnode from Terraform module. Example content for `main.tf`:
   ```
   terraform {
-    required_version = "~> 1.2.0"
+    required_version = "~> 1.3.6"
     backend "gcs" {
       bucket = "BUCKET_NAME" # bucket name created in step 2
       prefix = "state/aptos-node"


### PR DESCRIPTION
Terraform 1.3.6 is needed to run through steps now, so it might as well be updated.

I was running through this tutorial directly, and it wouldn't let me use a version less than this for devnet
