### PR TITLE
[aptos-move] Remove usage of bytecode version environment variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3816,7 +3816,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -6783,7 +6783,7 @@ checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6800,7 +6800,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
@@ -6816,12 +6816,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6836,7 +6836,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6848,7 +6848,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -6861,7 +6861,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -6878,7 +6878,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6924,7 +6924,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "difference",
@@ -6941,7 +6941,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6970,7 +6970,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
@@ -6992,7 +6992,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7012,7 +7012,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -7030,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "codespan",
@@ -7048,7 +7048,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7081,7 +7081,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -7100,7 +7100,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "hex",
@@ -7113,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "hex",
@@ -7127,7 +7127,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "codespan",
@@ -7153,7 +7153,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7189,7 +7189,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7226,7 +7226,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7255,7 +7255,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7266,7 +7266,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7281,7 +7281,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -7308,7 +7308,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -7326,7 +7326,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "hex",
@@ -7349,7 +7349,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "once_cell",
  "serde 1.0.149",
@@ -7358,7 +7358,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7375,7 +7375,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -7407,7 +7407,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "better_any",
@@ -7438,7 +7438,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -7455,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7469,7 +7469,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "bcs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-binary-format",
@@ -8869,7 +8869,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=69c1bd0b31827603653e03fa31752a10c275b0fc#69c1bd0b31827603653e03fa31752a10c275b0fc"
+source = "git+https://github.com/move-language/move?rev=4bfe59770f99e6148fed468d4c67b64fd44d1a50#4bfe59770f99e6148fed468d4c67b64fd44d1a50"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -490,36 +490,36 @@ x25519-dalek = "1.2.0"
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES
-move-abigen = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-cli = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-coverage = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-compiler ={ git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc", features = ["address32"] }
-move-docgen = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-model = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-package = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-prover = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc", features = ["table-extension"] }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc", features = ["lazy_natives"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc", features = ["table-extension"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "69c1bd0b31827603653e03fa31752a10c275b0fc" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-cli = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-coverage = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-compiler ={ git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50", features = ["address32"] }
+move-docgen = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-model = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-package = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-prover = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50", features = ["table-extension"] }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50", features = ["lazy_natives"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50", features = ["table-extension"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+read-write-set = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "4bfe59770f99e6148fed468d4c67b64fd44d1a50" }
 # END MOVE DEPENDENCIES
 
 [profile.release]

--- a/aptos-move/framework/src/prover.rs
+++ b/aptos-move/framework/src/prover.rs
@@ -100,10 +100,16 @@ impl ProverOptions {
         self,
         package_path: &Path,
         named_addresses: BTreeMap<String, AccountAddress>,
+        bytecode_version: Option<u32>,
     ) -> anyhow::Result<()> {
         let now = Instant::now();
         let for_test = self.for_test;
-        let model = build_model(package_path, named_addresses, self.filter.clone())?;
+        let model = build_model(
+            package_path,
+            named_addresses,
+            self.filter.clone(),
+            bytecode_version,
+        )?;
         let mut options = self.convert_options();
         // Need to ensure a distinct output.bpl file for concurrent execution. In non-test
         // mode, we actually want to use the static output.bpl for debugging purposes

--- a/aptos-move/framework/tests/move_prover_tests.rs
+++ b/aptos-move/framework/tests/move_prover_tests.rs
@@ -21,7 +21,7 @@ pub fn run_prover_for_pkg(path_to_pkg: impl Into<String>) {
     let pkg_path = path_in_crate(path_to_pkg);
     let options = ProverOptions::default_for_test();
     options
-        .prove(pkg_path.as_path(), BTreeMap::default())
+        .prove(pkg_path.as_path(), BTreeMap::default(), None)
         .unwrap()
 }
 

--- a/aptos-move/writeset-transaction-generator/src/admin_script_builder.rs
+++ b/aptos-move/writeset-transaction-generator/src/admin_script_builder.rs
@@ -9,7 +9,6 @@ use aptos_types::{
     transaction::{Script, WriteSetPayload},
 };
 use handlebars::Handlebars;
-use move_command_line_common::env::get_bytecode_version_from_env;
 use move_compiler::{compiled_unit::AnnotatedCompiledUnit, Compiler, Flags};
 use serde::Serialize;
 use std::{collections::HashMap, io::Write, path::PathBuf};
@@ -18,7 +17,7 @@ use tempfile::NamedTempFile;
 /// The relative path to the scripts templates
 pub const SCRIPTS_DIR_PATH: &str = "templates";
 
-pub fn compile_script(source_file_str: String) -> Vec<u8> {
+pub fn compile_script(source_file_str: String, bytecode_version: Option<u32>) -> Vec<u8> {
     let (_files, mut compiled_program) = Compiler::from_files(
         vec![source_file_str],
         aptos_cached_packages::head_release_bundle()
@@ -32,17 +31,19 @@ pub fn compile_script(source_file_str: String) -> Vec<u8> {
     assert!(compiled_program.len() == 1);
     match compiled_program.pop().unwrap() {
         AnnotatedCompiledUnit::Module(_) => panic!("Unexpected module when compiling script"),
-        x @ AnnotatedCompiledUnit::Script(_) => x
-            .into_compiled_unit()
-            .serialize(get_bytecode_version_from_env()),
+        x @ AnnotatedCompiledUnit::Script(_) => x.into_compiled_unit().serialize(bytecode_version),
     }
 }
 
-fn compile_admin_script(input: &str) -> Result<Script> {
+fn compile_admin_script(input: &str, bytecode_version: Option<u32>) -> Result<Script> {
     let mut temp_file = NamedTempFile::new()?;
     temp_file.write_all(input.as_bytes())?;
     let cur_path = temp_file.path().to_str().unwrap().to_owned();
-    Ok(Script::new(compile_script(cur_path), vec![], vec![]))
+    Ok(Script::new(
+        compile_script(cur_path, bytecode_version),
+        vec![],
+        vec![],
+    ))
 }
 
 pub fn template_path() -> PathBuf {
@@ -51,7 +52,10 @@ pub fn template_path() -> PathBuf {
     path
 }
 
-pub fn remove_validators_payload(validators: Vec<AccountAddress>) -> WriteSetPayload {
+pub fn remove_validators_payload(
+    validators: Vec<AccountAddress>,
+    bytecode_version: Option<u32>,
+) -> WriteSetPayload {
     assert!(!validators.is_empty(), "Unexpected validator set length");
     let mut script = template_path();
     script.push("remove_validators.move");
@@ -65,7 +69,7 @@ pub fn remove_validators_payload(validators: Vec<AccountAddress>) -> WriteSetPay
 
         let output = hb.render("script", &data).unwrap();
 
-        compile_admin_script(output.as_str()).unwrap()
+        compile_admin_script(output.as_str(), bytecode_version).unwrap()
     };
 
     WriteSetPayload::Script {
@@ -78,6 +82,7 @@ pub fn custom_script<T: Serialize>(
     script_name_in_templates: &str,
     args: &T,
     execute_as: Option<AccountAddress>,
+    bytecode_version: Option<u32>,
 ) -> WriteSetPayload {
     let mut script = template_path();
     script.push(script_name_in_templates);
@@ -88,7 +93,7 @@ pub fn custom_script<T: Serialize>(
         hb.set_strict_mode(true);
         let output = hb.render("script", args).unwrap();
 
-        compile_admin_script(output.as_str()).unwrap()
+        compile_admin_script(output.as_str(), bytecode_version).unwrap()
     };
 
     WriteSetPayload::Script {
@@ -97,13 +102,13 @@ pub fn custom_script<T: Serialize>(
     }
 }
 
-pub fn halt_network_payload() -> WriteSetPayload {
+pub fn halt_network_payload(bytecode_version: Option<u32>) -> WriteSetPayload {
     let mut script = template_path();
     script.push("halt_transactions.move");
 
     WriteSetPayload::Script {
         script: Script::new(
-            compile_script(script.to_str().unwrap().to_owned()),
+            compile_script(script.to_str().unwrap().to_owned(), bytecode_version),
             vec![],
             vec![],
         ),

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         },
         utils::prompt_yes_with_override,
     },
-    move_tool::{set_bytecode_version, FrameworkPackageArgs, IncludedArtifacts},
+    move_tool::{FrameworkPackageArgs, IncludedArtifacts},
     CliCommand, CliResult,
 };
 use aptos_cached_packages::aptos_stdlib;
@@ -747,7 +747,6 @@ impl CompileScriptFunction {
         script_name: &str,
         prompt_options: PromptOptions,
     ) -> CliTypedResult<(Vec<u8>, HashValue)> {
-        set_bytecode_version(self.bytecode_version);
         if let Some(compiled_script_path) = &self.compiled_script_path {
             let bytes = std::fs::read(compiled_script_path).map_err(|e| {
                 CliError::IO(format!("Unable to read {:?}", self.compiled_script_path), e)


### PR DESCRIPTION
### Description
This should remove any more dependency on the environment variable.  Now, bytecode version should be passed in via CLI arguments for every command if it is different than the default.

### Test Plan

Environment variable is now ignored, but you can override with a command line arg:
```
VAR_BYTECODE_VERSION=5 ./target/debug/aptos move compile --package-dir /opt/git/aptos-checkers/move/tic-tac-toe --named-addresses deploy_account=0x22 
Compiling, may take a little while to download git dependencies...
UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING ExampleTicTacToe
{
  "Result": [
    "0000000000000000000000000000000000000000000000000000000000000022::tic_tac_toe"
  ]
}

```

Then with all the command line arg combinations.
```
$ ./target/debug/aptos move compile --package-dir /opt/git/aptos-checkers/move/tic-tac-toe --named-addresses deploy_account=0x22
Compiling, may take a little while to download git dependencies...
UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git

INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING ExampleTicTacToe
{
  "Result": [
    "0000000000000000000000000000000000000000000000000000000000000022::tic_tac_toe"
  ]
}

$ ./target/debug/aptos move compile --package-dir /opt/git/aptos-checkers/move/tic-tac-toe --named-addresses deploy_account=0x22 --bytecode-version 5
Compiling, may take a little while to download git dependencies...
UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING ExampleTicTacToe
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Loading or casting u16, u32, u256 integers not supported in bytecode version 5', /Users/greg/.cargo/git/checkouts/move-0639dd674f581c30/4bfe597/language/move-compiler/src/compiled_unit.rs:204:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

$ ./target/debug/aptos move compile --package-dir /opt/git/aptos-checkers/move/tic-tac-toe --named-addresses deploy_account=0x22                    
Compiling, may take a little while to download git dependencies...
UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING ExampleTicTacToe
{
  "Result": [
    "0000000000000000000000000000000000000000000000000000000000000022::tic_tac_toe"
  ]
}

$ ./target/debug/aptos move compile --package-dir /opt/git/aptos-checkers/move/tic-tac-toe --named-addresses deploy_account=0x22 --bytecode-version 6
Compiling, may take a little while to download git dependencies...
UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING ExampleTicTacToe
{
  "Result": [
    "0000000000000000000000000000000000000000000000000000000000000022::tic_tac_toe"
  ]
}

```
