### PR TITLE
[Smoke test] Bump the timeout durations for smoke tests.

### DIFF
--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::smoke_test_environment::SwarmBuilder;
+use crate::{smoke_test_environment::SwarmBuilder, test_utils::MAX_CATCH_UP_WAIT_SECS};
 use aptos::{
     account::create::DEFAULT_FUNDED_COINS,
     common::types::TransactionSummary,
@@ -306,7 +306,7 @@ async fn test_onchain_config_change() {
         .await
         .unwrap();
     swarm
-        .wait_for_all_nodes_to_catchup_to_next(Duration::from_secs(30))
+        .wait_for_all_nodes_to_catchup_to_next(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
         .await
         .unwrap();
     println!(
@@ -418,7 +418,7 @@ async fn test_large_total_stake() {
     );
 
     swarm
-        .wait_for_all_nodes_to_catchup(Duration::from_secs(20))
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
         .await
         .unwrap();
 }

--- a/testsuite/smoke-test/src/client.rs
+++ b/testsuite/smoke-test/src/client.rs
@@ -5,6 +5,7 @@ use crate::{
     smoke_test_environment::new_local_swarm_with_aptos,
     test_utils::{
         assert_balance, check_create_mint_transfer, create_and_fund_account, transfer_coins,
+        MAX_HEALTHY_WAIT_SECS,
     },
 };
 use aptos_cached_packages::aptos_stdlib;
@@ -64,7 +65,7 @@ async fn test_basic_restartability() {
     let validator = swarm.validators_mut().next().unwrap();
     validator.restart().await.unwrap();
     validator
-        .wait_until_healthy(Instant::now() + Duration::from_secs(10))
+        .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
         .await
         .unwrap();
 

--- a/testsuite/smoke-test/src/consensus/consensusdb_recovery.rs
+++ b/testsuite/smoke-test/src/consensus/consensusdb_recovery.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     smoke_test_environment::new_local_swarm_with_aptos,
-    test_utils::{assert_balance, create_and_fund_account, transfer_coins},
+    test_utils::{assert_balance, create_and_fund_account, transfer_coins, MAX_HEALTHY_WAIT_SECS},
 };
 use aptos_consensus::CONSENSUS_DB_NAME;
 use aptos_forge::{HealthCheckError, NodeExt, Swarm};
@@ -56,7 +56,7 @@ async fn test_consensusdb_recovery() {
     }
 
     node.restart().await.unwrap();
-    node.wait_until_healthy(Instant::now() + Duration::from_secs(10))
+    node.wait_until_healthy(Instant::now() + Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
         .await
         .unwrap();
 

--- a/testsuite/smoke-test/src/full_nodes.rs
+++ b/testsuite/smoke-test/src/full_nodes.rs
@@ -3,7 +3,10 @@
 
 use crate::{
     smoke_test_environment::SwarmBuilder,
-    test_utils::{assert_balance, create_and_fund_account, transfer_coins},
+    test_utils::{
+        assert_balance, create_and_fund_account, transfer_coins, MAX_CATCH_UP_WAIT_SECS,
+        MAX_CONNECTIVITY_WAIT_SECS, MAX_HEALTHY_WAIT_SECS,
+    },
 };
 use aptos_config::{
     config::{DiscoveryMethod, NodeConfig, Peer, PeerRole, HANDSHAKE_VERSION},
@@ -17,8 +20,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-const MAX_WAIT_SECS: u64 = 60;
-
 #[tokio::test]
 async fn test_full_node_basic_flow() {
     let mut swarm = local_swarm_with_fullnodes(1, 1).await;
@@ -30,7 +31,7 @@ async fn test_full_node_basic_flow() {
         .unwrap();
     for fullnode in swarm.full_nodes_mut() {
         fullnode
-            .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
+            .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
             .await
             .unwrap();
     }
@@ -45,7 +46,7 @@ async fn test_full_node_basic_flow() {
     let account_1 = create_and_fund_account(&mut swarm, 10).await;
 
     swarm
-        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_WAIT_SECS))
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
         .await
         .unwrap();
 
@@ -122,11 +123,11 @@ async fn test_vfn_failover() {
 
     for fullnode in swarm.full_nodes_mut() {
         fullnode
-            .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
+            .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
             .await
             .unwrap();
         fullnode
-            .wait_for_connectivity(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
+            .wait_for_connectivity(Instant::now() + Duration::from_secs(MAX_CONNECTIVITY_WAIT_SECS))
             .await
             .unwrap();
     }
@@ -136,7 +137,7 @@ async fn test_vfn_failover() {
     let account_1 = create_and_fund_account(&mut swarm, 10).await;
 
     swarm
-        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_WAIT_SECS))
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
         .await
         .unwrap();
 
@@ -223,7 +224,7 @@ async fn test_private_full_node() {
     let user = swarm.add_full_node(&version, user_config).unwrap();
 
     swarm
-        .wait_for_connectivity(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
+        .wait_for_connectivity(Instant::now() + Duration::from_secs(MAX_CONNECTIVITY_WAIT_SECS))
         .await
         .unwrap();
 
@@ -249,7 +250,7 @@ async fn test_private_full_node() {
     let account_1 = create_and_fund_account(&mut swarm, 10).await;
 
     swarm
-        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_WAIT_SECS))
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
         .await
         .unwrap();
 

--- a/testsuite/smoke-test/src/fullnode.rs
+++ b/testsuite/smoke-test/src/fullnode.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::smoke_test_environment::new_local_swarm_with_aptos;
+use crate::{
+    smoke_test_environment::new_local_swarm_with_aptos, test_utils::MAX_HEALTHY_WAIT_SECS,
+};
 use anyhow::bail;
 use aptos_cached_packages::aptos_stdlib;
 use aptos_config::config::NodeConfig;
@@ -29,7 +31,7 @@ async fn test_indexer() {
 
     let fullnode = swarm.full_node_mut(fullnode_peer_id).unwrap();
     fullnode
-        .wait_until_healthy(Instant::now() + Duration::from_secs(10))
+        .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
         .await
         .unwrap();
 

--- a/testsuite/smoke-test/src/network.rs
+++ b/testsuite/smoke-test/src/network.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::smoke_test_environment::{new_local_swarm_with_aptos, SwarmBuilder};
+use crate::{
+    smoke_test_environment::{new_local_swarm_with_aptos, SwarmBuilder},
+    test_utils::{MAX_CONNECTIVITY_WAIT_SECS, MAX_HEALTHY_WAIT_SECS},
+};
 use aptos::{common::types::EncodingType, test::CliTestFramework};
 use aptos_config::{
     config::{
@@ -55,7 +58,7 @@ async fn test_connection_limiting() {
     swarm
         .fullnode_mut(vfn_peer_id)
         .unwrap()
-        .wait_until_healthy(Instant::now() + Duration::from_secs(10))
+        .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
         .await
         .unwrap();
 
@@ -74,13 +77,13 @@ async fn test_connection_limiting() {
     swarm
         .fullnode_mut(pfn_peer_id)
         .unwrap()
-        .wait_until_healthy(Instant::now() + Duration::from_secs(10))
+        .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
         .await
         .unwrap();
     // This node should connect
     FullNode::wait_for_connectivity(
         swarm.fullnode(pfn_peer_id).unwrap(),
-        Instant::now() + Duration::from_secs(10),
+        Instant::now() + Duration::from_secs(MAX_CONNECTIVITY_WAIT_SECS),
     )
     .await
     .unwrap();
@@ -116,7 +119,7 @@ async fn test_connection_limiting() {
     swarm
         .fullnode_mut(pfn_peer_id_fail)
         .unwrap()
-        .wait_until_healthy(Instant::now() + Duration::from_secs(10))
+        .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
         .await
         .unwrap();
     tokio::time::sleep(Duration::from_secs(5)).await;

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -3,7 +3,10 @@
 
 use crate::{
     smoke_test_environment::{new_local_swarm_with_aptos, SwarmBuilder},
-    test_utils::{create_and_fund_account, transfer_and_maybe_reconfig, transfer_coins},
+    test_utils::{
+        create_and_fund_account, transfer_and_maybe_reconfig, transfer_coins,
+        MAX_CATCH_UP_WAIT_SECS, MAX_HEALTHY_WAIT_SECS,
+    },
 };
 use aptos_config::config::{BootstrappingMode, ContinuousSyncingMode, NodeConfig};
 use aptos_forge::{LocalSwarm, Node, NodeExt, Swarm, SwarmExt};
@@ -14,8 +17,6 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-
-const MAX_CATCH_UP_SECS: u64 = 180; // The max time we'll wait for nodes to catch up
 
 #[tokio::test]
 async fn test_full_node_bootstrap_state_snapshot() {
@@ -38,7 +39,7 @@ async fn test_full_node_bootstrap_state_snapshot() {
     config.save(validator.config_path()).unwrap();
     validator.restart().await.unwrap();
     validator
-        .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
+        .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
         .await
         .unwrap();
 
@@ -253,7 +254,7 @@ async fn create_full_node(full_node_config: NodeConfig, swarm: &mut LocalSwarm) 
         .unwrap();
     for fullnode in swarm.full_nodes_mut() {
         fullnode
-            .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
+            .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
             .await
             .unwrap();
     }
@@ -792,7 +793,7 @@ async fn execute_transactions_and_wait(
 /// Waits for all nodes to catch up
 async fn wait_for_all_nodes(swarm: &mut LocalSwarm) {
     swarm
-        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_SECS))
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
         .await
         .unwrap();
 }

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -5,7 +5,7 @@ use crate::{
     smoke_test_environment::SwarmBuilder,
     test_utils::{
         assert_balance, create_and_fund_account, swarm_utils::insert_waypoint,
-        transfer_and_maybe_reconfig, transfer_coins,
+        transfer_and_maybe_reconfig, transfer_coins, MAX_CATCH_UP_WAIT_SECS, MAX_HEALTHY_WAIT_SECS,
     },
     workspace_builder,
     workspace_builder::workspace_root,
@@ -22,8 +22,6 @@ use std::{
     process::Command,
     time::{Duration, Instant},
 };
-
-const MAX_WAIT_SECS: u64 = 180;
 
 #[tokio::test]
 async fn test_db_restore() {
@@ -53,7 +51,7 @@ async fn test_db_restore() {
     // we need to wait for all nodes to see it, as client_1 is different node from the
     // one creating accounts above
     swarm
-        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_WAIT_SECS))
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
         .await
         .unwrap();
     info!("---------- 1.3 caught up.");
@@ -160,13 +158,13 @@ async fn test_db_restore() {
     swarm
         .validator_mut(node_to_restart)
         .unwrap()
-        .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
+        .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
         .await
         .unwrap();
     info!("---------- 5. Node 0 is healthy, verify it's caught up.");
     // verify it's caught up
     swarm
-        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_WAIT_SECS))
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
         .await
         .unwrap();
 

--- a/testsuite/smoke-test/src/test_smoke_tests.rs
+++ b/testsuite/smoke-test/src/test_smoke_tests.rs
@@ -1,15 +1,16 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::smoke_test_environment::SwarmBuilder;
+use crate::{
+    smoke_test_environment::SwarmBuilder,
+    test_utils::{MAX_CONNECTIVITY_WAIT_SECS, MAX_HEALTHY_WAIT_SECS},
+};
 use aptos_config::config::NodeConfig;
 use aptos_forge::{NodeExt, Swarm};
 use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-
-const MAX_WAIT_SECS: u64 = 60;
 
 /// Bring up a swarm normally, then run get_bin, and bring up a VFN.
 /// Previously get_bin triggered a rebuild of aptos-node, which caused issues that were only seen
@@ -41,11 +42,11 @@ async fn test_aptos_node_after_get_bin() {
 
     for fullnode in swarm.full_nodes_mut() {
         fullnode
-            .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
+            .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
             .await
             .unwrap();
         fullnode
-            .wait_for_connectivity(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
+            .wait_for_connectivity(Instant::now() + Duration::from_secs(MAX_CONNECTIVITY_WAIT_SECS))
             .await
             .unwrap();
     }

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -10,6 +10,10 @@ use aptos_sdk::{
 };
 use rand::random;
 
+pub const MAX_CATCH_UP_WAIT_SECS: u64 = 180; // The max time we'll wait for nodes to catch up
+pub const MAX_CONNECTIVITY_WAIT_SECS: u64 = 180; // The max time we'll wait for nodes to gain connectivity
+pub const MAX_HEALTHY_WAIT_SECS: u64 = 120; // The max time we'll wait for nodes to become healthy
+
 pub async fn create_and_fund_account(swarm: &'_ mut dyn Swarm, amount: u64) -> LocalAccount {
     let mut info = swarm.aptos_public_info();
     info.create_and_fund_user_account(amount).await.unwrap()

--- a/testsuite/smoke-test/src/txn_broadcast.rs
+++ b/testsuite/smoke-test/src/txn_broadcast.rs
@@ -3,7 +3,10 @@
 
 use crate::{
     smoke_test_environment::SwarmBuilder,
-    test_utils::{assert_balance, create_and_fund_account, transfer_coins},
+    test_utils::{
+        assert_balance, create_and_fund_account, transfer_coins, MAX_CATCH_UP_WAIT_SECS,
+        MAX_CONNECTIVITY_WAIT_SECS, MAX_HEALTHY_WAIT_SECS,
+    },
 };
 use aptos_config::config::NodeConfig;
 use aptos_forge::{NodeExt, Swarm, SwarmExt};
@@ -11,8 +14,6 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-
-const MAX_WAIT_SECS: u64 = 60;
 
 /// Checks txn goes through consensus even if the local validator is not creating proposals.
 /// This behavior should be true with both mempool and quorum store.
@@ -40,11 +41,11 @@ async fn test_txn_broadcast() {
 
     for fullnode in swarm.full_nodes_mut() {
         fullnode
-            .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
+            .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
             .await
             .unwrap();
         fullnode
-            .wait_for_connectivity(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
+            .wait_for_connectivity(Instant::now() + Duration::from_secs(MAX_CONNECTIVITY_WAIT_SECS))
             .await
             .unwrap();
     }
@@ -54,7 +55,7 @@ async fn test_txn_broadcast() {
     let account_1 = create_and_fund_account(&mut swarm, 10).await;
 
     swarm
-        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_WAIT_SECS))
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
         .await
         .unwrap();
 


### PR DESCRIPTION
### Description
This PR bumps the timeout durations for the smoke tests when bringing nodes online, waiting for connectivity and waiting for healthy nodes. It also defines constants for these which will make life easier if we need to bump and/or modify them.

### Test Plan
Existing test infrastructure.