### PR TITLE
[Aptos CLI] Added simple CLI command to check the network.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ dependencies = [
  "aptos-global-constants",
  "aptos-keygen",
  "aptos-logger",
+ "aptos-network-checker",
  "aptos-node",
  "aptos-rest-client",
  "aptos-sdk",

--- a/crates/aptos-network-checker/src/args.rs
+++ b/crates/aptos-network-checker/src/args.rs
@@ -59,7 +59,7 @@ pub struct CheckEndpointArgs {
     pub handshake_args: HandshakeArgs,
 }
 
-fn validate_address(address: &str) -> Result<NetworkAddress> {
+pub fn validate_address(address: &str) -> Result<NetworkAddress> {
     let address = NetworkAddress::from_str(address)
         .with_context(|| format!("Invalid address: {}", address))?;
     if !address.is_aptosnet_addr() {

--- a/crates/aptos-network-checker/src/check_endpoint.rs
+++ b/crates/aptos-network-checker/src/check_endpoint.rs
@@ -4,7 +4,7 @@
 use crate::args::CheckEndpointArgs;
 use anyhow::{bail, Context, Result};
 use aptos_config::{
-    config::{RoleType, HANDSHAKE_VERSION},
+    config::{Error, RoleType, HANDSHAKE_VERSION},
     network_id::{NetworkContext, NetworkId},
 };
 use aptos_crypto::x25519::{self, PRIVATE_KEY_SIZE};
@@ -102,7 +102,12 @@ async fn check_endpoint_with_handshake(
         remote_pubkey,
     )
     .await
-    .with_context(|| format!("Failed to connect to {}", address))?;
+    .map_err(|error| {
+        Error::Unexpected(format!(
+            "Failed to connect to {}. Error: {}",
+            address, error
+        ))
+    })?;
     let msg = format!("Successfully connected to {}", conn.metadata.addr);
 
     // Disconnect.
@@ -116,12 +121,19 @@ async fn check_endpoint_no_handshake(address: NetworkAddress) -> Result<String> 
     let mut socket = resolve_and_connect(address.clone(), TCPBufferCfg::new())
         .await
         .map(TcpSocket::new)
-        .with_context(|| format!("Failed to connect to {}", address))?;
+        .map_err(|error| {
+            Error::Unexpected(format!(
+                "Failed to connect to {}. Error: {}",
+                address, error
+            ))
+        })?;
 
     socket
         .write_all(INVALID_NOISE_HEADER)
         .await
-        .with_context(|| format!("Failed to write to {}", address))?;
+        .map_err(|error| {
+            Error::Unexpected(format!("Failed to write to {}. Error: {}", address, error))
+        })?;
 
     let buf = &mut [0; 1];
     match socket.read(buf).await {

--- a/crates/aptos-network-checker/src/lib.rs
+++ b/crates/aptos-network-checker/src/lib.rs
@@ -3,3 +3,5 @@
 
 pub mod args;
 pub mod check_endpoint;
+
+pub use check_endpoint::check_endpoint;

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -28,6 +28,7 @@ aptos-github-client = { workspace = true }
 aptos-global-constants = { workspace = true }
 aptos-keygen = { workspace = true }
 aptos-logger = { workspace = true }
+aptos-network-checker = { workspace = true }
 aptos-node = { workspace = true }
 aptos-rest-client = { workspace = true }
 aptos-sdk = { workspace = true }

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -30,6 +30,9 @@ use aptos_config::config::NodeConfig;
 use aptos_crypto::{bls12381, bls12381::PublicKey, x25519, ValidCryptoMaterialStringExt};
 use aptos_faucet::FaucetArgs;
 use aptos_genesis::config::{HostAndPort, OperatorConfiguration};
+use aptos_network_checker::args::{
+    validate_address, CheckEndpointArgs, HandshakeArgs, NodeAddressArgs,
+};
 use aptos_rest_client::{aptos_api_types::VersionedEvent, Client, State};
 use aptos_types::{
     account_address::AccountAddress,
@@ -70,6 +73,7 @@ const SECS_TO_MICROSECS: u64 = 1_000_000;
 /// identify issues with nodes, and show related information.
 #[derive(Parser)]
 pub enum NodeTool {
+    CheckNetworkConnectivity(CheckNetworkConnectivity),
     GetPerformance(GetPerformance),
     GetStakePool(GetStakePool),
     InitializeValidator(InitializeValidator),
@@ -90,6 +94,7 @@ impl NodeTool {
     pub async fn execute(self) -> CliResult {
         use NodeTool::*;
         match self {
+            CheckNetworkConnectivity(tool) => tool.execute_serialized().await,
             GetPerformance(tool) => tool.execute_serialized().await,
             GetStakePool(tool) => tool.execute_serialized().await,
             InitializeValidator(tool) => tool.execute_serialized().await,
@@ -1526,6 +1531,54 @@ impl CliCommand<()> for BootstrapDbFromBackup {
     }
 }
 
+/// Checks the network connectivity of a node
+///
+/// Checks network connectivity by dialing the node and attempting
+/// to establish a connection with a noise handshake.
+#[derive(Parser)]
+pub struct CheckNetworkConnectivity {
+    /// `NetworkAddress` of remote server interface.
+    /// Examples include:
+    /// - `/dns/example.com/tcp/6180/noise-ik/<x25519-pubkey>/handshake/1`
+    /// - `/ip4/<ip-address>/tcp/6182/noise-ik/<x25519-pubkey>/handshake/0`
+    #[clap(long, value_parser = validate_address)]
+    pub address: NetworkAddress,
+
+    /// `ChainId` of remote server.
+    /// Examples include:
+    /// - Chain numbers, e.g., `2`, `3` and `25`.
+    /// - Chain names, e.g., `devnet`, `testnet`, `mainnet` and `testing` (for local test networks).
+    #[clap(long)]
+    pub chain_id: ChainId,
+
+    #[clap(flatten)]
+    pub handshake_args: HandshakeArgs,
+}
+
+#[async_trait]
+impl CliCommand<String> for CheckNetworkConnectivity {
+    fn command_name(&self) -> &'static str {
+        "CheckNetworkConnectivity"
+    }
+
+    async fn execute(self) -> CliTypedResult<String> {
+        // Create the check endpoint args for the checker
+        let node_address_args = NodeAddressArgs {
+            address: self.address,
+            chain_id: self.chain_id,
+        };
+        let check_endpoint_args = CheckEndpointArgs {
+            node_address_args,
+            handshake_args: self.handshake_args,
+        };
+
+        // Check the endpoint
+        aptos_network_checker::check_endpoint(&check_endpoint_args, None)
+            .await
+            .map_err(|error| CliError::UnexpectedError(error.to_string()))
+    }
+}
+
 /// Show Epoch information
 ///
 /// Displays the current epoch, the epoch length, and the estimated time of the next epoch
@@ -1606,5 +1659,59 @@ impl Time {
 
     pub fn new_seconds(seconds: u64) -> Self {
         Self::new(Duration::from_secs(seconds))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{CliResult, Tool};
+    use clap::Parser;
+
+    // TODO: there have to be cleaner ways to test things. Maybe a CLI test framework?
+
+    #[tokio::test]
+    // Verifies basic properties about the network connectivity checker
+    async fn test_check_network_connectivity() {
+        // Verify the help function works
+        let args = &["aptos", "node", "check-network-connectivity", "--help"];
+        let help_message = run_tool_with_args(args).await.unwrap_err();
+        assert_contains(help_message, "USAGE:"); // We expect the command to return USAGE info
+
+        // Verify that an invalid address will return an error
+        let args = &[
+            "aptos",
+            "node",
+            "check-network-connectivity",
+            "--address",
+            "invalid-address",
+            "--chain-id",
+            "mainnet",
+        ];
+        let error_message = run_tool_with_args(args).await.unwrap_err();
+        assert_contains(error_message, "Invalid address");
+
+        // Verify that an invalid chain-id will return an error
+        let args = &["aptos", "node", "check-network-connectivity", "--address", "/ip4/34.70.116.169/tcp/6182/noise-ik/0x249f3301db104705652e0a0c471b46d13172b2baf14e31f007413f3baee46b0c/handshake/0", "--chain-id", "invalid-chain"];
+        let error_message = run_tool_with_args(args).await.unwrap_err();
+        assert_contains(error_message, "Invalid value");
+
+        // Verify that a failure to connect will return a timeout
+        let args = &["aptos", "node", "check-network-connectivity", "--address", "/ip4/31.71.116.169/tcp/0001/noise-ik/0x249f3301db104705652e0a0c471b46d13172b2baf14e31f007413f3baee46b0c/handshake/0", "--chain-id", "testnet"];
+        let error_message = run_tool_with_args(args).await.unwrap_err();
+        assert_contains(error_message, "Timed out while checking endpoint");
+    }
+
+    async fn run_tool_with_args(args: &[&str]) -> CliResult {
+        let tool: Tool = Tool::try_parse_from(args).map_err(|msg| msg.to_string())?;
+        tool.execute().await
+    }
+
+    fn assert_contains(message: String, expected_string: &str) {
+        if !message.contains(expected_string) {
+            panic!(
+                "Expected message to contain {:?}, but it did not! Message: {:?}",
+                expected_string, message
+            );
+        }
     }
 }

--- a/crates/aptos/src/test/tests.rs
+++ b/crates/aptos/src/test/tests.rs
@@ -68,6 +68,7 @@ async fn ensure_every_command_args_work() {
     assert_cmd_not_panic(&["aptos", "move", "view", "--help"]).await;
 
     assert_cmd_not_panic(&["aptos", "node"]).await;
+    assert_cmd_not_panic(&["aptos", "node", "check-network-connectivity", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "node", "get-stake-pool", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "node", "analyze-validator-performance", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "node", "bootstrap-db-from-backup", "--help"]).await;

--- a/types/src/chain_id.rs
+++ b/types/src/chain_id.rs
@@ -30,19 +30,9 @@ const TESTING: &str = "testing";
 const PREMAINNET: &str = "premainnet";
 
 impl NamedChain {
-    fn str_to_chain_id(s: &str) -> Result<ChainId> {
-        // TODO implement custom macro that derives FromStr impl for enum (similar to aptos-core/common/num-variants)
-        let reserved_chain = match s.to_lowercase().as_str() {
-            MAINNET => NamedChain::MAINNET,
-            TESTNET => NamedChain::TESTNET,
-            DEVNET => NamedChain::DEVNET,
-            TESTING => NamedChain::TESTING,
-            PREMAINNET => NamedChain::PREMAINNET,
-            _ => {
-                return Err(format_err!("Not a reserved chain: {:?}", s));
-            },
-        };
-        Ok(ChainId::new(reserved_chain.id()))
+    fn str_to_chain_id(string: &str) -> Result<ChainId> {
+        let named_chain = NamedChain::from_str(string)?;
+        Ok(ChainId::new(named_chain.id()))
     }
 
     pub fn id(&self) -> u8 {
@@ -50,14 +40,33 @@ impl NamedChain {
     }
 
     pub fn from_chain_id(chain_id: &ChainId) -> Result<NamedChain, String> {
-        match chain_id.id() {
+        let chain_id = chain_id.id();
+        match chain_id {
             1 => Ok(NamedChain::MAINNET),
             2 => Ok(NamedChain::TESTNET),
             3 => Ok(NamedChain::DEVNET),
             4 => Ok(NamedChain::TESTING),
             5 => Ok(NamedChain::PREMAINNET),
-            _ => Err(String::from("Not a named chain")),
+            _ => Err(format!("Not a named chain. Given ID: {:?}", chain_id)),
         }
+    }
+}
+
+impl FromStr for NamedChain {
+    type Err = Error;
+
+    fn from_str(string: &str) -> Result<Self> {
+        let named_chain = match string.to_lowercase().as_str() {
+            MAINNET => NamedChain::MAINNET,
+            TESTNET => NamedChain::TESTNET,
+            DEVNET => NamedChain::DEVNET,
+            TESTING => NamedChain::TESTING,
+            PREMAINNET => NamedChain::PREMAINNET,
+            _ => {
+                return Err(format_err!("Not a reserved chain name: {:?}", string));
+            },
+        };
+        Ok(named_chain)
     }
 }
 


### PR DESCRIPTION
### Description
This PR adds a new `check-network-connectivity` command to the Aptos CLI. This is useful for testing network connections to Aptos nodes by performing a noise handshake with the node. For example, this run verifies that we can connect to a VFN in testnet:

```
% cargo run -p aptos -- node check-network-connectivity --address "/ip4/34.70.116.169/tcp/6182/noise-ik/0x249f3301db104705652e0a0c471b46d13172b2baf14e31f007413f3baee46b0c/handshake/0" --chain-id testnet
...
{
  "Result": "Successfully connected to /ip4/34.70.116.169/tcp/6182/noise-ik/0x249f3301db104705652e0a0c471b46d13172b2baf14e31f007413f3baee46b0c/handshake/0"
}

```

### Test Plan
New unit tests have been added. Also, I verified the behaviour manually. For example, giving the tool the wrong chain ID:

```
% cargo run -p aptos -- node check-network-connectivity --address "/ip4/34.70.116.169/tcp/6182/noise-ik/0x249f3301db104705652e0a0c471b46d13172b2baf14e31f007413f3baee46b0c/handshake/0" --chain-id 5
...
{
  "Error": "Unexpected error: Unexpected error: Failed to connect to /ip4/34.70.116.169/tcp/6182/noise-ik/0x249f3301db104705652e0a0c471b46d13172b2baf14e31f007413f3baee46b0c/handshake/0. Error: handshake negotiation with peer 249f3301db104705652e0a0c471b46d13172b2baf14e31f007413f3baee46b0c failed: aptos-handshake: the received message has a different chain id: testnet, expected: premainnet"
}

```