### PR TITLE
[CLI] Add `aptos move show` subcommand group

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -5,6 +5,7 @@ mod aptos_debug_natives;
 pub mod coverage;
 mod manifest;
 pub mod package_hooks;
+mod show;
 pub mod stored_package;
 mod transactional_tests_runner;
 
@@ -95,6 +96,8 @@ pub enum MoveTool {
     View(ViewFunction),
     #[clap(subcommand)]
     Coverage(coverage::CoveragePackage),
+    #[clap(subcommand, hide = true)]
+    Show(show::ShowTool),
 }
 
 impl MoveTool {
@@ -119,6 +122,7 @@ impl MoveTool {
             },
             MoveTool::View(tool) => tool.execute_serialized().await,
             MoveTool::Coverage(tool) => tool.execute().await,
+            MoveTool::Show(tool) => tool.execute_serialized().await,
         }
     }
 }

--- a/crates/aptos/src/move_tool/show.rs
+++ b/crates/aptos/src/move_tool/show.rs
@@ -1,0 +1,109 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::IncludedArtifactsArgs;
+use crate::common::types::{CliCommand, CliError, CliResult, CliTypedResult, MovePackageDir};
+use anyhow::Context;
+use aptos_framework::{BuildOptions, BuiltPackage};
+use aptos_types::transaction::EntryABI;
+use async_trait::async_trait;
+use clap::{Parser, Subcommand};
+
+#[derive(Subcommand)]
+pub enum ShowTool {
+    Abi(ShowAbi),
+}
+
+impl ShowTool {
+    pub async fn execute_serialized(self) -> CliResult {
+        match self {
+            Self::Abi(tool) => tool.execute_serialized().await,
+        }
+    }
+}
+
+/// Compile the package and show information about the ABIs of the compiled modules.
+///
+/// For example, this would show the function `transfer` in the module `coin`:
+///
+/// aptos move show abi --modules coin --names transfer
+///
+#[derive(Parser)]
+pub struct ShowAbi {
+    /// If provided, only show items from the given Move modules. These should be module
+    /// names, not file paths. For example, `coin`.
+    #[clap(long, multiple_values = true)]
+    modules: Vec<String>,
+
+    /// If provided, only show items with the given names. For example, `transfer`.
+    #[clap(long, multiple_values = true)]
+    names: Vec<String>,
+
+    #[clap(flatten)]
+    included_artifacts_args: IncludedArtifactsArgs,
+
+    #[clap(flatten)]
+    move_options: MovePackageDir,
+}
+
+#[async_trait]
+impl CliCommand<Vec<EntryABI>> for ShowAbi {
+    fn command_name(&self) -> &'static str {
+        "ShowAbi"
+    }
+
+    async fn execute(self) -> CliTypedResult<Vec<EntryABI>> {
+        let build_options = BuildOptions {
+            install_dir: self.move_options.output_dir.clone(),
+            with_abis: true,
+            ..self
+                .included_artifacts_args
+                .included_artifacts
+                .build_options(
+                    self.move_options.skip_fetch_latest_git_deps,
+                    self.move_options.named_addresses(),
+                    self.move_options.bytecode_version,
+                )
+        };
+
+        // Build the package.
+        let package = BuiltPackage::build(self.move_options.get_package_path()?, build_options)
+            .map_err(|e| CliError::MoveCompilationError(format!("{:#}", e)))?;
+
+        // Get ABIs from the package.
+        let abis = package
+            .extract_abis()
+            .context("No ABIs found after compilation")?;
+
+        // Filter the ABIs based on the filters passed in.
+        let abis = abis
+            .into_iter()
+            .filter(|abi| {
+                let name = abi.name().to_string();
+                if !self.names.is_empty() && !self.names.contains(&name) {
+                    return false;
+                }
+                match &abi {
+                    EntryABI::EntryFunction(func) => {
+                        if !self.modules.is_empty()
+                            && !self
+                                .modules
+                                .contains(&func.module_name().name().to_string())
+                        {
+                            return false;
+                        }
+                    },
+                    EntryABI::TransactionScript(_) => {
+                        // If there were any modules specified we ignore scripts.
+                        if !self.modules.is_empty() {
+                            return false;
+                        }
+                    },
+                }
+                true
+            })
+            .collect();
+
+        Ok(abis)
+    }
+}


### PR DESCRIPTION
### Description
Occasionally we'll want to look at the ABI that comes directly out of the compiler. Previously when we wanted to do this we'd hack up a script for that one instance and then throw it away. This PR adds support for this in the CLI with the `aptos move show` subcommand group, starting with `aptos move show abi`.

I have marked this subcommand group has hidden for now, as the difference between this ABI and the ABI returned by the API might confuse some people.

### Test Plan
```
$ cargo run -p aptos -- move show abi --help
aptos-move-show-abi 1.0.8
Compile a package and show information about the ABIs of the compiled modules.

For example, this would show the function `transfer` in the module `coin`:

aptos move show abi --modules coin --names transfer

USAGE:
    aptos move show abi [OPTIONS]

OPTIONS:
        --bytecode-version <BYTECODE_VERSION>
            Specify the version of the bytecode the compiler is going to emit

    -h, --help
            Print help information

        --included-artifacts <INCLUDED_ARTIFACTS>
            Artifacts to be generated when building the package

            Which artifacts to include in the package. This can be one of `none`, `sparse`, and
            `all`. `none` is the most compact form and does not allow to reconstruct a source
            package from chain; `sparse` is the minimal set of artifacts needed to reconstruct a
            source package; `all` includes all available artifacts. The choice of included artifacts
            heavily influences the size and therefore gas cost of publishing: `none` is the size of
            bytecode alone; `sparse` is roughly 2 times as much; and `all` 3-4 as much.

            [default: sparse]

        --modules <MODULES>...
            If provided, only show items from the given Move modules. These should be module names,
            not file paths. For example, `coin`

        --named-addresses <NAMED_ADDRESSES>
            Named addresses for the move binary

            Example: alice=0x1234, bob=0x5678

            Note: This will fail if there are duplicates in the Move.toml file remove those first.

            [default: ]

        --names <NAMES>...
            If provided, only show items with the given names. For example, `transfer`

        --output-dir <OUTPUT_DIR>
            Path to save the compiled move package

            Defaults to `<package_dir>/build`

        --package-dir <PACKAGE_DIR>
            Path to a move package (the folder with a Move.toml file)

        --skip-fetch-latest-git-deps
            Skip pulling the latest git dependencies

            If you don't have a network connection, the compiler may fail due to no ability to pull
            git dependencies.  This will allow overriding this for local development.

    -V, --version
            Print version information
```
```
cargo run -p aptos -- move show abi --package-dir /Users/dport/a/core/aptos-move/framework/aptos-framework --modules coin
```
```
{
  "Result": [
    {
      "EntryFunction": {
        "name": "transfer",
        "module_name": {
          "address": "0000000000000000000000000000000000000000000000000000000000000001",
          "name": "coin"
        },
        "doc": " Transfers `amount` of coins `CoinType` from `from` to `to`.",
        "ty_args": [
          {
            "name": "coin_type"
          }
        ],
        "args": [
          {
            "name": "to",
            "type_tag": "address"
          },
          {
            "name": "amount",
            "type_tag": "u64"
          }
        ]
      }
    },
    {
      "EntryFunction": {
        "name": "upgrade_supply",
        "module_name": {
          "address": "0000000000000000000000000000000000000000000000000000000000000001",
          "name": "coin"
        },
        "doc": " Upgrade total supply to use a parallelizable implementation if it is\n available.",
        "ty_args": [
          {
            "name": "coin_type"
          }
        ],
        "args": []
      }
    }
  ]
}
```

```
cargo run -p aptos -- move show abi --package-dir /Users/dport/a/core/aptos-move/framework/aptos-framework --modules vesting --names update_operator unlock_rewards
```
```
{
  "Result": [
    {
      "EntryFunction": {
        "name": "unlock_rewards",
        "module_name": {
          "address": "0000000000000000000000000000000000000000000000000000000000000001",
          "name": "vesting"
        },
        "doc": " Unlock any accumulated rewards.",
        "ty_args": [],
        "args": [
          {
            "name": "contract_address",
            "type_tag": "address"
          }
        ]
      }
    },
    {
      "EntryFunction": {
        "name": "update_operator",
        "module_name": {
          "address": "0000000000000000000000000000000000000000000000000000000000000001",
          "name": "vesting"
        },
        "doc": "",
        "ty_args": [],
        "args": [
          {
            "name": "contract_address",
            "type_tag": "address"
          },
          {
            "name": "new_operator",
            "type_tag": "address"
          },
          {
            "name": "commission_percentage",
            "type_tag": "u64"
          }
        ]
      }
    }
  ]
}
```
