### PR TITLE
increase exclude round

### DIFF
--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -115,7 +115,7 @@ impl Default for ConsensusConfigV1 {
         Self {
             decoupled_execution: true,
             back_pressure_limit: 10,
-            exclude_round: 20,
+            exclude_round: 40,
             max_failed_authors_to_store: 10,
             proposer_election_type: ProposerElectionType::LeaderReputation(
                 LeaderReputationType::ProposerAndVoterV2(ProposerAndVoterConfig {


### PR DESCRIPTION
with high TPS, we can see up to 30-35 pending blocks. we are already using this on previewnet.

this will require governance proposal for testnet.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
