### PR TITLE
[cli] Add compile script command

### DIFF
--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -633,7 +633,8 @@ fn compile_script(
         ..BuildOptions::default()
     };
 
-    let pack = BuiltPackage::build(package_dir.to_path_buf(), build_options)?;
+    let pack = BuiltPackage::build(package_dir.to_path_buf(), build_options)
+        .map_err(|e| CliError::MoveCompilationError(format!("{:#}", e)))?;
 
     let scripts_count = pack.script_count();
 


### PR DESCRIPTION
### Description
The current move compile command doesn't let you also compile a script by itself.  This adds the functionality, and gives the hash of the bytecode for convenience.

### Test Plan
```
 ./target/debug/aptos move compile-script --package-dir aptos-move/move-examples/scripts/two_by_two_transfer/
Compiling, may take a little while to download git dependencies...
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING TwoByTwoTransfer
{
  "Result": {
    "script_location": "aptos-move/move-examples/scripts/two_by_two_transfer/script.mv",
    "script_hash": "79a45944e000a09a40983ada600a061daf861955747c1e37035cc551187af932"
  }
}
```
