### PR TITLE
[gha][docker-buildx-setup] bump the version

### DIFF
--- a/.github/actions/docker-buildx-setup/action.yaml
+++ b/.github/actions/docker-buildx-setup/action.yaml
@@ -11,4 +11,4 @@ runs:
       uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # pin@v2
       with:
         endpoint: builders
-        version: v0.8.2
+        # version: v0.8.2


### PR DESCRIPTION
### Description

Previously, docker setup is failing because it can't find the old release. Changing the version to see if it works

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
