### PR TITLE
[aptos-vm] change restriction on view functions to support legacy view

### DIFF
--- a/aptos-move/aptos-vm/src/verifier/view_function.rs
+++ b/aptos-move/aptos-vm/src/verifier/view_function.rs
@@ -5,7 +5,7 @@ use crate::{
     move_vm_ext::{MoveResolverExt, SessionExt},
     verifier::transaction_arg_validation,
 };
-use aptos_framework::{KnownAttribute, RuntimeModuleMetadataV1};
+use aptos_framework::RuntimeModuleMetadataV1;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{identifier::IdentStr, vm_status::StatusCode};
 use move_vm_runtime::session::LoadedFunctionInstantiation;
@@ -24,7 +24,7 @@ pub(crate) fn validate_view_function<S: MoveResolverExt>(
     let is_view = if let Some(data) = module_metadata {
         data.fun_attributes
             .get(fun_name.as_str())
-            .map(|attrs| attrs.contains(&KnownAttribute::view_function()))
+            .map(|attrs| attrs.iter().any(|attr| attr.is_view_function()))
             .unwrap_or_default()
     } else {
         false


### PR DESCRIPTION
unfortunately, some functions were compiled and published with an older compiler on a more permissive metadata check. As a result, there are some modules that have view function at 0 and not 1. The existing check for view functions only allowed for them to be called if they were at 1. This allows anything considered to be a view function to be called.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
