### PR TITLE
[storage][1/2] manual backup compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,8 +860,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-backup-cli",
+ "aptos-backup-service",
  "aptos-config",
  "aptos-db",
+ "aptos-executor-test-helpers",
  "aptos-executor-types",
  "aptos-logger",
  "aptos-push-metrics",

--- a/docker/compose/data-restore/gcs.yaml
+++ b/docker/compose/data-restore/gcs.yaml
@@ -13,3 +13,4 @@ commands:
   open_for_read: 'gsutil -q cp "gs://$BUCKET/$SUB_DIR/$FILE_HANDLE" - | gzip -cd'
   save_metadata_line: 'gzip -c | gsutil -q cp - "gs://$BUCKET/$SUB_DIR/metadata/$FILE_NAME"'
   list_metadata_files: '(gsutil -q ls gs://$BUCKET/$SUB_DIR/metadata/ ||:) | sed -ne "s#gs://.*/metadata/#metadata/#p"'
+  backup_metadata_file: 'gsutil mv gs://$BUCKET/$SUB_DIR/metadata/$FILE_NAME gs://$BUCKET/$SUB_DIR/metadata_backup/$FILE_NAME'

--- a/docker/compose/data-restore/s3.yaml
+++ b/docker/compose/data-restore/s3.yaml
@@ -13,3 +13,4 @@ commands:
   open_for_read: 'aws s3 cp "s3://$BUCKET/$SUB_DIR/$FILE_HANDLE" - --no-sign-request | gzip -cd'
   save_metadata_line: 'gzip -c | aws s3 cp - "s3://$BUCKET/$SUB_DIR/metadata/$FILE_NAME" --no-sign-request'
   list_metadata_files: '(aws s3 ls s3://$BUCKET/$SUB_DIR/metadata/ --no-sign-request ||:) | sed -ne "s#.* \(.*\)#metadata/\1#p"'
+  backup_metadata_file: 'aws s3 mv s3://$BUCKET/$SUB_DIR/metadata/$FILE_NAME s3://$BUCKET/$SUB_DIR/metadata_backup/$FILE_NAME --no-progress --no-sign-request'

--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -115,7 +115,6 @@ fn test_end_to_end_impl(d: TestData) {
             .run(),
         )
         .unwrap();
-
     // Restore
     let global_restore_opt: GlobalRestoreOptions = GlobalRestoreOpt {
         dry_run: false,

--- a/storage/backup/backup-cli/src/metadata/cache.rs
+++ b/storage/backup/backup-cli/src/metadata/cache.rs
@@ -34,7 +34,7 @@ static TEMP_METADATA_CACHE_DIR: Lazy<TempPath> = Lazy::new(|| {
     dir
 });
 
-#[derive(Parser)]
+#[derive(Clone, Parser)]
 pub struct MetadataCacheOpt {
     #[clap(
         long = "metadata-cache-dir",

--- a/storage/backup/backup-cli/src/metadata/mod.rs
+++ b/storage/backup/backup-cli/src/metadata/mod.rs
@@ -6,7 +6,7 @@ pub mod cache;
 pub mod view;
 
 use crate::storage::{FileHandle, ShellSafeName, TextLine};
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use aptos_crypto::HashValue;
 use aptos_types::transaction::Version;
 use serde::{Deserialize, Serialize};
@@ -58,6 +58,87 @@ impl Metadata {
         })
     }
 
+    pub fn compact_epoch_ending_backup_range(
+        backup_metas: Vec<EpochEndingBackupMeta>,
+    ) -> Result<(Vec<TextLine>, ShellSafeName)> {
+        ensure!(
+            !backup_metas.is_empty(),
+            "compacting an empty metadata vector"
+        );
+        let backup_meta = backup_metas[0].clone();
+        let first_epoch = backup_meta.first_epoch;
+        let mut next_epoch = backup_meta.last_epoch + 1; // non inclusive
+        let mut res = Vec::new();
+        res.push(Metadata::EpochEndingBackup(backup_meta).to_text_line()?);
+        for backup in backup_metas.iter().skip(1) {
+            ensure!(
+                next_epoch == backup.first_epoch,
+                "Epoch ending backup ranges is not continuous expecting epoch {}, got {}",
+                next_epoch,
+                backup.first_epoch,
+            );
+            next_epoch = backup.last_epoch + 1;
+            res.push(Metadata::EpochEndingBackup(backup.clone()).to_text_line()?)
+        }
+        let name = format!(
+            "epoch_ending_compacted_{}-{}.meta",
+            first_epoch,
+            next_epoch - 1
+        );
+        Ok((res, name.parse()?))
+    }
+
+    pub fn compact_statesnapshot_backup_range(
+        backup_metas: Vec<StateSnapshotBackupMeta>,
+    ) -> Result<(Vec<TextLine>, ShellSafeName)> {
+        ensure!(
+            !backup_metas.is_empty(),
+            "compacting an empty metadata vector"
+        );
+        let name = format!(
+            "state_snapshot_compacted_epoch_{}_{}.meta",
+            backup_metas[0].epoch,
+            backup_metas[backup_metas.len() - 1].epoch
+        );
+        let res: Vec<TextLine> = backup_metas
+            .into_iter()
+            .map(|e| Metadata::StateSnapshotBackup(e).to_text_line())
+            .collect::<Result<_>>()?;
+        Ok((res, name.parse()?))
+    }
+
+    pub fn compact_transaction_backup_range(
+        backup_metas: Vec<TransactionBackupMeta>,
+    ) -> Result<(Vec<TextLine>, ShellSafeName)> {
+        ensure!(
+            !backup_metas.is_empty(),
+            "compacting an empty metadata vector"
+        );
+        // assume the vector is sorted based on version
+        let backup_meta = backup_metas[0].clone();
+        let first_version = backup_meta.first_version;
+        // assume the last_version is inclusive in the backup meta
+        let mut next_version = backup_meta.last_version + 1;
+        let mut res: Vec<TextLine> = Vec::new();
+        res.push(Metadata::TransactionBackup(backup_meta).to_text_line()?);
+        for backup in backup_metas.iter().skip(1) {
+            ensure!(
+                next_version == backup.first_version,
+                "txn backup ranges is not continuous expecting version {}, got {}.",
+                next_version,
+                backup.first_version,
+            );
+            next_version = backup.last_version + 1;
+            res.push(Metadata::TransactionBackup(backup.clone()).to_text_line()?)
+        }
+        let name = format!(
+            "transaction_compacted_{}-{}.meta",
+            first_version,
+            next_version - 1
+        );
+        Ok((res, name.parse()?))
+    }
+
     pub fn new_random_identity() -> Self {
         Self::Identity(IdentityMeta {
             id: HashValue::random(),
@@ -71,7 +152,7 @@ impl Metadata {
             },
             Self::StateSnapshotBackup(s) => format!("state_snapshot_ver_{}.meta", s.version),
             Self::TransactionBackup(t) => {
-                format!("transaction_{}-{}.meta", t.first_version, t.last_version,)
+                format!("transaction_{}-{}.meta", t.first_version, t.last_version)
             },
             Metadata::Identity(_) => "identity.meta".into(),
         }
@@ -84,7 +165,7 @@ impl Metadata {
     }
 }
 
-#[derive(Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct EpochEndingBackupMeta {
     pub first_epoch: u64,
     pub last_epoch: u64,
@@ -93,21 +174,21 @@ pub struct EpochEndingBackupMeta {
     pub manifest: FileHandle,
 }
 
-#[derive(Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct StateSnapshotBackupMeta {
     pub epoch: u64,
     pub version: Version,
     pub manifest: FileHandle,
 }
 
-#[derive(Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct TransactionBackupMeta {
     pub first_version: Version,
     pub last_version: Version,
     pub manifest: FileHandle,
 }
 
-#[derive(Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct IdentityMeta {
     pub id: HashValue,
 }

--- a/storage/backup/backup-cli/src/storage/command_adapter/config.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/config.rs
@@ -22,8 +22,8 @@ impl EnvVar {
         Self::new("BACKUP_NAME".to_string(), value)
     }
 
-    pub fn file_name(value: String) -> Self {
-        Self::new("FILE_NAME".to_string(), value)
+    pub fn file_name(value: &str) -> Self {
+        Self::new("FILE_NAME".to_string(), value.to_string())
     }
 
     pub fn file_handle(value: FileHandle) -> Self {
@@ -68,6 +68,8 @@ pub struct Commands {
     /// Command line to list all existing metadata file handles.
     /// expected stdout to stream out lines of file handles.
     pub list_metadata_files: String,
+    /// Command line to backup one metadata file to a metadata backup folder
+    pub backup_metadata_file: Option<String>,
 }
 
 #[derive(Clone, Default, Deserialize)]

--- a/storage/backup/backup-cli/src/storage/command_adapter/sample_configs/azure.sample.yaml
+++ b/storage/backup/backup-cli/src/storage/command_adapter/sample_configs/azure.sample.yaml
@@ -31,3 +31,7 @@ commands:
     # list files under the metadata folder
     (azcopy ls "https://$ACCOUNT.blob.core.windows.net/$CONTAINER/$SUB_DIR/metadata/$SAS" ||:) \
     | sed -ne "s#; .*##;s#INFO: \(.*\.meta\)#metadata/\1#p"
+  backup_metadata_file: |
+    # move metadata files 
+    azcopy sync "https://$ACCOUNT.blob.core.windows.net/$CONTAINER/$SUB_DIR/metadata/$FILE_NAME$SAS" "https://$ACCOUNT.blob.core.windows.net/$CONTAINER/$SUB_DIR/metadata_backup/$FILE_NAME$SAS" --move=true
+

--- a/storage/backup/backup-cli/src/storage/command_adapter/sample_configs/gcp.sample.yaml
+++ b/storage/backup/backup-cli/src/storage/command_adapter/sample_configs/gcp.sample.yaml
@@ -26,3 +26,6 @@ commands:
     # list files under the metadata folder
     (gsutil -q ls gs://$BUCKET/$SUB_DIR/metadata/ ||:) \
     | sed -ne "s#gs://.*/metadata/#metadata/#p"
+  backup_metadata_file: |
+    # move metadata file to a metadata_backup folder
+    gsutil mv gs://$BUCKET/$SUB_DIR/metadata/$FILE_NAME gs://$BUCKET/$SUB_DIR/metadata_backup/$FILE_NAME

--- a/storage/backup/backup-cli/src/storage/command_adapter/sample_configs/local_folder.sample.yaml
+++ b/storage/backup/backup-cli/src/storage/command_adapter/sample_configs/local_folder.sample.yaml
@@ -8,3 +8,4 @@ commands:
   open_for_read: 'cat "$FOLDER/$FILE_HANDLE" | gzip -cd'
   save_metadata_line: 'cd "$FOLDER" && mkdir -p metadata && cd metadata && gzip -c > $FILE_NAME'
   list_metadata_files: 'cd "$FOLDER" && (test -d metadata && cd metadata && ls -1 || exec) | while read f; do echo metadata/$f; done'
+  backup_metadata_file: 'cd "$FOLDER" && mkdir -p metadata_backup && mv metadata/$FILE_NAME metadata_backup/$FILE_NAME'

--- a/storage/backup/backup-cli/src/storage/command_adapter/sample_configs/s3.sample.yaml
+++ b/storage/backup/backup-cli/src/storage/command_adapter/sample_configs/s3.sample.yaml
@@ -25,3 +25,7 @@ commands:
   list_metadata_files: |
     # list files under the metadata folder
     (aws s3 ls s3://$BUCKET/$SUB_DIR/metadata/ ||:) | sed -ne "s#.* \(.*\)#metadata/\1#p"
+  backup_metadata_file: |
+    # move metadata file to metadata backup folder
+    aws s3 mv s3://$BUCKET/$SUB_DIR/metadata/$FILE_NAME s3://$BUCKET/$SUB_DIR/metadata_backup/$FILE_NAME --no-progress
+    

--- a/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
@@ -30,6 +30,7 @@ commands:
   open_for_read: 'cat "$FOLDER/$FILE_HANDLE"'
   save_metadata_line: 'cd "$FOLDER" && mkdir -p metadata && cd metadata && cat > $FILE_NAME'
   list_metadata_files: 'cd "$FOLDER" && (test -d metadata && cd metadata && ls -1 || exec) | while read f; do echo metadata/$f; done'
+  backup_metadata_file: 'cd "$FOLDER" && mkdir -p metadata_backup && mv metadata/$FILE_NAME metadata_backup/$FILE_NAME'
 "#, tmpdir.path().to_str().unwrap()),
     ).unwrap();
 
@@ -68,6 +69,7 @@ fn dummy_store(cmd: &str) -> CommandAdapter {
             open_for_read: cmd.to_string(),
             save_metadata_line: cmd.to_string(),
             list_metadata_files: cmd.to_string(),
+            backup_metadata_file: Some(cmd.to_string()),
         },
         env_vars: Vec::new(),
     })

--- a/storage/backup/backup-cli/src/storage/local_fs/mod.rs
+++ b/storage/backup/backup-cli/src/storage/local_fs/mod.rs
@@ -10,16 +10,19 @@ use crate::{
     storage::{BackupStorage, ShellSafeName, TextLine},
     utils::{error_notes::ErrorNotes, path_exists, PathToString},
 };
-use anyhow::Result;
+use anyhow::{bail, format_err, Result};
+use aptos_logger::info;
 use async_trait::async_trait;
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use std::{
+    ffi::OsStr,
+    io,
     path::{Path, PathBuf},
     str::FromStr,
 };
 use tokio::{
-    fs::{create_dir_all, read_dir, OpenOptions},
+    fs::{create_dir_all, read_dir, rename, OpenOptions},
     io::{AsyncRead, AsyncWrite, AsyncWriteExt},
 };
 
@@ -50,6 +53,7 @@ pub struct LocalFs {
 }
 
 impl LocalFs {
+    const METADATA_BACKUP_DIR: &'static str = "metadata_backup";
     const METADATA_DIR: &'static str = "metadata";
 
     pub fn new(dir: PathBuf) -> Self {
@@ -62,6 +66,10 @@ impl LocalFs {
 
     pub fn metadata_dir(&self) -> PathBuf {
         self.dir.join(Self::METADATA_DIR)
+    }
+
+    pub fn metadata_backup_dir(&self) -> PathBuf {
+        self.dir.join(Self::METADATA_BACKUP_DIR)
     }
 }
 
@@ -106,22 +114,8 @@ impl BackupStorage for LocalFs {
     }
 
     async fn save_metadata_line(&self, name: &ShellSafeName, content: &TextLine) -> Result<()> {
-        let dir = self.metadata_dir();
-        create_dir_all(&dir).await.err_notes(name)?; // in case not yet created
-
-        let path = dir.join(name.as_ref());
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&path)
-            .await
-            .err_notes(&path)?;
-        file.write_all(content.as_ref().as_bytes())
-            .await
-            .err_notes(&path)?;
-        file.shutdown().await.err_notes(&path)?;
-
-        Ok(())
+        let txt = TextLine::new(content.as_ref().trim_end_matches('\n'))?;
+        self.save_metadata_lines(name, vec![txt].as_slice()).await
     }
 
     async fn list_metadata_files(&self) -> Result<Vec<FileHandle>> {
@@ -136,5 +130,57 @@ impl BackupStorage for LocalFs {
             }
         }
         Ok(res)
+    }
+
+    /// file_handle are expected to be the return results from list_metadata_files
+    /// file_handle is a path with `metadata` in the path, Ex: metadata/epoch_ending_1.meta
+    async fn backup_metadata_file(&self, file_handle: &FileHandleRef) -> Result<()> {
+        let dir = self.metadata_backup_dir();
+
+        // Check if the backup directory exists, create it if it doesn't
+        if !dir.exists() {
+            create_dir_all(&dir).await?;
+        }
+
+        // Get the file name and the backup file path
+        let name = Path::new(file_handle)
+            .file_name()
+            .and_then(OsStr::to_str)
+            .ok_or_else(|| format_err!("cannot extract filename from {}", file_handle))?;
+        let mut backup_path = PathBuf::from(&dir);
+        backup_path.push(name);
+
+        // Move the file to the backup directory
+        rename(&self.dir.join(file_handle), &backup_path).await?;
+
+        Ok(())
+    }
+
+    async fn save_metadata_lines(&self, name: &ShellSafeName, lines: &[TextLine]) -> Result<()> {
+        let dir = self.metadata_dir();
+        create_dir_all(&dir).await.err_notes(name)?; // in case not yet created
+        let content = lines
+            .iter()
+            .map(|e| e.as_ref())
+            .collect::<Vec<&str>>()
+            .join("");
+        let path = dir.join(name.as_ref());
+        let file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .await;
+        match file {
+            Ok(mut f) => {
+                f.write_all(content.as_bytes()).await.err_notes(&path)?;
+                f.shutdown().await.err_notes(&path)?;
+            },
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                info!("File {} already exists, Skip", name.as_ref());
+            },
+            _ => bail!("Unexpected Error in saving metadata file {}", name.as_ref()),
+        }
+
+        Ok(())
     }
 }

--- a/storage/backup/backup-cli/src/storage/mod.rs
+++ b/storage/backup/backup-cli/src/storage/mod.rs
@@ -168,6 +168,10 @@ pub trait BackupStorage: Send + Sync {
     ///   2. But the cache does expect the content stays the same for a file handle, so when
     /// reorganising metadata files, give them new unique names.
     async fn list_metadata_files(&self) -> Result<Vec<FileHandle>>;
+    /// Move a metadata file to the metadata file backup folder.
+    async fn backup_metadata_file(&self, file_handle: &FileHandleRef) -> Result<()>;
+    /// Save a vector of metadata lines to file. If the file exists, this will overwrite
+    async fn save_metadata_lines(&self, name: &ShellSafeName, lines: &[TextLine]) -> Result<()>;
 }
 
 #[derive(Parser)]

--- a/storage/db-tool/Cargo.toml
+++ b/storage/db-tool/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-backup-cli = { workspace = true }
+aptos-backup-service = { workspace = true }
 aptos-config = { workspace = true }
 aptos-db = { workspace = true, features = ["db-debugger"] }
 aptos-executor-types = { workspace = true }
@@ -24,3 +25,7 @@ aptos-types = { workspace = true }
 clap = { workspace = true }
 owo-colors = { workspace = true }
 tokio = { workspace = true }
+
+[dev-dependencies]
+aptos-backup-service = { workspace = true }
+aptos-executor-test-helpers = { workspace = true }

--- a/storage/db-tool/src/backup_maintenance.rs
+++ b/storage/db-tool/src/backup_maintenance.rs
@@ -1,0 +1,64 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+use anyhow::Result;
+use aptos_backup_cli::{
+    coordinators::backup::BackupCompactor, metadata::cache::MetadataCacheOpt,
+    storage::DBToolStorageOpt, utils::ConcurrentDownloadsOpt,
+};
+use clap::{Parser, Subcommand};
+
+/// Support compacting and cleaning obsolete metadata files
+#[derive(Subcommand)]
+pub enum Command {
+    #[clap(about = "Compact metdata files")]
+    Compact(CompactionOpt),
+    #[clap(about = "Cleanup the backup metadata files")]
+    Cleanup(CleanupOpt),
+}
+
+#[derive(Parser)]
+pub struct CompactionOpt {
+    /// Specify how many epoch files to be merged in one compacted epoch ending metadata file
+    #[clap(long, default_value = "1")]
+    pub epoch_ending_file_compact_factor: usize,
+    /// Specify how many state snapshot files to be merged in one compacted state snapshot metadata file
+    #[clap(long, default_value = "1")]
+    pub state_snapshot_file_compact_factor: usize,
+    /// Specify how many transaction files to be merged in one transaction metadata file
+    #[clap(long, default_value = "1")]
+    pub transaction_file_compact_factor: usize,
+    #[clap(flatten)]
+    pub metadata_cache_opt: MetadataCacheOpt,
+    #[clap(flatten)]
+    pub storage: DBToolStorageOpt,
+    #[clap(flatten)]
+    concurrent_downloads: ConcurrentDownloadsOpt,
+}
+
+#[derive(Parser)]
+pub struct CleanupOpt {
+    #[clap(flatten)]
+    pub storage: DBToolStorageOpt,
+}
+
+impl Command {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            Command::Compact(opt) => {
+                let compactor = BackupCompactor::new(
+                    opt.epoch_ending_file_compact_factor,
+                    opt.state_snapshot_file_compact_factor,
+                    opt.transaction_file_compact_factor,
+                    opt.metadata_cache_opt,
+                    opt.storage.init_storage().await?,
+                    opt.concurrent_downloads.get(),
+                );
+                compactor.run().await?
+            },
+            Command::Cleanup(_) => {
+                // TODO: add cleanup logic for removing obsolete metadata files
+            },
+        }
+        Ok(())
+    }
+}

--- a/storage/db-tool/src/lib.rs
+++ b/storage/db-tool/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate core;
 
 mod backup;
+mod backup_maintenance;
 mod debugger;
 mod replay_verify;
 mod restore;
@@ -23,6 +24,8 @@ pub enum DBTool {
     ReplayVerify(replay_verify::Opt),
     #[clap(subcommand)]
     Debug(debugger::Command),
+    #[clap(subcommand)]
+    BackupMaintenance(backup_maintenance::Command),
 }
 
 impl DBTool {
@@ -31,6 +34,7 @@ impl DBTool {
             DBTool::Backup(cmd) => cmd.run().await,
             DBTool::Restore(cmd) => cmd.run().await,
             DBTool::ReplayVerify(cmd) => cmd.run().await,
+            DBTool::BackupMaintenance(cmd) => cmd.run().await,
             DBTool::Debug(cmd) => cmd.run(),
         }
     }

--- a/storage/db-tool/src/tests.rs
+++ b/storage/db-tool/src/tests.rs
@@ -2,7 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::DBTool;
+use aptos_backup_cli::{
+    coordinators::backup::BackupCompactor,
+    metadata,
+    metadata::cache::MetadataCacheOpt,
+    storage::{local_fs::LocalFs, BackupStorage},
+};
+// use aptos_backup_cli::utils::test_utils::start_local_backup_service;
+use aptos_backup_service::start_backup_service;
+use aptos_executor_test_helpers::integration_test_impl::test_execution_with_storage_impl;
+use aptos_temppath::TempPath;
 use clap::Parser;
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
 
 #[test]
 fn test_various_cmd_parsing() {
@@ -59,4 +73,125 @@ fn test_various_cmd_parsing() {
 
 fn run_cmd(args: &[&str]) {
     DBTool::try_parse_from(args).expect("command parse unsuccessful");
+}
+
+#[tokio::test]
+async fn test_backup_compaction() {
+    let db = test_execution_with_storage_impl();
+    let backup_dir = TempPath::new();
+    backup_dir.create_as_dir().unwrap();
+    let local_fs = LocalFs::new(backup_dir.path().to_path_buf());
+    let store: Arc<dyn BackupStorage> = Arc::new(local_fs);
+    let rt = start_backup_service(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 6186), db);
+
+    // Backup the local_test DB
+    DBTool::try_parse_from([
+        "aptos-db-tool",
+        "backup",
+        "oneoff",
+        "epoch-ending",
+        "--start-epoch",
+        "0",
+        "--end-epoch",
+        "1",
+        "--local-fs-dir",
+        backup_dir.path().to_str().unwrap(),
+    ])
+    .unwrap()
+    .run()
+    .await
+    .unwrap();
+    DBTool::try_parse_from([
+        "aptos-db-tool",
+        "backup",
+        "oneoff",
+        "epoch-ending",
+        "--start-epoch",
+        "1",
+        "--end-epoch",
+        "2",
+        "--local-fs-dir",
+        backup_dir.path().to_str().unwrap(),
+    ])
+    .unwrap()
+    .run()
+    .await
+    .unwrap();
+    DBTool::try_parse_from([
+        "aptos-db-tool",
+        "backup",
+        "oneoff",
+        "state-snapshot",
+        "--state-snapshot-epoch",
+        "1",
+        "--local-fs-dir",
+        backup_dir.path().to_str().unwrap(),
+    ])
+    .unwrap()
+    .run()
+    .await
+    .unwrap();
+    DBTool::try_parse_from([
+        "aptos-db-tool",
+        "backup",
+        "oneoff",
+        "state-snapshot",
+        "--state-snapshot-epoch",
+        "2",
+        "--local-fs-dir",
+        backup_dir.path().to_str().unwrap(),
+    ])
+    .unwrap()
+    .run()
+    .await
+    .unwrap();
+    DBTool::try_parse_from([
+        "aptos-db-tool",
+        "backup",
+        "oneoff",
+        "transaction",
+        "--start-version",
+        "0",
+        "--num_transactions",
+        "15",
+        "--local-fs-dir",
+        backup_dir.path().to_str().unwrap(),
+    ])
+    .unwrap()
+    .run()
+    .await
+    .unwrap();
+    DBTool::try_parse_from([
+        "aptos-db-tool",
+        "backup",
+        "oneoff",
+        "transaction",
+        "--start-version",
+        "15",
+        "--num_transactions",
+        "15",
+        "--local-fs-dir",
+        backup_dir.path().to_str().unwrap(),
+    ])
+    .unwrap()
+    .run()
+    .await
+    .unwrap();
+    // assert the metadata views are same before and after compaction
+    let metadata_opt = MetadataCacheOpt::new(Some(TempPath::new().path().to_path_buf()));
+    let old_metaview = metadata::cache::sync_and_load(&metadata_opt, Arc::clone(&store), 1)
+        .await
+        .unwrap();
+    let compactor = BackupCompactor::new(2, 2, 2, metadata_opt.clone(), Arc::clone(&store), 1);
+    compactor.run().await.unwrap();
+
+    // run compaction again
+    compactor.run().await.unwrap();
+
+    let new_metaview = metadata::cache::sync_and_load(&metadata_opt, Arc::clone(&store), 1)
+        .await
+        .unwrap();
+
+    assert_eq!(old_metaview, new_metaview);
+    rt.shutdown_background();
 }

--- a/terraform/helm/fullnode/files/backup/azure.yaml
+++ b/terraform/helm/fullnode/files/backup/azure.yaml
@@ -11,3 +11,5 @@ commands:
   list_metadata_files: |
     (azcopy ls "https://$ACCOUNT.blob.core.windows.net/$CONTAINER/$SUB_DIR/metadata/$SAS" ||:) \
     | sed -ne "s#; .*##;s#INFO: \(.*\.meta\)#metadata/\1#p"
+  backup_metadata_file: |
+    azcopy sync "https://$ACCOUNT.blob.core.windows.net/$CONTAINER/$SUB_DIR/metadata/$FILE_NAME$SAS" "https://$ACCOUNT.blob.core.windows.net/$CONTAINER/$SUB_DIR/metadata_backup/$FILE_NAME$SAS" --move=true

--- a/terraform/helm/fullnode/files/backup/gcs.yaml
+++ b/terraform/helm/fullnode/files/backup/gcs.yaml
@@ -9,3 +9,4 @@ commands:
   open_for_read: 'gsutil -q cp "gs://$BUCKET/$SUB_DIR/$FILE_HANDLE" - | gzip -cd'
   save_metadata_line: 'gzip -c | gsutil -q cp - "gs://$BUCKET/$SUB_DIR/metadata/$FILE_NAME"'
   list_metadata_files: '(gsutil -q ls gs://$BUCKET/$SUB_DIR/metadata/ ||:) | sed -ne "s#gs://.*/metadata/#metadata/#p"'
+  backup_metadata_file: 'gsutil mv gs://$BUCKET/$SUB_DIR/metadata/$FILE_NAME gs://$BUCKET/$SUB_DIR/metadata_backup/$FILE_NAME'

--- a/terraform/helm/fullnode/files/backup/oci.yaml
+++ b/terraform/helm/fullnode/files/backup/oci.yaml
@@ -11,3 +11,5 @@ commands:
   list_metadata_files: |
     curl -s "$ENDPOINT$ACCESS_URI?prefix=/$SUB_DIR/metadata/" \
     | python -c 'import json, sys; print("\n".join("/".join(o["name"].split("/")[2:]) for o in json.loads(sys.stdin.read()).get("objects", [])), end="")'
+  backup_metadata_file: |
+    curl -sSf "$ENDPOINT$ACCESS_URI/$SUB_DIR/metadata_backup" || curl -X PUT "$ENDPOINT$ACCESS_URI/$SUB_DIR/metadata_backup" && curl -sSL "$ENDPOINT$ACCESS_URI/$SUB_DIR/metadata/$FILE_NAME" | curl -X POST -d @- "$ENDPOINT$ACCESS_URI/$SUB_DIR/metadata_backup/$FILE_NAME" && curl -X DELETE "$ENDPOINT$ACCESS_URI/$SUB_DIR/metadata/$FILE_NAME"

--- a/terraform/helm/fullnode/files/backup/s3-public.yaml
+++ b/terraform/helm/fullnode/files/backup/s3-public.yaml
@@ -9,3 +9,4 @@ commands:
   open_for_read: 'aws s3 cp "s3://$BUCKET/$SUB_DIR/$FILE_HANDLE" - --no-sign-request | gzip -cd'
   save_metadata_line: 'gzip -c | aws s3 cp - "s3://$BUCKET/$SUB_DIR/metadata/$FILE_NAME" --no-sign-request'
   list_metadata_files: '(aws s3 ls s3://$BUCKET/$SUB_DIR/metadata/ --no-sign-request ||:) | sed -ne "s#.* \(.*\)#metadata/\1#p"'
+  backup_metadata_file: 'aws s3 mv s3://$BUCKET/$SUB_DIR/metadata/$FILE_NAME s3://$BUCKET/$SUB_DIR/metadata_backup/$FILE_NAME --no-progress'

--- a/terraform/helm/fullnode/files/backup/s3.yaml
+++ b/terraform/helm/fullnode/files/backup/s3.yaml
@@ -9,3 +9,4 @@ commands:
   open_for_read: 'aws s3 cp "s3://$BUCKET/$SUB_DIR/$FILE_HANDLE" - | gzip -cd'
   save_metadata_line: 'gzip -c | aws s3 cp - "s3://$BUCKET/$SUB_DIR/metadata/$FILE_NAME"'
   list_metadata_files: '(aws s3 ls s3://$BUCKET/$SUB_DIR/metadata/ ||:) | sed -ne "s#.* \(.*\)#metadata/\1#p"'
+  backup_metadata_file: 'aws s3 mv s3://$BUCKET/$SUB_DIR/metadata/$FILE_NAME s3://$BUCKET/$SUB_DIR/metadata_backup/$FILE_NAME --no-progress'

--- a/terraform/helm/fullnode/files/backup/scw_s3.yaml
+++ b/terraform/helm/fullnode/files/backup/scw_s3.yaml
@@ -9,3 +9,4 @@ commands:
   open_for_read: 'aws --endpoint-url="$ENDPOINT_URL" s3 cp "s3://$BUCKET/$SUB_DIR/$FILE_HANDLE" - | gzip -cd'
   save_metadata_line: 'gzip -c | aws --endpoint-url="$ENDPOINT_URL" s3 cp - "s3://$BUCKET/$SUB_DIR/metadata/$FILE_NAME"'
   list_metadata_files: '(aws --endpoint-url="$ENDPOINT_URL" s3 ls s3://$BUCKET/$SUB_DIR/metadata/ ||:) | sed -ne "s#.* \(.*\)#metadata/\1#p"'
+  backup_metadata_file: 'aws --endpoint-url="$ENDPOINT_URL" s3 mv s3://$BUCKET/$SUB_DIR/metadata/$FILE_NAME s3://$BUCKET/$SUB_DIR/metadata_backup/$FILE_NAME --no-progress'


### PR DESCRIPTION
### Description
add manual backup compaction

TODO: 
1. add continuous backup compaction
2. add metadata backup cleanup
### Test Plan
1. updated smoke test
2. add unit test
3. local run DB restore on testnet with 2 concurrent downloads and 100 compaction counter
The metadata loading time reduces from 45 mins to less than 1 min after compaction

