### PR TITLE
[gha] replay-verify on cadence

### DIFF
--- a/.github/workflows/replay-verify.yaml
+++ b/.github/workflows/replay-verify.yaml
@@ -21,6 +21,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/replay-verify.yaml"
+  schedule:
+    - cron: "0 19 * * *" # the main branch cadence
 
 # cancel redundant builds
 concurrency:


### PR DESCRIPTION
### Description

The cron trigger was accidentally removed. Add it back as `0 19 * * *`, which will run at 11AM PST

### Test Plan

We can now trigger it manually: https://github.com/aptos-labs/aptos-core/actions/runs/4176814975

https://github.com/aptos-labs/aptos-core/actions/workflows/workflow-run-replay-verify.yaml 
Triggered testnet replay manually on the latest `main` at the time: `7fb9071ea877e5ddfe6e21bc546d478c3e7c2dfb`, using workflow specs from `main`.
 
We can also run the same workflow via:

```
gh workflow run replay-verify.yaml --ref main \
  -F=GIT_SHA=7fb9071ea877e5ddfe6e21bc546d478c3e7c2dfb \
  -F=BUCKET=aptos-testnet-backup-2223d95b \
  -F=SUB_DIR=e1 -F=HISTORY_START=250000000 \
  -F=TXNS_TO_SKIP="46874937 151020059 409163615 409163669 409163708 409163774 409163845 409163955 409164059 409164191 414625832" \
  -F=BACKUP_CONFIG_TEMPLATE=terraform/helm/fullnode/files/backup/s3-public.yaml
```

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/12578616/218823140-65b0ba40-3d81-47be-ac5f-776239918163.png">

<!-- Please provide us with clear details for verifying that your changes work. -->
