### PR TITLE
[Quorum Store] poll mempool at a faster pace to reduce mempool queueing time, except when backpressure

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -12,8 +12,8 @@ pub struct QuorumStoreBackPressureConfig {
     pub decrease_duration_ms: u64,
     pub increase_duration_ms: u64,
     pub decrease_fraction: f64,
-    pub dynamic_min_batch_count: u64,
-    pub dynamic_max_batch_count: u64,
+    pub dynamic_min_txn_per_s: u64,
+    pub dynamic_max_txn_per_s: u64,
 }
 
 impl Default for QuorumStoreBackPressureConfig {
@@ -24,8 +24,8 @@ impl Default for QuorumStoreBackPressureConfig {
             decrease_duration_ms: 1000,
             increase_duration_ms: 1000,
             decrease_fraction: 0.5,
-            dynamic_min_batch_count: 40,
-            dynamic_max_batch_count: 500,
+            dynamic_min_txn_per_s: 160,
+            dynamic_max_txn_per_s: 2000,
         }
     }
 }
@@ -36,7 +36,8 @@ pub struct QuorumStoreConfig {
     pub channel_size: usize,
     pub proof_timeout_ms: usize,
     pub batch_request_num_peers: usize,
-    pub mempool_pulling_interval: usize,
+    pub batch_generation_poll_interval_ms: usize,
+    pub batch_generation_max_interval_ms: usize,
     pub end_batch_ms: u64,
     pub max_batch_bytes: usize,
     pub batch_request_timeout_ms: usize,
@@ -63,7 +64,8 @@ impl Default for QuorumStoreConfig {
             channel_size: 1000,
             proof_timeout_ms: 10000,
             batch_request_num_peers: 2,
-            mempool_pulling_interval: 250,
+            batch_generation_poll_interval_ms: 25,
+            batch_generation_max_interval_ms: 250,
             // TODO: This essentially turns fragments off, because there was performance degradation. Needs more investigation.
             end_batch_ms: 10,
             max_batch_bytes: 4 * 1024 * 1024,

--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 #[serde(default, deny_unknown_fields)]
 pub struct QuorumStoreBackPressureConfig {
     pub backlog_txn_limit_count: u64,
+    pub backlog_batch_limit_count: u64,
     pub decrease_duration_ms: u64,
     pub increase_duration_ms: u64,
     pub decrease_fraction: f64,
@@ -21,6 +22,8 @@ impl Default for QuorumStoreBackPressureConfig {
         QuorumStoreBackPressureConfig {
             // QS will be backpressured if the remaining total txns is more than this number
             backlog_txn_limit_count: MAX_SENDING_BLOCK_TXNS_QUORUM_STORE_OVERRIDE * 4,
+            // QS will create batches immediately until this number is reached
+            backlog_batch_limit_count: 80,
             decrease_duration_ms: 1000,
             increase_duration_ms: 1000,
             decrease_fraction: 0.5,

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -420,10 +420,17 @@ pub static RECEIVED_BATCH_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static QS_BACKPRESSURE: Lazy<AverageIntCounter> = Lazy::new(|| {
+pub static QS_BACKPRESSURE_TXN_COUNT: Lazy<AverageIntCounter> = Lazy::new(|| {
     AverageIntCounter::register(
-        "quorum_store_backpressure",
-        "Indicator of whether Quorum Store is backpressured. QS should be backpressured when (1) number of batches exceeds the threshold, or (2) consensus is backpressured."
+        "quorum_store_backpressure_txn_count",
+        "Indicator of whether Quorum Store is backpressured due to txn count exceeding threshold.",
+    )
+});
+
+pub static QS_BACKPRESSURE_PROOF_COUNT: Lazy<AverageIntCounter> = Lazy::new(|| {
+    AverageIntCounter::register(
+        "quorum_store_backpressure_proof_count",
+        "Indicator of whether Quorum Store is backpressured due to proof count exceeding threshold."
     )
 });
 

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -202,6 +202,16 @@ pub static NUM_TOTAL_TXNS_LEFT_ON_COMMIT: Lazy<Histogram> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Histogram for the number of total batches/PoS left after cleaning up commit notifications.
+pub static NUM_TOTAL_PROOFS_LEFT_ON_COMMIT: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "quorum_store_num_total_proofs_left_on_commit",
+        "Histogram for the number of total batches/PoS left after cleaning up commit notifications.",
+        TRANSACTION_COUNT_BUCKETS.clone(),
+    )
+        .unwrap()
+});
+
 /// Histogram for the number of local batches/PoS left after cleaning up commit notifications.
 pub static NUM_LOCAL_PROOFS_LEFT_ON_COMMIT: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     network::{NetworkSender, QuorumStoreSender},
-    quorum_store::{counters, utils::ProofQueue},
+    quorum_store::{batch_generator::BackPressure, counters, utils::ProofQueue},
 };
 use aptos_consensus_types::{
     common::{Payload, PayloadFilter, ProofWithData},
@@ -29,15 +29,23 @@ pub struct ProofManager {
     latest_logical_time: LogicalTime,
     back_pressure_total_txn_limit: u64,
     remaining_total_txn_num: u64,
+    back_pressure_total_proof_limit: u64,
+    remaining_total_proof_num: u64,
 }
 
 impl ProofManager {
-    pub fn new(epoch: u64, back_pressure_total_txn_limit: u64) -> Self {
+    pub fn new(
+        epoch: u64,
+        back_pressure_total_txn_limit: u64,
+        back_pressure_total_proof_limit: u64,
+    ) -> Self {
         Self {
             proofs_for_consensus: ProofQueue::new(),
             latest_logical_time: LogicalTime::new(epoch, 0),
             back_pressure_total_txn_limit,
             remaining_total_txn_num: 0,
+            back_pressure_total_proof_limit,
+            remaining_total_proof_num: 0,
         }
     }
 
@@ -100,9 +108,12 @@ impl ProofManager {
                     max_bytes,
                     return_non_full,
                 );
-                self.remaining_total_txn_num = self
+                (self.remaining_total_txn_num, self.remaining_total_proof_num) = self
                     .proofs_for_consensus
-                    .num_total_txns(LogicalTime::new(self.latest_logical_time.epoch(), round));
+                    .num_total_txns_and_proofs(LogicalTime::new(
+                        self.latest_logical_time.epoch(),
+                        round,
+                    ));
 
                 let res = GetPayloadResponse::GetPayloadResponse(
                     if proof_block.is_empty() {
@@ -125,18 +136,24 @@ impl ProofManager {
     }
 
     /// return true when quorum store is back pressured
-    pub(crate) fn qs_back_pressure(&self) -> bool {
-        self.remaining_total_txn_num > self.back_pressure_total_txn_limit
+    pub(crate) fn qs_back_pressure(&self) -> BackPressure {
+        BackPressure {
+            txn_count: self.remaining_total_txn_num > self.back_pressure_total_txn_limit,
+            batch_count: self.remaining_total_proof_num > self.back_pressure_total_proof_limit,
+        }
     }
 
     pub async fn start(
         mut self,
         mut network_sender: NetworkSender,
-        back_pressure_tx: tokio::sync::mpsc::Sender<bool>,
+        back_pressure_tx: tokio::sync::mpsc::Sender<BackPressure>,
         mut proposal_rx: Receiver<GetPayloadCommand>,
         mut proof_rx: tokio::sync::mpsc::Receiver<ProofManagerCommand>,
     ) {
-        let mut back_pressure = false;
+        let mut back_pressure = BackPressure {
+            txn_count: false,
+            batch_count: false,
+        };
 
         loop {
             // TODO: additional main loop counter
@@ -172,7 +189,8 @@ impl ProofManager {
                             self.handle_commit_notification(logical_time, digests);
 
                             // update the backpressure upon new commit round
-                            self.remaining_total_txn_num = self.proofs_for_consensus.num_total_txns(logical_time);
+                            (self.remaining_total_txn_num, self.remaining_total_proof_num) =
+                                self.proofs_for_consensus.num_total_txns_and_proofs(logical_time);
                             // TODO: keeping here for metrics, might be part of the backpressure in the future?
                             self.proofs_for_consensus.clean_local_proofs(logical_time);
                             let updated_back_pressure = self.qs_back_pressure();

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -139,7 +139,7 @@ impl ProofManager {
     pub(crate) fn qs_back_pressure(&self) -> BackPressure {
         BackPressure {
             txn_count: self.remaining_total_txn_num > self.back_pressure_total_txn_limit,
-            batch_count: self.remaining_total_proof_num > self.back_pressure_total_proof_limit,
+            proof_count: self.remaining_total_proof_num > self.back_pressure_total_proof_limit,
         }
     }
 
@@ -152,7 +152,7 @@ impl ProofManager {
     ) {
         let mut back_pressure = BackPressure {
             txn_count: false,
-            batch_count: false,
+            proof_count: false,
         };
 
         loop {

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -9,7 +9,7 @@ use crate::{
     payload_manager::PayloadManager,
     quorum_store::{
         batch_coordinator::{BatchCoordinator, BatchCoordinatorCommand},
-        batch_generator::{BatchGenerator, BatchGeneratorCommand},
+        batch_generator::{BackPressure, BatchGenerator, BatchGeneratorCommand},
         batch_requester::BatchRequester,
         batch_store::BatchStore,
         counters,
@@ -133,8 +133,8 @@ pub struct InnerBuilder {
     proof_coordinator_cmd_rx: Option<tokio::sync::mpsc::Receiver<ProofCoordinatorCommand>>,
     proof_manager_cmd_tx: tokio::sync::mpsc::Sender<ProofManagerCommand>,
     proof_manager_cmd_rx: Option<tokio::sync::mpsc::Receiver<ProofManagerCommand>>,
-    back_pressure_tx: tokio::sync::mpsc::Sender<bool>,
-    back_pressure_rx: Option<tokio::sync::mpsc::Receiver<bool>>,
+    back_pressure_tx: tokio::sync::mpsc::Sender<BackPressure>,
+    back_pressure_rx: Option<tokio::sync::mpsc::Receiver<BackPressure>>,
     quorum_store_storage: Arc<dyn QuorumStoreStorage>,
     quorum_store_msg_tx: aptos_channel::Sender<AccountAddress, VerifiedEvent>,
     quorum_store_msg_rx: Option<aptos_channel::Receiver<AccountAddress, VerifiedEvent>>,
@@ -355,6 +355,7 @@ impl InnerBuilder {
         let proof_manager = ProofManager::new(
             self.epoch,
             self.config.back_pressure.backlog_txn_limit_count,
+            self.config.back_pressure.backlog_batch_limit_count,
         );
         spawn_named!(
             "proof_manager",

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -278,7 +278,7 @@ impl InnerBuilder {
     ) {
         // TODO: parameter? bring back back-off?
         let interval = tokio::time::interval(Duration::from_millis(
-            self.config.mempool_pulling_interval as u64,
+            self.config.batch_generation_poll_interval_ms as u64,
         ));
 
         let coordinator_rx = self.coordinator_rx.take().unwrap();

--- a/consensus/src/quorum_store/tests/proof_manager_test.rs
+++ b/consensus/src/quorum_store/tests/proof_manager_test.rs
@@ -14,7 +14,7 @@ use std::collections::HashSet;
 
 #[tokio::test]
 async fn test_block_request() {
-    let mut proof_manager = ProofManager::new(0, 10);
+    let mut proof_manager = ProofManager::new(0, 10, 10);
 
     let digest = HashValue::random();
     let proof = ProofOfStore::new(


### PR DESCRIPTION
### Description

We poll mempool for transactions at a fast rate (default 25 ms), unless there is backpressure. If there is backpressure then the next poll will be tried in + 25ms, until a max of 250 ms is reached. Since this makes the poll duration variable, we compute the max txns to pull based on the time passed since the last poll.

The backpressure is based on the number of proofs left in proof manager. So proofs are used for the rate of pulling, and txns are used for the max number of txns on the pull.

### Test Plan

Running tests with low TPS (2 TPS per validator), confirmed that the time spent in mempool reduced: roughly from an average of 125ms (from the previous 250ms poll time) to an average of 12.5ms (fro the 25ms faster poll time).