### PR TITLE
[API] Include private entry functions returned in ABI's exposed functions

### DIFF
--- a/api/src/tests/mod.rs
+++ b/api/src/tests/mod.rs
@@ -7,6 +7,7 @@ mod converter_test;
 mod events_test;
 mod index_test;
 mod invalid_post_request_test;
+mod modules;
 mod resource_groups;
 mod state_test;
 mod string_resource_test;

--- a/api/src/tests/modules.rs
+++ b/api/src/tests/modules.rs
@@ -1,0 +1,45 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    new_test_context,
+    resource_groups::{build_package, publish_package},
+};
+use aptos_api_test_context::current_function_name;
+use std::path::PathBuf;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_abi() {
+    let mut context = new_test_context(current_function_name!());
+    let mut root_account = context.root_account();
+    let mut account = context.gen_account();
+    let txn = context.create_user_account_by(&mut root_account, &account);
+    context.commit_block(&vec![txn]).await;
+
+    // Publish packages
+    let named_addresses = vec![("abi".to_string(), account.address())];
+    // TODO: Switch to build_package and publish_package in test_context once they're moved there.
+    let txn = futures::executor::block_on(async move {
+        let path = PathBuf::from(std::env!("CARGO_MANIFEST_DIR")).join("src/tests/move/pack_abi");
+        build_package(path, named_addresses)
+    });
+    publish_package(&mut context, &mut account, txn).await;
+
+    // Get abi.
+    let modules = context
+        .get(format!("/accounts/{}/modules", account.address(),).as_str())
+        .await;
+    let expose_functions: Vec<&str> = modules.as_array().unwrap()[0]["abi"]["exposed_functions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["name"].as_str().unwrap())
+        .collect();
+    // All entry (including private entry) and public functions should be in the ABI.
+    // Private (non-entry) functions should not be included.
+    assert_eq!(expose_functions, [
+        "private_entry_function",
+        "public_entry_function",
+        "public_function"
+    ]);
+}

--- a/api/src/tests/move/pack_abi/Move.toml
+++ b/api/src/tests/move/pack_abi/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "pack_abi"
+version = "0.0.0"
+
+[dependencies]
+AptosFramework = { local = "../../../../../aptos-move/framework/aptos-framework" }
+
+[addresses]
+abi = "_"

--- a/api/src/tests/move/pack_abi/sources/test.move
+++ b/api/src/tests/move/pack_abi/sources/test.move
@@ -1,0 +1,23 @@
+module abi::test {
+
+    struct State has key {
+        value: u64
+    }
+
+    public fun public_function(s: &signer, state: State) {
+        move_to(s, state)
+    }
+
+    public entry fun public_entry_function(s1: &signer, s2: &signer, value: u64) {
+        move_to(s1, State { value });
+        move_to(s2, State { value });
+    }
+
+    entry fun private_entry_function(s: &signer, value: u64) {
+        move_to(s, State { value });
+    }
+
+    fun private_function(s: &signer, value: u64) {
+        move_to(s, State { value });
+    }
+}

--- a/api/src/tests/resource_groups.rs
+++ b/api/src/tests/resource_groups.rs
@@ -158,7 +158,7 @@ async fn read_resource(
     context.get(&request).await
 }
 
-fn build_package(
+pub fn build_package(
     path: PathBuf,
     named_addresses: Vec<(String, AccountAddress)>,
 ) -> TransactionPayload {
@@ -175,7 +175,7 @@ fn build_package(
     aptos_stdlib::code_publish_package_txn(bcs::to_bytes(&metadata).unwrap(), code)
 }
 
-async fn publish_package(
+pub async fn publish_package(
     context: &mut TestContext,
     publisher: &mut LocalAccount,
     payload: TransactionPayload,

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -752,9 +752,15 @@ impl From<CompiledModule> for MoveModule {
             exposed_functions: m
                 .function_defs
                 .iter()
-                .filter(|def| match def.visibility {
-                    Visibility::Public | Visibility::Friend => true,
-                    Visibility::Private => false,
+                // Return all entry or public functions.
+                // Private entry functions are still callable by entry function transactions so
+                // they should be included.
+                .filter(|def| {
+                    def.is_entry
+                        || match def.visibility {
+                            Visibility::Public | Visibility::Friend => true,
+                            Visibility::Private => false,
+                        }
                 })
                 .map(|def| m.new_move_function(def))
                 .collect(),


### PR DESCRIPTION
### Description

The ABI currently returned by /modules doesn't include private entry functions in exposed_functions. It should as private entry functions are callable by entry func transactions.

### Test Plan
Newly added API test
