### PR TITLE
[WIP][gha] implement workflow-dispatch action to call from cli

### DIFF
--- a/.github/actions/workflow-dispatch/action.yaml
+++ b/.github/actions/workflow-dispatch/action.yaml
@@ -1,0 +1,13 @@
+inputs:
+  COMMAND:
+    description: "gh workflow run CLI command to run"
+    required: true
+
+runs:
+  using: composite
+  steps:
+
+    - name: Run workflow with commands
+      shell: bash
+      run: |
+        ./run.py ${{ inputs.COMMAND }}

--- a/.github/actions/workflow-dispatch/run.py
+++ b/.github/actions/workflow-dispatch/run.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+# A wrapper around https://cli.github.com/manual/gh_workflow_run
+# The arguments to this script should be the same as "gh workflow run"
+
+import argparse
+import subprocess
+import os
+import time
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "workflow_file",
+    help="The workflow file to run",
+)
+parser.add_argument(
+    "--field",
+    "-F",
+    help="Add a string parameber in key=value format",
+    action="append",
+)
+parser.add_argument(
+    "--ref",
+    "-r",
+    help="The branch or tag name which contains the workflow file",
+    required=True,
+)
+
+args = parser.parse_args()
+
+workflow_file = args.workflow_file
+workflow_ref = args.ref
+input_fields = args.field
+input_fields_args = [f"--field={field}" for field in input_fields]
+
+my_env = os.environ.copy()
+my_env["PAGER"] = ""  # disable the pager
+
+# Trigger the workflow
+subprocess.run(
+    [
+        "gh",
+        "workflow",
+        "run",
+        workflow_file,
+        f"--ref={workflow_ref}",
+        *input_fields_args,
+    ],
+    env=my_env,
+)
+
+# sleep a bit to get the run ID
+time.sleep(5)
+
+# Get the run ID
+out = subprocess.check_output(
+    [
+        "gh",
+        "run",
+        "list",
+        "--workflow",
+        workflow_file,
+        "--branch",
+        workflow_ref,
+        "--limit",
+        "10",
+        "--json",
+        "databaseId",
+        "--jq",
+        ".[0].databaseId",
+    ],
+    env=my_env,
+)
+run_id = out.decode().strip()
+
+# Show the output of the run
+print("=========================================")
+subprocess.run(["gh", "run", "view", run_id], env=my_env)
+print("=========================================")
+
+# Tail the status
+subprocess.run(["gh", "run", "watch", run_id, "--exit-status"], env=my_env)


### PR DESCRIPTION
### Description

NOTE: port this to Rust

A new composite action `workflow-dispatch` that calls a workflow run over the `gh` CLI. It thinly wraps this CLI command: https://cli.github.com/manual/gh_workflow_run, while extending it to print the workflow URL after it gets triggered.

We can use this script to trigger any workflow that has at any point been landed in `main` branch.
There is a caveat: the workflow file that is to be called must exist in the `main` branch. You can override the git ref of the workflow file you want to use, but the file must have been landed at some point. 

This unlocks a few capabilities for us:
* You can invoke workflows via CLI, which helps for ad-hoc testing without having to open a PR etc
* Workflows can invoke other workflows, which lets us overcome the 20 concurrent workflow limit for reusable workflows.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
