### PR TITLE
[tf/gcp][fullnode] fix trailing dot in GCE ingress domain

### DIFF
--- a/terraform/fullnode/gcp/addons.tf
+++ b/terraform/fullnode/gcp/addons.tf
@@ -32,7 +32,7 @@ data "google_dns_managed_zone" "pfn" {
 
 locals {
   dns_prefix = var.workspace_dns ? "${local.workspace_name}.${var.dns_prefix_name}." : "${var.dns_prefix_name}."
-  domain     = var.zone_name != "" ? "${local.dns_prefix}${data.google_dns_managed_zone.pfn[0].dns_name}" : null
+  domain     = var.zone_name != "" ? trimsuffix("${local.dns_prefix}${data.google_dns_managed_zone.pfn[0].dns_name}", ".") : null
 }
 
 resource "helm_release" "external-dns" {


### PR DESCRIPTION
### Description

Fixes an error reported by community member that looks like:

```
spec.domains[0] in body should match '^(([a-z0-9]+|[a-z0-9][-a-z0-9]*[a-z0-9])\.)+[a-z][-a-z0-9]*[a-z0-9]$
```

### Test Plan

Apply it and check if google ingress stops complaining

<!-- Please provide us with clear details for verifying that your changes work. -->
