### PR TITLE
[gha] do not add addl permissions in forge reuse workflow

### DIFF
--- a/.github/workflows/workflow-run-forge.yaml
+++ b/.github/workflows/workflow-run-forge.yaml
@@ -92,9 +92,6 @@ jobs:
   forge:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.TIMEOUT_MINUTES }}
-    permissions:
-      issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:


### PR DESCRIPTION
### Description

Use the permissions passed in via the workflow that invokes `.github/workflows/workflow-run-forge.yaml`, e.g. `.github/workflows/docker-build-test.yaml`

### Test Plan

Forge still works on this PR

<!-- Please provide us with clear details for verifying that your changes work. -->
