### PR TITLE
Update pruner progress after fast sync is done.

### DIFF
--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -836,6 +836,8 @@ async fn finalize_storage_and_send_commit<
         )
         .map_err(|error| format!("Failed to finalize the state snapshot! Error: {:?}", error))?;
 
+    info!("All states have synced, version: {}", version);
+
     // Update the metadata storage
     metadata_storage.update_last_persisted_state_value_index(
             target_ledger_info,

--- a/storage/aptosdb/src/pruner/db_pruner.rs
+++ b/storage/aptosdb/src/pruner/db_pruner.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{Context, Result};
 use aptos_logger::info;
+use aptos_schemadb::SchemaBatch;
 use aptos_types::transaction::Version;
 use std::cmp::min;
 
@@ -30,6 +31,9 @@ pub trait DBPruner: Send + Sync {
 
     /// Initializes the least readable version stored in underlying DB storage
     fn initialize_min_readable_version(&self) -> Result<Version>;
+
+    /// Saves the min readable version.
+    fn save_min_readable_version(&self, version: Version, batch: &SchemaBatch) -> Result<()>;
 
     /// Returns the least readable version stores in the DB pruner
     fn min_readable_version(&self) -> Version;

--- a/storage/aptosdb/src/pruner/ledger_store/ledger_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/ledger_store/ledger_store_pruner.rs
@@ -52,10 +52,7 @@ impl DBPruner for LedgerPruner {
         // Collect the schema batch writes
         let mut db_batch = SchemaBatch::new();
         let current_target_version = self.prune_inner(max_versions, &mut db_batch)?;
-        db_batch.put::<DbMetadataSchema>(
-            &DbMetadataKey::LedgerPrunerProgress,
-            &DbMetadataValue::Version(current_target_version),
-        )?;
+        self.save_min_readable_version(current_target_version, &db_batch)?;
         // Commit all the changes to DB atomically
         self.db.write_schemas(db_batch)?;
 
@@ -64,6 +61,17 @@ impl DBPruner for LedgerPruner {
         // progress.
         self.record_progress(current_target_version);
         Ok(current_target_version)
+    }
+
+    fn save_min_readable_version(
+        &self,
+        version: Version,
+        batch: &SchemaBatch,
+    ) -> anyhow::Result<()> {
+        batch.put::<DbMetadataSchema>(
+            &DbMetadataKey::LedgerPrunerProgress,
+            &DbMetadataValue::Version(version),
+        )
     }
 
     fn initialize_min_readable_version(&self) -> anyhow::Result<Version> {
@@ -172,6 +180,10 @@ impl LedgerPruner {
         // Current target version might be less than the target version to ensure we don't prune
         // more than max_version in one go.
         let current_target_version = self.get_current_batch_target(max_versions as Version);
+
+        if current_target_version < min_readable_version {
+            return Ok(min_readable_version);
+        }
 
         self.transaction_store_pruner.prune(
             db_batch,

--- a/storage/aptosdb/src/pruner/state_store/mod.rs
+++ b/storage/aptosdb/src/pruner/state_store/mod.rs
@@ -67,6 +67,14 @@ where
         }
     }
 
+    fn save_min_readable_version(
+        &self,
+        version: Version,
+        batch: &SchemaBatch,
+    ) -> anyhow::Result<()> {
+        batch.put::<DbMetadataSchema>(&S::tag(), &DbMetadataValue::Version(version))
+    }
+
     fn initialize_min_readable_version(&self) -> Result<Version> {
         Ok(self
             .state_merkle_db
@@ -129,6 +137,9 @@ where
         existing_schema_batch: Option<&mut SchemaBatch>,
     ) -> anyhow::Result<Version> {
         assert_ne!(batch_size, 0);
+        if target_version < min_readable_version {
+            return Ok(min_readable_version);
+        }
         let (indices, is_end_of_target_version) =
             self.get_stale_node_indices(min_readable_version, target_version, batch_size)?;
         if indices.is_empty() {
@@ -154,10 +165,7 @@ where
                     batch.delete::<S>(&index)
                 })?;
 
-                batch.put::<DbMetadataSchema>(
-                    &S::tag(),
-                    &DbMetadataValue::Version(new_min_readable_version),
-                )?;
+                self.save_min_readable_version(new_min_readable_version, &batch)?;
 
                 // Commit to DB.
                 self.state_merkle_db.write_schemas(batch)?;

--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -129,10 +129,11 @@ impl LocalNode {
 
         // We print out the commands and PIDs for debugging of local swarms
         info!(
-            "Started node {} (PID: {}) with command: {:?}",
+            "Started node {} (PID: {}) with command: {:?}, log_path: {:?}",
             self.name,
             process.id(),
-            node_command
+            node_command,
+            self.log_path(),
         );
 
         // We print out the API endpoints of each node for local debugging

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -50,6 +50,27 @@ async fn test_full_node_bootstrap_state_snapshot() {
     let vfn_client = swarm.fullnode_mut(vfn_peer_id).unwrap().rest_client();
     let ledger_information = vfn_client.get_ledger_information().await.unwrap();
     assert_ne!(ledger_information.inner().oldest_ledger_version, 0);
+
+    let inspection_client = swarm.fullnode(vfn_peer_id).unwrap().inspection_client();
+    let state_merkle_pruner_version = inspection_client
+        .get_node_metric_i64("aptos_pruner_min_readable_version{pruner_name=state_merkle_pruner}")
+        .await
+        .unwrap()
+        .unwrap();
+    let epoch_snapshot_pruner_version = inspection_client
+        .get_node_metric_i64("aptos_pruner_min_readable_version{pruner_name=epoch_snapshot_pruner}")
+        .await
+        .unwrap()
+        .unwrap();
+    let ledger_pruner_version = inspection_client
+        .get_node_metric_i64("aptos_pruner_min_readable_version{pruner_name=ledger_pruner}")
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert!(state_merkle_pruner_version > 0);
+    assert!(epoch_snapshot_pruner_version > 0);
+    assert!(ledger_pruner_version > 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Description
Also fixed a bug that we mistakenly used the SchemaBatch for ledger db to prune genesis in state merkle db.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
