### PR TITLE
Disable protoc dev dependencies in dev_setup.

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -147,7 +147,7 @@ function install_protoc {
   )
   rm -rf "$TMPFILE"
 
-  # TODO(larry): uncomment when unstream issue is resolved.
+  # TODO(larry): uncomment when upstream issue is resolved.
   # # Install the cargo plugins
   # if ! command -v protoc-gen-prost &> /dev/null; then
   #   cargo install protoc-gen-prost

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -147,16 +147,17 @@ function install_protoc {
   )
   rm -rf "$TMPFILE"
 
-  # Install the cargo plugins
-  if ! command -v protoc-gen-prost &> /dev/null; then
-    cargo install protoc-gen-prost
-  fi
-  if ! command -v protoc-gen-prost-serde &> /dev/null; then
-    cargo install protoc-gen-prost-serde
-  fi
-  if ! command -v protoc-gen-prost-crate &> /dev/null; then
-    cargo install protoc-gen-prost-crate
-  fi
+  # TODO(larry): uncomment when unstream issue is resolved.
+  # # Install the cargo plugins
+  # if ! command -v protoc-gen-prost &> /dev/null; then
+  #   cargo install protoc-gen-prost
+  # fi
+  # if ! command -v protoc-gen-prost-serde &> /dev/null; then
+  #   cargo install protoc-gen-prost-serde
+  # fi
+  # if ! command -v protoc-gen-prost-crate &> /dev/null; then
+  #   cargo install protoc-gen-prost-crate
+  # fi
 }
 
 function install_rustup {


### PR DESCRIPTION
### Description
* currently, `protoc-gen-prost` is broken from head; disable it right now since it's dev dependency.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

![image](https://user-images.githubusercontent.com/112209412/221024729-68bb3cdf-f4ec-4dcc-80fa-ceb2fa9906f6.png)

works on a fresh Ubuntu machine
