### PR TITLE
[helm][aptos-node] change validator/VFN AptosNet with era

### DIFF
--- a/terraform/helm/aptos-node/templates/haproxy.yaml
+++ b/terraform/helm/aptos-node/templates/haproxy.yaml
@@ -26,7 +26,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
     service.beta.kubernetes.io/oci-load-balancer-security-list-management-mode: All
     {{- if $.Values.service.domain }}
-    external-dns.alpha.kubernetes.io/hostname: val{{$i}}.{{ $.Values.service.domain }}
+    external-dns.alpha.kubernetes.io/hostname: val{{$i}}-{{ $.Values.chain.era }}.{{ $.Values.service.domain }}
     {{- end }}
 spec:
   selector:
@@ -69,7 +69,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
     service.beta.kubernetes.io/oci-load-balancer-security-list-management-mode: All
     {{- if $.Values.service.domain }}
-    external-dns.alpha.kubernetes.io/hostname: {{ $config.name }}{{$i}}.{{ $.Values.service.domain }}
+    external-dns.alpha.kubernetes.io/hostname: {{ $config.name }}{{$i}}-{{ $.Values.chain.era }}.{{ $.Values.service.domain }}
     {{- end }}
 spec:
   selector:


### PR DESCRIPTION
Instead of bumping the Chain ID every devnet release, we can simply change the DNS names of each of the validators based on the chain "era" when the chain is wiped. This means that old nodes on a previous devnet release will try to connect to an old DNS (and fail), while only new nodes will connect to the new validators since their devnet genesis will be up to date.

This means that we can consistently reuse the same Chain ID for devnet. In the long term, we can save Chain IDs, which are u8.

### Test Plan

Deploy it and bump the era to simulate devnet release 

<!-- Please provide us with clear details for verifying that your changes work. -->
