### PR TITLE
[gas] fix gas formulae for exists_at & table natives (load resource) 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3784,7 +3784,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -6750,7 +6750,7 @@ checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6767,7 +6767,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
@@ -6783,12 +6783,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6803,7 +6803,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6815,7 +6815,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -6828,7 +6828,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -6845,7 +6845,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6891,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "difference",
@@ -6908,7 +6908,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6937,7 +6937,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
@@ -6959,7 +6959,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6979,7 +6979,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -6997,7 +6997,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "codespan",
@@ -7015,7 +7015,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7029,7 +7029,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7048,7 +7048,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -7067,7 +7067,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "hex",
@@ -7080,7 +7080,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "hex",
@@ -7094,7 +7094,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "codespan",
@@ -7120,7 +7120,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7156,7 +7156,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7193,7 +7193,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7222,7 +7222,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7233,7 +7233,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7248,7 +7248,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -7275,7 +7275,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -7293,7 +7293,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "hex",
@@ -7316,7 +7316,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "once_cell",
  "serde 1.0.149",
@@ -7325,7 +7325,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -7374,7 +7374,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "better_any",
@@ -7405,7 +7405,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -7422,7 +7422,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7436,7 +7436,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-binary-format",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -8851,7 +8851,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
+source = "git+https://github.com/move-language/move?rev=2a0fc1bee971b13d48d7bf365fac5205689eaadd#2a0fc1bee971b13d48d7bf365fac5205689eaadd"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3784,7 +3784,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -6750,7 +6750,7 @@ checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6767,7 +6767,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
@@ -6783,12 +6783,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6803,7 +6803,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6815,7 +6815,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -6828,7 +6828,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -6845,7 +6845,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6891,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "difference",
@@ -6908,7 +6908,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6937,7 +6937,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
@@ -6959,7 +6959,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6979,7 +6979,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -6997,7 +6997,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "codespan",
@@ -7015,7 +7015,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7029,7 +7029,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7048,7 +7048,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -7067,7 +7067,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "hex",
@@ -7080,7 +7080,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "hex",
@@ -7094,7 +7094,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "codespan",
@@ -7120,7 +7120,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7156,7 +7156,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7193,7 +7193,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7222,7 +7222,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7233,7 +7233,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7248,7 +7248,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -7275,7 +7275,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -7293,7 +7293,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "hex",
@@ -7316,7 +7316,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "once_cell",
  "serde 1.0.149",
@@ -7325,7 +7325,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -7374,7 +7374,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "better_any",
@@ -7405,7 +7405,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -7422,7 +7422,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7436,7 +7436,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-binary-format",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -8851,7 +8851,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6bf0970221ecc0b27454d574a6cc89e8fa175cc7#6bf0970221ecc0b27454d574a6cc89e8fa175cc7"
+source = "git+https://github.com/move-language/move?rev=d8ff9bb7056a83c4da6a54514696c760f95e3e14#d8ff9bb7056a83c4da6a54514696c760f95e3e14"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -488,34 +488,34 @@ x25519-dalek = "1.2.0"
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES
-move-abigen = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-cli = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-compiler ={ git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7", features = ["address32"] }
-move-docgen = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-model = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-package = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-prover = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7", features = ["table-extension"] }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7", features = ["lazy_natives"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7", features = ["table-extension"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "6bf0970221ecc0b27454d574a6cc89e8fa175cc7" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-cli = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-compiler ={ git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14", features = ["address32"] }
+move-docgen = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-model = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-package = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-prover = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14", features = ["table-extension"] }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14", features = ["lazy_natives"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14", features = ["table-extension"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+read-write-set = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
 # END MOVE DEPENDENCIES
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -488,34 +488,34 @@ x25519-dalek = "1.2.0"
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES
-move-abigen = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-cli = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-compiler ={ git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14", features = ["address32"] }
-move-docgen = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-model = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-package = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-prover = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14", features = ["table-extension"] }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14", features = ["lazy_natives"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14", features = ["table-extension"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "d8ff9bb7056a83c4da6a54514696c760f95e3e14" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-cli = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-compiler ={ git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd", features = ["address32"] }
+move-docgen = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-model = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-package = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-prover = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd", features = ["table-extension"] }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd", features = ["lazy_natives"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd", features = ["table-extension"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+read-write-set = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "2a0fc1bee971b13d48d7bf365fac5205689eaadd" }
 # END MOVE DEPENDENCIES
 
 [profile.release]

--- a/aptos-move/aptos-gas/src/aptos_framework.rs
+++ b/aptos-move/aptos-gas/src/aptos_framework.rs
@@ -116,5 +116,8 @@ crate::natives::define_gas_parameters_for_natives!(GasParameters, "aptos_framewo
     [.aggregator.destroy.base, "aggregator.destroy.base", 500 * MUL],
     [.aggregator_factory.new_aggregator.base, "aggregator_factory.new_aggregator.base", 500 * MUL],
 
-    [.object.exists_at.base_cost, { 7.. => "object.exists_at.base" }, 250 * MUL]
+    [.object.exists_at.base_cost, { 7.. => "object.exists_at.base" }, 250 * MUL],
+    // These are dummy value, they copied from storage gas in aptos-core/aptos-vm/src/aptos_vm_impl.rs
+    [.object.exists_at.per_byte, { 7.. => "object.exists_at.per_byte" }, 1000],
+    [.object.exists_at.per_item, { 7.. => "object.exists_at.per_item" }, 8000]
 ]);

--- a/aptos-move/aptos-gas/src/aptos_framework.rs
+++ b/aptos-move/aptos-gas/src/aptos_framework.rs
@@ -116,8 +116,8 @@ crate::natives::define_gas_parameters_for_natives!(GasParameters, "aptos_framewo
     [.aggregator.destroy.base, "aggregator.destroy.base", 500 * MUL],
     [.aggregator_factory.new_aggregator.base, "aggregator_factory.new_aggregator.base", 500 * MUL],
 
-    [.object.exists_at.base_cost, { 7.. => "object.exists_at.base" }, 250 * MUL],
+    [.object.exists_at.base, { 7.. => "object.exists_at.base" }, 250 * MUL],
     // These are dummy value, they copied from storage gas in aptos-core/aptos-vm/src/aptos_vm_impl.rs
-    [.object.exists_at.per_byte, { 7.. => "object.exists_at.per_byte" }, 1000],
-    [.object.exists_at.per_item, { 7.. => "object.exists_at.per_item" }, 8000]
+    [.object.exists_at.per_byte_loaded, { 7.. => "object.exists_at.per_byte_loaded" }, 1000],
+    [.object.exists_at.per_item_loaded, { 7.. => "object.exists_at.per_item_loaded" }, 8000]
 ]);

--- a/aptos-move/aptos-gas/src/table.rs
+++ b/aptos-move/aptos-gas/src/table.rs
@@ -6,7 +6,8 @@ use move_table_extension::GasParameters;
 
 crate::natives::define_gas_parameters_for_natives!(GasParameters, "table", [
     // These are dummy value, they copied from storage gas in aptos-core/aptos-vm/src/aptos_vm_impl.rs
-    [.common.load_base, "common.load.base", 8000],
+    [.common.load_base_legacy, "common.load.base", 8000],
+    [.common.load_base_new, { 7.. => "common.load.base_new" }, 8000],
     [.common.load_per_byte, "common.load.per_byte", 1000],
     [.common.load_failure, "common.load.failure", 0],
 

--- a/aptos-move/aptos-gas/src/table.rs
+++ b/aptos-move/aptos-gas/src/table.rs
@@ -5,8 +5,7 @@ use crate::gas_meter::EXECUTION_GAS_MULTIPLIER as MUL;
 use move_table_extension::GasParameters;
 
 crate::natives::define_gas_parameters_for_natives!(GasParameters, "table", [
-    // Note(Gas): These are legacy parameters for loading from storage so they do not
-    //            need to be multiplied.
+    // These are dummy value, they copied from storage gas in aptos-core/aptos-vm/src/aptos_vm_impl.rs
     [.common.load_base, "common.load.base", 8000],
     [.common.load_per_byte, "common.load.per_byte", 1000],
     [.common.load_failure, "common.load.failure", 0],

--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -89,19 +89,24 @@ impl AptosVMImpl {
         if let (Some(gas_params), Some(storage_gas_schedule)) =
             (&mut gas_params, &storage_gas_schedule)
         {
-            if gas_feature_version >= 2 {
-                gas_params.natives.table.common.load_base =
-                    storage_gas_schedule.per_item_read.into();
-                gas_params.natives.table.common.load_per_byte =
-                    storage_gas_schedule.per_byte_read.into();
-                gas_params.natives.table.common.load_failure = 0.into();
-            }
-
-            if gas_feature_version >= 7 {
-                gas_params.natives.aptos_framework.object.exists_at.per_item =
-                    storage_gas_schedule.per_item_read.into();
-                gas_params.natives.aptos_framework.object.exists_at.per_byte =
-                    storage_gas_schedule.per_byte_read.into();
+            match gas_feature_version {
+                2..=6 => {
+                    gas_params.natives.table.common.load_base_legacy =
+                        storage_gas_schedule.per_item_read.into();
+                    gas_params.natives.table.common.load_base_new = 0.into();
+                    gas_params.natives.table.common.load_per_byte =
+                        storage_gas_schedule.per_byte_read.into();
+                    gas_params.natives.table.common.load_failure = 0.into();
+                },
+                7.. => {
+                    gas_params.natives.table.common.load_base_legacy = 0.into();
+                    gas_params.natives.table.common.load_base_new =
+                        storage_gas_schedule.per_item_read.into();
+                    gas_params.natives.table.common.load_per_byte =
+                        storage_gas_schedule.per_byte_read.into();
+                    gas_params.natives.table.common.load_failure = 0.into();
+                },
+                _ => (),
             }
         }
 

--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -85,17 +85,26 @@ impl AptosVMImpl {
             0 => None,
             _ => StorageGasSchedule::fetch_config(&storage),
         };
-        if gas_feature_version >= 2 {
-            if let (Some(gas_params), Some(storage_gas_schedule)) =
-                (&mut gas_params, &storage_gas_schedule)
-            {
+
+        if let (Some(gas_params), Some(storage_gas_schedule)) =
+            (&mut gas_params, &storage_gas_schedule)
+        {
+            if gas_feature_version >= 2 {
                 gas_params.natives.table.common.load_base =
                     storage_gas_schedule.per_item_read.into();
                 gas_params.natives.table.common.load_per_byte =
                     storage_gas_schedule.per_byte_read.into();
                 gas_params.natives.table.common.load_failure = 0.into();
             }
+
+            if gas_feature_version >= 7 {
+                gas_params.natives.aptos_framework.object.exists_at.per_item =
+                    storage_gas_schedule.per_item_read.into();
+                gas_params.natives.aptos_framework.object.exists_at.per_byte =
+                    storage_gas_schedule.per_byte_read.into();
+            }
         }
+
         let storage_gas_params = StorageGasParameters::new(
             gas_feature_version,
             gas_params.as_ref(),

--- a/aptos-move/framework/src/natives/mod.rs
+++ b/aptos-move/framework/src/natives/mod.rs
@@ -189,6 +189,8 @@ impl GasParameters {
             object: object::GasParameters {
                 exists_at: object::ExistsAtGasParameters {
                     base_cost: 0.into(),
+                    per_byte: 0.into(),
+                    per_item: 0.into(),
                 },
             },
         }

--- a/aptos-move/framework/src/natives/mod.rs
+++ b/aptos-move/framework/src/natives/mod.rs
@@ -188,9 +188,9 @@ impl GasParameters {
             },
             object: object::GasParameters {
                 exists_at: object::ExistsAtGasParameters {
-                    base_cost: 0.into(),
-                    per_byte: 0.into(),
-                    per_item: 0.into(),
+                    base: 0.into(),
+                    per_byte_loaded: 0.into(),
+                    per_item_loaded: 0.into(),
                 },
             },
         }


### PR DESCRIPTION
This fixes two gas issues
1. `exists_at` is not charging for loading resources
2. The table natives double charge the base read fee when an item has already been loaded

Note this is a continuation of https://github.com/aptos-labs/aptos-core/pull/6852