### PR TITLE
Allow coin::burn is able to burn coin without zero check.

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/coin.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.spec.move
@@ -83,7 +83,6 @@ spec aptos_framework::coin {
         let addr =  type_info::type_of<CoinType>().account_address;
         modifies global<CoinInfo<CoinType>>(addr);
         include ExistCoinInfo<CoinType>;
-        aborts_if coin.value == 0;
     }
 
     spec burn_from<CoinType>(


### PR DESCRIPTION
### Description
#6560 
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
