### PR TITLE
[framework] make a dedicated module for create_signer

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/account.md
+++ b/aptos-move/framework/aptos-framework/doc/account.md
@@ -18,7 +18,6 @@
 -  [Struct `RotationCapabilityOfferProofChallengeV2`](#0x1_account_RotationCapabilityOfferProofChallengeV2)
 -  [Struct `SignerCapabilityOfferProofChallengeV2`](#0x1_account_SignerCapabilityOfferProofChallengeV2)
 -  [Constants](#@Constants_0)
--  [Function `create_signer`](#0x1_account_create_signer)
 -  [Function `initialize`](#0x1_account_initialize)
 -  [Function `create_account`](#0x1_account_create_account)
 -  [Function `create_account_unchecked`](#0x1_account_create_account_unchecked)
@@ -48,7 +47,6 @@
 -  [Function `create_signer_with_capability`](#0x1_account_create_signer_with_capability)
 -  [Function `get_signer_capability_address`](#0x1_account_get_signer_capability_address)
 -  [Specification](#@Specification_1)
-    -  [Function `create_signer`](#@Specification_1_create_signer)
     -  [Function `initialize`](#@Specification_1_initialize)
     -  [Function `create_account`](#@Specification_1_create_account)
     -  [Function `create_account_unchecked`](#@Specification_1_create_account_unchecked)
@@ -73,6 +71,7 @@
 
 <pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs">0x1::bcs</a>;
 <b>use</b> <a href="chain_id.md#0x1_chain_id">0x1::chain_id</a>;
+<b>use</b> <a href="create_signer.md#0x1_create_signer">0x1::create_signer</a>;
 <b>use</b> <a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519">0x1::ed25519</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
@@ -775,28 +774,6 @@ Scheme identifier for MultiEd25519 signatures used to derive authentication keys
 
 
 
-<a name="0x1_account_create_signer"></a>
-
-## Function `create_signer`
-
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x1_account_create_signer">create_signer</a>(addr: <b>address</b>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>native</b> <b>fun</b> <a href="account.md#0x1_account_create_signer">create_signer</a>(addr: <b>address</b>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>;
-</code></pre>
-
-
-
-</details>
-
 <a name="0x1_account_initialize"></a>
 
 ## Function `initialize`
@@ -877,7 +854,7 @@ is returned. This way, the caller of this function can publish additional resour
 
 
 <pre><code><b>fun</b> <a href="account.md#0x1_account_create_account_unchecked">create_account_unchecked</a>(new_address: <b>address</b>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> {
-    <b>let</b> new_account = <a href="account.md#0x1_account_create_signer">create_signer</a>(new_address);
+    <b>let</b> new_account = <a href="create_signer.md#0x1_create_signer">create_signer</a>(new_address);
     <b>let</b> authentication_key = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&new_address);
     <b>assert</b>!(
         <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&authentication_key) == 32,
@@ -1500,7 +1477,7 @@ at the offerer's address.
     <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
     <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_contains">option::contains</a>(&account_resource.signer_capability_offer.for, &addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account.md#0x1_account_ENO_SUCH_SIGNER_CAPABILITY">ENO_SUCH_SIGNER_CAPABILITY</a>));
 
-    <a href="account.md#0x1_account_create_signer">create_signer</a>(offerer_address)
+    <a href="create_signer.md#0x1_create_signer">create_signer</a>(offerer_address)
 }
 </code></pre>
 
@@ -1673,7 +1650,7 @@ than <code>(1/2)^(256)</code>.
             <a href="account.md#0x1_account">account</a>.sequence_number == 0,
             <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="account.md#0x1_account_EACCOUNT_ALREADY_USED">EACCOUNT_ALREADY_USED</a>),
         );
-        <a href="account.md#0x1_account_create_signer">create_signer</a>(resource_addr)
+        <a href="create_signer.md#0x1_create_signer">create_signer</a>(resource_addr)
     } <b>else</b> {
         <a href="account.md#0x1_account_create_account_unchecked">create_account_unchecked</a>(resource_addr)
     };
@@ -1835,7 +1812,7 @@ Capability based functions for efficient use.
 
 <pre><code><b>public</b> <b>fun</b> <a href="account.md#0x1_account_create_signer_with_capability">create_signer_with_capability</a>(capability: &<a href="account.md#0x1_account_SignerCapability">SignerCapability</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> {
     <b>let</b> addr = &capability.<a href="account.md#0x1_account">account</a>;
-    <a href="account.md#0x1_account_create_signer">create_signer</a>(*addr)
+    <a href="create_signer.md#0x1_create_signer">create_signer</a>(*addr)
 }
 </code></pre>
 
@@ -1875,25 +1852,6 @@ Capability based functions for efficient use.
 
 <pre><code><b>pragma</b> verify = <b>true</b>;
 <b>pragma</b> aborts_if_is_strict;
-</code></pre>
-
-
-
-<a name="@Specification_1_create_signer"></a>
-
-### Function `create_signer`
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x1_account_create_signer">create_signer</a>(addr: <b>address</b>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
-</code></pre>
-
-
-Convert address to singer and return.
-
-
-<pre><code><b>pragma</b> opaque;
-<b>aborts_if</b> [abstract] <b>false</b>;
-<b>ensures</b> [abstract] <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(result) == addr;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/aptos_account.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_account.md
@@ -34,6 +34,7 @@
 <pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
 <b>use</b> <a href="aptos_coin.md#0x1_aptos_coin">0x1::aptos_coin</a>;
 <b>use</b> <a href="coin.md#0x1_coin">0x1::coin</a>;
+<b>use</b> <a href="create_signer.md#0x1_create_signer">0x1::create_signer</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
@@ -247,7 +248,7 @@ This would create the recipient account first, which also registers it to receiv
     // Resource accounts can be created without registering them <b>to</b> receive APT.
     // This conveniently does the registration <b>if</b> necessary.
     <b>if</b> (!<a href="coin.md#0x1_coin_is_account_registered">coin::is_account_registered</a>&lt;AptosCoin&gt;(<b>to</b>)) {
-        <a href="coin.md#0x1_coin_register">coin::register</a>&lt;AptosCoin&gt;(&<a href="account.md#0x1_account_create_signer">account::create_signer</a>(<b>to</b>));
+        <a href="coin.md#0x1_coin_register">coin::register</a>&lt;AptosCoin&gt;(&<a href="create_signer.md#0x1_create_signer">create_signer</a>(<b>to</b>));
     };
     <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;AptosCoin&gt;(source, <b>to</b>, amount)
 }
@@ -347,7 +348,7 @@ This would create the recipient account first and register it to receive the Coi
             <a href="aptos_account.md#0x1_aptos_account_can_receive_direct_coin_transfers">can_receive_direct_coin_transfers</a>(<b>to</b>),
             <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="aptos_account.md#0x1_aptos_account_EACCOUNT_DOES_NOT_ACCEPT_DIRECT_COIN_TRANSFERS">EACCOUNT_DOES_NOT_ACCEPT_DIRECT_COIN_TRANSFERS</a>),
         );
-        <a href="coin.md#0x1_coin_register">coin::register</a>&lt;CoinType&gt;(&<a href="account.md#0x1_account_create_signer">account::create_signer</a>(<b>to</b>));
+        <a href="coin.md#0x1_coin_register">coin::register</a>&lt;CoinType&gt;(&<a href="create_signer.md#0x1_create_signer">create_signer</a>(<b>to</b>));
     };
     <a href="coin.md#0x1_coin_deposit">coin::deposit</a>&lt;CoinType&gt;(<b>to</b>, coins)
 }

--- a/aptos-move/framework/aptos-framework/doc/create_signer.md
+++ b/aptos-move/framework/aptos-framework/doc/create_signer.md
@@ -1,0 +1,79 @@
+
+<a name="0x1_create_signer"></a>
+
+# Module `0x1::create_signer`
+
+Provides a common place for exporting <code><a href="create_signer.md#0x1_create_signer">create_signer</a></code> across the Aptos Framework.
+
+To use create_signer, add the module below, such that:
+<code><b>friend</b> aptos_framework::friend_wants_create_signer</code>
+where <code>friend_wants_create_signer</code> is the module that needs <code><a href="create_signer.md#0x1_create_signer">create_signer</a></code>.
+
+Note, that this is only available within the Aptos Framework.
+
+This exists to make auditing straight forward and to limit the need to depend
+on account to have access to this.
+
+
+-  [Function `create_signer`](#0x1_create_signer_create_signer)
+-  [Specification](#@Specification_0)
+    -  [Function `create_signer`](#@Specification_0_create_signer)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="0x1_create_signer_create_signer"></a>
+
+## Function `create_signer`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="create_signer.md#0x1_create_signer">create_signer</a>(addr: <b>address</b>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>native</b> <b>fun</b> <a href="create_signer.md#0x1_create_signer">create_signer</a>(addr: <b>address</b>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>;
+</code></pre>
+
+
+
+</details>
+
+<a name="@Specification_0"></a>
+
+## Specification
+
+
+
+<pre><code><b>pragma</b> verify = <b>true</b>;
+<b>pragma</b> aborts_if_is_strict;
+</code></pre>
+
+
+
+<a name="@Specification_0_create_signer"></a>
+
+### Function `create_signer`
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="create_signer.md#0x1_create_signer">create_signer</a>(addr: <b>address</b>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
+</code></pre>
+
+
+Convert address to singer and return.
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>false</b>;
+<b>ensures</b> [abstract] <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(result) == addr;
+</code></pre>
+
+
+[move-book]: https://move-language.github.io/move/introduction.html

--- a/aptos-move/framework/aptos-framework/doc/genesis.md
+++ b/aptos-move/framework/aptos-framework/doc/genesis.md
@@ -21,10 +21,8 @@
 -  [Function `create_initialize_validator`](#0x1_genesis_create_initialize_validator)
 -  [Function `initialize_validator`](#0x1_genesis_initialize_validator)
 -  [Function `set_genesis_end`](#0x1_genesis_set_genesis_end)
--  [Function `create_signer`](#0x1_genesis_create_signer)
 -  [Function `initialize_for_verification`](#0x1_genesis_initialize_for_verification)
 -  [Specification](#@Specification_1)
-    -  [Function `create_signer`](#@Specification_1_create_signer)
     -  [Function `initialize_for_verification`](#@Specification_1_initialize_for_verification)
 
 
@@ -37,6 +35,7 @@
 <b>use</b> <a href="chain_status.md#0x1_chain_status">0x1::chain_status</a>;
 <b>use</b> <a href="coin.md#0x1_coin">0x1::coin</a>;
 <b>use</b> <a href="consensus_config.md#0x1_consensus_config">0x1::consensus_config</a>;
+<b>use</b> <a href="create_signer.md#0x1_create_signer">0x1::create_signer</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/fixed_point32.md#0x1_fixed_point32">0x1::fixed_point32</a>;
@@ -488,7 +487,7 @@ If it exists, it just returns the signer.
 
 <pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_create_account">create_account</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, account_address: <b>address</b>, balance: u64): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> {
     <b>if</b> (<a href="account.md#0x1_account_exists_at">account::exists_at</a>(account_address)) {
-        <a href="genesis.md#0x1_genesis_create_signer">create_signer</a>(account_address)
+        <a href="create_signer.md#0x1_create_signer">create_signer</a>(account_address)
     } <b>else</b> {
         <b>let</b> <a href="account.md#0x1_account">account</a> = <a href="account.md#0x1_account_create_account">account::create_account</a>(account_address);
         <a href="coin.md#0x1_coin_register">coin::register</a>&lt;AptosCoin&gt;(&<a href="account.md#0x1_account">account</a>);
@@ -541,7 +540,7 @@ If it exists, it just returns the signer.
             );
             <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> unique_accounts, *<a href="account.md#0x1_account">account</a>);
 
-            <b>let</b> employee = <a href="genesis.md#0x1_genesis_create_signer">create_signer</a>(*<a href="account.md#0x1_account">account</a>);
+            <b>let</b> employee = <a href="create_signer.md#0x1_create_signer">create_signer</a>(*<a href="account.md#0x1_account">account</a>);
             <b>let</b> total = <a href="coin.md#0x1_coin_balance">coin::balance</a>&lt;AptosCoin&gt;(*<a href="account.md#0x1_account">account</a>);
             <b>let</b> coins = <a href="coin.md#0x1_coin_withdraw">coin::withdraw</a>&lt;AptosCoin&gt;(&employee, total);
             <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_add">simple_map::add</a>(&<b>mut</b> buy_ins, *<a href="account.md#0x1_account">account</a>, coins);
@@ -568,7 +567,7 @@ If it exists, it just returns the signer.
         );
 
         <b>let</b> admin = employee_group.validator.validator_config.owner_address;
-        <b>let</b> admin_signer = &<a href="genesis.md#0x1_genesis_create_signer">create_signer</a>(admin);
+        <b>let</b> admin_signer = &<a href="create_signer.md#0x1_create_signer">create_signer</a>(admin);
         <b>let</b> contract_address = <a href="vesting.md#0x1_vesting_create_vesting_contract">vesting::create_vesting_contract</a>(
             admin_signer,
             &employee_group.accounts,
@@ -776,7 +775,7 @@ encoded in a single BCS byte array.
 
 
 <pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize_validator">initialize_validator</a>(pool_address: <b>address</b>, validator: &<a href="genesis.md#0x1_genesis_ValidatorConfiguration">ValidatorConfiguration</a>) {
-    <b>let</b> operator = &<a href="genesis.md#0x1_genesis_create_signer">create_signer</a>(validator.operator_address);
+    <b>let</b> operator = &<a href="create_signer.md#0x1_create_signer">create_signer</a>(validator.operator_address);
 
     <a href="stake.md#0x1_stake_rotate_consensus_key">stake::rotate_consensus_key</a>(
         operator,
@@ -817,28 +816,6 @@ The last step of genesis.
 <pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_set_genesis_end">set_genesis_end</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
     <a href="chain_status.md#0x1_chain_status_set_genesis_end">chain_status::set_genesis_end</a>(aptos_framework);
 }
-</code></pre>
-
-
-
-</details>
-
-<a name="0x1_genesis_create_signer"></a>
-
-## Function `create_signer`
-
-
-
-<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_create_signer">create_signer</a>(addr: <b>address</b>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>native</b> <b>fun</b> <a href="genesis.md#0x1_genesis_create_signer">create_signer</a>(addr: <b>address</b>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>;
 </code></pre>
 
 
@@ -923,24 +900,6 @@ The last step of genesis.
 
 
 <pre><code><b>pragma</b> verify = <b>false</b>;
-</code></pre>
-
-
-
-<a name="@Specification_1_create_signer"></a>
-
-### Function `create_signer`
-
-
-<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_create_signer">create_signer</a>(addr: <b>address</b>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
-</code></pre>
-
-
-
-
-<pre><code><b>pragma</b> opaque;
-<b>aborts_if</b> <b>false</b>;
-<b>ensures</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(result) == addr;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/overview.md
+++ b/aptos-move/framework/aptos-framework/doc/overview.md
@@ -24,6 +24,7 @@ This is the reference documentation of the Aptos framework.
 -  [`0x1::code`](code.md#0x1_code)
 -  [`0x1::coin`](coin.md#0x1_coin)
 -  [`0x1::consensus_config`](consensus_config.md#0x1_consensus_config)
+-  [`0x1::create_signer`](create_signer.md#0x1_create_signer)
 -  [`0x1::event`](event.md#0x1_event)
 -  [`0x1::gas_schedule`](gas_schedule.md#0x1_gas_schedule)
 -  [`0x1::genesis`](genesis.md#0x1_genesis)

--- a/aptos-move/framework/aptos-framework/sources/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account.move
@@ -6,6 +6,7 @@ module aptos_framework::account {
     use std::signer;
     use std::vector;
     use aptos_framework::chain_id;
+    use aptos_framework::create_signer::create_signer;
     use aptos_framework::event::{Self, EventHandle};
     use aptos_framework::guid;
     use aptos_framework::system_addresses;
@@ -152,8 +153,6 @@ module aptos_framework::account {
     const EOFFERER_ADDRESS_DOES_NOT_EXIST: u64 = 17;
     /// The specified rotation capablity offer does not exist at the specified offerer address
     const ENO_SUCH_ROTATION_CAPABILITY_OFFER: u64 = 18;
-
-    public(friend) native fun create_signer(addr: address): signer;
 
     #[test_only]
     /// Create signer for testing, independently of an Aptos-style `Account`.

--- a/aptos-move/framework/aptos-framework/sources/account.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/account.spec.move
@@ -4,13 +4,6 @@ spec aptos_framework::account {
         pragma aborts_if_is_strict;
     }
 
-    /// Convert address to singer and return.
-    spec create_signer(addr: address): signer {
-        pragma opaque;
-        aborts_if [abstract] false;
-        ensures [abstract] signer::address_of(result) == addr;
-    }
-
     /// Only the address `@aptos_framework` can call.
     /// OriginatingAddress does not exist under `@aptos_framework` before the call.
     spec initialize(aptos_framework: &signer) {

--- a/aptos-move/framework/aptos-framework/sources/aptos_account.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_account.move
@@ -2,6 +2,7 @@ module aptos_framework::aptos_account {
     use aptos_framework::account::{Self, new_event_handle};
     use aptos_framework::aptos_coin::AptosCoin;
     use aptos_framework::coin::{Self, Coin};
+    use aptos_framework::create_signer::create_signer;
     use aptos_framework::event::{EventHandle, emit_event};
     use std::error;
     use std::signer;
@@ -69,7 +70,7 @@ module aptos_framework::aptos_account {
         // Resource accounts can be created without registering them to receive APT.
         // This conveniently does the registration if necessary.
         if (!coin::is_account_registered<AptosCoin>(to)) {
-            coin::register<AptosCoin>(&account::create_signer(to));
+            coin::register<AptosCoin>(&create_signer(to));
         };
         coin::transfer<AptosCoin>(source, to, amount)
     }
@@ -109,7 +110,7 @@ module aptos_framework::aptos_account {
                 can_receive_direct_coin_transfers(to),
                 error::permission_denied(EACCOUNT_DOES_NOT_ACCEPT_DIRECT_COIN_TRANSFERS),
             );
-            coin::register<CoinType>(&account::create_signer(to));
+            coin::register<CoinType>(&create_signer(to));
         };
         coin::deposit<CoinType>(to, coins)
     }

--- a/aptos-move/framework/aptos-framework/sources/create_signer.move
+++ b/aptos-move/framework/aptos-framework/sources/create_signer.move
@@ -1,0 +1,17 @@
+/// Provides a common place for exporting `create_signer` across the Aptos Framework.
+///
+/// To use create_signer, add the module below, such that:
+/// `friend aptos_framework::friend_wants_create_signer`
+/// where `friend_wants_create_signer` is the module that needs `create_signer`.
+///
+/// Note, that this is only available within the Aptos Framework.
+///
+/// This exists to make auditing straight forward and to limit the need to depend
+/// on account to have access to this.
+module aptos_framework::create_signer {
+    friend aptos_framework::account;
+    friend aptos_framework::aptos_account;
+    friend aptos_framework::genesis;
+
+    public(friend) native fun create_signer(addr: address): signer;
+}

--- a/aptos-move/framework/aptos-framework/sources/create_signer.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/create_signer.spec.move
@@ -1,0 +1,15 @@
+spec aptos_framework::create_signer {
+    use std::signer;
+
+    spec module {
+        pragma verify = true;
+        pragma aborts_if_is_strict;
+    }
+
+    /// Convert address to singer and return.
+    spec create_signer(addr: address): signer {
+        pragma opaque;
+        aborts_if [abstract] false;
+        ensures [abstract] signer::address_of(result) == addr;
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -14,6 +14,7 @@ module aptos_framework::genesis {
     use aptos_framework::chain_status;
     use aptos_framework::coin;
     use aptos_framework::consensus_config;
+    use aptos_framework::create_signer::create_signer;
     use aptos_framework::gas_schedule;
     use aptos_framework::reconfiguration;
     use aptos_framework::stake;
@@ -389,8 +390,6 @@ module aptos_framework::genesis {
     fun set_genesis_end(aptos_framework: &signer) {
         chain_status::set_genesis_end(aptos_framework);
     }
-
-    native fun create_signer(addr: address): signer;
 
     #[verify_only]
     use std::features;

--- a/aptos-move/framework/aptos-framework/sources/genesis.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.spec.move
@@ -11,11 +11,4 @@ spec aptos_framework::genesis {
     spec initialize_for_verification {
         pragma verify = true;
     }
-
-    spec create_signer(addr: address): signer {
-        use std::signer;
-        pragma opaque;
-        aborts_if false;
-        ensures signer::address_of(result) == addr;
-    }
 }

--- a/aptos-move/framework/src/natives/create_signer.rs
+++ b/aptos-move/framework/src/natives/create_signer.rs
@@ -1,0 +1,55 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::errors::PartialVMResult;
+use move_core_types::{account_address::AccountAddress, gas_algebra::InternalGas};
+use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
+use move_vm_types::{
+    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+};
+use smallvec::smallvec;
+use std::{collections::VecDeque, sync::Arc};
+
+/***************************************************************************************************
+ * native fun create_signer
+ *
+ *   gas cost: base_cost
+ *
+ **************************************************************************************************/
+fn native_create_signer(
+    gas_params: &CreateSignerGasParameters,
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut arguments: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(arguments.len() == 1);
+
+    let address = pop_arg!(arguments, AccountAddress);
+    Ok(NativeResult::ok(gas_params.base, smallvec![Value::signer(
+        address
+    )]))
+}
+
+pub fn make_native_create_signer(gas_params: CreateSignerGasParameters) -> NativeFunction {
+    Arc::new(move |context, ty_args, args| {
+        native_create_signer(&gas_params, context, ty_args, args)
+    })
+}
+
+/***************************************************************************************************
+ * module
+ *
+ **************************************************************************************************/
+#[derive(Debug, Clone)]
+pub struct CreateSignerGasParameters {
+    pub base: InternalGas,
+}
+
+pub fn make_all(
+    gas_param: CreateSignerGasParameters,
+) -> impl Iterator<Item = (String, NativeFunction)> {
+    let natives = [("create_signer", make_native_create_signer(gas_param))];
+
+    crate::natives::helpers::make_module_natives(natives)
+}

--- a/aptos-move/framework/src/natives/mod.rs
+++ b/aptos-move/framework/src/natives/mod.rs
@@ -5,6 +5,7 @@ pub mod account;
 pub mod aggregator_natives;
 pub mod any;
 pub mod code;
+pub mod create_signer;
 pub mod cryptography;
 pub mod event;
 pub mod hash;
@@ -52,7 +53,7 @@ impl GasParameters {
         Self {
             account: account::GasParameters {
                 create_address: account::CreateAddressGasParameters { base: 0.into() },
-                create_signer: account::CreateSignerGasParameters { base: 0.into() },
+                create_signer: create_signer::CreateSignerGasParameters { base: 0.into() },
             },
             bls12381: cryptography::bls12381::GasParameters {
                 base: 0.into(),
@@ -200,8 +201,15 @@ pub fn all_natives(
     }
 
     add_natives_from_module!("account", account::make_all(gas_params.account.clone()));
+    add_natives_from_module!(
+        "create_signer",
+        create_signer::make_all(gas_params.account.create_signer.clone())
+    );
     add_natives_from_module!("ed25519", ed25519::make_all(gas_params.ed25519.clone()));
-    add_natives_from_module!("genesis", account::make_all(gas_params.account));
+    add_natives_from_module!(
+        "genesis",
+        create_signer::make_all(gas_params.account.create_signer)
+    );
     add_natives_from_module!("multi_ed25519", multi_ed25519::make_all(gas_params.ed25519));
     add_natives_from_module!(
         "bls12381",


### PR DESCRIPTION
we already have 3 places that use create_signer... more are coming in order to support objects and account v2

placing create_signer in account can result in spaghetti code and adds to auditing overhead...

this PR isolates it to a single module

unfortunately due to the way natives / gas work, we can never remove the src/natives/* code related to this, but we need not add any more! unless another address wants access...

Forking this off from the object PR, since it can be landed independently of it...