### PR TITLE
[Workflows] Add 3 more fullnode sync tests for stable builds.

### DIFF
--- a/.github/actions/fullnode-sync/fullnode_sync.py
+++ b/.github/actions/fullnode-sync/fullnode_sync.py
@@ -186,7 +186,7 @@ def setup_fullnode_config(bootstrapping_mode, continuous_syncing_mode, data_dir_
 
   # Add the state sync configurations to the config template
   state_sync_driver_config = {"bootstrapping_mode": bootstrapping_mode, "continuous_syncing_mode": continuous_syncing_mode}
-  data_streaming_service_config = {"max_concurrent_requests": 10}
+  data_streaming_service_config = {"max_concurrent_requests": 10, "max_concurrent_state_requests": 12}
   fullnode_config['state_sync'] = {"state_sync_driver": state_sync_driver_config, "data_streaming_service":data_streaming_service_config}
 
   # Write the config file back to disk

--- a/.github/workflows/fullnode-execute-devnet-stable.yaml
+++ b/.github/workflows/fullnode-execute-devnet-stable.yaml
@@ -1,0 +1,57 @@
+# This workflow runs a public fullnode using the `devnet` branch,
+# connects the public fullnode to `devnet` and synchronizes the
+# node using execution syncing to verify that nothing has been broken.
+
+name: "fullnode-execute-devnet-stable"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9/12 * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/fullnode-execute-devnet-stable.yaml"
+
+jobs:
+  fullnode-execute-devnet-stable:
+    timeout-minutes: 300 # Run for at most 5 hours
+    runs-on: high-perf-docker-with-local-ssd
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+
+      - uses: ./.github/actions/fullnode-sync
+        with:
+          TIMEOUT_MINUTES: 300 # Run for at most 5 hours
+          BRANCH: devnet
+          NETWORK: devnet
+          BOOTSTRAPPING_MODE: ExecuteTransactionsFromGenesis
+          CONTINUOUS_SYNCING_MODE: ExecuteTransactions
+          DATA_DIR_FILE_PATH: /tmp/
+          NODE_LOG_FILE_PATH: /tmp/node_log
+
+      - name: Upload node logs as an artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: node_log
+          path: |
+            /tmp/node_log
+          retention-days: 14
+
+      - name: Post to a Slack channel on failure
+        if: failure()
+        id: slack
+        uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
+        with:
+          payload: |
+            {
+              "text": "${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} `${{ github.job }}`: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}
+
+      # Because we have to checkout the actions and then check out a different
+      # branch, it's possible the actions directory will be modified. So, we
+      # need to check it out again for the Post Run actions/checkout to succeed.
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          path: actions

--- a/.github/workflows/fullnode-fast-mainnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-stable.yaml
@@ -1,0 +1,57 @@
+# This workflow runs a public fullnode using the `mainnet` branch,
+# connects the public fullnode to `mainnet` and synchronizes the
+# node using fast syncing to verify that nothing has been broken.
+
+name: "fullnode-fast-mainnet-stable"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9/12 * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/fullnode-fast-mainnet-stable.yaml"
+
+jobs:
+  fullnode-fast-mainnet-stable:
+    timeout-minutes: 300 # Run for at most 5 hours
+    runs-on: high-perf-docker-with-local-ssd
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+
+      - uses: ./.github/actions/fullnode-sync
+        with:
+          TIMEOUT_MINUTES: 300 # Run for at most 5 hours
+          BRANCH: mainnet
+          NETWORK: mainnet
+          BOOTSTRAPPING_MODE: DownloadLatestStates
+          CONTINUOUS_SYNCING_MODE: ExecuteTransactions
+          DATA_DIR_FILE_PATH: /tmp/
+          NODE_LOG_FILE_PATH: /tmp/node_log
+
+      - name: Upload node logs as an artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: node_log
+          path: |
+            /tmp/node_log
+          retention-days: 14
+
+      - name: Post to a Slack channel on failure
+        if: failure()
+        id: slack
+        uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
+        with:
+          payload: |
+            {
+              "text": "${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} `${{ github.job }}`: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}
+
+      # Because we have to checkout the actions and then check out a different
+      # branch, it's possible the actions directory will be modified. So, we
+      # need to check it out again for the Post Run actions/checkout to succeed.
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          path: actions

--- a/.github/workflows/fullnode-fast-testnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-testnet-stable.yaml
@@ -1,0 +1,57 @@
+# This workflow runs a public fullnode using the `testnet` branch,
+# connects the public fullnode to `testnet` and synchronizes the
+# node using fast syncing to verify that nothing has been broken.
+
+name: "fullnode-fast-testnet-stable"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9/12 * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/fullnode-fast-testnet-stable.yaml"
+
+jobs:
+  fullnode-fast-testnet-stable:
+    timeout-minutes: 300 # Run for at most 5 hours
+    runs-on: high-perf-docker-with-local-ssd
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+
+      - uses: ./.github/actions/fullnode-sync
+        with:
+          TIMEOUT_MINUTES: 300 # Run for at most 5 hours
+          BRANCH: testnet
+          NETWORK: testnet
+          BOOTSTRAPPING_MODE: DownloadLatestStates
+          CONTINUOUS_SYNCING_MODE: ExecuteTransactions
+          DATA_DIR_FILE_PATH: /tmp/
+          NODE_LOG_FILE_PATH: /tmp/node_log
+
+      - name: Upload node logs as an artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: node_log
+          path: |
+            /tmp/node_log
+          retention-days: 14
+
+      - name: Post to a Slack channel on failure
+        if: failure()
+        id: slack
+        uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
+        with:
+          payload: |
+            {
+              "text": "${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} `${{ github.job }}`: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}
+
+      # Because we have to checkout the actions and then check out a different
+      # branch, it's possible the actions directory will be modified. So, we
+      # need to check it out again for the Post Run actions/checkout to succeed.
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          path: actions


### PR DESCRIPTION
### Description
This PR adds 3 final fullnode sync tests to ensure no breakages occur in any of our stable networks and releases:
1. Start a node using the `devnet` branch, connect it to `devnet` and verify it can sync using execution syncing from genesis.
2. Start a node using the `testnet` branch, connect it to `testnet` and verify it can sync using fast syncing (and tail the blockchain using execution syncing).
3. Start a node using the `mainnet` branch, connect it to `mainnet` and verify it can sync using fast syncing (and tail the blockchain using execution syncing).

Note: once these all land, we could probably clean things up a little regarding duplication, etc.

### Test Plan
Existing test infrastructure.