### PR TITLE
[telemetry-svc] Ingest metrics from unknown nodes

### DIFF
--- a/crates/aptos-telemetry-service/src/auth.rs
+++ b/crates/aptos-telemetry-service/src/auth.rs
@@ -116,18 +116,21 @@ pub async fn handle_auth(context: Context, body: AuthRequest) -> Result<impl Rep
     let node_type = match peer_role {
         PeerRole::Validator => NodeType::Validator,
         PeerRole::ValidatorFullNode => NodeType::ValidatorFullNode,
-        PeerRole::Unknown => context
-            .peers()
-            .public_fullnodes()
-            .get(&body.chain_id)
-            .map(|peer_set| {
-                if peer_set.contains_key(&body.peer_id) {
-                    NodeType::PublicFullNode
-                } else {
-                    NodeType::Unknown
-                }
-            })
-            .unwrap_or(NodeType::Unknown),
+        PeerRole::Unknown => match body.role_type {
+            RoleType::Validator => NodeType::UnknownValidator,
+            RoleType::FullNode => context
+                .peers()
+                .public_fullnodes()
+                .get(&body.chain_id)
+                .and_then(|peer_set| {
+                    if peer_set.contains_key(&body.peer_id) {
+                        Some(NodeType::PublicFullNode)
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(NodeType::UnknownFullNode),
+        },
         _ => NodeType::Unknown,
     };
 

--- a/crates/aptos-telemetry-service/src/context.rs
+++ b/crates/aptos-telemetry-service/src/context.rs
@@ -21,20 +21,25 @@ use std::{
 };
 use warp::Filter;
 
+/// Container that holds various metric clients used for sending metrics from
+/// various sources to appropriate backends.
 #[derive(Clone, Default)]
 pub struct GroupedMetricsClients {
-    pub telemetry_service_metrics: HashMap<String, MetricsClient>,
-    pub ingest_metrics: HashMap<String, MetricsClient>,
-    pub unclassified_ingest_metrics: HashMap<String, MetricsClient>,
+    /// Client(s) for exporting metrics of the running telemetry service
+    pub telemetry_service_metrics_clients: HashMap<String, MetricsClient>,
+    /// Clients for sending metrics from authenticated known nodes
+    pub ingest_metrics_client: HashMap<String, MetricsClient>,
+    /// Clients for sending metrics from authenticated unknown nodes
+    pub untrusted_ingest_metrics_clients: HashMap<String, MetricsClient>,
 }
 
 impl GroupedMetricsClients {
     #[cfg(test)]
     pub fn new_empty() -> Self {
         Self {
-            telemetry_service_metrics: HashMap::new(),
-            ingest_metrics: HashMap::new(),
-            unclassified_ingest_metrics: HashMap::new(),
+            telemetry_service_metrics_clients: HashMap::new(),
+            ingest_metrics_client: HashMap::new(),
+            untrusted_ingest_metrics_clients: HashMap::new(),
         }
     }
 }
@@ -42,9 +47,9 @@ impl GroupedMetricsClients {
 impl From<MetricsEndpointsConfig> for GroupedMetricsClients {
     fn from(config: MetricsEndpointsConfig) -> GroupedMetricsClients {
         GroupedMetricsClients {
-            telemetry_service_metrics: config.telemetry_service_metrics.make_client(),
-            ingest_metrics: config.ingest_metrics.make_client(),
-            unclassified_ingest_metrics: config.untrusted_ingest_metrics.make_client(),
+            telemetry_service_metrics_clients: config.telemetry_service_metrics.make_client(),
+            ingest_metrics_client: config.ingest_metrics.make_client(),
+            untrusted_ingest_metrics_clients: config.untrusted_ingest_metrics.make_client(),
         }
     }
 }

--- a/crates/aptos-telemetry-service/src/context.rs
+++ b/crates/aptos-telemetry-service/src/context.rs
@@ -7,6 +7,7 @@ use crate::{
         victoria_metrics_api::Client as MetricsClient,
     },
     types::common::EpochedPeerStore,
+    MetricsEndpointsConfig,
 };
 use aptos_crypto::{noise, x25519};
 use aptos_infallible::RwLock;
@@ -14,11 +15,39 @@ use aptos_types::{chain_id::ChainId, PeerId};
 use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, TokenData, Validation};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     convert::Infallible,
     sync::Arc,
 };
 use warp::Filter;
+
+#[derive(Clone, Default)]
+pub struct GroupedMetricsClients {
+    pub telemetry_service_metrics: HashMap<String, MetricsClient>,
+    pub ingest_metrics: HashMap<String, MetricsClient>,
+    pub unclassified_ingest_metrics: HashMap<String, MetricsClient>,
+}
+
+impl GroupedMetricsClients {
+    #[cfg(test)]
+    pub fn new_empty() -> Self {
+        Self {
+            telemetry_service_metrics: HashMap::new(),
+            ingest_metrics: HashMap::new(),
+            unclassified_ingest_metrics: HashMap::new(),
+        }
+    }
+}
+
+impl From<MetricsEndpointsConfig> for GroupedMetricsClients {
+    fn from(config: MetricsEndpointsConfig) -> GroupedMetricsClients {
+        GroupedMetricsClients {
+            telemetry_service_metrics: config.telemetry_service_metrics.make_client(),
+            ingest_metrics: config.ingest_metrics.make_client(),
+            unclassified_ingest_metrics: config.untrusted_ingest_metrics.make_client(),
+        }
+    }
+}
 
 #[derive(Clone, Default)]
 pub struct PeerStoreTuple {
@@ -56,14 +85,14 @@ impl PeerStoreTuple {
 #[derive(Clone)]
 pub struct ClientTuple {
     bigquery_client: Option<TableWriteClient>,
-    victoria_metrics_clients: Option<BTreeMap<String, MetricsClient>>,
+    victoria_metrics_clients: Option<GroupedMetricsClients>,
     humio_client: Option<HumioClient>,
 }
 
 impl ClientTuple {
     pub(crate) fn new(
         bigquery_client: Option<TableWriteClient>,
-        victoria_metrics_clients: Option<BTreeMap<String, MetricsClient>>,
+        victoria_metrics_clients: Option<GroupedMetricsClients>,
         humio_client: Option<HumioClient>,
     ) -> ClientTuple {
         Self {
@@ -157,12 +186,12 @@ impl Context {
         &self.jwt_service
     }
 
-    pub fn metrics_client(&self) -> &BTreeMap<String, MetricsClient> {
+    pub fn metrics_client(&self) -> &GroupedMetricsClients {
         self.clients.victoria_metrics_clients.as_ref().unwrap()
     }
 
     #[cfg(test)]
-    pub fn metrics_client_mut(&mut self) -> &mut BTreeMap<String, MetricsClient> {
+    pub fn metrics_client_mut(&mut self) -> &mut GroupedMetricsClients {
         self.clients.victoria_metrics_clients.as_mut().unwrap()
     }
 

--- a/crates/aptos-telemetry-service/src/lib.rs
+++ b/crates/aptos-telemetry-service/src/lib.rs
@@ -81,7 +81,7 @@ impl AptosTelemetryServiceArgs {
         let metrics_clients: GroupedMetricsClients = config.metrics_endpoints_config.clone().into();
 
         let telemetry_metrics_client = metrics_clients
-            .telemetry_service_metrics
+            .telemetry_service_metrics_clients
             .values()
             .next()
             .cloned()
@@ -158,10 +158,13 @@ impl AptosTelemetryServiceArgs {
     }
 }
 
+/// Per metric endpoint configuration.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MetricsEndpoint {
+    /// Map of endpoint canonical name to Urls
     endpoint_urls: HashMap<String, Url>,
+    /// Environment variable that holds the secrets
     keys_env_var: String,
 }
 
@@ -208,6 +211,8 @@ impl MetricsEndpoint {
     }
 }
 
+/// Metrics endpoints configuration for metrics from
+/// different datasources.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MetricsEndpointsConfig {

--- a/crates/aptos-telemetry-service/src/lib.rs
+++ b/crates/aptos-telemetry-service/src/lib.rs
@@ -11,19 +11,13 @@ use crate::{
 use aptos_crypto::{x25519, ValidCryptoMaterialStringExt};
 use aptos_types::{chain_id::ChainId, PeerId};
 use clap::Parser;
+use context::GroupedMetricsClients;
 use gcp_bigquery_client::Client as BigQueryClient;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, HashMap},
-    convert::Infallible,
-    env,
-    fs::File,
-    io::Read,
-    net::SocketAddr,
-    path::PathBuf,
-    sync::Arc,
-    time::Duration,
+    collections::HashMap, convert::Infallible, env, fs::File, io::Read, net::SocketAddr,
+    path::PathBuf, sync::Arc, time::Duration,
 };
 use warp::{Filter, Reply};
 
@@ -84,33 +78,14 @@ impl AptosTelemetryServiceArgs {
             config.custom_event_config.table_id.clone(),
         );
 
-        let victoria_metrics_secrets: HashMap<String, String> = serde_json::from_str(
-            &env::var("VICTORIA_METRICS_AUTH_TOKEN")
-                .expect("environment variable VICTORIA_METRICS_AUTH_TOKEN must be set"),
-        )
-        .expect("environment variable VICTORIA_METRICS_AUTH_TOKEN must be a map of name to secret");
+        let metrics_clients: GroupedMetricsClients = config.metrics_endpoints_config.clone().into();
 
-        let victoria_metrics_clients: BTreeMap<String, MetricsClient> = config
-            .victoria_metrics_endpoints
-            .iter()
-            .map(|(name, url)| {
-                let secret = victoria_metrics_secrets.get(name).unwrap_or_else(|| {
-                    panic!(
-                        "environment variable VICTORIA_METRICS_AUTH_TOKEN is missing secret for {}",
-                        name
-                    )
-                });
-                (
-                    name.clone(),
-                    MetricsClient::new(
-                        Url::parse(url).unwrap_or_else(|e| {
-                            panic!("invalid metrics ingest endpoint URL for {}: {}", name, e)
-                        }),
-                        secret.clone(),
-                    ),
-                )
-            })
-            .collect();
+        let telemetry_metrics_client = metrics_clients
+            .telemetry_service_metrics
+            .values()
+            .next()
+            .cloned()
+            .unwrap();
 
         let humio_client = humio::IngestClient::new(
             Url::parse(&config.humio_url).expect("invalid Humio ingest endpoint URL"),
@@ -142,7 +117,7 @@ impl AptosTelemetryServiceArgs {
             ),
             ClientTuple::new(
                 Some(bigquery_client),
-                Some(victoria_metrics_clients),
+                Some(metrics_clients),
                 Some(humio_client),
             ),
             chain_set,
@@ -159,14 +134,7 @@ impl AptosTelemetryServiceArgs {
         )
         .run();
 
-        let metrics_exporter_client = MetricsClient::new(
-            Url::parse(&config.metrics_exporter_base_url)
-                .expect("base url must be provided for victoria metrics exporter url"),
-            env::var("METRICS_EXPORTER_AUTH_TOKEN")
-                .expect("environment variable METRICS_EXPORTER_AUTH_TOKEN must be set"),
-        );
-
-        PrometheusExporter::new(metrics_exporter_client).run();
+        PrometheusExporter::new(telemetry_metrics_client).run();
 
         Self::serve(&config, routes(context)).await;
     }
@@ -192,6 +160,75 @@ impl AptosTelemetryServiceArgs {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub struct MetricsEndpoint {
+    endpoint_urls: HashMap<String, Url>,
+    keys_env_var: String,
+}
+
+impl MetricsEndpoint {
+    #[cfg(test)]
+    fn default_for_test() -> Self {
+        Self {
+            endpoint_urls: HashMap::new(),
+            keys_env_var: "".into(),
+        }
+    }
+
+    fn make_client(&self) -> HashMap<String, MetricsClient> {
+        let secrets: HashMap<String, String> =
+            serde_json::from_str(&env::var(&self.keys_env_var).unwrap_or_else(|_| {
+                panic!(
+                    "environment variable {} must be set and be a map of endpoint names to token",
+                    self.keys_env_var.clone()
+                )
+            }))
+            .unwrap_or_else(|_| {
+                panic!(
+                    "environment variable {} must be a map of name to secret",
+                    self.keys_env_var
+                )
+            });
+
+        self.endpoint_urls
+            .iter()
+            .map(|(name, url)| {
+                let secret = secrets.get(name).unwrap_or_else(|| {
+                    panic!(
+                        "environment variable {} is missing secret for {}",
+                        self.keys_env_var.clone(),
+                        name,
+                    )
+                });
+                (
+                    name.clone(),
+                    MetricsClient::new(url.clone(), secret.clone()),
+                )
+            })
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsEndpointsConfig {
+    pub telemetry_service_metrics: MetricsEndpoint,
+    pub ingest_metrics: MetricsEndpoint,
+    pub untrusted_ingest_metrics: MetricsEndpoint,
+}
+
+impl MetricsEndpointsConfig {
+    #[cfg(test)]
+    fn default_for_test() -> Self {
+        Self {
+            telemetry_service_metrics: MetricsEndpoint::default_for_test(),
+            ingest_metrics: MetricsEndpoint::default_for_test(),
+            untrusted_ingest_metrics: MetricsEndpoint::default_for_test(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TelemetryServiceConfig {
     pub address: SocketAddr,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -204,13 +241,12 @@ pub struct TelemetryServiceConfig {
     pub pfn_allowlist: HashMap<ChainId, HashMap<PeerId, x25519::PublicKey>>,
 
     pub custom_event_config: CustomEventConfig,
-    pub victoria_metrics_endpoints:
-        HashMap<String /* endpoint name */, String /* endpoint Url */>,
-    pub metrics_exporter_base_url: String,
     pub humio_url: String,
 
     pub log_env_map: HashMap<ChainId, HashMap<PeerId, String>>,
     pub peer_identities: HashMap<ChainId, HashMap<PeerId, String>>,
+
+    pub metrics_endpoints_config: MetricsEndpointsConfig,
 }
 
 impl TelemetryServiceConfig {

--- a/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
+++ b/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
@@ -67,9 +67,9 @@ pub async fn handle_metrics_ingest(
 
     let client = match claims.node_type {
         NodeType::UnknownValidator | NodeType::UnknownFullNode => {
-            &context.metrics_client().unclassified_ingest_metrics
+            &context.metrics_client().untrusted_ingest_metrics_clients
         },
-        _ => &context.metrics_client().ingest_metrics,
+        _ => &context.metrics_client().ingest_metrics_client,
     };
 
     let start_timer = Instant::now();
@@ -227,11 +227,11 @@ mod test {
         });
 
         let clients = test_context.inner.metrics_client_mut();
-        clients.ingest_metrics.insert(
+        clients.ingest_metrics_client.insert(
             "default1".into(),
             MetricsClient::new(Url::parse(&server1.base_url()).unwrap(), "token1".into()),
         );
-        clients.ingest_metrics.insert(
+        clients.ingest_metrics_client.insert(
             "default2".into(),
             MetricsClient::new(Url::parse(&server2.base_url()).unwrap(), "token2".into()),
         );
@@ -263,11 +263,11 @@ mod test {
         });
 
         let clients = test_context.inner.metrics_client_mut();
-        clients.ingest_metrics.insert(
+        clients.ingest_metrics_client.insert(
             "default1".into(),
             MetricsClient::new(Url::parse(&server1.base_url()).unwrap(), "token1".into()),
         );
-        clients.ingest_metrics.insert(
+        clients.ingest_metrics_client.insert(
             "default2".into(),
             MetricsClient::new(Url::parse(&server2.base_url()).unwrap(), "token2".into()),
         );
@@ -299,11 +299,11 @@ mod test {
         });
 
         let clients = test_context.inner.metrics_client_mut();
-        clients.ingest_metrics.insert(
+        clients.ingest_metrics_client.insert(
             "default1".into(),
             MetricsClient::new(Url::parse(&server1.base_url()).unwrap(), "token1".into()),
         );
-        clients.ingest_metrics.insert(
+        clients.ingest_metrics_client.insert(
             "default2".into(),
             MetricsClient::new(Url::parse(&server2.base_url()).unwrap(), "token2".into()),
         );

--- a/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
+++ b/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
@@ -10,7 +10,6 @@ use crate::{
     metrics::METRICS_INGEST_BACKEND_REQUEST_DURATION,
     types::{auth::Claims, common::NodeType},
 };
-use aptos_types::chain_id::ChainId;
 use reqwest::{header::CONTENT_ENCODING, StatusCode};
 use tokio::time::Instant;
 use warp::{filters::BoxedFilter, hyper::body::Bytes, reject, reply, Filter, Rejection, Reply};
@@ -40,6 +39,8 @@ pub fn metrics_ingest(context: Context) -> BoxedFilter<(impl Reply,)> {
             NodeType::Validator,
             NodeType::ValidatorFullNode,
             NodeType::PublicFullNode,
+            NodeType::UnknownValidator,
+            NodeType::UnknownFullNode,
         ]))
         .and(warp::header::optional(CONTENT_ENCODING.as_str()))
         .and(warp::body::content_length_limit(MAX_CONTENT_LENGTH))
@@ -64,66 +65,61 @@ pub async fn handle_metrics_ingest(
             .and_then(|peers| peers.get(&claims.peer_id)),
     );
 
+    let client = match claims.node_type {
+        NodeType::UnknownValidator | NodeType::UnknownFullNode => {
+            &context.metrics_client().unclassified_ingest_metrics
+        },
+        _ => &context.metrics_client().ingest_metrics,
+    };
+
     let start_timer = Instant::now();
 
-    let filtered_clients = context.metrics_client().iter().filter(|(name, _)| {
-        if claims.chain_id.id() == 3 {
-            return true;
-        } else if claims.chain_id == ChainId::mainnet() {
-            return !name.starts_with("default");
-        }
-        name.starts_with("default")
-    });
+    let post_futures = client.iter().map(|(name, client)| async {
+        let result = client
+            .post_prometheus_metrics(
+                metrics_body.clone(),
+                extra_labels.clone(),
+                encoding.clone().unwrap_or_default(),
+            )
+            .await;
 
-    let post_futures = filtered_clients.clone().map(|(_, client)| {
-        client.post_prometheus_metrics(
-            metrics_body.clone(),
-            extra_labels.clone(),
-            encoding.clone().unwrap_or_default(),
-        )
-    });
-
-    let results = futures::future::join_all(post_futures)
-        .await
-        .into_iter()
-        .zip(filtered_clients.map(|(name, _)| name))
-        .map(|(res, name)| {
-            match res {
-                Ok(res) => {
-                    METRICS_INGEST_BACKEND_REQUEST_DURATION
-                        .with_label_values(&[
-                            &claims.peer_id.to_string(),
-                            name,
-                            res.status().as_str(),
-                        ])
-                        .observe(start_timer.elapsed().as_secs_f64());
-                    if res.status().is_success() {
-                        debug!("remote write to victoria metrics succeeded");
-                    } else {
-                        error!(
-                            "remote write failed to victoria_metrics for client {}: {}",
-                            name,
-                            res.error_for_status().err().unwrap()
-                        );
-                        return Err(());
-                    }
-                },
-                Err(err) => {
-                    METRICS_INGEST_BACKEND_REQUEST_DURATION
-                        .with_label_values(&[name, "Unknown"])
-                        .observe(start_timer.elapsed().as_secs_f64());
+        match result {
+            Ok(res) => {
+                METRICS_INGEST_BACKEND_REQUEST_DURATION
+                    .with_label_values(&[&claims.peer_id.to_string(), name, res.status().as_str()])
+                    .observe(start_timer.elapsed().as_secs_f64());
+                if res.status().is_success() {
+                    debug!("remote write to victoria metrics succeeded");
+                } else {
                     error!(
-                        "error sending remote write request for client {}: {}",
-                        name, err
+                        "remote write failed to victoria_metrics for client {}: {}",
+                        name.clone(),
+                        res.error_for_status().err().unwrap()
                     );
                     return Err(());
-                },
-            }
-            Ok(())
-        });
+                }
+            },
+            Err(err) => {
+                METRICS_INGEST_BACKEND_REQUEST_DURATION
+                    .with_label_values(&[name, "Unknown"])
+                    .observe(start_timer.elapsed().as_secs_f64());
+                error!(
+                    "error sending remote write request for client {}: {}",
+                    name.clone(),
+                    err
+                );
+                return Err(());
+            },
+        }
+        Ok(())
+    });
 
     #[allow(clippy::unnecessary_fold)]
-    if results.fold(true, |acc, r| acc && r.is_err()) {
+    if futures::future::join_all(post_futures)
+        .await
+        .iter()
+        .all(|result| result.is_err())
+    {
         return Err(reject::custom(ServiceError::internal(
             MetricsIngestError::IngestionError.into(),
         )));
@@ -231,11 +227,11 @@ mod test {
         });
 
         let clients = test_context.inner.metrics_client_mut();
-        clients.insert(
+        clients.ingest_metrics.insert(
             "default1".into(),
             MetricsClient::new(Url::parse(&server1.base_url()).unwrap(), "token1".into()),
         );
-        clients.insert(
+        clients.ingest_metrics.insert(
             "default2".into(),
             MetricsClient::new(Url::parse(&server2.base_url()).unwrap(), "token2".into()),
         );
@@ -267,11 +263,11 @@ mod test {
         });
 
         let clients = test_context.inner.metrics_client_mut();
-        clients.insert(
+        clients.ingest_metrics.insert(
             "default1".into(),
             MetricsClient::new(Url::parse(&server1.base_url()).unwrap(), "token1".into()),
         );
-        clients.insert(
+        clients.ingest_metrics.insert(
             "default2".into(),
             MetricsClient::new(Url::parse(&server2.base_url()).unwrap(), "token2".into()),
         );
@@ -303,11 +299,11 @@ mod test {
         });
 
         let clients = test_context.inner.metrics_client_mut();
-        clients.insert(
+        clients.ingest_metrics.insert(
             "default1".into(),
             MetricsClient::new(Url::parse(&server1.base_url()).unwrap(), "token1".into()),
         );
-        clients.insert(
+        clients.ingest_metrics.insert(
             "default2".into(),
             MetricsClient::new(Url::parse(&server2.base_url()).unwrap(), "token2".into()),
         );

--- a/crates/aptos-telemetry-service/src/tests/test_context.rs
+++ b/crates/aptos-telemetry-service/src/tests/test_context.rs
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    context::{ClientTuple, Context, JsonWebTokenService, PeerStoreTuple},
-    index, CustomEventConfig, TelemetryServiceConfig,
+    context::{ClientTuple, Context, GroupedMetricsClients, JsonWebTokenService, PeerStoreTuple},
+    index, CustomEventConfig, MetricsEndpointsConfig, TelemetryServiceConfig,
 };
 use aptos_crypto::{x25519, Uniform};
 use aptos_rest_client::aptos_api_types::mime_types;
 use rand::SeedableRng;
 use reqwest::header::AUTHORIZATION;
 use serde_json::Value;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use warp::{
     http::{header::CONTENT_TYPE, Response},
     hyper::body::Bytes,
@@ -31,12 +31,11 @@ pub async fn new_test_context() -> TestContext {
             dataset_id: String::from("2"),
             table_id: String::from("3"),
         },
-        victoria_metrics_endpoints: HashMap::new(),
         humio_url: "".into(),
         pfn_allowlist: HashMap::new(),
         log_env_map: HashMap::new(),
-        metrics_exporter_base_url: "".into(),
         peer_identities: HashMap::new(),
+        metrics_endpoints_config: MetricsEndpointsConfig::default_for_test(),
     };
 
     let peers = PeerStoreTuple::default();
@@ -47,7 +46,7 @@ pub async fn new_test_context() -> TestContext {
         Context::new(
             server_private_key,
             peers,
-            ClientTuple::new(None, Some(BTreeMap::new()), None),
+            ClientTuple::new(None, Some(GroupedMetricsClients::new_empty()), None),
             HashSet::new(),
             jwt_service,
             HashMap::new(),

--- a/crates/aptos-telemetry-service/src/types/mod.rs
+++ b/crates/aptos-telemetry-service/src/types/mod.rs
@@ -41,6 +41,8 @@ pub mod common {
         ValidatorFullNode,
         PublicFullNode,
         Unknown,
+        UnknownValidator,
+        UnknownFullNode,
     }
 
     impl NodeType {
@@ -50,6 +52,8 @@ pub mod common {
                 NodeType::ValidatorFullNode => "validator_fullnode",
                 NodeType::PublicFullNode => "public_fullnode",
                 NodeType::Unknown => "unknown_peer",
+                NodeType::UnknownValidator => "unknown_validator",
+                NodeType::UnknownFullNode => "unknown_fullnode",
             }
         }
     }


### PR DESCRIPTION
### Description

This PR enables the telemetry service to accept prometheus metrics from any Aptos Node, either Validator or Full Node, even if they are not whitelisted or not part of the validator set. The service will categorize any node that is able to authenticate via handshake with the service as either `UnknownValidator` or `UnknownFullNode` based on what the node identifies itself as during the authentication. 

To prevent any adverse behavior from accepting metrics from untrusted sources, these metrics will be emitted to a separate configurable destination. 

As part of the change, I also cleaned up some metrics related configuration, streamlined how metrics urls and secrets are defined as part of the telemetry service config.

Also, cleans up certain hacks that was implemented for premainnet to allow data to be replicated to different backends. These are no longer required.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Ran a public full node locally connected to mainnet and was able to emit metrics to telemetry service running locally and see it in Grafana.
