### PR TITLE
Update call instructions forced by commit 3bbd3f3c

### DIFF
--- a/developer-docs-site/docs/tutorials/first-multisig.md
+++ b/developer-docs-site/docs/tutorials/first-multisig.md
@@ -23,16 +23,16 @@ Other developers are invited to add support for the [TypeScript SDK](../sdks/ts-
 
 ## Step 2: Start the example
 
-Navigate to the Python SDK examples directory:
+Navigate to the Python SDK directory:
 
 ```zsh
-cd <aptos-core-parent-directory>/aptos-core/ecosystem/python/sdk/examples
+cd <aptos-core-parent-directory>/aptos-core/ecosystem/python/sdk/
 ```
 
 Run the `multisig.py` example:
 
 ```zsh
-poetry run python multisig.py
+poetry run python -m examples.multisig
 ```
 
 :::tip


### PR DESCRIPTION
The inclusion of the `.` in the referenced commit forces the invocation style added here.

If not updated, an ImportError will be raised when running the example according to the unmodified instructions.

@davidiw 