### PR TITLE
Implement lychee-broken-link-checker to catch broken links in GitHub …

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: ".github/workflows"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: ".github/workflows"
-    schedule:
-      interval: "daily"

--- a/.github/workflows/links_checker.yml
+++ b/.github/workflows/links_checker.yml
@@ -1,0 +1,30 @@
+## Implementation of: https://github.com/marketplace/actions/lychee-broken-link-checker
+
+name: Aptos GitHub Links Checker
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "00 10 * * *"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.5.4
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Create Issue From File
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue
+          assignees: clay-aptos

--- a/.github/workflows/links_checker.yml
+++ b/.github/workflows/links_checker.yml
@@ -6,7 +6,7 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    - cron: "00 10 * * *"
+    - cron: "00 18 * * *"
 
 jobs:
   linkChecker:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,3 @@
+file://.*
+http://localhost.*
+http://127.0.0.1.*

--- a/developer-docs-site/README.md
+++ b/developer-docs-site/README.md
@@ -9,6 +9,9 @@
 
 This Aptos Developer Documenatation is built using [Docusaurus 2](https://docusaurus.io/). Follow the below steps to build the docs locally to test your contribution.
 
+[![Check GitHub Links](https://github.com/aptos-labs/aptos-core/actions/workflows/links.yml/badge.svg)](https://github.com/org/repo/actions/workflows/links.yml)
+
+
 ## Installation
 
 **IMPORTANT**: These installation steps apply to macOS environment.


### PR DESCRIPTION
…Markdown

### Description

This link checks GitHub Markdown to complement the link checking we have enabled during Aptos.dev builds.

### Test Plan

Receive automated issue and iteratively resolve the broken links.
