### PR TITLE
Cherry pick #7126 into devnet

### DIFF
--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -1102,9 +1102,12 @@ impl CliCommand<()> for RunLocalTestnet {
             .unwrap_or_else(StdRng::from_entropy);
 
         let global_config = GlobalConfig::load()?;
-        let test_dir = global_config
-            .get_config_location(ConfigSearchMode::CurrentDirAndParents)?
-            .join(TESTNET_FOLDER);
+        let test_dir = match self.test_dir {
+            Some(test_dir) => test_dir,
+            None => global_config
+                .get_config_location(ConfigSearchMode::CurrentDirAndParents)?
+                .join(TESTNET_FOLDER),
+        };
 
         // Remove the current test directory and start with a new node
         if self.force_restart && test_dir.exists() {


### PR DESCRIPTION
I have a PR that will add CI to run the faucet tests in https://github.com/aptos-labs/aptos-core/pull/7125. For that PR to work, I need the `--test-dir` flag to `aptos node run-local-testnet` to work correctly, which https://github.com/aptos-labs/aptos-core/pull/7126 fixed. This needs to be cherry picked into this branch specifically because those tests run the local testnet using the image built from this branch.