### PR TITLE
[VM] Update execution logic to invalidate loader cache upon all partial errors when there's a code publish

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_init_module_failed/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_init_module_failed/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "test_package"
+version = "0.0.0"
+upgrade_policy = "immutable"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_init_module_failed/sources/test.move
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_init_module_failed/sources/test.move
@@ -1,0 +1,26 @@
+module 0xcafe::test {
+    use aptos_framework::coin::{Self, Coin};
+    use aptos_framework::aptos_coin::AptosCoin;
+    use std::signer::address_of;
+
+    struct State has key {
+        important_value: u64,
+        coins: Coin<AptosCoin>,
+    }
+
+    fun init_module(s: &signer) {
+        // Transfer away all the APT from s so there's nothing left to pay for gas.
+        // This makes this init_module function fail for sure.
+        let balance = coin::balance<AptosCoin>(address_of(s));
+        let coins = coin::withdraw<AptosCoin>(s, balance);
+
+        move_to(s, State {
+            important_value: get_value(),
+            coins,
+        })
+    }
+
+    fun get_value(): u64 {
+        1
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_init_module_second_attempt/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_init_module_second_attempt/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "test_package"
+version = "0.0.0"
+upgrade_policy = "immutable"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_init_module_second_attempt/sources/test.move
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_init_module_second_attempt/sources/test.move
@@ -1,0 +1,20 @@
+module 0xcafe::test {
+    use aptos_framework::coin::{Self, Coin};
+    use aptos_framework::aptos_coin::AptosCoin;
+
+    struct State has key {
+        important_value: u64,
+        coins: Coin<AptosCoin>,
+    }
+
+    fun init_module(s: &signer) {
+        move_to(s, State {
+            important_value: get_value(),
+            coins: coin::zero<AptosCoin>(),
+        })
+    }
+
+    fun get_value(): u64 {
+        2
+    }
+}


### PR DESCRIPTION
Apply hotfix from v1.1.4 to 1.2.2