### PR TITLE
[gha][forge] promote formerly unstable tests to stable

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -99,30 +99,7 @@ jobs:
           fi
           echo "IMAGE_TAG: [${IMAGE_TAG}](https://github.com/${{ github.repository }}/commit/${IMAGE_TAG})" >> $GITHUB_STEP_SUMMARY
 
-  run-forge-three-region:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-three-region
-      FORGE_RUNNER_DURATION_SECS: 1800
-      FORGE_TEST_SUITE: three_region_simulation
-      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
-
-  run-forge-three-region-different-node-speed:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-three-region-with-different-node-speed
-      FORGE_RUNNER_DURATION_SECS: 3600
-      FORGE_TEST_SUITE: three_region_simulation_with_different_node_speed
-      FORGE_ENABLE_FAILPOINTS: true
-      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
+  ### Performance Forge tests
 
   run-forge-consensus-stress-test:
     if: ${{ github.event_name != 'pull_request' }}
@@ -148,43 +125,6 @@ jobs:
       FORGE_TEST_SUITE: account_creation
       POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
 
-  run-forge-fullnode-reboot-stress-test:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-fullnode-reboot-stress
-      FORGE_RUNNER_DURATION_SECS: 1800
-      FORGE_TEST_SUITE: fullnode_reboot_stress_test
-      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
-
-  run-forge-state-sync-failures-catching-up-test:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-state-sync-failures-catching-up-test
-      FORGE_RUNNER_DURATION_SECS: 900
-      FORGE_TEST_SUITE: state_sync_failures_catching_up
-      FORGE_ENABLE_FAILPOINTS: true
-      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
-
-  run-forge-state-sync-perf-fullnode-apply-test:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-apply
-      FORGE_RUNNER_DURATION_SECS: 2400
-      FORGE_TEST_SUITE: state_sync_perf_fullnodes_apply_outputs
-      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
-
   run-forge-performance-test:
     if: ${{ github.event_name != 'pull_request' }}
     needs: determine-test-metadata
@@ -198,6 +138,32 @@ jobs:
       FORGE_ENABLE_PERFORMANCE: true
       POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
 
+  run-forge-single-vfn-perf:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-continuous-e2e-single-vfn
+      # Run for 8 minutes
+      FORGE_RUNNER_DURATION_SECS: 480
+      FORGE_TEST_SUITE: single_vfn_perf
+      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
+
+  run-forge-haproxy:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-haproxy
+      FORGE_RUNNER_DURATION_SECS: 600
+      FORGE_ENABLE_HAPROXY: true
+      FORGE_TEST_SUITE: land_blocking
+      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
+
+  ### Compatibility Forge tests
+
   run-forge-compat:
     if: ${{ github.event_name != 'pull_request' }}
     needs: determine-test-metadata
@@ -210,4 +176,130 @@ jobs:
       # This will upgrade from testnet branch to the latest main
       FORGE_TEST_SUITE: compat
       IMAGE_TAG: testnet
+      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
+
+  ### Chaos Forge tests
+
+  run-forge-three-region:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-three-region
+      FORGE_RUNNER_DURATION_SECS: 1800
+      FORGE_TEST_SUITE: three_region_simulation
+      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
+
+  run-forge-fullnode-reboot-stress-test:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-fullnode-reboot-stress
+      FORGE_RUNNER_DURATION_SECS: 1800
+      FORGE_TEST_SUITE: fullnode_reboot_stress_test
+      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
+
+  run-forge-network-partition-test:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-network-partition
+      # Run for 15 minutes
+      FORGE_RUNNER_DURATION_SECS: 900
+      FORGE_TEST_SUITE: network_partition
+      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
+
+  ### Changing working quorum Forge tests
+
+  run-forge-changing-working-quorum-test:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-changing-working-quorum-test
+      FORGE_RUNNER_DURATION_SECS: 1200
+      FORGE_TEST_SUITE: changing_working_quorum_test
+      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
+      FORGE_ENABLE_FAILPOINTS: true
+
+  run-forge-different-node-speed-and-reliability-test:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-different-node-speed-and-reliability-test
+      FORGE_RUNNER_DURATION_SECS: 900
+      FORGE_TEST_SUITE: different_node_speed_and_reliability_test
+      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
+      FORGE_ENABLE_FAILPOINTS: true
+
+  run-forge-changing-working-quorum-test-high-load:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-changing-working-quorum-test-high-load
+      FORGE_RUNNER_DURATION_SECS: 900
+      FORGE_TEST_SUITE: changing_working_quorum_test_high_load
+      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
+      FORGE_ENABLE_FAILPOINTS: true
+
+  ### State sync Forge tests
+
+  run-forge-state-sync-perf-validator-test:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-state-sync-perf-validator
+      # Run for 40 minutes
+      FORGE_RUNNER_DURATION_SECS: 2400
+      FORGE_TEST_SUITE: state_sync_perf_validators
+      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
+
+  run-forge-state-sync-perf-fullnode-execute-test:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-execute
+      # Run for 40 minutes
+      FORGE_RUNNER_DURATION_SECS: 2400
+      FORGE_TEST_SUITE: state_sync_perf_fullnodes_execute_transactions
+      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
+
+  run-forge-state-sync-perf-fullnode-fast-sync-test:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-fast-sync
+      # Run for 40 minutes
+      FORGE_RUNNER_DURATION_SECS: 2400
+      FORGE_TEST_SUITE: state_sync_perf_fullnodes_fast_sync
+      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
+
+  run-forge-state-sync-perf-fullnode-apply-test:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-apply
+      FORGE_RUNNER_DURATION_SECS: 2400
+      FORGE_TEST_SUITE: state_sync_perf_fullnodes_apply_outputs
       POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch

--- a/.github/workflows/forge-unstable.yaml
+++ b/.github/workflows/forge-unstable.yaml
@@ -46,7 +46,7 @@ jobs:
         id: determine-test-branch
         run: |
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            if [[ "${{ github.event.schedule }}" == "0 9 * * *" ]]; then
+            if [[ "${{ github.event.schedule }}" == "0 15 * * *" ]]; then
               echo "Branch: main"
               echo "BRANCH=main" >> $GITHUB_OUTPUT
             else
@@ -98,42 +98,6 @@ jobs:
       # This test suite is configured using the forge.py config test command
       FORGE_TEST_SUITE: continuous
 
-  run-forge-changing-working-quorum-test:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      FORGE_NAMESPACE: forge-changing-working-quorum-test
-      FORGE_RUNNER_DURATION_SECS: 1200
-      FORGE_TEST_SUITE: changing_working_quorum_test
-      POST_TO_SLACK: true
-      FORGE_ENABLE_FAILPOINTS: true
-
-  run-forge-changing-working-quorum-test-high-load:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      FORGE_NAMESPACE: forge-changing-working-quorum-test-high-load
-      FORGE_RUNNER_DURATION_SECS: 900
-      FORGE_TEST_SUITE: changing_working_quorum_test_high_load
-      POST_TO_SLACK: true
-      FORGE_ENABLE_FAILPOINTS: true
-
-  run-forge-different-node-speed-and-reliability-test:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      FORGE_NAMESPACE: forge-different-node-speed-and-reliability-test
-      FORGE_RUNNER_DURATION_SECS: 900
-      FORGE_TEST_SUITE: different_node_speed_and_reliability_test
-      POST_TO_SLACK: true
-      FORGE_ENABLE_FAILPOINTS: true
-
   run-forge-graceful-overload-test:
     if: ${{ github.event_name != 'pull_request' }}
     needs: determine-test-metadata
@@ -145,30 +109,6 @@ jobs:
       FORGE_TEST_SUITE: graceful_overload
       POST_TO_SLACK: true
 
-  run-forge-haproxy:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      FORGE_NAMESPACE: forge-haproxy
-      FORGE_RUNNER_DURATION_SECS: 600
-      FORGE_ENABLE_HAPROXY: true
-      FORGE_TEST_SUITE: land_blocking
-      POST_TO_SLACK: true
-
-  run-forge-network-partition-test:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      FORGE_NAMESPACE: forge-network-partition
-      # Run for 15 minutes
-      FORGE_RUNNER_DURATION_SECS: 900
-      FORGE_TEST_SUITE: network_partition
-      POST_TO_SLACK: true
-
   run-forge-nft-mint-test:
     if: ${{ github.event_name != 'pull_request' }}
     needs: determine-test-metadata
@@ -178,54 +118,6 @@ jobs:
       FORGE_NAMESPACE: forge-nft-mint-test
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: nft_mint
-      POST_TO_SLACK: true
-
-  run-forge-single-vfn-perf:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      FORGE_NAMESPACE: forge-continuous-e2e-single-vfn
-      # Run for 8 minutes
-      FORGE_RUNNER_DURATION_SECS: 480
-      FORGE_TEST_SUITE: single_vfn_perf
-      POST_TO_SLACK: true
-
-  run-forge-state-sync-perf-fullnode-execute-test:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-execute
-      # Run for 40 minutes
-      FORGE_RUNNER_DURATION_SECS: 2400
-      FORGE_TEST_SUITE: state_sync_perf_fullnodes_execute_transactions
-      POST_TO_SLACK: true
-
-  run-forge-state-sync-perf-fullnode-fast-sync-test:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-fast-sync
-      # Run for 40 minutes
-      FORGE_RUNNER_DURATION_SECS: 2400
-      FORGE_TEST_SUITE: state_sync_perf_fullnodes_fast_sync
-      POST_TO_SLACK: true
-
-  run-forge-state-sync-perf-validator-test:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      FORGE_NAMESPACE: forge-state-sync-perf-validator
-      # Run for 40 minutes
-      FORGE_RUNNER_DURATION_SECS: 2400
-      FORGE_TEST_SUITE: state_sync_perf_validators
       POST_TO_SLACK: true
 
   run-forge-state-sync-slow-processing-catching-up-test:
@@ -250,6 +142,32 @@ jobs:
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: twin_validator_test
       POST_TO_SLACK: true
+
+  run-forge-three-region-different-node-speed:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-three-region-with-different-node-speed
+      FORGE_RUNNER_DURATION_SECS: 3600
+      FORGE_TEST_SUITE: three_region_simulation_with_different_node_speed
+      FORGE_ENABLE_FAILPOINTS: true
+      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
+
+  run-forge-state-sync-failures-catching-up-test:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-state-sync-failures-catching-up-test
+      FORGE_RUNNER_DURATION_SECS: 900
+      FORGE_TEST_SUITE: state_sync_failures_catching_up
+      FORGE_ENABLE_FAILPOINTS: true
+      POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
 
   run-forge-validator-reboot-stress-test:
     if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
### Description

Some formerly "unstable" Forge tests are now stable. Promote them to stable, so that we use their signal for release. They will also be run on the `quorum-store` branch!

Also since the number of stable Forge tests is now 17 (higher than I remember!), we may need to start thinking of separating them out into dedicated workflows based on test type. This is because the maximum number of nested workflows in Github Actions is 20: https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations. We can create workflows such as `forge-stable-chaos`, `forge-stable-changing-quorum`, `forge-stable-performance`, etc to further categorize these tests. For now, I've left some comments to divide the existing tests into rough categories.

Based off of discussion: https://aptos-org.slack.com/archives/C03PKBQM2RY/p1676594096419339?thread_ts=1676592185.638859&cid=C03PKBQM2RY

### Test Plan

Let it bake in CI

Also, observing the success rate for each of those tests over the last:
* 7d: [humio link](https://cloud.us.humio.com/github/search?live=false&query=%23type%3Dgithub-event%20event_type%3Djob%20%7C%20github.job.conclusion%20!%3D%20cancelled%20github.job.conclusion%20!%3D%20skipped%20github.job.conclusion%20!%3D%20null%20github.workflow.head_branch%3Dmain%20github.job.name%3D%2F.*forge%24%2F%0A%7C%20elapsed%20%3A%3D%20(now()%20-%20%40timestamp)%20%2F%2024%20%2F%203600%20%2F%201000%0A%7C%20days_ago%20%3A%3D%20math%3Aceil(elapsed)%0A%7C%20case%20%7B%20github.job.conclusion%20%3D%20%22success%22%20%7C%20success%20%3A%3D%201%3B%0A%20%20%20%20%20%20%20%20%20*%20%7C%20success%20%3A%3D%200%3B%7D%20%0A%7C%20failure%20%3A%3D%201%20-%20success%0A%0A%7C%20case%20%7B%20days_ago%20%3D%201%20%7C%20success_1d%20%3A%3D%20success%3B%0A%20%20%20%20%20%20%20%20%20*%20%7C%20success_1d%20%3A%3D%200%3B%7D%20%0A%7C%20case%20%7B%20days_ago%20%3D%201%20%7C%20count_1d%20%3A%3D%201%3B%0A%20%20%20%20%20%20%20%20%20*%20%7C%20count_1d%20%3A%3D%200%3B%7D%20%0A%0A%7C%20case%20%7B%20days_ago%20%3C%3D%203%20%7C%20success_3d%20%3A%3D%20success%3B%0A%20%20%20%20%20%20%20%20%20*%20%7C%20success_3d%20%3A%3D%200%3B%7D%20%0A%7C%20case%20%7B%20days_ago%20%3C%3D%203%20%7C%20count_3d%20%3A%3D%201%3B%0A%20%20%20%20%20%20%20%20%20*%20%7C%20count_3d%20%3A%3D%200%3B%7D%20%0A%0A%7C%20case%20%7B%20days_ago%20%3E%203%20%7C%20success_before_3d%20%3A%3D%20success%3B%0A%20%20%20%20%20%20%20%20%20*%20%7C%20success_before_3d%20%3A%3D%200%3B%7D%20%0A%7C%20case%20%7B%20days_ago%20%3E%203%20%7C%20count_before_3d%20%3A%3D%201%3B%0A%20%20%20%20%20%20%20%20%20*%20%7C%20count_before_3d%20%3A%3D%200%3B%7D%20%0A%0A%7C%20groupBy(%5Bgithub.job.name%5D%2C%20function%3D%5Bcount(as%3Dcount)%2C%20sum(field%3Dfailure%2C%20as%3Dfailures)%2C%20avg(field%3Dsuccess%2C%20as%3Dsuccess_rate)%2C%20sum(success_1d%2C%20as%3Dcount_success_1d)%2C%20sum(count_1d%2C%20as%3Dcount_count_1d)%2C%20sum(success_3d%2C%20as%3Dcount_success_3d)%2C%20sum(count_3d%2C%20as%3Dcount_count_3d)%2C%20sum(success_before_3d%2C%20as%3Dcount_success_before_3d)%2C%20sum(count_before_3d%2C%20as%3Dcount_count_before_3d)%5D)%20%0A%7C%20success_rate_1d%20%3A%3D%20count_success_1d%20%2F%20count_count_1d%0A%7C%20success_rate_3d%20%3A%3D%20count_success_3d%20%2F%20count_count_3d%0A%7C%20success_rate_7d_to_4d%20%3A%3D%20count_success_before_3d%20%2F%20count_count_before_3d%0A%7C%20table(%5Bgithub.job.name%2C%20count%2C%20failures%2C%20success_rate%2C%20success_rate_7d_to_4d%2C%20success_rate_3d%2C%20success_rate_1d%5D%2C%20sortby%3D%5Bsuccess_rate_1d%2C%20success_rate_3d%2C%20success_rate%5D%2C%20reverse%3Dtrue)&start=7d&tz=America%2FLos_Angeles&widgetType=table-view_)
* 30d: [humio link](https://cloud.us.humio.com/github/search?live=false&query=%23type%3Dgithub-event%20event_type%3Djob%20%7C%20github.job.conclusion%20!%3D%20cancelled%20github.job.conclusion%20!%3D%20skipped%20github.job.conclusion%20!%3D%20null%20github.workflow.head_branch%3Dmain%20github.job.name%3D%2F.*forge%24%2F%0A%7C%20elapsed%20%3A%3D%20(now()%20-%20%40timestamp)%20%2F%2024%20%2F%203600%20%2F%201000%0A%7C%20days_ago%20%3A%3D%20math%3Aceil(elapsed)%0A%7C%20case%20%7B%20github.job.conclusion%20%3D%20%22success%22%20%7C%20success%20%3A%3D%201%3B%0A%20%20%20%20%20%20%20%20%20*%20%7C%20success%20%3A%3D%200%3B%7D%20%0A%7C%20failure%20%3A%3D%201%20-%20success%0A%0A%7C%20case%20%7B%20days_ago%20%3D%201%20%7C%20success_1d%20%3A%3D%20success%3B%0A%20%20%20%20%20%20%20%20%20*%20%7C%20success_1d%20%3A%3D%200%3B%7D%20%0A%7C%20case%20%7B%20days_ago%20%3D%201%20%7C%20count_1d%20%3A%3D%201%3B%0A%20%20%20%20%20%20%20%20%20*%20%7C%20count_1d%20%3A%3D%200%3B%7D%20%0A%0A%7C%20case%20%7B%20days_ago%20%3C%3D%203%20%7C%20success_3d%20%3A%3D%20success%3B%0A%20%20%20%20%20%20%20%20%20*%20%7C%20success_3d%20%3A%3D%200%3B%7D%20%0A%7C%20case%20%7B%20days_ago%20%3C%3D%203%20%7C%20count_3d%20%3A%3D%201%3B%0A%20%20%20%20%20%20%20%20%20*%20%7C%20count_3d%20%3A%3D%200%3B%7D%20%0A%0A%7C%20case%20%7B%20days_ago%20%3E%203%20%7C%20success_before_3d%20%3A%3D%20success%3B%0A%20%20%20%20%20%20%20%20%20*%20%7C%20success_before_3d%20%3A%3D%200%3B%7D%20%0A%7C%20case%20%7B%20days_ago%20%3E%203%20%7C%20count_before_3d%20%3A%3D%201%3B%0A%20%20%20%20%20%20%20%20%20*%20%7C%20count_before_3d%20%3A%3D%200%3B%7D%20%0A%0A%7C%20groupBy(%5Bgithub.job.name%5D%2C%20function%3D%5Bcount(as%3Dcount)%2C%20sum(field%3Dfailure%2C%20as%3Dfailures)%2C%20avg(field%3Dsuccess%2C%20as%3Dsuccess_rate)%2C%20sum(success_1d%2C%20as%3Dcount_success_1d)%2C%20sum(count_1d%2C%20as%3Dcount_count_1d)%2C%20sum(success_3d%2C%20as%3Dcount_success_3d)%2C%20sum(count_3d%2C%20as%3Dcount_count_3d)%2C%20sum(success_before_3d%2C%20as%3Dcount_success_before_3d)%2C%20sum(count_before_3d%2C%20as%3Dcount_count_before_3d)%5D)%20%0A%7C%20success_rate_1d%20%3A%3D%20count_success_1d%20%2F%20count_count_1d%0A%7C%20success_rate_3d%20%3A%3D%20count_success_3d%20%2F%20count_count_3d%0A%7C%20success_rate_7d_to_4d%20%3A%3D%20count_success_before_3d%20%2F%20count_count_before_3d%0A%7C%20table(%5Bgithub.job.name%2C%20count%2C%20failures%2C%20success_rate%2C%20success_rate_7d_to_4d%2C%20success_rate_3d%2C%20success_rate_1d%5D%2C%20sortby%3D%5Bsuccess_rate_1d%2C%20success_rate_3d%2C%20success_rate%5D%2C%20reverse%3Dtrue)&start=30d&tz=America%2FLos_Angeles&widgetType=table-view)

<!-- Please provide us with clear details for verifying that your changes work. -->
