### PR TITLE
[Types] Add shared license to relevant files.

### DIFF
--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Suppose we have the following data structure in a smart contract:

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::transaction::authenticator::{AuthenticationKey, Scheme};
 use anyhow::bail;

--- a/types/src/account_config/constants/account.rs
+++ b/types/src/account_config/constants/account.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 pub use move_core_types::vm_status::known_locations::{

--- a/types/src/account_config/constants/addresses.rs
+++ b/types/src/account_config/constants/addresses.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account_address::AccountAddress;

--- a/types/src/account_config/constants/event.rs
+++ b/types/src/account_config/constants/event.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account_config::constants::CORE_CODE_ADDRESS;

--- a/types/src/account_config/constants/mod.rs
+++ b/types/src/account_config/constants/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod account;

--- a/types/src/account_config/events/mod.rs
+++ b/types/src/account_config/events/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod deposit;

--- a/types/src/account_config/events/new_block.rs
+++ b/types/src/account_config/events/new_block.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/types/src/account_config/events/new_epoch.rs
+++ b/types/src/account_config/events/new_epoch.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::event::EventKey;

--- a/types/src/account_config/mod.rs
+++ b/types/src/account_config/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod constants;

--- a/types/src/account_config/resources/chain_id.rs
+++ b/types/src/account_config/resources/chain_id.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::chain_id::ChainId;

--- a/types/src/account_config/resources/core_account.rs
+++ b/types/src/account_config/resources/core_account.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{account_address::AccountAddress, event::EventHandle};

--- a/types/src/account_config/resources/mod.rs
+++ b/types/src/account_config/resources/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod chain_id;

--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/types/src/block_info.rs
+++ b/types/src/block_info.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{epoch_state::EpochState, on_chain_config::ValidatorSet, transaction::Version};

--- a/types/src/block_metadata.rs
+++ b/types/src/block_metadata.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_crypto::HashValue;

--- a/types/src/chain_id.rs
+++ b/types/src/chain_id.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use anyhow::{ensure, format_err, Error, Result};
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize};

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/types/src/epoch_change.rs
+++ b/types/src/epoch_change.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/types/src/epoch_state.rs
+++ b/types/src/epoch_state.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account_address::AccountAddress;

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/types/src/mempool_status.rs
+++ b/types/src/mempool_status.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(clippy::unit_arg)]

--- a/types/src/move_resource.rs
+++ b/types/src/move_resource.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{access_path::AccessPath, on_chain_config::ConfigID, transaction::Version};

--- a/types/src/network_address/mod.rs
+++ b/types/src/network_address/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_crypto::{

--- a/types/src/nibble/mod.rs
+++ b/types/src/nibble/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/types/src/nibble/nibble_path/mod.rs
+++ b/types/src/nibble/nibble_path/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! NibblePath library simplify operations with nibbles in a compact format for modified sparse

--- a/types/src/nibble/nibble_path/nibble_path_test.rs
+++ b/types/src/nibble/nibble_path/nibble_path_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{arb_internal_nibble_path, skip_common_prefix, NibblePath};

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{block_info::Round, on_chain_config::OnChainConfig};

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/types/src/on_chain_config/validator_set.rs
+++ b/types/src/on_chain_config/validator_set.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{on_chain_config::OnChainConfig, validator_info::ValidatorInfo};

--- a/types/src/proof/accumulator/accumulator_test.rs
+++ b/types/src/proof/accumulator/accumulator_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::InMemoryAccumulator;

--- a/types/src/proof/accumulator/mock.rs
+++ b/types/src/proof/accumulator/mock.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/types/src/proof/accumulator/mod.rs
+++ b/types/src/proof/accumulator/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module implements an in-memory Merkle Accumulator that is similar to what we use in

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module has definition of various proofs.

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod accumulator;

--- a/types/src/proof/position/mod.rs
+++ b/types/src/proof/position/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module provides an abstraction for positioning a node in a binary tree,

--- a/types/src/proof/position/position_test.rs
+++ b/types/src/proof/position/position_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::proof::position::*;

--- a/types/src/proof/proptest_proof.rs
+++ b/types/src/proof/proptest_proof.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! All proofs generated in this module are not valid proofs. They are only for the purpose of

--- a/types/src/proof/unit_tests/mod.rs
+++ b/types/src/proof/unit_tests/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 mod proof_conversion_test;

--- a/types/src/proof/unit_tests/proof_conversion_test.rs
+++ b/types/src/proof/unit_tests/proof_conversion_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::proof::{

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/types/src/serde_helper/mod.rs
+++ b/types/src/serde_helper/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod vec_bytes;

--- a/types/src/serde_helper/vec_bytes.rs
+++ b/types/src/serde_helper/vec_bytes.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{

--- a/types/src/state_proof.rs
+++ b/types/src/state_proof.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/types/src/test_helpers/mod.rs
+++ b/types/src/test_helpers/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod transaction_test_helpers;

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/types/src/transaction/change_set.rs
+++ b/types/src/transaction/change_set.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{contract_event::ContractEvent, write_set::WriteSet};

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/types/src/transaction/module.rs
+++ b/types/src/transaction/module.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};

--- a/types/src/transaction/script.rs
+++ b/types/src/transaction/script.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{serde_helper::vec_bytes, transaction::transaction_argument::TransactionArgument};

--- a/types/src/transaction/transaction_argument.rs
+++ b/types/src/transaction/transaction_argument.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 pub use move_core_types::{

--- a/types/src/trusted_state.rs
+++ b/types/src/trusted_state.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/types/src/unit_tests/access_path_test.rs
+++ b/types/src/unit_tests/access_path_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{access_path::AccessPath, account_address::AccountAddress};

--- a/types/src/unit_tests/block_metadata_test.rs
+++ b/types/src/unit_tests/block_metadata_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::block_metadata::BlockMetadata;

--- a/types/src/unit_tests/code_debug_fmt_test.rs
+++ b/types/src/unit_tests/code_debug_fmt_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::transaction::Script;

--- a/types/src/unit_tests/contract_event_test.rs
+++ b/types/src/unit_tests/contract_event_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{contract_event::ContractEvent, event::EventKey};

--- a/types/src/unit_tests/mod.rs
+++ b/types/src/unit_tests/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 mod access_path_test;

--- a/types/src/unit_tests/transaction_test.rs
+++ b/types/src/unit_tests/transaction_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/types/src/unit_tests/trusted_state_test.rs
+++ b/types/src/unit_tests/trusted_state_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/types/src/unit_tests/validator_set_test.rs
+++ b/types/src/unit_tests/validator_set_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::on_chain_config::ValidatorSet;

--- a/types/src/unit_tests/write_set_test.rs
+++ b/types/src/unit_tests/write_set_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::write_set::WriteSet;

--- a/types/src/validator_config.rs
+++ b/types/src/validator_config.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::network_address::NetworkAddress;

--- a/types/src/validator_info.rs
+++ b/types/src/validator_info.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/validator_signer.rs
+++ b/types/src/validator_signer.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account_address::AccountAddress;

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/vm_status.rs
+++ b/types/src/vm_status.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 pub use move_core_types::vm_status::{
     known_locations, sub_status, AbortLocation, DiscardedVMStatus, KeptVMStatus, StatusCode,

--- a/types/src/waypoint.rs
+++ b/types/src/waypoint.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! For each transaction the VM executes, the VM will output a `WriteSet` that contains each access


### PR DESCRIPTION
Note: this PR requires https://github.com/aptos-labs/aptos-core/pull/6668 to land first (to pass the pre-commit checks).

### Description

This PR updates the `types` directory with shared licenses for rust files that also contain some Meta code.

The files were identified using:
- `git log --diff-filter=A --format=%ad -- <file>` (to identify file creation -- we take the oldest date).
- `git log --diff-filter=M --format=%ad -- <file>` (to identify file modification dates).

### Test Plan
Manual verification and tooling