### PR TITLE
Updated the docs to use --network instead of --rest-url

### DIFF
--- a/developer-docs-site/docs/nodes/validator-node/operator/connect-to-aptos-network.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/connect-to-aptos-network.md
@@ -16,13 +16,12 @@ The current required minimum for staking is 1M APT tokens.
 Before joining the network, make sure the validator node is bootstrapped with the correct genesis blob and waypoint for corresponding network. To bootstrap your node, first you need to know the pool address to use:
 
 :::tip 
-See the `--rest-url` value for testnet or devnet in [Aptos Blockchain Deployments](../../aptos-deployments.md).
+The command below uses the network you set for the account when [initializing the CLI](../../../nodes/validator-node/owner/index.md#initialize-cli).
 :::
 
 ```bash
 aptos node get-stake-pool \
   --owner-address <owner_address> 
-  --url https://fullnode.mainnet.aptoslabs.com/v1
 ```
 
 ### Using source code

--- a/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
@@ -8,7 +8,7 @@ slug: "staking-pool-operations"
 This document describes how to perform staking pool operations. Note that you can stake only when you meet the minimal staking requirement. 
 
 :::tip Minimum staking requirement
-The current required minimum for staking is 1M APT tokens.
+The current required minimum for staking is 1 million APT tokens.
 :::
 
 ## Connect to Aptos network
@@ -28,15 +28,15 @@ Make sure that this initializing the stake pool step was performed by the owner.
 Follow the below steps to set up the validator node using the operator account and join the validator set.
 
 :::tip Mainnet vs Testnet
-The below CLI command examples use mainnet. See the `--rest-url` value for testnet or devnet in [Aptos Blockchain Deployments](../../aptos-deployments.md).
+The below CLI command examples use mainnet. Change the `--network` value for testnet and devnet. View the values in [Aptos Blockchain Deployments](../../aptos-deployments.md) to see how profiles can be configured based on the network.
 :::
 
 ### 1. Initialize Aptos CLI
 
   ```bash
   aptos init --profile mainnet-operator \
+  --network mainnet \
   --private-key <operator_account_private_key> \
-  --rest-url https://fullnode.mainnet.aptoslabs.com/v1 \
   --skip-faucet
   ```
   

--- a/developer-docs-site/docs/nodes/validator-node/owner/index.md
+++ b/developer-docs-site/docs/nodes/validator-node/owner/index.md
@@ -17,7 +17,7 @@ The [Petra wallet extension](../../../guides/install-petra-wallet.md) is support
 ## Owner operations with CLI
 
 :::tip Testnet vs Mainnet
-The below CLI command examples use mainnet. See the `--rest-url` value for testnet and devnet in [Aptos Blockchain Deployments](../../aptos-deployments.md).
+The below CLI command examples use mainnet. Change the `--network` value for testnet and devnet. View the `--rest-url` values in [Aptos Blockchain Deployments](../../aptos-deployments.md) to see how profiles can be configured based on the network.
 :::
 
 ### Initialize CLI
@@ -26,7 +26,7 @@ Initialize CLI with your Petra wallet private key or create new wallet.
 
 ```bash
 aptos init --profile mainnet-owner \
-  --rest-url https://fullnode.mainnet.aptoslabs.com/v1
+  --network mainnet
 ```
 
 You can either enter the private key from an existing wallet, or create new wallet address.

--- a/developer-docs-site/docs/nodes/validator-node/owner/index.md
+++ b/developer-docs-site/docs/nodes/validator-node/owner/index.md
@@ -17,7 +17,7 @@ The [Petra wallet extension](../../../guides/install-petra-wallet.md) is support
 ## Owner operations with CLI
 
 :::tip Testnet vs Mainnet
-The below CLI command examples use mainnet. Change the `--network` value for testnet and devnet. View the `--rest-url` values in [Aptos Blockchain Deployments](../../aptos-deployments.md) to see how profiles can be configured based on the network.
+The below CLI command examples use mainnet. Change the `--network` value for testnet and devnet. View the values in [Aptos Blockchain Deployments](../../aptos-deployments.md) to see how profiles can be configured based on the network.
 :::
 
 ### Initialize CLI


### PR DESCRIPTION
I updated the relevant examples to use `--network` instead of `--rest-url`. These changes address [issue #6528](https://github.com/aptos-labs/aptos-core/issues/6528).
