### PR TITLE
[forge] list job contents

### DIFF
--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -1531,7 +1531,7 @@ def list_jobs(
     phase: List[str],
     regex: str,
 ) -> None:
-    """List all available clusters"""
+    """List all running forge jobs"""
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
@@ -1558,7 +1558,10 @@ def list_jobs(
         else:
             fg = "white"
 
-        click.secho(f"{job.cluster.name} {job.name} {job.phase}", fg=fg)
+        click.secho(
+            f"{job.cluster.name} {job.name} {job.phase}: (num_fullnodes: {job.num_fullnodes}, num_validators: {job.num_validators})",
+            fg=fg,
+        )
 
 
 @main.command()

--- a/testsuite/forge_test.py
+++ b/testsuite/forge_test.py
@@ -947,9 +947,10 @@ class TestListClusters(unittest.TestCase):
             shell.assert_commands(self)
 
 
-def fake_pod_item(name: str, phase: str) -> GetPodsItem:
+def fake_pod_item(name: str, phase: str, labels: Dict = {}) -> GetPodsItem:
     return GetPodsItem(
-        metadata=GetPodsItemMetadata(name=name), status=GetPodsItemStatus(phase=phase)
+        metadata=GetPodsItemMetadata(name=name, labels=labels),
+        status=GetPodsItemStatus(phase=phase),
     )
 
 
@@ -958,19 +959,69 @@ class GetForgeJobsTests(unittest.IsolatedAsyncioTestCase):
 
     async def testGetAllForgeJobs(self) -> None:
         fake_clusters = ["aptos-forge-banana", "aptos-forge-apple-2"]
+
+        # The first set of test runner pods and their test pods
         fake_first_pods = GetPodsResult(
             items=[
-                fake_pod_item("forge-first", "Running"),
-                fake_pod_item("forge-failed", "Failed"),
-                fake_pod_item("ignore-me", "Failed"),
+                fake_pod_item(
+                    "forge-first", "Running", labels={"forge-namespace": "forge-first"}
+                ),
+                fake_pod_item(
+                    "forge-failed", "Failed", labels={"forge-namespace": "forge-failed"}
+                ),
+                fake_pod_item(
+                    "ignore-me", "Failed", labels={"forge-namespace": "ignore-me"}
+                ),
             ]
         )
+        fake_forge_first_first_cluster_pods = GetPodsResult(
+            items=[
+                fake_pod_item("aptos-node-0-validator", "Running"),
+                fake_pod_item("aptos-node-1-validator", "Running"),
+            ]
+        )
+        fake_forge_first_failed_cluster_pods = GetPodsResult(
+            items=[
+                fake_pod_item("aptos-node-0-validator", "Running"),
+                fake_pod_item("aptos-node-1-validator", "Running"),
+                fake_pod_item("aptos-node-0-fullnode", "Running"),
+                fake_pod_item("aptos-node-1-fullnode", "Running"),
+            ]
+        )
+        fake_forge_first_ignore_me_cluster_pods = GetPodsResult(
+            items=[
+                fake_pod_item("aptos-node-0-validator", "Failed"),
+                fake_pod_item("aptos-node-1-validator", "Running"),
+            ]
+        )
+
+        # The second set of test runner pods and their test pods
         fake_second_pods = GetPodsResult(
             items=[
-                fake_pod_item("forge-second", "Running"),
-                fake_pod_item("forge-succeeded", "Succeeded"),
-                fake_pod_item("me-too", "Failed"),
+                fake_pod_item(
+                    "forge-second",
+                    "Running",
+                    labels={"forge-namespace": "forge-second"},
+                ),
+                fake_pod_item(
+                    "forge-succeeded",
+                    "Succeeded",
+                    labels={"forge-namespace": "forge-succeeded"},
+                ),
+                fake_pod_item("me-too", "Failed", labels={"forge-namespace": "me-too"}),
             ]
+        )
+        fake_forge_second_second_cluster_pods = GetPodsResult(
+            items=[
+                fake_pod_item("aptos-node-0-validator", "Running"),
+                fake_pod_item("aptos-node-1-fullnode", "Running"),
+            ]
+        )
+        fake_forge_second_succeeded_cluster_pods = GetPodsResult(
+            items=[]  # succeeded, so there might be no pods left in its namespace
+        )
+        fake_forge_second_me_too_cluster_pods = GetPodsResult(
+            items=[]  # failed, so there might be no pods left in its namespace
         )
         shell = SpyShell(
             [
@@ -983,12 +1034,48 @@ class GetForgeJobsTests(unittest.IsolatedAsyncioTestCase):
                     RunResult(0, json.dumps(fake_first_pods).encode()),
                 ),
                 FakeCommand(
+                    "kubectl get pods -n forge-first --kubeconfig temp1 -o json",
+                    RunResult(
+                        0, json.dumps(fake_forge_first_first_cluster_pods).encode()
+                    ),
+                ),
+                FakeCommand(
+                    "kubectl get pods -n forge-failed --kubeconfig temp1 -o json",
+                    RunResult(
+                        0, json.dumps(fake_forge_first_failed_cluster_pods).encode()
+                    ),
+                ),
+                FakeCommand(
+                    "kubectl get pods -n ignore-me --kubeconfig temp1 -o json",
+                    RunResult(
+                        0, json.dumps(fake_forge_first_ignore_me_cluster_pods).encode()
+                    ),
+                ),
+                FakeCommand(
                     "aws eks update-kubeconfig --name aptos-forge-apple-2 --kubeconfig temp2",
                     RunResult(0, b""),
                 ),
                 FakeCommand(
                     "kubectl get pods -n default --kubeconfig temp2 -o json",
                     RunResult(0, json.dumps(fake_second_pods).encode()),
+                ),
+                FakeCommand(
+                    "kubectl get pods -n forge-second --kubeconfig temp2 -o json",
+                    RunResult(
+                        0, json.dumps(fake_forge_second_second_cluster_pods).encode()
+                    ),
+                ),
+                FakeCommand(
+                    "kubectl get pods -n forge-succeeded --kubeconfig temp2 -o json",
+                    RunResult(
+                        0, json.dumps(fake_forge_second_succeeded_cluster_pods).encode()
+                    ),
+                ),
+                FakeCommand(
+                    "kubectl get pods -n me-too --kubeconfig temp2 -o json",
+                    RunResult(
+                        0, json.dumps(fake_forge_second_me_too_cluster_pods).encode()
+                    ),
                 ),
             ],
             strict=True,
@@ -1005,6 +1092,7 @@ class GetForgeJobsTests(unittest.IsolatedAsyncioTestCase):
                     name="aptos-forge-banana",
                     kubeconf="temp1",
                 ),
+                num_validators=2,
             ),
             ForgeJob(
                 name="forge-failed",
@@ -1013,6 +1101,8 @@ class GetForgeJobsTests(unittest.IsolatedAsyncioTestCase):
                     name="aptos-forge-banana",
                     kubeconf="temp1",
                 ),
+                num_validators=2,
+                num_fullnodes=2,
             ),
             ForgeJob(
                 name="forge-second",
@@ -1021,6 +1111,8 @@ class GetForgeJobsTests(unittest.IsolatedAsyncioTestCase):
                     name="aptos-forge-apple-2",
                     kubeconf="temp2",
                 ),
+                num_validators=1,
+                num_fullnodes=1,
             ),
             ForgeJob(
                 name="forge-succeeded",


### PR DESCRIPTION
### Description

List job contents so we can get a better picture of how many validators and fullnodes are in each running job.

Specifically, when getting all running Forge jobs, use the `forge-namespace` label to identify the namespace the test is running in, and search all pods in that namespace to determine how many validators and fullnodes are currently running in that namespace. This in conjunction with the Forge dashboards which show the number of active machines provisioned by the autoscaler will give us a better picture of utilization and capacity.

Also add `labels` field to `GetPodsItemMetadata` so we can model the pod better

### Test Plan

Unit tests

<!-- Please provide us with clear details for verifying that your changes work. -->
