### PR TITLE
[Quorum Store] Ignore a flaky test which is preventing some PRs landing

### DIFF
--- a/consensus/src/quorum_store/tests/batch_store_test.rs
+++ b/consensus/src/quorum_store/tests/batch_store_test.rs
@@ -107,6 +107,7 @@ async fn shutdown(batch_store_cmd_tx: tokio::sync::mpsc::Sender<BatchStoreComman
     rx.await.expect("Could not shutdown");
 }
 
+#[ignore] // TODO: debug and re-enable before deploying quorum store
 #[tokio::test(flavor = "multi_thread")]
 async fn test_batch_store_recovery() {
     let tmp_dir = TempPath::new();


### PR DESCRIPTION
### Description

Flaking with log messages like

```
--- TRY 4 STDERR:        aptos-consensus quorum_store::tests::batch_store_test::test_batch_store_recovery ---
thread 'quorum_store::tests::batch_store_test::test_batch_store_recovery' panicked at 'QuorumstoreDB open failed; unable to continue: IO error: lock hold by current process, acquire time 1676282739 acquiring thread 149771: 
/tmp/eb53042e829fdcb82884b45d8807d41a/quorumstoreDB/LOCK: No locks available', consensus/src/quorum_store/quorum_store_db.rs:38:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
