### PR TITLE
[telemetry-svc] Ability to identify nodes with duplicate identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,6 +2482,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "uuid",
  "warp",
 ]
 

--- a/crates/aptos-telemetry-service/Cargo.toml
+++ b/crates/aptos-telemetry-service/Cargo.toml
@@ -47,6 +47,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+uuid = { workspace = true }
 warp = { workspace = true }
 
 [dev-dependencies]

--- a/crates/aptos-telemetry-service/src/auth.rs
+++ b/crates/aptos-telemetry-service/src/auth.rs
@@ -140,6 +140,7 @@ pub async fn handle_auth(context: Context, body: AuthRequest) -> Result<impl Rep
         body.peer_id,
         node_type,
         epoch,
+        body.run_uuid,
     )
     .map_err(|e| {
         error!("unable to create jwt token: {}", e);

--- a/crates/aptos-telemetry-service/src/clients/humio.rs
+++ b/crates/aptos-telemetry-service/src/clients/humio.rs
@@ -12,6 +12,7 @@ pub const PEER_ID_FIELD_NAME: &str = "peer_id";
 pub const EPOCH_FIELD_NAME: &str = "epoch";
 pub const PEER_ROLE_TAG_NAME: &str = "peer_role";
 pub const CHAIN_ID_TAG_NAME: &str = "chain_id";
+pub const RUN_UUID_TAG_NAME: &str = "run_uuid";
 
 #[derive(Clone)]
 pub struct IngestClient {

--- a/crates/aptos-telemetry-service/src/jwt_auth.rs
+++ b/crates/aptos-telemetry-service/src/jwt_auth.rs
@@ -10,6 +10,7 @@ use crate::{
 use aptos_types::{chain_id::ChainId, PeerId};
 use chrono::Utc;
 use jsonwebtoken::{errors::Error, TokenData};
+use uuid::Uuid;
 use warp::{reject, Rejection};
 
 const BEARER: &str = "BEARER ";
@@ -20,6 +21,7 @@ pub fn create_jwt_token(
     peer_id: PeerId,
     node_type: NodeType,
     epoch: u64,
+    uuid: Uuid,
 ) -> Result<String, Error> {
     let issued = Utc::now().timestamp();
     let expiration = Utc::now()
@@ -34,6 +36,7 @@ pub fn create_jwt_token(
         epoch,
         exp: expiration as usize,
         iat: issued as usize,
+        run_uuid: uuid,
     };
     jwt_service.encode(claims)
 }
@@ -160,6 +163,7 @@ mod tests {
             PeerId::random(),
             NodeType::Validator,
             10,
+            Uuid::default(),
         )
         .unwrap();
         let result =
@@ -172,6 +176,7 @@ mod tests {
             PeerId::random(),
             NodeType::ValidatorFullNode,
             10,
+            Uuid::default(),
         )
         .unwrap();
         let result = authorize_jwt(token, test_context.inner, vec![NodeType::Validator]).await;

--- a/crates/aptos-telemetry-service/src/log_ingest.rs
+++ b/crates/aptos-telemetry-service/src/log_ingest.rs
@@ -3,7 +3,10 @@
 
 use crate::{
     auth::with_auth,
-    clients::humio::{CHAIN_ID_TAG_NAME, EPOCH_FIELD_NAME, PEER_ID_FIELD_NAME, PEER_ROLE_TAG_NAME},
+    clients::humio::{
+        CHAIN_ID_TAG_NAME, EPOCH_FIELD_NAME, PEER_ID_FIELD_NAME, PEER_ROLE_TAG_NAME,
+        RUN_UUID_TAG_NAME,
+    },
     constants::MAX_CONTENT_LENGTH,
     context::Context,
     debug, error,
@@ -72,6 +75,7 @@ pub async fn handle_log_ingest(
     };
     tags.insert(CHAIN_ID_TAG_NAME.into(), chain_name);
     tags.insert(PEER_ROLE_TAG_NAME.into(), claims.node_type.to_string());
+    tags.insert(RUN_UUID_TAG_NAME.into(), claims.run_uuid.to_string());
 
     let unstructured_log = UnstructuredLog {
         fields,

--- a/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
+++ b/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
@@ -138,6 +138,7 @@ fn claims_to_extra_labels(claims: &Claims, common_name: Option<&String>) -> Vec<
         chain_name,
         format!("namespace={}", "telemetry-service"),
         pod_name,
+        format!("run_uuid={}", claims.run_uuid),
     ]
 }
 
@@ -149,6 +150,7 @@ mod test {
     use httpmock::MockServer;
     use reqwest::Url;
     use std::str::FromStr;
+    use uuid::Uuid;
 
     #[test]
     fn verify_labels() {
@@ -160,6 +162,7 @@ mod test {
                 epoch: 3,
                 exp: 123,
                 iat: 123,
+                run_uuid: Uuid::default(),
             },
             Some(&String::from("test_name")),
         );
@@ -169,7 +172,10 @@ mod test {
             "chain_name=25",
             "namespace=telemetry-service",
             "kubernetes_pod_name=peer_id:test_name//0x1",
+            &format!("run_uuid={}", Uuid::default()),
         ]);
+
+        let test_uuid = Uuid::new_v4();
 
         let claims = claims_to_extra_labels(
             &super::Claims {
@@ -179,6 +185,7 @@ mod test {
                 epoch: 3,
                 exp: 123,
                 iat: 123,
+                run_uuid: test_uuid,
             },
             None,
         );
@@ -188,6 +195,7 @@ mod test {
             "chain_name=25",
             "namespace=telemetry-service",
             "kubernetes_pod_name=peer_id:0x1",
+            &format!("run_uuid={}", test_uuid),
         ]);
     }
 

--- a/crates/aptos-telemetry-service/src/remote_config.rs
+++ b/crates/aptos-telemetry-service/src/remote_config.rs
@@ -39,6 +39,7 @@ mod tests {
     use aptos_config::config::PeerSet;
     use aptos_types::{chain_id::ChainId, PeerId};
     use std::collections::HashMap;
+    use uuid::Uuid;
 
     #[tokio::test]
     async fn test_handle_telemetry_log_env() {
@@ -67,6 +68,7 @@ mod tests {
             peer_id,
             node_type,
             epoch,
+            Uuid::default(),
         )
         .unwrap();
 

--- a/crates/aptos-telemetry-service/src/tests/auth_test.rs
+++ b/crates/aptos-telemetry-service/src/tests/auth_test.rs
@@ -25,6 +25,7 @@ use aptos_types::{
     PeerId,
 };
 use serde_json::json;
+use uuid::Uuid;
 
 fn init(
     peer_role: PeerRole,
@@ -34,6 +35,7 @@ fn init(
     ChainId,
     PeerId,
     std::collections::HashMap<PeerId, Peer>,
+    Uuid,
 ) {
     let mut rng = rand::thread_rng();
     let initiator_static = x25519::PrivateKey::generate(&mut rng);
@@ -52,7 +54,9 @@ fn init(
     let mut peer_set = PeerSet::new();
     peer_set.insert(peer_id, peer);
 
-    (rng, initiator, chain_id, peer_id, peer_set)
+    let uuid = Uuid::new_v4();
+
+    (rng, initiator, chain_id, peer_id, peer_set, uuid)
 }
 
 fn init_handshake(
@@ -106,11 +110,11 @@ fn finish_handshake(
 }
 
 #[tokio::test]
-async fn test_auth_validator() {
+async fn test_auth_validator_backwards_compat_uuid() {
     let context = new_test_context().await;
     let server_public_key = context.inner.noise_config().public_key();
 
-    let (mut rng, initiator, chain_id, peer_id, peer_set) = init(PeerRole::Validator);
+    let (mut rng, initiator, chain_id, peer_id, peer_set, _) = init(PeerRole::Validator);
 
     context
         .inner
@@ -144,7 +148,53 @@ async fn test_auth_validator() {
         node_type: NodeType::Validator,
         epoch: 1,
         exp: decoded.claims.exp,
-        iat: decoded.claims.iat
+        iat: decoded.claims.iat,
+        run_uuid: Uuid::default(),
+    },)
+}
+
+#[tokio::test]
+async fn test_auth_validator() {
+    let context = new_test_context().await;
+    let server_public_key = context.inner.noise_config().public_key();
+
+    let (mut rng, initiator, chain_id, peer_id, peer_set, run_uuid) = init(PeerRole::Validator);
+
+    context
+        .inner
+        .peers()
+        .validators()
+        .write()
+        .insert(chain_id, (1, peer_set));
+
+    let (initiator_state, client_noise_msg) =
+        init_handshake(&mut rng, chain_id, peer_id, server_public_key, &initiator);
+
+    let req = json!({
+        "chain_id": chain_id,
+        "peer_id": peer_id,
+        "role_type": RoleType::Validator,
+        "server_public_key": server_public_key,
+        "handshake_msg": &client_noise_msg,
+        "run_uuid": run_uuid,
+    });
+    let resp = context.post("/api/v1/auth", req).await;
+
+    let decoded = finish_handshake(
+        context.inner.jwt_service(),
+        &initiator,
+        initiator_state,
+        resp,
+    );
+
+    assert_eq!(decoded.claims, Claims {
+        chain_id,
+        peer_id,
+        node_type: NodeType::Validator,
+        epoch: 1,
+        exp: decoded.claims.exp,
+        iat: decoded.claims.iat,
+        run_uuid,
     },)
 }
 
@@ -153,7 +203,8 @@ async fn test_auth_validatorfullnode() {
     let context = new_test_context().await;
     let server_public_key = context.inner.noise_config().public_key();
 
-    let (mut rng, initiator, chain_id, peer_id, peer_set) = init(PeerRole::ValidatorFullNode);
+    let (mut rng, initiator, chain_id, peer_id, peer_set, run_uuid) =
+        init(PeerRole::ValidatorFullNode);
 
     context
         .inner
@@ -171,6 +222,7 @@ async fn test_auth_validatorfullnode() {
         "role_type": RoleType::FullNode,
         "server_public_key": server_public_key,
         "handshake_msg": &client_noise_msg,
+        "run_uuid": run_uuid,
     });
     let resp = context.post("/api/v1/auth", req).await;
 
@@ -187,7 +239,8 @@ async fn test_auth_validatorfullnode() {
         node_type: NodeType::ValidatorFullNode,
         epoch: 1,
         exp: decoded.claims.exp,
-        iat: decoded.claims.iat
+        iat: decoded.claims.iat,
+        run_uuid
     },)
 }
 

--- a/crates/aptos-telemetry-service/src/tests/custom_event.rs
+++ b/crates/aptos-telemetry-service/src/tests/custom_event.rs
@@ -14,6 +14,7 @@ use aptos_types::{chain_id::ChainId, PeerId};
 use chrono::Utc;
 use serde_json::json;
 use std::collections::BTreeMap;
+use uuid::Uuid;
 
 #[tokio::test]
 async fn test_custom_event() {
@@ -21,6 +22,7 @@ async fn test_custom_event() {
     let chain_id = ChainId::new(28);
     let peer_id = PeerId::random();
     let node_type = NodeType::Validator;
+    let uuid = Uuid::new_v4();
     let epoch = 10;
 
     test_context
@@ -36,6 +38,7 @@ async fn test_custom_event() {
         peer_id,
         node_type,
         epoch,
+        uuid,
     )
     .unwrap();
 

--- a/crates/aptos-telemetry-service/src/types/auth.rs
+++ b/crates/aptos-telemetry-service/src/types/auth.rs
@@ -6,6 +6,7 @@ use aptos_config::config::RoleType;
 use aptos_crypto::x25519;
 use aptos_types::{chain_id::ChainId, PeerId};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AuthRequest {
@@ -15,6 +16,8 @@ pub struct AuthRequest {
     pub role_type: RoleType,
     pub server_public_key: x25519::PublicKey,
     pub handshake_msg: Vec<u8>,
+    #[serde(default = "default_uuid")]
+    pub run_uuid: Uuid,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -30,10 +33,15 @@ pub struct Claims {
     pub epoch: u64,
     pub exp: usize,
     pub iat: usize,
+    pub run_uuid: Uuid,
 }
 
 fn default_role_type() -> RoleType {
     RoleType::Validator
+}
+
+fn default_uuid() -> Uuid {
+    Uuid::default()
 }
 
 impl Claims {
@@ -51,6 +59,7 @@ impl Claims {
                 .checked_add_signed(Duration::seconds(3600))
                 .unwrap()
                 .timestamp() as usize,
+            run_uuid: Uuid::default(),
         }
     }
 }

--- a/crates/aptos-telemetry-service/src/types/mod.rs
+++ b/crates/aptos-telemetry-service/src/types/mod.rs
@@ -11,6 +11,7 @@ pub mod common {
     use aptos_types::{chain_id::ChainId, PeerId};
     use serde::{Deserialize, Serialize};
     use std::{collections::HashMap, fmt};
+    use uuid::Uuid;
 
     pub type EpochNum = u64;
     pub type EpochedPeerStore = HashMap<ChainId, (EpochNum, PeerSet)>;
@@ -23,6 +24,7 @@ pub mod common {
         pub chain_id: ChainId,
         pub role_type: NodeType,
         pub epoch: u64,
+        pub uuid: Uuid,
     }
 
     impl From<Claims> for EventIdentity {
@@ -32,6 +34,7 @@ pub mod common {
                 chain_id: claims.chain_id,
                 role_type: claims.node_type,
                 epoch: claims.epoch,
+                uuid: claims.run_uuid,
             }
         }
     }

--- a/crates/aptos-telemetry/src/sender.rs
+++ b/crates/aptos-telemetry/src/sender.rs
@@ -22,6 +22,7 @@ use reqwest::{header::CONTENT_ENCODING, Response, StatusCode, Url};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, RequestBuilder};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use std::{io::Write, sync::Arc};
+use uuid::Uuid;
 
 pub const DEFAULT_VERSION_PATH_BASE: &str = "api/v1/";
 
@@ -50,6 +51,7 @@ pub(crate) struct TelemetrySender {
     role_type: RoleType,
     client: ClientWithMiddleware,
     auth_context: Arc<AuthContext>,
+    uuid: Uuid,
 }
 
 impl TelemetrySender {
@@ -80,6 +82,7 @@ impl TelemetrySender {
             role_type: node_config.base.role,
             client,
             auth_context: Arc::new(AuthContext::new(node_config)),
+            uuid: uuid::Uuid::new_v4(),
         }
     }
 
@@ -313,6 +316,7 @@ impl TelemetrySender {
             role_type: self.role_type,
             server_public_key,
             handshake_msg: client_noise_msg,
+            run_uuid: self.uuid,
         };
 
         let response = self


### PR DESCRIPTION
### Description

This PR adds support to identify multiple (concurrent) runs of aptos-node with the same identity config (i.e. peer id, chain, etc). It is accomplished by generating a UUID every time a node boots up and using that UUID as part of authentication with the telemetry service. The telemetry service will include embed UUID into logs, events, and metrics so it is easily accessible.

Backwards Compatibility: A nil UUID will be generated at the telemetry service to maintain backwards compatibility until all nodes are upgraded.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Existing tests.
