### PR TITLE
[Executor-benchmark] Add support for pushing metrics to victoriametrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,6 +2188,7 @@ dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
  "ureq",
+ "url",
 ]
 
 [[package]]

--- a/crates/aptos-push-metrics/Cargo.toml
+++ b/crates/aptos-push-metrics/Cargo.toml
@@ -16,3 +16,4 @@ rust-version = { workspace = true }
 ureq = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
+url = { workspace = true }

--- a/crates/aptos-push-metrics/src/lib.rs
+++ b/crates/aptos-push-metrics/src/lib.rs
@@ -11,7 +11,15 @@ pub use aptos_metrics_core::{
     HistogramTimer, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
 };
 use aptos_metrics_core::{Encoder, TextEncoder};
-use std::{env, sync::mpsc, thread, thread::JoinHandle, time::Duration};
+use std::{
+    env,
+    ops::Sub,
+    sync::mpsc,
+    thread,
+    thread::JoinHandle,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+use url::Url;
 
 const DEFAULT_PUSH_FREQUENCY_SECS: u64 = 15;
 
@@ -25,7 +33,11 @@ pub struct MetricsPusher {
 }
 
 impl MetricsPusher {
-    fn push(push_metrics_endpoint: &str, api_token: Option<&str>) {
+    fn push(
+        push_metrics_endpoint: &str,
+        api_token: Option<&str>,
+        push_metrics_extra_labels: &[String],
+    ) {
         let mut buffer = Vec::new();
 
         if let Err(e) = TextEncoder::new().encode(&aptos_metrics_core::gather(), &mut buffer) {
@@ -35,12 +47,16 @@ impl MetricsPusher {
             if let Some(token) = api_token {
                 request.set("Authorization", format!("Bearer {}", token).as_str());
             }
+            push_metrics_extra_labels.iter().for_each(|label| {
+                request.query("extra_label", label);
+            });
             let response = request.timeout_connect(10_000).send_bytes(&buffer);
-            if let Some(error) = response.synthetic_error() {
+            if !response.ok() {
                 warn!(
-                    "Failed to push metrics to {}. Error: {}",
-                    push_metrics_endpoint, error
-                );
+                    "Failed to push metrics to {},  resp: {}",
+                    push_metrics_endpoint,
+                    response.status_text()
+                )
             }
         }
     }
@@ -50,19 +66,33 @@ impl MetricsPusher {
         push_metrics_endpoint: String,
         push_metrics_frequency_secs: u64,
         push_metrics_api_token: Option<String>,
+        push_metrics_extra_labels: Vec<String>,
     ) {
         while quit_receiver
             .recv_timeout(Duration::from_secs(push_metrics_frequency_secs))
             .is_err()
         {
             // Timeout, no quit signal received.
-            Self::push(&push_metrics_endpoint, push_metrics_api_token.as_deref());
+            Self::push(
+                &push_metrics_endpoint,
+                push_metrics_api_token.as_deref(),
+                &push_metrics_extra_labels,
+            );
         }
         // final push
-        Self::push(&push_metrics_endpoint, push_metrics_api_token.as_deref());
+        Self::push(
+            &push_metrics_endpoint,
+            push_metrics_api_token.as_deref(),
+            &push_metrics_extra_labels,
+        );
     }
 
-    fn start_worker_thread(quit_receiver: mpsc::Receiver<()>) -> Option<JoinHandle<()>> {
+    fn start_worker_thread(
+        quit_receiver: mpsc::Receiver<()>,
+        push_metrics_extra_labels: Vec<String>,
+        chain_name: &str,
+        namespace: &str,
+    ) -> Option<JoinHandle<()>> {
         // eg value for PUSH_METRICS_ENDPOINT: "http://pushgateway.server.com:9091/metrics/job/safety_rules"
         let push_metrics_endpoint = match env::var("PUSH_METRICS_ENDPOINT") {
             Ok(s) => s,
@@ -86,20 +116,71 @@ impl MetricsPusher {
             "Starting push metrics loop. Sending metrics to {} with a frequency of {} seconds",
             push_metrics_endpoint, push_metrics_frequency_secs
         );
+
+        info!(
+            "Execution dashboard link: {} ",
+            Self::get_dashboard_link(chain_name, namespace)
+        );
         Some(thread::spawn(move || {
             Self::worker(
                 quit_receiver,
                 push_metrics_endpoint,
                 push_metrics_frequency_secs,
                 push_metrics_api_token,
+                push_metrics_extra_labels,
             )
         }))
     }
 
+    fn get_dashboard_link(chain_name: &str, namespace: &str) -> Url {
+        let end_time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+            .to_string();
+        let start_time = SystemTime::now()
+            .sub(Duration::from_secs(600))
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+            .to_string();
+        let mut url =
+            Url::parse("https://o11y.aptosdev.com/grafana/d/execution/execution").unwrap();
+        url.query_pairs_mut()
+            .append_pair("from", &start_time)
+            .append_pair("to", &end_time)
+            .append_pair("var-Datasource", "VictoriaMetrics Global")
+            .append_pair("var-metrics_source", "All")
+            .append_pair("var-chain_name", chain_name)
+            .append_pair("var-cluster", "All")
+            .append_pair("var-namespace", namespace)
+            .append_pair("var-role", "All");
+
+        url
+    }
+
+    fn push_metrics_extra_labels(chain_name: &str, namespace: &str) -> Vec<String> {
+        vec![
+            format!("chain_name={}", chain_name),
+            "cluster=unknown".into(),
+            "metrics_source=unknown".into(),
+            "kubernetes_pod_name=unknown".into(),
+            "role=unknown".into(),
+            format!("namespace={}", namespace),
+        ]
+    }
+
     /// start starts a new thread and periodically pushes the metrics to a pushgateway endpoint
-    pub fn start() -> Self {
+    pub fn start(chain_name: &str) -> Self {
         let (tx, rx) = mpsc::channel();
-        let worker_thread = Self::start_worker_thread(rx);
+        let namespace = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+            .to_string();
+        let push_metrics_labels = Self::push_metrics_extra_labels(chain_name, &namespace);
+        let worker_thread =
+            Self::start_worker_thread(rx, push_metrics_labels, chain_name, &namespace);
 
         Self {
             worker_thread,

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -9,14 +9,24 @@ use aptos_executor::block_executor::TransactionBlockExecutor;
 use aptos_executor_benchmark::{
     benchmark_transaction::BenchmarkTransaction, fake_executor::FakeExecutor,
 };
+use aptos_metrics_core::{register_int_gauge, IntGauge};
 use aptos_push_metrics::MetricsPusher;
 use aptos_vm::AptosVM;
-use std::path::PathBuf;
+use once_cell::sync::Lazy;
+use std::{
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
 use structopt::StructOpt;
 
 #[cfg(unix)]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+/// This is needed for filters on the Grafana dashboard working as its used to populate the filter
+/// variables.
+pub static START_TIME: Lazy<IntGauge> =
+    Lazy::new(|| register_int_gauge!("node_process_start_time", "Start time").unwrap());
 
 #[derive(Debug, StructOpt)]
 struct PrunerOpt {
@@ -215,10 +225,15 @@ where
 }
 
 fn main() {
-    let _mp = MetricsPusher::start();
     let opt = Opt::from_args();
-
     aptos_logger::Logger::new().init();
+    START_TIME.set(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64,
+    );
+    let _mp = MetricsPusher::start("executor-benchmark");
 
     rayon::ThreadPoolBuilder::new()
         .thread_name(|index| format!("rayon-global-{}", index))

--- a/storage/backup/backup-cli/src/bin/db-backup-verify.rs
+++ b/storage/backup/backup-cli/src/bin/db-backup-verify.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
 async fn main_impl() -> Result<()> {
     Logger::new().level(Level::Info).init();
 
-    let _mp = MetricsPusher::start();
+    let _mp = MetricsPusher::start("db-backup-verifiy");
 
     let opt = Opt::from_args();
     VerifyCoordinator::new(

--- a/storage/backup/backup-cli/src/bin/db-backup.rs
+++ b/storage/backup/backup-cli/src/bin/db-backup.rs
@@ -142,7 +142,7 @@ async fn main() -> Result<()> {
 
 async fn main_impl() -> Result<()> {
     Logger::new().level(Level::Info).init();
-    let _mp = MetricsPusher::start();
+    let _mp = MetricsPusher::start("db-backup");
 
     let cmd = Command::from_args();
     match cmd {

--- a/storage/backup/backup-cli/src/bin/db-restore.rs
+++ b/storage/backup/backup-cli/src/bin/db-restore.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
 
 async fn main_impl() -> Result<()> {
     Logger::new().level(Level::Info).init();
-    let _mp = MetricsPusher::start();
+    let _mp = MetricsPusher::start("db-restore");
 
     let opt = Opt::from_args();
     let global_opt: GlobalRestoreOptions = opt.global.clone().try_into()?;

--- a/storage/db-tool/src/backup.rs
+++ b/storage/db-tool/src/backup.rs
@@ -136,7 +136,7 @@ pub struct VerifyOpt {
 impl Command {
     pub async fn run(self) -> Result<()> {
         Logger::new().level(Level::Info).init();
-        let _mp = MetricsPusher::start();
+        let _mp = MetricsPusher::start("db-backup");
         match self {
             Command::Oneoff(opt) => {
                 let client = Arc::new(BackupServiceClient::new_with_opt(opt.client));

--- a/storage/db-tool/src/restore.rs
+++ b/storage/db-tool/src/restore.rs
@@ -67,7 +67,7 @@ pub enum Oneoff {
 impl Command {
     pub async fn run(self) -> Result<()> {
         Logger::new().level(Level::Info).init();
-        let _mp = MetricsPusher::start();
+        let _mp = MetricsPusher::start("db-restore");
 
         match self {
             Command::Oneoff(oneoff) => {


### PR DESCRIPTION
### Description

Will be helpful to get insights from executor benchmark running on laptop. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Tested by running the benchmark on laptop

```
2023-03-05T00:58:06.877199Z [main] INFO crates/aptos-push-metrics/src/lib.rs:119 Execution dashboard link: https://o11y.aptosdev.com/grafana/d/execution/execution?from=now-5m&to=now&var-Datasource=VictoriaMetrics+Global&var-metrics_source=All&var-chain_name=executor-benchmark&var-cluster=All&var-namespace=1677977886876947000&var-role=All
```
