### PR TITLE
[Secure] Add shared license to relevant files.

### DIFF
--- a/secure/net/src/lib.rs
+++ b/secure/net/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/secure/storage/github/src/lib.rs
+++ b/secure/storage/github/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/secure/storage/src/crypto_kv_storage.rs
+++ b/secure/storage/src/crypto_kv_storage.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{CryptoStorage, Error, KVStorage, PublicKeyResponse};

--- a/secure/storage/src/crypto_storage.rs
+++ b/secure/storage/src/crypto_storage.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::Error;

--- a/secure/storage/src/error.rs
+++ b/secure/storage/src/error.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};

--- a/secure/storage/src/github.rs
+++ b/secure/storage/src/github.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{CryptoKVStorage, Error, GetResponse, KVStorage};

--- a/secure/storage/src/in_memory.rs
+++ b/secure/storage/src/in_memory.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{CryptoKVStorage, Error, GetResponse, KVStorage};

--- a/secure/storage/src/kv_storage.rs
+++ b/secure/storage/src/kv_storage.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::Error;

--- a/secure/storage/src/lib.rs
+++ b/secure/storage/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/secure/storage/src/namespaced.rs
+++ b/secure/storage/src/namespaced.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{CryptoStorage, Error, GetResponse, KVStorage, PublicKeyResponse};

--- a/secure/storage/src/on_disk.rs
+++ b/secure/storage/src/on_disk.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{CryptoKVStorage, Error, GetResponse, KVStorage};

--- a/secure/storage/src/policy.rs
+++ b/secure/storage/src/policy.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};

--- a/secure/storage/src/storage.rs
+++ b/secure/storage/src/storage.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     rocks_db::RocksDbStorage, CryptoStorage, Error, GetResponse, GitHubStorage, InMemoryStorage,

--- a/secure/storage/src/tests/github.rs
+++ b/secure/storage/src/tests/github.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{tests::suite, GitHubStorage, Storage};

--- a/secure/storage/src/tests/in_memory.rs
+++ b/secure/storage/src/tests/in_memory.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{tests::suite, InMemoryStorage, Storage};

--- a/secure/storage/src/tests/mod.rs
+++ b/secure/storage/src/tests/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 mod github;

--- a/secure/storage/src/tests/on_disk.rs
+++ b/secure/storage/src/tests/on_disk.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{tests::suite, OnDiskStorage, Storage};

--- a/secure/storage/src/tests/suite.rs
+++ b/secure/storage/src/tests/suite.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{CryptoStorage, Error, KVStorage, Storage};

--- a/secure/storage/src/tests/vault.rs
+++ b/secure/storage/src/tests/vault.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/secure/storage/vault/src/dev.rs
+++ b/secure/storage/vault/src/dev.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::Client;

--- a/secure/storage/vault/src/fuzzing.rs
+++ b/secure/storage/vault/src/fuzzing.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/secure/storage/vault/src/lib.rs
+++ b/secure/storage/vault/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]


### PR DESCRIPTION
Note: this PR requires https://github.com/aptos-labs/aptos-core/pull/6668 to land first (to pass the pre-commit checks).

### Description

This PR updates the `secure` directory with shared licenses for rust files that also contain some Meta code.

The files were identified using:
- `git log --diff-filter=A --format=%ad -- <file>` (to identify file creation -- we take the oldest date).
- `git log --diff-filter=M --format=%ad -- <file>` (to identify file modification dates).

### Test Plan
Manual verification and tooling