### PR TITLE
[consensus-only] disable consensus-only smoke test in v1.2

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -180,6 +180,7 @@ jobs:
 
   rust-consensus-only-smoke-test:
     runs-on: high-perf-docker
+    if: ${{ !github.ref || github.ref != 'aptos-node-v1.2.0' }} 
     steps:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main


### PR DESCRIPTION
### Description

This PR disables the consensus-only smoke test on the aptos-node-v1.2 branch because we don't have support for consensus-only on that branch. This PR is much simpler than cherry-picking the consensus-only changes to the branch which I consider is a much more involved change.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Forge works.
