### PR TITLE
[telemetry-service] use common names for chain full node mapping

### DIFF
--- a/crates/aptos-telemetry-service/src/context.rs
+++ b/crates/aptos-telemetry-service/src/context.rs
@@ -148,7 +148,6 @@ pub struct Context {
     noise_config: Arc<noise::NoiseConfig>,
     peers: PeerStoreTuple,
     clients: ClientTuple,
-    chain_set: HashSet<ChainId>,
     jwt_service: JsonWebTokenService,
     log_env_map: HashMap<ChainId, HashMap<PeerId, String>>,
     peer_identities: HashMap<ChainId, HashMap<PeerId, String>>,
@@ -159,7 +158,6 @@ impl Context {
         private_key: x25519::PrivateKey,
         peers: PeerStoreTuple,
         clients: ClientTuple,
-        chain_set: HashSet<ChainId>,
         jwt_service: JsonWebTokenService,
         log_env_map: HashMap<ChainId, HashMap<PeerId, String>>,
         peer_identities: HashMap<ChainId, HashMap<PeerId, String>>,
@@ -168,7 +166,6 @@ impl Context {
             noise_config: Arc::new(noise::NoiseConfig::new(private_key)),
             peers,
             clients,
-            chain_set,
             jwt_service,
             log_env_map,
             peer_identities,
@@ -212,13 +209,8 @@ impl Context {
         &self.peer_identities
     }
 
-    pub fn chain_set(&self) -> &HashSet<ChainId> {
-        &self.chain_set
-    }
-
-    #[cfg(test)]
-    pub fn chain_set_mut(&mut self) -> &mut HashSet<ChainId> {
-        &mut self.chain_set
+    pub fn chain_set(&self) -> HashSet<ChainId> {
+        self.peers.validators.read().keys().cloned().collect()
     }
 
     pub fn log_env_map(&self) -> &HashMap<ChainId, HashMap<PeerId, String>> {

--- a/crates/aptos-telemetry-service/src/errors.rs
+++ b/crates/aptos-telemetry-service/src/errors.rs
@@ -111,8 +111,6 @@ pub(crate) enum ValidatorCacheUpdateError {
     InvalidUrl,
     #[error("request error")]
     RestError(#[source] RestError),
-    #[error("chain id mismatch")]
-    ChainIdMismatch,
     #[error("both peer set empty")]
     BothPeerSetEmpty,
     #[error("validator set empty")]

--- a/crates/aptos-telemetry-service/src/lib.rs
+++ b/crates/aptos-telemetry-service/src/lib.rs
@@ -19,6 +19,7 @@ use std::{
     collections::HashMap, convert::Infallible, env, fs::File, io::Read, net::SocketAddr,
     path::PathBuf, sync::Arc, time::Duration,
 };
+use types::common::ChainCommonName;
 use warp::{Filter, Reply};
 
 mod auth;
@@ -102,11 +103,6 @@ impl AptosTelemetryServiceArgs {
         let validators = Arc::new(aptos_infallible::RwLock::new(HashMap::new()));
         let validator_fullnodes = Arc::new(aptos_infallible::RwLock::new(HashMap::new()));
         let public_fullnodes = config.pfn_allowlist.clone();
-        let chain_set = config
-            .trusted_full_node_addresses
-            .iter()
-            .map(|pair| pair.0.to_owned())
-            .collect();
 
         let context = Context::new(
             server_private_key,
@@ -120,7 +116,6 @@ impl AptosTelemetryServiceArgs {
                 Some(metrics_clients),
                 Some(humio_client),
             ),
-            chain_set,
             jwt_service,
             config.log_env_map.clone(),
             config.peer_identities.clone(),
@@ -241,7 +236,7 @@ pub struct TelemetryServiceConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls_key_path: Option<String>,
 
-    pub trusted_full_node_addresses: HashMap<ChainId, String>,
+    pub trusted_full_node_addresses: HashMap<ChainCommonName, String>,
     pub update_interval: u64,
     pub pfn_allowlist: HashMap<ChainId, HashMap<PeerId, x25519::PublicKey>>,
 

--- a/crates/aptos-telemetry-service/src/tests/auth_test.rs
+++ b/crates/aptos-telemetry-service/src/tests/auth_test.rs
@@ -244,10 +244,15 @@ async fn test_auth_wrong_key() {
 
 #[tokio::test]
 async fn test_chain_access() {
-    let mut context = new_test_context().await;
+    let context = new_test_context().await;
     let present_chain_id = ChainId::new(24);
     let missing_chain_id = ChainId::new(32);
-    context.inner.chain_set_mut().insert(present_chain_id);
+    context
+        .inner
+        .peers()
+        .validators()
+        .write()
+        .insert(present_chain_id, (1, PeerSet::new()));
 
     let resp = context
         .get(&format!("/api/v1/chain-access/{}", present_chain_id))

--- a/crates/aptos-telemetry-service/src/tests/test_context.rs
+++ b/crates/aptos-telemetry-service/src/tests/test_context.rs
@@ -10,7 +10,7 @@ use aptos_rest_client::aptos_api_types::mime_types;
 use rand::SeedableRng;
 use reqwest::header::AUTHORIZATION;
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use warp::{
     http::{header::CONTENT_TYPE, Response},
     hyper::body::Bytes,
@@ -47,7 +47,6 @@ pub async fn new_test_context() -> TestContext {
             server_private_key,
             peers,
             ClientTuple::new(None, Some(GroupedMetricsClients::new_empty()), None),
-            HashSet::new(),
             jwt_service,
             HashMap::new(),
             HashMap::new(),

--- a/crates/aptos-telemetry-service/src/types/mod.rs
+++ b/crates/aptos-telemetry-service/src/types/mod.rs
@@ -15,6 +15,7 @@ pub mod common {
     pub type EpochNum = u64;
     pub type EpochedPeerStore = HashMap<ChainId, (EpochNum, PeerSet)>;
     pub type PeerStore = HashMap<ChainId, PeerSet>;
+    pub type ChainCommonName = String;
 
     #[derive(Debug, Serialize, Deserialize, Clone)]
     pub struct EventIdentity {

--- a/crates/aptos-telemetry-service/src/validator_cache.rs
+++ b/crates/aptos-telemetry-service/src/validator_cache.rs
@@ -5,7 +5,7 @@ use crate::{
     debug, error,
     errors::ValidatorCacheUpdateError,
     metrics::{VALIDATOR_SET_UPDATE_FAILED_COUNT, VALIDATOR_SET_UPDATE_SUCCESS_COUNT},
-    types::common::EpochedPeerStore,
+    types::common::{ChainCommonName, EpochedPeerStore},
 };
 use aptos_config::config::{Peer, PeerRole, PeerSet};
 use aptos_infallible::RwLock;
@@ -22,7 +22,7 @@ pub struct PeerSetCacheUpdater {
     validators: Arc<RwLock<EpochedPeerStore>>,
     validator_fullnodes: Arc<RwLock<EpochedPeerStore>>,
 
-    query_addresses: Arc<HashMap<ChainId, String>>,
+    query_addresses: Arc<HashMap<ChainCommonName, String>>,
     update_interval: time::Duration,
 }
 
@@ -30,7 +30,7 @@ impl PeerSetCacheUpdater {
     pub fn new(
         validators: Arc<RwLock<EpochedPeerStore>>,
         validator_fullnodes: Arc<RwLock<EpochedPeerStore>>,
-        trusted_full_node_addresses: HashMap<ChainId, String>,
+        trusted_full_node_addresses: HashMap<ChainCommonName, String>,
         update_interval: Duration,
     ) -> Self {
         Self {
@@ -52,21 +52,24 @@ impl PeerSetCacheUpdater {
     }
 
     async fn update(&self) {
-        for (chain_id, url) in self.query_addresses.iter() {
-            match self.update_for_chain(chain_id, url).await {
+        for (chain_name, url) in self.query_addresses.iter() {
+            match self.update_for_chain(chain_name, url).await {
                 Ok(_) => {
                     VALIDATOR_SET_UPDATE_SUCCESS_COUNT
-                        .with_label_values(&[&chain_id.to_string()])
+                        .with_label_values(&[&chain_name.to_string()])
                         .inc();
-                    debug!("validator set update successful for chain id {}", chain_id);
+                    debug!(
+                        "validator set update successful for chain name {}",
+                        chain_name
+                    );
                 },
                 Err(err) => {
                     VALIDATOR_SET_UPDATE_FAILED_COUNT
-                        .with_label_values(&[&chain_id.to_string(), &err.to_string()])
+                        .with_label_values(&[&chain_name.to_string(), &err.to_string()])
                         .inc();
                     error!(
-                        "validator set update error for chain id {}: {:?}",
-                        chain_id, err
+                        "validator set update error for chain name {}: {:?}",
+                        chain_name, err
                     );
                 },
             }
@@ -75,11 +78,11 @@ impl PeerSetCacheUpdater {
 
     async fn update_for_chain(
         &self,
-        chain_id: &ChainId,
-        url: &String,
+        chain_name: &ChainCommonName,
+        url: &str,
     ) -> Result<(), ValidatorCacheUpdateError> {
         let client = aptos_rest_client::Client::new(Url::parse(url).map_err(|e| {
-            error!("invalid url for chain_id {}: {}", chain_id, e);
+            error!("invalid url for chain_id {}: {}", chain_name, e);
             ValidatorCacheUpdateError::InvalidUrl
         })?);
         let response: Response<ValidatorSet> = client
@@ -89,14 +92,7 @@ impl PeerSetCacheUpdater {
 
         let (peer_addrs, state) = response.into_parts();
 
-        let received_chain_id = ChainId::new(state.chain_id);
-        if received_chain_id != *chain_id {
-            error!(
-                "Chain Id mismatch: Received in headers: {}. Provided in configuration: {} for {}",
-                received_chain_id, chain_id, url
-            );
-            return Err(ValidatorCacheUpdateError::ChainIdMismatch);
-        }
+        let chain_id = ChainId::new(state.chain_id);
 
         let mut validator_cache = self.validators.write();
         let mut vfn_cache = self.validator_fullnodes.write();
@@ -116,8 +112,8 @@ impl PeerSetCacheUpdater {
                     })
                     .map_err(|err| {
                         error!(
-                            "unable to parse validator network address for validator info {} for chain id {}: {}",
-                            validator_info, chain_id, err
+                            "unable to parse validator network address for validator info {} for chain name {}: {}",
+                            validator_info, chain_name, err
                         )
                     })
                     .ok()
@@ -138,8 +134,8 @@ impl PeerSetCacheUpdater {
                     })
                     .map_err(|err| {
                         error!(
-                            "unable to parse fullnode network address for validator info {} in chain id {}: {}",
-                            validator_info, chain_id, err
+                            "unable to parse fullnode network address for validator info {} in chain name {}: {}",
+                            validator_info, chain_name, err
                         );
                     })
                     .ok()
@@ -147,8 +143,8 @@ impl PeerSetCacheUpdater {
             .collect();
 
         debug!(
-            "Validator peers for chain id {} at epoch {}: {:?}",
-            chain_id, state.epoch, validator_peers
+            "Validator peers for chain name {} (chain id {}) at epoch {}: {:?}",
+            chain_name, chain_id, state.epoch, validator_peers
         );
 
         let result = if validator_peers.is_empty() && vfn_peers.is_empty() {
@@ -162,16 +158,16 @@ impl PeerSetCacheUpdater {
         };
 
         if !validator_peers.is_empty() {
-            validator_cache.insert(*chain_id, (state.epoch, validator_peers));
+            validator_cache.insert(chain_id, (state.epoch, validator_peers));
         }
 
         debug!(
-            "Validator fullnode peers for chain id {} at epoch {}: {:?}",
-            chain_id, state.epoch, vfn_peers
+            "Validator fullnode peers for chain name {} (chain id {}) at epoch {}: {:?}",
+            chain_name, chain_id, state.epoch, vfn_peers
         );
 
         if !vfn_peers.is_empty() {
-            vfn_cache.insert(*chain_id, (state.epoch, vfn_peers));
+            vfn_cache.insert(chain_id, (state.epoch, vfn_peers));
         }
 
         result
@@ -223,7 +219,7 @@ mod tests {
         });
 
         let mut fullnodes = HashMap::new();
-        fullnodes.insert(ChainId::new(25), server.base_url());
+        fullnodes.insert("testing".into(), server.base_url());
 
         let updater = PeerSetCacheUpdater::new(
             Arc::new(RwLock::new(HashMap::new())),
@@ -271,7 +267,7 @@ mod tests {
         });
 
         let mut fullnodes = HashMap::new();
-        fullnodes.insert(ChainId::new(25), server.base_url());
+        fullnodes.insert("testing".into(), server.base_url());
 
         let updater = PeerSetCacheUpdater::new(
             Arc::new(RwLock::new(HashMap::new())),


### PR DESCRIPTION
### Description

Currently, telemetry service config `trusted_full_node_addresses` maps chain ID as key to full node address and asserts that the chain ID provided by the node matches the key. This causes friction for devnet releases because its chain ID changes for each release and increasing deployment burden.

Instead, this PR changes the mapping such that it maps common chain name (e.g. devnet, mainnet, testnet) to full node address and trusts the chain ID provided by the full node. We already trust the full node's validator set, so we can also trust it for the chain ID.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Existing tests.
