### PR TITLE
[Consensus] Add proposed block to the block store in case of backpres…

### DIFF
--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -692,7 +692,12 @@ impl RoundManager {
             // In case of back pressure, we delay processing proposal. This is done by resending the
             // same proposal to self after some time. Even if processing proposal is delayed, we add
             // the block to the block store so that we don't need to fetch it from remote once we
-            // are out of the backpressure.
+            // are out of the backpressure. Please note that delayed processing of proposal is not
+            // guaranteed to add the block to the block store if we don't get out of the backpressure
+            // before the timeout, so this is needed to ensure that the proposed block is added to
+            // the block store irrespective. Also, it is possible that delayed processing of proposal
+            // tries to add the same block again, which is okay as `execute_and_insert_block` call
+            // is idempotent.
             self.block_store
                 .execute_and_insert_block(proposal.clone())
                 .await


### PR DESCRIPTION
### Description

In the case of backpressure, we see a lot of remote block fetch, which leads to higher-than-expected proposal timeout. This is because, in the case of backpressure, we don't add the proposed block to the block store and hence once we are out of the backpressure, we need to fetch the blocks from the remote validators - which slows the node down further. This change, adds the proposed block to the block store so that the node doesn't need to fetch a bunch of blocks remotely once it is out of the backpressure. 

### Test Plan

UT and Forge test