### PR TITLE
[State Sync] Bump timeout in flaky test.

### DIFF
--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -76,7 +76,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::time::timeout;
 
 /// Various test constants for storage
-const MAX_RESPONSE_TIMEOUT_SECS: u64 = 40;
+const MAX_RESPONSE_TIMEOUT_SECS: u64 = 60;
 const PROTOCOL_VERSION: u64 = 1;
 
 #[tokio::test]


### PR DESCRIPTION
### Description
This PR bumps the storage service timeout in the storage service unit tests. We're seeing a very rare rate of flakes, so let's bump the timeout. If flakes still continue, I'll dig.

### Test Plan
Existing test infrastructure.