### PR TITLE
[Aptos Data Client] Increase timeout from 10 to 20 seconds.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -196,7 +196,7 @@ impl Default for AptosDataClientConfig {
             max_num_in_flight_regular_polls: 10,
             max_num_output_reductions: 0,
             max_response_timeout_ms: 60000, // 60 seconds
-            response_timeout_ms: 10000,     // 10 seconds
+            response_timeout_ms: 20000,     // 20 seconds
             subscription_timeout_ms: 5000,  // 5 seconds
             summary_poll_interval_ms: 200,
             use_compression: true,


### PR DESCRIPTION
### Description
This PR doubles the RPC timeout for data requests from 10 seconds to 20 seconds in the data client.

### Test Plan
Manual verification.