### PR TITLE
[gha] run forge stable against quorum-store branch

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -20,7 +20,7 @@ on:
         description: The git SHA1 to checkout. This affects the Forge test runner that is used. If not specified, the latest main will be used
   schedule:
     - cron: "0 9 * * *" # the main branch cadence
-    - cron: "0 21 * * *" # the QS "performance_benchmark" branch cadence
+    - cron: "0 21 * * *" # the QS "quorum-store" branch cadence
   pull_request:
     paths:
       - ".github/workflows/forge-stable.yaml"
@@ -48,8 +48,8 @@ jobs:
               echo "Branch: main"
               echo "BRANCH=main" >> $GITHUB_OUTPUT
             elif [[ "${{ github.event.schedule }}" == "0 21 * * *" ]]; then
-              echo "Branch: performance_benchmark"
-              echo "BRANCH=performance_benchmark" >> $GITHUB_OUTPUT
+              echo "Branch: quorum-store"
+              echo "BRANCH=quorum-store" >> $GITHUB_OUTPUT
             else
               echo "Unknown schedule: ${{ github.event.schedule }}"
               exit 1


### PR DESCRIPTION
### Description

separate cadence from `main` that runs the same suite of stable forge tests against the new `quorum-store` branch

### Test Plan

check the test determine-test-metadata job. Then, we include this in the `quorum-store` branch

<!-- Please provide us with clear details for verifying that your changes work. -->
