### PR TITLE
[Quorum Store] add latency metrics for better visibility

### DIFF
--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -174,6 +174,24 @@ pub static GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_ROUND_WHEN_PULL_PROOFS: Lazy
     .unwrap()
     });
 
+pub static POS_TO_PULL: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "quorum_store_pos_to_pull",
+        "Histogram for how long it took a PoS to go from inserted to pulled into a proposed block",
+        // exponential_buckets(/*start=*/ 100.0, /*factor=*/ 1.1, /*count=*/ 100).unwrap(),
+    )
+    .unwrap()
+});
+
+pub static POS_TO_COMMIT: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "quorum_store_pos_to_commit",
+        "Histogram for how long it took a PoS to go from inserted to commit notified",
+        // exponential_buckets(/*start=*/ 100.0, /*factor=*/ 1.1, /*count=*/ 100).unwrap(),
+    )
+    .unwrap()
+});
+
 /// Histogram for the number of total txns left after cleaning up commit notifications.
 pub static NUM_TOTAL_TXNS_LEFT_ON_COMMIT: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -313,7 +313,7 @@ impl ProofQueue {
                             break;
                         }
                         ret.push(proof.clone());
-                        if let Some(insertion_time) = self.digest_insertion_time.get(&digest) {
+                        if let Some(insertion_time) = self.digest_insertion_time.get(digest) {
                             counters::POS_TO_PULL.observe(insertion_time.elapsed().as_secs_f64());
                         }
                     },

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -26,7 +26,7 @@ use std::{
     },
     hash::Hash,
     mem,
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tokio::time::timeout;
 
@@ -223,6 +223,7 @@ pub struct ProofQueue {
     digest_queue: VecDeque<(HashValue, LogicalTime)>, // queue of all proofs
     local_digest_queue: VecDeque<(HashValue, LogicalTime)>, // queue of local proofs, to make back pressure update more efficient
     digest_proof: HashMap<HashValue, Option<ProofOfStore>>, // None means committed
+    digest_insertion_time: HashMap<HashValue, Instant>,
 }
 
 impl ProofQueue {
@@ -231,6 +232,7 @@ impl ProofQueue {
             digest_queue: VecDeque::new(),
             local_digest_queue: VecDeque::new(),
             digest_proof: HashMap::new(),
+            digest_insertion_time: HashMap::new(),
         }
     }
 
@@ -240,6 +242,8 @@ impl ProofQueue {
                 self.digest_queue
                     .push_back((*proof.digest(), proof.expiration()));
                 entry.insert(Some(proof.clone()));
+                self.digest_insertion_time
+                    .insert(*proof.digest(), Instant::now());
             },
             Occupied(mut entry) => {
                 if entry.get().is_some()
@@ -287,6 +291,7 @@ impl ProofQueue {
                 None => {}, // Proof was already committed
             }
             claims::assert_some!(self.digest_proof.remove(&digest));
+            self.digest_insertion_time.remove(&digest);
         }
 
         let mut ret = Vec::new();
@@ -308,6 +313,9 @@ impl ProofQueue {
                             break;
                         }
                         ret.push(proof.clone());
+                        if let Some(insertion_time) = self.digest_insertion_time.get(&digest) {
+                            counters::POS_TO_PULL.observe(insertion_time.elapsed().as_secs_f64());
+                        }
                     },
                     None => {}, // Proof was already committed, skip.
                 }
@@ -379,6 +387,9 @@ impl ProofQueue {
     pub(crate) fn mark_committed(&mut self, digests: Vec<HashValue>) {
         for digest in digests {
             self.digest_proof.insert(digest, None);
+            if let Some(insertion_time) = self.digest_insertion_time.get(&digest) {
+                counters::POS_TO_COMMIT.observe(insertion_time.elapsed().as_secs_f64());
+            }
         }
     }
 }

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -71,7 +71,7 @@ impl OnChainConsensusConfig {
     pub fn quorum_store_enabled(&self) -> bool {
         match &self {
             // TODO: this is hardcoded to true, so all continuous forge runs have quorum store enabled
-            OnChainConsensusConfig::V1(_config) => true,
+            OnChainConsensusConfig::V1(_config) => false,
             OnChainConsensusConfig::V2(_config) => true,
         }
     }

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -71,7 +71,7 @@ impl OnChainConsensusConfig {
     pub fn quorum_store_enabled(&self) -> bool {
         match &self {
             // TODO: this is hardcoded to true, so all continuous forge runs have quorum store enabled
-            OnChainConsensusConfig::V1(_config) => false,
+            OnChainConsensusConfig::V1(_config) => true,
             OnChainConsensusConfig::V2(_config) => true,
         }
     }


### PR DESCRIPTION
### Description

Add the time it takes proof-of-store to get pulled into a proposed block, and committed.

Fix a couple longstanding issues in mempool metrics:
* CONSENSUS_READY was wrongly including all txns that are checked for processing, rather than only the newly added txns.

### Test Plan

Run forge, observe dashboard.
