### PR TITLE
[CLI] Add support for now-public testnet faucet

### DIFF
--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -113,7 +113,8 @@ impl CliCommand<()> for InitTool {
             Network::Testnet => {
                 profile_config.rest_url =
                     Some("https://fullnode.testnet.aptoslabs.com".to_string());
-                profile_config.faucet_url = None;
+                profile_config.faucet_url =
+                    Some("https://faucet.testnet.aptoslabs.com".to_string());
             },
             Network::Devnet => {
                 profile_config.rest_url = Some("https://fullnode.devnet.aptoslabs.com".to_string());
@@ -216,8 +217,6 @@ impl CliCommand<()> for InitTool {
             }
         } else if account_exists {
             eprintln!("Account {} has been already found onchain", address);
-        } else if network == Network::Testnet {
-            eprintln!("Account {} does not exist, you will need to create and fund the account through a community faucet e.g. https://aptoslabs.com/testnet-faucet, or by transferring funds from another account", address);
         } else if network == Network::Mainnet {
             eprintln!("Account {} does not exist, you will need to create and fund the account through a faucet or by transferring funds from another account", address);
         } else {


### PR DESCRIPTION
### Description
We can do this now that the testnet faucet is captcha free.

### Test Plan
```
cd aptos-move/move-examples/hello_blockchain/
~/a/core/target/debug/aptos init 

Account 7aaafbea10f1ffe9d957953102b040939add4d40d6ffff41da0dd0c371901c92 doesn't exist, creating it and funding it with 100000000 Octas
Account 7aaafbea10f1ffe9d957953102b040939add4d40d6ffff41da0dd0c371901c92 funded successfully

---
Aptos CLI is now set up for account 7aaafbea10f1ffe9d957953102b040939add4d40d6ffff41da0dd0c371901c92 as profile default!  Run `aptos --help` for more information about commands
{
  "Result": "Success"
}
```
```
$ ~/a/core/target/debug/aptos account list | grep value
          "value": "100000000"
```
