### PR TITLE
[build-info] Recompute shadow_rs on Git changes

### DIFF
--- a/crates/aptos-build-info/build.rs
+++ b/crates/aptos-build-info/build.rs
@@ -8,5 +8,8 @@ fn main() -> shadow_rs::SdResult<()> {
         "cargo:rustc-env=USING_TOKIO_UNSTABLE={}",
         std::env::var("CARGO_CFG_TOKIO_UNSTABLE").is_ok()
     );
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
     shadow_rs::new()
 }


### PR DESCRIPTION
### Description

This PR adds change detection flags to `aptos-build-info/build.rs` to force run the aptos-build-info's build script on changes to the Git HEAD reference file that indicates changes to the source, build.rs changes, or if the SOURCE_DATE_EPOCH special distribution environment variable changes.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

I made three empty amend commits on this branch, and I ran `cargo run -p aptos-node -- --test` and verified that the commit hash changes every time in the build information from the logs.
