### PR TITLE
[gha] build on push to quorum-store branch and make IMAGE_TAG optional

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -38,11 +38,14 @@ on: # build on main branch OR when a PR is labeled with `CICD:build-images`
   push:
     branches:
       - main
+      # release branches
       - devnet
       - testnet
       - mainnet
       - aptos-node-v*
+      # experimental branches
       - performance_benchmark
+      - quorum-store
 
 # cancel redundant builds
 concurrency:

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -11,9 +11,9 @@ on:
   workflow_dispatch:
     inputs:
       IMAGE_TAG:
-        required: true
+        required: false
         type: string
-        description: The docker image tag to test. This may be a git SHA1, or a tag like "<branch>_<git SHA1>""
+        description: The docker image tag to test. This may be a git SHA1, or a tag like "<branch>_<git SHA1>". If not specified, Forge will find the latest build based on the git history (starting from GIT_SHA input)
       GIT_SHA:
         required: false
         type: string
@@ -29,6 +29,7 @@ env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  IMAGE_TAG: ${{ inputs.IMAGE_TAG }} # this is only used for workflow_dispatch, otherwise defaults to empty
   AWS_REGION: us-west-2
 
 jobs:

--- a/testsuite/find_latest_image.py
+++ b/testsuite/find_latest_image.py
@@ -49,7 +49,7 @@ def main():
     args = parser.parse_args()
 
     # If the IMAGE_TAG environment variable is set, check that
-    if IMAGE_TAG_ENV in os.environ:
+    if IMAGE_TAG_ENV in os.environ and os.environ[IMAGE_TAG_ENV]:
         image_tag = os.environ[IMAGE_TAG_ENV]
         if not image_exists(shell, IMAGE_NAME, image_tag):
             sys.exit(1)


### PR DESCRIPTION
### Description

so we can start battle-testing `quorum-store` branch:
(1) build on push to branch. important as this branch drifts from main
(2) once image is built, continous stable forge test will use the latest images from the branch for testing nightly

### Test Plan

forge stable `determine-test-metadata` test finds a valid `IMAGE_TAG` to test. On `workflow_dispatch`, we can manually specify it. Anywhere else, it will crawl the git history of the current checkout.

<!-- Please provide us with clear details for verifying that your changes work. -->
