### PR TITLE
[Quorum Store] End batch, backpressure fixes and gas market test configuration

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -49,12 +49,12 @@ pub struct ChainHealthBackoffValues {
 impl Default for ConsensusConfig {
     fn default() -> ConsensusConfig {
         ConsensusConfig {
-            max_sending_block_txns: 2500,
+            max_sending_block_txns: 4000,
             // defaulting to under 0.5s to broadcast the proposal to 100 validators
             // over 1gbps link
-            max_sending_block_bytes: 600 * 1024, // 600 KB
-            max_receiving_block_txns: 10000,
-            max_receiving_block_bytes: 3 * 1024 * 1024, // 3MB
+            max_sending_block_bytes: 5 * 1024 * 1024, // 5MB
+            max_receiving_block_txns: 5000,
+            max_receiving_block_bytes: 6 * 1024 * 1024, // 6MB
             max_pruned_blocks_in_mem: 100,
             mempool_executed_txn_timeout_ms: 1000,
             mempool_txn_pull_timeout_ms: 1000,

--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -39,7 +39,7 @@ impl Default for QuorumStoreConfig {
             channel_size: 1000,
             proof_timeout_ms: 10000,
             batch_request_num_peers: 2,
-            mempool_pulling_interval: 100,
+            mempool_pulling_interval: 200,
             end_batch_ms: 500,
             max_batch_counts: 300,
             max_batch_bytes: 1000000,

--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -41,7 +41,7 @@ impl Default for QuorumStoreConfig {
             batch_request_num_peers: 2,
             mempool_pulling_interval: 200,
             end_batch_ms: 500,
-            max_batch_counts: 300,
+            max_batch_counts: 80,
             max_batch_bytes: 1000000,
             batch_request_timeout_ms: 10000,
             batch_expiry_round_gap_when_init: 100,
@@ -50,12 +50,12 @@ impl Default for QuorumStoreConfig {
             batch_expiry_grace_rounds: 5,
             memory_quota: 100000000,
             db_quota: 10000000000,
-            mempool_txn_pull_max_count: 300,
-            mempool_txn_pull_max_bytes: 1000000,
+            mempool_txn_pull_max_count: 80,
+            mempool_txn_pull_max_bytes: 2 * 1024 * 1024,
             // QS will be backpressured if the remaining local batches is more than this number
-            back_pressure_local_batch_num: 10,
+            back_pressure_local_batch_num: 1,
             // number of batch coordinators to handle QS Fragment messages, should be >= 1
-            num_workers_for_remote_fragments: 2,
+            num_workers_for_remote_fragments: 10,
         }
     }
 }

--- a/consensus/src/quorum_store/batch_coordinator.rs
+++ b/consensus/src/quorum_store/batch_coordinator.rs
@@ -239,7 +239,7 @@ impl BatchCoordinator {
                         .await
                         .expect("Failed to send to BatchStore");
 
-                    counters::NUM_FRAGMENT_PER_BATCH.observe(self.local_fragment_id as f64);
+                    counters::NUM_FRAGMENT_PER_BATCH.observe((self.local_fragment_id + 1) as f64);
 
                     self.local_fragment_id = 0;
                 },

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -111,7 +111,7 @@ impl BatchGenerator {
     pub(crate) async fn handle_scheduled_pull(
         &mut self,
         end_batch_when_back_pressure: bool,
-    ) -> Option<ProofCompletedChannel> {
+    ) -> (Option<(ProofCompletedChannel, bool)>) {
         // TODO: as an optimization, we could filter out the txns that have expired
 
         let mut exclude_txns: Vec<_> = self
@@ -221,7 +221,7 @@ impl BatchGenerator {
 
             self.last_end_batch_time = Instant::now();
 
-            Some(proof_rx)
+            Some((proof_rx, end_batch))
         }
     }
 
@@ -263,27 +263,34 @@ impl BatchGenerator {
 
         // this is the flag that records whether there is backpressure during last txn pulling from the mempool
         let mut back_pressure_in_last_pull = false;
+        let mut end_batch_in_last_pull = false;
 
         loop {
             let _timer = counters::WRAPPER_MAIN_LOOP.start_timer();
 
             tokio::select! {
+                biased;
+                Some(updated_back_pressure) = back_pressure_rx.recv() => {
+                    self.qs_back_pressure = updated_back_pressure;
+                },
                 _ = interval.tick() => {
                     if self.qs_back_pressure {
                         counters::QS_BACKPRESSURE.set(1);
                         // quorum store needs to be back pressured
                         // if last txn pull is not back pressured, there may be unfinished batch so we need to end the batch
-                        if !back_pressure_in_last_pull {
-                            if let Some(proof_rx) = self.handle_scheduled_pull(true).await {
+                        if !back_pressure_in_last_pull && !end_batch_in_last_pull {
+                            if let Some((proof_rx, end_batch)) = self.handle_scheduled_pull(true).await {
                                 proofs_in_progress.push(Box::pin(proof_rx));
+                                end_batch_in_last_pull = end_batch;
                             }
                         }
                         back_pressure_in_last_pull = true;
                     } else {
                         counters::QS_BACKPRESSURE.set(0);
                         // no back pressure
-                        if let Some(proof_rx) = self.handle_scheduled_pull(false).await {
+                        if let Some((proof_rx, end_batch)) = self.handle_scheduled_pull(false).await {
                             proofs_in_progress.push(Box::pin(proof_rx));
+                            end_batch_in_last_pull = end_batch;
                         }
                         back_pressure_in_last_pull = false;
                     }
@@ -329,10 +336,7 @@ impl BatchGenerator {
                             break;
                         },
                     }
-                },
-                Some(updated_back_pressure) = back_pressure_rx.recv() => {
-                    self.qs_back_pressure = updated_back_pressure;
-                },
+                }
             }
         }
     }

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -269,7 +269,7 @@ impl BatchGenerator {
 
             tokio::select! {
                 _ = interval.tick() => {
-                    if self.qs_back_pressure || self.block_store.back_pressure() {
+                    if self.qs_back_pressure {
                         counters::QS_BACKPRESSURE.set(1);
                         // quorum store needs to be back pressured
                         // if last txn pull is not back pressured, there may be unfinished batch so we need to end the batch

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -67,7 +67,7 @@ impl BatchBuilder {
             });
             self.data.push(serialized_txn);
 
-            true
+            self.num_txns < self.max_txns && self.num_bytes < self.max_bytes
         } else {
             false
         }


### PR DESCRIPTION
### Description

* We no longer backpressure QS based on consensus backpressure. It's only based on local batch count.
* [bugfix] backpressure did not work properly if all fragments are end_batch fragments
* [bugfix] count end batch fragment to number of fragments per batch.
* [bugfix] batch builder should end batch if it can no longer accept more transactions when called again.
* Config changes based on results from gas market overload test #6537 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
