### PR TITLE
[Aptos-CLI] Add a test for compiling bytecode as dependencies

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_compile_bytecode/B/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_compile_bytecode/B/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Bar"
+version = "0.0.0"
+
+[addresses]
+B = "0x2"
+
+[dependencies]
+Foo = { local = "../C" }

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_compile_bytecode/B/sources/Bar.move
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_compile_bytecode/B/sources/Bar.move
@@ -1,0 +1,7 @@
+module B::Bar {
+    use C::Foo;
+
+    public fun foo(): u64 {
+        Foo::bar()
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_compile_bytecode/C/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_compile_bytecode/C/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Foo"
+version = "0.0.0"
+
+[addresses]
+C = "0x3"

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_compile_bytecode/C/sources/Foo.move
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_compile_bytecode/C/sources/Foo.move
@@ -1,0 +1,5 @@
+module C::Foo {
+    public fun bar(): u64 {
+        1
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_compile_bytecode/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_compile_bytecode/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "A"
+version = "0.0.0"
+
+[addresses]
+A = "0x2"
+
+[dependencies]
+Bar = { local = "./B" }
+Foo = { local = "./C" }

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_compile_bytecode/sources/A.move
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_compile_bytecode/sources/A.move
@@ -1,0 +1,8 @@
+module A::A {
+    use B::Bar;
+    use C::Foo;
+
+    public fun foo(): u64 {
+        Bar::foo() + Foo::bar()
+    }
+}


### PR DESCRIPTION
### Description

Add a test at the aptos-core side for the PR in [move-repo](https://github.com/move-language/move/pull/865), which enables bytecode as dependencies.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Add a test in `aptos-move/e2e-move-tests/src/tests/code_publishing.rs`
