### PR TITLE
Tell user if their CLI is out of date

### DIFF
--- a/crates/aptos/src/main.rs
+++ b/crates/aptos/src/main.rs
@@ -9,16 +9,47 @@
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-use aptos::{move_tool, Tool};
+use aptos::{move_tool, update::get_update_message, Tool};
+use aptos_logger::debug;
 use clap::Parser;
-use std::process::exit;
+use std::{process::exit, time::Duration};
+use tokio::runtime::Runtime;
 
-#[tokio::main]
-async fn main() {
+fn main() {
+    let runtime = Runtime::new().unwrap();
+    runtime.block_on(_main());
+    // We know when _main ends there are no tasks left running, so this should be safe.
+    // This is necessary for now because self_update doesn't allow you to set a timeout.
+    // https://github.com/jaemk/self_update/issues/100
+    runtime.shutdown_timeout(Duration::from_secs(0));
+}
+
+async fn _main() {
+    // Spin off a thread to check if the CLI needs to be updated. We take note of when
+    // we started this thread so we can give up after a timeout.
+    let update_check_handle =
+        tokio::task::spawn_blocking(move || get_update_message("aptos-labs", "aptos-core"));
+
     // Register hooks
     move_tool::register_package_hooks();
+
     // Run the corresponding tools
     let result = Tool::parse().execute().await;
+
+    // Wait for either the update check to complete or the timeout to happen. We only
+    // print anything if the update check worked, otherwise we just print nothing and
+    // move on. If RUST_LOG=debug is set, the inner function will log some helpful
+    // information if there is a problem.
+    match tokio::time::timeout(Duration::from_millis(1000), update_check_handle).await {
+        Ok(message) => {
+            if let Ok(Some(message)) = message {
+                println!("{}", message);
+            }
+        },
+        Err(e) => {
+            debug!("Self-update check timed out: {:#}", e);
+        },
+    }
 
     // At this point, we'll want to print and determine whether to exit for an error code
     match result {

--- a/crates/aptos/src/update/mod.rs
+++ b/crates/aptos/src/update/mod.rs
@@ -5,4 +5,5 @@ mod helpers;
 mod tool;
 
 use helpers::check_if_update_required;
+pub use helpers::get_update_message;
 pub use tool::UpdateTool;


### PR DESCRIPTION
### Description
This PR adds a notification to tell the user if their CLI is out of date. We print to stderr to not mess up the output of the CLI for piping.

### Test Plan
1. Lower the version of the CLI and build it locally.
2. Move it somewhere else, e.g. `/tmp`
3. Run it:
```
$ /tmp/aptos info
===
A new version of the Aptos CLI is available: v1.0.3 -> v1.0.4
Run this command to update: aptos update
===

{
  "Result": {
    "build_branch": "main",
    "build_cargo_version": "cargo 1.66.1 (ad779e08b 2023-01-10)",
    "build_commit_hash": "9728485d20d17647200376d4f534436d5ddff65f",
    "build_is_release_build": "false",
    "build_os": "macos-aarch64",
    "build_pkg_version": "1.0.3",
    "build_profile_name": "debug",
    "build_rust_channel": "1.66.1-aarch64-apple-darwin",
    "build_rust_version": "rustc 1.66.1 (90743e729 2023-01-10)",
    "build_tag": "",
    "build_time": "2023-01-23 15:49:23 +00:00",
    "build_using_tokio_unstable": "true"
  }
}
```
