### PR TITLE
[cli] Cleanup coverage tool so subcommands are at the beginning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "anyhow",
  "aptos-backup-cli",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "1.0.7"
+version = "1.0.8"
 
 # Workspace inherited keys
 authors = { workspace = true }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -903,7 +903,7 @@ impl RestOptions {
 }
 
 /// Options for compiling a move package dir
-#[derive(Debug, Parser)]
+#[derive(Debug, Clone, Parser)]
 pub struct MovePackageDir {
     /// Path to a move package (the folder with a Move.toml file)
     #[clap(long, parse(from_os_str))]

--- a/crates/aptos/src/move_tool/coverage.rs
+++ b/crates/aptos/src/move_tool/coverage.rs
@@ -1,0 +1,184 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::types::{CliCommand, CliError, CliResult, CliTypedResult, MovePackageDir};
+use async_trait::async_trait;
+use clap::{Parser, Subcommand};
+use move_compiler::compiled_unit::{CompiledUnit, NamedCompiledModule};
+use move_coverage::{
+    coverage_map::CoverageMap, format_csv_summary, format_human_summary,
+    source_coverage::SourceCoverageBuilder, summary::summarize_inst_cov,
+};
+use move_disassembler::disassembler::Disassembler;
+use move_package::{compilation::compiled_package::CompiledPackage, BuildConfig};
+
+/// Display a coverage summary for all modules in a package
+///
+#[derive(Debug, Parser)]
+pub struct SummaryCoverage {
+    /// Display function coverage summaries
+    ///
+    /// When provided, it will include coverage on a function level
+    #[clap(long)]
+    pub summarize_functions: bool,
+    /// Output CSV data of coverage
+    #[clap(long = "csv")]
+    pub output_csv: bool,
+    /// A filter string to determine which unit tests to compute coverage on
+    #[clap(long, short)]
+    pub filter: Option<String>,
+    #[clap(flatten)]
+    pub move_options: MovePackageDir,
+}
+
+impl SummaryCoverage {
+    pub fn coverage(self) -> CliTypedResult<()> {
+        let (coverage_map, package) = compile_coverage(self.move_options)?;
+        let modules: Vec<_> = package
+            .root_modules()
+            .filter_map(|unit| {
+                let mut retain = true;
+                if let Some(filter_str) = &self.filter {
+                    if !&unit.unit.name().as_str().contains(filter_str.as_str()) {
+                        retain = false;
+                    }
+                }
+                match &unit.unit {
+                    CompiledUnit::Module(NamedCompiledModule { module, .. }) if retain => {
+                        Some(module.clone())
+                    },
+                    _ => None,
+                }
+            })
+            .collect();
+        let coverage_map = coverage_map.to_unified_exec_map();
+        if self.output_csv {
+            format_csv_summary(
+                modules.as_slice(),
+                &coverage_map,
+                summarize_inst_cov,
+                &mut std::io::stdout(),
+            )
+        } else {
+            format_human_summary(
+                modules.as_slice(),
+                &coverage_map,
+                summarize_inst_cov,
+                &mut std::io::stdout(),
+                self.summarize_functions,
+            )
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl CliCommand<()> for SummaryCoverage {
+    fn command_name(&self) -> &'static str {
+        "SummaryCoverage"
+    }
+
+    async fn execute(self) -> CliTypedResult<()> {
+        self.coverage()
+    }
+}
+
+/// Display coverage information about the module against source code
+#[derive(Debug, Parser)]
+pub struct SourceCoverage {
+    #[clap(long = "module")]
+    pub module_name: String,
+    #[clap(flatten)]
+    pub move_options: MovePackageDir,
+}
+
+#[async_trait]
+impl CliCommand<()> for SourceCoverage {
+    fn command_name(&self) -> &'static str {
+        "SourceCoverage"
+    }
+
+    async fn execute(self) -> CliTypedResult<()> {
+        let (coverage_map, package) = compile_coverage(self.move_options)?;
+        let unit = package.get_module_by_name_from_root(&self.module_name)?;
+        let source_path = &unit.source_path;
+        let (module, source_map) = match &unit.unit {
+            CompiledUnit::Module(NamedCompiledModule {
+                module, source_map, ..
+            }) => (module, source_map),
+            _ => panic!("Should all be modules"),
+        };
+        let source_coverage = SourceCoverageBuilder::new(module, &coverage_map, source_map);
+        source_coverage
+            .compute_source_coverage(source_path)
+            .output_source_coverage(&mut std::io::stdout())
+            .map_err(|err| CliError::UnexpectedError(format!("Failed to get coverage {}", err)))
+    }
+}
+
+/// Display coverage information about the module against disassembled bytecode
+#[derive(Debug, Parser)]
+pub struct BytecodeCoverage {
+    #[clap(long = "module")]
+    pub module_name: String,
+    #[clap(flatten)]
+    pub move_options: MovePackageDir,
+}
+
+#[async_trait]
+impl CliCommand<()> for BytecodeCoverage {
+    fn command_name(&self) -> &'static str {
+        "BytecodeCoverage"
+    }
+
+    async fn execute(self) -> CliTypedResult<()> {
+        let (coverage_map, package) = compile_coverage(self.move_options)?;
+        let unit = package.get_module_by_name_from_root(&self.module_name)?;
+        let mut disassembler = Disassembler::from_unit(&unit.unit);
+        disassembler.add_coverage_map(coverage_map.to_unified_exec_map());
+        println!("{}", disassembler.disassemble()?);
+        Ok(())
+    }
+}
+
+fn compile_coverage(
+    move_options: MovePackageDir,
+) -> CliTypedResult<(CoverageMap, CompiledPackage)> {
+    let config = BuildConfig {
+        additional_named_addresses: move_options.named_addresses(),
+        test_mode: false,
+        install_dir: move_options.output_dir.clone(),
+        ..Default::default()
+    };
+    let path = move_options.get_package_path()?;
+    let coverage_map =
+        CoverageMap::from_binary_file(path.join(".coverage_map.mvcov")).map_err(|err| {
+            CliError::UnexpectedError(format!("Failed to retrieve coverage map {}", err))
+        })?;
+    let package = config
+        .compile_package(path.as_path(), &mut Vec::new())
+        .map_err(|err| CliError::MoveCompilationError(err.to_string()))?;
+
+    Ok((coverage_map, package))
+}
+
+/// Computes coverage for a package
+///
+/// Computes coverage on a previous unit test run for a package.  Coverage input must
+/// first be built with `aptos move test --coverage`
+#[derive(Subcommand)]
+pub enum CoveragePackage {
+    Summary(SummaryCoverage),
+    Source(SourceCoverage),
+    Bytecode(BytecodeCoverage),
+}
+
+impl CoveragePackage {
+    pub async fn execute(self) -> CliResult {
+        match self {
+            Self::Summary(tool) => tool.execute_serialized_success().await,
+            Self::Source(tool) => tool.execute_serialized_success().await,
+            Self::Bytecode(tool) => tool.execute_serialized_success().await,
+        }
+    }
+}


### PR DESCRIPTION
### Description
The UX was a little strange, where the command would be `aptos move coverage --package-dir X source --module-name Y`

It's now been cleaned up so all the flags are on the right side, `aptos move coverage source --package-dir X --module-name Y`

This additionally breaks it down to match the rest of the commands in the space.

I needed to make this change prior to releasing a new version of the CLI, because once something is set like this, I don't want to break the existing flow.

### Test Plan
```
$ ./target/debug/aptos move test --named-addresses hello_blockchain=0x22 --package-dir aptos-move/move-examples/hello_blockchain --coverage
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING Examples
Running Move unit tests
[ PASS    ] 0x22::message_tests::sender_can_set_message
[ PASS    ] 0x22::message::sender_can_set_message
Test result: OK. Total tests: 2; passed: 2; failed: 0
+-------------------------+
| Move Coverage Summary   |
+-------------------------+
Module 0000000000000000000000000000000000000000000000000000000000000022::message
>>> % Module coverage: 54.55
+-------------------------+
| % Move Coverage: 54.55  |
+-------------------------+
Please use `aptos move coverage -h` for more detailed test coverage of this package
{
  "Result": "Success"
}

$ ./target/debug/aptos move coverage source --package-dir aptos-move/move-examples/hello_blockchain --named-addresses hello_blockchain=0x22 --module message
module hello_blockchain::message {
    use std::error;
    use std::signer;
    use std::string;
    use aptos_framework::account;
    use aptos_framework::event;

//:!:>resource
    struct MessageHolder has key {
        message: string::String,
        message_change_events: event::EventHandle<MessageChangeEvent>,
    }
//<:!:resource

    struct MessageChangeEvent has drop, store {
        from_message: string::String,
        to_message: string::String,
    }

    /// There is no message present
    const ENO_MESSAGE: u64 = 0;
...
{
  "Result": null
}

$ ./target/debug/aptos move cover
age bytecode --package-dir aptos-move/move-examples/hello_blockchain --named-addresses hello_blockchain=0x22 --module message
// Move bytecode v6
module 22.message {
use 0000000000000000000000000000000000000000000000000000000000000001::account;
use 0000000000000000000000000000000000000000000000000000000000000001::error;
use 0000000000000000000000000000000000000000000000000000000000000001::event;
use 0000000000000000000000000000000000000000000000000000000000000001::signer;
use 0000000000000000000000000000000000000000000000000000000000000001::string;


struct MessageChangeEvent has drop, store {
        from_message: String,
        to_message: String
}
struct MessageHolder has key {
        message: String,
        message_change_events: EventHandle<MessageChangeEvent>
}

public get_message(addr: address): String {
B0:
[2]     0: CopyLoc[0](addr: address)
[2]     1: Exists[1](MessageHolder)
...

$ ./target/debug/aptos move coverage summary --package-dir aptos-move/move-examples/hello_blockchain --named-addresses hello_blockchain=0x22 --summarize-functions
+-------------------------+
| Move Coverage Summary   |
+-------------------------+
Module 0000000000000000000000000000000000000000000000000000000000000022::message
        fun get_message
                total: 12
                covered: 9
                % coverage: 75.00
        fun set_message
                total: 32
                covered: 15
                % coverage: 46.88
>>> % Module coverage: 54.55
+-------------------------+
| % Move Coverage: 54.55  |
+-------------------------+

```
