### PR TITLE
[consensus] dispatch verify message into executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,6 +544,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
+ "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
  "aptos-consensus-notifications",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-bitvec = { workspace = true }
+aptos-bounded-executor = { workspace = true }
 aptos-channels = { workspace = true }
 aptos-config = { workspace = true }
 aptos-consensus-notifications = { workspace = true }

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -13,6 +13,7 @@ use crate::{
     txn_notifier::MempoolNotifier,
     util::time_service::ClockTimeService,
 };
+use aptos_bounded_executor::BoundedExecutor;
 use aptos_config::config::NodeConfig;
 use aptos_consensus_notifications::ConsensusNotificationSender;
 use aptos_event_notifications::ReconfigNotificationListener;
@@ -60,6 +61,7 @@ pub fn start_consensus(
     let (self_sender, self_receiver) = aptos_channels::new(1_024, &counters::PENDING_SELF_MESSAGES);
 
     let consensus_network_client = ConsensusNetworkClient::new(network_client);
+    let bounded_executor = BoundedExecutor::new(4, runtime.handle().clone());
     let epoch_mgr = EpochManager::new(
         node_config,
         time_service,
@@ -71,6 +73,7 @@ pub fn start_consensus(
         storage,
         quorum_store_db,
         reconfig_events,
+        bounded_executor,
     );
 
     let (network_task, network_receiver) = NetworkTask::new(network_service_events, self_receiver);

--- a/consensus/src/experimental/tests/buffer_manager_tests.rs
+++ b/consensus/src/experimental/tests/buffer_manager_tests.rs
@@ -224,7 +224,10 @@ async fn loopback_commit_vote(
                 let event: UnverifiedEvent = msg.into();
                 // verify the message and send the message into self loop
                 msg_tx
-                    .push(author, event.verify(author, verifier, false).unwrap())
+                    .push(
+                        author,
+                        event.verify(author, verifier, false, false).unwrap(),
+                    )
                     .ok();
             }
         },

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -104,6 +104,10 @@ impl NetworkPlayground {
         }
     }
 
+    pub fn handle(&self) -> Handle {
+        self.executor.clone()
+    }
+
     /// HashMap of supported protocols to initialize ConsensusNetworkClient.
     pub fn peer_protocols(&self) -> Arc<PeersAndMetadata> {
         self.peers_and_metadata.clone()

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -81,37 +81,52 @@ impl UnverifiedEvent {
         peer_id: PeerId,
         validator: &ValidatorVerifier,
         quorum_store_enabled: bool,
+        self_message: bool,
     ) -> Result<VerifiedEvent, VerifyError> {
         Ok(match self {
             //TODO: no need to sign and verify the proposal
             UnverifiedEvent::ProposalMsg(p) => {
-                p.verify(validator, quorum_store_enabled)?;
+                if !self_message {
+                    p.verify(validator, quorum_store_enabled)?;
+                }
                 VerifiedEvent::ProposalMsg(p)
             },
             UnverifiedEvent::VoteMsg(v) => {
-                v.verify(validator)?;
+                if !self_message {
+                    v.verify(validator)?;
+                }
                 VerifiedEvent::VoteMsg(v)
             },
             // sync info verification is on-demand (verified when it's used)
             UnverifiedEvent::SyncInfo(s) => VerifiedEvent::UnverifiedSyncInfo(s),
             UnverifiedEvent::CommitVote(cv) => {
-                cv.verify(validator)?;
+                if !self_message {
+                    cv.verify(validator)?;
+                }
                 VerifiedEvent::CommitVote(cv)
             },
             UnverifiedEvent::CommitDecision(cd) => {
-                cd.verify(validator)?;
+                if !self_message {
+                    cd.verify(validator)?;
+                }
                 VerifiedEvent::CommitDecision(cd)
             },
             UnverifiedEvent::FragmentMsg(f) => {
-                f.verify(peer_id)?;
+                if !self_message {
+                    f.verify(peer_id)?;
+                }
                 VerifiedEvent::FragmentMsg(f)
             },
             UnverifiedEvent::SignedDigestMsg(sd) => {
-                sd.verify(validator)?;
+                if !self_message {
+                    sd.verify(validator)?;
+                }
                 VerifiedEvent::SignedDigestMsg(sd)
             },
             UnverifiedEvent::ProofOfStoreMsg(p) => {
-                p.verify(validator)?;
+                if !self_message {
+                    p.verify(validator)?;
+                }
                 VerifiedEvent::ProofOfStoreMsg(p)
             },
         })

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -14,6 +14,7 @@ use crate::{
     test_utils::{MockStateComputer, MockStorage},
     util::time_service::ClockTimeService,
 };
+use aptos_bounded_executor::BoundedExecutor;
 use aptos_channels::{self, aptos_channel, message_queues::QueueStyle};
 use aptos_config::{
     config::{NodeConfig, WaypointConfig},
@@ -138,6 +139,7 @@ impl SMRNode {
             aptos_channels::new(1_024, &counters::PENDING_SELF_MESSAGES);
 
         let quorum_store_storage = Arc::new(MockQuorumStoreDB::new());
+        let bounded_executor = BoundedExecutor::new(2, playground.handle());
 
         let epoch_mgr = EpochManager::new(
             &config,
@@ -150,6 +152,7 @@ impl SMRNode {
             storage.clone(),
             quorum_store_storage,
             reconfig_listener,
+            bounded_executor,
         );
         let (network_task, network_receiver) =
             NetworkTask::new(network_service_events, self_receiver);

--- a/crates/channel/src/aptos_channel.rs
+++ b/crates/channel/src/aptos_channel.rs
@@ -11,7 +11,6 @@
 use crate::message_queues::{PerKeyQueue, QueueStyle};
 use anyhow::{ensure, Result};
 use aptos_infallible::{Mutex, NonZeroUsize};
-use aptos_logger::debug;
 use aptos_metrics_core::IntCounterVec;
 use futures::{
     channel::oneshot,
@@ -105,7 +104,6 @@ impl<K: Eq + Hash + Clone, M> Sender<K, M> {
         // notify the corresponding status channel if it was registered.
         if let Some((dropped_val, Some(dropped_status_ch))) = dropped {
             // Ignore errors.
-            debug!("QS: dropped message in aptos channel");
             let _err = dropped_status_ch.send(ElementStatus::Dropped(dropped_val));
         }
         if let Some(w) = shared_state.waker.take() {


### PR DESCRIPTION
Dispatch message verification to multi threaded executor to avoid choking epoch manager since after quorum store we have many more messages flooding in.

Tested in https://github.com/aptos-labs/aptos-core/pull/7045 which wired self messages through network layer too, before the change it causes perf regression, after the change it looks good