### PR TITLE
[Dockerfile] Enable experimental docker build on push to main

### DIFF
--- a/.github/workflows/experimental-docker-build-test.yaml
+++ b/.github/workflows/experimental-docker-build-test.yaml
@@ -37,6 +37,9 @@ on: # build on main branch OR when a PR is labeled with `CICD:build-images`
       - ".github/workflows/docker-rust-build.yaml"
       - ".github/workflows/sdk-release.yaml"
       - ".github/workflows/lint-test.yaml"
+  push:
+    branches:
+      - main
 
 # cancel redundant builds
 concurrency:
@@ -120,6 +123,8 @@ jobs:
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+      IMAGE_TAG: experimental_${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+      FORGE_IMAGE_TAG: experimental_${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       COMMENT_HEADER: forge-e2e
       # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
       # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered

--- a/.github/workflows/experimental-docker-rust-build.yaml
+++ b/.github/workflows/experimental-docker-rust-build.yaml
@@ -60,3 +60,4 @@ jobs:
           FEATURES: ${{ env.FEATURES }}
           BUILD_ADDL_TESTING_IMAGES: ${{ env.BUILD_ADDL_TESTING_IMAGES }}
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+          CUSTOM_IMAGE_TAG_PREFIX: experimental

--- a/.github/workflows/workflow-run-forge.yaml
+++ b/.github/workflows/workflow-run-forge.yaml
@@ -12,6 +12,10 @@ on:
         required: false
         type: string
         description: The docker image tag to test. If not specified, falls back on GIT_SHA, and then to the latest commits on the current branch
+      FORGE_IMAGE_TAG:
+        required: false
+        type: string
+        description: The docker image tag to use for forge runner. If not specified, falls back on GIT_SHA, and then to the latest commits on the current branch
       FORGE_NAMESPACE:
         required: false
         type: string
@@ -70,6 +74,7 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: us-west-2
   IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
+  FORGE_IMAGE_TAG: ${{ inputs.FORGE_IMAGE_TAG }}
   FORGE_BLOCKING: ${{ secrets.FORGE_BLOCKING }}
   FORGE_CLUSTER_NAME: ${{ inputs.FORGE_CLUSTER_NAME }}
   FORGE_OUTPUT: forge_output.txt

--- a/docker/experimental/docker-bake-rust-all.sh
+++ b/docker/experimental/docker-bake-rust-all.sh
@@ -22,6 +22,7 @@ export NORMALIZED_GIT_BRANCH_OR_PR=$(printf "$TARGET_CACHE_ID" | sed -e 's/[^a-z
 export PROFILE=${PROFILE:-release}
 export FEATURES=${FEATURES:-""}
 export NORMALIZED_FEATURES_LIST=$(printf "$FEATURES" | sed -e 's/[^a-zA-Z0-9]/_/g')
+export CUSTOM_IMAGE_TAG_PREFIX=${CUSTOM_IMAGE_TAG_PREFIX:-""}
 
 if [ "$PROFILE" = "release" ]; then
   # Do not prefix image tags if we're building the default profile "release"
@@ -31,10 +32,16 @@ else
   profile_prefix="${PROFILE}_"
 fi
 
-if [ -n "$FEATURES" ]; then
-  export IMAGE_TAG_PREFIX="${profile_prefix}${NORMALIZED_FEATURES_LIST}_"
+if [ -n "$CUSTOM_IMAGE_TAG_PREFIX" ]; then
+  export IMAGE_TAG_PREFIX="${CUSTOM_IMAGE_TAG_PREFIX}_"
 else
-  export IMAGE_TAG_PREFIX="${profile_prefix}"
+  export IMAGE_TAG_PREFIX=""
+fi
+
+if [ -n "$FEATURES" ]; then
+  export IMAGE_TAG_PREFIX="${IMAGE_TAG_PREFIX}${profile_prefix}${NORMALIZED_FEATURES_LIST}_"
+else
+  export IMAGE_TAG_PREFIX="${IMAGE_TAG_PREFIX}${profile_prefix}"
 fi
 
 BUILD_TARGET="${1:-forge-images}"


### PR DESCRIPTION
### Description

This PR enables the docker experimental build action on each push to the main branch. The built images with have a `experimental` tag prefix and a separate land-blocking forge is run with image produced by the build workflow.

It is not enabled in the PRs yet because if it fails, it might send false-positive signals to PR authors and will add unnecessary friction. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Test in main.
