### PR TITLE
[Dockerfile][Experimental] Caching improvements

### DIFF
--- a/.github/actions/docker-setup/action.yaml
+++ b/.github/actions/docker-setup/action.yaml
@@ -45,6 +45,17 @@ runs:
         version: v0.10.1
         custom-name: "core-builder"
         keep-state: true
+        config-inline: |
+          [worker.oci]
+            gc = true
+            gckeepstorage = 900000000000
+            [[worker.oci.gcpolicy]]
+              keepBytes = 700000000000
+              keepDuration = 604800
+              filters = [ "type==source.local", "type==exec.cachemount", "type==source.git.checkout"]
+            [[worker.oci.gcpolicy]]
+              all = true
+              keepBytes = 900000000000
 
     - uses: imjasonh/setup-crane@5146f708a817ea23476677995bf2133943b9be0b # pin@v0.1
 

--- a/.github/actions/docker-setup/action.yaml
+++ b/.github/actions/docker-setup/action.yaml
@@ -48,10 +48,10 @@ runs:
         config-inline: |
           [worker.oci]
             gc = true
-            gckeepstorage = 900000000000
+            gckeepstorage = 900000000000 # Use 900GB out of 1TB for builder storage
             [[worker.oci.gcpolicy]]
-              keepBytes = 700000000000
-              keepDuration = 604800
+              keepBytes = 700000000000 # Use 700GB out of 900GB for cache storage
+              keepDuration = 604800 # Keep cache for 7 days
               filters = [ "type==source.local", "type==exec.cachemount", "type==source.git.checkout"]
             [[worker.oci.gcpolicy]]
               all = true

--- a/docker/experimental/build-node.sh
+++ b/docker/experimental/build-node.sh
@@ -30,5 +30,5 @@ BINS=(
 mkdir dist
 
 for BIN in "${BINS[@]}"; do
-    cp $CARGO_TARGET_DIR/$BIN dist/$BIN
+    cp $CARGO_TARGET_DIR/$PROFILE/$BIN dist/$BIN
 done

--- a/docker/experimental/build-node.sh
+++ b/docker/experimental/build-node.sh
@@ -9,6 +9,7 @@ FEATURES=${FEATURES:-""}
 echo "Building aptos-node"
 echo "PROFILE: $PROFILE"
 echo "FEATURES: $FEATURES"
+echo "CARGO_TARGET_DIR: $CARGO_TARGET_DIR"
 
 # Build and overwrite the aptos-node binary with features if specified
 if [ -n "$FEATURES" ]; then
@@ -29,5 +30,5 @@ BINS=(
 mkdir dist
 
 for BIN in "${BINS[@]}"; do
-    cp target/$PROFILE/$BIN dist/$BIN
+    cp $CARGO_TARGET_DIR/$BIN dist/$BIN
 done

--- a/docker/experimental/build-tools.sh
+++ b/docker/experimental/build-tools.sh
@@ -5,8 +5,9 @@ set -e
 
 PROFILE=${PROFILE:-release}
 
-echo "Building all rust-based docker images"
+echo "Building tools and services docker images"
 echo "PROFILE: $PROFILE"
+echo "CARGO_TARGET_DIR: $CARGO_TARGET_DIR"
 
 # Build all the rust binaries
 cargo build --locked --profile=$PROFILE \
@@ -40,7 +41,7 @@ BINS=(
 mkdir dist
 
 for BIN in "${BINS[@]}"; do
-    cp target/$PROFILE/$BIN dist/$BIN
+    cp $CARGO_TARGET_DIR/$BIN dist/$BIN
 done
 
 # Build the Aptos Move framework and place it in dist. It can be found afterwards in the current directory.

--- a/docker/experimental/build-tools.sh
+++ b/docker/experimental/build-tools.sh
@@ -41,8 +41,9 @@ BINS=(
 mkdir dist
 
 for BIN in "${BINS[@]}"; do
-    cp $CARGO_TARGET_DIR/$BIN dist/$BIN
+    cp $CARGO_TARGET_DIR/$PROFILE/$BIN dist/$BIN
 done
 
 # Build the Aptos Move framework and place it in dist. It can be found afterwards in the current directory.
+echo "Building the Aptos Move framework..."
 (cd dist && cargo run --locked --profile=$PROFILE --package aptos-framework -- release)

--- a/docker/experimental/builder.Dockerfile
+++ b/docker/experimental/builder.Dockerfile
@@ -45,13 +45,15 @@ COPY --link . /aptos/
 FROM builder-base as aptos-node-builder
 
 RUN --mount=type=secret,id=git-credentials,target=/root/.git-credentials \
-    --mount=type=cache,target=/root/.cargo,id=node-cargo-cache \
+    --mount=type=cache,target=/usr/local/cargo/git,id=node-cargo-git-cache \
+    --mount=type=cache,target=/usr/local/cargo/registry,id=node-cargo-registry-cache \
     --mount=type=cache,target=/aptos/target,id=node-target-cache \
         docker/experimental/build-node.sh
 
 FROM builder-base as tools-builder
 
 RUN --mount=type=secret,id=git-credentials,target=/root/.git-credentials \
-    --mount=type=cache,target=/root/.cargo,id=tools-cargo-cache \
+    --mount=type=cache,target=/usr/local/cargo/git,id=tools-cargo-git-cache \
+    --mount=type=cache,target=/usr/local/cargo/registry,id=tools-cargo-registry-cache \
     --mount=type=cache,target=/aptos/target,id=tools-target-cache \
         docker/experimental/build-tools.sh

--- a/docker/experimental/builder.Dockerfile
+++ b/docker/experimental/builder.Dockerfile
@@ -41,12 +41,14 @@ RUN ARCHITECTURE=$(uname -m | sed -e "s/arm64/arm_64/g" | sed -e "s/aarch64/aarc
     && unzip -o "protoc-21.5-linux-$ARCHITECTURE.zip" -d /usr/local 'include/*' \
     && chmod +x "/usr/local/bin/protoc" \
     && rm "protoc-21.5-linux-$ARCHITECTURE.zip"
+RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git_credentials \
+        git config --global credential.helper store
 
 COPY --link . /aptos/
 
 FROM builder-base as aptos-node-builder
 
-RUN --mount=type=secret,id=node-builder-git-credentials,target=/root/.git-credentials \
+RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git-credentials \
     --mount=type=cache,target=/usr/local/cargo/git,id=node-builder-cargo-git-cache \
     --mount=type=cache,target=/usr/local/cargo/registry,id=node-builder-cargo-registry-cache \
     --mount=type=cache,target=/aptos/target,id=node-builder-target-cache \
@@ -54,7 +56,7 @@ RUN --mount=type=secret,id=node-builder-git-credentials,target=/root/.git-creden
 
 FROM builder-base as tools-builder
 
-RUN --mount=type=secret,id=tools-builder-git-credentials,target=/root/.git-credentials \
+RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git-credentials \
     --mount=type=cache,target=/usr/local/cargo/git,id=tools-builder-cargo-git-cache \
     --mount=type=cache,target=/usr/local/cargo/registry,id=tools-builder-cargo-registry-cache \
     --mount=type=cache,target=/aptos/target,id=tools-builder-target-cache \

--- a/docker/experimental/builder.Dockerfile
+++ b/docker/experimental/builder.Dockerfile
@@ -32,6 +32,8 @@ ARG PROFILE
 ENV PROFILE ${PROFILE}
 ARG FEATURES
 ENV FEATURES ${FEATURES}
+ARG CARGO_TARGET_DIR
+ENV CARGO_TARGET_DIR ${CARGO_TARGET_DIR}
 
 RUN ARCHITECTURE=$(uname -m | sed -e "s/arm64/arm_64/g" | sed -e "s/aarch64/aarch_64/g") \
     && curl -LOs "https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-$ARCHITECTURE.zip" \
@@ -44,16 +46,16 @@ COPY --link . /aptos/
 
 FROM builder-base as aptos-node-builder
 
-RUN --mount=type=secret,id=git-credentials,target=/root/.git-credentials \
-    --mount=type=cache,target=/usr/local/cargo/git,id=node-cargo-git-cache \
-    --mount=type=cache,target=/usr/local/cargo/registry,id=node-cargo-registry-cache \
-    --mount=type=cache,target=/aptos/target,id=node-target-cache \
+RUN --mount=type=secret,id=node-builder-git-credentials,target=/root/.git-credentials \
+    --mount=type=cache,target=/usr/local/cargo/git,id=node-builder-cargo-git-cache \
+    --mount=type=cache,target=/usr/local/cargo/registry,id=node-builder-cargo-registry-cache \
+    --mount=type=cache,target=/aptos/target,id=node-builder-target-cache \
         docker/experimental/build-node.sh
 
 FROM builder-base as tools-builder
 
-RUN --mount=type=secret,id=git-credentials,target=/root/.git-credentials \
-    --mount=type=cache,target=/usr/local/cargo/git,id=tools-cargo-git-cache \
-    --mount=type=cache,target=/usr/local/cargo/registry,id=tools-cargo-registry-cache \
-    --mount=type=cache,target=/aptos/target,id=tools-target-cache \
+RUN --mount=type=secret,id=tools-builder-git-credentials,target=/root/.git-credentials \
+    --mount=type=cache,target=/usr/local/cargo/git,id=tools-builder-cargo-git-cache \
+    --mount=type=cache,target=/usr/local/cargo/registry,id=tools-builder-cargo-registry-cache \
+    --mount=type=cache,target=/aptos/target,id=tools-builder-target-cache \
         docker/experimental/build-tools.sh

--- a/docker/experimental/docker-bake-rust-all.hcl
+++ b/docker/experimental/docker-bake-rust-all.hcl
@@ -16,6 +16,8 @@ variable "GIT_BRANCH" {}
 
 variable "GIT_TAG" {}
 
+variable "GIT_CREDENTIALS" {}
+
 variable "BUILT_VIA_BUILDKIT" {}
 
 variable "GCP_DOCKER_ARTIFACT_REPO" {}
@@ -75,6 +77,9 @@ target "builder-base" {
     CARGO_TARGET_DIR   = "${CARGO_TARGET_DIR}"
     BUILT_VIA_BUILDKIT = "true"
   }
+  secret = [
+    "id=GIT_CREDENTIALS"
+  ]
 }
 
 target "aptos-node-builder" {
@@ -83,6 +88,9 @@ target "aptos-node-builder" {
   contexts = {
     builder-base = "target:builder-base"
   }
+  secret = [
+    "id=GIT_CREDENTIALS"
+  ]
 }
 
 target "tools-builder" {
@@ -91,6 +99,9 @@ target "tools-builder" {
   contexts = {
     builder-base =  "target:builder-base"
   }
+  secret = [
+    "id=GIT_CREDENTIALS"
+  ]
 }
 
 target "_common" {

--- a/docker/experimental/docker-bake-rust-all.hcl
+++ b/docker/experimental/docker-bake-rust-all.hcl
@@ -35,6 +35,9 @@ variable "PROFILE" {
 variable "FEATURES" {
   // Cargo features to enable, as a comma separated string
 }
+variable "CARGO_TARGET_DIR" {
+  // Cargo target directory
+}
 
 group "all" {
   targets = flatten([
@@ -69,10 +72,7 @@ target "builder-base" {
   args = {
     PROFILE            = "${PROFILE}"
     FEATURES           = "${FEATURES}"
-    GIT_SHA            = "${GIT_SHA}"
-    GIT_BRANCH         = "${GIT_BRANCH}"
-    GIT_TAG            = "${GIT_TAG}"
-    BUILD_DATE         = "${BUILD_DATE}"
+    CARGO_TARGET_DIR   = "${CARGO_TARGET_DIR}"
     BUILT_VIA_BUILDKIT = "true"
   }
 }
@@ -83,15 +83,6 @@ target "aptos-node-builder" {
   contexts = {
     builder-base = "target:builder-base"
   }
-  args = {
-    PROFILE            = "${PROFILE}"
-    FEATURES           = "${FEATURES}"
-    GIT_SHA            = "${GIT_SHA}"
-    GIT_BRANCH         = "${GIT_BRANCH}"
-    GIT_TAG            = "${GIT_TAG}"
-    BUILD_DATE         = "${BUILD_DATE}"
-    BUILT_VIA_BUILDKIT = "true"
-  }
 }
 
 target "tools-builder" {
@@ -100,20 +91,13 @@ target "tools-builder" {
   contexts = {
     builder-base =  "target:builder-base"
   }
-  args = {
-    PROFILE            = "${PROFILE}"
-    GIT_SHA            = "${GIT_SHA}"
-    GIT_BRANCH         = "${GIT_BRANCH}"
-    GIT_TAG            = "${GIT_TAG}"
-    BUILD_DATE         = "${BUILD_DATE}"
-    BUILT_VIA_BUILDKIT = "true"
-  }
 }
 
 target "_common" {
   contexts = {
     debian-base = "target:debian-base"
-    builder = "target:tools-builder"
+    node-builder = "target:aptos-node-builder"
+    tools-builder = "target:tools-builder"
   }
   labels = {
     "org.label-schema.schema-version" = "1.0",
@@ -127,124 +111,79 @@ target "_common" {
     GIT_BRANCH         = "${GIT_BRANCH}"
     GIT_TAG            = "${GIT_TAG}"
     BUILD_DATE         = "${BUILD_DATE}"
-    BUILT_VIA_BUILDKIT = "true"
   }
 }
 
 target "validator-testing" {
+  inherits   = ["_common"]
   dockerfile = "docker/experimental/validator-testing.Dockerfile"
-  target = "validator-testing"
-
-  contexts = {
-    debian-base = "target:debian-base"
-    node-builder = "target:aptos-node-builder"
-    tools-builder = "target:tools-builder"
-  }
-  
-  labels = {
-    "org.label-schema.schema-version" = "1.0",
-    "org.label-schema.build-date"     = "${BUILD_DATE}"
-    "org.label-schema.git-sha"        = "${GIT_SHA}"
-  }
-  
-  args = {
-    PROFILE            = "${PROFILE}"
-    FEATURES           = "${FEATURES}"
-    GIT_SHA            = "${GIT_SHA}"
-    GIT_BRANCH         = "${GIT_BRANCH}"
-    GIT_TAG            = "${GIT_TAG}"
-    BUILD_DATE         = "${BUILD_DATE}"
-    BUILT_VIA_BUILDKIT = "true"
-  }
-
+  target     = "validator-testing"
   cache-from = generate_cache_from("validator-testing") 
-  cache-to = generate_cache_to("validator-testing")
-  tags     = generate_tags("validator-testing")
+  cache-to   = generate_cache_to("validator-testing")
+  tags       = generate_tags("validator-testing")
 }
 
 target "tools" {
-  inherits = ["_common"]
+  inherits   = ["_common"]
   dockerfile = "docker/experimental/tools.Dockerfile"
-  target   = "tools"
+  target     = "tools"
   cache-from = generate_cache_from("tools") 
-  cache-to = generate_cache_to("tools")
-  tags     = generate_tags("tools")
+  cache-to   = generate_cache_to("tools")
+  tags       = generate_tags("tools")
 }
 
 target "forge" {
-  inherits = ["_common"]
+  inherits   = ["_common"]
   dockerfile = "docker/experimental/forge.Dockerfile"
-  target   = "forge"
+  target     = "forge"
   cache-from = generate_cache_from("forge") 
-  cache-to = generate_cache_to("forge")
-  tags     = generate_tags("forge")
+  cache-to   = generate_cache_to("forge")
+  tags       = generate_tags("forge")
 }
 
 target "validator" {
+  inherits   = ["_common"]
   dockerfile = "docker/experimental/validator.Dockerfile"
-  target = "validator"
-
-  contexts = {
-    debian-base = "target:debian-base"
-    node-builder = "target:aptos-node-builder"
-    tools-builder = "target:tools-builder"
-  }
-  
-  labels = {
-    "org.label-schema.schema-version" = "1.0",
-    "org.label-schema.build-date"     = "${BUILD_DATE}"
-    "org.label-schema.git-sha"        = "${GIT_SHA}"
-  }
-  
-  args = {
-    PROFILE            = "${PROFILE}"
-    FEATURES           = "${FEATURES}"
-    GIT_SHA            = "${GIT_SHA}"
-    GIT_BRANCH         = "${GIT_BRANCH}"
-    GIT_TAG            = "${GIT_TAG}"
-    BUILD_DATE         = "${BUILD_DATE}"
-    BUILT_VIA_BUILDKIT = "true"
-  }
-
+  target     = "validator"
   cache-from = generate_cache_from("validator") 
-  cache-to = generate_cache_to("validator")
-  tags     = generate_tags("validator")
+  cache-to   = generate_cache_to("validator")
+  tags       = generate_tags("validator")
 }
 
 target "tools" {
-  inherits = ["_common"]
+  inherits   = ["_common"]
   dockerfile = "docker/experimental/tools.Dockerfile"
-  target   = "tools"
+  target     = "tools"
   cache-from = generate_cache_from("tools") 
-  cache-to = generate_cache_to("tools")
-  tags     = generate_tags("tools")
+  cache-to   = generate_cache_to("tools")
+  tags       = generate_tags("tools")
 }
 
 target "node-checker" {
-  inherits = ["_common"]
+  inherits   = ["_common"]
   dockerfile = "docker/experimental/node-checker.Dockerfile"
-  target   = "node-checker"
+  target     = "node-checker"
   cache-from = generate_cache_from("node-checker") 
-  cache-to = generate_cache_to("node-checker")
-  tags     = generate_tags("node-checker")
+  cache-to   = generate_cache_to("node-checker")
+  tags       = generate_tags("node-checker")
 }
 
 target "faucet" {
-  inherits = ["_common"]
+  inherits   = ["_common"]
   dockerfile = "docker/experimental/faucet.Dockerfile"
-  target   = "faucet"
+  target     = "faucet"
   cache-from = generate_cache_from("faucet") 
-  cache-to = generate_cache_to("faucet")  
-  tags     = generate_tags("faucet")
+  cache-to   = generate_cache_to("faucet")  
+  tags       = generate_tags("faucet")
 }
 
 target "telemetry-service" {
-  inherits = ["_common"]
+  inherits   = ["_common"]
   dockerfile = "docker/experimental/telemetry-service.Dockerfile"
-  target   = "telemetry-service"
+  target     = "telemetry-service"
   cache-from = generate_cache_from("telemetry-service") 
-  cache-to = generate_cache_to("telemetry-service")  
-  tags     = generate_tags("telemetry-service")  
+  cache-to   = generate_cache_to("telemetry-service")  
+  tags       = generate_tags("telemetry-service")  
 }
 
 function "generate_cache_from" {

--- a/docker/experimental/docker-bake-rust-all.sh
+++ b/docker/experimental/docker-bake-rust-all.sh
@@ -49,7 +49,7 @@ BUILD_TARGET="${1:-forge-images}"
 if [ "$CI" == "true" ]; then
   TARGET_REGISTRY=remote docker buildx bake --progress=plain --file docker/experimental/docker-bake-rust-all.hcl --push $BUILD_TARGET
 else
-  TARGET_REGISTRY=local docker buildx bake --file docker/experimental/docker-bake-rust-all.hcl $BUILD_TARGET --progress=plain 
+  TARGET_REGISTRY=local docker buildx bake --file docker/experimental/docker-bake-rust-all.hcl $BUILD_TARGET 
 fi
 
 echo "Build complete. Docker buildx cache usage:"

--- a/docker/experimental/docker-bake-rust-all.sh
+++ b/docker/experimental/docker-bake-rust-all.sh
@@ -23,6 +23,7 @@ export PROFILE=${PROFILE:-release}
 export FEATURES=${FEATURES:-""}
 export NORMALIZED_FEATURES_LIST=$(printf "$FEATURES" | sed -e 's/[^a-zA-Z0-9]/_/g')
 export CUSTOM_IMAGE_TAG_PREFIX=${CUSTOM_IMAGE_TAG_PREFIX:-""}
+export CARGO_TARGET_DIR="target/${FEATURES:-"default"}"
 
 if [ "$PROFILE" = "release" ]; then
   # Do not prefix image tags if we're building the default profile "release"
@@ -48,5 +49,8 @@ BUILD_TARGET="${1:-forge-images}"
 if [ "$CI" == "true" ]; then
   TARGET_REGISTRY=remote docker buildx bake --progress=plain --file docker/experimental/docker-bake-rust-all.hcl --push $BUILD_TARGET
 else
-  TARGET_REGISTRY=local docker buildx bake --file docker/experimental/docker-bake-rust-all.hcl $BUILD_TARGET --load
+  TARGET_REGISTRY=local docker buildx bake --file docker/experimental/docker-bake-rust-all.hcl $BUILD_TARGET --progress=plain 
 fi
+
+echo "Build complete. Docker buildx cache usage:"
+docker buildx du --verbose --filter type=exec.cachemount

--- a/docker/experimental/faucet.Dockerfile
+++ b/docker/experimental/faucet.Dockerfile
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 RUN mkdir -p /aptos/client/data/wallet/
 
-COPY --link --from=builder /aptos/dist/aptos-faucet-service /usr/local/bin/aptos-faucet-service
+COPY --link --from=tools-builder /aptos/dist/aptos-faucet-service /usr/local/bin/aptos-faucet-service
 
 # Mint proxy listening address
 EXPOSE 8000

--- a/docker/experimental/forge.Dockerfile
+++ b/docker/experimental/forge.Dockerfile
@@ -17,15 +17,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 RUN mkdir /aptos
 
 # copy helm charts from source
-COPY --link --from=builder /aptos/terraform/helm /aptos/terraform/helm
-COPY --link --from=builder /aptos/testsuite/forge/src/backend/k8s/helm-values/aptos-node-default-values.yaml /aptos/terraform/aptos-node-default-values.yaml
+COPY --link --from=tools-builder /aptos/terraform/helm /aptos/terraform/helm
+COPY --link --from=tools-builder /aptos/testsuite/forge/src/backend/k8s/helm-values/aptos-node-default-values.yaml /aptos/terraform/aptos-node-default-values.yaml
 
 RUN cd /usr/local/bin && wget "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl" -O kubectl && chmod +x kubectl
 RUN cd /usr/local/bin && wget "https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz" -O- | busybox tar -zxvf - && mv linux-amd64/helm . && chmod +x helm
 ENV PATH "$PATH:/root/bin"
 
 WORKDIR /aptos
-COPY --link --from=builder /aptos/dist/forge /usr/local/bin/forge
+COPY --link --from=tools-builder /aptos/dist/forge /usr/local/bin/forge
 ENV RUST_LOG_FORMAT=json
 
 # add build info

--- a/docker/experimental/forge.Dockerfile
+++ b/docker/experimental/forge.Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         unzip \
         awscli 
 
-RUN mkdir /aptos
+WORKDIR /aptos
 
 # copy helm charts from source
 COPY --link --from=tools-builder /aptos/terraform/helm /aptos/terraform/helm

--- a/docker/experimental/node-checker.Dockerfile
+++ b/docker/experimental/node-checker.Dockerfile
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         netcat \
         libpq-dev
 
-COPY  --link --from=builder /aptos/dist/aptos-node-checker /usr/local/bin/aptos-node-checker
+COPY  --link --from=tools-builder /aptos/dist/aptos-node-checker /usr/local/bin/aptos-node-checker
 
 ENV RUST_LOG_FORMAT=json
 

--- a/docker/experimental/telemetry-service.Dockerfile
+++ b/docker/experimental/telemetry-service.Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libpq-dev \
         curl
 
-COPY --link --from=builder /aptos/dist/aptos-telemetry-service /usr/local/bin/aptos-telemetry-service
+COPY --link --from=tools-builder /aptos/dist/aptos-telemetry-service /usr/local/bin/aptos-telemetry-service
 
 EXPOSE 8000
 ENV RUST_LOG_FORMAT=json

--- a/docker/experimental/tools.Dockerfile
+++ b/docker/experimental/tools.Dockerfile
@@ -22,16 +22,16 @@ COPY --link docker/tools/boto.cfg /etc/boto.cfg
 RUN wget https://storage.googleapis.com/pub/gsutil.tar.gz -O- | tar --gzip --directory /opt --extract && ln -s /opt/gsutil/gsutil /usr/local/bin
 RUN cd /usr/local/bin && wget "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl" -O kubectl && chmod +x kubectl
 
-COPY --link --from=builder /aptos/dist/aptos-db-bootstrapper /usr/local/bin/aptos-db-bootstrapper
-COPY --link --from=builder /aptos/dist/aptos-db-tool /usr/local/bin/aptos-db-tool
-COPY --link --from=builder /aptos/dist/aptos /usr/local/bin/aptos
-COPY --link --from=builder /aptos/dist/aptos-openapi-spec-generator /usr/local/bin/aptos-openapi-spec-generator
-COPY --link --from=builder /aptos/dist/aptos-fn-check-client /usr/local/bin/aptos-fn-check-client
-COPY --link --from=builder /aptos/dist/aptos-transaction-emitter /usr/local/bin/aptos-transaction-emitter
+COPY --link --from=tools-builder /aptos/dist/aptos-db-bootstrapper /usr/local/bin/aptos-db-bootstrapper
+COPY --link --from=tools-builder /aptos/dist/aptos-db-tool /usr/local/bin/aptos-db-tool
+COPY --link --from=tools-builder /aptos/dist/aptos /usr/local/bin/aptos
+COPY --link --from=tools-builder /aptos/dist/aptos-openapi-spec-generator /usr/local/bin/aptos-openapi-spec-generator
+COPY --link --from=tools-builder /aptos/dist/aptos-fn-check-client /usr/local/bin/aptos-fn-check-client
+COPY --link --from=tools-builder /aptos/dist/aptos-transaction-emitter /usr/local/bin/aptos-transaction-emitter
 
 ### Get Aptos Move releases for genesis ceremony
 RUN mkdir -p /aptos-framework/move
-COPY --link --from=builder /aptos/dist/head.mrb /aptos-framework/move/head.mrb
+COPY --link --from=tools-builder /aptos/dist/head.mrb /aptos-framework/move/head.mrb
 
 # add build info
 ARG BUILD_DATE


### PR DESCRIPTION
### Description

This PR makes some caching improvements to the experimental builder.
- Fixes the cache location for `CARGO_HOME`, which is located at `/usr/local/cargo` in the Rust Docker image. We want to cache only the registry and git directories. 
- Uses separate `CARGO_TAGET_DIR`s for different features/profiles to make caching more effective when building different images in parallel using the same builder pool.
- Increases the buildx buildkit GC config to use up to 900GB of storage (assuming 1TB of disk, currently provided by the experimental docker builder node pool)
- Mount GIT_CREDENTIALS as secret instead of copying it over into the image.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Latest build ran in ~13 mins.
