### PR TITLE
[CANARY][gha] fix forge checkout perms  

### DIFF
--- a/.github/actions/check-aptos-core/action.yaml
+++ b/.github/actions/check-aptos-core/action.yaml
@@ -5,6 +5,10 @@ inputs:
     description: "Cancel the workflow if the calling repository is not aptos-core"
     required: false
     default: false
+  token:
+    description: "The GitHub token to use"
+    required: false
+    default: ${{ github.token }}
 outputs:
   is-aptos-core:
     description: "Whether the calling repository is aptos-core"
@@ -16,11 +20,7 @@ runs:
       id: determine-repo
       shell: bash
       run: |
-        if [[ "${{ github.repository }}" == "aptos-labs/aptos-core" ]]; then
-          echo "is-aptos-core=true" >> $GITHUB_OUTPUT
-        else
-          echo "is-aptos-core=false" >> $GITHUB_OUTPUT
-        fi
+        echo "is-aptos-core=false" >> $GITHUB_OUTPUT
         echo "Calling repo: ${{ github.repository }}"
     - name: Cancel the workflow if the calling repo is not aptos-core
       if: ${{ inputs.cancel-workflow == 'true' && steps.determine-repo.outputs.is-aptos-core == 'false' }}
@@ -28,3 +28,5 @@ runs:
       run: |
         echo "Canceling workflow because the calling repo is not aptos-core"
         gh run cancel ${{ github.run_id }}
+      env:
+        GH_TOKEN: ${{ inputs.token }}

--- a/.github/workflows/copy-images-to-dockerhub-nightly.yaml
+++ b/.github/workflows/copy-images-to-dockerhub-nightly.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -6,6 +6,7 @@ permissions:
   pull-requests: write
   contents: read
   id-token: write
+  actions: write
 
 on:
   # Allow triggering manually
@@ -68,7 +69,7 @@ jobs:
           ref: ${{ steps.determine-test-branch.outputs.BRANCH }}
           fetch-depth: 0
 
-      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
+      - uses: ./.github/actions/check-aptos-core
         with:
           cancel-workflow: true
 

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -68,7 +68,7 @@ jobs:
           ref: ${{ steps.determine-test-branch.outputs.BRANCH }}
           fetch-depth: 0
 
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -4,6 +4,8 @@ name: Continuous Forge Tests - Stable
 permissions:
   issues: write
   pull-requests: write
+  contents: read
+  id-token: write
 
 on:
   # Allow triggering manually

--- a/.github/workflows/forge-unstable.yaml
+++ b/.github/workflows/forge-unstable.yaml
@@ -4,6 +4,8 @@ name: Continuous Forge Tests - Unstable
 permissions:
   issues: write
   pull-requests: write
+  contents: read
+  id-token: write
 
 on:
   # Allow triggering manually

--- a/.github/workflows/forge-unstable.yaml
+++ b/.github/workflows/forge-unstable.yaml
@@ -64,7 +64,7 @@ jobs:
           ref: ${{ steps.determine-test-branch.outputs.BRANCH }}
           fetch-depth: 0
 
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-execute-devnet-main.yaml
+++ b/.github/workflows/fullnode-execute-devnet-main.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-execute-devnet-stable.yaml
+++ b/.github/workflows/fullnode-execute-devnet-stable.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-fast-mainnet-main.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-main.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-fast-mainnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-stable.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-fast-testnet-main.yaml
+++ b/.github/workflows/fullnode-fast-testnet-main.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-fast-testnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-testnet-stable.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-intelligent-devnet-main.yaml
+++ b/.github/workflows/fullnode-intelligent-devnet-main.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 

--- a/.github/workflows/fullnode-output-mainnet-main.yaml
+++ b/.github/workflows/fullnode-output-mainnet-main.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/check-aptos-core
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: true
 


### PR DESCRIPTION
### Description

Canary for https://github.com/aptos-labs/aptos-core/pull/6726, to check the perms for cancelling workflows already in flight

### Test Plan
Forge stable `determine-test-metadata` step should be cancelled

<!-- Please provide us with clear details for verifying that your changes work. -->
