### PR TITLE
[gha] fix replay-verify run on push & only cancel scheduled workflows

### DIFF
--- a/.github/workflows/copy-images-to-dockerhub-nightly.yaml
+++ b/.github/workflows/copy-images-to-dockerhub-nightly.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
-          cancel-workflow: true
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
 
   copy-images-to-dockerhub:
     needs: check-repo

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
-          cancel-workflow: true
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
 
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4
 

--- a/.github/workflows/forge-unstable.yaml
+++ b/.github/workflows/forge-unstable.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
-          cancel-workflow: true
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
 
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4
 

--- a/.github/workflows/fullnode-execute-devnet-main.yaml
+++ b/.github/workflows/fullnode-execute-devnet-main.yaml
@@ -7,9 +7,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0,12 * * *" # At hour 0 and 12 - aka twice a day (UTC)
-  pull_request:
-    paths:
-      - ".github/workflows/fullnode-execute-devnet-main.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/fullnode-execute-devnet-main.yaml
+++ b/.github/workflows/fullnode-execute-devnet-main.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
-          cancel-workflow: true
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
 
   fullnode-execute-devnet-main:
     needs: check-repo

--- a/.github/workflows/fullnode-execute-devnet-stable.yaml
+++ b/.github/workflows/fullnode-execute-devnet-stable.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
-          cancel-workflow: true
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
 
   fullnode-execute-devnet-stable:
     needs: check-repo

--- a/.github/workflows/fullnode-execute-devnet-stable.yaml
+++ b/.github/workflows/fullnode-execute-devnet-stable.yaml
@@ -7,9 +7,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0,12 * * *" # At hour 0 and 12 - aka twice a day (UTC)
-  pull_request:
-    paths:
-      - ".github/workflows/fullnode-execute-devnet-stable.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/fullnode-fast-mainnet-main.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-main.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
-          cancel-workflow: true
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
 
   fullnode-fast-mainnet-main:
     needs: check-repo

--- a/.github/workflows/fullnode-fast-mainnet-main.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-main.yaml
@@ -7,9 +7,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0,12 * * *" # At hour 0 and 12 - aka twice a day (UTC)
-  pull_request:
-    paths:
-      - ".github/workflows/fullnode-fast-mainnet-main.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/fullnode-fast-mainnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-stable.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
-          cancel-workflow: true
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
 
   fullnode-fast-mainnet-stable:
     needs: check-repo

--- a/.github/workflows/fullnode-fast-mainnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-stable.yaml
@@ -7,9 +7,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0,12 * * *" # At hour 0 and 12 - aka twice a day (UTC)
-  pull_request:
-    paths:
-      - ".github/workflows/fullnode-fast-mainnet-stable.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/fullnode-fast-testnet-main.yaml
+++ b/.github/workflows/fullnode-fast-testnet-main.yaml
@@ -7,9 +7,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0,12 * * *" # At hour 0 and 12 - aka twice a day (UTC)
-  pull_request:
-    paths:
-      - ".github/workflows/fullnode-fast-testnet-main.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/fullnode-fast-testnet-main.yaml
+++ b/.github/workflows/fullnode-fast-testnet-main.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
-          cancel-workflow: true
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
 
   fullnode-fast-testnet-main:
     needs: check-repo

--- a/.github/workflows/fullnode-fast-testnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-testnet-stable.yaml
@@ -7,9 +7,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0,12 * * *" # At hour 0 and 12 - aka twice a day (UTC)
-  pull_request:
-    paths:
-      - ".github/workflows/fullnode-fast-testnet-stable.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/fullnode-fast-testnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-testnet-stable.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
-          cancel-workflow: true
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
 
   fullnode-fast-testnet-stable:
     needs: check-repo

--- a/.github/workflows/fullnode-intelligent-devnet-main.yaml
+++ b/.github/workflows/fullnode-intelligent-devnet-main.yaml
@@ -8,9 +8,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0,12 * * *" # At hour 0 and 12 - aka twice a day (UTC)
-  pull_request:
-    paths:
-      - ".github/workflows/fullnode-intelligent-devnet-main.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/fullnode-intelligent-devnet-main.yaml
+++ b/.github/workflows/fullnode-intelligent-devnet-main.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
-          cancel-workflow: true
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
 
   fullnode-intelligent-devnet-main:
     needs: check-repo

--- a/.github/workflows/fullnode-output-mainnet-main.yaml
+++ b/.github/workflows/fullnode-output-mainnet-main.yaml
@@ -7,9 +7,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0,12 * * *" # At hour 0 and 12 - aka twice a day (UTC)
-  pull_request:
-    paths:
-      - ".github/workflows/fullnode-output-mainnet-main.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/fullnode-output-mainnet-main.yaml
+++ b/.github/workflows/fullnode-output-mainnet-main.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
-          cancel-workflow: true
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
 
   fullnode-output-mainnet-main:
     uses: ./.github/workflows/run-fullnode-sync.yaml

--- a/.github/workflows/replay-verify.yaml
+++ b/.github/workflows/replay-verify.yaml
@@ -37,7 +37,7 @@ concurrency:
 
 jobs:
   replay-testnet:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.CHAIN_NAME == 'testnet' || inputs.CHAIN_NAME == 'all' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' && inputs.CHAIN_NAME == 'testnet' || inputs.CHAIN_NAME == 'all' }}
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-replay-verify.yaml@main
     secrets: inherit
     with:
@@ -53,7 +53,7 @@ jobs:
       TIMEOUT_MINUTES: 720
 
   replay-mainnet:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.CHAIN_NAME == 'testnet' || inputs.CHAIN_NAME == 'all' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' && inputs.CHAIN_NAME == 'testnet' || inputs.CHAIN_NAME == 'all' }}
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-replay-verify.yaml@main
     secrets: inherit
     with:

--- a/.github/workflows/replay-verify.yaml
+++ b/.github/workflows/replay-verify.yaml
@@ -36,6 +36,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  determine-test-metadata:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
+        with:
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
+
   replay-testnet:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' && inputs.CHAIN_NAME == 'testnet' || inputs.CHAIN_NAME == 'all' }}
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-replay-verify.yaml@main


### PR DESCRIPTION
### Description

`replay-verify` workflow was not getting triggered on `push`, since the conditional was not updated after https://github.com/aptos-labs/aptos-core/commit/d11074b7bc27edc53ff95885f06a1909243be92f, this fixes that

Also amend the usage of `check-aptos-core` to only  cancel workflows that are scheduled. Workflows should still run on other triggers, such as `workflow_dispatch` and `push` especially

Also stop running fullnode sync workflows on `pull_request`. They can continue to be tested via `schedule` or `workflow_dispatch`. 

### Test Plan

CI

<!-- Please provide us with clear details for verifying that your changes work. -->
