### PR TITLE
[Quorum Store] fix backpressure only checking on commits

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 #[serde(default, deny_unknown_fields)]
 pub struct QuorumStoreBackPressureConfig {
     pub backlog_txn_limit_count: u64,
-    pub backlog_batch_limit_count: u64,
+    pub backlog_per_validator_batch_limit_count: u64,
     pub decrease_duration_ms: u64,
     pub increase_duration_ms: u64,
     pub decrease_fraction: f64,
@@ -22,8 +22,8 @@ impl Default for QuorumStoreBackPressureConfig {
         QuorumStoreBackPressureConfig {
             // QS will be backpressured if the remaining total txns is more than this number
             backlog_txn_limit_count: MAX_SENDING_BLOCK_TXNS_QUORUM_STORE_OVERRIDE * 4,
-            // QS will create batches immediately until this number is reached
-            backlog_batch_limit_count: 80,
+            // QS will create batches at the max rate until this number is reached
+            backlog_per_validator_batch_limit_count: 4,
             decrease_duration_ms: 1000,
             increase_duration_ms: 1000,
             decrease_fraction: 0.5,
@@ -40,6 +40,7 @@ pub struct QuorumStoreConfig {
     pub proof_timeout_ms: usize,
     pub batch_request_num_peers: usize,
     pub batch_generation_poll_interval_ms: usize,
+    pub batch_generation_min_non_empty_interval_ms: usize,
     pub batch_generation_max_interval_ms: usize,
     pub end_batch_ms: u64,
     pub max_batch_bytes: usize,
@@ -68,6 +69,7 @@ impl Default for QuorumStoreConfig {
             proof_timeout_ms: 10000,
             batch_request_num_peers: 2,
             batch_generation_poll_interval_ms: 25,
+            batch_generation_min_non_empty_interval_ms: 100,
             batch_generation_max_interval_ms: 250,
             // TODO: This essentially turns fragments off, because there was performance degradation. Needs more investigation.
             end_batch_ms: 10,

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -644,6 +644,7 @@ impl EpochManager {
             QuorumStoreBuilder::QuorumStore(InnerBuilder::new(
                 self.epoch(),
                 self.author,
+                epoch_state.verifier.len() as u64,
                 self.config.quorum_store_configs.clone(),
                 consensus_to_quorum_store_rx,
                 self.quorum_store_to_mempool_sender.clone(),

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -54,12 +54,18 @@ impl ProofManager {
         proof: ProofOfStore,
         network_sender: &mut NetworkSender,
     ) {
+        let num_txns = proof.info().num_txns;
         self.proofs_for_consensus.push(proof.clone(), true);
+        self.remaining_total_txn_num += num_txns;
+        self.remaining_total_proof_num += 1;
         network_sender.broadcast_proof_of_store(proof).await;
     }
 
     pub(crate) fn handle_remote_proof(&mut self, proof: ProofOfStore) {
+        let num_txns = proof.info().num_txns;
         self.proofs_for_consensus.push(proof, false);
+        self.remaining_total_txn_num += num_txns;
+        self.remaining_total_proof_num += 1;
     }
 
     pub(crate) fn handle_commit_notification(
@@ -197,14 +203,14 @@ impl ProofManager {
                                 self.proofs_for_consensus.num_total_txns_and_proofs(logical_time);
                             // TODO: keeping here for metrics, might be part of the backpressure in the future?
                             self.proofs_for_consensus.clean_local_proofs(logical_time);
-                            let updated_back_pressure = self.qs_back_pressure();
-                            if updated_back_pressure != back_pressure {
-                                back_pressure = updated_back_pressure;
-                                if back_pressure_tx.send(back_pressure).await.is_err() {
-                                    debug!("Failed to send back_pressure for commit notification");
-                                }
-                            }
                         },
+                    }
+                    let updated_back_pressure = self.qs_back_pressure();
+                    if updated_back_pressure != back_pressure {
+                        back_pressure = updated_back_pressure;
+                        if back_pressure_tx.send(back_pressure).await.is_err() {
+                            debug!("Failed to send back_pressure for commit notification");
+                        }
                     }
                 },
             }

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -49,6 +49,12 @@ impl ProofManager {
         }
     }
 
+    #[inline]
+    fn increment_remaining_txns(&mut self, num_txns: u64) {
+        self.remaining_total_txn_num += num_txns;
+        self.remaining_total_proof_num += 1;
+    }
+
     pub(crate) async fn handle_local_proof(
         &mut self,
         proof: ProofOfStore,
@@ -56,16 +62,14 @@ impl ProofManager {
     ) {
         let num_txns = proof.info().num_txns;
         self.proofs_for_consensus.push(proof.clone(), true);
-        self.remaining_total_txn_num += num_txns;
-        self.remaining_total_proof_num += 1;
+        self.increment_remaining_txns(num_txns);
         network_sender.broadcast_proof_of_store(proof).await;
     }
 
     pub(crate) fn handle_remote_proof(&mut self, proof: ProofOfStore) {
         let num_txns = proof.info().num_txns;
         self.proofs_for_consensus.push(proof, false);
-        self.remaining_total_txn_num += num_txns;
-        self.remaining_total_proof_num += 1;
+        self.increment_remaining_txns(num_txns);
     }
 
     pub(crate) fn handle_commit_notification(

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -115,6 +115,7 @@ impl DirectMempoolInnerBuilder {
 pub struct InnerBuilder {
     epoch: u64,
     author: Author,
+    num_validators: u64,
     config: QuorumStoreConfig,
     consensus_to_quorum_store_receiver: Receiver<GetPayloadCommand>,
     quorum_store_to_mempool_sender: Sender<QuorumStoreRequest>,
@@ -147,6 +148,7 @@ impl InnerBuilder {
     pub(crate) fn new(
         epoch: u64,
         author: Author,
+        num_validators: u64,
         config: QuorumStoreConfig,
         consensus_to_quorum_store_receiver: Receiver<GetPayloadCommand>,
         quorum_store_to_mempool_sender: Sender<QuorumStoreRequest>,
@@ -185,6 +187,7 @@ impl InnerBuilder {
         Self {
             epoch,
             author,
+            num_validators,
             config,
             consensus_to_quorum_store_receiver,
             quorum_store_to_mempool_sender,
@@ -355,7 +358,10 @@ impl InnerBuilder {
         let proof_manager = ProofManager::new(
             self.epoch,
             self.config.back_pressure.backlog_txn_limit_count,
-            self.config.back_pressure.backlog_batch_limit_count,
+            self.config
+                .back_pressure
+                .backlog_per_validator_batch_limit_count
+                * self.num_validators,
         );
         spawn_named!(
             "proof_manager",


### PR DESCRIPTION
### Description

In consensus-only tests, we saw large gaps where backpressure seemed "stuck". This was because we only checked the numbers after commit, and if commit is delayed then the numbers didn't get updated at all. This PR now increments when proofs are received. It can be an overestimate until the actual cleaning takes place.

In addition
* Make the minimum time between pulls that had transactions 100 ms. 25 ms pulls seem unsustainable, even if there is no other load in the network.
* Change the config for proof-based backpressure so it is a multiple of number of validators. This makes the config more portable between networks.

### Test Plan

Re-run consensus only tests where we saw issues.
