### PR TITLE
[Move-prover] Remove ignore annotation from prover tests

### DIFF
--- a/aptos-move/framework/FRAMEWORK-PROVER-GUIDE.md
+++ b/aptos-move/framework/FRAMEWORK-PROVER-GUIDE.md
@@ -1,0 +1,41 @@
+This guide gives some hints to troubleshoot issues when using the prover for specifying the Aptos frameworks.
+
+## Installation
+
+Please refer to the [doc](https://aptos.dev/cli-tools/install-move-prover/).
+
+## Timeout
+
+When the prover cannot finish the verification job within a specified time (by default 40s), it will exit and generate an error message.
+In this case, users should add a pragma `pragma verify = false` to the specification
+that causes the timeout with a `TODO` comment for the prover developer to debug, as shown in the example.
+
+```move
+spec foo {
+   pragma verify = false; // TODO: set to false because of timeout
+}
+```
+
+## Internal errors
+
+Bugs in the prover often lead to `boogie internal errors`. When it happens, you could try to locate the specs that causes this issue and comment them out. 
+If the error is caused by the Move code, e.g., `foo.move`, You could add the following code in `foo.spec.move` (create one if it does not exist) with 
+a `TODO` comment preferably containing the URL to the corresponding Github issue.
+
+```move
+spec module {
+   pragma verify = false; // TODO: see issue <url>
+}
+```
+After making these changes, please submit a Github issue for the prover team to fix.
+
+## Suppressing prover tests
+
+Prover tests are land-blockers for PRs which change the Move code and/or specifications in the `framework` directory. To disable them locally for efficiency,
+you could use the command `cargo test --release -p aptos-framework -- --skip prover`.
+
+
+## Specification guide
+
+Please refer to this [doc](https://github.com/aptos-labs/aptos-core/blob/main/third_party/move/move-prover/doc/user/spec-lang.md)
+for detailed introduction on how to write Move specifications.

--- a/aptos-move/framework/tests/move_prover_tests.rs
+++ b/aptos-move/framework/tests/move_prover_tests.rs
@@ -17,33 +17,45 @@ where
     path
 }
 
+pub fn read_env_var(v: &str) -> String {
+    std::env::var(v).unwrap_or_else(|_| String::new())
+}
+
 pub fn run_prover_for_pkg(path_to_pkg: impl Into<String>) {
     let pkg_path = path_in_crate(path_to_pkg);
     let options = ProverOptions::default_for_test();
-    options
-        .prove(pkg_path.as_path(), BTreeMap::default(), None)
-        .unwrap()
+    let no_tools = read_env_var("BOOGIE_EXE").is_empty()
+        || !options.cvc5 && read_env_var("Z3_EXE").is_empty()
+        || options.cvc5 && read_env_var("CVC5_EXE").is_empty();
+    if no_tools {
+        panic!(
+            "Prover tools are not configured, \
+        See https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/FRAMEWORK-PROVER-GUIDE.md \
+        for instructions, or \
+        use \"-- --skip prover\" to filter out the prover tests"
+        );
+    } else {
+        options
+            .prove(pkg_path.as_path(), BTreeMap::default(), None)
+            .unwrap()
+    }
 }
 
-#[ignore]
 #[test]
 fn move_framework_prover_tests() {
     run_prover_for_pkg("aptos-framework");
 }
 
-#[ignore]
 #[test]
 fn move_token_prover_tests() {
     run_prover_for_pkg("aptos-token");
 }
 
-#[ignore]
 #[test]
 fn move_aptos_stdlib_prover_tests() {
     run_prover_for_pkg("aptos-stdlib");
 }
 
-#[ignore]
 #[test]
 fn move_stdlib_prover_tests() {
     run_prover_for_pkg("move-stdlib");

--- a/aptos-move/move-examples/tests/move_prover_tests.rs
+++ b/aptos-move/move-examples/tests/move_prover_tests.rs
@@ -36,7 +36,6 @@ pub fn run_prover_for_pkg(
     .unwrap();
 }
 
-#[ignore]
 #[test]
 fn test_hello_prover() {
     let named_address = BTreeMap::new();


### PR DESCRIPTION
### Description

This PR makes prover tests regular by removing `#[ignore]` and adds error messages when the prover tools are not installed.
