### PR TITLE
[testsuite] find latest image variants

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -73,10 +73,8 @@ jobs:
 
       - name: Determine image tag
         id: determine-test-image-tag
-        run: |
-          LATEST_IMAGE_TAG=$(python3 testsuite/find_latest_image.py)
-          echo "Latest image tag: $LATEST_IMAGE_TAG"
-          echo "IMAGE_TAG=$LATEST_IMAGE_TAG" >> $GITHUB_OUTPUT
+        # forge relies on the default and failpoints variants
+        run: python3 testsuite/find_latest_image.py --variant failpoints
 
   run-forge-three-region:
     if: ${{ github.event_name != 'pull_request' }}

--- a/testsuite/find_latest_image.py
+++ b/testsuite/find_latest_image.py
@@ -9,16 +9,44 @@ from forge import find_recent_images, image_exists
 from forge_wrapper_core.shell import LocalShell
 from forge_wrapper_core.git import Git
 
+# gh output logic from determinator
+from determinator import GithubOutput, write_github_output
+
+import argparse
 import os
 import sys
 
+# the image name in the repo to search for the image tag in
+# all images are exported together, so this currently checks for validator-testing as well
 IMAGE_NAME = "aptos/validator"
+# the environment variable containing the image tag to check for existence
 IMAGE_TAG_ENV = "IMAGE_TAG"
+# if running in github actions, this is the output key that will contain the latest image tag
+GH_OUTPUT_KEY = "IMAGE_TAG"
+
+# map of build variant (e.g. cargo profile and )
+BUILD_VARIANT_TAG_PREFIX_MAP = {
+    "performance": "performance",
+    "failpoints": "failpoints",
+    "indexer": "indexer",
+    "release": "",  # the default release profile has no tag prefix
+}
 
 
 def main():
     shell = LocalShell()
     git = Git(shell)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--variant",
+        "-v",
+        help="A build variant",
+        action="append",
+        dest="variants",
+        default=[],
+    )
+    args = parser.parse_args()
 
     # If the IMAGE_TAG environment variable is set, check that
     if IMAGE_TAG_ENV in os.environ:
@@ -26,9 +54,31 @@ def main():
         if not image_exists(shell, IMAGE_NAME, image_tag):
             sys.exit(1)
 
+    variants = args.variants
+    print(f"Finding latest image with build variants: {variants}")
+    variant_prefixes = [f"{v}_" if v != "" else "" for v in variants]
+    print(f"With prefixes: {variant_prefixes}")
+
     # Find the latest image from git history
-    images = list(find_recent_images(shell, git, 1, IMAGE_NAME))
-    print(images[0])
+    num_images_to_find = 1  # for the purposes of this script, this is always 1
+    images = list(
+        find_recent_images(shell, git, num_images_to_find, IMAGE_NAME, variant_prefixes)
+    )
+    print(f"Found latest images: {images}")
+
+    # write the output to Github outputs (via stdout)
+    git_sha_set = set([x.split("_")[-1] for x in images])  # trim to get the base sha
+    assert len(git_sha_set) == num_images_to_find
+    git_sha = git_sha_set.pop()
+    print(f"Exporting latest image as base GIT_SHA: {git_sha}")
+    latest_image_gh_output = GithubOutput(GH_OUTPUT_KEY, git_sha)
+    try:
+        write_github_output(latest_image_gh_output)
+    except Exception as e:
+        print(e)
+        print(
+            "This may be an indication that you're running locally or the environment is not configured correctly"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

fix the forge stable issue where it can't find the failpoints build https://github.com/aptos-labs/aptos-core/actions/runs/4172126738

also start to abstract in some places image tag --> build variant

### Test Plan

check the test run in `determine-test-metadata`

https://github.com/aptos-labs/aptos-core/actions/runs/4181370693/jobs/7243247681
log snippet from run:
```
Finding latest image with build variants: ['failpoints']
With prefixes: ['failpoints_']
Found latest images: ['failpoints_a4e24eace8204f9ae[16](https://github.com/aptos-labs/aptos-core/actions/runs/4181370693/jobs/7243247681#step:6:17)b329b5f419bcac20501ad']
Exporting latest image as base GIT_SHA: a4e24eace8204f9ae16b329b5f419bcac20501ad
```
<!-- Please provide us with clear details for verifying that your changes work. -->
