### PR TITLE
[protobuf] upgrade the aptos proto version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-protos"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "pbjson",
  "prost",

--- a/crates/aptos-protos/Cargo.toml
+++ b/crates/aptos-protos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aptos-protos"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Aptos Labs <opensource@aptoslabs.com>"]
 description = "Aptos Protobuf Definitions"
 repository = "https://github.com/aptos-labs/aptos-core"


### PR DESCRIPTION
### Description

* Using the same aptos-proto version may have compiler invalidating the build cache incorrectly(in this case, compiler believes there is no change). 
* A minor version bump to mark the recent changes. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
