### PR TITLE
[Quorum Store] Use a single quorum_store_db instance across epochs

### DIFF
--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -8,6 +8,7 @@ use crate::{
     network::NetworkTask,
     network_interface::{ConsensusMsg, ConsensusNetworkClient},
     persistent_liveness_storage::StorageWriteProxy,
+    quorum_store::quorum_store_db::QuorumStoreDB,
     state_computer::ExecutionProxy,
     txn_notifier::MempoolNotifier,
     util::time_service::ClockTimeService,
@@ -38,6 +39,8 @@ pub fn start_consensus(
 ) -> Runtime {
     let runtime = aptos_runtimes::spawn_named_runtime("consensus".into(), None);
     let storage = Arc::new(StorageWriteProxy::new(node_config, aptos_db.reader.clone()));
+    let quorum_store_db = Arc::new(QuorumStoreDB::new(node_config.storage.dir()));
+
     let txn_notifier = Arc::new(MempoolNotifier::new(
         consensus_to_mempool_sender.clone(),
         node_config.consensus.mempool_executed_txn_timeout_ms,
@@ -66,6 +69,7 @@ pub fn start_consensus(
         consensus_to_mempool_sender,
         state_computer,
         storage,
+        quorum_store_db,
         reconfig_events,
     );
 

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -36,7 +36,7 @@ use crate::{
     quorum_store::{
         quorum_store_builder::{DirectMempoolInnerBuilder, InnerBuilder, QuorumStoreBuilder},
         quorum_store_coordinator::CoordinatorCommand,
-        quorum_store_db::QuorumStoreDB,
+        quorum_store_db::{QuorumStoreDB, QuorumStoreStorage},
     },
     recovery_manager::RecoveryManager,
     round_manager::{RoundManager, UnverifiedEvent, VerifiedEvent},
@@ -125,11 +125,11 @@ pub struct EpochManager {
         Option<aptos_channel::Sender<AccountAddress, IncomingBlockRetrievalRequest>>,
     quorum_store_msg_tx: Option<aptos_channel::Sender<AccountAddress, VerifiedEvent>>,
     quorum_store_coordinator_tx: Option<Sender<CoordinatorCommand>>,
-    quorum_store_db: Arc<QuorumStoreDB>,
+    quorum_store_storage: Arc<dyn QuorumStoreStorage>,
 }
 
 impl EpochManager {
-    pub fn new(
+    pub(crate) fn new(
         node_config: &NodeConfig,
         time_service: Arc<dyn TimeService>,
         self_sender: aptos_channels::Sender<Event<ConsensusMsg>>,
@@ -138,13 +138,13 @@ impl EpochManager {
         quorum_store_to_mempool_sender: Sender<QuorumStoreRequest>,
         commit_state_computer: Arc<dyn StateComputer>,
         storage: Arc<dyn PersistentLivenessStorage>,
+        quorum_store_storage: Arc<dyn QuorumStoreStorage>,
         reconfig_events: ReconfigNotificationListener,
     ) -> Self {
         let author = node_config.validator_network.as_ref().unwrap().peer_id();
         let config = node_config.consensus.clone();
         let sr_config = &node_config.consensus.safety_rules;
         let safety_rules_manager = SafetyRulesManager::new(sr_config);
-        let quorum_store_db = Arc::new(QuorumStoreDB::new(node_config.storage.dir()));
         Self {
             author,
             config,
@@ -167,7 +167,7 @@ impl EpochManager {
             block_retrieval_tx: None,
             quorum_store_msg_tx: None,
             quorum_store_coordinator_tx: None,
-            quorum_store_db,
+            quorum_store_storage,
         }
     }
 
@@ -640,7 +640,7 @@ impl EpochManager {
                 network_sender.clone(),
                 epoch_state.verifier.clone(),
                 self.config.safety_rules.backend.clone(),
-                self.quorum_store_db.clone(),
+                self.quorum_store_storage.clone(),
             ))
         } else {
             info!("Building DirectMempool");

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -4,7 +4,7 @@
 use crate::quorum_store::{
     batch_coordinator::BatchCoordinatorCommand,
     counters,
-    quorum_store_db::BatchIdDB,
+    quorum_store_db::QuorumStoreStorage,
     types::BatchId,
     utils::{BatchBuilder, MempoolProxy, RoundExpirations},
 };
@@ -39,7 +39,7 @@ pub enum ProofError {
 }
 
 pub struct BatchGenerator {
-    db: Arc<dyn BatchIdDB>,
+    db: Arc<dyn QuorumStoreStorage>,
     config: QuorumStoreConfig,
     mempool_proxy: MempoolProxy,
     batch_coordinator_tx: TokioSender<BatchCoordinatorCommand>,
@@ -53,10 +53,10 @@ pub struct BatchGenerator {
 }
 
 impl BatchGenerator {
-    pub fn new(
+    pub(crate) fn new(
         epoch: u64,
         config: QuorumStoreConfig,
-        db: Arc<dyn BatchIdDB>,
+        db: Arc<dyn QuorumStoreStorage>,
         mempool_tx: Sender<QuorumStoreRequest>,
         batch_coordinator_tx: TokioSender<BatchCoordinatorCommand>,
         mempool_txn_pull_timeout_ms: u64,

--- a/consensus/src/quorum_store/batch_store.rs
+++ b/consensus/src/quorum_store/batch_store.rs
@@ -1,13 +1,13 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use super::quorum_store_db::QuorumStoreStorage;
 use crate::{
     network::QuorumStoreSender,
     quorum_store::{
         batch_reader::{BatchReader, BatchReaderCommand},
         counters,
         proof_coordinator::ProofCoordinatorCommand,
-        quorum_store_db::QuorumStoreDB,
         types::{Batch, PersistedValue},
     },
 };
@@ -67,7 +67,7 @@ pub(crate) struct BatchStore<T> {
     my_peer_id: PeerId,
     network_sender: T,
     batch_reader: Arc<BatchReader>,
-    db: Arc<QuorumStoreDB>,
+    db: Arc<dyn QuorumStoreStorage>,
     validator_signer: Arc<ValidatorSigner>,
 }
 
@@ -82,7 +82,7 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
         batch_store_tx: Sender<BatchStoreCommand>,
         batch_reader_tx: Sender<BatchReaderCommand>,
         batch_reader_rx: Receiver<BatchReaderCommand>,
-        db: Arc<QuorumStoreDB>,
+        db: Arc<dyn QuorumStoreStorage>,
         validator_verifier: ValidatorVerifier,
         validator_signer: Arc<ValidatorSigner>,
         batch_expiry_round_gap_when_init: Round,

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -32,7 +32,7 @@ use aptos_types::{
     validator_verifier::ValidatorVerifier,
 };
 use futures_channel::mpsc::{Receiver, Sender};
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 pub enum QuorumStoreBuilder {
     DirectMempool(DirectMempoolInnerBuilder),
@@ -129,8 +129,7 @@ pub struct InnerBuilder {
     batch_reader_cmd_rx: Option<tokio::sync::mpsc::Receiver<BatchReaderCommand>>,
     back_pressure_tx: tokio::sync::mpsc::Sender<bool>,
     back_pressure_rx: Option<tokio::sync::mpsc::Receiver<bool>>,
-    quorum_store_storage_path: PathBuf,
-    quorum_store_storage: Option<Arc<QuorumStoreDB>>,
+    quorum_store_storage: Arc<QuorumStoreDB>,
     quorum_store_msg_tx: aptos_channel::Sender<AccountAddress, VerifiedEvent>,
     quorum_store_msg_rx: Option<aptos_channel::Receiver<AccountAddress, VerifiedEvent>>,
     remote_batch_coordinator_cmd_tx: Vec<tokio::sync::mpsc::Sender<BatchCoordinatorCommand>>,
@@ -149,7 +148,7 @@ impl InnerBuilder {
         network_sender: NetworkSender,
         verifier: ValidatorVerifier,
         backend: SecureBackend,
-        quorum_store_storage_path: PathBuf,
+        quorum_store_storage: Arc<QuorumStoreDB>,
     ) -> Self {
         let (coordinator_tx, coordinator_rx) = futures_channel::mpsc::channel(config.channel_size);
         let (batch_generator_cmd_tx, batch_generator_cmd_rx) =
@@ -207,8 +206,7 @@ impl InnerBuilder {
             batch_reader_cmd_rx: Some(batch_reader_cmd_rx),
             back_pressure_tx,
             back_pressure_rx: Some(back_pressure_rx),
-            quorum_store_storage_path,
-            quorum_store_storage: None,
+            quorum_store_storage,
             quorum_store_msg_tx,
             quorum_store_msg_rx: Some(quorum_store_msg_rx),
             remote_batch_coordinator_cmd_tx,
@@ -256,7 +254,7 @@ impl InnerBuilder {
             self.batch_store_cmd_tx.clone(),
             self.batch_reader_cmd_tx.clone(),
             batch_reader_cmd_rx,
-            self.quorum_store_storage.as_ref().unwrap().clone(),
+            self.quorum_store_storage.clone(),
             self.verifier.clone(),
             Arc::new(signer),
             self.config.batch_expiry_round_gap_when_init,
@@ -277,8 +275,6 @@ impl InnerBuilder {
     }
 
     fn spawn_quorum_store_wrapper(mut self) -> Sender<CoordinatorCommand> {
-        let quorum_store_storage = self.quorum_store_storage.as_ref().unwrap().clone();
-
         // TODO: parameter? bring back back-off?
         let interval = tokio::time::interval(Duration::from_millis(
             self.config.mempool_pulling_interval as u64,
@@ -305,7 +301,7 @@ impl InnerBuilder {
         let batch_generator = BatchGenerator::new(
             self.epoch,
             self.config.clone(),
-            quorum_store_storage,
+            self.quorum_store_storage.clone(),
             self.quorum_store_to_mempool_sender,
             self.batch_coordinator_cmd_tx.clone(),
             self.mempool_txn_pull_timeout_ms,
@@ -389,10 +385,6 @@ impl InnerBuilder {
         Arc<PayloadManager>,
         Option<aptos_channel::Sender<AccountAddress, VerifiedEvent>>,
     ) {
-        self.quorum_store_storage = Some(Arc::new(QuorumStoreDB::new(
-            self.quorum_store_storage_path.clone(),
-        )));
-
         let batch_reader = self.spawn_quorum_store();
 
         (

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use super::quorum_store_db::QuorumStoreStorage;
 use crate::{
     network::NetworkSender,
     payload_manager::PayloadManager,
@@ -129,7 +130,7 @@ pub struct InnerBuilder {
     batch_reader_cmd_rx: Option<tokio::sync::mpsc::Receiver<BatchReaderCommand>>,
     back_pressure_tx: tokio::sync::mpsc::Sender<bool>,
     back_pressure_rx: Option<tokio::sync::mpsc::Receiver<bool>>,
-    quorum_store_storage: Arc<QuorumStoreDB>,
+    quorum_store_storage: Arc<dyn QuorumStoreStorage>,
     quorum_store_msg_tx: aptos_channel::Sender<AccountAddress, VerifiedEvent>,
     quorum_store_msg_rx: Option<aptos_channel::Receiver<AccountAddress, VerifiedEvent>>,
     remote_batch_coordinator_cmd_tx: Vec<tokio::sync::mpsc::Sender<BatchCoordinatorCommand>>,
@@ -137,7 +138,7 @@ pub struct InnerBuilder {
 }
 
 impl InnerBuilder {
-    pub fn new(
+    pub(crate) fn new(
         epoch: u64,
         author: Author,
         config: QuorumStoreConfig,
@@ -148,7 +149,7 @@ impl InnerBuilder {
         network_sender: NetworkSender,
         verifier: ValidatorVerifier,
         backend: SecureBackend,
-        quorum_store_storage: Arc<QuorumStoreDB>,
+        quorum_store_storage: Arc<dyn QuorumStoreStorage>,
     ) -> Self {
         let (coordinator_tx, coordinator_rx) = futures_channel::mpsc::channel(config.channel_size);
         let (batch_generator_cmd_tx, batch_generator_cmd_rx) =

--- a/consensus/src/quorum_store/quorum_store_db.rs
+++ b/consensus/src/quorum_store/quorum_store_db.rs
@@ -14,13 +14,23 @@ use aptos_logger::{debug, info};
 use aptos_schemadb::{Options, ReadOptions, SchemaBatch, DB};
 use std::{collections::HashMap, path::Path, time::Instant};
 
-/// The name of the quorum store db file
-pub const QUORUM_STORE_DB_NAME: &str = "quorumstoreDB";
+pub(crate) trait QuorumStoreStorage: Sync + Send {
+    fn delete_batches(&self, digests: Vec<HashValue>) -> Result<(), DbError>;
 
-pub trait BatchIdDB: Send + Sync {
+    fn get_all_batches(&self) -> Result<HashMap<HashValue, PersistedValue>>;
+
+    fn save_batch(&self, digest: HashValue, batch: PersistedValue) -> Result<(), DbError>;
+
+    fn get_batch(&self, digest: HashValue) -> Result<Option<PersistedValue>, DbError>;
+
+    fn delete_batch_id(&self, epoch: u64) -> Result<(), DbError>;
+
     fn clean_and_get_batch_id(&self, current_epoch: u64) -> Result<Option<BatchId>, DbError>;
     fn save_batch_id(&self, epoch: u64, batch_id: BatchId) -> Result<(), DbError>;
 }
+
+/// The name of the quorum store db file
+pub const QUORUM_STORE_DB_NAME: &str = "quorumstoreDB";
 
 pub struct QuorumStoreDB {
     db: DB,
@@ -47,8 +57,10 @@ impl QuorumStoreDB {
 
         Self { db }
     }
+}
 
-    pub(crate) fn delete_batches(&self, digests: Vec<HashValue>) -> Result<(), DbError> {
+impl QuorumStoreStorage for QuorumStoreDB {
+    fn delete_batches(&self, digests: Vec<HashValue>) -> Result<(), DbError> {
         let batch = SchemaBatch::new();
         for digest in digests.iter() {
             debug!("QS: db delete digest {}", digest);
@@ -58,17 +70,13 @@ impl QuorumStoreDB {
         Ok(())
     }
 
-    pub(crate) fn get_all_batches(&self) -> Result<HashMap<HashValue, PersistedValue>> {
+    fn get_all_batches(&self) -> Result<HashMap<HashValue, PersistedValue>> {
         let mut iter = self.db.iter::<BatchSchema>(ReadOptions::default())?;
         iter.seek_to_first();
         iter.collect::<Result<HashMap<HashValue, PersistedValue>>>()
     }
 
-    pub(crate) fn save_batch(
-        &self,
-        digest: HashValue,
-        batch: PersistedValue,
-    ) -> Result<(), DbError> {
+    fn save_batch(&self, digest: HashValue, batch: PersistedValue) -> Result<(), DbError> {
         debug!(
             "QS: db persists digest {} expiration {:?}",
             digest, batch.expiration
@@ -76,7 +84,7 @@ impl QuorumStoreDB {
         Ok(self.db.put::<BatchSchema>(&digest, &batch)?)
     }
 
-    pub(crate) fn get_batch(&self, digest: HashValue) -> Result<Option<PersistedValue>, DbError> {
+    fn get_batch(&self, digest: HashValue) -> Result<Option<PersistedValue>, DbError> {
         Ok(self.db.get::<BatchSchema>(&digest)?)
     }
 
@@ -86,9 +94,7 @@ impl QuorumStoreDB {
         self.db.write_schemas(batch)?;
         Ok(())
     }
-}
 
-impl BatchIdDB for QuorumStoreDB {
     fn clean_and_get_batch_id(&self, current_epoch: u64) -> Result<Option<BatchId>, DbError> {
         let mut iter = self.db.iter::<BatchIdSchema>(ReadOptions::default())?;
         iter.seek_to_first();
@@ -108,5 +114,44 @@ impl BatchIdDB for QuorumStoreDB {
 
     fn save_batch_id(&self, epoch: u64, batch_id: BatchId) -> Result<(), DbError> {
         Ok(self.db.put::<BatchIdSchema>(&epoch, &batch_id)?)
+    }
+}
+
+pub(crate) struct MockQuorumStoreDB {}
+
+impl MockQuorumStoreDB {
+    #[cfg(test)]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl QuorumStoreStorage for MockQuorumStoreDB {
+    fn delete_batches(&self, _: Vec<HashValue>) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    fn get_all_batches(&self) -> Result<HashMap<HashValue, PersistedValue>> {
+        Ok(HashMap::new())
+    }
+
+    fn save_batch(&self, _: HashValue, _: PersistedValue) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    fn get_batch(&self, _: HashValue) -> Result<Option<PersistedValue>, DbError> {
+        Ok(None)
+    }
+
+    fn delete_batch_id(&self, _: u64) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    fn clean_and_get_batch_id(&self, _: u64) -> Result<Option<BatchId>, DbError> {
+        Ok(Some(BatchId::new_for_test(0)))
+    }
+
+    fn save_batch_id(&self, _: u64, _: BatchId) -> Result<(), DbError> {
+        Ok(())
     }
 }

--- a/consensus/src/quorum_store/tests/batch_generator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_generator_test.rs
@@ -6,7 +6,7 @@ use crate::{
     quorum_store::{
         batch_coordinator::BatchCoordinatorCommand,
         batch_generator::BatchGenerator,
-        quorum_store_db::BatchIdDB,
+        quorum_store_db::MockQuorumStoreDB,
         tests::utils::{create_vec_serialized_transactions, create_vec_signed_transactions},
         types::{BatchId, SerializedTransaction},
     },
@@ -21,28 +21,6 @@ use futures::{
 };
 use std::{sync::Arc, time::Duration};
 use tokio::{sync::mpsc::channel as TokioChannel, time::timeout};
-
-pub struct MockBatchIdDB {}
-
-impl MockBatchIdDB {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-impl BatchIdDB for MockBatchIdDB {
-    // The first batch will be index 1
-    fn clean_and_get_batch_id(
-        &self,
-        _current_epoch: u64,
-    ) -> anyhow::Result<Option<BatchId>, DbError> {
-        Ok(Some(BatchId::new_for_test(0)))
-    }
-
-    fn save_batch_id(&self, _epoch: u64, _batch_id: BatchId) -> anyhow::Result<(), DbError> {
-        Ok(())
-    }
-}
 
 async fn queue_mempool_batch_response(
     txns: Vec<SignedTransaction>,
@@ -87,7 +65,7 @@ async fn test_batch_creation() {
     let mut batch_generator = BatchGenerator::new(
         0,
         config,
-        Arc::new(MockBatchIdDB::new()),
+        Arc::new(MockQuorumStoreDB::new()),
         quorum_store_to_mempool_tx,
         batch_coordinator_cmd_tx,
         1000,

--- a/consensus/src/quorum_store/tests/quorum_store_db_test.rs
+++ b/consensus/src/quorum_store/tests/quorum_store_db_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::quorum_store::{
-    quorum_store_db::{BatchIdDB, QuorumStoreDB},
+    quorum_store_db::{QuorumStoreDB, QuorumStoreStorage},
     tests::utils::{compute_digest_from_signed_transaction, create_vec_signed_transactions},
     types::{BatchId, PersistedValue},
 };

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -10,6 +10,7 @@ use crate::{
     network_interface::{ConsensusNetworkClient, DIRECT_SEND, RPC},
     network_tests::{NetworkPlayground, TwinId},
     payload_manager::PayloadManager,
+    quorum_store::quorum_store_db::MockQuorumStoreDB,
     test_utils::{MockStateComputer, MockStorage},
     util::time_service::ClockTimeService,
 };
@@ -136,6 +137,8 @@ impl SMRNode {
         let (self_sender, self_receiver) =
             aptos_channels::new(1_024, &counters::PENDING_SELF_MESSAGES);
 
+        let quorum_store_storage = Arc::new(MockQuorumStoreDB::new());
+
         let epoch_mgr = EpochManager::new(
             &config,
             time_service,
@@ -145,6 +148,7 @@ impl SMRNode {
             quorum_store_to_mempool_sender,
             state_computer.clone(),
             storage.clone(),
+            quorum_store_storage,
             reconfig_listener,
         );
         let (network_task, network_receiver) =


### PR DESCRIPTION
### Description

Previously, the quorum_store_db instance was torn down and restarted on epoch changes.
We observed this occasionally caused panic when the new instance couldn't start.
The DB doesn't have to be torn down and restarted. The only interesting thing here is the DB
will be created regardless of whether quorum store is turned on, but that should be negligible overhead.

### Test Plan

Existing tests

