### PR TITLE
[Move] Setup copybara for keeping a synchronized copy of Move

### DIFF
--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,0 +1,60 @@
+This directory contains synchronized copies of external repositories (currently only Move). Code can be submitted in this directory using a single atomic PR. Periodically, changes in this directory
+are pushed upstream or pulled from upstream, using the [copybara](https://github.com/google/copybara) tool.
+
+## Usage
+
+Assuming `copybara` is available from the command line, to pull from the
+Move repo (for example), use:
+
+### Pulling
+
+```shell
+copybara copy.bar.sky pull_move
+```
+
+This will create a draft PR in aptos_core (in the fixed branch `from_move`) with the needed changes. The PR should be massaged and send out for regular review.
+
+### Pushing
+
+In order to push to the Move repo, use:
+
+```shell
+copybara copy.bar.sky push_move
+```
+
+This will directly push to the `aptos_main` branch in the Move repo.
+
+
+## Installing Copybara
+
+Copybara must be build from source. 
+
+### MacOS
+
+We first need Java. If its not yet in your path (`java` should show), you can install the openjdk with relative little hassle:
+
+```shell
+brew update
+brew install java
+```
+
+The last step should print out instructions how to update the PATH so `java` is found.
+
+We also need bazel:
+
+```shell
+brew install bazel
+```
+
+Finally we can clone the copybara repo and compile the program:
+
+```shell
+git clone https://github.com/google/copybara.git
+cd copybara
+bazel build //java/com/google/copybara
+alias copybara="$PWD/bazel-bin/java/com/google/copybara/copybara"
+```
+
+### Linux
+
+TBD

--- a/third_party/copy.bara.sky
+++ b/third_party/copy.bara.sky
@@ -1,0 +1,46 @@
+moveUrl = "https://github.com/move-language/move.git"
+aptosUrl = "https://github.com/aptos-labs/aptos-core.git"
+
+# Workflow to pull from Move to Aptos. This creates a draft PR at the fixed branch `from_move`
+# which should be further massaged before sending out.
+core.workflow(
+    name = "pull_move",
+    origin = git.origin(
+        url = moveUrl,
+        ref = "aptos-main",
+    ),
+    destination = git.github_pr_destination(
+        url = aptosUrl,
+        destination_ref = "main",
+        draft = True,
+        title = "Pull from move-language",
+        pr_branch = "from_move"
+    ),
+    #origin_files = glob(["language/**"]),
+    origin_files = glob(["language/README.md"]), # During testing use only one file
+    destination_files = glob(["third_party/move/**"]),
+    authoring = authoring.pass_thru("Wolfgang <wg@aptoslabs.com>"),
+    transformations = [
+        core.move("", "third_party/move"),
+    ],
+)
+
+# Workflow to push from Aptos to Move. This directly pushes without PR.
+core.workflow(
+    name = "push_move",
+    origin = git.origin(
+        url = aptosUrl,
+        ref = "main",
+    ),
+    destination = git.github_destination(
+        url = moveUrl,
+        push = "aptos_main",
+    ),
+    #origin_files = glob(["third_party/move/language/**"]),
+    origin_files = glob(["third_party/move/language/README.md"]), # During testing only one file
+    destination_files = glob(["language/**"]),
+    authoring = authoring.pass_thru("Wolfgang <wg@aptoslabs.com>"),
+    transformations = [
+        core.move("third_party/move", ""),
+    ],
+)

--- a/third_party/move/language/README.md
+++ b/third_party/move/language/README.md
@@ -1,0 +1,24 @@
+---
+id: move-language
+title: Move Language
+custom_edit_url: https://github.com/move-language/move/edit/main/language/README.md
+---
+
+
+Move is a new programming language developed to provide a safe and programmable foundation for the Diem Blockchain.
+
+## Overview
+
+The Move language directory consists of four main parts:
+
+- [virtual machine](move-vm/) (VM) &mdash; contains the bytecode format, a bytecode interpreter, and infrastructure for executing a block of transactions. This directory also contains the infrastructure to generate the genesis block.
+
+- [bytecode verifier](move-bytecode-verifier/) &mdash; contains a static analysis tool for rejecting invalid Move bytecode. The virtual machine runs the bytecode verifier on any new Move code it encounters before executing it. The compiler runs the bytecode verifier on its output and surfaces the errors to the programmer.
+
+- [move-compiler](move-compiler/) &mdash; contains the Move source language compiler.
+
+- [standard library](move-stdlib/) &mdash; contains the standard library transaction scripts.
+
+## Exploring the Move language
+
+- You can find many small Move examples in the [tests](move-compiler/tests/move_check/) directory. The easiest way to experiment with Move is to create a new test in this directory and run it with `cargo test`.


### PR DESCRIPTION
This sets up [copybara](https://github.com/google/copybara) for maintaining a copy of the Move tree within the aptos tree. A workflow to push and to pull from the Move repo is defined. The `pull_move` workflow has been used to seed the initial content of `third_party/move`, the proposed directory to hold the Move tree.

Copybara will allow us submit code to the Move tree in lockstep to the Aptos tree. We then can periodically (or via some cron job) synchronize the state with the upstream Move repo. The mechanism works bidirectional. For a tutorial of the tool, see [here](https://blog.kubesimplify.com/moving-code-between-git-repositories-with-copybara).

For now we only pull in only the `language/README.md` file from Move, so this mechanism can be further studied also in the push direction. (Which requires this PR to land.) Eventually, the PR which pulls in all of Move contains a couple of thousand of files.