### PR TITLE
[PREVIEWNET ONLY][docker] expose validator REST API

### DIFF
--- a/docker/compose/aptos-node/docker-compose-src.yaml
+++ b/docker/compose/aptos-node/docker-compose-src.yaml
@@ -32,8 +32,8 @@ services:
       # Preface these with 127 to only expose them locally
       - "127.0.0.1:9101:9101"
       - "127.0.0.1:9102:9102"
-      # Disable access to rest API port 80 for validator by default
-      # - 8180:8180
+      # Enable access to rest API for validator for loadtesting during PreviewNet
+      - 8180:8180
 
 
   validator:
@@ -69,8 +69,8 @@ services:
       - 6181
       # Validator Metrics
       - 9101
-      # Disable access to rest API port 80 for validator by default
-      # - 8080
+      # Enable access to rest API port for validator
+      - 8080
 
 networks:
   shared:

--- a/docker/compose/aptos-node/docker-compose.yaml
+++ b/docker/compose/aptos-node/docker-compose.yaml
@@ -23,8 +23,8 @@ services:
       - 9101
       # Haproxy internal stats
       - 9102
-      # Disable access to rest API port 80 for validator by default
-      # - 8180
+      # Enable access to rest API for validator for loadtesting during PreviewNet
+      - 8180
     ports:
       # Expose these to the outside
       - "6180:6180"
@@ -32,8 +32,8 @@ services:
       # Preface these with 127 to only expose them locally
       - "127.0.0.1:9101:9101"
       - "127.0.0.1:9102:9102"
-      # Disable access to rest API port 80 for validator by default
-      # - 8180:8180
+      # Enable access to rest API for validator for loadtesting during PreviewNet
+      - 8180:8180
 
 
   validator:
@@ -66,8 +66,8 @@ services:
       - 6181
       # Validator Metrics
       - 9101
-      # Disable access to rest API port 80 for validator by default
-      # - 8080
+      # Enable access to rest API port for validator
+      - 8080
 
 networks:
   shared:


### PR DESCRIPTION
### Description

Port 8180 on machines running docker-compose validator will expose validator REST API via HAProxy. Port 8080 is already the VFN REST API, exposed via a separate HAProxy 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
