### PR TITLE
[Indexer] Avoid panics running old indexer and new grpc indexer 

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/counters.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/counters.rs
@@ -4,10 +4,10 @@
 use aptos_metrics_core::{register_int_counter, IntCounter};
 use once_cell::sync::Lazy;
 
-pub static TRANSACTIONS_SENT: Lazy<IntCounter> = Lazy::new(|| {
+pub static TRANSACTIONS_STREAMED: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
-        "aptos_grpc_stream_transactions_sent_count",
-        "Transactions converted and printed out to stdout, picked up by the StreamingFast Firehose indexer",
+        "indexer_grpc_transactions_streamed_count",
+        "Transaction streamed via GRPC",
     )
     .unwrap()
 });
@@ -15,8 +15,8 @@ pub static TRANSACTIONS_SENT: Lazy<IntCounter> = Lazy::new(|| {
 /// Number of times the indexer has been unable to fetch a transaction. Ideally zero.
 pub static UNABLE_TO_FETCH_TRANSACTION: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
-        "indexer_unable_to_fetch_transaction_count",
-        "Number of times the indexer has been unable to fetch a transaction"
+        "indexer_grpc_unable_to_fetch_transaction_count",
+        "Number of times the indexer has been unable to fetch a transaction from storage"
     )
     .unwrap()
 });
@@ -24,8 +24,8 @@ pub static UNABLE_TO_FETCH_TRANSACTION: Lazy<IntCounter> = Lazy::new(|| {
 /// Number of times the indexer has been able to fetch a transaction
 pub static FETCHED_TRANSACTION: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
-        "indexer_fetched_transaction_count",
-        "Number of times the indexer has been able to fetch a transaction"
+        "indexer_grpc_fetched_transaction_count",
+        "Number of times the indexer has been able to fetch a transaction from storage"
     )
     .unwrap()
 });


### PR DESCRIPTION

### Description
Thanks @levicook for calling out the interesting issue here. Basically we're using the same counter names for old and new indexer (grpc) and if run at the same time they will lead to naming collision. This PR fixes that. 
https://gist.github.com/levicook/cf365cb89def0c6d9633c31cddaf7f31

<img width="669" alt="image" src="https://user-images.githubusercontent.com/11738325/224412164-5b89a4ff-33ea-4938-97be-51d3ea7b8c3f.png">


### Test Plan
Error doesn't happen anymore when running
```
grpcurl  -max-msg-sz 10000000  -d '{ "starting_version": 0 }' -import-path crates/aptos-protos/proto -proto aptos/datastream/v1/datastream.proto  -plaintext localhost:50051 aptos.datastream.v1.IndexerStream/RawDatastream
```
