### PR TITLE
[CLI] Add a CLI for explicitly approving execution hash for governance proposals

### DIFF
--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -58,6 +58,7 @@ pub enum GovernanceTool {
     VerifyProposal(VerifyProposal),
     ExecuteProposal(ExecuteProposal),
     GenerateUpgradeProposal(GenerateUpgradeProposal),
+    ApproveExecutionHash(ApproveExecutionHash),
 }
 
 impl GovernanceTool {
@@ -71,6 +72,7 @@ impl GovernanceTool {
             ShowProposal(tool) => tool.execute_serialized().await,
             ListProposals(tool) => tool.execute_serialized().await,
             VerifyProposal(tool) => tool.execute_serialized().await,
+            ApproveExecutionHash(tool) => tool.execute_serialized().await,
         }
     }
 }
@@ -543,6 +545,35 @@ impl CliCommand<Vec<TransactionSummary>> for SubmitVote {
             );
         }
         Ok(summaries)
+    }
+}
+
+/// Submit a transaction to approve a proposal's script hash to bypass the transaction size limit.
+/// This is needed for upgrading large packages such as aptos-framework.
+#[derive(Parser)]
+pub struct ApproveExecutionHash {
+    /// Id of the proposal to vote on
+    #[clap(long)]
+    pub(crate) proposal_id: u64,
+
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+}
+
+#[async_trait]
+impl CliCommand<TransactionSummary> for ApproveExecutionHash {
+    fn command_name(&self) -> &'static str {
+        "ApproveExecutionHash"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
+        Ok(self
+            .txn_options
+            .submit_transaction(
+                aptos_stdlib::aptos_governance_add_approved_script_hash_script(self.proposal_id),
+            )
+            .await
+            .map(TransactionSummary::from)?)
     }
 }
 


### PR DESCRIPTION
### Description
For large transactions such as aptos-framework package upgrade, the script hash needs to be approved to bypass transaction size limit. This is not always done automatically when voting ends (depends on if the last vote brings total yes to > 50%).

This PR adds a CLI that can be used to explicitly approve the execution hash for an approved governance proposal.

### Test Plan
Manual tests
