### PR TITLE
[Quorum Store] fix consensus config quorum store overrides

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -11,6 +11,7 @@ pub(crate) const MAX_SENDING_BLOCK_TXNS_QUORUM_STORE_OVERRIDE: u64 = 4000;
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ConsensusConfig {
+    // Use getters to read the correct value with/without quorum store.
     pub max_sending_block_txns: u64,
     pub max_sending_block_txns_quorum_store_override: u64,
     pub max_sending_block_bytes: u64,
@@ -141,12 +142,36 @@ impl ConsensusConfig {
         self.safety_rules.set_data_dir(data_dir);
     }
 
-    // TODO: This is ugly. Remove this and configs when quorum store is always the default.
-    pub fn apply_quorum_store_overrides(&mut self) {
-        self.max_sending_block_txns = self.max_sending_block_txns_quorum_store_override;
-        self.max_sending_block_bytes = self.max_sending_block_bytes_quorum_store_override;
-        self.max_receiving_block_txns = self.max_receiving_block_txns_quorum_store_override;
-        self.max_receiving_block_bytes = self.max_receiving_block_bytes_quorum_store_override;
+    pub fn max_sending_block_txns(&self, quorum_store_enabled: bool) -> u64 {
+        if quorum_store_enabled {
+            self.max_sending_block_txns_quorum_store_override
+        } else {
+            self.max_sending_block_txns
+        }
+    }
+
+    pub fn max_sending_block_bytes(&self, quorum_store_enabled: bool) -> u64 {
+        if quorum_store_enabled {
+            self.max_sending_block_bytes_quorum_store_override
+        } else {
+            self.max_sending_block_bytes
+        }
+    }
+
+    pub fn max_receiving_block_txns(&self, quorum_store_enabled: bool) -> u64 {
+        if quorum_store_enabled {
+            self.max_receiving_block_txns_quorum_store_override
+        } else {
+            self.max_receiving_block_txns
+        }
+    }
+
+    pub fn max_receiving_block_bytes(&self, quorum_store_enabled: bool) -> u64 {
+        if quorum_store_enabled {
+            self.max_receiving_block_bytes_quorum_store_override
+        } else {
+            self.max_receiving_block_bytes
+        }
     }
 }
 

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -798,7 +798,7 @@ impl EpochManager {
             LivenessStorageData::FullRecoveryData(initial_data) => {
                 let consensus_config = onchain_consensus_config.unwrap_or_default();
                 let execution_config = onchain_execution_config.unwrap_or_default();
-                self.quorum_store_enabled = self.enable_quourum_store(&consensus_config);
+                self.quorum_store_enabled = self.enable_quorum_store(&consensus_config);
                 self.start_round_manager(
                     initial_data,
                     epoch_state,
@@ -813,7 +813,7 @@ impl EpochManager {
         }
     }
 
-    fn enable_quourum_store(&mut self, onchain_config: &OnChainConsensusConfig) -> bool {
+    fn enable_quorum_store(&mut self, onchain_config: &OnChainConsensusConfig) -> bool {
         fail_point!("consensus::start_new_epoch::disable_qs", |_| false);
         onchain_config.quorum_store_enabled()
     }

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -721,8 +721,10 @@ impl EpochManager {
             block_store.clone(),
             Arc::new(payload_client),
             self.time_service.clone(),
-            self.config.max_sending_block_txns,
-            self.config.max_sending_block_bytes,
+            self.config
+                .max_sending_block_txns(self.quorum_store_enabled),
+            self.config
+                .max_sending_block_bytes(self.quorum_store_enabled),
             onchain_consensus_config.max_failed_authors_to_store(),
             chain_health_backoff_config,
             self.quorum_store_enabled,
@@ -797,9 +799,6 @@ impl EpochManager {
                 let consensus_config = onchain_consensus_config.unwrap_or_default();
                 let execution_config = onchain_execution_config.unwrap_or_default();
                 self.quorum_store_enabled = self.enable_quourum_store(&consensus_config);
-                if self.quorum_store_enabled {
-                    self.config.apply_quorum_store_overrides();
-                }
                 self.start_round_manager(
                     initial_data,
                     epoch_state,

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -641,17 +641,25 @@ impl RoundManager {
         let payload_len = proposal.payload().map_or(0, |payload| payload.len());
         let payload_size = proposal.payload().map_or(0, |payload| payload.size());
         ensure!(
-            payload_len as u64 <= self.local_config.max_receiving_block_txns,
+            payload_len as u64
+                <= self
+                    .local_config
+                    .max_receiving_block_txns(self.onchain_config.quorum_store_enabled()),
             "Payload len {} exceeds the limit {}",
             payload_len,
-            self.local_config.max_receiving_block_txns,
+            self.local_config
+                .max_receiving_block_txns(self.onchain_config.quorum_store_enabled()),
         );
 
         ensure!(
-            payload_size as u64 <= self.local_config.max_receiving_block_bytes,
+            payload_size as u64
+                <= self
+                    .local_config
+                    .max_receiving_block_bytes(self.onchain_config.quorum_store_enabled()),
             "Payload size {} exceeds the limit {}",
             payload_size,
-            self.local_config.max_receiving_block_bytes,
+            self.local_config
+                .max_receiving_block_bytes(self.onchain_config.quorum_store_enabled()),
         );
 
         ensure!(


### PR DESCRIPTION
### Description

This fixes a bug where a rollback of quorum store would not rollback the configs to non-quorum store values.

Config fields have to be public, so we'll just have to be careful not to read the raw values.
