### PR TITLE
[build-info][bugfix] trigger shadow-rs on git ref change

### DIFF
--- a/crates/aptos-build-info/build.rs
+++ b/crates/aptos-build-info/build.rs
@@ -8,8 +8,7 @@ fn main() -> shadow_rs::SdResult<()> {
         "cargo:rustc-env=USING_TOKIO_UNSTABLE={}",
         std::env::var("CARGO_CFG_TOKIO_UNSTABLE").is_ok()
     );
-    println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
     shadow_rs::new()
 }


### PR DESCRIPTION
### Description

With #6348 , `aptos-build-info` ended up compiling with every change, increasing build times by recompiling the crate and a long list of dependencies, even if git reference did not change. The change did not actually trigger with changes to `.git/HEAD` changes because the `rerun-if-changed` path is relative to where `build.rs` is located. Moreover, the `cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH` does not seem useful.

This PR fixes the path so that `rerun-if-changed` is triggered properly. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Made sure the crate only compiles when `.git/HEAD` is touched.
