### PR TITLE
[DOC] Update e2e dapp tutorial

### DIFF
--- a/aptos-move/move-examples/my_first_dapp/client/package-lock.json
+++ b/aptos-move/move-examples/my_first_dapp/client/package-lock.json
@@ -18,7 +18,7 @@
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
         "antd": "^5.1.4",
-        "aptos": "^1.6.0",
+        "aptos": "^1.7.1",
         "petra-plugin-wallet-adapter": "^0.1.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -4796,9 +4796,9 @@
       }
     },
     "node_modules/aptos": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aptos/-/aptos-1.6.0.tgz",
-      "integrity": "sha512-5khjDwrDeNMDBFRcZAmETW20D+V2AqTdsgqkh6bvvl70BtRXdkitN0saM05gf1rK3atnO9PyUKO8iRaBDG5qtA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/aptos/-/aptos-1.7.1.tgz",
+      "integrity": "sha512-PCOtfC6JG+wg8AwN2jwWmewGW5eaYNzomsrAjlIRRjmwIkOffL6+lyFjorulMl8YnmfNWjJTb6yTVtfKqYCUUA==",
       "dependencies": {
         "@noble/hashes": "1.1.3",
         "@scure/bip39": "1.1.0",

--- a/aptos-move/move-examples/my_first_dapp/client/package.json
+++ b/aptos-move/move-examples/my_first_dapp/client/package.json
@@ -13,7 +13,7 @@
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "antd": "^5.1.4",
-    "aptos": "^1.6.0",
+    "aptos": "^1.7.1",
     "petra-plugin-wallet-adapter": "^0.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/aptos-move/move-examples/my_first_dapp/client/src/App.tsx
+++ b/aptos-move/move-examples/my_first_dapp/client/src/App.tsx
@@ -17,7 +17,7 @@ type Task = {
 
 export const provider = new Provider(Network.DEVNET);
 // change this to be your module account address
-export const moduleAddress = "0xdf45ae6235bf48c2036f0e32f98af74890773b8cd229db8a078b118708632585";
+export const moduleAddress = "0xcbddf398841353776903dbab2fdaefc54f181d07e114ae818b1a67af28d1b018";
 
 function App() {
   const [tasks, setTasks] = useState<Task[]>([]);

--- a/aptos-move/move-examples/my_first_dapp/client/src/App.tsx
+++ b/aptos-move/move-examples/my_first_dapp/client/src/App.tsx
@@ -6,7 +6,7 @@ import { useWallet } from "@aptos-labs/wallet-adapter-react";
 
 import "@aptos-labs/wallet-adapter-ant-design/dist/index.css";
 import { CheckboxChangeEvent } from "antd/es/checkbox";
-import { AptosClient } from "aptos";
+import { Network, Provider } from "aptos";
 
 type Task = {
   address: string;
@@ -15,10 +15,9 @@ type Task = {
   task_id: string;
 };
 
-export const NODE_URL = "https://fullnode.devnet.aptoslabs.com";
-export const client = new AptosClient(NODE_URL);
+export const provider = new Provider(Network.DEVNET);
 // change this to be your module account address
-export const moduleAddress = "0xcbddf398841353776903dbab2fdaefc54f181d07e114ae818b1a67af28d1b018";
+export const moduleAddress = "0xdf45ae6235bf48c2036f0e32f98af74890773b8cd229db8a078b118708632585";
 
 function App() {
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -35,7 +34,10 @@ function App() {
   const fetchList = async () => {
     if (!account) return [];
     try {
-      const todoListResource = await client.getAccountResource(account?.address, `${moduleAddress}::main::TodoList`);
+      const todoListResource = await provider.getAccountResource(
+        account?.address,
+        `${moduleAddress}::todolist::TodoList`,
+      );
       setAccountHasList(true);
       // tasks table handle
       const tableHandle = (todoListResource as any).data.tasks.handle;
@@ -47,10 +49,10 @@ function App() {
       while (counter <= taskCounter) {
         const tableItem = {
           key_type: "u64",
-          value_type: `${moduleAddress}::main::Task`,
+          value_type: `${moduleAddress}::todolist::Task`,
           key: `${counter}`,
         };
-        const task = await client.getTableItem(tableHandle, tableItem);
+        const task = await provider.getTableItem(tableHandle, tableItem);
         tasks.push(task);
         counter++;
       }
@@ -67,7 +69,7 @@ function App() {
     // build a transaction payload to be submited
     const payload = {
       type: "entry_function_payload",
-      function: `${moduleAddress}::main::create_list`,
+      function: `${moduleAddress}::todolist::create_list`,
       type_arguments: [],
       arguments: [],
     };
@@ -75,7 +77,7 @@ function App() {
       // sign and submit transaction to chain
       const response = await signAndSubmitTransaction(payload);
       // wait for transaction
-      await client.waitForTransaction(response.hash);
+      await provider.waitForTransaction(response.hash);
       setAccountHasList(true);
     } catch (error: any) {
       setAccountHasList(false);
@@ -91,7 +93,7 @@ function App() {
     // build a transaction payload to be submited
     const payload = {
       type: "entry_function_payload",
-      function: `${moduleAddress}::main::create_task`,
+      function: `${moduleAddress}::todolist::create_task`,
       type_arguments: [],
       arguments: [newTask],
     };
@@ -111,7 +113,7 @@ function App() {
       // sign and submit transaction to chain
       const response = await signAndSubmitTransaction(payload);
       // wait for transaction
-      await client.waitForTransaction(response.hash);
+      await provider.waitForTransaction(response.hash);
 
       // Create a new array based on current state:
       let newTasks = [...tasks];
@@ -135,7 +137,7 @@ function App() {
     setTransactionInProgress(true);
     const payload = {
       type: "entry_function_payload",
-      function: `${moduleAddress}::main::complete_task`,
+      function: `${moduleAddress}::todolist::complete_task`,
       type_arguments: [],
       arguments: [taskId],
     };
@@ -144,7 +146,7 @@ function App() {
       // sign and submit transaction to chain
       const response = await signAndSubmitTransaction(payload);
       // wait for transaction
-      await client.waitForTransaction(response.hash);
+      await provider.waitForTransaction(response.hash);
 
       setTasks((prevState) => {
         const newState = prevState.map((obj) => {
@@ -232,7 +234,7 @@ function App() {
                       ]}
                     >
                       <List.Item.Meta
-                        title={task.task_id}
+                        title={task.content}
                         description={
                           <a
                             href={`https://explorer.aptoslabs.com/account/${task.address}/`}

--- a/aptos-move/move-examples/my_first_dapp/move/Move.toml
+++ b/aptos-move/move-examples/my_first_dapp/move/Move.toml
@@ -6,4 +6,4 @@ git = 'https://github.com/aptos-labs/aptos-core.git'
 rev = 'main'
 subdir = 'aptos-move/framework/aptos-framework'
 [addresses]
-myaddr='cbddf398841353776903dbab2fdaefc54f181d07e114ae818b1a67af28d1b018'
+todolist_addr='_'

--- a/aptos-move/move-examples/my_first_dapp/move/sources/todolist.move
+++ b/aptos-move/move-examples/my_first_dapp/move/sources/todolist.move
@@ -1,11 +1,10 @@
-module myaddr::main {
+module todolist_addr::todolist {
 
   use aptos_framework::account;
-  use aptos_framework::event;
-  use aptos_std::table::{Self, Table};
   use std::signer;
+  use aptos_framework::event;
   use std::string::String;
-
+  use aptos_std::table::{Self, Table};
   #[test_only]
   use std::string;
 
@@ -22,7 +21,7 @@ module myaddr::main {
 
   struct Task has store, drop, copy {
     task_id: u64,
-    address: address,
+    address:address,
     content: String,
     completed: bool,
   }
@@ -83,7 +82,7 @@ module myaddr::main {
 
   #[test(admin = @0x123)]
   public entry fun test_flow(admin: signer) acquires TodoList {
-    // creates an admin @myaddr account for test
+    // creates an admin @todolist_addr account for test
     account::create_account_for_test(signer::address_of(&admin));
     // initialize contract with admin account
     create_list(&admin);
@@ -113,7 +112,7 @@ module myaddr::main {
   #[test(admin = @0x123)]
   #[expected_failure(abort_code = E_NOT_INITIALIZED)]
   public entry fun account_can_not_update_task(admin: signer) acquires TodoList {
-    // creates an admin @myaddr account for test
+    // creates an admin @todolist_addr account for test
     account::create_account_for_test(signer::address_of(&admin));
     // account can not toggle task as no list was created
     complete_task(&admin, 2);

--- a/developer-docs-site/docs/tutorials/build-e2e-dapp/4-fetch-data-from-chain.md
+++ b/developer-docs-site/docs/tutorials/build-e2e-dapp/4-fetch-data-from-chain.md
@@ -16,23 +16,26 @@ To fetch data from chain, we can use the [Aptos TypeScript SDK](../../sdks/ts-sd
 To get started:
 
 1. Stop the local server if running.
-2. In the `client` directory, run: `npm i aptos@1.6.0`
-3. In the `App.tsx` file, import the `AptosClient` class like so:
+2. In the `client` directory, run: `npm i aptos`
+3. In the `App.tsx` file, import the `Provider` class and the `Network` type like so:
 
 ```js
-import { AptosClient } from "aptos";
+import { Provider, Network } from "aptos";
 ```
 
-The TypeScript SDK provides us with an `AptosClient` class where we can initialize and query the Aptos chain. `AptosClient` expects`node_url` as an argument, which is the [network URL](../../guides/system-integrators-guide.md#choose-a-network) we want to interact with.
+The TypeScript SDK provides us with a `Provider` class where we can initialize and query the Aptos chain and Indexer. `Provider` expects `Network` type as an argument, which is the [network name](../../guides/system-integrators-guide.md#choose-a-network) we want to interact with.
+
+:::tip
+Read more about the `Provider` class [here](../../sdks/ts-sdk/typescript-sdk-overview.md#provider-class)
+:::
 
 1. In the `App.tsx` file, add:
 
 ```js
-const NODE_URL = "https://fullnode.devnet.aptoslabs.com";
-const client = new AptosClient(NODE_URL);
+const provider = new Provider(Network.DEVNET);
 ```
 
-This will initialize an `AptosClient` instance for us with the devnet node URL.
+This will initialize a `Provider` instance for us with the devnet network.
 
 Our app displays different UIs based on a user resource (i.e if a user has a list ⇒ if a user has a `TodoList` resource). For that, we need to know the current account connected to our app.
 
@@ -54,7 +57,7 @@ function App (
 The `account` object is `null` if there is no account connected; when an account is connected, the `account` object holds the account information, including the account address.
 
 3. Next, we want to fetch the account’s TodoList resource.
-   Begin by importing `useEffect` by using ```jsx import useEffect from "react"; ```
+   Begin by importing `useEffect` by using `jsx import useEffect from "react"; `
    Let’s add a `useEffect` hook to our file that would call a function to fetch the resource whenever our account address changes:
 
 ```jsx
@@ -87,7 +90,7 @@ const fetchList = async () => {
   // change this to be your module account address
   const moduleAddress = "0xcbddf398841353776903dbab2fdaefc54f181d07e114ae818b1a67af28d1b018";
   try {
-    const TodoListResource = await client.getAccountResource(
+    const TodoListResource = await provider.getAccountResource(
       account.address,
       `${moduleAddress}::todolist::TodoList`
     );
@@ -100,7 +103,7 @@ const fetchList = async () => {
 
 The `moduleAddress` is the address we publish the module under, i.e the account address you have in your `Move.toml` file (`myaddr`).
 
-The `client.getAccountResource()`expects an *account address* that holds the resource we are looking for and a string representation of an on-chain *Move struct type*.
+The `provider.getAccountResource()`expects an _account address_ that holds the resource we are looking for and a string representation of an on-chain _Move struct type_.
 
 - account address - is the current connected account (we are getting it from the wallet account object)
 - Move struct type string syntax:

--- a/developer-docs-site/docs/tutorials/build-e2e-dapp/4-fetch-data-from-chain.md
+++ b/developer-docs-site/docs/tutorials/build-e2e-dapp/4-fetch-data-from-chain.md
@@ -26,7 +26,7 @@ import { Provider, Network } from "aptos";
 The TypeScript SDK provides us with a `Provider` class where we can initialize and query the Aptos chain and Indexer. `Provider` expects `Network` type as an argument, which is the [network name](../../guides/system-integrators-guide.md#choose-a-network) we want to interact with.
 
 :::tip
-Read more about the `Provider` class [here](../../sdks/ts-sdk/typescript-sdk-overview.md#provider-class)
+Read more about the [`Provider`](../../sdks/ts-sdk/typescript-sdk-overview.md#provider-class) class in the Aptos TypeScript SDK overview.
 :::
 
 1. In the `App.tsx` file, add:

--- a/developer-docs-site/docs/tutorials/build-e2e-dapp/5-submit-data-to-chain.md
+++ b/developer-docs-site/docs/tutorials/build-e2e-dapp/5-submit-data-to-chain.md
@@ -39,7 +39,7 @@ const addNewList = async () => {
     // sign and submit transaction to chain
     const response = await signAndSubmitTransaction(payload);
     // wait for transaction
-    await client.waitForTransaction(response.hash);
+    await provider.waitForTransaction(response.hash);
     setAccountHasList(true);
   } catch (error: any) {
     setAccountHasList(false);
@@ -56,11 +56,10 @@ In our `fetchList` function, find the line:
 const moduleAddress = "0xcbddf398841353776903dbab2fdaefc54f181d07e114ae818b1a67af28d1b018";
 ```
 
-And move it to outside of the main `App` function, right beneath our const `NODE_URL` and const `client` declarations.
+And move it to outside of the main `App` function, right beneath our const `provider` declarations.
 
 ```js
-export const NODE_URL = "https://fullnode.devnet.aptoslabs.com";
-export const client = new AptosClient(NODE_URL);
+export const provider = new Provider(Network.DEVNET);
 // change this to be your module account address
 export const moduleAddress = "0xcbddf398841353776903dbab2fdaefc54f181d07e114ae818b1a67af28d1b018";
 ```
@@ -111,7 +110,7 @@ const addNewList = async () => {
     // sign and submit transaction to chain
     const response = await signAndSubmitTransaction(payload);
     // wait for transaction
-    await client.waitForTransaction(response.hash);
+    await provider.waitForTransaction(response.hash);
     setAccountHasList(true);
   } catch (error: any) {
     setAccountHasList(false);

--- a/developer-docs-site/docs/tutorials/build-e2e-dapp/6-handle-tasks.md
+++ b/developer-docs-site/docs/tutorials/build-e2e-dapp/6-handle-tasks.md
@@ -35,7 +35,7 @@ function App() {
 const fetchList = async () => {
   if (!account) return [];
   try {
-    const TodoListResource = await client.getAccountResource(
+    const TodoListResource = await provider.getAccountResource(
       account?.address,
       `${moduleAddress}::todolist::TodoList`
     );
@@ -53,7 +53,7 @@ const fetchList = async () => {
         value_type: `${moduleAddress}::todolist::Task`,
         key: `${counter}`,
       };
-      const task = await client.getTableItem(tableHandle, tableItem);
+      const task = await provider.getTableItem(tableHandle, tableItem);
       tasks.push(task);
       counter++;
     }
@@ -87,7 +87,7 @@ while (counter <= taskCounter) {
     value_type: `${moduleAddress}::todolist::Task`,
     key: `${counter}`,
   };
-  const task = await client.getTableItem(tableHandle, tableItem);
+  const task = await provider.getTableItem(tableHandle, tableItem);
   tasks.push(task);
   counter++;
 }
@@ -179,7 +179,7 @@ We haven’t added any tasks yet, so we simply see a box of empty data. Let’s 
 
 ## Add task
 
-1. Update our UI with an *add task* input:
+1. Update our UI with an _add task_ input:
 
 ```jsx
 {!accountHasList ? (
@@ -289,7 +289,7 @@ const onTaskAdded = async () => {
       // sign and submit transaction to chain
       const response = await signAndSubmitTransaction(payload);
       // wait for transaction
-      await client.waitForTransaction(response.hash);
+      await provider.waitForTransaction(response.hash);
 
 			// hold the latest task.task_id from our local state
       const latestId = tasks.length > 0 ? parseInt(tasks[tasks.length - 1].task_id) + 1 : 1;
@@ -381,7 +381,7 @@ const onCheckboxChange = async (
       // sign and submit transaction to chain
       const response = await signAndSubmitTransaction(payload);
       // wait for transaction
-      await client.waitForTransaction(response.hash);
+      await provider.waitForTransaction(response.hash);
 
       setTasks((prevState) => {
         const newState = prevState.map((obj) => {

--- a/developer-docs-site/docs/tutorials/build-e2e-dapp/index.md
+++ b/developer-docs-site/docs/tutorials/build-e2e-dapp/index.md
@@ -7,7 +7,7 @@ slug: "e2e-dapp-index"
 
 A common way to learn a new framework or programming language is to build a simple todo list. In this tutorial, we will learn how to build an end-to-end todo list dapp, starting from the smart contract side through the front-end side and finally use of a wallet to interact with the two.
 
-See the completed code in the [todolist-dapp-tutorial](https://github.com/aptos-labs/todolist-dapp-tutorial).
+See the completed code in the [my_first_dapp](https://github.com/aptos-labs/aptos-core/tree/main/aptos-move/move-examples/my_first_dapp).
 
 ## Chapters
 
@@ -25,7 +25,7 @@ After meeting the [prerequisites](#prerequisites) and [getting set up](#setup) a
 You must have:
 
 * [Aptos CLI](../../cli-tools/aptos-cli-tool/index.md) `@1.0.4` or later
-* [Aptos TypeScript SDK](../../sdks/ts-sdk/index.md) `@1.6.0` or later
+* [Aptos TypeScript SDK](../../sdks/ts-sdk/index.md) `@1.7.1` or later
 * [Aptos Wallet Adapter](../../concepts/wallet-adapter-concept.md) `@0.2.2` or later
 * [Create React App](https://create-react-app.dev/)
 * [node and npm](https://nodejs.org/en/)


### PR DESCRIPTION
### Description
Update e2e dapp tutorial with
- Use TS SDK `Provider` class instead of `AptosClient` to interact with the network
- Link the tutorial on aptos-core repo instead of an external repo (will delete external repo after this PR lands)
- Change move module name to `todolist` due to issues with the `main` name.

### Test Plan
Tests are passing