### PR TITLE
[cli] Add ability for vector<string> in CLI inputs

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -1463,6 +1463,13 @@ impl FunctionArgType {
                         hex::decode(arg)
                             .map_err(|err| CliError::UnableToParse("vector<hex>", err.to_string()))
                     }),
+                    // Note commas cannot be put into the strings.  But, this should be a less likely case,
+                    // and the utility from having this available should be worth it.
+                    FunctionArgType::String => parse_vector_arg(arg, |arg| {
+                        bcs::to_bytes(arg).map_err(|err| {
+                            CliError::UnableToParse("vector<string>", err.to_string())
+                        })
+                    }),
                     FunctionArgType::U8 => parse_vector_arg(arg, |arg| {
                         u8::from_str(arg)
                             .map_err(|err| CliError::UnableToParse("vector<u8>", err.to_string()))
@@ -1533,12 +1540,7 @@ impl FromStr for FunctionArgType {
                 if str.starts_with("vector<") && str.ends_with('>') {
                     let arg = FunctionArgType::from_str(&str[7..str.len() - 1])?;
 
-                    // String gets confusing on parsing by commas
-                    if arg == FunctionArgType::String {
-                        return Err(CliError::CommandArgumentError(
-                            "vector<string> is not supported".to_string(),
-                        ));
-                    } else if arg == FunctionArgType::Raw {
+                    if arg == FunctionArgType::Raw {
                         return Err(CliError::CommandArgumentError(
                             "vector<raw> is not supported".to_string(),
                         ));


### PR DESCRIPTION
### Description
There was a bug / feature request on discord https://github.com/aptos-labs/aptos-core/issues/7134 about that `vector<string>` didn't work.  I put it off because commas in strings can be hard, but I don't see a reason to block people from doing more common use cases (strings without commas)

### Test Plan
Manual testing (using a modified hello blockchain):
This one we insert an array, then we view the output
```
./target/debug/aptos move run --function-id  devnet::testing::set_message --profile devnet --args 'vector<string>:hello,blockchain'
Do you want to submit a transaction for a range of [300 - 400] Octas at a gas unit price of 100 Octas? [yes/no] >
yes
{
  "Result": {
    "transaction_hash": "0xe369bfab40ee86853fd6993e162d310f8e2326af1f36c3a1338c4ab0fb19caf0",
    "gas_used": 3,
    "gas_unit_price": 100,
    "sender": "b11affd5c514bb969e988710ef57813d9556cc1e3fe6dc9aa6a82b56aee53d98",
    "sequence_number": 17,
    "success": true,
    "timestamp_us": 1678822315108164,
    "version": 3135032,
    "vm_status": "Executed successfully"
  }
}

./target/debug/aptos move view --function-id devnet::testing::get_message --profile devnet --args address:devnet
{
  "Result": [
    [
      "\u0005hello",
      "\nblockchain"
    ]
  ]
}

```

This one does a bounceback of the input arguments for verification in view functions
```
./target/debug/aptos move view --function-id devnet::testing::bounceback --profile devnet --args 'vector<string>:hello,my, friends'       
{
  "Result": [
    [
      "\u0005hello",
      "\u0002my",
      "\b friends"
    ]
  ]
}
```