### PR TITLE
[Workflows] Some improvements to the fullnode sync workflows.

### DIFF
--- a/.github/workflows/fullnode-execute-devnet-main.yaml
+++ b/.github/workflows/fullnode-execute-devnet-main.yaml
@@ -13,45 +13,11 @@ on:
 
 jobs:
   fullnode-execute-devnet-main:
-    timeout-minutes: 300 # Run for at most 5 hours
-    runs-on: high-perf-docker-with-local-ssd
-    steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-
-      - uses: ./.github/actions/fullnode-sync
-        with:
-          TIMEOUT_MINUTES: 300 # Run for at most 5 hours
-          BRANCH: main
-          NETWORK: devnet
-          BOOTSTRAPPING_MODE: ExecuteTransactionsFromGenesis
-          CONTINUOUS_SYNCING_MODE: ExecuteTransactions
-          DATA_DIR_FILE_PATH: /tmp/
-          NODE_LOG_FILE_PATH: /tmp/node_log
-
-      - name: Upload node logs as an artifact
-        uses: actions/upload-artifact@v3
-        if: ${{ always() }}
-        with:
-          name: node_log
-          path: |
-            /tmp/node_log
-          retention-days: 14
-
-      - name: Post to a Slack channel on failure
-        if: failure()
-        id: slack
-        uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
-        with:
-          payload: |
-            {
-              "text": "${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} `${{ github.job }}`: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}
-
-      # Because we have to checkout the actions and then check out a different
-      # branch, it's possible the actions directory will be modified. So, we
-      # need to check it out again for the Post Run actions/checkout to succeed.
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-        with:
-          path: actions
+    uses: ./.github/workflows/run-fullnode-sync.yaml
+    secrets: inherit
+    with:
+      TEST_NAME: fullnode-execute-devnet-main
+      BRANCH: main
+      NETWORK: devnet
+      BOOTSTRAPPING_MODE: ExecuteTransactionsFromGenesis
+      CONTINUOUS_SYNCING_MODE: ExecuteTransactions

--- a/.github/workflows/fullnode-execute-devnet-stable.yaml
+++ b/.github/workflows/fullnode-execute-devnet-stable.yaml
@@ -13,45 +13,11 @@ on:
 
 jobs:
   fullnode-execute-devnet-stable:
-    timeout-minutes: 300 # Run for at most 5 hours
-    runs-on: high-perf-docker-with-local-ssd
-    steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-
-      - uses: ./.github/actions/fullnode-sync
-        with:
-          TIMEOUT_MINUTES: 300 # Run for at most 5 hours
-          BRANCH: devnet
-          NETWORK: devnet
-          BOOTSTRAPPING_MODE: ExecuteTransactionsFromGenesis
-          CONTINUOUS_SYNCING_MODE: ExecuteTransactions
-          DATA_DIR_FILE_PATH: /tmp/
-          NODE_LOG_FILE_PATH: /tmp/node_log
-
-      - name: Upload node logs as an artifact
-        uses: actions/upload-artifact@v3
-        if: ${{ always() }}
-        with:
-          name: node_log
-          path: |
-            /tmp/node_log
-          retention-days: 14
-
-      - name: Post to a Slack channel on failure
-        if: failure()
-        id: slack
-        uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
-        with:
-          payload: |
-            {
-              "text": "${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} `${{ github.job }}`: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}
-
-      # Because we have to checkout the actions and then check out a different
-      # branch, it's possible the actions directory will be modified. So, we
-      # need to check it out again for the Post Run actions/checkout to succeed.
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-        with:
-          path: actions
+    uses: ./.github/workflows/run-fullnode-sync.yaml
+    secrets: inherit
+    with:
+      TEST_NAME: fullnode-execute-devnet-stable
+      BRANCH: devnet
+      NETWORK: devnet
+      BOOTSTRAPPING_MODE: ExecuteTransactionsFromGenesis
+      CONTINUOUS_SYNCING_MODE: ExecuteTransactions

--- a/.github/workflows/fullnode-fast-mainnet-main.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-main.yaml
@@ -13,45 +13,11 @@ on:
 
 jobs:
   fullnode-fast-mainnet-main:
-    timeout-minutes: 300 # Run for at most 5 hours
-    runs-on: high-perf-docker-with-local-ssd
-    steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-
-      - uses: ./.github/actions/fullnode-sync
-        with:
-          TIMEOUT_MINUTES: 300 # Run for at most 5 hours
-          BRANCH: main
-          NETWORK: mainnet
-          BOOTSTRAPPING_MODE: DownloadLatestStates
-          CONTINUOUS_SYNCING_MODE: ExecuteTransactions
-          DATA_DIR_FILE_PATH: /tmp/
-          NODE_LOG_FILE_PATH: /tmp/node_log
-
-      - name: Upload node logs as an artifact
-        uses: actions/upload-artifact@v3
-        if: ${{ always() }}
-        with:
-          name: node_log
-          path: |
-            /tmp/node_log
-          retention-days: 14
-
-      - name: Post to a Slack channel on failure
-        if: failure()
-        id: slack
-        uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
-        with:
-          payload: |
-            {
-              "text": "${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} `${{ github.job }}`: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}
-
-      # Because we have to checkout the actions and then check out a different
-      # branch, it's possible the actions directory will be modified. So, we
-      # need to check it out again for the Post Run actions/checkout to succeed.
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-        with:
-          path: actions
+    uses: ./.github/workflows/run-fullnode-sync.yaml
+    secrets: inherit
+    with:
+      TEST_NAME: fullnode-fast-mainnet-main
+      BRANCH: main
+      NETWORK: mainnet
+      BOOTSTRAPPING_MODE: DownloadLatestStates
+      CONTINUOUS_SYNCING_MODE: ExecuteTransactions

--- a/.github/workflows/fullnode-fast-mainnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-stable.yaml
@@ -13,45 +13,11 @@ on:
 
 jobs:
   fullnode-fast-mainnet-stable:
-    timeout-minutes: 300 # Run for at most 5 hours
-    runs-on: high-perf-docker-with-local-ssd
-    steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-
-      - uses: ./.github/actions/fullnode-sync
-        with:
-          TIMEOUT_MINUTES: 300 # Run for at most 5 hours
-          BRANCH: mainnet
-          NETWORK: mainnet
-          BOOTSTRAPPING_MODE: DownloadLatestStates
-          CONTINUOUS_SYNCING_MODE: ExecuteTransactions
-          DATA_DIR_FILE_PATH: /tmp/
-          NODE_LOG_FILE_PATH: /tmp/node_log
-
-      - name: Upload node logs as an artifact
-        uses: actions/upload-artifact@v3
-        if: ${{ always() }}
-        with:
-          name: node_log
-          path: |
-            /tmp/node_log
-          retention-days: 14
-
-      - name: Post to a Slack channel on failure
-        if: failure()
-        id: slack
-        uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
-        with:
-          payload: |
-            {
-              "text": "${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} `${{ github.job }}`: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}
-
-      # Because we have to checkout the actions and then check out a different
-      # branch, it's possible the actions directory will be modified. So, we
-      # need to check it out again for the Post Run actions/checkout to succeed.
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-        with:
-          path: actions
+    uses: ./.github/workflows/run-fullnode-sync.yaml
+    secrets: inherit
+    with:
+      TEST_NAME: fullnode-fast-mainnet-stable
+      BRANCH: mainnet
+      NETWORK: mainnet
+      BOOTSTRAPPING_MODE: DownloadLatestStates
+      CONTINUOUS_SYNCING_MODE: ExecuteTransactions

--- a/.github/workflows/fullnode-fast-testnet-main.yaml
+++ b/.github/workflows/fullnode-fast-testnet-main.yaml
@@ -13,45 +13,11 @@ on:
 
 jobs:
   fullnode-fast-testnet-main:
-    timeout-minutes: 300 # Run for at most 5 hours
-    runs-on: high-perf-docker-with-local-ssd
-    steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-
-      - uses: ./.github/actions/fullnode-sync
-        with:
-          TIMEOUT_MINUTES: 300 # Run for at most 5 hours
-          BRANCH: main
-          NETWORK: testnet
-          BOOTSTRAPPING_MODE: DownloadLatestStates
-          CONTINUOUS_SYNCING_MODE: ExecuteTransactions
-          DATA_DIR_FILE_PATH: /tmp/
-          NODE_LOG_FILE_PATH: /tmp/node_log
-
-      - name: Upload node logs as an artifact
-        uses: actions/upload-artifact@v3
-        if: ${{ always() }}
-        with:
-          name: node_log
-          path: |
-            /tmp/node_log
-          retention-days: 14
-
-      - name: Post to a Slack channel on failure
-        if: failure()
-        id: slack
-        uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
-        with:
-          payload: |
-            {
-              "text": "${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} `${{ github.job }}`: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}
-
-      # Because we have to checkout the actions and then check out a different
-      # branch, it's possible the actions directory will be modified. So, we
-      # need to check it out again for the Post Run actions/checkout to succeed.
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-        with:
-          path: actions
+    uses: ./.github/workflows/run-fullnode-sync.yaml
+    secrets: inherit
+    with:
+      TEST_NAME: fullnode-fast-testnet-main
+      BRANCH: main
+      NETWORK: testnet
+      BOOTSTRAPPING_MODE: DownloadLatestStates
+      CONTINUOUS_SYNCING_MODE: ExecuteTransactions

--- a/.github/workflows/fullnode-fast-testnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-testnet-stable.yaml
@@ -13,45 +13,11 @@ on:
 
 jobs:
   fullnode-fast-testnet-stable:
-    timeout-minutes: 300 # Run for at most 5 hours
-    runs-on: high-perf-docker-with-local-ssd
-    steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-
-      - uses: ./.github/actions/fullnode-sync
-        with:
-          TIMEOUT_MINUTES: 300 # Run for at most 5 hours
-          BRANCH: testnet
-          NETWORK: testnet
-          BOOTSTRAPPING_MODE: DownloadLatestStates
-          CONTINUOUS_SYNCING_MODE: ExecuteTransactions
-          DATA_DIR_FILE_PATH: /tmp/
-          NODE_LOG_FILE_PATH: /tmp/node_log
-
-      - name: Upload node logs as an artifact
-        uses: actions/upload-artifact@v3
-        if: ${{ always() }}
-        with:
-          name: node_log
-          path: |
-            /tmp/node_log
-          retention-days: 14
-
-      - name: Post to a Slack channel on failure
-        if: failure()
-        id: slack
-        uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
-        with:
-          payload: |
-            {
-              "text": "${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} `${{ github.job }}`: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}
-
-      # Because we have to checkout the actions and then check out a different
-      # branch, it's possible the actions directory will be modified. So, we
-      # need to check it out again for the Post Run actions/checkout to succeed.
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-        with:
-          path: actions
+    uses: ./.github/workflows/run-fullnode-sync.yaml
+    secrets: inherit
+    with:
+      TEST_NAME: fullnode-fast-testnet-stable
+      BRANCH: testnet
+      NETWORK: testnet
+      BOOTSTRAPPING_MODE: DownloadLatestStates
+      CONTINUOUS_SYNCING_MODE: ExecuteTransactions

--- a/.github/workflows/fullnode-intelligent-devnet-main.yaml
+++ b/.github/workflows/fullnode-intelligent-devnet-main.yaml
@@ -14,45 +14,11 @@ on:
 
 jobs:
   fullnode-intelligent-devnet-main:
-    timeout-minutes: 300 # Run for at most 5 hours
-    runs-on: high-perf-docker-with-local-ssd
-    steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-
-      - uses: ./.github/actions/fullnode-sync
-        with:
-          TIMEOUT_MINUTES: 300 # Run for at most 5 hours
-          BRANCH: main
-          NETWORK: devnet
-          BOOTSTRAPPING_MODE: ExecuteOrApplyFromGenesis
-          CONTINUOUS_SYNCING_MODE: ExecuteTransactionsOrApplyOutputs
-          DATA_DIR_FILE_PATH: /tmp/
-          NODE_LOG_FILE_PATH: /tmp/node_log
-
-      - name: Upload node logs as an artifact
-        uses: actions/upload-artifact@v3
-        if: ${{ always() }}
-        with:
-          name: node_log
-          path: |
-            /tmp/node_log
-          retention-days: 14
-
-      - name: Post to a Slack channel on failure
-        if: failure()
-        id: slack
-        uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
-        with:
-          payload: |
-            {
-              "text": "${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} `${{ github.job }}`: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}
-
-      # Because we have to checkout the actions and then check out a different
-      # branch, it's possible the actions directory will be modified. So, we
-      # need to check it out again for the Post Run actions/checkout to succeed.
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-        with:
-          path: actions
+    uses: ./.github/workflows/run-fullnode-sync.yaml
+    secrets: inherit
+    with:
+      TEST_NAME: fullnode-intelligent-devnet-main
+      BRANCH: main
+      NETWORK: devnet
+      BOOTSTRAPPING_MODE: ExecuteOrApplyFromGenesis
+      CONTINUOUS_SYNCING_MODE: ExecuteTransactionsOrApplyOutputs

--- a/.github/workflows/fullnode-output-mainnet-main.yaml
+++ b/.github/workflows/fullnode-output-mainnet-main.yaml
@@ -13,45 +13,11 @@ on:
 
 jobs:
   fullnode-output-mainnet-main:
-    timeout-minutes: 300 # Run for at most 5 hours
-    runs-on: high-perf-docker-with-local-ssd
-    steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-
-      - uses: ./.github/actions/fullnode-sync
-        with:
-          TIMEOUT_MINUTES: 300 # Run for at most 5 hours
-          BRANCH: main
-          NETWORK: mainnet
-          BOOTSTRAPPING_MODE: ApplyTransactionOutputsFromGenesis
-          CONTINUOUS_SYNCING_MODE: ApplyTransactionOutputs
-          DATA_DIR_FILE_PATH: /tmp/
-          NODE_LOG_FILE_PATH: /tmp/node_log
-
-      - name: Upload node logs as an artifact
-        uses: actions/upload-artifact@v3
-        if: ${{ always() }}
-        with:
-          name: node_log
-          path: |
-            /tmp/node_log
-          retention-days: 14
-
-      - name: Post to a Slack channel on failure
-        if: failure()
-        id: slack
-        uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
-        with:
-          payload: |
-            {
-              "text": "${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} `${{ github.job }}`: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}
-
-      # Because we have to checkout the actions and then check out a different
-      # branch, it's possible the actions directory will be modified. So, we
-      # need to check it out again for the Post Run actions/checkout to succeed.
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-        with:
-          path: actions
+    uses: ./.github/workflows/run-fullnode-sync.yaml
+    secrets: inherit
+    with:
+      TEST_NAME: fullnode-output-mainnet-main
+      BRANCH: main
+      NETWORK: mainnet
+      BOOTSTRAPPING_MODE: ApplyTransactionOutputsFromGenesis
+      CONTINUOUS_SYNCING_MODE: ApplyTransactionOutputs

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -133,7 +133,7 @@ jobs:
           # For posting a rich message using Block Kit
           payload: |
             {
-              "text": "${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} ${{ github.job }}(suite: `${{ inputs.FORGE_TEST_SUITE }}`, namespace: `${{ inputs.FORGE_NAMESPACE }}`): <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>"
+              "text": "${{ ':x:' }} ${{ github.job }}(suite: `${{ inputs.FORGE_TEST_SUITE }}`, namespace: `${{ inputs.FORGE_NAMESPACE }}`): <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/run-fullnode-sync.yaml
+++ b/.github/workflows/run-fullnode-sync.yaml
@@ -1,0 +1,79 @@
+# This workflow is a simple wrapper around the fullnode-sync github
+# action. It invokes the action with all the neccessary configurations
+# required by the specific fullnode sync test instance.
+
+name: "Run Fullnode Sync"
+
+on:
+  workflow_call:
+    inputs:
+      TEST_NAME:
+        description: "The unique name of the fullnode test."
+        type: string
+        required: true
+      BRANCH:
+        description: "The aptos-core branch to switch to before running the fullnode."
+        type: string
+        required: true
+      NETWORK:
+        description: "The network to connect the fullnode to: devnet, testnet, or mainnet."
+        type: string
+        required: true
+      BOOTSTRAPPING_MODE:
+        description: "The state sync bootstrapping mode for the fullnode."
+        type: string
+        required: true
+      CONTINUOUS_SYNCING_MODE:
+        description: "The state sync continuous syncing mode for the fullnode."
+        type: string
+        required: true
+      TIMEOUT_MINUTES:
+        description: "The number of minutes to wait for fullnode sync to finish."
+        type: number
+        required: false
+        default: 300 # Run for at most 5 hours
+
+jobs:
+  fullnode-sync:
+    runs-on: high-perf-docker-with-local-ssd
+    timeout-minutes: ${{ inputs.TIMEOUT_MINUTES }}
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+
+      - uses: ./.github/actions/fullnode-sync
+        with:
+          TIMEOUT_MINUTES: ${{ inputs.TIMEOUT_MINUTES }}
+          BRANCH: ${{ inputs.BRANCH }}
+          NETWORK: ${{ inputs.NETWORK }}
+          BOOTSTRAPPING_MODE: ${{ inputs.BOOTSTRAPPING_MODE }}
+          CONTINUOUS_SYNCING_MODE: ${{ inputs.CONTINUOUS_SYNCING_MODE }}
+          DATA_DIR_FILE_PATH: /tmp/
+          NODE_LOG_FILE_PATH: /tmp/node_log
+
+      - name: Upload node logs as an artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: node_log
+          path: |
+            /tmp/node_log
+          retention-days: 14
+
+      - name: Post to a Slack channel on failure
+        if: failure()
+        id: slack
+        uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
+        with:
+          payload: |
+            {
+              "text": "${{ ':x:' }} `${{ inputs.TEST_NAME  }}`: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}
+
+      # Because we have to checkout the actions and then check out a different
+      # branch, it's possible the actions directory will be modified. So, we
+      # need to check it out again for the Post Run actions/checkout to succeed.
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          path: actions


### PR DESCRIPTION
### Description
This PR makes the following small improvements to the fullnode sync workflows:
1. Updates the fullnode sync python script to track the node syncing progress via the metrics port instead of the REST API. This allows the script to be more accurate and avoid the limitations in the REST API regarding syncing versions and states.
2. Removes the duplication between the various fullnode workflow files by introducing a new unified workflow file that individual test instances call.
3. Simplifies the slack message logic for displaying failures (e.g., see the comment here https://github.com/aptos-labs/aptos-core/pull/6443 by @ibalajiarun) 😄 

### Test Plan
Manual verification.