### PR TITLE
mask indexer’s database password when logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,6 +1977,7 @@ dependencies = [
  "serde 1.0.149",
  "tokio",
  "tokio-stream",
+ "url",
 ]
 
 [[package]]

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -68,6 +68,7 @@ rayon = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
+url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 jemallocator = { workspace = true }

--- a/aptos-node/src/logger.rs
+++ b/aptos-node/src/logger.rs
@@ -77,5 +77,17 @@ fn log_config_and_build_information(node_config: &NodeConfig) {
     log_feature_info!("failpoints", "assert-private-keys-not-cloneable");
 
     // Log the node config
-    info!(config = node_config, "Loaded AptosNode config");
+    let mut config = node_config;
+    let mut masked_config;
+    if let Some(u) = &node_config.indexer.postgres_uri {
+        let mut parsed_url = url::Url::parse(u).expect("Invalid postgres uri");
+        if parsed_url.password().is_some() {
+            masked_config = node_config.clone();
+            parsed_url.set_password(Some("*")).unwrap();
+            masked_config.indexer.postgres_uri = Some(parsed_url.to_string());
+            config = &masked_config;
+        }
+    }
+
+    info!(config = config, "Loaded AptosNode config");
 }

--- a/config/src/config/indexer_config.rs
+++ b/config/src/config/indexer_config.rs
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Formatter};
 
 pub const DEFAULT_BATCH_SIZE: u16 = 500;
 pub const DEFAULT_FETCH_TASKS: u8 = 5;
 pub const DEFAULT_PROCESSOR_TASKS: u8 = 5;
 pub const DEFAULT_EMIT_EVERY: u64 = 1000;
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Default, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct IndexerConfig {
     /// Whether the indexer is enabled or not
@@ -69,6 +70,32 @@ pub struct IndexerConfig {
     /// Which address does the ans contract live at. Only available for token_processor. If null, disable ANS indexing
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ans_contract_address: Option<String>,
+}
+
+impl Debug for IndexerConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let postgres_uri = self.postgres_uri.as_ref().map(|u| {
+            let mut parsed_url = url::Url::parse(u).expect("Invalid postgres uri");
+            if parsed_url.password().is_some() {
+                parsed_url.set_password(Some("*")).unwrap();
+            }
+            parsed_url.to_string()
+        });
+        f.debug_struct("IndexerConfig")
+            .field("enabled", &self.enabled)
+            .field("postgres_uri", &postgres_uri)
+            .field("processor", &self.processor)
+            .field("starting_version", &self.starting_version)
+            .field("skip_migrations", &self.skip_migrations)
+            .field("check_chain_id", &self.check_chain_id)
+            .field("batch_size", &self.batch_size)
+            .field("fetch_tasks", &self.fetch_tasks)
+            .field("processor_tasks", &self.processor_tasks)
+            .field("emit_every", &self.emit_every)
+            .field("gap_lookback_versions", &self.gap_lookback_versions)
+            .field("ans_contract_address", &self.ans_contract_address)
+            .finish()
+    }
 }
 
 pub fn env_or_default<T: std::str::FromStr>(


### PR DESCRIPTION
### Description
Mask the password of indexer's database when logging. Resolve issue #6206 .
If the `postgres_uri` has password ,then replace it with `*`.

1. For `printltn`,  implement `Debug` trait manually.
Usage:
https://github.com/aptos-labs/aptos-core/blob/35976bfa00bc06d376285da38739ee86f8a96d75/aptos-node/src/lib.rs#L126

2. for `aptos-logger`, clone `NodeConfig` and change `postgre_uri` of `IndexerConfig` if needed.
Usage: 
https://github.com/aptos-labs/aptos-core/blob/35976bfa00bc06d376285da38739ee86f8a96d75/aptos-node/src/logger.rs#L80


### Test Plan
Build `aptos-node`, run with different config, check the output
1. With password
```
Using node config NodeConfig....
, indexer: IndexerConfig { enabled: true, postgres_uri: Some("postgres://postgres:*@localhost:5432/postgres").....}
``` 

```
2023-01-29T04:00:28.808522Z [main] INFO aptos-node/src/logger.rs:92 Loaded AptosNode config ....
{......"indexer":{"enabled":true,"postgres_uri":"postgres://postgres:*@localhost:5432/postgres", ......}
```
2. Without password
```
Using node config NodeConfig....
, indexer: IndexerConfig { enabled: true, postgres_uri: Some("postgres://postgres@localhost:5432/postgres").....}
``` 

```
2023-01-29T04:00:28.808522Z [main] INFO aptos-node/src/logger.rs:92 Loaded AptosNode config ....
{......"indexer":{"enabled":true,"postgres_uri":"postgres://postgres@localhost:5432/postgres", ......}
```