### PR TITLE
Updated broken links in docs

### DIFF
--- a/developer-docs-site/docs/sdks/python-sdk.md
+++ b/developer-docs-site/docs/sdks/python-sdk.md
@@ -42,4 +42,4 @@ cp -r /path/to/aptos-core/ecosystem/python/sdk/aptos-sdk aptos-sdk
 
 ## Using the Python SDK
 
-See the [Developer Tutorials](/tutorials/index.md) for code examples showing how to use the Python SDK.
+See the [Developer Tutorials](https://aptos.dev/tutorials/aptos-quickstarts) for code examples showing how to use the Python SDK.

--- a/developer-docs-site/docs/sdks/python-sdk.md
+++ b/developer-docs-site/docs/sdks/python-sdk.md
@@ -42,4 +42,4 @@ cp -r /path/to/aptos-core/ecosystem/python/sdk/aptos-sdk aptos-sdk
 
 ## Using the Python SDK
 
-See the [Developer Tutorials](https://aptos.dev/tutorials/aptos-quickstarts) for code examples showing how to use the Python SDK.
+See the [Developer Tutorials](../tutorials/index.md) for code examples showing how to use the Python SDK.

--- a/developer-docs-site/docs/sdks/rust-sdk.md
+++ b/developer-docs-site/docs/sdks/rust-sdk.md
@@ -17,4 +17,4 @@ The source code for the official Rust SDK is available in the [aptos-core GitHub
 
 ## Using Rust SDK
 
-See the [Developer Tutorials](https://aptos.dev/tutorials/aptos-quickstarts) for code examples showing how to use the Rust SDK.
+See the [Developer Tutorials](../tutorials/index.md) for code examples showing how to use the Rust SDK.

--- a/developer-docs-site/docs/sdks/rust-sdk.md
+++ b/developer-docs-site/docs/sdks/rust-sdk.md
@@ -17,4 +17,4 @@ The source code for the official Rust SDK is available in the [aptos-core GitHub
 
 ## Using Rust SDK
 
-See the [Developer Tutorials](/tutorials/index.md) for code examples showing how to use the Rust SDK.
+See the [Developer Tutorials](https://aptos.dev/tutorials/aptos-quickstarts) for code examples showing how to use the Rust SDK.


### PR DESCRIPTION
### Description
The links to getting started on working with the SDKs weren't working. Fixed that with the commits in this PR.

### Test Plan
N/A - Just changes in readmes
