### PR TITLE
[Aptos Data Client] Improvements around chunk size calculations.

### DIFF
--- a/aptos-node/src/state_sync.rs
+++ b/aptos-node/src/state_sync.rs
@@ -179,7 +179,6 @@ fn setup_aptos_data_client(
     let (aptos_data_client, data_summary_poller) = AptosNetDataClient::new(
         node_config.state_sync.aptos_data_client,
         node_config.base.clone(),
-        node_config.state_sync.storage_service,
         TimeService::real(),
         storage_service_client,
         Some(aptos_data_client_runtime.handle().clone()),

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -5,7 +5,13 @@
 use serde::{Deserialize, Serialize};
 
 // The maximum message size per state sync message
-pub const MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024; /* 4 MiB */
+const MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024; /* 4 MiB */
+
+// The maximum chunk sizes for data client requests and response
+const MAX_EPOCH_CHUNK_SIZE: u64 = 200;
+const MAX_STATE_CHUNK_SIZE: u64 = 4000;
+const MAX_TRANSACTION_CHUNK_SIZE: u64 = 2000;
+const MAX_TRANSACTION_OUTPUT_CHUNK_SIZE: u64 = 1000;
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -120,14 +126,14 @@ impl Default for StorageServiceConfig {
     fn default() -> Self {
         Self {
             max_concurrent_requests: 4000,
-            max_epoch_chunk_size: 200,
+            max_epoch_chunk_size: MAX_EPOCH_CHUNK_SIZE,
             max_lru_cache_size: 500, // At ~0.6MiB per chunk, this should take no more than 0.5GiB
             max_network_channel_size: 4000,
             max_network_chunk_bytes: MAX_MESSAGE_SIZE as u64,
-            max_state_chunk_size: 4000,
+            max_state_chunk_size: MAX_STATE_CHUNK_SIZE,
             max_subscription_period_ms: 5000,
-            max_transaction_chunk_size: 2000,
-            max_transaction_output_chunk_size: 1000,
+            max_transaction_chunk_size: MAX_TRANSACTION_CHUNK_SIZE,
+            max_transaction_output_chunk_size: MAX_TRANSACTION_OUTPUT_CHUNK_SIZE,
             storage_summary_refresh_interval_ms: 50,
         }
     }
@@ -179,10 +185,14 @@ impl Default for DataStreamingServiceConfig {
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct AptosDataClientConfig {
+    pub max_epoch_chunk_size: u64, // Max num of epoch ending ledger infos per chunk
     pub max_num_in_flight_priority_polls: u64, // Max num of in-flight polls for priority peers
-    pub max_num_in_flight_regular_polls: u64,  // Max num of in-flight polls for regular peers
+    pub max_num_in_flight_regular_polls: u64, // Max num of in-flight polls for regular peers
     pub max_num_output_reductions: u64, // The max num of output reductions before transactions are returned
     pub max_response_timeout_ms: u64, // Max timeout (in ms) when waiting for a response (after exponential increases)
+    pub max_state_chunk_size: u64,    // Max num of state keys and values per chunk
+    pub max_transaction_chunk_size: u64, // Max num of transactions per chunk
+    pub max_transaction_output_chunk_size: u64, // Max num of transaction outputs per chunk
     pub response_timeout_ms: u64,     // First timeout (in ms) when waiting for a response
     pub subscription_timeout_ms: u64, // Timeout (in ms) when waiting for a subscription response
     pub summary_poll_interval_ms: u64, // Interval (in ms) between data summary polls
@@ -192,12 +202,16 @@ pub struct AptosDataClientConfig {
 impl Default for AptosDataClientConfig {
     fn default() -> Self {
         Self {
+            max_epoch_chunk_size: MAX_EPOCH_CHUNK_SIZE,
             max_num_in_flight_priority_polls: 10,
             max_num_in_flight_regular_polls: 10,
             max_num_output_reductions: 0,
             max_response_timeout_ms: 60000, // 60 seconds
-            response_timeout_ms: 10000,     // 10 seconds
-            subscription_timeout_ms: 5000,  // 5 seconds
+            max_state_chunk_size: MAX_STATE_CHUNK_SIZE,
+            max_transaction_chunk_size: MAX_TRANSACTION_CHUNK_SIZE,
+            max_transaction_output_chunk_size: MAX_TRANSACTION_OUTPUT_CHUNK_SIZE,
+            response_timeout_ms: 10000,    // 10 seconds
+            subscription_timeout_ms: 5000, // 5 seconds
             summary_poll_interval_ms: 200,
             use_compression: true,
         }

--- a/state-sync/aptos-data-client/src/aptosnet/mod.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     ResponseError, ResponseId, Result,
 };
 use aptos_config::{
-    config::{AptosDataClientConfig, BaseConfig, StorageServiceConfig},
+    config::{AptosDataClientConfig, BaseConfig},
     network_id::PeerNetworkId,
 };
 use aptos_id_generator::{IdGenerator, U64IdGenerator};
@@ -50,9 +50,6 @@ mod metrics;
 mod state;
 #[cfg(test)]
 mod tests;
-
-// TODO(joshlind): this code needs to be restructured. There are no clear APIs
-// and little separation between components.
 
 // Useful constants for the Aptos Data Client
 const GLOBAL_DATA_LOG_FREQ_SECS: u64 = 10;
@@ -98,7 +95,6 @@ impl AptosNetDataClient {
     pub fn new(
         data_client_config: AptosDataClientConfig,
         base_config: BaseConfig,
-        storage_service_config: StorageServiceConfig,
         time_service: TimeService,
         storage_service_client: StorageServiceClient<NetworkClient<StorageServiceMessage>>,
         runtime: Option<Handle>,
@@ -108,7 +104,7 @@ impl AptosNetDataClient {
             storage_service_client: storage_service_client.clone(),
             peer_states: Arc::new(RwLock::new(PeerStates::new(
                 base_config,
-                storage_service_config,
+                data_client_config,
                 storage_service_client.get_peers_and_metadata(),
             ))),
             global_summary_cache: Arc::new(RwLock::new(GlobalDataSummary::empty())),
@@ -143,10 +139,30 @@ impl AptosNetDataClient {
         self.peer_states.write().update_summary(peer, summary)
     }
 
-    /// Recompute and update the global data summary cache.
-    fn update_global_summary_cache(&self) {
+    /// Recompute and update the global data summary cache
+    fn update_global_summary_cache(&self) -> Result<(), Error> {
+        // Before calculating the summary, we should garbage collect
+        // the peer states (to handle disconnected peers).
+        self.garbage_collect_peer_states()?;
+
+        // Calculate the aggregate data summary
         let aggregate = self.peer_states.read().calculate_aggregate_summary();
         *self.global_summary_cache.write() = aggregate;
+
+        Ok(())
+    }
+
+    /// Garbage collects the peer states to remove data for disconnected peers
+    fn garbage_collect_peer_states(&self) -> Result<(), Error> {
+        // Get all connected peers
+        let all_connected_peers = self.get_all_connected_peers()?;
+
+        // Garbage collect the disconnected peers
+        self.peer_states
+            .write()
+            .garbage_collect_peer_states(all_connected_peers);
+
+        Ok(())
     }
 
     /// Choose a connected peer that can service the given request.
@@ -704,7 +720,17 @@ impl DataSummaryPoller {
             ticker.next().await;
 
             // Update the global storage summary
-            self.data_client.update_global_summary_cache();
+            if let Err(error) = self.data_client.update_global_summary_cache() {
+                sample!(
+                    SampleRate::Duration(Duration::from_secs(POLLER_LOG_FREQ_SECS)),
+                    warn!(
+                        (LogSchema::new(LogEntry::DataSummaryPoller)
+                            .event(LogEvent::AggregateSummary)
+                            .message("Unable to update global summary cache!")
+                            .error(&error))
+                    );
+                );
+            }
 
             // Fetch the prioritized and regular peers to poll (if any)
             let prioritized_peer = self.try_fetch_peer(true);
@@ -715,7 +741,7 @@ impl DataSummaryPoller {
                 sample!(
                     SampleRate::Duration(Duration::from_secs(POLLER_LOG_FREQ_SECS)),
                     debug!(
-                        (LogSchema::new(LogEntry::StorageSummaryRequest)
+                        (LogSchema::new(LogEntry::DataSummaryPoller)
                             .event(LogEvent::NoPeersToPoll)
                             .message("No prioritized or regular peers to poll this round!"))
                     );

--- a/state-sync/aptos-data-client/src/aptosnet/state.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/state.rs
@@ -6,7 +6,7 @@ use crate::{
     AdvertisedData, GlobalDataSummary, OptimalChunkSizes, ResponseError,
 };
 use aptos_config::{
-    config::{BaseConfig, StorageServiceConfig},
+    config::{AptosDataClientConfig, BaseConfig},
     network_id::{NetworkId, PeerNetworkId},
 };
 use aptos_logger::prelude::*;
@@ -55,8 +55,8 @@ impl From<ResponseError> for ErrorType {
     }
 }
 
-#[derive(Debug)]
-struct PeerState {
+#[derive(Clone, Debug)]
+pub struct PeerState {
     /// The latest observed advertised data for this peer, or `None` if we
     /// haven't polled them yet.
     storage_summary: Option<StorageServerSummary>,
@@ -105,11 +105,10 @@ impl PeerState {
 
 /// Contains all of the unbanned peers' most recent [`StorageServerSummary`] data
 /// advertisements and data-client internal metadata for scoring.
-// TODO(philiphayes): this map needs to be garbage collected
 #[derive(Debug)]
 pub(crate) struct PeerStates {
     base_config: BaseConfig,
-    storage_service_config: StorageServiceConfig,
+    data_client_config: AptosDataClientConfig,
     peer_to_state: HashMap<PeerNetworkId, PeerState>,
     in_flight_priority_polls: HashSet<PeerNetworkId>, // The priority peers with in-flight polls
     in_flight_regular_polls: HashSet<PeerNetworkId>,  // The regular peers with in-flight polls
@@ -119,12 +118,12 @@ pub(crate) struct PeerStates {
 impl PeerStates {
     pub fn new(
         base_config: BaseConfig,
-        storage_service_config: StorageServiceConfig,
+        data_client_config: AptosDataClientConfig,
         peers_and_metadata: Arc<PeersAndMetadata>,
     ) -> Self {
         Self {
             base_config,
-            storage_service_config,
+            data_client_config,
             peer_to_state: HashMap::new(),
             in_flight_priority_polls: HashSet::new(),
             in_flight_regular_polls: HashSet::new(),
@@ -296,6 +295,12 @@ impl PeerStates {
             .update_storage_summary(summary);
     }
 
+    /// Garbage collects the peer states to remove data for disconnected peers
+    pub fn garbage_collect_peer_states(&mut self, connected_peers: Vec<PeerNetworkId>) {
+        self.peer_to_state
+            .retain(|peer_network_id, _| connected_peers.contains(peer_network_id));
+    }
+
     /// Calculates a global data summary using all known storage summaries
     pub fn calculate_aggregate_summary(&self) -> GlobalDataSummary {
         // Only include likely-not-malicious peers in the data summary aggregation
@@ -352,7 +357,7 @@ impl PeerStates {
 
         // Calculate optimal chunk sizes based on the advertised data
         let optimal_chunk_sizes = calculate_optimal_chunk_sizes(
-            &self.storage_service_config,
+            &self.data_client_config,
             max_epoch_chunk_sizes,
             max_state_chunk_sizes,
             max_transaction_chunk_sizes,
@@ -363,13 +368,19 @@ impl PeerStates {
             optimal_chunk_sizes,
         }
     }
+
+    #[cfg(test)]
+    /// Returns a copy of the peer to states map for test purposes
+    pub fn get_peer_to_states(&self) -> HashMap<PeerNetworkId, PeerState> {
+        self.peer_to_state.clone()
+    }
 }
 
 /// To calculate the optimal chunk size, we take the median for each
 /// chunk size parameter. This works well when we have an honest
 /// majority that mostly agrees on the same chunk sizes.
 pub(crate) fn calculate_optimal_chunk_sizes(
-    config: &StorageServiceConfig,
+    config: &AptosDataClientConfig,
     max_epoch_chunk_sizes: Vec<u64>,
     max_state_chunk_sizes: Vec<u64>,
     max_transaction_chunk_sizes: Vec<u64>,

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
@@ -304,7 +304,6 @@ async fn create_driver_for_tests(
     let (aptos_data_client, _) = AptosNetDataClient::new(
         node_config.state_sync.aptos_data_client,
         node_config.base.clone(),
-        node_config.state_sync.storage_service,
         time_service.clone(),
         network_client,
         None,

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver_factory.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver_factory.rs
@@ -75,7 +75,6 @@ fn test_new_initialized_configs() {
     let (aptos_data_client, _) = AptosNetDataClient::new(
         node_config.state_sync.aptos_data_client,
         node_config.base.clone(),
-        node_config.state_sync.storage_service,
         TimeService::mock(),
         network_client,
         None,

--- a/state-sync/storage-service/types/src/responses.rs
+++ b/state-sync/storage-service/types/src/responses.rs
@@ -375,62 +375,11 @@ pub struct ProtocolMetadata {
 }
 
 impl ProtocolMetadata {
-    /// Returns true iff the request can be serviced
-    pub fn can_service(&self, request: &StorageServiceRequest) -> bool {
-        match &request.data_request {
-            GetNewTransactionsWithProof(_)
-            | GetNewTransactionOutputsWithProof(_)
-            | GetNewTransactionsOrOutputsWithProof(_)
-            | GetNumberOfStatesAtVersion(_)
-            | GetServerProtocolVersion
-            | GetStorageServerSummary => true,
-            GetStateValuesWithProof(request) => CompleteDataRange::new(
-                request.start_index,
-                request.end_index,
-            )
-            .map_or(false, |range| {
-                range
-                    .len()
-                    .map_or(false, |chunk_size| self.max_state_chunk_size >= chunk_size)
-            }),
-            GetEpochEndingLedgerInfos(request) => CompleteDataRange::new(
-                request.start_epoch,
-                request.expected_end_epoch,
-            )
-            .map_or(false, |range| {
-                range
-                    .len()
-                    .map_or(false, |chunk_size| self.max_epoch_chunk_size >= chunk_size)
-            }),
-            GetTransactionOutputsWithProof(request) => CompleteDataRange::new(
-                request.start_version,
-                request.end_version,
-            )
-            .map_or(false, |range| {
-                range.len().map_or(false, |chunk_size| {
-                    self.max_transaction_output_chunk_size >= chunk_size
-                })
-            }),
-            GetTransactionsWithProof(request) => CompleteDataRange::new(
-                request.start_version,
-                request.end_version,
-            )
-            .map_or(false, |range| {
-                range.len().map_or(false, |chunk_size| {
-                    self.max_transaction_chunk_size >= chunk_size
-                })
-            }),
-            GetTransactionsOrOutputsWithProof(request) => CompleteDataRange::new(
-                request.start_version,
-                request.end_version,
-            )
-            .map_or(false, |range| {
-                range.len().map_or(false, |chunk_size| {
-                    self.max_transaction_chunk_size >= chunk_size
-                        && self.max_transaction_output_chunk_size >= chunk_size
-                })
-            }),
-        }
+    /// We deem all requests serviceable, even if the requested chunk
+    /// sizes are larger than the maximum sizes that can be served (the
+    /// response will simply be truncated on the server side).
+    pub fn can_service(&self, _request: &StorageServiceRequest) -> bool {
+        true // TODO: figure out if should eventually remove this
     }
 }
 

--- a/state-sync/storage-service/types/src/tests.rs
+++ b/state-sync/storage-service/types/src/tests.rs
@@ -219,17 +219,17 @@ fn test_protocol_metadata_can_service() {
     };
 
     for compression in [true, false] {
-        assert!(metadata.can_service(&txns_request(200, 100, 199, compression)));
-        assert!(!metadata.can_service(&txns_request(200, 100, 200, compression)));
-
+        // Requests with smaller chunk sizes can be serviced
+        assert!(metadata.can_service(&txns_request(200, 100, 101, compression)));
         assert!(metadata.can_service(&epochs_request(100, 199, compression)));
-        assert!(!metadata.can_service(&epochs_request(100, 200, compression)));
-
-        assert!(metadata.can_service(&outputs_request(200, 100, 199, compression)));
-        assert!(!metadata.can_service(&outputs_request(200, 100, 200, compression)));
-
+        assert!(metadata.can_service(&outputs_request(200, 100, 100, compression)));
         assert!(metadata.can_service(&state_values_request(200, 100, 199, compression)));
-        assert!(!metadata.can_service(&state_values_request(200, 100, 200, compression)));
+
+        // Requests with larger chunk sizes (beyond the max) can also be serviced
+        assert!(metadata.can_service(&txns_request(200, 100, 1000, compression)));
+        assert!(metadata.can_service(&epochs_request(100, 10000, compression)));
+        assert!(metadata.can_service(&outputs_request(200, 100, 9999989, compression)));
+        assert!(metadata.can_service(&state_values_request(200, 100, 200, compression)));
     }
 }
 


### PR DESCRIPTION
### Description
This PR makes three small improvements to the Aptos data client:
1. Decouple the chunk sizes between the data client and storage service (by adding chunk sizes to the data client config). Now, we can specify the data sizes of chunks to request and the data sizes of chunks to return, independently.
2. Garbage collect peer states for peers that are no longer connected (and add a new unit test).
3. Update data summary logic to always allow clients to request data from peers, even if that peer cannot return the entire data chunk.

### Test Plan
Existing test infrastructure.