### PR TITLE
oops, these flags should be disabled for now

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -16,7 +16,6 @@ feature_flags:
     - resource_groups
     - multisig_accounts
     - delegation_pools
-    - bls12381_basic_operations
   disabled: []
 is_multi_step: true
 framework_release_at_end: true

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -419,7 +419,6 @@ pub fn default_features() -> Vec<FeatureFlag> {
         FeatureFlag::RESOURCE_GROUPS,
         FeatureFlag::MULTISIG_ACCOUNTS,
         FeatureFlag::DELEGATION_POOLS,
-        FeatureFlag::BLS12381_BASIC_OPERATIONS,
     ]
 }
 


### PR DESCRIPTION
### Description

Disables the feature flags that were not supposed to be enabled in https://github.com/aptos-labs/aptos-core/pull/7015.

The flags will be enabled during the release process.

@thepomeranian and @perryjrandall, for visibility.