### PR TITLE
[Peer Monitoring Service] Add jitter and simplify network info responses.

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -332,6 +332,7 @@ pub struct PeerMonitoringServiceConfig {
     pub latency_monitoring: LatencyMonitoringConfig,
     pub max_concurrent_requests: u64, // Max num of concurrent server tasks
     pub max_network_channel_size: u64, // Max num of pending network messages
+    pub max_request_jitter_ms: u64, // Max amount of jitter (ms) that a request will be delayed for
     pub metadata_update_interval_ms: u64, // The interval (ms) between metadata updates
     pub network_monitoring: NetworkMonitoringConfig,
     pub peer_monitor_interval_ms: u64, // The interval (ms) between peer monitor executions
@@ -344,6 +345,7 @@ impl Default for PeerMonitoringServiceConfig {
             latency_monitoring: LatencyMonitoringConfig::default(),
             max_concurrent_requests: 1000,
             max_network_channel_size: 1000,
+            max_request_jitter_ms: 1000, // Monitoring requests are very infrequent, so 1 sec is acceptable
             metadata_update_interval_ms: 5000,
             network_monitoring: NetworkMonitoringConfig::default(),
             peer_monitor_interval_ms: 1000,

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -345,7 +345,7 @@ impl Default for PeerMonitoringServiceConfig {
             latency_monitoring: LatencyMonitoringConfig::default(),
             max_concurrent_requests: 1000,
             max_network_channel_size: 1000,
-            max_request_jitter_ms: 1000, // Monitoring requests are very infrequent, so 1 sec is acceptable
+            max_request_jitter_ms: 1000, // Monitoring requests are very infrequent
             metadata_update_interval_ms: 5000,
             network_monitoring: NetworkMonitoringConfig::default(),
             peer_monitor_interval_ms: 1000,

--- a/network/peer-monitoring-service/client/Cargo.toml
+++ b/network/peer-monitoring-service/client/Cargo.toml
@@ -27,6 +27,7 @@ async-trait = { workspace = true }
 enum_dispatch = { workspace = true }
 futures = { workspace = true }
 once_cell = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
@@ -37,5 +38,4 @@ aptos-network = { workspace = true, features = ["fuzzing"] }
 aptos-peer-monitoring-service-server = { workspace = true }
 bcs = { workspace = true }
 maplit = { workspace = true }
-rand = { workspace = true }
 tokio-stream = { workspace = true }

--- a/network/peer-monitoring-service/client/src/lib.rs
+++ b/network/peer-monitoring-service/client/src/lib.rs
@@ -95,8 +95,9 @@ async fn start_peer_monitor_with_state(
     let peers_and_metadata = peer_monitoring_client.get_peers_and_metadata();
 
     // Create an interval ticker for the monitor loop
+    let monitoring_service_config = node_config.peer_monitoring_service.clone();
     let peer_monitor_duration =
-        Duration::from_millis(node_config.peer_monitoring_service.peer_monitor_interval_ms);
+        Duration::from_millis(monitoring_service_config.peer_monitor_interval_ms);
     let peer_monitor_ticker = time_service.interval(peer_monitor_duration);
     futures::pin_mut!(peer_monitor_ticker);
 
@@ -137,6 +138,7 @@ async fn start_peer_monitor_with_state(
 
         // Refresh the peer states
         if let Err(error) = peer_states::refresh_peer_states(
+            &monitoring_service_config,
             peer_monitor_state.clone(),
             peer_monitoring_client.clone(),
             connected_peers_and_metadata,

--- a/network/peer-monitoring-service/client/src/peer_states/mod.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{metrics, Error, PeerMonitorState, PeerMonitoringServiceClient, PeerState};
-use aptos_config::network_id::PeerNetworkId;
+use aptos_config::{config::PeerMonitoringServiceConfig, network_id::PeerNetworkId};
 use aptos_network::application::{interface::NetworkClient, metadata::PeerMetadata};
 use aptos_peer_monitoring_service_types::PeerMonitoringServiceMessage;
 use aptos_time_service::TimeService;
@@ -18,6 +18,7 @@ mod request_tracker;
 
 /// Refreshes the states of the connected peers
 pub fn refresh_peer_states(
+    monitoring_service_config: &PeerMonitoringServiceConfig,
     peer_monitor_state: PeerMonitorState,
     peer_monitoring_client: PeerMonitoringServiceClient<
         NetworkClient<PeerMonitoringServiceMessage>,
@@ -46,6 +47,7 @@ pub fn refresh_peer_states(
             let should_refresh_peer_state_key = request_tracker.read().new_request_required();
             if should_refresh_peer_state_key {
                 peer_state.refresh_peer_state_key(
+                    monitoring_service_config,
                     &peer_state_key,
                     peer_monitoring_client.clone(),
                     *peer_network_id,

--- a/network/peer-monitoring-service/client/src/peer_states/network_info.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/network_info.rs
@@ -405,7 +405,7 @@ mod test {
         // Create the service response
         let peer_monitoring_service_response =
             PeerMonitoringServiceResponse::NetworkInformation(NetworkInformationResponse {
-                connected_peers_and_metadata: Default::default(),
+                connected_peers: Default::default(),
                 distance_from_validators,
             });
 

--- a/network/peer-monitoring-service/client/src/peer_states/peer_state.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/peer_state.rs
@@ -105,9 +105,7 @@ impl PeerState {
             .await;
 
             // Stop the timer and calculate the duration
-            let finish_time = time_service.now();
-            let request_duration: Duration = finish_time.duration_since(start_time);
-            let request_duration_secs = request_duration.as_secs_f64();
+            let request_duration_secs = start_time.elapsed().as_secs_f64();
 
             // Mark the in-flight request as now complete
             request_tracker.write().request_completed();
@@ -169,10 +167,10 @@ impl PeerState {
             .map(|network_info_response| network_info_response.distance_from_validators);
         peer_monitoring_metadata.distance_from_validators = distance_from_validators;
 
-        // Get and store the connected peers and metadata
+        // Get and store the connected peers and connection metadata
         let connected_peers_and_metadata = network_info_response
-            .map(|network_info_response| network_info_response.connected_peers_and_metadata);
-        peer_monitoring_metadata.connected_peers_and_metadata = connected_peers_and_metadata;
+            .map(|network_info_response| network_info_response.connected_peers);
+        peer_monitoring_metadata.connected_peers = connected_peers_and_metadata;
 
         Ok(peer_monitoring_metadata)
     }

--- a/network/peer-monitoring-service/client/src/tests/multiple_peers.rs
+++ b/network/peer-monitoring-service/client/src/tests/multiple_peers.rs
@@ -23,7 +23,7 @@ use aptos_config::{
     network_id::{NetworkId, PeerNetworkId},
 };
 use aptos_infallible::RwLock;
-use aptos_network::{application::metadata::PeerMetadata, transport::ConnectionMetadata};
+use aptos_network::transport::ConnectionMetadata;
 use aptos_peer_monitoring_service_types::{
     LatencyPingResponse, NetworkInformationResponse, PeerMonitoringServiceRequest,
     PeerMonitoringServiceResponse,
@@ -107,13 +107,14 @@ async fn test_peer_updater_loop_multiple_peers() {
         let peer_state = peer_states.get_mut(peer).unwrap();
 
         // Update the network info
-        let connected_peers_and_metadata = hashmap! { PeerNetworkId::random() => PeerMetadata::new(ConnectionMetadata::mock(PeerId::random())) };
+        let connected_peers =
+            hashmap! { PeerNetworkId::random() => ConnectionMetadata::mock(PeerId::random()) };
         let distance_from_validators = get_distance_from_validators(peer);
         update_network_info_for_peer(
             peers_and_metadata.clone(),
             peer,
             peer_state,
-            connected_peers_and_metadata,
+            connected_peers,
             distance_from_validators,
             1.0,
         );
@@ -391,10 +392,11 @@ async fn test_network_info() {
         let peer_monitor_state = peer_monitor_state.clone();
         let handle_requests = async move {
             // Create a response for the network info requests
-            let connected_peers_and_metadata = hashmap! { PeerNetworkId::random() => PeerMetadata::new(ConnectionMetadata::mock(PeerId::random())) };
+            let connected_peers =
+                hashmap! { PeerNetworkId::random() => ConnectionMetadata::mock(PeerId::random()) };
             let response =
                 PeerMonitoringServiceResponse::NetworkInformation(NetworkInformationResponse {
-                    connected_peers_and_metadata: connected_peers_and_metadata.clone(),
+                    connected_peers: connected_peers.clone(),
                     distance_from_validators: 0,
                 });
 

--- a/network/peer-monitoring-service/server/src/lib.rs
+++ b/network/peer-monitoring-service/server/src/lib.rs
@@ -173,15 +173,21 @@ impl Handler {
     }
 
     fn get_network_information(&self) -> Result<PeerMonitoringServiceResponse, Error> {
-        // Get all required network information
+        // Get the connected peers
         let connected_peers_and_metadata =
             self.peers_and_metadata.get_connected_peers_and_metadata()?;
+        let connected_peers = connected_peers_and_metadata
+            .into_iter()
+            .map(|(peer, metadata)| (peer, metadata.get_connection_metadata()))
+            .collect();
+
+        // Get the distance from the validators
         let distance_from_validators =
             get_distance_from_validators(&self.base_config, self.peers_and_metadata.clone());
 
         // Create and send the response
         let network_information_response = NetworkInformationResponse {
-            connected_peers_and_metadata,
+            connected_peers,
             distance_from_validators,
         };
         Ok(PeerMonitoringServiceResponse::NetworkInformation(

--- a/network/peer-monitoring-service/server/src/tests.rs
+++ b/network/peer-monitoring-service/server/src/tests.rs
@@ -17,7 +17,7 @@ use aptos_netcore::transport::ConnectionOrigin;
 use aptos_network::{
     application::{
         interface::NetworkServiceEvents,
-        metadata::{ConnectionState, PeerMetadata, PeerMonitoringMetadata},
+        metadata::{ConnectionState, PeerMonitoringMetadata},
         storage::PeersAndMetadata,
     },
     peer_manager::PeerManagerNotification,
@@ -91,7 +91,7 @@ async fn test_get_network_information_fullnode() {
     // Process a client request to fetch the network information and verify the response
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => PeerMetadata::new(connection_metadata_1.clone())},
+        hashmap! {peer_network_id_1 => connection_metadata_1.clone()},
         MAX_DISTANCE_FROM_VALIDATORS,
     )
     .await;
@@ -104,11 +104,9 @@ async fn test_get_network_information_fullnode() {
         .unwrap();
 
     // Process a client request to fetch the network information and verify the response
-    let peer_metadata_1 =
-        PeerMetadata::new_for_test(connection_metadata_1.clone(), peer_monitoring_metadata_1);
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => peer_metadata_1.clone()},
+        hashmap! {peer_network_id_1 => connection_metadata_1.clone()},
         MAX_DISTANCE_FROM_VALIDATORS,
     )
     .await;
@@ -125,11 +123,9 @@ async fn test_get_network_information_fullnode() {
         .unwrap();
 
     // Process a client request to fetch the network information and verify the response
-    let peer_metadata_1 =
-        PeerMetadata::new_for_test(connection_metadata_1.clone(), peer_monitoring_metadata_1);
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => peer_metadata_1.clone()},
+        hashmap! {peer_network_id_1 => connection_metadata_1.clone()},
         peer_distance_1 + 1,
     )
     .await;
@@ -148,11 +144,9 @@ async fn test_get_network_information_fullnode() {
         .unwrap();
 
     // Process a client request to fetch the network information and verify the response
-    let peer_metadata_2 =
-        PeerMetadata::new_for_test(connection_metadata_2.clone(), peer_monitoring_metadata_2);
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => peer_metadata_1.clone(), peer_network_id_2 => peer_metadata_2},
+        hashmap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2},
         peer_distance_2 + 1,
     )
     .await;
@@ -165,7 +159,7 @@ async fn test_get_network_information_fullnode() {
     // Process a request to fetch the network information and verify the response
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => peer_metadata_1},
+        hashmap! {peer_network_id_1 => connection_metadata_1},
         peer_distance_1 + 1,
     )
     .await;
@@ -196,7 +190,7 @@ async fn test_get_network_information_validator() {
     // Process a client request to fetch the network information and verify the response
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => PeerMetadata::new(connection_metadata_1.clone())},
+        hashmap! {peer_network_id_1 => connection_metadata_1.clone()},
         0,
     )
     .await;
@@ -209,11 +203,9 @@ async fn test_get_network_information_validator() {
         .unwrap();
 
     // Process a client request to fetch the network information and verify the response
-    let peer_metadata_1 =
-        PeerMetadata::new_for_test(connection_metadata_1.clone(), peer_monitoring_metadata_1);
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => peer_metadata_1.clone()},
+        hashmap! {peer_network_id_1 => connection_metadata_1.clone()},
         0,
     )
     .await;
@@ -232,11 +224,9 @@ async fn test_get_network_information_validator() {
         .unwrap();
 
     // Process a client request to fetch the network information and verify the response
-    let peer_metadata_2 =
-        PeerMetadata::new_for_test(connection_metadata_2.clone(), peer_monitoring_metadata_2);
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => peer_metadata_1.clone(), peer_network_id_2 => peer_metadata_2},
+        hashmap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2},
         0,
     )
         .await;
@@ -249,7 +239,7 @@ async fn test_get_network_information_validator() {
     // Process a request to fetch the network information and verify the response
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => peer_metadata_1},
+        hashmap! {peer_network_id_1 => connection_metadata_1},
         0,
     )
     .await;
@@ -292,7 +282,7 @@ fn create_connection_metadata(peer_id: AccountAddress) -> ConnectionMetadata {
 /// client, and verifies the response is correct.
 async fn verify_network_information(
     client: &mut MockClient,
-    expected_peers_and_metadata: HashMap<PeerNetworkId, PeerMetadata>,
+    expected_peers: HashMap<PeerNetworkId, ConnectionMetadata>,
     expected_distance_from_validators: u64,
 ) {
     // Send a request to fetch the network information
@@ -302,7 +292,7 @@ async fn verify_network_information(
     // Verify the response is correct
     let expected_response =
         PeerMonitoringServiceResponse::NetworkInformation(NetworkInformationResponse {
-            connected_peers_and_metadata: expected_peers_and_metadata,
+            connected_peers: expected_peers,
             distance_from_validators: expected_distance_from_validators,
         });
     assert_eq!(response, expected_response);

--- a/network/peer-monitoring-service/types/src/lib.rs
+++ b/network/peer-monitoring-service/types/src/lib.rs
@@ -4,7 +4,7 @@
 #![forbid(unsafe_code)]
 
 use aptos_config::network_id::PeerNetworkId;
-use aptos_network::application::metadata::PeerMetadata;
+use aptos_network::transport::ConnectionMetadata;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::TryFrom};
 use thiserror::Error;
@@ -87,7 +87,7 @@ pub struct LatencyPingResponse {
 /// A response for the network information request
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct NetworkInformationResponse {
-    pub connected_peers_and_metadata: HashMap<PeerNetworkId, PeerMetadata>, // Connected peers and metadata
+    pub connected_peers: HashMap<PeerNetworkId, ConnectionMetadata>, // Connected peers
     pub distance_from_validators: u64, // The distance of the peer from the validator set
                                        // TODO: add the rest of the information here!
 }

--- a/network/src/application/metadata.rs
+++ b/network/src/application/metadata.rs
@@ -22,7 +22,7 @@ pub enum ConnectionState {
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct PeerMonitoringMetadata {
     pub average_ping_latency_secs: Option<f64>, // The average latency ping for the peer
-    pub connected_peers_and_metadata: Option<HashMap<PeerNetworkId, PeerMetadata>>, // Connected peers and metadata
+    pub connected_peers: Option<HashMap<PeerNetworkId, ConnectionMetadata>>, // Connected peers and metadata
     pub distance_from_validators: Option<u64>, // The known distance from the validator set
 }
 
@@ -33,12 +33,12 @@ impl Eq for PeerMonitoringMetadata {}
 impl PeerMonitoringMetadata {
     pub fn new(
         average_ping_latency_secs: Option<f64>,
-        connected_peers_and_metadata: Option<HashMap<PeerNetworkId, PeerMetadata>>,
+        connected_peers: Option<HashMap<PeerNetworkId, ConnectionMetadata>>,
         distance_from_validators: Option<u64>,
     ) -> Self {
         PeerMonitoringMetadata {
             average_ping_latency_secs,
-            connected_peers_and_metadata,
+            connected_peers,
             distance_from_validators,
         }
     }


### PR DESCRIPTION
Notes:
- This PR relates to: https://github.com/aptos-labs/aptos-core/issues/6789.

### Description
This PR makes two incremental changes to the peer monitoring service (each in their own commit):
1. Add jitter to each peer monitoring request (this adds up to 1 second of delay before sending the request). This helps prevent bursty requests.
2. Simplify the metadata being returned by the network info responses. We will add discovery information in a separate request/response type, so this is not needed.

### Test Plan
Existing test infrastructure.