### PR TITLE
[docs] fix broken URLs due to dot at the end

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/hash.md
+++ b/aptos-move/framework/aptos-stdlib/doc/hash.md
@@ -65,7 +65,7 @@ A newly-added native function is not yet enabled.
 
 ## Function `sip_hash`
 
-Returns the (non-cryptographic) SipHash of <code>bytes</code>. See https://en.wikipedia.org/wiki/SipHash.
+Returns the (non-cryptographic) SipHash of <code>bytes</code>. See https://en.wikipedia.org/wiki/SipHash
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_sip_hash">sip_hash</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): u64
@@ -88,7 +88,7 @@ Returns the (non-cryptographic) SipHash of <code>bytes</code>. See https://en.wi
 
 ## Function `sip_hash_from_value`
 
-Returns the (non-cryptographic) SipHash of the BCS serialization of <code>v</code>. See https://en.wikipedia.org/wiki/SipHash.
+Returns the (non-cryptographic) SipHash of the BCS serialization of <code>v</code>. See https://en.wikipedia.org/wiki/SipHash
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_sip_hash_from_value">sip_hash_from_value</a>&lt;MoveValue&gt;(v: &MoveValue): u64

--- a/aptos-move/framework/aptos-stdlib/sources/hash.move
+++ b/aptos-move/framework/aptos-stdlib/sources/hash.move
@@ -21,10 +21,10 @@ module aptos_std::aptos_hash {
     // Functions
     //
 
-    /// Returns the (non-cryptographic) SipHash of `bytes`. See https://en.wikipedia.org/wiki/SipHash.
+    /// Returns the (non-cryptographic) SipHash of `bytes`. See https://en.wikipedia.org/wiki/SipHash
     native public fun sip_hash(bytes: vector<u8>): u64;
 
-    /// Returns the (non-cryptographic) SipHash of the BCS serialization of `v`. See https://en.wikipedia.org/wiki/SipHash.
+    /// Returns the (non-cryptographic) SipHash of the BCS serialization of `v`. See https://en.wikipedia.org/wiki/SipHash
     public fun sip_hash_from_value<MoveValue>(v: &MoveValue): u64 {
         let bytes = bcs::to_bytes(v);
 
@@ -223,7 +223,7 @@ module aptos_std::aptos_hash {
         b"testing again", // empty message doesn't yield an output on the online generator
         ];
 
-        // From https://www.toolkitbay.com/tkb/tool/BLAKE2b_256.
+        // From https://www.toolkitbay.com/tkb/tool/BLAKE2b_256
         //
         // For computing the hash of an empty string, we use the following Python3 script:
         // ```


### PR DESCRIPTION
### Description

Dots at the end of URL are breaking the links.