### PR TITLE
[gha] forge continuous summary & trigger on release branch push

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -83,6 +83,15 @@ jobs:
         # forge relies on the default and failpoints variants
         run: python3 testsuite/find_latest_image.py --variant failpoints --variant performance
 
+      - name: Write summary
+        run: |
+          IMAGE_TAG=${{ steps.determine-test-image-tag.outputs.IMAGE_TAG }}
+          BRANCH=${{ steps.determine-test-branch.outputs.BRANCH }}
+          if [ -n "${BRANCH}" ]; then
+            echo "BRANCH: [${BRANCH}](https://github.com/${{ github.repository }}/tree/${BRANCH})" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "IMAGE_TAG: [${IMAGE_TAG}](https://github.com/${{ github.repository }}/commit/${IMAGE_TAG})" >> $GITHUB_STEP_SUMMARY
+
   run-forge-three-region:
     if: ${{ github.event_name != 'pull_request' }}
     needs: determine-test-metadata

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -26,6 +26,9 @@ on:
   pull_request:
     paths:
       - ".github/workflows/forge-stable.yaml"
+  push:
+    branches:
+      - aptos-release-v* # the aptos release branches
 
 env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
@@ -57,6 +60,9 @@ jobs:
               echo "Unknown schedule: ${{ github.event.schedule }}"
               exit 1
             fi
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+              echo "Branch: ${{ github.ref_name }}"
+              echo "BRANCH=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           else
             echo "Using GIT_SHA"
             # on workflow_dispatch, this will simply use the inputs.GIT_SHA given (or the default)

--- a/.github/workflows/forge-unstable.yaml
+++ b/.github/workflows/forge-unstable.yaml
@@ -79,6 +79,15 @@ jobs:
         # forge relies on the default and failpoints variants
         run: python3 testsuite/find_latest_image.py --variant failpoints --variant performance
 
+      - name: Write summary
+        run: |
+          IMAGE_TAG=${{ steps.determine-test-image-tag.outputs.IMAGE_TAG }}
+          BRANCH=${{ steps.determine-test-branch.outputs.BRANCH }}
+          if [ -n "${BRANCH}" ]; then
+            echo "BRANCH: [${BRANCH}](https://github.com/${{ github.repository }}/tree/${BRANCH})" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "IMAGE_TAG: [${IMAGE_TAG}](https://github.com/${{ github.repository }}/commit/${IMAGE_TAG})" >> $GITHUB_STEP_SUMMARY
+
   forge-continuous:
     if: ${{ github.event_name != 'pull_request' }}
     needs: determine-test-metadata

--- a/.github/workflows/replay-verify.yaml
+++ b/.github/workflows/replay-verify.yaml
@@ -24,6 +24,9 @@ on:
       - "testsuite/replay_verify.py"
   schedule:
     - cron: "0 8,20 * * *"
+  push:
+    branches:
+      - aptos-release-v* # the aptos release branches
 
 # cancel redundant builds
 concurrency:


### PR DESCRIPTION
### Description

Write a job summary to each Forge Stable/Unstable job that includes the branch and image tag, which helps with determining which jobs are for which cadence. On the UI for scheduled workflows, Github will not show the ref it is running, because it only runs on the default `main` branch -- we change the branch based on the cadence via some special workflow logic. This makes it difficult to determine whether the workflow is for `main` or `quorum-store` branch. 
<img width="1276" alt="image" src="https://user-images.githubusercontent.com/12578616/221298117-c72369ae-a904-42ef-bc52-426349564582.png">


Also, start to run `forge-stable` and `replay-verify` (both testnet and mainnet) against push to new release branches `aptos-release-v*` e.g. #6768 

### Test Plan

CI

<!-- Please provide us with clear details for verifying that your changes work. -->
