### PR TITLE
[Parallel Executor] MVHashMap refactoring to separate data / modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,6 +1871,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
+ "aptos-crypto",
  "aptos-infallible",
  "aptos-types",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -11,6 +11,7 @@ use crate::{
 use aptos_aggregator::{delta_change_set::DeltaChangeSet, transaction::TransactionOutputExt};
 use aptos_block_executor::task::{ExecutionStatus, ExecutorTask};
 use aptos_logger::{enabled, Level};
+use aptos_mvhashmap::types::TxnIndex;
 use aptos_state_view::StateView;
 use aptos_vm_logging::{log_schema::AdapterLogSchema, prelude::*};
 use move_core_types::{
@@ -59,10 +60,10 @@ impl<'a, S: 'a + StateView + Sync> ExecutorTask for AptosExecutorTask<'a, S> {
         &self,
         view: &impl StateView,
         txn: &PreprocessedTransaction,
-        txn_idx: usize,
+        txn_idx: TxnIndex,
         materialize_deltas: bool,
     ) -> ExecutionStatus<AptosTransactionOutput, VMStatus> {
-        let log_context = AdapterLogSchema::new(self.base_view.id(), txn_idx);
+        let log_context = AdapterLogSchema::new(self.base_view.id(), txn_idx as usize);
 
         match self
             .vm

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -406,7 +406,7 @@ fn publishing_fixed_params() {
 // Test a single transaction intersection interleaves with a lot of dependencies and
 // not overlapping module r/w keys.
 fn module_publishing_races() {
-    for _ in 0..10 {
+    for _ in 0..5 {
         publishing_fixed_params();
     }
 }

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -4,20 +4,18 @@
 
 use crate::{
     errors::{Error, Result},
-    scheduler::TxnIndex,
-    task::{
-        ExecutionStatus, ExecutorTask, ModulePath, Transaction as TransactionType,
-        TransactionOutput,
-    },
+    task::{ExecutionStatus, ExecutorTask, Transaction as TransactionType, TransactionOutput},
 };
 use aptos_aggregator::{
     delta_change_set::{delta_add, delta_sub, deserialize, serialize, DeltaOp},
     transaction::AggregatorValue,
 };
+use aptos_mvhashmap::types::TxnIndex;
 use aptos_state_view::{StateViewId, TStateView};
 use aptos_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
+    executable::ModulePath,
     state_store::{state_storage_usage::StateStorageUsage, state_value::StateValue},
     write_set::{TransactionWrite, WriteOp},
 };
@@ -304,6 +302,9 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
         let is_module_read = |_| -> bool { module_access.1 };
         let is_delta = |_, _: &V| -> Option<DeltaOp> { None };
 
+        // Module deletion isn't allowed.
+        let allow_deletes = !(module_access.0 || module_access.1);
+
         Transaction::Write {
             incarnation: Arc::new(AtomicUsize::new(0)),
             writes_and_deltas: Self::writes_and_deltas_from_gen(
@@ -311,7 +312,7 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
                 self.keys_modified,
                 &is_module_write,
                 &is_delta,
-                true,
+                allow_deletes,
             ),
             reads: Self::reads_from_gen(universe, self.keys_read, &is_module_read),
         }
@@ -380,7 +381,7 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
                 self.keys_modified,
                 &is_module_write,
                 &is_delta,
-                true,
+                false, // Module deletion isn't allowed
             ),
             reads: Self::reads_from_gen(universe, self.keys_read, &is_module_read),
         }
@@ -457,7 +458,7 @@ where
                 ))
             },
             Transaction::SkipRest => ExecutionStatus::SkipRest(Output(vec![], vec![], vec![])),
-            Transaction::Abort => ExecutionStatus::Abort(txn_idx),
+            Transaction::Abort => ExecutionStatus::Abort(txn_idx as usize),
         }
     }
 }

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -3,12 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_aggregator::delta_change_set::DeltaOp;
+use aptos_mvhashmap::types::TxnIndex;
 use aptos_state_view::TStateView;
-use aptos_types::{
-    access_path::AccessPath,
-    state_store::state_key::{StateKey, StateKeyInner},
-    write_set::TransactionWrite,
-};
+use aptos_types::{executable::ModulePath, write_set::TransactionWrite};
 use std::{fmt::Debug, hash::Hash};
 
 /// The execution result of a transaction
@@ -22,21 +19,6 @@ pub enum ExecutionStatus<T, E> {
     /// Transaction was executed successfully, but will skip the execution of the trailing
     /// transactions in the list
     SkipRest(T),
-}
-
-pub trait ModulePath {
-    fn module_path(&self) -> Option<AccessPath>;
-}
-
-impl ModulePath for StateKey {
-    fn module_path(&self) -> Option<AccessPath> {
-        if let StateKeyInner::AccessPath(ap) = self.inner() {
-            if ap.is_code() {
-                return Some(ap.clone());
-            }
-        }
-        None
-    }
 }
 
 /// Trait that defines a transaction that could be parallel executed by the scheduler. Each
@@ -76,7 +58,7 @@ pub trait ExecutorTask: Sync {
         &self,
         view: &impl TStateView<Key = <Self::Txn as Transaction>::Key>,
         txn: &Self::Txn,
-        txn_idx: usize,
+        txn_idx: TxnIndex,
         materialize_deltas: bool,
     ) -> ExecutionStatus<Self::Output, Self::Error>;
 }

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -6,10 +6,10 @@ use crate::{
     executor::BlockExecutor,
     proptest_types::types::{DeltaDataView, ExpectedOutput, KeyType, Task, Transaction, ValueType},
     scheduler::{Scheduler, SchedulerTask},
-    task::ModulePath,
 };
 use aptos_aggregator::delta_change_set::{delta_add, delta_sub, DeltaOp, DeltaUpdate};
-use aptos_types::write_set::TransactionWrite;
+use aptos_mvhashmap::types::TxnIndex;
+use aptos_types::{executable::ModulePath, write_set::TransactionWrite};
 use claims::{assert_matches, assert_some_eq};
 use rand::{prelude::*, random};
 use std::{
@@ -438,7 +438,7 @@ fn scheduler_dependency() {
 
 // Will return a scheduler in a state where all transactions are scheduled for
 // for execution, validation index = num_txns, and wave = 0.
-fn incarnation_one_scheduler(num_txns: usize) -> Scheduler {
+fn incarnation_one_scheduler(num_txns: TxnIndex) -> Scheduler {
     let s = Scheduler::new(num_txns);
 
     for i in 0..num_txns {
@@ -739,7 +739,7 @@ fn no_conflict_task_count() {
     // 2. all incarnations should be 0.
     // 3. current wave should always be 0.
 
-    let num_txns = 1000;
+    let num_txns: TxnIndex = 1000;
     for num_concurrent_tasks in [1, 5, 10, 20] {
         let s = Scheduler::new(num_txns);
 

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -2,17 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    counters,
-    scheduler::{Scheduler, TxnIndex},
-    task::{ModulePath, Transaction},
-    txn_last_input_output::ReadDescriptor,
+    counters, scheduler::Scheduler, task::Transaction, txn_last_input_output::ReadDescriptor,
 };
 use anyhow::Result;
 use aptos_aggregator::delta_change_set::{deserialize, serialize, DeltaOp};
 use aptos_logger::error;
-use aptos_mvhashmap::{MVHashMap, MVHashMapError, MVHashMapOutput};
+use aptos_mvhashmap::{
+    types::{MVCodeError, MVCodeOutput, MVDataError, MVDataOutput, TxnIndex},
+    MVHashMap,
+};
 use aptos_state_view::{StateViewId, TStateView};
 use aptos_types::{
+    executable::{ExecutableTestType, ModulePath},
     state_store::{state_storage_usage::StateStorageUsage, state_value::StateValue},
     vm_status::{StatusCode, VMStatus},
     write_set::TransactionWrite,
@@ -21,9 +22,6 @@ use aptos_vm_logging::{log_schema::AdapterLogSchema, prelude::*};
 use move_binary_format::errors::Location;
 use std::{cell::RefCell, collections::BTreeMap, hash::Hash, sync::Arc};
 
-/// Resolved and serialized data for WriteOps, None means deletion.
-pub type ResolvedData = Option<Vec<u8>>;
-
 /// A struct that is always used by a single thread performing an execution task. The struct is
 /// passed to the VM and acts as a proxy to resolve reads first in the shared multi-version
 /// data-structure. It also allows the caller to track the read-set and any dependencies.
@@ -31,8 +29,8 @@ pub type ResolvedData = Option<Vec<u8>>;
 /// TODO(issue 10177): MvHashMapView currently needs to be sync due to trait bounds, but should
 /// not be. In this case, the read_dependency member can have a RefCell<bool> type and the
 /// captured_reads member can have RefCell<Vec<ReadDescriptor<K>>> type.
-pub(crate) struct MVHashMapView<'a, K, V> {
-    versioned_map: &'a MVHashMap<K, V>,
+pub(crate) struct MVHashMapView<'a, K, V: TransactionWrite> {
+    versioned_map: &'a MVHashMap<K, V, ExecutableTestType>, // TODO: proper generic type
     scheduler: &'a Scheduler,
     captured_reads: RefCell<Vec<ReadDescriptor<K>>>,
 }
@@ -40,7 +38,7 @@ pub(crate) struct MVHashMapView<'a, K, V> {
 /// A struct which describes the result of the read from the proxy. The client
 /// can interpret these types to further resolve the reads.
 #[derive(Debug)]
-pub enum ReadResult<V> {
+pub(crate) enum ReadResult<V> {
     // Successful read of a value.
     Value(Arc<V>),
     // Similar to above, but the value was aggregated and is an integer.
@@ -57,7 +55,10 @@ impl<
         V: TransactionWrite + Send + Sync,
     > MVHashMapView<'a, K, V>
 {
-    pub(crate) fn new(versioned_map: &'a MVHashMap<K, V>, scheduler: &'a Scheduler) -> Self {
+    pub(crate) fn new(
+        versioned_map: &'a MVHashMap<K, V, ExecutableTestType>,
+        scheduler: &'a Scheduler,
+    ) -> Self {
         Self {
             versioned_map,
             scheduler,
@@ -70,14 +71,29 @@ impl<
         self.captured_reads.take()
     }
 
+    // TODO: Actually fill in the logic to record fetched executables, etc.
+    fn fetch_code(
+        &self,
+        key: &K,
+        txn_idx: TxnIndex,
+    ) -> anyhow::Result<MVCodeOutput<V, ExecutableTestType>, MVCodeError> {
+        // Add a fake read from storage to register in reads for now in order
+        // for the read / write path intersection fallback for modules to still work.
+        self.captured_reads
+            .borrow_mut()
+            .push(ReadDescriptor::from_storage(key.clone()));
+
+        self.versioned_map.fetch_code(key, txn_idx)
+    }
+
     /// Captures a read from the VM execution.
-    fn read(&self, key: &K, txn_idx: TxnIndex) -> ReadResult<V> {
-        use MVHashMapError::*;
-        use MVHashMapOutput::*;
+    fn fetch_data(&self, key: &K, txn_idx: TxnIndex) -> ReadResult<V> {
+        use MVDataError::*;
+        use MVDataOutput::*;
 
         loop {
-            match self.versioned_map.read(key, txn_idx) {
-                Ok(Version(version, v)) => {
+            match self.versioned_map.fetch_data(key, txn_idx) {
+                Ok(Versioned(version, v)) => {
                     let (idx, incarnation) = version;
                     self.captured_reads
                         .borrow_mut()
@@ -186,7 +202,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
         if ret.is_err() {
             // Even speculatively, reading from base view should not return an error.
             // Thus, this critical error log and count does not need to be buffered.
-            let log_context = AdapterLogSchema::new(self.base_view.id(), self.txn_idx);
+            let log_context = AdapterLogSchema::new(self.base_view.id(), self.txn_idx as usize);
             alert!(
                 log_context,
                 "[VM, StateView] Error getting data from storage for {:?}",
@@ -202,20 +218,38 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> TStateView for LatestView<
 
     fn get_state_value(&self, state_key: &T::Key) -> anyhow::Result<Option<StateValue>> {
         match self.latest_view {
-            ViewMapKind::MultiVersion(map) => match map.read(state_key, self.txn_idx) {
-                ReadResult::Value(v) => Ok(v.as_state_value()),
-                ReadResult::U128(v) => Ok(Some(StateValue::new_legacy(serialize(&v)))),
-                ReadResult::Unresolved(delta) => {
-                    let from_storage = self.base_view.get_state_value_bytes(state_key)?.map_or(
-                        Err(VMStatus::Error(StatusCode::STORAGE_ERROR, None)),
-                        |bytes| Ok(deserialize(&bytes)),
-                    )?;
-                    let result = delta
-                        .apply_to(from_storage)
-                        .map_err(|pe| pe.finish(Location::Undefined).into_vm_status())?;
-                    Ok(Some(StateValue::new_legacy(serialize(&result))))
+            ViewMapKind::MultiVersion(map) => match state_key.module_path() {
+                Some(_) => {
+                    use MVCodeError::*;
+                    use MVCodeOutput::*;
+
+                    match map.fetch_code(state_key, self.txn_idx) {
+                        Ok(Executable(_)) => unreachable!("Versioned executable not implemented"),
+                        Ok(Module((v, _))) => Ok(v.as_state_value()),
+                        Err(Dependency(_)) => {
+                            // Return anything (e.g. module does not exist) to avoid waiting,
+                            // because parallel execution will fall back to sequential anyway.
+                            Ok(None)
+                        },
+                        Err(NotFound) => self.base_view.get_state_value(state_key),
+                    }
                 },
-                ReadResult::None => self.get_base_value(state_key),
+                None => match map.fetch_data(state_key, self.txn_idx) {
+                    ReadResult::Value(v) => Ok(v.as_state_value()),
+                    ReadResult::U128(v) => Ok(Some(StateValue::new_legacy(serialize(&v)))),
+                    ReadResult::Unresolved(delta) => {
+                        let from_storage =
+                            self.base_view.get_state_value_bytes(state_key)?.map_or(
+                                Err(VMStatus::Error(StatusCode::STORAGE_ERROR, None)),
+                                |bytes| Ok(deserialize(&bytes)),
+                            )?;
+                        let result = delta
+                            .apply_to(from_storage)
+                            .map_err(|pe| pe.finish(Location::Undefined).into_vm_status())?;
+                        Ok(Some(StateValue::new_legacy(serialize(&result))))
+                    },
+                    ReadResult::None => self.get_base_value(state_key),
+                },
             },
             ViewMapKind::BTree(map) => map.get(state_key).map_or_else(
                 || self.get_base_value(state_key),

--- a/aptos-move/mvhashmap/Cargo.toml
+++ b/aptos-move/mvhashmap/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-aggregator = { workspace = true }
+aptos-crypto = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }

--- a/aptos-move/mvhashmap/src/lib.rs
+++ b/aptos-move/mvhashmap/src/lib.rs
@@ -2,304 +2,128 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_aggregator::{delta_change_set::DeltaOp, transaction::AggregatorValue};
-use aptos_infallible::Mutex;
-use aptos_types::write_set::TransactionWrite;
-use crossbeam::utils::CachePadded;
-use dashmap::DashMap;
-use std::{
-    collections::btree_map::BTreeMap,
-    hash::Hash,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+use crate::{
+    types::{MVCodeError, MVCodeOutput, MVDataError, MVDataOutput, TxnIndex, Version},
+    versioned_code::VersionedCode,
+    versioned_data::VersionedData,
 };
+use aptos_aggregator::delta_change_set::DeltaOp;
+use aptos_types::{
+    executable::{Executable, ExecutableDescriptor, ModulePath},
+    write_set::TransactionWrite,
+};
+use std::hash::Hash;
+
+pub mod types;
+pub mod versioned_code;
+pub mod versioned_data;
 
 #[cfg(test)]
 mod unit_tests;
 
-// TODO: re-use definitions with the scheduler.
-pub type TxnIndex = usize;
-pub type Incarnation = usize;
-pub type Version = (TxnIndex, Incarnation);
-
-const FLAG_DONE: usize = 0;
-const FLAG_ESTIMATE: usize = 1;
-
-/// Every entry in shared multi-version data-structure has an "estimate" flag
-/// and some content.
-pub struct Entry<V> {
-    /// Used to mark the entry as a "write estimate".
-    flag: AtomicUsize,
-    /// Actual content.
-    pub cell: EntryCell<V>,
-}
-
-/// Represents the content of a single entry in multi-version data-structure.
-pub enum EntryCell<V> {
-    /// Recorded in the shared multi-version data-structure for each write. It
-    /// has: 1) Incarnation number of the transaction that wrote the entry (note
-    /// that TxnIndex is part of the key and not recorded here), 2) actual data
-    /// stored in a shared pointer (to ensure ownership and avoid clones).
-    Write(Incarnation, Arc<V>),
-    /// Recorded in the shared multi-version data-structure for each delta.
-    Delta(DeltaOp),
-}
-
-impl<V> Entry<V> {
-    pub fn new_write_from(flag: usize, incarnation: Incarnation, data: V) -> Entry<V> {
-        Entry {
-            flag: AtomicUsize::new(flag),
-            cell: EntryCell::Write(incarnation, Arc::new(data)),
-        }
-    }
-
-    pub fn new_delta_from(flag: usize, data: DeltaOp) -> Entry<V> {
-        Entry {
-            flag: AtomicUsize::new(flag),
-            cell: EntryCell::Delta(data),
-        }
-    }
-
-    pub fn flag(&self) -> usize {
-        self.flag.load(Ordering::SeqCst)
-    }
-
-    pub fn mark_estimate(&self) {
-        self.flag.store(FLAG_ESTIMATE, Ordering::SeqCst);
-    }
-}
-
-pub(crate) struct VersionedValue<V> {
-    pub(crate) versioned_map: BTreeMap<TxnIndex, CachePadded<Entry<V>>>,
-    // Note: this can cache base (storage) value in Option<u128> to facilitate
-    // aggregator validation & reading in the future, if needed.
-    pub(crate) contains_delta: bool,
-}
-
-impl<V: TransactionWrite> VersionedValue<V> {
-    pub fn new() -> Self {
-        Self {
-            versioned_map: BTreeMap::new(),
-            contains_delta: false,
-        }
-    }
-}
-
-impl<V: TransactionWrite> Default for VersionedValue<V> {
-    fn default() -> Self {
-        VersionedValue::new()
-    }
-}
-
 /// Main multi-version data-structure used by threads to read/write during parallel
-/// execution. Maps each access path to an interal BTreeMap that contains the indices
-/// of transactions that write at the given access path alongside the corresponding
-/// entries of WriteCell type.
+/// execution.
 ///
 /// Concurrency is managed by DashMap, i.e. when a method accesses a BTreeMap at a
 /// given key, it holds exclusive access and doesn't need to explicitly synchronize
 /// with other reader/writers.
-pub struct MVHashMap<K, V> {
-    data: DashMap<K, VersionedValue<V>>,
-    delta_keys: Mutex<Vec<K>>,
+///
+/// TODO: separate V into different generic types for data and modules / code (currently
+/// both WriteOp for executor, and use extract_raw_bytes. data for aggregators, and
+/// code for computing the module hash.
+pub struct MVHashMap<K, V: TransactionWrite, X: Executable> {
+    data: VersionedData<K, V>,
+    code: VersionedCode<K, V, X>,
 }
 
-/// Returned as Err(..) when failed to read from the multi-version data-structure.
-#[derive(Debug, PartialEq, Eq)]
-pub enum MVHashMapError {
-    /// No prior entry is found.
-    NotFound,
-    /// Read resulted in an unresolved delta value.
-    Unresolved(DeltaOp),
-    /// A dependency on other transaction has been found during the read.
-    Dependency(TxnIndex),
-    /// Delta application failed, txn execution should fail.
-    DeltaApplicationFailure,
-}
+impl<K: ModulePath + Hash + Clone + Eq, V: TransactionWrite, X: Executable> MVHashMap<K, V, X> {
+    // -----------------------------------
+    // Functions shared for data and code.
 
-/// Returned as Ok(..) when read successfully from the multi-version data-structure.
-#[derive(Debug, PartialEq, Eq)]
-pub enum MVHashMapOutput<V> {
-    /// Result of resolved delta op, always u128. Unlike with `Version`, we return
-    /// actual data because u128 is cheap to copy amd validation can be done correctly
-    /// on values as well (ABA is not a problem).
-    Resolved(u128),
-    /// Information from the last versioned-write. Note that the version is returned
-    /// and not the data to avoid passing big values around.
-    Version(Version, Arc<V>),
-}
-
-impl<K: Hash + Clone + Eq, V: TransactionWrite> MVHashMap<K, V> {
-    pub fn new() -> MVHashMap<K, V> {
+    // Option<VersionedCode> is passed to allow re-using code cache between blocks.
+    pub fn new(code_cache: Option<VersionedCode<K, V, X>>) -> MVHashMap<K, V, X> {
         MVHashMap {
-            data: DashMap::new(),
-            delta_keys: Mutex::new(Vec::new()),
+            data: VersionedData::new(),
+            code: code_cache.unwrap_or_default(),
         }
     }
 
-    /// For processing outputs - removes the BTreeMap from the MVHashMap.
-    pub fn entry_map_for_key(&self, key: &K) -> Option<BTreeMap<TxnIndex, CachePadded<Entry<V>>>> {
-        self.data
-            .remove(key)
-            .map(|(_, v)| v)
-            .map(|p| p.versioned_map)
-    }
-
-    /// Returns the list of keys that had an associated delta entry at any prior point.
-    pub fn aggregator_keys(&self) -> Vec<K> {
-        std::mem::take(&mut self.delta_keys.lock())
-    }
-
-    /// Add a write of versioned data at a specified key. If the entry is overwritten, asserts
-    /// that the new incarnation is strictly higher.
-    pub fn add_write(&self, key: &K, version: Version, data: V) {
-        let (txn_idx, incarnation) = version;
-
-        let mut v = self.data.entry(key.clone()).or_default();
-        let prev_entry = v.versioned_map.insert(
-            txn_idx,
-            CachePadded::new(Entry::new_write_from(FLAG_DONE, incarnation, data)),
-        );
-
-        // Assert that the previous entry for txn_idx, if present, had lower incarnation.
-        assert!(prev_entry.map_or(true, |entry| -> bool {
-            if let EntryCell::Write(i, _) = entry.cell {
-                i < incarnation
-            } else {
-                true
-            }
-        }));
-    }
-
-    /// Add a delta at a specified key.
-    pub fn add_delta(&self, key: &K, txn_idx: usize, delta: DeltaOp) {
-        let mut v = self.data.entry(key.clone()).or_default();
-        v.versioned_map.insert(
-            txn_idx,
-            CachePadded::new(Entry::new_delta_from(FLAG_DONE, delta)),
-        );
-
-        if !v.contains_delta {
-            v.contains_delta = true;
-            self.delta_keys.lock().push(key.clone());
-        }
+    pub fn take(self) -> (VersionedData<K, V>, VersionedCode<K, V, X>) {
+        (self.data, self.code)
     }
 
     /// Mark an entry from transaction 'txn_idx' at access path 'key' as an estimated write
     /// (for future incarnation). Will panic if the entry is not in the data-structure.
     pub fn mark_estimate(&self, key: &K, txn_idx: TxnIndex) {
-        let v = self.data.get(key).expect("Path must exist");
-        v.versioned_map
-            .get(&txn_idx)
-            .expect("Entry by txn must exist")
-            .mark_estimate();
+        match key.module_path() {
+            Some(_) => self.code.mark_estimate(key, txn_idx),
+            None => self.data.mark_estimate(key, txn_idx),
+        }
     }
 
     /// Delete an entry from transaction 'txn_idx' at access path 'key'. Will panic
-    /// if the access path has never been written before.
+    /// if the corresponding entry does not exist.
     pub fn delete(&self, key: &K, txn_idx: TxnIndex) {
-        // TODO: investigate logical deletion.
-        let mut v = self.data.get_mut(key).expect("Path must exist");
-        v.versioned_map.remove(&txn_idx);
+        // This internally deserializes the path, TODO: fix.
+        match key.module_path() {
+            Some(_) => self.code.delete(key, txn_idx),
+            None => self.data.delete(key, txn_idx),
+        };
     }
 
-    /// Read entry from transaction 'txn_idx' at access path 'key'.
-    pub fn read(
+    /// Add a versioned write at a specified key, in code or data map according to the key.
+    pub fn write(&self, key: &K, version: Version, value: V) {
+        match key.module_path() {
+            Some(_) => self.code.write(key, version.0, value),
+            None => self.data.write(key, version, value),
+        }
+    }
+
+    // -----------------------------------------------
+    // Functions specific to the multi-versioned data.
+
+    /// Add a delta at a specified key.
+    pub fn add_delta(&self, key: &K, txn_idx: TxnIndex, delta: DeltaOp) {
+        debug_assert!(
+            key.module_path().is_none(),
+            "Delta must be stored at a path corresponding to data"
+        );
+
+        self.data.add_delta(key, txn_idx, delta);
+    }
+
+    /// Read data at access path 'key', from the perspective of transaction 'txn_idx'.
+    pub fn fetch_data(
         &self,
         key: &K,
         txn_idx: TxnIndex,
-    ) -> anyhow::Result<MVHashMapOutput<V>, MVHashMapError> {
-        use MVHashMapError::*;
-        use MVHashMapOutput::*;
+    ) -> anyhow::Result<MVDataOutput<V>, MVDataError> {
+        self.data.fetch_data(key, txn_idx)
+    }
 
-        match self.data.get(key) {
-            Some(v) => {
-                let mut iter = v.versioned_map.range(0..txn_idx);
+    // ----------------------------------------------
+    // Functions specific to the multi-versioned code.
 
-                // If read encounters a delta, it must traverse the block of transactions
-                // (top-down) until it encounters a write or reaches the end of the block.
-                // During traversal, all aggregator deltas have to be accumulated together.
-                let mut accumulator: Option<Result<DeltaOp, ()>> = None;
-                while let Some((idx, entry)) = iter.next_back() {
-                    let flag = entry.flag();
+    /// Adds a new executable to the multiversion data-structure. The executable is either
+    /// storage-version (and fixed) or uniquely identified by the (cryptographic) hash of the
+    /// module published during the block.
+    pub fn store_executable(&self, key: &K, descriptor: ExecutableDescriptor, executable: X) {
+        self.code.store_executable(key, descriptor, executable);
+    }
 
-                    if flag == FLAG_ESTIMATE {
-                        // Found a dependency.
-                        return Err(Dependency(*idx));
-                    }
-
-                    // The entry should be populated.
-                    debug_assert!(flag == FLAG_DONE);
-
-                    match (&entry.cell, accumulator.as_mut()) {
-                        (EntryCell::Write(incarnation, data), None) => {
-                            // Resolve to the write if no deltas were applied in between.
-                            let write_version = (*idx, *incarnation);
-                            return Ok(Version(write_version, data.clone()));
-                        },
-                        (EntryCell::Write(incarnation, data), Some(accumulator)) => {
-                            // Deltas were applied. We must deserialize the value
-                            // of the write and apply the aggregated delta accumulator.
-
-                            // None if data represents deletion. Otherwise, panics if the
-                            // data can't be resolved to an aggregator value.
-                            let maybe_value = AggregatorValue::from_write(data.as_ref());
-
-                            if maybe_value.is_none() {
-                                // Resolve to the write if the WriteOp was deletion
-                                // (MoveVM will observe 'deletion'). This takes precedence
-                                // over any speculative delta accumulation errors on top.
-                                let write_version = (*idx, *incarnation);
-                                return Ok(Version(write_version, data.clone()));
-                            }
-                            return accumulator.map_err(|_| DeltaApplicationFailure).and_then(
-                                |a| {
-                                    // Apply accumulated delta to resolve the aggregator value.
-                                    a.apply_to(maybe_value.unwrap().into())
-                                        .map(|result| Resolved(result))
-                                        .map_err(|_| DeltaApplicationFailure)
-                                },
-                            );
-                        },
-                        (EntryCell::Delta(delta), Some(accumulator)) => {
-                            *accumulator = accumulator.and_then(|mut a| {
-                                // Read hit a delta during traversing the block and aggregating
-                                // other deltas. Merge two deltas together. If Delta application
-                                // fails, we record an error, but continue processing (to e.g.
-                                // account for the case when the aggregator was deleted).
-                                if a.merge_onto(*delta).is_err() {
-                                    Err(())
-                                } else {
-                                    Ok(a)
-                                }
-                            });
-                        },
-                        (EntryCell::Delta(delta), None) => {
-                            // Read hit a delta and must start accumulating.
-                            // Initialize the accumulator and continue traversal.
-                            accumulator = Some(Ok(*delta))
-                        },
-                    }
-                }
-
-                // It can happen that while traversing the block and resolving
-                // deltas the actual written value has not been seen yet (i.e.
-                // it is not added as an entry to the data-structure).
-                match accumulator {
-                    Some(Ok(accumulator)) => Err(Unresolved(accumulator)),
-                    Some(Err(_)) => Err(DeltaApplicationFailure),
-                    None => Err(NotFound),
-                }
-            },
-            None => Err(NotFound),
-        }
+    pub fn fetch_code(
+        &self,
+        key: &K,
+        txn_idx: TxnIndex,
+    ) -> anyhow::Result<MVCodeOutput<V, X>, MVCodeError> {
+        self.code.fetch_code(key, txn_idx)
     }
 }
 
-impl<K: Hash + Clone + Eq, V: TransactionWrite> Default for MVHashMap<K, V> {
+impl<K: ModulePath + Hash + Clone + Eq, V: TransactionWrite, X: Executable> Default
+    for MVHashMap<K, V, X>
+{
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }

--- a/aptos-move/mvhashmap/src/types.rs
+++ b/aptos-move/mvhashmap/src/types.rs
@@ -1,0 +1,57 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_aggregator::delta_change_set::DeltaOp;
+use aptos_crypto::hash::HashValue;
+use aptos_types::executable::ExecutableDescriptor;
+use std::sync::Arc;
+
+pub type TxnIndex = u32;
+pub type Incarnation = u32;
+pub type Version = (TxnIndex, Incarnation);
+
+/// Returned as Err(..) when failed to read from the multi-version data-structure.
+#[derive(Debug, PartialEq, Eq)]
+pub enum MVDataError {
+    /// No prior entry is found.
+    NotFound,
+    /// Read resulted in an unresolved delta value.
+    Unresolved(DeltaOp),
+    /// A dependency on other transaction has been found during the read.
+    Dependency(TxnIndex),
+    /// Delta application failed, txn execution should fail.
+    DeltaApplicationFailure,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum MVCodeError {
+    /// No prior entry is found.
+    NotFound,
+    /// A dependency on other transaction has been found during the read.
+    Dependency(TxnIndex),
+}
+
+/// Returned as Ok(..) when read successfully from the multi-version data-structure.
+#[derive(Debug, PartialEq, Eq)]
+pub enum MVDataOutput<V> {
+    /// Result of resolved delta op, always u128. Unlike with `Version`, we return
+    /// actual data because u128 is cheap to copy and validation can be done correctly
+    /// on values as well (ABA is not a problem).
+    Resolved(u128),
+    /// Information from the last versioned-write. Note that the version is returned
+    /// and not the data to avoid copying big values around.
+    Versioned(Version, Arc<V>),
+}
+
+/// Returned as Ok(..) when read successfully from the multi-version data-structure.
+#[derive(Debug, PartialEq, Eq)]
+pub enum MVCodeOutput<M, X> {
+    /// Arc to the executable corresponding to the latest module, and a descriptor
+    /// with either the module hash or indicator that the module is from storage.
+    Executable((Arc<X>, ExecutableDescriptor)),
+    /// Arc to the latest module, together with its (cryptographic) hash. Note that
+    /// this can't be a storage-level module, as it's from multi-versioned code map.
+    /// The Option can be None if HashValue can't be computed, currently may happen
+    /// if the latest entry corresponded to the module deletion.
+    Module((Arc<M>, HashValue)),
+}

--- a/aptos-move/mvhashmap/src/unit_tests/mod.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/mod.rs
@@ -2,17 +2,25 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::*;
+use super::{
+    types::{Incarnation, MVDataError, MVDataOutput, TxnIndex},
+    *,
+};
 use aptos_aggregator::{
     delta_change_set::{delta_add, delta_sub, DeltaOp, DeltaUpdate},
     transaction::AggregatorValue,
 };
-use aptos_types::state_store::state_value::StateValue;
+use aptos_types::{
+    access_path::AccessPath,
+    executable::{ExecutableTestType, ModulePath},
+    state_store::state_value::StateValue,
+};
+use std::sync::Arc;
 
 mod proptest_types;
 
 #[derive(Debug, PartialEq, Eq)]
-struct Value(Vec<usize>);
+struct Value(Vec<u32>);
 
 impl TransactionWrite for Value {
     fn extract_raw_bytes(&self) -> Option<Vec<u8>> {
@@ -32,61 +40,73 @@ impl TransactionWrite for Value {
 }
 
 // Generate a Vec deterministically based on txn_idx and incarnation.
-fn value_for(txn_idx: usize, incarnation: usize) -> Value {
+fn value_for(txn_idx: TxnIndex, incarnation: Incarnation) -> Value {
     Value(vec![txn_idx * 5, txn_idx + incarnation, incarnation * 5])
 }
 
 // Generate the value_for txn_idx and incarnation in arc.
-fn arc_value_for(txn_idx: usize, incarnation: usize) -> Arc<Value> {
+fn arc_value_for(txn_idx: TxnIndex, incarnation: Incarnation) -> Arc<Value> {
     // Generate a Vec deterministically based on txn_idx and incarnation.
     Arc::new(value_for(txn_idx, incarnation))
 }
 
 // Convert value for txn_idx and incarnation into u128.
-fn u128_for(txn_idx: usize, incarnation: usize) -> u128 {
+fn u128_for(txn_idx: TxnIndex, incarnation: Incarnation) -> u128 {
     AggregatorValue::from_write(&value_for(txn_idx, incarnation))
         .unwrap()
         .into()
 }
 
 // Generate determinitc additions.
-fn add_for(txn_idx: usize, limit: u128) -> DeltaOp {
+fn add_for(txn_idx: TxnIndex, limit: u128) -> DeltaOp {
     delta_add(txn_idx as u128, limit)
 }
 
 // Generate determinitc subtractions.
-fn sub_for(txn_idx: usize, base: u128) -> DeltaOp {
+fn sub_for(txn_idx: TxnIndex, base: u128) -> DeltaOp {
     delta_sub(base + (txn_idx as u128), u128::MAX)
+}
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+pub(crate) struct KeyType<K: Hash + Clone + Eq>(
+    /// Wrapping the types used for testing to add ModulePath trait implementation.
+    pub K,
+);
+
+impl<K: Hash + Clone + Eq> ModulePath for KeyType<K> {
+    fn module_path(&self) -> Option<AccessPath> {
+        None
+    }
 }
 
 #[test]
 fn create_write_read_placeholder_struct() {
-    use MVHashMapError::*;
-    use MVHashMapOutput::*;
+    use MVDataError::*;
+    use MVDataOutput::*;
 
-    let ap1 = b"/foo/b".to_vec();
-    let ap2 = b"/foo/c".to_vec();
-    let ap3 = b"/foo/d".to_vec();
+    let ap1 = KeyType(b"/foo/b".to_vec());
+    let ap2 = KeyType(b"/foo/c".to_vec());
+    let ap3 = KeyType(b"/foo/d".to_vec());
 
-    let mvtbl = MVHashMap::new();
+    let mvtbl: MVHashMap<KeyType<Vec<u8>>, Value, ExecutableTestType> = MVHashMap::new(None);
 
     // Reads that should go the DB return Err(NotFound)
-    let r_db = mvtbl.read(&ap1, 5);
+    let r_db = mvtbl.fetch_data(&ap1, 5);
     assert_eq!(Err(NotFound), r_db);
 
     // Write by txn 10.
-    mvtbl.add_write(&ap1, (10, 1), value_for(10, 1));
+    mvtbl.write(&ap1, (10, 1), value_for(10, 1));
 
     // Reads that should go the DB return Err(NotFound)
-    let r_db = mvtbl.read(&ap1, 9);
+    let r_db = mvtbl.fetch_data(&ap1, 9);
     assert_eq!(Err(NotFound), r_db);
     // Reads return entries from smaller txns, not txn 10.
-    let r_db = mvtbl.read(&ap1, 10);
+    let r_db = mvtbl.fetch_data(&ap1, 10);
     assert_eq!(Err(NotFound), r_db);
 
     // Reads for a higher txn return the entry written by txn 10.
-    let r_10 = mvtbl.read(&ap1, 15);
-    assert_eq!(Ok(Version((10, 1), arc_value_for(10, 1))), r_10);
+    let r_10 = mvtbl.fetch_data(&ap1, 15);
+    assert_eq!(Ok(Versioned((10, 1), arc_value_for(10, 1))), r_10);
 
     // More deltas.
     mvtbl.add_delta(&ap1, 11, add_for(11, 1000));
@@ -94,47 +114,47 @@ fn create_write_read_placeholder_struct() {
     mvtbl.add_delta(&ap1, 13, sub_for(13, 61));
 
     // Reads have to go traverse deltas until a write is found.
-    let r_sum = mvtbl.read(&ap1, 14);
+    let r_sum = mvtbl.fetch_data(&ap1, 14);
     assert_eq!(Ok(Resolved(u128_for(10, 1) + 11 + 12 - (61 + 13))), r_sum);
 
     // More writes.
-    mvtbl.add_write(&ap1, (12, 0), value_for(12, 0));
-    mvtbl.add_write(&ap1, (8, 3), value_for(8, 3));
+    mvtbl.write(&ap1, (12, 0), value_for(12, 0));
+    mvtbl.write(&ap1, (8, 3), value_for(8, 3));
 
     // Verify reads.
-    let r_12 = mvtbl.read(&ap1, 15);
+    let r_12 = mvtbl.fetch_data(&ap1, 15);
     assert_eq!(Ok(Resolved(u128_for(12, 0) - (61 + 13))), r_12);
-    let r_10 = mvtbl.read(&ap1, 11);
-    assert_eq!(Ok(Version((10, 1), arc_value_for(10, 1))), r_10);
-    let r_8 = mvtbl.read(&ap1, 10);
-    assert_eq!(Ok(Version((8, 3), arc_value_for(8, 3))), r_8);
+    let r_10 = mvtbl.fetch_data(&ap1, 11);
+    assert_eq!(Ok(Versioned((10, 1), arc_value_for(10, 1))), r_10);
+    let r_8 = mvtbl.fetch_data(&ap1, 10);
+    assert_eq!(Ok(Versioned((8, 3), arc_value_for(8, 3))), r_8);
 
     // Mark the entry written by 10 as an estimate.
     mvtbl.mark_estimate(&ap1, 10);
 
     // Read for txn 11 must observe a dependency.
-    let r_10 = mvtbl.read(&ap1, 11);
+    let r_10 = mvtbl.fetch_data(&ap1, 11);
     assert_eq!(Err(Dependency(10)), r_10);
 
     // Read for txn 12 must observe a dependency when resolving deltas at txn 11.
-    let r_11 = mvtbl.read(&ap1, 12);
+    let r_11 = mvtbl.fetch_data(&ap1, 12);
     assert_eq!(Err(Dependency(10)), r_11);
 
     // Delete the entry written by 10, write to a different ap.
     mvtbl.delete(&ap1, 10);
-    mvtbl.add_write(&ap2, (10, 2), value_for(10, 2));
+    mvtbl.write(&ap2, (10, 2), value_for(10, 2));
 
     // Read by txn 11 no longer observes entry from txn 10.
-    let r_8 = mvtbl.read(&ap1, 11);
-    assert_eq!(Ok(Version((8, 3), arc_value_for(8, 3))), r_8);
+    let r_8 = mvtbl.fetch_data(&ap1, 11);
+    assert_eq!(Ok(Versioned((8, 3), arc_value_for(8, 3))), r_8);
 
     // Reads, writes for ap2 and ap3.
-    mvtbl.add_write(&ap2, (5, 0), value_for(5, 0));
-    mvtbl.add_write(&ap3, (20, 4), value_for(20, 4));
-    let r_5 = mvtbl.read(&ap2, 10);
-    assert_eq!(Ok(Version((5, 0), arc_value_for(5, 0))), r_5);
-    let r_20 = mvtbl.read(&ap3, 21);
-    assert_eq!(Ok(Version((20, 4), arc_value_for(20, 4))), r_20);
+    mvtbl.write(&ap2, (5, 0), value_for(5, 0));
+    mvtbl.write(&ap3, (20, 4), value_for(20, 4));
+    let r_5 = mvtbl.fetch_data(&ap2, 10);
+    assert_eq!(Ok(Versioned((5, 0), arc_value_for(5, 0))), r_5);
+    let r_20 = mvtbl.fetch_data(&ap3, 21);
+    assert_eq!(Ok(Versioned((20, 4), arc_value_for(20, 4))), r_20);
 
     // Clear ap1 and ap3.
     mvtbl.delete(&ap1, 12);
@@ -142,32 +162,29 @@ fn create_write_read_placeholder_struct() {
     mvtbl.delete(&ap3, 20);
 
     // Reads from ap1 and ap3 go to db.
-    let r_db = mvtbl.read(&ap1, 30);
+    let r_db = mvtbl.fetch_data(&ap1, 30);
     match r_db {
         Err(Unresolved(delta)) => delta.get_update() == DeltaUpdate::Minus((61 + 13) - 11),
         _ => unreachable!(),
     };
-    let r_db = mvtbl.read(&ap3, 30);
+    let r_db = mvtbl.fetch_data(&ap3, 30);
     assert_eq!(Err(NotFound), r_db);
 
-    // No-op delete at ap2.
-    mvtbl.delete(&ap2, 11);
-
     // Read entry by txn 10 at ap2.
-    let r_10 = mvtbl.read(&ap2, 15);
-    assert_eq!(Ok(Version((10, 2), arc_value_for(10, 2))), r_10);
+    let r_10 = mvtbl.fetch_data(&ap2, 15);
+    assert_eq!(Ok(Versioned((10, 2), arc_value_for(10, 2))), r_10);
 
     // Both delta-write and delta-delta application failures are detected.
     mvtbl.add_delta(&ap1, 30, add_for(30, 32));
     mvtbl.add_delta(&ap1, 31, add_for(31, 32));
-    let r_33 = mvtbl.read(&ap1, 33);
+    let r_33 = mvtbl.fetch_data(&ap1, 33);
     assert_eq!(Err(DeltaApplicationFailure), r_33);
 
     let val = value_for(10, 3);
     // sub base sub_for for which should underflow (with txn index)
     let sub_base = AggregatorValue::from_write(&val).unwrap().into();
-    mvtbl.add_write(&ap2, (10, 3), val);
+    mvtbl.write(&ap2, (10, 3), val);
     mvtbl.add_delta(&ap2, 30, sub_for(30, sub_base));
-    let r_31 = mvtbl.read(&ap2, 31);
+    let r_31 = mvtbl.fetch_data(&ap2, 31);
     assert_eq!(Err(DeltaApplicationFailure), r_31);
 }

--- a/aptos-move/mvhashmap/src/versioned_code.rs
+++ b/aptos-move/mvhashmap/src/versioned_code.rs
@@ -1,0 +1,199 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::types::{MVCodeError, MVCodeOutput, TxnIndex};
+use aptos_crypto::hash::{DefaultHasher, HashValue};
+use aptos_types::{
+    executable::{Executable, ExecutableDescriptor},
+    write_set::TransactionWrite,
+};
+use crossbeam::utils::CachePadded;
+use dashmap::DashMap;
+use std::{
+    collections::{btree_map::BTreeMap, HashMap},
+    hash::Hash,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+
+const FLAG_DONE: usize = 0;
+const FLAG_ESTIMATE: usize = 1;
+
+/// Every entry in shared multi-version data-structure has an "estimate" flag
+/// and some content.
+struct Entry<V: TransactionWrite> {
+    /// Used to mark the entry as a "write estimate". Even though the entry
+    /// lives inside the DashMap and the entry access will have barriers, we
+    /// still make the flag Atomic to provide acq/rel semantics on its own.
+    flag: AtomicUsize,
+
+    /// The contents of the module as produced by the VM (can be WriteOp based on a
+    /// blob or CompiledModule, but must satisfy TransactionWrite to be able to
+    /// generate the hash below.
+    module: Arc<V>,
+    /// The hash of the blob, used instead of incarnation for validation purposes,
+    /// and also for uniquely identifying associated executables.
+    hash: HashValue,
+}
+
+/// A VersionedValue internally contains a BTreeMap from indices of transactions
+/// that update the given access path alongside the corresponding entries.
+struct VersionedValue<V: TransactionWrite, X: Executable> {
+    versioned_map: BTreeMap<TxnIndex, CachePadded<Entry<V>>>,
+
+    /// Executable based on the storage version of the module.
+    base_executable: Option<Arc<X>>,
+    /// Executables corresponding to published versions of the module, based on hash.
+    executables: HashMap<HashValue, Arc<X>>,
+}
+
+/// Maps each key (access path) to an interal VersionedValue.
+pub struct VersionedCode<K, V: TransactionWrite, X: Executable> {
+    values: DashMap<K, VersionedValue<V, X>>,
+}
+
+impl<V: TransactionWrite> Entry<V> {
+    pub fn new_write_from(flag: usize, module: V) -> Entry<V> {
+        let hash = module
+            .extract_raw_bytes()
+            .map(|bytes| {
+                let mut hasher = DefaultHasher::new(b"Module");
+                hasher.update(&bytes);
+                hasher.finish()
+            })
+            .expect("Module can't be deleted");
+
+        Entry {
+            flag: AtomicUsize::new(flag),
+            module: Arc::new(module),
+            hash,
+        }
+    }
+
+    pub fn flag(&self) -> usize {
+        self.flag.load(Ordering::Acquire)
+    }
+
+    pub fn mark_estimate(&self) {
+        self.flag.store(FLAG_ESTIMATE, Ordering::Release);
+    }
+}
+
+impl<V: TransactionWrite, X: Executable> VersionedValue<V, X> {
+    pub fn new() -> Self {
+        Self {
+            versioned_map: BTreeMap::new(),
+            base_executable: None,
+            executables: HashMap::new(),
+        }
+    }
+
+    fn read(&self, txn_idx: TxnIndex) -> anyhow::Result<(Arc<V>, HashValue), MVCodeError> {
+        use MVCodeError::*;
+
+        if let Some((idx, entry)) = self.versioned_map.range(0..txn_idx).next_back() {
+            let flag = entry.flag();
+            if flag == FLAG_ESTIMATE {
+                // Found a dependency.
+                return Err(Dependency(*idx));
+            }
+            // The entry should be populated.
+            debug_assert!(flag == FLAG_DONE);
+
+            Ok((entry.module.clone(), entry.hash))
+        } else {
+            Err(NotFound)
+        }
+    }
+}
+
+impl<V: TransactionWrite, X: Executable> Default for VersionedValue<V, X> {
+    fn default() -> Self {
+        VersionedValue::new()
+    }
+}
+
+impl<K: Hash + Clone + Eq, V: TransactionWrite, X: Executable> VersionedCode<K, V, X> {
+    pub(crate) fn new() -> Self {
+        Self {
+            values: DashMap::new(),
+        }
+    }
+
+    pub(crate) fn mark_estimate(&self, key: &K, txn_idx: TxnIndex) {
+        let v = self.values.get(key).expect("Path must exist");
+        v.versioned_map
+            .get(&txn_idx)
+            .expect("Entry by the txn must exist to mark estimate")
+            .mark_estimate();
+    }
+
+    pub(crate) fn write(&self, key: &K, txn_idx: TxnIndex, data: V) {
+        let mut v = self.values.entry(key.clone()).or_default();
+        v.versioned_map.insert(
+            txn_idx,
+            CachePadded::new(Entry::new_write_from(FLAG_DONE, data)),
+        );
+    }
+
+    pub(crate) fn store_executable(
+        &self,
+        key: &K,
+        descriptor: ExecutableDescriptor,
+        executable: X,
+    ) {
+        let x = Arc::new(executable);
+        match descriptor {
+            ExecutableDescriptor::Published(hash) => {
+                let mut v = self.values.get_mut(key).expect("Path must exist");
+                v.executables.entry(hash).or_insert(x);
+            },
+            ExecutableDescriptor::Storage => {
+                let mut v = self.values.entry(key.clone()).or_default();
+                v.base_executable.get_or_insert(x);
+            },
+        };
+    }
+
+    pub(crate) fn fetch_code(
+        &self,
+        key: &K,
+        txn_idx: TxnIndex,
+    ) -> anyhow::Result<MVCodeOutput<V, X>, MVCodeError> {
+        use MVCodeError::*;
+        use MVCodeOutput::*;
+
+        match self.values.get(key) {
+            Some(v) => match v.read(txn_idx) {
+                Ok((module, hash)) => Ok(match v.executables.get(&hash) {
+                    Some(x) => Executable((x.clone(), ExecutableDescriptor::Published(hash))),
+                    None => Module((module, hash)),
+                }),
+                Err(NotFound) => v
+                    .base_executable
+                    .as_ref()
+                    .map(|x| Executable((x.clone(), ExecutableDescriptor::Storage)))
+                    .ok_or(NotFound),
+                Err(Dependency(idx)) => Err(Dependency(idx)),
+            },
+            None => Err(NotFound),
+        }
+    }
+
+    pub(crate) fn delete(&self, key: &K, txn_idx: TxnIndex) {
+        // TODO: investigate logical deletion.
+        let mut v = self.values.get_mut(key).expect("Path must exist");
+        assert!(
+            v.versioned_map.remove(&txn_idx).is_some(),
+            "Entry must exist to be deleted"
+        );
+    }
+}
+
+impl<K: Hash + Clone + Eq, V: TransactionWrite, X: Executable> Default for VersionedCode<K, V, X> {
+    fn default() -> Self {
+        VersionedCode::new()
+    }
+}

--- a/aptos-move/mvhashmap/src/versioned_data.rs
+++ b/aptos-move/mvhashmap/src/versioned_data.rs
@@ -1,0 +1,297 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::types::{Incarnation, MVDataError, MVDataOutput, TxnIndex, Version};
+use aptos_aggregator::{
+    delta_change_set::{deserialize, DeltaOp},
+    transaction::AggregatorValue,
+};
+use aptos_infallible::Mutex;
+use aptos_types::write_set::TransactionWrite;
+use crossbeam::utils::CachePadded;
+use dashmap::DashMap;
+use std::{
+    collections::btree_map::BTreeMap,
+    hash::Hash,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+
+const FLAG_DONE: usize = 0;
+const FLAG_ESTIMATE: usize = 1;
+
+/// Every entry in shared multi-version data-structure has an "estimate" flag
+/// and some content.
+struct Entry<V> {
+    /// Used to mark the entry as a "write estimate". Even though the entry
+    /// lives inside the DashMap and the entry access will have barriers, we
+    /// still make the flag Atomic to provide acq/rel semantics on its own.
+    flag: AtomicUsize,
+
+    /// Actual contents.
+    pub cell: EntryCell<V>,
+}
+
+/// Represents the content of a single entry in multi-version data-structure.
+enum EntryCell<V> {
+    /// Recorded in the shared multi-version data-structure for each write. It
+    /// has: 1) Incarnation number of the transaction that wrote the entry (note
+    /// that TxnIndex is part of the key and not recorded here), 2) actual data
+    /// stored in a shared pointer (to ensure ownership and avoid clones).
+    Write(Incarnation, Arc<V>),
+
+    /// Recorded in the shared multi-version data-structure for each delta.
+    Delta(DeltaOp),
+}
+
+/// A VersionedValue internally contains a BTreeMap from indices of transactions
+/// that update the given access path alongside the corresponding entries.
+struct VersionedValue<V> {
+    versioned_map: BTreeMap<TxnIndex, CachePadded<Entry<V>>>,
+
+    // Note: this can cache base (storage) value in Option<u128> to facilitate
+    // aggregator validation & reading in the future, if needed.
+    contains_delta: bool,
+}
+
+/// Maps each key (access path) to an interal VersionedValue.
+pub struct VersionedData<K, V> {
+    values: DashMap<K, VersionedValue<V>>,
+    delta_keys: Mutex<Vec<K>>,
+}
+
+impl<V> Entry<V> {
+    pub fn new_write_from(flag: usize, incarnation: Incarnation, data: V) -> Entry<V> {
+        Entry {
+            flag: AtomicUsize::new(flag),
+            cell: EntryCell::Write(incarnation, Arc::new(data)),
+        }
+    }
+
+    pub fn new_delta_from(flag: usize, data: DeltaOp) -> Entry<V> {
+        Entry {
+            flag: AtomicUsize::new(flag),
+            cell: EntryCell::Delta(data),
+        }
+    }
+
+    pub fn flag(&self) -> usize {
+        self.flag.load(Ordering::Acquire)
+    }
+
+    pub fn mark_estimate(&self) {
+        self.flag.store(FLAG_ESTIMATE, Ordering::Release);
+    }
+}
+
+impl<V: TransactionWrite> VersionedValue<V> {
+    pub fn new() -> Self {
+        Self {
+            versioned_map: BTreeMap::new(),
+            contains_delta: false,
+        }
+    }
+}
+
+impl<V: TransactionWrite> Default for VersionedValue<V> {
+    fn default() -> Self {
+        VersionedValue::new()
+    }
+}
+
+impl<K: Hash + Clone + Eq, V: TransactionWrite> VersionedData<K, V> {
+    pub(crate) fn new() -> Self {
+        Self {
+            values: DashMap::new(),
+            delta_keys: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Takes the list of recorded keys that had an associated delta entry at any prior point.
+    pub fn take_aggregator_keys(&self) -> Vec<K> {
+        std::mem::take(&mut self.delta_keys.lock())
+    }
+
+    /// For processing outputs - removes the BTreeMap from the MVHashMap for a given
+    /// key - the key should be an aggregator key with at least one delta update during
+    /// the block execution (such keys are provided by 'aggregator_keys' function).
+    /// Returns the aggregator values for each transaction index w. a delta update.
+    pub fn take_materialized_deltas(
+        &self,
+        key: &K,
+        base_value: Option<u128>,
+    ) -> Vec<(TxnIndex, u128)> {
+        let (_, v) = self
+            .values
+            .remove(key)
+            .expect("No entry at MVHashMap for an aggregator key");
+        assert!(v.contains_delta, "No delta update at an aggregator key");
+
+        let mut latest_value = base_value;
+        v.versioned_map
+            .into_iter()
+            .filter_map(|(idx, entry)| {
+                match &entry.cell {
+                    EntryCell::Write(_, data) => {
+                        latest_value = data.extract_raw_bytes().map(|bytes| deserialize(&bytes));
+                        None
+                    },
+                    EntryCell::Delta(delta) => {
+                        // Apply to the latest value to obtain the materialized delta value.
+                        let aggregator_value = delta
+                            .apply_to(
+                                latest_value
+                                    .expect("Failed to apply delta to (non-existent) aggregator"),
+                            )
+                            .expect("Failed to apply aggregator delta output");
+
+                        latest_value = Some(aggregator_value);
+                        Some((idx, aggregator_value))
+                    },
+                }
+            })
+            .collect()
+    }
+
+    pub(crate) fn add_delta(&self, key: &K, txn_idx: TxnIndex, delta: DeltaOp) {
+        let mut v = self.values.entry(key.clone()).or_default();
+        v.versioned_map.insert(
+            txn_idx,
+            CachePadded::new(Entry::new_delta_from(FLAG_DONE, delta)),
+        );
+
+        if !v.contains_delta {
+            v.contains_delta = true;
+            self.delta_keys.lock().push(key.clone());
+        }
+    }
+
+    pub(crate) fn mark_estimate(&self, key: &K, txn_idx: TxnIndex) {
+        let v = self.values.get(key).expect("Path must exist");
+        v.versioned_map
+            .get(&txn_idx)
+            .expect("Entry by the txn must exist to mark estimate")
+            .mark_estimate();
+    }
+
+    pub(crate) fn delete(&self, key: &K, txn_idx: TxnIndex) {
+        // TODO: investigate logical deletion.
+        let mut v = self.values.get_mut(key).expect("Path must exist");
+        assert!(
+            v.versioned_map.remove(&txn_idx).is_some(),
+            "Entry must exist to be deleted"
+        );
+    }
+
+    pub(crate) fn fetch_data(
+        &self,
+        key: &K,
+        txn_idx: TxnIndex,
+    ) -> anyhow::Result<MVDataOutput<V>, MVDataError> {
+        use MVDataError::*;
+        use MVDataOutput::*;
+
+        match self.values.get(key) {
+            Some(v) => {
+                let mut iter = v.versioned_map.range(0..txn_idx);
+
+                // If read encounters a delta, it must traverse the block of transactions
+                // (top-down) until it encounters a write or reaches the end of the block.
+                // During traversal, all aggregator deltas have to be accumulated together.
+                let mut accumulator: Option<Result<DeltaOp, ()>> = None;
+                while let Some((idx, entry)) = iter.next_back() {
+                    let flag = entry.flag();
+
+                    if flag == FLAG_ESTIMATE {
+                        // Found a dependency.
+                        return Err(Dependency(*idx));
+                    }
+
+                    // The entry should be populated.
+                    debug_assert!(flag == FLAG_DONE);
+
+                    match (&entry.cell, accumulator.as_mut()) {
+                        (EntryCell::Write(incarnation, data), None) => {
+                            // Resolve to the write if no deltas were applied in between.
+                            let write_version = (*idx, *incarnation);
+                            return Ok(Versioned(write_version, data.clone()));
+                        },
+                        (EntryCell::Write(incarnation, data), Some(accumulator)) => {
+                            // Deltas were applied. We must deserialize the value
+                            // of the write and apply the aggregated delta accumulator.
+
+                            // None if data represents deletion. Otherwise, panics if the
+                            // data can't be resolved to an aggregator value.
+                            let maybe_value = AggregatorValue::from_write(data.as_ref());
+
+                            if maybe_value.is_none() {
+                                // Resolve to the write if the WriteOp was deletion
+                                // (MoveVM will observe 'deletion'). This takes precedence
+                                // over any speculative delta accumulation errors on top.
+                                let write_version = (*idx, *incarnation);
+                                return Ok(Versioned(write_version, data.clone()));
+                            }
+                            return accumulator.map_err(|_| DeltaApplicationFailure).and_then(
+                                |a| {
+                                    // Apply accumulated delta to resolve the aggregator value.
+                                    a.apply_to(maybe_value.unwrap().into())
+                                        .map(|result| Resolved(result))
+                                        .map_err(|_| DeltaApplicationFailure)
+                                },
+                            );
+                        },
+                        (EntryCell::Delta(delta), Some(accumulator)) => {
+                            *accumulator = accumulator.and_then(|mut a| {
+                                // Read hit a delta during traversing the block and aggregating
+                                // other deltas. Merge two deltas together. If Delta application
+                                // fails, we record an error, but continue processing (to e.g.
+                                // account for the case when the aggregator was deleted).
+                                if a.merge_onto(*delta).is_err() {
+                                    Err(())
+                                } else {
+                                    Ok(a)
+                                }
+                            });
+                        },
+                        (EntryCell::Delta(delta), None) => {
+                            // Read hit a delta and must start accumulating.
+                            // Initialize the accumulator and continue traversal.
+                            accumulator = Some(Ok(*delta))
+                        },
+                    }
+                }
+
+                // It can happen that while traversing the block and resolving
+                // deltas the actual written value has not been seen yet (i.e.
+                // it is not added as an entry to the data-structure).
+                match accumulator {
+                    Some(Ok(accumulator)) => Err(Unresolved(accumulator)),
+                    Some(Err(_)) => Err(DeltaApplicationFailure),
+                    None => Err(NotFound),
+                }
+            },
+            None => Err(NotFound),
+        }
+    }
+
+    pub(crate) fn write(&self, key: &K, version: Version, data: V) {
+        let (txn_idx, incarnation) = version;
+
+        let mut v = self.values.entry(key.clone()).or_default();
+        let prev_entry = v.versioned_map.insert(
+            txn_idx,
+            CachePadded::new(Entry::new_write_from(FLAG_DONE, incarnation, data)),
+        );
+
+        // Assert that the previous entry for txn_idx, if present, had lower incarnation.
+        assert!(prev_entry.map_or(true, |entry| -> bool {
+            if let EntryCell::Write(i, _) = entry.cell {
+                i < incarnation
+            } else {
+                true
+            }
+        }));
+    }
+}

--- a/types/src/executable.rs
+++ b/types/src/executable.rs
@@ -1,0 +1,87 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    access_path::AccessPath,
+    state_store::state_key::{StateKey, StateKeyInner},
+};
+use aptos_crypto::HashValue;
+use std::sync::Arc;
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum ExecutableDescriptor {
+    /// Possibly speculative, based on code published during the block.
+    Published(HashValue),
+
+    /// Based on code published (and committed) in previous blocks.
+    Storage,
+}
+
+pub trait ModulePath {
+    fn module_path(&self) -> Option<AccessPath>;
+}
+
+impl ModulePath for StateKey {
+    fn module_path(&self) -> Option<AccessPath> {
+        if let StateKeyInner::AccessPath(ap) = self.inner() {
+            if ap.is_code() {
+                return Some(ap.clone());
+            }
+        }
+        None
+    }
+}
+
+/// For now we will handle the VM code cache / arena memory consumption on the
+/// executor side, likely naively in the beginning (e.g. flushing after a threshold).
+/// For the executor to manage memory consumption, executables should provide size.
+/// Note: explore finer-grained eviction mechanisms, e.g. LRU-based, or having
+/// different ownership for the arena / memory.
+pub trait Executable {
+    fn size(&self) -> usize;
+}
+
+pub struct ExecutableTestType(());
+
+impl Executable for ExecutableTestType {
+    fn size(&self) -> usize {
+        0
+    }
+}
+
+pub enum FetchedModule<X: Executable> {
+    Blob(Option<Vec<u8>>),
+    // TODO: compiled module when available to avoid deserialization.
+    Executable(Arc<X>),
+}
+
+/// View for the VM for interacting with the multi-versioned executable cache.
+pub trait ExecutableView {
+    type Key;
+    type Executable: Executable;
+
+    /// This is an optimization to bypass transactional semantics and share the
+    /// executable (and all the useful work for producing it) as early as possible
+    /// other txns / VM sessions. It is safe as storage-version module can't change,
+    /// and o.w. the key is the (cryptographic) hash of the module blob.
+    ///
+    /// W.o. this, we would have to include executables in TransactionOutputExt.
+    /// This may occur much later leading to work duplication (producing the same
+    /// executable by other sessions) in the common case when the executable isn't
+    /// based on the module published by the transaction itself.
+    fn store_executable(
+        &self,
+        key: &Self::Key,
+        descriptor: ExecutableDescriptor,
+        executable: Self::Executable,
+    );
+
+    /// Returns either the blob of the module, that will need to be deserialized into
+    /// CompiledModule and then made into an executable, or executable directly, if
+    /// the executable corresponding to the latest published module was already stored.
+    /// TODO: Return CompiledModule directly to avoid deserialization.
+    fn fetch_module(
+        &self,
+        key: &Self::Key,
+    ) -> anyhow::Result<(ExecutableDescriptor, FetchedModule<Self::Executable>)>;
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -15,6 +15,7 @@ pub mod contract_event;
 pub mod epoch_change;
 pub mod epoch_state;
 pub mod event;
+pub mod executable;
 pub mod governance;
 pub mod ledger_info;
 pub mod mempool_status;


### PR DESCRIPTION
Separate out data & modules - useful for executable / versioned code work, but also for caching MoveValues / CompiledModules, as these types (and handling) might be different.

Introduced some Executable tooling, but a separate diff will incorporate module versioning and executable treatment in parallel executor (e.g. validation based on fetching, view traits) & respective testing.