### PR TITLE
[Network] Move trusted peers into peers and metadata.

### DIFF
--- a/crates/aptos-network-checker/src/check_endpoint.rs
+++ b/crates/aptos-network-checker/src/check_endpoint.rs
@@ -178,7 +178,7 @@ fn build_upgrade_context(
             network_context,
             private_key,
             // If we had an incoming message, auth mode would matter.
-            HandshakeAuthMode::server_only(),
+            HandshakeAuthMode::server_only(&[network_id]),
         ),
         HANDSHAKE_VERSION,
         supported_protocols,

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -11,7 +11,6 @@ use aptos_config::{
     network_id::{NetworkContext, NetworkId, PeerNetworkId},
 };
 use aptos_crypto::{test_utils::TEST_SEED, x25519, Uniform};
-use aptos_infallible::RwLock;
 use aptos_netcore::transport::ConnectionOrigin;
 use aptos_network::{
     application::{interface::NetworkClient, storage::PeersAndMetadata},
@@ -27,10 +26,7 @@ use futures::{executor::block_on, StreamExt};
 use maplit::hashmap;
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::collections::HashSet;
 use tokio::runtime::Runtime;
 
 const TEST_RPC_PROTOCOL: ProtocolId = ProtocolId::ConsensusRpcBcs;
@@ -96,7 +92,6 @@ pub fn setup_network() -> DummyNetwork {
         Peer::new(vec![], dialer_pubkeys, PeerRole::Validator),
     );
 
-    let trusted_peers = Arc::new(RwLock::new(HashMap::new()));
     let authentication_mode = AuthenticationMode::Mutual(listener_identity_private_key);
     let peers_and_metadata = PeersAndMetadata::new(&[network_id]);
     // Set up the listener network
@@ -104,7 +99,6 @@ pub fn setup_network() -> DummyNetwork {
     let mut network_builder = NetworkBuilder::new_for_test(
         chain_id,
         seeds.clone(),
-        trusted_peers,
         network_context,
         TimeService::real(),
         listener_addr,
@@ -135,12 +129,9 @@ pub fn setup_network() -> DummyNetwork {
     // Set up the dialer network
     let network_context = NetworkContext::new(role, network_id, dialer_peer.peer_id());
 
-    let trusted_peers = Arc::new(RwLock::new(HashMap::new()));
-
     let mut network_builder = NetworkBuilder::new_for_test(
         chain_id,
         seeds,
-        trusted_peers,
         network_context,
         TimeService::real(),
         dialer_addr,

--- a/network/src/connectivity_manager/builder.rs
+++ b/network/src/connectivity_manager/builder.rs
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    application::storage::PeersAndMetadata,
     connectivity_manager::{ConnectivityManager, ConnectivityRequest},
     counters,
     peer_manager::{conn_notifs_channel, ConnectionRequestSender},
 };
 use aptos_config::{config::PeerSet, network_id::NetworkContext};
-use aptos_infallible::RwLock;
 use aptos_time_service::TimeService;
 use std::{sync::Arc, time::Duration};
 use tokio::runtime::Handle;
@@ -25,7 +25,7 @@ impl ConnectivityManagerBuilder {
     pub fn create(
         network_context: NetworkContext,
         time_service: TimeService,
-        eligible: Arc<RwLock<PeerSet>>,
+        peers_and_metadata: Arc<PeersAndMetadata>,
         seeds: PeerSet,
         connectivity_check_interval_ms: u64,
         backoff_base: u64,
@@ -46,7 +46,7 @@ impl ConnectivityManagerBuilder {
             connectivity_manager: Some(ConnectivityManager::new(
                 network_context,
                 time_service,
-                eligible,
+                peers_and_metadata,
                 seeds,
                 connection_reqs_tx,
                 connection_notifs_rx,

--- a/network/src/noise/error.rs
+++ b/network/src/noise/error.rs
@@ -2,6 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::application;
 use aptos_crypto::noise::NoiseError;
 use aptos_short_hex_str::ShortHexStr;
 use aptos_types::PeerId;
@@ -79,6 +80,9 @@ pub enum NoiseHandshakeError {
 
     #[error("noise server: client {0}: error sending server handshake response message: {1}")]
     ServerWriteFailed(ShortHexStr, io::Error),
+
+    #[error("unexpected error encountered: {0}")]
+    UnexpectedError(String),
 }
 
 impl NoiseHandshakeError {
@@ -87,5 +91,11 @@ impl NoiseHandshakeError {
     pub fn should_security_log(&self) -> bool {
         use NoiseHandshakeError::*;
         matches!(self, ServerReplayDetected(_, _))
+    }
+}
+
+impl From<application::error::Error> for NoiseHandshakeError {
+    fn from(error: application::error::Error) -> Self {
+        NoiseHandshakeError::UnexpectedError(error.to_string())
     }
 }

--- a/network/src/noise/mod.rs
+++ b/network/src/noise/mod.rs
@@ -21,6 +21,7 @@
 //! use rand::{rngs::StdRng, SeedableRng};
 //! use aptos_types::PeerId;
 //! use std::{collections::{HashSet, HashMap}, io, sync::Arc};
+//! use aptos_network::application::storage::PeersAndMetadata;
 //!
 //! fn example() -> io::Result<()> {
 //! // create client and server NoiseUpgrader
@@ -34,26 +35,27 @@
 //! let server_peer_id = PeerId::random();
 //!
 //! // create list of trusted peers
+//! let network_id = NetworkId::Validator;
 //! let client_pubkey_set: HashSet<_> = vec![client_public].into_iter().collect();
 //! let server_pubkey_set: HashSet<_> = vec![server_public].into_iter().collect();
-//! let trusted_peers: HashMap<_, _> = vec![
-//!     (client_peer_id, Peer::new(Vec::new(), client_pubkey_set, PeerRole::Validator)),
-//!     (server_peer_id, Peer::new(Vec::new(), server_pubkey_set, PeerRole::Validator))
-//! ].into_iter().collect();
-//! let trusted_peers = Arc::new(RwLock::new(trusted_peers));
 //!
-//! let client_auth = HandshakeAuthMode::mutual(trusted_peers.clone());
+//! let peers_and_metadata = PeersAndMetadata::new(&[network_id]);
+//! let mut trusted_peers = peers_and_metadata.get_trusted_peers(&network_id).unwrap();
+//! trusted_peers.write().insert(client_peer_id, Peer::new(Vec::new(), client_pubkey_set, PeerRole::Validator));
+//! trusted_peers.write().insert(server_peer_id, Peer::new(Vec::new(), server_pubkey_set, PeerRole::Validator));
+//!
+//! let client_auth = HandshakeAuthMode::mutual(peers_and_metadata.clone());
 //! let client_context = NetworkContext::new(
 //!     RoleType::Validator,
-//!     NetworkId::Validator,
+//!     network_id,
 //!     client_peer_id,
 //! );
 //! let client = NoiseUpgrader::new(client_context, client_private, client_auth);
 //!
-//! let server_auth = HandshakeAuthMode::mutual(trusted_peers);
+//! let server_auth = HandshakeAuthMode::mutual(peers_and_metadata);
 //! let server_context = NetworkContext::new(
 //!     RoleType::Validator,
-//!     NetworkId::Validator,
+//!     network_id,
 //!     server_peer_id,
 //! );
 //! let server = NoiseUpgrader::new(server_context, server_private, server_auth);

--- a/network/src/noise/stream.rs
+++ b/network/src/noise/stream.rs
@@ -547,20 +547,22 @@ mod test {
         let client_private = x25519::PrivateKey::generate(&mut rng);
         let client_public = client_private.public_key();
         let client_peer_id = aptos_types::account_address::from_identity_public_key(client_public);
+        let client_network_context = NetworkContext::mock_with_peer_id(client_peer_id);
 
         let server_private = x25519::PrivateKey::generate(&mut rng);
         let server_public = server_private.public_key();
         let server_peer_id = aptos_types::account_address::from_identity_public_key(server_public);
+        let server_network_context = NetworkContext::mock_with_peer_id(server_peer_id);
 
         let client = NoiseUpgrader::new(
-            NetworkContext::mock_with_peer_id(client_peer_id),
+            client_network_context,
             client_private,
-            HandshakeAuthMode::server_only(),
+            HandshakeAuthMode::server_only(&[client_network_context.network_id()]),
         );
         let server = NoiseUpgrader::new(
-            NetworkContext::mock_with_peer_id(server_peer_id),
+            server_network_context,
             server_private,
-            HandshakeAuthMode::server_only(),
+            HandshakeAuthMode::server_only(&[server_network_context.network_id()]),
         );
 
         ((client, client_public), (server, server_public))

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -27,7 +27,6 @@ use aptos_config::{
     config::{PeerRole, MAX_INBOUND_CONNECTIONS},
     network_id::{NetworkContext, NetworkId},
 };
-use aptos_infallible::RwLock;
 use aptos_memsocket::MemorySocket;
 use aptos_netcore::transport::{
     boxed::BoxedTransport, memory::MemoryTransport, ConnectionOrigin, TransportExt,
@@ -37,7 +36,7 @@ use aptos_time_service::TimeService;
 use aptos_types::{network_address::NetworkAddress, PeerId};
 use bytes::Bytes;
 use futures::{channel::oneshot, io::AsyncWriteExt, stream::StreamExt};
-use std::{collections::HashMap, error::Error, sync::Arc};
+use std::error::Error;
 use tokio::runtime::Handle;
 use tokio_util::compat::{
     FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt,
@@ -108,7 +107,6 @@ fn build_test_peer_manager(
         NetworkContext::mock_with_peer_id(peer_id),
         "/memory/0".parse().unwrap(),
         PeersAndMetadata::new(&[network_id]),
-        Arc::new(RwLock::new(HashMap::new())),
         peer_manager_request_rx,
         connection_reqs_rx,
         [(ProtocolId::mock(), hello_tx)].iter().cloned().collect(),

--- a/network/src/testutils/mod.rs
+++ b/network/src/testutils/mod.rs
@@ -2,7 +2,49 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::application::storage::PeersAndMetadata;
+use aptos_config::network_id::NetworkContext;
+use aptos_crypto::x25519::PublicKey;
+use aptos_types::PeerId;
+use std::sync::Arc;
+
 pub mod builder;
 pub mod fake_socket;
 pub mod test_framework;
 pub mod test_node;
+
+/// Creates a network context for a client and server, and returns the
+/// contexts alongside peers and metadata.
+pub fn create_client_server_network_context(
+    client_public_key: Option<PublicKey>,
+    server_public_key: Option<PublicKey>,
+) -> (NetworkContext, NetworkContext, Arc<PeersAndMetadata>) {
+    // Create the client context
+    let client_network_context = create_context_for_public_key(client_public_key);
+
+    // Create the server context
+    let server_network_context = create_context_for_public_key(server_public_key);
+    assert_eq!(
+        client_network_context.network_id(),
+        server_network_context.network_id()
+    );
+
+    // Create the trusted peers and metadata
+    let peers_and_metadata = PeersAndMetadata::new(&[client_network_context.network_id()]);
+
+    (
+        client_network_context,
+        server_network_context,
+        peers_and_metadata,
+    )
+}
+
+/// Creates a network context for the given public key.
+/// Otherwise, uses a random peer ID.
+fn create_context_for_public_key(public_key: Option<PublicKey>) -> NetworkContext {
+    let peer_id = match public_key {
+        Some(public_key) => aptos_types::account_address::from_identity_public_key(public_key),
+        None => PeerId::random(),
+    };
+    NetworkContext::mock_with_peer_id(peer_id)
+}


### PR DESCRIPTION
Note: this PR relates to: https://github.com/aptos-labs/aptos-core/issues/6789.

### Description
This PR offers a simple refactor for moving the trusted peers into the peers and metadata container. This provides several benefits:
1. It offers better encapsulation: (i) we no longer have to pass around the trusted peers to all objects that require them; and (ii) it is easier to reason about because the trusted peers are now part of a single container.
2. It makes the trusted peers available to the applications, e.g., the peer monitoring service, which is useful for sharing discovery information between nodes.

Note: other than this simple refactor, the network logic should not change in this PR.

### Test Plan
New and existing test infrastructure.