### PR TITLE
Revert "[aptos-vm] change restriction on view functions to support legacy view (1.2.0 hotfix)"

### DIFF
--- a/aptos-move/aptos-vm/src/verifier/view_function.rs
+++ b/aptos-move/aptos-vm/src/verifier/view_function.rs
@@ -1,13 +1,12 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    move_vm_ext::{MoveResolverExt, SessionExt},
-    verifier::transaction_arg_validation,
-};
-use aptos_framework::RuntimeModuleMetadataV1;
+use crate::move_vm_ext::{MoveResolverExt, SessionExt};
+use crate::verifier::transaction_arg_validation;
+use aptos_framework::{KnownAttribute, RuntimeModuleMetadataV1};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
-use move_core_types::{identifier::IdentStr, vm_status::StatusCode};
+use move_core_types::identifier::IdentStr;
+use move_core_types::vm_status::StatusCode;
 use move_vm_runtime::session::LoadedFunctionInstantiation;
 use move_vm_types::loaded_data::runtime_types::Type;
 
@@ -24,7 +23,7 @@ pub(crate) fn validate_view_function<S: MoveResolverExt>(
     let is_view = if let Some(data) = module_metadata {
         data.fun_attributes
             .get(fun_name.as_str())
-            .map(|attrs| attrs.iter().any(|attr| attr.is_view_function()))
+            .map(|attrs| attrs.contains(&KnownAttribute::view_function()))
             .unwrap_or_default()
     } else {
         false


### PR DESCRIPTION
Reverts aptos-labs/aptos-core#6504

revert this change until we get gatekeeper approval for the fix