### PR TITLE
[Config] Add config for API runtime workers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "mime",
  "move-core-types",
  "move-package",
+ "num_cpus",
  "once_cell",
  "paste",
  "percent-encoding",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -37,6 +37,7 @@ hyper = { workspace = true }
 itertools = { workspace = true }
 mime = { workspace = true }
 move-core-types = { workspace = true }
+num_cpus = { workspace = true }
 once_cell = { workspace = true }
 paste = { workspace = true }
 poem = { workspace = true }

--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -9,7 +9,7 @@ use crate::{
     view_function::ViewFunctionApi,
 };
 use anyhow::Context as AnyhowContext;
-use aptos_config::config::NodeConfig;
+use aptos_config::config::{ApiConfig, NodeConfig};
 use aptos_logger::info;
 use aptos_mempool::MempoolClientSender;
 use aptos_storage_interface::DbReader;
@@ -33,7 +33,8 @@ pub fn bootstrap(
     db: Arc<dyn DbReader>,
     mp_sender: MempoolClientSender,
 ) -> anyhow::Result<Runtime> {
-    let runtime = aptos_runtimes::spawn_named_runtime("api".into(), None);
+    let max_runtime_workers = get_max_runtime_workers(&config.api);
+    let runtime = aptos_runtimes::spawn_named_runtime("api".into(), Some(max_runtime_workers));
 
     let context = Context::new(chain_id, db, mp_sender, config.clone());
 
@@ -201,11 +202,21 @@ pub fn attach_poem_to_runtime(
     Ok(actual_address)
 }
 
+/// Returns the maximum number of runtime workers to be given to the
+/// API runtime. Defaults to 2 * number of CPU cores if not specified
+/// via the given config.
+fn get_max_runtime_workers(api_config: &ApiConfig) -> usize {
+    api_config
+        .max_runtime_workers
+        .unwrap_or_else(|| num_cpus::get() * api_config.runtime_worker_multiplier)
+}
+
 #[cfg(test)]
 mod tests {
     use super::bootstrap;
+    use crate::runtime::get_max_runtime_workers;
     use aptos_api_test_context::{new_test_context, TestContext};
-    use aptos_config::config::NodeConfig;
+    use aptos_config::config::{ApiConfig, NodeConfig};
     use aptos_types::chain_id::ChainId;
     use std::time::Duration;
 
@@ -218,6 +229,43 @@ mod tests {
         let mut cfg = NodeConfig::default();
         cfg.randomize_ports();
         bootstrap_with_config(cfg);
+    }
+
+    #[test]
+    fn test_max_runtime_workers() {
+        // Specify the number of workers for the runtime
+        let max_runtime_workers = 100;
+        let api_config = ApiConfig {
+            max_runtime_workers: Some(max_runtime_workers),
+            ..Default::default()
+        };
+
+        // Verify the correct number of workers is returned
+        assert_eq!(get_max_runtime_workers(&api_config), max_runtime_workers);
+
+        // Don't specify the number of workers for the runtime
+        let api_config = ApiConfig {
+            max_runtime_workers: None,
+            ..Default::default()
+        };
+
+        // Verify the correct number of workers is returned
+        assert_eq!(
+            get_max_runtime_workers(&api_config),
+            num_cpus::get() * api_config.runtime_worker_multiplier
+        );
+
+        // Update the multiplier
+        let api_config = ApiConfig {
+            runtime_worker_multiplier: 10,
+            ..Default::default()
+        };
+
+        // Verify the correct number of workers is returned
+        assert_eq!(
+            get_max_runtime_workers(&api_config),
+            num_cpus::get() * api_config.runtime_worker_multiplier
+        );
     }
 
     pub fn bootstrap_with_config(cfg: NodeConfig) {

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -34,7 +34,7 @@ pub struct ApiConfig {
 
     pub max_submit_transaction_batch_size: usize,
 
-    /// Maximum page size for paginated APIs
+    // Maximum page size for paginated APIs
     pub max_transactions_page_size: u16,
     pub max_events_page_size: u16,
     pub max_account_resources_page_size: u16,
@@ -42,6 +42,10 @@ pub struct ApiConfig {
 
     /// Max gas unit for view function.
     pub max_gas_view_function: u64,
+
+    // Performance functionality
+    pub max_runtime_workers: Option<usize>, // The maximum number of workers to use for the API runtime
+    pub runtime_worker_multiplier: usize, // If max_runtime_workers is None, use runtime_worker_multiplier * num CPU cores
 }
 
 pub const DEFAULT_ADDRESS: &str = "127.0.0.1";
@@ -83,6 +87,8 @@ impl Default for ApiConfig {
             max_account_resources_page_size: DEFAULT_MAX_ACCOUNT_RESOURCES_PAGE_SIZE,
             max_account_modules_page_size: DEFAULT_MAX_ACCOUNT_MODULES_PAGE_SIZE,
             max_gas_view_function: DEFAULT_MAX_VIEW_GAS,
+            max_runtime_workers: None,
+            runtime_worker_multiplier: 2,
         }
     }
 }


### PR DESCRIPTION
### Description
This PR updates the config for the API runtime. Specifically, it:
1. Adds a new config entry to specify the maximum number of worker threads for the runtime (defaults to None).
2. Adds a new config entry to specify the worker amplification factor (defaults to 2).

If the config does not specify the maximum number of worker threads for the API runtime, we choose 2 * the number of CPU cores. This seems to be more optimal based on the findings here: https://github.com/aptos-labs/aptos-core/issues/7082

### Test Plan
Manual verification.