### PR TITLE
[gha] use git credentials for verify jobs

### DIFF
--- a/.github/actions/replay-verify/action.yaml
+++ b/.github/actions/replay-verify/action.yaml
@@ -1,7 +1,14 @@
+inputs:
+  GIT_CREDENTIALS:
+    description: "Optional credentials to pass to git"
+    required: false
+
 runs:
   using: composite
   steps:
     - uses: ./.github/actions/rust-setup
+      with:
+        GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
     - name: install dependencies
       shell: bash
       run: |

--- a/.github/actions/verify-modules/action.yaml
+++ b/.github/actions/verify-modules/action.yaml
@@ -1,7 +1,14 @@
+inputs:
+  GIT_CREDENTIALS:
+    description: "Optional credentials to pass to git"
+    required: false
+
 runs:
   using: composite
   steps:
     - uses: ./.github/actions/rust-setup
+      with:
+        GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
     - name: install dependencies
       shell: bash
       run: |

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -85,6 +85,8 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
       - uses: ./.github/actions/rust-setup
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - run: python3 scripts/check-cryptohasher-symbols.py
 
   rust-lint:

--- a/.github/workflows/replay-verify-mainnet.yaml
+++ b/.github/workflows/replay-verify-mainnet.yaml
@@ -30,3 +30,5 @@ jobs:
           ref: ${{ inputs.GIT_SHA }}
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: ./.github/actions/replay-verify
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}

--- a/.github/workflows/replay-verify-testnet.yaml
+++ b/.github/workflows/replay-verify-testnet.yaml
@@ -30,3 +30,5 @@ jobs:
           ref: ${{ inputs.GIT_SHA }}
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: ./.github/actions/replay-verify
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}

--- a/.github/workflows/verify-on-chain-modules-mainnet.yaml
+++ b/.github/workflows/verify-on-chain-modules-mainnet.yaml
@@ -29,3 +29,5 @@ jobs:
           ref: ${{ inputs.GIT_SHA }}
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: ./.github/actions/verify-modules
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}

--- a/.github/workflows/verify-on-chain-modules-mainnet.yaml
+++ b/.github/workflows/verify-on-chain-modules-mainnet.yaml
@@ -12,7 +12,7 @@ on:
         description: The git SHA1 to test. If not specified, Forge will check the latest commits on the current branch
   pull_request:
     paths:
-      - ".github/workflows/nightly-replay-verify.yaml"
+      - ".github/workflows/verify-on-chain-modules-mainnet.yaml"
 
 env:
   BUCKET:  aptos-mainnet-backup-backup-831a69a8

--- a/.github/workflows/verify-on-chain-modules-testnet.yaml
+++ b/.github/workflows/verify-on-chain-modules-testnet.yaml
@@ -29,3 +29,5 @@ jobs:
           ref: ${{ inputs.GIT_SHA }}
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: ./.github/actions/verify-modules
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}


### PR DESCRIPTION
### Description

`verify-modules` and `replay-verify` composite actions now take in `GIT_CREDENTIALS`, which is used by cargo  to pull in dependencies. Since `rust-setup` is run within these other composite actions, the `GIT_CREDENTIALS` input needs to be propagated down from caller > `verify-modules`/`replay-verify` > `rust-setup`

This also needs to be included in https://github.com/aptos-labs/aptos-core/pull/6435

### Test Plan

mainnet module verify is triggered on PR that touches the workflow file. Ensure that the workflow run that is triggered includes the git credentials setup

<!-- Please provide us with clear details for verifying that your changes work. -->
