### PR TITLE
[cli] Add view function support

### DIFF
--- a/aptos-move/move-examples/hello_blockchain/sources/hello_blockchain.move
+++ b/aptos-move/move-examples/hello_blockchain/sources/hello_blockchain.move
@@ -20,6 +20,7 @@ module hello_blockchain::message {
     /// There is no message present
     const ENO_MESSAGE: u64 = 0;
 
+    #[view]
     public fun get_message(addr: address): string::String acquires MessageHolder {
         assert!(exists<MessageHolder>(addr), error::not_found(ENO_MESSAGE));
         *&borrow_global<MessageHolder>(addr).message

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -20,7 +20,11 @@ use aptos_crypto::{
 };
 use aptos_global_constants::adjust_gas_headroom;
 use aptos_keygen::KeyGen;
-use aptos_rest_client::{aptos_api_types::HashValue, error::RestError, Client, Transaction};
+use aptos_rest_client::{
+    aptos_api_types::{HashValue, ViewRequest},
+    error::RestError,
+    Client, Transaction,
+};
 use aptos_sdk::{transaction_builder::TransactionFactory, types::LocalAccount};
 use aptos_types::{
     chain_id::ChainId,
@@ -1318,6 +1322,11 @@ impl TransactionOptions {
     pub async fn sequence_number(&self, sender_address: AccountAddress) -> CliTypedResult<u64> {
         let client = self.rest_client()?;
         get_sequence_number(&client, sender_address).await
+    }
+
+    pub async fn view(&self, payload: ViewRequest) -> CliTypedResult<Vec<serde_json::Value>> {
+        let client = self.rest_client()?;
+        Ok(client.view(&payload, None).await?.into_inner())
     }
 
     /// Submit a transaction

--- a/crates/aptos/src/test/tests.rs
+++ b/crates/aptos/src/test/tests.rs
@@ -55,6 +55,7 @@ async fn ensure_every_command_args_work() {
     assert_cmd_not_panic(&["aptos", "move"]).await;
     assert_cmd_not_panic(&["aptos", "move", "clean", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "move", "compile", "--help"]).await;
+    assert_cmd_not_panic(&["aptos", "move", "compile-script", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "move", "download", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "move", "init", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "move", "list", "--help"]).await;
@@ -64,6 +65,7 @@ async fn ensure_every_command_args_work() {
     assert_cmd_not_panic(&["aptos", "move", "run-script", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "move", "test", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "move", "transactional-test", "--help"]).await;
+    assert_cmd_not_panic(&["aptos", "move", "view", "--help"]).await;
 
     assert_cmd_not_panic(&["aptos", "node"]).await;
     assert_cmd_not_panic(&["aptos", "node", "get-stake-pool", "--help"]).await;


### PR DESCRIPTION
### Description
Adds view function support to the CLI, tested with adding to hello blockchain

### Test Plan

```
aptos move view --function-id devnet::message::get_message --profile devnet --args address:devnet
{
  "Result": [
    "ViewFunctions!"
  ]
}

aptos move run  --function-id devnet::message::set_message --profile devnet --args "string:I can use view functions"
Do you want to submit a transaction for a range of [41200 - 61800] Octas at a gas unit price of 100 Octas? [yes/no] >
yes
{
  "Result": {
    "transaction_hash": "0xf04af6810f40b3b6ba6de5445c9c7896c4fad12ef09aa523c3d2c1c7839e7702",
    "gas_used": 412,
    "gas_unit_price": 100,
    "sender": "b11affd5c514bb969e988710ef57813d9556cc1e3fe6dc9aa6a82b56aee53d98",
    "sequence_number": 3,
    "success": true,
    "timestamp_us": 1675409546603551,
    "version": 9800433,
    "vm_status": "Executed successfully"
  }
}

aptos move view --function-id devnet::message::get_message --profile devnet --args address:devnet                   
{
  "Result": [
    "I can use view functions"
  ]
}
```
