### PR TITLE
[helm][aptos-node/fullnode] use helm lookup to avoid overwriting image tag if specified

### DIFF
--- a/terraform/aptos-node-testnet/aws/variables.tf
+++ b/terraform/aptos-node-testnet/aws/variables.tf
@@ -214,6 +214,6 @@ variable "fullnode_storage_class" {
 }
 
 variable "manage_via_tf" {
-  description = "Whether to manage the aptos-node k8s workload via Terraform"
+  description = "Whether to manage the aptos-node k8s workload via Terraform. If set to false, the helm_release resource will still be created and updated when values change, but it may not be updated on every apply"
   default     = true
 }

--- a/terraform/aptos-node-testnet/gcp/variables.tf
+++ b/terraform/aptos-node-testnet/gcp/variables.tf
@@ -16,7 +16,7 @@ variable "zone" {
 }
 
 variable "manage_via_tf" {
-  description = "Whether to manage the aptos-node k8s workload via Terraform"
+  description = "Whether to manage the aptos-node k8s workload via Terraform. If set to false, the helm_release resource will still be created and updated when values change, but it may not be updated on every apply"
   default     = true
 }
 

--- a/terraform/aptos-node/aws/kubernetes.tf
+++ b/terraform/aptos-node/aws/kubernetes.tf
@@ -124,6 +124,7 @@ locals {
     numValidators     = var.num_validators
     numFullnodeGroups = var.num_fullnode_groups
     imageTag          = var.image_tag
+    mangeImages       = var.manage_via_tf # if we're managing the entire deployment via terraform, override the images as well
     chain = {
       era      = var.era
       chain_id = var.chain_id

--- a/terraform/aptos-node/aws/variables.tf
+++ b/terraform/aptos-node/aws/variables.tf
@@ -267,6 +267,6 @@ variable "fullnode_storage_class" {
 }
 
 variable "manage_via_tf" {
-  description = "Whether to manage the aptos-node k8s workload via Terraform"
+  description = "Whether to manage the aptos-node k8s workload via Terraform. If set to false, the helm_release resource will still be created and updated when values change, but it may not be updated on every apply"
   default     = true
 }

--- a/terraform/aptos-node/gcp/kubernetes.tf
+++ b/terraform/aptos-node/gcp/kubernetes.tf
@@ -44,6 +44,7 @@ resource "helm_release" "validator" {
       numValidators     = var.num_validators
       numFullnodeGroups = var.num_fullnode_groups
       imageTag          = var.image_tag
+      mangeImages       = var.manage_via_tf # if we're managing the entire deployment via terraform, override the images as well
       chain = {
         era      = var.era
         chain_id = var.chain_id

--- a/terraform/aptos-node/gcp/variables.tf
+++ b/terraform/aptos-node/gcp/variables.tf
@@ -154,7 +154,7 @@ variable "node_exporter_helm_values" {
 }
 
 variable "manage_via_tf" {
-  description = "Whether to manage the aptos-node k8s workload via Terraform"
+  description = "Whether to manage the aptos-node k8s workload via Terraform. If set to false, the helm_release resource will still be created and updated when values change, but it may not be updated on every apply"
   default     = true
 }
 

--- a/terraform/fullnode/aws/kubernetes.tf
+++ b/terraform/fullnode/aws/kubernetes.tf
@@ -103,10 +103,13 @@ resource "helm_release" "fullnode" {
     jsonencode(var.fullnode_helm_values_list == {} ? {} : var.fullnode_helm_values_list[count.index]),
   ]
 
-  # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
-  set {
-    name  = "chart_sha1"
-    value = sha1(join("", [for f in fileset(local.fullnode_helm_chart_path, "**") : filesha1("${local.fullnode_helm_chart_path}/${f}")]))
+  dynamic "set" {
+    for_each = var.manage_via_tf ? toset([""]) : toset([])
+    content {
+      # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
+      name  = "chart_sha1"
+      value = sha1(join("", [for f in fileset(local.fullnode_helm_chart_path, "**") : filesha1("${local.fullnode_helm_chart_path}/${f}")]))
+    }
   }
 }
 

--- a/terraform/fullnode/aws/variables.tf
+++ b/terraform/fullnode/aws/variables.tf
@@ -182,3 +182,8 @@ variable "enable_kube_state_metrics" {
   description = "Enable kube-state-metrics within monitoring helm chart"
   default     = false
 }
+
+variable "manage_via_tf" {
+  description = "Whether to manage the aptos-node k8s workload via Terraform. If set to false, the helm_release resource will still be created and updated when values change, but it may not be updated on every apply"
+  default     = true
+}

--- a/terraform/fullnode/gcp/kubernetes.tf
+++ b/terraform/fullnode/gcp/kubernetes.tf
@@ -129,9 +129,13 @@ resource "helm_release" "fullnode" {
   ]
 
   # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
-  set {
-    name  = "chart_sha1"
-    value = sha1(join("", [for f in fileset(local.fullnode_helm_chart_path, "**") : filesha1("${local.fullnode_helm_chart_path}/${f}")]))
+  dynamic "set" {
+    for_each = var.manage_via_tf ? toset([""]) : toset([])
+    content {
+      # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
+      name  = "chart_sha1"
+      value = sha1(join("", [for f in fileset(local.fullnode_helm_chart_path, "**") : filesha1("${local.fullnode_helm_chart_path}/${f}")]))
+    }
   }
 }
 

--- a/terraform/fullnode/gcp/variables.tf
+++ b/terraform/fullnode/gcp/variables.tf
@@ -188,3 +188,8 @@ variable "gke_autoscaling_max_node_count" {
   description = "Maximum number of nodes for GKE nodepool autoscaling"
   default     = 10
 }
+
+variable "manage_via_tf" {
+  description = "Whether to manage the aptos-node k8s workload via Terraform. If set to false, the helm_release resource will still be created and updated when values change, but it may not be updated on every apply"
+  default     = true
+}

--- a/terraform/helm/aptos-node/README.md
+++ b/terraform/helm/aptos-node/README.md
@@ -1,6 +1,6 @@
 # aptos-node
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Aptos blockchain node deployment
 
@@ -17,8 +17,10 @@ Aptos blockchain node deployment
 | chain.chain_id | int | `4` | Chain ID |
 | chain.era | int | `1` | Bump this number to wipe the underlying storage |
 | chain.name | string | `"testnet"` | Internal: name of the testnet to connect to |
+| enablePrivilegedMode | bool | `false` | TEST ONLY: Enable running as root for profiling |
 | fullnode.affinity | object | `{}` |  |
-| fullnode.config | object | `{"api":{},"base":{},"consensus":{},"execution":{},"failpoints":{},"firehose_stream":{},"full_node_networks":[{"discovery_method":"onchain","enable_proxy_protocol":false,"identity":{"path":"/opt/aptos/genesis/validator-full-node-identity.yaml","type":"from_file"},"listen_address":"/ip4/0.0.0.0/tcp/6182","max_inbound_connections":100,"network_id":"public","seeds":{}}],"inspection_service":{},"logger":{},"mempool":{"default_failovers":0,"max_broadcasts_per_peer":4,"shared_mempool_batch_size":200,"shared_mempool_max_concurrent_inbound_syncs":16,"shared_mempool_tick_interval_ms":10},"metrics":{},"peer_monitoring_service":{},"state_sync":{},"storage":{},"test":{},"validator_network":{}}` | Fullnode configuration. See NodeConfig https://github.com/aptos-labs/aptos-core/blob/main/config/src/config/mod.rs |
+| fullnode.config | object | `{"full_node_networks":[{"max_inbound_connections":100,"network_id":"public","seeds":{}}],"mempool":{"default_failovers":0,"max_broadcasts_per_peer":4,"shared_mempool_batch_size":200,"shared_mempool_max_concurrent_inbound_syncs":16,"shared_mempool_tick_interval_ms":10}}` | Fullnode configuration. See NodeConfig https://github.com/aptos-labs/aptos-core/blob/main/config/src/config/mod.rs |
+| fullnode.force_enable_telemetry | bool | `false` | Flag to force enable telemetry service (useful for forge tests) |
 | fullnode.groups | list | `[{"name":"fullnode","replicas":1}]` | Specify fullnode groups by `name` and number of `replicas` |
 | fullnode.nodeSelector | object | `{}` |  |
 | fullnode.resources.limits.cpu | float | `15.5` |  |
@@ -27,7 +29,7 @@ Aptos blockchain node deployment
 | fullnode.resources.requests.memory | string | `"26Gi"` |  |
 | fullnode.rust_log | string | `"info"` | Log level for the fullnode |
 | fullnode.storage.class | string | `nil` | Kubernetes storage class to use for fullnode persistent storage |
-| fullnode.storage.size | string | `"1000Gi"` | Size of fullnode persistent storage |
+| fullnode.storage.size | string | `"2048Gi"` | Size of fullnode persistent storage |
 | fullnode.tolerations | list | `[]` |  |
 | haproxy.affinity | object | `{}` |  |
 | haproxy.config.send_proxy_protocol | bool | `false` | Whether to send Proxy Protocol v2 |
@@ -35,38 +37,47 @@ Aptos blockchain node deployment
 | haproxy.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy to use for HAProxy images |
 | haproxy.image.repo | string | `"haproxy"` | Image repo to use for HAProxy images |
 | haproxy.image.tag | string | `"2.2.14@sha256:36aa98fff27dcb2d12c93e68515a6686378c783ea9b1ab1d01ce993a5cbc73e1"` | Image tag to use for HAProxy images |
-| haproxy.limits.validator.connectionsPerIPPerMin | int | `2` | Limit the number of connections per IP address per minute |
+| haproxy.limits.validator.connectionsPerIPPerMin | int | `12` | Limit the number of connections per IP address per min |
+| haproxy.limits.validator.maxBytesOutRate10sec | int | `134217728` |  |
+| haproxy.limits.validator.rateLimitSession | int | `256` |  |
+| haproxy.limits.validator.tcpBufSize | int | `524288` |  |
 | haproxy.nodeSelector | object | `{}` |  |
 | haproxy.replicas | int | `1` | Number of HAProxy replicas |
-| haproxy.resources.limits.cpu | float | `1.5` |  |
-| haproxy.resources.limits.memory | string | `"2Gi"` |  |
-| haproxy.resources.requests.cpu | float | `1.5` |  |
-| haproxy.resources.requests.memory | string | `"2Gi"` |  |
+| haproxy.resources.limits.cpu | int | `4` |  |
+| haproxy.resources.limits.memory | string | `"8Gi"` |  |
+| haproxy.resources.requests.cpu | int | `4` |  |
+| haproxy.resources.requests.memory | string | `"8Gi"` |  |
 | haproxy.tls_secret | string | `nil` | Name of the Kubernetes TLS secret to use for HAProxy |
 | haproxy.tolerations | list | `[]` |  |
 | imageTag | string | `"devnet"` | Default image tag to use for all validator and fullnode images |
 | labels | string | `nil` |  |
 | loadTestGenesis | bool | `false` | Load test-data for starting a test network |
+| manageImages | bool | `true` | If true, helm will always override the deployed image with what is configured in the helm values. If not, helm will take the latest image from the currently running workloads, which is useful if you have a separate procedure to update images (e.g. rollout) |
 | numFullnodeGroups | int | `1` | Total number of fullnode groups to deploy |
 | numValidators | int | `1` | Number of validators to deploy |
 | overrideNodeConfig | bool | `false` | Specify validator and fullnode NodeConfigs via named ConfigMaps, rather than the generated ones from this chart. |
 | podSecurityPolicy | bool | `true` | LEGACY: create PodSecurityPolicy, which exists at the cluster-level |
+| pyroscope.enabled | bool | `false` | Enable Pyroscope profiling |
+| pyroscope.secretName | string | `"pyroscope"` | Secret which contains the Pyroscope API key and other configuration |
 | service.domain | string | `nil` | If set, the base domain name to use for External DNS |
 | service.fullnode.enableMetricsPort | bool | `true` | Enable the metrics port on fullnodes |
 | service.fullnode.enableRestApi | bool | `true` | Enable the REST API on fullnodes |
-| service.fullnode.external.type | string | `"LoadBalancer"` | The Kubernetes ServiceType to use for fullnodes |
+| service.fullnode.external.type | string | `"LoadBalancer"` | The Kubernetes ServiceType to use for fullnodes' HAProxy |
 | service.fullnode.externalTrafficPolicy | string | `"Local"` | The externalTrafficPolicy for the fullnode service |
+| service.fullnode.internal.type | string | `"ClusterIP"` | The Kubernetes ServiceType to use for fullnodes |
 | service.fullnode.loadBalancerSourceRanges | string | `nil` | If set and if the ServiceType is LoadBalancer, allow traffic to fullnodes from these CIDRs |
 | service.validator.enableMetricsPort | bool | `true` | Enable the metrics port on the validator |
 | service.validator.enableRestApi | bool | `true` | Enable the REST API on the validator |
-| service.validator.external.type | string | `"LoadBalancer"` | The Kubernetes ServiceType to use for validator |
+| service.validator.external.type | string | `"LoadBalancer"` | The Kubernetes ServiceType to use for validator's HAProxy |
 | service.validator.externalTrafficPolicy | string | `"Local"` | The externalTrafficPolicy for the validator service |
+| service.validator.internal.type | string | `"ClusterIP"` | The Kubernetes ServiceType to use for validator |
 | service.validator.loadBalancerSourceRanges | string | `nil` | If set and if the ServiceType is LoadBalancer, allow traffic to validators from these CIDRs |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `nil` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | validator.affinity | object | `{}` |  |
-| validator.config | object | `{"api":{},"base":{},"consensus":{},"execution":{},"failpoints":{},"firehose_stream":{},"full_node_networks":[],"inspection_service":{},"logger":{},"mempool":{"default_failovers":0,"max_broadcasts_per_peer":2,"shared_mempool_max_concurrent_inbound_syncs":16},"metrics":{},"peer_monitoring_service":{},"state_sync":{},"storage":{},"test":{},"validator_network":{}}` | Validator configuration. See NodeConfig https://github.com/aptos-labs/aptos-core/blob/main/config/src/config/mod.rs |
+| validator.config | object | `{}` | Validator configuration. See NodeConfig https://github.com/aptos-labs/aptos-core/blob/main/config/src/config/mod.rs |
 | validator.enableNetworkPolicy | bool | `true` | Lock down network ingress and egress with Kubernetes NetworkPolicy |
+| validator.force_enable_telemetry | bool | `false` | Flag to force enable telemetry service (useful for forge tests) |
 | validator.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy to use for validator images |
 | validator.image.repo | string | `"aptoslabs/validator"` | Image repo to use for validator images |
 | validator.image.tag | string | `nil` | Image tag to use for validator images. If set, overrides `imageTag` |
@@ -79,7 +90,7 @@ Aptos blockchain node deployment
 | validator.resources.requests.memory | string | `"26Gi"` |  |
 | validator.rust_log | string | `"info"` | Log level for the validator |
 | validator.storage.class | string | `nil` | Kubernetes storage class to use for validator persistent storage |
-| validator.storage.size | string | `"1000Gi"` | Size of validator persistent storage |
+| validator.storage.size | string | `"2048Gi"` | Size of validator persistent storage |
 | validator.tolerations | list | `[]` |  |
 
 ## Resource Descriptions

--- a/terraform/helm/aptos-node/templates/fullnode.yaml
+++ b/terraform/helm/aptos-node/templates/fullnode.yaml
@@ -24,7 +24,7 @@ spec:
     port: 8080
 
 ---
-
+{{ $fullnode_statefulset := lookup "apps/v1" "StatefulSet" $.Release.Namespace (printf "%s-%d-%s-e%s" (include "aptos-validator.fullname" $) $i .name (toYaml $.Values.chain.era)) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -75,7 +75,11 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: fullnode
+        {{- if and $fullnode_statefulset (not $.Values.manageImages) }} # if the statefulset already exists and we do not want helm to simply overwrite the image, use the existing image
+        image: {{ (first $fullnode_statefulset.spec.template.spec.containers).image }}
+        {{- else }}
         image: {{ $.Values.validator.image.repo }}:{{ $.Values.validator.image.tag | default $.Values.imageTag }}
+        {{- end }}
         imagePullPolicy: {{ $.Values.validator.image.pullPolicy }}
         {{- if not $.Values.pyroscope.enabled }}
         command: ["/usr/local/bin/aptos-node", "-f", "/opt/aptos/etc/fullnode.yaml"]

--- a/terraform/helm/aptos-node/templates/validator.yaml
+++ b/terraform/helm/aptos-node/templates/validator.yaml
@@ -46,7 +46,7 @@ spec:
   {{- end }}
 
 ---
-
+{{ $validator_statefulset := lookup "apps/v1" "StatefulSet" $.Release.Namespace (printf "%s-%d-validator" (include "aptos-validator.fullname" $) $i) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -79,7 +79,11 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: validator
+        {{- if and $validator_statefulset (not $.Values.manageImages) }} # if the statefulset already exists and we do not want helm to simply overwrite the image, use the existing image
+        image: {{ (first $validator_statefulset.spec.template.spec.containers).image }}
+        {{- else }}
         image: {{ $.Values.validator.image.repo }}:{{ $.Values.validator.image.tag | default $.Values.imageTag }}
+        {{- end }}
       {{- with $.Values.validator }}
         imagePullPolicy: {{ .image.pullPolicy }}
         {{- if not $.Values.pyroscope.enabled }}

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -17,6 +17,9 @@ numFullnodeGroups: 1
 # -- Specify validator and fullnode NodeConfigs via named ConfigMaps, rather than the generated ones from this chart.
 overrideNodeConfig: false
 
+# -- If true, helm will always override the deployed image with what is configured in the helm values. If not, helm will take the latest image from the currently running workloads, which is useful if you have a separate procedure to update images (e.g. rollout)
+manageImages: true
+
 haproxy:
   # -- Enable HAProxy deployment in front of validator and fullnodes
   enabled: true

--- a/terraform/helm/fullnode/README.md
+++ b/terraform/helm/fullnode/README.md
@@ -1,13 +1,13 @@
 # aptos-fullnode
 
-![Version: 1.5.0-rc.1](https://img.shields.io/badge/Version-1.5.0--rc.1-informational?style=flat-square) ![AppVersion: 1.5.0-rc.1](https://img.shields.io/badge/AppVersion-1.5.0--rc.1-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| aptos_chains | object | `{"ait3":{"genesis_blob_url":"https://raw.githubusercontent.com/aptos-labs/aptos-ait3/main/genesis.blob","waypoint_txt_url":"https://raw.githubusercontent.com/aptos-labs/aptos-ait3/main/waypoint.txt"},"devnet":{"genesis_blob_url":"https://devnet.aptoslabs.com/genesis.blob","waypoint_txt_url":"https://devnet.aptoslabs.com/waypoint.txt"},"testnet":{"genesis_blob_url":"https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/testnet/genesis.blob","waypoint_txt_url":"https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/testnet/waypoint.txt"}}` | For each supported chain, specify the URLs from which to download the genesis.blob and waypoint.txt |
+| aptos_chains | object | `{"devnet":{"genesis_blob_url":"https://devnet.aptoslabs.com/genesis.blob","waypoint_txt_url":"https://devnet.aptoslabs.com/waypoint.txt"},"mainnet":{"genesis_blob_url":"https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/mainnet/genesis.blob","waypoint_txt_url":"https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/mainnet/waypoint.txt"},"testnet":{"genesis_blob_url":"https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/testnet/genesis.blob","waypoint_txt_url":"https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/testnet/waypoint.txt"}}` | For each supported chain, specify the URLs from which to download the genesis.blob and waypoint.txt |
 | backup.affinity | object | `{}` |  |
 | backup.config.azure.account | string | `nil` |  |
 | backup.config.azure.container | string | `nil` |  |
@@ -20,7 +20,7 @@
 | backup.enable | bool | `false` | Whether to enable backup |
 | backup.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy to use for backup images |
 | backup.image.repo | string | `"aptoslabs/tools"` | Image repo to use for backup images |
-| backup.image.tag | string | `"devnet"` | Image tag to use for backup images |
+| backup.image.tag | string | `nil` | Image tag to use for backup images |
 | backup.nodeSelector | object | `{}` |  |
 | backup.resources.limits.cpu | int | `1` |  |
 | backup.resources.limits.memory | string | `"1Gi"` |  |
@@ -29,9 +29,9 @@
 | backup.tolerations | list | `[]` |  |
 | backup_verify.affinity | object | `{}` |  |
 | backup_verify.nodeSelector | object | `{}` |  |
-| backup_verify.resources.limits.cpu | float | `4` |  |
+| backup_verify.resources.limits.cpu | int | `4` |  |
 | backup_verify.resources.limits.memory | string | `"4Gi"` |  |
-| backup_verify.resources.requests.cpu | float | `4` |  |
+| backup_verify.resources.requests.cpu | int | `4` |  |
 | backup_verify.resources.requests.memory | string | `"4Gi"` |  |
 | backup_verify.schedule | string | `"@daily"` | The schedule for backup verification |
 | backup_verify.tolerations | list | `[]` |  |
@@ -42,12 +42,14 @@
 | fullnode.config | object | `{"full_node_networks":[{"identity":{},"inbound_rate_limit_config":null,"max_inbound_connections":100,"network_id":"public","outbound_rate_limit_config":null,"seeds":{}}]}` | Fullnode configuration. See NodeConfig https://github.com/aptos-labs/aptos-core/blob/main/config/src/config/mod.rs |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy to use for fullnode images |
 | image.repo | string | `"aptoslabs/validator"` | Image repo to use for fullnode images. Fullnodes and validators use the same image |
-| image.tag | string | `"devnet"` | Image tag to use for fullnode images |
+| image.tag | string | `nil` | Image tag to use for fullnode images. If set, overrides `imageTag` |
+| imageTag | string | `"devnet"` | Default image tag to use for all fullnode images |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` | Change enabled to true and fill out the rest of the fields to expose the REST API externally via your ingress controller |
 | ingress.hostName | string | `nil` | The hostname to use for the ingress |
 | ingress.ingressClassName | string | `nil` | The ingress class for fullnode ingress. Leaving class empty will result in an ingress that implicity uses the default ingress class |
 | logging.address | string | `nil` | Address for remote logging |
+| manageImages | bool | `true` | If true, helm will always override the deployed image with what is configured in the helm values. If not, helm will take the latest image from the currently running workloads, which is useful if you have a separate procedure to update images (e.g. rollout) |
 | nodeSelector | object | `{}` |  |
 | resources.limits.cpu | int | `14` |  |
 | resources.limits.memory | string | `"26Gi"` |  |
@@ -65,7 +67,7 @@
 | restore.config.trusted_waypoints | list | `[]` | List of trusted waypoints for restore |
 | restore.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy to use for restore images |
 | restore.image.repo | string | `"aptoslabs/tools"` | Image repo to use for restore images |
-| restore.image.tag | string | `"devnet"` | Image tag to use for restore images |
+| restore.image.tag | string | `nil` | Image tag to use for restore images |
 | restore.nodeSelector | object | `{}` |  |
 | restore.resources.limits.cpu | int | `6` |  |
 | restore.resources.limits.memory | string | `"15Gi"` |  |
@@ -74,6 +76,7 @@
 | restore.tolerations | list | `[]` |  |
 | rust_log | string | `"info"` | Log level for the fullnode |
 | service.annotations | object | `{}` |  |
+| service.exposeApi | bool | `true` | Whether to expose the node REST API |
 | service.externalTrafficPolicy | string | `nil` | The externalTrafficPolicy for the fullnode service |
 | service.loadBalancerSourceRanges | list | `[]` | If set and if the ServiceType is LoadBalancer, allow traffic to fullnode from these CIDRs |
 | service.type | string | `"ClusterIP"` | The Kubernetes ServiceType to use for the fullnode. Change this to LoadBalancer expose the REST API, aptosnet endpoint externally |

--- a/terraform/helm/fullnode/templates/fullnode.yaml
+++ b/terraform/helm/fullnode/templates/fullnode.yaml
@@ -1,3 +1,4 @@
+{{ $fullnode_statefulset := lookup "apps/v1" "StatefulSet" $.Release.Namespace (include "aptos-fullnode.fullname" .) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -26,7 +27,11 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: fullnode
-        image: {{ .Values.image.repo }}:{{ .Values.image.tag }}
+        {{- if and $fullnode_statefulset (not $.Values.manageImages) }} # if the statefulset already exists and we do not want helm to simply overwrite the image, use the existing image
+        image: {{ (first $fullnode_statefulset.spec.template.spec.containers).image }}
+        {{- else }}
+        image: {{ .Values.image.repo }}:{{ .Values.image.tag | default $.Values.imageTag }}
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - /bin/sh

--- a/terraform/helm/fullnode/values.yaml
+++ b/terraform/helm/fullnode/values.yaml
@@ -1,5 +1,8 @@
-# -- Default image tag to use for all validator and fullnode images
+# -- Default image tag to use for all fullnode images
 imageTag: devnet
+
+# -- If true, helm will always override the deployed image with what is configured in the helm values. If not, helm will take the latest image from the currently running workloads, which is useful if you have a separate procedure to update images (e.g. rollout)
+manageImages: true
 
 chain:
   # -- Bump this number to wipe the underlying storage
@@ -41,8 +44,8 @@ rust_log: info
 image:
   # -- Image repo to use for fullnode images. Fullnodes and validators use the same image
   repo: aptoslabs/validator
-  # -- Image tag to use for fullnode images
-  tag: devnet
+  # -- Image tag to use for fullnode images. If set, overrides `imageTag`
+  tag:
   # -- Image pull policy to use for fullnode images
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
### Description

Use the helm `lookup` function (https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-lookup-function) to avoid overwriting the image if `.Values.manageImages = false`. Many complex setups may require helm to do the initial workload setup, but require a separate procedure to handle release rollouts. This is the case with testnets: we want to be able to roll out each validator and fullnode more or less independently, and definitely not all at once, which is what Terraform/helm would do. With this new config flag flipped, this allows the operator to set the validator and fullnode images using a separate process like `kubectl set image`, etc, and then subsequent `helm upgrade` or `terraform apply` will fetch the image set separately, rather than blowing it away with what's in the deployment config.

This also allows the case where we want to be decoupled from Terraform/helm for image updates, but we can use it for other updates, like Service (Open/close ports), ConfigMap (NodeConfig), etc updates. For now, only the image is controlled by helm `lookup`, so all other attributes of a helm release are still tunable as before. 

For Terraform/helm setups, this is wrapped into the `manage_via_tf` variable. Basically, with `manage_via_tf = true`, Terraform variables are the source of truth and each `terraform apply` has the potential to blow away changes with state drift. This is OK for managing single-node deployments. With `manage_via_tf = false`, Terraform still can control some aspects of the k8s workloads, but (1) cannot change the image tag (2) will not `helm upgrade` each time -- only when values are changed.

### Test Plan

Local setup with KinD, and test manually the scenarios:
* `manageImages = false` && `imageTag = testnet` -- initially, all workloads spin up with the `testnet` tag. Then mutate the image tag using `kubectl set image sts/<STS_NAME> <CONTAINER>=..../mainnet`. The workload is then running the `mainnet` tag. Subsequent `terraform apply` or `helm upgrade` does not affect the image tag, since helm takes the latest state in the cluster.
* `manageImages = true` && `imageTag = testnet` -- this is basically the default behavior. initially, all workloads spin up with the `testnet` tag. Then mutate the image tag using `kubectl set image... mainnet`. The workload is then running the `mainnet` tag. Subsequent `terraform apply` or `helm upgrade` rolls back the image tag to `testnet` since that's what's specified in config.

<!-- Please provide us with clear details for verifying that your changes work. -->
