### PR TITLE
[aptos-logger][tracing] add source path to log metadata

### DIFF
--- a/crates/aptos-logger/src/tracing_adapter.rs
+++ b/crates/aptos-logger/src/tracing_adapter.rs
@@ -83,7 +83,7 @@ fn translate_metadata(metadata: &Metadata<'static>) -> Option<dl::Metadata> {
         level,
         metadata.target(),
         metadata.module_path().unwrap_or(""),
-        "",
+        metadata.file().unwrap_or(""),
     ))
 }
 


### PR DESCRIPTION
### Description

With this PR, we will include source path in the logs from crates that log using the `tracing` crate. 

The aptos-logger subscribes to tracing events from crates that log using the `tracing` crate (e.g. move-vm) and logs those events. This change populates the source path field of the logger from the event trace metadata. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

N/A