### PR TITLE
[rosetta] Change docker to 1.66 buster from bullseye

### DIFF
--- a/docker/rosetta/rosetta.Dockerfile
+++ b/docker/rosetta/rosetta.Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04@sha256:a06ae92523384c2cd182dcfe7f8b2bf09075062e937d5653d7d0db0375ad2221 AS ubuntu-base
 
 ## get rust build environment ready
-FROM rust:1.66.1-bullseye@sha256:f72949bcf1daf8954c0e0ed8b7e10ac4c641608f6aa5f0ef7c172c49f35bd9b5 AS rust-base
+FROM rust:1.66.1-buster@sha256:e518dbab65069f4869f0159a460a989161ed277913c03427ed8b84542b771f7e AS rust-base
 
 WORKDIR /aptos
 RUN apt-get update && apt-get install -y cmake curl clang git pkg-config libssl-dev libpq-dev lld


### PR DESCRIPTION
### Description
Looks like some compatibility issues with some build systems for bullseye, so changing back to buster for now.

### Test Plan
Autobuild
