### PR TITLE
[smoke-test] Fix flaky test for upgrade flow

### DIFF
--- a/testsuite/smoke-test/src/upgrade.rs
+++ b/testsuite/smoke-test/src/upgrade.rs
@@ -13,8 +13,7 @@ use aptos_release_builder::components::{
     gas::generate_gas_upgrade_proposal,
 };
 use aptos_temppath::TempPath;
-use std::fs;
-use std::process::Command;
+use std::{fs, path::PathBuf, process::Command};
 
 #[tokio::test]
 /// This test verifies the flow of aptos framework upgrade process.
@@ -57,6 +56,13 @@ async fn test_upgrade_flow() {
     gas_script_path.set_extension("move");
     fs::write(gas_script_path.as_path(), update_gas_script).unwrap();
 
+    let framework_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("aptos-move")
+        .join("framework")
+        .join("aptos-framework");
+
     assert!(Command::new(aptos_cli.as_path())
         .current_dir(workspace_root())
         .args(&vec![
@@ -64,6 +70,8 @@ async fn test_upgrade_flow() {
             "run-script",
             "--script-path",
             gas_script_path.to_str().unwrap(),
+            "--framework-local-dir",
+            framework_path.as_os_str().to_str().unwrap(),
             "--sender-account",
             "0xA550C18",
             "--url",
@@ -110,6 +118,8 @@ async fn test_upgrade_flow() {
                 "run-script",
                 "--script-path",
                 path.to_str().unwrap(),
+                "--framework-local-dir",
+                framework_path.as_os_str().to_str().unwrap(),
                 "--sender-account",
                 "0xA550C18",
                 "--url",


### PR DESCRIPTION
### Description

Previous upgrade flow test is now flaky because the CLI will by default fetch the aptos framework from main and the recent inline feature is causing old move compiler to panic. 

### Test Plan

Tested `test_upgrade_flow`
