### PR TITLE
[typo] fix misspelled words in aptos-framework

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/staking_contract.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_contract.md
@@ -1253,7 +1253,8 @@ Convenient function to allow the staker to reset their stake pool's lockup perio
 
 ## Function `update_commision`
 
-Convenience function to allow a staker to update the commision percentage paid to the operator.
+Convenience function to allow a staker to update the commission percentage paid to the operator.
+TODO: fix the typo in function name. commision -> commission
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="staking_contract.md#0x1_staking_contract_update_commision">update_commision</a>(staker: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, operator: <b>address</b>, new_commission_percentage: u64)

--- a/aptos-move/framework/aptos-framework/sources/staking_contract.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.move
@@ -361,7 +361,8 @@ module aptos_framework::staking_contract {
         emit_event(&mut store.reset_lockup_events, ResetLockupEvent { operator, pool_address });
     }
 
-    /// Convenience function to allow a staker to update the commision percentage paid to the operator.
+    /// Convenience function to allow a staker to update the commission percentage paid to the operator.
+    /// TODO: fix the typo in function name. commision -> commission
     public entry fun update_commision(staker: &signer, operator: address, new_commission_percentage: u64) acquires Store, StakingGroupUpdateCommissionEvent {
         assert!(
             new_commission_percentage >= 0 && new_commission_percentage <= 100,
@@ -908,7 +909,7 @@ module aptos_framework::staking_contract {
         let new_balance = with_rewards(INITIAL_BALANCE);
         stake::assert_stake_pool(pool_address, new_balance, 0, 0, 0);
 
-        // Operator tries to request commision multiple times. But their distribution shouldn't change.
+        // Operator tries to request commission multiple times. But their distribution shouldn't change.
         let expected_commission = (new_balance - last_recorded_principal(staker_address, operator_address)) / 10;
         request_commission(operator, staker_address, operator_address);
         assert_distribution(staker_address, operator_address, operator_address, expected_commission);

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -629,7 +629,8 @@ pub enum EntryFunctionCall {
         amount: u64,
     },
 
-    /// Convenience function to allow a staker to update the commision percentage paid to the operator.
+    /// Convenience function to allow a staker to update the commission percentage paid to the operator.
+    /// TODO: fix the typo in function name. commision -> commission
     StakingContractUpdateCommision {
         operator: AccountAddress,
         new_commission_percentage: u64,
@@ -2907,7 +2908,8 @@ pub fn staking_contract_unlock_stake(operator: AccountAddress, amount: u64) -> T
     ))
 }
 
-/// Convenience function to allow a staker to update the commision percentage paid to the operator.
+/// Convenience function to allow a staker to update the commission percentage paid to the operator.
+/// TODO: fix the typo in function name. commision -> commission
 pub fn staking_contract_update_commision(
     operator: AccountAddress,
     new_commission_percentage: u64,


### PR DESCRIPTION
### Description
Fixed several typos(_commision_ => _commis**s**ion_).
The typo also exists in a entry function name. There is no easy way to correct. Leave a TODO there.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Unit tests.