### PR TITLE
[API] Expose whether a function is a view function via the ABI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "anyhow",
  "aptos-config",
  "aptos-crypto",
+ "aptos-framework",
  "aptos-logger",
  "aptos-openapi",
  "aptos-storage-interface",

--- a/api/doc/spec.json
+++ b/api/doc/spec.json
@@ -12632,6 +12632,7 @@
           "name",
           "visibility",
           "is_entry",
+          "is_view",
           "generic_type_params",
           "params",
           "return"
@@ -12646,6 +12647,10 @@
           "is_entry": {
             "type": "boolean",
             "description": "Whether the function can be called as an entry function directly in a transaction"
+          },
+          "is_view": {
+            "type": "boolean",
+            "description": "Whether the function is a view function or not"
           },
           "generic_type_params": {
             "type": "array",

--- a/api/doc/spec.yaml
+++ b/api/doc/spec.yaml
@@ -9474,6 +9474,7 @@ components:
       - name
       - visibility
       - is_entry
+      - is_view
       - generic_type_params
       - params
       - return
@@ -9486,6 +9487,9 @@ components:
           type: boolean
           description: Whether the function can be called as an entry function directly
             in a transaction
+        is_view:
+          type: boolean
+          description: Whether the function is a view function or not
         generic_type_params:
           type: array
           description: Generic type params associated with the Move function

--- a/api/goldens/aptos_api__tests__state_test__test_get_account_module.json
+++ b/api/goldens/aptos_api__tests__state_test__test_get_account_module.json
@@ -12,6 +12,7 @@
         "name": "create",
         "visibility": "friend",
         "is_entry": false,
+        "is_view": false,
         "generic_type_params": [],
         "params": [
           "address",
@@ -25,6 +26,7 @@
         "name": "create_id",
         "visibility": "public",
         "is_entry": false,
+        "is_view": false,
         "generic_type_params": [],
         "params": [
           "address",
@@ -38,6 +40,7 @@
         "name": "creation_num",
         "visibility": "public",
         "is_entry": false,
+        "is_view": false,
         "generic_type_params": [],
         "params": [
           "&0x1::guid::GUID"
@@ -50,6 +53,7 @@
         "name": "creator_address",
         "visibility": "public",
         "is_entry": false,
+        "is_view": false,
         "generic_type_params": [],
         "params": [
           "&0x1::guid::GUID"
@@ -62,6 +66,7 @@
         "name": "eq_id",
         "visibility": "public",
         "is_entry": false,
+        "is_view": false,
         "generic_type_params": [],
         "params": [
           "&0x1::guid::GUID",
@@ -75,6 +80,7 @@
         "name": "id",
         "visibility": "public",
         "is_entry": false,
+        "is_view": false,
         "generic_type_params": [],
         "params": [
           "&0x1::guid::GUID"
@@ -87,6 +93,7 @@
         "name": "id_creation_num",
         "visibility": "public",
         "is_entry": false,
+        "is_view": false,
         "generic_type_params": [],
         "params": [
           "&0x1::guid::ID"
@@ -99,6 +106,7 @@
         "name": "id_creator_address",
         "visibility": "public",
         "is_entry": false,
+        "is_view": false,
         "generic_type_params": [],
         "params": [
           "&0x1::guid::ID"

--- a/api/src/tests/move/pack_abi/sources/test.move
+++ b/api/src/tests/move/pack_abi/sources/test.move
@@ -17,6 +17,11 @@ module abi::test {
         move_to(s, State { value });
     }
 
+    #[view]
+    public fun view_function(value: u64): u64 {
+        value + 42
+    }
+
     fun private_function(s: &signer, value: u64) {
         move_to(s, State { value });
     }

--- a/api/types/Cargo.toml
+++ b/api/types/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }
+aptos-framework = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-openapi = { workspace = true }
 aptos-storage-interface = { workspace = true }

--- a/api/types/src/bytecode.rs
+++ b/api/types/src/bytecode.rs
@@ -9,6 +9,10 @@ use crate::{
     },
     MoveFunction, MoveStructTag, MoveType,
 };
+use aptos_framework::{
+    get_metadata_from_compiled_module, get_metadata_from_compiled_script, RuntimeModuleMetadataV1,
+};
+use aptos_vm::determine_is_view;
 use move_binary_format::{
     access::{ModuleAccess, ScriptAccess},
     file_format::{
@@ -37,6 +41,10 @@ pub trait Bytecode {
     fn find_entry_function(&self, name: &IdentStr) -> Option<MoveFunction>;
 
     fn find_function(&self, name: &IdentStr) -> Option<MoveFunction>;
+
+    fn metadata(&self) -> Option<RuntimeModuleMetadataV1>;
+
+    fn function_is_view(&self, name: &IdentStr) -> bool;
 
     fn new_move_struct_field(&self, def: &FieldDefinition) -> MoveStructField {
         MoveStructField {
@@ -125,10 +133,12 @@ pub trait Bytecode {
     fn new_move_function(&self, def: &FunctionDefinition) -> MoveFunction {
         let fhandle = self.function_handle_at(def.function);
         let name = self.identifier_at(fhandle.name).to_owned();
+        let is_view = self.function_is_view(&name);
         MoveFunction {
             name: name.into(),
             visibility: def.visibility.into(),
             is_entry: def.is_entry,
+            is_view,
             generic_type_params: fhandle
                 .type_parameters
                 .iter()
@@ -195,6 +205,14 @@ impl Bytecode for CompiledModule {
             })
             .map(|def| self.new_move_function(def))
     }
+
+    fn metadata(&self) -> Option<RuntimeModuleMetadataV1> {
+        get_metadata_from_compiled_module(self)
+    }
+
+    fn function_is_view(&self, name: &IdentStr) -> bool {
+        determine_is_view(self.metadata().as_ref(), name)
+    }
 }
 
 impl Bytecode for CompiledScript {
@@ -236,5 +254,13 @@ impl Bytecode for CompiledScript {
         } else {
             None
         }
+    }
+
+    fn metadata(&self) -> Option<RuntimeModuleMetadataV1> {
+        get_metadata_from_compiled_script(self)
+    }
+
+    fn function_is_view(&self, _name: &IdentStr) -> bool {
+        false
     }
 }

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -960,6 +960,8 @@ pub struct MoveFunction {
     pub visibility: MoveFunctionVisibility,
     /// Whether the function can be called as an entry function directly in a transaction
     pub is_entry: bool,
+    /// Whether the function is a view function or not
+    pub is_view: bool,
     /// Generic type params associated with the Move function
     pub generic_type_params: Vec<MoveFunctionGenericTypeParam>,
     /// Parameters associated with the move function
@@ -976,6 +978,7 @@ impl From<&CompiledScript> for MoveFunction {
             name: Identifier::new("main").unwrap().into(),
             visibility: MoveFunctionVisibility::Public,
             is_entry: true,
+            is_view: false,
             generic_type_params: script
                 .type_parameters
                 .iter()

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -129,6 +129,7 @@ use aptos_types::{
     vm_status::VMStatus,
 };
 use std::marker::Sync;
+pub use verifier::view_function::determine_is_view;
 
 /// This trait describes the VM's validation interfaces.
 pub trait VMValidator {

--- a/aptos-move/aptos-vm/src/verifier/view_function.rs
+++ b/aptos-move/aptos-vm/src/verifier/view_function.rs
@@ -11,6 +11,22 @@ use move_core_types::{identifier::IdentStr, vm_status::StatusCode};
 use move_vm_runtime::session::LoadedFunctionInstantiation;
 use move_vm_types::loaded_data::runtime_types::Type;
 
+/// Based on the function attributes in the module metadata, determine whether a
+/// function is a view function.
+pub fn determine_is_view(
+    module_metadata: Option<&RuntimeModuleMetadataV1>,
+    fun_name: &IdentStr,
+) -> bool {
+    if let Some(data) = module_metadata {
+        data.fun_attributes
+            .get(fun_name.as_str())
+            .map(|attrs| attrs.iter().any(|attr| attr.is_view_function()))
+            .unwrap_or_default()
+    } else {
+        false
+    }
+}
+
 /// Validate view function call. This checks whether the function is marked as a view
 /// function, and validates the arguments.
 pub(crate) fn validate_view_function<S: MoveResolverExt>(
@@ -22,14 +38,7 @@ pub(crate) fn validate_view_function<S: MoveResolverExt>(
     struct_constructors_feature: bool,
 ) -> PartialVMResult<Vec<Vec<u8>>> {
     // Must be marked as view function
-    let is_view = if let Some(data) = module_metadata {
-        data.fun_attributes
-            .get(fun_name.as_str())
-            .map(|attrs| attrs.iter().any(|attr| attr.is_view_function()))
-            .unwrap_or_default()
-    } else {
-        false
-    };
+    let is_view = determine_is_view(module_metadata, fun_name);
     if !is_view {
         return Err(
             PartialVMError::new(StatusCode::INVALID_MAIN_FUNCTION_SIGNATURE)

--- a/crates/aptos-protos/Cargo.lock
+++ b/crates/aptos-protos/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "a26fa4d7e3f2eebadf743988fc8aec9fa9a9e82611acafd77c1462ed6262440a"
 
 [[package]]
 name = "aptos-protos"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "pbjson",
  "prost",

--- a/ecosystem/typescript/sdk/src/generated/models/MoveFunction.ts
+++ b/ecosystem/typescript/sdk/src/generated/models/MoveFunction.ts
@@ -18,6 +18,10 @@ export type MoveFunction = {
      */
     is_entry: boolean;
     /**
+     * Whether the function is a view function or not
+     */
+    is_view: boolean;
+    /**
      * Generic type params associated with the Move function
      */
     generic_type_params: Array<MoveFunctionGenericTypeParam>;

--- a/ecosystem/typescript/sdk/src/generated/schemas/$MoveFunction.ts
+++ b/ecosystem/typescript/sdk/src/generated/schemas/$MoveFunction.ts
@@ -17,6 +17,11 @@ export const $MoveFunction = {
             description: `Whether the function can be called as an entry function directly in a transaction`,
             isRequired: true,
         },
+        is_view: {
+            type: 'boolean',
+            description: `Whether the function is a view function or not`,
+            isRequired: true,
+        },
         generic_type_params: {
             type: 'array',
             contains: {


### PR DESCRIPTION
### Description
This PR adds support for returning whether a function is a view function in the ABI returned from the API. While the better long term solution would be to cut out this intermediate ABI representation and directly enhance the ABI created as part of compilation, this provides this functionality in the short term by looking up the module metadata through the VM.

### Test Plan
Run a local testnet:
```
cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes --with-faucet
```

See that view function information is attached:
```
curl localhost:8080/v1/accounts/0x1/module/coin | jq '.abi.exposed_functions[1]'
```
```
{
  "name": "balance",
  "visibility": "public",
  "is_entry": false,
  "is_view_function": true,
  "generic_type_params": [
    {
      "constraints": []
    }
  ],
  "params": [
    "address"
  ],
  "return": [
    "u64"
  ]
}
```

For a different non view function:
```
curl localhost:8080/v1/accounts/0x1/module/coin | jq '.abi.exposed_functions[2]'
```
```
{
  "name": "burn",
  "visibility": "public",
  "is_entry": false,
  "is_view_function": false,
  "generic_type_params": [
    {
      "constraints": []
    }
  ],
  "params": [
    "0x1::coin::Coin<T0>",
    "&0x1::coin::BurnCapability<T0>"
  ],
  "return": []
}
```

See also the new unit tests.