### PR TITLE
[gha] copy preview images to dockerhub

### DIFF
--- a/.github/workflows/copy-images-to-dockerhub-release.yaml
+++ b/.github/workflows/copy-images-to-dockerhub-release.yaml
@@ -2,9 +2,12 @@ name: Copy images to dockerhub on release
 on:
   push:
     branches:
+      # release branches
       - devnet
       - testnet
       - mainnet
+      # preview branches
+      - preview
     tags:
       - aptos-node-v*
 

--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -6,6 +6,10 @@ on:
         required: true
         type: string
         description: a prefix to use for image tags. E.g. `devnet`. It results in an image tag like `:devnet_<git_sha>`
+      GIT_SHA:
+        required: false
+        type: string
+        description: the git sha to use for the image tag. If not provided, the git sha of the triggering branch will be used
   workflow_dispatch:
     inputs:
       image_tag_prefix:
@@ -13,6 +17,10 @@ on:
         type: string
         default: adhoc
         description: a prefix to use for image tags. E.g. `devnet`. It results in an image tag like `:devnet_<git_sha>`
+      GIT_SHA:
+        required: false
+        type: string
+        description: the git sha to use for the image tag. If not provided, the git sha of the triggering branch will be used
 
 permissions:
   contents: read
@@ -47,7 +55,7 @@ jobs:
       - name: Release Images
         env:
           FORCE_COLOR: 3 # Force color output as per https://github.com/google/zx#using-github-actions
-          GIT_SHA: ${{ github.sha }}
+          GIT_SHA: ${{ inputs.GIT_SHA || github.sha }} # If GIT_SHA is not provided, use the sha of the triggering branch
           GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ECR_ACCOUNT_NUM }}
           IMAGE_TAG_PREFIX: ${{ inputs.image_tag_prefix }}


### PR DESCRIPTION
### Description

* copy images that are built on the `preview` branch to dockerhub (on every push)
* add to `copy-images-to-dockerhub.yaml` the ability to trigger release of any commit's built image via `workflow_dispatch`. this is useful in scenarios where we haven't updated the workflows to trigger on push, so we can release manually in those cases



<!-- Please provide us with clear details for verifying that your changes work. -->
