### PR TITLE
[replay-verify] add lazy-quit mode which prints out all violations

### DIFF
--- a/.github/actions/replay-verify/action.yaml
+++ b/.github/actions/replay-verify/action.yaml
@@ -46,6 +46,7 @@ runs:
           --target-db-dir ./$NAME/db \
           --start-version $START \
           --end-version $END \
+          --lazy-quit \
           command-adapter --config terraform/helm/fullnode/files/backup/s3-public.yaml 2>&1 \
           | sed --unbuffered -e "s/^/[partition $NAME] /" &
         done

--- a/.github/actions/replay-verify/action.yaml
+++ b/.github/actions/replay-verify/action.yaml
@@ -24,7 +24,7 @@ runs:
       shell: bash
       run: |
         set -o nounset -o errexit -o pipefail
-        N=8
+        N=32
         PER_PARTITION=$(( ($LATEST_VERSION - $HISTORY_START) / $N ))
 
         for n in `seq 1 $N`
@@ -40,8 +40,8 @@ runs:
           echo [main process] spawning $NAME
           unbuffer target/release/replay-verify \
           --txns-to-skip $TXNS_TO_SKIP \
-          --concurrent-downloads 8 \
-          --replay-concurrency-level 8 \
+          --concurrent-downloads 2 \
+          --replay-concurrency-level 2 \
           --metadata-cache-dir ./$NAME/metadata-cache \
           --target-db-dir ./$NAME/db \
           --start-version $START \

--- a/.github/workflows/replay-verify-testnet.yaml
+++ b/.github/workflows/replay-verify-testnet.yaml
@@ -16,7 +16,7 @@ on:
 env:
   BUCKET: aptos-testnet-backup-2223d95b
   SUB_DIR: e1
-  HISTORY_START: 350000000 # TODO: We need an exhaustive list of txns_to_skip before we can set this to 0.
+  HISTORY_START: 250000000 # TODO: We need an exhaustive list of txns_to_skip before we can set this to 0.
   TXNS_TO_SKIP: 46874937 151020059 409163615 409163669 409163708 409163774 409163845 409163955 409164059 409164191 414625832
   CONFIG_TEMPLATE_NAME: s3-public.yaml
 

--- a/execution/executor-types/src/executed_chunk.rs
+++ b/execution/executor-types/src/executed_chunk.rs
@@ -181,19 +181,12 @@ impl ExecutedChunk {
         }
     }
 
-    pub fn combine(self, rhs: Self) -> Result<Self> {
-        let mut to_commit = self.to_commit;
-        to_commit.extend(rhs.to_commit.into_iter());
-        let mut status = self.status;
-        status.extend(rhs.status.into_iter());
-
-        Ok(Self {
-            status,
-            to_commit,
-            result_view: rhs.result_view,
-            next_epoch_state: rhs.next_epoch_state,
-            ledger_info: rhs.ledger_info,
-        })
+    pub fn combine(&mut self, rhs: Self) {
+        self.to_commit.extend(rhs.to_commit.into_iter());
+        self.status.extend(rhs.status.into_iter());
+        self.result_view = rhs.result_view;
+        self.next_epoch_state = rhs.next_epoch_state;
+        self.ledger_info = rhs.ledger_info;
     }
 
     pub fn as_state_compute_result(

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -146,6 +146,10 @@ impl VerifyExecutionMode {
             VerifyExecutionMode::Verify { txns_to_skip } => txns_to_skip.clone(),
         }
     }
+
+    pub fn should_verify(&self) -> bool {
+        !matches!(self, Self::NoVerify)
+    }
 }
 
 pub trait TransactionReplayer: Send {
@@ -153,8 +157,8 @@ pub trait TransactionReplayer: Send {
         &self,
         transactions: Vec<Transaction>,
         transaction_infos: Vec<TransactionInfo>,
-        writesets: Vec<WriteSet>,
-        events: Vec<Vec<ContractEvent>>,
+        write_sets: Vec<WriteSet>,
+        event_vecs: Vec<Vec<ContractEvent>>,
         verify_execution_mode: &VerifyExecutionMode,
     ) -> Result<()>;
 

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -28,7 +28,11 @@ use serde::{Deserialize, Serialize};
 use std::{
     cmp::max,
     collections::{BTreeSet, HashMap},
-    sync::Arc,
+    fmt::Debug,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 
 mod error;
@@ -124,6 +128,8 @@ pub enum VerifyExecutionMode {
     NoVerify,
     Verify {
         txns_to_skip: Arc<BTreeSet<Version>>,
+        lazy_quit: bool,
+        seen_error: Arc<AtomicBool>,
     },
 }
 
@@ -131,24 +137,61 @@ impl VerifyExecutionMode {
     pub fn verify_all() -> Self {
         Self::Verify {
             txns_to_skip: Arc::new(BTreeSet::new()),
+            lazy_quit: false,
+            seen_error: Arc::new(AtomicBool::new(false)),
         }
     }
 
     pub fn verify_except(txns_to_skip: Vec<Version>) -> Self {
         Self::Verify {
             txns_to_skip: Arc::new(txns_to_skip.into_iter().collect()),
+            lazy_quit: false,
+            seen_error: Arc::new(AtomicBool::new(false)),
         }
     }
 
     pub fn txns_to_skip(&self) -> Arc<BTreeSet<Version>> {
         match self {
             VerifyExecutionMode::NoVerify => Arc::new(BTreeSet::new()),
-            VerifyExecutionMode::Verify { txns_to_skip } => txns_to_skip.clone(),
+            VerifyExecutionMode::Verify { txns_to_skip, .. } => txns_to_skip.clone(),
+        }
+    }
+
+    pub fn set_lazy_quit(mut self, is_lazy_quit: bool) -> Self {
+        if let Self::Verify {
+            ref mut lazy_quit, ..
+        } = self
+        {
+            *lazy_quit = is_lazy_quit
+        }
+        self
+    }
+
+    pub fn is_lazy_quit(&self) -> bool {
+        match self {
+            VerifyExecutionMode::NoVerify => false,
+            VerifyExecutionMode::Verify { lazy_quit, .. } => *lazy_quit,
+        }
+    }
+
+    pub fn mark_seen_error(&self) {
+        match self {
+            VerifyExecutionMode::NoVerify => unreachable!("Should not call in no-verify mode."),
+            VerifyExecutionMode::Verify { seen_error, .. } => {
+                seen_error.store(true, Ordering::Relaxed)
+            },
         }
     }
 
     pub fn should_verify(&self) -> bool {
         !matches!(self, Self::NoVerify)
+    }
+
+    pub fn seen_error(&self) -> bool {
+        match self {
+            VerifyExecutionMode::NoVerify => false,
+            VerifyExecutionMode::Verify { seen_error, .. } => seen_error.load(Ordering::Relaxed),
+        }
     }
 }
 

--- a/execution/executor-types/src/parsed_transaction_output.rs
+++ b/execution/executor-types/src/parsed_transaction_output.rs
@@ -14,12 +14,15 @@ pub struct ParsedTransactionOutput {
     reconfig_events: Vec<ContractEvent>,
 }
 
+impl ParsedTransactionOutput {
+    pub fn parse_reconfig_events(events: &[ContractEvent]) -> impl Iterator<Item = &ContractEvent> {
+        events.iter().filter(|e| *e.key() == *NEW_EPOCH_EVENT_KEY)
+    }
+}
+
 impl From<TransactionOutput> for ParsedTransactionOutput {
     fn from(output: TransactionOutput) -> Self {
-        let reconfig_events = output
-            .events()
-            .iter()
-            .filter(|e| *e.key() == *NEW_EPOCH_EVENT_KEY)
+        let reconfig_events = Self::parse_reconfig_events(output.events())
             .cloned()
             .collect();
         Self {

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -17,8 +17,8 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_executor_types::{
-    ChunkCommitNotification, ChunkExecutorTrait, ExecutedChunk, TransactionReplayer,
-    VerifyExecutionMode,
+    ChunkCommitNotification, ChunkExecutorTrait, ExecutedChunk, ParsedTransactionOutput,
+    TransactionReplayer, VerifyExecutionMode,
 };
 use aptos_infallible::{Mutex, RwLock};
 use aptos_logger::prelude::*;
@@ -38,7 +38,8 @@ use aptos_types::{
 };
 use aptos_vm::VMExecutor;
 use fail::fail_point;
-use std::{marker::PhantomData, sync::Arc};
+use itertools::multizip;
+use std::{iter::once, marker::PhantomData, sync::Arc};
 
 pub struct ChunkExecutor<V> {
     db: DbReaderWriter,
@@ -362,16 +363,16 @@ impl<V: VMExecutor> TransactionReplayer for ChunkExecutor<V> {
         &self,
         transactions: Vec<Transaction>,
         transaction_infos: Vec<TransactionInfo>,
-        writesets: Vec<WriteSet>,
-        events: Vec<Vec<ContractEvent>>,
+        write_sets: Vec<WriteSet>,
+        event_vecs: Vec<Vec<ContractEvent>>,
         verify_execution_mode: &VerifyExecutionMode,
     ) -> Result<()> {
         self.maybe_initialize()?;
         self.inner.read().as_ref().expect("not reset").replay(
             transactions,
             transaction_infos,
-            writesets,
-            events,
+            write_sets,
+            event_vecs,
             verify_execution_mode,
         )
     }
@@ -386,43 +387,48 @@ impl<V: VMExecutor> TransactionReplayer for ChunkExecutorInner<V> {
         &self,
         mut transactions: Vec<Transaction>,
         mut transaction_infos: Vec<TransactionInfo>,
-        writesets: Vec<WriteSet>,
-        events: Vec<Vec<ContractEvent>>,
+        mut write_sets: Vec<WriteSet>,
+        mut event_vecs: Vec<Vec<ContractEvent>>,
         verify_execution_mode: &VerifyExecutionMode,
     ) -> Result<()> {
-        let (_parent_view, latest_view) = self.commit_queue.lock().persisted_and_latest_view();
-        let first_version = latest_view.num_transactions() as Version;
-        let mut offset = first_version;
-        let total_length = transactions.len();
+        let (_parent_view, mut latest_view) = self.commit_queue.lock().persisted_and_latest_view();
+        let chunk_begin = latest_view.num_transactions() as Version;
+        let chunk_end = chunk_begin + transactions.len() as Version; // right-exclusive
 
-        for version in verify_execution_mode
-            .txns_to_skip()
-            .range(first_version..first_version + total_length as u64)
-        {
-            let version = *version;
-            let remaining = transactions.split_off((version - offset + 1) as usize);
-            let remaining_info = transaction_infos.split_off((version - offset + 1) as usize);
-            let txn_to_skip = transactions.pop().unwrap();
-            let txn_info = transaction_infos.pop().unwrap();
-
-            self.replay_impl(transactions, transaction_infos)?;
-
-            self.apply_transaction_and_output(
-                txn_to_skip,
-                TransactionOutput::new(
-                    writesets[(version - first_version) as usize].clone(),
-                    events[(version - first_version) as usize].clone(),
-                    txn_info.gas_used(),
-                    TransactionStatus::Keep(txn_info.status().clone()),
-                ),
-                txn_info,
-            )?;
-
-            transactions = remaining;
-            transaction_infos = remaining_info;
-            offset = version + 1;
+        // Find epoch boundaries.
+        let mut epochs = Vec::new();
+        let mut epoch_begin = chunk_begin;
+        for (version, events) in multizip((chunk_begin..chunk_end, event_vecs.iter())) {
+            let is_epoch_ending = ParsedTransactionOutput::parse_reconfig_events(events)
+                .next()
+                .is_some();
+            if is_epoch_ending {
+                epochs.push((epoch_begin, version + 1));
+                epoch_begin = version + 1;
+            }
         }
-        self.replay_impl(transactions, transaction_infos)
+        if epoch_begin < chunk_end {
+            epochs.push((epoch_begin, chunk_end));
+        }
+
+        let mut executed_chunk = ExecutedChunk::default();
+        // Replay epoch by epoch.
+        for (begin, end) in epochs {
+            self.remove_and_replay_epoch(
+                &mut executed_chunk,
+                &mut latest_view,
+                &mut transactions,
+                &mut transaction_infos,
+                &mut write_sets,
+                &mut event_vecs,
+                begin,
+                end,
+                verify_execution_mode,
+            )?;
+        }
+
+        self.commit_queue.lock().enqueue(executed_chunk);
+        Ok(())
     }
 
     fn commit(&self) -> Result<Arc<ExecutedChunk>> {
@@ -431,66 +437,150 @@ impl<V: VMExecutor> TransactionReplayer for ChunkExecutorInner<V> {
 }
 
 impl<V: VMExecutor> ChunkExecutorInner<V> {
-    fn replay_impl(
+    fn remove_and_replay_epoch(
         &self,
-        transactions: Vec<Transaction>,
-        mut transaction_infos: Vec<TransactionInfo>,
+        executed_chunk: &mut ExecutedChunk,
+        latest_view: &mut ExecutedTrees,
+        transactions: &mut Vec<Transaction>,
+        transaction_infos: &mut Vec<TransactionInfo>,
+        write_sets: &mut Vec<WriteSet>,
+        event_vecs: &mut Vec<Vec<ContractEvent>>,
+        begin_version: Version,
+        end_version: Version,
+        verify_execution_mode: &VerifyExecutionMode,
     ) -> Result<()> {
-        let (_persisted_view, mut latest_view) =
-            self.commit_queue.lock().persisted_and_latest_view();
+        // we try to apply the txns in sub-batches split by known txns to skip and the end of the batch
+        let txns_to_skip = verify_execution_mode.txns_to_skip();
+        let mut batch_ends = txns_to_skip
+            .range(begin_version..end_version)
+            .chain(once(&end_version));
 
-        let mut executed_chunk = ExecutedChunk::default();
-        let mut to_run = Some(transactions);
+        let mut batch_begin = begin_version;
+        let mut batch_end = *batch_ends.next().unwrap();
+        while batch_begin < end_version {
+            if batch_begin == batch_end {
+                // batch_end is a known broken version that won't pass execution verification
+                self.remove_and_apply(
+                    executed_chunk,
+                    latest_view,
+                    transactions,
+                    transaction_infos,
+                    write_sets,
+                    event_vecs,
+                    batch_begin,
+                    batch_begin + 1,
+                )?;
+                batch_begin += 1;
+                batch_end = *batch_ends.next().unwrap();
+                continue;
+            }
 
-        while !to_run.as_ref().unwrap().is_empty() {
-            // Execute transactions.
-            let state_view = self.state_view(&latest_view)?;
-            let txns = to_run.take().unwrap();
-            let chunk_output = ChunkOutput::by_transaction_execution::<V>(txns, state_view)?;
-
-            let (executed, to_discard, to_retry) = chunk_output.apply_to_ledger(&latest_view)?;
-
-            // Accumulate result and deal with retry
-            ensure_no_discard(to_discard)?;
-            let n = executed.to_commit.len();
-            executed.ensure_transaction_infos_match(&transaction_infos[..n])?;
-            transaction_infos.drain(..n);
-
-            to_run = Some(to_retry);
-            executed_chunk = executed_chunk.combine(executed)?;
-            latest_view = executed_chunk.result_view.clone();
+            // Try to run the transactions with the VM
+            if verify_execution_mode.should_verify() {
+                self.verify_execution(
+                    latest_view,
+                    transactions,
+                    transaction_infos,
+                    write_sets,
+                    event_vecs,
+                    batch_begin,
+                    batch_end,
+                )?;
+            }
+            self.remove_and_apply(
+                executed_chunk,
+                latest_view,
+                transactions,
+                transaction_infos,
+                write_sets,
+                event_vecs,
+                batch_begin,
+                batch_end,
+            )?;
+            batch_begin = batch_end;
         }
-
-        // Add result to commit queue.
-        self.commit_queue.lock().enqueue(executed_chunk);
 
         Ok(())
     }
 
-    fn apply_transaction_and_output(
+    fn verify_execution(
         &self,
-        txn: Transaction,
-        output: TransactionOutput,
-        expected_info: TransactionInfo,
+        latest_view: &mut ExecutedTrees,
+        transactions: &[Transaction],
+        transaction_infos: &[TransactionInfo],
+        write_sets: &[WriteSet],
+        event_vecs: &[Vec<ContractEvent>],
+        begin_version: Version,
+        end_version: Version,
     ) -> Result<()> {
-        let (_persisted_view, latest_view) = self.commit_queue.lock().persisted_and_latest_view();
+        // Execute transactions.
+        let state_view = self.state_view(latest_view)?;
+        let txns = transactions
+            .iter()
+            .take((end_version - begin_version) as usize)
+            .cloned()
+            .collect();
 
-        info!(
-            "Overiding the output of txn at version: {:?}",
-            latest_view.version().map_or(0, |v| v + 1),
-        );
+        let chunk_output = ChunkOutput::by_transaction_execution::<V>(txns, state_view)?;
+        // not `zip_eq`, deliberately
+        for (version, txn_out, txn_info, write_set, events) in multizip((
+            begin_version..end_version,
+            chunk_output.transaction_outputs.iter(),
+            transaction_infos.iter(),
+            write_sets.iter(),
+            event_vecs.iter(),
+        )) {
+            txn_out.ensure_match_transaction_info(
+                version,
+                txn_info,
+                Some(write_set),
+                Some(events),
+            )?;
+        }
+        Ok(())
+    }
 
-        let chunk_output = ChunkOutput::by_transaction_output(
-            vec![(txn, output)],
-            self.state_view(&latest_view)?,
-        )?;
+    fn remove_and_apply(
+        &self,
+        executed_chunk: &mut ExecutedChunk,
+        latest_view: &mut ExecutedTrees,
+        transactions: &mut Vec<Transaction>,
+        transaction_infos: &mut Vec<TransactionInfo>,
+        write_sets: &mut Vec<WriteSet>,
+        event_vecs: &mut Vec<Vec<ContractEvent>>,
+        begin_version: Version,
+        end_version: Version,
+    ) -> Result<()> {
+        let num_txns = (end_version - begin_version) as usize;
+        let txn_infos: Vec<_> = transaction_infos.drain(..num_txns).collect();
+        let txns_and_outputs = multizip((
+            transactions.drain(..num_txns),
+            txn_infos.iter(),
+            write_sets.drain(..num_txns),
+            event_vecs.drain(..num_txns),
+        ))
+        .map(|(txn, txn_info, write_set, events)| {
+            (
+                txn,
+                TransactionOutput::new(
+                    write_set,
+                    events,
+                    txn_info.gas_used(),
+                    TransactionStatus::Keep(txn_info.status().clone()),
+                ),
+            )
+        })
+        .collect();
 
-        let (executed, to_discard, _to_retry) = chunk_output.apply_to_ledger(&latest_view)?;
-
-        // Accumulate result and deal with retry
+        let state_view = self.state_view(latest_view)?;
+        let chunk_output = ChunkOutput::by_transaction_output(txns_and_outputs, state_view)?;
+        let (executed_batch, to_discard, to_retry) = chunk_output.apply_to_ledger(latest_view)?;
         ensure_no_discard(to_discard)?;
-        executed.ensure_transaction_infos_match(&vec![expected_info])?;
-        self.commit_queue.lock().enqueue(executed);
+        ensure_no_retry(to_retry)?;
+        executed_batch.ensure_transaction_infos_match(&txn_infos)?;
+
+        executed_chunk.combine(executed_batch);
+        *latest_view = executed_chunk.result_view.clone();
         Ok(())
     }
 }

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -13,7 +13,9 @@ use crate::{
 };
 use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, SigningKey, Uniform};
 use aptos_db::AptosDB;
-use aptos_executor_types::{BlockExecutorTrait, ChunkExecutorTrait, TransactionReplayer};
+use aptos_executor_types::{
+    BlockExecutorTrait, ChunkExecutorTrait, TransactionReplayer, VerifyExecutionMode,
+};
 use aptos_state_view::StateViewId;
 use aptos_storage_interface::{
     sync_proof_fetcher::SyncProofFetcher, DbReaderWriter, ExecutedTrees,
@@ -35,7 +37,7 @@ use aptos_types::{
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use proptest::prelude::*;
-use std::{collections::BTreeSet, iter::once, sync::Arc};
+use std::{iter::once, sync::Arc};
 
 mod chunk_executor_tests;
 
@@ -693,7 +695,7 @@ proptest! {
             // replay txns in one batch across epoch boundary,
             // and the replayer should deal with `Retry`s automatically
             let replayer = chunk_executor_tests::TestExecutor::new();
-            replayer.executor.replay(block.txns, txn_infos, vec![], vec![], Arc::new(BTreeSet::new())).unwrap();
+            replayer.executor.replay(block.txns, txn_infos, vec![], vec![], &VerifyExecutionMode::verify_all()).unwrap();
             replayer.executor.commit().unwrap();
             let replayed_db = replayer.db.reader.clone();
             prop_assert_eq!(

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -116,6 +116,7 @@ use move_resource_viewer::MoveValueAnnotator;
 use once_cell::sync::Lazy;
 use std::{
     collections::HashMap,
+    fmt::{Debug, Formatter},
     iter::Iterator,
     path::Path,
     sync::{mpsc, Arc},
@@ -246,7 +247,6 @@ impl Drop for RocksdbPropertyReporter {
 
 /// This holds a handle to the underlying DB responsible for physical storage and provides APIs for
 /// access to the core Aptos data structures.
-#[derive(Debug)]
 pub struct AptosDB {
     ledger_db: Arc<DB>,
     state_merkle_db: Arc<DB>,
@@ -1992,4 +1992,10 @@ where
         .observe(timer.elapsed().as_secs_f64());
 
     res
+}
+
+impl Debug for AptosDB {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("{AptosDB}")
+    }
 }

--- a/storage/aptosdb/src/lru_node_cache.rs
+++ b/storage/aptosdb/src/lru_node_cache.rs
@@ -9,7 +9,6 @@ use lru::LruCache;
 
 const NUM_SHARDS: usize = 256;
 
-#[derive(Debug)]
 pub(crate) struct LruNodeCache {
     shards: [Mutex<LruCache<NibblePath, (Version, Node)>>; NUM_SHARDS],
 }

--- a/storage/aptosdb/src/pruner/db_sub_pruner.rs
+++ b/storage/aptosdb/src/pruner/db_sub_pruner.rs
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_schemadb::SchemaBatch;
-use std::fmt::Debug;
 
 /// Defines the trait for sub-pruner of a parent DB pruner
-pub trait DBSubPruner: Debug {
+pub trait DBSubPruner {
     /// Performs the actual pruning, a target version is passed, which is the target the pruner
     /// tries to prune.
     fn prune(

--- a/storage/aptosdb/src/pruner/ledger_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/ledger_pruner_manager.rs
@@ -16,7 +16,6 @@ use aptos_types::transaction::Version;
 use std::{sync::Arc, thread::JoinHandle};
 
 /// The `PrunerManager` for `LedgerPruner`.
-#[derive(Debug)]
 pub(crate) struct LedgerPrunerManager {
     pruner_enabled: bool,
     /// DB version window, which dictates how many version of other stores like transaction, ledger

--- a/storage/aptosdb/src/pruner/ledger_pruner_worker.rs
+++ b/storage/aptosdb/src/pruner/ledger_pruner_worker.rs
@@ -18,7 +18,6 @@ use std::{
 
 /// Maintains the ledger pruner and periodically calls the db_pruner's prune method to prune the DB.
 /// This also exposes API to report the progress to the parent thread.
-#[derive(Debug)]
 pub struct LedgerPrunerWorker {
     /// The worker will sleep for this period of time after pruning each batch.
     pruning_time_interval_in_ms: u64,

--- a/storage/aptosdb/src/pruner/ledger_store/ledger_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/ledger_store/ledger_store_pruner.rs
@@ -27,7 +27,6 @@ use std::sync::{atomic::Ordering, Arc};
 
 pub const LEDGER_PRUNER_NAME: &str = "ledger_pruner";
 
-#[derive(Debug)]
 /// Responsible for pruning everything except for the state tree.
 pub(crate) struct LedgerPruner {
     db: Arc<DB>,

--- a/storage/aptosdb/src/pruner/pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/pruner_manager.rs
@@ -3,7 +3,6 @@
 
 use crate::pruner::db_pruner::DBPruner;
 use aptos_types::transaction::Version;
-use std::fmt::Debug;
 
 /// This module provides `Pruner` which manages a thread pruning old data in the background and is
 /// meant to be triggered by other threads as they commit new data to the DB.
@@ -13,7 +12,7 @@ use std::fmt::Debug;
 ///
 /// It creates a worker thread on construction and joins it on destruction. When destructed, it
 /// quits the worker thread eagerly without waiting for all pending work to be done.
-pub trait PrunerManager: Debug + Sync {
+pub trait PrunerManager: Sync {
     type Pruner: DBPruner;
 
     fn is_pruner_enabled(&self) -> bool;

--- a/storage/aptosdb/src/pruner/state_store/state_value_pruner.rs
+++ b/storage/aptosdb/src/pruner/state_store/state_value_pruner.rs
@@ -4,7 +4,6 @@ use crate::{pruner::db_sub_pruner::DBSubPruner, StateStore};
 use aptos_schemadb::SchemaBatch;
 use std::sync::Arc;
 
-#[derive(Debug)]
 pub struct StateValuePruner {
     state_store: Arc<StateStore>,
 }

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -28,7 +28,6 @@ pub(crate) type LeafNode = aptos_jellyfish_merkle::node_type::LeafNode<StateKey>
 pub(crate) type Node = aptos_jellyfish_merkle::node_type::Node<StateKey>;
 type NodeBatch = aptos_jellyfish_merkle::NodeBatch<StateKey>;
 
-#[derive(Debug)]
 pub struct StateMerkleDb {
     pub(crate) db: Arc<DB>,
     enable_cache: bool,

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -73,7 +73,6 @@ static IO_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| {
         .unwrap()
 });
 
-#[derive(Debug)]
 pub(crate) struct StateDb {
     pub ledger_db: Arc<DB>,
     pub state_merkle_db: Arc<StateMerkleDb>,
@@ -81,7 +80,6 @@ pub(crate) struct StateDb {
     pub epoch_snapshot_pruner: StatePrunerManager<StaleNodeIndexCrossEpochSchema>,
 }
 
-#[derive(Debug)]
 pub(crate) struct StateStore {
     pub(crate) state_db: Arc<StateDb>,
     // The `base` of buffered_state is the latest snapshot in state_merkle_db while `current`

--- a/storage/aptosdb/src/versioned_node_cache.rs
+++ b/storage/aptosdb/src/versioned_node_cache.rs
@@ -13,7 +13,6 @@ use std::{
 
 type NodeCache = HashMap<NodeKey, Node>;
 
-#[derive(Debug)]
 pub(crate) struct VersionedNodeCache {
     inner: RwLock<VecDeque<(Version, Arc<NodeCache>)>>,
 }

--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use aptos_db::AptosDB;
 use aptos_executor_test_helpers::integration_test_impl::test_execution_with_storage_impl;
+use aptos_executor_types::VerifyExecutionMode;
 use aptos_storage_interface::DbReader;
 use aptos_temppath::TempPath;
 use aptos_types::transaction::Version;
@@ -153,7 +154,7 @@ fn test_end_to_end_impl(d: TestData) {
             global_restore_opt,
             store,
             None, /* epoch_history */
-            vec![],
+            VerifyExecutionMode::verify_all(),
         )
         .run(),
     )

--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -200,7 +200,7 @@ proptest! {
 
     #[test]
     #[cfg_attr(feature = "consensus-only-perf-test", ignore)]
-    fn test_end_to_end(d in test_data_strategy()) {
+    fn test_end_to_end(d in test_data_strategy().no_shrink()) {
         test_end_to_end_impl(d)
     }
 }

--- a/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
@@ -23,7 +23,7 @@ use crate::{
 use anyhow::{anyhow, ensure, Result};
 use aptos_db::backup::restore_handler::RestoreHandler;
 use aptos_executor::chunk_executor::ChunkExecutor;
-use aptos_executor_types::TransactionReplayer;
+use aptos_executor_types::{TransactionReplayer, VerifyExecutionMode};
 use aptos_logger::prelude::*;
 use aptos_storage_interface::DbReaderWriter;
 use aptos_types::{
@@ -45,7 +45,6 @@ use futures::{
 use itertools::{izip, Itertools};
 use std::{
     cmp::{max, min},
-    collections::BTreeSet,
     pin::Pin,
     sync::Arc,
     time::Instant,
@@ -160,7 +159,7 @@ impl TransactionRestoreController {
         global_opt: GlobalRestoreOptions,
         storage: Arc<dyn BackupStorage>,
         epoch_history: Option<Arc<EpochHistory>>,
-        txns_to_skip: Vec<Version>,
+        verify_execution_mode: VerifyExecutionMode,
     ) -> Self {
         let inner = TransactionRestoreBatchController::new(
             global_opt,
@@ -168,7 +167,7 @@ impl TransactionRestoreController {
             vec![opt.manifest_handle],
             opt.replay_from_version,
             epoch_history,
-            txns_to_skip.into_iter().collect(),
+            verify_execution_mode,
         );
 
         Self { inner }
@@ -188,7 +187,7 @@ pub struct TransactionRestoreBatchController {
     manifest_handles: Vec<FileHandle>,
     replay_from_version: Option<Version>,
     epoch_history: Option<Arc<EpochHistory>>,
-    txns_to_skip: Arc<BTreeSet<Version>>,
+    verify_execution_mode: VerifyExecutionMode,
 }
 
 impl TransactionRestoreBatchController {
@@ -198,7 +197,7 @@ impl TransactionRestoreBatchController {
         manifest_handles: Vec<FileHandle>,
         replay_from_version: Option<Version>,
         epoch_history: Option<Arc<EpochHistory>>,
-        txns_to_skip: Vec<Version>,
+        verify_execution_mode: VerifyExecutionMode,
     ) -> Self {
         Self {
             global_opt,
@@ -206,7 +205,7 @@ impl TransactionRestoreBatchController {
             manifest_handles,
             replay_from_version,
             epoch_history,
-            txns_to_skip: Arc::new(txns_to_skip.into_iter().collect()),
+            verify_execution_mode,
         }
     }
 
@@ -458,14 +457,20 @@ impl TransactionRestoreBatchController {
                 let (txns, txn_infos, write_sets, events): (Vec<_>, Vec<_>, Vec<_>, Vec<_>) =
                     chunk.into_iter().multiunzip();
                 let chunk_replayer = chunk_replayer.clone();
-                let txns_to_skip = self.txns_to_skip.clone();
+                let verify_execution_mode = self.verify_execution_mode.clone();
 
                 async move {
                     let _timer = OTHER_TIMERS_SECONDS
                         .with_label_values(&["replay_txn_chunk"])
                         .start_timer();
                     tokio::task::spawn_blocking(move || {
-                        chunk_replayer.replay(txns, txn_infos, write_sets, events, txns_to_skip)
+                        chunk_replayer.replay(
+                            txns,
+                            txn_infos,
+                            write_sets,
+                            events,
+                            &verify_execution_mode,
+                        )
                     })
                     .err_into::<anyhow::Error>()
                     .await

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -15,6 +15,7 @@ use crate::{
     },
 };
 use aptos_db::AptosDB;
+use aptos_executor_types::VerifyExecutionMode;
 use aptos_storage_interface::DbReader;
 use aptos_temppath::TempPath;
 use aptos_types::transaction::Version;
@@ -90,7 +91,7 @@ fn end_to_end() {
             .unwrap(),
             store,
             None, /* epoch_history */
-            vec![],
+            VerifyExecutionMode::verify_all(),
         )
         .run(),
     )

--- a/storage/backup/backup-cli/src/bin/db-restore.rs
+++ b/storage/backup/backup-cli/src/bin/db-restore.rs
@@ -12,6 +12,7 @@ use aptos_backup_cli::{
     storage::StorageOpt,
     utils::{GlobalRestoreOpt, GlobalRestoreOptions},
 };
+use aptos_executor_types::VerifyExecutionMode;
 use aptos_logger::{prelude::*, Level, Logger};
 use aptos_push_metrics::MetricsPusher;
 use clap::Parser;
@@ -92,7 +93,7 @@ async fn main_impl() -> Result<()> {
                 global_opt,
                 storage.init_storage().await?,
                 None, /* epoch_history */
-                vec![],
+                VerifyExecutionMode::NoVerify,
             )
             .run()
             .await?;

--- a/storage/backup/backup-cli/src/bin/replay-verify.rs
+++ b/storage/backup/backup-cli/src/bin/replay-verify.rs
@@ -13,6 +13,7 @@ use aptos_config::config::{
     NO_OP_STORAGE_PRUNER_CONFIG,
 };
 use aptos_db::{AptosDB, GetRestoreHandler};
+use aptos_executor_types::VerifyExecutionMode;
 use aptos_logger::{prelude::*, Level, Logger};
 use aptos_types::transaction::Version;
 use clap::Parser;
@@ -88,7 +89,7 @@ async fn main_impl() -> Result<()> {
         opt.start_version.unwrap_or(0),
         opt.end_version.unwrap_or(Version::MAX),
         opt.validate_modules,
-        opt.txns_to_skip,
+        VerifyExecutionMode::verify_except(opt.txns_to_skip),
     )?
     .run()
     .await

--- a/storage/backup/backup-cli/src/bin/replay-verify.rs
+++ b/storage/backup/backup-cli/src/bin/replay-verify.rs
@@ -54,6 +54,8 @@ struct Opt {
         help = "Skip the execution for txns that are known to break compatibility."
     )]
     txns_to_skip: Vec<Version>,
+    #[clap(long, help = "Do not quit right away when a replay issue is detected.")]
+    lazy_quit: bool,
 }
 
 #[tokio::main]
@@ -89,7 +91,7 @@ async fn main_impl() -> Result<()> {
         opt.start_version.unwrap_or(0),
         opt.end_version.unwrap_or(Version::MAX),
         opt.validate_modules,
-        VerifyExecutionMode::verify_except(opt.txns_to_skip),
+        VerifyExecutionMode::verify_except(opt.txns_to_skip).set_lazy_quit(opt.lazy_quit),
     )?
     .run()
     .await

--- a/storage/backup/backup-cli/src/coordinators/replay_verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/replay_verify.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use anyhow::{ensure, Result};
 use aptos_db::backup::restore_handler::RestoreHandler;
+use aptos_executor_types::VerifyExecutionMode;
 use aptos_logger::prelude::*;
 use aptos_types::transaction::Version;
 use aptos_vm::AptosVM;
@@ -28,7 +29,7 @@ pub struct ReplayVerifyCoordinator {
     start_version: Version,
     end_version: Version,
     validate_modules: bool,
-    txns_to_skip: Vec<Version>,
+    verify_execution_mode: VerifyExecutionMode,
 }
 
 impl ReplayVerifyCoordinator {
@@ -42,7 +43,7 @@ impl ReplayVerifyCoordinator {
         start_version: Version,
         end_version: Version,
         validate_modules: bool,
-        txns_to_skip: Vec<Version>,
+        verify_execution_mode: VerifyExecutionMode,
     ) -> Result<Self> {
         Ok(Self {
             storage,
@@ -54,7 +55,7 @@ impl ReplayVerifyCoordinator {
             start_version,
             end_version,
             validate_modules,
-            txns_to_skip,
+            verify_execution_mode,
         })
     }
 
@@ -155,7 +156,7 @@ impl ReplayVerifyCoordinator {
             txn_manifests,
             Some(replay_transactions_from_version), /* replay_from_version */
             None,                                   /* epoch_history */
-            self.txns_to_skip,
+            self.verify_execution_mode,
         )
         .run()
         .await?;

--- a/storage/backup/backup-cli/src/coordinators/replay_verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/replay_verify.rs
@@ -11,7 +11,7 @@ use crate::{
     storage::BackupStorage,
     utils::{GlobalRestoreOptions, RestoreRunMode, TrustedWaypointOpt},
 };
-use anyhow::{ensure, Result};
+use anyhow::{bail, ensure, Result};
 use aptos_db::backup::restore_handler::RestoreHandler;
 use aptos_executor_types::VerifyExecutionMode;
 use aptos_logger::prelude::*;
@@ -156,11 +156,15 @@ impl ReplayVerifyCoordinator {
             txn_manifests,
             Some(replay_transactions_from_version), /* replay_from_version */
             None,                                   /* epoch_history */
-            self.verify_execution_mode,
+            self.verify_execution_mode.clone(),
         )
         .run()
         .await?;
 
-        Ok(())
+        if self.verify_execution_mode.seen_error() {
+            bail!("Seen replay errors, check out logs.")
+        } else {
+            Ok(())
+        }
     }
 }

--- a/storage/backup/backup-cli/src/coordinators/restore.rs
+++ b/storage/backup/backup-cli/src/coordinators/restore.rs
@@ -16,6 +16,7 @@ use crate::{
     utils::{unix_timestamp_sec, GlobalRestoreOptions},
 };
 use anyhow::{anyhow, bail, Result};
+use aptos_executor_types::VerifyExecutionMode;
 use aptos_logger::prelude::*;
 use aptos_types::transaction::Version;
 use clap::Parser;
@@ -187,7 +188,7 @@ impl RestoreCoordinator {
             txn_manifests,
             None,
             epoch_history,
-            vec![],
+            VerifyExecutionMode::NoVerify,
         )
         .run()
         .await?;

--- a/storage/backup/backup-cli/src/coordinators/verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/verify.rs
@@ -16,6 +16,7 @@ use crate::{
     utils::{unix_timestamp_sec, GlobalRestoreOptions, RestoreRunMode, TrustedWaypointOpt},
 };
 use anyhow::Result;
+use aptos_executor_types::VerifyExecutionMode;
 use aptos_logger::prelude::*;
 use aptos_types::transaction::Version;
 use std::sync::Arc;
@@ -117,7 +118,7 @@ impl VerifyCoordinator {
             txn_manifests,
             None, /* replay_from_version */
             Some(epoch_history),
-            vec![],
+            VerifyExecutionMode::NoVerify,
         )
         .run()
         .await?;


### PR DESCRIPTION
### Description
1. db-restore doesn't go through the VM, which will make it faster
2. replay-verify has --lazy-quit option which will list out all execution problems and quit with an error in the end.


### Test Plan
existing UTs and manually played with the CLI
