### PR TITLE
[telemetry-service] Add hostname to metrics kubernetes_pod_name label 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2430,6 +2430,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-metrics-core",
  "aptos-network",
+ "aptos-node-identity",
  "aptos-node-resource-metrics",
  "aptos-runtimes",
  "aptos-state-sync-driver",

--- a/crates/aptos-node-identity/src/lib.rs
+++ b/crates/aptos-node-identity/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{format_err, Result};
-use aptos_types::{chain_id::ChainId, PeerId};
+use aptos_types::{chain_id::ChainId, hostname::Hostname, PeerId};
 use once_cell::sync::OnceCell;
 use std::sync::Arc;
 
@@ -15,6 +15,7 @@ pub struct AptosNodeIdentity {
     pub peer_id: Option<PeerId>,
     // Holds Peer ID as String to reduce overhead for frequent lookups.
     pub peer_id_str: Option<String>,
+    pub hostname: Option<Hostname>,
 }
 
 /// Initializes the [AptosNodeIdentity] using the provided [PeerId] and
@@ -24,6 +25,10 @@ pub fn init(peer_id: Option<PeerId>) -> Result<()> {
         chain_id: OnceCell::new(),
         peer_id,
         peer_id_str: peer_id.map(|id| id.to_string()),
+        hostname: hostname::get()
+            .ok()
+            .and_then(|name| name.into_string().ok())
+            .map(Hostname::new),
     };
 
     APTOS_NODE_IDENTITY
@@ -62,6 +67,13 @@ pub fn chain_id() -> Option<ChainId> {
     APTOS_NODE_IDENTITY
         .get()
         .and_then(|identity| identity.chain_id.get().cloned())
+}
+
+/// Returns the hostname from the global [APTOS_NODE_IDENTITY]
+pub fn hostname() -> Option<Hostname> {
+    APTOS_NODE_IDENTITY
+        .get()
+        .and_then(|identity| identity.hostname.clone())
 }
 
 #[cfg(test)]

--- a/crates/aptos-telemetry-service/src/auth.rs
+++ b/crates/aptos-telemetry-service/src/auth.rs
@@ -141,6 +141,7 @@ pub async fn handle_auth(context: Context, body: AuthRequest) -> Result<impl Rep
         node_type,
         epoch,
         body.run_uuid,
+        body.hostname,
     )
     .map_err(|e| {
         error!("unable to create jwt token: {}", e);

--- a/crates/aptos-telemetry-service/src/jwt_auth.rs
+++ b/crates/aptos-telemetry-service/src/jwt_auth.rs
@@ -7,7 +7,7 @@ use crate::{
     errors::{JwtAuthError, ServiceError},
     types::{auth::Claims, common::NodeType},
 };
-use aptos_types::{chain_id::ChainId, PeerId};
+use aptos_types::{chain_id::ChainId, hostname::Hostname, PeerId};
 use chrono::Utc;
 use jsonwebtoken::{errors::Error, TokenData};
 use uuid::Uuid;
@@ -22,6 +22,7 @@ pub fn create_jwt_token(
     node_type: NodeType,
     epoch: u64,
     uuid: Uuid,
+    hostname: Option<Hostname>,
 ) -> Result<String, Error> {
     let issued = Utc::now().timestamp();
     let expiration = Utc::now()
@@ -34,6 +35,7 @@ pub fn create_jwt_token(
         peer_id,
         node_type,
         epoch,
+        hostname,
         exp: expiration as usize,
         iat: issued as usize,
         run_uuid: uuid,
@@ -164,6 +166,7 @@ mod tests {
             NodeType::Validator,
             10,
             Uuid::default(),
+            None,
         )
         .unwrap();
         let result =
@@ -177,6 +180,7 @@ mod tests {
             NodeType::ValidatorFullNode,
             10,
             Uuid::default(),
+            None,
         )
         .unwrap();
         let result = authorize_jwt(token, test_context.inner, vec![NodeType::Validator]).await;

--- a/crates/aptos-telemetry-service/src/remote_config.rs
+++ b/crates/aptos-telemetry-service/src/remote_config.rs
@@ -69,6 +69,7 @@ mod tests {
             node_type,
             epoch,
             Uuid::default(),
+            None,
         )
         .unwrap();
 

--- a/crates/aptos-telemetry-service/src/tests/auth_test.rs
+++ b/crates/aptos-telemetry-service/src/tests/auth_test.rs
@@ -18,6 +18,7 @@ use aptos_crypto::{
 use aptos_types::{
     account_address,
     chain_id::ChainId,
+    hostname::Hostname,
     network_address::{
         DnsName, NetworkAddress,
         Protocol::{Dns, Handshake, NoiseIK, Tcp},
@@ -147,6 +148,7 @@ async fn test_auth_validator_backwards_compat_uuid() {
         peer_id,
         node_type: NodeType::Validator,
         epoch: 1,
+        hostname: None,
         exp: decoded.claims.exp,
         iat: decoded.claims.iat,
         run_uuid: Uuid::default(),
@@ -192,6 +194,7 @@ async fn test_auth_validator() {
         peer_id,
         node_type: NodeType::Validator,
         epoch: 1,
+        hostname: None,
         exp: decoded.claims.exp,
         iat: decoded.claims.iat,
         run_uuid,
@@ -223,6 +226,7 @@ async fn test_auth_validatorfullnode() {
         "server_public_key": server_public_key,
         "handshake_msg": &client_noise_msg,
         "run_uuid": run_uuid,
+        "hostname": Hostname::new("test_host".into()),
     });
     let resp = context.post("/api/v1/auth", req).await;
 
@@ -238,6 +242,7 @@ async fn test_auth_validatorfullnode() {
         peer_id,
         node_type: NodeType::ValidatorFullNode,
         epoch: 1,
+        hostname: Some("test_host".into()),
         exp: decoded.claims.exp,
         iat: decoded.claims.iat,
         run_uuid

--- a/crates/aptos-telemetry-service/src/tests/custom_event.rs
+++ b/crates/aptos-telemetry-service/src/tests/custom_event.rs
@@ -39,6 +39,7 @@ async fn test_custom_event() {
         node_type,
         epoch,
         uuid,
+        None,
     )
     .unwrap();
 

--- a/crates/aptos-telemetry-service/src/types/auth.rs
+++ b/crates/aptos-telemetry-service/src/types/auth.rs
@@ -4,7 +4,7 @@
 use super::common::NodeType;
 use aptos_config::config::RoleType;
 use aptos_crypto::x25519;
-use aptos_types::{chain_id::ChainId, PeerId};
+use aptos_types::{chain_id::ChainId, hostname::Hostname, PeerId};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -14,6 +14,8 @@ pub struct AuthRequest {
     pub peer_id: PeerId,
     #[serde(default = "default_role_type")]
     pub role_type: RoleType,
+    #[serde(default)]
+    pub hostname: Option<Hostname>,
     pub server_public_key: x25519::PublicKey,
     pub handshake_msg: Vec<u8>,
     #[serde(default = "default_uuid")]
@@ -30,6 +32,7 @@ pub struct Claims {
     pub chain_id: ChainId,
     pub peer_id: PeerId,
     pub node_type: NodeType,
+    pub hostname: Option<Hostname>,
     pub epoch: u64,
     pub exp: usize,
     pub iat: usize,
@@ -53,6 +56,7 @@ impl Claims {
             chain_id: ChainId::test(),
             peer_id: PeerId::random(),
             node_type: NodeType::Validator,
+            hostname: Some("test".into()),
             epoch: 10,
             exp: Utc::now().timestamp() as usize,
             iat: Utc::now()

--- a/crates/aptos-telemetry/Cargo.toml
+++ b/crates/aptos-telemetry/Cargo.toml
@@ -24,6 +24,7 @@ aptos-logger = { workspace = true }
 aptos-mempool = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-network = { workspace = true }
+aptos-node-identity = { workspace = true }
 aptos-node-resource-metrics = { workspace = true }
 aptos-runtimes = { workspace = true }
 aptos-state-sync-driver = { workspace = true }

--- a/crates/aptos-telemetry/src/sender.rs
+++ b/crates/aptos-telemetry/src/sender.rs
@@ -15,7 +15,7 @@ use aptos_telemetry_service::types::{
     response::IndexResponse,
     telemetry::TelemetryDump,
 };
-use aptos_types::{chain_id::ChainId, PeerId};
+use aptos_types::{chain_id::ChainId, hostname::Hostname, PeerId};
 use flate2::{write::GzEncoder, Compression};
 use prometheus::{default_registry, Registry};
 use reqwest::{header::CONTENT_ENCODING, Response, StatusCode, Url};
@@ -49,6 +49,7 @@ pub(crate) struct TelemetrySender {
     chain_id: ChainId,
     peer_id: PeerId,
     role_type: RoleType,
+    hostname: Option<Hostname>,
     client: ClientWithMiddleware,
     auth_context: Arc<AuthContext>,
     uuid: Uuid,
@@ -80,6 +81,7 @@ impl TelemetrySender {
             chain_id,
             peer_id: node_config.peer_id().unwrap_or(PeerId::ZERO),
             role_type: node_config.base.role,
+            hostname: aptos_node_identity::hostname(),
             client,
             auth_context: Arc::new(AuthContext::new(node_config)),
             uuid: uuid::Uuid::new_v4(),
@@ -314,6 +316,7 @@ impl TelemetrySender {
             chain_id: self.chain_id,
             peer_id: self.peer_id,
             role_type: self.role_type,
+            hostname: self.hostname.clone(),
             server_public_key,
             handshake_msg: client_noise_msg,
             run_uuid: self.uuid,

--- a/types/src/hostname.rs
+++ b/types/src/hostname.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use std::{fmt, ops::Deref};
+
+/// Hostname limit: https://www.rfc-editor.org/rfc/rfc1123#page-13
+const MAX_HOSTNAME_LENGTH: usize = 255;
+
+/// A basic wrapper around String to hold a size-limited hostname
+/// It truncates strings that are longer than expected length
+/// to prevent attacks.
+#[derive(Clone, Default, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct Hostname {
+    inner: String,
+}
+
+impl Hostname {
+    /// Creates a new size-limited Hostname from [String]
+    pub fn new(value: String) -> Self {
+        let mut value = value;
+        value.truncate(MAX_HOSTNAME_LENGTH);
+        Self { inner: value }
+    }
+}
+
+impl Deref for Hostname {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl From<String> for Hostname {
+    fn from(value: String) -> Self {
+        Hostname::new(value)
+    }
+}
+
+impl From<&str> for Hostname {
+    fn from(value: &str) -> Self {
+        Hostname::new(value.into())
+    }
+}
+
+impl fmt::Display for Hostname {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Hostname;
+    use rand::{distributions::Alphanumeric, Rng};
+
+    #[test]
+    fn test_hostname() {
+        let hostname_string = String::from("test-hostname");
+        let hostname = Hostname::new(hostname_string.clone());
+
+        assert_eq!(*hostname, hostname_string);
+
+        let too_long_string: String = rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(super::MAX_HOSTNAME_LENGTH + 20)
+            .map(char::from)
+            .collect();
+
+        let hostname = Hostname::new(too_long_string.clone());
+
+        assert_eq!(hostname.len(), super::MAX_HOSTNAME_LENGTH);
+
+        assert_eq!(*hostname, too_long_string[..super::MAX_HOSTNAME_LENGTH]);
+    }
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -15,6 +15,7 @@ pub mod epoch_change;
 pub mod epoch_state;
 pub mod event;
 pub mod governance;
+pub mod hostname;
 pub mod ledger_info;
 pub mod mempool_status;
 pub mod move_resource;


### PR DESCRIPTION
### Description

This PR includes support for adding hostnames as part of `kubernetes_pod_name` label when ingesting metrics via the telemetry service. The aptos-node authentication request contains an optional hostname field that when populated will be included as part of the authentication token. At ingestion, the hostname is appended to the `kubernetes_pod_name` label.

`Hostname` is introduced to wrap a string and limit its size to 255 characters so we avoid any potential attacks from nodes setting an arbitrarily long string as the host name.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Ran a node and service locally and observe that the hostname is properly ingested.
