### PR TITLE
[gha] run on push to aptos-node-v branches

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -29,6 +29,7 @@ on:
   push:
     branches:
       - aptos-release-v* # the aptos release branches
+      - aptos-node-v*
 
 env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}

--- a/.github/workflows/replay-verify.yaml
+++ b/.github/workflows/replay-verify.yaml
@@ -27,6 +27,7 @@ on:
   push:
     branches:
       - aptos-release-v* # the aptos release branches
+      - aptos-node-v*
 
 # cancel redundant builds
 concurrency:


### PR DESCRIPTION
### Description

Run Forge and replay-verify to `aptos-node-v*` branches as well as the newer `aptos-release-v*` branches.
This keeps the support for existing branches

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
