### PR TITLE
[forge][gcp] Fix chaos-mesh daemon config

### DIFF
--- a/terraform/aptos-node-testnet/gcp/addons.tf
+++ b/terraform/aptos-node-testnet/gcp/addons.tf
@@ -24,6 +24,8 @@ resource "helm_release" "chaos-mesh" {
     jsonencode({
       chaos-mesh = {
         chaosDaemon = {
+          runtime    = "containerd"
+          socketPath = "/run/containerd/containerd.sock"
         }
       }
     })


### PR DESCRIPTION
### Description

GKE uses containerd but chaos-mesh assumes Docker by default. This PR configures chaos-mesh daemon to use containerd.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Deployed to gcp-forge and verified it works.