### PR TITLE
Add `load_function_without_types` to VM session and loader

### DIFF
--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -325,6 +325,21 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         Ok(instantiation)
     }
 
+    /// Load a module and a function into cache. To load types for the function into
+    /// cache as well, use `load_function`.
+    pub fn load_function_without_types(
+        &self,
+        module_id: &ModuleId,
+        function_name: &IdentStr,
+    ) -> VMResult<()> {
+        self.runtime.loader().load_function_without_types(
+            module_id,
+            function_name,
+            &self.data_cache,
+        )?;
+        Ok(())
+    }
+
     pub fn load_type(&self, type_tag: &TypeTag) -> VMResult<Type> {
         self.runtime.loader().load_type(type_tag, &self.data_cache)
     }


### PR DESCRIPTION
## Motivation

For Aptos, in order to expose whether a function is a view function in the API-based ABI today, we need to be able to load function metadata through the Aptos VM. The existing function exposed by the Session for this, `load_function`, loads information about arguments, generic types, and return types, which is more than is necessary for this use case. 

To that end I've exposed a version of this function that loads only the module and function, without this additional type information.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan
Not sure. As far as I can tell, `load_function` does not have unit tests either.