### PR TITLE
[Quorum Store] adjust memory and db quotas

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -77,8 +77,8 @@ impl Default for QuorumStoreConfig {
             batch_expiry_round_gap_behind_latest_certified: 500,
             batch_expiry_round_gap_beyond_latest_certified: 500,
             batch_expiry_grace_rounds: 5,
-            memory_quota: 100000000,
-            db_quota: 10000000000,
+            memory_quota: 120_000_000,
+            db_quota: 300_000_000,
             mempool_txn_pull_max_bytes: 4 * 1024 * 1024,
             back_pressure: QuorumStoreBackPressureConfig::default(),
             // number of batch coordinators to handle QS Fragment messages, should be >= 1


### PR DESCRIPTION
### Description

Set defaults to be suitable for a 100 validator network.

Paraphrasing Sasha:

20000 tps * 1000B (size of a tnx) * 60 s (duration) = 1_200_000_000 bytes
Divide by 100 validator = 12_000_000B each validator ask me to persist on average.

Adding some buffer for peaks:
Memory: 10x - 120_000_000 bytes
Storage 25x - 300_000_000 bytes

