### PR TITLE
[gha][replay-verify] fix job cancellation

### DIFF
--- a/.github/workflows/replay-verify.yaml
+++ b/.github/workflows/replay-verify.yaml
@@ -39,12 +39,15 @@ jobs:
   determine-test-metadata:
     runs-on: ubuntu-latest
     steps:
+      # checkout the repo first, so check-aptos-core can use it and cancel the workflow if necessary
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
 
   replay-testnet:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' && inputs.CHAIN_NAME == 'testnet' || inputs.CHAIN_NAME == 'all' }}
+    needs: determine-test-metadata
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-replay-verify.yaml@main
     secrets: inherit
     with:
@@ -61,6 +64,7 @@ jobs:
 
   replay-mainnet:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' && inputs.CHAIN_NAME == 'testnet' || inputs.CHAIN_NAME == 'all' }}
+    needs: determine-test-metadata
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-replay-verify.yaml@main
     secrets: inherit
     with:
@@ -77,6 +81,7 @@ jobs:
 
   test-replay:
     if: ${{ github.event_name == 'pull_request' }}
+    needs: determine-test-metadata
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-replay-verify.yaml@main
     secrets: inherit
     with:


### PR DESCRIPTION
Like some other expensive cron jobs, we only want to run them on the aptos-core repo, and not anywhere else like forks. `check-aptos-core` action only works when the repo has already been checked out, since it uses the `gh` CLI which needs it for context. This PR fixes that.

Also, make the replay jobs depend on the `determine-test-metadata` job, so replay will not run even if the initial check fails.