### PR TITLE
[cli] Release for 1.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "aptos-backup-cli",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "1.0.4"
+version = "1.0.5"
 
 # Workspace inherited keys
 authors = { workspace = true }

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         },
         utils::prompt_yes_with_override,
     },
-    move_tool::{FrameworkPackageArgs, IncludedArtifacts},
+    move_tool::{set_bytecode_version, FrameworkPackageArgs, IncludedArtifacts},
     CliCommand, CliResult,
 };
 use aptos_cached_packages::aptos_stdlib;
@@ -708,6 +708,7 @@ impl CompileScriptFunction {
         script_name: &str,
         prompt_options: PromptOptions,
     ) -> CliTypedResult<(Vec<u8>, HashValue)> {
+        set_bytecode_version(self.bytecode_version);
         if let Some(compiled_script_path) = &self.compiled_script_path {
             let bytes = std::fs::read(compiled_script_path).map_err(|e| {
                 CliError::IO(format!("Unable to read {:?}", self.compiled_script_path), e)

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -109,7 +109,7 @@ impl MoveTool {
 
 const VAR_BYTECODE_VERSION: &str = "MOVE_BYTECODE_VERSION";
 
-fn set_bytecode_version(version: Option<u32>) {
+pub(crate) fn set_bytecode_version(version: Option<u32>) {
     // Note: this is a bit of a hack to get the compiler emit bytecode with the right
     //       version. In the future, we should add an option to the Move package system
     //       that would allow us to configure this directly instead of relying on
@@ -322,7 +322,7 @@ pub struct TestPackage {
     pub filter: Option<String>,
 
     /// A boolean value to skip warnings.
-    #[clap(long, short = 'w')]
+    #[clap(long)]
     pub ignore_compile_warnings: bool,
 
     #[clap(flatten)]


### PR DESCRIPTION
### Description
* Bytecode version fixed for scripts
* Removed w as shorthand for ignore warnings

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
