### PR TITLE
[Spec] Spec for to_vec_pair and upsert in simple_map

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/simple_map.md
+++ b/aptos-move/framework/aptos-stdlib/doc/simple_map.md
@@ -634,7 +634,14 @@ Primarily used to destroy a map
 
 
 
-<pre><code><b>pragma</b> verify=<b>false</b>;
+<pre><code><b>pragma</b> intrinsic;
+<b>pragma</b> opaque;
+<b>ensures</b> [abstract] !<a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(<b>old</b>(map), key) ==&gt; <a href="../../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(result_1);
+<b>ensures</b> [abstract] !<a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(<b>old</b>(map), key) ==&gt; <a href="../../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(result_2);
+<b>ensures</b> [abstract] <a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(map, key);
+<b>ensures</b> [abstract] <a href="simple_map.md#0x1_simple_map_spec_get">spec_get</a>(map, key) == value;
+<b>ensures</b> [abstract] <a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(<b>old</b>(map), key) ==&gt; ((<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(result_1)) && (<a href="../../move-stdlib/doc/option.md#0x1_option_spec_borrow">option::spec_borrow</a>(result_1) == key));
+<b>ensures</b> [abstract] <a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(<b>old</b>(map), key) ==&gt; ((<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(result_2)) && (<a href="../../move-stdlib/doc/option.md#0x1_option_spec_borrow">option::spec_borrow</a>(result_2) == <a href="simple_map.md#0x1_simple_map_spec_get">spec_get</a>(<b>old</b>(map), key)));
 </code></pre>
 
 
@@ -695,7 +702,13 @@ Primarily used to destroy a map
 
 
 
-<pre><code><b>pragma</b> verify=<b>false</b>;
+<pre><code><b>pragma</b> intrinsic;
+<b>pragma</b> opaque;
+<b>ensures</b> [abstract]
+    <b>forall</b> k: Key: <a href="../../move-stdlib/doc/vector.md#0x1_vector_spec_contains">vector::spec_contains</a>(result_1, k) &lt;==&gt;
+        <a href="simple_map.md#0x1_simple_map_spec_contains_key">spec_contains_key</a>(map, k);
+<b>ensures</b> [abstract] <b>forall</b> i in 0..len(result_1):
+    <a href="simple_map.md#0x1_simple_map_spec_get">spec_get</a>(map, <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(result_1, i)) == <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(result_2, i);
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/sources/simple_map.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/simple_map.spec.move
@@ -56,12 +56,29 @@ spec aptos_std::simple_map {
         pragma verify=false;
     }
 
-    spec to_vec_pair {
-        pragma verify=false;
+    spec to_vec_pair<Key: store, Value: store>(map: SimpleMap<Key, Value>): (vector<Key>, vector<Value>) {
+        pragma intrinsic;
+        pragma opaque;
+        ensures [abstract]
+            forall k: Key: vector::spec_contains(result_1, k) <==>
+                spec_contains_key(map, k);
+        ensures [abstract] forall i in 0..len(result_1):
+            spec_get(map, vector::borrow(result_1, i)) == vector::borrow(result_2, i);
     }
 
-    spec upsert {
-        pragma verify=false;
+    spec upsert<Key: store, Value: store>(
+        map: &mut SimpleMap<Key, Value>,
+        key: Key,
+        value: Value
+        ): (std::option::Option<Key>, std::option::Option<Value>) {
+        pragma intrinsic;
+        pragma opaque;
+        ensures [abstract] !spec_contains_key(old(map), key) ==> option::is_none(result_1);
+        ensures [abstract] !spec_contains_key(old(map), key) ==> option::is_none(result_2);
+        ensures [abstract] spec_contains_key(map, key);
+        ensures [abstract] spec_get(map, key) == value;
+        ensures [abstract] spec_contains_key(old(map), key) ==> ((option::is_some(result_1)) && (option::spec_borrow(result_1) == key));
+        ensures [abstract] spec_contains_key(old(map), key) ==> ((option::is_some(result_2)) && (option::spec_borrow(result_2) == spec_get(old(map), key)));
     }
 
     // Specification functions for tables


### PR DESCRIPTION
### Description

As requested in #7204, this PR adds spec for newly added public API `to_vec_pair` and `upsert`. Since both functions do not fit the table model in boogie, they are written in an abstract way. 