### PR TITLE
[telemetry-svc] Ingest logs from unknown nodes

### DIFF
--- a/crates/aptos-telemetry-service/src/context.rs
+++ b/crates/aptos-telemetry-service/src/context.rs
@@ -2,12 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    clients::{
-        big_query::TableWriteClient, humio::IngestClient as HumioClient,
-        victoria_metrics_api::Client as MetricsClient,
-    },
+    clients::{big_query::TableWriteClient, humio, victoria_metrics_api::Client as MetricsClient},
     types::common::EpochedPeerStore,
-    MetricsEndpointsConfig,
+    LogIngestConfig, MetricsEndpointsConfig,
 };
 use aptos_crypto::{noise, x25519};
 use aptos_infallible::RwLock;
@@ -54,6 +51,23 @@ impl From<MetricsEndpointsConfig> for GroupedMetricsClients {
     }
 }
 
+#[derive(Clone)]
+pub struct LogIngestClients {
+    pub known_logs_ingest_client: humio::IngestClient,
+    pub unknown_logs_ingest_client: humio::IngestClient,
+    pub blacklist: Option<HashSet<PeerId>>,
+}
+
+impl From<LogIngestConfig> for LogIngestClients {
+    fn from(config: LogIngestConfig) -> Self {
+        Self {
+            known_logs_ingest_client: config.known_logs_endpoint.make_client(),
+            unknown_logs_ingest_client: config.unknown_logs_endpoint.make_client(),
+            blacklist: config.blacklist_peers,
+        }
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct PeerStoreTuple {
     validators: Arc<RwLock<EpochedPeerStore>>,
@@ -91,19 +105,19 @@ impl PeerStoreTuple {
 pub struct ClientTuple {
     bigquery_client: Option<TableWriteClient>,
     victoria_metrics_clients: Option<GroupedMetricsClients>,
-    humio_client: Option<HumioClient>,
+    log_ingest_clients: Option<LogIngestClients>,
 }
 
 impl ClientTuple {
     pub(crate) fn new(
         bigquery_client: Option<TableWriteClient>,
         victoria_metrics_clients: Option<GroupedMetricsClients>,
-        humio_client: Option<HumioClient>,
+        log_ingest_clients: Option<LogIngestClients>,
     ) -> ClientTuple {
         Self {
             bigquery_client,
             victoria_metrics_clients,
-            humio_client,
+            log_ingest_clients,
         }
     }
 }
@@ -197,8 +211,8 @@ impl Context {
         self.clients.victoria_metrics_clients.as_mut().unwrap()
     }
 
-    pub fn humio_client(&self) -> &HumioClient {
-        self.clients.humio_client.as_ref().unwrap()
+    pub fn log_ingest_clients(&self) -> &LogIngestClients {
+        self.clients.log_ingest_clients.as_ref().unwrap()
     }
 
     pub(crate) fn bigquery_client(&self) -> Option<&TableWriteClient> {

--- a/crates/aptos-telemetry-service/src/custom_event.rs
+++ b/crates/aptos-telemetry-service/src/custom_event.rs
@@ -29,6 +29,8 @@ pub fn custom_event_ingest(context: Context) -> BoxedFilter<(impl Reply,)> {
             NodeType::ValidatorFullNode,
             NodeType::PublicFullNode,
             NodeType::Unknown,
+            NodeType::UnknownValidator,
+            NodeType::UnknownFullNode,
         ]))
         .and(warp::body::json())
         .and_then(handle_custom_event)

--- a/crates/aptos-telemetry-service/src/errors.rs
+++ b/crates/aptos-telemetry-service/src/errors.rs
@@ -97,6 +97,8 @@ pub(crate) enum LogIngestError {
     UnexpectedContentEncoding,
     #[error("unable to ingest logs")]
     IngestionError,
+    #[error("peer id forbidden from posting logs")]
+    Forbidden(PeerId),
 }
 
 #[derive(Debug, ThisError)]

--- a/crates/aptos-telemetry-service/src/tests/test_context.rs
+++ b/crates/aptos-telemetry-service/src/tests/test_context.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     context::{ClientTuple, Context, GroupedMetricsClients, JsonWebTokenService, PeerStoreTuple},
-    index, CustomEventConfig, MetricsEndpointsConfig, TelemetryServiceConfig,
+    index, CustomEventConfig, LogIngestConfig, MetricsEndpointsConfig, TelemetryServiceConfig,
 };
 use aptos_crypto::{x25519, Uniform};
 use aptos_rest_client::aptos_api_types::mime_types;
@@ -31,11 +31,11 @@ pub async fn new_test_context() -> TestContext {
             dataset_id: String::from("2"),
             table_id: String::from("3"),
         },
-        humio_url: "".into(),
         pfn_allowlist: HashMap::new(),
         log_env_map: HashMap::new(),
         peer_identities: HashMap::new(),
         metrics_endpoints_config: MetricsEndpointsConfig::default_for_test(),
+        humio_ingest_config: LogIngestConfig::default_for_test(),
     };
 
     let peers = PeerStoreTuple::default();

--- a/crates/aptos-telemetry/src/sender.rs
+++ b/crates/aptos-telemetry/src/sender.rs
@@ -321,7 +321,7 @@ impl TelemetrySender {
 
         let response = self
             .client
-            .post(format!("{}/api/v1/auth", self.base_url))
+            .post(self.build_path("auth")?)
             .json::<AuthRequest>(&auth_request)
             .send()
             .await?;


### PR DESCRIPTION
### Description

This PR introduces the ability to ingest logs from all aptos-nodes even though their identity is not on chain. The service exposes the ability to configure the backend for known and unknown logs individually, so that unknown logs can be kept separate from known ones.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Ran an Aptos full node locally and was able to send logs to log service.
