### PR TITLE
[cherry-pick] PR 7194: [Quorum Store] block timestamp-based expiration of batches

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::MAX_SENDING_BLOCK_TXNS_QUORUM_STORE_OVERRIDE;
-use aptos_types::block_info::Round;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -45,15 +45,7 @@ pub struct QuorumStoreConfig {
     pub max_batch_bytes: usize,
     pub batch_request_timeout_ms: usize,
     /// Used when setting up the expiration time for the batch initation.
-    pub batch_expiry_round_gap_when_init: Round,
-    /// Batches may have expiry set for batch_expiry_rounds_gap rounds after the
-    /// latest committed round, and it will not be cleared from storage for another
-    /// so other batch_expiry_grace_rounds rounds, so the peers on the network
-    /// can still fetch the data they fall behind (later, they would have to state-sync).
-    /// Used when checking the expiration time of the received batch against current logical time to prevent DDoS.
-    pub batch_expiry_round_gap_behind_latest_certified: Round,
-    pub batch_expiry_round_gap_beyond_latest_certified: Round,
-    pub batch_expiry_grace_rounds: Round,
+    pub batch_expiry_gap_when_init_usecs: u64,
     pub memory_quota: usize,
     pub db_quota: usize,
     pub batch_quota: usize,
@@ -73,10 +65,7 @@ impl Default for QuorumStoreConfig {
             batch_generation_max_interval_ms: 250,
             max_batch_bytes: 4 * 1024 * 1024,
             batch_request_timeout_ms: 10000,
-            batch_expiry_round_gap_when_init: 100,
-            batch_expiry_round_gap_behind_latest_certified: 500,
-            batch_expiry_round_gap_beyond_latest_certified: 500,
-            batch_expiry_grace_rounds: 5,
+            batch_expiry_gap_when_init_usecs: Duration::from_secs(60).as_micros() as u64,
             memory_quota: 120_000_000,
             db_quota: 300_000_000,
             batch_quota: 300_000,

--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -1,7 +1,6 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::Round;
 use anyhow::{bail, Context};
 use aptos_crypto::{bls12381, CryptoMaterialError, HashValue};
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
@@ -17,26 +16,6 @@ use std::{
     hash::Hash,
     ops::Deref,
 };
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize, Hash)]
-pub struct LogicalTime {
-    epoch: u64,
-    round: Round,
-}
-
-impl LogicalTime {
-    pub fn new(epoch: u64, round: Round) -> Self {
-        Self { epoch, round }
-    }
-
-    pub fn epoch(&self) -> u64 {
-        self.epoch
-    }
-
-    pub fn round(&self) -> Round {
-        self.round
-    }
-}
 
 #[derive(
     Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash, CryptoHasher, BCSCryptoHash,
@@ -91,7 +70,8 @@ impl Display for BatchId {
 pub struct BatchInfo {
     author: PeerId,
     batch_id: BatchId,
-    expiration: LogicalTime,
+    epoch: u64,
+    expiration: u64,
     digest: HashValue,
     num_txns: u64,
     num_bytes: u64,
@@ -101,7 +81,8 @@ impl BatchInfo {
     pub fn new(
         author: PeerId,
         batch_id: BatchId,
-        expiration: LogicalTime,
+        epoch: u64,
+        expiration: u64,
         digest: HashValue,
         num_txns: u64,
         num_bytes: u64,
@@ -109,6 +90,7 @@ impl BatchInfo {
         Self {
             author,
             batch_id,
+            epoch,
             expiration,
             digest,
             num_txns,
@@ -117,7 +99,7 @@ impl BatchInfo {
     }
 
     pub fn epoch(&self) -> u64 {
-        self.expiration.epoch
+        self.epoch
     }
 
     pub fn author(&self) -> PeerId {
@@ -128,7 +110,7 @@ impl BatchInfo {
         self.batch_id
     }
 
-    pub fn expiration(&self) -> LogicalTime {
+    pub fn expiration(&self) -> u64 {
         self.expiration
     }
 

--- a/consensus/consensus-types/src/request_response.rs
+++ b/consensus/consensus-types/src/request_response.rs
@@ -1,19 +1,14 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    common::{Payload, PayloadFilter, Round},
-    proof_of_store::LogicalTime,
-};
+use crate::common::{Payload, PayloadFilter};
 use anyhow::Result;
-use aptos_crypto::HashValue;
 use futures::channel::oneshot;
 use std::{fmt, fmt::Formatter};
 
 pub enum GetPayloadCommand {
     /// Request to pull block to submit to consensus.
     GetPayloadRequest(
-        Round,
         // max block size
         u64,
         // max byte size
@@ -31,7 +26,6 @@ impl fmt::Display for GetPayloadCommand {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             GetPayloadCommand::GetPayloadRequest(
-                round,
                 max_txns,
                 max_bytes,
                 return_non_full,
@@ -40,28 +34,8 @@ impl fmt::Display for GetPayloadCommand {
             ) => {
                 write!(
                     f,
-                    "GetPayloadRequest [round: {}, max_txns: {}, max_bytes: {}, return_non_full: {},  excluded: {}]",
-                    round, max_txns, max_bytes, return_non_full, excluded
-                )
-            },
-        }
-    }
-}
-
-pub enum CleanCommand {
-    CleanRequest(LogicalTime, Vec<HashValue>),
-}
-
-impl fmt::Display for CleanCommand {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            CleanCommand::CleanRequest(logical_time, digests) => {
-                write!(
-                    f,
-                    "CleanRequest [epoch: {}, round: {}, digests: {:?}]",
-                    logical_time.epoch(),
-                    logical_time.round(),
-                    digests
+                    "GetPayloadRequest [max_txns: {}, max_bytes: {}, return_non_full: {},  excluded: {}]",
+                    max_txns, max_bytes, return_non_full, excluded
                 )
             },
         }

--- a/consensus/src/liveness/proposal_generator.rs
+++ b/consensus/src/liveness/proposal_generator.rs
@@ -273,7 +273,6 @@ impl ProposalGenerator {
             let payload = self
                 .payload_client
                 .pull_payload(
-                    round,
                     max_block_txns,
                     max_block_bytes,
                     payload_filter,

--- a/consensus/src/payload_client.rs
+++ b/consensus/src/payload_client.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_consensus_types::{
-    common::{Payload, PayloadFilter, Round},
+    common::{Payload, PayloadFilter},
     request_response::{GetPayloadCommand, GetPayloadResponse},
 };
 use aptos_logger::prelude::*;
@@ -55,7 +55,6 @@ impl QuorumStoreClient {
 
     async fn pull_internal(
         &self,
-        round: Round,
         max_items: u64,
         max_bytes: u64,
         return_non_full: bool,
@@ -63,7 +62,6 @@ impl QuorumStoreClient {
     ) -> Result<Payload, QuorumStoreError> {
         let (callback, callback_rcv) = oneshot::channel();
         let req = GetPayloadCommand::GetPayloadRequest(
-            round,
             max_items,
             max_bytes,
             return_non_full,
@@ -94,7 +92,6 @@ impl QuorumStoreClient {
 impl PayloadClient for QuorumStoreClient {
     async fn pull_payload(
         &self,
-        round: Round,
         max_items: u64,
         max_bytes: u64,
         exclude_payloads: PayloadFilter,
@@ -124,7 +121,6 @@ impl PayloadClient for QuorumStoreClient {
             let done = count == 0 || start_time.elapsed().as_millis() >= max_duration;
             let payload = self
                 .pull_internal(
-                    round,
                     max_items,
                     max_bytes,
                     return_non_full || return_empty || done || self.poll_count == u64::MAX,

--- a/consensus/src/payload_manager.rs
+++ b/consensus/src/payload_manager.rs
@@ -11,7 +11,7 @@ use crate::{
 use aptos_consensus_types::{
     block::Block,
     common::{DataStatus, Payload},
-    proof_of_store::{LogicalTime, ProofOfStore},
+    proof_of_store::ProofOfStore,
 };
 use aptos_crypto::HashValue;
 use aptos_executor_types::{Error::DataNotFound, *};
@@ -31,7 +31,7 @@ pub enum PayloadManager {
 impl PayloadManager {
     async fn request_transactions(
         proofs: Vec<ProofOfStore>,
-        logical_time: LogicalTime,
+        block_timestamp: u64,
         batch_store: &BatchStore<NetworkSender>,
     ) -> Vec<(
         HashValue,
@@ -40,12 +40,12 @@ impl PayloadManager {
         let mut receivers = Vec::new();
         for pos in proofs {
             trace!(
-                "QSE: requesting pos {:?}, digest {}, time = {:?}",
+                "QSE: requesting pos {:?}, digest {}, time = {}",
                 pos,
                 pos.digest(),
-                logical_time
+                block_timestamp
             );
-            if logical_time <= pos.expiration() {
+            if block_timestamp <= pos.expiration() {
                 receivers.push((*pos.digest(), batch_store.get_batch(pos)));
             } else {
                 debug!("QSE: skipped expired pos {}", pos.digest());
@@ -55,12 +55,14 @@ impl PayloadManager {
     }
 
     ///Pass commit information to BatchReader and QuorumStore wrapper for their internal cleanups.
-    pub async fn notify_commit(&self, logical_time: LogicalTime, payloads: Vec<Payload>) {
+    pub async fn notify_commit(&self, block_timestamp: u64, payloads: Vec<Payload>) {
         match self {
             PayloadManager::DirectMempool => {},
             PayloadManager::InQuorumStore(batch_store, coordinator_tx) => {
                 // TODO: move this to somewhere in quorum store, so this can be a batch reader
-                batch_store.update_certified_round(logical_time).await;
+                batch_store
+                    .update_certified_timestamp(block_timestamp)
+                    .await;
 
                 let digests: Vec<HashValue> = payloads
                     .into_iter()
@@ -77,7 +79,7 @@ impl PayloadManager {
 
                 if let Err(e) = tx
                     .send(CoordinatorCommand::CommitNotification(
-                        logical_time,
+                        block_timestamp,
                         digests,
                     ))
                     .await
@@ -104,7 +106,7 @@ impl PayloadManager {
                     if proof_with_status.status.lock().is_none() {
                         let receivers = PayloadManager::request_transactions(
                             proof_with_status.proofs.clone(),
-                            LogicalTime::new(block.epoch(), block.round()),
+                            block.timestamp_usecs(),
                             batch_store,
                         )
                         .await;
@@ -167,7 +169,7 @@ impl PayloadManager {
                                     warn!("Oneshot channel to get a batch was dropped with error {:?}", e);
                                     let new_receivers = PayloadManager::request_transactions(
                                         proof_with_data.proofs.clone(),
-                                        LogicalTime::new(block.epoch(), block.round()),
+                                        block.timestamp_usecs(),
                                         batch_store,
                                     )
                                     .await;
@@ -184,7 +186,7 @@ impl PayloadManager {
                                 Ok(Err(e)) => {
                                     let new_receivers = PayloadManager::request_transactions(
                                         proof_with_data.proofs.clone(),
-                                        LogicalTime::new(block.epoch(), block.round()),
+                                        block.timestamp_usecs(),
                                         batch_store,
                                     )
                                     .await;

--- a/consensus/src/quorum_store/batch_store.rs
+++ b/consensus/src/quorum_store/batch_store.rs
@@ -8,13 +8,13 @@ use crate::{
         counters,
         quorum_store_db::QuorumStoreStorage,
         types::{PersistedValue, StorageMode},
-        utils::RoundExpirations,
+        utils::TimeExpirations,
     },
 };
 use anyhow::bail;
 use aptos_consensus_types::{
     common::Round,
-    proof_of_store::{LogicalTime, ProofOfStore, SignedBatchInfo},
+    proof_of_store::{ProofOfStore, SignedBatchInfo},
 };
 use aptos_crypto::HashValue;
 use aptos_executor_types::Error;
@@ -100,15 +100,11 @@ impl QuotaManager {
 /// efficient concurrent readers.
 pub struct BatchStore<T> {
     epoch: OnceCell<u64>,
-    last_certified_round: AtomicU64,
+    last_certified_time: AtomicU64,
     db_cache: DashMap<HashValue, PersistedValue>,
     peer_quota: DashMap<PeerId, QuotaManager>,
-    expirations: Mutex<RoundExpirations<HashValue>>,
+    expirations: Mutex<TimeExpirations<HashValue>>,
     db: Arc<dyn QuorumStoreStorage>,
-    batch_expiry_round_gap_when_init: Round,
-    batch_expiry_round_gap_behind_latest_certified: Round,
-    batch_expiry_round_gap_beyond_latest_certified: Round,
-    expiry_grace_rounds: Round,
     memory_quota: usize,
     db_quota: usize,
     batch_quota: usize,
@@ -120,12 +116,8 @@ pub struct BatchStore<T> {
 impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
     pub(crate) fn new(
         epoch: u64,
-        last_certified_round: Round,
+        last_certified_time: u64,
         db: Arc<dyn QuorumStoreStorage>,
-        batch_expiry_round_gap_when_init: Round,
-        batch_expiry_round_gap_behind_latest_certified: Round,
-        batch_expiry_round_gap_beyond_latest_certified: Round,
-        expiry_grace_rounds: Round,
         memory_quota: usize,
         db_quota: usize,
         batch_quota: usize,
@@ -136,15 +128,11 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
         let db_clone = db.clone();
         let batch_store = Self {
             epoch: OnceCell::with_value(epoch),
-            last_certified_round: AtomicU64::new(last_certified_round),
+            last_certified_time: AtomicU64::new(last_certified_time),
             db_cache: DashMap::new(),
             peer_quota: DashMap::new(),
-            expirations: Mutex::new(RoundExpirations::new()),
+            expirations: Mutex::new(TimeExpirations::new()),
             db,
-            batch_expiry_round_gap_when_init,
-            batch_expiry_round_gap_behind_latest_certified,
-            batch_expiry_round_gap_beyond_latest_certified,
-            expiry_grace_rounds,
             memory_quota,
             db_quota,
             batch_quota,
@@ -160,7 +148,7 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
             "QS: Batchreader {} {} {}",
             db_content.len(),
             epoch,
-            last_certified_round
+            last_certified_time
         );
         for (digest, value) in db_content {
             let expiration = value.expiration();
@@ -170,11 +158,8 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
                 expiration,
                 digest
             );
-            assert!(epoch >= expiration.epoch());
 
-            if epoch > expiration.epoch()
-                || last_certified_round >= expiration.round() + expiry_grace_rounds
-            {
+            if last_certified_time >= expiration {
                 expired_keys.push(digest);
             } else {
                 batch_store
@@ -220,14 +205,14 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
         mut value: PersistedValue,
     ) -> anyhow::Result<bool> {
         let author = value.author();
-        let expiration_round = value.expiration().round();
+        let expiration_time = value.expiration();
 
         {
             // Acquire dashmap internal lock on the entry corresponding to the digest.
             let cache_entry = self.db_cache.entry(digest);
 
             if let Occupied(entry) = &cache_entry {
-                if entry.get().expiration().round() >= value.expiration().round() {
+                if entry.get().expiration() >= expiration_time {
                     debug!(
                         "QS: already have the digest with higher expiration {}",
                         digest
@@ -266,61 +251,31 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
         self.expirations
             .lock()
             .unwrap()
-            .add_item(digest, expiration_round);
+            .add_item(digest, expiration_time);
         Ok(true)
     }
 
     pub(crate) fn save(&self, digest: HashValue, value: PersistedValue) -> anyhow::Result<bool> {
-        let expiration = value.expiration();
-        if expiration.epoch() == self.epoch() {
-            // record the round gaps
-            if expiration.round() > self.last_certified_round() {
-                counters::GAP_BETWEEN_BATCH_EXPIRATION_AND_LAST_CERTIFIED_ROUND_HIGHER
-                    .observe((expiration.round() - self.last_certified_round()) as f64);
-            }
-            if expiration.round() < self.last_certified_round() {
-                counters::GAP_BETWEEN_BATCH_EXPIRATION_AND_LAST_CERTIFIED_ROUND_LOWER
-                    .observe((self.last_certified_round() - expiration.round()) as f64);
-            }
+        let last_certified_time = self.last_certified_time();
+        if value.expiration() > last_certified_time {
+            fail_point!("quorum_store::save", |_| {
+                // Skip caching and storing value to the db
+                Ok(false)
+            });
 
-            if expiration.round() + self.batch_expiry_round_gap_behind_latest_certified
-                >= self.last_certified_round()
-                && expiration.round()
-                    <= self.last_certified_round()
-                        + self.batch_expiry_round_gap_beyond_latest_certified
-            {
-                fail_point!("quorum_store::save", |_| {
-                    // Skip caching and storing value to the db
-                    Ok(false)
-                });
-
-                return self.insert_to_cache(digest, value);
-            }
+            return self.insert_to_cache(digest, value);
         }
-        bail!("Incorrect expiration {:?} with init gap {} in epoch {}, last committed round {} and max behind gap {} max beyond gap {}",
-            expiration,
-            self.batch_expiry_round_gap_when_init,
+        bail!(
+            "Incorrect expiration {} in epoch {}, last committed timestamp {}",
+            value.expiration(),
             self.epoch(),
-            self.last_certified_round(),
-            self.batch_expiry_round_gap_behind_latest_certified,
-            self.batch_expiry_round_gap_beyond_latest_certified);
+            last_certified_time,
+        );
     }
 
     // pub(crate) for testing
-    pub(crate) fn clear_expired_payload(&self, certified_time: LogicalTime) -> Vec<HashValue> {
-        assert_eq!(
-            certified_time.epoch(),
-            self.epoch(),
-            "Execution epoch inconsistent with BatchReader"
-        );
-
-        let expired_round = if certified_time.round() >= self.expiry_grace_rounds {
-            certified_time.round() - self.expiry_grace_rounds
-        } else {
-            0
-        };
-
-        let expired_digests = self.expirations.lock().unwrap().expire(expired_round);
+    pub(crate) fn clear_expired_payload(&self, certified_time: u64) -> Vec<HashValue> {
+        let expired_digests = self.expirations.lock().unwrap().expire(certified_time);
         let mut ret = Vec::new();
         for h in expired_digests {
             let removed_value = match self.db_cache.entry(h) {
@@ -328,7 +283,7 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
                     // We need to check up-to-date expiration again because receiving the same
                     // digest with a higher expiration would update the persisted value and
                     // effectively extend the expiration.
-                    if entry.get().expiration().round() <= expired_round {
+                    if entry.get().expiration() <= certified_time {
                         Some(entry.remove())
                     } else {
                         None
@@ -346,14 +301,6 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
     }
 
     pub fn persist(&self, persist_request: PersistRequest) -> Option<SignedBatchInfo> {
-        let expiration = persist_request.value.expiration();
-        // Network listener should filter messages with wrong expiration epoch.
-        assert_eq!(
-            expiration.epoch(),
-            self.epoch(),
-            "Persist Request for a batch with an incorrect epoch"
-        );
-
         match self.save(persist_request.digest, persist_request.value.clone()) {
             Ok(needs_db) => {
                 let batch_info = persist_request.value.batch_info().clone();
@@ -379,26 +326,18 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
     // batches with expiration in this round can be cleaned up. The parameter
     // expiry grace rounds just keeps the batches around for a little longer
     // for lagging nodes to be able to catch up (without state-sync).
-    pub async fn update_certified_round(&self, certified_time: LogicalTime) {
+    pub async fn update_certified_timestamp(&self, certified_time: u64) {
         trace!("QS: batch reader updating time {:?}", certified_time);
-        assert_eq!(
-            self.epoch(),
-            certified_time.epoch(),
-            "QS: wrong epoch {} != {}",
-            self.epoch(),
-            certified_time.epoch()
-        );
-
-        let prev_round = self
-            .last_certified_round
-            .fetch_max(certified_time.round(), Ordering::SeqCst);
-        // Note: prev_round may be equal to certified_time round due to state-sync
+        let prev_time = self
+            .last_certified_time
+            .fetch_max(certified_time, Ordering::SeqCst);
+        // Note: prev_time may be equal to certified_time due to state-sync
         // at the epoch boundary.
         assert!(
-            prev_round <= certified_time.round(),
-            "Decreasing executed rounds reported to BatchReader {} {}",
-            prev_round,
-            certified_time.round(),
+            prev_time <= certified_time,
+            "Decreasing executed block timestamp reported to BatchReader {} {}",
+            prev_time,
+            certified_time,
         );
 
         let expired_keys = self.clear_expired_payload(certified_time);
@@ -407,8 +346,8 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
         }
     }
 
-    fn last_certified_round(&self) -> Round {
-        self.last_certified_round.load(Ordering::Relaxed)
+    fn last_certified_time(&self) -> Round {
+        self.last_certified_time.load(Ordering::Relaxed)
     }
 
     fn get_batch_from_db(&self, digest: &HashValue) -> Result<PersistedValue, Error> {

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -130,6 +130,25 @@ pub static EXPIRED_PROOFS_WHEN_PULL: Lazy<Histogram> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_SAVE: Lazy<Histogram> = Lazy::new(
+    || {
+        register_histogram!(
+        "quorum_store_gap_batch_expiration_and_current_time_when_save",
+        "Histogram for the gaps between expiration round and the current round when saving proofs, and expiration time is lower.",
+        // exponential_buckets(/*start=*/ 100.0, /*factor=*/ 1.1, /*count=*/ 100).unwrap(),
+    )
+    .unwrap()
+    },
+);
+
+pub static NUM_BATCH_EXPIRED_WHEN_SAVE: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "quorum_store_num_batch_expired_when_save",
+        "Number of batches that were already expired when save is called"
+    )
+    .unwrap()
+});
+
 /// Histogram for the gaps between expiration round and the current round when pulling the proofs, and expiration round is lower.
 pub static GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_PULL_PROOFS: Lazy<Histogram> =
     Lazy::new(|| {

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -130,31 +130,8 @@ pub static EXPIRED_PROOFS_WHEN_PULL: Lazy<Histogram> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Histogram for the gaps between expiration round of the batch and the last certified round, and expiration round is higher.
-pub static GAP_BETWEEN_BATCH_EXPIRATION_AND_LAST_CERTIFIED_ROUND_HIGHER: Lazy<Histogram> =
-    Lazy::new(|| {
-        register_histogram!(
-        "quorum_store_gap_batch_expiration_and_last_certified_round_higher",
-        "Histogram for the gaps between expiration round of the batch and the last certified round, and expiration round is higher.",
-        // exponential_buckets(/*start=*/ 100.0, /*factor=*/ 1.1, /*count=*/ 100).unwrap(),
-    )
-    .unwrap()
-    });
-
-/// Histogram for the gaps between expiration round of the batch and the last certified round, and expiration round is lower.
-pub static GAP_BETWEEN_BATCH_EXPIRATION_AND_LAST_CERTIFIED_ROUND_LOWER: Lazy<Histogram> = Lazy::new(
-    || {
-        register_histogram!(
-        "quorum_store_gap_batch_expiration_and_last_certified_round_lower",
-        "Histogram for the gaps between expiration round of the batch and the last certified round, and expiration round is lower.",
-        // exponential_buckets(/*start=*/ 100.0, /*factor=*/ 1.1, /*count=*/ 100).unwrap(),
-    )
-    .unwrap()
-    },
-);
-
 /// Histogram for the gaps between expiration round and the current round when pulling the proofs, and expiration round is lower.
-pub static GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_ROUND_WHEN_PULL_PROOFS: Lazy<Histogram> =
+pub static GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_PULL_PROOFS: Lazy<Histogram> =
     Lazy::new(|| {
         register_histogram!(
         "quorum_store_gap_batch_expiration_and_current_round_when_pull",

--- a/consensus/src/quorum_store/direct_mempool_quorum_store.rs
+++ b/consensus/src/quorum_store/direct_mempool_quorum_store.rs
@@ -131,7 +131,6 @@ impl DirectMempoolQuorumStore {
     async fn handle_consensus_request(&self, req: GetPayloadCommand) {
         match req {
             GetPayloadCommand::GetPayloadRequest(
-                _round,
                 max_txns,
                 max_bytes,
                 return_non_full,

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use aptos_consensus_types::{
     common::{Payload, PayloadFilter, ProofWithData},
-    proof_of_store::{LogicalTime, ProofOfStore},
+    proof_of_store::ProofOfStore,
     request_response::{GetPayloadCommand, GetPayloadResponse},
 };
 use aptos_crypto::HashValue;
@@ -20,14 +20,14 @@ use std::collections::HashSet;
 #[derive(Debug)]
 pub enum ProofManagerCommand {
     ReceiveProof(ProofOfStore),
-    CommitNotification(LogicalTime, Vec<HashValue>),
+    CommitNotification(u64, Vec<HashValue>),
     Shutdown(tokio::sync::oneshot::Sender<()>),
 }
 
 pub struct ProofManager {
     my_peer_id: PeerId,
     proofs_for_consensus: ProofQueue,
-    latest_logical_time: LogicalTime,
+    latest_block_timestamp: u64,
     back_pressure_total_txn_limit: u64,
     remaining_total_txn_num: u64,
     back_pressure_total_proof_limit: u64,
@@ -36,7 +36,6 @@ pub struct ProofManager {
 
 impl ProofManager {
     pub fn new(
-        epoch: u64,
         my_peer_id: PeerId,
         back_pressure_total_txn_limit: u64,
         back_pressure_total_proof_limit: u64,
@@ -44,7 +43,7 @@ impl ProofManager {
         Self {
             my_peer_id,
             proofs_for_consensus: ProofQueue::new(),
-            latest_logical_time: LogicalTime::new(epoch, 0),
+            latest_block_timestamp: 0,
             back_pressure_total_txn_limit,
             remaining_total_txn_num: 0,
             back_pressure_total_proof_limit,
@@ -67,24 +66,18 @@ impl ProofManager {
 
     pub(crate) fn handle_commit_notification(
         &mut self,
-        logical_time: LogicalTime,
+        block_timestamp: u64,
         digests: Vec<HashValue>,
     ) {
         trace!(
-            "QS: got clean request from execution at epoch {}, round {}",
-            logical_time.epoch(),
-            logical_time.round()
-        );
-        assert_eq!(
-            self.latest_logical_time.epoch(),
-            logical_time.epoch(),
-            "Wrong epoch"
+            "QS: got clean request from execution at block timestamp {}",
+            block_timestamp
         );
         assert!(
-            self.latest_logical_time <= logical_time,
-            "Decreasing logical time"
+            self.latest_block_timestamp <= block_timestamp,
+            "Decreasing block timestamp"
         );
-        self.latest_logical_time = logical_time;
+        self.latest_block_timestamp = block_timestamp;
         self.proofs_for_consensus.mark_committed(digests);
     }
 
@@ -92,7 +85,6 @@ impl ProofManager {
         match msg {
             // TODO: check what max_txns consensus is using
             GetPayloadCommand::GetPayloadRequest(
-                round,
                 max_txns,
                 max_bytes,
                 return_non_full,
@@ -110,17 +102,14 @@ impl ProofManager {
 
                 let proof_block = self.proofs_for_consensus.pull_proofs(
                     &excluded_proofs,
-                    LogicalTime::new(self.latest_logical_time.epoch(), round),
+                    self.latest_block_timestamp,
                     max_txns,
                     max_bytes,
                     return_non_full,
                 );
                 (self.remaining_total_txn_num, self.remaining_total_proof_num) = self
                     .proofs_for_consensus
-                    .num_total_txns_and_proofs(LogicalTime::new(
-                        self.latest_logical_time.epoch(),
-                        round,
-                    ));
+                    .num_total_txns_and_proofs(self.latest_block_timestamp);
 
                 let res = GetPayloadResponse::GetPayloadResponse(
                     if proof_block.is_empty() {
@@ -189,14 +178,14 @@ impl ProofManager {
                         ProofManagerCommand::ReceiveProof(proof) => {
                             self.receive_proof(proof);
                         },
-                        ProofManagerCommand::CommitNotification(logical_time, digests) => {
-                            self.handle_commit_notification(logical_time, digests);
+                        ProofManagerCommand::CommitNotification(block_timestamp, digests) => {
+                            self.handle_commit_notification(block_timestamp, digests);
 
                             // update the backpressure upon new commit round
                             (self.remaining_total_txn_num, self.remaining_total_proof_num) =
-                                self.proofs_for_consensus.num_total_txns_and_proofs(logical_time);
+                                self.proofs_for_consensus.num_total_txns_and_proofs(block_timestamp);
                             // TODO: keeping here for metrics, might be part of the backpressure in the future?
-                            self.proofs_for_consensus.clean_local_proofs(logical_time);
+                            self.proofs_for_consensus.clean_local_proofs(block_timestamp);
                         },
                     }
                     });

--- a/consensus/src/quorum_store/tests/batch_store_test.rs
+++ b/consensus/src/quorum_store/tests/batch_store_test.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     test_utils::mock_quorum_store_sender::MockQuorumStoreSender,
 };
-use aptos_consensus_types::proof_of_store::{BatchId, LogicalTime};
+use aptos_consensus_types::proof_of_store::BatchId;
 use aptos_crypto::HashValue;
 use aptos_temppath::TempPath;
 use aptos_types::{account_address::AccountAddress, validator_verifier::random_validator_verifier};
@@ -39,10 +39,6 @@ fn batch_store_for_test_no_db(memory_quota: usize) -> Arc<BatchStore<MockQuorumS
         10, // epoch
         10, // last committed round
         db,
-        0,
-        0,
-        2100,
-        0,            // grace period rounds
         memory_quota, // memory_quota
         1000,         // db quota
         1000,         //batch quota
@@ -60,7 +56,8 @@ fn test_insert_expire() {
     let batch = Batch::new(
         BatchId::new_for_test(1),
         vec![],
-        LogicalTime::new(10, 15),
+        10,
+        15,
         AccountAddress::random(),
     );
     let persisted_request: PersistRequest = batch.into();
@@ -71,7 +68,8 @@ fn test_insert_expire() {
     let batch = Batch::new(
         BatchId::new_for_test(1),
         vec![],
-        LogicalTime::new(10, 30),
+        10,
+        30,
         AccountAddress::random(),
     );
     let persisted_request: PersistRequest = batch.into();
@@ -82,7 +80,8 @@ fn test_insert_expire() {
     let batch = Batch::new(
         BatchId::new_for_test(1),
         vec![],
-        LogicalTime::new(10, 25),
+        10,
+        25,
         AccountAddress::random(),
     );
     let persisted_request: PersistRequest = batch.into();
@@ -90,14 +89,11 @@ fn test_insert_expire() {
         batch_store.insert_to_cache(digest, persisted_request.value),
         false,
     );
-    let expired = batch_store.clear_expired_payload(LogicalTime::new(10, 27));
+    let expired = batch_store.clear_expired_payload(27);
     assert!(expired.is_empty());
-    let expired = batch_store.clear_expired_payload(LogicalTime::new(10, 29));
+    let expired = batch_store.clear_expired_payload(29);
     assert!(expired.is_empty());
-    assert_eq!(
-        batch_store.clear_expired_payload(LogicalTime::new(10, 30)),
-        vec![digest]
-    );
+    assert_eq!(batch_store.clear_expired_payload(30), vec![digest]);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -116,7 +112,8 @@ async fn test_extend_expiration_vs_save() {
                 let batch = Batch::new(
                     BatchId::new_for_test(1),
                     vec![],
-                    LogicalTime::new(10, i as u64 + 30),
+                    10,
+                    i as u64 + 30,
                     AccountAddress::random(),
                 );
                 let persisted_request: PersistRequest = batch.into();
@@ -127,7 +124,8 @@ async fn test_extend_expiration_vs_save() {
             let batch = Batch::new(
                 BatchId::new_for_test(1),
                 vec![],
-                LogicalTime::new(10, i as u64 + 40),
+                10,
+                i as u64 + 40,
                 AccountAddress::random(),
             );
             let persisted_request: PersistRequest = batch.into();
@@ -168,9 +166,7 @@ async fn test_extend_expiration_vs_save() {
                 }
             }
 
-            block_on(
-                batch_store_clone2.update_certified_round(LogicalTime::new(10, i as u64 + 30)),
-            );
+            block_on(batch_store_clone2.update_certified_timestamp(i as u64 + 30));
             start_clone2.fetch_add(1, Ordering::Relaxed);
         }
     });
@@ -183,7 +179,8 @@ async fn test_extend_expiration_vs_save() {
             let batch = Batch::new(
                 BatchId::new_for_test(1),
                 vec![],
-                LogicalTime::new(10, i as u64 + 30),
+                10,
+                i as u64 + 30,
                 AccountAddress::random(),
             );
             let persisted_request: PersistRequest = batch.into();
@@ -199,7 +196,7 @@ async fn test_extend_expiration_vs_save() {
     // Expire everything, call for higher times as well.
     for i in 35..50 {
         batch_store
-            .update_certified_round(LogicalTime::new(10, (i + num_experiments) as u64))
+            .update_certified_timestamp((i + num_experiments) as u64)
             .await;
     }
 }

--- a/consensus/src/quorum_store/tests/direct_mempool_quorum_store_test.rs
+++ b/consensus/src/quorum_store/tests/direct_mempool_quorum_store_test.rs
@@ -30,7 +30,6 @@ async fn test_block_request_no_txns() {
     let (consensus_callback, consensus_callback_rcv) = oneshot::channel();
     consensus_to_quorum_store_sender
         .try_send(GetPayloadCommand::GetPayloadRequest(
-            1,
             100,
             1000,
             true,

--- a/consensus/src/quorum_store/tests/proof_coordinator_test.rs
+++ b/consensus/src/quorum_store/tests/proof_coordinator_test.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     test_utils::mock_quorum_store_sender::MockQuorumStoreSender,
 };
-use aptos_consensus_types::proof_of_store::{BatchId, LogicalTime, ProofOfStore, SignedBatchInfo};
+use aptos_consensus_types::proof_of_store::{BatchId, ProofOfStore, SignedBatchInfo};
 use aptos_crypto::HashValue;
 use aptos_executor_types::Error;
 use aptos_types::{
@@ -55,7 +55,7 @@ async fn test_proof_coordinator_basic() {
     let batch_author = signers[0].author();
     let batch_id = BatchId::new_for_test(1);
     let payload = create_vec_signed_transactions(100);
-    let batch = Batch::new(batch_id, payload, LogicalTime::new(1, 20), batch_author);
+    let batch = Batch::new(batch_id, payload, 1, 20, batch_author);
     let digest = batch.digest();
 
     for signer in &signers {

--- a/consensus/src/quorum_store/tests/proof_manager_test.rs
+++ b/consensus/src/quorum_store/tests/proof_manager_test.rs
@@ -4,7 +4,7 @@
 use crate::quorum_store::proof_manager::ProofManager;
 use aptos_consensus_types::{
     common::{Payload, PayloadFilter},
-    proof_of_store::{BatchId, BatchInfo, LogicalTime, ProofOfStore},
+    proof_of_store::{BatchId, BatchInfo, ProofOfStore},
     request_response::{GetPayloadCommand, GetPayloadResponse},
 };
 use aptos_crypto::HashValue;
@@ -15,26 +15,18 @@ use std::collections::HashSet;
 
 #[tokio::test]
 async fn test_block_request() {
-    let mut proof_manager = ProofManager::new(0, AccountAddress::random(), 10, 10);
+    let mut proof_manager = ProofManager::new(AccountAddress::random(), 10, 10);
 
     let digest = HashValue::random();
     let batch_id = BatchId::new_for_test(1);
     let proof = ProofOfStore::new(
-        BatchInfo::new(
-            PeerId::random(),
-            batch_id,
-            LogicalTime::new(0, 10),
-            digest,
-            1,
-            1,
-        ),
+        BatchInfo::new(PeerId::random(), batch_id, 0, 10, digest, 1, 1),
         AggregateSignature::empty(),
     );
     proof_manager.receive_proof(proof.clone());
 
     let (callback_tx, callback_rx) = oneshot::channel();
     let req = GetPayloadCommand::GetPayloadRequest(
-        1,
         100,
         1000000,
         true,

--- a/consensus/src/quorum_store/tests/quorum_store_db_test.rs
+++ b/consensus/src/quorum_store/tests/quorum_store_db_test.rs
@@ -7,7 +7,7 @@ use crate::quorum_store::{
     tests::utils::create_vec_signed_transactions,
     types::Batch,
 };
-use aptos_consensus_types::proof_of_store::{BatchId, LogicalTime};
+use aptos_consensus_types::proof_of_store::BatchId;
 use aptos_temppath::TempPath;
 use aptos_types::account_address::AccountAddress;
 
@@ -18,13 +18,8 @@ fn test_db_for_data() {
 
     let source = AccountAddress::random();
     let signed_txns = create_vec_signed_transactions(100);
-    let persist_request_1: PersistRequest = Batch::new(
-        BatchId::new_for_test(1),
-        signed_txns,
-        LogicalTime::new(1, 20),
-        source,
-    )
-    .into();
+    let persist_request_1: PersistRequest =
+        Batch::new(BatchId::new_for_test(1), signed_txns, 1, 20, source).into();
     let digest_1 = persist_request_1.digest;
     let value_1 = persist_request_1.value;
     assert!(db.save_batch(digest_1, value_1.clone()).is_ok());
@@ -37,25 +32,15 @@ fn test_db_for_data() {
     );
 
     let signed_txns = create_vec_signed_transactions(200);
-    let persist_request_2: PersistRequest = Batch::new(
-        BatchId::new_for_test(1),
-        signed_txns,
-        LogicalTime::new(1, 20),
-        source,
-    )
-    .into();
+    let persist_request_2: PersistRequest =
+        Batch::new(BatchId::new_for_test(1), signed_txns, 1, 20, source).into();
     let digest_2 = persist_request_2.digest;
     let value_2 = persist_request_2.value;
     assert!(db.save_batch(digest_2, value_2).is_ok());
 
     let signed_txns = create_vec_signed_transactions(300);
-    let persist_request_3: PersistRequest = Batch::new(
-        BatchId::new_for_test(1),
-        signed_txns,
-        LogicalTime::new(1, 20),
-        source,
-    )
-    .into();
+    let persist_request_3: PersistRequest =
+        Batch::new(BatchId::new_for_test(1), signed_txns, 1, 20, source).into();
     let digest_3 = persist_request_3.digest;
     let value_3 = persist_request_3.value;
     assert!(db.save_batch(digest_3, value_3).is_ok());

--- a/consensus/src/quorum_store/tests/types_test.rs
+++ b/consensus/src/quorum_store/tests/types_test.rs
@@ -5,7 +5,7 @@ use crate::quorum_store::{
     tests::utils::create_vec_signed_transactions,
     types::{Batch, BatchPayload, BatchRequest},
 };
-use aptos_consensus_types::proof_of_store::{BatchId, LogicalTime};
+use aptos_consensus_types::proof_of_store::BatchId;
 use aptos_crypto::hash::CryptoHash;
 use aptos_types::account_address::AccountAddress;
 
@@ -26,7 +26,8 @@ fn test_batch() {
     let batch = Batch::new(
         BatchId::new_for_test(1),
         signed_txns.clone(),
-        LogicalTime::new(epoch, 1),
+        epoch,
+        1,
         source,
     );
 

--- a/consensus/src/quorum_store/types.rs
+++ b/consensus/src/quorum_store/types.rs
@@ -3,7 +3,7 @@
 
 use crate::quorum_store::batch_store::PersistRequest;
 use anyhow::ensure;
-use aptos_consensus_types::proof_of_store::{BatchId, BatchInfo, LogicalTime};
+use aptos_consensus_types::proof_of_store::{BatchId, BatchInfo};
 use aptos_crypto::{
     hash::{CryptoHash, CryptoHasher},
     HashValue,
@@ -128,13 +128,15 @@ impl Batch {
     pub fn new(
         batch_id: BatchId,
         payload: Vec<SignedTransaction>,
-        expiration: LogicalTime,
+        epoch: u64,
+        expiration: u64,
         batch_author: PeerId,
     ) -> Self {
         let payload = BatchPayload::new(payload);
         let batch_info = BatchInfo::new(
             batch_author,
             batch_id,
+            epoch,
             expiration,
             payload.hash(),
             payload.num_txns() as u64,

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -54,7 +54,7 @@ pub struct ExecutionProxy {
     state_sync_notifier: Arc<dyn ConsensusNotificationSender>,
     async_state_sync_notifier: aptos_channels::Sender<NotificationType>,
     validators: Mutex<Vec<AccountAddress>>,
-    write_mutex: AsyncMutex<LogicalTime>, // TODO: mutex needed?
+    write_mutex: AsyncMutex<LogicalTime>,
     payload_manager: Mutex<Option<Arc<PayloadManager>>>,
     transaction_shuffler: Mutex<Option<Arc<dyn TransactionShuffler>>>,
 }

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -14,9 +14,7 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_consensus_notifications::ConsensusNotificationSender;
-use aptos_consensus_types::{
-    block::Block, executed_block::ExecutedBlock, proof_of_store::LogicalTime,
-};
+use aptos_consensus_types::{block::Block, common::Round, executed_block::ExecutedBlock};
 use aptos_crypto::HashValue;
 use aptos_executor_types::{BlockExecutorTrait, Error as ExecutionError, StateComputeResult};
 use aptos_infallible::Mutex;
@@ -36,6 +34,18 @@ type NotificationType = (
     Vec<ContractEvent>,
 );
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
+struct LogicalTime {
+    epoch: u64,
+    round: Round,
+}
+
+impl LogicalTime {
+    pub fn new(epoch: u64, round: Round) -> Self {
+        Self { epoch, round }
+    }
+}
+
 /// Basic communication with the Execution module;
 /// implements StateComputer traits.
 pub struct ExecutionProxy {
@@ -44,7 +54,7 @@ pub struct ExecutionProxy {
     state_sync_notifier: Arc<dyn ConsensusNotificationSender>,
     async_state_sync_notifier: aptos_channels::Sender<NotificationType>,
     validators: Mutex<Vec<AccountAddress>>,
-    write_mutex: AsyncMutex<LogicalTime>,
+    write_mutex: AsyncMutex<LogicalTime>, // TODO: mutex needed?
     payload_manager: Mutex<Option<Arc<PayloadManager>>>,
     transaction_shuffler: Mutex<Option<Arc<dyn TransactionShuffler>>>,
 }
@@ -159,6 +169,7 @@ impl StateComputer for ExecutionProxy {
             finality_proof.ledger_info().epoch(),
             finality_proof.ledger_info().round(),
         );
+        let block_timestamp = finality_proof.commit_info().timestamp_usecs();
 
         let payload_manager = self.payload_manager.lock().as_ref().unwrap().clone();
         let txn_shuffler = self.transaction_shuffler.lock().as_ref().unwrap().clone();
@@ -201,7 +212,9 @@ impl StateComputer for ExecutionProxy {
             .expect("Failed to send async state sync notification");
 
         *latest_logical_time = logical_time;
-        payload_manager.notify_commit(logical_time, payloads).await;
+        payload_manager
+            .notify_commit(block_timestamp, payloads)
+            .await;
         Ok(())
     }
 
@@ -210,12 +223,13 @@ impl StateComputer for ExecutionProxy {
         let mut latest_logical_time = self.write_mutex.lock().await;
         let logical_time =
             LogicalTime::new(target.ledger_info().epoch(), target.ledger_info().round());
+        let block_timestamp = target.commit_info().timestamp_usecs();
 
         // Before the state synchronization, we have to call finish() to free the in-memory SMT
         // held by BlockExecutor to prevent memory leak.
         self.executor.finish();
 
-        // The pipeline phase already committed beyond the target synced round, just return.
+        // The pipeline phase already committed beyond the target block timestamp, just return.
         if *latest_logical_time >= logical_time {
             warn!(
                 "State sync target {:?} is lower than already committed logical time {:?}",
@@ -230,7 +244,7 @@ impl StateComputer for ExecutionProxy {
         let maybe_payload_manager = self.payload_manager.lock().as_ref().cloned();
         if let Some(payload_manager) = maybe_payload_manager {
             payload_manager
-                .notify_commit(logical_time, Vec::new())
+                .notify_commit(block_timestamp, Vec::new())
                 .await;
         }
 

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -10,7 +10,7 @@ use crate::{
 use anyhow::Result;
 use aptos_consensus_types::{
     block::Block,
-    common::{Payload, PayloadFilter, Round},
+    common::{Payload, PayloadFilter},
     executed_block::ExecutedBlock,
 };
 use aptos_crypto::HashValue;
@@ -26,7 +26,6 @@ pub type StateComputerCommitCallBackType =
 pub trait PayloadClient: Send + Sync {
     async fn pull_payload(
         &self,
-        round: Round,
         max_items: u64,
         max_bytes: u64,
         exclude: PayloadFilter,

--- a/consensus/src/test_utils/mock_payload_manager.rs
+++ b/consensus/src/test_utils/mock_payload_manager.rs
@@ -7,7 +7,7 @@ use crate::{
 use anyhow::Result;
 use aptos_consensus_types::{
     block::block_test_utils::random_payload,
-    common::{Payload, PayloadFilter, Round},
+    common::{Payload, PayloadFilter},
     request_response::GetPayloadCommand,
 };
 use aptos_types::{
@@ -52,7 +52,6 @@ impl PayloadClient for MockPayloadManager {
     /// The returned future is fulfilled with the vector of SignedTransactions
     async fn pull_payload(
         &self,
-        _round: Round,
         _max_size: u64,
         _max_bytes: u64,
         _exclude: PayloadFilter,

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -54,8 +54,8 @@ BatchInfo:
         TYPENAME: AccountAddress
     - batch_id:
         TYPENAME: BatchId
-    - expiration:
-        TYPENAME: LogicalTime
+    - epoch: U64
+    - expiration: U64
     - digest:
         TYPENAME: HashValue
     - num_txns: U64
@@ -323,10 +323,6 @@ LedgerInfoWithV0:
         TYPENAME: LedgerInfo
     - signatures:
         TYPENAME: AggregateSignature
-LogicalTime:
-  STRUCT:
-    - epoch: U64
-    - round: U64
 Module:
   STRUCT:
     - code: BYTES


### PR DESCRIPTION
### Description

Previously, batches were expired using logical time, i.e., (epoch, round). Validators set batch expiration based on their local logical time. For validators that fell behind in consensus, this causes an issue where batches they create are more likely to not reach quorum or expire after quorum, as other validators have a more advanced round. There were several gap buffers introduced to try to mitigate this, which added complexity.

In this PR, logical time is replaced with system clock times (for creation) and block timestamp times (for expiration). Validators set expiration when creating a batch using their local clock time. The system clock is less likely to fall behind than round times (it doesn't depend on consensus progress). Expiration is based on the block timestamp, which is monotonically increasing on committed blocks, so all validators will still see the same expiration at the same round.

This simplifies things, now there is a single expiration limit (default to 60 seconds) at batch creation time.

### Test Plan

Ran land-blocking and three regions tests and did not see any regression.