### PR TITLE
aptos-debugger: trivial: use non-proved state access version

### DIFF
--- a/aptos-move/aptos-validator-interface/src/storage_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/storage_interface.rs
@@ -62,10 +62,7 @@ impl AptosValidatorInterface for DBDebuggerInterface {
         state_key: &StateKey,
         version: Version,
     ) -> Result<Option<StateValue>> {
-        Ok(self
-            .0
-            .get_state_value_with_proof_by_version(state_key, version)?
-            .0)
+        self.0.get_state_value_by_version(state_key, version)
     }
 
     async fn get_committed_transactions(


### PR DESCRIPTION
### Description

So it works even if the state tree is pruned (but the ledger is not)

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
`aptos-debugger --begin-version 4 --limit 1 db ~/work/testnet-fullnode/data/db`
