### PR TITLE
[don't review][storage] add retry in loading metadata chunk files

### DIFF
--- a/storage/backup/backup-cli/src/storage/command_adapter/mod.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/mod.rs
@@ -140,7 +140,6 @@ impl BackupStorage for CommandAdapter {
         let child = self
             .cmd(&self.config.commands.list_metadata_files, vec![])
             .spawn()?;
-
         let mut buf = FileHandle::new();
         child
             .into_data_source()


### PR DESCRIPTION
### Description
got the error below. could use retry to make it more robust
`2023-02-22T08:18:13.5566197Z gzip: stdin: unexpected end of file
2023-02-22T08:18:13.5574192Z [partition 15] b'2023-02-22T08:18:13.557057Z [tokio-runtime-worker] ERROR storage/backup/backup-cli/src/utils/error_notes.rs:15 Error raised, see notes. {"error":"Command \\"set -o nounset -o errexit -o pipefail; aws s3 cp \\"s3://$BUCKET/$SUB_DIR/$FILE_HANDLE\\" - --no-sign-request | gzip -cd\\" with params [FILE_HANDLE=state_epoch_1277_ver_329569731.dae1/22791479-.chunk] failed with exit status: exit status: 1","notes":"\\"\\""}\n'
2023-02-22T08:18:16.5849689Z [partition 15] b'2023-02-22T08:18:16.584463Z [main] ERROR storage/backup/backup-cli/src/coordinators/replay_verify.rs:69 ReplayVerify coordinator failed. {"error":"state snapshot restore failed: Command \\"set -o nounset -o errexit -o pipefail; aws s3 cp \\"s3://$BUCKET/$SUB_DIR/$FILE_HANDLE\\" - --no-sign-request | gzip -cd\\" with params [FILE_HANDLE=state_epoch_1277_ver_329569731.dae1/22791479-.chunk] failed with exit status: exit status: 1"}\n'
2023-02-22T08:18:16.7173996Z Error: state snapshot restore failed: Command "set -o nounset -o errexit -o pipefail; aws s3 cp "s3://$BUCKET/$SUB_DIR/$FILE_HANDLE" - --no-sign-request | gzip -cd" with params [FILE_HANDLE=state_epoch_1277_ver_329569731.dae1/22791479-.chunk] failed with exit status: exit status: 1`
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
