### PR TITLE
Silence dead code warnings in consensus

### DIFF
--- a/consensus/src/payload_manager.rs
+++ b/consensus/src/payload_manager.rs
@@ -20,6 +20,7 @@ use tokio::sync::oneshot;
 /// If QuorumStore is enabled, has to ask BatchReader for the transaction behind the proofs of availability in the payload.
 pub enum PayloadManager {
     DirectMempool,
+    #[allow(dead_code)]
     InQuorumStore(BatchReader, Mutex<Sender<PayloadRequest>>),
 }
 

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -37,6 +37,7 @@ type NotificationType = (
     Vec<ContractEvent>,
 );
 
+#[allow(dead_code)]
 type CommitType = (u64, Round, Vec<Payload>);
 
 /// Basic communication with the Execution module;


### PR DESCRIPTION
### Description
These warnings have been here for a long time. I'll open an issue to clean these up later.

### Test Plan
```
cargo run -p aptos-node
```
