### PR TITLE
[Consensus] Add shared license to relevant files.

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/consensus-types/src/block_data.rs
+++ b/consensus/consensus-types/src/block_data.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::block::Block;

--- a/consensus/consensus-types/src/block_test.rs
+++ b/consensus/consensus-types/src/block_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/consensus-types/src/block_test_utils.rs
+++ b/consensus/consensus-types/src/block_test_utils.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 #![allow(clippy::integer_arithmetic)]
 

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::proof_of_store::ProofOfStore;

--- a/consensus/consensus-types/src/epoch_retrieval.rs
+++ b/consensus/consensus-types/src/epoch_retrieval.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};

--- a/consensus/consensus-types/src/executed_block.rs
+++ b/consensus/consensus-types/src/executed_block.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/consensus-types/src/experimental/commit_decision.rs
+++ b/consensus/consensus-types/src/experimental/commit_decision.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::common::Round;

--- a/consensus/consensus-types/src/experimental/commit_vote.rs
+++ b/consensus/consensus-types/src/experimental/commit_vote.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::common::{Author, Round};

--- a/consensus/consensus-types/src/experimental/mod.rs
+++ b/consensus/consensus-types/src/experimental/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod commit_decision;

--- a/consensus/consensus-types/src/lib.rs
+++ b/consensus/consensus-types/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{block::Block, common::Author, sync_info::SyncInfo};

--- a/consensus/consensus-types/src/quorum_cert.rs
+++ b/consensus/consensus-types/src/quorum_cert.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::vote_data::VoteData;

--- a/consensus/consensus-types/src/safety_data.rs
+++ b/consensus/consensus-types/src/safety_data.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::vote::Vote;

--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{common::Round, quorum_cert::QuorumCert, timeout_2chain::TwoChainTimeoutCertificate};

--- a/consensus/consensus-types/src/timeout_2chain.rs
+++ b/consensus/consensus-types/src/timeout_2chain.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{common::Author, quorum_cert::QuorumCert};

--- a/consensus/consensus-types/src/vote.rs
+++ b/consensus/consensus-types/src/vote.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/consensus-types/src/vote_data.rs
+++ b/consensus/consensus-types/src/vote_data.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};

--- a/consensus/consensus-types/src/vote_msg.rs
+++ b/consensus/consensus-types/src/vote_msg.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{sync_info::SyncInfo, vote::Vote};

--- a/consensus/consensus-types/src/vote_proposal.rs
+++ b/consensus/consensus-types/src/vote_proposal.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{block::Block, vote_data::VoteData};

--- a/consensus/safety-rules/benches/safety_rules.rs
+++ b/consensus/safety-rules/benches/safety_rules.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_consensus_types::block::block_test_utils;

--- a/consensus/safety-rules/src/consensus_state.rs
+++ b/consensus/safety-rules/src/consensus_state.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_consensus_types::{common::Round, safety_data::SafetyData};

--- a/consensus/safety-rules/src/counters.rs
+++ b/consensus/safety-rules/src/counters.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_metrics_core::{

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};

--- a/consensus/safety-rules/src/fuzzing_utils.rs
+++ b/consensus/safety-rules/src/fuzzing_utils.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::serializer::SafetyRulesInput;

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/consensus/safety-rules/src/local_client.rs
+++ b/consensus/safety-rules/src/local_client.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{ConsensusState, Error, SafetyRules, TSafetyRules};

--- a/consensus/safety-rules/src/logging.rs
+++ b/consensus/safety-rules/src/logging.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::Error;

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/safety-rules/src/process.rs
+++ b/consensus/safety-rules/src/process.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/safety-rules/src/remote_service.rs
+++ b/consensus/safety-rules/src/remote_service.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/safety-rules/src/safety_rules_2chain.rs
+++ b/consensus/safety-rules/src/safety_rules_2chain.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{error::Error, safety_rules::next_round, SafetyRules};

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/safety-rules/src/serializer.rs
+++ b/consensus/safety-rules/src/serializer.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{counters, logging::LogEntry, ConsensusState, Error, SafetyRules, TSafetyRules};

--- a/consensus/safety-rules/src/t_safety_rules.rs
+++ b/consensus/safety-rules/src/t_safety_rules.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{ConsensusState, Error};

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/safety-rules/src/tests/local.rs
+++ b/consensus/safety-rules/src/tests/local.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{test_utils, tests::suite, SafetyRulesManager};

--- a/consensus/safety-rules/src/tests/mod.rs
+++ b/consensus/safety-rules/src/tests/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 mod local;

--- a/consensus/safety-rules/src/tests/networking.rs
+++ b/consensus/safety-rules/src/tests/networking.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{test_utils, SafetyRulesManager};

--- a/consensus/safety-rules/src/tests/safety_rules.rs
+++ b/consensus/safety-rules/src/tests/safety_rules.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{test_utils, tests::suite, SafetyRules};

--- a/consensus/safety-rules/src/tests/serializer.rs
+++ b/consensus/safety-rules/src/tests/serializer.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{test_utils, tests::suite, SafetyRulesManager};

--- a/consensus/safety-rules/src/tests/suite.rs
+++ b/consensus/safety-rules/src/tests/suite.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{test_utils, test_utils::make_timeout_cert, Error, TSafetyRules};

--- a/consensus/safety-rules/src/tests/thread.rs
+++ b/consensus/safety-rules/src/tests/thread.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{test_utils, tests::suite, SafetyRulesManager};

--- a/consensus/safety-rules/src/tests/vault.rs
+++ b/consensus/safety-rules/src/tests/vault.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{tests::suite, PersistentSafetyStorage, SafetyRulesManager};

--- a/consensus/safety-rules/src/thread.rs
+++ b/consensus/safety-rules/src/thread.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! This provides a execution separation between SafetyRules and Consensus without requiring the

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/block_storage/block_store_test.rs
+++ b/consensus/src/block_storage/block_store_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/block_storage/block_tree.rs
+++ b/consensus/src/block_storage/block_tree.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/block_storage/mod.rs
+++ b/consensus/src/block_storage/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_consensus_types::{

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/block_storage/tracing.rs
+++ b/consensus/src/block_storage/tracing.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::counters;

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/consensusdb/consensusdb_test.rs
+++ b/consensus/src/consensusdb/consensusdb_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;

--- a/consensus/src/consensusdb/mod.rs
+++ b/consensus/src/consensusdb/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(test)]

--- a/consensus/src/consensusdb/schema/block/mod.rs
+++ b/consensus/src/consensusdb/schema/block/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines physical storage schema for consensus block.

--- a/consensus/src/consensusdb/schema/block/test.rs
+++ b/consensus/src/consensusdb/schema/block/test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;

--- a/consensus/src/consensusdb/schema/mod.rs
+++ b/consensus/src/consensusdb/schema/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 pub(crate) mod block;

--- a/consensus/src/consensusdb/schema/quorum_certificate/mod.rs
+++ b/consensus/src/consensusdb/schema/quorum_certificate/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines physical storage schema for consensus quorum certificate (of a block).

--- a/consensus/src/consensusdb/schema/quorum_certificate/test.rs
+++ b/consensus/src/consensusdb/schema/quorum_certificate/test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;

--- a/consensus/src/consensusdb/schema/single_entry/mod.rs
+++ b/consensus/src/consensusdb/schema/single_entry/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines physical storage schema for any single-entry data.

--- a/consensus/src/consensusdb/schema/single_entry/test.rs
+++ b/consensus/src/consensusdb/schema/single_entry/test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_metrics_core::{

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/error.rs
+++ b/consensus/src/error.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::experimental;

--- a/consensus/src/experimental/buffer.rs
+++ b/consensus/src/experimental/buffer.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::experimental::hashable::Hashable;

--- a/consensus/src/experimental/buffer_item.rs
+++ b/consensus/src/experimental/buffer_item.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{experimental::hashable::Hashable, state_replication::StateComputerCommitCallBackType};

--- a/consensus/src/experimental/buffer_manager.rs
+++ b/consensus/src/experimental/buffer_manager.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/experimental/decoupled_execution_utils.rs
+++ b/consensus/src/experimental/decoupled_execution_utils.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/experimental/errors.rs
+++ b/consensus/src/experimental/errors.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_types::block_info::BlockInfo;

--- a/consensus/src/experimental/execution_phase.rs
+++ b/consensus/src/experimental/execution_phase.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{experimental::pipeline_phase::StatelessPipeline, state_replication::StateComputer};

--- a/consensus/src/experimental/hashable.rs
+++ b/consensus/src/experimental/hashable.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_crypto::HashValue;

--- a/consensus/src/experimental/linkedlist.rs
+++ b/consensus/src/experimental/linkedlist.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // modified from https://rust-unofficial.github.io/too-many-lists/fourth-final.html (MIT License)

--- a/consensus/src/experimental/mod.rs
+++ b/consensus/src/experimental/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 /*

--- a/consensus/src/experimental/ordering_state_computer.rs
+++ b/consensus/src/experimental/ordering_state_computer.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/experimental/persisting_phase.rs
+++ b/consensus/src/experimental/persisting_phase.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/experimental/pipeline_phase.rs
+++ b/consensus/src/experimental/pipeline_phase.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::experimental::buffer_manager::{Receiver, Sender};

--- a/consensus/src/experimental/signing_phase.rs
+++ b/consensus/src/experimental/signing_phase.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/experimental/tests/buffer_manager_tests.rs
+++ b/consensus/src/experimental/tests/buffer_manager_tests.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/experimental/tests/execution_phase_tests.rs
+++ b/consensus/src/experimental/tests/execution_phase_tests.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/experimental/tests/integration_tests.rs
+++ b/consensus/src/experimental/tests/integration_tests.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // TODO: integration tests

--- a/consensus/src/experimental/tests/mod.rs
+++ b/consensus/src/experimental/tests/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 mod buffer_manager_tests;

--- a/consensus/src/experimental/tests/ordering_state_computer_tests.rs
+++ b/consensus/src/experimental/tests/ordering_state_computer_tests.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #[test]

--- a/consensus/src/experimental/tests/phase_tester.rs
+++ b/consensus/src/experimental/tests/phase_tester.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/experimental/tests/signing_phase_tests.rs
+++ b/consensus/src/experimental/tests/signing_phase_tests.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/experimental/tests/test_utils.rs
+++ b/consensus/src/experimental/tests/test_utils.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{metrics_safety_rules::MetricsSafetyRules, test_utils::MockStorage};

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/liveness/leader_reputation_test.rs
+++ b/consensus/src/liveness/leader_reputation_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::leader_reputation::{

--- a/consensus/src/liveness/mod.rs
+++ b/consensus/src/liveness/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 pub(crate) mod cached_proposer_election;

--- a/consensus/src/liveness/proposal_generator.rs
+++ b/consensus/src/liveness/proposal_generator.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{

--- a/consensus/src/liveness/proposal_generator_test.rs
+++ b/consensus/src/liveness/proposal_generator_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/liveness/proposer_election.rs
+++ b/consensus/src/liveness/proposer_election.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_consensus_types::common::{Author, Round};

--- a/consensus/src/liveness/rotating_proposer_election.rs
+++ b/consensus/src/liveness/rotating_proposer_election.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::liveness::proposer_election::ProposerElection;

--- a/consensus/src/liveness/rotating_proposer_test.rs
+++ b/consensus/src/liveness/rotating_proposer_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::liveness::{

--- a/consensus/src/liveness/round_proposer_election.rs
+++ b/consensus/src/liveness/round_proposer_election.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::liveness::proposer_election::ProposerElection;

--- a/consensus/src/liveness/round_proposer_test.rs
+++ b/consensus/src/liveness/round_proposer_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::liveness::{

--- a/consensus/src/liveness/round_state.rs
+++ b/consensus/src/liveness/round_state.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/liveness/round_state_test.rs
+++ b/consensus/src/liveness/round_state_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/logging.rs
+++ b/consensus/src/logging.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_consensus_types::common::Author;

--- a/consensus/src/metrics_safety_rules.rs
+++ b/consensus/src/metrics_safety_rules.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{monitor, persistent_liveness_storage::PersistentLivenessStorage};

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Interface between Consensus and Network layers.

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/pending_votes.rs
+++ b/consensus/src/pending_votes.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! PendingVotes store pending votes observed for a fixed epoch and round.

--- a/consensus/src/persistent_liveness_storage.rs
+++ b/consensus/src/persistent_liveness_storage.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{consensusdb::ConsensusDB, epoch_manager::LivenessStorageData, error::DbError};

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/test_utils/mock_storage.rs
+++ b/consensus/src/test_utils/mock_storage.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/test_utils/mod.rs
+++ b/consensus/src/test_utils/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::block_storage::{BlockReader, BlockStore};

--- a/consensus/src/twins/basic_twins_test.rs
+++ b/consensus/src/twins/basic_twins_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/twins/mod.rs
+++ b/consensus/src/twins/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 mod basic_twins_test;

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/consensus/src/util/mock_time_service.rs
+++ b/consensus/src/util/mock_time_service.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::util::time_service::{ScheduledTask, TimeService};

--- a/consensus/src/util/mod.rs
+++ b/consensus/src/util/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(any(test, feature = "fuzzing"))]

--- a/consensus/src/util/time_service.rs
+++ b/consensus/src/util/time_service.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::counters;


### PR DESCRIPTION
Note: this PR requires https://github.com/aptos-labs/aptos-core/pull/6668 to land first (to pass the pre-commit checks).

### Description

This PR updates the `consensus` directory with shared licenses for rust files that also contain some Meta code.

The files were identified using:
- `git log --diff-filter=A --format=%ad -- <file>` (to identify file creation -- we take the oldest date).
- `git log --diff-filter=M --format=%ad -- <file>` (to identify file modification dates).

### Test Plan
Manual verification and tooling