### PR TITLE
Ignore dependency docs when searching for DST collision

### DIFF
--- a/scripts/check-cryptohasher-symbols.py
+++ b/scripts/check-cryptohasher-symbols.py
@@ -27,7 +27,7 @@ ignored_crates = set([
     'siphasher',
 ])
 
-proc = subprocess.run("cargo doc --workspace --document-private-items", shell=True)
+proc = subprocess.run("cargo doc --workspace --no-deps --document-private-items", shell=True)
 assert proc.returncode == 0
 assert os.path.exists('target/doc')
 


### PR DESCRIPTION
### Description

The current domain separation tag collision detector search unnecessarily look for structs inside dependencies, causing false alert...