### PR TITLE
[Monitoring] Emit prometheus metrics for hostname and git sha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,6 +1816,7 @@ dependencies = [
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
 dependencies = [
+ "aptos-build-info",
  "aptos-infallible",
  "aptos-logger",
  "aptos-metrics-core",

--- a/crates/node-resource-metrics/Cargo.toml
+++ b/crates/node-resource-metrics/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+aptos-build-info = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }

--- a/crates/node-resource-metrics/src/collectors/basic_node_info_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/basic_node_info_collector.rs
@@ -14,17 +14,17 @@ use sysinfo::{RefreshKind, System, SystemExt};
 
 const BASIC_NODE_INFO_METRICS_COUNT: usize = 2;
 const RELEASE_GIT_HASH_LABEL: &str = "release_git_hash";
-const NODE_HOST_NAME_LABEL: &str = "host_name";
+const NODE_HOSTNAME_LABEL: &str = "hostname";
 
 const GIT_HASH_LABEL: &str = "git_hash";
-const HOST_NAME_LABEL: &str = "name";
+const HOSTNAME_LABEL: &str = "name";
 
 const UNKNOW_LABEL: &str = "unknown";
 
 pub(crate) struct BasicNodeInfoCollector {
     system: Arc<Mutex<System>>,
     release: Desc,
-    host_name: Desc,
+    hostname: Desc,
 }
 
 impl BasicNodeInfoCollector {
@@ -36,16 +36,16 @@ impl BasicNodeInfoCollector {
             .variable_label(GIT_HASH_LABEL)
             .describe()
             .unwrap();
-        let host_name = Opts::new(NODE_HOST_NAME_LABEL, "Host name.")
+        let hostname = Opts::new(NODE_HOSTNAME_LABEL, "Hostname.")
             .namespace(NAMESPACE)
-            .variable_label(HOST_NAME_LABEL)
+            .variable_label(HOSTNAME_LABEL)
             .describe()
             .unwrap();
 
         Self {
             system,
             release,
-            host_name,
+            hostname,
         }
     }
 }
@@ -58,18 +58,18 @@ impl Default for BasicNodeInfoCollector {
 
 impl Collector for BasicNodeInfoCollector {
     fn desc(&self) -> Vec<&Desc> {
-        vec![&self.host_name, &self.release]
+        vec![&self.hostname, &self.release]
     }
 
     fn collect(&self) -> Vec<MetricFamily> {
-        let host_name = self
+        let hostname = self
             .system
             .lock()
             .host_name()
             .unwrap_or_else(|| String::from(UNKNOW_LABEL));
 
         let host_name_metrics =
-            ConstMetric::new_gauge(self.host_name.clone(), 1.0, Some(&[host_name])).unwrap();
+            ConstMetric::new_gauge(self.hostname.clone(), 1.0, Some(&[hostname])).unwrap();
 
         let git_hash = aptos_build_info::get_git_hash();
         let release_metrics =

--- a/crates/node-resource-metrics/src/collectors/basic_node_info_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/basic_node_info_collector.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use once_cell::sync::Lazy;
+use prometheus::{
+    core::{Collector, Desc},
+    proto::MetricFamily,
+    register_int_gauge_vec, IntGaugeVec,
+};
+
+/// Current host name
+pub static HOST_NAME: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!("aptos_node_host_name", "A no-op counter value", &[
+        "host_name"
+    ])
+    .unwrap()
+});
+
+/// Git hash of the current release.
+pub static NODE_RELEASE_GIT_HASH: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!("aptos_node_release_git_hash", "A no-op counter value", &[
+        "git_hash"
+    ])
+    .unwrap()
+});
+
+pub(crate) struct BasicNodeInfoCollector<'a> {
+    metrics: &'a Lazy<IntGaugeVec>,
+}
+
+impl<'a> BasicNodeInfoCollector<'a> {
+    pub(crate) fn new(metrics: &'a Lazy<IntGaugeVec>) -> Self {
+        Self { metrics }
+    }
+}
+
+impl Collector for BasicNodeInfoCollector<'_> {
+    fn desc(&self) -> Vec<&Desc> {
+        self.metrics.desc()
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        self.metrics.collect()
+    }
+}
+
+pub fn register_basic_node_info_collectors() {
+    prometheus::register(Box::new(BasicNodeInfoCollector::new(
+        &NODE_RELEASE_GIT_HASH,
+    )))
+    .unwrap();
+    prometheus::register(Box::new(BasicNodeInfoCollector::new(&HOST_NAME))).unwrap();
+}

--- a/crates/node-resource-metrics/src/collectors/cpu_metrics_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/cpu_metrics_collector.rs
@@ -23,7 +23,6 @@ const CPU_VENDOR_LABEL: &str = "vendor";
 /// A Collector for exposing CPU metrics
 pub(crate) struct CpuMetricsCollector {
     system: Arc<Mutex<System>>,
-
     cpu: Desc,
     cpu_info: Desc,
 }

--- a/crates/node-resource-metrics/src/collectors/mod.rs
+++ b/crates/node-resource-metrics/src/collectors/mod.rs
@@ -10,7 +10,7 @@ mod memory_metrics_collector;
 mod network_metrics_collector;
 mod process_metrics_collector;
 
-pub(crate) use basic_node_info_collector::register_basic_node_info_collectors;
+pub(crate) use basic_node_info_collector::BasicNodeInfoCollector;
 pub(crate) use common::CollectorLatencyCollector;
 pub(crate) use cpu_metrics_collector::CpuMetricsCollector;
 pub(crate) use disk_metrics_collector::DiskMetricsCollector;

--- a/crates/node-resource-metrics/src/collectors/mod.rs
+++ b/crates/node-resource-metrics/src/collectors/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+mod basic_node_info_collector;
 mod common;
 mod cpu_metrics_collector;
 mod disk_metrics_collector;
@@ -9,6 +10,7 @@ mod memory_metrics_collector;
 mod network_metrics_collector;
 mod process_metrics_collector;
 
+pub(crate) use basic_node_info_collector::register_basic_node_info_collectors;
 pub(crate) use common::CollectorLatencyCollector;
 pub(crate) use cpu_metrics_collector::CpuMetricsCollector;
 pub(crate) use disk_metrics_collector::DiskMetricsCollector;
@@ -19,6 +21,7 @@ pub(crate) use process_metrics_collector::ProcessMetricsCollector;
 
 #[cfg(all(target_os = "linux"))]
 mod linux_collectors;
+
 #[cfg(all(target_os = "linux"))]
 pub(crate) use linux_collectors::LinuxCpuMetricsCollector;
 #[cfg(all(target_os = "linux"))]

--- a/crates/node-resource-metrics/src/lib.rs
+++ b/crates/node-resource-metrics/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::collectors::register_basic_node_info_collectors;
 use aptos_infallible::Mutex;
 use cfg_if::cfg_if;
 use collectors::{
@@ -28,6 +29,7 @@ pub fn register_node_metrics_collector() {
     prometheus::register(Box::<NetworkMetricsCollector>::default()).unwrap();
     prometheus::register(Box::<LoadAvgCollector>::default()).unwrap();
     prometheus::register(Box::<ProcessMetricsCollector>::default()).unwrap();
+    register_basic_node_info_collectors();
     cfg_if! {
         if #[cfg(all(target_os="linux"))] {
             prometheus::register(Box::<collectors::LinuxCpuMetricsCollector>::default()).unwrap();

--- a/crates/node-resource-metrics/src/lib.rs
+++ b/crates/node-resource-metrics/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::collectors::register_basic_node_info_collectors;
+use crate::collectors::BasicNodeInfoCollector;
 use aptos_infallible::Mutex;
 use cfg_if::cfg_if;
 use collectors::{
@@ -29,7 +29,7 @@ pub fn register_node_metrics_collector() {
     prometheus::register(Box::<NetworkMetricsCollector>::default()).unwrap();
     prometheus::register(Box::<LoadAvgCollector>::default()).unwrap();
     prometheus::register(Box::<ProcessMetricsCollector>::default()).unwrap();
-    register_basic_node_info_collectors();
+    prometheus::register(Box::<BasicNodeInfoCollector>::default()).unwrap();
     cfg_if! {
         if #[cfg(all(target_os="linux"))] {
             prometheus::register(Box::<collectors::LinuxCpuMetricsCollector>::default()).unwrap();


### PR DESCRIPTION
### Description

This will help us map peer_id to hostname as well as gives us release split information in real-time.

### Test Plan
Existing UTs
