### PR TITLE
Make CLI installation / self updating lookup latest CLI release correctly

### DIFF
--- a/crates/aptos/src/update/helpers.rs
+++ b/crates/aptos/src/update/helpers.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, Context, Result};
-use self_update::{backends::github::Update, cargo_crate_version, version::bump_is_greater};
+use self_update::{backends::github::ReleaseList, cargo_crate_version, version::bump_is_greater};
 
+#[derive(Debug)]
 pub struct UpdateRequiredInfo {
     pub update_required: bool,
     pub current_version: String,
@@ -14,29 +15,41 @@ pub struct UpdateRequiredInfo {
 /// Return information about whether an update is required.
 pub fn check_if_update_required(repo_owner: &str, repo_name: &str) -> Result<UpdateRequiredInfo> {
     // Build a configuration for determining the latest release.
-    let config = Update::configure()
+    let config = ReleaseList::configure()
         .repo_owner(repo_owner)
         .repo_name(repo_name)
-        .bin_name("aptos")
-        .current_version(cargo_crate_version!())
         .build()
-        .map_err(|e| anyhow!("Failed to build self-update configuration: {:#}", e))?;
+        .map_err(|e| anyhow!("Failed to build configuration to fetch releases: {:#}", e))?;
 
-    // Get information about the latest release.
-    let latest_release = config
-        .get_latest_release()
-        .map_err(|e| anyhow!("Failed to lookup latest release: {:#}", e))?;
+    // Get the most recent releases.
+    let releases = config
+        .fetch()
+        .map_err(|e| anyhow!("Failed to fetch releases: {:#}", e))?;
+
+    // Find the latest release of the CLI, in which we filter for the CLI tag.
+    // If the release isn't in the last 30 items (the default API page size)
+    // this will fail. See https://github.com/aptos-labs/aptos-core/issues/6411.
+    let mut releases = releases.into_iter();
+    let latest_release = loop {
+        let release = match releases.next() {
+            Some(release) => release,
+            None => return Err(anyhow!("Failed to find latest CLI release")),
+        };
+        if release.version.starts_with("aptos-cli-") {
+            break release;
+        }
+    };
     let latest_version_tag = latest_release.version;
     let latest_version = latest_version_tag.split("-v").last().unwrap();
 
     // Return early if we're up to date already.
-    let current_version = config.current_version();
-    let update_required = bump_is_greater(&current_version, latest_version)
+    let current_version = cargo_crate_version!();
+    let update_required = bump_is_greater(current_version, latest_version)
         .context("Failed to compare current and latest CLI versions")?;
 
     Ok(UpdateRequiredInfo {
         update_required,
-        current_version,
+        current_version: current_version.to_string(),
         latest_version: latest_version.to_string(),
         latest_version_tag,
     })


### PR DESCRIPTION
### Description
You know how sometimes you think "this might be an issue" but then do nothing about it and then it turns out to be an issue? Well that's what happened here.

The problem is the "latest" tag points to the latest release of any description, but these tools just blindly look at the latest release. This PR makes it filter through the tags to look for the latest CLI release only.

### Test Plan
Installation script:
```
$ python3 install_cli.py
Latest CLI release: 1.0.4
Currently installed CLI: 1.0.4

The latest version (1.0.4) is already installed.
```

Self update:
```
$ cargo build -p aptos
$ cp target/debug/aptos
$ /tmp/aptos update
{
  "Result": "CLI already up to date (v1.0.4)"
}
```
