### PR TITLE
[State Sync] Update output syncing chunk sizes.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -5,7 +5,7 @@
 use serde::{Deserialize, Serialize};
 
 // The maximum message size per state sync message
-pub const MAX_MESSAGE_SIZE: usize = 20 * 1024 * 1024; /* 4 MiB */
+pub const MAX_MESSAGE_SIZE: usize = 20 * 1024 * 1024; /* 20 MiB */
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -127,7 +127,7 @@ impl Default for StorageServiceConfig {
             max_state_chunk_size: 4000,
             max_subscription_period_ms: 5000,
             max_transaction_chunk_size: 5000,
-            max_transaction_output_chunk_size: 1000,
+            max_transaction_output_chunk_size: 5000,
             storage_summary_refresh_interval_ms: 50,
         }
     }


### PR DESCRIPTION
### Description
This PR updates the output syncing chunk sizes to 5k (to match those of execution syncing).

### Test Plan
Manual verification.
