### PR TITLE
[Misc] Add a script to install dependencies for the prover independent of the repo

### DIFF
--- a/developer-docs-site/static/scripts/prover_setup.sh
+++ b/developer-docs-site/static/scripts/prover_setup.sh
@@ -1,0 +1,365 @@
+#!/bin/bash
+# Copyright © Aptos Foundation
+# Parts of the project are originally copyright © Meta Platforms, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script sets up the environment for the build by installing necessary dependencies.
+#
+# Usage ./dev_setup.sh <options>
+#   v - verbose, print all statements
+
+# Assumptions for nix systems:
+# 1 The running user is the user who will execute the builds.
+# 2 .profile will be used to configure the shell
+# 3 ${HOME}/bin/, or ${INSTALL_DIR} is expected to be on the path - hashicorp tools/etc.  will be installed there on linux systems.
+
+# fast fail.
+set -eo pipefail
+
+Z3_VERSION=4.11.2
+CVC5_VERSION=0.0.3
+DOTNET_VERSION=6.0
+BOOGIE_VERSION=2.15.8
+
+SCRIPT_PATH="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
+cd "$SCRIPT_PATH/.." || exit
+
+function usage {
+  echo "Usage:"
+  echo "Installs or updates necessary dependencies for the Move prover."
+  echo "-b batch mode, no user interactions and miminal output"
+  echo "-p update ${HOME}/.profile"
+  echo "-y installs or updates Move prover tools: z3, cvc5, dotnet, boogie"
+  echo "-v verbose mode"
+  echo "-n will target the /opt/ dir rather than the $HOME dir.  /opt/bin/ and /opt/dotnet/ rather than $HOME/bin/ and $HOME/.dotnet/"
+  echo "If no toolchain component is selected with -y, or -p, the behavior is as if -y had been provided."
+  echo "After all dependencies are installed, please source the profile file: 'source ~/.profile'."
+}
+
+function add_to_profile {
+  eval "$1"
+  FOUND=$(grep -c "$1" < "${HOME}/.profile" || true)  # grep error return would kill the script.
+  if [ "$FOUND" == "0" ]; then
+    echo "$1" >> "${HOME}"/.profile
+  fi
+}
+
+
+# It is important to keep all path updates together to allow this script to work well when run in github actions
+# inside of a docker image created using this script.   GHA wipes the home directory via docker mount options, so
+# this profile needs built and sourced on every execution of a job using the docker image.   See the .github/actions/build-setup
+# action in this repo, as well as docker/ci/github/Dockerfile.
+function update_path_and_profile {
+  touch "${HOME}"/.profile
+
+  DOTNET_ROOT="$HOME/.dotnet"
+  BIN_DIR="$HOME/bin"
+  if [[ "$OPT_DIR" == "true" ]]; then
+    DOTNET_ROOT="/opt/dotnet"
+    BIN_DIR="/opt/bin"
+  fi
+
+  mkdir -p "${BIN_DIR}"
+  if [[ "$INSTALL_PROVER" == "true" ]]; then
+    add_to_profile "export DOTNET_ROOT=\"${DOTNET_ROOT}\""
+    add_to_profile "export PATH=\"${DOTNET_ROOT}/tools:\$PATH\""
+    add_to_profile "export Z3_EXE=\"${BIN_DIR}/z3\""
+    add_to_profile "export CVC5_EXE=\"${BIN_DIR}/cvc5\""
+    add_to_profile "export BOOGIE_EXE=\"${DOTNET_ROOT}/tools/boogie\""
+  fi
+}
+
+function install_dotnet {
+  echo "Installing .Net"
+  mkdir -p "${DOTNET_INSTALL_DIR}" || true
+  if [[ $("${DOTNET_INSTALL_DIR}/dotnet" --list-sdks | grep -c "^${DOTNET_VERSION}" || true) == "0" ]]; then
+    if [[ "$(uname)" == "Linux" ]]; then
+        # Install various prerequisites for .dotnet. There are known bugs
+        # in the dotnet installer to warn even if they are present. We try
+        # to install anyway based on the warnings the dotnet installer creates.
+        if [ "$PACKAGE_MANAGER" == "apk" ]; then
+          install_pkg icu "$PACKAGE_MANAGER"
+          install_pkg zlib "$PACKAGE_MANAGER"
+          install_pkg libintl "$PACKAGE_MANAGER"
+          install_pkg libcurl "$PACKAGE_MANAGER"
+        elif [ "$PACKAGE_MANAGER" == "apt-get" ]; then
+          install_pkg gettext "$PACKAGE_MANAGER"
+          install_pkg zlib1g "$PACKAGE_MANAGER"
+        elif [ "$PACKAGE_MANAGER" == "yum" ] || [ "$PACKAGE_MANAGER" == "dnf" ]; then
+          install_pkg icu "$PACKAGE_MANAGER"
+          install_pkg zlib "$PACKAGE_MANAGER"
+        elif [ "$PACKAGE_MANAGER" == "pacman" ]; then
+          install_pkg icu "$PACKAGE_MANAGER"
+          install_pkg zlib "$PACKAGE_MANAGER"
+        fi
+    fi
+    # Below we need to (a) set TERM variable because the .net installer expects it and it is not set
+    # in some environments (b) use bash not sh because the installer uses bash features.
+    curl -sSL https://dot.net/v1/dotnet-install.sh \
+        | TERM=linux /bin/bash -s -- --channel $DOTNET_VERSION --install-dir "${DOTNET_INSTALL_DIR}" --version latest
+  else
+    echo Dotnet already installed.
+  fi
+}
+
+function install_boogie {
+  echo "Installing boogie"
+  mkdir -p "${DOTNET_INSTALL_DIR}tools/" || true
+  if [[ "$("${DOTNET_INSTALL_DIR}dotnet" tool list --tool-path "${DOTNET_INSTALL_DIR}tools/")" =~ .*boogie.*${BOOGIE_VERSION}.* ]]; then
+    echo "Boogie $BOOGIE_VERSION already installed"
+  else
+    "${DOTNET_INSTALL_DIR}dotnet" tool update --tool-path "${DOTNET_INSTALL_DIR}tools/" Boogie --version $BOOGIE_VERSION
+  fi
+}
+
+function install_z3 {
+  echo "Installing Z3"
+  if command -v /usr/local/bin/z3 &>/dev/null; then
+    echo "z3 already exists at /usr/local/bin/z3"
+    echo "but this install will go to ${INSTALL_DIR}/z3."
+    echo "you may want to remove the shared instance to avoid version confusion"
+  fi
+  if command -v "${INSTALL_DIR}z3" &>/dev/null && [[ "$("${INSTALL_DIR}z3" --version || true)" =~ .*${Z3_VERSION}.* ]]; then
+     echo "Z3 ${Z3_VERSION} already installed"
+     return
+  fi
+  if [[ "$(uname)" == "Linux" ]]; then
+    Z3_PKG="z3-$Z3_VERSION-x64-glibc-2.31"
+  elif [[ "$(uname)" == "Darwin" ]]; then
+    Z3_PKG="z3-$Z3_VERSION-x64-osx-10.16"
+  else
+    echo "Z3 support not configured for this platform (uname=$(uname))"
+    return
+  fi
+  TMPFILE=$(mktemp)
+  rm "$TMPFILE"
+  mkdir -p "$TMPFILE"/
+  (
+    cd "$TMPFILE" || exit
+    curl -LOs "https://github.com/Z3Prover/z3/releases/download/z3-$Z3_VERSION/$Z3_PKG.zip"
+    unzip -q "$Z3_PKG.zip"
+    cp "$Z3_PKG/bin/z3" "${INSTALL_DIR}"
+    chmod +x "${INSTALL_DIR}z3"
+  )
+  rm -rf "$TMPFILE"
+}
+
+function install_cvc5 {
+  echo "Installing cvc5"
+  if command -v /usr/local/bin/cvc5 &>/dev/null; then
+    echo "cvc5 already exists at /usr/local/bin/cvc5"
+    echo "but this install will go to $${INSTALL_DIR}cvc5."
+    echo "you may want to remove the shared instance to avoid version confusion"
+  fi
+  if command -v "${INSTALL_DIR}cvc5" &>/dev/null && [[ "$("${INSTALL_DIR}cvc5" --version || true)" =~ .*${CVC5_VERSION}.* ]]; then
+     echo "cvc5 ${CVC5_VERSION} already installed"
+     return
+  fi
+  if [[ "$(uname)" == "Linux" ]]; then
+    CVC5_PKG="cvc5-Linux"
+  elif [[ "$(uname)" == "Darwin" ]]; then
+    CVC5_PKG="cvc5-macOS"
+  else
+    echo "cvc5 support not configured for this platform (uname=$(uname))"
+    return
+  fi
+  TMPFILE=$(mktemp)
+  rm "$TMPFILE"
+  mkdir -p "$TMPFILE"/
+  (
+    cd "$TMPFILE" || exit
+    curl -LOs "https://github.com/cvc5/cvc5/releases/download/cvc5-$CVC5_VERSION/$CVC5_PKG"
+    cp "$CVC5_PKG" "${INSTALL_DIR}cvc5"
+    chmod +x "${INSTALL_DIR}cvc5"
+  )
+  rm -rf "$TMPFILE"
+}
+
+function install_pkg {
+  package=$1
+  PACKAGE_MANAGER=$2
+  PRE_COMMAND=()
+  if [ "$(whoami)" != 'root' ]; then
+    PRE_COMMAND=(sudo)
+  fi
+  if command -v "$package" &>/dev/null; then
+    echo "$package is already installed"
+  else
+    echo "Installing ${package}."
+    if [[ "$PACKAGE_MANAGER" == "yum" ]]; then
+      "${PRE_COMMAND[@]}" yum install "${package}" -y
+    elif [[ "$PACKAGE_MANAGER" == "apt-get" ]]; then
+      "${PRE_COMMAND[@]}" apt-get install "${package}" --no-install-recommends -y
+      echo apt-get install result code: $?
+    elif [[ "$PACKAGE_MANAGER" == "pacman" ]]; then
+      "${PRE_COMMAND[@]}" pacman -Syu "$package" --noconfirm
+    elif [[ "$PACKAGE_MANAGER" == "apk" ]]; then
+      apk --update add --no-cache "${package}"
+    elif [[ "$PACKAGE_MANAGER" == "dnf" ]]; then
+      dnf install "$package"
+    elif [[ "$PACKAGE_MANAGER" == "brew" ]]; then
+      brew install "$package"
+    fi
+  fi
+}
+
+function welcome_message {
+cat <<EOF
+Welcome to Aptos!
+
+This script will download and install the necessary dependencies needed to
+build, test and inspect Aptos Core.
+
+Based on your selection, these tools will be included:
+EOF
+
+  if [[ "$INSTALL_PROVER" == "true" ]]; then
+cat <<EOF
+Move prover tools (since -y was provided):
+  * z3
+  * cvc5
+  * dotnet
+  * boogie
+  * graphviz
+EOF
+  fi
+
+  if [[ "$INSTALL_PROFILE" == "true" ]]; then
+cat <<EOF
+Moreover, ~/.profile will be updated (since -p was provided).
+EOF
+  fi
+
+cat <<EOF
+If you'd prefer to install these dependencies yourself, please exit this script
+now with Ctrl-C.
+EOF
+}
+
+BATCH_MODE=false;
+VERBOSE=false;
+INSTALL_PROFILE="false";
+INSTALL_PROVER="false";
+INSTALL_DIR="${HOME}/bin/"
+OPT_DIR="false"
+
+#parse args
+while getopts "btoprvysah:i:n" arg; do
+  case "$arg" in
+    b)
+      BATCH_MODE="true"
+      ;;
+    p)
+      INSTALL_PROFILE="true"
+      ;;
+    v)
+      VERBOSE=true
+      ;;
+    y)
+      INSTALL_PROVER="true"
+      ;;
+    n)
+      OPT_DIR="true"
+      ;;
+    *)
+      usage;
+      exit 0;
+      ;;
+  esac
+done
+
+if [[ "$VERBOSE" == "true" ]]; then
+	set -x
+fi
+
+if [[ "$INSTALL_PROFILE" == "false" ]] && \
+   [[ "$INSTALL_PROVER" == "false" ]]; then
+   INSTALL_PROVER="true"
+fi
+
+if [[ "${OPT_DIR}" == "true" ]]; then
+  INSTALL_DIR="/opt/bin/"
+fi
+mkdir -p "$INSTALL_DIR" || true
+
+PRE_COMMAND=()
+if [ "$(whoami)" != 'root' ]; then
+  PRE_COMMAND=(sudo)
+fi
+
+PACKAGE_MANAGER=
+if [[ "$(uname)" == "Linux" ]]; then
+	if command -v yum &> /dev/null; then
+		PACKAGE_MANAGER="yum"
+	elif command -v apt-get &> /dev/null; then
+		PACKAGE_MANAGER="apt-get"
+	elif command -v pacman &> /dev/null; then
+		PACKAGE_MANAGER="pacman"
+  elif command -v apk &>/dev/null; then
+		PACKAGE_MANAGER="apk"
+  elif command -v dnf &>/dev/null; then
+    echo "WARNING: dnf package manager support is experimental"
+    PACKAGE_MANAGER="dnf"
+	else
+		echo "Unable to find supported package manager (yum, apt-get, dnf, or pacman). Abort"
+		exit 1
+	fi
+elif [[ "$(uname)" == "Darwin" ]]; then
+	if command -v brew &>/dev/null; then
+		PACKAGE_MANAGER="brew"
+	else
+		echo "Missing package manager Homebrew (https://brew.sh/). Abort"
+		exit 1
+	fi
+else
+	echo "Unknown OS. Abort."
+	exit 1
+fi
+
+if [[ "$BATCH_MODE" == "false" ]]; then
+    welcome_message
+    printf "Proceed with installing necessary dependencies? (y/N) > "
+    read -e -r input
+    if [[ "$input" != "y"* ]]; then
+	    echo "Exiting..."
+	    exit 0
+    fi
+fi
+
+if [[ "$PACKAGE_MANAGER" == "apt-get" ]]; then
+	if [[ "$BATCH_MODE" == "false" ]]; then
+    echo "Updating apt-get......"
+  fi
+	"${PRE_COMMAND[@]}" apt-get update
+  if [[ "$BATCH_MODE" == "false" ]]; then
+   echo "Installing ca-certificates......"
+  fi
+	install_pkg ca-certificates "$PACKAGE_MANAGER"
+fi
+
+if [[ "$INSTALL_PROFILE" == "true" ]]; then
+  update_path_and_profile
+fi
+
+if [[ "$INSTALL_PROVER" == "true" ]]; then
+  export DOTNET_INSTALL_DIR="${HOME}/.dotnet/"
+  if [[ "$OPT_DIR" == "true" ]]; then
+    export DOTNET_INSTALL_DIR="/opt/dotnet/"
+    mkdir -p "$DOTNET_INSTALL_DIR" || true
+  fi
+  install_pkg curl "$PACKAGE_MANAGER"
+  install_pkg unzip "$PACKAGE_MANAGER"
+  install_pkg graphviz "$PACKAGE_MANAGER"
+  install_z3
+  install_cvc5
+  install_dotnet
+  install_boogie
+fi
+
+if [[ "${BATCH_MODE}" == "false" ]]; then
+cat <<EOF
+Finished installing all dependencies.
+EOF
+fi
+
+exit 0


### PR DESCRIPTION
### Description

As the first step to resolve #7148, this PR adds a script to install dependencies of the Move prover (`.net`, `z3`, `cvc5` and`boogie`) and `graphviz` without relying on the `aptos-core` repo. It can be run outside the repo. The usage of this script is similar to `dev_setup.sh` because the code is borrowed from it. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Need to test this script in different OS environments. 

