### PR TITLE
Fix faucet build in docker/experimental/build-tools.sh

### DIFF
--- a/docker/experimental/build-tools.sh
+++ b/docker/experimental/build-tools.sh
@@ -12,7 +12,7 @@ echo "PROFILE: $PROFILE"
 cargo build --locked --profile=$PROFILE \
     -p aptos \
     -p aptos-backup-cli \
-    -p aptos-faucet \
+    -p aptos-faucet-service \
     -p aptos-forge-cli \
     -p aptos-fn-check-client \
     -p aptos-node-checker \
@@ -25,7 +25,7 @@ cargo build --locked --profile=$PROFILE \
 # After building, copy the binaries we need to `dist` since the `target` directory is used as docker cache mount and only available during the RUN step
 BINS=(
     aptos
-    aptos-faucet
+    aptos-faucet-service
     aptos-node-checker
     aptos-openapi-spec-generator
     aptos-telemetry-service

--- a/docker/experimental/faucet.Dockerfile
+++ b/docker/experimental/faucet.Dockerfile
@@ -11,11 +11,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         tcpdump \
         iproute2 \
         netcat \
-        procps  
+        procps
 
 RUN mkdir -p /aptos/client/data/wallet/
 
-COPY --link --from=builder /aptos/dist/aptos-faucet /usr/local/bin/aptos-faucet
+COPY --link --from=builder /aptos/dist/aptos-faucet-service /usr/local/bin/aptos-faucet-service
 
 # Mint proxy listening address
 EXPOSE 8000


### PR DESCRIPTION
### Description
It seems like the CI/CD for the experimental docker build stuff didn't run in https://github.com/aptos-labs/aptos-core/pull/6748. This PR fixes it.

### Test Plan
Add the `CICD:experimental-*` labels and see that they pass.

I also confirmed that this works locally now:
```
docker/experimental/build-tools.sh
```
