### PR TITLE
Fixed some version numbers in cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -362,8 +362,8 @@ fail = "0.5.0"
 field_count = "0.1.1"
 flate2 = "1.0.24"
 fs_extra = "1.2.0"
-futures = "= 0.3.24" # Previously futures v0.3.23 caused some consensus network_tests to fail. We now pin the dependency to v0.3.24.
-futures-channel = "= 0.3.24"
+futures = "0.3.24" # Previously futures v0.3.23 caused some consensus network_tests to fail. We now pin the dependency to v0.3.24.
+futures-channel = "0.3.24"
 futures-core = "0.3.25"
 futures-util = "0.3.21"
 gcp-bigquery-client = "0.13.0"
@@ -396,7 +396,7 @@ k8s-openapi = { version = "0.11.0", default-features = false, features = [
     "v1_15",
 ] }
 kube = { version = "0.51.0", features = ["jsonpatch"] }
-libfuzzer-sys = "=0.3.2"
+libfuzzer-sys = "0.3.2"
 libsecp256k1 = "0.7.0"
 log = "0.4.17"
 lru = "0.7.5"


### PR DESCRIPTION
The following dependencies had `=` inside of the quotes as part of the version number instead of outside the quotes:
- libfuzzer-sys
- futures
- futures-channel