### PR TITLE
[BlockSTM] Sender aware transaction shuffling

### DIFF
--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -54,6 +54,7 @@ futures-channel = { workspace = true }
 itertools = { workspace = true }
 maplit = { workspace = true }
 mirai-annotations = { workspace = true }
+move-core-types = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 once_cell = { workspace = true }

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_metrics_core::{
-    op_counters::DurationHistogram, register_counter, register_gauge, register_gauge_vec,
-    register_histogram, register_histogram_vec, register_int_counter, register_int_counter_vec,
-    register_int_gauge, register_int_gauge_vec, Counter, Gauge, GaugeVec, Histogram, HistogramVec,
-    IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+    exponential_buckets, op_counters::DurationHistogram, register_counter, register_gauge,
+    register_gauge_vec, register_histogram, register_histogram_vec, register_int_counter,
+    register_int_counter_vec, register_int_gauge, register_int_gauge_vec, Counter, Gauge, GaugeVec,
+    Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
 
@@ -88,6 +88,23 @@ pub static TOTAL_VOTING_POWER: Lazy<Gauge> = Lazy::new(|| {
     register_gauge!(
         "aptos_total_voting_power",
         "Total voting power of validators in validator set"
+    )
+    .unwrap()
+});
+
+/// Number of distinct senders in a block
+pub static NUM_SENDERS_IN_BLOCK: Lazy<Gauge> = Lazy::new(|| {
+    register_gauge!("num_senders_in_block", "Total number of senders in a block").unwrap()
+});
+
+/// Transaction shuffling call latency
+pub static TXN_SHUFFLE_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        // metric name
+        "aptos_execution_transaction_shuffle_seconds",
+        // metric description
+        "The time spent in seconds in initializing the VM in the block executor",
+        exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 30).unwrap(),
     )
     .unwrap()
 });

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -40,6 +40,7 @@ use crate::{
     recovery_manager::RecoveryManager,
     round_manager::{RoundManager, UnverifiedEvent, VerifiedEvent},
     state_replication::StateComputer,
+    transaction_shuffler::create_transaction_shuffler,
     util::time_service::TimeService,
 };
 use anyhow::{bail, ensure, Context};
@@ -60,8 +61,8 @@ use aptos_types::{
     epoch_change::EpochChangeProof,
     epoch_state::EpochState,
     on_chain_config::{
-        LeaderReputationType, OnChainConfigPayload, OnChainConsensusConfig, ProposerElectionType,
-        ValidatorSet,
+        LeaderReputationType, OnChainConfigPayload, OnChainConsensusConfig, OnChainExecutionConfig,
+        ProposerElectionType, ValidatorSet,
     },
     validator_verifier::ValidatorVerifier,
 };
@@ -583,7 +584,8 @@ impl EpochManager {
         &mut self,
         recovery_data: RecoveryData,
         epoch_state: EpochState,
-        onchain_config: OnChainConsensusConfig,
+        onchain_consensus_config: OnChainConsensusConfig,
+        onchain_execution_config: OnChainExecutionConfig,
     ) {
         let epoch = epoch_state.epoch;
         counters::EPOCH.set(epoch_state.epoch as i64);
@@ -613,7 +615,8 @@ impl EpochManager {
             self.create_round_state(self.time_service.clone(), self.timeout_sender.clone());
 
         info!(epoch = epoch, "Create ProposerElection");
-        let proposer_election = self.create_proposer_election(&epoch_state, &onchain_config);
+        let proposer_election =
+            self.create_proposer_election(&epoch_state, &onchain_consensus_config);
         let network_sender = NetworkSender::new(
             self.author,
             self.network_sender.clone(),
@@ -653,6 +656,8 @@ impl EpochManager {
         };
 
         let (payload_manager, quorum_store_msg_tx) = quorum_store_builder.init_payload_manager();
+        let transaction_shuffler =
+            create_transaction_shuffler(onchain_execution_config.transaction_shuffler_type());
         self.quorum_store_msg_tx = quorum_store_msg_tx;
 
         let payload_client = QuorumStoreClient::new(
@@ -660,10 +665,12 @@ impl EpochManager {
             self.config.quorum_store_poll_count, // TODO: consider moving it to a quorum store config in later PRs.
             self.config.quorum_store_pull_timeout_ms,
         );
-
-        self.commit_state_computer
-            .new_epoch(&epoch_state, payload_manager.clone());
-        let state_computer = if onchain_config.decoupled_execution() {
+        self.commit_state_computer.new_epoch(
+            &epoch_state,
+            payload_manager.clone(),
+            transaction_shuffler,
+        );
+        let state_computer = if onchain_consensus_config.decoupled_execution() {
             Arc::new(self.spawn_decoupled_execution(
                 safety_rules_container.clone(),
                 epoch_state.verifier.clone(),
@@ -679,7 +686,7 @@ impl EpochManager {
             state_computer,
             self.config.max_pruned_blocks_in_mem,
             Arc::clone(&self.time_service),
-            onchain_config.back_pressure_limit(),
+            onchain_consensus_config.back_pressure_limit(),
             payload_manager.clone(),
         ));
 
@@ -695,7 +702,7 @@ impl EpochManager {
             self.time_service.clone(),
             self.config.max_sending_block_txns,
             self.config.max_sending_block_bytes,
-            onchain_config.max_failed_authors_to_store(),
+            onchain_consensus_config.max_failed_authors_to_store(),
             chain_health_backoff_config,
             self.quorum_store_enabled,
         );
@@ -733,7 +740,7 @@ impl EpochManager {
             safety_rules_container,
             network_sender,
             self.storage.clone(),
-            onchain_config,
+            onchain_consensus_config,
             round_manager_tx,
             self.config.clone(),
         );
@@ -756,8 +763,9 @@ impl EpochManager {
             verifier: (&validator_set).into(),
         };
 
-        let onchain_config: anyhow::Result<OnChainConsensusConfig> = payload.get();
-        if let Err(error) = &onchain_config {
+        let onchain_consensus_config: anyhow::Result<OnChainConsensusConfig> = payload.get();
+        let onchain_execution_config: anyhow::Result<OnChainExecutionConfig> = payload.get();
+        if let Err(error) = &onchain_consensus_config {
             error!("Failed to read on-chain consensus config {}", error);
         }
 
@@ -765,13 +773,19 @@ impl EpochManager {
 
         match self.storage.start() {
             LivenessStorageData::FullRecoveryData(initial_data) => {
-                let onchain_config = onchain_config.unwrap_or_default();
-                self.quorum_store_enabled = onchain_config.quorum_store_enabled();
+                let consensus_config = onchain_consensus_config.unwrap_or_default();
+                let execution_config = onchain_execution_config.unwrap_or_default();
+                self.quorum_store_enabled = consensus_config.quorum_store_enabled();
                 if self.quorum_store_enabled {
                     self.config.apply_quorum_store_overrides();
                 }
-                self.start_round_manager(initial_data, epoch_state, onchain_config)
-                    .await
+                self.start_round_manager(
+                    initial_data,
+                    epoch_state,
+                    consensus_config,
+                    execution_config,
+                )
+                .await
             },
             LivenessStorageData::PartialRecoveryData(ledger_data) => {
                 self.start_recovery_manager(ledger_data, epoch_state).await

--- a/consensus/src/experimental/ordering_state_computer.rs
+++ b/consensus/src/experimental/ordering_state_computer.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     payload_manager::PayloadManager,
     state_replication::{StateComputer, StateComputerCommitCallBackType},
+    transaction_shuffler::TransactionShuffler,
 };
 use anyhow::Result;
 use aptos_consensus_types::{block::Block, executed_block::ExecutedBlock};
@@ -119,7 +120,7 @@ impl StateComputer for OrderingStateComputer {
         Ok(())
     }
 
-    fn new_epoch(&self, _: &EpochState, _payload_manager: Arc<PayloadManager>) {}
+    fn new_epoch(&self, _: &EpochState, _payload_manager: Arc<PayloadManager>, _: Arc<dyn TransactionShuffler>,) {}
 
     fn end_epoch(&self) {}
 }

--- a/consensus/src/experimental/ordering_state_computer.rs
+++ b/consensus/src/experimental/ordering_state_computer.rs
@@ -120,7 +120,13 @@ impl StateComputer for OrderingStateComputer {
         Ok(())
     }
 
-    fn new_epoch(&self, _: &EpochState, _payload_manager: Arc<PayloadManager>, _: Arc<dyn TransactionShuffler>,) {}
+    fn new_epoch(
+        &self,
+        _: &EpochState,
+        _payload_manager: Arc<PayloadManager>,
+        _: Arc<dyn TransactionShuffler>,
+    ) {
+    }
 
     fn end_epoch(&self) {}
 }

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -48,6 +48,8 @@ pub mod counters;
 /// AptosNet interface.
 pub mod network_interface;
 mod payload_manager;
+mod sender_aware_shuffler;
+mod transaction_shuffler;
 
 pub use consensusdb::create_checkpoint;
 /// Required by the smoke tests

--- a/consensus/src/payload_manager.rs
+++ b/consensus/src/payload_manager.rs
@@ -119,7 +119,14 @@ impl PayloadManager {
     }
 
     /// Extract transaction from a given block
+    ///
+    //
+    ///
+    /// /
+    ///
     /// Assumes it is never called for the same block concurrently. Otherwise status can be None.
+    ///
+    ///
     pub async fn get_transactions(&self, block: &Block) -> Result<Vec<SignedTransaction>, Error> {
         let payload = match block.payload() {
             Some(p) => p,

--- a/consensus/src/payload_manager.rs
+++ b/consensus/src/payload_manager.rs
@@ -119,14 +119,7 @@ impl PayloadManager {
     }
 
     /// Extract transaction from a given block
-    ///
-    //
-    ///
-    /// /
-    ///
     /// Assumes it is never called for the same block concurrently. Otherwise status can be None.
-    ///
-    ///
     pub async fn get_transactions(&self, block: &Block) -> Result<Vec<SignedTransaction>, Error> {
         let payload = match block.payload() {
             Some(p) => p,

--- a/consensus/src/sender_aware_shuffler.rs
+++ b/consensus/src/sender_aware_shuffler.rs
@@ -1,3 +1,5 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
 use crate::{
     counters::{NUM_SENDERS_IN_BLOCK, TXN_SHUFFLE_SECONDS},
     transaction_shuffler::TransactionShuffler,

--- a/consensus/src/sender_aware_shuffler.rs
+++ b/consensus/src/sender_aware_shuffler.rs
@@ -1,0 +1,467 @@
+use crate::{
+    counters::{NUM_SENDERS_IN_BLOCK, TXN_SHUFFLE_SECONDS},
+    transaction_shuffler::TransactionShuffler,
+};
+use aptos_types::transaction::SignedTransaction;
+use move_core_types::account_address::AccountAddress;
+use std::collections::{HashMap, VecDeque};
+
+/// An implementation of transaction shuffler, which tries to spread transactions from same senders
+/// in a block in order to reduce conflict. On a high level, it works as follows - It defines a
+/// `conflict_window_size`, which maintains a set of senders added to the block in last `conflict_window_size`
+/// transactions. When trying to select a new transaction to the block, the shuffler tries to find
+/// a transaction which are not part of the conflicting senders in the window. If it does, it adds
+/// the first non-conflicting transaction it finds to the block, if it doesn't then it preserves the
+/// order and adds the first transaction in the remaining block. It always maintains the following
+/// invariant in terms of ordering
+/// 1. Relative ordering of all transactions from the same before and after shuffling is same
+/// 2. Relative ordering of all transactions across different senders will also be maintained if they are
+/// non-conflicting. In other words, if the input block has only one transaction per sender, the output
+/// ordering will remain unchanged.
+///
+/// The shuffling algorithm is O(n) and following is the pseudo code for it.
+/// loop:
+///   if a sender fell out of the sliding window in previous iteration,
+///      then: we add the first pending transaction from that sender to the block
+///   else while we have transactions to process in the original transaction order
+///         take a new one,
+///         if it conflicts, add to the pending set
+///         else we add it to the block
+///   else
+///       take the first transaction from the pending transactions and add it to the block
+
+pub struct SenderAwareShuffler {
+    conflict_window_size: usize,
+}
+
+impl TransactionShuffler for SenderAwareShuffler {
+    fn shuffle(&self, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
+        let _timer = TXN_SHUFFLE_SECONDS.start_timer();
+
+        // maintains the intermediate state of the shuffled transactions
+        let mut sliding_window = SlidingWindowState::new(self.conflict_window_size);
+        let mut pending_txns = PendingTransactions::new();
+        let num_transactions = txns.len();
+        let mut orig_txns = VecDeque::from(txns);
+        'outer: loop {
+            if sliding_window.num_txns() == num_transactions {
+                break;
+            }
+            // First check if we have a sender dropped off of conflict window in previous step, if so,
+            // we try to find pending transaction from the corresponding sender and add it to the block.
+            if let Some(sender) = sliding_window.last_dropped_sender() {
+                if let Some(txn) = pending_txns.remove_pending_from_sender(sender) {
+                    sliding_window.add_transaction(txn);
+                    continue 'outer;
+                }
+            }
+
+            // Iterate through the original transactions and try to find the next candidate
+            let mut txn_opt = orig_txns.pop_front();
+            while txn_opt.is_some() {
+                let txn = txn_opt.unwrap();
+                if !sliding_window.has_conflict(&txn.sender()) {
+                    sliding_window.add_transaction(txn);
+                    continue 'outer;
+                }
+                pending_txns.add_transaction(txn);
+                txn_opt = orig_txns.pop_front();
+            }
+            // Add pending transactions in the order if we can't find any other candidate
+            sliding_window.add_transaction(pending_txns.remove_first_pending().unwrap())
+        }
+        sliding_window.finalize()
+    }
+}
+
+impl SenderAwareShuffler {
+    pub fn new(conflict_window_size: usize) -> Self {
+        Self {
+            conflict_window_size,
+        }
+    }
+}
+
+/// A structure to maintain a set of transactions that are pending to be added to the block indexed by
+/// the sender. For a particular sender, relative ordering of transactions are maintained,
+/// so that the final block preserves the ordering of transactions by sender. It also maintains a vector
+/// to preserve the original order of the transactions. This is needed in case we can't find
+/// any non-conflicting transactions and we need to add the first pending transaction to the block.
+struct PendingTransactions {
+    txns_by_senders: HashMap<AccountAddress, VecDeque<SignedTransaction>>,
+    // Transactions are kept in the original order. This is not kept in sync with pending transactions,
+    // so this can contain a bunch of transactions that are already added to the block.
+    ordered_txns: VecDeque<SignedTransaction>,
+}
+
+impl PendingTransactions {
+    pub fn new() -> Self {
+        Self {
+            txns_by_senders: HashMap::new(),
+            ordered_txns: VecDeque::new(),
+        }
+    }
+
+    pub fn add_transaction(&mut self, txn: SignedTransaction) {
+        self.ordered_txns.push_back(txn.clone());
+        self.txns_by_senders
+            .entry(txn.sender())
+            .or_insert_with(VecDeque::new)
+            .push_back(txn);
+    }
+
+    /// Removes the first pending transaction from the sender. Please note that the transaction is not
+    /// removed from the `ordered_txns`, so the `ordered_txns` will contain a set of transactions that
+    /// are removed from pending transactions already.
+    pub fn remove_pending_from_sender(
+        &mut self,
+        sender: AccountAddress,
+    ) -> Option<SignedTransaction> {
+        self.txns_by_senders
+            .get_mut(&sender)
+            .and_then(|txns| txns.pop_front())
+    }
+
+    pub fn remove_first_pending(&mut self) -> Option<SignedTransaction> {
+        let mut txn_opt = self.ordered_txns.pop_front();
+        while txn_opt.is_some() {
+            let sender = txn_opt.as_ref().unwrap().sender();
+            // We don't remove the txns from ordered_txns when remove_pending_from_sender is called.
+            // So it is possible that the ordered_txns has some transactions that are not pending
+            // anymore.
+            if txn_opt.as_ref() == self.txns_by_senders.get(&sender).unwrap().front() {
+                return self.remove_pending_from_sender(sender);
+            }
+            txn_opt = self.ordered_txns.pop_front();
+        }
+        None
+    }
+}
+
+/// A state full data structure maintained by the transaction shuffler during shuffling. On a
+/// high level, it maintains a sliding window of the conflicting transactions, which helps the payload
+/// generator include a set of transactions which are non-conflicting with each other within a particular
+/// window size.
+struct SlidingWindowState {
+    // Please note that the start index can be negative in case the window size is larger than the
+    // end_index.
+    start_index: i64,
+    // Hashmap of senders to the number of transactions included in the window for the corresponding
+    // sender.
+    senders_in_window: HashMap<AccountAddress, usize>,
+    // Partially ordered transactions, needs to be updated every time add_transactions is called.
+    txns: Vec<SignedTransaction>,
+}
+
+impl SlidingWindowState {
+    pub fn new(window_size: usize) -> Self {
+        Self {
+            start_index: -(window_size as i64),
+            senders_in_window: HashMap::new(),
+            txns: Vec::new(),
+        }
+    }
+
+    /// Slides the current window. Essentially, it increments the start_index and
+    /// updates the senders_in_window map if start_index is greater than 0
+    pub fn add_transaction(&mut self, txn: SignedTransaction) {
+        if self.start_index >= 0 {
+            // if the start_index is negative, then no sender falls out of the window.
+            let sender = self
+                .txns
+                .get(self.start_index as usize)
+                .expect("Transaction expected")
+                .sender();
+            self.senders_in_window
+                .entry(sender)
+                .and_modify(|count| *count -= 1);
+        }
+        let count = self
+            .senders_in_window
+            .entry(txn.sender())
+            .or_insert_with(|| 0);
+        *count += 1;
+        self.txns.push(txn);
+        self.start_index += 1;
+    }
+
+    pub fn has_conflict(&self, addr: &AccountAddress) -> bool {
+        self.senders_in_window
+            .get(addr)
+            .map_or(false, |count| *count != 0)
+    }
+
+    /// Returns the sender which was dropped off of the conflict window in previous iteration.
+    pub fn last_dropped_sender(&self) -> Option<AccountAddress> {
+        let prev_start_index = self.start_index - 1;
+        if prev_start_index >= 0 {
+            let last_sender = self.txns.get(prev_start_index as usize).unwrap().sender();
+            if *self.senders_in_window.get(&last_sender).unwrap() == 0 {
+                return Some(last_sender);
+            }
+        }
+        None
+    }
+
+    pub fn num_txns(&self) -> usize {
+        self.txns.len()
+    }
+
+    pub fn finalize(self) -> Vec<SignedTransaction> {
+        NUM_SENDERS_IN_BLOCK.set(self.senders_in_window.len() as f64);
+        self.txns
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        sender_aware_shuffler::SenderAwareShuffler, transaction_shuffler::TransactionShuffler,
+    };
+    use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, SigningKey, Uniform};
+    use aptos_types::{
+        chain_id::ChainId,
+        transaction::{RawTransaction, Script, SignedTransaction, TransactionPayload},
+    };
+    use move_core_types::account_address::AccountAddress;
+    use rand::{rngs::OsRng, Rng};
+    use std::{
+        collections::{HashMap, HashSet},
+        time::Instant,
+    };
+
+    fn create_signed_transaction(num_transactions: usize) -> Vec<SignedTransaction> {
+        let private_key = Ed25519PrivateKey::generate_for_testing();
+        let public_key = private_key.public_key();
+        let sender = AccountAddress::random();
+
+        let mut transactions = Vec::new();
+
+        for i in 0..num_transactions {
+            let transaction_payload =
+                TransactionPayload::Script(Script::new(vec![], vec![], vec![]));
+            let raw_transaction = RawTransaction::new(
+                sender,
+                i as u64,
+                transaction_payload,
+                0,
+                0,
+                0,
+                ChainId::new(10),
+            );
+            let signed_transaction = SignedTransaction::new(
+                raw_transaction.clone(),
+                public_key.clone(),
+                private_key.sign(&raw_transaction).unwrap(),
+            );
+            transactions.push(signed_transaction)
+        }
+        transactions
+    }
+
+    #[test]
+    fn test_single_user_txns() {
+        for num_txns in [1, 5, 50, 500] {
+            let txns = create_signed_transaction(num_txns);
+            let txn_shuffer = SenderAwareShuffler::new(10);
+            let optimized_txns = txn_shuffer.shuffle(txns.clone());
+            assert_eq!(txns.len(), optimized_txns.len());
+            // Assert that ordering is unchanged in case of single sender block
+            assert_eq!(txns, optimized_txns)
+        }
+    }
+
+    #[test]
+    fn test_unique_sender_txns() {
+        for num_senders in [1, 5, 50, 500] {
+            let mut txns = Vec::new();
+            let mut senders = Vec::new();
+            for _ in 0..num_senders {
+                let mut sender_txns = create_signed_transaction(1);
+                senders.push(sender_txns.get(0).unwrap().sender());
+                txns.append(&mut sender_txns);
+            }
+            let txn_shuffer = SenderAwareShuffler::new(10);
+            let optimized_txns = txn_shuffer.shuffle(txns.clone());
+            assert_eq!(txns.len(), optimized_txns.len());
+            // Assert that the ordering is unchanged in case of unique senders txns.
+            assert_eq!(txns, optimized_txns)
+        }
+    }
+
+    #[test]
+    fn test_perfect_shuffling() {
+        let num_senders = 50;
+        let mut txns = Vec::new();
+        let mut senders = Vec::new();
+        for _ in 0..num_senders {
+            let mut sender_txns = create_signed_transaction(10);
+            senders.push(sender_txns.get(0).unwrap().sender());
+            txns.append(&mut sender_txns);
+        }
+
+        let txn_shuffler = SenderAwareShuffler::new(num_senders - 1);
+        let optimized_txns = txn_shuffler.shuffle(txns.clone());
+        assert_eq!(txns.len(), optimized_txns.len());
+        let mut sender_index = 0;
+        for txn in optimized_txns {
+            assert_eq!(&txn.sender(), senders.get(sender_index).unwrap());
+            sender_index = (sender_index + 1) % senders.len()
+        }
+    }
+
+    #[test]
+    fn test_shuffling_benchmark() {
+        let num_senders = 200;
+        let mut txns = Vec::new();
+        let mut senders = Vec::new();
+        for _ in 0..num_senders {
+            let mut sender_txns = create_signed_transaction(10);
+            senders.push(sender_txns.get(0).unwrap().sender());
+            txns.append(&mut sender_txns);
+        }
+
+        let now = Instant::now();
+        let txn_shuffler = SenderAwareShuffler::new(32);
+        let optimized_txns = txn_shuffler.shuffle(txns.clone());
+        println!("elapsed time is {}", now.elapsed().as_millis());
+        assert_eq!(txns.len(), optimized_txns.len());
+    }
+
+    #[test]
+    fn test_same_sender_relative_order() {
+        let mut rng = OsRng;
+        let max_txn_per_sender = 100;
+        let num_senders = 100;
+        let mut orig_txns = Vec::new();
+        let mut orig_txns_by_sender = HashMap::new();
+        for _ in 0..num_senders {
+            let mut sender_txns = create_signed_transaction(rng.gen_range(1, max_txn_per_sender));
+            orig_txns_by_sender.insert(sender_txns.get(0).unwrap().sender(), sender_txns.clone());
+            orig_txns.append(&mut sender_txns);
+        }
+        let txn_shuffler = SenderAwareShuffler::new(num_senders - 1);
+        let optimized_txns = txn_shuffler.shuffle(orig_txns.clone());
+        let mut optimized_txns_by_sender = HashMap::new();
+        for txn in optimized_txns {
+            optimized_txns_by_sender
+                .entry(txn.sender())
+                .or_insert_with(Vec::new)
+                .push(txn);
+        }
+
+        for (sender, orig_txns) in orig_txns_by_sender {
+            assert_eq!(optimized_txns_by_sender.get(&sender).unwrap(), &orig_txns)
+        }
+    }
+
+    #[test]
+    // S1_1, S2_1, S3_1, S3_2
+    // with conflict_window_size=3, should return (keep the order, fairness to early transactions):
+    // S1_1, S2_1, S3_1, S3_2
+    fn test_3_sender_shuffling() {
+        let mut orig_txns = Vec::new();
+        let sender1_txns = create_signed_transaction(1);
+        let sender2_txns = create_signed_transaction(1);
+        let sender3_txns = create_signed_transaction(2);
+        orig_txns.extend(sender1_txns.clone());
+        orig_txns.extend(sender2_txns.clone());
+        orig_txns.extend(sender3_txns.clone());
+        let txn_shuffler = SenderAwareShuffler::new(3);
+        let optimized_txns = txn_shuffler.shuffle(orig_txns);
+        assert_eq!(optimized_txns.get(0).unwrap(), sender1_txns.get(0).unwrap());
+        assert_eq!(optimized_txns.get(1).unwrap(), sender2_txns.get(0).unwrap());
+        assert_eq!(optimized_txns.get(2).unwrap(), sender3_txns.get(0).unwrap());
+        assert_eq!(optimized_txns.get(3).unwrap(), sender3_txns.get(1).unwrap());
+    }
+
+    #[test]
+    // S1_1, S2_1, S1_2, S3_1, S4_1, S5_1
+    // with conflict_window_size=3, should return
+    // (we separate transactions from same sender, even if they are not consecutive):
+    // S1_1, S2_1, S3_1, S4_1, S1_2, S5_1
+    fn test_5_sender_shuffling() {
+        let mut orig_txns = Vec::new();
+        let sender1_txns = create_signed_transaction(2);
+        let sender2_txns = create_signed_transaction(1);
+        let sender3_txns = create_signed_transaction(1);
+        let sender4_txns = create_signed_transaction(1);
+        let sender5_txns = create_signed_transaction(1);
+        orig_txns.extend(sender1_txns.clone());
+        orig_txns.extend(sender2_txns.clone());
+        orig_txns.extend(sender3_txns.clone());
+        orig_txns.extend(sender4_txns.clone());
+        orig_txns.extend(sender5_txns.clone());
+        let txn_shuffler = SenderAwareShuffler::new(3);
+        let optimized_txns = txn_shuffler.shuffle(orig_txns);
+        assert_eq!(optimized_txns.get(0).unwrap(), sender1_txns.get(0).unwrap());
+        assert_eq!(optimized_txns.get(1).unwrap(), sender2_txns.get(0).unwrap());
+        assert_eq!(optimized_txns.get(2).unwrap(), sender3_txns.get(0).unwrap());
+        assert_eq!(optimized_txns.get(3).unwrap(), sender4_txns.get(0).unwrap());
+        assert_eq!(optimized_txns.get(4).unwrap(), sender1_txns.get(1).unwrap());
+        assert_eq!(optimized_txns.get(5).unwrap(), sender5_txns.get(0).unwrap());
+    }
+
+    #[test]
+    // S1_1, S1_2, S2_1, S3_1, S3_2, S4_1, S5_1, S6_1
+    // with conflict_window_size=3, should return (each batches are separated from the point they appear on):
+    // S1_1, S2_1, S3_1, S4_1, S1_2, S5_1, S3_2, S6_1
+    fn test_6_sender_shuffling() {
+        let mut orig_txns = Vec::new();
+        let sender1_txns = create_signed_transaction(2);
+        let sender2_txns = create_signed_transaction(1);
+        let sender3_txns = create_signed_transaction(2);
+        let sender4_txns = create_signed_transaction(1);
+        let sender5_txns = create_signed_transaction(1);
+        let sender6_txns = create_signed_transaction(1);
+        orig_txns.extend(sender1_txns.clone());
+        orig_txns.extend(sender2_txns.clone());
+        orig_txns.extend(sender3_txns.clone());
+        orig_txns.extend(sender4_txns.clone());
+        orig_txns.extend(sender5_txns.clone());
+        orig_txns.extend(sender6_txns.clone());
+        let txn_shuffler = SenderAwareShuffler::new(3);
+        let optimized_txns = txn_shuffler.shuffle(orig_txns);
+        assert_eq!(optimized_txns.get(0).unwrap(), sender1_txns.get(0).unwrap());
+        assert_eq!(optimized_txns.get(1).unwrap(), sender2_txns.get(0).unwrap());
+        assert_eq!(optimized_txns.get(2).unwrap(), sender3_txns.get(0).unwrap());
+        assert_eq!(optimized_txns.get(3).unwrap(), sender4_txns.get(0).unwrap());
+        assert_eq!(optimized_txns.get(4).unwrap(), sender1_txns.get(1).unwrap());
+        assert_eq!(optimized_txns.get(5).unwrap(), sender5_txns.get(0).unwrap());
+        assert_eq!(optimized_txns.get(6).unwrap(), sender3_txns.get(1).unwrap());
+        assert_eq!(optimized_txns.get(7).unwrap(), sender6_txns.get(0).unwrap());
+    }
+
+    #[test]
+    fn test_random_shuffling() {
+        let mut rng = OsRng;
+        let max_senders = 50;
+        let max_txn_per_sender = 100;
+        let num_senders = rng.gen_range(1, max_senders);
+        let mut orig_txns = Vec::new();
+        let mut senders = Vec::new();
+        let mut orig_txn_set = HashSet::new();
+        for _ in 0..num_senders {
+            let mut sender_txns = create_signed_transaction(rng.gen_range(1, max_txn_per_sender));
+            senders.push(sender_txns.get(0).unwrap().sender());
+            orig_txns.append(&mut sender_txns);
+        }
+        for txn in orig_txns.clone() {
+            orig_txn_set.insert(txn.into_raw_transaction());
+        }
+
+        let txn_shuffler = SenderAwareShuffler::new(num_senders - 1);
+        let optimized_txns = txn_shuffler.shuffle(orig_txns.clone());
+        let mut optimized_txn_set = HashSet::new();
+        assert_eq!(orig_txns.len(), optimized_txns.len());
+
+        for optimized_txn in optimized_txns {
+            assert!(orig_txn_set.contains(&optimized_txn.clone().into_raw_transaction()));
+            optimized_txn_set.insert(optimized_txn.into_raw_transaction());
+        }
+
+        for orig_txn in orig_txns {
+            assert!(optimized_txn_set.contains(&orig_txn.into_raw_transaction()));
+        }
+    }
+}

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -284,11 +284,11 @@ impl StateComputer for ExecutionProxy {
 
 #[tokio::test]
 async fn test_commit_sync_race() {
-    use crate::error::MempoolError;
+    use crate::{error::MempoolError, transaction_shuffler::create_transaction_shuffler};
     use aptos_consensus_notifications::Error;
     use aptos_types::{
         aggregate_signature::AggregateSignature, block_info::BlockInfo, ledger_info::LedgerInfo,
-        transaction::SignedTransaction,
+        on_chain_config::TransactionShufflerType, transaction::SignedTransaction,
     };
 
     struct RecordedCommit {
@@ -387,6 +387,7 @@ async fn test_commit_sync_race() {
     executor.new_epoch(
         &EpochState::empty(),
         Arc::new(PayloadManager::DirectMempool),
+        create_transaction_shuffler(TransactionShufflerType::NoShuffling),
     );
     executor
         .commit(&[], generate_li(1, 1), callback.clone())

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -9,6 +9,7 @@ use crate::{
     monitor,
     payload_manager::PayloadManager,
     state_replication::{StateComputer, StateComputerCommitCallBackType},
+    transaction_shuffler::TransactionShuffler,
     txn_notifier::TxnNotifier,
 };
 use anyhow::Result;
@@ -45,6 +46,7 @@ pub struct ExecutionProxy {
     validators: Mutex<Vec<AccountAddress>>,
     write_mutex: AsyncMutex<LogicalTime>,
     payload_manager: Mutex<Option<Arc<PayloadManager>>>,
+    transaction_shuffler: Mutex<Option<Arc<dyn TransactionShuffler>>>,
 }
 
 impl ExecutionProxy {
@@ -77,6 +79,7 @@ impl ExecutionProxy {
             validators: Mutex::new(vec![]),
             write_mutex: AsyncMutex::new(LogicalTime::new(0, 0)),
             payload_manager: Mutex::new(None),
+            transaction_shuffler: Mutex::new(None),
         }
     }
 }
@@ -104,13 +107,16 @@ impl StateComputer for ExecutionProxy {
         );
 
         let payload_manager = self.payload_manager.lock().as_ref().unwrap().clone();
+        let txn_shuffler = self.transaction_shuffler.lock().as_ref().unwrap().clone();
         let txns = payload_manager.get_transactions(block).await?;
+
+        let shuffled_txns = txn_shuffler.shuffle(txns);
 
         // TODO: figure out error handling for the prologue txn
         let executor = self.executor.clone();
 
         let transactions_to_execute =
-            block.transactions_to_execute(&self.validators.lock(), txns.clone());
+            block.transactions_to_execute(&self.validators.lock(), shuffled_txns.clone());
 
         let compute_result = monitor!(
             "execute_block",
@@ -126,7 +132,7 @@ impl StateComputer for ExecutionProxy {
         // notify mempool about failed transaction
         if let Err(e) = self
             .txn_notifier
-            .notify_failed_txn(txns, &compute_result)
+            .notify_failed_txn(shuffled_txns, &compute_result)
             .await
         {
             error!(
@@ -155,6 +161,8 @@ impl StateComputer for ExecutionProxy {
         );
 
         let payload_manager = self.payload_manager.lock().as_ref().unwrap().clone();
+        let txn_shuffler = self.transaction_shuffler.lock().as_ref().unwrap().clone();
+
         for block in blocks {
             block_ids.push(block.id());
 
@@ -163,8 +171,9 @@ impl StateComputer for ExecutionProxy {
             }
 
             let signed_txns = payload_manager.get_transactions(block.block()).await?;
+            let shuffled_txns = txn_shuffler.shuffle(signed_txns);
 
-            txns.extend(block.transactions_to_commit(&self.validators.lock(), signed_txns));
+            txns.extend(block.transactions_to_commit(&self.validators.lock(), shuffled_txns));
             reconfig_events.extend(block.reconfig_event());
         }
 
@@ -249,12 +258,20 @@ impl StateComputer for ExecutionProxy {
         })
     }
 
-    fn new_epoch(&self, epoch_state: &EpochState, payload_manager: Arc<PayloadManager>) {
+    fn new_epoch(
+        &self,
+        epoch_state: &EpochState,
+        payload_manager: Arc<PayloadManager>,
+        transaction_shuffler: Arc<dyn TransactionShuffler>,
+    ) {
         *self.validators.lock() = epoch_state
             .verifier
             .get_ordered_account_addresses_iter()
             .collect();
         self.payload_manager.lock().replace(payload_manager);
+        self.transaction_shuffler
+            .lock()
+            .replace(transaction_shuffler);
     }
 
     // Clears the epoch-specific state. Only a sync_to call is expected before calling new_epoch

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -68,7 +68,12 @@ pub trait StateComputer: Send + Sync {
     async fn sync_to(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError>;
 
     // Reconfigure to execute transactions for a new epoch.
-    fn new_epoch(&self, epoch_state: &EpochState, payload_manager: Arc<PayloadManager>, transaction_shuffler: Arc<dyn TransactionShuffler>,);
+    fn new_epoch(
+        &self,
+        epoch_state: &EpochState,
+        payload_manager: Arc<PayloadManager>,
+        transaction_shuffler: Arc<dyn TransactionShuffler>,
+    );
 
     // Reconfigure to clear epoch state at end of epoch.
     fn end_epoch(&self);

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -5,6 +5,7 @@
 use crate::{
     error::{QuorumStoreError, StateSyncError},
     payload_manager::PayloadManager,
+    transaction_shuffler::TransactionShuffler,
 };
 use anyhow::Result;
 use aptos_consensus_types::{
@@ -67,7 +68,7 @@ pub trait StateComputer: Send + Sync {
     async fn sync_to(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError>;
 
     // Reconfigure to execute transactions for a new epoch.
-    fn new_epoch(&self, epoch_state: &EpochState, payload_manager: Arc<PayloadManager>);
+    fn new_epoch(&self, epoch_state: &EpochState, payload_manager: Arc<PayloadManager>, transaction_shuffler: Arc<dyn TransactionShuffler>,);
 
     // Reconfigure to clear epoch state at end of epoch.
     fn end_epoch(&self);

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -163,13 +163,9 @@ impl StateComputer for EmptyStateComputer {
         Ok(())
     }
 
-<<<<<<< HEAD
-    fn new_epoch(&self, _: &EpochState, _: Arc<PayloadManager>) {}
+    fn new_epoch(&self, _: &EpochState, _: Arc<PayloadManager>, _: Arc<dyn TransactionShuffler>) {}
 
     fn end_epoch(&self) {}
-=======
-    fn new_epoch(&self, _: &EpochState, _: Arc<PayloadManager>, _: Arc<dyn TransactionShuffler>) {}
->>>>>>> 20b20fc676 ([BlockSTM] Optimized transaction shuffling)
 }
 
 /// Random Compute Result State Computer
@@ -221,11 +217,7 @@ impl StateComputer for RandomComputeResultStateComputer {
         Ok(())
     }
 
-<<<<<<< HEAD
-    fn new_epoch(&self, _: &EpochState, _: Arc<PayloadManager>) {}
+    fn new_epoch(&self, _: &EpochState, _: Arc<PayloadManager>, _: Arc<dyn TransactionShuffler>) {}
 
     fn end_epoch(&self) {}
-=======
-    fn new_epoch(&self, _: &EpochState, _: Arc<PayloadManager>, _: Arc<dyn TransactionShuffler>) {}
->>>>>>> 20b20fc676 ([BlockSTM] Optimized transaction shuffling)
 }

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -8,6 +8,7 @@ use crate::{
     payload_manager::PayloadManager,
     state_replication::{StateComputer, StateComputerCommitCallBackType},
     test_utils::mock_storage::MockStorage,
+    transaction_shuffler::TransactionShuffler,
 };
 use anyhow::{format_err, Result};
 use aptos_consensus_types::{block::Block, common::Payload, executed_block::ExecutedBlock};
@@ -132,7 +133,7 @@ impl StateComputer for MockStateComputer {
         Ok(())
     }
 
-    fn new_epoch(&self, _: &EpochState, _: Arc<PayloadManager>) {}
+    fn new_epoch(&self, _: &EpochState, _: Arc<PayloadManager>, _: Arc<dyn TransactionShuffler>) {}
 
     fn end_epoch(&self) {}
 }
@@ -162,9 +163,13 @@ impl StateComputer for EmptyStateComputer {
         Ok(())
     }
 
+<<<<<<< HEAD
     fn new_epoch(&self, _: &EpochState, _: Arc<PayloadManager>) {}
 
     fn end_epoch(&self) {}
+=======
+    fn new_epoch(&self, _: &EpochState, _: Arc<PayloadManager>, _: Arc<dyn TransactionShuffler>) {}
+>>>>>>> 20b20fc676 ([BlockSTM] Optimized transaction shuffling)
 }
 
 /// Random Compute Result State Computer
@@ -216,7 +221,11 @@ impl StateComputer for RandomComputeResultStateComputer {
         Ok(())
     }
 
+<<<<<<< HEAD
     fn new_epoch(&self, _: &EpochState, _: Arc<PayloadManager>) {}
 
     fn end_epoch(&self) {}
+=======
+    fn new_epoch(&self, _: &EpochState, _: Arc<PayloadManager>, _: Arc<dyn TransactionShuffler>) {}
+>>>>>>> 20b20fc676 ([BlockSTM] Optimized transaction shuffling)
 }

--- a/consensus/src/transaction_shuffler.rs
+++ b/consensus/src/transaction_shuffler.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::sender_aware_shuffler::SenderAwareShuffler;
+use aptos_types::{
+    on_chain_config::{
+        TransactionShufflerType,
+        TransactionShufflerType::{NoShuffling, SenderAwareV1},
+    },
+    transaction::SignedTransaction,
+};
+use std::sync::Arc;
+
+/// Interface to shuffle transactions
+pub trait TransactionShuffler: Send + Sync {
+    fn shuffle(&self, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction>;
+}
+
+/// No Op Shuffler to maintain backward compatibility
+pub struct NoOpShuffler {}
+
+impl TransactionShuffler for NoOpShuffler {
+    fn shuffle(&self, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
+        txns
+    }
+}
+
+pub fn create_transaction_shuffler(
+    shuffler_type: TransactionShufflerType,
+) -> Arc<dyn TransactionShuffler> {
+    match shuffler_type {
+        NoShuffling => Arc::new(NoOpShuffler {}),
+        SenderAwareV1(confict_window_size) => {
+            Arc::new(SenderAwareShuffler::new(confict_window_size as usize))
+        },
+    }
+}

--- a/consensus/src/transaction_shuffler.rs
+++ b/consensus/src/transaction_shuffler.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Aptos
+// Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::sender_aware_shuffler::SenderAwareShuffler;

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -187,7 +187,10 @@ pub fn update_counters_for_processed_chunk(
             TransactionStatus::Discard(discard_status_code) => {
                 sample!(
                     SampleRate::Duration(Duration::from_secs(15)),
-                    warn!("Txn being discarded is {:?}", txn)
+                    warn!(
+                        "Txn being discarded is {:?} with status code {:?}",
+                        txn, discard_status_code
+                    )
                 );
                 (
                     "discard",

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Aptos
+// Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::on_chain_config::OnChainConfig;

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -1,0 +1,126 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::on_chain_config::OnChainConfig;
+use anyhow::{format_err, Result};
+use serde::{Deserialize, Serialize};
+
+/// The on-chain execution config, in order to be able to add fields, we use enum to wrap the actual struct.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub enum OnChainExecutionConfig {
+    V1(ExecutionConfigV1),
+}
+
+/// The public interface that exposes all values with safe fallback.
+impl OnChainExecutionConfig {
+    /// The number of recent rounds that don't count into reputations.
+    pub fn transaction_shuffler_type(&self) -> TransactionShufflerType {
+        match &self {
+            OnChainExecutionConfig::V1(config) => config.transaction_shuffler_type.clone(),
+        }
+    }
+}
+
+/// This is used when on-chain config is not initialized.
+impl Default for OnChainExecutionConfig {
+    fn default() -> Self {
+        OnChainExecutionConfig::V1(ExecutionConfigV1::default())
+    }
+}
+
+impl OnChainConfig for OnChainExecutionConfig {
+    const MODULE_IDENTIFIER: &'static str = "execution_config";
+    const TYPE_IDENTIFIER: &'static str = "ExecutionConfig";
+
+    /// The Move resource is
+    /// ```ignore
+    /// struct AptosExecutionConfig has copy, drop, store {
+    ///    config: vector<u8>,
+    /// }
+    /// ```
+    /// so we need two rounds of bcs deserilization to turn it back to OnChainExecutionConfig
+    fn deserialize_into_config(bytes: &[u8]) -> Result<Self> {
+        let raw_bytes: Vec<u8> = bcs::from_bytes(bytes)?;
+        bcs::from_bytes(&raw_bytes)
+            .map_err(|e| format_err!("[on-chain config] Failed to deserialize into config: {}", e))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct ExecutionConfigV1 {
+    pub transaction_shuffler_type: TransactionShufflerType,
+}
+
+impl Default for ExecutionConfigV1 {
+    fn default() -> Self {
+        Self {
+            transaction_shuffler_type: TransactionShufflerType::NoShuffling,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")] // cannot use tag = "type" as nested enums cannot work, and bcs doesn't support it
+pub enum TransactionShufflerType {
+    NoShuffling,
+    SenderAwareV1(u32),
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::on_chain_config::OnChainConfigPayload;
+    use std::{collections::HashMap, sync::Arc};
+
+    #[test]
+    fn test_config_yaml_serialization() {
+        let config = OnChainExecutionConfig::default();
+        let s = serde_yaml::to_string(&config).unwrap();
+
+        serde_yaml::from_str::<OnChainExecutionConfig>(&s).unwrap();
+    }
+
+    #[test]
+    fn test_config_bcs_serialization() {
+        let config = OnChainExecutionConfig::default();
+        let s = bcs::to_bytes(&config).unwrap();
+
+        bcs::from_bytes::<OnChainExecutionConfig>(&s).unwrap();
+    }
+
+    #[test]
+    fn test_config_serialization() {
+        let config = OnChainExecutionConfig::V1(ExecutionConfigV1 {
+            transaction_shuffler_type: TransactionShufflerType::SenderAwareV1(32),
+        });
+
+        let s = serde_yaml::to_string(&config).unwrap();
+        let result = serde_yaml::from_str::<OnChainExecutionConfig>(&s).unwrap();
+        assert!(matches!(
+            result.transaction_shuffler_type(),
+            TransactionShufflerType::SenderAwareV1(32)
+        ));
+    }
+
+    #[test]
+    fn test_config_onchain_payload() {
+        let execution_config = OnChainExecutionConfig::V1(ExecutionConfigV1 {
+            transaction_shuffler_type: TransactionShufflerType::SenderAwareV1(32),
+        });
+
+        let mut configs = HashMap::new();
+        configs.insert(
+            OnChainExecutionConfig::CONFIG_ID,
+            // Requires double serialization, check deserialize_into_config for more details
+            bcs::to_bytes(&bcs::to_bytes(&execution_config).unwrap()).unwrap(),
+        );
+
+        let payload = OnChainConfigPayload::new(1, Arc::new(configs));
+
+        let result: OnChainExecutionConfig = payload.get().unwrap();
+        assert!(matches!(
+            result.transaction_shuffler_type(),
+            TransactionShufflerType::SenderAwareV1(32)
+        ));
+    }
+}

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -23,6 +23,7 @@ mod aptos_features;
 mod aptos_version;
 mod chain_id;
 mod consensus_config;
+mod execution_config;
 mod gas_schedule;
 mod timed_features;
 mod validator_set;
@@ -37,6 +38,7 @@ pub use self::{
         ConsensusConfigV1, LeaderReputationType, OnChainConsensusConfig, ProposerAndVoterConfig,
         ProposerElectionType,
     },
+    execution_config::{ExecutionConfigV1, OnChainExecutionConfig, TransactionShufflerType},
     gas_schedule::{GasSchedule, GasScheduleV2, StorageGasSchedule},
     timed_features::{TimedFeatureFlag, TimedFeatureOverride, TimedFeatures},
     validator_set::{ConsensusScheme, ValidatorSet},
@@ -72,6 +74,7 @@ pub const ON_CHAIN_CONFIG_REGISTRY: &[ConfigID] = &[
     Version::CONFIG_ID,
     OnChainConsensusConfig::CONFIG_ID,
     ChainId::CONFIG_ID,
+    OnChainExecutionConfig::CONFIG_ID,
 ];
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -74,7 +74,6 @@ pub const ON_CHAIN_CONFIG_REGISTRY: &[ConfigID] = &[
     Version::CONFIG_ID,
     OnChainConsensusConfig::CONFIG_ID,
     ChainId::CONFIG_ID,
-    OnChainExecutionConfig::CONFIG_ID,
 ];
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
### Description

An implementation of transaction shuffler, which tries to spread transactions from same senders in a block in order to reduce conflict. On a high level, it works as follows - It defines a `conflict_window_size`, which maintains a set of senders added to the block in last `conflict_window_size` transactions. When trying to select a new transaction to the block, the shuffler tries to find a transaction which are not part of the conflicting senders in the window. If it does, it adds
the first non-conflicting transaction it finds to the block, if it doesn't then it preserves the order and adds the first transaction in the remaining block. It always maintains the following invariant in terms of ordering 
1. Relative ordering of all transactions from the same before and after shuffling is same
2. Relative ordering of all transactions across different senders will also be maintained if they are
non-conflicting. In other words, if the input block has only one transaction per sender, the output ordering will remain unchanged.

 The shuffling algorithm is O(n) and following is the pseudo-code for it.

```
 loop:
   if a sender fell out of the sliding window in previous iteration,
      then: we add the first pending transaction from that sender to the block
   else while we have transactions to process in the original transaction order
         take a new one,
         if it conflicts, add to the pending set
         else we add it to the block
  else
      take the first transaction from the pending transactions and add it to the block

```
### Test Plan

Tested on Forge and this can give us a 25% TPS boost in case of P2P benchmark. Also verified the latency of the shuffle after all the optimizations is less than 10 ms. 
