### PR TITLE
[VM] Invalidate loader cache upon all failures if a newly published module is loaded

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_init_module_failed/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_init_module_failed/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "test_package"
+version = "0.0.0"
+upgrade_policy = "immutable"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_init_module_failed/sources/test.move
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_init_module_failed/sources/test.move
@@ -1,0 +1,26 @@
+module 0xcafe::test {
+    use aptos_framework::coin::{Self, Coin};
+    use aptos_framework::aptos_coin::AptosCoin;
+    use std::signer::address_of;
+
+    struct State has key {
+        important_value: u64,
+        coins: Coin<AptosCoin>,
+    }
+
+    fun init_module(s: &signer) {
+        // Transfer away all the APT from s so there's nothing left to pay for gas.
+        // This makes this init_module function fail for sure.
+        let balance = coin::balance<AptosCoin>(address_of(s));
+        let coins = coin::withdraw<AptosCoin>(s, balance);
+
+        move_to(s, State {
+            important_value: get_value(),
+            coins,
+        })
+    }
+
+    fun get_value(): u64 {
+        1
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_init_module_second_attempt/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_init_module_second_attempt/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "test_package"
+version = "0.0.0"
+upgrade_policy = "immutable"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_init_module_second_attempt/sources/test.move
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_init_module_second_attempt/sources/test.move
@@ -1,0 +1,20 @@
+module 0xcafe::test {
+    use aptos_framework::coin::{Self, Coin};
+    use aptos_framework::aptos_coin::AptosCoin;
+
+    struct State has key {
+        important_value: u64,
+        coins: Coin<AptosCoin>,
+    }
+
+    fun init_module(s: &signer) {
+        move_to(s, State {
+            important_value: get_value(),
+            coins: coin::zero<AptosCoin>(),
+        })
+    }
+
+    fun get_value(): u64 {
+        2
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.rs
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.rs
@@ -22,6 +22,13 @@ struct State {
     value: u64,
 }
 
+/// Mimics `0xcafe::test::State`
+#[derive(Serialize, Deserialize)]
+struct StateWithCoins {
+    important_value: u64,
+    value: u64,
+}
+
 /// Runs the basic publishing test for all legacy flag combinations. Otherwise we will only
 /// run tests which are expected to make a difference for legacy flag combinations.
 #[rstest(enabled, disabled,
@@ -242,6 +249,44 @@ fn code_publishing_using_resource_account() {
         ),
     );
     assert_success!(result);
+}
+
+#[test]
+fn code_publishing_with_two_attempts_and_verify_loader_is_invalidated() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+
+    // First module publish attempt failed when executing the init_module.
+    // Second attempt should pass.
+    // We expect the correct logic in init_module to be executed from the second attempt so the
+    // value stored is from the second code, and not the first (which would be the case if the
+    // VM's loader cache is not properly cleared after the first attempt).
+    //
+    // Depending on how the loader cache is flushed, the second attempt might even fail if the
+    // entire init_module from the first attempt still lingers around and will fail if invoked.
+    let failed_module_publish = h.create_publish_package(
+        &acc,
+        &common::test_dir_path("code_publishing.data/pack_init_module_failed"),
+        None,
+        |_| {},
+    );
+    let module_publish_second_attempt = h.create_publish_package(
+        &acc,
+        &common::test_dir_path("code_publishing.data/pack_init_module_second_attempt"),
+        None,
+        |_| {},
+    );
+    let results = h.run_block(vec![failed_module_publish, module_publish_second_attempt]);
+    assert_abort!(results[0], _);
+    assert_success!(results[1]);
+
+    let value_resource = h
+        .read_resource::<StateWithCoins>(
+            acc.address(),
+            parse_struct_tag("0xcafe::test::State").unwrap(),
+        )
+        .unwrap();
+    assert_eq!(2, value_resource.important_value);
 }
 
 #[rstest(enabled, disabled,


### PR DESCRIPTION
## Description
VM's loader cache is not properly flushed when a code publish fails either during init_module execution or later steps (e.g. in success_cleanup). This means re-attempts of publishing the same module (not upgrade because earlier attempts failed) would still use the loaded code from the failed attempts.

This PR addresses this by properly invalidating the loader cache further up the stack to account for all possible failures.

## Test Plan
E2E test that tries to upload the same module twice (first attempt always fails).

Without the fix, the second attempt would also fail because the same init_module from the first attempt lingers around in the loader cache and is used.
With the fix, the second attempt succeeds (loader cache is cleared and new init_module logic is used).