### PR TITLE
[fix] fix node_checker_lib helpers

### DIFF
--- a/ecosystem/node-checker/src/provider/helpers.rs
+++ b/ecosystem/node-checker/src/provider/helpers.rs
@@ -10,11 +10,13 @@ pub const MISSING_PROVIDER_MESSAGE: &str = "Incomplete request";
 /// Example invocations:
 ///
 /// ```
-/// let target_metrics_provider = get_provider!(
+/// # use std::io;
+/// let target_metrics_provider = aptos_node_checker_lib::get_provider!(
 ///     input.target_metrics_provider,
 ///     true,
 ///     MetricsProvider
-/// );
+/// )?;
+/// # Ok::<_, io::Error>(vec![])
 /// ```
 ///
 /// The first argument is the Option, the second is `required`, and the last is


### PR DESCRIPTION
### Description
`cargo test -p aptos-node-checker --doc` is broken.

### Test Plan
cargo test -p aptos-node-checker --doc
