### PR TITLE
Fix when passing array to wallet extension, array cannot be detected using instanceof

### DIFF
--- a/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.ts
@@ -324,7 +324,7 @@ export function serializeArg(argVal: any, argType: TypeTag, serializer: Serializ
       }
     }
 
-    if (!(argVal instanceof Array)) {
+    if (!Array.isArray(argVal)) {
       throw new Error("Invalid vector args.");
     }
 


### PR DESCRIPTION
### Description
If method contains array (ie `code::publish_package_txn`), when we send array argument from browser to wallet extension to sign and submit. Transaction should sign and submit successfully, but it throw `Invalid vector args` instead. 

`instanceof Array` doesn't work properly if array was created from different context, this is known issue. (https://www.samanthaming.com/tidbits/63-better-array-check-with-array-isarray/)

NOTE: this problem doesn't happen in nodejs, because array was created and check from the same js context.

### Test Plan
Try publish code using `code::publish_package_txn` from browser and sign with wallet extension.