### PR TITLE
[Performance] Enable sse4.2.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,8 +14,9 @@ xclippy = [
 [build]
 rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes"]
 
+# TODO(grao): Figure out whether we should enable other cpu features, and whether we should use a different way to configure them rather than list every single one here.
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["--cfg", "tokio_unstable", "-C", "link-arg=-fuse-ld=lld", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes"]
+rustflags = ["--cfg", "tokio_unstable", "-C", "link-arg=-fuse-ld=lld", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes", "-C", "target-feature=+sse4.2"]
 
 # 64 bit MSVC
 [target.x86_64-pc-windows-msvc]


### PR DESCRIPTION
### Description

This will significantly improve RocksDB performance (when DB is getting enough load and becomes the bottleneck) since it provides CRC32 instructions.

![image](https://user-images.githubusercontent.com/3603304/216261300-4b4e3493-1ceb-46c9-9f53-2ebbdd7445d2.png)


### Test Plan
The graph shows the JMT node reading latency before and after the change, on a 600M items DB, doing account creation by a fake executor that simulates read/write.
