### PR TITLE
Run faucet tests on main

### DIFF
--- a/.github/workflows/faucet-tests.yaml
+++ b/.github/workflows/faucet-tests.yaml
@@ -3,8 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - devnet
-      - testnet
+      - main
 
 jobs:
   run-tests-devnet:


### PR DESCRIPTION
### Description
Previously, besides running on PRs, we were only running faucet tests on the devnet and testnet branches. This doesn't really make sense, since we never deploy faucet built off those branches, we deploy faucet built off the main branch. This PR changes it so we run the tests against `main` instead of those other branches.

To clarify, this doesn't change the nature of the tests themselves, we will still run the faucet integration tests against a local testnet from devnet / testnet. It's just where we choose to build and run the integration tests from.

### Test Plan
CI.
