### PR TITLE
[Previewnet] [cherry-pick] PR 6889: [Quorum Store] Implement end_epoch to clear state_computer between epoch end and start

### DIFF
--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -547,6 +547,8 @@ impl EpochManager {
                 .expect("Could not send shutdown indicator to QuorumStore");
             ack_rx.await.expect("Failed to stop QuorumStore");
         }
+
+        self.commit_state_computer.end_epoch();
     }
 
     async fn start_recovery_manager(

--- a/consensus/src/experimental/ordering_state_computer.rs
+++ b/consensus/src/experimental/ordering_state_computer.rs
@@ -127,4 +127,6 @@ impl StateComputer for OrderingStateComputer {
         _: Arc<dyn TransactionShuffler>,
     ) {
     }
+
+    fn end_epoch(&self) {}
 }

--- a/consensus/src/quorum_store/batch_reader.rs
+++ b/consensus/src/quorum_store/batch_reader.rs
@@ -331,7 +331,13 @@ impl BatchReader {
     // for lagging nodes to be able to catch up (without state-sync).
     pub async fn update_certified_round(&self, certified_time: LogicalTime) {
         debug!("QS: batch reader updating time {:?}", certified_time);
-        assert!(self.epoch() == certified_time.epoch(), "QS: wrong epoch");
+        assert_eq!(
+            self.epoch(),
+            certified_time.epoch(),
+            "QS: wrong epoch {} != {}",
+            self.epoch(),
+            certified_time.epoch()
+        );
 
         let prev_round = self
             .last_certified_round

--- a/consensus/src/sender_aware_shuffler.rs
+++ b/consensus/src/sender_aware_shuffler.rs
@@ -1,3 +1,6 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     counters::{NUM_SENDERS_IN_BLOCK, TXN_SHUFFLE_SECONDS},
     transaction_shuffler::TransactionShuffler,

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -74,4 +74,7 @@ pub trait StateComputer: Send + Sync {
         payload_manager: Arc<PayloadManager>,
         transaction_shuffler: Arc<dyn TransactionShuffler>,
     );
+
+    // Reconfigure to clear epoch state at end of epoch.
+    fn end_epoch(&self);
 }

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -134,6 +134,8 @@ impl StateComputer for MockStateComputer {
     }
 
     fn new_epoch(&self, _: &EpochState, _: Arc<PayloadManager>, _: Arc<dyn TransactionShuffler>) {}
+
+    fn end_epoch(&self) {}
 }
 
 pub struct EmptyStateComputer;
@@ -162,6 +164,8 @@ impl StateComputer for EmptyStateComputer {
     }
 
     fn new_epoch(&self, _: &EpochState, _: Arc<PayloadManager>, _: Arc<dyn TransactionShuffler>) {}
+
+    fn end_epoch(&self) {}
 }
 
 /// Random Compute Result State Computer
@@ -214,4 +218,6 @@ impl StateComputer for RandomComputeResultStateComputer {
     }
 
     fn new_epoch(&self, _: &EpochState, _: Arc<PayloadManager>, _: Arc<dyn TransactionShuffler>) {}
+
+    fn end_epoch(&self) {}
 }

--- a/consensus/src/transaction_shuffler.rs
+++ b/consensus/src/transaction_shuffler.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Aptos
+// Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::sender_aware_shuffler::SenderAwareShuffler;

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Aptos
+// Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::on_chain_config::OnChainConfig;


### PR DESCRIPTION
[Quorum Store] Implement end_epoch to clear state_computer between epoch end and start (#6889)

We should not be using a stale PayloadManager after epoch end, so adding a end_epoch function that sets the PayloadManager to None.

This fixes a panic that was observed because the stale PayloadManager was still held at StateComputer during sync_to called from initiate_new_epoch. The PayloadManager expects to only see commits from its epoch, which is violated if the epoch change includes multiple epochs.

changing_working_quorum_test (with failpoints) failed with panics. Rerun and observe no panics. TODO (not in this PR): would be nice to have a test that explicitly causes a multiple epoch sync_to from epoch manager.
