### PR TITLE
add e2e dapp tutorial to top menu

### DIFF
--- a/developer-docs-site/docusaurus.config.js
+++ b/developer-docs-site/docusaurus.config.js
@@ -156,6 +156,11 @@ const config = {
                 label: "Integrate with Wallets",
                 docId: "concepts/wallet-adapter-concept",
               },
+              {
+                type: "doc",
+                label: "Build E2E Dapp on Aptos",
+                docId: "tutorials/build-e2e-dapp/index",
+              },
             ],
           },
           {


### PR DESCRIPTION
### Description
This PR adds the new "Build E2E Dapp on Aptos" tutorial to the top nav menu under "Build Apps"

