### PR TITLE
[Indexer] Fix string escape in json data for parser only

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-parser/README.md
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/README.md
@@ -3,12 +3,12 @@
 ## Example Yaml file
 
 ```yaml
-indexer_grpc_address: http://192.168.1.123:50051
-postgres_connection_string: postgres://postgres@localhost/indexer_v3
+indexer_grpc_address: "ADDRESS:PORT" # port typically 50051
+postgres_connection_string: "POSTGRES URL" # e.g. postgres://postgres@localhost/indexer_v3
 number_concurrent_processing_tasks: 20
 processor_name: default_processor
 health_check_port: 8089
-indexer_grpc_auth_token: "PUT YOUR OWN AUTH TOKEN"
+indexer_grpc_auth_token: "AUTH TOKEN"
 ```
 
 * Command to run the parser

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/default_models/transactions.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/default_models/transactions.rs
@@ -186,8 +186,6 @@ impl Transaction {
                     version,
                     block_height,
                 );
-                // let payload = serde_json::to_value(&genesis_txn.payload)
-                //     .expect("Unable to deserialize Genesis transaction");
                 let payload = genesis_txn.payload.as_ref().unwrap();
                 let payload_cleaned = get_clean_writeset(payload, version);
                 (

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/default_models/transactions.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/default_models/transactions.rs
@@ -16,7 +16,7 @@ use crate::{
     schema::{block_metadata_transactions, transactions, user_transactions},
     utils::{
         database::PgPoolConnection,
-        util::{standardize_address, u64_to_bigdecimal},
+        util::{get_clean_payload, get_clean_writeset, standardize_address, u64_to_bigdecimal},
     },
 };
 use aptos_protos::transaction::testing1::v1::{
@@ -155,21 +155,19 @@ impl Transaction {
                     version,
                     block_height,
                 );
+                let payload = user_txn
+                    .request
+                    .as_ref()
+                    .expect("Getting user request failed.")
+                    .payload
+                    .as_ref()
+                    .expect("Getting payload failed.");
+                let payload_cleaned = get_clean_payload(payload, version);
+
                 (
                     Self::from_transaction_info(
                         transaction_info,
-                        Some(
-                            serde_json::to_value(
-                                user_txn
-                                    .request
-                                    .as_ref()
-                                    .expect("Getting user request failed.")
-                                    .payload
-                                    .as_ref()
-                                    .expect("Getting payload failed."),
-                            )
-                            .expect("Unable to deserialize transaction payload"),
-                        ),
+                        payload_cleaned,
                         version,
                         transaction_type,
                         user_txn.events.len() as i64,
@@ -188,13 +186,14 @@ impl Transaction {
                     version,
                     block_height,
                 );
+                // let payload = serde_json::to_value(&genesis_txn.payload)
+                //     .expect("Unable to deserialize Genesis transaction");
+                let payload = genesis_txn.payload.as_ref().unwrap();
+                let payload_cleaned = get_clean_writeset(payload, version);
                 (
                     Self::from_transaction_info(
                         transaction_info,
-                        Some(
-                            serde_json::to_value(&genesis_txn.payload)
-                                .expect("Unable to deserialize Genesis transaction"),
-                        ),
+                        payload_cleaned,
                         version,
                         transaction_type,
                         0,

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/src/utils/util.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/src/utils/util.rs
@@ -169,7 +169,7 @@ pub fn get_clean_payload(payload: &TransactionPayload, version: i64) -> Option<V
 }
 
 /// Part of the json comes escaped from the protobuf so we need to unescape in a safe way
-/// Note that DirectWriteSet is just events + writeset which is already represented separately 
+/// Note that DirectWriteSet is just events + writeset which is already represented separately
 pub fn get_clean_writeset(writeset: &WriteSet, version: i64) -> Option<Value> {
     match writeset.write_set.as_ref().unwrap() {
         WriteSetType::ScriptWriteSet(inner) => {

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/src/utils/util.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/src/utils/util.rs
@@ -4,12 +4,15 @@
 use crate::models::property_map::PropertyMap;
 use aptos_protos::{
     transaction::testing1::v1::{
-        transaction_payload::Payload as PayloadPB, UserTransactionRequest,
+        multisig_transaction_payload::Payload as MultisigPayloadType,
+        transaction_payload::Payload as PayloadType, write_set::WriteSet as WriteSetType,
+        EntryFunctionId, EntryFunctionPayload, MoveScriptBytecode, MoveType, ScriptPayload,
+        TransactionPayload, UserTransactionRequest, WriteSet,
     },
     util::timestamp::Timestamp,
 };
 use bigdecimal::{BigDecimal, Signed, ToPrimitive, Zero};
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use sha2::Digest;
 use std::str::FromStr;
@@ -18,6 +21,33 @@ use std::str::FromStr;
 pub const MAX_TIMESTAMP_SECS: i64 = 253_402_300_799;
 // Max length of entry function id string to ensure that db doesn't explode
 const MAX_ENTRY_FUNCTION_LENGTH: usize = 100;
+
+// Supporting structs to get clean payload without escaped strings
+#[derive(Debug, Deserialize, Serialize)]
+pub struct EntryFunctionPayloadClean {
+    pub function: Option<EntryFunctionId>,
+    pub type_arguments: Vec<MoveType>,
+    pub arguments: Vec<Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ScriptPayloadClean {
+    pub code: Option<MoveScriptBytecode>,
+    pub type_arguments: Vec<MoveType>,
+    pub arguments: Vec<Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ScriptWriteSetClean {
+    pub execute_as: String,
+    pub script: ScriptPayloadClean,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct MultisigPayloadClean {
+    pub multisig_address: String,
+    pub transaction_payload: Option<Value>,
+}
 
 /// Standardizes all addresses and table handles to be length 66 (0x-64 length hash)
 pub fn standardize_address(handle: &str) -> String {
@@ -57,13 +87,147 @@ pub fn get_entry_function_from_user_request(
     user_request: &UserTransactionRequest,
 ) -> Option<String> {
     let entry_function_id_str: String = match &user_request.payload.as_ref().unwrap().payload {
-        Some(PayloadPB::EntryFunctionPayload(payload)) => payload.entry_function_id_str.clone(),
+        Some(PayloadType::EntryFunctionPayload(payload)) => payload.entry_function_id_str.clone(),
+        Some(PayloadType::MultisigPayload(payload)) => {
+            if let Some(payload) = payload.transaction_payload.as_ref() {
+                match payload.payload.as_ref().unwrap() {
+                    MultisigPayloadType::EntryFunctionPayload(payload) => {
+                        Some(payload.entry_function_id_str.clone())
+                    },
+                };
+            }
+            return None;
+        },
         _ => return None,
     };
     Some(truncate_str(
         &entry_function_id_str,
         MAX_ENTRY_FUNCTION_LENGTH,
     ))
+}
+
+pub fn get_clean_payload(payload: &TransactionPayload, version: i64) -> Option<Value> {
+    match payload.payload.as_ref().unwrap() {
+        PayloadType::EntryFunctionPayload(inner) => {
+            let clean = get_clean_entry_function_payload(inner, version);
+            Some(serde_json::to_value(clean).unwrap_or_else(|_| {
+                aptos_logger::error!(version = version, "Unable to serialize payload into value");
+                panic!()
+            }))
+        },
+        PayloadType::ScriptPayload(inner) => {
+            let clean = get_clean_script_payload(inner, version);
+            Some(serde_json::to_value(clean).unwrap_or_else(|_| {
+                aptos_logger::error!(version = version, "Unable to serialize payload into value");
+                panic!()
+            }))
+        },
+        PayloadType::ModuleBundlePayload(inner) => {
+            Some(serde_json::to_value(inner).unwrap_or_else(|_| {
+                aptos_logger::error!(version = version, "Unable to serialize payload into value");
+                panic!()
+            }))
+        },
+        PayloadType::WriteSetPayload(inner) => {
+            if let Some(writeset) = inner.write_set.as_ref() {
+                get_clean_writeset(writeset, version)
+            } else {
+                None
+            }
+        },
+        PayloadType::MultisigPayload(inner) => {
+            let clean = if let Some(payload) = inner.transaction_payload.as_ref() {
+                let payload_clean = match payload.payload.as_ref().unwrap() {
+                    MultisigPayloadType::EntryFunctionPayload(payload) => {
+                        let clean = get_clean_entry_function_payload(payload, version);
+                        Some(serde_json::to_value(clean).unwrap_or_else(|_| {
+                            aptos_logger::error!(
+                                version = version,
+                                "Unable to serialize payload into value"
+                            );
+                            panic!()
+                        }))
+                    },
+                };
+                MultisigPayloadClean {
+                    multisig_address: inner.multisig_address.clone(),
+                    transaction_payload: payload_clean,
+                }
+            } else {
+                MultisigPayloadClean {
+                    multisig_address: inner.multisig_address.clone(),
+                    transaction_payload: None,
+                }
+            };
+            Some(serde_json::to_value(clean).unwrap_or_else(|_| {
+                aptos_logger::error!(version = version, "Unable to serialize payload into value");
+                panic!()
+            }))
+        },
+    }
+}
+
+pub fn get_clean_writeset(writeset: &WriteSet, version: i64) -> Option<Value> {
+    match writeset.write_set.as_ref().unwrap() {
+        WriteSetType::ScriptWriteSet(inner) => {
+            let payload = inner.script.as_ref().unwrap();
+            Some(
+                serde_json::to_value(get_clean_script_payload(payload, version)).unwrap_or_else(
+                    |_| {
+                        aptos_logger::error!(
+                            version = version,
+                            "Unable to serialize payload into value"
+                        );
+                        panic!()
+                    },
+                ),
+            )
+        },
+        WriteSetType::DirectWriteSet(_) => None,
+    }
+}
+
+fn get_clean_entry_function_payload(
+    payload: &EntryFunctionPayload,
+    version: i64,
+) -> EntryFunctionPayloadClean {
+    EntryFunctionPayloadClean {
+        function: payload.function.clone(),
+        type_arguments: payload.type_arguments.clone(),
+        arguments: payload
+            .arguments
+            .iter()
+            .map(|arg| {
+                serde_json::from_str(arg).unwrap_or_else(|_| {
+                    aptos_logger::error!(
+                        version = version,
+                        "Unable to serialize payload into value"
+                    );
+                    panic!()
+                })
+            })
+            .collect(),
+    }
+}
+
+fn get_clean_script_payload(payload: &ScriptPayload, version: i64) -> ScriptPayloadClean {
+    ScriptPayloadClean {
+        code: payload.code.clone(),
+        type_arguments: payload.type_arguments.clone(),
+        arguments: payload
+            .arguments
+            .iter()
+            .map(|arg| {
+                serde_json::from_str(arg).unwrap_or_else(|_| {
+                    aptos_logger::error!(
+                        version = version,
+                        "Unable to serialize payload into value"
+                    );
+                    panic!()
+                })
+            })
+            .collect(),
+    }
 }
 
 pub fn parse_timestamp(ts: &Timestamp, version: i64) -> chrono::NaiveDateTime {

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/src/utils/util.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/src/utils/util.rs
@@ -106,6 +106,7 @@ pub fn get_entry_function_from_user_request(
     ))
 }
 
+/// Part of the json comes escaped from the protobuf so we need to unescape in a safe way
 pub fn get_clean_payload(payload: &TransactionPayload, version: i64) -> Option<Value> {
     match payload.payload.as_ref().unwrap() {
         PayloadType::EntryFunctionPayload(inner) => {
@@ -167,6 +168,8 @@ pub fn get_clean_payload(payload: &TransactionPayload, version: i64) -> Option<V
     }
 }
 
+/// Part of the json comes escaped from the protobuf so we need to unescape in a safe way
+/// Note that DirectWriteSet is just events + writeset which is already represented separately 
 pub fn get_clean_writeset(writeset: &WriteSet, version: i64) -> Option<Value> {
     match writeset.write_set.as_ref().unwrap() {
         WriteSetType::ScriptWriteSet(inner) => {
@@ -187,6 +190,7 @@ pub fn get_clean_writeset(writeset: &WriteSet, version: i64) -> Option<Value> {
     }
 }
 
+/// Part of the json comes escaped from the protobuf so we need to unescape in a safe way
 fn get_clean_entry_function_payload(
     payload: &EntryFunctionPayload,
     version: i64,
@@ -210,6 +214,7 @@ fn get_clean_entry_function_payload(
     }
 }
 
+/// Part of the json comes escaped from the protobuf so we need to unescape in a safe way
 fn get_clean_script_payload(payload: &ScriptPayload, version: i64) -> ScriptPayloadClean {
     ScriptPayloadClean {
         code: payload.code.clone(),


### PR DESCRIPTION
### Description
Part of the protobuf (e.g. payload data, events data, etc.) are converted to string from json in the fullnode and that causes the string to be escaped. This PR unescapes those parts in a safe way. 

### Test Plan
Verified that `type_arguments` in `payload` are no longer escaped. 
```
{"function": {"name": "transfer", "module": {"name": "coin", "address": "0x1"}}, "arguments": ["0xd11d0bb59e6dc3689f20c28171fe38ff5527806a5b20ad6d0aa08cb30a8e5239", "123"], "type_arguments": [{"type": "MOVE_TYPES_STRUCT", "struct": {"name": "AptosCoin", "module": "aptos_coin", "address": "0x1"}}]}
```
