### PR TITLE
[Previewnet] [cherry-pick] PR 6830: [consensus] better protect sync condition

### DIFF
--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -244,7 +244,7 @@ impl BlockStore {
             blocks.first().expect("blocks are empty").id(),
         );
 
-        // Confirm retrival ended when it hit the last block we care about, even if it didn't reach all num_blocks blocks.
+        // Confirm retrieval ended when it hit the last block we care about, even if it didn't reach all num_blocks blocks.
         assert_eq!(
             blocks.last().expect("blocks are empty").id(),
             highest_commit_cert.commit_info().id()

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -27,7 +27,7 @@ use aptos_types::{
 };
 use fail::fail_point;
 use futures::{SinkExt, StreamExt};
-use std::{boxed::Box, cmp::max, sync::Arc};
+use std::{boxed::Box, sync::Arc};
 use tokio::sync::Mutex as AsyncMutex;
 
 type NotificationType = (
@@ -44,7 +44,7 @@ pub struct ExecutionProxy {
     state_sync_notifier: Arc<dyn ConsensusNotificationSender>,
     async_state_sync_notifier: aptos_channels::Sender<NotificationType>,
     validators: Mutex<Vec<AccountAddress>>,
-    write_mutex: AsyncMutex<()>,
+    write_mutex: AsyncMutex<LogicalTime>,
     payload_manager: Mutex<Option<Arc<PayloadManager>>>,
     transaction_shuffler: Mutex<Option<Arc<dyn TransactionShuffler>>>,
 }
@@ -77,7 +77,7 @@ impl ExecutionProxy {
             state_sync_notifier,
             async_state_sync_notifier: tx,
             validators: Mutex::new(vec![]),
-            write_mutex: AsyncMutex::new(()),
+            write_mutex: AsyncMutex::new(LogicalTime::new(0, 0)),
             payload_manager: Mutex::new(None),
             transaction_shuffler: Mutex::new(None),
         }
@@ -149,15 +149,16 @@ impl StateComputer for ExecutionProxy {
         finality_proof: LedgerInfoWithSignatures,
         callback: StateComputerCommitCallBackType,
     ) -> Result<(), ExecutionError> {
-        let _guard = self.write_mutex.lock().await;
+        let mut latest_logical_time = self.write_mutex.lock().await;
 
         let mut block_ids = Vec::new();
         let mut txns = Vec::new();
         let mut reconfig_events = Vec::new();
-        let skip_clean = blocks.is_empty();
-        let mut latest_epoch: u64 = 0;
-        let mut latest_round: u64 = 0;
         let mut payloads = Vec::new();
+        let logical_time = LogicalTime::new(
+            finality_proof.ledger_info().epoch(),
+            finality_proof.ledger_info().round(),
+        );
 
         let payload_manager = self.payload_manager.lock().as_ref().unwrap().clone();
         let txn_shuffler = self.transaction_shuffler.lock().as_ref().unwrap().clone();
@@ -174,9 +175,6 @@ impl StateComputer for ExecutionProxy {
 
             txns.extend(block.transactions_to_commit(&self.validators.lock(), shuffled_txns));
             reconfig_events.extend(block.reconfig_event());
-
-            latest_epoch = max(latest_epoch, block.epoch());
-            latest_round = max(latest_round, block.round());
         }
 
         let executor = self.executor.clone();
@@ -202,35 +200,37 @@ impl StateComputer for ExecutionProxy {
             .await
             .expect("Failed to send async state sync notification");
 
-        // If there are no blocks, epoch and round will be invalid.
-        // TODO: is this ever the case? why?
-        if skip_clean {
-            return Ok(());
-        }
-        payload_manager
-            .notify_commit(LogicalTime::new(latest_epoch, latest_round), payloads)
-            .await;
+        *latest_logical_time = logical_time;
+        payload_manager.notify_commit(logical_time, payloads).await;
         Ok(())
     }
 
     /// Synchronize to a commit that not present locally.
     async fn sync_to(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
-        let _guard = self.write_mutex.lock().await;
+        let mut latest_logical_time = self.write_mutex.lock().await;
+        let logical_time =
+            LogicalTime::new(target.ledger_info().epoch(), target.ledger_info().round());
 
         // Before the state synchronization, we have to call finish() to free the in-memory SMT
         // held by BlockExecutor to prevent memory leak.
         self.executor.finish();
 
+        // The pipeline phase already committed beyond the target synced round, just return.
+        if *latest_logical_time >= logical_time {
+            warn!(
+                "State sync target {:?} is lower than already committed logical time {:?}",
+                logical_time, *latest_logical_time
+            );
+            return Ok(());
+        }
+
         // This is to update QuorumStore with the latest known commit in the system,
         // so it can set batches expiration accordingly.
-        //Might be none if called in the recovery path.
+        // Might be none if called in the recovery path.
         let maybe_payload_manager = self.payload_manager.lock().as_ref().cloned();
         if let Some(payload_manager) = maybe_payload_manager {
             payload_manager
-                .notify_commit(
-                    LogicalTime::new(target.ledger_info().epoch(), target.ledger_info().round()),
-                    Vec::new(),
-                )
+                .notify_commit(logical_time, Vec::new())
                 .await;
         }
 
@@ -246,6 +246,7 @@ impl StateComputer for ExecutionProxy {
             "sync_to",
             self.state_sync_notifier.sync_to_target(target).await
         );
+        *latest_logical_time = logical_time;
 
         // Similarly, after the state synchronization, we have to reset the cache
         // of BlockExecutor to guarantee the latest committed state is up to date.
@@ -272,4 +273,124 @@ impl StateComputer for ExecutionProxy {
             .lock()
             .replace(transaction_shuffler);
     }
+}
+
+#[tokio::test]
+async fn test_commit_sync_race() {
+    use crate::error::MempoolError;
+    use aptos_consensus_notifications::Error;
+    use aptos_types::{
+        aggregate_signature::AggregateSignature, block_info::BlockInfo, ledger_info::LedgerInfo,
+        transaction::SignedTransaction,
+    };
+
+    struct RecordedCommit {
+        time: Mutex<LogicalTime>,
+    }
+
+    impl BlockExecutorTrait<Transaction> for RecordedCommit {
+        fn committed_block_id(&self) -> HashValue {
+            HashValue::zero()
+        }
+
+        fn reset(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn execute_block(
+            &self,
+            _block: (HashValue, Vec<Transaction>),
+            _parent_block_id: HashValue,
+        ) -> Result<StateComputeResult, ExecutionError> {
+            Ok(StateComputeResult::new_dummy())
+        }
+
+        fn commit_blocks_ext(
+            &self,
+            _block_ids: Vec<HashValue>,
+            ledger_info_with_sigs: LedgerInfoWithSignatures,
+            _save_state_snapshots: bool,
+        ) -> Result<(), ExecutionError> {
+            *self.time.lock() = LogicalTime::new(
+                ledger_info_with_sigs.ledger_info().epoch(),
+                ledger_info_with_sigs.ledger_info().round(),
+            );
+            Ok(())
+        }
+
+        fn finish(&self) {}
+    }
+
+    #[async_trait::async_trait]
+    impl TxnNotifier for RecordedCommit {
+        async fn notify_failed_txn(
+            &self,
+            _txns: Vec<SignedTransaction>,
+            _compute_results: &StateComputeResult,
+        ) -> Result<(), MempoolError> {
+            Ok(())
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ConsensusNotificationSender for RecordedCommit {
+        async fn notify_new_commit(
+            &self,
+            _transactions: Vec<Transaction>,
+            _reconfiguration_events: Vec<ContractEvent>,
+        ) -> std::result::Result<(), Error> {
+            Ok(())
+        }
+
+        async fn sync_to_target(
+            &self,
+            target: LedgerInfoWithSignatures,
+        ) -> std::result::Result<(), Error> {
+            let logical_time =
+                LogicalTime::new(target.ledger_info().epoch(), target.ledger_info().round());
+            if logical_time <= *self.time.lock() {
+                return Err(Error::NotificationError(
+                    "Decreasing logical time".to_string(),
+                ));
+            }
+            *self.time.lock() = logical_time;
+            Ok(())
+        }
+    }
+
+    let callback = Box::new(move |_a: &[Arc<ExecutedBlock>], _b: LedgerInfoWithSignatures| {});
+    let recorded_commit = Arc::new(RecordedCommit {
+        time: Mutex::new(LogicalTime::new(0, 0)),
+    });
+    let generate_li = |epoch, round| {
+        LedgerInfoWithSignatures::new(
+            LedgerInfo::new(
+                BlockInfo::random_with_epoch(epoch, round),
+                HashValue::zero(),
+            ),
+            AggregateSignature::empty(),
+        )
+    };
+    let executor = ExecutionProxy::new(
+        recorded_commit.clone(),
+        recorded_commit.clone(),
+        recorded_commit.clone(),
+        &tokio::runtime::Handle::current(),
+    );
+    executor.new_epoch(
+        &EpochState::empty(),
+        Arc::new(PayloadManager::DirectMempool),
+    );
+    executor
+        .commit(&[], generate_li(1, 1), callback.clone())
+        .await
+        .unwrap();
+    executor
+        .commit(&[], generate_li(1, 10), callback)
+        .await
+        .unwrap();
+    assert!(executor.sync_to(generate_li(1, 8)).await.is_ok());
+    assert_eq!(*recorded_commit.time.lock(), LogicalTime::new(1, 10));
+    assert!(executor.sync_to(generate_li(2, 8)).await.is_ok());
+    assert_eq!(*recorded_commit.time.lock(), LogicalTime::new(2, 8));
 }

--- a/types/src/block_info.rs
+++ b/types/src/block_info.rs
@@ -87,6 +87,19 @@ impl BlockInfo {
         }
     }
 
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn random_with_epoch(epoch: u64, round: Round) -> Self {
+        Self {
+            epoch,
+            round,
+            id: HashValue::zero(),
+            executed_state_id: HashValue::zero(),
+            version: 0,
+            timestamp_usecs: 0,
+            next_epoch_state: None,
+        }
+    }
+
     /// Create a new genesis block. The genesis block is effectively the
     /// blockchain state after executing the initial genesis transaction.
     ///


### PR DESCRIPTION
This commit avoids that sync_to races with commit in state computer. previously it'd result in state sync error, with quorum store, it may panic the node because of decreasing round number.
