### PR TITLE
Make node config logging a warn

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -351,7 +351,7 @@ pub fn setup_environment_and_start_node(
     logger_filter_update_job: Option<LoggerFilterUpdater>,
 ) -> anyhow::Result<AptosHandle> {
     // Log the node config at node startup
-    info!("Using node config {:?}", &node_config);
+    warn!("Using node config {:?}", &node_config);
 
     // Start the node inspection service
     services::start_node_inspection_service(&node_config);


### PR DESCRIPTION
### Description

We ship warn and above logs by default, so lets make node config logging a warn level.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

