### PR TITLE
fix script path on ts sdk release workflow

### DIFF
--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -131,7 +131,7 @@ jobs:
       - run: cd ./ecosystem/typescript/sdk && pnpm build
 
       # Ensure the version, changelog, etc. are valid.
-      - run: cd ./ecosystem/typescript/sdk && ./check.sh
+      - run: cd ./ecosystem/typescript/sdk && ./scripts/check.sh
         if: github.event_name == 'push' && github.ref_name == 'devnet'
 
       # Finally, if this is a push and the version in package.json is different,


### PR DESCRIPTION
### Description
SDK Release failed on latest devnet branch due to some missing CI file
https://github.com/aptos-labs/aptos-core/actions/runs/4138826024/jobs/7155774880

https://aptos-org.slack.com/archives/C03N83P7QUC/p1675981353946149

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
