### PR TITLE
[Spec] Disable some specs in vector and SimpleMap

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/simple_map.md
+++ b/aptos-move/framework/aptos-stdlib/doc/simple_map.md
@@ -470,6 +470,12 @@ Primarily used to destroy a map
 ## Specification
 
 
+
+<pre><code><b>pragma</b> verify = <b>false</b>;
+</code></pre>
+
+
+
 <a name="@Specification_1_SimpleMap"></a>
 
 ### Struct `SimpleMap`

--- a/aptos-move/framework/aptos-stdlib/sources/simple_map.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/simple_map.spec.move
@@ -1,6 +1,9 @@
 /// Specifications of the `simple_map` module.
 spec aptos_std::simple_map {
 
+    spec module {
+        pragma verify = false;
+    }
     // Make most of the public API intrinsic. Those functions have custom specifications in the prover.
 
     spec SimpleMap {

--- a/aptos-move/framework/move-stdlib/doc/vector.md
+++ b/aptos-move/framework/move-stdlib/doc/vector.md
@@ -840,11 +840,6 @@ Check if <code>v</code> contains <code>e</code>.
 
 
 
-<pre><code><b>pragma</b> intrinsic = <b>true</b>;
-</code></pre>
-
-
-
 <a name="@Specification_1_append"></a>
 
 ### Function `append`

--- a/aptos-move/framework/move-stdlib/sources/vector.move
+++ b/aptos-move/framework/move-stdlib/sources/vector.move
@@ -85,7 +85,7 @@ module std::vector {
         }
     }
     spec reverse_slice {
-        pragma intrinsic = true;
+        // pragma intrinsic = true;
     }
 
     /// Pushes all of the elements of the `other` vector into the `lhs` vector.


### PR DESCRIPTION
### Description

Recent changes in `move-stdlib` and `aptos-stdlib` break some specs in the `vector` and `SimpleMap` module. This PR temporarily disable them. 
