### PR TITLE
[gha][forge] specify IMAGE_TAG for all tests

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -144,6 +144,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-continuous-e2e-single-vfn
       # Run for 8 minutes
       FORGE_RUNNER_DURATION_SECS: 480
@@ -156,6 +157,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-haproxy
       FORGE_RUNNER_DURATION_SECS: 600
       FORGE_ENABLE_HAPROXY: true
@@ -176,6 +178,7 @@ jobs:
       # This will upgrade from testnet branch to the latest main
       FORGE_TEST_SUITE: compat
       IMAGE_TAG: testnet
+      GIT_SHA: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }} # this is the git ref to checkout
       POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
 
   ### Chaos Forge tests
@@ -210,6 +213,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-network-partition
       # Run for 15 minutes
       FORGE_RUNNER_DURATION_SECS: 900
@@ -224,6 +228,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-changing-working-quorum-test
       FORGE_RUNNER_DURATION_SECS: 1200
       FORGE_TEST_SUITE: changing_working_quorum_test
@@ -236,6 +241,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-different-node-speed-and-reliability-test
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: different_node_speed_and_reliability_test
@@ -248,6 +254,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-changing-working-quorum-test-high-load
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: changing_working_quorum_test_high_load
@@ -262,6 +269,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-state-sync-perf-validator
       # Run for 40 minutes
       FORGE_RUNNER_DURATION_SECS: 2400
@@ -274,6 +282,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-state-sync-perf-fullnode-execute
       # Run for 40 minutes
       FORGE_RUNNER_DURATION_SECS: 2400
@@ -286,6 +295,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-state-sync-perf-fullnode-fast-sync
       # Run for 40 minutes
       FORGE_RUNNER_DURATION_SECS: 2400

--- a/.github/workflows/forge-unstable.yaml
+++ b/.github/workflows/forge-unstable.yaml
@@ -94,6 +94,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       COMMENT_HEADER: forge-continuous
       # This test suite is configured using the forge.py config test command
       FORGE_TEST_SUITE: continuous
@@ -104,6 +105,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-graceful-overload-test
       FORGE_RUNNER_DURATION_SECS: 1800
       FORGE_TEST_SUITE: graceful_overload
@@ -115,6 +117,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-nft-mint-test
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: nft_mint
@@ -126,6 +129,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-state-sync-slow-processing-catching-up-test
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: state_sync_slow_processing_catching_up
@@ -138,6 +142,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-twin-validator
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: twin_validator_test
@@ -175,6 +180,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-validator-reboot-stress
       # Run for 40 minutes
       FORGE_RUNNER_DURATION_SECS: 2400


### PR DESCRIPTION
### Description

Fix a bug where some Forge tests in both `forge-stable.yaml` and `forge-unstable.yaml` did not have an `IMAGE_TAG` specified, meaning that they would resort to searching the git history of the current checked out branch to find an image tag. While this works for `main` branch, this means that tests on `quorum-store` branch will actually test images from `main` branch in this case.

Also for the `compat` test, the base swarm `IMAGE_TAG = testnet` but set `GIT_SHA` to the correct latest commit with built images on the right branch

### Test Plan

@bchocho 's `quorum-store` tests are healthy :p 

<!-- Please provide us with clear details for verifying that your changes work. -->
