### PR TITLE
Pin crane version in docker-setup

### DIFF
--- a/.github/actions/docker-setup/action.yaml
+++ b/.github/actions/docker-setup/action.yaml
@@ -47,6 +47,8 @@ runs:
         keep-state: true
 
     - uses: imjasonh/setup-crane@5146f708a817ea23476677995bf2133943b9be0b # pin@v0.1
+      with:
+        version: v3.6.0
 
     - id: auth
       name: "Authenticate to Google Cloud"


### PR DESCRIPTION
### Description
I saw an issue where the latest version lookup failed, this will avoid that problem. Beyond that, it's likely good to pin anyway, like we do with most deps.

### Test Plan
CI.
