### PR TITLE
[Storage][Sharding] Split state k/v commit from ledger db commit.

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -53,8 +53,9 @@ impl Default for RocksdbConfig {
 pub struct RocksdbConfigs {
     pub ledger_db_config: RocksdbConfig,
     pub state_merkle_db_config: RocksdbConfig,
-    pub use_kv_db: bool,
-    pub kv_db_config: RocksdbConfig,
+    // Note: Not ready for production use yet.
+    pub use_state_kv_db: bool,
+    pub state_kv_db_config: RocksdbConfig,
     pub index_db_config: RocksdbConfig,
 }
 
@@ -63,8 +64,8 @@ impl Default for RocksdbConfigs {
         Self {
             ledger_db_config: RocksdbConfig::default(),
             state_merkle_db_config: RocksdbConfig::default(),
-            use_kv_db: false,
-            kv_db_config: RocksdbConfig::default(),
+            use_state_kv_db: false,
+            state_kv_db_config: RocksdbConfig::default(),
             index_db_config: RocksdbConfig {
                 max_open_files: 1000,
                 ..Default::default()

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -25,6 +25,7 @@ pub fn run<V>(
     db_dir: impl AsRef<Path>,
     storage_pruner_config: PrunerConfig,
     verify_sequence_numbers: bool,
+    use_state_kv_db: bool,
 ) where
     V: TransactionBlockExecutor<BenchmarkTransaction> + 'static,
 {
@@ -36,7 +37,7 @@ pub fn run<V>(
     // create if not exists
     fs::create_dir_all(db_dir.as_ref()).unwrap();
 
-    bootstrap_with_genesis(&db_dir);
+    bootstrap_with_genesis(&db_dir, use_state_kv_db);
 
     println!(
         "Finished empty DB creation, DB dir: {}. Creating accounts now...",
@@ -51,14 +52,16 @@ pub fn run<V>(
         &db_dir,
         storage_pruner_config,
         verify_sequence_numbers,
+        use_state_kv_db,
     );
 }
 
-fn bootstrap_with_genesis(db_dir: impl AsRef<Path>) {
+fn bootstrap_with_genesis(db_dir: impl AsRef<Path>, use_state_kv_db: bool) {
     let (config, _genesis_key) = aptos_genesis::test_utils::test_config();
 
     let mut rocksdb_configs = RocksdbConfigs::default();
     rocksdb_configs.state_merkle_db_config.max_open_files = -1;
+    rocksdb_configs.use_state_kv_db = use_state_kv_db;
     let (_db, db_rw) = DbReaderWriter::wrap(
         AptosDB::open(
             &db_dir,

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -16,7 +16,7 @@ use crate::{
     transaction_committer::TransactionCommitter, transaction_executor::TransactionExecutor,
     transaction_generator::TransactionGenerator,
 };
-use aptos_config::config::{NodeConfig, PrunerConfig, RocksdbConfigs};
+use aptos_config::config::{NodeConfig, PrunerConfig};
 use aptos_db::AptosDB;
 use aptos_executor::block_executor::{BlockExecutor, TransactionBlockExecutor};
 use aptos_jellyfish_merkle::metrics::{
@@ -36,7 +36,7 @@ where
             &config.storage.dir(),
             false, /* readonly */
             config.storage.storage_pruner_config,
-            RocksdbConfigs::default(),
+            config.storage.rocksdb_configs,
             false,
             config.storage.buffered_state_target_items,
             config.storage.max_num_nodes_per_lru_cache_shard,
@@ -67,6 +67,7 @@ pub fn run_benchmark<V>(
     checkpoint_dir: impl AsRef<Path>,
     verify_sequence_numbers: bool,
     pruner_config: PrunerConfig,
+    use_state_kv_db: bool,
 ) where
     V: TransactionBlockExecutor<BenchmarkTransaction> + 'static,
 {
@@ -75,6 +76,7 @@ pub fn run_benchmark<V>(
     let (mut config, genesis_key) = aptos_genesis::test_utils::test_config();
     config.storage.dir = checkpoint_dir.as_ref().to_path_buf();
     config.storage.storage_pruner_config = pruner_config;
+    config.storage.rocksdb_configs.use_state_kv_db = use_state_kv_db;
 
     let (db, executor) = init_db_and_executor::<V>(&config);
     let version = db.reader.get_latest_version().unwrap();
@@ -105,6 +107,7 @@ pub fn add_accounts<V>(
     checkpoint_dir: impl AsRef<Path>,
     pruner_config: PrunerConfig,
     verify_sequence_numbers: bool,
+    use_state_kv_db: bool,
 ) where
     V: TransactionBlockExecutor<BenchmarkTransaction> + 'static,
 {
@@ -118,6 +121,7 @@ pub fn add_accounts<V>(
         checkpoint_dir,
         pruner_config,
         verify_sequence_numbers,
+        use_state_kv_db,
     );
 }
 
@@ -129,12 +133,14 @@ fn add_accounts_impl<V>(
     output_dir: impl AsRef<Path>,
     pruner_config: PrunerConfig,
     verify_sequence_numbers: bool,
+    use_state_kv_db: bool,
 ) where
     V: TransactionBlockExecutor<BenchmarkTransaction> + 'static,
 {
     let (mut config, genesis_key) = aptos_genesis::test_utils::test_config();
     config.storage.dir = output_dir.as_ref().to_path_buf();
     config.storage.storage_pruner_config = pruner_config;
+    config.storage.rocksdb_configs.use_state_kv_db = use_state_kv_db;
     let (db, executor) = init_db_and_executor::<V>(&config);
 
     let version = db.reader.get_latest_version().unwrap();
@@ -204,6 +210,7 @@ mod tests {
             storage_dir.as_ref(),
             NO_OP_STORAGE_PRUNER_CONFIG, /* prune_window */
             true,
+            false,
         );
 
         super::run_benchmark::<AptosVM>(
@@ -213,6 +220,7 @@ mod tests {
             checkpoint_dir,
             true,
             NO_OP_STORAGE_PRUNER_CONFIG,
+            false,
         );
     }
 }

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -81,6 +81,9 @@ struct Opt {
     #[structopt(flatten)]
     pruner_opt: PrunerOpt,
 
+    #[structopt(long)]
+    use_state_kv_db: bool,
+
     #[structopt(subcommand)]
     cmd: Command,
 
@@ -168,6 +171,7 @@ where
                 data_dir,
                 opt.pruner_opt.pruner_config(),
                 opt.verify_sequence_numbers,
+                opt.use_state_kv_db,
             );
         },
         Command::RunExecutor {
@@ -182,6 +186,7 @@ where
                 checkpoint_dir,
                 opt.verify_sequence_numbers,
                 opt.pruner_opt.pruner_config(),
+                opt.use_state_kv_db,
             );
         },
         Command::AddAccounts {
@@ -198,6 +203,7 @@ where
                 checkpoint_dir,
                 opt.pruner_opt.pruner_config(),
                 opt.verify_sequence_numbers,
+                opt.use_state_kv_db,
             );
         },
     }

--- a/storage/aptosdb/src/db_options.rs
+++ b/storage/aptosdb/src/db_options.rs
@@ -43,9 +43,10 @@ pub(super) fn state_merkle_db_column_families() -> Vec<ColumnFamilyName> {
     ]
 }
 
-pub(super) fn kv_db_column_families() -> Vec<ColumnFamilyName> {
+pub(super) fn state_kv_db_column_families() -> Vec<ColumnFamilyName> {
     vec![
         /* empty cf */ DEFAULT_COLUMN_FAMILY_NAME,
+        DB_METADATA_CF_NAME,
         STALE_STATE_VALUE_INDEX_CF_NAME,
         STATE_VALUE_CF_NAME,
     ]
@@ -94,8 +95,8 @@ pub(super) fn gen_state_merkle_cfds(rocksdb_config: &RocksdbConfig) -> Vec<Colum
     gen_cfds(rocksdb_config, cfs, |_, _| {})
 }
 
-pub(super) fn gen_kv_cfds(rocksdb_config: &RocksdbConfig) -> Vec<ColumnFamilyDescriptor> {
-    let cfs = kv_db_column_families();
+pub(super) fn gen_state_kv_cfds(rocksdb_config: &RocksdbConfig) -> Vec<ColumnFamilyDescriptor> {
+    let cfs = state_kv_db_column_families();
     gen_cfds(rocksdb_config, cfs, with_state_key_extractor_processor)
 }
 

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -44,8 +44,8 @@ pub mod db_debugger;
 use crate::{
     backup::{backup_handler::BackupHandler, restore_handler::RestoreHandler, restore_utils},
     db_options::{
-        gen_kv_cfds, gen_ledger_cfds, gen_state_merkle_cfds, kv_db_column_families,
-        ledger_db_column_families, state_merkle_db_column_families,
+        gen_ledger_cfds, gen_state_kv_cfds, gen_state_merkle_cfds, ledger_db_column_families,
+        state_kv_db_column_families, state_merkle_db_column_families,
     },
     errors::AptosDbError,
     event_store::EventStore,
@@ -127,7 +127,7 @@ use std::{
 
 pub const LEDGER_DB_NAME: &str = "ledger_db";
 pub const STATE_MERKLE_DB_NAME: &str = "state_merkle_db";
-pub const KV_DB_NAME: &str = "kv_db";
+pub const STATE_KV_DB_NAME: &str = "state_kv_db";
 
 // TODO: Either implement an iteration API to allow a very old client to loop through a long history
 // or guarantee that there is always a recent enough waypoint and client knows to boot from there.
@@ -250,7 +250,7 @@ impl Drop for RocksdbPropertyReporter {
 pub struct AptosDB {
     ledger_db: Arc<DB>,
     state_merkle_db: Arc<DB>,
-    _kv_db: Arc<Option<DB>>,
+    _state_kv_db: Arc<Option<DB>>,
     event_store: Arc<EventStore>,
     ledger_store: Arc<LedgerStore>,
     state_store: Arc<StateStore>,
@@ -265,7 +265,7 @@ impl AptosDB {
     fn new_with_dbs(
         ledger_rocksdb: DB,
         state_merkle_rocksdb: DB,
-        kv_rocksdb: Option<DB>,
+        state_kv_rocksdb: Option<DB>,
         pruner_config: PrunerConfig,
         buffered_state_target_items: usize,
         max_nodes_per_lru_cache_shard: usize,
@@ -273,7 +273,7 @@ impl AptosDB {
     ) -> Self {
         let arc_ledger_rocksdb = Arc::new(ledger_rocksdb);
         let arc_state_merkle_rocksdb = Arc::new(state_merkle_rocksdb);
-        let arc_kv_rocksdb = Arc::new(kv_rocksdb);
+        let arc_state_kv_rocksdb = Arc::new(state_kv_rocksdb);
         let state_pruner = StatePrunerManager::new(
             Arc::clone(&arc_state_merkle_rocksdb),
             pruner_config.state_merkle_pruner_config,
@@ -300,7 +300,7 @@ impl AptosDB {
         AptosDB {
             ledger_db: Arc::clone(&arc_ledger_rocksdb),
             state_merkle_db: Arc::clone(&arc_state_merkle_rocksdb),
-            _kv_db: Arc::clone(&arc_kv_rocksdb),
+            _state_kv_db: Arc::clone(&arc_state_kv_rocksdb),
             event_store: Arc::new(EventStore::new(Arc::clone(&arc_ledger_rocksdb))),
             ledger_store: Arc::new(LedgerStore::new(Arc::clone(&arc_ledger_rocksdb))),
             state_store,
@@ -329,13 +329,13 @@ impl AptosDB {
             "Do not set prune_window when opening readonly.",
         );
 
-        let (ledger_db, state_merkle_db, kv_db) =
+        let (ledger_db, state_merkle_db, state_kv_db) =
             Self::open_dbs(db_root_path.as_ref(), rocksdb_configs, readonly)?;
 
         let mut myself = Self::new_with_dbs(
             ledger_db,
             state_merkle_db,
-            kv_db,
+            state_kv_db,
             pruner_config,
             buffered_state_target_items,
             max_num_nodes_per_lru_cache_shard,
@@ -358,9 +358,9 @@ impl AptosDB {
 
         let ledger_db_path = db_root_path.as_ref().join(LEDGER_DB_NAME);
         let state_merkle_db_path = db_root_path.as_ref().join(STATE_MERKLE_DB_NAME);
-        let kv_db_path = db_root_path.as_ref().join(KV_DB_NAME);
+        let state_kv_db_path = db_root_path.as_ref().join(STATE_KV_DB_NAME);
 
-        let (ledger_db, state_merkle_db, kv_db) = if readonly {
+        let (ledger_db, state_merkle_db, state_kv_db) = if readonly {
             (
                 DB::open_cf_readonly(
                     &gen_rocksdb_options(&rocksdb_configs.ledger_db_config, true),
@@ -374,12 +374,12 @@ impl AptosDB {
                     STATE_MERKLE_DB_NAME,
                     state_merkle_db_column_families(),
                 )?,
-                if rocksdb_configs.use_kv_db {
+                if rocksdb_configs.use_state_kv_db {
                     Some(DB::open_cf_readonly(
-                        &gen_rocksdb_options(&rocksdb_configs.kv_db_config, true),
-                        kv_db_path.clone(),
-                        KV_DB_NAME,
-                        kv_db_column_families(),
+                        &gen_rocksdb_options(&rocksdb_configs.state_kv_db_config, true),
+                        state_kv_db_path.clone(),
+                        STATE_KV_DB_NAME,
+                        state_kv_db_column_families(),
                     )?)
                 } else {
                     None
@@ -399,12 +399,12 @@ impl AptosDB {
                     STATE_MERKLE_DB_NAME,
                     gen_state_merkle_cfds(&rocksdb_configs.state_merkle_db_config),
                 )?,
-                if rocksdb_configs.use_kv_db {
+                if rocksdb_configs.use_state_kv_db {
                     Some(DB::open_cf(
-                        &gen_rocksdb_options(&rocksdb_configs.kv_db_config, false),
-                        kv_db_path.clone(),
-                        KV_DB_NAME,
-                        gen_kv_cfds(&rocksdb_configs.kv_db_config),
+                        &gen_rocksdb_options(&rocksdb_configs.state_kv_db_config, false),
+                        state_kv_db_path.clone(),
+                        STATE_KV_DB_NAME,
+                        gen_state_kv_cfds(&rocksdb_configs.state_kv_db_config),
                     )?)
                 } else {
                     None
@@ -412,8 +412,8 @@ impl AptosDB {
             )
         };
 
-        if rocksdb_configs.use_kv_db {
-            info!(kv_db_path = kv_db_path, "Opened K/V DB.",);
+        if rocksdb_configs.use_state_kv_db {
+            info!(state_kv_db_path = state_kv_db_path, "Opened state K/V DB.",);
         }
         info!(
             ledger_db_path = ledger_db_path,
@@ -422,7 +422,7 @@ impl AptosDB {
             "Opened AptosDB (LedgerDB + StateMerkleDB).",
         );
 
-        Ok((ledger_db, state_merkle_db, kv_db))
+        Ok((ledger_db, state_merkle_db, state_kv_db))
     }
 
     fn open_indexer(
@@ -478,8 +478,8 @@ impl AptosDB {
         let state_merkle_db_primary_path = db_root_path.as_ref().join(STATE_MERKLE_DB_NAME);
         let state_merkle_db_secondary_path =
             secondary_db_root_path.as_ref().join(STATE_MERKLE_DB_NAME);
-        let kv_db_primary_path = db_root_path.as_ref().join(KV_DB_NAME);
-        let kv_db_secondary_path = secondary_db_root_path.as_ref().join(KV_DB_NAME);
+        let state_kv_db_primary_path = db_root_path.as_ref().join(STATE_KV_DB_NAME);
+        let state_kv_db_secondary_path = secondary_db_root_path.as_ref().join(STATE_KV_DB_NAME);
 
         // Secondary needs `max_open_files = -1` per
         // https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances
@@ -501,13 +501,13 @@ impl AptosDB {
                 "state_merkle_db_sec",
                 state_merkle_db_column_families(),
             )?,
-            if rocksdb_configs.use_kv_db {
+            if rocksdb_configs.use_state_kv_db {
                 Some(DB::open_cf_as_secondary(
-                    &gen_rocksdb_options(&rocksdb_configs.kv_db_config, false),
-                    kv_db_primary_path,
-                    kv_db_secondary_path,
-                    "kv_db_sec",
-                    kv_db_column_families(),
+                    &gen_rocksdb_options(&rocksdb_configs.state_kv_db_config, false),
+                    state_kv_db_primary_path,
+                    state_kv_db_secondary_path,
+                    "state_kv_db_sec",
+                    state_kv_db_column_families(),
                 )?)
             } else {
                 None

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -43,6 +43,7 @@ pub mod db_debugger;
 
 use crate::{
     backup::{backup_handler::BackupHandler, restore_handler::RestoreHandler, restore_utils},
+    db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
     db_options::{
         gen_ledger_cfds, gen_state_kv_cfds, gen_state_merkle_cfds, ledger_db_column_families,
         state_kv_db_column_families, state_merkle_db_column_families,
@@ -250,7 +251,7 @@ impl Drop for RocksdbPropertyReporter {
 pub struct AptosDB {
     ledger_db: Arc<DB>,
     state_merkle_db: Arc<DB>,
-    _state_kv_db: Arc<Option<DB>>,
+    state_kv_db: Arc<DB>,
     event_store: Arc<EventStore>,
     ledger_store: Arc<LedgerStore>,
     state_store: Arc<StateStore>,
@@ -273,7 +274,11 @@ impl AptosDB {
     ) -> Self {
         let arc_ledger_rocksdb = Arc::new(ledger_rocksdb);
         let arc_state_merkle_rocksdb = Arc::new(state_merkle_rocksdb);
-        let arc_state_kv_rocksdb = Arc::new(state_kv_rocksdb);
+        let arc_state_kv_rocksdb = if let Some(db) = state_kv_rocksdb {
+            Arc::new(db)
+        } else {
+            Arc::clone(&arc_ledger_rocksdb)
+        };
         let state_pruner = StatePrunerManager::new(
             Arc::clone(&arc_state_merkle_rocksdb),
             pruner_config.state_merkle_pruner_config,
@@ -285,12 +290,14 @@ impl AptosDB {
         let state_store = Arc::new(StateStore::new(
             Arc::clone(&arc_ledger_rocksdb),
             Arc::clone(&arc_state_merkle_rocksdb),
+            Arc::clone(&arc_state_kv_rocksdb),
             state_pruner,
             epoch_snapshot_pruner,
             buffered_state_target_items,
             max_nodes_per_lru_cache_shard,
             hack_for_tests,
         ));
+        // TODO(grao): Handle state kv db pruning.
         let ledger_pruner = LedgerPrunerManager::new(
             Arc::clone(&arc_ledger_rocksdb),
             Arc::clone(&state_store),
@@ -300,7 +307,7 @@ impl AptosDB {
         AptosDB {
             ledger_db: Arc::clone(&arc_ledger_rocksdb),
             state_merkle_db: Arc::clone(&arc_state_merkle_rocksdb),
-            _state_kv_db: Arc::clone(&arc_state_kv_rocksdb),
+            state_kv_db: Arc::clone(&arc_state_kv_rocksdb),
             event_store: Arc::new(EventStore::new(Arc::clone(&arc_ledger_rocksdb))),
             ledger_store: Arc::new(LedgerStore::new(Arc::clone(&arc_ledger_rocksdb))),
             state_store,
@@ -414,6 +421,8 @@ impl AptosDB {
 
         if rocksdb_configs.use_state_kv_db {
             info!(state_kv_db_path = state_kv_db_path, "Opened state K/V DB.",);
+        } else {
+            info!("State K/V DB is not enabled!");
         }
         info!(
             ledger_db_path = ledger_db_path,
@@ -718,9 +727,12 @@ impl AptosDB {
         let ledger_cp_path = cp_path.as_ref().join(LEDGER_DB_NAME);
         let state_merkle_db_path = db_path.as_ref().join(STATE_MERKLE_DB_NAME);
         let state_merkle_cp_path = cp_path.as_ref().join(STATE_MERKLE_DB_NAME);
+        let state_kv_db_path = db_path.as_ref().join(STATE_KV_DB_NAME);
+        let state_kv_cp_path = cp_path.as_ref().join(STATE_KV_DB_NAME);
 
         std::fs::remove_dir_all(&ledger_cp_path).unwrap_or(());
         std::fs::remove_dir_all(&state_merkle_cp_path).unwrap_or(());
+        std::fs::remove_dir_all(&state_kv_cp_path).unwrap_or(());
 
         // Weird enough, checkpoint doesn't work with readonly or secondary mode (gets stuck).
         // https://github.com/facebook/rocksdb/issues/11167
@@ -741,6 +753,16 @@ impl AptosDB {
                 &aptos_schemadb::Options::default(),
             )?;
             state_merkle_db.create_checkpoint(state_merkle_cp_path)?;
+        }
+        {
+            if let Ok(state_kv_db) = aptos_schemadb::DB::open(
+                state_kv_db_path,
+                STATE_KV_DB_NAME,
+                state_kv_db_column_families(),
+                &aptos_schemadb::Options::default(),
+            ) {
+                state_kv_db.create_checkpoint(state_kv_cp_path)?;
+            }
         }
 
         info!(
@@ -819,12 +841,44 @@ impl AptosDB {
         Ok(events_with_version)
     }
 
+    fn save_ledger_info(
+        &self,
+        new_root_hash: HashValue,
+        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        ledger_batch: &SchemaBatch,
+    ) -> Result<()> {
+        // If expected ledger info is provided, verify result root hash and save the ledger info.
+        if let Some(x) = ledger_info_with_sigs {
+            let expected_root_hash = x.ledger_info().transaction_accumulator_hash();
+            ensure!(
+                new_root_hash == expected_root_hash,
+                "Root hash calculated doesn't match expected. {:?} vs {:?}",
+                new_root_hash,
+                expected_root_hash,
+            );
+            let current_epoch = self
+                .ledger_store
+                .get_latest_ledger_info_option()
+                .map_or(0, |li| li.ledger_info().next_block_epoch());
+            ensure!(
+                x.ledger_info().epoch() == current_epoch,
+                "Gap in epoch history. Trying to put in LedgerInfo in epoch: {}, current epoch: {}",
+                x.ledger_info().epoch(),
+                current_epoch,
+            );
+
+            self.ledger_store.put_ledger_info(x, ledger_batch)?;
+        }
+        Ok(())
+    }
+
     fn save_transactions_impl(
         &self,
         txns_to_commit: &[TransactionToCommit],
         first_version: u64,
         expected_state_db_usage: StateStorageUsage,
-        cs: &SchemaBatch,
+        ledger_batch: &SchemaBatch,
+        state_kv_batch: &SchemaBatch,
     ) -> Result<HashValue> {
         let last_version = first_version + txns_to_commit.len() as u64 - 1;
 
@@ -847,7 +901,8 @@ impl AptosDB {
                     state_updates_vec,
                     first_version,
                     expected_state_db_usage,
-                    cs,
+                    ledger_batch,
+                    state_kv_batch,
                 )
             });
 
@@ -858,7 +913,8 @@ impl AptosDB {
                     .start_timer();
                 zip_eq(first_version..=last_version, txns_to_commit)
                     .map(|(ver, txn_to_commit)| {
-                        self.event_store.put_events(ver, txn_to_commit.events(), cs)
+                        self.event_store
+                            .put_events(ver, txn_to_commit.events(), ledger_batch)
                     })
                     .collect::<Result<Vec<_>>>()
             });
@@ -873,10 +929,13 @@ impl AptosDB {
                         self.transaction_store.put_transaction(
                             ver,
                             txn_to_commit.transaction(),
-                            cs,
+                            ledger_batch,
                         )?;
-                        self.transaction_store
-                            .put_write_set(ver, txn_to_commit.write_set(), cs)
+                        self.transaction_store.put_write_set(
+                            ver,
+                            txn_to_commit.write_set(),
+                            ledger_batch,
+                        )
                     },
                 )?;
                 // Transaction accumulator updates. Get result root hash.
@@ -886,20 +945,12 @@ impl AptosDB {
                     .cloned()
                     .collect();
                 self.ledger_store
-                    .put_transaction_infos(first_version, &txn_infos, cs)
+                    .put_transaction_infos(first_version, &txn_infos, ledger_batch)
             });
             t0.join().unwrap()?;
             t1.join().unwrap()?;
             t2.join().unwrap()
         })
-    }
-
-    /// Write the whole schema batch including all data necessary to mutate the ledger
-    /// state of some transaction by leveraging rocksdb atomicity support. Also committed are the
-    /// LedgerCounters.
-    fn commit(&self, batch: SchemaBatch) -> Result<()> {
-        self.ledger_db.write_schemas(batch)?;
-        Ok(())
     }
 
     fn get_table_info_option(&self, handle: TableHandle) -> Result<Option<TableInfo>> {
@@ -1699,37 +1750,16 @@ impl DbWriter for AptosDB {
             }
 
             // Gather db mutations to `batch`.
-            let batch = SchemaBatch::new();
+            let ledger_batch = SchemaBatch::new();
+            let state_kv_batch = SchemaBatch::new();
 
             let new_root_hash = self.save_transactions_impl(
                 txns_to_commit,
                 first_version,
                 latest_in_memory_state.current.usage(),
-                &batch,
+                &ledger_batch,
+                &state_kv_batch,
             )?;
-
-            // If expected ledger info is provided, verify result root hash and save the ledger info.
-            if let Some(x) = ledger_info_with_sigs {
-                let expected_root_hash = x.ledger_info().transaction_accumulator_hash();
-                ensure!(
-                    new_root_hash == expected_root_hash,
-                    "Root hash calculated doesn't match expected. {:?} vs {:?}",
-                    new_root_hash,
-                    expected_root_hash,
-                );
-                let current_epoch = self
-                    .ledger_store
-                    .get_latest_ledger_info_option()
-                    .map_or(0, |li| li.ledger_info().next_block_epoch());
-                ensure!(
-                    x.ledger_info().epoch() == current_epoch,
-                    "Gap in epoch history. Trying to put in LedgerInfo in epoch: {}, current epoch: {}",
-                    x.ledger_info().epoch(),
-                    current_epoch,
-                );
-
-                self.ledger_store.put_ledger_info(x, &batch)?;
-            }
 
             ensure!(Some(last_version) == latest_in_memory_state.current_version,
                 "the last_version {:?} to commit doesn't match the current_version {:?} in latest_in_memory_state",
@@ -1766,12 +1796,36 @@ impl DbWriter for AptosDB {
                     num_transactions_in_db,
                 );
 
-                // Persist ledgerDB data first.
+                // Commit multiple batches for different DBs in parallel, then write the overall
+                // progress.
                 {
                     let _timer = OTHER_TIMERS_SECONDS
                         .with_label_values(&["save_transactions_commit"])
                         .start_timer();
-                    self.commit(batch)?;
+                    state_kv_batch.put::<DbMetadataSchema>(
+                        &DbMetadataKey::StateKVCommitProgress,
+                        &DbMetadataValue::Version(last_version),
+                    )?;
+
+                    ledger_batch.put::<DbMetadataSchema>(
+                        &DbMetadataKey::LedgerCommitProgress,
+                        &DbMetadataValue::Version(last_version),
+                    )?;
+
+                    thread::scope(|s| {
+                        let t0 = s.spawn(|| self.state_kv_db.write_schemas(state_kv_batch));
+                        let t1 = s.spawn(|| self.ledger_db.write_schemas(ledger_batch));
+                        t0.join().unwrap().unwrap();
+                        t1.join().unwrap().unwrap();
+                    });
+
+                    let ledger_batch = SchemaBatch::new();
+                    self.save_ledger_info(new_root_hash, ledger_info_with_sigs, &ledger_batch)?;
+                    ledger_batch.put::<DbMetadataSchema>(
+                        &DbMetadataKey::OverallCommitProgress,
+                        &DbMetadataValue::Version(last_version),
+                    )?;
+                    self.ledger_db.write_schemas(ledger_batch)?;
                 }
 
                 let mut end_with_reconfig = false;

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -26,7 +26,6 @@ use proptest::{prelude::*, proptest};
 use std::{collections::HashMap, sync::Arc};
 
 fn put_value_set(
-    db: &DB,
     state_store: &StateStore,
     value_set: Vec<(StateKey, StateValue)>,
     version: Version,
@@ -46,16 +45,22 @@ fn put_value_set(
         )
         .unwrap();
 
-    let batch = SchemaBatch::new();
+    let ledger_batch = SchemaBatch::new();
+    let state_kv_batch = SchemaBatch::new();
     state_store
         .put_value_sets(
             vec![&value_set],
             version,
             StateStorageUsage::new_untracked(),
-            &batch,
+            &ledger_batch,
+            &state_kv_batch,
         )
         .unwrap();
-    db.write_schemas(batch).unwrap();
+    state_store.ledger_db.write_schemas(ledger_batch).unwrap();
+    state_store
+        .state_kv_db
+        .write_schemas(state_kv_batch)
+        .unwrap();
 
     root
 }
@@ -99,7 +104,6 @@ fn test_state_store_pruner() {
     for i in 0..num_versions {
         let value = StateValue::from(vec![i as u8]);
         root_hashes.push(put_value_set(
-            &aptos_db.ledger_db,
             state_store,
             vec![(key.clone(), value.clone())],
             i, /* version */
@@ -178,13 +182,11 @@ fn test_state_store_pruner_partial_version() {
     let state_store = &aptos_db.state_store;
 
     let _root0 = put_value_set(
-        &aptos_db.ledger_db,
         state_store,
         vec![(key1.clone(), value1.clone()), (key2.clone(), value2)],
         0, /* version */
     );
     let _root1 = put_value_set(
-        &aptos_db.ledger_db,
         state_store,
         vec![
             (key2.clone(), value2_update.clone()),
@@ -193,7 +195,6 @@ fn test_state_store_pruner_partial_version() {
         1, /* version */
     );
     let _root2 = put_value_set(
-        &aptos_db.ledger_db,
         state_store,
         vec![(key3.clone(), value3_update.clone())],
         2, /* version */
@@ -269,7 +270,6 @@ fn test_state_store_pruner_disabled() {
     for i in 0..num_versions {
         let value = StateValue::from(vec![i as u8]);
         root_hashes.push(put_value_set(
-            &aptos_db.ledger_db,
             state_store,
             vec![(key.clone(), value.clone())],
             i, /* version */
@@ -317,23 +317,19 @@ fn test_worker_quit_eagerly() {
 
     let tmp_dir = TempPath::new();
     let aptos_db = AptosDB::new_for_test(&tmp_dir);
-    let db = Arc::clone(&aptos_db.ledger_db);
     let state_store = &aptos_db.state_store;
 
     let _root0 = put_value_set(
-        &db,
         state_store,
         vec![(key.clone(), value0.clone())],
         0, /* version */
     );
     let _root1 = put_value_set(
-        &db,
         state_store,
         vec![(key.clone(), value1.clone())],
         1, /* version */
     );
     let _root2 = put_value_set(
-        &db,
         state_store,
         vec![(key.clone(), value2.clone())],
         2, /* version */

--- a/storage/aptosdb/src/schema/db_metadata/mod.rs
+++ b/storage/aptosdb/src/schema/db_metadata/mod.rs
@@ -48,6 +48,9 @@ pub enum DbMetadataKey {
     StateMerklePrunerProgress,
     EpochEndingStateMerklePrunerProgress,
     StateSnapshotRestoreProgress(Version),
+    LedgerCommitProgress,
+    StateKVCommitProgress,
+    OverallCommitProgress,
 }
 
 define_schema!(

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -12,7 +12,10 @@ use crate::{
     state_merkle_db::StateMerkleDb,
     state_restore::{StateSnapshotProgress, StateSnapshotRestore, StateValueWriter},
     state_store::buffered_state::BufferedState,
-    utils::iterators::PrefixedStateValueIterator,
+    utils::{
+        iterators::PrefixedStateValueIterator,
+        truncation_helper::{truncate_ledger_db, truncate_state_kv_db},
+    },
     version_data::VersionDataSchema,
     AptosDbError, LedgerStore, StaleNodeIndexCrossEpochSchema, StaleNodeIndexSchema,
     StatePrunerManager, TransactionStore, OTHER_TIMERS_SECONDS,
@@ -42,6 +45,7 @@ use aptos_types::{
     },
     transaction::Version,
 };
+use claims::{assert_ge, assert_le};
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
 use rayon::prelude::*;
@@ -65,6 +69,8 @@ const MAX_WRITE_SETS_AFTER_SNAPSHOT: LeafCount = buffered_state::TARGET_SNAPSHOT
     * (buffered_state::ASYNC_COMMIT_CHANNEL_BUFFER_SIZE + 2 + 1/*  Rendezvous channel */)
     * 2;
 
+const MAX_COMMIT_PROGRESS_DIFFERENCE: u64 = 100000;
+
 static IO_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| {
     rayon::ThreadPoolBuilder::new()
         .num_threads(32)
@@ -76,6 +82,7 @@ static IO_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| {
 pub(crate) struct StateDb {
     pub ledger_db: Arc<DB>,
     pub state_merkle_db: Arc<StateMerkleDb>,
+    pub state_kv_db: Arc<DB>,
     pub state_pruner: StatePrunerManager<StaleNodeIndexSchema>,
     pub epoch_snapshot_pruner: StatePrunerManager<StaleNodeIndexCrossEpochSchema>,
 }
@@ -178,7 +185,7 @@ impl StateDb {
         let mut read_opts = ReadOptions::default();
         // We want `None` if the state_key changes in iteration.
         read_opts.set_prefix_same_as_start(true);
-        let mut iter = self.ledger_db.iter::<StateValueSchema>(read_opts)?;
+        let mut iter = self.state_kv_db.iter::<StateValueSchema>(read_opts)?;
         iter.seek(&(state_key.clone(), version))?;
         Ok(iter
             .next()
@@ -267,12 +274,69 @@ impl StateStore {
     pub fn new(
         ledger_db: Arc<DB>,
         state_merkle_db: Arc<DB>,
+        state_kv_db: Arc<DB>,
         state_pruner: StatePrunerManager<StaleNodeIndexSchema>,
         epoch_snapshot_pruner: StatePrunerManager<StaleNodeIndexCrossEpochSchema>,
         buffered_state_target_items: usize,
         max_nodes_per_lru_cache_shard: usize,
         hack_for_tests: bool,
     ) -> Self {
+        if let Some(DbMetadataValue::Version(overall_commit_progress)) = ledger_db
+            .get::<DbMetadataSchema>(&DbMetadataKey::OverallCommitProgress)
+            .expect("Failed to read overall commit progress.")
+        {
+            info!(
+                overall_commit_progress = overall_commit_progress,
+                "Start syncing databases..."
+            );
+            let ledger_commit_progress = ledger_db
+                .get::<DbMetadataSchema>(&DbMetadataKey::LedgerCommitProgress)
+                .expect("Failed to read ledger commit progress.")
+                .expect("Ledger commit progress cannot be None.")
+                .expect_version();
+            assert_ge!(ledger_commit_progress, overall_commit_progress);
+
+            let state_kv_commit_progress = state_kv_db
+                .get::<DbMetadataSchema>(&DbMetadataKey::StateKVCommitProgress)
+                .expect("Failed to read state K/V commit progress.")
+                .expect("State K/V commit progress cannot be None.")
+                .expect_version();
+            assert_ge!(state_kv_commit_progress, overall_commit_progress);
+
+            if ledger_commit_progress != overall_commit_progress {
+                info!(
+                    ledger_commit_progress = ledger_commit_progress,
+                    "Start truncation...",
+                );
+                let difference = ledger_commit_progress - overall_commit_progress;
+                assert_le!(difference, MAX_COMMIT_PROGRESS_DIFFERENCE);
+                truncate_ledger_db(
+                    Arc::clone(&ledger_db),
+                    ledger_commit_progress,
+                    overall_commit_progress,
+                    difference as usize,
+                )
+                .expect("Failed to truncate ledger db.");
+            }
+
+            if state_kv_commit_progress != overall_commit_progress {
+                info!(
+                    state_kv_commit_progress = state_kv_commit_progress,
+                    "Start truncation..."
+                );
+                let difference = state_kv_commit_progress - overall_commit_progress;
+                assert_le!(difference, MAX_COMMIT_PROGRESS_DIFFERENCE);
+                truncate_state_kv_db(
+                    Arc::clone(&state_kv_db),
+                    state_kv_commit_progress,
+                    overall_commit_progress,
+                    difference as usize,
+                )
+                .expect("Failed to truncate state K/V db.");
+            }
+        } else {
+            info!("No overall commit progress was found!");
+        }
         let state_merkle_db = Arc::new(StateMerkleDb::new(
             state_merkle_db,
             max_nodes_per_lru_cache_shard,
@@ -280,6 +344,7 @@ impl StateStore {
         let state_db = Arc::new(StateDb {
             ledger_db,
             state_merkle_db,
+            state_kv_db,
             state_pruner,
             epoch_snapshot_pruner,
         });
@@ -316,9 +381,11 @@ impl StateStore {
             NO_OP_STORAGE_PRUNER_CONFIG.state_merkle_pruner_config,
         );
         let state_merkle_db = Arc::new(StateMerkleDb::new(arc_state_merkle_rocksdb, 0));
+        let state_kv_db = Arc::clone(&ledger_db);
         let state_db = Arc::new(StateDb {
             ledger_db,
             state_merkle_db,
+            state_kv_db,
             state_pruner,
             epoch_snapshot_pruner,
         });
@@ -460,7 +527,7 @@ impl StateStore {
         desired_version: Version,
     ) -> Result<PrefixedStateValueIterator> {
         PrefixedStateValueIterator::new(
-            &self.ledger_db,
+            &self.state_kv_db,
             key_prefix.clone(),
             first_key_opt.cloned(),
             desired_version,
@@ -482,16 +549,23 @@ impl StateStore {
         value_state_sets: Vec<&HashMap<StateKey, Option<StateValue>>>,
         first_version: Version,
         expected_usage: StateStorageUsage,
-        batch: &SchemaBatch,
+        ledger_batch: &SchemaBatch,
+        state_kv_batch: &SchemaBatch,
     ) -> Result<()> {
         let _timer = OTHER_TIMERS_SECONDS
             .with_label_values(&["put_value_sets"])
             .start_timer();
 
-        self.put_stats_and_indices(&value_state_sets, first_version, expected_usage, batch)?;
+        self.put_stats_and_indices(
+            &value_state_sets,
+            first_version,
+            expected_usage,
+            ledger_batch,
+            state_kv_batch,
+        )?;
 
         let _timer = OTHER_TIMERS_SECONDS
-            .with_label_values(&["add_kv_batch"])
+            .with_label_values(&["add_state_kv_batch"])
             .start_timer();
 
         value_state_sets
@@ -499,8 +573,9 @@ impl StateStore {
             .enumerate()
             .flat_map_iter(|(i, kvs)| {
                 let version = first_version + i as Version;
-                kvs.iter()
-                    .map(move |(k, v)| batch.put::<StateValueSchema>(&(k.clone(), version), v))
+                kvs.iter().map(move |(k, v)| {
+                    state_kv_batch.put::<StateValueSchema>(&(k.clone(), version), v)
+                })
             })
             .collect()
     }
@@ -527,6 +602,7 @@ impl StateStore {
         first_version: Version,
         expected_usage: StateStorageUsage,
         batch: &SchemaBatch,
+        state_kv_batch: &SchemaBatch,
     ) -> Result<()> {
         let _timer = OTHER_TIMERS_SECONDS
             .with_label_values(&["put_stats_and_indices"])
@@ -578,7 +654,7 @@ impl StateStore {
                     usage.add_item(key.size() + value.size());
                 } else {
                     // stale index of the tombstone at current version.
-                    batch.put::<StaleStateValueIndexSchema>(
+                    state_kv_batch.put::<StaleStateValueIndexSchema>(
                         &StaleStateValueIndex {
                             stale_since_version: version,
                             version,
@@ -599,7 +675,7 @@ impl StateStore {
                 if let Some((old_version, old_value)) = old_version_and_value_opt {
                     usage.remove_item(key.size() + old_value.size());
                     // stale index of the old value at its version.
-                    batch.put::<StaleStateValueIndexSchema>(
+                    state_kv_batch.put::<StaleStateValueIndexSchema>(
                         &StaleStateValueIndex {
                             stale_since_version: version,
                             version: old_version,
@@ -739,6 +815,7 @@ impl StateStore {
         end: Version,
         db_batch: &SchemaBatch,
     ) -> Result<()> {
+        // TODO(grao): Replace ledger_db by state_kv_db.
         let mut iter = self
             .state_db
             .ledger_db
@@ -793,8 +870,12 @@ impl StateValueWriter<StateKey, StateValue> for StateStore {
         let _timer = OTHER_TIMERS_SECONDS
             .with_label_values(&["state_value_writer_write_chunk"])
             .start_timer();
+        // TODO(grao): Support state kv db here.
         let batch = SchemaBatch::new();
-        add_kv_batch(&batch, node_batch)?;
+        node_batch
+            .par_iter()
+            .map(|(k, v)| batch.put::<StateValueSchema>(k, v))
+            .collect::<Result<Vec<_>>>()?;
         batch.put::<DbMetadataSchema>(
             &DbMetadataKey::StateSnapshotRestoreProgress(version),
             &DbMetadataValue::StateSnapshotProgress(progress),
@@ -813,12 +894,4 @@ impl StateValueWriter<StateKey, StateValue> for StateStore {
             .get::<DbMetadataSchema>(&DbMetadataKey::StateSnapshotRestoreProgress(version))?
             .map(|v| v.expect_state_snapshot_progress()))
     }
-}
-
-fn add_kv_batch(batch: &SchemaBatch, kv_batch: &StateValueBatch) -> Result<()> {
-    kv_batch
-        .par_iter()
-        .map(|(k, v)| batch.put::<StateValueSchema>(k, v))
-        .collect::<Result<Vec<_>>>()?;
-    Ok(())
 }

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -32,16 +32,22 @@ fn put_value_set(
     let root = state_store
         .merklize_value_set(jmt_update_refs(&jmt_updates), None, version, base_version)
         .unwrap();
-    let batch = SchemaBatch::new();
+    let ledger_batch = SchemaBatch::new();
+    let state_kv_batch = SchemaBatch::new();
     state_store
         .put_value_sets(
             vec![&value_set],
             version,
             StateStorageUsage::new_untracked(),
-            &batch,
+            &ledger_batch,
+            &state_kv_batch,
         )
         .unwrap();
-    state_store.ledger_db.write_schemas(batch).unwrap();
+    state_store.ledger_db.write_schemas(ledger_batch).unwrap();
+    state_store
+        .state_kv_db
+        .write_schemas(state_kv_batch)
+        .unwrap();
     root
 }
 

--- a/storage/aptosdb/src/test_helper.rs
+++ b/storage/aptosdb/src/test_helper.rs
@@ -62,16 +62,19 @@ pub(crate) fn update_store(
                 version.checked_sub(1),
             )
             .unwrap();
-        let batch = SchemaBatch::new();
+        let ledger_batch = SchemaBatch::new();
+        let state_kv_batch = SchemaBatch::new();
         store
             .put_value_sets(
                 vec![&value_state_set],
                 version,
                 StateStorageUsage::new_untracked(),
-                &batch,
+                &ledger_batch,
+                &state_kv_batch,
             )
             .unwrap();
-        store.ledger_db.write_schemas(batch).unwrap();
+        store.ledger_db.write_schemas(ledger_batch).unwrap();
+        store.state_kv_db.write_schemas(state_kv_batch).unwrap();
     }
     root_hash
 }

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -65,11 +65,11 @@ pub struct RocksdbOpt {
     #[clap(long, hidden(true), default_value = "1073741824")] // 1GB
     state_merkle_db_max_total_wal_size: u64,
     #[clap(long, hidden(true))]
-    use_kv_db: bool,
+    use_state_kv_db: bool,
     #[clap(long, hidden(true), default_value = "5000")]
-    kv_db_max_open_files: i32,
+    state_kv_db_max_open_files: i32,
     #[clap(long, hidden(true), default_value = "1073741824")] // 1GB
-    kv_db_max_total_wal_size: u64,
+    state_kv_db_max_total_wal_size: u64,
     #[clap(long, hidden(true), default_value = "1000")]
     index_db_max_open_files: i32,
     #[clap(long, hidden(true), default_value = "1073741824")] // 1GB
@@ -93,10 +93,10 @@ impl From<RocksdbOpt> for RocksdbConfigs {
                 max_background_jobs: opt.max_background_jobs,
                 ..Default::default()
             },
-            use_kv_db: opt.use_kv_db,
-            kv_db_config: RocksdbConfig {
-                max_open_files: opt.kv_db_max_open_files,
-                max_total_wal_size: opt.kv_db_max_total_wal_size,
+            use_state_kv_db: opt.use_state_kv_db,
+            state_kv_db_config: RocksdbConfig {
+                max_open_files: opt.state_kv_db_max_open_files,
+                max_total_wal_size: opt.state_kv_db_max_total_wal_size,
                 max_background_jobs: opt.max_background_jobs,
                 ..Default::default()
             },


### PR DESCRIPTION
### Description
Commit state k/v and the rest of data in parallel in different Rocksdb commits. Add logic at the start to ensure they are consistent.

The change of using a separate database for state k/v is guarded by a config flag, thus without turning on the flag, this just split a commit batch into two batches, and both will still get committed into ledger db.

Pruner is not handled in this PR.
Truncation tool is not handled in this PR.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
