### PR TITLE
fix that a wrong gas parameter was assumed before feature version 3

### DIFF
--- a/aptos-move/aptos-gas/src/transaction/storage.rs
+++ b/aptos-move/aptos-gas/src/transaction/storage.rs
@@ -283,7 +283,7 @@ impl ChangeSetConfigs {
     fn for_feature_version_3() -> Self {
         const MB: u64 = 1 << 20;
 
-        Self::new_impl(3, MB, u64::MAX, MB, MB << 10)
+        Self::new_impl(3, MB, u64::MAX, MB, 10 * MB)
     }
 
     fn from_gas_params(gas_feature_version: u64, gas_params: &AptosGasParameters) -> Self {


### PR DESCRIPTION
I don't think the limit was ever triggered, so doesn't matter.

### Description

### Test Plan
replay-verify to make sure there was no hitorical transaction that was affected by this oversight.
https://github.com/aptos-labs/aptos-core/actions/runs/4198903814