### PR TITLE
[API] Add shared license to relevant files.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
     hooks:
       # - id: fmt // Not currently supported for the nightly build, e.g., https://github.com/doublify/pre-commit-rust/issues/15
       - id: cargo-check
+  # Once this issue is resolved, we can add the full license check: https://github.com/Lucas-C/pre-commit-hooks/issues/68
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.3.0
     hooks:

--- a/api/src/accounts.rs
+++ b/api/src/accounts.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/api/src/events.rs
+++ b/api/src/events.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/api/src/failpoint.rs
+++ b/api/src/failpoint.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(unused_imports)]

--- a/api/src/index.rs
+++ b/api/src/index.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use poem_openapi::Tags;

--- a/api/src/log.rs
+++ b/api/src/log.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::metrics::{HISTOGRAM, RESPONSE_STATUS};

--- a/api/src/metrics.rs
+++ b/api/src/metrics.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_metrics_core::{register_histogram_vec, HistogramVec};

--- a/api/src/page.rs
+++ b/api/src/page.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::response::BadRequestError;

--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/api/src/tests/accounts_test.rs
+++ b/api/src/tests/accounts_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::new_test_context;

--- a/api/src/tests/events_test.rs
+++ b/api/src/tests/events_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::new_test_context;

--- a/api/src/tests/index_test.rs
+++ b/api/src/tests/index_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::new_test_context;

--- a/api/src/tests/invalid_post_request_test.rs
+++ b/api/src/tests/invalid_post_request_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::new_test_context;

--- a/api/src/tests/mod.rs
+++ b/api/src/tests/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 mod accounts_test;

--- a/api/src/tests/string_resource_test.rs
+++ b/api/src/tests/string_resource_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::new_test_context;

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::new_test_context;

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -1,7 +1,5 @@
 // Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
-
-// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/api/types/src/account.rs
+++ b/api/types/src/account.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{HexEncodedBytes, U64};

--- a/api/types/src/address.rs
+++ b/api/types/src/address.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_types::account_address::AccountAddress;

--- a/api/types/src/bytecode.rs
+++ b/api/types/src/bytecode.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/api/types/src/error.rs
+++ b/api/types/src/error.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_types::vm_status::StatusCode;

--- a/api/types/src/hash.rs
+++ b/api/types/src/hash.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};

--- a/api/types/src/ledger_info.rs
+++ b/api/types/src/ledger_info.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::U64;

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 mod account;

--- a/api/types/src/mime_types.rs
+++ b/api/types/src/mime_types.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 /// MIME type to submit BCS transactions

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Address, Bytecode, IdentifierWrapper, VerifyInput, VerifyInputWithRecursion};

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/devtools/assets/license_header.txt
+++ b/devtools/assets/license_header.txt
@@ -1,2 +1,1 @@
 Copyright © Aptos Foundation
-SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
### Description

This PR updates the `api` directory with shared licenses for rust files that also contain some Meta code.

The files were identified using:
- `git log --diff-filter=A --format=%ad -- <file>` (to identify file creation -- we take the oldest date).
- `git log --diff-filter=M --format=%ad -- <file>` (to identify file modification dates).

### Test Plan
Manual verification and tooling