### PR TITLE
[storage] db tool tests

### DIFF
--- a/storage/db-tool/src/backup.rs
+++ b/storage/db-tool/src/backup.rs
@@ -19,8 +19,6 @@ use aptos_backup_cli::{
         ConcurrentDownloadsOpt, GlobalBackupOpt, TrustedWaypointOpt,
     },
 };
-use aptos_logger::{Level, Logger};
-use aptos_push_metrics::MetricsPusher;
 use clap::{Parser, Subcommand};
 use std::sync::Arc;
 
@@ -135,8 +133,6 @@ pub struct VerifyOpt {
 
 impl Command {
     pub async fn run(self) -> Result<()> {
-        Logger::new().level(Level::Info).init();
-        let _mp = MetricsPusher::start(vec![]);
         match self {
             Command::Oneoff(opt) => {
                 let client = Arc::new(BackupServiceClient::new_with_opt(opt.client));

--- a/storage/db-tool/src/main.rs
+++ b/storage/db-tool/src/main.rs
@@ -3,10 +3,15 @@
 
 use anyhow::Result;
 use aptos_db_tool::DBTool;
+use aptos_logger::{Level, Logger};
+use aptos_push_metrics::MetricsPusher;
 use clap::Parser;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    Logger::new().level(Level::Info).init();
+    let _mp = MetricsPusher::start(vec![]);
+
     DBTool::from_args().run().await?;
     Ok(())
 }

--- a/storage/db-tool/src/replay_verify.rs
+++ b/storage/db-tool/src/replay_verify.rs
@@ -14,7 +14,6 @@ use aptos_config::config::{
 };
 use aptos_db::{AptosDB, GetRestoreHandler};
 use aptos_executor_types::VerifyExecutionMode;
-use aptos_logger::{Level, Logger};
 use aptos_types::transaction::Version;
 use clap::Parser;
 use std::{path::PathBuf, sync::Arc};
@@ -61,8 +60,6 @@ pub struct Opt {
 
 impl Opt {
     pub async fn run(self) -> Result<()> {
-        Logger::new().level(Level::Info).init();
-
         let restore_handler = Arc::new(AptosDB::open(
             self.db_dir,
             false,                       /* read_only */

--- a/storage/db-tool/src/restore.rs
+++ b/storage/db-tool/src/restore.rs
@@ -13,8 +13,6 @@ use aptos_backup_cli::{
     utils::GlobalRestoreOpt,
 };
 use aptos_executor_types::VerifyExecutionMode;
-use aptos_logger::{Level, Logger};
-use aptos_push_metrics::MetricsPusher;
 use clap::{Parser, Subcommand};
 
 /// Restore the database using either a one-time or continuous backup.
@@ -66,9 +64,6 @@ pub enum Oneoff {
 
 impl Command {
     pub async fn run(self) -> Result<()> {
-        Logger::new().level(Level::Info).init();
-        let _mp = MetricsPusher::start(vec![]);
-
         match self {
             Command::Oneoff(oneoff) => {
                 match oneoff {


### PR DESCRIPTION
### Description
improve the robustness of the test
1. txn end_to_end has random test inputs generated, in some scenarios, there could be 0 txn to backup for the first backup. Update the logic to only backup txns when there are more than 0 txn to backup. 
2. close the runtime after a duration to avoid pthread error, also remove duplicated logger initiation
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
