### PR TITLE
[prover] spec for `big_vector`

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/smart_vector.md
+++ b/aptos-move/framework/aptos-stdlib/doc/smart_vector.md
@@ -25,6 +25,13 @@
 -  [Function `length`](#0x1_smart_vector_length)
 -  [Function `is_empty`](#0x1_smart_vector_is_empty)
 -  [Specification](#@Specification_1)
+    -  [Struct `SmartVector`](#@Specification_1_SmartVector)
+    -  [Function `empty`](#@Specification_1_empty)
+    -  [Function `empty_with_config`](#@Specification_1_empty_with_config)
+    -  [Function `destroy_empty`](#@Specification_1_destroy_empty)
+    -  [Function `borrow`](#@Specification_1_borrow)
+    -  [Function `pop_back`](#@Specification_1_pop_back)
+    -  [Function `swap_remove`](#@Specification_1_swap_remove)
     -  [Function `swap`](#@Specification_1_swap)
 
 
@@ -753,6 +760,168 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 ## Specification
 
 
+<a name="@Specification_1_SmartVector"></a>
+
+### Struct `SmartVector`
+
+
+<pre><code><b>struct</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt; <b>has</b> store
+</code></pre>
+
+
+
+<dl>
+<dt>
+<code>inline_vec: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;T&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>big_vec: <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>inline_capacity: <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>bucket_size: <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+
+<pre><code><b>invariant</b> <a href="../../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(bucket_size)
+    || (<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(bucket_size) && <a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(bucket_size) != 0);
+<b>invariant</b> <a href="../../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(inline_capacity)
+    || (<a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(inline_vec) &lt;= <a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(inline_capacity));
+<b>invariant</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(inline_capacity) && <a href="../../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(bucket_size))
+    || (<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(inline_capacity) && <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(bucket_size));
+</code></pre>
+
+
+
+<a name="@Specification_1_empty"></a>
+
+### Function `empty`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_empty">empty</a>&lt;T: store&gt;(): <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
+</code></pre>
+
+
+
+<a name="@Specification_1_empty_with_config"></a>
+
+### Function `empty_with_config`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_empty_with_config">empty_with_config</a>&lt;T: store&gt;(inline_capacity: u64, bucket_size: u64): <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> bucket_size == 0;
+</code></pre>
+
+
+
+<a name="@Specification_1_destroy_empty"></a>
+
+### Function `destroy_empty`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_destroy_empty">destroy_empty</a>&lt;T&gt;(v: <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !(<a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>(v));
+<b>aborts_if</b> <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(v.inline_vec) != 0
+    || <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(v.big_vec);
+</code></pre>
+
+
+
+<a name="@Specification_1_borrow"></a>
+
+### Function `borrow`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_borrow">borrow</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64): &T
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> i &gt;= <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v);
+<b>aborts_if</b> <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(v.big_vec) && (
+    (<a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(v.inline_vec) + <a href="big_vector.md#0x1_big_vector_length">big_vector::length</a>&lt;T&gt;(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(v.big_vec))) &gt; MAX_U64
+);
+</code></pre>
+
+
+
+<a name="@Specification_1_pop_back"></a>
+
+### Function `pop_back`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_pop_back">pop_back</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;): T
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b>  <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(v.big_vec)
+    &&
+    (<a href="table_with_length.md#0x1_table_with_length_spec_len">table_with_length::spec_len</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(v.big_vec).buckets) == 0);
+<b>aborts_if</b> <a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>(v);
+<b>aborts_if</b> <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(v.big_vec) && (
+    (<a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(v.inline_vec) + <a href="big_vector.md#0x1_big_vector_length">big_vector::length</a>&lt;T&gt;(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(v.big_vec))) &gt; MAX_U64
+);
+<b>ensures</b> <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v) == <a href="smart_vector.md#0x1_smart_vector_length">length</a>(<b>old</b>(v)) - 1;
+</code></pre>
+
+
+
+<a name="@Specification_1_swap_remove"></a>
+
+### Function `swap_remove`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_swap_remove">swap_remove</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">smart_vector::SmartVector</a>&lt;T&gt;, i: u64): T
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> verify_duration_estimate = 120;
+<b>aborts_if</b> i &gt;= <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v);
+<b>aborts_if</b> <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(v.big_vec) && (
+    (<a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(v.inline_vec) + <a href="big_vector.md#0x1_big_vector_length">big_vector::length</a>&lt;T&gt;(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(v.big_vec))) &gt; MAX_U64
+);
+<b>ensures</b> <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v) == <a href="smart_vector.md#0x1_smart_vector_length">length</a>(<b>old</b>(v)) - 1;
+</code></pre>
+
+
+
 <a name="@Specification_1_swap"></a>
 
 ### Function `swap`
@@ -764,7 +933,7 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 
 
 
-<pre><code><b>pragma</b> opaque;
+<pre><code><b>pragma</b> verify = <b>false</b>;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/big_vector.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/big_vector.spec.move
@@ -1,0 +1,62 @@
+spec aptos_std::big_vector {
+    spec BigVector {
+        invariant bucket_size != 0;
+        // ensure all buckets except last has `bucket_size`
+        invariant table_with_length::spec_len(buckets) == 0 || (forall i in 0..table_with_length::spec_len(buckets)-1: vector::length(table_with_length::spec_get(buckets, i)) == bucket_size);
+        // ensure last bucket doesn't have more than `bucket_size` elements
+        invariant table_with_length::spec_len(buckets) == 0 || vector::length(table_with_length::spec_get(buckets, table_with_length::spec_len(buckets) -1 )) <= bucket_size;
+        // ensure each table entry exists due to a bad spec in `Table::spec_get`
+        invariant (forall i in 0..table_with_length::spec_len(buckets): table_with_length::spec_contains(buckets, i));
+        // ensure correct number of buckets
+        invariant table_with_length::spec_len(buckets) == (end_index + bucket_size - 1) / bucket_size;
+        // ensure bucket lengths add up to `end_index`
+        invariant (table_with_length::spec_len(buckets) == 0 && end_index == 0)
+            || (table_with_length::spec_len(buckets) != 0 && ((table_with_length::spec_len(buckets) - 1) * bucket_size) + (vector::length(table_with_length::spec_get(buckets, table_with_length::spec_len(buckets) - 1))) == end_index);
+    }
+
+    spec empty {
+        aborts_if bucket_size == 0;
+        ensures(length(result) == 0);
+        ensures(result.bucket_size == bucket_size);
+    }
+
+    spec singleton {
+        ensures(length(result) == 1);
+        ensures(result.bucket_size == bucket_size);
+    }
+
+    spec destroy_empty {
+        aborts_if !is_empty(v);
+    }
+
+    spec borrow {
+        aborts_if i >= length(v);
+        ensures result == vector::borrow(table_with_length::spec_get(v.buckets, i/v.bucket_size), i % v.bucket_size);
+    }
+
+    spec borrow_mut {
+        aborts_if i >= length(v);
+        ensures result == vector::borrow(table_with_length::spec_get(v.buckets, i/v.bucket_size), i % v.bucket_size);
+    }
+
+    spec push_back {
+        ensures(length(v) == length(old(v)) + 1);
+        ensures val == vector::borrow(table_with_length::spec_get(v.buckets, (length(v)-1)/v.bucket_size), (length(v)-1) % v.bucket_size);
+    }
+
+    spec pop_back {
+        aborts_if is_empty(v);
+        ensures(length(v) == length(old(v)) - 1);
+        ensures result == vector::borrow(table_with_length::spec_get(old(v).buckets, (length(old(v))-1)/v.bucket_size), (length(old(v))-1) % v.bucket_size);
+    }
+
+    spec swap_remove {
+        aborts_if i >= length(v);
+        ensures(length(v) == length(old(v)) - 1);
+    }
+
+    spec swap {
+        aborts_if i >= length(v) || j >= length(v);
+        ensures(length(v) == length(old(v)));
+    }
+}

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_vector.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_vector.spec.move
@@ -1,6 +1,63 @@
 spec aptos_std::smart_vector {
+
+    spec SmartVector {
+        // `bucket_size` shouldn't be 0, if specified.
+        invariant option::is_none(bucket_size)
+            || (option::is_some(bucket_size) && option::borrow(bucket_size) != 0);
+        // vector length should be <= `inline_capacity`, if specified.
+        invariant option::is_none(inline_capacity)
+            || (vector::length(inline_vec) <= option::borrow(inline_capacity));
+        // both `inline_capacity` and `bucket_size` should either exist or shouldn't exist at all.
+        invariant (option::is_none(inline_capacity) && option::is_none(bucket_size))
+            || (option::is_some(inline_capacity) && option::is_some(bucket_size));
+    }
+
+    spec empty {
+        aborts_if false;
+    }
+
+    spec empty_with_config {
+        aborts_if bucket_size == 0;
+    }
+
+    spec destroy_empty {
+        aborts_if !(is_empty(v));
+        aborts_if vector::length(v.inline_vec) != 0
+            || option::is_some(v.big_vec);
+    }
+
+    spec borrow {
+        aborts_if i >= length(v);
+        aborts_if option::is_some(v.big_vec) && (
+            (vector::length(v.inline_vec) + big_vector::length<T>(option::borrow(v.big_vec))) > MAX_U64
+        );
+    }
+
+    spec pop_back {
+        use aptos_std::table_with_length;
+
+        aborts_if  option::is_some(v.big_vec)
+            &&
+            (table_with_length::spec_len(option::borrow(v.big_vec).buckets) == 0);
+        aborts_if is_empty(v);
+        aborts_if option::is_some(v.big_vec) && (
+            (vector::length(v.inline_vec) + big_vector::length<T>(option::borrow(v.big_vec))) > MAX_U64
+        );
+
+        ensures length(v) == length(old(v)) - 1;
+    }
+
+    spec swap_remove {
+        pragma verify_duration_estimate = 120; // TODO: set because of timeout (property proved)
+        aborts_if i >= length(v);
+        aborts_if option::is_some(v.big_vec) && (
+            (vector::length(v.inline_vec) + big_vector::length<T>(option::borrow(v.big_vec))) > MAX_U64
+        );
+        ensures length(v) == length(old(v)) - 1;
+    }
+
     spec swap {
         // TODO: temporarily mocked up.
-        pragma opaque;
+        pragma verify = false;
     }
 }


### PR DESCRIPTION
### Description

Here we add specifications for `big_vector`. In particular, we specify
1. Critical data invariants about the structure of `big_vector`
2. Well-scoped `aborts_if` clauses 

The goal is for this to serve as a model for further data structure specifications. 

As an aside, we also note potentially confusing behavior with `table::spec_get`. It might make sense to add a `safe_spec_get` variant that checks for the existence of the key instead of returning garbage. 

### Test Plan

Use the Aptos prover. 
