### PR TITLE
[release-tooling] Fix release tooling for 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,6 +1981,7 @@ dependencies = [
  "clap 3.2.23",
  "futures",
  "hex",
+ "move-binary-format",
  "move-core-types",
  "move-model",
  "serde 1.0.149",

--- a/aptos-move/aptos-release-builder/Cargo.toml
+++ b/aptos-move/aptos-release-builder/Cargo.toml
@@ -24,6 +24,7 @@ bcs = { workspace = true }
 clap = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
+move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 move-model = { workspace = true }
 serde = { workspace = true }

--- a/aptos-move/aptos-release-builder/data/example.yaml
+++ b/aptos-move/aptos-release-builder/data/example.yaml
@@ -1,9 +1,10 @@
 ---
 testnet: true
-is_multi_step: false
-framework_release: true
+remote_endpoint: ~
+framework_release:
+  bytecode_version: 5
 gas_schedule:
-  feature_version: 4
+  feature_version: 6
   entries:
     - - instr.nop
       - 200
@@ -21,9 +22,15 @@ gas_schedule:
       - 800
     - - instr.ld_u8
       - 1200
+    - - instr.ld_u16
+      - 1200
+    - - instr.ld_u32
+      - 1200
     - - instr.ld_u64
       - 1200
     - - instr.ld_u128
+      - 1600
+    - - instr.ld_u256
       - 1600
     - - instr.ld_true
       - 1200
@@ -93,9 +100,15 @@ gas_schedule:
       - 200
     - - instr.cast_u8
       - 2400
+    - - instr.cast_u16
+      - 2400
+    - - instr.cast_u32
+      - 2400
     - - instr.cast_u64
       - 2400
     - - instr.cast_u128
+      - 2400
+    - - instr.cast_u256
       - 2400
     - - instr.add
       - 3200
@@ -211,6 +224,16 @@ gas_schedule:
       - 10000
     - - txn.memory_quota
       - 10000000
+    - - txn.free_write_bytes_quota
+      - 1024
+    - - txn.max_bytes_per_write_op
+      - 1048576
+    - - txn.max_bytes_all_write_ops_per_transaction
+      - 10485760
+    - - txn.max_bytes_per_event
+      - 1048576
+    - - txn.max_bytes_all_events_per_transaction
+      - 10485760
     - - move_stdlib.bcs.to_bytes.per_byte_serialized
       - 200
     - - move_stdlib.bcs.to_bytes.failure
@@ -367,6 +390,10 @@ gas_schedule:
       - 3000
     - - aptos_framework.hash.ripemd160.per_byte
       - 50
+    - - aptos_framework.hash.blake2b_256.base
+      - 1750
+    - - aptos_framework.hash.blake2b_256.per_byte
+      - 15
     - - aptos_framework.util.from_bytes.base
       - 6000
     - - aptos_framework.util.from_bytes.per_byte
@@ -423,9 +450,15 @@ gas_schedule:
       - 2000
     - - misc.abs_val.u8
       - 40
+    - - misc.abs_val.u16
+      - 40
+    - - misc.abs_val.u32
+      - 40
     - - misc.abs_val.u64
       - 40
     - - misc.abs_val.u128
+      - 40
+    - - misc.abs_val.u256
       - 40
     - - misc.abs_val.bool
       - 40
@@ -439,21 +472,20 @@ gas_schedule:
       - 40
     - - misc.abs_val.per_u8_packed
       - 1
+    - - misc.abs_val.per_u16_packed
+      - 2
+    - - misc.abs_val.per_u32_packed
+      - 4
     - - misc.abs_val.per_u64_packed
       - 8
     - - misc.abs_val.per_u128_packed
       - 16
+    - - misc.abs_val.per_u256_packed
+      - 32
     - - misc.abs_val.per_bool_packed
       - 1
     - - misc.abs_val.per_address_packed
       - 32
-version:
-  major: 4
-feature_flags:
-  enabled:
-    - code_dependency_check
-    - treat_friend_as_private
-  disabled: []
 consensus_config:
   V1:
     decoupled_execution: true
@@ -471,3 +503,4 @@ consensus_config:
           weight_by_voting_power: true
           use_history_from_previous_epoch_max_count: 5
     max_failed_authors_to_store: 10
+is_multi_step: false

--- a/aptos-move/aptos-release-builder/data/example.yaml
+++ b/aptos-move/aptos-release-builder/data/example.yaml
@@ -2,7 +2,7 @@
 testnet: true
 remote_endpoint: ~
 framework_release:
-  bytecode_version: 5
+  bytecode_version: 6
 gas_schedule:
   feature_version: 6
   entries:

--- a/aptos-move/aptos-release-builder/src/components/consensus_config.rs
+++ b/aptos-move/aptos-release-builder/src/components/consensus_config.rs
@@ -20,7 +20,7 @@ pub fn generate_consensus_upgrade_proposal(
     let proposal = generate_governance_proposal(
         &writer,
         is_testnet,
-        next_execution_hash,
+        next_execution_hash.clone(),
         "aptos_framework::consensus_config",
         |writer| {
             let consensus_config_blob = bcs::to_bytes(consensus_config).unwrap();
@@ -30,10 +30,17 @@ pub fn generate_consensus_upgrade_proposal(
             generate_blob(writer, &consensus_config_blob);
             emitln!(writer, ";\n");
 
-            emitln!(
-                writer,
-                "consensus_config::set(framework_signer, consensus_blob);"
-            );
+            if is_testnet && next_execution_hash.is_empty() {
+                emitln!(
+                    writer,
+                    "consensus_config::set(framework_signer, consensus_blob);"
+                );
+            } else {
+                emitln!(
+                    writer,
+                    "consensus_config::set(&framework_signer, consensus_blob);"
+                );
+            }
         },
     );
 

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -72,7 +72,7 @@ pub fn generate_feature_upgrade_proposal(
     let proposal = generate_governance_proposal(
         &writer,
         is_testnet,
-        next_execution_hash,
+        next_execution_hash.clone(),
         "std::features",
         |writer| {
             emit!(writer, "let enabled_blob: vector<u64> = ");
@@ -83,10 +83,17 @@ pub fn generate_feature_upgrade_proposal(
             generate_features_blob(writer, &disabled);
             emitln!(writer, ";\n");
 
-            emitln!(
-                writer,
-                "features::change_feature_flags(framework_signer, enabled_blob, disabled_blob);"
-            );
+            if is_testnet && next_execution_hash.is_empty() {
+                emitln!(
+                    writer,
+                    "features::change_feature_flags(framework_signer, enabled_blob, disabled_blob);"
+                );
+            } else {
+                emitln!(
+                    writer,
+                    "features::change_feature_flags(&framework_signer, enabled_blob, disabled_blob);"
+                );
+            }
         },
     );
 

--- a/aptos-move/aptos-release-builder/src/components/framework.rs
+++ b/aptos-move/aptos-release-builder/src/components/framework.rs
@@ -4,9 +4,16 @@
 use crate::components::get_execution_hash;
 use anyhow::Result;
 use aptos_temppath::TempPath;
+use serde::{Deserialize, Serialize};
 use std::process::Command;
 
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct FrameworkReleaseConfig {
+    pub bytecode_version: u32,
+}
+
 pub fn generate_upgrade_proposals(
+    config: &FrameworkReleaseConfig,
     is_testnet: bool,
     next_execution_hash: Vec<u8>,
 ) -> Result<Vec<(String, String)>> {
@@ -46,6 +53,8 @@ pub fn generate_upgrade_proposals(
             .unwrap()
             .to_string();
 
+        let bytecode_version = format!("{:?}", config.bytecode_version);
+
         let mut args = vec![
             "run",
             "--bin",
@@ -53,15 +62,14 @@ pub fn generate_upgrade_proposals(
             "--",
             "governance",
             "generate-upgrade-proposal",
-            // TODO: 6 should be the default across the system
-            "--bytecode-version",
-            "6",
             "--account",
             publish_addr,
             "--output",
             move_script_path.to_str().unwrap(),
             "--package-dir",
             package_path.to_str().unwrap(),
+            "--bytecode-version",
+            bytecode_version.as_str(),
         ];
 
         if is_testnet {

--- a/aptos-move/aptos-release-builder/src/components/mod.rs
+++ b/aptos-move/aptos-release-builder/src/components/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use self::framework::FrameworkReleaseConfig;
 use crate::components::feature_flags::Features;
 use anyhow::{anyhow, Result};
 use aptos::governance::GenerateExecutionHash;
@@ -30,7 +31,7 @@ pub mod version;
 pub struct ReleaseConfig {
     pub testnet: bool,
     pub remote_endpoint: Option<Url>,
-    pub framework_release: bool,
+    pub framework_release: Option<FrameworkReleaseConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gas_schedule: Option<GasScheduleV2>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -124,9 +125,10 @@ impl ReleaseConfig {
         _client: &Option<Client>,
         result: &mut Vec<(String, String)>,
     ) -> Result<()> {
-        if self.framework_release {
+        if let Some(framework_release) = &self.framework_release {
             result.append(
                 &mut framework::generate_upgrade_proposals(
+                    framework_release,
                     self.testnet,
                     if self.is_multi_step {
                         get_execution_hash(result)
@@ -188,7 +190,7 @@ impl ReleaseConfig {
         result: &mut Vec<(String, String)>,
     ) -> Result<()> {
         if let Some(feature_flags) = &self.feature_flags {
-            let mut needs_update = false;
+            let mut needs_update = true;
             if let Some(client) = client {
                 let features = block_on(async {
                     client
@@ -222,7 +224,7 @@ impl ReleaseConfig {
         result: &mut Vec<(String, String)>,
     ) -> Result<()> {
         if let Some(consensus_config) = &self.consensus_config {
-            if fetch_and_equals(client, consensus_config)? {
+            if !fetch_and_equals(client, consensus_config)? {
                 result.append(&mut consensus_config::generate_consensus_upgrade_proposal(
                     consensus_config,
                     self.testnet,
@@ -279,7 +281,9 @@ impl Default for ReleaseConfig {
     fn default() -> Self {
         ReleaseConfig {
             testnet: true,
-            framework_release: true,
+            framework_release: Some(FrameworkReleaseConfig {
+                bytecode_version: 5,
+            }),
             gas_schedule: Some(aptos_gas::gen::current_gas_schedule()),
             version: None,
             feature_flags: None,

--- a/aptos-move/aptos-release-builder/src/components/mod.rs
+++ b/aptos-move/aptos-release-builder/src/components/mod.rs
@@ -282,7 +282,7 @@ impl Default for ReleaseConfig {
         ReleaseConfig {
             testnet: true,
             framework_release: Some(FrameworkReleaseConfig {
-                bytecode_version: 5,
+                bytecode_version: 6,
             }),
             gas_schedule: Some(aptos_gas::gen::current_gas_schedule()),
             version: None,

--- a/testsuite/smoke-test/src/upgrade.rs
+++ b/testsuite/smoke-test/src/upgrade.rs
@@ -60,6 +60,13 @@ async fn test_upgrade_flow() {
     gas_script_path.set_extension("move");
     fs::write(gas_script_path.as_path(), update_gas_script).unwrap();
 
+    let framework_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("aptos-move")
+        .join("framework")
+        .join("aptos-framework");
+
     assert!(Command::new(aptos_cli.as_path())
         .current_dir(workspace_root())
         .args(&vec![
@@ -67,6 +74,8 @@ async fn test_upgrade_flow() {
             "run-script",
             "--script-path",
             gas_script_path.to_str().unwrap(),
+            "--framework-local-dir",
+            framework_path.as_os_str().to_str().unwrap(),
             "--sender-account",
             "0xA550C18",
             "--url",
@@ -105,6 +114,13 @@ async fn test_upgrade_flow() {
 
     scripts.sort();
 
+    let framework_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("aptos-move")
+        .join("framework")
+        .join("aptos-framework");
+
     for path in scripts.iter() {
         assert!(Command::new(aptos_cli.as_path())
             .current_dir(workspace_root())
@@ -113,6 +129,8 @@ async fn test_upgrade_flow() {
                 "run-script",
                 "--script-path",
                 path.to_str().unwrap(),
+                "--framework-local-dir",
+                framework_path.as_os_str().to_str().unwrap(),
                 "--sender-account",
                 "0xA550C18",
                 "--url",


### PR DESCRIPTION
### Description

Cherrypick the fix from v.1.2.0 to main. The biggest change is to add an option for the framework release to force cli to compile the framework at a given bytecode version to avoid release framework at a newer unexpected bytecode version.

Original PR is #6248.


### Test Plan

Updated the example config via

`cargo run -p aptos-release-builder -- write-default --output-path aptos-move/aptos-release-builder/data/example.yaml`


And generated the scripts via

`cargo run -p aptos-release-builder -- generate-proposals --release-config aptos-move/aptos-release-builder/data/example.yaml  --output-dir ~/release`

And manually inspected the generated scripts to verify that the modules are indeed emitted at file format version 5.
