### PR TITLE
Update NHC config examples

### DIFF
--- a/ecosystem/node-checker/configuration_examples/mainnet_fullnode.yaml
+++ b/ecosystem/node-checker/configuration_examples/mainnet_fullnode.yaml
@@ -6,10 +6,10 @@
 # metrics port for example, we'll only run metrics checks.
 ---
 node_address:
-  url: "https://fullnode.devnet.aptoslabs.com/"
+  url: "https://fullnode.mainnet.aptoslabs.com/"
   api_port: 443
-configuration_id: devnet_fullnode
-configuration_name: "Devnet Fullnode"
+configuration_id: mainnet_fullnode
+configuration_name: "Mainnet Fullnode"
 checkers:
   - type: "BuildVersion"
   - type: "Latency"

--- a/ecosystem/node-checker/configuration_examples/testnet_fullnode.yaml
+++ b/ecosystem/node-checker/configuration_examples/testnet_fullnode.yaml
@@ -6,10 +6,10 @@
 # metrics port for example, we'll only run metrics checks.
 ---
 node_address:
-  url: "https://fullnode.devnet.aptoslabs.com/"
+  url: "https://fullnode.testnet.aptoslabs.com/"
   api_port: 443
-configuration_id: devnet_fullnode
-configuration_name: "Devnet Fullnode"
+configuration_id: testnet_fullnode
+configuration_name: "Testnet Fullnode"
 checkers:
   - type: "BuildVersion"
   - type: "Latency"


### PR DESCRIPTION
### Description
The config we had for devnet was referring to a baseline node that isn't there.

This PR also adds configs for testnet and mainnet.

### Test Plan
We're using these in prod.
