### PR TITLE
[Github Actions] Add new workflows for fullnode syncing.

### DIFF
--- a/.github/actions/fullnode-sync/README
+++ b/.github/actions/fullnode-sync/README
@@ -1,0 +1,19 @@
+## Description
+
+Runs a fullnode from aptos-core, assuming it is already checked out in the current working directory.
+
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| TIMEOUT_MINUTES | The number of minutes to wait for fullnode sync to finish. | `true` |  |
+| BRANCH | The aptos-core branch to switch to before running the fullnode. | `true` |  |
+| NETWORK | The network to connect the fullnode to: devnet, testnet, or mainnet. | `true` |  |
+| BOOTSTRAPPING_MODE | The state sync bootstrapping mode for the fullnode. | `true` |  |
+| CONTINUOUS_SYNCING_MODE |  The state sync continuous syncing mode for the fullnode. | `true` |  |
+| DATA_DIR_FILE_PATH | The file path for the node data directory. | `true` |  |
+| NODE_LOG_FILE_PATH | The file path for the node logs to be written to. | `true` |  |
+
+## Runs
+
+This action is a `composite` action.

--- a/.github/actions/fullnode-sync/action.yaml
+++ b/.github/actions/fullnode-sync/action.yaml
@@ -1,0 +1,48 @@
+name: "Fullnode Sync"
+description: |
+  Runs a fullnode from aptos-core, assuming it is already checked out in the current working directory.
+inputs:
+  TIMEOUT_MINUTES:
+    description: "The number of minutes to wait for fullnode sync to finish."
+    required: true
+  BRANCH:
+    description: "The aptos-core branch to switch to before running the fullnode."
+    required: true
+  NETWORK:
+    description: "The network to connect the fullnode to: devnet, testnet, or mainnet."
+    required: true
+  BOOTSTRAPPING_MODE:
+    description: "The state sync bootstrapping mode for the fullnode."
+    required: true
+  CONTINUOUS_SYNCING_MODE:
+    description: "The state sync continuous syncing mode for the fullnode."
+    required: true
+  DATA_DIR_FILE_PATH:
+    description: "The file path for the node data directory."
+    required: true
+  NODE_LOG_FILE_PATH:
+    description: "The file path for the node logs to be written to."
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        echo "${HOME}/bin/" >> $GITHUB_PATH # default INSTALL_DIR to path
+        scripts/dev_setup.sh -b # Install dependencies
+        sudo apt-get update -y && sudo apt-get install -y expect
+    - name: Run fullnode sync
+      shell: bash
+      run: |
+        source "$HOME/.cargo/env" # Required for allowing python access to cargo
+        pip install pyyaml # Required for parsing YAML
+        timeout "${{ inputs.TIMEOUT_MINUTES }}m" python3 ${{ github.action_path }}/fullnode_sync.py
+      env:
+        BRANCH: ${{ inputs.BRANCH }}
+        NETWORK: ${{ inputs.NETWORK }}
+        BOOTSTRAPPING_MODE: ${{ inputs.BOOTSTRAPPING_MODE }}
+        CONTINUOUS_SYNCING_MODE: ${{ inputs.CONTINUOUS_SYNCING_MODE }}
+        DATA_DIR_FILE_PATH: ${{ inputs.DATA_DIR_FILE_PATH }}
+        NODE_LOG_FILE_PATH: ${{ inputs.NODE_LOG_FILE_PATH }}

--- a/.github/actions/fullnode-sync/fullnode_sync.py
+++ b/.github/actions/fullnode-sync/fullnode_sync.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import subprocess
+import sys
+import time
+import yaml
+
+# This script runs the fullnode-sync from the root of aptos-core.
+
+# Useful file constants
+FULLNODE_CONFIG_NAME = "public_full_node.yaml" # Relative to the aptos-core repo
+FULLNODE_CONFIG_TEMPLATE_PATH = "config/src/config/test_data/public_full_node.yaml" # Relative to the aptos-core repo
+GENESIS_BLOB_PATH = "https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/{network}/genesis.blob" # Location inside the aptos-networks repo
+LOCAL_REST_ENDPOINT = "http://127.0.0.1:8080/v1" # The rest endpoint running on the local host
+LEDGER_VERSION_API_STRING = "ledger_version" # The string to fetch the ledger version from the REST API
+MAX_TIME_BETWEEN_VERSION_INCREASES_SECS = 3600 # The number of seconds after which to fail if the node isn't syncing
+REMOTE_REST_ENDPOINTS = "https://fullnode.{network}.aptoslabs.com/v1" # The remote rest endpoint
+SYNCING_DELTA_VERSIONS = 20000 # The number of versions to sync beyond the highest known at the job start
+WAYPOINT_FILE_PATH = "https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/{network}/waypoint.txt" # Location inside the aptos-networks repo
+
+def print_error_and_exit(error):
+  """Prints the given error and exits the process"""
+  print(error)
+  sys.exit(error)
+
+
+def ping_rest_api_index_page(rest_endpoint, exit_if_none):
+  """Pings and returns the index page from a REST API endpoint"""
+  # Ping the REST API index page
+  process = subprocess.Popen(["curl", "-s", rest_endpoint], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  api_index_response, errors = process.communicate()
+  if exit_if_none and api_index_response is None:
+      print_error_and_exit("Exiting! Unable to get the REST API index page from the endpoint at: {rest_endpoint}. Response is empty.".format(rest_endpoint=rest_endpoint))
+  if errors is not None and errors != b'':
+    print("Found output on stderr for ping_rest_api_index_page: {errors}".format(errors=errors))
+
+  # Return the index page response
+  return api_index_response
+
+
+def get_synced_version_from_index_response(api_index_response, exit_if_none):
+  """Gets and returns the synced version from a REST index page response"""
+  # Parse the synced ledger version
+  api_index_response = json.loads(api_index_response)
+  synced_version = api_index_response[LEDGER_VERSION_API_STRING]
+  if exit_if_none and synced_version is None:
+    print_error_and_exit("Exiting! Unable to get the synced version from the given API index response: {api_index_response}! Synced version is empty".format(api_index_response=api_index_response))
+
+  # Return the synced version
+  return int(synced_version)
+
+
+def check_fullnode_is_still_running(fullnode_process_handle):
+  """Verifies the fullnode is still running and exits if not"""
+  return_code = fullnode_process_handle.poll()
+  if return_code is not None:
+    print_error_and_exit("Exiting! The fullnode process terminated prematurely with return code: {return_code}!".format(return_code=return_code))
+
+
+def monitor_fullnode_syncing(fullnode_process_handle, node_log_file_path, public_version, target_version):
+  """Monitors the ability of the fullnode to sync"""
+  print("Waiting for the node to synchronize!")
+  last_synced_version = 0 # The most recent synced version
+  last_sync_update_time = time.time() # The latest timestamp of when we were able to sync to a higher version
+  start_sync_time = time.time() # The time at which we started syncing the node
+  synced_to_public_version = False # If we've synced to the public version
+
+  # Loop while we wait for the fullnode to sync
+  while True:
+    # Ensure the fullnode is still running
+    check_fullnode_is_still_running(fullnode_process_handle)
+
+    # Fetch the latest synced version
+    api_index_response = ping_rest_api_index_page(LOCAL_REST_ENDPOINT, True)
+    synced_version = get_synced_version_from_index_response(api_index_response, True)
+
+    # Check if we've synced to the public version
+    if not synced_to_public_version:
+      if synced_version >= public_version:
+        time_to_sync_to_public = time.time() - start_sync_time
+        syncing_throughput = public_version / time_to_sync_to_public
+        print("Synced to version: {public_version}, in: {time_to_sync_to_public} seconds.".format(public_version=public_version, time_to_sync_to_public=time_to_sync_to_public))
+        print("Syncing throughput: {syncing_throughput} (versions per seconds).".format(syncing_throughput=syncing_throughput))
+        synced_to_public_version = True
+
+    # Check if we've synced to the target version
+    if synced_version >= target_version:
+      print("Successfully synced to the target! Target version: {target_version}, Synced version: {synced_version}".format(target_version=target_version, synced_version=synced_version))
+      sys.exit(0)
+
+    # Ensure we're actually making syncing progress
+    if synced_version <= last_synced_version:
+      time_since_last_version_increase = time.time() - last_sync_update_time
+      if time_since_last_version_increase > MAX_TIME_BETWEEN_VERSION_INCREASES_SECS:
+        print_error_and_exit("Exiting! The fullnode is not making any syncing progress!")
+    else:
+      last_synced_version = synced_version
+      last_sync_update_time = time.time()
+
+    # We're still syncing. Display the last 10 lines of the node log.
+    print("Still syncing. Target version: {target_version}, Synced version: {synced_version}".format(target_version=target_version, synced_version=synced_version))
+    process = subprocess.Popen(["tail", "-10", node_log_file_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    recent_log_lines, errors = process.communicate()
+    print(recent_log_lines)
+    print(errors)
+
+    # Sleep for a few seconds while the fullnode synchronizes
+    time.sleep(10)
+
+
+def wait_for_fullnode_to_start(fullnode_process_handle):
+  """Monitors the ability of the fullnode to start up"""
+  api_index_response = ping_rest_api_index_page(LOCAL_REST_ENDPOINT, False)
+  while api_index_response is None or api_index_response == b'':
+    print("Waiting for the fullnode to start.")
+
+    # Check if the fullnode is still running
+    check_fullnode_is_still_running(fullnode_process_handle)
+
+    # Sleep for a bit while the fullnode comes up
+    time.sleep(5)
+
+    # Ping the endpoint again
+    api_index_response = ping_rest_api_index_page(LOCAL_REST_ENDPOINT, False)
+
+
+def get_public_and_target_version(network):
+  """Calculates the syncing target version of the fullnode"""
+  # Fetch the latest version from the public fullnode endpoint
+  public_fullnode_endpoint = REMOTE_REST_ENDPOINTS.format(network=network)
+  api_index_response = ping_rest_api_index_page(public_fullnode_endpoint, True)
+  public_version = get_synced_version_from_index_response(api_index_response, True)
+  print("Synced version found from the public endpoint: {public_version}".format(public_version=public_version))
+
+  # Calculate the target syncing version
+  target_version = public_version + SYNCING_DELTA_VERSIONS
+  print("Setting target version to: {target_version}".format(target_version=target_version))
+
+  # Return both versions
+  return (public_version, target_version)
+
+
+def spawn_fullnode(branch, network, bootstrapping_mode, continuous_syncing_mode, node_log_file_path):
+  """Spawns the fullnode"""
+  # Display the fullnode setup
+  print("Starting the fullnode using branch: {branch}, for network: {network}, " \
+        "with bootstrapping mode: {bootstrapping_mode} and continuous syncing " \
+        "mode: {continuous_syncing_mode}!".format(branch=branch, network=network,
+                                                  bootstrapping_mode=bootstrapping_mode,
+                                                  continuous_syncing_mode=continuous_syncing_mode))
+
+  # Display the fullnode config
+  with open(FULLNODE_CONFIG_NAME) as file:
+    fullnode_config = yaml.safe_load(file)
+  if fullnode_config is None:
+    print_error_and_exit("Exiting! Failed to load the fullnode config template at {template_path}!".format(template_path=FULLNODE_CONFIG_NAME))
+  print("Starting the fullnode using the config: {fullnode_config}".format(fullnode_config=fullnode_config))
+
+  # Start the fullnode
+  node_log_file = open(node_log_file_path, "w")
+  process_handle = subprocess.Popen(["cargo", "run", "-p", "aptos-node", "--release", "--", "-f", FULLNODE_CONFIG_NAME], stdout=node_log_file, stderr=node_log_file)
+
+  # Return the process handle
+  return process_handle
+
+
+def setup_fullnode_config(bootstrapping_mode, continuous_syncing_mode, data_dir_file_path):
+  """Initializes and configures the fullnode config file"""
+  # Copy the node config template to the working directory
+  if not os.path.exists(FULLNODE_CONFIG_TEMPLATE_PATH):
+    print_error_and_exit("Exiting! The fullnode config template wasn't found: {template_path}!".format(template_path=FULLNODE_CONFIG_TEMPLATE_PATH))
+  subprocess.run(["cp", FULLNODE_CONFIG_TEMPLATE_PATH, FULLNODE_CONFIG_NAME])
+
+  # Update the data_dir in the node config template
+  with open(FULLNODE_CONFIG_NAME) as file:
+    fullnode_config = yaml.safe_load(file)
+  if fullnode_config is None:
+    print_error_and_exit("Exiting! Failed to load the fullnode config template at {template_path}!".format(template_path=FULLNODE_CONFIG_TEMPLATE_PATH))
+  fullnode_config['base']['data_dir'] = data_dir_file_path
+
+  # Add the state sync configurations to the config template
+  state_sync_driver_config = {"bootstrapping_mode": bootstrapping_mode, "continuous_syncing_mode": continuous_syncing_mode}
+  data_streaming_service_config = {"max_concurrent_requests": 10}
+  fullnode_config['state_sync'] = {"state_sync_driver": state_sync_driver_config, "data_streaming_service":data_streaming_service_config}
+
+  # Write the config file back to disk
+  with open(FULLNODE_CONFIG_NAME, "w") as file:
+    yaml.dump(fullnode_config, file)
+
+
+def get_genesis_and_waypoint(network):
+  """Clones the genesis blob and waypoint to the current working directory"""
+  genesis_blob_path = GENESIS_BLOB_PATH.format(network=network)
+  waypoint_file_path = WAYPOINT_FILE_PATH.format(network=network)
+  subprocess.run(["curl", "-s", "-O", genesis_blob_path])
+  subprocess.run(["curl", "-s", "-O", waypoint_file_path])
+
+
+def checkout_git_branch(branch):
+  """Checkout the specified git branch. This assumes the working directory is aptos-core"""
+  subprocess.run(["git", "fetch"])
+  subprocess.run(["git", "checkout", branch])
+  subprocess.run(["git", "log", "-1"]) # Display the git commit we're running on
+
+
+def main():
+  # Ensure we have all required environment variables
+  REQUIRED_ENVS = [
+    "BRANCH",
+    "NETWORK",
+    "BOOTSTRAPPING_MODE",
+    "CONTINUOUS_SYNCING_MODE",
+    "DATA_DIR_FILE_PATH",
+    "NODE_LOG_FILE_PATH",
+  ]
+  if not all(env in os.environ for env in REQUIRED_ENVS):
+    raise Exception("Missing required ENV variables!")
+
+  # Fetch each of the environment variables
+  BRANCH = os.environ["BRANCH"]
+  NETWORK = os.environ["NETWORK"]
+  BOOTSTRAPPING_MODE = os.environ["BOOTSTRAPPING_MODE"]
+  CONTINUOUS_SYNCING_MODE = os.environ["CONTINUOUS_SYNCING_MODE"]
+  DATA_DIR_FILE_PATH = os.environ["DATA_DIR_FILE_PATH"]
+  NODE_LOG_FILE_PATH = os.environ["NODE_LOG_FILE_PATH"]
+
+  # Check out the correct git branch
+  checkout_git_branch(BRANCH)
+
+  # Get the genesis blob and waypoint
+  get_genesis_and_waypoint(NETWORK)
+
+  # Setup the fullnode config
+  setup_fullnode_config(BOOTSTRAPPING_MODE, CONTINUOUS_SYNCING_MODE, DATA_DIR_FILE_PATH)
+
+  # Get the public synced version and calculate the fullnode syncing target version
+  (public_version, target_version) = get_public_and_target_version(NETWORK)
+
+  # Spawn the fullnode
+  fullnode_process_handle = spawn_fullnode(BRANCH, NETWORK, BOOTSTRAPPING_MODE, CONTINUOUS_SYNCING_MODE, NODE_LOG_FILE_PATH)
+
+  # Wait for the fullnode to come up
+  wait_for_fullnode_to_start(fullnode_process_handle)
+
+  # Monitor the ability for the fullnode to sync
+  monitor_fullnode_syncing(fullnode_process_handle, NODE_LOG_FILE_PATH, public_version, target_version)
+
+
+if __name__ == "__main__":
+  main()

--- a/.github/workflows/fullnode-execute-devnet-main.yaml
+++ b/.github/workflows/fullnode-execute-devnet-main.yaml
@@ -1,0 +1,45 @@
+# This workflow runs a public fullnode using the `main` branch,
+# connects the public fullnode to `devnet` and synchronizes the
+# node using execution syncing to verify that nothing has been broken.
+
+name: "fullnode-execute-devnet-main"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9/12 * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/fullnode-execute-devnet-main.yaml"
+
+jobs:
+  fullnode-execute-devnet-main:
+    timeout-minutes: 300 # Run for at most 5 hours
+    runs-on: high-perf-docker-with-local-ssd
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+
+      - uses: ./.github/actions/fullnode-sync
+        with:
+          TIMEOUT_MINUTES: 300 # Run for at most 5 hours
+          BRANCH: main
+          NETWORK: devnet
+          BOOTSTRAPPING_MODE: ExecuteTransactionsFromGenesis
+          CONTINUOUS_SYNCING_MODE: ExecuteTransactions
+          DATA_DIR_FILE_PATH: /tmp/
+          NODE_LOG_FILE_PATH: /tmp/node_log
+
+      - name: Upload node logs as an artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: node_log
+          path: |
+            /tmp/node_log
+          retention-days: 14
+
+      # Because we have to checkout the actions and then check out a different
+      # branch, it's possible the actions directory will be modified. So, we
+      # need to check it out again for the Post Run actions/checkout to succeed.
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          path: actions

--- a/.github/workflows/fullnode-fast-mainnet-main.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-main.yaml
@@ -1,0 +1,45 @@
+# This workflow runs a public fullnode using the `main` branch,
+# connects the public fullnode to `mainnet` and synchronizes the
+# node using fast syncing to verify that nothing has been broken.
+
+name: "fullnode-fast-mainnet-main"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9/12 * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/fullnode-fast-mainnet-main.yaml"
+
+jobs:
+  fullnode-fast-mainnet-main:
+    timeout-minutes: 300 # Run for at most 5 hours
+    runs-on: high-perf-docker-with-local-ssd
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+
+      - uses: ./.github/actions/fullnode-sync
+        with:
+          TIMEOUT_MINUTES: 300 # Run for at most 5 hours
+          BRANCH: main
+          NETWORK: mainnet
+          BOOTSTRAPPING_MODE: DownloadLatestStates
+          CONTINUOUS_SYNCING_MODE: ExecuteTransactions
+          DATA_DIR_FILE_PATH: /tmp/
+          NODE_LOG_FILE_PATH: /tmp/node_log
+
+      - name: Upload node logs as an artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: node_log
+          path: |
+            /tmp/node_log
+          retention-days: 14
+
+      # Because we have to checkout the actions and then check out a different
+      # branch, it's possible the actions directory will be modified. So, we
+      # need to check it out again for the Post Run actions/checkout to succeed.
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          path: actions

--- a/.github/workflows/fullnode-fast-testnet-main.yaml
+++ b/.github/workflows/fullnode-fast-testnet-main.yaml
@@ -1,0 +1,45 @@
+# This workflow runs a public fullnode using the `main` branch,
+# connects the public fullnode to `testnet` and synchronizes the
+# node using fast syncing to verify that nothing has been broken.
+
+name: "fullnode-fast-testnet-main"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9/12 * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/fullnode-fast-testnet-main.yaml"
+
+jobs:
+  fullnode-fast-testnet-main:
+    timeout-minutes: 300 # Run for at most 5 hours
+    runs-on: high-perf-docker-with-local-ssd
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+
+      - uses: ./.github/actions/fullnode-sync
+        with:
+          TIMEOUT_MINUTES: 300 # Run for at most 5 hours
+          BRANCH: main
+          NETWORK: testnet
+          BOOTSTRAPPING_MODE: DownloadLatestStates
+          CONTINUOUS_SYNCING_MODE: ExecuteTransactions
+          DATA_DIR_FILE_PATH: /tmp/
+          NODE_LOG_FILE_PATH: /tmp/node_log
+
+      - name: Upload node logs as an artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: node_log
+          path: |
+            /tmp/node_log
+          retention-days: 14
+
+      # Because we have to checkout the actions and then check out a different
+      # branch, it's possible the actions directory will be modified. So, we
+      # need to check it out again for the Post Run actions/checkout to succeed.
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          path: actions

--- a/.github/workflows/fullnode-intelligent-devnet-main.yaml
+++ b/.github/workflows/fullnode-intelligent-devnet-main.yaml
@@ -1,0 +1,46 @@
+# This workflow runs a public fullnode using the `main` branch,
+# connects the public fullnode to `devnet` and synchronizes the
+# node using execution or output syncing to verify that nothing
+# has been broken.
+
+name: "fullnode-intelligent-devnet-main"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9/12 * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/fullnode-intelligent-devnet-main.yaml"
+
+jobs:
+  fullnode-intelligent-devnet-main:
+    timeout-minutes: 300 # Run for at most 5 hours
+    runs-on: high-perf-docker-with-local-ssd
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+
+      - uses: ./.github/actions/fullnode-sync
+        with:
+          TIMEOUT_MINUTES: 300 # Run for at most 5 hours
+          BRANCH: main
+          NETWORK: devnet
+          BOOTSTRAPPING_MODE: ExecuteOrApplyFromGenesis
+          CONTINUOUS_SYNCING_MODE: ExecuteTransactionsOrApplyOutputs
+          DATA_DIR_FILE_PATH: /tmp/
+          NODE_LOG_FILE_PATH: /tmp/node_log
+
+      - name: Upload node logs as an artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: node_log
+          path: |
+            /tmp/node_log
+          retention-days: 14
+
+      # Because we have to checkout the actions and then check out a different
+      # branch, it's possible the actions directory will be modified. So, we
+      # need to check it out again for the Post Run actions/checkout to succeed.
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          path: actions

--- a/.github/workflows/fullnode-output-mainnet-main.yaml
+++ b/.github/workflows/fullnode-output-mainnet-main.yaml
@@ -1,0 +1,45 @@
+# This workflow runs a public fullnode using the `main` branch,
+# connects the public fullnode to `mainnet` and synchronizes the
+# node using output syncing to verify that nothing has been broken.
+
+name: "fullnode-output-mainnet-main"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9/12 * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/fullnode-output-mainnet-main.yaml"
+
+jobs:
+  fullnode-output-mainnet-main:
+    timeout-minutes: 300 # Run for at most 5 hours
+    runs-on: high-perf-docker-with-local-ssd
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+
+      - uses: ./.github/actions/fullnode-sync
+        with:
+          TIMEOUT_MINUTES: 300 # Run for at most 5 hours
+          BRANCH: main
+          NETWORK: mainnet
+          BOOTSTRAPPING_MODE: ApplyTransactionOutputsFromGenesis
+          CONTINUOUS_SYNCING_MODE: ApplyTransactionOutputs
+          DATA_DIR_FILE_PATH: /tmp/
+          NODE_LOG_FILE_PATH: /tmp/node_log
+
+      - name: Upload node logs as an artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: node_log
+          path: |
+            /tmp/node_log
+          retention-days: 14
+
+      # Because we have to checkout the actions and then check out a different
+      # branch, it's possible the actions directory will be modified. So, we
+      # need to check it out again for the Post Run actions/checkout to succeed.
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          path: actions


### PR DESCRIPTION
### Description
This PR adds nightly Github action workflows to verify fullnode health. Specifically, we add the following workflows:
1. Start a node using the `main` branch, connect it to `devnet` and verify it can sync using execution syncing.
2. Start a node using the `main` branch, connect it to `testnet` and verify it can sync using fast syncing.
3. Start a node using the `main` branch, connect it to `mainnet` and verify it can sync using output syncing.
4. Start a node using the `main` branch, connect it to `mainnet` and verify it can sync using fast syncing.
5. Start a node using the `main` branch, connect it to `devnet` and verify it can sync using intelligent syncing mode.


The workflows will spawn and monitor the node and wait for it to sync to a target version (where the target is the latest version of the blockchain plus some delta). If this fails, the workflow will fail.

We'll likely add more of these tests in the future, but let's see how these do.

### Test Plan
Manual verification.