### PR TITLE
[mergify] make framework upgrade test land-blocking

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -19,6 +19,7 @@ pull_request_rules:
               - check-success=rust-smoke-test
               - check-success=forge-e2e-test / forge
               - check-success=forge-compat-test / forge
+              - check-success=forge-framework-upgrade-test / forge
               - check-success=sdk-release / test-sdk-confirm-client-generated-publish
               - check-success=rust-images / rust-all
           - and:


### PR DESCRIPTION
### Description

Make the new forge framework upgrade test land-blocking. The test has been running since https://github.com/aptos-labs/aptos-core/pull/6638 landed, but has not been land-blocking

### Test Plan

Tests on this PR. Test takes roughly the same amount of time as the rest

<img width="315" alt="image" src="https://user-images.githubusercontent.com/12578616/221093517-5055ae4d-2e9a-48dd-b478-ef66f8581f21.png">


<!-- Please provide us with clear details for verifying that your changes work. -->
