### PR TITLE
[Rosetta] Add staking_contract distribute implementation

### DIFF
--- a/crates/aptos-rosetta/src/client.rs
+++ b/crates/aptos-rosetta/src/client.rs
@@ -387,6 +387,45 @@ impl RosettaClient {
         .await
     }
 
+    pub async fn distribute_staking_rewards(
+        &self,
+        network_identifier: &NetworkIdentifier,
+        private_key: &Ed25519PrivateKey,
+        operator: AccountAddress,
+        staker: AccountAddress,
+        expiry_time_secs: u64,
+        sequence_number: Option<u64>,
+        max_gas: Option<u64>,
+        gas_unit_price: Option<u64>,
+    ) -> anyhow::Result<TransactionIdentifier> {
+        let sender = self
+            .get_account_address(network_identifier.clone(), private_key)
+            .await?;
+        let mut keys = HashMap::new();
+        keys.insert(sender, private_key);
+
+        let operations = vec![Operation::distribute_staking_rewards(
+            0,
+            None,
+            sender,
+            AccountIdentifier::base_account(operator),
+            AccountIdentifier::base_account(staker),
+        )];
+
+        self.submit_operations(
+            sender,
+            network_identifier.clone(),
+            &keys,
+            operations,
+            expiry_time_secs,
+            sequence_number,
+            max_gas,
+            gas_unit_price,
+            false,
+        )
+        .await
+    }
+
     pub async fn create_stake_pool(
         &self,
         network_identifier: &NetworkIdentifier,

--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -102,6 +102,7 @@ pub enum OperationType {
 impl OperationType {
     const CREATE_ACCOUNT: &'static str = "create_account";
     const DEPOSIT: &'static str = "deposit";
+    const DISTRIBUTE_STAKING_REWARDS: &'static str = "distribute_staking_rewards";
     const FEE: &'static str = "fee";
     const INITIALIZE_STAKE_POOL: &'static str = "initialize_stake_pool";
     const RESET_LOCKUP: &'static str = "reset_lockup";
@@ -109,7 +110,6 @@ impl OperationType {
     const SET_VOTER: &'static str = "set_voter";
     const STAKING_REWARD: &'static str = "staking_reward";
     const UNLOCK_STAKE: &'static str = "unlock_stake";
-    const DISTRIBUTE_STAKING_REWARDS: &'static str = "distribute_staking_rewards";
     const WITHDRAW: &'static str = "withdraw";
 
     pub fn all() -> Vec<OperationType> {

--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -94,6 +94,7 @@ pub enum OperationType {
     InitializeStakePool,
     ResetLockup,
     UnlockStake,
+    DistributeStakingRewards,
     // Fee must always be last for ordering
     Fee,
 }
@@ -108,6 +109,7 @@ impl OperationType {
     const SET_VOTER: &'static str = "set_voter";
     const STAKING_REWARD: &'static str = "staking_reward";
     const UNLOCK_STAKE: &'static str = "unlock_stake";
+    const DISTRIBUTE_STAKING_REWARDS: &'static str = "distribute_staking_rewards";
     const WITHDRAW: &'static str = "withdraw";
 
     pub fn all() -> Vec<OperationType> {
@@ -123,6 +125,7 @@ impl OperationType {
             InitializeStakePool,
             ResetLockup,
             UnlockStake,
+            DistributeStakingRewards,
         ]
     }
 }
@@ -142,6 +145,7 @@ impl FromStr for OperationType {
             Self::INITIALIZE_STAKE_POOL => Ok(OperationType::InitializeStakePool),
             Self::RESET_LOCKUP => Ok(OperationType::ResetLockup),
             Self::UNLOCK_STAKE => Ok(OperationType::UnlockStake),
+            Self::DISTRIBUTE_STAKING_REWARDS => Ok(OperationType::DistributeStakingRewards),
             _ => Err(ApiError::DeserializationFailed(Some(format!(
                 "Invalid OperationType: {}",
                 s
@@ -163,6 +167,7 @@ impl Display for OperationType {
             InitializeStakePool => Self::INITIALIZE_STAKE_POOL,
             ResetLockup => Self::RESET_LOCKUP,
             UnlockStake => Self::UNLOCK_STAKE,
+            DistributeStakingRewards => Self::DISTRIBUTE_STAKING_REWARDS,
             Fee => Self::FEE,
         })
     }

--- a/crates/aptos-rosetta/src/types/move_types.rs
+++ b/crates/aptos-rosetta/src/types/move_types.rs
@@ -34,6 +34,7 @@ pub const SWITCH_OPERATOR_WITH_SAME_COMMISSION_FUNCTION: &str =
     "switch_operator_with_same_commission";
 pub const UPDATE_VOTER_FUNCTION: &str = "update_voter";
 pub const UNLOCK_STAKE_FUNCTION: &str = "unlock_stake";
+pub const DISTRIBUTE_STAKING_REWARDS_FUNCTION: &str = "distribute";
 
 pub const DECIMALS_FIELD: &str = "decimal";
 pub const DEPOSIT_EVENTS_FIELD: &str = "deposit_events";

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -8,9 +8,9 @@
 use crate::{
     common::{is_native_coin, native_coin, native_coin_tag},
     construction::{
-        parse_create_stake_pool_operation, parse_reset_lockup_operation,
-        parse_set_operator_operation, parse_set_voter_operation,
-        parse_unlock_stake_operation, parse_distribute_staking_rewards_operation,
+        parse_create_stake_pool_operation, parse_distribute_staking_rewards_operation,
+        parse_reset_lockup_operation, parse_set_operator_operation, parse_set_voter_operation,
+        parse_unlock_stake_operation,
     },
     error::ApiResult,
     types::{
@@ -840,11 +840,7 @@ fn parse_failed_operations_from_txn_payload(
                     warn!("Failed to parse unlock stake {:?}", inner);
                 }
             },
-            (
-                AccountAddress::ONE,
-                STAKING_CONTRACT_MODULE,
-                DISTRIBUTE_STAKING_REWARDS_FUNCTION,
-            ) => {
+            (AccountAddress::ONE, STAKING_CONTRACT_MODULE, DISTRIBUTE_STAKING_REWARDS_FUNCTION) => {
                 if let Ok(mut ops) = parse_distribute_staking_rewards_operation(
                     sender,
                     inner.ty_args(),

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -9,7 +9,8 @@ use crate::{
     common::{is_native_coin, native_coin, native_coin_tag},
     construction::{
         parse_create_stake_pool_operation, parse_reset_lockup_operation,
-        parse_set_operator_operation, parse_set_voter_operation, parse_unlock_stake_operation,
+        parse_set_operator_operation, parse_set_voter_operation,
+        parse_unlock_stake_operation, parse_distribute_staking_rewards_operation,
     },
     error::ApiResult,
     types::{
@@ -387,6 +388,25 @@ impl Operation {
             Some(OperationMetadata::unlock_stake(operator, amount)),
         )
     }
+
+    pub fn distribute_staking_rewards(
+        operation_index: u64,
+        status: Option<OperationStatusType>,
+        account: AccountAddress,
+        operator: AccountIdentifier,
+        staker: AccountIdentifier,
+    ) -> Operation {
+        Operation::new(
+            OperationType::DistributeStakingRewards,
+            operation_index,
+            status,
+            AccountIdentifier::base_account(account),
+            None,
+            Some(OperationMetadata::distribute_staking_rewards(
+                operator, staker,
+            )),
+        )
+    }
 }
 
 impl std::cmp::PartialOrd for Operation {
@@ -437,6 +457,8 @@ pub struct OperationMetadata {
     pub commission_percentage: Option<U64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<U64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub staker: Option<AccountIdentifier>,
 }
 
 impl OperationMetadata {
@@ -494,6 +516,17 @@ impl OperationMetadata {
         OperationMetadata {
             operator,
             amount: amount.map(U64::from),
+            ..Default::default()
+        }
+    }
+
+    pub fn distribute_staking_rewards(
+        operator: AccountIdentifier,
+        staker: AccountIdentifier,
+    ) -> Self {
+        OperationMetadata {
+            operator: Some(operator),
+            staker: Some(staker),
             ..Default::default()
         }
     }
@@ -805,6 +838,23 @@ fn parse_failed_operations_from_txn_payload(
                     }
                 } else {
                     warn!("Failed to parse unlock stake {:?}", inner);
+                }
+            },
+            (
+                AccountAddress::ONE,
+                STAKING_CONTRACT_MODULE,
+                DISTRIBUTE_STAKING_REWARDS_FUNCTION,
+            ) => {
+                if let Ok(mut ops) = parse_distribute_staking_rewards_operation(
+                    sender,
+                    inner.ty_args(),
+                    inner.args(),
+                ) {
+                    if let Some(operation) = ops.get_mut(0) {
+                        operation.status = Some(OperationStatusType::Failure.to_string());
+                    }
+                } else {
+                    warn!("Failed to parse distribute staking rewards {:?}", inner);
                 }
             },
             _ => {
@@ -1298,6 +1348,34 @@ async fn parse_staking_contract_resource_changes(
             }
             operations.push(operation);
         }
+
+        // Handle distribute events, there are no events on the stake pool
+        let distribute_staking_rewards_events =
+            filter_events(events, store.distribute_events.key(), |event_key, event| {
+                if let Ok(event) = bcs::from_bytes::<DistributeEvent>(event.event_data()) {
+                    Some(event)
+                } else {
+                    // If we can't parse the withdraw event, then there's nothing
+                    warn!(
+                        "Failed to parse distribute event!  Skipping for {}:{}",
+                        event_key.get_creator_address(),
+                        event_key.get_creation_number()
+                    );
+                    None
+                }
+            });
+
+        // For every distribute events, add staking reward operation
+        for event in distribute_staking_rewards_events {
+            operations.push(Operation::staking_reward(
+                operation_index,
+                Some(OperationStatusType::Success),
+                AccountIdentifier::base_account(event.recipient),
+                native_coin(),
+                event.amount,
+            ));
+            operation_index += 1;
+        }
     }
 
     Ok(operations)
@@ -1400,6 +1478,7 @@ pub enum InternalOperation {
     InitializeStakePool(InitializeStakePool),
     ResetLockup(ResetLockup),
     UnlockStake(UnlockStake),
+    DistributeStakingRewards(DistributeStakingRewards),
 }
 
 impl InternalOperation {
@@ -1544,6 +1623,25 @@ impl InternalOperation {
                                 }));
                             }
                         },
+                        Ok(OperationType::DistributeStakingRewards) => {
+                            if let (
+                                Some(OperationMetadata {
+                                    operator: Some(operator),
+                                    staker: Some(staker),
+                                    ..
+                                }),
+                                Some(account),
+                            ) = (&operation.metadata, &operation.account)
+                            {
+                                return Ok(Self::DistributeStakingRewards(
+                                    DistributeStakingRewards {
+                                        sender: account.account_address()?,
+                                        operator: operator.account_address()?,
+                                        staker: staker.account_address()?,
+                                    },
+                                ));
+                            }
+                        },
                         _ => {},
                     }
                 }
@@ -1572,6 +1670,7 @@ impl InternalOperation {
             Self::InitializeStakePool(inner) => inner.owner,
             Self::ResetLockup(inner) => inner.owner,
             Self::UnlockStake(inner) => inner.owner,
+            Self::DistributeStakingRewards(inner) => inner.sender,
         }
     }
 
@@ -1638,6 +1737,13 @@ impl InternalOperation {
                     unlock_stake.amount,
                 ),
                 unlock_stake.owner,
+            ),
+            InternalOperation::DistributeStakingRewards(distribute_staking_rewards) => (
+                aptos_stdlib::staking_contract_distribute(
+                    distribute_staking_rewards.operator,
+                    distribute_staking_rewards.staker,
+                ),
+                distribute_staking_rewards.sender,
             ),
         })
     }
@@ -1803,4 +1909,11 @@ pub struct UnlockStake {
     pub owner: AccountAddress,
     pub operator: AccountAddress,
     pub amount: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DistributeStakingRewards {
+    pub sender: AccountAddress,
+    pub operator: AccountAddress,
+    pub staker: AccountAddress,
 }

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -967,7 +967,7 @@ async fn test_block() {
     .expect("Set voter should work!");
 
     // Unlock stake
-    let final_txn = unlock_stake_and_wait(
+    unlock_stake_and_wait(
         &rosetta_client,
         &rest_client,
         &network_identifier,
@@ -981,6 +981,37 @@ async fn test_block() {
     )
     .await
     .expect("Should successfully unlock stake");
+
+    // Failed distribution with wrong staker
+    distribute_staking_rewards_and_wait(
+        &rosetta_client,
+        &rest_client,
+        &network_identifier,
+        private_key_3,
+        account_id_1,
+        account_id_3,
+        Duration::from_secs(5),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect_err("Staker has no staking contracts.");
+
+    let final_txn = distribute_staking_rewards_and_wait(
+        &rosetta_client,
+        &rest_client,
+        &network_identifier,
+        private_key_3,
+        account_id_2,
+        account_id_2,
+        Duration::from_secs(5),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("Distribute staking rewards should work!");
 
     let final_block_to_check = rest_client
         .get_block_by_version(final_txn.info.version.0, false)
@@ -1678,6 +1709,61 @@ async fn parse_operations(
                     panic!("Not a user transaction");
                 }
             },
+            OperationType::DistributeStakingRewards => {
+                if actual_successful {
+                    assert_eq!(
+                        OperationStatusType::Success,
+                        status,
+                        "Successful transaction should have successful distribute operation"
+                    );
+                } else {
+                    assert_eq!(
+                        OperationStatusType::Failure,
+                        status,
+                        "Failed transaction should have failed distribute operation"
+                    );
+                }
+
+                // Check that distribute was set the same
+                if let aptos_types::transaction::Transaction::UserTransaction(ref txn) =
+                    actual_txn.transaction
+                {
+                    if let aptos_types::transaction::TransactionPayload::EntryFunction(
+                        ref payload,
+                    ) = txn.payload()
+                    {
+                        let actual_operator_address: AccountAddress =
+                            bcs::from_bytes(payload.args().first().unwrap()).unwrap();
+                        let operator = operation
+                            .metadata
+                            .as_ref()
+                            .unwrap()
+                            .operator
+                            .as_ref()
+                            .unwrap()
+                            .account_address()
+                            .unwrap();
+                        assert_eq!(actual_operator_address, operator);
+
+                        let actual_staker_address: AccountAddress =
+                            bcs::from_bytes(payload.args().get(1).unwrap()).unwrap();
+                        let staker = operation
+                            .metadata
+                            .as_ref()
+                            .unwrap()
+                            .staker
+                            .as_ref()
+                            .unwrap()
+                            .account_address()
+                            .unwrap();
+                        assert_eq!(actual_staker_address, staker);
+                    } else {
+                        panic!("Not an entry function");
+                    }
+                } else {
+                    panic!("Not a user transaction");
+                }
+            },
         }
     }
 
@@ -2178,6 +2264,38 @@ async fn unlock_stake_and_wait(
             sender_key,
             operator,
             amount,
+            expiry_time.as_secs(),
+            sequence_number,
+            max_gas,
+            gas_unit_price,
+        )
+        .await
+        .map_err(ErrorWrapper::BeforeSubmission)?
+        .hash;
+    wait_for_transaction(rest_client, expiry_time, txn_hash)
+        .await
+        .map_err(ErrorWrapper::AfterSubmission)
+}
+
+async fn distribute_staking_rewards_and_wait(
+    rosetta_client: &RosettaClient,
+    rest_client: &aptos_rest_client::Client,
+    network_identifier: &NetworkIdentifier,
+    sender_key: &Ed25519PrivateKey,
+    operator: AccountAddress,
+    staker: AccountAddress,
+    txn_expiry_duration: Duration,
+    sequence_number: Option<u64>,
+    max_gas: Option<u64>,
+    gas_unit_price: Option<u64>,
+) -> Result<Box<UserTransaction>, ErrorWrapper> {
+    let expiry_time = expiry_time(txn_expiry_duration);
+    let txn_hash = rosetta_client
+        .distribute_staking_rewards(
+            network_identifier,
+            sender_key,
+            operator,
+            staker,
             expiry_time.as_secs(),
             sequence_number,
             max_gas,


### PR DESCRIPTION
### Description
This PR adds `distribute` supports in Rosetta to support Unstake. Based on the [description](https://github.com/aptos-labs/aptos-core/commit/4f3f0859dc24a1240d713f1e0505f1391b5f0e14), anyone can trigger the tx, so in the PR we put both operator and staker to the metadata. However this tx involve implicit balance change. The amount can only be determined once tx issued on the blockchain. Wanna see if there is any better way to put balance change in the parsing/construction logic.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Will add smoke test once balance change required in this has been confirmed.
