### PR TITLE
Add fixed point 64

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/fixed_point64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/fixed_point64.md
@@ -1,0 +1,883 @@
+
+<a name="0x1_fixed_point64"></a>
+
+# Module `0x1::fixed_point64`
+
+Defines a fixed-point numeric type with a 64-bit integer part and
+a 64-bit fractional part.
+
+
+-  [Struct `FixedPoint64`](#0x1_fixed_point64_FixedPoint64)
+-  [Constants](#@Constants_0)
+-  [Function `multiply_u128`](#0x1_fixed_point64_multiply_u128)
+-  [Function `divide_u128`](#0x1_fixed_point64_divide_u128)
+-  [Function `create_from_rational`](#0x1_fixed_point64_create_from_rational)
+-  [Function `create_from_raw_value`](#0x1_fixed_point64_create_from_raw_value)
+-  [Function `get_raw_value`](#0x1_fixed_point64_get_raw_value)
+-  [Function `is_zero`](#0x1_fixed_point64_is_zero)
+-  [Function `min`](#0x1_fixed_point64_min)
+-  [Function `max`](#0x1_fixed_point64_max)
+-  [Function `create_from_u128`](#0x1_fixed_point64_create_from_u128)
+-  [Function `floor`](#0x1_fixed_point64_floor)
+-  [Function `ceil`](#0x1_fixed_point64_ceil)
+-  [Function `round`](#0x1_fixed_point64_round)
+-  [Specification](#@Specification_1)
+    -  [Function `multiply_u128`](#@Specification_1_multiply_u128)
+    -  [Function `divide_u128`](#@Specification_1_divide_u128)
+    -  [Function `create_from_rational`](#@Specification_1_create_from_rational)
+    -  [Function `create_from_raw_value`](#@Specification_1_create_from_raw_value)
+    -  [Function `min`](#@Specification_1_min)
+    -  [Function `max`](#@Specification_1_max)
+    -  [Function `create_from_u128`](#@Specification_1_create_from_u128)
+    -  [Function `floor`](#@Specification_1_floor)
+    -  [Function `ceil`](#@Specification_1_ceil)
+    -  [Function `round`](#@Specification_1_round)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="0x1_fixed_point64_FixedPoint64"></a>
+
+## Struct `FixedPoint64`
+
+Define a fixed-point numeric type with 64 fractional bits.
+This is just a u128 integer but it is wrapped in a struct to
+make a unique type. This is a binary representation, so decimal
+values may not be exactly representable, but it provides more
+than 9 decimal digits of precision both before and after the
+decimal point (18 digits total). For comparison, double precision
+floating-point has less than 16 decimal digits of precision, so
+be careful about using floating-point to convert these values to
+decimal.
+
+
+<pre><code><b>struct</b> <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>value: u128</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x1_fixed_point64_MAX_U128"></a>
+
+
+
+<pre><code><b>const</b> <a href="fixed_point64.md#0x1_fixed_point64_MAX_U128">MAX_U128</a>: u256 = 340282366920938463463374607431768211455;
+</code></pre>
+
+
+
+<a name="0x1_fixed_point64_EDENOMINATOR"></a>
+
+The denominator provided was zero
+
+
+<pre><code><b>const</b> <a href="fixed_point64.md#0x1_fixed_point64_EDENOMINATOR">EDENOMINATOR</a>: u64 = 65537;
+</code></pre>
+
+
+
+<a name="0x1_fixed_point64_EDIVISION"></a>
+
+The quotient value would be too large to be held in a <code>u128</code>
+
+
+<pre><code><b>const</b> <a href="fixed_point64.md#0x1_fixed_point64_EDIVISION">EDIVISION</a>: u64 = 131074;
+</code></pre>
+
+
+
+<a name="0x1_fixed_point64_EDIVISION_BY_ZERO"></a>
+
+A division by zero was encountered
+
+
+<pre><code><b>const</b> <a href="fixed_point64.md#0x1_fixed_point64_EDIVISION_BY_ZERO">EDIVISION_BY_ZERO</a>: u64 = 65540;
+</code></pre>
+
+
+
+<a name="0x1_fixed_point64_EMULTIPLICATION"></a>
+
+The multiplied value would be too large to be held in a <code>u128</code>
+
+
+<pre><code><b>const</b> <a href="fixed_point64.md#0x1_fixed_point64_EMULTIPLICATION">EMULTIPLICATION</a>: u64 = 131075;
+</code></pre>
+
+
+
+<a name="0x1_fixed_point64_ERATIO_OUT_OF_RANGE"></a>
+
+The computed ratio when converting to a <code><a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a></code> would be unrepresentable
+
+
+<pre><code><b>const</b> <a href="fixed_point64.md#0x1_fixed_point64_ERATIO_OUT_OF_RANGE">ERATIO_OUT_OF_RANGE</a>: u64 = 131077;
+</code></pre>
+
+
+
+<a name="0x1_fixed_point64_multiply_u128"></a>
+
+## Function `multiply_u128`
+
+Multiply a u128 integer by a fixed-point number, truncating any
+fractional part of the product. This will abort if the product
+overflows.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_multiply_u128">multiply_u128</a>(val: u128, multiplier: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_multiply_u128">multiply_u128</a>(val: u128, multiplier: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
+    // The product of two 128 bit values <b>has</b> 256 bits, so perform the
+    // multiplication <b>with</b> u256 types and keep the full 256 bit product
+    // <b>to</b> avoid losing accuracy.
+    <b>let</b> unscaled_product = (val <b>as</b> u256) * (multiplier.value <b>as</b> u256);
+    // The unscaled product <b>has</b> 64 fractional bits (from the multiplier)
+    // so rescale it by shifting away the low bits.
+    <b>let</b> product = unscaled_product &gt;&gt; 64;
+    // Check whether the value is too large.
+    <b>assert</b>!(product &lt;= <a href="fixed_point64.md#0x1_fixed_point64_MAX_U128">MAX_U128</a>, <a href="fixed_point64.md#0x1_fixed_point64_EMULTIPLICATION">EMULTIPLICATION</a>);
+    (product <b>as</b> u128)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_divide_u128"></a>
+
+## Function `divide_u128`
+
+Divide a u128 integer by a fixed-point number, truncating any
+fractional part of the quotient. This will abort if the divisor
+is zero or if the quotient overflows.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_divide_u128">divide_u128</a>(val: u128, divisor: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_divide_u128">divide_u128</a>(val: u128, divisor: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
+    // Check for division by zero.
+    <b>assert</b>!(divisor.value != 0, <a href="fixed_point64.md#0x1_fixed_point64_EDIVISION_BY_ZERO">EDIVISION_BY_ZERO</a>);
+    // First convert <b>to</b> 256 bits and then shift left <b>to</b>
+    // add 64 fractional zero bits <b>to</b> the dividend.
+    <b>let</b> scaled_value = (val <b>as</b> u256) &lt;&lt; 64;
+    <b>let</b> quotient = scaled_value / (divisor.value <b>as</b> u256);
+    // Check whether the value is too large.
+    <b>assert</b>!(quotient &lt;= <a href="fixed_point64.md#0x1_fixed_point64_MAX_U128">MAX_U128</a>, <a href="fixed_point64.md#0x1_fixed_point64_EDIVISION">EDIVISION</a>);
+    // the value may be too large, which will cause the cast <b>to</b> fail
+    // <b>with</b> an arithmetic <a href="../../move-stdlib/doc/error.md#0x1_error">error</a>.
+    (quotient <b>as</b> u128)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_create_from_rational"></a>
+
+## Function `create_from_rational`
+
+Create a fixed-point value from a rational number specified by its
+numerator and denominator. Calling this function should be preferred
+for using <code><a href="fixed_point64.md#0x1_fixed_point64_create_from_raw_value">Self::create_from_raw_value</a></code> which is also available.
+This will abort if the denominator is zero. It will also
+abort if the numerator is nonzero and the ratio is not in the range
+2^-64 .. 2^64-1. When specifying decimal fractions, be careful about
+rounding errors: if you round to display N digits after the decimal
+point, you can use a denominator of 10^N to avoid numbers where the
+very small imprecision in the binary representation could change the
+rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_create_from_rational">create_from_rational</a>(numerator: u128, denominator: u128): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_create_from_rational">create_from_rational</a>(numerator: u128, denominator: u128): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {
+    // If the denominator is zero, this will <b>abort</b>.
+    // Scale the numerator <b>to</b> have 64 fractional bits, so that the quotient will have 64
+    // fractional bits.
+    <b>let</b> scaled_numerator = (numerator <b>as</b> u256) &lt;&lt; 64;
+    <b>assert</b>!(denominator != 0, <a href="fixed_point64.md#0x1_fixed_point64_EDENOMINATOR">EDENOMINATOR</a>);
+    <b>let</b> quotient = scaled_numerator / (denominator <b>as</b> u256);
+    <b>assert</b>!(quotient != 0 || numerator == 0, <a href="fixed_point64.md#0x1_fixed_point64_ERATIO_OUT_OF_RANGE">ERATIO_OUT_OF_RANGE</a>);
+    // Return the quotient <b>as</b> a fixed-point number. We first need <b>to</b> check whether the cast
+    // can succeed.
+    <b>assert</b>!(quotient &lt;= <a href="fixed_point64.md#0x1_fixed_point64_MAX_U128">MAX_U128</a>, <a href="fixed_point64.md#0x1_fixed_point64_ERATIO_OUT_OF_RANGE">ERATIO_OUT_OF_RANGE</a>);
+    <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> { value: (quotient <b>as</b> u128) }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_create_from_raw_value"></a>
+
+## Function `create_from_raw_value`
+
+Create a fixedpoint value from a raw value.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_create_from_raw_value">create_from_raw_value</a>(value: u128): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_create_from_raw_value">create_from_raw_value</a>(value: u128): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {
+    <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> { value }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_get_raw_value"></a>
+
+## Function `get_raw_value`
+
+Accessor for the raw u128 value. Other less common operations, such as
+adding or subtracting FixedPoint64 values, can be done using the raw
+values directly.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_get_raw_value">get_raw_value</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_get_raw_value">get_raw_value</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
+    num.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_is_zero"></a>
+
+## Function `is_zero`
+
+Returns true if the ratio is zero.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_is_zero">is_zero</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_is_zero">is_zero</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+    num.value == 0
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_min"></a>
+
+## Function `min`
+
+Returns the smaller of the two FixedPoint64 numbers.
+
+
+<pre><code><b>public</b> <b>fun</b> <b>min</b>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <b>min</b>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {
+    <b>if</b> (num1.value &lt; num2.value) {
+        num1
+    } <b>else</b> {
+        num2
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_max"></a>
+
+## Function `max`
+
+Returns the larger of the two FixedPoint64 numbers.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_max">max</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_max">max</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {
+    <b>if</b> (num1.value &gt; num2.value) {
+        num1
+    } <b>else</b> {
+        num2
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_create_from_u128"></a>
+
+## Function `create_from_u128`
+
+Create a fixedpoint value from a u128 value.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_create_from_u128">create_from_u128</a>(val: u128): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_create_from_u128">create_from_u128</a>(val: u128): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {
+    <b>let</b> value = (val <b>as</b> u256) &lt;&lt; 64;
+    <b>assert</b>!(value &lt;= <a href="fixed_point64.md#0x1_fixed_point64_MAX_U128">MAX_U128</a>, <a href="fixed_point64.md#0x1_fixed_point64_ERATIO_OUT_OF_RANGE">ERATIO_OUT_OF_RANGE</a>);
+    <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {value: (value <b>as</b> u128)}
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_floor"></a>
+
+## Function `floor`
+
+Returns the largest integer less than or equal to a given number.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_floor">floor</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_floor">floor</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
+    num.value &gt;&gt; 64
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_ceil"></a>
+
+## Function `ceil`
+
+Rounds up the given FixedPoint64 to the next largest integer.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_ceil">ceil</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_ceil">ceil</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
+    <b>let</b> floored_num = <a href="fixed_point64.md#0x1_fixed_point64_floor">floor</a>(num) &lt;&lt; 64;
+    <b>if</b> (num.value == floored_num) {
+        <b>return</b> floored_num &gt;&gt; 64
+    };
+    <b>let</b> val = ((floored_num <b>as</b> u256) + (1 &lt;&lt; 64));
+    (val &gt;&gt; 64 <b>as</b> u128)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_round"></a>
+
+## Function `round`
+
+Returns the value of a FixedPoint64 to the nearest integer.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_round">round</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_round">round</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
+    <b>let</b> floored_num = <a href="fixed_point64.md#0x1_fixed_point64_floor">floor</a>(num) &lt;&lt; 64;
+    <b>let</b> boundary = floored_num + ((1 &lt;&lt; 64) / 2);
+    <b>if</b> (num.value &lt; boundary) {
+        floored_num &gt;&gt; 64
+    } <b>else</b> {
+        <a href="fixed_point64.md#0x1_fixed_point64_ceil">ceil</a>(num)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="@Specification_1"></a>
+
+## Specification
+
+
+
+
+<pre><code><b>pragma</b> aborts_if_is_strict;
+</code></pre>
+
+
+
+<a name="@Specification_1_multiply_u128"></a>
+
+### Function `multiply_u128`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_multiply_u128">multiply_u128</a>(val: u128, multiplier: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>include</b> <a href="fixed_point64.md#0x1_fixed_point64_MultiplyAbortsIf">MultiplyAbortsIf</a>;
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_multiply_u128">spec_multiply_u128</a>(val, multiplier);
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_MultiplyAbortsIf"></a>
+
+
+<pre><code><b>schema</b> <a href="fixed_point64.md#0x1_fixed_point64_MultiplyAbortsIf">MultiplyAbortsIf</a> {
+    val: num;
+    multiplier: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>;
+    <b>aborts_if</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_multiply_u128">spec_multiply_u128</a>(val, multiplier) &gt; <a href="fixed_point64.md#0x1_fixed_point64_MAX_U128">MAX_U128</a> <b>with</b> <a href="fixed_point64.md#0x1_fixed_point64_EMULTIPLICATION">EMULTIPLICATION</a>;
+}
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_spec_multiply_u128"></a>
+
+
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_multiply_u128">spec_multiply_u128</a>(val: num, multiplier: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): num {
+   (val * multiplier.value) &gt;&gt; 64
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_divide_u128"></a>
+
+### Function `divide_u128`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_divide_u128">divide_u128</a>(val: u128, divisor: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>include</b> <a href="fixed_point64.md#0x1_fixed_point64_DivideAbortsIf">DivideAbortsIf</a>;
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_divide_u128">spec_divide_u128</a>(val, divisor);
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_DivideAbortsIf"></a>
+
+
+<pre><code><b>schema</b> <a href="fixed_point64.md#0x1_fixed_point64_DivideAbortsIf">DivideAbortsIf</a> {
+    val: num;
+    divisor: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>;
+    <b>aborts_if</b> divisor.value == 0 <b>with</b> <a href="fixed_point64.md#0x1_fixed_point64_EDIVISION_BY_ZERO">EDIVISION_BY_ZERO</a>;
+    <b>aborts_if</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_divide_u128">spec_divide_u128</a>(val, divisor) &gt; <a href="fixed_point64.md#0x1_fixed_point64_MAX_U128">MAX_U128</a> <b>with</b> <a href="fixed_point64.md#0x1_fixed_point64_EDIVISION">EDIVISION</a>;
+}
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_spec_divide_u128"></a>
+
+
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_divide_u128">spec_divide_u128</a>(val: num, divisor: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): num {
+   (val &lt;&lt; 64) / divisor.value
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_create_from_rational"></a>
+
+### Function `create_from_rational`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_create_from_rational">create_from_rational</a>(numerator: u128, denominator: u128): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>include</b> <a href="fixed_point64.md#0x1_fixed_point64_CreateFromRationalAbortsIf">CreateFromRationalAbortsIf</a>;
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_create_from_rational">spec_create_from_rational</a>(numerator, denominator);
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_CreateFromRationalAbortsIf"></a>
+
+
+<pre><code><b>schema</b> <a href="fixed_point64.md#0x1_fixed_point64_CreateFromRationalAbortsIf">CreateFromRationalAbortsIf</a> {
+    numerator: u128;
+    denominator: u128;
+    <b>let</b> scaled_numerator = (numerator <b>as</b> u256)&lt;&lt; 64;
+    <b>let</b> scaled_denominator = (denominator <b>as</b> u256);
+    <b>let</b> quotient = scaled_numerator / scaled_denominator;
+    <b>aborts_if</b> scaled_denominator == 0 <b>with</b> <a href="fixed_point64.md#0x1_fixed_point64_EDENOMINATOR">EDENOMINATOR</a>;
+    <b>aborts_if</b> quotient == 0 && scaled_numerator != 0 <b>with</b> <a href="fixed_point64.md#0x1_fixed_point64_ERATIO_OUT_OF_RANGE">ERATIO_OUT_OF_RANGE</a>;
+    <b>aborts_if</b> quotient &gt; <a href="fixed_point64.md#0x1_fixed_point64_MAX_U128">MAX_U128</a> <b>with</b> <a href="fixed_point64.md#0x1_fixed_point64_ERATIO_OUT_OF_RANGE">ERATIO_OUT_OF_RANGE</a>;
+}
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_spec_create_from_rational"></a>
+
+
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_create_from_rational">spec_create_from_rational</a>(numerator: num, denominator: num): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {
+   <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>{value: (numerator &lt;&lt; 128) / (denominator &lt;&lt; 64)}
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_create_from_raw_value"></a>
+
+### Function `create_from_raw_value`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_create_from_raw_value">create_from_raw_value</a>(value: u128): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result.value == value;
+</code></pre>
+
+
+
+<a name="@Specification_1_min"></a>
+
+### Function `min`
+
+
+<pre><code><b>public</b> <b>fun</b> <b>min</b>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_min">spec_min</a>(num1, num2);
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_spec_min"></a>
+
+
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_min">spec_min</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {
+   <b>if</b> (num1.value &lt; num2.value) {
+       num1
+   } <b>else</b> {
+       num2
+   }
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_max"></a>
+
+### Function `max`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_max">max</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_max">spec_max</a>(num1, num2);
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_spec_max"></a>
+
+
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_max">spec_max</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {
+   <b>if</b> (num1.value &gt; num2.value) {
+       num1
+   } <b>else</b> {
+       num2
+   }
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_create_from_u128"></a>
+
+### Function `create_from_u128`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_create_from_u128">create_from_u128</a>(val: u128): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>include</b> <a href="fixed_point64.md#0x1_fixed_point64_CreateFromU64AbortsIf">CreateFromU64AbortsIf</a>;
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_create_from_u128">spec_create_from_u128</a>(val);
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_CreateFromU64AbortsIf"></a>
+
+
+<pre><code><b>schema</b> <a href="fixed_point64.md#0x1_fixed_point64_CreateFromU64AbortsIf">CreateFromU64AbortsIf</a> {
+    val: num;
+    <b>let</b> scaled_value = (val <b>as</b> u256) &lt;&lt; 64;
+    <b>aborts_if</b> scaled_value &gt; <a href="fixed_point64.md#0x1_fixed_point64_MAX_U128">MAX_U128</a>;
+}
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_spec_create_from_u128"></a>
+
+
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_create_from_u128">spec_create_from_u128</a>(val: num): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {
+   <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {value: val &lt;&lt; 64}
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_floor"></a>
+
+### Function `floor`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_floor">floor</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_floor">spec_floor</a>(num);
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_spec_floor"></a>
+
+
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_floor">spec_floor</a>(val: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
+   <b>let</b> fractional = val.value % (1 &lt;&lt; 64);
+   <b>if</b> (fractional == 0) {
+       val.value &gt;&gt; 64
+   } <b>else</b> {
+       (val.value - fractional) &gt;&gt; 64
+   }
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_ceil"></a>
+
+### Function `ceil`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_ceil">ceil</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+</code></pre>
+
+
+
+TODO: worked in the past but started to time out since last z3 update
+
+
+<pre><code><b>pragma</b> verify = <b>false</b>;
+<b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_ceil">spec_ceil</a>(num);
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_spec_ceil"></a>
+
+
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_ceil">spec_ceil</a>(val: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
+   <b>let</b> fractional = val.value % (1 &lt;&lt; 64);
+   <b>let</b> one = 1 &lt;&lt; 64;
+   <b>if</b> (fractional == 0) {
+       val.value &gt;&gt; 64
+   } <b>else</b> {
+       (val.value - fractional + one) &gt;&gt; 64
+   }
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_round"></a>
+
+### Function `round`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_round">round</a>(num: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): u128
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_round">spec_round</a>(num);
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_spec_round"></a>
+
+
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_round">spec_round</a>(val: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): u128 {
+   <b>let</b> fractional = val.value % (1 &lt;&lt; 64);
+   <b>let</b> boundary = (1 &lt;&lt; 64) / 2;
+   <b>let</b> one = 1 &lt;&lt; 64;
+   <b>if</b> (fractional &lt; boundary) {
+       (val.value - fractional) &gt;&gt; 64
+   } <b>else</b> {
+       (val.value - fractional + one) &gt;&gt; 64
+   }
+}
+</code></pre>
+
+
+[move-book]: https://move-language.github.io/move/introduction.html

--- a/aptos-move/framework/aptos-stdlib/doc/overview.md
+++ b/aptos-move/framework/aptos-stdlib/doc/overview.md
@@ -21,6 +21,7 @@ This is the reference documentation of the Aptos standard library.
 -  [`0x1::copyable_any`](copyable_any.md#0x1_copyable_any)
 -  [`0x1::debug`](debug.md#0x1_debug)
 -  [`0x1::ed25519`](ed25519.md#0x1_ed25519)
+-  [`0x1::fixed_point64`](fixed_point64.md#0x1_fixed_point64)
 -  [`0x1::from_bcs`](from_bcs.md#0x1_from_bcs)
 -  [`0x1::math128`](math128.md#0x1_math128)
 -  [`0x1::math64`](math64.md#0x1_math64)

--- a/aptos-move/framework/aptos-stdlib/sources/fixed_point64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/fixed_point64.move
@@ -1,0 +1,293 @@
+/// Defines a fixed-point numeric type with a 64-bit integer part and
+/// a 64-bit fractional part.
+
+module aptos_std::fixed_point64 {
+
+    /// Define a fixed-point numeric type with 64 fractional bits.
+    /// This is just a u128 integer but it is wrapped in a struct to
+    /// make a unique type. This is a binary representation, so decimal
+    /// values may not be exactly representable, but it provides more
+    /// than 9 decimal digits of precision both before and after the
+    /// decimal point (18 digits total). For comparison, double precision
+    /// floating-point has less than 16 decimal digits of precision, so
+    /// be careful about using floating-point to convert these values to
+    /// decimal.
+    struct FixedPoint64 has copy, drop, store { value: u128 }
+
+    const MAX_U128: u256 = 340282366920938463463374607431768211455;
+
+    /// The denominator provided was zero
+    const EDENOMINATOR: u64 = 0x10001;
+    /// The quotient value would be too large to be held in a `u128`
+    const EDIVISION: u64 = 0x20002;
+    /// The multiplied value would be too large to be held in a `u128`
+    const EMULTIPLICATION: u64 = 0x20003;
+    /// A division by zero was encountered
+    const EDIVISION_BY_ZERO: u64 = 0x10004;
+    /// The computed ratio when converting to a `FixedPoint64` would be unrepresentable
+    const ERATIO_OUT_OF_RANGE: u64 = 0x20005;
+
+    /// Multiply a u128 integer by a fixed-point number, truncating any
+    /// fractional part of the product. This will abort if the product
+    /// overflows.
+    public fun multiply_u128(val: u128, multiplier: FixedPoint64): u128 {
+        // The product of two 128 bit values has 256 bits, so perform the
+        // multiplication with u256 types and keep the full 256 bit product
+        // to avoid losing accuracy.
+        let unscaled_product = (val as u256) * (multiplier.value as u256);
+        // The unscaled product has 64 fractional bits (from the multiplier)
+        // so rescale it by shifting away the low bits.
+        let product = unscaled_product >> 64;
+        // Check whether the value is too large.
+        assert!(product <= MAX_U128, EMULTIPLICATION);
+        (product as u128)
+    }
+    spec multiply_u128 {
+        pragma opaque;
+        include MultiplyAbortsIf;
+        ensures result == spec_multiply_u128(val, multiplier);
+    }
+    spec schema MultiplyAbortsIf {
+        val: num;
+        multiplier: FixedPoint64;
+        aborts_if spec_multiply_u128(val, multiplier) > MAX_U128 with EMULTIPLICATION;
+    }
+    spec fun spec_multiply_u128(val: num, multiplier: FixedPoint64): num {
+        (val * multiplier.value) >> 64
+    }
+
+    /// Divide a u128 integer by a fixed-point number, truncating any
+    /// fractional part of the quotient. This will abort if the divisor
+    /// is zero or if the quotient overflows.
+    public fun divide_u128(val: u128, divisor: FixedPoint64): u128 {
+        // Check for division by zero.
+        assert!(divisor.value != 0, EDIVISION_BY_ZERO);
+        // First convert to 256 bits and then shift left to
+        // add 64 fractional zero bits to the dividend.
+        let scaled_value = (val as u256) << 64;
+        let quotient = scaled_value / (divisor.value as u256);
+        // Check whether the value is too large.
+        assert!(quotient <= MAX_U128, EDIVISION);
+        // the value may be too large, which will cause the cast to fail
+        // with an arithmetic error.
+        (quotient as u128)
+    }
+    spec divide_u128 {
+        pragma opaque;
+        include DivideAbortsIf;
+        ensures result == spec_divide_u128(val, divisor);
+    }
+    spec schema DivideAbortsIf {
+        val: num;
+        divisor: FixedPoint64;
+        aborts_if divisor.value == 0 with EDIVISION_BY_ZERO;
+        aborts_if spec_divide_u128(val, divisor) > MAX_U128 with EDIVISION;
+    }
+    spec fun spec_divide_u128(val: num, divisor: FixedPoint64): num {
+        (val << 64) / divisor.value
+    }
+
+    /// Create a fixed-point value from a rational number specified by its
+    /// numerator and denominator. Calling this function should be preferred
+    /// for using `Self::create_from_raw_value` which is also available.
+    /// This will abort if the denominator is zero. It will also
+    /// abort if the numerator is nonzero and the ratio is not in the range
+    /// 2^-64 .. 2^64-1. When specifying decimal fractions, be careful about
+    /// rounding errors: if you round to display N digits after the decimal
+    /// point, you can use a denominator of 10^N to avoid numbers where the
+    /// very small imprecision in the binary representation could change the
+    /// rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
+    public fun create_from_rational(numerator: u128, denominator: u128): FixedPoint64 {
+        // If the denominator is zero, this will abort.
+        // Scale the numerator to have 64 fractional bits, so that the quotient will have 64
+        // fractional bits.
+        let scaled_numerator = (numerator as u256) << 64;
+        assert!(denominator != 0, EDENOMINATOR);
+        let quotient = scaled_numerator / (denominator as u256);
+        assert!(quotient != 0 || numerator == 0, ERATIO_OUT_OF_RANGE);
+        // Return the quotient as a fixed-point number. We first need to check whether the cast
+        // can succeed.
+        assert!(quotient <= MAX_U128, ERATIO_OUT_OF_RANGE);
+        FixedPoint64 { value: (quotient as u128) }
+    }
+    spec create_from_rational {
+        pragma opaque;
+        include CreateFromRationalAbortsIf;
+        ensures result == spec_create_from_rational(numerator, denominator);
+    }
+    spec schema CreateFromRationalAbortsIf {
+        numerator: u128;
+        denominator: u128;
+        let scaled_numerator = (numerator as u256)<< 64;
+        let scaled_denominator = (denominator as u256);
+        let quotient = scaled_numerator / scaled_denominator;
+        aborts_if scaled_denominator == 0 with EDENOMINATOR;
+        aborts_if quotient == 0 && scaled_numerator != 0 with ERATIO_OUT_OF_RANGE;
+        aborts_if quotient > MAX_U128 with ERATIO_OUT_OF_RANGE;
+    }
+    spec fun spec_create_from_rational(numerator: num, denominator: num): FixedPoint64 {
+        FixedPoint64{value: (numerator << 128) / (denominator << 64)}
+    }
+
+    /// Create a fixedpoint value from a raw value.
+    public fun create_from_raw_value(value: u128): FixedPoint64 {
+        FixedPoint64 { value }
+    }
+    spec create_from_raw_value {
+        pragma opaque;
+        aborts_if false;
+        ensures result.value == value;
+    }
+
+    /// Accessor for the raw u128 value. Other less common operations, such as
+    /// adding or subtracting FixedPoint64 values, can be done using the raw
+    /// values directly.
+    public fun get_raw_value(num: FixedPoint64): u128 {
+        num.value
+    }
+
+    /// Returns true if the ratio is zero.
+    public fun is_zero(num: FixedPoint64): bool {
+        num.value == 0
+    }
+
+    /// Returns the smaller of the two FixedPoint64 numbers.
+    public fun min(num1: FixedPoint64, num2: FixedPoint64): FixedPoint64 {
+        if (num1.value < num2.value) {
+            num1
+        } else {
+            num2
+        }
+    }
+    spec min {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_min(num1, num2);
+    }
+    spec fun spec_min(num1: FixedPoint64, num2: FixedPoint64): FixedPoint64 {
+        if (num1.value < num2.value) {
+            num1
+        } else {
+            num2
+        }
+    }
+
+    /// Returns the larger of the two FixedPoint64 numbers.
+    public fun max(num1: FixedPoint64, num2: FixedPoint64): FixedPoint64 {
+        if (num1.value > num2.value) {
+            num1
+        } else {
+            num2
+        }
+    }
+    spec max {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_max(num1, num2);
+    }
+    spec fun spec_max(num1: FixedPoint64, num2: FixedPoint64): FixedPoint64 {
+        if (num1.value > num2.value) {
+            num1
+        } else {
+            num2
+        }
+    }
+
+    /// Create a fixedpoint value from a u128 value.
+    public fun create_from_u128(val: u128): FixedPoint64 {
+        let value = (val as u256) << 64;
+        assert!(value <= MAX_U128, ERATIO_OUT_OF_RANGE);
+        FixedPoint64 {value: (value as u128)}
+    }
+    spec create_from_u128 {
+        pragma opaque;
+        include CreateFromU64AbortsIf;
+        ensures result == spec_create_from_u128(val);
+    }
+    spec schema CreateFromU64AbortsIf {
+        val: num;
+        let scaled_value = (val as u256) << 64;
+        aborts_if scaled_value > MAX_U128;
+    }
+    spec fun spec_create_from_u128(val: num): FixedPoint64 {
+        FixedPoint64 {value: val << 64}
+    }
+
+    /// Returns the largest integer less than or equal to a given number.
+    public fun floor(num: FixedPoint64): u128 {
+        num.value >> 64
+    }
+    spec floor {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_floor(num);
+    }
+    spec fun spec_floor(val: FixedPoint64): u128 {
+        let fractional = val.value % (1 << 64);
+        if (fractional == 0) {
+            val.value >> 64
+        } else {
+            (val.value - fractional) >> 64
+        }
+    }
+
+    /// Rounds up the given FixedPoint64 to the next largest integer.
+    public fun ceil(num: FixedPoint64): u128 {
+        let floored_num = floor(num) << 64;
+        if (num.value == floored_num) {
+            return floored_num >> 64
+        };
+        let val = ((floored_num as u256) + (1 << 64));
+        (val >> 64 as u128)
+    }
+    spec ceil {
+        /// TODO: worked in the past but started to time out since last z3 update
+        pragma verify = false;
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_ceil(num);
+    }
+    spec fun spec_ceil(val: FixedPoint64): u128 {
+        let fractional = val.value % (1 << 64);
+        let one = 1 << 64;
+        if (fractional == 0) {
+            val.value >> 64
+        } else {
+            (val.value - fractional + one) >> 64
+        }
+    }
+
+    /// Returns the value of a FixedPoint64 to the nearest integer.
+    public fun round(num: FixedPoint64): u128 {
+        let floored_num = floor(num) << 64;
+        let boundary = floored_num + ((1 << 64) / 2);
+        if (num.value < boundary) {
+            floored_num >> 64
+        } else {
+            ceil(num)
+        }
+    }
+    spec round {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_round(num);
+    }
+    spec fun spec_round(val: FixedPoint64): u128 {
+        let fractional = val.value % (1 << 64);
+        let boundary = (1 << 64) / 2;
+        let one = 1 << 64;
+        if (fractional < boundary) {
+            (val.value - fractional) >> 64
+        } else {
+            (val.value - fractional + one) >> 64
+        }
+    }
+
+    // **************** SPECIFICATIONS ****************
+
+    spec module {} // switch documentation context to module level
+
+    spec module {
+        pragma aborts_if_is_strict;
+    }
+}

--- a/aptos-move/framework/aptos-stdlib/tests/fixedpoint64_tests.move
+++ b/aptos-move/framework/aptos-stdlib/tests/fixedpoint64_tests.move
@@ -1,0 +1,191 @@
+#[test_only]
+module aptos_std::fixed_point64_tests {
+    use aptos_std::fixed_point64;
+
+    const POW2_64: u128 = 1 << 64;
+    const MAX_U128: u128 = 340282366920938463463374607431768211455;
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point64::EDENOMINATOR)]
+    fun create_div_zero() {
+        // A denominator of zero should cause an arithmetic error.
+        fixed_point64::create_from_rational(2, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point64::ERATIO_OUT_OF_RANGE)]
+    fun create_overflow() {
+        // The maximum value is 2^32 - 1. Check that anything larger aborts
+        // with an overflow.
+        fixed_point64::create_from_rational(POW2_64, 1); // 2^64
+    }
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point64::ERATIO_OUT_OF_RANGE)]
+    fun create_underflow() {
+        // The minimum non-zero value is 2^-32. Check that anything smaller
+        // aborts.
+        fixed_point64::create_from_rational(1, 2 * POW2_64); // 2^-65
+    }
+
+    #[test]
+    fun create_zero() {
+        let x = fixed_point64::create_from_rational(0, 1);
+        assert!(fixed_point64::is_zero(x), 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point64::EDIVISION_BY_ZERO)]
+    fun divide_by_zero() {
+        // Dividing by zero should cause an arithmetic error.
+        let f = fixed_point64::create_from_raw_value(0);
+        fixed_point64::divide_u128(1, f);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point64::EDIVISION)]
+    fun divide_overflow_small_divisore() {
+        let f = fixed_point64::create_from_raw_value(1); // 2^-64
+        // Divide 2^64 by the minimum fractional value. This should overflow.
+        fixed_point64::divide_u128(POW2_64, f);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point64::EDIVISION)]
+    fun divide_overflow_large_numerator() {
+        let f = fixed_point64::create_from_rational(1, 2); // 0.5
+        // Divide the maximum u128 value by 0.5. This should overflow.
+        fixed_point64::divide_u128(MAX_U128, f);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point64::EMULTIPLICATION)]
+    fun multiply_overflow_small_multiplier() {
+        let f = fixed_point64::create_from_rational(3, 2); // 1.5
+        // Multiply the maximum u64 value by 1.5. This should overflow.
+        fixed_point64::multiply_u128(MAX_U128, f);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point64::EMULTIPLICATION)]
+    fun multiply_overflow_large_multiplier() {
+        let f = fixed_point64::create_from_raw_value(MAX_U128);
+        // Multiply 2^65 by the maximum fixed-point value. This should overflow.
+        fixed_point64::multiply_u128(2 * POW2_64, f);
+    }
+
+    #[test]
+    fun exact_multiply() {
+        let f = fixed_point64::create_from_rational(3, 4); // 0.75
+        let nine = fixed_point64::multiply_u128(12, f); // 12 * 0.75
+        assert!(nine == 9, 0);
+    }
+
+    #[test]
+    fun exact_divide() {
+        let f = fixed_point64::create_from_rational(3, 4); // 0.75
+        let twelve = fixed_point64::divide_u128(9, f); // 9 / 0.75
+        assert!(twelve == 12, 0);
+    }
+
+    #[test]
+    fun multiply_truncates() {
+        let f = fixed_point64::create_from_rational(1, 3); // 0.333...
+        let not_three = fixed_point64::multiply_u128(9, copy f); // 9 * 0.333...
+        // multiply_u128 does NOT round -- it truncates -- so values that
+        // are not perfectly representable in binary may be off by one.
+        assert!(not_three == 2, 0);
+
+        // Try again with a fraction slightly larger than 1/3.
+        let f = fixed_point64::create_from_raw_value(fixed_point64::get_raw_value(f) + 1);
+        let three = fixed_point64::multiply_u128(9, f);
+        assert!(three == 3, 1);
+    }
+
+    #[test]
+    fun create_from_rational_max_numerator_denominator() {
+        // Test creating a 1.0 fraction from the maximum u64 value.
+        let f = fixed_point64::create_from_rational(MAX_U128, MAX_U128);
+        let one = fixed_point64::get_raw_value(f);
+        assert!(one == POW2_64, 0); // 0x1.00000000
+    }
+
+    #[test]
+    fun min_can_return_smaller_fixed_point_number() {
+        let one = fixed_point64::create_from_rational(1, 1);
+        let two = fixed_point64::create_from_rational(2, 1);
+        let smaller_number1 = fixed_point64::min(one, two);
+        let val1 = fixed_point64::get_raw_value(smaller_number1);
+        assert!(val1 == POW2_64, 0);  // 0x1.00000000
+        let smaller_number2 = fixed_point64::min(two, one);
+        let val2 = fixed_point64::get_raw_value(smaller_number2);
+        assert!(val2 == POW2_64, 0);  // 0x1.00000000
+    }
+
+    #[test]
+    fun max_can_return_larger_fixed_point_number() {
+        let one = fixed_point64::create_from_rational(1, 1);
+        let two = fixed_point64::create_from_rational(2, 1);
+        let larger_number1 = fixed_point64::max(one, two);
+        let larger_number2 = fixed_point64::max(two, one);
+        let val1 = fixed_point64::get_raw_value(larger_number1);
+        assert!(val1 == 2 * POW2_64, 0);  // 0x2.00000000
+        let val2 = fixed_point64::get_raw_value(larger_number2);
+        assert!(val2 == 2 * POW2_64, 0);  // 0x2.00000000
+    }
+
+    #[test]
+    fun floor_can_return_the_correct_number_zero() {
+        let point_five = fixed_point64::create_from_rational(1, 2);
+        let val = fixed_point64::floor(point_five);
+        assert!(val == 0, 0);
+    }
+
+    #[test]
+    fun create_from_u128_create_correct_fixed_point_number() {
+        let one = fixed_point64::create_from_u128(1);
+        let val = fixed_point64::get_raw_value(one);
+        assert!(val == POW2_64, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point64::ERATIO_OUT_OF_RANGE)]
+    fun create_from_u128_throw_error_when_number_too_large() {
+        fixed_point64::create_from_u128(POW2_64);
+    }
+
+    #[test]
+    fun floor_can_return_the_correct_number_one() {
+        let three_point_five = fixed_point64::create_from_rational(7, 2); // 3.5
+        let val = fixed_point64::floor(three_point_five);
+        assert!(val == 3, 0);
+    }
+
+    #[test]
+    fun ceil_can_round_up_correctly() {
+        let point_five = fixed_point64::create_from_rational(1, 2); // 0.5
+        let val = fixed_point64::ceil(point_five);
+        assert!(val == 1, 0);
+    }
+
+    #[test]
+    fun ceil_will_not_change_if_number_already_integer() {
+        let one = fixed_point64::create_from_rational(1, 1); // 0.5
+        let val = fixed_point64::ceil(one);
+        assert!(val == 1, 0);
+    }
+
+    #[test]
+    fun round_can_round_up_correctly() {
+        let point_five = fixed_point64::create_from_rational(1, 2); // 0.5
+        let val = fixed_point64::round(point_five);
+        assert!(val == 1, 0);
+    }
+
+    #[test]
+    fun round_can_round_down_correctly() {
+        let num = fixed_point64::create_from_rational(499, 1000); // 0.499
+        let val = fixed_point64::round(num);
+        assert!(val == 0, 0);
+    }
+}


### PR DESCRIPTION
### Description

Add the analogue of 64 bit precision analogue of fixed_point32 to aptos_stdlib

### Test Plan
Comes with same set of unittests as fixedpoint32