### PR TITLE
[panic] Supress panics from move deserializer

### DIFF
--- a/crates/crash-handler/src/lib.rs
+++ b/crates/crash-handler/src/lib.rs
@@ -49,7 +49,7 @@ fn handle_panic(panic_info: &PanicInfo<'_>) {
     // This is safe because the `state::get_state()` uses a thread_local for storing states. Thus the state can only be mutated to VERIFIER by the thread that's running the bytecode verifier.
     //
     // TODO: once `can_unwind` is stable, we should assert it. See https://github.com/rust-lang/rust/issues/92988.
-    if state::get_state() == VMState::VERIFIER {
+    if state::get_state() == VMState::VERIFIER || state::get_state() == VMState::DESERIALIZER {
         return;
     }
 


### PR DESCRIPTION
### Description

Ignore the move deserializer error as well cuz we've already set up the catch unwind handler there as well.


### Test Plan

Not sure what's the best way to test it.
