### PR TITLE
[TS SDK] Add indexer ledger info query

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 
 - `CoinClient` and `TokenClient` to use remote ABI instead of local ABIs
 - Reorganize SDK files structure for a better readability and maintainability
+- Add `getIndexerLedgerInfo` query to `IndexerClient`
 
 ## 1.7.1 (2023-03-02)
 

--- a/ecosystem/typescript/sdk/src/indexer/generated/operations.ts
+++ b/ecosystem/typescript/sdk/src/indexer/generated/operations.ts
@@ -13,6 +13,11 @@ export type TokenDataFieldsFragment = { __typename?: 'current_token_datas', crea
 
 export type CollectionDataFieldsFragment = { __typename?: 'current_collection_datas', metadata_uri: string, supply: any, description: string, collection_name: string, collection_data_id_hash: string, table_handle: string, creator_address: string };
 
+export type GetIndexerLedgerInfoQueryVariables = Types.Exact<{ [key: string]: never; }>;
+
+
+export type GetIndexerLedgerInfoQuery = { __typename?: 'query_root', ledger_infos: Array<{ __typename?: 'ledger_infos', chain_id: any }> };
+
 export type GetTokenActivitiesQueryVariables = Types.Exact<{
   idHash: Types.Scalars['String'];
 }>;

--- a/ecosystem/typescript/sdk/src/indexer/generated/queries.ts
+++ b/ecosystem/typescript/sdk/src/indexer/generated/queries.ts
@@ -45,6 +45,13 @@ export const GetAccountCurrentTokens = `
 }
     ${TokenDataFieldsFragmentDoc}
 ${CollectionDataFieldsFragmentDoc}`;
+export const GetIndexerLedgerInfo = `
+    query getIndexerLedgerInfo {
+  ledger_infos {
+    chain_id
+  }
+}
+    `;
 export const GetTokenActivities = `
     query getTokenActivities($idHash: String!) {
   token_activities(where: {token_data_id_hash: {_eq: $idHash}}) {
@@ -74,6 +81,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
   return {
     getAccountCurrentTokens(variables: Types.GetAccountCurrentTokensQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Types.GetAccountCurrentTokensQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<Types.GetAccountCurrentTokensQuery>(GetAccountCurrentTokens, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getAccountCurrentTokens', 'query');
+    },
+    getIndexerLedgerInfo(variables?: Types.GetIndexerLedgerInfoQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Types.GetIndexerLedgerInfoQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<Types.GetIndexerLedgerInfoQuery>(GetIndexerLedgerInfo, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getIndexerLedgerInfo', 'query');
     },
     getTokenActivities(variables: Types.GetTokenActivitiesQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Types.GetTokenActivitiesQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<Types.GetTokenActivitiesQuery>(GetTokenActivities, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getTokenActivities', 'query');

--- a/ecosystem/typescript/sdk/src/indexer/queries/getLedgerInfo.graphql
+++ b/ecosystem/typescript/sdk/src/indexer/queries/getLedgerInfo.graphql
@@ -1,0 +1,5 @@
+query getIndexerLedgerInfo {
+  ledger_infos {
+    chain_id
+  }
+}

--- a/ecosystem/typescript/sdk/src/providers/indexer.ts
+++ b/ecosystem/typescript/sdk/src/providers/indexer.ts
@@ -2,8 +2,12 @@ import axios from "axios";
 
 import { AnyNumber } from "../bcs/types";
 import { MaybeHexString } from "../utils";
-import { GetAccountCurrentTokensQuery, GetTokenActivitiesQuery } from "../indexer/generated/operations";
-import { GetAccountCurrentTokens, GetTokenActivities } from "../indexer/generated/queries";
+import {
+  GetAccountCurrentTokensQuery,
+  GetIndexerLedgerInfoQuery,
+  GetTokenActivitiesQuery,
+} from "../indexer/generated/operations";
+import { GetAccountCurrentTokens, GetIndexerLedgerInfo, GetTokenActivities } from "../indexer/generated/queries";
 
 interface PaginationArgs {
   offset?: AnyNumber;
@@ -40,6 +44,18 @@ export class IndexerClient {
       throw new Error(`Indexer data error ${JSON.stringify(data.errors, null, " ")}`);
     }
     return data.data;
+  }
+
+  /**
+   * Queries Indexer Ledger Info
+   *
+   * @returns GetLedgerInfoQuery response type
+   */
+  async getIndexerLedgerInfo(): Promise<GetIndexerLedgerInfoQuery> {
+    const graphqlQuery = {
+      query: GetIndexerLedgerInfo,
+    };
+    return this.queryIndexer(graphqlQuery);
   }
 
   /**

--- a/ecosystem/typescript/sdk/src/tests/e2e/indexer.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/indexer.test.ts
@@ -77,5 +77,10 @@ describe("Indexer", () => {
       },
       longTestTimeout,
     );
+
+    test("gets indexer ledger info", async () => {
+      const ledgerInfo = await indexerClient.getIndexerLedgerInfo();
+      expect(ledgerInfo.ledger_infos[0].chain_id).toBeGreaterThan(1);
+    });
   });
 });


### PR DESCRIPTION
### Description
We rely on indexer devnet and fullnode devnet to be in sync when running tests - in some cases they are not yet updated and tests are failing.

This PR is a part 1 of fixing the problem by adding `getIndexerLedgerInfo` query to `IndexerClient`.

In a second PR (and after releasing a new sdk version) we would use this query to check indexer devnet chainId with fullnode chainId and make sure they are synced before running tests.

### Test Plan
tests are passing
