### PR TITLE
[gha] pin composite actions and reusable workflows to main

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Ubuntu"
       - name: Upload Binary
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Ubuntu-22.04"
       - name: Upload Binary

--- a/.github/workflows/continuous-e2e-changing-working-quorum-test copy.yaml
+++ b/.github/workflows/continuous-e2e-changing-working-quorum-test copy.yaml
@@ -13,7 +13,7 @@ jobs:
   ### Please remember to use different namespace for different tests
   # Performance test in an optimal setting
   run-forge-changing-working-quorum-test:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-changing-working-quorum-test

--- a/.github/workflows/continuous-e2e-changing-working-quorum-test-high-load.yaml
+++ b/.github/workflows/continuous-e2e-changing-working-quorum-test-high-load.yaml
@@ -13,7 +13,7 @@ jobs:
   ### Please remember to use different namespace for different tests
   # Performance test in an optimal setting
   run-forge-changing-working-quorum-test-high-load:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-changing-working-quorum-test-high-load

--- a/.github/workflows/continuous-e2e-compat-test.yaml
+++ b/.github/workflows/continuous-e2e-compat-test.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run-forge-compat:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-compat

--- a/.github/workflows/continuous-e2e-different-node-speed-and-reliability-test.yaml
+++ b/.github/workflows/continuous-e2e-different-node-speed-and-reliability-test.yaml
@@ -13,7 +13,7 @@ jobs:
   ### Please remember to use different namespace for different tests
   # Performance test in an optimal setting
   run-forge-different-node-speed-and-reliability-test:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-different-node-speed-and-reliability-test

--- a/.github/workflows/continuous-e2e-forge-continuous.yaml
+++ b/.github/workflows/continuous-e2e-forge-continuous.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   forge-continuous:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       COMMENT_HEADER: forge-continuous

--- a/.github/workflows/continuous-e2e-graceful-overload-test.yaml
+++ b/.github/workflows/continuous-e2e-graceful-overload-test.yaml
@@ -13,7 +13,7 @@ jobs:
   ### Please remember to use different namespace for different tests
   # Performance test in an optimal setting
   run-forge-graceful-overload-test:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-graceful-overload-test

--- a/.github/workflows/continuous-e2e-haproxy-test.yaml
+++ b/.github/workflows/continuous-e2e-haproxy-test.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run-forge-haproxy:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-haproxy

--- a/.github/workflows/continuous-e2e-network-partition-test.yaml
+++ b/.github/workflows/continuous-e2e-network-partition-test.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run-forge-network-partition-test:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-network-partition

--- a/.github/workflows/continuous-e2e-nft-mint-test.yaml
+++ b/.github/workflows/continuous-e2e-nft-mint-test.yaml
@@ -13,7 +13,7 @@ jobs:
   ### Please remember to use different namespace for different tests
   # Performance test in an optimal setting
   run-forge-nft-mint-test:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-nft-mint-test

--- a/.github/workflows/continuous-e2e-performance-test.yaml
+++ b/.github/workflows/continuous-e2e-performance-test.yaml
@@ -13,7 +13,7 @@ jobs:
   ### Please remember to use different namespace for different tests
   # Performance test in an optimal setting with the performance profile
   run-forge-performance:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-performance

--- a/.github/workflows/continuous-e2e-release-test.yaml
+++ b/.github/workflows/continuous-e2e-release-test.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   # Run a faster chaos forge to quickly surface correctness failures
   run-release-blocking-forge:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       # Run for 5 hours unless its on a pr

--- a/.github/workflows/continuous-e2e-single-vfn-test.yaml
+++ b/.github/workflows/continuous-e2e-single-vfn-test.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   # Test transaction processing throughput at a single VFN
   run-forge-single-vfn-perf:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-continuous-e2e-single-vfn

--- a/.github/workflows/continuous-e2e-state-sync-perf-fullnode-execute-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-perf-fullnode-execute-test.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   # Performance test in an optimal setting
   run-forge-state-sync-perf-fullnode-execute-test:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-state-sync-perf-fullnode-execute

--- a/.github/workflows/continuous-e2e-state-sync-perf-fullnode-fast-sync-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-perf-fullnode-fast-sync-test.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   # Performance test in an optimal setting
   run-forge-state-sync-perf-fullnode-fast-sync-test:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-state-sync-perf-fullnode-fast-sync

--- a/.github/workflows/continuous-e2e-state-sync-perf-validator-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-perf-validator-test.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   # Performance test in an optimal setting
   run-forge-state-sync-perf-validator-test:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-state-sync-perf-validator

--- a/.github/workflows/continuous-e2e-state-sync-slow-processing-catching-up-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-slow-processing-catching-up-test.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run-forge-state-sync-slow-processing-catching-up-test:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-state-sync-slow-processing-catching-up-test

--- a/.github/workflows/continuous-e2e-twin-validator-test.yaml
+++ b/.github/workflows/continuous-e2e-twin-validator-test.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run-forge-twin-validator-test:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-twin-validator

--- a/.github/workflows/continuous-e2e-validator-reboot-stress-test.yaml
+++ b/.github/workflows/continuous-e2e-validator-reboot-stress-test.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run-forge-validator-reboot-stress-test:
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-validator-reboot-stress

--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
 
-      - uses: ./.github/actions/docker-setup
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - run: rustup component add llvm-tools-preview
       - uses: taiki-e/install-action@6f1ebcd9e21315fc37d7f7bc851dfcc8356d7da3 # pin@v1.5.6
         with:
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - run: rustup component add llvm-tools-preview
       - uses: taiki-e/install-action@6f1ebcd9e21315fc37d7f7bc851dfcc8356d7da3 # pin@v1.5.6
         with:

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -186,7 +186,7 @@ jobs:
         github.event.pull_request.auto_merge != null ||
         contains(github.event.pull_request.body, '#e2e')
       )
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -208,7 +208,7 @@ jobs:
         github.event.pull_request.auto_merge != null ||
         contains(github.event.pull_request.body, '#e2e')
       )
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -226,7 +226,7 @@ jobs:
       [rust-images-consensus-only-perf-test, determine-docker-build-metadata]
     if: |
       contains(github.event.pull_request.labels.*.name, 'CICD:run-consensus-only-perf-test')
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}

--- a/.github/workflows/docker-rust-build.yaml
+++ b/.github/workflows/docker-rust-build.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           ref: ${{ env.GIT_SHA }}
 
-      - uses: ./.github/actions/docker-setup
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}

--- a/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
+++ b/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
@@ -10,5 +10,5 @@ jobs:
     runs-on: high-perf-docker
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - run: scripts/find-packages-with-undeclared-feature-dependencies.sh

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -81,7 +81,7 @@ jobs:
   run-forge-three-region:
     if: ${{ github.event_name != 'pull_request' }}
     needs: determine-test-metadata
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
@@ -93,7 +93,7 @@ jobs:
   run-forge-three-region-different-node-speed:
     if: ${{ github.event_name != 'pull_request' }}
     needs: determine-test-metadata
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
@@ -106,7 +106,7 @@ jobs:
   run-forge-consensus-stress-test:
     if: ${{ github.event_name != 'pull_request' }}
     needs: determine-test-metadata
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
@@ -118,7 +118,7 @@ jobs:
   run-forge-account-creation-test:
     if: ${{ github.event_name != 'pull_request' }}
     needs: determine-test-metadata
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
@@ -130,7 +130,7 @@ jobs:
   run-forge-fullnode-reboot-stress-test:
     if: ${{ github.event_name != 'pull_request' }}
     needs: determine-test-metadata
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
@@ -142,7 +142,7 @@ jobs:
   run-forge-state-sync-failures-catching-up-test:
     if: ${{ github.event_name != 'pull_request' }}
     needs: determine-test-metadata
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
@@ -155,7 +155,7 @@ jobs:
   run-forge-state-sync-perf-fullnode-apply-test:
     if: ${{ github.event_name != 'pull_request' }}
     needs: determine-test-metadata
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - run: python3 scripts/check-cryptohasher-symbols.py
@@ -93,7 +93,7 @@ jobs:
     runs-on: high-perf-docker
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - uses: pre-commit/action@v3.0.0
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - run: cargo test --locked --doc --workspace --exclude aptos-node-checker
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - run: docker run --detach -p 5432:5432 cimg/postgres:14.2
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - uses: taiki-e/install-action@v1.5.6
@@ -148,7 +148,7 @@ jobs:
     runs-on: high-perf-docker
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - run: docker run --detach -p 5432:5432 cimg/postgres:14.2
@@ -178,7 +178,7 @@ jobs:
     runs-on: high-perf-docker
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - uses: taiki-e/install-action@v1.5.6
@@ -205,7 +205,7 @@ jobs:
     runs-on: high-perf-docker
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - run: cargo test --locked --features check-vm-features -p aptos-node

--- a/.github/workflows/module-verify.yaml
+++ b/.github/workflows/module-verify.yaml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   verify-modules-testnet:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.CHAIN_NAME == 'testnet' || inputs.CHAIN_NAME == 'all' }}
-    uses: ./.github/workflows/workflow-run-module-verify.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-module-verify.yaml@main
     with:
       GIT_SHA: ${{ inputs.GIT_SHA }}
       BUCKET: aptos-testnet-backup-2223d95b
@@ -43,7 +43,7 @@ jobs:
 
   verify-modules-mainnet:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.CHAIN_NAME == 'mainnet' || inputs.CHAIN_NAME == 'all' }}
-    uses: ./.github/workflows/workflow-run-module-verify.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-module-verify.yaml@main
     with:
       GIT_SHA: ${{ inputs.GIT_SHA }}
       BUCKET: aptos-mainnet-backup-backup-831a69a8
@@ -55,7 +55,7 @@ jobs:
 
   test-verify-modules:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: ./.github/workflows/workflow-run-module-verify.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-module-verify.yaml@main
     with:
       GIT_SHA: ${{ github.event.pull_request.head.sha }}
       BUCKET: aptos-testnet-backup-2223d95b

--- a/.github/workflows/prover-daily-test.yaml
+++ b/.github/workflows/prover-daily-test.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - name: install Prover dependencies
         shell: bash
         run: scripts/dev_setup.sh -b -p -y

--- a/.github/workflows/prover-test.yaml
+++ b/.github/workflows/prover-test.yaml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - name: install Prover dependencies
         shell: bash
         run: scripts/dev_setup.sh -b -p -y

--- a/.github/workflows/replay-verify.yaml
+++ b/.github/workflows/replay-verify.yaml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   replay-testnet:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.CHAIN_NAME == 'testnet' || inputs.CHAIN_NAME == 'all' }}
-    uses: ./.github/workflows/workflow-run-replay-verify.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-replay-verify.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ inputs.GIT_SHA }}
@@ -47,7 +47,7 @@ jobs:
 
   replay-mainnet:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.CHAIN_NAME == 'testnet' || inputs.CHAIN_NAME == 'all' }}
-    uses: ./.github/workflows/workflow-run-replay-verify.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-replay-verify.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ inputs.GIT_SHA }}
@@ -63,7 +63,7 @@ jobs:
 
   test-replay:
     if: ${{ github.event_name == 'pull_request' }}
-    uses: ./.github/workflows/workflow-run-replay-verify.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-replay-verify.yaml@main
     with:
       GIT_SHA: ${{ github.event.pull_request.head.sha }}
       # replay-verify config

--- a/.github/workflows/run-gas-calibration.yaml
+++ b/.github/workflows/run-gas-calibration.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - name: install Valgrind
         shell: bash
         run: sudo apt-get -y install valgrind

--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -118,7 +118,7 @@ jobs:
       - run: wait-on -t 60000 --httpTimeout 60000 http-get://127.0.0.1:8081/health
 
       # Confirm the Rust API client examples pass.
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - run: cargo run -p aptos-rest-client --example account -- --api-url http://127.0.01:8080
 
       # Test and build.

--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           ref: ${{ inputs.GIT_SHA }}
 
-      - uses: ./.github/actions/docker-setup
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}

--- a/.github/workflows/workflow-run-module-verify.yaml
+++ b/.github/workflows/workflow-run-module-verify.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           ref: ${{ inputs.GIT_SHA }}
 
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
 

--- a/.github/workflows/workflow-run-replay-verify.yaml
+++ b/.github/workflows/workflow-run-replay-verify.yaml
@@ -85,7 +85,7 @@ jobs:
         with:
           ref: ${{ inputs.GIT_SHA }}
 
-      - uses: ./.github/actions/rust-setup
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
 


### PR DESCRIPTION
### Description

Pin to main, so we're versioning on something other than the current branch.

### Test Plan

Everything that's triggered by `pull_request` should still work, as the corresponding PR to create the composite actions and reusable workflows have already landed in #6435 . The composite actions should be checking out `main`, and work as expected, and the workflow as a whole should succeed.

cc'ing owners of some of the below workflows to verify these criteria. 

* Forge stable: https://github.com/aptos-labs/aptos-core/actions/runs/4167674092/jobs/7213548073
* replay-verify: https://github.com/aptos-labs/aptos-core/actions/runs/4167674094/jobs/7213549035
* module-verify: https://github.com/aptos-labs/aptos-core/actions/runs/4167674087/jobs/7213548802
* gas calibration: https://github.com/aptos-labs/aptos-core/actions/runs/4167674049/jobs/7213547889
* lint+test: https://github.com/aptos-labs/aptos-core/actions/runs/4167674106/jobs/7213548610
* docker build + forge: https://github.com/aptos-labs/aptos-core/actions/runs/4167694680 (triggered by both `pull_request` and `pull_request_target`, which actually results in forge test clobbering if they happen to get scheduled on the same cluster. :/ Issue filed here: https://linear.app/aptoslabs/issue/PE-212/only-trigger-for-one-of-pull-request-and-pull-request-target)

<!-- Please provide us with clear details for verifying that your changes work. -->
