### PR TITLE
[Dev Docs] Add a quick start tip for fullnode syncing.

### DIFF
--- a/developer-docs-site/docs/guides/state-sync.md
+++ b/developer-docs-site/docs/guides/state-sync.md
@@ -10,6 +10,14 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 Nodes in an Aptos network, both the validator nodes and the fullnodes, must always be synchronized to the latest Aptos blockchain state. The state synchronization (state sync) component that runs on each node is responsible for this synchronization. To achieve this synchronization, state sync identifies and fetches new blockchain data from the peers, validates the data and persists it to the local storage.
 
+:::tip Need to start a node quickly?
+If you need to start a node quickly, here's what we recommend by use case:
+  - **Devnet public fullnode**: To sync the entire blockchain history, download [a snapshot](/nodes/full-node/bootstrap-fullnode). Otherwise, use [fast sync](/guides/state-sync#fast-syncing).
+  - **Testnet public fullnode**: To sync the entire blockchain history, download [a snapshot](/nodes/full-node/bootstrap-fullnode). Otherwise, use [fast sync](/guides/state-sync#fast-syncing).
+  - **Mainnet public fullnode**: To sync the entire blockchain history, use [output syncing](/guides/state-sync#applying-all-transaction-outputs). Otherwise, use [fast sync](/guides/state-sync#fast-syncing).
+  - **Mainnet validator or validator fullnode**: Use [output syncing](/guides/state-sync#applying-all-transaction-outputs). Note: [fast sync](/guides/state-sync#fast-syncing) is not recommended.
+:::
+
 ## State sync modes
 
 State sync runs in two modes. All nodes will first bootstrap (in bootstrapping mode) on startup, and then continuously synchronize (in continuous sync mode). 

--- a/developer-docs-site/docs/guides/state-sync.md
+++ b/developer-docs-site/docs/guides/state-sync.md
@@ -12,10 +12,10 @@ Nodes in an Aptos network, both the validator nodes and the fullnodes, must alwa
 
 :::tip Need to start a node quickly?
 If you need to start a node quickly, here's what we recommend by use case:
-  - **Devnet public fullnode**: To sync the entire blockchain history, download [a snapshot](/nodes/full-node/bootstrap-fullnode). Otherwise, use [fast sync](/guides/state-sync#fast-syncing).
-  - **Testnet public fullnode**: To sync the entire blockchain history, download [a snapshot](/nodes/full-node/bootstrap-fullnode). Otherwise, use [fast sync](/guides/state-sync#fast-syncing).
-  - **Mainnet public fullnode**: To sync the entire blockchain history, use [output syncing](/guides/state-sync#applying-all-transaction-outputs). Otherwise, use [fast sync](/guides/state-sync#fast-syncing).
-  - **Mainnet validator or validator fullnode**: Use [output syncing](/guides/state-sync#applying-all-transaction-outputs). Note: [fast sync](/guides/state-sync#fast-syncing) is not recommended.
+  - **Devnet public fullnode**: To sync the entire blockchain history, download [a snapshot](../nodes/full-node/bootstrap-fullnode.md). Otherwise, use [fast sync](state-sync.md#fast-syncing).
+  - **Testnet public fullnode**: To sync the entire blockchain history, download [a snapshot](../nodes/full-node/bootstrap-fullnode.md). Otherwise, use [fast sync](state-sync.md#fast-syncing).
+  - **Mainnet public fullnode**: To sync the entire blockchain history, use [output syncing](state-sync.md#applying-all-transaction-outputs). Otherwise, use [fast sync](state-sync.md#fast-syncing).
+  - **Mainnet validator or validator fullnode**: Use [output syncing](state-sync.md#applying-all-transaction-outputs). Note: [fast sync](state-sync.md#fast-syncing) is not recommended.
 :::
 
 ## State sync modes


### PR DESCRIPTION
### Description

This PR provides a quick start tip for state sync configuration. Some users in discord have asked for a cheat sheet like this. It also provides a step a forward for https://github.com/aptos-labs/aptos-core/issues/6308, but doesn't address all use cases 😄 

<img width="994" alt="Screen Shot 2023-02-16 at 5 10 47 PM" src="https://user-images.githubusercontent.com/4578587/219498505-5f082fce-be84-4fcf-ab3a-50d781c66503.png">


### Test Plan
Manual verification.