### PR TITLE
[gha] pin setup-buildx-action to v2.4.0

### DIFF
--- a/.github/actions/docker-buildx-setup/action.yaml
+++ b/.github/actions/docker-buildx-setup/action.yaml
@@ -8,7 +8,7 @@ runs:
       shell: bash
       run: docker context create builders
     - name: setup docker buildx
-      uses: docker/setup-buildx-action@a024221c6058476635d42c4083d4e65a69e1a770 # pin fix 191
+      uses: docker/setup-buildx-action@15c905b16b06416d2086efa066dd8e3a35cc7f98 # pin v2.4.0
       with:
         endpoint: builders
         version: v0.8.2


### PR DESCRIPTION
### Description

Following incident and discussion from last week. Synced from upstream https://github.com/docker/setup-buildx-action/issues/190#issuecomment-1408660839

NOTE: this will soon be migrated out of this repo to: https://github.com/aptos-labs/actions/pull/1

### Test Plan

Docker build works

<!-- Please provide us with clear details for verifying that your changes work. -->
