### PR TITLE
[Quorum Store] fairness and priority in proposal via per-author queue

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -22,7 +22,7 @@ impl Default for QuorumStoreBackPressureConfig {
     fn default() -> QuorumStoreBackPressureConfig {
         QuorumStoreBackPressureConfig {
             // QS will be backpressured if the remaining total txns is more than this number
-            backlog_txn_limit_count: MAX_SENDING_BLOCK_TXNS_QUORUM_STORE_OVERRIDE * 8,
+            backlog_txn_limit_count: MAX_SENDING_BLOCK_TXNS_QUORUM_STORE_OVERRIDE * 3,
             // QS will create batches at the max rate until this number is reached
             backlog_per_validator_batch_limit_count: 4,
             decrease_duration_ms: 1000,

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -2,7 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::proof_of_store::ProofOfStore;
+use crate::proof_of_store::{BatchInfo, ProofOfStore};
 use aptos_crypto::HashValue;
 use aptos_executor_types::Error;
 use aptos_infallible::Mutex;
@@ -185,7 +185,7 @@ impl fmt::Display for Payload {
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub enum PayloadFilter {
     DirectMempool(Vec<TransactionSummary>),
-    InQuorumStore(HashSet<HashValue>),
+    InQuorumStore(HashSet<BatchInfo>),
     Empty,
 }
 
@@ -214,7 +214,7 @@ impl From<&Vec<&Payload>> for PayloadFilter {
             for payload in exclude_payloads {
                 if let Payload::InQuorumStore(proof_with_status) = payload {
                     for proof in &proof_with_status.proofs {
-                        exclude_proofs.insert(*proof.digest());
+                        exclude_proofs.insert(proof.info().clone());
                     }
                 }
             }
@@ -236,7 +236,7 @@ impl fmt::Display for PayloadFilter {
             PayloadFilter::InQuorumStore(excluded_proofs) => {
                 let mut proofs_str = "".to_string();
                 for proof in excluded_proofs.iter() {
-                    write!(proofs_str, "{} ", proof)?;
+                    write!(proofs_str, "{} ", proof.digest())?;
                 }
                 write!(f, "{}", proofs_str)
             },

--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -22,9 +22,9 @@ use std::{
 )]
 pub struct BatchId {
     pub id: u64,
-    /// A random number that is stored in the DB and updated only if the value does not exist in
+    /// A number that is stored in the DB and updated only if the value does not exist in
     /// the DB: (a) at the start of an epoch, or (b) the DB was wiped. When the nonce is updated,
-    /// id starts again at 0.
+    /// id starts again at 0. Using the current system time allows the nonce to be ordering.
     pub nonce: u64,
 }
 
@@ -50,11 +50,11 @@ impl PartialOrd<Self> for BatchId {
 
 impl Ord for BatchId {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self.id.cmp(&other.id) {
+        match self.nonce.cmp(&other.nonce) {
             Ordering::Equal => {},
             ordering => return ordering,
         }
-        self.nonce.cmp(&other.nonce)
+        self.id.cmp(&other.id)
     }
 }
 
@@ -313,6 +313,10 @@ impl ProofOfStore {
             .get_voter_addresses(&validator.get_ordered_account_addresses());
         ret.shuffle(&mut thread_rng());
         ret
+    }
+
+    pub fn info(&self) -> &BatchInfo {
+        &self.info
     }
 }
 

--- a/consensus/src/payload_manager.rs
+++ b/consensus/src/payload_manager.rs
@@ -65,7 +65,7 @@ impl PayloadManager {
                     .update_certified_timestamp(block_timestamp)
                     .await;
 
-                let digests: Vec<HashValue> = payloads
+                let batches: Vec<_> = payloads
                     .into_iter()
                     .flat_map(|payload| match payload {
                         Payload::DirectMempool(_) => {
@@ -73,7 +73,7 @@ impl PayloadManager {
                         },
                         Payload::InQuorumStore(proof_with_status) => proof_with_status.proofs,
                     })
-                    .map(|proof| *proof.digest())
+                    .map(|proof| proof.info().clone())
                     .collect();
 
                 let mut tx = coordinator_tx.clone();
@@ -81,7 +81,7 @@ impl PayloadManager {
                 if let Err(e) = tx
                     .send(CoordinatorCommand::CommitNotification(
                         block_timestamp,
-                        digests,
+                        batches,
                     ))
                     .await
                 {

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -19,7 +19,6 @@ use aptos_logger::prelude::*;
 use aptos_mempool::QuorumStoreRequest;
 use aptos_types::{transaction::SignedTransaction, PeerId};
 use futures_channel::mpsc::Sender;
-use rand::{thread_rng, RngCore};
 use std::{
     collections::HashMap,
     sync::Arc,
@@ -72,7 +71,7 @@ impl BatchGenerator {
             id.increment();
             id
         } else {
-            BatchId::new(thread_rng().next_u64())
+            BatchId::new(aptos_infallible::duration_since_epoch().as_micros() as u64)
         };
         debug!("Initialized with batch_id of {}", batch_id);
         let mut incremented_batch_id = batch_id;
@@ -285,7 +284,7 @@ impl BatchGenerator {
             / 2;
 
         loop {
-            let _timer = counters::WRAPPER_MAIN_LOOP.start_timer();
+            let _timer = counters::BATCH_GENERATOR_MAIN_LOOP.start_timer();
 
             tokio::select! {
                 biased;

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -7,10 +7,9 @@ use crate::{
 };
 use aptos_consensus_types::{
     common::{Payload, PayloadFilter, ProofWithData},
-    proof_of_store::{ProofOfStore, ProofOfStoreMsg},
+    proof_of_store::{BatchInfo, ProofOfStore, ProofOfStoreMsg},
     request_response::{GetPayloadCommand, GetPayloadResponse},
 };
-use aptos_crypto::HashValue;
 use aptos_logger::prelude::*;
 use aptos_types::PeerId;
 use futures::StreamExt;
@@ -20,14 +19,12 @@ use std::collections::HashSet;
 #[derive(Debug)]
 pub enum ProofManagerCommand {
     ReceiveProofs(ProofOfStoreMsg),
-    CommitNotification(u64, Vec<HashValue>),
+    CommitNotification(u64, Vec<BatchInfo>),
     Shutdown(tokio::sync::oneshot::Sender<()>),
 }
 
 pub struct ProofManager {
-    my_peer_id: PeerId,
     proofs_for_consensus: ProofQueue,
-    latest_block_timestamp: u64,
     back_pressure_total_txn_limit: u64,
     remaining_total_txn_num: u64,
     back_pressure_total_proof_limit: u64,
@@ -41,9 +38,7 @@ impl ProofManager {
         back_pressure_total_proof_limit: u64,
     ) -> Self {
         Self {
-            my_peer_id,
-            proofs_for_consensus: ProofQueue::new(),
-            latest_block_timestamp: 0,
+            proofs_for_consensus: ProofQueue::new(my_peer_id),
             back_pressure_total_txn_limit,
             remaining_total_txn_num: 0,
             back_pressure_total_proof_limit,
@@ -51,41 +46,33 @@ impl ProofManager {
         }
     }
 
-    #[inline]
-    fn increment_remaining_txns(&mut self, num_txns: u64) {
-        self.remaining_total_txn_num += num_txns;
-        self.remaining_total_proof_num += 1;
-    }
-
     pub(crate) fn receive_proofs(&mut self, proofs: Vec<ProofOfStore>) {
         for proof in proofs.into_iter() {
-            let is_local = proof.author() == self.my_peer_id;
-            let num_txns = proof.num_txns();
-            self.increment_remaining_txns(num_txns);
-            self.proofs_for_consensus.push(proof, is_local);
+            self.proofs_for_consensus.push(proof);
         }
+        (self.remaining_total_txn_num, self.remaining_total_proof_num) =
+            self.proofs_for_consensus.remaining_txns_and_proofs();
     }
 
     pub(crate) fn handle_commit_notification(
         &mut self,
         block_timestamp: u64,
-        digests: Vec<HashValue>,
+        batches: Vec<BatchInfo>,
     ) {
         trace!(
             "QS: got clean request from execution at block timestamp {}",
             block_timestamp
         );
-        assert!(
-            self.latest_block_timestamp <= block_timestamp,
-            "Decreasing block timestamp"
-        );
-        self.latest_block_timestamp = block_timestamp;
-        self.proofs_for_consensus.mark_committed(digests);
+
+        self.proofs_for_consensus.mark_committed(batches);
+        self.proofs_for_consensus
+            .handle_updated_block_timestamp(block_timestamp);
+        (self.remaining_total_txn_num, self.remaining_total_proof_num) =
+            self.proofs_for_consensus.remaining_txns_and_proofs();
     }
 
     pub(crate) fn handle_proposal_request(&mut self, msg: GetPayloadCommand) {
         match msg {
-            // TODO: check what max_txns consensus is using
             GetPayloadCommand::GetPayloadRequest(
                 max_txns,
                 max_bytes,
@@ -93,8 +80,7 @@ impl ProofManager {
                 filter,
                 callback,
             ) => {
-                // TODO: Pass along to batch_store
-                let excluded_proofs: HashSet<HashValue> = match filter {
+                let excluded_batches: HashSet<_> = match filter {
                     PayloadFilter::Empty => HashSet::new(),
                     PayloadFilter::DirectMempool(_) => {
                         unreachable!()
@@ -103,15 +89,11 @@ impl ProofManager {
                 };
 
                 let proof_block = self.proofs_for_consensus.pull_proofs(
-                    &excluded_proofs,
-                    self.latest_block_timestamp,
+                    &excluded_batches,
                     max_txns,
                     max_bytes,
                     return_non_full,
                 );
-                (self.remaining_total_txn_num, self.remaining_total_proof_num) = self
-                    .proofs_for_consensus
-                    .num_total_txns_and_proofs(self.latest_block_timestamp);
 
                 let res = GetPayloadResponse::GetPayloadResponse(
                     if proof_block.is_empty() {
@@ -119,7 +101,7 @@ impl ProofManager {
                     } else {
                         trace!(
                             "QS: GetBlockRequest excluded len {}, block len {}",
-                            excluded_proofs.len(),
+                            excluded_batches.len(),
                             proof_block.len()
                         );
                         Payload::InQuorumStore(ProofWithData::new(proof_block))
@@ -153,8 +135,7 @@ impl ProofManager {
         };
 
         loop {
-            // TODO: additional main loop counter
-            let _timer = counters::WRAPPER_MAIN_LOOP.start_timer();
+            let _timer = counters::PROOF_MANAGER_MAIN_LOOP.start_timer();
 
             tokio::select! {
                     Some(msg) = proposal_rx.next() => monitor!("proof_manager_handle_proposal", {
@@ -180,14 +161,11 @@ impl ProofManager {
                             ProofManagerCommand::ReceiveProofs(proofs) => {
                                 self.receive_proofs(proofs.take());
                             },
-                            ProofManagerCommand::CommitNotification(block_timestamp, digests) => {
-                                self.handle_commit_notification(block_timestamp, digests);
-
-                                // update the backpressure upon new commit round
-                                (self.remaining_total_txn_num, self.remaining_total_proof_num) =
-                                    self.proofs_for_consensus.num_total_txns_and_proofs(block_timestamp);
-                                // TODO: keeping here for metrics, might be part of the backpressure in the future?
-                                self.proofs_for_consensus.clean_local_proofs(block_timestamp);
+                            ProofManagerCommand::CommitNotification(block_timestamp, batches) => {
+                                self.handle_commit_notification(
+                                    block_timestamp,
+                                    batches,
+                                );
                             },
                         }
                         let updated_back_pressure = self.qs_back_pressure();

--- a/consensus/src/quorum_store/quorum_store_coordinator.rs
+++ b/consensus/src/quorum_store/quorum_store_coordinator.rs
@@ -10,14 +10,14 @@ use crate::{
     round_manager::VerifiedEvent,
 };
 use aptos_channels::aptos_channel;
-use aptos_crypto::HashValue;
+use aptos_consensus_types::proof_of_store::BatchInfo;
 use aptos_logger::prelude::*;
 use aptos_types::{account_address::AccountAddress, PeerId};
 use futures::StreamExt;
 use tokio::sync::{mpsc, oneshot};
 
 pub enum CoordinatorCommand {
-    CommitNotification(u64, Vec<HashValue>),
+    CommitNotification(u64, Vec<BatchInfo>),
     Shutdown(futures_channel::oneshot::Sender<()>),
 }
 
@@ -53,11 +53,11 @@ impl QuorumStoreCoordinator {
         while let Some(cmd) = rx.next().await {
             monitor!("quorum_store_coordinator_loop", {
                 match cmd {
-                    CoordinatorCommand::CommitNotification(block_timestamp, digests) => {
+                    CoordinatorCommand::CommitNotification(block_timestamp, batches) => {
                         self.proof_manager_cmd_tx
                             .send(ProofManagerCommand::CommitNotification(
                                 block_timestamp,
-                                digests,
+                                batches,
                             ))
                             .await
                             .expect("Failed to send to ProofManager");

--- a/consensus/src/quorum_store/tests/proof_manager_test.rs
+++ b/consensus/src/quorum_store/tests/proof_manager_test.rs
@@ -10,35 +10,226 @@ use aptos_consensus_types::{
 use aptos_crypto::HashValue;
 use aptos_types::{aggregate_signature::AggregateSignature, PeerId};
 use futures::channel::oneshot;
-use move_core_types::account_address::AccountAddress;
 use std::collections::HashSet;
 
-#[tokio::test]
-async fn test_block_request() {
-    let mut proof_manager = ProofManager::new(AccountAddress::random(), 10, 10);
+fn create_proof_manager() -> ProofManager {
+    ProofManager::new(PeerId::random(), 10, 10)
+}
 
+fn create_proof(author: PeerId, expiration: u64, batch_sequence: u64) -> ProofOfStore {
+    create_proof_with_gas(author, expiration, batch_sequence, 0)
+}
+
+fn create_proof_with_gas(
+    author: PeerId,
+    expiration: u64,
+    batch_sequence: u64,
+    gas_bucket_start: u64,
+) -> ProofOfStore {
     let digest = HashValue::random();
-    let batch_id = BatchId::new_for_test(1);
-    let proof = ProofOfStore::new(
-        BatchInfo::new(PeerId::random(), batch_id, 0, 10, digest, 1, 1, 0),
+    let batch_id = BatchId::new_for_test(batch_sequence);
+    ProofOfStore::new(
+        BatchInfo::new(
+            author,
+            batch_id,
+            0,
+            expiration,
+            digest,
+            1,
+            1,
+            gas_bucket_start,
+        ),
         AggregateSignature::empty(),
-    );
-    proof_manager.receive_proofs(vec![proof.clone()]);
+    )
+}
 
+async fn get_proposal_and_assert(
+    proof_manager: &mut ProofManager,
+    max_txns: u64,
+    filter: &[BatchInfo],
+    expected: &[ProofOfStore],
+) {
     let (callback_tx, callback_rx) = oneshot::channel();
+    let filter_set = HashSet::from_iter(filter.iter().cloned());
     let req = GetPayloadCommand::GetPayloadRequest(
-        100,
+        max_txns,
         1000000,
         true,
-        PayloadFilter::InQuorumStore(HashSet::new()),
+        PayloadFilter::InQuorumStore(filter_set),
         callback_tx,
     );
     proof_manager.handle_proposal_request(req);
     let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
     if let Payload::InQuorumStore(proofs) = payload {
-        assert_eq!(proofs.proofs.len(), 1);
-        assert_eq!(proofs.proofs[0], proof);
+        assert_eq!(proofs.proofs.len(), expected.len());
+        for proof in proofs.proofs {
+            assert!(expected.contains(&proof));
+        }
     } else {
         panic!("Unexpected variant")
     }
+}
+
+#[tokio::test]
+async fn test_block_request() {
+    let mut proof_manager = create_proof_manager();
+
+    let proof = create_proof(PeerId::random(), 10, 1);
+    proof_manager.receive_proofs(vec![proof.clone()]);
+
+    get_proposal_and_assert(&mut proof_manager, 100, &[], &vec![proof.clone()]).await;
+}
+
+#[tokio::test]
+async fn test_block_timestamp_expiration() {
+    let mut proof_manager = create_proof_manager();
+
+    let proof = create_proof(PeerId::random(), 10, 1);
+    proof_manager.receive_proofs(vec![proof.clone()]);
+
+    proof_manager.handle_commit_notification(1, vec![]);
+    get_proposal_and_assert(&mut proof_manager, 100, &[], &vec![proof]).await;
+
+    proof_manager.handle_commit_notification(20, vec![]);
+    get_proposal_and_assert(&mut proof_manager, 100, &[], &[]).await;
+}
+
+#[tokio::test]
+async fn test_batch_commit() {
+    let mut proof_manager = create_proof_manager();
+
+    let proof0 = create_proof(PeerId::random(), 10, 1);
+    proof_manager.receive_proofs(vec![proof0.clone()]);
+
+    let proof1 = create_proof(PeerId::random(), 11, 2);
+    proof_manager.receive_proofs(vec![proof1.clone()]);
+
+    proof_manager.handle_commit_notification(1, vec![proof1.info().clone()]);
+    get_proposal_and_assert(&mut proof_manager, 100, &[], &vec![proof0]).await;
+}
+
+#[tokio::test]
+async fn test_proposal_priority() {
+    let mut proof_manager = create_proof_manager();
+    let peer0 = PeerId::random();
+
+    let peer0_proof0 = create_proof_with_gas(peer0, 10, 2, 1000);
+    let peer0_proof1 = create_proof_with_gas(peer0, 10, 1, 0);
+    proof_manager.receive_proofs(vec![peer0_proof1.clone(), peer0_proof0.clone()]);
+
+    let peer0_proof2 = create_proof_with_gas(peer0, 10, 4, 500);
+    proof_manager.receive_proofs(vec![peer0_proof2.clone()]);
+    let peer0_proof3 = create_proof_with_gas(peer0, 10, 3, 500);
+    proof_manager.receive_proofs(vec![peer0_proof3.clone()]);
+
+    // Gas bucket is the most significant prioritization
+    let expected = vec![peer0_proof0.clone()];
+    get_proposal_and_assert(&mut proof_manager, 1, &[], &expected).await;
+
+    // Batch sequence is prioritized next
+    let expected = vec![peer0_proof3.clone()];
+    get_proposal_and_assert(
+        &mut proof_manager,
+        1,
+        &[peer0_proof0.info().clone()],
+        &expected,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_proposal_fairness() {
+    let mut proof_manager = create_proof_manager();
+    let peer0 = PeerId::random();
+    let peer1 = PeerId::random();
+
+    let mut peer0_proofs = vec![];
+    for i in 0..4 {
+        let proof = create_proof(peer0, 10 + i, 1 + i);
+        proof_manager.receive_proofs(vec![proof.clone()]);
+        peer0_proofs.push(proof);
+    }
+
+    let peer1_proof_0 = create_proof(peer1, 7, 1);
+    proof_manager.receive_proofs(vec![peer1_proof_0.clone()]);
+
+    // Without filter, and large max size, all proofs are retrieved
+    let mut expected = peer0_proofs.clone();
+    expected.push(peer1_proof_0.clone());
+    get_proposal_and_assert(&mut proof_manager, 100, &[], &expected).await;
+
+    // The first two proofs are taken fairly from each peer
+    get_proposal_and_assert(&mut proof_manager, 2, &[], &vec![
+        peer0_proofs[0].clone(),
+        peer1_proof_0.clone(),
+    ])
+    .await;
+
+    // The next two proofs are taken from the remaining peer
+    let filter = vec![peer0_proofs[0].clone(), peer1_proof_0.clone()];
+    let filter: Vec<_> = filter.iter().map(ProofOfStore::info).cloned().collect();
+    get_proposal_and_assert(&mut proof_manager, 2, &filter, &peer0_proofs[1..3]).await;
+
+    // The last proof is also taken from the remaining peer
+    let mut filter = peer0_proofs[0..3].to_vec();
+    filter.push(peer1_proof_0.clone());
+    let filter: Vec<_> = filter.iter().map(ProofOfStore::info).cloned().collect();
+    get_proposal_and_assert(&mut proof_manager, 2, &filter, &peer0_proofs[3..4]).await;
+}
+
+#[tokio::test]
+async fn test_duplicate_batches_on_commit() {
+    let mut proof_manager = create_proof_manager();
+
+    let author = PeerId::random();
+    let digest = HashValue::random();
+    let batch_id = BatchId::new_for_test(1);
+    let batch = BatchInfo::new(author, batch_id, 0, 10, digest, 1, 1, 0);
+    let proof0 = ProofOfStore::new(batch.clone(), AggregateSignature::empty());
+    let proof1 = ProofOfStore::new(batch.clone(), AggregateSignature::empty());
+    let proof2 = ProofOfStore::new(batch.clone(), AggregateSignature::empty());
+
+    proof_manager.receive_proofs(vec![proof0.clone()]);
+    proof_manager.receive_proofs(vec![proof1.clone()]);
+
+    // Only one copy of the batch exists
+    get_proposal_and_assert(&mut proof_manager, 10, &[], &vec![proof0.clone()]).await;
+
+    // Nothing goes wrong on commits
+    proof_manager.handle_commit_notification(4, vec![batch.clone()]);
+    get_proposal_and_assert(&mut proof_manager, 10, &[], &[]).await;
+
+    // Before expiration, still marked as committed
+    proof_manager.receive_proofs(vec![proof2.clone()]);
+    get_proposal_and_assert(&mut proof_manager, 10, &[], &[]).await;
+
+    // Nothing goes wrong on expiration
+    proof_manager.handle_commit_notification(5, vec![]);
+    get_proposal_and_assert(&mut proof_manager, 10, &[], &[]).await;
+    proof_manager.handle_commit_notification(12, vec![]);
+    get_proposal_and_assert(&mut proof_manager, 10, &[], &[]).await;
+}
+
+#[tokio::test]
+async fn test_duplicate_batches_on_expiration() {
+    let mut proof_manager = create_proof_manager();
+
+    let author = PeerId::random();
+    let digest = HashValue::random();
+    let batch_id = BatchId::new_for_test(1);
+    let batch = BatchInfo::new(author, batch_id, 0, 10, digest, 1, 1, 0);
+    let proof0 = ProofOfStore::new(batch.clone(), AggregateSignature::empty());
+    let proof1 = ProofOfStore::new(batch.clone(), AggregateSignature::empty());
+
+    proof_manager.receive_proofs(vec![proof0.clone()]);
+    proof_manager.receive_proofs(vec![proof1.clone()]);
+
+    // Only one copy of the batch exists
+    get_proposal_and_assert(&mut proof_manager, 10, &[], &vec![proof0.clone()]).await;
+
+    // Nothing goes wrong on expiration
+    proof_manager.handle_commit_notification(5, vec![]);
+    get_proposal_and_assert(&mut proof_manager, 10, &[], &vec![proof0.clone()]).await;
+    proof_manager.handle_commit_notification(12, vec![]);
+    get_proposal_and_assert(&mut proof_manager, 10, &[], &[]).await;
 }

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -2,19 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{monitor, quorum_store::counters};
-use aptos_consensus_types::{common::TransactionInProgress, proof_of_store::ProofOfStore};
-use aptos_crypto::HashValue;
+use aptos_consensus_types::{
+    common::TransactionInProgress,
+    proof_of_store::{BatchId, BatchInfo, ProofOfStore},
+};
 use aptos_logger::prelude::*;
 use aptos_mempool::{QuorumStoreRequest, QuorumStoreResponse};
-use aptos_types::transaction::SignedTransaction;
+use aptos_types::{transaction::SignedTransaction, PeerId};
 use chrono::Utc;
 use futures::channel::{mpsc::Sender, oneshot};
+use move_core_types::account_address::AccountAddress;
+use rand::{seq::SliceRandom, thread_rng};
 use std::{
-    cmp::Reverse,
-    collections::{
-        hash_map::Entry::{Occupied, Vacant},
-        BinaryHeap, HashMap, HashSet, VecDeque,
-    },
+    cmp::{Ordering, Reverse},
+    collections::{BTreeMap, BinaryHeap, HashMap, HashSet, VecDeque},
     hash::Hash,
     time::{Duration, Instant},
 };
@@ -140,215 +141,274 @@ impl MempoolProxy {
     }
 }
 
-// TODO: unitest
-pub struct ProofQueue {
-    digest_queue: VecDeque<(HashValue, u64)>, // queue of all proofs
-    local_digest_queue: VecDeque<(HashValue, u64)>, // queue of local proofs, to make back pressure update more efficient
-    digest_proof: HashMap<HashValue, Option<ProofOfStore>>, // None means committed
-    digest_insertion_time: HashMap<HashValue, Instant>,
+#[derive(PartialEq, Eq, Hash, Clone)]
+struct BatchKey {
+    author: PeerId,
+    batch_id: BatchId,
 }
 
-impl ProofQueue {
-    pub(crate) fn new() -> Self {
+impl BatchKey {
+    pub fn from_info(info: &BatchInfo) -> Self {
         Self {
-            digest_queue: VecDeque::new(),
-            local_digest_queue: VecDeque::new(),
-            digest_proof: HashMap::new(),
-            digest_insertion_time: HashMap::new(),
+            author: info.author(),
+            batch_id: info.batch_id(),
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Hash)]
+struct BatchSortKey {
+    batch_key: BatchKey,
+    gas_bucket_start: u64,
+}
+
+impl BatchSortKey {
+    pub fn from_info(info: &BatchInfo) -> Self {
+        Self {
+            batch_key: BatchKey::from_info(info),
+            gas_bucket_start: info.gas_bucket_start(),
         }
     }
 
-    pub(crate) fn push(&mut self, proof: ProofOfStore, local: bool) {
-        match self.digest_proof.entry(*proof.digest()) {
-            Vacant(entry) => {
-                self.digest_queue
-                    .push_back((*proof.digest(), proof.expiration()));
-                entry.insert(Some(proof.clone()));
-                self.digest_insertion_time
-                    .insert(*proof.digest(), Instant::now());
-            },
-            Occupied(mut entry) => {
-                if entry.get().is_some()
-                    && entry.get().as_ref().unwrap().expiration() < proof.expiration()
-                {
-                    entry.insert(Some(proof.clone()));
-                }
-            },
+    pub fn author(&self) -> PeerId {
+        self.batch_key.author
+    }
+}
+
+impl PartialOrd<Self> for BatchSortKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BatchSortKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // ascending
+        match self.gas_bucket_start.cmp(&other.gas_bucket_start) {
+            Ordering::Equal => {},
+            ordering => return ordering,
         }
-        if local {
-            counters::inc_local_pos_count(proof.gas_bucket_start().to_string().as_str());
-            self.local_digest_queue
-                .push_back((*proof.digest(), proof.expiration()));
+        // descending
+        other.batch_key.batch_id.cmp(&self.batch_key.batch_id)
+    }
+}
+
+pub struct ProofQueue {
+    my_peer_id: PeerId,
+    // Queue per peer to ensure fairness between peers and priority within peer
+    author_to_batches: HashMap<PeerId, BTreeMap<BatchSortKey, BatchInfo>>,
+    // ProofOfStore and insertion_time. None if committed
+    batch_to_proof: HashMap<BatchKey, Option<(ProofOfStore, Instant)>>,
+    // Expiration index
+    expirations: TimeExpirations<BatchSortKey>,
+    latest_block_timestamp: u64,
+    remaining_txns: u64,
+    remaining_proofs: u64,
+    remaining_local_txns: u64,
+    remaining_local_proofs: u64,
+}
+
+impl ProofQueue {
+    pub(crate) fn new(my_peer_id: PeerId) -> Self {
+        Self {
+            my_peer_id,
+            author_to_batches: HashMap::new(),
+            batch_to_proof: HashMap::new(),
+            expirations: TimeExpirations::new(),
+            latest_block_timestamp: 0,
+            remaining_txns: 0,
+            remaining_proofs: 0,
+            remaining_local_txns: 0,
+            remaining_local_proofs: 0,
+        }
+    }
+
+    #[inline]
+    fn inc_remaining(&mut self, author: &AccountAddress, num_txns: u64) {
+        self.remaining_txns += num_txns;
+        self.remaining_proofs += 1;
+        if *author == self.my_peer_id {
+            self.remaining_local_txns += num_txns;
+            self.remaining_local_proofs += 1;
+        }
+    }
+
+    #[inline]
+    fn dec_remaining(&mut self, author: &AccountAddress, num_txns: u64) {
+        self.remaining_txns -= num_txns;
+        self.remaining_proofs -= 1;
+        if *author == self.my_peer_id {
+            self.remaining_local_txns -= num_txns;
+            self.remaining_local_proofs -= 1;
+        }
+    }
+
+    pub(crate) fn push(&mut self, proof: ProofOfStore) {
+        if proof.expiration() < self.latest_block_timestamp {
+            counters::inc_rejected_pos_count(counters::POS_EXPIRED_LABEL);
+            return;
+        }
+        let batch_key = BatchKey::from_info(proof.info());
+        if self.batch_to_proof.get(&batch_key).is_some() {
+            counters::inc_rejected_pos_count(counters::POS_DUPLICATE_LABEL);
+            return;
+        }
+
+        let author = proof.author();
+        let bucket = proof.gas_bucket_start();
+        let num_txns = proof.num_txns();
+        let expiration = proof.expiration();
+
+        let batch_sort_key = BatchSortKey::from_info(proof.info());
+        let queue = self.author_to_batches.entry(author).or_default();
+        queue.insert(batch_sort_key.clone(), proof.info().clone());
+        self.expirations.add_item(batch_sort_key, expiration);
+        self.batch_to_proof
+            .insert(batch_key, Some((proof, Instant::now())));
+
+        if author == self.my_peer_id {
+            counters::inc_local_pos_count(bucket);
         } else {
-            counters::inc_remote_pos_count(proof.gas_bucket_start().to_string().as_str());
+            counters::inc_remote_pos_count(bucket);
         }
+
+        self.inc_remaining(&author, num_txns);
     }
 
     // gets excluded and iterates over the vector returning non excluded or expired entries.
     // return the vector of pulled PoS, and the size of the remaining PoS
     pub(crate) fn pull_proofs(
         &mut self,
-        excluded_proofs: &HashSet<HashValue>,
-        current_block_timestamp: u64,
+        excluded_batches: &HashSet<BatchInfo>,
         max_txns: u64,
         max_bytes: u64,
         return_non_full: bool,
     ) -> Vec<ProofOfStore> {
-        let num_expired = self
-            .digest_queue
-            .iter()
-            .take_while(|(_, expiration_time)| *expiration_time < current_block_timestamp)
-            .count();
-        let mut num_expired_but_not_committed = 0;
-        for (digest, expiration_time) in self.digest_queue.drain(0..num_expired) {
-            if self
-                .digest_proof
-                .get(&digest)
-                .expect("Entry for unexpired digest must exist")
-                .is_some()
-            {
-                // non-committed proof that is expired
-                num_expired_but_not_committed += 1;
-                if expiration_time < current_block_timestamp {
-                    counters::GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_PULL_PROOFS
-                        .observe((current_block_timestamp - expiration_time) as f64);
-                }
-            }
-            claims::assert_some!(self.digest_proof.remove(&digest));
-            self.digest_insertion_time.remove(&digest);
-        }
-
-        let mut ret = Vec::new();
+        let mut ret = vec![];
         let mut cur_bytes = 0;
         let mut cur_txns = 0;
-        let initial_size = self.digest_queue.len();
-        let mut size = self.digest_queue.len();
+        let mut excluded_txns = 0;
         let mut full = false;
 
-        for (digest, expiration) in self
-            .digest_queue
-            .iter()
-            .filter(|(digest, _)| !excluded_proofs.contains(digest))
-        {
-            if let Some(proof) = self
-                .digest_proof
-                .get(digest)
-                .expect("Entry for unexpired digest must exist")
-            {
-                if *expiration >= current_block_timestamp {
-                    // non-committed proof that has not expired
-                    cur_bytes += proof.num_bytes();
-                    cur_txns += proof.num_txns();
-                    if cur_bytes > max_bytes || cur_txns > max_txns {
-                        // Exceeded the limit for requested bytes or number of transactions.
-                        full = true;
+        let mut author_to_num_remaining = HashMap::new();
+        for (author, batches) in self.author_to_batches.iter() {
+            author_to_num_remaining.insert(*author, batches.len());
+        }
+
+        'outer: while !author_to_num_remaining.is_empty() {
+            let shuffled_peers: Vec<_> = {
+                let mut peers: Vec<_> = author_to_num_remaining.keys().cloned().collect();
+                peers.shuffle(&mut thread_rng());
+                peers
+            };
+
+            for peer in shuffled_peers {
+                let queue = self.author_to_batches.get(&peer).unwrap();
+                let num_remaining = author_to_num_remaining.remove(&peer).unwrap();
+                let to_skip = queue.len() - num_remaining;
+
+                let mut num_read = 0;
+                for (sort_key, batch) in queue.iter().rev().skip(to_skip) {
+                    num_read += 1;
+                    if excluded_batches.contains(batch) {
+                        excluded_txns += batch.num_txns();
+                    } else if let Some(Some((proof, insertion_time))) =
+                        self.batch_to_proof.get(&sort_key.batch_key)
+                    {
+                        cur_bytes += batch.num_bytes();
+                        cur_txns += batch.num_txns();
+                        if cur_bytes > max_bytes || cur_txns > max_txns {
+                            // Exceeded the limit for requested bytes or number of transactions.
+                            full = true;
+                            break 'outer;
+                        }
+                        let bucket = proof.gas_bucket_start();
+                        ret.push(proof.clone());
+                        counters::pos_to_pull(bucket, insertion_time.elapsed().as_secs_f64());
                         break;
                     }
-                    ret.push(proof.clone());
-                    if let Some(insertion_time) = self.digest_insertion_time.get(digest) {
-                        counters::pos_to_pull(
-                            proof.gas_bucket_start(),
-                            insertion_time.elapsed().as_secs_f64(),
-                        );
-                    }
-                } else {
-                    // non-committed proof that is expired
-                    num_expired_but_not_committed += 1;
-                    if *expiration < current_block_timestamp {
-                        counters::GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_PULL_PROOFS
-                            .observe((current_block_timestamp - expiration) as f64);
-                    }
+                }
+                if num_remaining != num_read {
+                    author_to_num_remaining.insert(peer, num_remaining - num_read);
                 }
             }
-            size -= 1;
         }
         info!(
             // before non full check
             byte_size = cur_bytes,
             block_size = cur_txns,
             batch_count = ret.len(),
-            remaining_proof_num = size,
-            initial_remaining_proof_num = initial_size,
             full = full,
             return_non_full = return_non_full,
             "Pull payloads from QuorumStore: internal"
         );
 
         if full || return_non_full {
-            counters::EXPIRED_PROOFS_WHEN_PULL.observe(num_expired_but_not_committed as f64);
             counters::BLOCK_SIZE_WHEN_PULL.observe(cur_txns as f64);
             counters::BLOCK_BYTES_WHEN_PULL.observe(cur_bytes as f64);
             counters::PROOF_SIZE_WHEN_PULL.observe(ret.len() as f64);
+            counters::EXCLUDED_TXNS_WHEN_PULL.observe(excluded_txns as f64);
             ret
         } else {
             Vec::new()
         }
     }
 
-    pub(crate) fn num_total_txns_and_proofs(&mut self, current_block_timestamp: u64) -> (u64, u64) {
-        let mut remaining_txns = 0;
-        let mut remaining_proofs = 0;
-        // TODO: if the digest_queue is large, this may be too inefficient
-        for (digest, expiration) in self.digest_queue.iter() {
-            // Not expired
-            if *expiration >= current_block_timestamp {
-                // Not committed
-                if let Some(Some(proof)) = self.digest_proof.get(digest) {
-                    remaining_txns += proof.num_txns();
-                    remaining_proofs += 1;
-                }
-            }
-        }
-        counters::NUM_TOTAL_TXNS_LEFT_ON_COMMIT.observe(remaining_txns as f64);
-        counters::NUM_TOTAL_PROOFS_LEFT_ON_COMMIT.observe(remaining_proofs as f64);
+    pub(crate) fn handle_updated_block_timestamp(&mut self, block_timestamp: u64) {
+        assert!(
+            self.latest_block_timestamp <= block_timestamp,
+            "Decreasing block timestamp"
+        );
+        self.latest_block_timestamp = block_timestamp;
 
-        (remaining_txns, remaining_proofs)
-    }
-
-    // returns the number of unexpired local proofs
-    pub(crate) fn clean_local_proofs(&mut self, current_block_timestamp: u64) -> Option<u64> {
-        let num_expired = self
-            .local_digest_queue
-            .iter()
-            .take_while(|(_, expiration_time)| *expiration_time < current_block_timestamp)
-            .count();
-        self.local_digest_queue.drain(0..num_expired);
-
-        let mut remaining_local_proof_size = 0;
-
-        for (digest, expiration) in self.local_digest_queue.iter() {
-            // Not expired. It is possible that the proof entry in digest_proof was already removed
-            // when draining the digest_queue but local_digest_queue is not drained yet.
-            if *expiration >= current_block_timestamp {
-                if let Some(entry) = self.digest_proof.get(digest) {
-                    // Not committed
-                    if entry.is_some() {
-                        remaining_local_proof_size += 1;
+        let expired = self.expirations.expire(block_timestamp);
+        let mut num_expired_but_not_committed = 0;
+        for key in &expired {
+            if let Some(mut queue) = self.author_to_batches.remove(&key.author()) {
+                if let Some(batch) = queue.remove(key) {
+                    if self
+                        .batch_to_proof
+                        .get(&key.batch_key)
+                        .expect("Entry for unexpired batch must exist")
+                        .is_some()
+                    {
+                        // non-committed proof that is expired
+                        num_expired_but_not_committed += 1;
+                        counters::GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_COMMIT
+                            .observe((block_timestamp - batch.expiration()) as f64);
+                        self.dec_remaining(&batch.author(), batch.num_txns());
                     }
+                    claims::assert_some!(self.batch_to_proof.remove(&key.batch_key));
+                }
+                if !queue.is_empty() {
+                    self.author_to_batches.insert(key.author(), queue);
                 }
             }
         }
-        counters::NUM_LOCAL_PROOFS_LEFT_ON_COMMIT.observe(remaining_local_proof_size as f64);
-
-        if let Some(&(_, time)) = self.local_digest_queue.iter().next() {
-            Some(time)
-        } else {
-            None
-        }
+        counters::NUM_PROOFS_EXPIRED_WHEN_COMMIT.inc_by(num_expired_but_not_committed);
     }
 
-    //mark in the hashmap committed PoS, but keep them until they expire
-    pub(crate) fn mark_committed(&mut self, digests: Vec<HashValue>) {
-        for digest in digests {
-            let bucket = if let Some(Some(proof)) = self.digest_proof.get(&digest) {
-                Some(proof.gas_bucket_start())
-            } else {
-                None
-            };
-            self.digest_proof.insert(digest, None);
-            if let Some(insertion_time) = self.digest_insertion_time.get(&digest) {
-                counters::pos_to_commit(bucket, insertion_time.elapsed().as_secs_f64());
+    pub(crate) fn remaining_txns_and_proofs(&self) -> (u64, u64) {
+        counters::NUM_TOTAL_TXNS_LEFT_ON_UPDATE.observe(self.remaining_txns as f64);
+        counters::NUM_TOTAL_PROOFS_LEFT_ON_UPDATE.observe(self.remaining_proofs as f64);
+        counters::NUM_LOCAL_TXNS_LEFT_ON_UPDATE.observe(self.remaining_local_txns as f64);
+        counters::NUM_LOCAL_PROOFS_LEFT_ON_UPDATE.observe(self.remaining_local_proofs as f64);
+
+        (self.remaining_txns, self.remaining_proofs)
+    }
+
+    // Mark in the hashmap committed PoS, but keep them until they expire
+    pub(crate) fn mark_committed(&mut self, batches: Vec<BatchInfo>) {
+        for batch in batches {
+            let batch_key = BatchKey::from_info(&batch);
+            if let Some(Some((proof, insertion_time))) = self.batch_to_proof.get(&batch_key) {
+                counters::pos_to_commit(
+                    proof.gas_bucket_start(),
+                    insertion_time.elapsed().as_secs_f64(),
+                );
+                self.dec_remaining(&batch.author(), batch.num_txns());
             }
+            self.batch_to_proof.insert(batch_key, None);
         }
     }
 }

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -317,6 +317,11 @@ impl ProofQueue {
                         let bucket = proof.gas_bucket_start();
                         ret.push(proof.clone());
                         counters::pos_to_pull(bucket, insertion_time.elapsed().as_secs_f64());
+                        if cur_bytes == max_bytes || cur_txns == max_txns {
+                            // Exactly the limit for requested bytes or number of transactions.
+                            full = true;
+                            return false;
+                        }
                     }
                     true
                 } else {

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -864,7 +864,7 @@ fn three_region_sim_graceful_overload(config: ForgeConfig) -> ForgeConfig {
                 // Additionally - we are not really gracefully handling overlaods,
                 // setting limits based on current reality, to make sure they
                 // don't regress, but something to investigate
-                avg_tps: 1500,
+                avg_tps: 1400,
                 latency_thresholds: &[],
             },
         }])

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -864,7 +864,7 @@ fn three_region_sim_graceful_overload(config: ForgeConfig) -> ForgeConfig {
                 // Additionally - we are not really gracefully handling overlaods,
                 // setting limits based on current reality, to make sure they
                 // don't regress, but something to investigate
-                avg_tps: 3400,
+                avg_tps: 1500,
                 latency_thresholds: &[],
             },
         }])


### PR DESCRIPTION
### Description

Add a per-author queue in proof manager. On proposal, proofs are taken in a (shuffled) round-robin of authors. This helps maintain some amount of fairness. For example, a single author that creates a huge backlog of proofs can't monopolize blocks if other proofs are also being received.

The per-author queue is prioritized. The tail is taken of the queue, which is sorted by gas bucket (ascending) and batch id (descending).

As a safeguard to spamming attacks, only a single proof can be stored at a time for a given batch.

### Test Plan

Added unit tests, run three region overload tests.
