### PR TITLE
[Aptos node] Add simple log line for node config.

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -122,7 +122,6 @@ impl AptosNodeArgs {
                     error
                 )
             });
-            println!("Using node config {:?}", &config);
 
             // Start the node
             start(config, None, true).expect("Node should start correctly");
@@ -349,6 +348,9 @@ pub fn setup_environment_and_start_node(
     remote_log_rx: Option<mpsc::Receiver<TelemetryLog>>,
     logger_filter_update_job: Option<LoggerFilterUpdater>,
 ) -> anyhow::Result<AptosHandle> {
+    // Log the node config at node startup
+    info!("Using node config {:?}", &node_config);
+
     // Start the node inspection service
     services::start_node_inspection_service(&node_config);
 


### PR DESCRIPTION
### Description

This PR adds a simple `info` log line for the node config and removes the use of `println!`.

### Test Plan
Manual verification.