### PR TITLE
[Consensus] Dedicated channel for proposal processing

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -91,12 +91,13 @@ jobs:
   # Because the docker build happens in a reusable workflow, have a separate job that collects the right metadata
   # for the subsequent docker builds. Reusable workflows do not currently have the "env" context: https://github.com/orgs/community/discussions/26671
   determine-docker-build-metadata:
+    needs: [permission-check]
     runs-on: ubuntu-latest
     steps:
       - name: collect metadata
         run: |
-          echo "GIT_SHA: ${{ env.GIT_SHA }}"
-          echo "TARGET_CACHE_ID: ${{ env.TARGET_CACHE_ID }}"
+          echo "GIT_SHA: ${GIT_SHA}"
+          echo "TARGET_CACHE_ID: ${TARGET_CACHE_ID}"
     outputs:
       gitSha: ${{ env.GIT_SHA }}
       targetCacheId: ${{ env.TARGET_CACHE_ID }}

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -48,6 +48,7 @@ concurrency:
 
 env:
   GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
+  GCP_DOCKER_ARTIFACT_REPO_US: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO_US }}
   AWS_ECR_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
   # In case of pull_request events by default github actions merges main into the PR branch and then runs the tests etc
   # on the prospective merge result instead of only on the tip of the PR.
@@ -69,15 +70,15 @@ permissions:
 # Note on the job-level `if` conditions:
 # This workflow is designed such that:
 # 1. Run ALL jobs when a 'push', 'workflow_dispatch' triggered the workflow or on 'pull_request's which have set auto_merge=true or have the label "CICD:run-e2e-tests".
-# 2. Run ONLY the docker image building jobs on PRs with the "CICD:build-images" label.
+# 2. Run ONLY the docker image building jobs on PRs with the "CICD:build[-<PROFILE/FEATURE>]-images" label.
 # 3. Run NOTHING when neither 1. or 2.'s conditions are satisfied.
 jobs:
   permission-check:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'CICD:build-images') ||
-      contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'CICD:build-') ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'CICD:run-') ||
       github.event.pull_request.auto_merge != null ||
       contains(github.event.pull_request.body, '#e2e')
     runs-on: ubuntu-latest
@@ -104,7 +105,7 @@ jobs:
 
   rust-images:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: ./.github/workflows/docker-rust-build.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -114,7 +115,11 @@ jobs:
 
   rust-images-indexer:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: ./.github/workflows/docker-rust-build.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'CICD:build-indexer-images')
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -125,7 +130,11 @@ jobs:
 
   rust-images-failpoints:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: ./.github/workflows/docker-rust-build.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'CICD:build-failpoints-images')
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -136,7 +145,11 @@ jobs:
 
   rust-images-performance:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: ./.github/workflows/docker-rust-build.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'CICD:build-performance-images')
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -149,7 +162,7 @@ jobs:
     if: |
       contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image') ||
       contains(github.event.pull_request.labels.*.name, 'CICD:run-consensus-only-perf-test')
-    uses: ./.github/workflows/docker-rust-build.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -159,38 +172,57 @@ jobs:
       BUILD_ADDL_TESTING_IMAGES: true
 
   sdk-release:
-    needs: [rust-images, determine-docker-build-metadata]
+    needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'CICD:skip-sdk-integration-test') && (
-      github.event_name == 'push' ||
+      (github.event_name == 'push' && github.ref_name != 'main') ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
-      github.event.pull_request.auto_merge != null) ||
+      github.event.pull_request.auto_merge != null ||
       contains(github.event.pull_request.body, '#e2e')
-    uses: ./.github/workflows/sdk-release.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/sdk-release.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
 
   cli-e2e-tests:
-    needs: [rust-images, determine-docker-build-metadata]
+    needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
     if: |
       !contains(github.event.pull_request.labels.*.name, 'CICD:skip-sdk-integration-test') && (
-      github.event_name == 'push' ||
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+        github.event.pull_request.auto_merge != null) ||
+        contains(github.event.pull_request.body, '#e2e'
+      )
+    uses: ./.github/workflows/cli-e2e-tests.yaml
+    secrets: inherit
+    with:
+      GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+
+  indexer-grpc-e2e-tests:
+    needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
+    if: |
+      (github.event_name == 'push' && github.ref_name != 'main') ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
-      github.event.pull_request.auto_merge != null) ||
+      github.event.pull_request.auto_merge != null ||
       contains(github.event.pull_request.body, '#e2e')
-    uses: ./.github/workflows/cli-e2e-tests.yaml
+    uses: ./.github/workflows/docker-indexer-grpc-test.yaml
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
 
   forge-e2e-test:
     needs:
-      [rust-images, rust-images-failpoints, determine-docker-build-metadata]
+      - permission-check
+      - determine-docker-build-metadata
+      - rust-images
+      - rust-images-indexer
+      - rust-images-failpoints
+      - rust-images-performance
+      - rust-images-consensus-only-perf-test
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'CICD:skip-forge-e2e-test') && (
+      !failure() && !cancelled() && needs.permission-check.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
@@ -201,6 +233,9 @@ jobs:
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+      FORGE_TEST_SUITE: land_blocking
+      IMAGE_TAG: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+      FORGE_RUNNER_DURATION_SECS: 480
       COMMENT_HEADER: forge-e2e
       # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
       # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
@@ -210,9 +245,15 @@ jobs:
   # Run e2e compat test against testnet branch
   forge-compat-test:
     needs:
-      [rust-images, rust-images-failpoints, determine-docker-build-metadata]
+      - permission-check
+      - determine-docker-build-metadata
+      - rust-images
+      - rust-images-indexer
+      - rust-images-failpoints
+      - rust-images-performance
+      - rust-images-consensus-only-perf-test
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'CICD:skip-forge-e2e-test') && (
+      !failure() && !cancelled() && needs.permission-check.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
@@ -224,20 +265,23 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: compat
-      IMAGE_TAG: testnet_2d8b1b57553d869190f61df1aaf7f31a8fc19a7b # test against the latest build on testnet branch
+      IMAGE_TAG: testnet_2d8b1b57553d869190f61df1aaf7f31a8fc19a7b # test against a previous testnet release
       FORGE_RUNNER_DURATION_SECS: 300
       COMMENT_HEADER: forge-compat
-      # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
-      # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
-      # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
       FORGE_NAMESPACE: forge-compat-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
-  
+
   # Run forge framework upgradability test
   forge-framework-upgrade-test:
     needs:
-      [rust-images, rust-images-failpoints, determine-docker-build-metadata]
+      - permission-check
+      - determine-docker-build-metadata
+      - rust-images
+      - rust-images-indexer
+      - rust-images-failpoints
+      - rust-images-performance
+      - rust-images-consensus-only-perf-test
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'CICD:skip-forge-e2e-test') && (
+      !failure() && !cancelled() && needs.permission-check.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
@@ -249,18 +293,22 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: framework_upgrade
-      IMAGE_TAG: cb4ba0a57c998c60cbab65af31a64875d2588ca5  # This workflow only gets stablized after the 1.2 release because of the multi-step governance proposal.
+      IMAGE_TAG: aptos-node-v1.3.0_3fc3d42b6cfe27460004f9a0326451bcda840a60 # This workflow will test the upgradability from the current tip of the release branch to the current main branch.
       FORGE_RUNNER_DURATION_SECS: 300
       COMMENT_HEADER: forge-framework-upgrade
-      # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
-      # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
-      # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
       FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
 
   forge-consensus-only-perf-test:
     needs:
-      [rust-images-consensus-only-perf-test, determine-docker-build-metadata]
+      - permission-check
+      - determine-docker-build-metadata
+      - rust-images
+      - rust-images-indexer
+      - rust-images-failpoints
+      - rust-images-performance
+      - rust-images-consensus-only-perf-test
     if: |
+      !failure() && !cancelled() && needs.permission-check.result == 'success' &&
       contains(github.event.pull_request.labels.*.name, 'CICD:run-consensus-only-perf-test')
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
@@ -270,7 +318,4 @@ jobs:
       IMAGE_TAG: consensus_only_perf_test_${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_RUNNER_DURATION_SECS: 300
       COMMENT_HEADER: forge-consensus-only-perf-test
-      # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
-      # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
-      # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
       FORGE_NAMESPACE: forge-consensus-only-perf-test-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}

--- a/consensus/src/block_storage/block_store_test.rs
+++ b/consensus/src/block_storage/block_store_test.rs
@@ -473,7 +473,7 @@ async fn test_need_sync_for_ledger_info() {
     assert!(block_store.need_sync_for_ledger_info(&ordered_too_far));
 
     let committed_round_too_far =
-        block_store.commit_root().round() + block_store.back_pressure_limit * 2 + 1;
+        block_store.commit_root().round() + block_store.back_pressure_limit * 3 + 1;
     let committed_too_far = create_ledger_info(committed_round_too_far);
     assert!(block_store.need_sync_for_ledger_info(&committed_too_far));
 

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -47,7 +47,7 @@ impl BlockStore {
     pub fn need_sync_for_ledger_info(&self, li: &LedgerInfoWithSignatures) -> bool {
         (self.ordered_root().round() < li.commit_info().round()
             && !self.block_exists(li.commit_info().id()))
-            || self.commit_root().round() + 2 * self.back_pressure_limit < li.commit_info().round()
+            || self.commit_root().round() + 3 * self.back_pressure_limit < li.commit_info().round()
     }
 
     /// Checks if quorum certificate can be inserted in block store without RPC

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -150,6 +150,15 @@ pub static PROPOSER_COLLECTED_TIMEOUT_VOTING_POWER: Lazy<Counter> = Lazy::new(||
         .unwrap()
 });
 
+/// Total number of stale proposals received by the validator
+pub static STALE_PROPOSALS_RECEIVED: Lazy<Counter> = Lazy::new(|| {
+    register_counter!(
+        "aptos_proposer_stale_proposals_received",
+        "Total number of stale proposals received by the validator",
+    )
+    .unwrap()
+});
+
 /// Committed proposals map when using LeaderReputation as the ProposerElection
 pub static COMMITTED_PROPOSALS_IN_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -54,6 +54,7 @@ use aptos_config::config::{ConsensusConfig, NodeConfig};
 use aptos_consensus_types::{
     common::{Author, Round},
     epoch_retrieval::EpochRetrievalRequest,
+    proposal_msg::ProposalMsg,
 };
 use aptos_event_notifications::ReconfigNotificationListener;
 use aptos_infallible::{duration_since_epoch, Mutex};
@@ -92,10 +93,10 @@ use std::{
 
 /// Range of rounds (window) that we might be calling proposer election
 /// functions with at any given time, in addition to the proposer history length.
-const PROPSER_ELECTION_CACHING_WINDOW_ADDITION: usize = 3;
+const PROPOSER_ELECTION_CACHING_WINDOW_ADDITION: usize = 3;
 /// Number of rounds we expect storage to be ahead of the proposer round,
 /// used for fetching data from DB.
-const PROPSER_ROUND_BEHIND_STORAGE_BUFFER: usize = 10;
+const PROPOSER_ROUND_BEHIND_STORAGE_BUFFER: usize = 10;
 
 #[allow(clippy::large_enum_variant)]
 pub enum LivenessStorageData {
@@ -125,6 +126,8 @@ pub struct EpochManager {
     round_manager_tx: Option<
         aptos_channel::Sender<(Author, Discriminant<VerifiedEvent>), (Author, VerifiedEvent)>,
     >,
+    // channels to send proposal messages to the round manager
+    proposal_msg_tx: Option<aptos_channel::Sender<Author, Box<ProposalMsg>>>,
     round_manager_close_tx: Option<oneshot::Sender<oneshot::Sender<()>>>,
     epoch_state: Option<Arc<EpochState>>,
     block_retrieval_tx:
@@ -172,6 +175,7 @@ impl EpochManager {
             buffer_manager_msg_tx: None,
             buffer_manager_reset_tx: None,
             round_manager_tx: None,
+            proposal_msg_tx: None,
             round_manager_close_tx: None,
             epoch_state: None,
             block_retrieval_tx: None,
@@ -211,19 +215,19 @@ impl EpochManager {
         &self,
         epoch_state: &EpochState,
         onchain_config: &OnChainConsensusConfig,
-    ) -> Box<dyn ProposerElection + Send + Sync> {
+    ) -> Arc<dyn ProposerElection + Send + Sync> {
         let proposers = epoch_state
             .verifier
             .get_ordered_account_addresses_iter()
             .collect::<Vec<_>>();
         match &onchain_config.proposer_election_type() {
             ProposerElectionType::RotatingProposer(contiguous_rounds) => {
-                Box::new(RotatingProposer::new(proposers, *contiguous_rounds))
+                Arc::new(RotatingProposer::new(proposers, *contiguous_rounds))
             },
             // We don't really have a fixed proposer!
             ProposerElectionType::FixedProposer(contiguous_rounds) => {
                 let proposer = choose_leader(proposers);
-                Box::new(RotatingProposer::new(vec![proposer], *contiguous_rounds))
+                Arc::new(RotatingProposer::new(vec![proposer], *contiguous_rounds))
             },
             ProposerElectionType::LeaderReputation(leader_reputation_type) => {
                 let (
@@ -260,7 +264,7 @@ impl EpochManager {
 
                 let seek_len = onchain_config.leader_reputation_exclude_round() as usize
                     + onchain_config.max_failed_authors_to_store()
-                    + PROPSER_ROUND_BEHIND_STORAGE_BUFFER;
+                    + PROPOSER_ROUND_BEHIND_STORAGE_BUFFER;
 
                 let backend = Box::new(AptosDBBackend::new(
                     window_size,
@@ -324,17 +328,18 @@ impl EpochManager {
                     self.config.window_for_chain_health,
                 ));
                 // LeaderReputation is not cheap, so we can cache the amount of rounds round_manager needs.
-                Box::new(CachedProposerElection::new(
+                Arc::new(CachedProposerElection::new(
                     epoch_state.epoch,
                     proposer_election,
                     onchain_config.max_failed_authors_to_store()
-                        + PROPSER_ELECTION_CACHING_WINDOW_ADDITION,
+                        + PROPOSER_ELECTION_CACHING_WINDOW_ADDITION
+                        + onchain_config.leader_reputation_exclude_round() as usize,
                 ))
             },
             ProposerElectionType::RoundProposer(round_proposers) => {
                 // Hardcoded to the first proposer
                 let default_proposer = proposers.first().unwrap();
-                Box::new(RoundProposer::new(
+                Arc::new(RoundProposer::new(
                     round_proposers.clone(),
                     *default_proposer,
                 ))
@@ -532,6 +537,7 @@ impl EpochManager {
                 .expect("[EpochManager] Fail to drop round manager");
         }
         self.round_manager_tx = None;
+        self.proposal_msg_tx = None;
 
         // Shutdown the previous buffer manager, to release the SafetyRule client
         self.buffer_manager_msg_tx = None;
@@ -736,7 +742,14 @@ impl EpochManager {
             Some(&counters::ROUND_MANAGER_CHANNEL_MSGS),
         );
 
-        self.round_manager_tx = Some(round_manager_tx.clone());
+        let (proposal_msg_tx, mut proposal_msg_rx) = aptos_channel::new(
+            QueueStyle::FIFO,
+            1,
+            Some(&counters::ROUND_MANAGER_CHANNEL_MSGS),
+        );
+
+        self.round_manager_tx = Some(round_manager_tx);
+        self.proposal_msg_tx = Some(proposal_msg_tx);
 
         counters::TOTAL_VOTING_POWER.set(epoch_state.verifier.total_voting_power() as f64);
         counters::VALIDATOR_VOTING_POWER.set(
@@ -754,6 +767,36 @@ impl EpochManager {
                     .set(epoch_state.verifier.get_voting_power(&peer_id).unwrap_or(0) as i64)
             });
 
+        let (checked_proposal_tx, checked_proposal_rx) = aptos_channel::new(
+            QueueStyle::KLAST,
+            onchain_consensus_config.leader_reputation_exclude_round() as usize,
+            None,
+        );
+
+        let proposer_election_clone = proposer_election.clone();
+        let checked_proposal_tx_clone = checked_proposal_tx.clone();
+
+        // Spawn task to buffer valid proposals
+        tokio::spawn(async move {
+            while let Some(proposal_msg) = proposal_msg_rx.next().await {
+                if proposer_election_clone
+                    .is_valid_proposer(proposal_msg.proposer(), proposal_msg.proposal().round())
+                {
+                    if let Err(e) =
+                        checked_proposal_tx_clone.push((), VerifiedEvent::ProposalMsg(proposal_msg))
+                    {
+                        warn!("Failed to send to proposal channel {:?}", e);
+                    }
+                } else {
+                    warn!(
+                        "Invalid proposal {} from {}",
+                        proposal_msg.proposal(),
+                        proposal_msg.proposer(),
+                    );
+                }
+            }
+        });
+
         let mut round_manager = RoundManager::new(
             epoch_state,
             block_store.clone(),
@@ -764,7 +807,7 @@ impl EpochManager {
             network_sender,
             self.storage.clone(),
             onchain_consensus_config,
-            round_manager_tx,
+            checked_proposal_tx,
             self.config.clone(),
         );
 
@@ -772,7 +815,7 @@ impl EpochManager {
 
         let (close_tx, close_rx) = oneshot::channel();
         self.round_manager_close_tx = Some(close_tx);
-        tokio::spawn(round_manager.start(round_manager_rx, close_rx));
+        tokio::spawn(round_manager.start(round_manager_rx, checked_proposal_rx, close_rx));
 
         self.spawn_block_retrieval_task(epoch, block_store);
     }
@@ -846,6 +889,7 @@ impl EpochManager {
             let quorum_store_msg_tx = self.quorum_store_msg_tx.clone();
             let buffer_manager_msg_tx = self.buffer_manager_msg_tx.clone();
             let round_manager_tx = self.round_manager_tx.clone();
+            let proposal_msg_tx = self.proposal_msg_tx.clone();
             let my_peer_id = self.author;
             self.bounded_executor
                 .spawn(async move {
@@ -863,6 +907,7 @@ impl EpochManager {
                                 quorum_store_msg_tx,
                                 buffer_manager_msg_tx,
                                 round_manager_tx,
+                                proposal_msg_tx,
                                 peer_id,
                                 verified_event,
                             );
@@ -982,15 +1027,10 @@ impl EpochManager {
         round_manager_tx: Option<
             aptos_channel::Sender<(Author, Discriminant<VerifiedEvent>), (Author, VerifiedEvent)>,
         >,
+        proposal_msg_tx: Option<aptos_channel::Sender<Author, Box<ProposalMsg>>>,
         peer_id: AccountAddress,
         event: VerifiedEvent,
     ) {
-        if let VerifiedEvent::ProposalMsg(proposal) = &event {
-            observe_block(
-                proposal.proposal().timestamp_usecs(),
-                BlockStage::EPOCH_MANAGER_VERIFIED,
-            );
-        }
         if let Err(e) = match event {
             quorum_store_event @ (VerifiedEvent::SignedBatchInfo(_)
             | VerifiedEvent::ProofOfStoreMsg(_)
@@ -1003,12 +1043,23 @@ impl EpochManager {
                 Self::forward_event_to(buffer_manager_msg_tx, peer_id, buffer_manager_event)
                     .context("buffer manager sender")
             },
-            round_manager_event => Self::forward_event_to(
-                round_manager_tx,
-                (peer_id, discriminant(&round_manager_event)),
-                (peer_id, round_manager_event),
-            )
-            .context("round manager sender"),
+            VerifiedEvent::ProposalMsg(proposal_msg) => {
+                observe_block(
+                    proposal_msg.proposal().timestamp_usecs(),
+                    BlockStage::EPOCH_MANAGER_VERIFIED,
+                );
+                Self::forward_event_to(proposal_msg_tx, peer_id, proposal_msg)
+                    .context("proposal sender")
+            },
+            round_manager_event => {
+                let tx = round_manager_tx;
+                Self::forward_event_to(
+                    tx,
+                    (peer_id, discriminant(&round_manager_event)),
+                    (peer_id, round_manager_event),
+                )
+                .context("round manager sender")
+            },
         } {
             warn!("Failed to forward event: {}", e);
         }

--- a/consensus/src/liveness/proposal_generator_test.rs
+++ b/consensus/src/liveness/proposal_generator_test.rs
@@ -40,7 +40,7 @@ async fn test_proposal_generation_empty_tree() {
         false,
     );
     let mut proposer_election =
-        UnequivocalProposerElection::new(Box::new(RotatingProposer::new(vec![signer.author()], 1)));
+        UnequivocalProposerElection::new(Arc::new(RotatingProposer::new(vec![signer.author()], 1)));
     let genesis = block_store.ordered_root();
 
     // Generate proposals for an empty tree.
@@ -77,7 +77,7 @@ async fn test_proposal_generation_parent() {
         ChainHealthBackoffConfig::new_no_backoff(),
         false,
     );
-    let mut proposer_election = UnequivocalProposerElection::new(Box::new(RotatingProposer::new(
+    let mut proposer_election = UnequivocalProposerElection::new(Arc::new(RotatingProposer::new(
         vec![inserter.signer().author()],
         1,
     )));
@@ -147,7 +147,7 @@ async fn test_old_proposal_generation() {
         ChainHealthBackoffConfig::new_no_backoff(),
         false,
     );
-    let mut proposer_election = UnequivocalProposerElection::new(Box::new(RotatingProposer::new(
+    let mut proposer_election = UnequivocalProposerElection::new(Arc::new(RotatingProposer::new(
         vec![inserter.signer().author()],
         1,
     )));
@@ -182,7 +182,7 @@ async fn test_correct_failed_authors() {
         ChainHealthBackoffConfig::new_no_backoff(),
         false,
     );
-    let mut proposer_election = UnequivocalProposerElection::new(Box::new(RotatingProposer::new(
+    let mut proposer_election = UnequivocalProposerElection::new(Arc::new(RotatingProposer::new(
         vec![author, peer1, peer2],
         1,
     )));

--- a/consensus/src/liveness/unequivocal_proposer_election.rs
+++ b/consensus/src/liveness/unequivocal_proposer_election.rs
@@ -9,14 +9,14 @@ use aptos_consensus_types::{
 use aptos_crypto::HashValue;
 use aptos_infallible::Mutex;
 use aptos_logger::{error, SecurityEvent};
-use std::cmp::Ordering;
+use std::{cmp::Ordering, sync::Arc};
 
 // Wrapper around ProposerElection.
 //
 // Provides is_valid_proposal that remembers, and rejects if
 // the same leader proposes multiple blocks.
 pub struct UnequivocalProposerElection {
-    proposer_election: Box<dyn ProposerElection + Send + Sync>,
+    proposer_election: Arc<dyn ProposerElection + Send + Sync>,
     already_proposed: Mutex<(Round, HashValue)>,
 }
 
@@ -32,7 +32,7 @@ impl ProposerElection for UnequivocalProposerElection {
 }
 
 impl UnequivocalProposerElection {
-    pub fn new(proposer_election: Box<dyn ProposerElection + Send + Sync>) -> Self {
+    pub fn new(proposer_election: Arc<dyn ProposerElection + Send + Sync>) -> Self {
         Self {
             proposer_election,
             already_proposed: Mutex::new((0, HashValue::zero())),
@@ -56,7 +56,6 @@ impl UnequivocalProposerElection {
                     block.id()
                 );
 
-                println!("Not a valid author");
                 return false;
             }
             let mut already_proposed = self.already_proposed.lock();
@@ -82,10 +81,7 @@ impl UnequivocalProposerElection {
                         true
                     }
                 },
-                Ordering::Less => {
-                    println!("Older Block");
-                    false
-                },
+                Ordering::Less => false,
             }
         })
     }

--- a/consensus/src/liveness/unequivocal_proposer_election_test.rs
+++ b/consensus/src/liveness/unequivocal_proposer_election_test.rs
@@ -8,7 +8,7 @@ use aptos_consensus_types::{
     common::{Author, Payload, Round},
 };
 use aptos_types::validator_signer::ValidatorSigner;
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 struct MockProposerElection {
     proposers: HashMap<Round, Author>,
@@ -83,7 +83,7 @@ fn test_is_valid_proposal() {
     .unwrap();
 
     let pe =
-        UnequivocalProposerElection::new(Box::new(MockProposerElection::new(HashMap::from([
+        UnequivocalProposerElection::new(Arc::new(MockProposerElection::new(HashMap::from([
             (1, chosen_author),
             (2, chosen_author),
         ]))));

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -307,10 +307,6 @@ impl NetworkSender {
         self.send(msg, vec![self.author]).await
     }
 
-    pub fn author(&self) -> Author {
-        self.author
-    }
-
     pub async fn broadcast_commit_proof(&mut self, ledger_info: LedgerInfoWithSignatures) {
         fail_point!("consensus::send::broadcast_commit_proof", |_| ());
         let msg = ConsensusMsg::CommitDecisionMsg(Box::new(CommitDecision::new(ledger_info)));

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -8,6 +8,7 @@ use crate::{
         BlockReader, BlockRetriever, BlockStore,
     },
     counters,
+    counters::STALE_PROPOSALS_RECEIVED,
     error::{error_kind, VerifyError},
     liveness::{
         proposal_generator::ProposalGenerator,
@@ -51,11 +52,7 @@ use aptos_types::{
 use fail::fail_point;
 use futures::{channel::oneshot, FutureExt, StreamExt};
 use serde::Serialize;
-use std::{
-    mem::{discriminant, Discriminant},
-    sync::Arc,
-    time::Duration,
-};
+use std::{mem::Discriminant, sync::Arc, time::Duration};
 use tokio::{
     sync::oneshot as TokioOneshot,
     time::{sleep, Instant},
@@ -180,6 +177,16 @@ pub enum VerifiedEvent {
     Shutdown(TokioOneshot::Sender<()>),
 }
 
+impl VerifiedEvent {
+    pub fn round(&self) -> Option<Round> {
+        match self {
+            VerifiedEvent::ProposalMsg(p) => Some(p.proposal().round()),
+            VerifiedEvent::VerifiedProposalMsg(p) => Some(p.round()),
+            _ => None,
+        }
+    }
+}
+
 #[cfg(test)]
 #[path = "round_manager_test.rs"]
 mod round_manager_test;
@@ -203,8 +210,7 @@ pub struct RoundManager {
     network: NetworkSender,
     storage: Arc<dyn PersistentLivenessStorage>,
     onchain_config: OnChainConsensusConfig,
-    round_manager_tx:
-        aptos_channel::Sender<(Author, Discriminant<VerifiedEvent>), (Author, VerifiedEvent)>,
+    proposal_msg_tx: aptos_channel::Sender<(), VerifiedEvent>,
     local_config: ConsensusConfig,
 }
 
@@ -213,16 +219,13 @@ impl RoundManager {
         epoch_state: EpochState,
         block_store: Arc<BlockStore>,
         round_state: RoundState,
-        proposer_election: Box<dyn ProposerElection + Send + Sync>,
+        proposer_election: Arc<dyn ProposerElection + Send + Sync>,
         proposal_generator: ProposalGenerator,
         safety_rules: Arc<Mutex<MetricsSafetyRules>>,
         network: NetworkSender,
         storage: Arc<dyn PersistentLivenessStorage>,
         onchain_config: OnChainConsensusConfig,
-        round_manager_tx: aptos_channel::Sender<
-            (Author, Discriminant<VerifiedEvent>),
-            (Author, VerifiedEvent),
-        >,
+        proposal_msg_tx: aptos_channel::Sender<(), VerifiedEvent>,
         local_config: ConsensusConfig,
     ) -> Self {
         // when decoupled execution is false,
@@ -243,7 +246,7 @@ impl RoundManager {
             network,
             storage,
             onchain_config,
-            round_manager_tx,
+            proposal_msg_tx,
             local_config,
         }
     }
@@ -427,6 +430,7 @@ impl RoundManager {
         info!(
             self.new_log(LogEvent::ReceiveProposal)
                 .remote_peer(proposal_msg.proposer()),
+            block_round = proposal_msg.proposal().round(),
             block_hash = proposal_msg.proposal().id(),
             block_parent_hash = proposal_msg.proposal().quorum_cert().certified_block().id(),
         );
@@ -442,6 +446,7 @@ impl RoundManager {
         {
             self.process_proposal(proposal_msg.take_proposal()).await
         } else {
+            STALE_PROPOSALS_RECEIVED.inc();
             bail!(
                 "Stale proposal {}, current round {}",
                 proposal_msg.proposal(),
@@ -728,17 +733,17 @@ impl RoundManager {
         timeout_ms: u64,
     ) {
         let start = Instant::now();
-        let author = self.network.author();
         let block_store = self.block_store.clone();
-        let self_sender = self.round_manager_tx.clone();
+        let self_sender = self.proposal_msg_tx.clone();
         let event = VerifiedEvent::VerifiedProposalMsg(Box::new(proposal));
         tokio::spawn(async move {
             while start.elapsed() < Duration::from_millis(timeout_ms) {
                 if !block_store.back_pressure() {
-                    if let Err(e) =
-                        self_sender.push((author, discriminant(&event)), (author, event))
-                    {
-                        error!("Failed to send event to round manager {:?}", e);
+                    if let Err(e) = self_sender.push((), event) {
+                        error!(
+                            "Failed to re-send verified proposal to round manager {:?}",
+                            e
+                        );
                     }
                     break;
                 }
@@ -977,26 +982,54 @@ impl RoundManager {
             (Author, Discriminant<VerifiedEvent>),
             (Author, VerifiedEvent),
         >,
+        mut checked_proposal_rx: aptos_channel::Receiver<(), VerifiedEvent>,
         close_rx: oneshot::Receiver<oneshot::Sender<()>>,
     ) {
         info!(epoch = self.epoch_state().epoch, "RoundManager started");
         let mut close_rx = close_rx.into_stream();
         loop {
-            futures::select! {
+            tokio::select! {
+                biased;
+                close_req = close_rx.select_next_some() => {
+                    if let Ok(ack_sender) = close_req {
+                        ack_sender.send(()).expect("[RoundManager] Fail to ack shutdown");
+                    }
+                    break;
+                },
+                proposal = checked_proposal_rx.select_next_some() => {
+                    let mut proposals = vec![proposal];
+                    while let Some(Some(proposal)) = checked_proposal_rx.next().now_or_never() {
+                        proposals.push(proposal);
+                    }
+                    proposals.sort_by(|a, b| a.round().unwrap().cmp(&b.round().unwrap()));
+                    for proposal in proposals {
+                        let result = match proposal {
+                            VerifiedEvent::ProposalMsg(proposal_msg) => {
+                                monitor!(
+                                    "process_proposal",
+                                    self.process_proposal_msg(*proposal_msg).await
+                                )
+                            }
+                            VerifiedEvent::VerifiedProposalMsg(proposal_msg) => {
+                                monitor!(
+                                    "process_verified_proposal",
+                                    self.process_delayed_proposal_msg(*proposal_msg).await
+                                )
+                            }
+                            unexpected_event => unreachable!("Unexpected event: {:?}", unexpected_event),
+                        };
+                        let round_state = self.round_state();
+                        match result {
+                            Ok(_) => trace!(RoundStateLogSchema::new(round_state)),
+                            Err(e) => {
+                                counters::ERROR_COUNT.inc();
+                                warn!(error = ?e, kind = error_kind(&e), RoundStateLogSchema::new(round_state));
+                            }
+                        }
+                    }
+                },
                 (peer_id, event) = event_rx.select_next_some() => {
                     let result = match event {
-                        VerifiedEvent::ProposalMsg(proposal_msg) => {
-                            monitor!(
-                                "process_proposal",
-                                self.process_proposal_msg(*proposal_msg).await
-                            )
-                        }
-                        VerifiedEvent::VerifiedProposalMsg(proposal_msg) => {
-                            monitor!(
-                                "process_verified_proposal",
-                                self.process_delayed_proposal_msg(*proposal_msg).await
-                            )
-                        }
                         VerifiedEvent::VoteMsg(vote_msg) => {
                             monitor!("process_vote", self.process_vote_msg(*vote_msg).await)
                         }
@@ -1022,13 +1055,7 @@ impl RoundManager {
                             warn!(error = ?e, kind = error_kind(&e), RoundStateLogSchema::new(round_state));
                         }
                     }
-                }
-                close_req = close_rx.select_next_some() => {
-                    if let Ok(ack_sender) = close_req {
-                        ack_sender.send(()).expect("[RoundManager] Fail to ack shutdown");
-                    }
-                    break;
-                }
+                },
             }
         }
         info!(epoch = self.epoch_state().epoch, "RoundManager stopped");

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -112,8 +112,8 @@ impl NodeSetup {
         RoundState::new(time_interval, time_service, round_timeout_sender)
     }
 
-    fn create_proposer_election(proposers: Vec<Author>) -> Box<dyn ProposerElection + Send + Sync> {
-        Box::new(RotatingProposer::new(proposers, 1))
+    fn create_proposer_election(proposers: Vec<Author>) -> Arc<dyn ProposerElection + Send + Sync> {
+        Arc::new(RotatingProposer::new(proposers, 1))
     }
 
     fn create_nodes(
@@ -255,7 +255,7 @@ impl NodeSetup {
             MetricsSafetyRules::new(safety_rules_manager.client(), storage.clone());
         safety_rules.perform_initialize().unwrap();
 
-        let (round_manager_tx, _) = aptos_channel::new(QueueStyle::LIFO, 1, None);
+        let (round_manager_tx, _) = tokio::sync::mpsc::channel(10);
 
         let mut round_manager = RoundManager::new(
             epoch_state,


### PR DESCRIPTION
### Description

We have seen cases where proposals are being processed after the QS for that proposal, which causes the nodes to fetch the block from remote. This change dedicates a channel for proposal, so that we can prioritize processing proposals above other messages. Please note that it can still happen that the proposals arrive out of order - we need to see how often that happens and re-evaluate the ordering if needed. 

### Test Plan

Run Forge
