### PR TITLE
[indexer grpc] Move the WriteResource data one-level down. 

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/convert.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/convert.rs
@@ -376,7 +376,7 @@ pub fn convert_write_set_change(change: &WriteSetChange) -> transaction::WriteSe
                     state_key_hash: convert_hex_string_to_bytes(&write_resource.state_key_hash),
                     r#type: Some(convert_move_struct_tag(&write_resource.data.typ)),
                     type_str: write_resource.data.typ.to_string(),
-                    data: serde_json::to_string(&write_resource.data).unwrap_or_else(|_| {
+                    data: serde_json::to_string(&write_resource.data.data).unwrap_or_else(|_| {
                         panic!(
                             "Could not convert move_resource data to json '{:?}'",
                             write_resource.data


### PR DESCRIPTION


### Description
* Now it's `write_resource.data.data` and type information doesn't include in the result data.
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
