### PR TITLE
[Crates] Add shared license to relevant files.

### DIFF
--- a/crates/aptos-bitvec/src/lib.rs
+++ b/crates/aptos-bitvec/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! This library defines a BitVec struct that represents a bit vector.

--- a/crates/aptos-crypto-derive/src/hasher.rs
+++ b/crates/aptos-crypto-derive/src/hasher.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 /// Converts a camel-case string to snake-case

--- a/crates/aptos-crypto-derive/src/lib.rs
+++ b/crates/aptos-crypto-derive/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/crates/aptos-crypto-derive/src/unions.rs
+++ b/crates/aptos-crypto-derive/src/unions.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use proc_macro::TokenStream;

--- a/crates/aptos-crypto/benches/ed25519.rs
+++ b/crates/aptos-crypto/benches/ed25519.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #[macro_use]

--- a/crates/aptos-crypto/benches/noise.rs
+++ b/crates/aptos-crypto/benches/noise.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Don't forget to run this benchmark with AES-NI enable.

--- a/crates/aptos-crypto/src/compat.rs
+++ b/crates/aptos-crypto/src/compat.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Wrapper structs for types that need [RustCrypto](https://github.com/RustCrypto)

--- a/crates/aptos-crypto/src/error.rs
+++ b/crates/aptos-crypto/src/error.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Rexport the error types needed for the various crypto traits

--- a/crates/aptos-crypto/src/hash.rs
+++ b/crates/aptos-crypto/src/hash.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines traits and implementations of

--- a/crates/aptos-crypto/src/hkdf.rs
+++ b/crates/aptos-crypto/src/hkdf.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! An implementation of HKDF, the HMAC-based Extract-and-Expand Key Derivation Function

--- a/crates/aptos-crypto/src/lib.rs
+++ b/crates/aptos-crypto/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/crates/aptos-crypto/src/multi_ed25519.rs
+++ b/crates/aptos-crypto/src/multi_ed25519.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module provides an API for the accountable threshold multi-sig PureEdDSA signature scheme

--- a/crates/aptos-crypto/src/noise.rs
+++ b/crates/aptos-crypto/src/noise.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Noise is a [protocol framework](https://noiseprotocol.org/) which we use to

--- a/crates/aptos-crypto/src/test_utils.rs
+++ b/crates/aptos-crypto/src/test_utils.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Internal module containing convenience utility functions mainly for testing

--- a/crates/aptos-crypto/src/traits.rs
+++ b/crates/aptos-crypto/src/traits.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module provides a generic set of traits for dealing with cryptographic primitives.

--- a/crates/aptos-crypto/src/validatable.rs
+++ b/crates/aptos-crypto/src/validatable.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module provides the `Validate` trait and `Validatable` type in order to aid in deferred

--- a/crates/aptos-crypto/src/x25519.rs
+++ b/crates/aptos-crypto/src/x25519.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! An abstraction of x25519 elliptic curve keys required for

--- a/crates/aptos-faucet/src/lib.rs
+++ b/crates/aptos-faucet/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // README: The aptos-faucet is deprecated in favor of the tap. Do not add new code

--- a/crates/aptos-faucet/src/main.rs
+++ b/crates/aptos-faucet/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // README: The aptos-faucet is deprecated in favor of the tap. Do not add new code

--- a/crates/aptos-faucet/src/mint.rs
+++ b/crates/aptos-faucet/src/mint.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // README: The aptos-faucet is deprecated in favor of the tap. Do not add new code

--- a/crates/aptos-id-generator/src/lib.rs
+++ b/crates/aptos-id-generator/src/lib.rs
@@ -1,6 +1,9 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 #![forbid(unsafe_code)]
+
 use std::{
     fmt::Debug,
     sync::atomic::{AtomicU32, AtomicU64, Ordering},

--- a/crates/aptos-infallible/src/lib.rs
+++ b/crates/aptos-infallible/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 mod math;

--- a/crates/aptos-infallible/src/math.rs
+++ b/crates/aptos-infallible/src/math.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 /// Utility macro for writing secure arithmetic operations in order to avoid

--- a/crates/aptos-infallible/src/mutex.rs
+++ b/crates/aptos-infallible/src/mutex.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Mutex as StdMutex;

--- a/crates/aptos-infallible/src/nonzero.rs
+++ b/crates/aptos-infallible/src/nonzero.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 /// A wrapper around `std::num::NonZeroUsize` to no longer worry about `unwrap()`

--- a/crates/aptos-infallible/src/rwlock.rs
+++ b/crates/aptos-infallible/src/rwlock.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::RwLock as StdRwLock;

--- a/crates/aptos-infallible/src/time.rs
+++ b/crates/aptos-infallible/src/time.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/crates/aptos-log-derive/src/lib.rs
+++ b/crates/aptos-log-derive/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use proc_macro::TokenStream;

--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Implementation of writing logs to both local printers (e.g. stdout) and remote loggers

--- a/crates/aptos-logger/src/counters.rs
+++ b/crates/aptos-logger/src/counters.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Logging metrics for determining quality of log submission

--- a/crates/aptos-logger/src/event.rs
+++ b/crates/aptos-logger/src/event.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Metadata, Schema};

--- a/crates/aptos-logger/src/filter.rs
+++ b/crates/aptos-logger/src/filter.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Filtering definitions for controlling what modules and levels are logged

--- a/crates/aptos-logger/src/kv.rs
+++ b/crates/aptos-logger/src/kv.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Key-Value definitions for macros

--- a/crates/aptos-logger/src/lib.rs
+++ b/crates/aptos-logger/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! This crates provides an API for logging.

--- a/crates/aptos-logger/src/logger.rs
+++ b/crates/aptos-logger/src/logger.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Global logger definition and functions

--- a/crates/aptos-logger/src/macros.rs
+++ b/crates/aptos-logger/src/macros.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Macros for sending logs at predetermined log `Level`s

--- a/crates/aptos-logger/src/metadata.rs
+++ b/crates/aptos-logger/src/metadata.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};

--- a/crates/aptos-logger/src/sample.rs
+++ b/crates/aptos-logger/src/sample.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Periodic sampling for logs, metrics, and other use cases through a simple macro

--- a/crates/aptos-logger/src/security.rs
+++ b/crates/aptos-logger/src/security.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //!

--- a/crates/aptos-logger/src/tracing_adapter.rs
+++ b/crates/aptos-logger/src/tracing_adapter.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{self as dl};

--- a/crates/aptos-logger/tests/derive.rs
+++ b/crates/aptos-logger/tests/derive.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_log_derive::Schema;

--- a/crates/aptos-logger/tests/logger.rs
+++ b/crates/aptos-logger/tests/logger.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_infallible::RwLock;

--- a/crates/aptos-logger/tests/logger_custom_format.rs
+++ b/crates/aptos-logger/tests/logger_custom_format.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_infallible::RwLock;

--- a/crates/aptos-logger/tests/tracing_translation_tests.rs
+++ b/crates/aptos-logger/tests/tracing_translation_tests.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_infallible::RwLock;

--- a/crates/aptos-metrics-core/src/lib.rs
+++ b/crates/aptos-metrics-core/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // Re-export counter types from prometheus crate

--- a/crates/aptos-proptest-helpers/src/growing_subset.rs
+++ b/crates/aptos-proptest-helpers/src/growing_subset.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use proptest::sample::Index;

--- a/crates/aptos-proptest-helpers/src/lib.rs
+++ b/crates/aptos-proptest-helpers/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/crates/aptos-proptest-helpers/src/repeat_vec.rs
+++ b/crates/aptos-proptest-helpers/src/repeat_vec.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::pick_slice_idxs;

--- a/crates/aptos-proptest-helpers/src/unit_tests.rs
+++ b/crates/aptos-proptest-helpers/src/unit_tests.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 mod growing_subset_tests;

--- a/crates/aptos-proptest-helpers/src/unit_tests/growing_subset_tests.rs
+++ b/crates/aptos-proptest-helpers/src/unit_tests/growing_subset_tests.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::GrowingSubset;

--- a/crates/aptos-proptest-helpers/src/unit_tests/pick_idx_tests.rs
+++ b/crates/aptos-proptest-helpers/src/unit_tests/pick_idx_tests.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{pick_slice_idxs, Index};

--- a/crates/aptos-proptest-helpers/src/unit_tests/repeat_vec_tests.rs
+++ b/crates/aptos-proptest-helpers/src/unit_tests/repeat_vec_tests.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::RepeatVec;

--- a/crates/aptos-proptest-helpers/src/value_generator.rs
+++ b/crates/aptos-proptest-helpers/src/value_generator.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use proptest::{

--- a/crates/aptos-rate-limiter/src/async_lib.rs
+++ b/crates/aptos-rate-limiter/src/async_lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::rate_limit::{Bucket, SharedBucket};

--- a/crates/aptos-rate-limiter/src/lib.rs
+++ b/crates/aptos-rate-limiter/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/crates/aptos-rate-limiter/src/main.rs
+++ b/crates/aptos-rate-limiter/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_infallible::Mutex;

--- a/crates/aptos-rate-limiter/src/rate_limit.rs
+++ b/crates/aptos-rate-limiter/src/rate_limit.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_infallible::{Mutex, RwLock};

--- a/crates/aptos-rest-client/src/faucet.rs
+++ b/crates/aptos-rest-client/src/faucet.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{error::FaucetClientError, Client, Result};

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 extern crate core;

--- a/crates/aptos-rest-client/src/types.rs
+++ b/crates/aptos-rest-client/src/types.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 pub use aptos_api_types::deserialize_from_string;

--- a/crates/aptos-retrier/src/lib.rs
+++ b/crates/aptos-retrier/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/crates/aptos-temppath/src/lib.rs
+++ b/crates/aptos-temppath/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/crates/aptos-time-service/src/interval.rs
+++ b/crates/aptos-time-service/src/interval.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Sleep, SleepTrait, ZERO_DURATION};

--- a/crates/aptos-time-service/src/lib.rs
+++ b/crates/aptos-time-service/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/crates/aptos-time-service/src/mock.rs
+++ b/crates/aptos-time-service/src/mock.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Sleep, SleepTrait, TimeServiceTrait, ZERO_DURATION};

--- a/crates/aptos-time-service/src/real.rs
+++ b/crates/aptos-time-service/src/real.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::TimeServiceTrait;

--- a/crates/aptos-time-service/src/timeout.rs
+++ b/crates/aptos-time-service/src/timeout.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::Sleep;

--- a/crates/aptos-warp-webserver/src/error.rs
+++ b/crates/aptos-warp-webserver/src/error.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_api_types::U64;

--- a/crates/aptos-warp-webserver/src/lib.rs
+++ b/crates/aptos-warp-webserver/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module is just used for testing in other crates that expect the API

--- a/crates/aptos-warp-webserver/src/log.rs
+++ b/crates/aptos-warp-webserver/src/log.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_logger::{

--- a/crates/aptos-warp-webserver/src/response.rs
+++ b/crates/aptos-warp-webserver/src/response.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;

--- a/crates/aptos-warp-webserver/src/webserver.rs
+++ b/crates/aptos-warp-webserver/src/webserver.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_config::config::ApiConfig;

--- a/crates/bounded-executor/src/lib.rs
+++ b/crates/bounded-executor/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/crates/channel/src/aptos_channel.rs
+++ b/crates/channel/src/aptos_channel.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! aptos_channel provides an mpsc channel which has two ends `aptos_channel::Receiver`

--- a/crates/channel/src/aptos_channel_test.rs
+++ b/crates/channel/src/aptos_channel_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{aptos_channel, aptos_channel::ElementStatus, message_queues::QueueStyle};

--- a/crates/channel/src/lib.rs
+++ b/crates/channel/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/crates/channel/src/message_queues.rs
+++ b/crates/channel/src/message_queues.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_metrics_core::IntCounterVec;

--- a/crates/channel/src/message_queues_test.rs
+++ b/crates/channel/src/message_queues_test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::message_queues::{PerKeyQueue, QueueStyle};

--- a/crates/channel/src/test.rs
+++ b/crates/channel/src/test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate as channel;

--- a/crates/channel/tests/many-keys-stress-test.rs
+++ b/crates/channel/tests/many-keys-stress-test.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};

--- a/crates/crash-handler/src/lib.rs
+++ b/crates/crash-handler/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]

--- a/crates/fallible/src/copy_from_slice.rs
+++ b/crates/fallible/src/copy_from_slice.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use thiserror::Error;

--- a/crates/fallible/src/lib.rs
+++ b/crates/fallible/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod copy_from_slice;

--- a/crates/num-variants/src/lib.rs
+++ b/crates/num-variants/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Add an associated constant to an enum describing the number of variants it has.

--- a/crates/num-variants/tests/basic.rs
+++ b/crates/num-variants/tests/basic.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(dead_code)]

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use ipnet::IpNet;

--- a/crates/short-hex-str/src/lib.rs
+++ b/crates/short-hex-str/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use mirai_annotations::debug_checked_precondition;

--- a/crates/transaction-emitter/src/main.rs
+++ b/crates/transaction-emitter/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 mod diag;


### PR DESCRIPTION
Note: this PR requires https://github.com/aptos-labs/aptos-core/pull/6668 to land first (to pass the pre-commit checks).

### Description

This PR updates the `crates` directory with shared licenses for rust files that also contain some Meta code.

The files were identified using:
- `git log --diff-filter=A --format=%ad -- <file>` (to identify file creation -- we take the oldest date).
- `git log --diff-filter=M --format=%ad -- <file>` (to identify file modification dates).

### Test Plan
Manual verification and tooling