### PR TITLE
[Peer Monitoring Service] Add extensive test suite for the client side.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2189,17 +2189,21 @@ dependencies = [
  "aptos-metrics-core",
  "aptos-netcore",
  "aptos-network",
+ "aptos-peer-monitoring-service-server",
  "aptos-peer-monitoring-service-types",
  "aptos-time-service",
  "aptos-types",
  "async-trait",
+ "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "enum_dispatch",
  "futures",
+ "maplit",
  "once_cell",
  "rand 0.7.3",
  "serde 1.0.149",
  "thiserror",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/network/peer-monitoring-service/client/Cargo.toml
+++ b/network/peer-monitoring-service/client/Cargo.toml
@@ -34,4 +34,8 @@ tokio = { workspace = true }
 [dev-dependencies]
 aptos-netcore = { workspace = true }
 aptos-network = { workspace = true, features = ["fuzzing"] }
+aptos-peer-monitoring-service-server = { workspace = true }
+bcs = { workspace = true }
+maplit = { workspace = true }
 rand = { workspace = true }
+tokio-stream = { workspace = true }

--- a/network/peer-monitoring-service/client/src/lib.rs
+++ b/network/peer-monitoring-service/client/src/lib.rs
@@ -29,6 +29,8 @@ mod logging;
 mod metrics;
 mod network;
 pub mod peer_states;
+#[cfg(test)]
+mod tests;
 
 /// A simple container that holds the state of the peer monitor
 #[derive(Clone, Debug, Default)]
@@ -151,7 +153,7 @@ async fn start_peer_monitor_with_state(
 
 /// Spawns a task that continuously updates the peers and metadata
 /// struct with the latest information stored for each peer.
-fn spawn_peer_metadata_updater(
+pub(crate) fn spawn_peer_metadata_updater(
     peer_monitoring_config: PeerMonitoringServiceConfig,
     peer_monitor_state: PeerMonitorState,
     peers_and_metadata: Arc<PeersAndMetadata>,

--- a/network/peer-monitoring-service/client/src/peer_states/peer_state.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/peer_state.rs
@@ -168,7 +168,7 @@ impl PeerState {
     }
 
     /// Returns the peer state value associated with the given key
-    fn get_peer_state_value(
+    pub(crate) fn get_peer_state_value(
         &self,
         peer_state_key: &PeerStateKey,
     ) -> Result<Arc<RwLock<PeerStateValue>>, Error> {
@@ -182,7 +182,7 @@ impl PeerState {
     }
 
     /// Returns a copy of the latency ping state
-    fn get_latency_info_state(&self) -> Result<LatencyInfoState, Error> {
+    pub(crate) fn get_latency_info_state(&self) -> Result<LatencyInfoState, Error> {
         let peer_state_value = self
             .get_peer_state_value(&PeerStateKey::LatencyInfo)?
             .read()
@@ -197,7 +197,7 @@ impl PeerState {
     }
 
     /// Returns a copy of the network info state
-    fn get_network_info_state(&self) -> Result<NetworkInfoState, Error> {
+    pub(crate) fn get_network_info_state(&self) -> Result<NetworkInfoState, Error> {
         let peer_state_value = self
             .get_peer_state_value(&PeerStateKey::NetworkInfo)?
             .read()

--- a/network/peer-monitoring-service/client/src/tests/mock.rs
+++ b/network/peer-monitoring-service/client/src/tests/mock.rs
@@ -1,0 +1,185 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{PeerMonitorState, PeerMonitoringServiceClient, StreamExt};
+use aptos_channels::{aptos_channel, aptos_channel::Receiver, message_queues::QueueStyle};
+use aptos_config::{
+    config::PeerRole,
+    network_id::{NetworkId, PeerNetworkId},
+};
+use aptos_netcore::transport::ConnectionOrigin;
+use aptos_network::{
+    application::{interface::NetworkClient, metadata::ConnectionState, storage::PeersAndMetadata},
+    peer_manager::{ConnectionRequestSender, PeerManagerRequest, PeerManagerRequestSender},
+    protocols::{
+        network::{NetworkSender, NewNetworkSender},
+        wire::handshake::v1::ProtocolId,
+    },
+    transport::ConnectionMetadata,
+};
+use aptos_peer_monitoring_service_server::network::{NetworkRequest, ResponseSender};
+use aptos_peer_monitoring_service_types::PeerMonitoringServiceMessage;
+use aptos_time_service::TimeService;
+use aptos_types::account_address::{AccountAddress as PeerId, AccountAddress};
+use futures::FutureExt;
+use std::{collections::HashMap, sync::Arc};
+
+/// A simple mock of the peer monitoring server for test purposes
+pub struct MockMonitoringServer {
+    peer_manager_request_receivers:
+        HashMap<NetworkId, aptos_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>>,
+    peers_and_metadata: Arc<PeersAndMetadata>,
+}
+
+impl MockMonitoringServer {
+    pub fn new(
+        all_network_ids: Vec<NetworkId>,
+    ) -> (
+        PeerMonitoringServiceClient<NetworkClient<PeerMonitoringServiceMessage>>,
+        Self,
+        PeerMonitorState,
+        TimeService,
+    ) {
+        // Setup the test logger (if it hasn't already been initialized)
+        ::aptos_logger::Logger::init_for_testing();
+
+        // Setup the request channels and the network sender for each network
+        let mut network_senders = HashMap::new();
+        let mut peer_manager_request_receivers = HashMap::new();
+        for network_id in &all_network_ids {
+            // Create the channels and network sender
+            let queue_config = aptos_channel::Config::new(10).queue_style(QueueStyle::FIFO);
+            let (peer_manager_request_sender, peer_manager_request_receiver) = queue_config.build();
+            let (connection_request_sender, _connection_request_receiver) = queue_config.build();
+            let network_sender = NetworkSender::new(
+                PeerManagerRequestSender::new(peer_manager_request_sender),
+                ConnectionRequestSender::new(connection_request_sender),
+            );
+
+            // Store the channels and network sender
+            peer_manager_request_receivers.insert(*network_id, peer_manager_request_receiver);
+            network_senders.insert(*network_id, network_sender);
+        }
+
+        // Setup the network client
+        let peers_and_metadata = PeersAndMetadata::new(&all_network_ids);
+        let network_client = NetworkClient::new(
+            vec![], // The peer monitoring service doesn't use direct send
+            vec![ProtocolId::PeerMonitoringServiceRpc],
+            network_senders,
+            peers_and_metadata.clone(),
+        );
+
+        // Create the mock server
+        let mock_monitoring_server = Self {
+            peer_manager_request_receivers,
+            peers_and_metadata,
+        };
+
+        (
+            PeerMonitoringServiceClient::new(network_client),
+            mock_monitoring_server,
+            PeerMonitorState::new(),
+            TimeService::mock(),
+        )
+    }
+
+    /// Add a new peer to the peers and metadata struct
+    pub fn add_new_peer(&mut self, network_id: NetworkId, role: PeerRole) -> PeerNetworkId {
+        // Create a new peer
+        let peer_id = PeerId::random();
+        let peer_network_id = PeerNetworkId::new(network_id, peer_id);
+
+        // Create and save a new connection metadata
+        let mut connection_metadata = ConnectionMetadata::mock_with_role_and_origin(
+            peer_id,
+            role,
+            ConnectionOrigin::Outbound,
+        );
+        connection_metadata
+            .application_protocols
+            .insert(ProtocolId::PeerMonitoringServiceRpc);
+        self.peers_and_metadata
+            .insert_connection_metadata(peer_network_id, connection_metadata)
+            .unwrap();
+
+        // Return the new peer
+        peer_network_id
+    }
+
+    /// Disconnects the peer in the peers and metadata struct
+    pub fn disconnect_peer(&mut self, peer: PeerNetworkId) {
+        self.update_peer_state(peer, ConnectionState::Disconnected);
+    }
+
+    /// Reconnects the peer in the peers and metadata struct
+    pub fn reconnected_peer(&mut self, peer: PeerNetworkId) {
+        self.update_peer_state(peer, ConnectionState::Connected);
+    }
+
+    /// Updates the state of the given peer in the peers and metadata struct
+    fn update_peer_state(&mut self, peer: PeerNetworkId, state: ConnectionState) {
+        self.peers_and_metadata
+            .update_connection_state(peer, state)
+            .unwrap();
+    }
+
+    /// Get the next request sent from the client
+    pub async fn next_request(&mut self, network_id: &NetworkId) -> Option<NetworkRequest> {
+        // Get the request receiver
+        let peer_manager_request_receiver = self.get_request_receiver(network_id);
+
+        // Wait for the next request
+        match peer_manager_request_receiver.next().await {
+            Some(PeerManagerRequest::SendRpc(peer_id, network_request)) => {
+                // Deconstruct the network request
+                let peer_network_id = PeerNetworkId::new(*network_id, peer_id);
+                let protocol_id = network_request.protocol_id;
+                let request_data = network_request.data;
+                let response_sender = network_request.res_tx;
+
+                // Deserialize the network message
+                let peer_monitoring_message: PeerMonitoringServiceMessage =
+                    bcs::from_bytes(request_data.as_ref()).unwrap();
+                let peer_monitoring_service_request = match peer_monitoring_message {
+                    PeerMonitoringServiceMessage::Request(request) => request,
+                    _ => panic!("Unexpected message received: {:?}", peer_monitoring_message),
+                };
+
+                // Return the network request
+                Some(NetworkRequest {
+                    peer_network_id,
+                    protocol_id,
+                    peer_monitoring_service_request,
+                    response_sender: ResponseSender::new(response_sender),
+                })
+            },
+            Some(PeerManagerRequest::SendDirectSend(_, _)) => {
+                panic!("Unexpected direct send message received!")
+            },
+            None => None,
+        }
+    }
+
+    /// Verifies that there are no pending requests on the network
+    pub async fn verify_no_pending_requests(&mut self, network_id: &NetworkId) {
+        // Get the request receiver
+        let peer_manager_request_receiver = self.get_request_receiver(network_id);
+
+        // Verify that there is no request pending
+        assert!(peer_manager_request_receiver
+            .select_next_some()
+            .now_or_never()
+            .is_none());
+    }
+
+    /// Gets the request receiver for the specified network
+    fn get_request_receiver(
+        &mut self,
+        network_id: &NetworkId,
+    ) -> &mut Receiver<(AccountAddress, ProtocolId), PeerManagerRequest> {
+        self.peer_manager_request_receivers
+            .get_mut(network_id)
+            .unwrap()
+    }
+}

--- a/network/peer-monitoring-service/client/src/tests/mod.rs
+++ b/network/peer-monitoring-service/client/src/tests/mod.rs
@@ -1,0 +1,7 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+mod mock;
+mod multiple_peers;
+mod single_peer;
+mod utils;

--- a/network/peer-monitoring-service/client/src/tests/multiple_peers.rs
+++ b/network/peer-monitoring-service/client/src/tests/multiple_peers.rs
@@ -1,0 +1,564 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    peer_states::key_value::PeerStateKey,
+    tests::{
+        mock::MockMonitoringServer,
+        utils::{
+            elapse_latency_update_interval, elapse_metadata_updater_interval,
+            elapse_network_info_update_interval, get_config_without_latency_pings,
+            get_config_without_network_info_requests, get_distance_from_validators,
+            initialize_and_verify_peer_states, spawn_with_timeout, start_peer_metadata_updater,
+            start_peer_monitor, update_latency_info_for_peer, update_network_info_for_peer,
+            verify_and_handle_latency_ping, verify_empty_peer_states,
+            verify_latency_request_and_respond, wait_for_monitoring_latency_update,
+            wait_for_monitoring_network_update, wait_for_peer_state_update,
+        },
+    },
+    PeerState,
+};
+use aptos_config::{
+    config::{NodeConfig, PeerRole},
+    network_id::{NetworkId, PeerNetworkId},
+};
+use aptos_infallible::RwLock;
+use aptos_network::{application::metadata::PeerMetadata, transport::ConnectionMetadata};
+use aptos_peer_monitoring_service_types::{
+    LatencyPingResponse, NetworkInformationResponse, PeerMonitoringServiceRequest,
+    PeerMonitoringServiceResponse,
+};
+use aptos_time_service::TimeServiceTrait;
+use aptos_types::PeerId;
+use maplit::hashmap;
+use std::sync::Arc;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_peer_updater_loop_multiple_peers() {
+    // Create the peer monitoring client and server
+    let all_network_ids = vec![NetworkId::Validator, NetworkId::Vfn, NetworkId::Public];
+    let (peer_monitoring_client, mut mock_monitoring_server, peer_monitor_state, time_service) =
+        MockMonitoringServer::new(all_network_ids.clone());
+
+    // Verify peers and metadata is empty
+    let peers_and_metadata = peer_monitoring_client.get_peers_and_metadata();
+    assert!(peers_and_metadata.get_all_peers().unwrap().is_empty());
+
+    // Add a connected validator peer
+    let validator_peer =
+        mock_monitoring_server.add_new_peer(NetworkId::Validator, PeerRole::Validator);
+
+    // Add a connected VFN peer
+    let vfn_peer = mock_monitoring_server.add_new_peer(NetworkId::Vfn, PeerRole::ValidatorFullNode);
+
+    // Add a connected fullnode peer
+    let fullnode_peer = mock_monitoring_server.add_new_peer(NetworkId::Public, PeerRole::Unknown);
+
+    // Create peer states for all the peers and update
+    let node_config = NodeConfig::default();
+    let all_peers = vec![validator_peer, vfn_peer, fullnode_peer];
+    for peer in &all_peers {
+        let peer_state = PeerState::new(node_config.clone(), time_service.clone());
+        peer_monitor_state
+            .peer_states
+            .write()
+            .insert(*peer, peer_state.clone());
+    }
+
+    // Update the latency ping info for all the peers
+    let response_time_secs = 3.0;
+    for peer in &all_peers {
+        let mut peer_states = peer_monitor_state.peer_states.write();
+        let peer_state = peer_states.get_mut(peer).unwrap();
+        update_latency_info_for_peer(
+            peers_and_metadata.clone(),
+            peer,
+            peer_state,
+            0,
+            0,
+            response_time_secs,
+        );
+    }
+
+    // Spawn the peer metadata updater
+    let peers_and_metadata = peer_monitoring_client.get_peers_and_metadata();
+    start_peer_metadata_updater(
+        &peer_monitor_state,
+        peers_and_metadata.clone(),
+        &time_service,
+        &node_config,
+    )
+    .await;
+
+    // Elapse enough time for the metadata updater to run
+    let mock_time = time_service.into_mock();
+    elapse_metadata_updater_interval(node_config.clone(), mock_time.clone()).await;
+
+    // Verify the peer metadata is updated for all peers
+    for peer in &all_peers {
+        wait_for_monitoring_latency_update(peers_and_metadata.clone(), peer, response_time_secs)
+            .await;
+    }
+
+    // Update the network for all the peers
+    for peer in &all_peers {
+        // Get the peer state
+        let mut peer_states = peer_monitor_state.peer_states.write();
+        let peer_state = peer_states.get_mut(peer).unwrap();
+
+        // Update the network info
+        let connected_peers_and_metadata = hashmap! { PeerNetworkId::random() => PeerMetadata::new(ConnectionMetadata::mock(PeerId::random())) };
+        let distance_from_validators = get_distance_from_validators(peer);
+        update_network_info_for_peer(
+            peers_and_metadata.clone(),
+            peer,
+            peer_state,
+            connected_peers_and_metadata,
+            distance_from_validators,
+            1.0,
+        );
+    }
+
+    // Disconnect the validator and VFN peers
+    mock_monitoring_server.disconnect_peer(validator_peer);
+    mock_monitoring_server.disconnect_peer(vfn_peer);
+
+    // Elapse enough time for the metadata updater to run
+    elapse_metadata_updater_interval(node_config.clone(), mock_time.clone()).await;
+
+    // Verify the peer metadata is updated for all the peers (metadata
+    // should always be updated, even if some peers are disconnected).
+    for peer in &all_peers {
+        let distance_from_validators = get_distance_from_validators(peer);
+        wait_for_monitoring_network_update(
+            peers_and_metadata.clone(),
+            peer,
+            distance_from_validators,
+        )
+        .await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_initial_states() {
+    // Create the peer monitoring client and server
+    let all_network_ids = vec![NetworkId::Validator, NetworkId::Vfn, NetworkId::Public];
+    let (peer_monitoring_client, mut mock_monitoring_server, peer_monitor_state, time_service) =
+        MockMonitoringServer::new(all_network_ids.clone());
+
+    // Spawn the peer monitoring client
+    let node_config = NodeConfig::default();
+    start_peer_monitor(
+        peer_monitoring_client,
+        &peer_monitor_state,
+        &time_service,
+        &node_config,
+    )
+    .await;
+
+    // Verify the initial state of the peer monitor
+    verify_empty_peer_states(&peer_monitor_state);
+
+    // Add a connected validator peer
+    let validator_peer =
+        mock_monitoring_server.add_new_peer(NetworkId::Validator, PeerRole::Validator);
+
+    // Initialize all the validator states by running the peer monitor once
+    let mock_time = time_service.into_mock();
+    let _ = initialize_and_verify_peer_states(
+        &NetworkId::Validator,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer,
+        &mock_time,
+    )
+    .await;
+
+    // Add a connected VFN peer
+    let vfn_peer = mock_monitoring_server.add_new_peer(NetworkId::Vfn, PeerRole::ValidatorFullNode);
+
+    // Initialize all the VFN states by running the peer monitor once
+    let _ = initialize_and_verify_peer_states(
+        &NetworkId::Vfn,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &vfn_peer,
+        &mock_time,
+    )
+    .await;
+
+    // Add a connected public fullnode peer
+    let fullnode_peer = mock_monitoring_server.add_new_peer(NetworkId::Public, PeerRole::Unknown);
+
+    // Initialize all the VFN states by running the peer monitor once
+    let _ = initialize_and_verify_peer_states(
+        &NetworkId::Public,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &fullnode_peer,
+        &mock_time,
+    )
+    .await;
+
+    // Verify no pending messages
+    for network_id in &[NetworkId::Validator, NetworkId::Vfn, NetworkId::Public] {
+        mock_monitoring_server
+            .verify_no_pending_requests(network_id)
+            .await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_latency_ping() {
+    // Create the peer monitoring client and server
+    let all_network_ids = vec![NetworkId::Validator, NetworkId::Vfn, NetworkId::Public];
+    let (peer_monitoring_client, mut mock_monitoring_server, peer_monitor_state, time_service) =
+        MockMonitoringServer::new(all_network_ids.clone());
+
+    // Create a node config where network info requests don't refresh
+    let node_config = get_config_without_network_info_requests();
+
+    // Spawn the peer monitoring client
+    start_peer_monitor(
+        peer_monitoring_client,
+        &peer_monitor_state,
+        &time_service,
+        &node_config,
+    )
+    .await;
+
+    // Add a connected public fullnode
+    let fullnode_peer_1 = mock_monitoring_server.add_new_peer(NetworkId::Public, PeerRole::Unknown);
+
+    // Initialize all the fullnode states by running the peer monitor once
+    let mock_time = time_service.into_mock();
+    let _ = initialize_and_verify_peer_states(
+        &NetworkId::Public,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &fullnode_peer_1,
+        &mock_time,
+    )
+    .await;
+
+    // Add a connected public fullnode
+    let fullnode_peer_2 = mock_monitoring_server.add_new_peer(NetworkId::Public, PeerRole::Unknown);
+
+    // Initialize all the fullnode states by running the peer monitor once
+    let _ = initialize_and_verify_peer_states(
+        &NetworkId::Public,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &fullnode_peer_2,
+        &mock_time,
+    )
+    .await;
+
+    // Handle several latency info requests for the fullnodes
+    let mock_monitoring_server = Arc::new(RwLock::new(mock_monitoring_server)).clone();
+    for i in 0..10 {
+        // Elapse enough time for a latency ping update
+        let time_before_update = mock_time.now();
+        elapse_latency_update_interval(node_config.clone(), mock_time.clone()).await;
+
+        // Create a task that waits for the requests and sends responses
+        let mock_monitoring_server = mock_monitoring_server.clone();
+        let peer_monitor_state = peer_monitor_state.clone();
+        let handle_requests = async move {
+            // Create a response for the latency pings
+            let response = PeerMonitoringServiceResponse::LatencyPing(LatencyPingResponse {
+                ping_counter: i + 1,
+            });
+
+            // Verify that a latency ping is received for each peer
+            for _ in 0..2 {
+                // Get the network request
+                let network_request = mock_monitoring_server
+                    .write()
+                    .next_request(&NetworkId::Public)
+                    .await
+                    .unwrap();
+
+                // Verify the request type and respond
+                match network_request.peer_monitoring_service_request {
+                    PeerMonitoringServiceRequest::LatencyPing(_) => {
+                        network_request.response_sender.send(Ok(response.clone()));
+                    },
+                    request => panic!("Unexpected monitoring request received: {:?}", request),
+                }
+            }
+
+            // Wait for the peer states to update
+            for peer_network_id in &[fullnode_peer_1, fullnode_peer_2] {
+                wait_for_peer_state_update(
+                    time_before_update,
+                    &peer_monitor_state,
+                    peer_network_id,
+                    vec![PeerStateKey::LatencyInfo],
+                )
+                .await;
+            }
+        };
+
+        // Spawn the task with a timeout
+        spawn_with_timeout(
+            handle_requests,
+            "Timed-out while waiting for the latency ping requests",
+        )
+        .await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_network_info() {
+    // Create the peer monitoring client and server
+    let all_network_ids = vec![NetworkId::Validator, NetworkId::Vfn, NetworkId::Public];
+    let (peer_monitoring_client, mut mock_monitoring_server, peer_monitor_state, time_service) =
+        MockMonitoringServer::new(all_network_ids.clone());
+
+    // Create a node config where latency pings don't refresh
+    let node_config = get_config_without_latency_pings();
+
+    // Spawn the peer monitoring client
+    start_peer_monitor(
+        peer_monitoring_client,
+        &peer_monitor_state,
+        &time_service,
+        &node_config,
+    )
+    .await;
+
+    // Add a connected validator peer
+    let validator_peer_1 =
+        mock_monitoring_server.add_new_peer(NetworkId::Validator, PeerRole::Validator);
+
+    // Initialize all the validator states by running the peer monitor once
+    let mock_time = time_service.into_mock();
+    let _ = initialize_and_verify_peer_states(
+        &NetworkId::Validator,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer_1,
+        &mock_time,
+    )
+    .await;
+
+    // Add another connected validator peer
+    let validator_peer_2 =
+        mock_monitoring_server.add_new_peer(NetworkId::Validator, PeerRole::Validator);
+
+    // Initialize all the validator states by running the peer monitor once
+    let _ = initialize_and_verify_peer_states(
+        &NetworkId::Validator,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer_2,
+        &mock_time,
+    )
+    .await;
+
+    // Add another connected validator peer
+    let validator_peer_3 =
+        mock_monitoring_server.add_new_peer(NetworkId::Validator, PeerRole::Validator);
+
+    // Initialize all the validator states by running the peer monitor once
+    let _ = initialize_and_verify_peer_states(
+        &NetworkId::Validator,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer_3,
+        &mock_time,
+    )
+    .await;
+
+    // Handle several network info requests for the validators
+    let mock_monitoring_server = Arc::new(RwLock::new(mock_monitoring_server)).clone();
+    for _ in 0..10 {
+        // Elapse enough time for a network info update
+        let time_before_update = mock_time.now();
+        elapse_network_info_update_interval(node_config.clone(), mock_time.clone()).await;
+
+        // Create a task that waits for the requests and sends responses
+        let mock_monitoring_server = mock_monitoring_server.clone();
+        let peer_monitor_state = peer_monitor_state.clone();
+        let handle_requests = async move {
+            // Create a response for the network info requests
+            let connected_peers_and_metadata = hashmap! { PeerNetworkId::random() => PeerMetadata::new(ConnectionMetadata::mock(PeerId::random())) };
+            let response =
+                PeerMonitoringServiceResponse::NetworkInformation(NetworkInformationResponse {
+                    connected_peers_and_metadata: connected_peers_and_metadata.clone(),
+                    distance_from_validators: 0,
+                });
+
+            // Verify that a network info request is received for each peer
+            for _ in 0..3 {
+                // Get the network request
+                let network_request = mock_monitoring_server
+                    .write()
+                    .next_request(&NetworkId::Validator)
+                    .await
+                    .unwrap();
+
+                // Verify the request type and respond
+                match network_request.peer_monitoring_service_request {
+                    PeerMonitoringServiceRequest::GetNetworkInformation => {
+                        network_request.response_sender.send(Ok(response.clone()));
+                    },
+                    request => panic!("Unexpected monitoring request received: {:?}", request),
+                }
+            }
+
+            // Wait for the peer states to update
+            for peer_network_id in &[validator_peer_1, validator_peer_2, validator_peer_3] {
+                wait_for_peer_state_update(
+                    time_before_update,
+                    &peer_monitor_state,
+                    peer_network_id,
+                    vec![PeerStateKey::NetworkInfo],
+                )
+                .await;
+            }
+        };
+
+        // Spawn the task with a timeout
+        spawn_with_timeout(
+            handle_requests,
+            "Timed-out while waiting for the network info requests",
+        )
+        .await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_peer_connections() {
+    // Create the peer monitoring client and server
+    let all_network_ids = vec![NetworkId::Validator, NetworkId::Vfn, NetworkId::Public];
+    let (peer_monitoring_client, mut mock_monitoring_server, peer_monitor_state, time_service) =
+        MockMonitoringServer::new(all_network_ids.clone());
+
+    // Create a node config where network info requests don't refresh
+    let node_config = get_config_without_network_info_requests();
+
+    // Spawn the peer monitoring client
+    start_peer_monitor(
+        peer_monitoring_client,
+        &peer_monitor_state,
+        &time_service,
+        &node_config,
+    )
+    .await;
+
+    // Add a connected validator peer
+    let validator_peer =
+        mock_monitoring_server.add_new_peer(NetworkId::Validator, PeerRole::Validator);
+
+    // Initialize all the validator states by running the peer monitor once
+    let mock_time = time_service.into_mock();
+    let _ = initialize_and_verify_peer_states(
+        &NetworkId::Validator,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer,
+        &mock_time,
+    )
+    .await;
+
+    // Add a connected VFN peer
+    let vfn_peer = mock_monitoring_server.add_new_peer(NetworkId::Vfn, PeerRole::ValidatorFullNode);
+
+    // Initialize all the VFN states by running the peer monitor once
+    let _ = initialize_and_verify_peer_states(
+        &NetworkId::Vfn,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &vfn_peer,
+        &mock_time,
+    )
+    .await;
+
+    // Disconnect the validator peer
+    mock_monitoring_server.disconnect_peer(validator_peer);
+
+    // Handle several latency ping requests and responses for the VFN
+    for i in 0..5 {
+        verify_and_handle_latency_ping(
+            &NetworkId::Vfn,
+            &mut mock_monitoring_server,
+            &peer_monitor_state,
+            &node_config,
+            &vfn_peer,
+            &mock_time,
+            i + 1,
+            i + 2,
+        )
+        .await;
+    }
+
+    // Disconnect the VFN and reconnect the validator peer
+    mock_monitoring_server.disconnect_peer(vfn_peer);
+    mock_monitoring_server.reconnected_peer(validator_peer);
+
+    // Handle several latency ping requests and responses for the validator peer
+    for i in 0..5 {
+        verify_and_handle_latency_ping(
+            &NetworkId::Validator,
+            &mut mock_monitoring_server,
+            &peer_monitor_state,
+            &node_config,
+            &validator_peer,
+            &mock_time,
+            i + 1,
+            i + 2,
+        )
+        .await;
+    }
+
+    // Elapse enough time for a latency ping update
+    elapse_latency_update_interval(node_config.clone(), mock_time.clone()).await;
+
+    // Verify no pending messages for the validator
+    mock_monitoring_server
+        .verify_no_pending_requests(&NetworkId::Validator)
+        .await;
+
+    // Reconnect the VFN
+    mock_monitoring_server.reconnected_peer(vfn_peer);
+
+    // Handle several latency ping requests and responses for the peers
+    for i in 5..10 {
+        // Elapse enough time for a latency ping update
+        let time_before_update = mock_time.now();
+        elapse_latency_update_interval(node_config.clone(), mock_time.clone()).await;
+
+        // Handle the pings for the peers
+        for peer_network_id in &[validator_peer, vfn_peer] {
+            verify_latency_request_and_respond(
+                &peer_network_id.network_id(),
+                &mut mock_monitoring_server,
+                i + 1,
+                false,
+                false,
+                false,
+            )
+            .await;
+
+            wait_for_peer_state_update(
+                time_before_update,
+                &peer_monitor_state,
+                peer_network_id,
+                vec![PeerStateKey::LatencyInfo],
+            )
+            .await;
+        }
+    }
+}

--- a/network/peer-monitoring-service/client/src/tests/single_peer.rs
+++ b/network/peer-monitoring-service/client/src/tests/single_peer.rs
@@ -1,0 +1,643 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    peer_states::key_value::PeerStateKey,
+    tests::{
+        mock::MockMonitoringServer,
+        utils::{
+            elapse_latency_update_interval, elapse_metadata_updater_interval,
+            elapse_network_info_update_interval, get_config_without_latency_pings,
+            get_config_without_network_info_requests, initialize_and_verify_peer_states,
+            start_peer_metadata_updater, start_peer_monitor, update_latency_info_for_peer,
+            update_network_info_for_peer, verify_all_requests_and_respond,
+            verify_and_handle_latency_ping, verify_and_handle_network_info_request,
+            verify_empty_peer_states, verify_latency_request_and_respond,
+            verify_network_info_request_and_respond, verify_peer_latency_state,
+            verify_peer_monitor_state, verify_peer_network_state, wait_for_latency_ping_failure,
+            wait_for_monitoring_latency_update, wait_for_monitoring_network_update,
+            wait_for_network_info_request_failure, wait_for_peer_state_update,
+        },
+    },
+    PeerState,
+};
+use aptos_config::{
+    config::{NodeConfig, PeerRole},
+    network_id::{NetworkId, PeerNetworkId},
+};
+use aptos_network::{application::metadata::PeerMetadata, transport::ConnectionMetadata};
+use aptos_time_service::TimeServiceTrait;
+use aptos_types::PeerId;
+use maplit::hashmap;
+use std::cmp::min;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_basic_peer_monitor_loop() {
+    // Create the peer monitoring client and server
+    let network_id = NetworkId::Validator;
+    let (peer_monitoring_client, mut mock_monitoring_server, peer_monitor_state, time_service) =
+        MockMonitoringServer::new(vec![network_id]);
+
+    // Spawn the peer monitoring client
+    let node_config = NodeConfig::default();
+    start_peer_monitor(
+        peer_monitoring_client,
+        &peer_monitor_state,
+        &time_service,
+        &node_config,
+    )
+    .await;
+
+    // Verify the initial state of the peer monitor
+    verify_empty_peer_states(&peer_monitor_state);
+
+    // Add a connected validator peer
+    let validator_peer = mock_monitoring_server.add_new_peer(network_id, PeerRole::Validator);
+
+    // Initialize all the peer states by running the peer monitor once
+    let mock_time = time_service.into_mock();
+    let (connected_peers_and_metadata, distance_from_validators) =
+        initialize_and_verify_peer_states(
+            &network_id,
+            &mut mock_monitoring_server,
+            &peer_monitor_state,
+            &node_config,
+            &validator_peer,
+            &mock_time,
+        )
+        .await;
+
+    // Elapse enough time for a latency ping and verify correct execution
+    verify_and_handle_latency_ping(
+        &network_id,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer,
+        &mock_time,
+        1,
+        2,
+    )
+    .await;
+
+    // Elapse enough time for a network info request (which should also
+    // trigger another latency ping).
+    let time_before_update = mock_time.now();
+    elapse_network_info_update_interval(node_config, mock_time).await;
+
+    // Verify that both a latency and network request are received and respond
+    verify_all_requests_and_respond(
+        &network_id,
+        &mut mock_monitoring_server,
+        &connected_peers_and_metadata,
+        distance_from_validators,
+    )
+    .await;
+
+    // Wait until the network peer state is updated by the client
+    wait_for_peer_state_update(
+        time_before_update,
+        &peer_monitor_state,
+        &validator_peer,
+        PeerStateKey::get_all_keys(),
+    )
+    .await;
+
+    // Verify the new state of the peer monitor
+    verify_peer_monitor_state(
+        &peer_monitor_state,
+        &validator_peer,
+        &connected_peers_and_metadata,
+        distance_from_validators,
+        3,
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_basic_peer_updater_loop() {
+    // Create the peer monitoring client and server
+    let network_id = NetworkId::Public;
+    let (peer_monitoring_client, mut mock_monitoring_server, peer_monitor_state, time_service) =
+        MockMonitoringServer::new(vec![network_id]);
+
+    // Verify peers and metadata is empty
+    let peers_and_metadata = peer_monitoring_client.get_peers_and_metadata();
+    assert!(peers_and_metadata.get_all_peers().unwrap().is_empty());
+
+    // Add a connected fullnode peer
+    let fullnode_peer = mock_monitoring_server.add_new_peer(NetworkId::Public, PeerRole::Unknown);
+
+    // Create a peer state for the fullnode
+    let node_config = NodeConfig::default();
+    let mut peer_state = PeerState::new(node_config.clone(), time_service.clone());
+    peer_monitor_state
+        .peer_states
+        .write()
+        .insert(fullnode_peer, peer_state.clone());
+
+    // Update the latency ping info for the fullnode
+    let response_time_secs = 1.0;
+    update_latency_info_for_peer(
+        peers_and_metadata,
+        &fullnode_peer,
+        &mut peer_state,
+        0,
+        0,
+        response_time_secs,
+    );
+
+    // Spawn the peer metadata updater
+    let peers_and_metadata = peer_monitoring_client.get_peers_and_metadata();
+    start_peer_metadata_updater(
+        &peer_monitor_state,
+        peers_and_metadata.clone(),
+        &time_service,
+        &node_config,
+    )
+    .await;
+
+    // Elapse enough time for the metadata updater to run
+    let mock_time = time_service.into_mock();
+    elapse_metadata_updater_interval(node_config.clone(), mock_time.clone()).await;
+
+    // Verify the peer metadata is updated
+    wait_for_monitoring_latency_update(
+        peers_and_metadata.clone(),
+        &fullnode_peer,
+        response_time_secs,
+    )
+    .await;
+
+    // Update the latency ping info for the fullnode several times
+    for (i, (response_time_secs, new_average_secs)) in
+        [(11.0, 6.0), (9.0, 7.0), (7.0, 7.0)].iter().enumerate()
+    {
+        // Update the latency ping info for the fullnode
+        update_latency_info_for_peer(
+            peers_and_metadata.clone(),
+            &fullnode_peer,
+            &mut peer_state,
+            (i + 1) as u64,
+            (i + 1) as u64,
+            *response_time_secs,
+        );
+
+        // Elapse enough time for the metadata updater to run
+        elapse_metadata_updater_interval(node_config.clone(), mock_time.clone()).await;
+
+        // Verify the peer metadata is updated
+        wait_for_monitoring_latency_update(
+            peers_and_metadata.clone(),
+            &fullnode_peer,
+            *new_average_secs,
+        )
+        .await;
+    }
+
+    // Update the network info for the fullnode several times
+    for distance_from_validators in 2..10 {
+        // Update the network info for the fullnode
+        let connected_peers_and_metadata = hashmap! { PeerNetworkId::random() => PeerMetadata::new(ConnectionMetadata::mock(PeerId::random())) };
+        update_network_info_for_peer(
+            peers_and_metadata.clone(),
+            &fullnode_peer,
+            &mut peer_state,
+            connected_peers_and_metadata,
+            distance_from_validators,
+            1.0,
+        );
+
+        // Elapse enough time for the metadata updater to run
+        elapse_metadata_updater_interval(node_config.clone(), mock_time.clone()).await;
+
+        // Verify the peer metadata is updated
+        wait_for_monitoring_network_update(
+            peers_and_metadata.clone(),
+            &fullnode_peer,
+            distance_from_validators,
+        )
+        .await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_latency_pings() {
+    // Create the peer monitoring client and server
+    let network_id = NetworkId::Validator;
+    let (peer_monitoring_client, mut mock_monitoring_server, peer_monitor_state, time_service) =
+        MockMonitoringServer::new(vec![network_id]);
+
+    // Create a node config where network info requests don't refresh
+    let node_config = get_config_without_network_info_requests();
+
+    // Spawn the peer monitoring client
+    start_peer_monitor(
+        peer_monitoring_client,
+        &peer_monitor_state,
+        &time_service,
+        &node_config,
+    )
+    .await;
+
+    // Verify the initial state of the peer monitor
+    verify_empty_peer_states(&peer_monitor_state);
+
+    // Add a connected validator peer
+    let validator_peer = mock_monitoring_server.add_new_peer(network_id, PeerRole::Validator);
+
+    // Initialize all the peer states by running the peer monitor once
+    let mock_time = time_service.into_mock();
+    let _ = initialize_and_verify_peer_states(
+        &network_id,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer,
+        &mock_time,
+    )
+    .await;
+
+    // Handle many latency ping requests and responses
+    let latency_monitoring_config = &node_config.peer_monitoring_service.latency_monitoring;
+    let max_num_pings_to_retain = latency_monitoring_config.max_num_latency_pings_to_retain as u64;
+    for i in 0..max_num_pings_to_retain * 2 {
+        verify_and_handle_latency_ping(
+            &network_id,
+            &mut mock_monitoring_server,
+            &peer_monitor_state,
+            &node_config,
+            &validator_peer,
+            &mock_time,
+            i + 1,
+            min(i + 2, max_num_pings_to_retain), // Only retain max number of pings
+        )
+        .await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_latency_ping_failures() {
+    // Create the peer monitoring client and server
+    let network_id = NetworkId::Validator;
+    let (peer_monitoring_client, mut mock_monitoring_server, peer_monitor_state, time_service) =
+        MockMonitoringServer::new(vec![network_id]);
+
+    // Create a node config where network info requests don't refresh
+    let node_config = get_config_without_network_info_requests();
+
+    // Spawn the peer monitoring client
+    start_peer_monitor(
+        peer_monitoring_client,
+        &peer_monitor_state,
+        &time_service,
+        &node_config,
+    )
+    .await;
+
+    // Add a connected validator peer
+    let validator_peer = mock_monitoring_server.add_new_peer(network_id, PeerRole::Validator);
+
+    // Initialize all the peer states by running the peer monitor once
+    let mock_time = time_service.into_mock();
+    let _ = initialize_and_verify_peer_states(
+        &network_id,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer,
+        &mock_time,
+    )
+    .await;
+
+    // Handle several latency ping requests with bad responses
+    for i in 0..5 {
+        // Elapse enough time for a latency ping update
+        elapse_latency_update_interval(node_config.clone(), mock_time.clone()).await;
+
+        // Verify that a single latency request is received and send a bad response
+        verify_latency_request_and_respond(
+            &network_id,
+            &mut mock_monitoring_server,
+            i + 1,
+            false,
+            true,
+            false,
+        )
+        .await;
+
+        // Wait until the latency peer state is updated with the failure
+        wait_for_latency_ping_failure(&peer_monitor_state, &validator_peer, i + 1).await;
+    }
+
+    // Handle several latency ping requests with invalid counter responses
+    for i in 5..10 {
+        // Elapse enough time for a latency ping update
+        elapse_latency_update_interval(node_config.clone(), mock_time.clone()).await;
+
+        // Verify that a single latency request is received and send an invalid counter response
+        verify_latency_request_and_respond(
+            &network_id,
+            &mut mock_monitoring_server,
+            i + 1,
+            true,
+            false,
+            false,
+        )
+        .await;
+
+        // Wait until the latency peer state is updated with the failure
+        wait_for_latency_ping_failure(&peer_monitor_state, &validator_peer, i + 1).await;
+    }
+
+    // Verify the new latency state of the peer monitor
+    verify_peer_latency_state(&peer_monitor_state, &validator_peer, 1, 10);
+
+    // Elapse enough time for a latency ping and perform a successful execution
+    verify_and_handle_latency_ping(
+        &network_id,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer,
+        &mock_time,
+        11,
+        2,
+    )
+    .await;
+
+    // Verify the new latency state of the peer monitor (the number
+    // of failures should have been reset).
+    verify_peer_latency_state(&peer_monitor_state, &validator_peer, 2, 0);
+
+    // Handle several latency ping requests without responses
+    for i in 11..16 {
+        // Elapse enough time for a latency ping update
+        elapse_latency_update_interval(node_config.clone(), mock_time.clone()).await;
+
+        // Verify that a single latency request is received and don't send a response
+        verify_latency_request_and_respond(
+            &network_id,
+            &mut mock_monitoring_server,
+            i + 1,
+            false,
+            false,
+            true,
+        )
+        .await;
+
+        // Wait until the latency peer state is updated with the failure
+        wait_for_latency_ping_failure(&peer_monitor_state, &validator_peer, i - 10).await;
+    }
+
+    // Verify the new latency state of the peer monitor
+    verify_peer_latency_state(&peer_monitor_state, &validator_peer, 2, 5);
+
+    // Elapse enough time for a latency ping and perform a successful execution
+    verify_and_handle_latency_ping(
+        &network_id,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer,
+        &mock_time,
+        17,
+        3,
+    )
+    .await;
+
+    // Verify the new latency state of the peer monitor (the number
+    // of failures should have been reset).
+    verify_peer_latency_state(&peer_monitor_state, &validator_peer, 3, 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_network_info_requests() {
+    // Create the peer monitoring client and server
+    let network_id = NetworkId::Validator;
+    let (peer_monitoring_client, mut mock_monitoring_server, peer_monitor_state, time_service) =
+        MockMonitoringServer::new(vec![network_id]);
+
+    // Create a node config where latency pings don't refresh
+    let node_config = get_config_without_latency_pings();
+
+    // Spawn the peer monitoring client
+    start_peer_monitor(
+        peer_monitoring_client,
+        &peer_monitor_state,
+        &time_service,
+        &node_config,
+    )
+    .await;
+
+    // Verify the initial state of the peer monitor
+    verify_empty_peer_states(&peer_monitor_state);
+
+    // Add a connected validator peer
+    let validator_peer = mock_monitoring_server.add_new_peer(network_id, PeerRole::Validator);
+
+    // Initialize all the peer states by running the peer monitor once
+    let mock_time = time_service.into_mock();
+    let _ = initialize_and_verify_peer_states(
+        &network_id,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer,
+        &mock_time,
+    )
+    .await;
+
+    // Handle many network info requests and responses
+    let distance_from_validators = 0;
+    for _ in 0..20 {
+        let connected_peers_and_metadata = hashmap! { PeerNetworkId::random() => PeerMetadata::new(ConnectionMetadata::mock(PeerId::random())) };
+        verify_and_handle_network_info_request(
+            &network_id,
+            &mut mock_monitoring_server,
+            &peer_monitor_state,
+            &node_config,
+            &validator_peer,
+            &mock_time,
+            &connected_peers_and_metadata,
+            distance_from_validators,
+        )
+        .await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_network_info_request_failures() {
+    // Create the peer monitoring client and server
+    let network_id = NetworkId::Validator;
+    let (peer_monitoring_client, mut mock_monitoring_server, peer_monitor_state, time_service) =
+        MockMonitoringServer::new(vec![network_id]);
+
+    // Create a node config where latency pings don't refresh
+    let node_config = get_config_without_latency_pings();
+
+    // Spawn the peer monitoring client
+    start_peer_monitor(
+        peer_monitoring_client,
+        &peer_monitor_state,
+        &time_service,
+        &node_config,
+    )
+    .await;
+
+    // Add a connected validator peer
+    let validator_peer = mock_monitoring_server.add_new_peer(network_id, PeerRole::Validator);
+
+    // Initialize all the peer states by running the peer monitor once
+    let mock_time = time_service.into_mock();
+    let (connected_peers_and_metadata, distance_from_validators) =
+        initialize_and_verify_peer_states(
+            &network_id,
+            &mut mock_monitoring_server,
+            &peer_monitor_state,
+            &node_config,
+            &validator_peer,
+            &mock_time,
+        )
+        .await;
+
+    // Handle several network info requests with bad responses
+    for i in 0..5 {
+        // Elapse enough time for a network info update
+        elapse_network_info_update_interval(node_config.clone(), mock_time.clone()).await;
+
+        // Verify that a single network info request is received and send a bad response
+        let connected_peers_and_metadata = hashmap! { PeerNetworkId::random() => PeerMetadata::new(ConnectionMetadata::mock(PeerId::random())) };
+        verify_network_info_request_and_respond(
+            &network_id,
+            &mut mock_monitoring_server,
+            &connected_peers_and_metadata,
+            distance_from_validators,
+            false,
+            true,
+            false,
+        )
+        .await;
+
+        // Wait until the network info state is updated with the failure
+        wait_for_network_info_request_failure(&peer_monitor_state, &validator_peer, i + 1).await;
+    }
+
+    // Verify the new network info state of the peer monitor
+    verify_peer_network_state(
+        &peer_monitor_state,
+        &validator_peer,
+        &connected_peers_and_metadata,
+        distance_from_validators,
+        5,
+    );
+
+    // Handle several network info requests with invalid depth responses responses
+    for i in 5..10 {
+        // Elapse enough time for a network info update
+        elapse_network_info_update_interval(node_config.clone(), mock_time.clone()).await;
+
+        // Verify that a single network info request is received and send an invalid peer depth response
+        let connected_peers_and_metadata = hashmap! { PeerNetworkId::random() => PeerMetadata::new(ConnectionMetadata::mock(PeerId::random())) };
+        verify_network_info_request_and_respond(
+            &network_id,
+            &mut mock_monitoring_server,
+            &connected_peers_and_metadata,
+            distance_from_validators,
+            true,
+            false,
+            false,
+        )
+        .await;
+
+        // Wait until the network info state is updated with the failure
+        wait_for_network_info_request_failure(&peer_monitor_state, &validator_peer, i + 1).await;
+    }
+
+    // Verify the new network info state of the peer monitor
+    verify_peer_network_state(
+        &peer_monitor_state,
+        &validator_peer,
+        &connected_peers_and_metadata,
+        distance_from_validators,
+        10,
+    );
+
+    // Elapse enough time for a network info request and perform a successful execution
+    let connected_peers_and_metadata = hashmap! { PeerNetworkId::random() => PeerMetadata::new(ConnectionMetadata::mock(PeerId::random())) };
+    verify_and_handle_network_info_request(
+        &network_id,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer,
+        &mock_time,
+        &connected_peers_and_metadata,
+        distance_from_validators,
+    )
+    .await;
+
+    // Verify the new network info state of the peer monitor (the number
+    // of failures should have been reset).
+    verify_peer_network_state(
+        &peer_monitor_state,
+        &validator_peer,
+        &connected_peers_and_metadata,
+        distance_from_validators,
+        0,
+    );
+
+    // Handle several network info requests without responses
+    for i in 11..16 {
+        // Elapse enough time for a network info update
+        elapse_network_info_update_interval(node_config.clone(), mock_time.clone()).await;
+
+        // Verify that a single network info request is received and don't send a response
+        let connected_peers_and_metadata = hashmap! { PeerNetworkId::random() => PeerMetadata::new(ConnectionMetadata::mock(PeerId::random())) };
+        verify_network_info_request_and_respond(
+            &network_id,
+            &mut mock_monitoring_server,
+            &connected_peers_and_metadata,
+            distance_from_validators,
+            false,
+            false,
+            true,
+        )
+        .await;
+
+        // Wait until the network info state is updated with the failure
+        wait_for_network_info_request_failure(&peer_monitor_state, &validator_peer, i - 10).await;
+    }
+
+    // Verify the new network info state of the peer monitor
+    verify_peer_network_state(
+        &peer_monitor_state,
+        &validator_peer,
+        &connected_peers_and_metadata,
+        distance_from_validators,
+        5,
+    );
+
+    // Elapse enough time for a latency ping and perform a successful execution
+    let connected_peers_and_metadata = hashmap! { PeerNetworkId::random() => PeerMetadata::new(ConnectionMetadata::mock(PeerId::random())) };
+    verify_and_handle_network_info_request(
+        &network_id,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer,
+        &mock_time,
+        &connected_peers_and_metadata,
+        distance_from_validators,
+    )
+    .await;
+
+    // Verify the new network info state of the peer monitor (the number
+    // of failures should have been reset).
+    verify_peer_network_state(
+        &peer_monitor_state,
+        &validator_peer,
+        &connected_peers_and_metadata,
+        distance_from_validators,
+        0,
+    );
+}

--- a/network/peer-monitoring-service/client/src/tests/utils.rs
+++ b/network/peer-monitoring-service/client/src/tests/utils.rs
@@ -1,0 +1,838 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    peer_states::key_value::{PeerStateKey, StateValueInterface},
+    spawn_peer_metadata_updater, start_peer_monitor_with_state,
+    tests::mock::MockMonitoringServer,
+    PeerMonitorState, PeerMonitoringServiceClient, PeerState,
+};
+use aptos_config::{
+    config::{
+        LatencyMonitoringConfig, NetworkMonitoringConfig, NodeConfig, PeerMonitoringServiceConfig,
+    },
+    network_id::{NetworkId, PeerNetworkId},
+};
+use aptos_network::{
+    application::{interface::NetworkClient, metadata::PeerMetadata, storage::PeersAndMetadata},
+    transport::ConnectionMetadata,
+};
+use aptos_peer_monitoring_service_types::{
+    LatencyPingRequest, LatencyPingResponse, NetworkInformationResponse,
+    PeerMonitoringServiceMessage, PeerMonitoringServiceRequest, PeerMonitoringServiceResponse,
+    ServerProtocolVersionResponse,
+};
+use aptos_time_service::{MockTimeService, TimeService, TimeServiceTrait};
+use aptos_types::PeerId;
+use maplit::hashmap;
+use std::{
+    collections::HashMap,
+    future::Future,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tokio::{
+    runtime::Handle,
+    time::{sleep, timeout},
+};
+
+// Useful test constants
+const PAUSE_FOR_SETUP_SECS: u64 = 1;
+const MAX_WAIT_TIME_SECS: u64 = 10;
+const SLEEP_DURATION_MS: u64 = 500;
+
+/// Elapses enough time for a latency update to occur
+pub async fn elapse_latency_update_interval(node_config: NodeConfig, mock_time: MockTimeService) {
+    let latency_monitoring_config = node_config.peer_monitoring_service.latency_monitoring;
+    mock_time
+        .advance_ms_async(latency_monitoring_config.latency_ping_interval_ms + 1)
+        .await;
+}
+
+/// Elapses enough time for the peer metadata updater loop to execute
+pub async fn elapse_metadata_updater_interval(node_config: NodeConfig, mock_time: MockTimeService) {
+    let peer_monitoring_config = node_config.peer_monitoring_service;
+    mock_time
+        .advance_ms_async(peer_monitoring_config.metadata_update_interval_ms + 1)
+        .await;
+}
+
+/// Elapses enough time for a network info update to occur
+pub async fn elapse_network_info_update_interval(
+    node_config: NodeConfig,
+    mock_time: MockTimeService,
+) {
+    let network_monitoring_config = node_config.peer_monitoring_service.network_monitoring;
+    mock_time
+        .advance_ms_async(network_monitoring_config.network_info_request_interval_ms + 1)
+        .await;
+}
+
+/// Elapses enough time for the monitoring loop to execute
+pub async fn elapse_peer_monitor_interval(node_config: NodeConfig, mock_time: MockTimeService) {
+    let peer_monitoring_config = node_config.peer_monitoring_service;
+    mock_time
+        .advance_ms_async(peer_monitoring_config.peer_monitor_interval_ms + 1)
+        .await;
+}
+
+/// Returns a config where latency pings don't refresh
+pub fn get_config_without_latency_pings() -> NodeConfig {
+    NodeConfig {
+        peer_monitoring_service: PeerMonitoringServiceConfig {
+            latency_monitoring: LatencyMonitoringConfig {
+                latency_ping_interval_ms: 1_000_000_000, // Unrealistically high
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Returns a config where network info requests don't refresh
+pub fn get_config_without_network_info_requests() -> NodeConfig {
+    NodeConfig {
+        peer_monitoring_service: PeerMonitoringServiceConfig {
+            network_monitoring: NetworkMonitoringConfig {
+                network_info_request_interval_ms: 1_000_000_000, // Unrealistically high
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// A simple helper function that returns a valid distance from
+/// the validators based on the given peer.
+pub fn get_distance_from_validators(peer_network_id: &PeerNetworkId) -> u64 {
+    match peer_network_id.network_id() {
+        NetworkId::Validator => 0,
+        NetworkId::Vfn => 1,
+        NetworkId::Public => 2,
+    }
+}
+
+/// Initializes all the peer states by running the peer monitor loop
+/// once and ensuring the correct requests and responses are received.
+pub async fn initialize_and_verify_peer_states(
+    network_id: &NetworkId,
+    mock_monitoring_server: &mut MockMonitoringServer,
+    peer_monitor_state: &PeerMonitorState,
+    node_config: &NodeConfig,
+    peer_network_id: &PeerNetworkId,
+    mock_time: &MockTimeService,
+) -> (HashMap<PeerNetworkId, PeerMetadata>, u64) {
+    // Elapse enough time for the peer monitor to execute
+    let time_before_update = mock_time.now();
+    elapse_peer_monitor_interval(node_config.clone(), mock_time.clone()).await;
+
+    // Create the test response data
+    let connected_peers_and_metadata = hashmap! { PeerNetworkId::random() => PeerMetadata::new(ConnectionMetadata::mock(PeerId::random())) };
+    let distance_from_validators = get_distance_from_validators(peer_network_id);
+
+    // Verify the initial client requests and send responses
+    verify_all_requests_and_respond(
+        network_id,
+        mock_monitoring_server,
+        &connected_peers_and_metadata,
+        distance_from_validators,
+    )
+    .await;
+
+    // Wait until the peer state is updated by the client
+    wait_for_peer_state_update(
+        time_before_update,
+        peer_monitor_state,
+        peer_network_id,
+        PeerStateKey::get_all_keys(),
+    )
+    .await;
+
+    // Verify the new state of the peer monitor
+    verify_peer_monitor_state(
+        peer_monitor_state,
+        peer_network_id,
+        &connected_peers_and_metadata,
+        distance_from_validators,
+        1,
+    );
+
+    (connected_peers_and_metadata, distance_from_validators)
+}
+
+/// Spawns the given task with a timeout
+pub async fn spawn_with_timeout(task: impl Future<Output = ()>, timeout_error_message: &str) {
+    let timeout_duration = Duration::from_secs(MAX_WAIT_TIME_SECS);
+    timeout(timeout_duration, task)
+        .await
+        .expect(timeout_error_message)
+}
+
+/// Spawns the peer metadata updater
+pub async fn start_peer_metadata_updater(
+    peer_monitor_state: &PeerMonitorState,
+    peers_and_metadata: Arc<PeersAndMetadata>,
+    time_service: &TimeService,
+    node_config: &NodeConfig,
+) {
+    // Spawn the peer metadata updater
+    tokio::spawn(spawn_peer_metadata_updater(
+        node_config.peer_monitoring_service.clone(),
+        peer_monitor_state.clone(),
+        peers_and_metadata,
+        time_service.clone(),
+        Some(Handle::current()),
+    ));
+
+    // Wait for some time so that the peer metadata updater starts before we return
+    sleep(Duration::from_secs(PAUSE_FOR_SETUP_SECS)).await
+}
+
+/// Spawns the peer monitor
+pub async fn start_peer_monitor(
+    peer_monitoring_client: PeerMonitoringServiceClient<
+        NetworkClient<PeerMonitoringServiceMessage>,
+    >,
+    peer_monitor_state: &PeerMonitorState,
+    time_service: &TimeService,
+    node_config: &NodeConfig,
+) {
+    // Spawn the peer monitor state
+    tokio::spawn(start_peer_monitor_with_state(
+        node_config.clone(),
+        peer_monitoring_client,
+        peer_monitor_state.clone(),
+        time_service.clone(),
+        Some(Handle::current()),
+    ));
+
+    // Wait for some time so that the peer monitor starts before we return
+    sleep(Duration::from_secs(PAUSE_FOR_SETUP_SECS)).await
+}
+
+/// Updates the latency info state for the peer
+pub fn update_latency_info_for_peer(
+    peers_and_metadata: Arc<PeersAndMetadata>,
+    peer_network_id: &PeerNetworkId,
+    peer_state: &mut PeerState,
+    request_ping_counter: u64,
+    response_ping_counter: u64,
+    response_time_secs: f64,
+) {
+    // Get the latency info state
+    let latency_info_state = peer_state
+        .get_peer_state_value(&PeerStateKey::LatencyInfo)
+        .unwrap();
+
+    // Get the peer metadata
+    let peer_metadata = peers_and_metadata
+        .get_metadata_for_peer(*peer_network_id)
+        .unwrap();
+
+    // Create the latency info request and response
+    let latency_info_request = PeerMonitoringServiceRequest::LatencyPing(LatencyPingRequest {
+        ping_counter: request_ping_counter,
+    });
+    let latency_info_response = PeerMonitoringServiceResponse::LatencyPing(LatencyPingResponse {
+        ping_counter: response_ping_counter,
+    });
+
+    // Update the latency info state
+    latency_info_state
+        .write()
+        .handle_monitoring_service_response(
+            peer_network_id,
+            peer_metadata,
+            latency_info_request,
+            latency_info_response,
+            response_time_secs,
+        );
+}
+
+/// Updates the network info state for the peer
+pub fn update_network_info_for_peer(
+    peers_and_metadata: Arc<PeersAndMetadata>,
+    peer_network_id: &PeerNetworkId,
+    peer_state: &mut PeerState,
+    connected_peers_and_metadata: HashMap<PeerNetworkId, PeerMetadata>,
+    distance_from_validators: u64,
+    response_time_secs: f64,
+) {
+    // Get the network info state
+    let network_info_state = peer_state
+        .get_peer_state_value(&PeerStateKey::NetworkInfo)
+        .unwrap();
+
+    // Get the peer metadata
+    let peer_metadata = peers_and_metadata
+        .get_metadata_for_peer(*peer_network_id)
+        .unwrap();
+
+    // Create the network info request and response
+    let network_info_request = PeerMonitoringServiceRequest::GetNetworkInformation;
+    let network_info_response =
+        PeerMonitoringServiceResponse::NetworkInformation(NetworkInformationResponse {
+            connected_peers_and_metadata,
+            distance_from_validators,
+        });
+
+    // Update the network info state
+    network_info_state
+        .write()
+        .handle_monitoring_service_response(
+            peer_network_id,
+            peer_metadata,
+            network_info_request,
+            network_info_response,
+            response_time_secs,
+        );
+}
+
+/// Elapses enough time for a latency ping and handles the ping
+pub async fn verify_and_handle_latency_ping(
+    network_id: &NetworkId,
+    mock_monitoring_server: &mut MockMonitoringServer,
+    peer_monitor_state: &PeerMonitorState,
+    node_config: &NodeConfig,
+    peer_network_id: &PeerNetworkId,
+    mock_time: &MockTimeService,
+    expected_latency_ping_counter: u64,
+    expected_num_recorded_latency_pings: u64,
+) {
+    // Elapse enough time for a latency ping update
+    let time_before_update = mock_time.now();
+    elapse_latency_update_interval(node_config.clone(), mock_time.clone()).await;
+
+    // Verify that a single latency request is received and respond
+    verify_latency_request_and_respond(
+        network_id,
+        mock_monitoring_server,
+        expected_latency_ping_counter,
+        false,
+        false,
+        false,
+    )
+    .await;
+
+    // Wait until the latency peer state is updated by the client
+    wait_for_peer_state_update(
+        time_before_update,
+        peer_monitor_state,
+        peer_network_id,
+        vec![PeerStateKey::LatencyInfo],
+    )
+    .await;
+
+    // Verify the latency ping state
+    verify_peer_latency_state(
+        peer_monitor_state,
+        peer_network_id,
+        expected_num_recorded_latency_pings,
+        0,
+    );
+}
+
+/// Elapses enough time for a network info request and handles the response
+pub async fn verify_and_handle_network_info_request(
+    network_id: &NetworkId,
+    mock_monitoring_server: &mut MockMonitoringServer,
+    peer_monitor_state: &PeerMonitorState,
+    node_config: &NodeConfig,
+    peer_network_id: &PeerNetworkId,
+    mock_time: &MockTimeService,
+    connected_peers_and_metadata: &HashMap<PeerNetworkId, PeerMetadata>,
+    distance_from_validators: u64,
+) {
+    // Elapse enough time for a network info update
+    let time_before_update = mock_time.now();
+    elapse_network_info_update_interval(node_config.clone(), mock_time.clone()).await;
+
+    // Verify that a single network info request is received and respond
+    verify_network_info_request_and_respond(
+        network_id,
+        mock_monitoring_server,
+        connected_peers_and_metadata,
+        distance_from_validators,
+        false,
+        false,
+        false,
+    )
+    .await;
+
+    // Wait until the network info state is updated by the client
+    wait_for_peer_state_update(
+        time_before_update,
+        peer_monitor_state,
+        peer_network_id,
+        vec![PeerStateKey::NetworkInfo],
+    )
+    .await;
+
+    // Verify the network info state
+    verify_peer_network_state(
+        peer_monitor_state,
+        peer_network_id,
+        connected_peers_and_metadata,
+        distance_from_validators,
+        0,
+    );
+}
+
+/// Verifies that all request types are received by the server
+/// and responds to them using the specified data.
+pub async fn verify_all_requests_and_respond(
+    network_id: &NetworkId,
+    mock_monitoring_server: &mut MockMonitoringServer,
+    connected_peers_and_metadata: &HashMap<PeerNetworkId, PeerMetadata>,
+    distance_from_validators: u64,
+) {
+    // Create a task that waits for all the requests and sends responses
+    let handle_requests = async move {
+        // Counters to ensure we only receive one type of each request
+        let mut num_received_latency_pings = 0;
+        let mut num_received_network_requests = 0;
+
+        // We expect a request to be sent for each peer state type
+        let num_state_types = PeerStateKey::get_all_keys().len();
+        for _ in 0..num_state_types {
+            // Process the peer monitoring request
+            let network_request = mock_monitoring_server
+                .next_request(network_id)
+                .await
+                .unwrap();
+            let response = match network_request.peer_monitoring_service_request {
+                PeerMonitoringServiceRequest::GetNetworkInformation => {
+                    // Increment the counter
+                    num_received_network_requests += 1;
+
+                    // Return the response
+                    PeerMonitoringServiceResponse::NetworkInformation(NetworkInformationResponse {
+                        connected_peers_and_metadata: connected_peers_and_metadata.clone(),
+                        distance_from_validators,
+                    })
+                },
+                PeerMonitoringServiceRequest::LatencyPing(latency_ping) => {
+                    // Increment the counter
+                    num_received_latency_pings += 1;
+
+                    // Return the response
+                    PeerMonitoringServiceResponse::LatencyPing(LatencyPingResponse {
+                        ping_counter: latency_ping.ping_counter,
+                    })
+                },
+                request => panic!("Unexpected monitoring request received: {:?}", request),
+            };
+
+            // Send the response
+            network_request.response_sender.send(Ok(response));
+        }
+
+        // Verify each request was received exactly once
+        if (num_received_latency_pings != 1) || (num_received_network_requests != 1) {
+            panic!("The requests were not received exactly once!");
+        }
+    };
+
+    // Spawn the task with a timeout
+    spawn_with_timeout(
+        handle_requests,
+        "Timed-out while waiting for all the requests!",
+    )
+    .await;
+}
+
+/// Verifies that the peer states is empty
+pub fn verify_empty_peer_states(peer_monitor_state: &PeerMonitorState) {
+    assert!(peer_monitor_state.peer_states.read().is_empty());
+}
+
+/// Verifies that a latency ping request is received and sends a
+/// response based on the given parameters.
+pub async fn verify_latency_request_and_respond(
+    network_id: &NetworkId,
+    mock_monitoring_server: &mut MockMonitoringServer,
+    expected_ping_counter: u64,
+    respond_with_invalid_counter: bool,
+    respond_with_invalid_message: bool,
+    skip_sending_a_response: bool,
+) {
+    // Create a task that waits for the request and sends a response
+    let handle_request = async move {
+        // Process the latency ping request
+        let network_request = mock_monitoring_server
+            .next_request(network_id)
+            .await
+            .unwrap();
+        let response = match network_request.peer_monitoring_service_request {
+            PeerMonitoringServiceRequest::LatencyPing(latency_ping) => {
+                // Verify the ping counter
+                assert_eq!(latency_ping.ping_counter, expected_ping_counter);
+
+                // Create the response
+                if respond_with_invalid_counter {
+                    // Respond with an invalid ping counter
+                    PeerMonitoringServiceResponse::LatencyPing(LatencyPingResponse {
+                        ping_counter: 1010101,
+                    })
+                } else if respond_with_invalid_message {
+                    // Respond with the wrong message type
+                    PeerMonitoringServiceResponse::ServerProtocolVersion(
+                        ServerProtocolVersionResponse { version: 999 },
+                    )
+                } else {
+                    // Send a valid response
+                    PeerMonitoringServiceResponse::LatencyPing(LatencyPingResponse {
+                        ping_counter: latency_ping.ping_counter,
+                    })
+                }
+            },
+            request => panic!("Unexpected monitoring request received: {:?}", request),
+        };
+
+        // Send the response
+        if !skip_sending_a_response {
+            network_request.response_sender.send(Ok(response));
+        }
+    };
+
+    // Spawn the task with a timeout
+    spawn_with_timeout(
+        handle_request,
+        "Timed-out while waiting for a latency ping request",
+    )
+    .await;
+}
+
+/// Verifies that a network info request is received by the
+/// server and sends a response.
+pub async fn verify_network_info_request_and_respond(
+    network_id: &NetworkId,
+    mock_monitoring_server: &mut MockMonitoringServer,
+    connected_peers_and_metadata: &HashMap<PeerNetworkId, PeerMetadata>,
+    distance_from_validators: u64,
+    respond_with_invalid_distance: bool,
+    respond_with_invalid_message: bool,
+    skip_sending_a_response: bool,
+) {
+    // Create a task that waits for the request and sends a response
+    let handle_request = async move {
+        // Process the latency ping request
+        let network_request = mock_monitoring_server
+            .next_request(network_id)
+            .await
+            .unwrap();
+        let response = match network_request.peer_monitoring_service_request {
+            PeerMonitoringServiceRequest::GetNetworkInformation => {
+                if respond_with_invalid_distance {
+                    // Respond with an invalid distance
+                    PeerMonitoringServiceResponse::NetworkInformation(NetworkInformationResponse {
+                        connected_peers_and_metadata: connected_peers_and_metadata.clone(),
+                        distance_from_validators: 1,
+                    })
+                } else if respond_with_invalid_message {
+                    // Respond with the wrong message type
+                    PeerMonitoringServiceResponse::LatencyPing(LatencyPingResponse {
+                        ping_counter: 10,
+                    })
+                } else {
+                    // Send a valid response
+                    PeerMonitoringServiceResponse::NetworkInformation(NetworkInformationResponse {
+                        connected_peers_and_metadata: connected_peers_and_metadata.clone(),
+                        distance_from_validators,
+                    })
+                }
+            },
+            request => panic!("Unexpected monitoring request received: {:?}", request),
+        };
+
+        // Send the response
+        if !skip_sending_a_response {
+            network_request.response_sender.send(Ok(response));
+        }
+    };
+
+    // Spawn the task with a timeout
+    spawn_with_timeout(
+        handle_request,
+        "Timed-out while waiting for a network info request",
+    )
+    .await;
+}
+
+/// Verifies the latency state of the peer monitor
+pub fn verify_peer_latency_state(
+    peer_monitor_state: &PeerMonitorState,
+    peer_network_id: &PeerNetworkId,
+    expected_num_recorded_latency_pings: u64,
+    expected_num_consecutive_failures: u64,
+) {
+    // Fetch the peer monitoring metadata
+    let peer_states = peer_monitor_state.peer_states.read();
+    let peer_state = peer_states.get(peer_network_id).unwrap();
+
+    // Verify the latency ping state
+    let latency_info_state = peer_state.get_latency_info_state().unwrap();
+    assert_eq!(
+        latency_info_state.get_recorded_latency_pings().len(),
+        expected_num_recorded_latency_pings as usize
+    );
+    assert_eq!(
+        latency_info_state
+            .get_request_tracker()
+            .read()
+            .get_num_consecutive_failures(),
+        expected_num_consecutive_failures
+    );
+}
+
+/// Verifies the state of the peer monitor
+pub fn verify_peer_monitor_state(
+    peer_monitor_state: &PeerMonitorState,
+    peer_network_id: &PeerNetworkId,
+    expected_connected_peers_and_metadata: &HashMap<PeerNetworkId, PeerMetadata>,
+    expected_distance_from_validators: u64,
+    expected_num_recorded_latency_pings: u64,
+) {
+    // Verify the latency ping state
+    verify_peer_latency_state(
+        peer_monitor_state,
+        peer_network_id,
+        expected_num_recorded_latency_pings,
+        0,
+    );
+
+    // Verify the network state
+    verify_peer_network_state(
+        peer_monitor_state,
+        peer_network_id,
+        expected_connected_peers_and_metadata,
+        expected_distance_from_validators,
+        0,
+    );
+}
+
+/// Verifies the network state of the peer monitor
+pub fn verify_peer_network_state(
+    peer_monitor_state: &PeerMonitorState,
+    peer_network_id: &PeerNetworkId,
+    expected_connected_peers_and_metadata: &HashMap<PeerNetworkId, PeerMetadata>,
+    expected_distance_from_validators: u64,
+    expected_num_consecutive_failures: u64,
+) {
+    // Fetch the peer monitoring metadata
+    let peer_states = peer_monitor_state.peer_states.read();
+    let peer_state = peer_states.get(peer_network_id).unwrap();
+
+    // Verify the network state
+    let network_info_state = peer_state.get_network_info_state().unwrap();
+    let latest_network_info_response = network_info_state
+        .get_latest_network_info_response()
+        .unwrap();
+    assert_eq!(
+        latest_network_info_response.connected_peers_and_metadata,
+        expected_connected_peers_and_metadata.clone()
+    );
+    assert_eq!(
+        latest_network_info_response.distance_from_validators,
+        expected_distance_from_validators
+    );
+    assert_eq!(
+        network_info_state
+            .get_request_tracker()
+            .read()
+            .get_num_consecutive_failures(),
+        expected_num_consecutive_failures
+    );
+}
+
+/// Waits for the peer monitor state to be updated with
+/// a latency ping failure.
+pub async fn wait_for_latency_ping_failure(
+    peer_monitor_state: &PeerMonitorState,
+    peer_network_id: &PeerNetworkId,
+    num_expected_consecutive_failures: u64,
+) {
+    // Create a task that waits for the updated states
+    let wait_for_update = async move {
+        loop {
+            // Fetch the request tracker for the latency state
+            let peers_states_lock = peer_monitor_state.peer_states.read();
+            let peer_state = peers_states_lock.get(peer_network_id).unwrap();
+            let request_tracker = peer_state
+                .get_request_tracker(&PeerStateKey::LatencyInfo)
+                .unwrap();
+            drop(peers_states_lock);
+
+            // Check if the request tracker failures matches the expected number
+            let num_consecutive_failures = request_tracker.read().get_num_consecutive_failures();
+            if num_consecutive_failures == num_expected_consecutive_failures {
+                return; // The peer state was updated!
+            }
+
+            // Sleep for some time before retrying
+            sleep(Duration::from_millis(SLEEP_DURATION_MS)).await;
+        }
+    };
+
+    // Spawn the task with a timeout
+    spawn_with_timeout(
+        wait_for_update,
+        "Timed-out while waiting for a latency ping failure!",
+    )
+    .await;
+}
+
+/// Waits for the peer monitoring metadata to be updated
+/// with new latency information.
+pub async fn wait_for_monitoring_latency_update(
+    peers_and_metadata: Arc<PeersAndMetadata>,
+    peer_network_id: &PeerNetworkId,
+    expected_average_latency_secs: f64,
+) {
+    // Create a task that waits for the updated latency information
+    let wait_for_update = async move {
+        loop {
+            // Get the peer monitoring metadata
+            let peer_metadata = peers_and_metadata
+                .get_metadata_for_peer(*peer_network_id)
+                .unwrap();
+            let peer_monitoring_metadata = peer_metadata.get_peer_monitoring_metadata();
+
+            // Check if the average ping latency matches the expected value
+            if let Some(average_ping_latency_secs) =
+                peer_monitoring_metadata.average_ping_latency_secs
+            {
+                if average_ping_latency_secs == expected_average_latency_secs {
+                    return; // The average latency info was updated!
+                }
+            }
+
+            // Sleep for some time before retrying
+            sleep(Duration::from_millis(SLEEP_DURATION_MS)).await;
+        }
+    };
+
+    // Spawn the task with a timeout
+    spawn_with_timeout(
+        wait_for_update,
+        "Timed-out while waiting for new latency information!",
+    )
+    .await;
+}
+
+/// Waits for the peer monitoring metadata to be updated
+/// with new network information.
+pub async fn wait_for_monitoring_network_update(
+    peers_and_metadata: Arc<PeersAndMetadata>,
+    peer_network_id: &PeerNetworkId,
+    expected_distance_from_validators: u64,
+) {
+    // Create a task that waits for the updated network information
+    let wait_for_update = async move {
+        loop {
+            // Get the peer monitoring metadata
+            let peer_metadata = peers_and_metadata
+                .get_metadata_for_peer(*peer_network_id)
+                .unwrap();
+            let peer_monitoring_metadata = peer_metadata.get_peer_monitoring_metadata();
+
+            // Check if the distance from validators matches the expected value
+            if let Some(distance_from_validators) =
+                peer_monitoring_metadata.distance_from_validators
+            {
+                if distance_from_validators == expected_distance_from_validators {
+                    return; // The average latency info was updated!
+                }
+            }
+
+            // Sleep for some time before retrying
+            sleep(Duration::from_millis(SLEEP_DURATION_MS)).await;
+        }
+    };
+
+    // Spawn the task with a timeout
+    spawn_with_timeout(
+        wait_for_update,
+        "Timed-out while waiting for new network information!",
+    )
+    .await;
+}
+
+/// Waits for the peer monitor state to be updated with
+/// a network info request failure.
+pub async fn wait_for_network_info_request_failure(
+    peer_monitor_state: &PeerMonitorState,
+    peer_network_id: &PeerNetworkId,
+    num_expected_consecutive_failures: u64,
+) {
+    // Create a task that waits for the updated states
+    let wait_for_update = async move {
+        loop {
+            // Fetch the request tracker for the network info state
+            let peers_states_lock = peer_monitor_state.peer_states.read();
+            let peer_state = peers_states_lock.get(peer_network_id).unwrap();
+            let request_tracker = peer_state
+                .get_request_tracker(&PeerStateKey::NetworkInfo)
+                .unwrap();
+            drop(peers_states_lock);
+
+            // Check if the request tracker failures matches the expected number
+            let num_consecutive_failures = request_tracker.read().get_num_consecutive_failures();
+            if num_consecutive_failures == num_expected_consecutive_failures {
+                return; // The peer state was updated!
+            }
+
+            // Sleep for some time before retrying
+            sleep(Duration::from_millis(SLEEP_DURATION_MS)).await;
+        }
+    };
+
+    // Spawn the task with a timeout
+    spawn_with_timeout(
+        wait_for_update,
+        "Timed-out while waiting for a network info failure!",
+    )
+    .await;
+}
+
+/// Waits for the peer monitor state to be updated with
+/// metadata after the given timestamp.
+pub async fn wait_for_peer_state_update(
+    time_before_update: Instant,
+    peer_monitor_state: &PeerMonitorState,
+    peer_network_id: &PeerNetworkId,
+    peer_state_keys: Vec<PeerStateKey>,
+) {
+    // Create a task that waits for the updated states
+    let wait_for_update = async move {
+        // Go through all peer states and ensure each one is updated
+        for peer_state_key in peer_state_keys {
+            loop {
+                // Fetch the request tracker for the peer state
+                let peers_states_lock = peer_monitor_state.peer_states.read();
+                let peer_state = peers_states_lock.get(peer_network_id).unwrap();
+                let request_tracker = peer_state.get_request_tracker(&peer_state_key).unwrap();
+                drop(peers_states_lock);
+
+                // Check if the request tracker has a response with a newer timestamp
+                if let Some(last_response_time) = request_tracker.read().get_last_response_time() {
+                    if last_response_time > time_before_update {
+                        break; // The peer state was updated!
+                    }
+                };
+
+                // Sleep for some time before retrying
+                sleep(Duration::from_millis(SLEEP_DURATION_MS)).await;
+            }
+        }
+    };
+
+    // Spawn the task with a timeout
+    spawn_with_timeout(
+        wait_for_update,
+        "Timed-out while waiting for a peer state update!",
+    )
+    .await;
+}


### PR DESCRIPTION
Notes:
- This PR relates to: https://github.com/aptos-labs/aptos-core/issues/6789.
- This PR is built on: https://github.com/aptos-labs/aptos-core/pull/6942

### Description
This PR adds a new suite of integration tests to verify the correct behavior of the peer monitoring service. Specifically, the test suite verifies:
- Correct loop executions using timing signals (for both the peer monitor and peer metadata updater).
- Correct verification of service requests and responses (for latency info and network info requests).
- Single and multi-peer execution support (including disconnecting and reconnecting peers).

Note: even though this PR is huge, I've broken the tests and mock infrastructure into multiple files, so it should be relatively easy to parse.

### Test Plan
Existing test infrastructure.