### PR TITLE
[aptos] Enable move debugger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3742,7 +3742,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -6729,7 +6729,7 @@ checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6746,7 +6746,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
@@ -6762,12 +6762,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6782,7 +6782,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6794,7 +6794,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -6807,7 +6807,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -6824,7 +6824,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6870,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "difference",
@@ -6887,7 +6887,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6916,7 +6916,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
@@ -6938,7 +6938,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6958,7 +6958,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -6976,7 +6976,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6994,7 +6994,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7008,7 +7008,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7027,7 +7027,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -7046,7 +7046,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "hex",
@@ -7059,7 +7059,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "hex",
@@ -7073,7 +7073,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "codespan",
@@ -7099,7 +7099,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7135,7 +7135,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7172,7 +7172,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7183,6 +7183,7 @@ dependencies = [
  "log",
  "move-binary-format",
  "move-command-line-common",
+ "move-compiler",
  "move-core-types",
  "move-model",
  "move-stackless-bytecode",
@@ -7200,7 +7201,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7211,7 +7212,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7226,7 +7227,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -7253,7 +7254,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -7271,7 +7272,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "hex",
@@ -7294,7 +7295,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "once_cell",
  "serde 1.0.149",
@@ -7303,7 +7304,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7320,7 +7321,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -7352,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "better_any",
@@ -7383,7 +7384,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -7400,7 +7401,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7414,7 +7415,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-binary-format",
@@ -8814,7 +8815,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -8829,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=080cb5c4feddaa87990faa4767156e422c7ec90d#080cb5c4feddaa87990faa4767156e422c7ec90d"
+source = "git+https://github.com/move-language/move?rev=bd25b900ccb4da6d1ece214595cb992e5be7c471#bd25b900ccb4da6d1ece214595cb992e5be7c471"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -483,34 +483,34 @@ x25519-dalek = "1.2.0"
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES
-move-abigen = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-cli = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-compiler ={ git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d", features = ["address32"] }
-move-docgen = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-model = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-package = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-prover = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d", features = ["table-extension"] }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d", features = ["lazy_natives"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d", features = ["table-extension"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "080cb5c4feddaa87990faa4767156e422c7ec90d" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-cli = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-compiler ={ git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471", features = ["address32"] }
+move-docgen = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-model = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-package = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-prover = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471", features = ["table-extension"] }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471", features = ["lazy_natives"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471", features = ["table-extension"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+read-write-set = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "bd25b900ccb4da6d1ece214595cb992e5be7c471" }
 # END MOVE DEPENDENCIES
 
 [profile.release]

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -58,7 +58,7 @@ move-package = { workspace = true }
 move-prover = { workspace = true }
 move-prover-boogie-backend = { workspace = true }
 move-symbol-pool = { workspace = true }
-move-unit-test = { workspace = true }
+move-unit-test = { workspace = true, features = [ "debugging" ] }
 move-vm-runtime = { workspace = true, features = [ "testing" ] }
 rand = { workspace = true }
 regex = { workspace = true }


### PR DESCRIPTION
### Description

Resurrected the awesome debugger feature that move vm once implemented.

### Test Plan

To run the debugger, simply do `MOVE_VM_STEP=1 aptos move test`. We can also generate the VM execution trace via `MOVE_VM_TRACE=1`

This is a really awesome feature and maybe we should document it down somewhere. cc @clay-aptos 
