### PR TITLE
[aptos-logger] Add Peer ID and Chain ID as a field to each log entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,7 @@ version = "0.1.0"
 dependencies = [
  "aptos-infallible",
  "aptos-log-derive",
+ "aptos-node-identity",
  "backtrace",
  "chrono",
  "console-subscriber",
@@ -1766,6 +1767,7 @@ dependencies = [
  "aptos-mempool-notifications",
  "aptos-network",
  "aptos-network-builder",
+ "aptos-node-identity",
  "aptos-runtimes",
  "aptos-secure-storage",
  "aptos-state-sync-driver",
@@ -1822,6 +1824,17 @@ dependencies = [
  "thiserror",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "aptos-node-identity"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-types",
+ "claims",
+ "hostname",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "crates/aptos-logger",
     "crates/aptos-metrics-core",
     "crates/aptos-network-checker",
+    "crates/aptos-node-identity",
     "crates/aptos-openapi",
     "crates/aptos-proptest-helpers",
     "crates/aptos-rate-limiter",
@@ -231,6 +232,7 @@ aptos-network-checker = { path = "crates/aptos-network-checker" }
 aptos-network-discovery = { path = "network/discovery" }
 aptos-node = { path = "aptos-node" }
 aptos-node-checker = { path = "ecosystem/node-checker" }
+aptos-node-identity = { path = "crates/aptos-node-identity" }
 aptos-node-resource-metrics = { path = "crates/node-resource-metrics" }
 aptos-num-variants = { path = "crates/num-variants" }
 aptos-openapi = { path = "crates/aptos-openapi" }

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -40,6 +40,7 @@ aptos-mempool = { workspace = true }
 aptos-mempool-notifications = { workspace = true }
 aptos-network = { workspace = true }
 aptos-network-builder = { workspace = true }
+aptos-node-identity = { workspace = true }
 aptos-runtimes = { workspace = true }
 aptos-secure-storage = { workspace = true }
 aptos-state-sync-driver = { workspace = true }

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -154,6 +154,9 @@ pub fn start(
     // Create global rayon thread pool
     utils::create_global_rayon_pool(create_global_rayon_pool);
 
+    // Initialize the global aptos-node-identity
+    aptos_node_identity::init(config.peer_id())?;
+
     // Instantiate the global logger
     let (remote_log_receiver, logger_filter_update) = logger::create_logger(&config, log_file);
 
@@ -355,8 +358,13 @@ pub fn setup_environment_and_start_node(
     // Set the Aptos VM configurations
     utils::set_aptos_vm_configurations(&node_config);
 
-    // Start the telemetry service (as early as possible and before any blocking calls)
+    // Obtain the chain_id from the DB
     let chain_id = utils::fetch_chain_id(&db_rw)?;
+
+    // Set the chain_id in global AptosNodeIdentity
+    aptos_node_identity::set_chain_id(chain_id)?;
+
+    // Start the telemetry service (as early as possible and before any blocking calls)
     let telemetry_runtime = services::start_telemetry_service(
         &node_config,
         remote_log_rx,

--- a/crates/aptos-logger/Cargo.toml
+++ b/crates/aptos-logger/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = { workspace = true }
 [dependencies]
 aptos-infallible = { workspace = true }
 aptos-log-derive = { workspace = true }
+aptos-node-identity = { workspace = true }
 backtrace = { workspace = true }
 chrono = { workspace = true }
 console-subscriber = { workspace = true, optional = true }

--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -62,6 +62,8 @@ pub struct LogEntry {
     timestamp: String,
     data: BTreeMap<Key, serde_json::Value>,
     message: Option<String>,
+    peer_id: Option<&'static str>,
+    chain_id: Option<u8>,
 }
 
 // implement custom serializer for LogEntry since we want to promote the `metadata.level` field into a top-level `level` field
@@ -92,6 +94,9 @@ impl Serialize for LogEntry {
         }
         if let Some(backtrace) = &self.backtrace {
             state.serialize_field("backtrace", backtrace)?;
+        }
+        if let Some(peer_id) = &self.peer_id {
+            state.serialize_field("peer_id", peer_id)?;
         }
         state.end()
     }
@@ -137,6 +142,8 @@ impl LogEntry {
 
         let hostname = HOSTNAME.as_deref();
         let namespace = NAMESPACE.as_deref();
+        let peer_id = aptos_node_identity::peer_id_as_str();
+        let chain_id = aptos_node_identity::chain_id().map(|chain_id| chain_id.id());
 
         let backtrace = if enable_backtrace && matches!(metadata.level(), Level::Error) {
             let mut backtrace = Backtrace::new();
@@ -164,6 +171,8 @@ impl LogEntry {
             timestamp: Utc::now().to_rfc3339_opts(SecondsFormat::Micros, true),
             data,
             message,
+            peer_id,
+            chain_id,
         }
     }
 
@@ -197,6 +206,14 @@ impl LogEntry {
 
     pub fn message(&self) -> Option<&str> {
         self.message.as_deref()
+    }
+
+    pub fn peer_id(&self) -> Option<&str> {
+        self.peer_id
+    }
+
+    pub fn chain_id(&self) -> Option<u8> {
+        self.chain_id
     }
 }
 

--- a/crates/aptos-node-identity/Cargo.toml
+++ b/crates/aptos-node-identity/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "aptos-node-identity"
+description = "Provides identifying information about the running node"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+aptos-types = { workspace = true }
+claims = { workspace = true }
+hostname = { workspace = true }
+once_cell = { workspace = true }

--- a/crates/aptos-node-identity/src/lib.rs
+++ b/crates/aptos-node-identity/src/lib.rs
@@ -1,0 +1,99 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{format_err, Result};
+use aptos_types::{chain_id::ChainId, PeerId};
+use once_cell::sync::OnceCell;
+use std::sync::Arc;
+
+/// The global [AptosNodeIdentity]
+static APTOS_NODE_IDENTITY: OnceCell<Arc<AptosNodeIdentity>> = OnceCell::new();
+
+/// Structure that holds information related to a node's identity
+pub struct AptosNodeIdentity {
+    pub chain_id: OnceCell<ChainId>,
+    pub peer_id: Option<PeerId>,
+    // Holds Peer ID as String to reduce overhead for frequent lookups.
+    pub peer_id_str: Option<String>,
+}
+
+/// Initializes the [AptosNodeIdentity] using the provided [PeerId] and
+/// sets it globally exactly once.
+pub fn init(peer_id: Option<PeerId>) -> Result<()> {
+    let identity = AptosNodeIdentity {
+        chain_id: OnceCell::new(),
+        peer_id,
+        peer_id_str: peer_id.map(|id| id.to_string()),
+    };
+
+    APTOS_NODE_IDENTITY
+        .set(Arc::new(identity))
+        .map_err(|_| format_err!("APTOS_NODE_IDENTITY was already set"))
+}
+
+/// Sets the [ChainId] in the global [AptosNodeIdentity], returning an error
+/// if [init] was not called already.
+pub fn set_chain_id(chain_id: ChainId) -> Result<()> {
+    match APTOS_NODE_IDENTITY.get() {
+        Some(identity) => identity
+            .chain_id
+            .set(chain_id)
+            .map_err(|_| format_err!("chain_id was already set.")),
+        None => Err(format_err!("APTOS_NODE_IDENTITY has not been set yet")),
+    }
+}
+
+/// Returns the [PeerId] from the global [APTOS_NODE_IDENTITY]
+pub fn peer_id() -> Option<PeerId> {
+    APTOS_NODE_IDENTITY
+        .get()
+        .and_then(|identity| identity.peer_id)
+}
+
+/// Returns the [PeerId] as [str] from the global [APTOS_NODE_IDENTITY]
+pub fn peer_id_as_str() -> Option<&'static str> {
+    APTOS_NODE_IDENTITY
+        .get()
+        .and_then(|identity| identity.peer_id_str.as_deref())
+}
+
+/// Returns the [ChainId] from the global [APTOS_NODE_IDENTITY]
+pub fn chain_id() -> Option<ChainId> {
+    APTOS_NODE_IDENTITY
+        .get()
+        .and_then(|identity| identity.chain_id.get().cloned())
+}
+
+#[cfg(test)]
+mod tests {
+    use aptos_types::{chain_id::ChainId, PeerId};
+    use claims::{assert_err, assert_ok};
+
+    #[test]
+    fn test_aptos_node_identity() {
+        // Should return None before init is called
+        assert_eq!(super::peer_id(), None);
+        assert_eq!(super::chain_id(), None);
+
+        // Init with peer_id
+        let peer_id = PeerId::random();
+        assert_ok!(super::init(Some(peer_id)));
+
+        assert_eq!(super::peer_id(), Some(peer_id));
+        assert_eq!(
+            super::peer_id_as_str(),
+            Some(peer_id.to_string()).as_deref()
+        );
+
+        // Calling init again should error
+        assert_err!(super::init(None));
+
+        // Init chain_id
+        let chain_id = ChainId::test();
+        assert_ok!(super::set_chain_id(chain_id));
+        assert_eq!(super::chain_id(), Some(chain_id));
+
+        // Calling set chain ID again should error
+        assert_err!(super::set_chain_id(chain_id));
+    }
+}


### PR DESCRIPTION
### Description

This PR adds Peer ID as a field to each log entry. It does so by introducing a new crate `aptos-node-identity` that acts as a global object to provide this information to callers using a `static OnceCell` variable. The variable is initialized from `aptos-node` via the `init()` method. It has as few internal dependencies as possible to avoid any possible cyclic dependency errors. It also separates initializing chain_id from peer_id, because the latter is available at node boot, while the former is only available later after DB bootstrap. To add to the log entry, a new `peer_id` Entry field is introduced, which is populated by calling the new crate. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

`RUST_LOG_FORMAT=json cargo run -p aptos-node -- --test`
