### PR TITLE
[forge] Change default to send traffic only to FN (if any are defined)

### DIFF
--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -104,6 +104,8 @@ pub enum LoadDestination {
     AllNodes,
     AllValidators,
     AllFullnodes,
+    // Send to AllFullnodes, if any exist, otherwise to AllValidators
+    FullnodesOtherwiseValidators,
     Peers(Vec<PeerId>),
 }
 
@@ -116,6 +118,13 @@ impl LoadDestination {
             LoadDestination::AllNodes => [&all_validators[..], &all_fullnodes[..]].concat(),
             LoadDestination::AllValidators => all_validators,
             LoadDestination::AllFullnodes => all_fullnodes,
+            LoadDestination::FullnodesOtherwiseValidators => {
+                if all_fullnodes.is_empty() {
+                    all_validators
+                } else {
+                    all_fullnodes
+                }
+            },
             LoadDestination::Peers(peers) => peers,
         }
     }
@@ -123,7 +132,7 @@ impl LoadDestination {
 
 pub trait NetworkLoadTest: Test {
     fn setup(&self, _ctx: &mut NetworkContext) -> Result<LoadDestination> {
-        Ok(LoadDestination::AllNodes)
+        Ok(LoadDestination::FullnodesOtherwiseValidators)
     }
     // Load is started before this function is called, and stops after this function returns.
     // Expected duration is passed into this function, expecting this function to take that much

--- a/testsuite/testcases/src/network_bandwidth_test.rs
+++ b/testsuite/testcases/src/network_bandwidth_test.rs
@@ -34,7 +34,7 @@ impl NetworkLoadTest for NetworkBandwidthTest {
         );
         println!("{}", msg);
         ctx.report.report_text(msg);
-        Ok(LoadDestination::AllNodes)
+        Ok(LoadDestination::FullnodesOtherwiseValidators)
     }
 
     fn finish(&self, swarm: &mut dyn Swarm) -> anyhow::Result<()> {

--- a/testsuite/testcases/src/network_loss_test.rs
+++ b/testsuite/testcases/src/network_loss_test.rs
@@ -30,7 +30,7 @@ impl NetworkLoadTest for NetworkLossTest {
         );
         println!("{}", msg);
         ctx.report.report_text(msg);
-        Ok(LoadDestination::AllNodes)
+        Ok(LoadDestination::FullnodesOtherwiseValidators)
     }
 
     fn finish(&self, swarm: &mut dyn Swarm) -> anyhow::Result<()> {

--- a/testsuite/testcases/src/performance_with_fullnode_test.rs
+++ b/testsuite/testcases/src/performance_with_fullnode_test.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{LoadDestination, NetworkLoadTest};
+use crate::NetworkLoadTest;
 use aptos_forge::{NetworkContext, NetworkTest, Result, Test};
 
 pub struct PerformanceBenchmarkWithFN;
@@ -12,11 +12,7 @@ impl Test for PerformanceBenchmarkWithFN {
     }
 }
 
-impl NetworkLoadTest for PerformanceBenchmarkWithFN {
-    fn setup(&self, _ctx: &mut NetworkContext) -> Result<LoadDestination> {
-        Ok(LoadDestination::AllFullnodes)
-    }
-}
+impl NetworkLoadTest for PerformanceBenchmarkWithFN {}
 
 impl NetworkTest for PerformanceBenchmarkWithFN {
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {

--- a/testsuite/testcases/src/three_region_simulation_test.rs
+++ b/testsuite/testcases/src/three_region_simulation_test.rs
@@ -198,7 +198,7 @@ impl NetworkLoadTest for ThreeRegionSimulationTest {
             add_execution_delay(ctx.swarm(), config)?;
         }
 
-        Ok(LoadDestination::AllNodes)
+        Ok(LoadDestination::FullnodesOtherwiseValidators)
     }
 
     fn finish(&self, swarm: &mut dyn Swarm) -> anyhow::Result<()> {

--- a/testsuite/testcases/src/twin_validator_test.rs
+++ b/testsuite/testcases/src/twin_validator_test.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{LoadDestination, NetworkLoadTest};
+use crate::NetworkLoadTest;
 use anyhow::Context;
 use aptos_forge::{NetworkContext, NetworkTest, NodeExt, Test};
 use aptos_sdk::move_types::account_address::AccountAddress;
@@ -16,11 +16,7 @@ impl Test for TwinValidatorTest {
     }
 }
 
-impl NetworkLoadTest for TwinValidatorTest {
-    fn setup(&self, _ctx: &mut NetworkContext) -> anyhow::Result<LoadDestination> {
-        Ok(LoadDestination::AllFullnodes)
-    }
-}
+impl NetworkLoadTest for TwinValidatorTest {}
 
 impl NetworkTest for TwinValidatorTest {
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> anyhow::Result<()> {

--- a/testsuite/testcases/src/two_traffics_test.rs
+++ b/testsuite/testcases/src/two_traffics_test.rs
@@ -31,10 +31,6 @@ impl Test for TwoTrafficsTest {
 }
 
 impl NetworkLoadTest for TwoTrafficsTest {
-    fn setup(&self, _ctx: &mut NetworkContext) -> Result<LoadDestination> {
-        Ok(LoadDestination::AllFullnodes)
-    }
-
     fn test(&self, swarm: &mut dyn Swarm, duration: Duration) -> Result<()> {
         info!(
             "Running TwoTrafficsTest test for duration {}s",

--- a/testsuite/testcases/src/validator_join_leave_test.rs
+++ b/testsuite/testcases/src/validator_join_leave_test.rs
@@ -25,7 +25,7 @@ impl Test for ValidatorJoinLeaveTest {
 
 impl NetworkLoadTest for ValidatorJoinLeaveTest {
     fn setup(&self, _ctx: &mut NetworkContext) -> Result<LoadDestination> {
-        Ok(LoadDestination::AllValidators)
+        Ok(LoadDestination::FullnodesOtherwiseValidators)
     }
 
     fn test(&self, swarm: &mut dyn Swarm, duration: Duration) -> Result<()> {

--- a/testsuite/testcases/src/validator_reboot_stress_test.rs
+++ b/testsuite/testcases/src/validator_reboot_stress_test.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{LoadDestination, NetworkLoadTest};
+use crate::NetworkLoadTest;
 use aptos_forge::{NetworkContext, NetworkTest, Result, Swarm, Test};
 use rand::{seq::SliceRandom, thread_rng};
 use std::time::Duration;
@@ -20,10 +20,6 @@ impl Test for ValidatorRebootStressTest {
 }
 
 impl NetworkLoadTest for ValidatorRebootStressTest {
-    fn setup(&self, _ctx: &mut NetworkContext) -> Result<LoadDestination> {
-        Ok(LoadDestination::AllFullnodes)
-    }
-
     fn test(&self, swarm: &mut dyn Swarm, duration: Duration) -> Result<()> {
         let start = Instant::now();
         let runtime = Runtime::new().unwrap();


### PR DESCRIPTION
and to validators otherwise


This is generally always the intention of the test, I thought it was always the default, but isn't. Some test override if needed (or if they override the function, as there is no super in traits in rust)