### PR TITLE
[smart_table] refine bucket_table to smart_table

### DIFF
--- a/aptos-move/move-examples/data_structures/sources/bucket_table.move
+++ b/aptos-move/move-examples/data_structures/sources/bucket_table.move
@@ -1,4 +1,4 @@
-/// A bucket table implementation based on linear hashing. (https://en.wikipedia.org/wiki/Linear_hashing)
+/// A smart table implementation based on linear hashing. (https://en.wikipedia.org/wiki/Linear_hashing)
 /// Compare to Table, it uses less storage slots but has higher chance of collision, it's a trade-off between space and time.
 /// Compare to other implementation, linear hashing splits one bucket a time instead of doubling buckets when expanding to avoid unexpected gas cost.
 /// BucketTable uses faster hash function SipHash instead of cryptographically secure hash functions like sha3-256 since it tolerates collisions.
@@ -7,9 +7,8 @@ module aptos_std::bucket_table {
     use std::vector;
     use aptos_std::aptos_hash::sip_hash_from_value;
     use aptos_std::table_with_length::{Self, TableWithLength};
-
-    const TARGET_LOAD_PER_BUCKET: u64 = 10;
-    const SPLIT_THRESHOLD: u64 = 75;
+    use aptos_std::type_info::size_of_val;
+    use aptos_std::math64::max;
 
     /// Key not found in the bucket table
     const ENOT_FOUND: u64 = 1;
@@ -19,6 +18,12 @@ module aptos_std::bucket_table {
     const ENOT_EMPTY: u64 = 3;
     /// Key already exists
     const EALREADY_EXIST: u64 = 4;
+    /// Invalid load threshold percent to trigger split.
+    const EINVALID_LOAD_THRESHOLD_PERCENT: u64 = 5;
+    /// Invalid target bucket size.
+    const EINVALID_TARGET_BUCKET_SIZE: u64 = 6;
+    /// Invariable broken.
+    const EINVARIABLE_BROKEN: u64 = 7;
 
     /// BucketTable entry contains both the key and value.
     struct Entry<K, V> has store {
@@ -33,34 +38,53 @@ module aptos_std::bucket_table {
         // number of bits to represent num_buckets
         level: u8,
         // total number of items
-        len: u64,
+        size: u64,
+        // Split will be triggered when target load threshold is reached when adding a new entry. In percent.
+        split_load_threshold: u8,
+        // The target size of each bucket, which is NOT enforced so oversized buckets can exist.
+        bucket_size: u64,
     }
 
     /// Create an empty BucketTable with `initial_buckets` buckets.
-    public fun new<K: drop + store, V: store>(initial_buckets: u64): BucketTable<K, V> {
-        assert!(initial_buckets > 0, error::invalid_argument(EZERO_CAPACITY));
+    public fun new<K: copy + drop + store, V: store>(): BucketTable<K, V> {
+        new_with_config<K, V>(0, 0, 0)
+    }
+
+    /// num_initial_buckets: The number of buckets on initialization. 0 means using default value.
+    /// split_load_threshold: The percent number which once reached, split will be triggered. 0 means using default value.
+    /// bucket_size: The target number of entries per bucket, though not enforced. 0 means not set and will dynamically
+    ///              assgined by the contract code.
+    public fun new_with_config<K: copy + drop + store, V: store>(num_initial_buckets: u64, split_load_threshold: u8, bucket_size: u64): BucketTable<K, V> {
+        assert!(split_load_threshold <= 100, error::invalid_argument(EINVALID_LOAD_THRESHOLD_PERCENT));
         let buckets = table_with_length::new();
         table_with_length::add(&mut buckets, 0, vector::empty());
         let map = BucketTable {
             buckets,
             num_buckets: 1,
             level: 0,
-            len: 0,
+            size: 0,
+            // The default split load threshold is 75%.
+            split_load_threshold: if (split_load_threshold == 0) {75} else {split_load_threshold},
+            bucket_size,
         };
-        split(&mut map, initial_buckets - 1);
+        // The default number of initial buckets is 2.
+        if (num_initial_buckets == 0) {
+            num_initial_buckets = 2;
+        };
+        split(&mut map, num_initial_buckets- 1);
         map
     }
 
-    /// Destroy empty map.
+    /// Destroy empty tab-le.
     /// Aborts if it's not empty.
     public fun destroy_empty<K, V>(map: BucketTable<K, V>) {
-        assert!(map.len == 0, error::invalid_argument(ENOT_EMPTY));
+        assert!(map.size == 0, error::invalid_argument(ENOT_EMPTY));
         let i = 0;
         while (i < map.num_buckets) {
             vector::destroy_empty(table_with_length::remove(&mut map.buckets, i));
             i = i + 1;
         };
-        let BucketTable {buckets, num_buckets: _, level: _, len: _} = map;
+        let BucketTable {buckets, num_buckets: _, level: _, size: _, split_load_threshold:_, bucket_size: _} = map;
         table_with_length::destroy_empty(buckets);
     }
 
@@ -78,27 +102,25 @@ module aptos_std::bucket_table {
             assert!(&entry.key != &key, error::invalid_argument(EALREADY_EXIST));
             i = i + 1;
         };
-        vector::push_back(bucket, Entry {hash, key, value});
-        map.len = map.len + 1;
+        let e = Entry {hash, key, value};
+        if (map.bucket_size == 0) {
+            assert!(map.size == 0, error::internal(EINVARIABLE_BROKEN));
+            let estimated_entry_size = max(size_of_val(&e), 1);
+            map.bucket_size = max(1024 /* free_write_quota */ / estimated_entry_size, 1);
+        };
+        vector::push_back(bucket, e);
+        map.size = map.size + 1;
 
-        if (load_factor(map) > SPLIT_THRESHOLD) {
+        if (load_factor(map) >= (map.split_load_threshold as u64)) {
             split_one_bucket(map);
         }
-    }
-
-    fun xor(a: u64, b: u64): u64 {
-        a ^ b
-    }
-    spec xor { // TODO: temporary mockup until Prover supports the operator `^`.
-        pragma opaque;
-        pragma verify = false;
     }
 
     /// Split the next bucket into two and re-insert existing items.
     fun split_one_bucket<K, V>(map: &mut BucketTable<K, V>) {
         let new_bucket_index = map.num_buckets;
         // the next bucket to split is num_bucket without the most significant bit.
-        let to_split = xor(new_bucket_index, (1 << map.level));
+        let to_split = new_bucket_index ^ (1 << map.level);
         let new_bucket = vector::empty();
         map.num_buckets = new_bucket_index + 1;
         // if the whole level is splitted once, bump the level.
@@ -142,11 +164,9 @@ module aptos_std::bucket_table {
 
     /// Acquire an immutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    /// The requirement of &mut BucketTable is to bypass the borrow checker issue described in https://github.com/move-language/move/issues/95
-    /// Once Table supports borrow by K, we can remove the &mut
-    public fun borrow<K: copy + drop, V>(map: &mut BucketTable<K, V>, key: K): &V {
+    public fun borrow<K: drop, V>(map: &BucketTable<K, V>, key: K): &V {
         let index = bucket_index(map.level, map.num_buckets, sip_hash_from_value(&key));
-        let bucket = table_with_length::borrow_mut(&mut map.buckets, index);
+        let bucket = table_with_length::borrow(&map.buckets, index);
         let i = 0;
         let len = vector::length(bucket);
         while (i < len) {
@@ -161,7 +181,7 @@ module aptos_std::bucket_table {
 
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun borrow_mut<K: copy + drop, V>(map: &mut BucketTable<K, V>, key: K): &mut V {
+    public fun borrow_mut<K: drop, V>(map: &mut BucketTable<K, V>, key: K): &mut V {
         let index = bucket_index(map.level, map.num_buckets, sip_hash_from_value(&key));
         let bucket = table_with_length::borrow_mut(&mut map.buckets, index);
         let i = 0;
@@ -177,14 +197,14 @@ module aptos_std::bucket_table {
     }
 
     /// Returns true iff `table` contains an entry for `key`.
-    public fun contains<K, V>(map: &BucketTable<K, V>, key: &K): bool {
-        let index = bucket_index(map.level, map.num_buckets, sip_hash_from_value(key));
+    public fun contains<K: drop, V>(map: &BucketTable<K, V>, key: K): bool {
+        let index = bucket_index(map.level, map.num_buckets, sip_hash_from_value(&key));
         let bucket = table_with_length::borrow(&map.buckets, index);
         let i = 0;
         let len = vector::length(bucket);
         while (i < len) {
             let entry = vector::borrow(bucket, i);
-            if (&entry.key == key) {
+            if (&entry.key == &key) {
                 return true
             };
             i = i + 1;
@@ -194,16 +214,16 @@ module aptos_std::bucket_table {
 
     /// Remove from `table` and return the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun remove<K: drop, V>(map: &mut BucketTable<K,V>, key: &K): V {
-        let index = bucket_index(map.level, map.num_buckets, sip_hash_from_value(key));
+    public fun remove<K: copy + drop, V>(map: &mut BucketTable<K, V>, key: K): V {
+        let index = bucket_index(map.level, map.num_buckets, sip_hash_from_value(&key));
         let bucket = table_with_length::borrow_mut(&mut map.buckets, index);
         let i = 0;
         let len = vector::length(bucket);
         while (i < len) {
             let entry = vector::borrow(bucket, i);
-            if (&entry.key == key) {
+            if (&entry.key == &key) {
                 let Entry {hash:_, key:_, value} = vector::swap_remove(bucket, i);
-                map.len = map.len - 1;
+                map.size = map.size - 1;
                 return value
             };
             i = i + 1;
@@ -213,16 +233,28 @@ module aptos_std::bucket_table {
 
     /// Returns the length of the table, i.e. the number of entries.
     public fun length<K, V>(map: &BucketTable<K, V>): u64 {
-        map.len
+        map.size
     }
 
     /// Return the load factor of the hashmap.
     public fun load_factor<K, V>(map: &BucketTable<K, V>): u64 {
-        map.len * 100 / (map.num_buckets * TARGET_LOAD_PER_BUCKET)
+        map.size * 100 / (map.num_buckets * map.bucket_size)
+    }
+
+    /// Update `split_load_threshold`.
+    public fun update_split_load_threshold<K, V>(map: &mut BucketTable<K, V>, split_load_threshold: u8) {
+        assert!(split_load_threshold <= 100 && split_load_threshold > 0, error::invalid_argument(EINVALID_LOAD_THRESHOLD_PERCENT));
+        map.split_load_threshold = split_load_threshold;
+    }
+
+    /// Update `bucket_size`.
+    public fun update_bucket_size<K, V>(map: &mut BucketTable<K, V>, bucket_size: u64) {
+        assert!(bucket_size > 0, error::invalid_argument(EINVALID_LOAD_THRESHOLD_PERCENT));
+        map.bucket_size = bucket_size;
     }
 
     /// Reserve `additional_buckets` more buckets.
-    public fun split<K, V>(map: &mut BucketTable<K, V>, additional_buckets: u64) {
+    fun split<K, V>(map: &mut BucketTable<K, V>, additional_buckets: u64) {
         while (additional_buckets > 0) {
             additional_buckets = additional_buckets - 1;
             split_one_bucket(map);
@@ -230,8 +262,8 @@ module aptos_std::bucket_table {
     }
 
     #[test]
-    fun hash_map_test() {
-        let map = new(1);
+    fun bucket_map_test() {
+        let map = new();
         let i = 0;
         while (i < 200) {
             add(&mut map, i, i);
@@ -245,20 +277,20 @@ module aptos_std::bucket_table {
             i = i + 1;
         };
         i = 0;
-        assert!(map.num_buckets > 20, map.num_buckets);
+        assert!(map.num_buckets > 5, map.num_buckets);
         while (i < 200) {
-            assert!(contains(&map, &i), 0);
-            assert!(remove(&mut map, &i) == i * 2, 0);
+            assert!(contains(&map, i), 0);
+            assert!(remove(&mut map, i) == i * 2, 0);
             i = i + 1;
         };
         destroy_empty(map);
     }
 
     #[test]
-    fun hash_map_split_test() {
-        let map: BucketTable<u64, u64> = new(1);
-        let i = 1;
-        let level = 0;
+    fun bucket_table_split_test() {
+        let map: BucketTable<u64, u64> = new();
+        let i = 2;
+        let level = 1;
         while (i <= 256) {
             assert!(map.num_buckets == i, 0);
             assert!(map.level == level, i);
@@ -272,8 +304,8 @@ module aptos_std::bucket_table {
     }
 
     #[test]
-    fun hash_map_bucket_index_test() {
-        let map: BucketTable<u64, u64> = new(8);
+    fun bucket_table_bucket_index_test() {
+        let map: BucketTable<u64, u64> = new_with_config<u64, u64>(8, 75, 0);
         assert!(map.level == 3, 0);
         let i = 0;
         while (i < 4) {
@@ -286,7 +318,7 @@ module aptos_std::bucket_table {
         while (i < 256) {
             let j = i & 15; // i % 16
             if (j >= map.num_buckets) {
-                j = xor(j, 8); // i % 8
+                j = j ^ 8; // i % 8
             };
             let index = bucket_index(map.level, map.num_buckets, i);
             assert!(index == j, 0);

--- a/aptos-move/move-examples/data_structures/sources/smart_table.move
+++ b/aptos-move/move-examples/data_structures/sources/smart_table.move
@@ -1,8 +1,8 @@
 /// A smart table implementation based on linear hashing. (https://en.wikipedia.org/wiki/Linear_hashing)
 /// Compare to Table, it uses less storage slots but has higher chance of collision, it's a trade-off between space and time.
 /// Compare to other implementation, linear hashing splits one bucket a time instead of doubling buckets when expanding to avoid unexpected gas cost.
-/// BucketTable uses faster hash function SipHash instead of cryptographically secure hash functions like sha3-256 since it tolerates collisions.
-module aptos_std::bucket_table {
+/// SmartTable uses faster hash function SipHash instead of cryptographically secure hash functions like sha3-256 since it tolerates collisions.
+module aptos_std::smart_table {
     use std::error;
     use std::vector;
     use aptos_std::aptos_hash::sip_hash_from_value;
@@ -10,9 +10,9 @@ module aptos_std::bucket_table {
     use aptos_std::type_info::size_of_val;
     use aptos_std::math64::max;
 
-    /// Key not found in the bucket table
+    /// Key not found in the smart table
     const ENOT_FOUND: u64 = 1;
-    /// Bucket table capacity must be larger than 0
+    /// Smart table capacity must be larger than 0
     const EZERO_CAPACITY: u64 = 2;
     /// Cannot destroy non-empty hashmap
     const ENOT_EMPTY: u64 = 3;
@@ -25,14 +25,14 @@ module aptos_std::bucket_table {
     /// Invariable broken.
     const EINVARIABLE_BROKEN: u64 = 7;
 
-    /// BucketTable entry contains both the key and value.
+    /// SmartTable entry contains both the key and value.
     struct Entry<K, V> has store {
         hash: u64,
         key: K,
         value: V,
     }
 
-    struct BucketTable<K, V> has store {
+    struct SmartTable<K, V> has store {
         buckets: TableWithLength<u64, vector<Entry<K, V>>>,
         num_buckets: u64,
         // number of bits to represent num_buckets
@@ -45,8 +45,8 @@ module aptos_std::bucket_table {
         bucket_size: u64,
     }
 
-    /// Create an empty BucketTable with `initial_buckets` buckets.
-    public fun new<K: copy + drop + store, V: store>(): BucketTable<K, V> {
+    /// Create an empty SmartTable with `initial_buckets` buckets.
+    public fun new<K: copy + drop + store, V: store>(): SmartTable<K, V> {
         new_with_config<K, V>(0, 0, 0)
     }
 
@@ -54,11 +54,11 @@ module aptos_std::bucket_table {
     /// split_load_threshold: The percent number which once reached, split will be triggered. 0 means using default value.
     /// bucket_size: The target number of entries per bucket, though not enforced. 0 means not set and will dynamically
     ///              assgined by the contract code.
-    public fun new_with_config<K: copy + drop + store, V: store>(num_initial_buckets: u64, split_load_threshold: u8, bucket_size: u64): BucketTable<K, V> {
+    public fun new_with_config<K: copy + drop + store, V: store>(num_initial_buckets: u64, split_load_threshold: u8, bucket_size: u64): SmartTable<K, V> {
         assert!(split_load_threshold <= 100, error::invalid_argument(EINVALID_LOAD_THRESHOLD_PERCENT));
         let buckets = table_with_length::new();
         table_with_length::add(&mut buckets, 0, vector::empty());
-        let map = BucketTable {
+        let table = SmartTable {
             buckets,
             num_buckets: 1,
             level: 0,
@@ -71,30 +71,30 @@ module aptos_std::bucket_table {
         if (num_initial_buckets == 0) {
             num_initial_buckets = 2;
         };
-        split(&mut map, num_initial_buckets- 1);
-        map
+        split(&mut table, num_initial_buckets- 1);
+        table
     }
 
     /// Destroy empty tab-le.
     /// Aborts if it's not empty.
-    public fun destroy_empty<K, V>(map: BucketTable<K, V>) {
-        assert!(map.size == 0, error::invalid_argument(ENOT_EMPTY));
+    public fun destroy_empty<K, V>(table: SmartTable<K, V>) {
+        assert!(table.size == 0, error::invalid_argument(ENOT_EMPTY));
         let i = 0;
-        while (i < map.num_buckets) {
-            vector::destroy_empty(table_with_length::remove(&mut map.buckets, i));
+        while (i < table.num_buckets) {
+            vector::destroy_empty(table_with_length::remove(&mut table.buckets, i));
             i = i + 1;
         };
-        let BucketTable {buckets, num_buckets: _, level: _, size: _, split_load_threshold:_, bucket_size: _} = map;
+        let SmartTable {buckets, num_buckets: _, level: _, size: _, split_load_threshold:_, bucket_size: _} = table;
         table_with_length::destroy_empty(buckets);
     }
 
     /// Add (key, value) pair in the hash map, it may grow one bucket if current load factor exceeds the threshold.
     /// Note it may not split the actual overflowed bucket.
     /// Abort if `key` already exists.
-    public fun add<K, V>(map: &mut BucketTable<K, V>, key: K, value: V) {
+    public fun add<K, V>(table: &mut SmartTable<K, V>, key: K, value: V) {
         let hash = sip_hash_from_value(&key);
-        let index = bucket_index(map.level, map.num_buckets, hash);
-        let bucket = table_with_length::borrow_mut(&mut map.buckets, index);
+        let index = bucket_index(table.level, table.num_buckets, hash);
+        let bucket = table_with_length::borrow_mut(&mut table.buckets, index);
         let i = 0;
         let len = vector::length(bucket);
         while (i < len) {
@@ -103,38 +103,38 @@ module aptos_std::bucket_table {
             i = i + 1;
         };
         let e = Entry {hash, key, value};
-        if (map.bucket_size == 0) {
-            assert!(map.size == 0, error::internal(EINVARIABLE_BROKEN));
+        if (table.bucket_size == 0) {
+            assert!(table.size == 0, error::internal(EINVARIABLE_BROKEN));
             let estimated_entry_size = max(size_of_val(&e), 1);
-            map.bucket_size = max(1024 /* free_write_quota */ / estimated_entry_size, 1);
+            table.bucket_size = max(1024 /* free_write_quota */ / estimated_entry_size, 1);
         };
         vector::push_back(bucket, e);
-        map.size = map.size + 1;
+        table.size = table.size + 1;
 
-        if (load_factor(map) >= (map.split_load_threshold as u64)) {
-            split_one_bucket(map);
+        if (load_factor(table) >= (table.split_load_threshold as u64)) {
+            split_one_bucket(table);
         }
     }
 
     /// Split the next bucket into two and re-insert existing items.
-    fun split_one_bucket<K, V>(map: &mut BucketTable<K, V>) {
-        let new_bucket_index = map.num_buckets;
+    fun split_one_bucket<K, V>(table: &mut SmartTable<K, V>) {
+        let new_bucket_index = table.num_buckets;
         // the next bucket to split is num_bucket without the most significant bit.
-        let to_split = new_bucket_index ^ (1 << map.level);
+        let to_split = new_bucket_index ^ (1 << table.level);
         let new_bucket = vector::empty();
-        map.num_buckets = new_bucket_index + 1;
+        table.num_buckets = new_bucket_index + 1;
         // if the whole level is splitted once, bump the level.
-        if (to_split + 1 == 1 << map.level) {
-            map.level = map.level + 1;
+        if (to_split + 1 == 1 << table.level) {
+            table.level = table.level + 1;
         };
-        let old_bucket = table_with_length::borrow_mut(&mut map.buckets, to_split);
+        let old_bucket = table_with_length::borrow_mut(&mut table.buckets, to_split);
         // partition the bucket. after the loop, i == j and [0..i) stays in old bucket, [j..len) goes to new bucket
         let i = 0;
         let j = vector::length(old_bucket);
         let len = j;
         while (i < j) {
             let entry = vector::borrow(old_bucket, i);
-            let index = bucket_index(map.level, map.num_buckets, entry.hash);
+            let index = bucket_index(table.level, table.num_buckets, entry.hash);
             if (index == new_bucket_index) {
                 j = j - 1;
                 vector::swap(old_bucket, i, j);
@@ -147,7 +147,7 @@ module aptos_std::bucket_table {
             vector::push_back(&mut new_bucket, entry);
             len = len - 1;
         };
-        table_with_length::add(&mut map.buckets, new_bucket_index, new_bucket);
+        table_with_length::add(&mut table.buckets, new_bucket_index, new_bucket);
     }
 
     /// Return the expected bucket index to find the hash.
@@ -164,9 +164,9 @@ module aptos_std::bucket_table {
 
     /// Acquire an immutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun borrow<K: drop, V>(map: &BucketTable<K, V>, key: K): &V {
-        let index = bucket_index(map.level, map.num_buckets, sip_hash_from_value(&key));
-        let bucket = table_with_length::borrow(&map.buckets, index);
+    public fun borrow<K: drop, V>(table: &SmartTable<K, V>, key: K): &V {
+        let index = bucket_index(table.level, table.num_buckets, sip_hash_from_value(&key));
+        let bucket = table_with_length::borrow(&table.buckets, index);
         let i = 0;
         let len = vector::length(bucket);
         while (i < len) {
@@ -181,9 +181,9 @@ module aptos_std::bucket_table {
 
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun borrow_mut<K: drop, V>(map: &mut BucketTable<K, V>, key: K): &mut V {
-        let index = bucket_index(map.level, map.num_buckets, sip_hash_from_value(&key));
-        let bucket = table_with_length::borrow_mut(&mut map.buckets, index);
+    public fun borrow_mut<K: drop, V>(table: &mut SmartTable<K, V>, key: K): &mut V {
+        let index = bucket_index(table.level, table.num_buckets, sip_hash_from_value(&key));
+        let bucket = table_with_length::borrow_mut(&mut table.buckets, index);
         let i = 0;
         let len = vector::length(bucket);
         while (i < len) {
@@ -197,9 +197,9 @@ module aptos_std::bucket_table {
     }
 
     /// Returns true iff `table` contains an entry for `key`.
-    public fun contains<K: drop, V>(map: &BucketTable<K, V>, key: K): bool {
-        let index = bucket_index(map.level, map.num_buckets, sip_hash_from_value(&key));
-        let bucket = table_with_length::borrow(&map.buckets, index);
+    public fun contains<K: drop, V>(table: &SmartTable<K, V>, key: K): bool {
+        let index = bucket_index(table.level, table.num_buckets, sip_hash_from_value(&key));
+        let bucket = table_with_length::borrow(&table.buckets, index);
         let i = 0;
         let len = vector::length(bucket);
         while (i < len) {
@@ -214,16 +214,16 @@ module aptos_std::bucket_table {
 
     /// Remove from `table` and return the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun remove<K: copy + drop, V>(map: &mut BucketTable<K, V>, key: K): V {
-        let index = bucket_index(map.level, map.num_buckets, sip_hash_from_value(&key));
-        let bucket = table_with_length::borrow_mut(&mut map.buckets, index);
+    public fun remove<K: copy + drop, V>(table: &mut SmartTable<K, V>, key: K): V {
+        let index = bucket_index(table.level, table.num_buckets, sip_hash_from_value(&key));
+        let bucket = table_with_length::borrow_mut(&mut table.buckets, index);
         let i = 0;
         let len = vector::length(bucket);
         while (i < len) {
             let entry = vector::borrow(bucket, i);
             if (&entry.key == &key) {
                 let Entry {hash:_, key:_, value} = vector::swap_remove(bucket, i);
-                map.size = map.size - 1;
+                table.size = table.size - 1;
                 return value
             };
             i = i + 1;
@@ -232,98 +232,98 @@ module aptos_std::bucket_table {
     }
 
     /// Returns the length of the table, i.e. the number of entries.
-    public fun length<K, V>(map: &BucketTable<K, V>): u64 {
-        map.size
+    public fun length<K, V>(table: &SmartTable<K, V>): u64 {
+        table.size
     }
 
-    /// Return the load factor of the hashmap.
-    public fun load_factor<K, V>(map: &BucketTable<K, V>): u64 {
-        map.size * 100 / (map.num_buckets * map.bucket_size)
+    /// Return the load factor of the hashtable.
+    public fun load_factor<K, V>(table: &SmartTable<K, V>): u64 {
+        table.size * 100 / (table.num_buckets * table.bucket_size)
     }
 
     /// Update `split_load_threshold`.
-    public fun update_split_load_threshold<K, V>(map: &mut BucketTable<K, V>, split_load_threshold: u8) {
+    public fun update_split_load_threshold<K, V>(table: &mut SmartTable<K, V>, split_load_threshold: u8) {
         assert!(split_load_threshold <= 100 && split_load_threshold > 0, error::invalid_argument(EINVALID_LOAD_THRESHOLD_PERCENT));
-        map.split_load_threshold = split_load_threshold;
+        table.split_load_threshold = split_load_threshold;
     }
 
     /// Update `bucket_size`.
-    public fun update_bucket_size<K, V>(map: &mut BucketTable<K, V>, bucket_size: u64) {
+    public fun update_bucket_size<K, V>(table: &mut SmartTable<K, V>, bucket_size: u64) {
         assert!(bucket_size > 0, error::invalid_argument(EINVALID_LOAD_THRESHOLD_PERCENT));
-        map.bucket_size = bucket_size;
+        table.bucket_size = bucket_size;
     }
 
     /// Reserve `additional_buckets` more buckets.
-    fun split<K, V>(map: &mut BucketTable<K, V>, additional_buckets: u64) {
+    fun split<K, V>(table: &mut SmartTable<K, V>, additional_buckets: u64) {
         while (additional_buckets > 0) {
             additional_buckets = additional_buckets - 1;
-            split_one_bucket(map);
+            split_one_bucket(table);
         }
     }
 
     #[test]
-    fun bucket_map_test() {
-        let map = new();
+    fun smart_table_test() {
+        let table = new();
         let i = 0;
         while (i < 200) {
-            add(&mut map, i, i);
+            add(&mut table, i, i);
             i = i + 1;
         };
-        assert!(length(&map) == 200, 0);
+        assert!(length(&table) == 200, 0);
         i = 0;
         while (i < 200) {
-            *borrow_mut(&mut map, i) = i * 2;
-            assert!(*borrow(&mut map, i) == i * 2, 0);
+            *borrow_mut(&mut table, i) = i * 2;
+            assert!(*borrow(&mut table, i) == i * 2, 0);
             i = i + 1;
         };
         i = 0;
-        assert!(map.num_buckets > 5, map.num_buckets);
+        assert!(table.num_buckets > 5, table.num_buckets);
         while (i < 200) {
-            assert!(contains(&map, i), 0);
-            assert!(remove(&mut map, i) == i * 2, 0);
+            assert!(contains(&table, i), 0);
+            assert!(remove(&mut table, i) == i * 2, 0);
             i = i + 1;
         };
-        destroy_empty(map);
+        destroy_empty(table);
     }
 
     #[test]
-    fun bucket_table_split_test() {
-        let map: BucketTable<u64, u64> = new();
+    fun smart_table_split_test() {
+        let table: SmartTable<u64, u64> = new();
         let i = 2;
         let level = 1;
         while (i <= 256) {
-            assert!(map.num_buckets == i, 0);
-            assert!(map.level == level, i);
-            split_one_bucket(&mut map);
+            assert!(table.num_buckets == i, 0);
+            assert!(table.level == level, i);
+            split_one_bucket(&mut table);
             i = i + 1;
             if (i == 1 << (level + 1)) {
                 level = level + 1;
             };
         };
-        destroy_empty(map);
+        destroy_empty(table);
     }
 
     #[test]
-    fun bucket_table_bucket_index_test() {
-        let map: BucketTable<u64, u64> = new_with_config<u64, u64>(8, 75, 0);
-        assert!(map.level == 3, 0);
+    fun smart_table_bucket_index_test() {
+        let table: SmartTable<u64, u64> = new_with_config<u64, u64>(8, 75, 0);
+        assert!(table.level == 3, 0);
         let i = 0;
         while (i < 4) {
-            split_one_bucket(&mut map);
+            split_one_bucket(&mut table);
             i = i + 1;
         };
-        assert!(map.level == 3, 0);
-        assert!(map.num_buckets == 12, 0);
+        assert!(table.level == 3, 0);
+        assert!(table.num_buckets == 12, 0);
         i = 0;
         while (i < 256) {
             let j = i & 15; // i % 16
-            if (j >= map.num_buckets) {
+            if (j >= table.num_buckets) {
                 j = j ^ 8; // i % 8
             };
-            let index = bucket_index(map.level, map.num_buckets, i);
+            let index = bucket_index(table.level, table.num_buckets, i);
             assert!(index == j, 0);
             i = i + 1;
         };
-        destroy_empty(map);
+        destroy_empty(table);
     }
 }

--- a/aptos-move/move-examples/data_structures/sources/smart_table.move
+++ b/aptos-move/move-examples/data_structures/sources/smart_table.move
@@ -22,11 +22,9 @@ module aptos_std::smart_table {
     const EINVALID_LOAD_THRESHOLD_PERCENT: u64 = 5;
     /// Invalid target bucket size.
     const EINVALID_TARGET_BUCKET_SIZE: u64 = 6;
-    /// Invariable broken.
-    const EINVARIABLE_BROKEN: u64 = 7;
 
     /// SmartTable entry contains both the key and value.
-    struct Entry<K, V> has store {
+    struct Entry<K, V> has copy, drop, store {
         hash: u64,
         key: K,
         value: V,
@@ -39,22 +37,24 @@ module aptos_std::smart_table {
         level: u8,
         // total number of items
         size: u64,
-        // Split will be triggered when target load threshold is reached when adding a new entry. In percent.
+        // Split will be triggered when target load threshold in percentage is reached when adding a new entry.
         split_load_threshold: u8,
         // The target size of each bucket, which is NOT enforced so oversized buckets can exist.
-        bucket_size: u64,
+        target_bucket_size: u64,
     }
 
-    /// Create an empty SmartTable with `initial_buckets` buckets.
+    /// Create an empty SmartTable with default configurations.
     public fun new<K: copy + drop + store, V: store>(): SmartTable<K, V> {
         new_with_config<K, V>(0, 0, 0)
     }
 
-    /// num_initial_buckets: The number of buckets on initialization. 0 means using default value.
-    /// split_load_threshold: The percent number which once reached, split will be triggered. 0 means using default value.
-    /// bucket_size: The target number of entries per bucket, though not enforced. 0 means not set and will dynamically
-    ///              assgined by the contract code.
-    public fun new_with_config<K: copy + drop + store, V: store>(num_initial_buckets: u64, split_load_threshold: u8, bucket_size: u64): SmartTable<K, V> {
+    /// Create an empty SmartTable with customized configurations.
+    /// `num_initial_buckets`: The number of buckets on initialization. 0 means using default value.
+    /// `split_load_threshold`: The percent number which once reached, split will be triggered. 0 means using default
+    /// value.
+    /// `target_bucket_size`: The target number of entries per bucket, though not guaranteed. 0 means not set and will
+    /// dynamically assgined by the contract code.
+    public fun new_with_config<K: copy + drop + store, V: store>(num_initial_buckets: u64, split_load_threshold: u8, target_bucket_size: u64): SmartTable<K, V> {
         assert!(split_load_threshold <= 100, error::invalid_argument(EINVALID_LOAD_THRESHOLD_PERCENT));
         let buckets = table_with_length::new();
         table_with_length::add(&mut buckets, 0, vector::empty());
@@ -65,17 +65,20 @@ module aptos_std::smart_table {
             size: 0,
             // The default split load threshold is 75%.
             split_load_threshold: if (split_load_threshold == 0) {75} else {split_load_threshold},
-            bucket_size,
+            target_bucket_size,
         };
         // The default number of initial buckets is 2.
         if (num_initial_buckets == 0) {
             num_initial_buckets = 2;
         };
-        split(&mut table, num_initial_buckets- 1);
+        while (num_initial_buckets > 1) {
+            num_initial_buckets = num_initial_buckets - 1;
+            split_one_bucket(&mut table);
+        };
         table
     }
 
-    /// Destroy empty tab-le.
+    /// Destroy empty table.
     /// Aborts if it's not empty.
     public fun destroy_empty<K, V>(table: SmartTable<K, V>) {
         assert!(table.size == 0, error::invalid_argument(ENOT_EMPTY));
@@ -84,29 +87,38 @@ module aptos_std::smart_table {
             vector::destroy_empty(table_with_length::remove(&mut table.buckets, i));
             i = i + 1;
         };
-        let SmartTable {buckets, num_buckets: _, level: _, size: _, split_load_threshold:_, bucket_size: _} = table;
+        let SmartTable {buckets, num_buckets: _, level: _, size: _, split_load_threshold:_, target_bucket_size: _} = table;
+        table_with_length::destroy_empty(buckets);
+    }
+
+    /// Destroy a table completely when V is dropable.
+    public fun destroy<K: drop, V: drop>(table: SmartTable<K, V>) {
+        let i = 0;
+        while (i < table.num_buckets) {
+            table_with_length::remove(&mut table.buckets, i);
+            i = i + 1;
+        };
+        let SmartTable {buckets, num_buckets: _, level: _, size: _, split_load_threshold:_, target_bucket_size: _} = table;
         table_with_length::destroy_empty(buckets);
     }
 
     /// Add (key, value) pair in the hash map, it may grow one bucket if current load factor exceeds the threshold.
-    /// Note it may not split the actual overflowed bucket.
+    /// Note it may not split the actual overflowed bucket. Instead, it was determined by `num_buckets` and `level`.
+    /// For standard linear hash algorithm, it is stored as a variable but `num_buckets` here could be leveraged.
     /// Abort if `key` already exists.
+    /// Note: This method may occasionally cost much more gas when triggering bucket split.
     public fun add<K, V>(table: &mut SmartTable<K, V>, key: K, value: V) {
         let hash = sip_hash_from_value(&key);
         let index = bucket_index(table.level, table.num_buckets, hash);
         let bucket = table_with_length::borrow_mut(&mut table.buckets, index);
-        let i = 0;
-        let len = vector::length(bucket);
-        while (i < len) {
-            let entry = vector::borrow(bucket, i);
-            assert!(&entry.key != &key, error::invalid_argument(EALREADY_EXIST));
-            i = i + 1;
-        };
+        assert!(vector::all(bucket, |entry| {
+            let e: &Entry<K, V> = entry;
+            &e.key != &key
+        }), error::invalid_argument(EALREADY_EXIST));
         let e = Entry {hash, key, value};
-        if (table.bucket_size == 0) {
-            assert!(table.size == 0, error::internal(EINVARIABLE_BROKEN));
+        if (table.target_bucket_size == 0) {
             let estimated_entry_size = max(size_of_val(&e), 1);
-            table.bucket_size = max(1024 /* free_write_quota */ / estimated_entry_size, 1);
+            table.target_bucket_size = max(1024 /* free_write_quota */ / estimated_entry_size, 1);
         };
         vector::push_back(bucket, e);
         table.size = table.size + 1;
@@ -116,7 +128,7 @@ module aptos_std::smart_table {
         }
     }
 
-    /// Split the next bucket into two and re-insert existing items.
+    /// Decide which is the next bucket to split and split it into two with the elements inside the bucket.
     fun split_one_bucket<K, V>(table: &mut SmartTable<K, V>) {
         let new_bucket_index = table.num_buckets;
         // the next bucket to split is num_bucket without the most significant bit.
@@ -151,6 +163,8 @@ module aptos_std::smart_table {
     }
 
     /// Return the expected bucket index to find the hash.
+    /// Basically, it use different base `1 << level` vs `1 << (level + 1)` in modulo operation based on the target
+    /// bucket index compared to the index of the next bucket to split.
     fun bucket_index(level: u8, num_buckets: u64, hash: u64): u64 {
         let index = hash % (1 << (level + 1));
         if (index < num_buckets) {
@@ -179,6 +193,16 @@ module aptos_std::smart_table {
         abort error::invalid_argument(ENOT_FOUND)
     }
 
+    /// Acquire an immutable reference to the value which `key` maps to.
+    /// Returns specified default value if there is no entry for `key`.
+    public fun borrow_with_default<K: copy + drop, V>(table: &SmartTable<K, V>, key: K, default: &V): &V {
+        if (!contains(table, copy key)) {
+            default
+        } else {
+            borrow(table, copy key)
+        }
+    }
+
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
     public fun borrow_mut<K: drop, V>(table: &mut SmartTable<K, V>, key: K): &mut V {
@@ -196,20 +220,24 @@ module aptos_std::smart_table {
         abort error::invalid_argument(ENOT_FOUND)
     }
 
+    /// Acquire a mutable reference to the value which `key` maps to.
+    /// Insert the pair (`key`, `default`) first if there is no entry for `key`.
+    public fun borrow_mut_with_default<K: copy + drop, V: drop>(table: &mut SmartTable<K, V>, key: K, default: V): &mut V {
+        if (!contains(table, copy key)) {
+            add(table, copy key, default)
+        };
+        borrow_mut(table, key)
+    }
+
     /// Returns true iff `table` contains an entry for `key`.
     public fun contains<K: drop, V>(table: &SmartTable<K, V>, key: K): bool {
-        let index = bucket_index(table.level, table.num_buckets, sip_hash_from_value(&key));
+        let hash = sip_hash_from_value(&key);
+        let index = bucket_index(table.level, table.num_buckets, hash);
         let bucket = table_with_length::borrow(&table.buckets, index);
-        let i = 0;
-        let len = vector::length(bucket);
-        while (i < len) {
-            let entry = vector::borrow(bucket, i);
-            if (&entry.key == &key) {
-                return true
-            };
-            i = i + 1;
-        };
-        false
+        vector::any(bucket, |entry| {
+            let e: &Entry<K, V> = entry;
+            e.hash == hash && &e.key == &key
+        })
     }
 
     /// Remove from `table` and return the value which `key` maps to.
@@ -231,14 +259,126 @@ module aptos_std::smart_table {
         abort error::invalid_argument(ENOT_FOUND)
     }
 
+    /// Insert the pair (`key`, `value`) if there is no entry for `key`.
+    /// update the value of the entry for `key` to `value` otherwise
+    public fun upsert<K: copy + drop, V: drop>(table: &mut SmartTable<K, V>, key: K, value: V) {
+        if (!contains(table, copy key)) {
+            add(table, copy key, value)
+        } else {
+            let ref = borrow_mut(table, key);
+            *ref = value;
+        };
+    }
+
     /// Returns the length of the table, i.e. the number of entries.
     public fun length<K, V>(table: &SmartTable<K, V>): u64 {
         table.size
     }
 
+
+    /// Apply the function to each key-value pair in the table, consuming it.
+    public inline fun for_each<K: copy + drop, V>(table: SmartTable<K, V>, f: |K, V|) {
+        let SmartTable {buckets, num_buckets, level: _, size: _, split_load_threshold:_, target_bucket_size: _} = table;
+        let i = 0;
+        while (i < num_buckets) {
+            vector::for_each(table_with_length::remove(&mut buckets, i), |elem| {
+                let Entry {hash: _, key, value} = elem;
+                f(key, value)
+            });
+            i = i + 1;
+        };
+        table_with_length::destroy_empty(buckets);
+    }
+
+    /// Apply the function to a reference of each key-value pair in the table.
+    public inline fun for_each_ref<K, V>(table: &SmartTable<K, V>, f: |&K, &V|) {
+        let i = 0;
+        while (i < table.num_buckets) {
+            vector::for_each_ref(table_with_length::borrow(&table.buckets, i), |elem| {
+                let e: &Entry<K, V> = elem;
+                f(&e.key, &e.value)
+            });
+            i = i + 1;
+        }
+    }
+
+    /// Apply the function to a reference of each key-value pair in the table.
+    public inline fun for_each_mut<K, V>(table: &mut SmartTable<K, V>, f: |&K, &mut V|) {
+        let i = 0;
+        while (i < table.num_buckets) {
+            vector::for_each_mut(table_with_length::borrow_mut(&mut table.buckets, i), |elem| {
+                let e: &mut Entry<K, V> = elem;
+                f(&e.key, &mut e.value)
+            });
+            i = i + 1;
+        };
+    }
+
+    /// Fold the function over the key-value pairs of the table.
+    public inline fun fold<A, K: copy + drop, V>(
+        table: SmartTable<K, V>,
+        init: A,
+        f: |A,K,V|A
+    ): A {
+        for_each(table, |key, value| init = f(init, key, value));
+        init
+    }
+
+    /// Map the function over the key-value pairs of the table.
+    public inline fun map<K: copy + drop + store, V1, V2: store>(
+        table: SmartTable<K, V1>,
+        f: |V1|V2
+    ): SmartTable<K, V2> {
+        let new_table = new_with_config<K, V2>(0, table.split_load_threshold, 0);
+        for_each(table, |key, value| add(&mut new_table, key, f(value)));
+        new_table
+    }
+
+    /// Map the function over the references of key-value pairs in the table without modifying it.
+    public inline fun map_ref<K: copy + drop + store, V1, V2: store>(
+        table: &SmartTable<K, V1>,
+        f: |&V1|V2
+    ): SmartTable<K, V2> {
+        let new_table = new_with_config<K, V2>(0, table.split_load_threshold, 0);
+        for_each_ref(table, |key, value| add(&mut new_table, *key, f(value)));
+        new_table
+    }
+
+    /// Filter entries in the table.
+    public inline fun filter<K: copy + drop + store, V: store>(
+        table: SmartTable<K, V>,
+        p: |&V|bool
+    ): SmartTable<K, V> {
+        let new_table = new_with_config<K, V>(table.num_buckets, table.split_load_threshold, table.target_bucket_size);
+        for_each(table, |key, value| {
+            if (p(&value)) {
+                add(&mut new_table, key, value);
+            }
+        });
+        new_table
+}
+
+    /// Return true if any key-value pair in the table satisfies the predicate.
+    public inline fun any<K, V>(
+        table: &SmartTable<K, V>,
+        p: |&K, &V|bool
+    ): bool {
+        let found = false;
+        let i = 0;
+        while (i < table.num_buckets) {
+            found = vector::any(table_with_length::borrow(&table.buckets, i), |elem| {
+                let e: &Entry<K, V> = elem;
+                p(&e.key, &e.value)
+            });
+            if (found) break;
+            i = i + 1;
+        };
+        found
+    }
+
     /// Return the load factor of the hashtable.
     public fun load_factor<K, V>(table: &SmartTable<K, V>): u64 {
-        table.size * 100 / (table.num_buckets * table.bucket_size)
+        table.size * 100 / table.num_buckets / table.target_bucket_size
     }
 
     /// Update `split_load_threshold`.
@@ -247,18 +387,10 @@ module aptos_std::smart_table {
         table.split_load_threshold = split_load_threshold;
     }
 
-    /// Update `bucket_size`.
-    public fun update_bucket_size<K, V>(table: &mut SmartTable<K, V>, bucket_size: u64) {
-        assert!(bucket_size > 0, error::invalid_argument(EINVALID_LOAD_THRESHOLD_PERCENT));
-        table.bucket_size = bucket_size;
-    }
-
-    /// Reserve `additional_buckets` more buckets.
-    fun split<K, V>(table: &mut SmartTable<K, V>, additional_buckets: u64) {
-        while (additional_buckets > 0) {
-            additional_buckets = additional_buckets - 1;
-            split_one_bucket(table);
-        }
+    /// Update `target_bucket_size`.
+    public fun update_target_bucket_size<K, V>(table: &mut SmartTable<K, V>, target_bucket_size: u64) {
+        assert!(target_bucket_size > 0, error::invalid_argument(EINVALID_TARGET_BUCKET_SIZE));
+        table.target_bucket_size = target_bucket_size;
     }
 
     #[test]
@@ -273,7 +405,7 @@ module aptos_std::smart_table {
         i = 0;
         while (i < 200) {
             *borrow_mut(&mut table, i) = i * 2;
-            assert!(*borrow(&mut table, i) == i * 2, 0);
+            assert!(*borrow(&table, i) == i * 2, 0);
             i = i + 1;
         };
         i = 0;
@@ -288,42 +420,145 @@ module aptos_std::smart_table {
 
     #[test]
     fun smart_table_split_test() {
-        let table: SmartTable<u64, u64> = new();
-        let i = 2;
-        let level = 1;
+        let table: SmartTable<u64, u64> = new_with_config(1, 100, 1);
+        let i = 1;
+        let level = 0;
         while (i <= 256) {
             assert!(table.num_buckets == i, 0);
             assert!(table.level == level, i);
-            split_one_bucket(&mut table);
+            add(&mut table, i, i);
             i = i + 1;
             if (i == 1 << (level + 1)) {
                 level = level + 1;
             };
         };
-        destroy_empty(table);
+        let i = 1;
+        while (i <= 256) {
+            assert!(*borrow(&table, i) == i, 0);
+            i = i + 1;
+        };
+        assert!(table.num_buckets == 257, table.num_buckets);
+        assert!(load_factor(&table) == 99, 0);
+        assert!(length(&table) == 256, 0);
+        destroy(table);
     }
 
     #[test]
-    fun smart_table_bucket_index_test() {
-        let table: SmartTable<u64, u64> = new_with_config<u64, u64>(8, 75, 0);
-        assert!(table.level == 3, 0);
+    fun smart_table_update_configs() {
+        let table = new();
         let i = 0;
-        while (i < 4) {
-            split_one_bucket(&mut table);
+        while (i < 200) {
+            add(&mut table, i, i);
             i = i + 1;
         };
-        assert!(table.level == 3, 0);
-        assert!(table.num_buckets == 12, 0);
+        assert!(length(&table) == 200, 0);
+        update_target_bucket_size(&mut table, 10);
+        update_split_load_threshold(&mut table, 50);
+        while (i < 400) {
+            add(&mut table, i, i);
+            i = i + 1;
+        };
+        assert!(length(&table) == 400, 0);
         i = 0;
-        while (i < 256) {
-            let j = i & 15; // i % 16
-            if (j >= table.num_buckets) {
-                j = j ^ 8; // i % 8
-            };
-            let index = bucket_index(table.level, table.num_buckets, i);
-            assert!(index == j, 0);
+        while (i < 400) {
+            assert!(contains(&table, i), 0);
+            assert!(remove(&mut table, i) == i, 0);
             i = i + 1;
         };
         destroy_empty(table);
+    }
+
+    #[test_only]
+    fun make(): SmartTable<u64, u64> {
+        let table = new_with_config<u64, u64>(0, 50, 10);
+        let i = 0u64;
+        while (i < 100) {
+            add(&mut table, i, i);
+            i = i + 1;
+        };
+        table
+    }
+
+    #[test]
+    fun test_for_each() {
+        let t = make();
+        let s = 0;
+        for_each(t, |x, y| {
+            s = s + x + y;
+        });
+        assert!(s == 9900, 0)
+    }
+
+    #[test]
+    fun test_for_each_ref() {
+        let t = make();
+        let s = 0;
+        for_each_ref(&t, |x, y| {
+            s = s + *x + *y;
+        });
+        assert!(s == 9900, 0);
+        destroy(t);
+    }
+
+    #[test]
+    fun test_for_each_mut() {
+        let t = make();
+        for_each_mut(&mut t, |_key, val| {
+            let val : &mut u64 = val;
+            *val = *val + 1
+        });
+        for_each_ref(&t, |key, val| {
+            assert!(*key + 1 == *val, *key);
+        });
+        destroy(t);
+    }
+
+    #[test]
+    fun test_fold() {
+        let t = make();
+        let r = fold(t, 1, |accu, key, val| {
+            accu + key + val
+        });
+        assert!(r == 9901, 0);
+    }
+
+    #[test]
+    fun test_map() {
+        let t = make();
+        let r = map(t, |val| val + 1);
+        for_each_ref(&r, |key, val| {
+            assert!(*key + 1 == *val, *key);
+        });
+        destroy(r);
+    }
+
+    #[test]
+    fun test_map_ref() {
+        let t = make();
+        let r = map_ref(&t, |val| *val + 1);
+        for_each_ref(&r, |key, val| {
+            assert!(*key + 1 == *val, *key);
+        });
+        destroy(t);
+        destroy(r);
+    }
+
+    #[test]
+    fun test_filter() {
+        let t = make();
+        let r = filter(t, |val| *val < 50);
+        assert!(length(&r) == 50, 0);
+        assert!(
+            fold(r, 0, |accu, _key, val| {
+                accu + val
+            }) == 1225, 1);
+    }
+
+    #[test]
+    fun test_any() {
+        let t = make();
+        let r = any(&t, |_k, v| *v >= 99);
+        assert!(r, 1);
+        destroy(t);
     }
 }


### PR DESCRIPTION
### Description
Personally I researched again around linear hashing, spiral storage and extendible hashing schemes. And still admit the best option for us is linear hashing. So I made a similar change to `bucket_table` to intelligently set the configurations such as
bucket_size and split_threshold.

Also, add two public functions to change these two values at any time as it does not have to be fixed after creation. Those methods give the users more flexibility to adjust their needs on the fly.

### Test Plan
cargo test
