### PR TITLE
[indexer grpc][docker] add the docker image building script for indexer grpc.

### DIFF
--- a/docker/build-rust-all.sh
+++ b/docker/build-rust-all.sh
@@ -22,6 +22,9 @@ cargo build --locked --profile=$PROFILE \
     -p aptos-telemetry-service \
     -p aptos-db-bootstrapper \
     -p aptos-transaction-emitter \
+    -p aptos-indexer-grpc-cache-worker \
+    -p aptos-indexer-grpc-file-store \
+    -p aptos-indexer-grpc-data-service \
     "$@"
 
 # Build aptos-node separately
@@ -43,6 +46,9 @@ BINS=(
     aptos-node-checker
     aptos-openapi-spec-generator
     aptos-telemetry-service
+    aptos-indexer-grpc-cache-worker
+    aptos-indexer-grpc-file-store
+    aptos-indexer-grpc-data-service
     aptos-fn-check-client
     db-backup
     db-backup-verify

--- a/docker/docker-bake-rust-all.hcl
+++ b/docker/docker-bake-rust-all.hcl
@@ -59,6 +59,7 @@ group "all" {
     "faucet",
     "forge",
     "telemetry-service",
+    "indexer-grpc",
     BUILD_ADDL_TESTING_IMAGES == "true" ? [
       "validator-testing"
     ] : []
@@ -76,6 +77,7 @@ target "_common" {
     generate_cache_from("faucet"),
     generate_cache_from("forge"),
     generate_cache_from("telemetry-service"),
+    generate_cache_from("indexer-grpc"),
 
     // testing targets
     generate_cache_from("validator-testing"),
@@ -144,6 +146,13 @@ target "telemetry-service" {
   target   = "telemetry-service"
   cache-to = generate_cache_to("telemetry-service")
   tags     = generate_tags("telemetry-service")
+}
+
+target "indexer-grpc" {
+  inherits = ["_common"]
+  target   = "indexer-grpc"
+  cache-to = generate_cache_to("indexer-grpc")
+  tags     = generate_tags("indexer-grpc")
 }
 
 function "generate_cache_from" {

--- a/docker/retag-rust-images.sh
+++ b/docker/retag-rust-images.sh
@@ -9,6 +9,7 @@ IMAGES=(
   faucet
   forge
   telemetry-service
+  indexer-grpc
 )
 
 for IMAGE in "${IMAGES[@]}"

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -274,6 +274,39 @@ ENV GIT_BRANCH ${GIT_BRANCH}
 ARG GIT_SHA
 ENV GIT_SHA ${GIT_SHA}
 
+### Indexer GRPC Image ###
+
+FROM debian-base AS indexer-grpc
+
+RUN apt-get update && apt-get install -y \
+    libssl1.1 \
+    ca-certificates \
+    net-tools \
+    tcpdump \
+    iproute2 \
+    netcat \
+    libpq-dev \
+    curl \
+    && apt-get clean && rm -r /var/lib/apt/lists/*
+
+COPY --link --from=builder /aptos/dist/aptos-indexer-grpc-cache-worker /usr/local/bin/aptos-indexer-grpc-cache-worker
+COPY --link --from=builder /aptos/dist/aptos-indexer-grpc-file-store /usr/local/bin/aptos-indexer-grpc-file-store
+COPY --link --from=builder /aptos/dist/aptos-indexer-grpc-data-service /usr/local/bin/aptos-indexer-grpc-data-service
+
+# The health check port
+EXPOSE 8080
+# The gRPC port
+EXPOSE 50501
+
+ENV RUST_LOG_FORMAT=json
+
+# add build info
+ARG GIT_TAG
+ENV GIT_TAG ${GIT_TAG}
+ARG GIT_BRANCH
+ENV GIT_BRANCH ${GIT_BRANCH}
+ARG GIT_SHA
+ENV GIT_SHA ${GIT_SHA}
 
 ### EXPERIMENTAL ###
 


### PR DESCRIPTION
### Description

* Add a docker image build for `indexer-grpc`, which includes binary:
  * `aptos-indexer-grpc-cache-worker`: worker fetches data from fullnode grpc to cache
  * `aptos-indexer-grpc-file-store`: worker fetches data from cache to gcs
  * `aptos-indexer-grpc-data-service`: service that serves data from cache and gcs. 
  
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Built successfully:

<img width="892" alt="image" src="https://user-images.githubusercontent.com/112209412/219456230-807b2c81-1366-486e-b766-32ef118929c4.png">

