### PR TITLE
[Consensus] Add more information to commit mismatch message

### DIFF
--- a/consensus/src/experimental/buffer_manager.rs
+++ b/consensus/src/experimental/buffer_manager.rs
@@ -454,7 +454,12 @@ impl BufferManager {
                     let new_item = match item.add_signature_if_matched(*vote) {
                         Ok(()) => item.try_advance_to_aggregated(&self.verifier),
                         Err(e) => {
-                            error!("Failed to add commit vote {:?} from author {:?} with commit info {:?}", e, author, commit_info);
+                            error!(
+                                error = ?e,
+                                author = author,
+                                commit_info = commit_info,
+                                "Failed to add commit vote",
+                            );
                             item
                         },
                     };

--- a/consensus/src/experimental/buffer_manager.rs
+++ b/consensus/src/experimental/buffer_manager.rs
@@ -442,11 +442,9 @@ impl BufferManager {
         match commit_msg {
             VerifiedEvent::CommitVote(vote) => {
                 // find the corresponding item
-                info!(
-                    "Receive commit vote {} from {}",
-                    vote.commit_info(),
-                    vote.author()
-                );
+                let author = vote.author();
+                let commit_info = vote.commit_info().clone();
+                info!("Receive commit vote {} from {}", commit_info, author);
                 let target_block_id = vote.commit_info().id();
                 let current_cursor = self
                     .buffer
@@ -456,7 +454,7 @@ impl BufferManager {
                     let new_item = match item.add_signature_if_matched(*vote) {
                         Ok(()) => item.try_advance_to_aggregated(&self.verifier),
                         Err(e) => {
-                            error!("Failed to add commit vote {:?}", e);
+                            error!("Failed to add commit vote {:?} from author {:?} with commit info {:?}", e, author, commit_info);
                             item
                         },
                     };


### PR DESCRIPTION
### Description

Minor change to add basic information like author and commit info to the error message. 

### Test Plan

Existing UTs
