### PR TITLE
Prevent Overwrite of Docker-Compose

### DIFF
--- a/developer-docs-site/docs/nodes/node-files-all-networks/node-files.md
+++ b/developer-docs-site/docs/nodes/node-files-all-networks/node-files.md
@@ -91,7 +91,7 @@ Fullnode means either a validator fullnode or a public fullnode.
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
 - **Command to download:**
   ```bash
-  wget -O docker-compose.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose-fullnode.yaml
+  wget -O docker-compose-fullnode.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose-fullnode.yaml
   ```
 
 ## fullnode.yaml (fullnode only)


### PR DESCRIPTION
On the [Run a Validator Node setup pages](https://aptos.dev/nodes/validator-node/operator/running-validator-node/run-validator-node-using-docker) page and similar, you are asked to download docker-compose.yaml and docker-compose-fullnode.yaml from this [nodes file page](https://aptos.dev/nodes/node-files-all-networks/node-files/). If you use the commands on this page how ever, you will end up with only 1 file as the wget for docker-compose-full node overwrites the docker-compose.yaml. Please confirm this isn't intentional

### Description
Documentation improvement
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
