### PR TITLE
[gha] fix permissions for forge and check-aptos-core on forks

### DIFF
--- a/.github/workflows/copy-images-to-dockerhub-nightly.yaml
+++ b/.github/workflows/copy-images-to-dockerhub-nightly.yaml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   id-token: write #required for GCP Workload Identity federation
+  actions: write #required for workflow cancellation via check-aptos-core
 
 jobs:
   check-repo:

--- a/.github/workflows/copy-images-to-dockerhub-nightly.yaml
+++ b/.github/workflows/copy-images-to-dockerhub-nightly.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -6,6 +6,7 @@ permissions:
   pull-requests: write
   contents: read
   id-token: write
+  actions: write #required for workflow cancellation via check-aptos-core
 
 on:
   # Allow triggering manually

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -68,7 +68,7 @@ jobs:
           ref: ${{ steps.determine-test-branch.outputs.BRANCH }}
           fetch-depth: 0
 
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -4,6 +4,8 @@ name: Continuous Forge Tests - Stable
 permissions:
   issues: write
   pull-requests: write
+  contents: read
+  id-token: write
 
 on:
   # Allow triggering manually

--- a/.github/workflows/forge-unstable.yaml
+++ b/.github/workflows/forge-unstable.yaml
@@ -6,6 +6,7 @@ permissions:
   pull-requests: write
   contents: read
   id-token: write
+  actions: write #required for workflow cancellation via check-aptos-core
 
 on:
   # Allow triggering manually

--- a/.github/workflows/forge-unstable.yaml
+++ b/.github/workflows/forge-unstable.yaml
@@ -4,6 +4,8 @@ name: Continuous Forge Tests - Unstable
 permissions:
   issues: write
   pull-requests: write
+  contents: read
+  id-token: write
 
 on:
   # Allow triggering manually

--- a/.github/workflows/forge-unstable.yaml
+++ b/.github/workflows/forge-unstable.yaml
@@ -64,7 +64,7 @@ jobs:
           ref: ${{ steps.determine-test-branch.outputs.BRANCH }}
           fetch-depth: 0
 
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-execute-devnet-main.yaml
+++ b/.github/workflows/fullnode-execute-devnet-main.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-execute-devnet-main.yaml
+++ b/.github/workflows/fullnode-execute-devnet-main.yaml
@@ -11,6 +11,11 @@ on:
     paths:
       - ".github/workflows/fullnode-execute-devnet-main.yaml"
 
+permissions:
+  contents: read
+  id-token: write
+  actions: write #required for workflow cancellation via check-aptos-core
+
 jobs:
   check-repo:
     runs-on: ubuntu-latest

--- a/.github/workflows/fullnode-execute-devnet-stable.yaml
+++ b/.github/workflows/fullnode-execute-devnet-stable.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-execute-devnet-stable.yaml
+++ b/.github/workflows/fullnode-execute-devnet-stable.yaml
@@ -11,6 +11,11 @@ on:
     paths:
       - ".github/workflows/fullnode-execute-devnet-stable.yaml"
 
+permissions:
+  contents: read
+  id-token: write
+  actions: write #required for workflow cancellation via check-aptos-core
+
 jobs:
   check-repo:
     runs-on: ubuntu-latest

--- a/.github/workflows/fullnode-fast-mainnet-main.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-main.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-fast-mainnet-main.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-main.yaml
@@ -11,6 +11,11 @@ on:
     paths:
       - ".github/workflows/fullnode-fast-mainnet-main.yaml"
 
+permissions:
+  contents: read
+  id-token: write
+  actions: write #required for workflow cancellation via check-aptos-core
+
 jobs:
   check-repo:
     runs-on: ubuntu-latest

--- a/.github/workflows/fullnode-fast-mainnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-stable.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-fast-mainnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-stable.yaml
@@ -11,6 +11,11 @@ on:
     paths:
       - ".github/workflows/fullnode-fast-mainnet-stable.yaml"
 
+permissions:
+  contents: read
+  id-token: write
+  actions: write #required for workflow cancellation via check-aptos-core
+
 jobs:
   check-repo:
     runs-on: ubuntu-latest

--- a/.github/workflows/fullnode-fast-testnet-main.yaml
+++ b/.github/workflows/fullnode-fast-testnet-main.yaml
@@ -11,6 +11,11 @@ on:
     paths:
       - ".github/workflows/fullnode-fast-testnet-main.yaml"
 
+permissions:
+  contents: read
+  id-token: write
+  actions: write #required for workflow cancellation via check-aptos-core
+
 jobs:
   check-repo:
     runs-on: ubuntu-latest

--- a/.github/workflows/fullnode-fast-testnet-main.yaml
+++ b/.github/workflows/fullnode-fast-testnet-main.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-fast-testnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-testnet-stable.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-fast-testnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-testnet-stable.yaml
@@ -11,6 +11,11 @@ on:
     paths:
       - ".github/workflows/fullnode-fast-testnet-stable.yaml"
 
+permissions:
+  contents: read
+  id-token: write
+  actions: write #required for workflow cancellation via check-aptos-core
+
 jobs:
   check-repo:
     runs-on: ubuntu-latest

--- a/.github/workflows/fullnode-intelligent-devnet-main.yaml
+++ b/.github/workflows/fullnode-intelligent-devnet-main.yaml
@@ -12,6 +12,11 @@ on:
     paths:
       - ".github/workflows/fullnode-intelligent-devnet-main.yaml"
 
+permissions:
+  contents: read
+  id-token: write
+  actions: write #required for workflow cancellation via check-aptos-core
+
 jobs:
   check-repo:
     runs-on: ubuntu-latest

--- a/.github/workflows/fullnode-intelligent-devnet-main.yaml
+++ b/.github/workflows/fullnode-intelligent-devnet-main.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-output-mainnet-main.yaml
+++ b/.github/workflows/fullnode-output-mainnet-main.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-output-mainnet-main.yaml
+++ b/.github/workflows/fullnode-output-mainnet-main.yaml
@@ -11,6 +11,11 @@ on:
     paths:
       - ".github/workflows/fullnode-output-mainnet-main.yaml"
 
+permissions:
+  contents: read
+  id-token: write
+  actions: write #required for workflow cancellation via check-aptos-core
+
 jobs:
   check-repo:
     runs-on: ubuntu-latest

--- a/.github/workflows/module-verify.yaml
+++ b/.github/workflows/module-verify.yaml
@@ -32,6 +32,7 @@ jobs:
   verify-modules-testnet:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.CHAIN_NAME == 'testnet' || inputs.CHAIN_NAME == 'all' }}
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-module-verify.yaml@main
+    secrets: inherit
     with:
       GIT_SHA: ${{ inputs.GIT_SHA }}
       BUCKET: aptos-testnet-backup-2223d95b
@@ -44,6 +45,7 @@ jobs:
   verify-modules-mainnet:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.CHAIN_NAME == 'mainnet' || inputs.CHAIN_NAME == 'all' }}
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-module-verify.yaml@main
+    secrets: inherit
     with:
       GIT_SHA: ${{ inputs.GIT_SHA }}
       BUCKET: aptos-mainnet-backup-backup-831a69a8
@@ -56,6 +58,7 @@ jobs:
   test-verify-modules:
     if: ${{ github.event_name == 'pull_request' }}
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-module-verify.yaml@main
+    secrets: inherit
     with:
       GIT_SHA: ${{ github.event.pull_request.head.sha }}
       BUCKET: aptos-testnet-backup-2223d95b

--- a/.github/workflows/replay-verify.yaml
+++ b/.github/workflows/replay-verify.yaml
@@ -67,6 +67,7 @@ jobs:
   test-replay:
     if: ${{ github.event_name == 'pull_request' }}
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-replay-verify.yaml@main
+    secrets: inherit
     with:
       GIT_SHA: ${{ github.event.pull_request.head.sha }}
       # replay-verify config


### PR DESCRIPTION
### Description

The top level `permissions` block will override the default token permissions, which may not work in all cases (e.g. private forks). We need to add back the permissions https://github.com/actions/checkout/issues/254

* Also, pin `check-aptos-core` action to `@main`, rather than using the one in the checkout. This resolves failures like this: https://github.com/aptos-labs/aptos-core/actions/runs/4246942647/jobs/7384389591, which runs Forge on the `quorum-store` branch, which does not have this GHA.
* Also, grant `actions: write` to any workflows that call `check-aptos-core`, since it is needed for the action to cancel the workflow

### Test Plan

Test checkout in a private fork. The `determine-test-metadata` job in each `forge-stable` and `forge-unstable` should pass
Also canary the `check-aptos-core` workflow cancellation via PR: https://github.com/aptos-labs/aptos-core/pull/6733

<!-- Please provide us with clear details for verifying that your changes work. -->
