### PR TITLE
[docs] Add dedicated page for brew instructions

### DIFF
--- a/developer-docs-site/docs/cli-tools/aptos-cli-tool/index.md
+++ b/developer-docs-site/docs/cli-tools/aptos-cli-tool/index.md
@@ -10,5 +10,5 @@ The Aptos command line interface (CLI) helps you develop apps, debug issues, and
 You may install the Aptos CLI in any of these ways:
 
 * [Download Aptos CLI binaries](./install-aptos-cli.md) - Ensures you get a stable version of the Aptos CLI built on a regular cadence from the `main` upstream development branch.
-* [Install Aptos CLI with Homebrew](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos/homebrew/README.md) - Simplifies install on Linux and macOS machines by using the `brew` CLI to manage packages. Homebrew also offers limited support for  [Windows Subsystem for Linux (WSL)](https://docs.brew.sh/Homebrew-on-Linux).
+* [Build Aptos CLI with brew](../build-from-brew.md) - Simplifies install on Linux and macOS machines by using the `brew` CLI to manage packages. Homebrew also offers limited support for [Windows Subsystem for Linux (WSL)](https://docs.brew.sh/Homebrew-on-Linux).
 * [Build Aptos CLI from source code](../build-from-source.md) - Allows you to build from any of the Aptos branches, including `devnet`, `testnet`, `mainnet`, and the latest code in the `main` upstream development branch.

--- a/developer-docs-site/docs/cli-tools/build-from-brew.md
+++ b/developer-docs-site/docs/cli-tools/build-from-brew.md
@@ -1,0 +1,39 @@
+---
+title: "Build CLI from Brew"
+id: "build-aptos-cli-brew"
+---
+
+# Build Aptos CLI from Brew
+
+On macOS and some Linux, `brew` is a package manager that allows for installing and updating packages in a single 
+command.
+
+:::tip Not supported on Windows
+Brew is not supported fully on Windows
+:::
+
+## Installation
+
+1. Ensure you have `brew` installed https://brew.sh/
+2. Open a terminal and enter the following commands
+```bash
+    brew update        # Gets the latest updates for packages
+    brew install aptos # Installs the Aptos CLI
+```
+3. You can now get help instructions by running `aptos help`. You may have to open a new terminal window.
+```bash
+   aptos help
+```
+
+## Upgrading the CLI
+
+Upgrading the CLI with brew is very simple, simply run
+
+```bash
+  brew update        # Gets the latest updates for packages
+  brew upgrade aptos # Upgrades the Aptos CLI
+```
+
+## Additional details
+
+[Aptos CLI homebrew Readme](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos/homebrew/README.md)

--- a/developer-docs-site/sidebars.js
+++ b/developer-docs-site/sidebars.js
@@ -67,6 +67,7 @@ const sidebars = {
           items: [
             "cli-tools/aptos-cli-tool/install-aptos-cli",
             "cli-tools/build-aptos-cli",
+            "cli-tools/build-aptos-cli-brew",
             "cli-tools/aptos-cli-tool/use-aptos-cli",
           ],
         },


### PR DESCRIPTION
### Description
Simplify the homebrew instructions.  The README currently linked gives too much information, when this should be dead simple.