### PR TITLE
[Network] Add client side of the peer monitoring service.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,6 +1950,7 @@ dependencies = [
  "aptos-network",
  "aptos-network-builder",
  "aptos-node-identity",
+ "aptos-peer-monitoring-service-client",
  "aptos-peer-monitoring-service-server",
  "aptos-peer-monitoring-service-types",
  "aptos-runtimes",
@@ -2088,11 +2089,21 @@ version = "0.1.0"
 dependencies = [
  "aptos-channels",
  "aptos-config",
+ "aptos-id-generator",
+ "aptos-infallible",
+ "aptos-logger",
+ "aptos-metrics-core",
  "aptos-network",
  "aptos-peer-monitoring-service-types",
+ "aptos-time-service",
  "aptos-types",
  "async-trait",
+ "enum_dispatch",
+ "futures",
+ "once_cell",
+ "serde 1.0.149",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -42,6 +42,7 @@ aptos-mempool-notifications = { workspace = true }
 aptos-network = { workspace = true }
 aptos-network-builder = { workspace = true }
 aptos-node-identity = { workspace = true }
+aptos-peer-monitoring-service-client = { workspace = true }
 aptos-peer-monitoring-service-server = { workspace = true }
 aptos-peer-monitoring-service-types = { workspace = true }
 aptos-runtimes = { workspace = true }

--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -156,6 +156,10 @@ impl fmt::Display for NetworkId {
 const VFN_NETWORK: &str = "vfn";
 
 impl NetworkId {
+    pub fn is_public_network(&self) -> bool {
+        self == &NetworkId::Public
+    }
+
     pub fn is_vfn_network(&self) -> bool {
         self == &NetworkId::Vfn
     }

--- a/crates/aptos-id-generator/src/lib.rs
+++ b/crates/aptos-id-generator/src/lib.rs
@@ -44,7 +44,7 @@ impl IdGenerator<u32> for U32IdGenerator {
 }
 
 /// A generic in order [`IdGenerator`] using an [`AtomicU64`] to guarantee uniqueness
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct U64IdGenerator {
     inner: AtomicU64,
 }

--- a/network/peer-monitoring-service/client/Cargo.toml
+++ b/network/peer-monitoring-service/client/Cargo.toml
@@ -15,8 +15,18 @@ rust-version = { workspace = true }
 [dependencies]
 aptos-channels = { workspace = true }
 aptos-config = { workspace = true }
+aptos-id-generator = { workspace = true }
+aptos-infallible = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-metrics-core = { workspace = true }
 aptos-network = { workspace = true }
 aptos-peer-monitoring-service-types = { workspace = true }
+aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
 async-trait = { workspace = true }
+enum_dispatch = { workspace = true }
+futures = { workspace = true }
+once_cell = { workspace = true }
+serde = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }

--- a/network/peer-monitoring-service/client/src/error.rs
+++ b/network/peer-monitoring-service/client/src/error.rs
@@ -1,0 +1,45 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_network::protocols::network::RpcError;
+use aptos_peer_monitoring_service_types::{PeerMonitoringServiceError, UnexpectedResponseError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Network error: {0}")]
+    NetworkError(String),
+
+    #[error("Error from remote monitoring service: {0}")]
+    PeerMonitoringServiceError(#[from] PeerMonitoringServiceError),
+
+    #[error("Aptos network rpc error: {0}")]
+    RpcError(#[from] RpcError),
+
+    #[error("Unexpected error encountered: {0}")]
+    UnexpectedError(String),
+}
+
+impl Error {
+    /// Returns a summary label for the error
+    pub fn get_label(&self) -> &'static str {
+        match self {
+            Self::NetworkError(_) => "network_error",
+            Self::PeerMonitoringServiceError(_) => "peer_monitoring_service_error",
+            Self::RpcError(_) => "rpc_error",
+            Self::UnexpectedError(_) => "unexpected_error",
+        }
+    }
+}
+
+impl From<aptos_network::application::error::Error> for Error {
+    fn from(error: aptos_network::application::error::Error) -> Self {
+        Error::NetworkError(error.to_string())
+    }
+}
+
+impl From<UnexpectedResponseError> for Error {
+    fn from(error: UnexpectedResponseError) -> Self {
+        Error::UnexpectedError(error.to_string())
+    }
+}

--- a/network/peer-monitoring-service/client/src/lib.rs
+++ b/network/peer-monitoring-service/client/src/lib.rs
@@ -3,77 +3,204 @@
 
 #![forbid(unsafe_code)]
 
-use aptos_config::network_id::PeerNetworkId;
-use aptos_network::{
-    application::{interface::NetworkClientInterface, storage::PeersAndMetadata},
-    protocols::network::{NetworkClientConfig, RpcError},
-    ProtocolId,
+use crate::logging::{LogEntry, LogEvent, LogSchema};
+use aptos_config::{
+    config::{NodeConfig, PeerMonitoringServiceConfig},
+    network_id::PeerNetworkId,
 };
-use aptos_peer_monitoring_service_types::{
-    PeerMonitoringServiceError, PeerMonitoringServiceMessage, PeerMonitoringServiceRequest,
-    PeerMonitoringServiceResponse,
+use aptos_id_generator::U64IdGenerator;
+use aptos_infallible::RwLock;
+use aptos_logger::{info, warn};
+use aptos_network::application::{
+    interface::NetworkClient, metadata::PeerMonitoringMetadata, storage::PeersAndMetadata,
 };
-use std::{sync::Arc, time::Duration};
+use aptos_peer_monitoring_service_types::PeerMonitoringServiceMessage;
+use aptos_time_service::{TimeService, TimeServiceTrait};
+use error::Error;
+use futures::StreamExt;
+use network::PeerMonitoringServiceClient;
+use peer_states::peer_state::PeerState;
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use thiserror::Error;
+use tokio::{runtime::Handle, task::JoinHandle};
 
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Network error: {0}")]
-    NetworkError(String),
+mod error;
+mod logging;
+mod metrics;
+mod network;
+mod peer_states;
 
-    #[error("Aptos network rpc error: {0}")]
-    RpcError(#[from] RpcError),
-
-    #[error("Error from remote monitoring service: {0}")]
-    PeerMonitoringServiceError(#[from] PeerMonitoringServiceError),
+/// A simple container that holds the state of the peer monitor
+#[derive(Clone, Debug, Default)]
+pub struct PeerMonitorState {
+    peer_states: Arc<RwLock<HashMap<PeerNetworkId, PeerState>>>, // Map of peers to states
+    request_id_generator: Arc<U64IdGenerator>, // Used for generating request/response IDs
 }
 
-/// The interface for sending peer monitoring service requests and querying
-/// peer information.
-#[derive(Clone, Debug)]
-pub struct PeerMonitoringServiceClient<NetworkClient> {
-    network_client: NetworkClient,
-}
-
-impl<NetworkClient: NetworkClientInterface<PeerMonitoringServiceMessage>>
-    PeerMonitoringServiceClient<NetworkClient>
-{
-    pub fn new(network_client: NetworkClient) -> Self {
-        Self { network_client }
-    }
-
-    pub async fn send_request(
-        &self,
-        recipient: PeerNetworkId,
-        request: PeerMonitoringServiceRequest,
-        timeout: Duration,
-    ) -> Result<PeerMonitoringServiceResponse, Error> {
-        let response = self
-            .network_client
-            .send_to_peer_rpc(
-                PeerMonitoringServiceMessage::Request(request),
-                timeout,
-                recipient,
-            )
-            .await
-            .map_err(|error| Error::NetworkError(error.to_string()))?;
-        match response {
-            PeerMonitoringServiceMessage::Response(Ok(response)) => Ok(response),
-            PeerMonitoringServiceMessage::Response(Err(err)) => {
-                Err(Error::PeerMonitoringServiceError(err))
-            },
-            PeerMonitoringServiceMessage::Request(_) => {
-                Err(Error::RpcError(RpcError::InvalidRpcResponse))
-            },
+impl PeerMonitorState {
+    pub fn new() -> Self {
+        Self {
+            peer_states: Arc::new(RwLock::new(HashMap::new())),
+            request_id_generator: Arc::new(U64IdGenerator::new()),
         }
     }
+}
 
-    pub fn get_peers_and_metadata(&self) -> Arc<PeersAndMetadata> {
-        self.network_client.get_peers_and_metadata()
+/// Runs the peer monitor that continuously monitors
+/// the state of the peers.
+pub async fn start_peer_monitor(
+    node_config: NodeConfig,
+    network_client: NetworkClient<PeerMonitoringServiceMessage>,
+    time_service: TimeService,
+    runtime: Option<Handle>,
+) {
+    // Create a new client and peer monitor state
+    let peer_monitoring_client = PeerMonitoringServiceClient::new(network_client);
+    let peer_monitor_state = PeerMonitorState::new();
+
+    // Get the peers and metadata struct
+    let peers_and_metadata = peer_monitoring_client.get_peers_and_metadata();
+
+    // Spawns the updater for the peers and metadata
+    let peer_monitoring_config = node_config.peer_monitoring_service.clone();
+    spawn_peer_metadata_updater(
+        peer_monitoring_config.clone(),
+        peer_monitor_state.clone(),
+        peers_and_metadata.clone(),
+        time_service.clone(),
+        runtime.clone(),
+    );
+
+    // Create an interval ticker for the monitor loop
+    let peer_monitor_duration =
+        Duration::from_millis(peer_monitoring_config.peer_monitor_interval_ms);
+    let peer_monitor_ticker = time_service.interval(peer_monitor_duration);
+    futures::pin_mut!(peer_monitor_ticker);
+
+    // Start the peer monitoring loop
+    info!(LogSchema::new(LogEntry::PeerMonitorLoop)
+        .event(LogEvent::StartedPeerMonitorLoop)
+        .message("Starting the peer monitor!"));
+    loop {
+        // Wait for the next round before pinging peers
+        peer_monitor_ticker.next().await;
+
+        // Get all connected peers
+        let connected_peers_and_metadata =
+            match peers_and_metadata.get_connected_peers_and_metadata() {
+                Ok(connected_peers_and_metadata) => connected_peers_and_metadata,
+                Err(error) => {
+                    warn!(LogSchema::new(LogEntry::PeerMonitorLoop)
+                        .event(LogEvent::UnexpectedErrorEncountered)
+                        .error(&error.into())
+                        .message("Failed to get connected peers and metadata!"));
+                    continue; // Move to the next loop iteration
+                },
+            };
+
+        // Ensure all peers have a state (and create one for newly connected peers)
+        for peer_network_id in connected_peers_and_metadata.keys() {
+            let state_exists = peer_monitor_state
+                .peer_states
+                .read()
+                .contains_key(peer_network_id);
+            if !state_exists {
+                peer_monitor_state.peer_states.write().insert(
+                    *peer_network_id,
+                    PeerState::new(node_config.clone(), time_service.clone()),
+                );
+            }
+        }
+
+        // Refresh the peer states
+        if let Err(error) = peer_states::refresh_peer_states(
+            peer_monitor_state.clone(),
+            peer_monitoring_client.clone(),
+            connected_peers_and_metadata,
+            time_service.clone(),
+            runtime.clone(),
+        ) {
+            warn!(LogSchema::new(LogEntry::PeerMonitorLoop)
+                .event(LogEvent::UnexpectedErrorEncountered)
+                .error(&error)
+                .message("Failed to refresh peer states!"));
+        }
     }
 }
 
-/// Returns a network application config for the peer monitoring client
-pub fn peer_monitoring_client_network_config() -> NetworkClientConfig {
-    NetworkClientConfig::new(vec![ProtocolId::PeerMonitoringServiceRpc], vec![])
+/// Spawns a task that continuously updates the peers and metadata
+/// struct with the latest information stored for each peer.
+fn spawn_peer_metadata_updater(
+    peer_monitoring_config: PeerMonitoringServiceConfig,
+    peer_monitor_state: PeerMonitorState,
+    peers_and_metadata: Arc<PeersAndMetadata>,
+    time_service: TimeService,
+    runtime: Option<Handle>,
+) -> JoinHandle<()> {
+    // Create the updater task for the peers and metadata struct
+    let metadata_updater = async move {
+        // Create an interval ticker for the updater loop
+        let metadata_update_loop_duration =
+            Duration::from_millis(peer_monitoring_config.metadata_update_interval_ms);
+        let metadata_update_loop_ticker = time_service.interval(metadata_update_loop_duration);
+        futures::pin_mut!(metadata_update_loop_ticker);
+
+        // Start the updater loop
+        info!(LogSchema::new(LogEntry::MetadataUpdateLoop)
+            .event(LogEvent::StartedMetadataUpdaterLoop)
+            .message("Starting the peers and metadata updater!"));
+        loop {
+            // Wait for the next round before updating peers and metadata
+            metadata_update_loop_ticker.next().await;
+
+            // Get all peers
+            let all_peers = match peers_and_metadata.get_all_peers() {
+                Ok(all_peers) => all_peers,
+                Err(error) => {
+                    warn!(LogSchema::new(LogEntry::MetadataUpdateLoop)
+                        .event(LogEvent::UnexpectedErrorEncountered)
+                        .error(&error.into())
+                        .message("Failed to get all peers!"));
+                    continue; // Move to the next loop iteration
+                },
+            };
+
+            // Update the latest peer monitoring metadata
+            for peer_network_id in all_peers {
+                let peer_monitoring_metadata =
+                    match peer_monitor_state.peer_states.read().get(&peer_network_id) {
+                        Some(peer_state) => {
+                            peer_state
+                                .extract_peer_monitoring_metadata()
+                                .unwrap_or_else(|error| {
+                                    // Log the error and return the default
+                                    warn!(LogSchema::new(LogEntry::MetadataUpdateLoop)
+                                        .event(LogEvent::UnexpectedErrorEncountered)
+                                        .peer(&peer_network_id)
+                                        .error(&error));
+                                    PeerMonitoringMetadata::default()
+                                })
+                        },
+                        None => PeerMonitoringMetadata::default(), // Use the default
+                    };
+
+                // Insert the latest peer monitoring metadata into peers and metadata
+                if let Err(error) = peers_and_metadata
+                    .update_peer_monitoring_metadata(peer_network_id, peer_monitoring_metadata)
+                {
+                    warn!(LogSchema::new(LogEntry::MetadataUpdateLoop)
+                        .event(LogEvent::UnexpectedErrorEncountered)
+                        .peer(&peer_network_id)
+                        .error(&error.into()));
+                }
+            }
+        }
+    };
+
+    // Spawn the peer metadata updater task
+    if let Some(runtime) = runtime {
+        runtime.spawn(metadata_updater)
+    } else {
+        tokio::spawn(metadata_updater)
+    }
 }

--- a/network/peer-monitoring-service/client/src/logging.rs
+++ b/network/peer-monitoring-service/client/src/logging.rs
@@ -1,0 +1,62 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Error;
+use aptos_config::network_id::PeerNetworkId;
+use aptos_logger::Schema;
+use aptos_peer_monitoring_service_types::PeerMonitoringServiceRequest;
+use serde::Serialize;
+
+#[derive(Schema)]
+pub struct LogSchema<'a> {
+    name: LogEntry,
+    #[schema(debug)]
+    error: Option<&'a Error>,
+    event: Option<LogEvent>,
+    message: Option<&'a str>,
+    #[schema(display)]
+    peer: Option<&'a PeerNetworkId>,
+    #[schema(debug)]
+    request: Option<&'a PeerMonitoringServiceRequest>,
+    request_id: Option<u64>,
+    request_type: Option<&'a str>,
+}
+
+impl<'a> LogSchema<'a> {
+    pub fn new(name: LogEntry) -> Self {
+        Self {
+            name,
+            error: None,
+            event: None,
+            message: None,
+            peer: None,
+            request: None,
+            request_id: None,
+            request_type: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LogEntry {
+    LatencyPing,
+    MetadataUpdateLoop,
+    NetworkInfoRequest,
+    PeerMonitorLoop,
+    SendRequest,
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LogEvent {
+    InvalidResponse,
+    PeerPingError,
+    ResponseError,
+    ResponseSuccess,
+    SendRequest,
+    StartedMetadataUpdaterLoop,
+    StartedPeerMonitorLoop,
+    TooManyPingFailures,
+    UnexpectedErrorEncountered,
+}

--- a/network/peer-monitoring-service/client/src/metrics.rs
+++ b/network/peer-monitoring-service/client/src/metrics.rs
@@ -1,0 +1,98 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_config::network_id::PeerNetworkId;
+use aptos_metrics_core::{
+    register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, HistogramVec,
+    IntCounterVec, IntGaugeVec,
+};
+use once_cell::sync::Lazy;
+
+/// The special label TOTAL_COUNT stores the sum of all values in the counter
+pub const TOTAL_COUNT_LABEL: &str = "TOTAL_COUNT";
+
+/// Counter for tracking sent requests
+pub static SENT_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "peer_monitoring_client_sent_requests",
+        "Counters related to sent requests",
+        &["request_types", "network"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking success responses
+pub static SUCCESS_RESPONSES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "peer_monitoring_client_success_responses",
+        "Counters related to success responses",
+        &["response_type", "network"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking error responses
+pub static ERROR_RESPONSES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "peer_monitoring_client_error_responses",
+        "Counters related to error responses",
+        &["response_type", "network"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking request latencies
+pub static REQUEST_LATENCIES: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "peer_monitoring_client_request_latencies",
+        "Counters related to request latencies",
+        &["request_type", "network"]
+    )
+    .unwrap()
+});
+
+/// Gauge for tracking the number of in-flight requests
+pub static IN_FLIGHT_REQUESTS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "peer_monitoring_client_in_flight_requests",
+        "Gauge related to the number of in-flight requests",
+        &["request_type"]
+    )
+    .unwrap()
+});
+
+/// Updates the metrics for the number of in-flight requests
+pub fn update_in_flight_requests(request_label: &str, num_in_flight_requests: u64) {
+    set_gauge(&IN_FLIGHT_REQUESTS, request_label, num_in_flight_requests);
+}
+
+/// Increments the given request counter with the provided values
+pub fn increment_request_counter(
+    counter: &Lazy<IntCounterVec>,
+    label: &str,
+    peer_network_id: &PeerNetworkId,
+) {
+    let network = peer_network_id.network_id();
+    counter.with_label_values(&[label, network.as_str()]).inc();
+    counter
+        .with_label_values(&[TOTAL_COUNT_LABEL, network.as_str()])
+        .inc();
+}
+
+/// Sets the gauge with the specific label and value
+pub fn set_gauge(counter: &Lazy<IntGaugeVec>, label: &str, value: u64) {
+    counter.with_label_values(&[label]).set(value as i64);
+}
+
+/// Observes the value for the provided histogram and label values
+pub fn observe_value(
+    histogram: &Lazy<HistogramVec>,
+    request_label: &str,
+    peer_network_id: &PeerNetworkId,
+    value: f64,
+) {
+    let network = peer_network_id.network_id();
+    histogram
+        .with_label_values(&[request_label, network.as_str()])
+        .observe(value)
+}

--- a/network/peer-monitoring-service/client/src/network.rs
+++ b/network/peer-monitoring-service/client/src/network.rs
@@ -1,0 +1,132 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    logging::{LogEntry, LogEvent, LogSchema},
+    metrics, Error,
+};
+use aptos_config::network_id::PeerNetworkId;
+use aptos_logger::{trace, warn};
+use aptos_network::application::{
+    interface::{NetworkClient, NetworkClientInterface},
+    storage::PeersAndMetadata,
+};
+use aptos_peer_monitoring_service_types::{
+    PeerMonitoringServiceMessage, PeerMonitoringServiceRequest, PeerMonitoringServiceResponse,
+};
+use std::{sync::Arc, time::Duration};
+
+/// The interface for sending peer monitoring service requests
+/// and querying peer information.
+#[derive(Clone, Debug)]
+pub struct PeerMonitoringServiceClient<NetworkClient> {
+    network_client: NetworkClient,
+}
+
+impl<NetworkClient: NetworkClientInterface<PeerMonitoringServiceMessage>>
+    PeerMonitoringServiceClient<NetworkClient>
+{
+    pub fn new(network_client: NetworkClient) -> Self {
+        Self { network_client }
+    }
+
+    /// Sends an RPC request to the specified peer with the given timeout
+    pub async fn send_request(
+        &self,
+        recipient: PeerNetworkId,
+        request: PeerMonitoringServiceRequest,
+        timeout: Duration,
+    ) -> Result<PeerMonitoringServiceResponse, Error> {
+        let response = self
+            .network_client
+            .send_to_peer_rpc(
+                PeerMonitoringServiceMessage::Request(request),
+                timeout,
+                recipient,
+            )
+            .await
+            .map_err(|error| Error::NetworkError(error.to_string()))?;
+        match response {
+            PeerMonitoringServiceMessage::Response(Ok(response)) => Ok(response),
+            PeerMonitoringServiceMessage::Response(Err(err)) => {
+                Err(Error::PeerMonitoringServiceError(err))
+            },
+            PeerMonitoringServiceMessage::Request(request) => Err(Error::NetworkError(format!(
+                "Got peer monitoring request instead of response! Request: {:?}",
+                request
+            ))),
+        }
+    }
+
+    /// Returns the peers and metadata struct
+    pub fn get_peers_and_metadata(&self) -> Arc<PeersAndMetadata> {
+        self.network_client.get_peers_and_metadata()
+    }
+}
+
+/// Sends a request to a specific peer
+pub async fn send_request_to_peer(
+    peer_monitoring_client: PeerMonitoringServiceClient<
+        NetworkClient<PeerMonitoringServiceMessage>,
+    >,
+    peer_network_id: &PeerNetworkId,
+    request_id: u64,
+    request: PeerMonitoringServiceRequest,
+    request_timeout_ms: u64,
+) -> Result<PeerMonitoringServiceResponse, Error> {
+    trace!(
+        (LogSchema::new(LogEntry::SendRequest)
+            .event(LogEvent::SendRequest)
+            .request_type(request.get_label())
+            .request_id(request_id)
+            .peer(peer_network_id)
+            .request(&request))
+    );
+    metrics::increment_request_counter(
+        &metrics::SENT_REQUESTS,
+        request.get_label(),
+        peer_network_id,
+    );
+
+    // Send the request and process the result
+    let result = peer_monitoring_client
+        .send_request(
+            *peer_network_id,
+            request,
+            Duration::from_millis(request_timeout_ms),
+        )
+        .await;
+    match result {
+        Ok(response) => {
+            trace!(
+                (LogSchema::new(LogEntry::SendRequest)
+                    .event(LogEvent::ResponseSuccess)
+                    .request_type(request.get_label())
+                    .request_id(request_id)
+                    .peer(peer_network_id))
+            );
+            metrics::increment_request_counter(
+                &metrics::SUCCESS_RESPONSES,
+                request.get_label(),
+                peer_network_id,
+            );
+            Ok(response)
+        },
+        Err(error) => {
+            warn!(
+                (LogSchema::new(LogEntry::SendRequest)
+                    .event(LogEvent::ResponseError)
+                    .request_type(request.get_label())
+                    .request_id(request_id)
+                    .peer(peer_network_id)
+                    .error(&error))
+            );
+            metrics::increment_request_counter(
+                &metrics::ERROR_RESPONSES,
+                error.get_label(),
+                peer_network_id,
+            );
+            Err(error)
+        },
+    }
+}

--- a/network/peer-monitoring-service/client/src/peer_states/key_value.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/key_value.rs
@@ -1,0 +1,104 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    peer_states::{
+        latency_info::LatencyInfoState, network_info::NetworkInfoState,
+        request_tracker::RequestTracker,
+    },
+    Error,
+};
+use aptos_config::{config::NodeConfig, network_id::PeerNetworkId};
+use aptos_infallible::RwLock;
+use aptos_network::application::metadata::PeerMetadata;
+use aptos_peer_monitoring_service_types::{
+    LatencyPingRequest, PeerMonitoringServiceRequest, PeerMonitoringServiceResponse,
+};
+use aptos_time_service::TimeService;
+use enum_dispatch::enum_dispatch;
+use std::sync::Arc;
+
+/// A simple enum representing the different types of
+/// states held for each peer.
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
+pub enum PeerStateKey {
+    LatencyInfo,
+    NetworkInfo,
+}
+
+impl PeerStateKey {
+    /// A utility function for getting all peer state keys
+    pub fn get_all_keys() -> Vec<PeerStateKey> {
+        vec![PeerStateKey::LatencyInfo, PeerStateKey::NetworkInfo]
+    }
+
+    // TODO: Can we avoid exposing this label construction here?
+    /// Returns the metric label for the requests sent by the peer state key
+    pub fn get_metrics_request_label(&self) -> &str {
+        match self {
+            PeerStateKey::LatencyInfo => {
+                PeerMonitoringServiceRequest::LatencyPing(LatencyPingRequest { ping_counter: 0 })
+                    .get_label()
+            },
+            PeerStateKey::NetworkInfo => {
+                PeerMonitoringServiceRequest::GetNetworkInformation.get_label()
+            },
+        }
+    }
+}
+
+/// The interface offered by all peer state value types
+#[enum_dispatch]
+pub trait StateValueInterface {
+    /// Creates the monitoring service request
+    fn create_monitoring_service_request(&mut self) -> PeerMonitoringServiceRequest;
+
+    /// Returns the request timeout (ms)
+    fn get_request_timeout_ms(&self) -> u64;
+
+    /// Returns the request tracker
+    fn get_request_tracker(&self) -> Arc<RwLock<RequestTracker>>;
+
+    /// Handles the monitoring service response
+    fn handle_monitoring_service_response(
+        &mut self,
+        peer_network_id: &PeerNetworkId,
+        peer_metadata: PeerMetadata,
+        monitoring_service_request: PeerMonitoringServiceRequest,
+        monitoring_service_response: PeerMonitoringServiceResponse,
+        response_time_secs: f64,
+    );
+
+    /// Handles a monitoring service error
+    fn handle_monitoring_service_response_error(
+        &self,
+        peer_network_id: &PeerNetworkId,
+        error: Error,
+    );
+}
+
+/// A simple enum representing the different types of
+/// states values for each peer.
+#[enum_dispatch(StateValueInterface)]
+#[derive(Clone, Debug)]
+pub enum PeerStateValue {
+    LatencyInfoState,
+    NetworkInfoState,
+}
+
+impl PeerStateValue {
+    pub fn new(
+        node_config: NodeConfig,
+        time_service: TimeService,
+        peer_state_key: &PeerStateKey,
+    ) -> Self {
+        match peer_state_key {
+            PeerStateKey::LatencyInfo => {
+                let latency_monitoring_config =
+                    node_config.peer_monitoring_service.latency_monitoring;
+                LatencyInfoState::new(latency_monitoring_config, time_service).into()
+            },
+            PeerStateKey::NetworkInfo => NetworkInfoState::new(node_config, time_service).into(),
+        }
+    }
+}

--- a/network/peer-monitoring-service/client/src/peer_states/latency_info.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/latency_info.rs
@@ -1,0 +1,191 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    peer_states::{key_value::StateValueInterface, request_tracker::RequestTracker},
+    Error, LogEntry, LogEvent, LogSchema,
+};
+use aptos_config::{config::LatencyMonitoringConfig, network_id::PeerNetworkId};
+use aptos_infallible::RwLock;
+use aptos_logger::{error, warn};
+use aptos_network::application::metadata::PeerMetadata;
+use aptos_peer_monitoring_service_types::{
+    LatencyPingRequest, PeerMonitoringServiceRequest, PeerMonitoringServiceResponse,
+};
+use aptos_time_service::TimeService;
+use std::{collections::BTreeMap, sync::Arc};
+
+/// A simple container that holds a peer's latency info
+#[derive(Clone, Debug)]
+pub struct LatencyInfoState {
+    latency_monitoring_config: LatencyMonitoringConfig, // The config for latency monitoring
+    latency_ping_counter: u64, // The monotonically increasing counter for each ping
+    recorded_latency_ping_durations_secs: BTreeMap<u64, f64>, // Successful ping durations by counter (secs)
+    request_tracker: Arc<RwLock<RequestTracker>>, // The request tracker for latency ping requests
+}
+
+impl LatencyInfoState {
+    pub fn new(
+        latency_monitoring_config: LatencyMonitoringConfig,
+        time_service: TimeService,
+    ) -> Self {
+        let request_tracker = RequestTracker::new(
+            latency_monitoring_config.latency_ping_interval_ms,
+            time_service,
+        );
+
+        Self {
+            latency_monitoring_config,
+            latency_ping_counter: 0,
+            recorded_latency_ping_durations_secs: BTreeMap::new(),
+            request_tracker: Arc::new(RwLock::new(request_tracker)),
+        }
+    }
+
+    /// Returns the current latency ping counter and increments it internally
+    pub fn get_and_increment_latency_ping_counter(&mut self) -> u64 {
+        let latency_ping_counter = self.latency_ping_counter;
+        self.latency_ping_counter += 1;
+        latency_ping_counter
+    }
+
+    /// Handles a ping failure for the specified peer
+    fn handle_request_failure(&self, peer_network_id: &PeerNetworkId) {
+        // Update the number of ping failures for the request tracker
+        self.request_tracker.write().record_response_failure();
+
+        // TODO: If the number of ping failures is too high, disconnect from the node
+        let num_consecutive_failures = self.request_tracker.read().get_num_consecutive_failures();
+        if num_consecutive_failures >= self.latency_monitoring_config.max_latency_ping_failures {
+            warn!(LogSchema::new(LogEntry::LatencyPing)
+                .event(LogEvent::TooManyPingFailures)
+                .peer(peer_network_id)
+                .message("Too many ping failures occurred for the peer!"));
+        }
+    }
+
+    /// Records the new latency ping entry for the peer and resets the
+    /// consecutive failure counter.
+    pub fn record_new_latency_and_reset_failures(
+        &mut self,
+        latency_ping_counter: u64,
+        latency_ping_time_secs: f64,
+    ) {
+        // Update the request tracker with a successful response
+        self.request_tracker.write().record_response_success();
+
+        // Save the latency ping time
+        self.recorded_latency_ping_durations_secs
+            .insert(latency_ping_counter, latency_ping_time_secs);
+
+        // Perform garbage collection on the recorded latency pings
+        let max_num_latency_pings_to_retain = self
+            .latency_monitoring_config
+            .max_num_latency_pings_to_retain;
+        if self.recorded_latency_ping_durations_secs.len() > max_num_latency_pings_to_retain {
+            // We only need to pop a single element because insertion only happens in this method.
+            // Thus, the size can only ever grow to be 1 greater than the max.
+            let _ = self.recorded_latency_ping_durations_secs.pop_first();
+        }
+    }
+
+    /// Returns the average latency ping in seconds. If no latency
+    /// pings have been recorded, None is returned.
+    pub fn get_average_latency_ping_secs(&self) -> Option<f64> {
+        let num_latency_pings = self.recorded_latency_ping_durations_secs.len();
+        if num_latency_pings > 0 {
+            let average_latency_secs_sum: f64 =
+                self.recorded_latency_ping_durations_secs.values().sum();
+            Some(average_latency_secs_sum / num_latency_pings as f64)
+        } else {
+            None
+        }
+    }
+}
+
+impl StateValueInterface for LatencyInfoState {
+    fn create_monitoring_service_request(&mut self) -> PeerMonitoringServiceRequest {
+        let ping_counter = self.get_and_increment_latency_ping_counter();
+        PeerMonitoringServiceRequest::LatencyPing(LatencyPingRequest { ping_counter })
+    }
+
+    fn get_request_timeout_ms(&self) -> u64 {
+        self.latency_monitoring_config.latency_ping_timeout_ms
+    }
+
+    fn get_request_tracker(&self) -> Arc<RwLock<RequestTracker>> {
+        self.request_tracker.clone()
+    }
+
+    fn handle_monitoring_service_response(
+        &mut self,
+        peer_network_id: &PeerNetworkId,
+        _peer_metadata: PeerMetadata,
+        monitoring_service_request: PeerMonitoringServiceRequest,
+        monitoring_service_response: PeerMonitoringServiceResponse,
+        response_time_secs: f64,
+    ) {
+        // Verify the request type is correctly formed
+        let latency_ping_request = match monitoring_service_request {
+            PeerMonitoringServiceRequest::LatencyPing(latency_ping_request) => latency_ping_request,
+            request => {
+                error!(LogSchema::new(LogEntry::LatencyPing)
+                    .event(LogEvent::UnexpectedErrorEncountered)
+                    .peer(peer_network_id)
+                    .request(&request)
+                    .message("An unexpected request was sent instead of a latency ping!"));
+                self.handle_request_failure(peer_network_id);
+                return;
+            },
+        };
+
+        // Verify the response type is valid
+        let latency_ping_response = match monitoring_service_response {
+            PeerMonitoringServiceResponse::LatencyPing(latency_ping_response) => {
+                latency_ping_response
+            },
+            _ => {
+                warn!(LogSchema::new(LogEntry::LatencyPing)
+                    .event(LogEvent::ResponseError)
+                    .peer(peer_network_id)
+                    .message("An unexpected response was received instead of a latency ping!"));
+                self.handle_request_failure(peer_network_id);
+                return;
+            },
+        };
+
+        // Verify the latency ping response contains the correct counter
+        let request_ping_counter = latency_ping_request.ping_counter;
+        let response_ping_counter = latency_ping_response.ping_counter;
+        if request_ping_counter != response_ping_counter {
+            warn!(LogSchema::new(LogEntry::LatencyPing)
+                .event(LogEvent::PeerPingError)
+                .peer(peer_network_id)
+                .message(&format!(
+                    "Peer responded with the incorrect ping counter! Expected: {:?}, found: {:?}",
+                    request_ping_counter, response_ping_counter
+                )));
+            self.handle_request_failure(peer_network_id);
+            return;
+        }
+
+        // Store the new latency ping result
+        self.record_new_latency_and_reset_failures(request_ping_counter, response_time_secs);
+    }
+
+    fn handle_monitoring_service_response_error(
+        &self,
+        peer_network_id: &PeerNetworkId,
+        error: Error,
+    ) {
+        // Handle the failure
+        self.handle_request_failure(peer_network_id);
+
+        // Log the error
+        warn!(LogSchema::new(LogEntry::LatencyPing)
+            .event(LogEvent::ResponseError)
+            .message("Error encountered when pinging peer!")
+            .peer(peer_network_id)
+            .error(&error));
+    }
+}

--- a/network/peer-monitoring-service/client/src/peer_states/mod.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/mod.rs
@@ -1,0 +1,89 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{metrics, Error, PeerMonitorState, PeerMonitoringServiceClient, PeerState};
+use aptos_config::network_id::PeerNetworkId;
+use aptos_network::application::{interface::NetworkClient, metadata::PeerMetadata};
+use aptos_peer_monitoring_service_types::PeerMonitoringServiceMessage;
+use aptos_time_service::TimeService;
+use key_value::PeerStateKey;
+use std::collections::HashMap;
+use tokio::runtime::Handle;
+
+mod key_value;
+mod latency_info;
+mod network_info;
+pub mod peer_state;
+mod request_tracker;
+
+/// Refreshes the states of the connected peers
+pub fn refresh_peer_states(
+    peer_monitor_state: PeerMonitorState,
+    peer_monitoring_client: PeerMonitoringServiceClient<
+        NetworkClient<PeerMonitoringServiceMessage>,
+    >,
+    connected_peers_and_metadata: HashMap<PeerNetworkId, PeerMetadata>,
+    time_service: TimeService,
+    runtime: Option<Handle>,
+) -> Result<(), Error> {
+    // Process all state entries (in order) and update the ones that
+    // need to be refreshed for each peer.
+    for peer_state_key in PeerStateKey::get_all_keys() {
+        let mut num_in_flight_requests = 0;
+
+        // Go through all connected peers and see if we should refresh the state
+        for (peer_network_id, peer_metadata) in &connected_peers_and_metadata {
+            // Get the peer state
+            let peer_state = get_peer_state(&peer_monitor_state, peer_network_id)?;
+
+            // If there's an-flight request, update the metrics counter
+            let request_tracker = peer_state.get_request_tracker(&peer_state_key)?;
+            if request_tracker.read().in_flight_request() {
+                num_in_flight_requests += 1;
+            }
+
+            // Update the state if it needs to be refreshed
+            let should_refresh_peer_state_key = request_tracker.read().new_request_required();
+            if should_refresh_peer_state_key {
+                peer_state.refresh_peer_state_key(
+                    &peer_state_key,
+                    peer_monitoring_client.clone(),
+                    *peer_network_id,
+                    peer_metadata.clone(),
+                    peer_monitor_state.request_id_generator.clone(),
+                    time_service.clone(),
+                    runtime.clone(),
+                )?;
+            }
+        }
+
+        // Update the in-flight request metrics
+        update_in_flight_metrics(peer_state_key, num_in_flight_requests);
+    }
+
+    Ok(())
+}
+
+/// Returns the peer state for the given peer
+fn get_peer_state(
+    peer_monitor_state: &PeerMonitorState,
+    peer_network_id: &PeerNetworkId,
+) -> Result<PeerState, Error> {
+    let peer_state = peer_monitor_state
+        .peer_states
+        .read()
+        .get(peer_network_id)
+        .cloned();
+    peer_state.ok_or_else(|| {
+        Error::UnexpectedError(format!(
+            "Failed to find the peer state. This shouldn't happen! Peer: {:?}",
+            peer_network_id
+        ))
+    })
+}
+
+/// Updates the in-flight metrics for on-going requests
+fn update_in_flight_metrics(peer_state_key: PeerStateKey, num_in_flight_requests: u64) {
+    let request_label = peer_state_key.get_metrics_request_label();
+    metrics::update_in_flight_requests(request_label, num_in_flight_requests);
+}

--- a/network/peer-monitoring-service/client/src/peer_states/network_info.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/network_info.rs
@@ -1,0 +1,171 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    peer_states::{key_value::StateValueInterface, request_tracker::RequestTracker},
+    Error, LogEntry, LogEvent, LogSchema,
+};
+use aptos_config::{
+    config::{BaseConfig, NetworkMonitoringConfig, NodeConfig, RoleType},
+    network_id::PeerNetworkId,
+};
+use aptos_infallible::RwLock;
+use aptos_logger::warn;
+use aptos_network::application::metadata::PeerMetadata;
+use aptos_peer_monitoring_service_types::{
+    NetworkInformationResponse, PeerMonitoringServiceRequest, PeerMonitoringServiceResponse,
+    MAX_DISTANCE_FROM_VALIDATORS,
+};
+use aptos_time_service::TimeService;
+use std::sync::Arc;
+
+/// A simple container that holds a single peer's network info
+#[derive(Clone, Debug)]
+pub struct NetworkInfoState {
+    base_config: BaseConfig, // The base config of this node
+    network_monitoring_config: NetworkMonitoringConfig, // The config for network monitoring
+    recorded_network_info_response: Option<NetworkInformationResponse>, // The last network info response
+    request_tracker: Arc<RwLock<RequestTracker>>, // The request tracker for network info requests
+}
+
+impl NetworkInfoState {
+    pub fn new(node_config: NodeConfig, time_service: TimeService) -> Self {
+        let base_config = node_config.base;
+        let network_monitoring_config = node_config.peer_monitoring_service.network_monitoring;
+        let request_tracker = RequestTracker::new(
+            network_monitoring_config.network_info_request_interval_ms,
+            time_service,
+        );
+
+        Self {
+            base_config,
+            network_monitoring_config,
+            recorded_network_info_response: None,
+            request_tracker: Arc::new(RwLock::new(request_tracker)),
+        }
+    }
+
+    /// Records the new network info response for the peer
+    pub fn record_network_info_response(
+        &mut self,
+        mut network_info_response: NetworkInformationResponse,
+        peer_network_id: &PeerNetworkId,
+        peer_metadata: PeerMetadata,
+    ) {
+        // Update the request tracker with a successful response
+        self.request_tracker.write().record_response_success();
+
+        // Sanity check the response depth from the peer metadata
+        let network_id = peer_network_id.network_id();
+        let is_valid_depth = match network_info_response.distance_from_validators {
+            0 => {
+                // Verify the peer is a validator and has the correct network id
+                let peer_is_validator = peer_metadata.get_connection_metadata().role.is_validator();
+                let peer_has_correct_network = match self.base_config.role {
+                    RoleType::Validator => network_id.is_validator_network(), // We're a validator
+                    RoleType::FullNode => network_id.is_vfn_network(),        // We're a VFN
+                };
+                peer_is_validator && peer_has_correct_network
+            },
+            1 => {
+                // Verify the peer is a VFN and has the correct network id
+                let peer_is_vfn = peer_metadata.get_connection_metadata().role.is_vfn();
+                let peer_has_correct_network = match self.base_config.role {
+                    RoleType::Validator => network_id.is_vfn_network(), // We're a validator
+                    RoleType::FullNode => network_id.is_public_network(), // We're a PFN
+                };
+                peer_is_vfn && peer_has_correct_network
+            },
+            distance_from_validators => {
+                // The depth must be less than or equal to the max
+                distance_from_validators <= MAX_DISTANCE_FROM_VALIDATORS
+            },
+        };
+
+        // If the depth did not pass our sanity checks, store the max
+        if !is_valid_depth {
+            warn!(LogSchema::new(LogEntry::NetworkInfoRequest)
+                .event(LogEvent::InvalidResponse)
+                .peer(peer_network_id)
+                .message(&format!(
+                    "Peer returned invalid depth from validators: {}",
+                    network_info_response.distance_from_validators
+                )));
+            network_info_response.distance_from_validators = MAX_DISTANCE_FROM_VALIDATORS;
+        }
+
+        // Save the network info
+        self.recorded_network_info_response = Some(network_info_response);
+    }
+
+    /// Handles a request failure for the specified peer
+    fn handle_request_failure(&self) {
+        // Update the number of ping failures for the request tracker
+        self.request_tracker.write().record_response_failure();
+    }
+
+    /// Returns the latest network info response
+    pub fn get_latest_network_info_response(&self) -> Option<NetworkInformationResponse> {
+        self.recorded_network_info_response.clone()
+    }
+}
+
+impl StateValueInterface for NetworkInfoState {
+    fn create_monitoring_service_request(&mut self) -> PeerMonitoringServiceRequest {
+        PeerMonitoringServiceRequest::GetNetworkInformation
+    }
+
+    fn get_request_timeout_ms(&self) -> u64 {
+        self.network_monitoring_config
+            .network_info_request_timeout_ms
+    }
+
+    fn get_request_tracker(&self) -> Arc<RwLock<RequestTracker>> {
+        self.request_tracker.clone()
+    }
+
+    fn handle_monitoring_service_response(
+        &mut self,
+        peer_network_id: &PeerNetworkId,
+        peer_metadata: PeerMetadata,
+        _monitoring_service_request: PeerMonitoringServiceRequest,
+        monitoring_service_response: PeerMonitoringServiceResponse,
+        _response_time_secs: f64,
+    ) {
+        // Verify the response type is valid
+        let network_info_response = match monitoring_service_response {
+            PeerMonitoringServiceResponse::NetworkInformation(network_information_response) => {
+                network_information_response
+            },
+            _ => {
+                warn!(LogSchema::new(LogEntry::NetworkInfoRequest)
+                    .event(LogEvent::ResponseError)
+                    .peer(peer_network_id)
+                    .message(
+                        "An unexpected response was received instead of a network info response!"
+                    ));
+                self.handle_request_failure();
+                return;
+            },
+        };
+
+        // Store the new latency ping result
+        self.record_network_info_response(network_info_response, peer_network_id, peer_metadata);
+    }
+
+    fn handle_monitoring_service_response_error(
+        &self,
+        peer_network_id: &PeerNetworkId,
+        error: Error,
+    ) {
+        // Record the failure
+        self.request_tracker.write().record_response_failure();
+
+        // Log the error
+        warn!(LogSchema::new(LogEntry::NetworkInfoRequest)
+            .event(LogEvent::ResponseError)
+            .message("Error encountered when requesting network information from the peer!")
+            .peer(peer_network_id)
+            .error(&error));
+    }
+}

--- a/network/peer-monitoring-service/client/src/peer_states/peer_state.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/peer_state.rs
@@ -1,0 +1,213 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    metrics, network,
+    peer_states::{
+        key_value::{PeerStateKey, PeerStateValue, StateValueInterface},
+        latency_info::LatencyInfoState,
+        network_info::NetworkInfoState,
+        request_tracker::RequestTracker,
+    },
+    Error, PeerMonitoringServiceClient,
+};
+use aptos_config::{config::NodeConfig, network_id::PeerNetworkId};
+use aptos_id_generator::{IdGenerator, U64IdGenerator};
+use aptos_infallible::RwLock;
+use aptos_network::application::{
+    interface::NetworkClient,
+    metadata::{PeerMetadata, PeerMonitoringMetadata},
+};
+use aptos_peer_monitoring_service_types::PeerMonitoringServiceMessage;
+use aptos_time_service::{TimeService, TimeServiceTrait};
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use tokio::{runtime::Handle, task::JoinHandle};
+
+#[derive(Clone, Debug)]
+pub struct PeerState {
+    state_entries: Arc<RwLock<HashMap<PeerStateKey, Arc<RwLock<PeerStateValue>>>>>, // The state entries for the peer
+}
+
+impl PeerState {
+    pub fn new(node_config: NodeConfig, time_service: TimeService) -> Self {
+        // Create a state entry for each peer state key
+        let state_entries = Arc::new(RwLock::new(HashMap::new()));
+        for peer_state_key in PeerStateKey::get_all_keys() {
+            let peer_state_value =
+                PeerStateValue::new(node_config.clone(), time_service.clone(), &peer_state_key);
+            state_entries
+                .write()
+                .insert(peer_state_key, Arc::new(RwLock::new(peer_state_value)));
+        }
+
+        Self { state_entries }
+    }
+
+    /// Returns the request tracker for the given peer state key
+    pub fn get_request_tracker(
+        &self,
+        peer_state_key: &PeerStateKey,
+    ) -> Result<Arc<RwLock<RequestTracker>>, Error> {
+        self.get_peer_state_value(peer_state_key)
+            .map(|peer_state_value| peer_state_value.read().get_request_tracker())
+    }
+
+    /// Refreshes the peer state key by sending a request to the peer
+    pub fn refresh_peer_state_key(
+        &self,
+        peer_state_key: &PeerStateKey,
+        peer_monitoring_client: PeerMonitoringServiceClient<
+            NetworkClient<PeerMonitoringServiceMessage>,
+        >,
+        peer_network_id: PeerNetworkId,
+        peer_metadata: PeerMetadata,
+        request_id_generator: Arc<U64IdGenerator>,
+        time_service: TimeService,
+        runtime: Option<Handle>,
+    ) -> Result<JoinHandle<()>, Error> {
+        // Mark the request as having started. We do this here to prevent
+        // the monitor loop from selecting the same peer state key concurrently.
+        let request_tracker = self.get_request_tracker(peer_state_key)?;
+        request_tracker.write().request_started();
+
+        // Create the monitoring service request for the peer
+        let peer_state_value = self.get_peer_state_value(peer_state_key)?;
+        let monitoring_service_request =
+            peer_state_value.write().create_monitoring_service_request();
+
+        // Get the timeout for the request
+        let request_timeout_ms = peer_state_value.read().get_request_timeout_ms();
+
+        // Create the request task
+        let request_task = async move {
+            // Start the request timer
+            let start_time = time_service.now();
+
+            // Send the request to the peer and wait for a response
+            let request_id = request_id_generator.next();
+            let monitoring_service_response = network::send_request_to_peer(
+                peer_monitoring_client,
+                &peer_network_id,
+                request_id,
+                monitoring_service_request,
+                request_timeout_ms,
+            )
+            .await;
+
+            // Stop the timer and calculate the duration
+            let finish_time = time_service.now();
+            let request_duration: Duration = finish_time.duration_since(start_time);
+            let request_duration_secs = request_duration.as_secs_f64();
+
+            // Mark the in-flight request as now complete
+            request_tracker.write().request_completed();
+
+            // Process any response errors
+            let monitoring_service_response = match monitoring_service_response {
+                Ok(monitoring_service_response) => monitoring_service_response,
+                Err(error) => {
+                    peer_state_value
+                        .write()
+                        .handle_monitoring_service_response_error(&peer_network_id, error);
+                    return;
+                },
+            };
+
+            // Handle the monitoring service response
+            peer_state_value.write().handle_monitoring_service_response(
+                &peer_network_id,
+                peer_metadata,
+                monitoring_service_request,
+                monitoring_service_response,
+                request_duration_secs,
+            );
+
+            // Update the latency ping metrics
+            metrics::observe_value(
+                &metrics::REQUEST_LATENCIES,
+                monitoring_service_request.get_label(),
+                &peer_network_id,
+                request_duration_secs,
+            );
+        };
+
+        // Spawn the request task
+        let join_handle = if let Some(runtime) = runtime {
+            runtime.spawn(request_task)
+        } else {
+            tokio::spawn(request_task)
+        };
+
+        Ok(join_handle)
+    }
+
+    /// Extracts peer monitoring metadata from the overall peer state
+    pub fn extract_peer_monitoring_metadata(&self) -> Result<PeerMonitoringMetadata, Error> {
+        // Create an empty metadata entry for the peer
+        let mut peer_monitoring_metadata = PeerMonitoringMetadata::default();
+
+        // Get and store the average latency ping
+        let latency_info_state = self.get_latency_info_state()?;
+        let average_latency_ping_secs = latency_info_state.get_average_latency_ping_secs();
+        peer_monitoring_metadata.average_ping_latency_secs = average_latency_ping_secs;
+
+        // Get and store the depth from the validators
+        let network_info_state = self.get_network_info_state()?;
+        let network_info_response = network_info_state.get_latest_network_info_response();
+        let distance_from_validators = network_info_response
+            .as_ref()
+            .map(|network_info_response| network_info_response.distance_from_validators);
+        peer_monitoring_metadata.distance_from_validators = distance_from_validators;
+
+        // Get and store the connected peers and metadata
+        let connected_peers_and_metadata = network_info_response
+            .map(|network_info_response| network_info_response.connected_peers_and_metadata);
+        peer_monitoring_metadata.connected_peers_and_metadata = connected_peers_and_metadata;
+
+        Ok(peer_monitoring_metadata)
+    }
+
+    /// Returns the peer state value associated with the given key
+    fn get_peer_state_value(
+        &self,
+        peer_state_key: &PeerStateKey,
+    ) -> Result<Arc<RwLock<PeerStateValue>>, Error> {
+        let peer_state_value = self.state_entries.read().get(peer_state_key).cloned();
+        peer_state_value.ok_or_else(|| {
+            Error::UnexpectedError(format!(
+                "Failed to find the peer state value for the peer state key: {:?} This shouldn't happen!",
+                peer_state_key
+            ))
+        })
+    }
+
+    /// Returns a copy of the latency ping state
+    fn get_latency_info_state(&self) -> Result<LatencyInfoState, Error> {
+        let peer_state_value = self
+            .get_peer_state_value(&PeerStateKey::LatencyInfo)?
+            .read()
+            .clone();
+        match peer_state_value {
+            PeerStateValue::LatencyInfoState(latency_info_state) => Ok(latency_info_state),
+            peer_state_value => Err(Error::UnexpectedError(format!(
+                "Invalid peer state value found! Expected latency_info_state but got: {:?}",
+                peer_state_value
+            ))),
+        }
+    }
+
+    /// Returns a copy of the network info state
+    fn get_network_info_state(&self) -> Result<NetworkInfoState, Error> {
+        let peer_state_value = self
+            .get_peer_state_value(&PeerStateKey::NetworkInfo)?
+            .read()
+            .clone();
+        match peer_state_value {
+            PeerStateValue::NetworkInfoState(network_info_state) => Ok(network_info_state),
+            peer_state_value => Err(Error::UnexpectedError(format!(
+                "Invalid peer state value found! Expected network_info_state but got: {:?}",
+                peer_state_value
+            ))),
+        }
+    }
+}

--- a/network/peer-monitoring-service/client/src/peer_states/request_tracker.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/request_tracker.rs
@@ -1,0 +1,82 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_time_service::{TimeService, TimeServiceTrait};
+use std::{
+    ops::Add,
+    time::{Duration, Instant},
+};
+
+/// A simple container that tracks request and response states
+#[derive(Clone, Debug)]
+pub struct RequestTracker {
+    in_flight_request: bool, // If there is a request currently in-flight
+    last_response_time: Option<Instant>, // The most recent response time
+    num_consecutive_request_failures: u64, // The number of consecutive request failures
+    request_interval_ms: u64, // The interval (ms) between requests
+    time_service: TimeService, // The time service to use for duration calculation
+}
+
+impl RequestTracker {
+    pub fn new(request_interval_ms: u64, time_service: TimeService) -> Self {
+        Self {
+            in_flight_request: false,
+            last_response_time: None,
+            num_consecutive_request_failures: 0,
+            request_interval_ms,
+            time_service,
+        }
+    }
+
+    /// Returns the number of consecutive failures
+    pub fn get_num_consecutive_failures(&self) -> u64 {
+        self.num_consecutive_request_failures
+    }
+
+    /// Returns true iff there is a request currently in-flight
+    pub fn in_flight_request(&self) -> bool {
+        self.in_flight_request
+    }
+
+    /// Updates the state to mark a request as having started
+    pub fn request_started(&mut self) {
+        self.in_flight_request = true;
+    }
+
+    /// Updates the state to mark a request as having completed
+    pub fn request_completed(&mut self) {
+        self.in_flight_request = false;
+    }
+
+    /// Returns true iff a new request should be sent (based
+    /// on the latest response time).
+    pub fn new_request_required(&self) -> bool {
+        // There's already an in-flight request. A new one should not be sent.
+        if self.in_flight_request() {
+            return false;
+        }
+
+        // Otherwise, check the last response time for freshness
+        match self.last_response_time {
+            Some(last_response_time) => {
+                self.time_service.now()
+                    > last_response_time.add(Duration::from_millis(self.request_interval_ms))
+            },
+            None => true, // A request should be sent immediately
+        }
+    }
+
+    /// Records a successful response for the request
+    pub fn record_response_success(&mut self) {
+        // Update the last response time
+        self.last_response_time = Some(self.time_service.now());
+
+        // Reset the number of consecutive failures
+        self.num_consecutive_request_failures = 0;
+    }
+
+    /// Records a failure for the request
+    pub fn record_response_failure(&mut self) {
+        self.num_consecutive_request_failures += 1;
+    }
+}

--- a/network/peer-monitoring-service/server/src/lib.rs
+++ b/network/peer-monitoring-service/server/src/lib.rs
@@ -15,7 +15,7 @@ use aptos_network::{application::storage::PeersAndMetadata, ProtocolId};
 use aptos_peer_monitoring_service_types::{
     LatencyPingRequest, LatencyPingResponse, NetworkInformationResponse,
     PeerMonitoringServiceError, PeerMonitoringServiceRequest, PeerMonitoringServiceResponse,
-    Result, ServerProtocolVersionResponse,
+    Result, ServerProtocolVersionResponse, MAX_DISTANCE_FROM_VALIDATORS,
 };
 use error::Error;
 use futures::stream::StreamExt;
@@ -32,7 +32,6 @@ mod tests;
 
 /// Peer monitoring server constants
 pub const PEER_MONITORING_SERVER_VERSION: u64 = 1;
-const MAX_DISTANCE_FROM_VALIDATORS: u64 = 100; // Nodes that aren't connected to the network
 
 /// The server-side actor for the peer monitoring service
 pub struct PeerMonitoringServiceServer {

--- a/network/peer-monitoring-service/types/src/lib.rs
+++ b/network/peer-monitoring-service/types/src/lib.rs
@@ -11,6 +11,9 @@ use thiserror::Error;
 
 pub type Result<T, E = PeerMonitoringServiceError> = ::std::result::Result<T, E>;
 
+/// Useful global constants
+pub const MAX_DISTANCE_FROM_VALIDATORS: u64 = 100; // Nodes that aren't connected to the network
+
 /// An error that can be returned to the client on a failure to
 /// process a request.
 #[derive(Clone, Debug, Deserialize, Error, PartialEq, Eq, Serialize)]

--- a/network/src/application/metadata.rs
+++ b/network/src/application/metadata.rs
@@ -103,7 +103,7 @@ impl PeerMetadata {
     }
 
     /// Returns a copy of the connection metadata
-    pub fn get_connection_medata(&self) -> ConnectionMetadata {
+    pub fn get_connection_metadata(&self) -> ConnectionMetadata {
         self.connection_metadata.clone()
     }
 

--- a/network/src/application/storage.rs
+++ b/network/src/application/storage.rs
@@ -53,6 +53,22 @@ impl PeersAndMetadata {
         Arc::new(peers_and_metadata)
     }
 
+    /// Returns all peers. Note: this will return disconnected and unhealthy peers, so
+    /// it is not recommended for applications to use this interface. Instead,
+    /// `get_connected_peers_and_metadata()` should be used.
+    pub fn get_all_peers(&self) -> Result<Vec<PeerNetworkId>, Error> {
+        let mut all_peers = Vec::new();
+        for network_id in self.get_registered_networks() {
+            let peer_metadata_for_network = self.get_peer_metadata_for_network(&network_id)?;
+            for (peer_id, _) in peer_metadata_for_network.read().iter() {
+                let peer_network_id = PeerNetworkId::new(network_id, *peer_id);
+                all_peers.push(peer_network_id);
+            }
+        }
+
+        Ok(all_peers)
+    }
+
     /// Returns all connected peers that support at least one of
     /// the given protocols.
     pub fn get_connected_supported_peers(

--- a/state-sync/aptos-data-client/src/aptosnet/state.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/state.rs
@@ -268,7 +268,7 @@ impl PeerStates {
         // PFNs should only prioritize outbound connections (this targets seed peers and VFNs)
         match self.peers_and_metadata.get_metadata_for_peer(*peer) {
             Ok(peer_metadata) => {
-                if peer_metadata.get_connection_medata().origin == ConnectionOrigin::Outbound {
+                if peer_metadata.get_connection_metadata().origin == ConnectionOrigin::Outbound {
                     return true;
                 }
             },

--- a/state-sync/storage-service/client/src/lib.rs
+++ b/state-sync/storage-service/client/src/lib.rs
@@ -28,8 +28,8 @@ pub enum Error {
     StorageServiceError(#[from] StorageServiceError),
 }
 
-/// The interface for sending Storage Service requests and querying network peer
-/// information.
+/// The interface for sending Storage Service requests and
+/// querying network peer information.
 #[derive(Clone, Debug)]
 pub struct StorageServiceClient<NetworkClient> {
     network_client: NetworkClient,

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -679,7 +679,7 @@ async fn test_validator_failure_bootstrap_execution() {
 
 /// A helper method that tests that all validators can sync after a failure and
 /// continue to stay up-to-date.
-async fn test_all_validator_failures(mut swarm: LocalSwarm) {
+pub async fn test_all_validator_failures(mut swarm: LocalSwarm) {
     // Execute multiple transactions through validator 0
     let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
     let validator_0 = validator_peer_ids[0];


### PR DESCRIPTION
Note:
- This PR relates to: https://github.com/aptos-labs/aptos-core/issues/6789.
- The structure of the peer monitoring client is very similar to that of the Aptos Data Client, so 70% of this PR is just boilerplate.

### Description
This PR adds a basic framework for the client side of the peer monitoring service. Specifically, it:
- Adds configs for the peer monitoring client. The client is disabled by default.
- Adds a peer monitor loop, which loops over all connected peers and refreshes the state for each peer.
- Adds the state refresher loop, which goes through all types of states and sends out network requests to refresh those states if they're stale. At the moment we only track two state types: (i) latency info; and (ii) network info.
- Adds basic support for structured logging and metrics.
- Adds a very simple smoke test that enables the peer monitoring client and verifies nothing breaks.

Given the size of this PR, I'm going to follow up with unit tests in a separate PR.

### Test Plan
Existing testing infrastructure.