### PR TITLE
[TEST BRANCH ONLY] hard code quorum store enabled in onchain config

### DIFF
--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -69,7 +69,8 @@ impl OnChainConsensusConfig {
 
     pub fn quorum_store_enabled(&self) -> bool {
         match &self {
-            OnChainConsensusConfig::V1(_config) => false,
+            // TODO: this is hardcoded to true, so all continuous forge runs have quorum store enabled
+            OnChainConsensusConfig::V1(_config) => true,
             OnChainConsensusConfig::V2(_config) => true,
         }
     }


### PR DESCRIPTION
So continuous forge runs will always run with quorum store enabled.