### PR TITLE
[Quorum Store] Allow batches even if a validator restarts with a fresh DB

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -51,6 +51,7 @@ mod payload_manager;
 pub use consensusdb::create_checkpoint;
 /// Required by the smoke tests
 pub use consensusdb::CONSENSUS_DB_NAME;
+pub use quorum_store::quorum_store_db::QUORUM_STORE_DB_NAME;
 #[cfg(feature = "fuzzing")]
 pub use round_manager::round_manager_fuzzing;
 

--- a/consensus/src/quorum_store/batch_aggregator.rs
+++ b/consensus/src/quorum_store/batch_aggregator.rs
@@ -115,15 +115,10 @@ impl BatchAggregator {
         }
     }
 
+    #[inline]
     fn is_new_batch(batch_id: BatchId, prev_batch_id: BatchId) -> bool {
         // If the nonce has changed, this is a new batch (after validator DB was wiped).
-        if batch_id.nonce != prev_batch_id.nonce {
-            true
-        } else if batch_id > prev_batch_id {
-            true
-        } else {
-            false
-        }
+        batch_id.nonce != prev_batch_id.nonce || batch_id > prev_batch_id
     }
 
     fn is_outdated_fragment(&self, batch_id: BatchId, fragment_id: usize) -> bool {

--- a/consensus/src/quorum_store/batch_aggregator.rs
+++ b/consensus/src/quorum_store/batch_aggregator.rs
@@ -117,6 +117,9 @@ impl BatchAggregator {
 
     fn is_outdated_fragment(&self, batch_id: BatchId, fragment_id: usize) -> bool {
         if let Some(self_batch_id) = self.batch_id {
+            if self_batch_id.nonce != batch_id.nonce {
+                return false;
+            }
             let next_fragment_id = self.next_fragment_id();
             if next_fragment_id == 0 {
                 // In this case, the next fragment must start self_batch_id + 1
@@ -133,7 +136,7 @@ impl BatchAggregator {
     fn is_missed_fragment(&self, batch_id: BatchId, fragment_id: usize) -> bool {
         match self.batch_id {
             Some(self_batch_id) => {
-                if batch_id > self_batch_id {
+                if self_batch_id.nonce != batch_id.nonce || batch_id > self_batch_id {
                     self.batch_state.is_some() || fragment_id > 0
                 } else {
                     assert!(

--- a/consensus/src/quorum_store/batch_aggregator.rs
+++ b/consensus/src/quorum_store/batch_aggregator.rs
@@ -115,9 +115,20 @@ impl BatchAggregator {
         }
     }
 
+    fn is_new_batch(batch_id: BatchId, prev_batch_id: BatchId) -> bool {
+        // If the nonce has changed, this is a new batch (after validator DB was wiped).
+        if batch_id.nonce != prev_batch_id.nonce {
+            true
+        } else if batch_id > prev_batch_id {
+            true
+        } else {
+            false
+        }
+    }
+
     fn is_outdated_fragment(&self, batch_id: BatchId, fragment_id: usize) -> bool {
         if let Some(self_batch_id) = self.batch_id {
-            if self_batch_id.nonce != batch_id.nonce {
+            if Self::is_new_batch(batch_id, self_batch_id) {
                 return false;
             }
             let next_fragment_id = self.next_fragment_id();
@@ -136,7 +147,7 @@ impl BatchAggregator {
     fn is_missed_fragment(&self, batch_id: BatchId, fragment_id: usize) -> bool {
         match self.batch_id {
             Some(self_batch_id) => {
-                if self_batch_id.nonce != batch_id.nonce || batch_id > self_batch_id {
+                if Self::is_new_batch(batch_id, self_batch_id) {
                     self.batch_state.is_some() || fragment_id > 0
                 } else {
                     assert!(

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -19,6 +19,7 @@ use aptos_logger::prelude::*;
 use aptos_mempool::QuorumStoreRequest;
 use futures::{future::BoxFuture, stream::FuturesUnordered, StreamExt};
 use futures_channel::{mpsc::Sender, oneshot};
+use rand::{thread_rng, RngCore};
 use std::{
     collections::HashMap,
     sync::Arc,
@@ -73,15 +74,21 @@ impl BatchGenerator {
         end_batch_ms: u128,
         block_store: Arc<dyn BlockReader + Send + Sync>,
     ) -> Self {
-        let batch_id = if let Some(id) = db
+        let batch_id = if let Some(mut id) = db
             .clean_and_get_batch_id(epoch)
             .expect("Could not read from db")
         {
-            id + 1
+            // If the node shutdown mid-batch, then this increment is needed
+            id.increment();
+            id
         } else {
-            0
+            // The first batch starts at index 1
+            BatchId::new(thread_rng().next_u64())
         };
-        db.save_batch_id(epoch, batch_id + 1)
+        info!("Initialized with batch_id of {}", batch_id);
+        let mut incremented_batch_id = batch_id.clone();
+        incremented_batch_id.increment();
+        db.save_batch_id(epoch, incremented_batch_id)
             .expect("Could not save to db");
 
         Self {
@@ -188,8 +195,10 @@ impl BatchGenerator {
 
             counters::NUM_TXN_PER_BATCH.observe(self.batch_builder.summaries().len() as f64);
 
+            let mut incremented_batch_id = batch_id.clone();
+            incremented_batch_id.increment();
             self.db
-                .save_batch_id(self.latest_logical_time.epoch(), batch_id + 1)
+                .save_batch_id(self.latest_logical_time.epoch(), incremented_batch_id)
                 .expect("Could not save to db");
 
             let (proof_tx, proof_rx) = oneshot::channel();

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -78,11 +78,10 @@ impl BatchGenerator {
             .clean_and_get_batch_id(epoch)
             .expect("Could not read from db")
         {
-            // If the node shutdown mid-batch, then this increment is needed
+            // If the node shut down mid-batch, then this increment is needed
             id.increment();
             id
         } else {
-            // The first batch starts at index 1
             BatchId::new(thread_rng().next_u64())
         };
         info!("Initialized with batch_id of {}", batch_id);

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -86,7 +86,7 @@ impl BatchGenerator {
             BatchId::new(thread_rng().next_u64())
         };
         info!("Initialized with batch_id of {}", batch_id);
-        let mut incremented_batch_id = batch_id.clone();
+        let mut incremented_batch_id = batch_id;
         incremented_batch_id.increment();
         db.save_batch_id(epoch, incremented_batch_id)
             .expect("Could not save to db");
@@ -195,7 +195,7 @@ impl BatchGenerator {
 
             counters::NUM_TXN_PER_BATCH.observe(self.batch_builder.summaries().len() as f64);
 
-            let mut incremented_batch_id = batch_id.clone();
+            let mut incremented_batch_id = batch_id;
             incremented_batch_id.increment();
             self.db
                 .save_batch_id(self.latest_logical_time.epoch(), incremented_batch_id)

--- a/consensus/src/quorum_store/quorum_store_db.rs
+++ b/consensus/src/quorum_store/quorum_store_db.rs
@@ -14,6 +14,9 @@ use aptos_logger::{debug, info};
 use aptos_schemadb::{Options, ReadOptions, SchemaBatch, DB};
 use std::{collections::HashMap, path::Path, time::Instant};
 
+/// The name of the quorum store db file
+pub const QUORUM_STORE_DB_NAME: &str = "quorumstoreDB";
+
 pub trait BatchIdDB: Send + Sync {
     fn clean_and_get_batch_id(&self, current_epoch: u64) -> Result<Option<BatchId>, DbError>;
     fn save_batch_id(&self, epoch: u64, batch_id: BatchId) -> Result<(), DbError>;
@@ -28,12 +31,12 @@ impl QuorumStoreDB {
         let column_families = vec![BATCH_CF_NAME, BATCH_ID_CF_NAME];
 
         // TODO: this fails twins tests because it assumes a unique path per process
-        let path = db_root_path.as_ref().join("quorumstoreDB");
+        let path = db_root_path.as_ref().join(QUORUM_STORE_DB_NAME);
         let instant = Instant::now();
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
-        let db = DB::open(path.clone(), "quorumstoreDB", column_families, &opts)
+        let db = DB::open(path.clone(), QUORUM_STORE_DB_NAME, column_families, &opts)
             .expect("QuorumstoreDB open failed; unable to continue");
 
         info!(

--- a/consensus/src/quorum_store/quorum_store_db.rs
+++ b/consensus/src/quorum_store/quorum_store_db.rs
@@ -9,7 +9,6 @@ use crate::{
     },
 };
 use anyhow::Result;
-use aptos_consensus_types::common::Round;
 use aptos_crypto::HashValue;
 use aptos_logger::{debug, info};
 use aptos_schemadb::{Options, ReadOptions, SchemaBatch, DB};
@@ -90,7 +89,7 @@ impl BatchIdDB for QuorumStoreDB {
     fn clean_and_get_batch_id(&self, current_epoch: u64) -> Result<Option<BatchId>, DbError> {
         let mut iter = self.db.iter::<BatchIdSchema>(ReadOptions::default())?;
         iter.seek_to_first();
-        let epoch_batch_id = iter.collect::<Result<HashMap<u64, Round>>>()?;
+        let epoch_batch_id = iter.collect::<Result<HashMap<u64, BatchId>>>()?;
         let mut ret = None;
         for (epoch, batch_id) in epoch_batch_id {
             assert!(current_epoch >= epoch);

--- a/consensus/src/quorum_store/tests/batch_aggregator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_aggregator_test.rs
@@ -148,7 +148,7 @@ fn test_batch_aggregator_ids() {
     // Forwards batch_id to 3, realizes fragment 0 is skipped.
     assert_eq!(
         aggregator
-            .append_transactions(3, 1, Vec::new())
+            .append_transactions(BatchId::new_for_test(3), 1, Vec::new())
             .unwrap_err(),
         BatchAggregationError::MissedFragment
     );
@@ -157,37 +157,46 @@ fn test_batch_aggregator_ids() {
         for j in 0..2 {
             assert_eq!(
                 aggregator
-                    .append_transactions(i, j, Vec::new())
+                    .append_transactions(BatchId::new_for_test(i), j, Vec::new())
                     .unwrap_err(),
                 BatchAggregationError::OutdatedFragment
             );
         }
     }
 
-    assert_ok!(aggregator.append_transactions(4, 0, Vec::new()));
-    assert_ok!(aggregator.append_transactions(4, 1, Vec::new()));
-    assert_ok!(aggregator.append_transactions(4, 2, Vec::new()));
+    assert_ok!(aggregator.append_transactions(BatchId::new_for_test(4), 0, Vec::new()));
+    assert_ok!(aggregator.append_transactions(BatchId::new_for_test(4), 1, Vec::new()));
+    assert_ok!(aggregator.append_transactions(BatchId::new_for_test(4), 2, Vec::new()));
     check_outdated_fragments(
         &mut aggregator,
         (0..5)
             .into_iter()
-            .flat_map(move |i| (0..3).into_iter().map(move |j| (i, j)))
+            .flat_map(move |i| {
+                (0..3)
+                    .into_iter()
+                    .map(move |j| (BatchId::new_for_test(i), j))
+            })
             .collect(),
     );
-    assert_ok!(aggregator.append_transactions(4, 3, Vec::new()));
+    assert_ok!(aggregator.append_transactions(BatchId::new_for_test(4), 3, Vec::new()));
     let _empty_vec: Vec<SignedTransaction> = Vec::new();
     assert_matches!(
-        aggregator.end_batch(4, 4, Vec::new()),
+        aggregator.end_batch(BatchId::new_for_test(4), 4, Vec::new()),
         Ok((0, _empty_vec, _))
     );
 
     // Starting with (3,0) should work for a newly created aggregator.
     aggregator = BatchAggregator::new(1000);
-    assert_ok!(aggregator.append_transactions(3, 0, Vec::new()));
+    assert_ok!(aggregator.append_transactions(BatchId::new_for_test(3), 0, Vec::new()));
 
-    check_outdated_fragments(&mut aggregator, vec![(3, 0), (2, 0), (2, 7), (0, 0)]);
+    check_outdated_fragments(&mut aggregator, vec![
+        (BatchId::new_for_test(3), 0),
+        (BatchId::new_for_test(2), 0),
+        (BatchId::new_for_test(2), 7),
+        (BatchId::new_for_test(0), 0),
+    ]);
     assert_matches!(
-        aggregator.end_batch(3, 1, Vec::new()),
+        aggregator.end_batch(BatchId::new_for_test(3), 1, Vec::new()),
         Ok((0, _empty_vec, _))
     );
 }
@@ -207,106 +216,152 @@ fn test_batch_aggregator() {
     assert_eq!(base_res.0, txns_size);
 
     let mut aggregator = BatchAggregator::new(txns_size);
-    assert_ok!(aggregator.append_transactions(4, 0, fragmented_txns1[0].clone()));
-    assert_ok!(aggregator.append_transactions(4, 1, fragmented_txns1[1].clone()));
-    check_outdated_fragments(&mut aggregator, vec![(4, 0), (4, 1), (3, 0)]);
-    assert_ok_eq!(aggregator.end_batch(4, 2, Vec::new()), base_res);
-
-    assert_ok!(aggregator.append_transactions(6, 0, fragmented_txns1[0].clone()));
-    assert_ok!(aggregator.append_transactions(6, 1, Vec::new()));
-    assert_ok!(aggregator.append_transactions(6, 2, Vec::new()));
+    assert_ok!(aggregator.append_transactions(
+        BatchId::new_for_test(4),
+        0,
+        fragmented_txns1[0].clone()
+    ));
+    assert_ok!(aggregator.append_transactions(
+        BatchId::new_for_test(4),
+        1,
+        fragmented_txns1[1].clone()
+    ));
+    check_outdated_fragments(&mut aggregator, vec![
+        (BatchId::new_for_test(4), 0),
+        (BatchId::new_for_test(4), 1),
+        (BatchId::new_for_test(3), 0),
+    ]);
     assert_ok_eq!(
-        aggregator.end_batch(6, 3, fragmented_txns1[1].clone()),
+        aggregator.end_batch(BatchId::new_for_test(4), 2, Vec::new()),
+        base_res
+    );
+
+    assert_ok!(aggregator.append_transactions(
+        BatchId::new_for_test(6),
+        0,
+        fragmented_txns1[0].clone()
+    ));
+    assert_ok!(aggregator.append_transactions(BatchId::new_for_test(6), 1, Vec::new()));
+    assert_ok!(aggregator.append_transactions(BatchId::new_for_test(6), 2, Vec::new()));
+    assert_ok_eq!(
+        aggregator.end_batch(BatchId::new_for_test(6), 3, fragmented_txns1[1].clone()),
         base_res
     );
 
     assert_eq!(
         aggregator
-            .append_transactions(6, 0, Vec::new())
+            .append_transactions(BatchId::new_for_test(6), 0, Vec::new())
             .unwrap_err(),
         BatchAggregationError::OutdatedFragment
     );
 
     assert_eq!(
         aggregator
-            .append_transactions(7, 1, fragmented_txns1[0].clone())
+            .append_transactions(BatchId::new_for_test(7), 1, fragmented_txns1[0].clone())
             .unwrap_err(),
         BatchAggregationError::MissedFragment
     );
     assert_eq!(
         aggregator
-            .append_transactions(7, 0, Vec::new())
+            .append_transactions(BatchId::new_for_test(7), 0, Vec::new())
             .unwrap_err(),
         BatchAggregationError::OutdatedFragment
     );
-    assert_ok_eq!(aggregator.end_batch(8, 0, all_txns_clone), base_res);
+    assert_ok_eq!(
+        aggregator.end_batch(BatchId::new_for_test(8), 0, all_txns_clone),
+        base_res
+    );
 
-    assert_ok!(aggregator.append_transactions(9, 0, fragmented_txns1[0].clone()));
-    assert_ok!(aggregator.append_transactions(9, 1, fragmented_txns1[0].clone()));
+    assert_ok!(aggregator.append_transactions(
+        BatchId::new_for_test(9),
+        0,
+        fragmented_txns1[0].clone()
+    ));
+    assert_ok!(aggregator.append_transactions(
+        BatchId::new_for_test(9),
+        1,
+        fragmented_txns1[0].clone()
+    ));
     assert_eq!(
         aggregator
-            .append_transactions(9, 2, fragmented_txns1[1].clone())
+            .append_transactions(BatchId::new_for_test(9), 2, fragmented_txns1[1].clone())
             .unwrap_err(),
         BatchAggregationError::SizeLimitExceeded
     );
 
     assert_eq!(
-        aggregator.end_batch(9, 2, Vec::new()).unwrap_err(),
+        aggregator
+            .end_batch(BatchId::new_for_test(9), 2, Vec::new())
+            .unwrap_err(),
         BatchAggregationError::OutdatedFragment
     );
     assert_eq!(
-        aggregator.end_batch(9, 3, Vec::new()).unwrap_err(),
+        aggregator
+            .end_batch(BatchId::new_for_test(9), 3, Vec::new())
+            .unwrap_err(),
         BatchAggregationError::SizeLimitExceeded
     );
 
     // Observes missed fragment but still starts aggregating 10. Since aggregation was
     // successful, the return type is Ok(()).
-    assert_ok!(aggregator.append_transactions(10, 0, Vec::new()));
+    assert_ok!(aggregator.append_transactions(BatchId::new_for_test(10), 0, Vec::new()));
 
     // Observes missed fragment but still processes batch 11.
     let half_res = aggregator
-        .end_batch(11, 0, fragmented_txns1[0].clone())
+        .end_batch(BatchId::new_for_test(11), 0, fragmented_txns1[0].clone())
         .unwrap();
     assert_eq!(half_res.1.len(), 5);
     assert_ne!(half_res.2, base_res.2);
 
     for (i, txn) in fragmented_txns2.iter().enumerate().take(3) {
-        assert_ok!(aggregator.append_transactions(12, 2 * i, txn.clone()));
-        assert_ok!(aggregator.append_transactions(12, 2 * i + 1, Vec::new()));
+        assert_ok!(aggregator.append_transactions(BatchId::new_for_test(12), 2 * i, txn.clone()));
+        assert_ok!(aggregator.append_transactions(
+            BatchId::new_for_test(12),
+            2 * i + 1,
+            Vec::new()
+        ));
     }
     assert_ok_eq!(
-        aggregator.end_batch(12, 6, fragmented_txns2[3].clone()),
+        aggregator.end_batch(BatchId::new_for_test(12), 6, fragmented_txns2[3].clone()),
         base_res
     );
 
-    assert_ok!(aggregator.append_transactions(15, 0, fragmented_txns1[0].clone()));
+    assert_ok!(aggregator.append_transactions(
+        BatchId::new_for_test(15),
+        0,
+        fragmented_txns1[0].clone()
+    ));
     assert_eq!(
         aggregator
-            .end_batch(15, 2, fragmented_txns1[1].clone())
+            .end_batch(BatchId::new_for_test(15), 2, fragmented_txns1[1].clone())
             .unwrap_err(),
         BatchAggregationError::MissedFragment
     );
     assert_eq!(
         aggregator
-            .end_batch(15, 2, fragmented_txns1[1].clone())
+            .end_batch(BatchId::new_for_test(15), 2, fragmented_txns1[1].clone())
             .unwrap_err(),
         BatchAggregationError::OutdatedFragment
     );
 
-    assert_ok!(aggregator.append_transactions(16, 0, fragmented_txns1[0].clone()));
+    assert_ok!(aggregator.append_transactions(
+        BatchId::new_for_test(16),
+        0,
+        fragmented_txns1[0].clone()
+    ));
     assert_eq!(
         aggregator
-            .append_transactions(16, 2, fragmented_txns1[1].clone())
+            .append_transactions(BatchId::new_for_test(16), 2, fragmented_txns1[1].clone())
             .unwrap_err(),
         BatchAggregationError::MissedFragment
     );
     assert_eq!(
         aggregator
-            .end_batch(16, 2, fragmented_txns1[1].clone())
+            .end_batch(BatchId::new_for_test(16), 2, fragmented_txns1[1].clone())
             .unwrap_err(),
         BatchAggregationError::OutdatedFragment
     );
 
-    assert_ok!(aggregator.end_batch(17, 0, Vec::new()));
-    assert_ok!(aggregator.end_batch(18, 0, Vec::new()));
+    assert_ok!(aggregator.end_batch(BatchId::new_for_test(17), 0, Vec::new()));
+    assert_ok!(aggregator.end_batch(BatchId::new_for_test(18), 0, Vec::new()));
 }

--- a/consensus/src/quorum_store/tests/batch_generator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_generator_test.rs
@@ -37,7 +37,7 @@ impl BatchIdDB for MockBatchIdDB {
         &self,
         _current_epoch: u64,
     ) -> anyhow::Result<Option<BatchId>, DbError> {
-        Ok(Some(0))
+        Ok(Some(BatchId::new_for_test(0)))
     }
 
     fn save_batch_id(&self, _epoch: u64, _batch_id: BatchId) -> anyhow::Result<(), DbError> {
@@ -121,7 +121,7 @@ async fn test_batch_creation() {
         // Expect AppendToBatch for 1 txn
         let quorum_store_command = batch_coordinator_cmd_rx.recv().await.unwrap();
         if let BatchCoordinatorCommand::AppendToBatch(data, batch_id) = quorum_store_command {
-            assert_eq!(batch_id, 1);
+            assert_eq!(batch_id, BatchId::new_for_test(1));
             assert_eq!(data.len(), signed_txns.len());
             assert_eq!(data, serialize(&signed_txns));
         } else {
@@ -154,7 +154,7 @@ async fn test_batch_creation() {
         // Expect AppendBatch for 9 txns
         let quorum_store_command = batch_coordinator_cmd_rx.recv().await.unwrap();
         if let BatchCoordinatorCommand::AppendToBatch(data, batch_id) = quorum_store_command {
-            assert_eq!(batch_id, 2);
+            assert_eq!(batch_id, BatchId::new_for_test(2));
             assert_eq!(data.len(), signed_txns.len());
             assert_eq!(data, serialize(&signed_txns));
         } else {

--- a/consensus/src/quorum_store/tests/quorum_store_db_test.rs
+++ b/consensus/src/quorum_store/tests/quorum_store_db_test.rs
@@ -4,7 +4,7 @@
 use crate::quorum_store::{
     quorum_store_db::{BatchIdDB, QuorumStoreDB},
     tests::utils::{compute_digest_from_signed_transaction, create_vec_signed_transactions},
-    types::PersistedValue,
+    types::{BatchId, PersistedValue},
 };
 use aptos_consensus_types::proof_of_store::LogicalTime;
 use aptos_temppath::TempPath;
@@ -60,20 +60,20 @@ fn test_db_for_batch_id() {
         .clean_and_get_batch_id(0)
         .expect("could not read from db")
         .is_none());
-    assert!(db.save_batch_id(0, 0).is_ok());
-    assert!(db.save_batch_id(0, 4).is_ok());
+    assert!(db.save_batch_id(0, BatchId::new_for_test(0)).is_ok());
+    assert!(db.save_batch_id(0, BatchId::new_for_test(4)).is_ok());
     assert_eq!(
         db.clean_and_get_batch_id(0)
             .expect("could not read from db")
             .unwrap(),
-        4
+        BatchId::new_for_test(4)
     );
-    assert!(db.save_batch_id(1, 1).is_ok());
-    assert!(db.save_batch_id(2, 2).is_ok());
+    assert!(db.save_batch_id(1, BatchId::new_for_test(1)).is_ok());
+    assert!(db.save_batch_id(2, BatchId::new_for_test(2)).is_ok());
     assert_eq!(
         db.clean_and_get_batch_id(2)
             .expect("could not read from db")
             .unwrap(),
-        2
+        BatchId::new_for_test(2)
     );
 }

--- a/consensus/src/quorum_store/tests/types_test.rs
+++ b/consensus/src/quorum_store/tests/types_test.rs
@@ -3,7 +3,7 @@
 
 use crate::quorum_store::{
     tests::utils::create_vec_signed_transactions,
-    types::{Batch, BatchRequest, Fragment, SerializedTransaction},
+    types::{Batch, BatchId, BatchRequest, Fragment, SerializedTransaction},
 };
 use aptos_consensus_types::proof_of_store::LogicalTime;
 use aptos_crypto::hash::DefaultHasher;
@@ -36,7 +36,7 @@ fn test_batch() {
 #[test]
 fn test_fragment() {
     let epoch = 0;
-    let batch_id = 0;
+    let batch_id = BatchId::new_for_test(0);
     let fragment_id = 0;
     let mut data = Vec::new();
     let mut maybe_expiration = None;

--- a/consensus/src/quorum_store/types.rs
+++ b/consensus/src/quorum_store/types.rs
@@ -18,6 +18,9 @@ use std::{
 )]
 pub struct BatchId {
     pub id: u64,
+    /// A random number that is stored in the DB and updated only if the value does not exist in
+    /// the DB: (a) at the start of an epoch, or (b) the DB was wiped. When the nonce is updated,
+    /// id starts again at 0.
     pub nonce: u64,
 }
 

--- a/consensus/src/quorum_store/types.rs
+++ b/consensus/src/quorum_store/types.rs
@@ -7,9 +7,55 @@ use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use aptos_types::{transaction::SignedTransaction, PeerId};
 use bcs::to_bytes;
 use serde::{Deserialize, Serialize};
-use std::mem;
+use std::{
+    cmp::Ordering,
+    fmt::{Display, Formatter},
+    mem,
+};
 
-pub type BatchId = u64;
+#[derive(
+    Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash, CryptoHasher, BCSCryptoHash,
+)]
+pub struct BatchId {
+    pub id: u64,
+    pub nonce: u64,
+}
+
+impl BatchId {
+    pub fn new(nonce: u64) -> Self {
+        Self { id: 0, nonce }
+    }
+
+    pub fn new_for_test(id: u64) -> Self {
+        Self { id, nonce: 0 }
+    }
+
+    pub fn increment(&mut self) {
+        self.id += 1;
+    }
+}
+
+impl PartialOrd<Self> for BatchId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BatchId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.id.cmp(&other.id) {
+            Ordering::Equal => {},
+            ordering => return ordering,
+        }
+        self.nonce.cmp(&other.nonce)
+    }
+}
+
+impl Display for BatchId {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "({}, {})", self.id, self.nonce)
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct SerializedTransaction {
@@ -74,7 +120,7 @@ impl PersistedValue {
 #[derive(Clone, Debug, Deserialize, Serialize, CryptoHasher, BCSCryptoHash)]
 pub struct FragmentInfo {
     epoch: u64,
-    batch_id: u64,
+    batch_id: BatchId,
     fragment_id: usize,
     payload: Vec<SerializedTransaction>,
     maybe_expiration: Option<LogicalTime>,
@@ -83,7 +129,7 @@ pub struct FragmentInfo {
 impl FragmentInfo {
     fn new(
         epoch: u64,
-        batch_id: u64,
+        batch_id: BatchId,
         fragment_id: usize,
         fragment_payload: Vec<SerializedTransaction>,
         maybe_expiration: Option<LogicalTime>,
@@ -123,7 +169,7 @@ pub struct Fragment {
 impl Fragment {
     pub fn new(
         epoch: u64,
-        batch_id: u64,
+        batch_id: BatchId,
         fragment_id: usize,
         fragment_payload: Vec<SerializedTransaction>,
         maybe_expiration: Option<LogicalTime>,

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -89,7 +89,7 @@ impl BatchBuilder {
     pub(crate) fn take_summaries(&mut self) -> Vec<TransactionSummary> {
         assert!(self.data.is_empty());
 
-        self.id += 1;
+        self.id.increment();
         self.num_bytes = 0;
         self.num_txns = 0;
         mem::take(&mut self.summaries)

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -47,6 +47,10 @@ Batch:
     - payload:
         SEQ:
           TYPENAME: SignedTransaction
+BatchId:
+  STRUCT:
+    - id: U64
+    - nonce: U64
 BatchInfo:
   STRUCT:
     - epoch: U64
@@ -288,7 +292,8 @@ Fragment:
 FragmentInfo:
   STRUCT:
     - epoch: U64
-    - batch_id: U64
+    - batch_id:
+        TYPENAME: BatchId
     - fragment_id: U64
     - payload:
         SEQ:

--- a/testsuite/smoke-test/src/consensus/quorum_store_fault_tolerance.rs
+++ b/testsuite/smoke-test/src/consensus/quorum_store_fault_tolerance.rs
@@ -5,6 +5,7 @@ use crate::{
     aptos_cli::validator::generate_blob, smoke_test_environment::SwarmBuilder,
     txn_emitter::generate_traffic,
 };
+use aptos_consensus::QUORUM_STORE_DB_NAME;
 use aptos_forge::{NodeExt, Swarm, SwarmExt, TransactionType};
 use aptos_logger::info;
 use aptos_types::{
@@ -209,10 +210,9 @@ async fn test_batch_id_on_restart(do_wipe_db: bool) {
     if do_wipe_db {
         info!("wipe only quorum store db");
         let node0_config = swarm.validator(node_to_restart).unwrap().config().clone();
-        // TODO: get this dir from quorum store code
         let db_dir = node0_config.storage.dir();
-        let quorum_store_db_dir = db_dir.join("quorumstoreDB");
-        fs::remove_dir_all(quorum_store_db_dir.clone()).unwrap();
+        let quorum_store_db_dir = db_dir.join(QUORUM_STORE_DB_NAME);
+        fs::remove_dir_all(quorum_store_db_dir).unwrap();
     } else {
         info!("don't do anything to quorum store db");
     }
@@ -240,12 +240,12 @@ async fn test_batch_id_on_restart(do_wipe_db: bool) {
 /// Checks that a validator can still get signatures on batches on restart when the db is intact.
 #[tokio::test]
 async fn test_batch_id_on_restart_same_db() {
-    test_batch_id_on_restart(false);
+    test_batch_id_on_restart(false).await;
 }
 
 /// Checks that a validator can still get signatures on batches even if its db is reset (e.g.,
 /// the disk failed, or the validator had to be moved to another node).
 #[tokio::test]
 async fn test_batch_id_on_restart_wiped_db() {
-    test_batch_id_on_restart(true);
+    test_batch_id_on_restart(true).await;
 }


### PR DESCRIPTION
# Description

Introduce a nonce into BatchId. If a validator restarts with a fresh DB, the change in nonce indicates that the id will start back at 0, and other validators will accept the new batches.

Without this, a validator with a wiped DB would timeout all batches until it reached the previous batch ID.

# Test Plan

Add smoke test for both when DB exists on restart and when it is wiped on restart. The latter failed before this change.
