### PR TITLE
[txn emitter] Improve minting speed and more debug details

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/transaction_executor.rs
+++ b/crates/transaction-emitter-lib/src/emitter/transaction_executor.rs
@@ -3,20 +3,21 @@
 
 use super::RETRY_POLICY;
 use crate::transaction_generator::TransactionExecutor;
-use anyhow::{format_err, Result};
+use anyhow::Result;
 use aptos_logger::{sample, sample::SampleRate, warn};
-use aptos_rest_client::{error::RestError, Client as RestClient};
+use aptos_rest_client::Client as RestClient;
 use aptos_sdk::{
     move_types::account_address::AccountAddress, types::transaction::SignedTransaction,
 };
 use async_trait::async_trait;
 use futures::future::join_all;
-use rand::{seq::SliceRandom, thread_rng};
+use rand::{rngs::StdRng, seq::SliceRandom, thread_rng, Rng, SeedableRng};
 use std::{sync::atomic::AtomicUsize, time::Duration};
 
 // Reliable/retrying transaction executor, used for initializing
 pub struct RestApiTransactionExecutor {
     pub rest_clients: Vec<RestClient>,
+    pub max_retries: usize,
 }
 
 impl RestApiTransactionExecutor {
@@ -25,46 +26,92 @@ impl RestApiTransactionExecutor {
         self.rest_clients.choose(&mut rng).unwrap()
     }
 
-    async fn submit_and_check(
+    fn random_rest_client_from_rng<R>(&self, rng: &mut R) -> &RestClient
+    where
+        R: Rng + ?Sized,
+    {
+        self.rest_clients.choose(rng).unwrap()
+    }
+
+    async fn submit_check_and_retry(
         &self,
         txn: &SignedTransaction,
-        failure_counter: &AtomicUsize,
+        failure_counter: &[AtomicUsize],
+        run_seed: u64,
     ) -> Result<()> {
-        let rest_client = self.random_rest_client();
-        if let Err(err) = rest_client.submit_bcs(txn).await {
-            sample!(
-                SampleRate::Duration(Duration::from_secs(60)),
-                warn!(
-                    "[{}] Failed submitting transaction: {}",
-                    rest_client.path_prefix_string(),
-                    err,
-                )
-            );
-            failure_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            // even if txn fails submitting, it might get committed, so wait to see if that is the case.
-        }
-        if let Err(err) = rest_client
-            .wait_for_transaction_by_hash(
-                txn.clone().committed_hash(),
-                txn.expiration_timestamp_secs(),
-                None,
-                Some(Duration::from_secs(10)),
+        for i in 0..self.max_retries {
+            // All transactions from the same sender, need to be submitted to the same client
+            // in the same retry round, so that they are not placed in parking lot.
+            // Do so by selecting a client via seeded random selection.
+            let seed = [
+                i.to_le_bytes().to_vec(),
+                run_seed.to_le_bytes().to_vec(),
+                txn.sender().to_vec(),
+            ]
+            .concat();
+            let mut seeded_rng = StdRng::from_seed(*aptos_crypto::HashValue::sha3_256_of(&seed));
+            let rest_client = self.random_rest_client_from_rng(&mut seeded_rng);
+            if submit_and_check(
+                rest_client,
+                txn,
+                &failure_counter[(i * 2).min(failure_counter.len() - 1)],
+                &failure_counter[(i * 2 + 1).min(failure_counter.len() - 1)],
             )
             .await
-        {
-            sample!(
-                SampleRate::Duration(Duration::from_secs(60)),
-                warn!(
-                    "[{}] Failed waiting on a transaction: {}",
-                    rest_client.path_prefix_string(),
-                    err,
-                )
-            );
-            failure_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            Err(err)?;
+            .is_ok()
+            {
+                return Ok(());
+            };
         }
+
+        // if submission timeouts, it might still get committed:
+        self.random_rest_client()
+            .wait_for_signed_transaction_bcs(txn)
+            .await?;
+
         Ok(())
     }
+}
+
+async fn submit_and_check(
+    rest_client: &RestClient,
+    txn: &SignedTransaction,
+    submit_failure_counter: &AtomicUsize,
+    wait_failure_counter: &AtomicUsize,
+) -> Result<()> {
+    if let Err(err) = rest_client.submit_bcs(txn).await {
+        sample!(
+            SampleRate::Duration(Duration::from_secs(60)),
+            warn!(
+                "[{}] Failed submitting transaction: {}",
+                rest_client.path_prefix_string(),
+                err,
+            )
+        );
+        submit_failure_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        // even if txn fails submitting, it might get committed, so wait to see if that is the case.
+    }
+    if let Err(err) = rest_client
+        .wait_for_transaction_by_hash(
+            txn.clone().committed_hash(),
+            txn.expiration_timestamp_secs(),
+            None,
+            Some(Duration::from_secs(10)),
+        )
+        .await
+    {
+        sample!(
+            SampleRate::Duration(Duration::from_secs(60)),
+            warn!(
+                "[{}] Failed waiting on a transaction: {}",
+                rest_client.path_prefix_string(),
+                err,
+            )
+        );
+        wait_failure_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Err(err)?;
+    }
+    Ok(())
 }
 
 #[async_trait]
@@ -89,34 +136,24 @@ impl TransactionExecutor for RestApiTransactionExecutor {
     }
 
     async fn execute_transactions(&self, txns: &[SignedTransaction]) -> Result<()> {
-        self.execute_transactions_with_counter(txns, &AtomicUsize::new(0))
+        self.execute_transactions_with_counter(txns, &[AtomicUsize::new(0)])
             .await
     }
 
     async fn execute_transactions_with_counter(
         &self,
         txns: &[SignedTransaction],
-        failure_counter: &AtomicUsize,
+        failure_counter: &[AtomicUsize],
     ) -> Result<()> {
-        join_all(txns.iter().map(|txn| async move {
-            let submit_result = RETRY_POLICY
-                .retry(move || self.submit_and_check(txn, failure_counter))
-                .await;
-            if let Err(e) = submit_result {
-                warn!("Failed submitting transaction {:?} with {:?}", txn, e);
-            }
-        }))
-        .await;
+        let run_seed: u64 = thread_rng().gen();
 
-        // if submission timeouts, it might still get committed:
-        join_all(txns.iter().map(|req| {
-            self.random_rest_client()
-                .wait_for_signed_transaction_bcs(req)
-        }))
+        join_all(
+            txns.iter()
+                .map(|txn| self.submit_check_and_retry(txn, failure_counter, run_seed)),
+        )
         .await
         .into_iter()
-        .collect::<Result<Vec<_>, RestError>>()
-        .map_err(|e| format_err!("Failed to commit transactions: {:?}", e))?;
+        .collect::<Result<Vec<()>, anyhow::Error>>()?;
 
         Ok(())
     }

--- a/crates/transaction-emitter-lib/src/transaction_generator/mod.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/mod.rs
@@ -58,7 +58,7 @@ pub trait TransactionExecutor: Sync + Send {
     async fn execute_transactions_with_counter(
         &self,
         txns: &[SignedTransaction],
-        failure_counter: &AtomicUsize,
+        failure_counter: &[AtomicUsize],
     ) -> Result<()>;
 }
 


### PR DESCRIPTION
Improved minting for graceful test from 40minutes to 120s.

- organizing all initialization in the RestApiTransactionExecutor class, made it so that transactions from same sender were going to a different rest endpoint, causing them to be parked
- plan for huge number of accounts was imbalanced - 180000 accounts via only 100 seed accounts, each doing 1800. split the stages into more balanced - 425 seed accounts with 424 accounts each
- increased parallelism to utilize larger TPS for initialization
- increased fee to use for initialization in TwoTraffic test

Before:

```
2023-02-03 23:39:17.862	Account creation plan created for 180000 accounts with 5555600055555 balance each.
2023-02-03 23:39:17.862	    through 100 seed accounts with 10003682099999000 each, each to fund 1800 accounts
2023-02-03 23:39:17.862	    because of expecting 10000000000 txns and 1000000 gas at 100 gas price for each 
2023-02-03 23:39:17.866	Source account 000000000000000000000000000000000000000000000000000000000a550c18 current balance is 13446679562769055615, needed 1000368211999900000 coins
2023-02-03 23:39:17.866	Creating and minting seeds accounts
2023-02-03 23:39:58.703	Completed creating 100 seed accounts, each with 10003682099999000 coins, had to retry 0 transactions
2023-02-03 23:39:58.703	Minting additional 180000 accounts with 5555600055555 coins each
2023-02-04 00:14:01.989	Successfully completed creating accounts, had to retry 30247 transactions
```

After:
```
Account creation plan created for 180000 accounts with 5555600055555 balance each.
    through 425 seed accounts with 2356424423555320 each, each to fund 424 accounts
    because of expecting 10000000000 txns and 1000000 gas at 100 gas price for each 
Source account 000000000000000000000000000000000000000000000000000000000a550c18 current balance is 13405012312591672315, needed 1001480382011011000 coins
Creating and funding seeds accounts
Completed creating 425 seed accounts in 31s, each with 2356424423555320 coins, had to retry [0] transactions
Creating additional 180000 accounts with 5555600055555 coins each
Successfully completed creating 180200 accounts in 120s, had to retry [0, 1230, 0, 120] transactions
```