### PR TITLE
[API] Create counter for request source

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -42,6 +42,7 @@ once_cell = { workspace = true }
 paste = { workspace = true }
 poem = { workspace = true }
 poem-openapi = { workspace = true }
+regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/api/src/metrics.rs
+++ b/api/src/metrics.rs
@@ -2,7 +2,9 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_metrics_core::{register_histogram_vec, HistogramVec};
+use aptos_metrics_core::{
+    register_histogram_vec, register_int_counter_vec, HistogramVec, IntCounterVec,
+};
 use once_cell::sync::Lazy;
 
 pub static HISTOGRAM: Lazy<HistogramVec> = Lazy::new(|| {
@@ -19,6 +21,15 @@ pub static RESPONSE_STATUS: Lazy<HistogramVec> = Lazy::new(|| {
         "aptos_api_response_status",
         "API requests latency grouped by status code only",
         &["status"]
+    )
+    .unwrap()
+});
+
+pub static REQUEST_SOURCE_CLIENT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_api_request_source_client",
+        "API requests grouped by source (e.g. which SDK, unknown, etc), operation_id, and status",
+        &["request_source_client", "operation_id", "status"]
     )
     .unwrap()
 });


### PR DESCRIPTION
### Description
We want some more insight into where requests to the API are coming from, this counter helps with that.

@0xmaayan this slices up the requests by source, method they're calling, and status they got. Does that sound good, or did you want the data sliced up differently?

### Test Plan
Run local testnet:
```
cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes --with-faucet
```

Make a couple of requests with just curl:
```
curl http://127.0.0.1:8080/v1
curl http://127.0.0.1:8080/v1/accounts/0x1
```
Make a couple of requests with the CLI, to which we just added the User-Agent stuff.
```
aptos account list --url http://127.0.0.1:8080 --account 0x1
```

See the metrics pushed appropriately, with `request-source-client-unknown` for the former and `aptos-cli/1.8.0` for the latter:
```
curl -s http://127.0.0.1:9101/metrics | grep -i request_source
```
```
# HELP aptos_api_request_source_client API requests grouped by source (e.g. which SDK, unknown, etc), operation_id, and status
# TYPE aptos_api_request_source_client counter
aptos_api_request_source_client{operation_id="estimate_gas_price",request_source_client="request-source-client-unknown",status="200"} 1
aptos_api_request_source_client{operation_id="get_account",request_source_client="request-source-client-unknown",status="200"} 1
aptos_api_request_source_client{operation_id="get_account",request_source_client="request-source-client-unknown",status="404"} 1
aptos_api_request_source_client{operation_id="get_account_resources",request_source_client="aptos-cli/1.0.8",status="200"} 1
aptos_api_request_source_client{operation_id="get_ledger_info",request_source_client="request-source-client-unknown",status="200"} 2
aptos_api_request_source_client{operation_id="get_transaction_by_hash",request_source_client="request-source-client-unknown",status="200"} 13
aptos_api_request_source_client{operation_id="submit_transaction",request_source_client="request-source-client-unknown",status="202"} 1
```