### PR TITLE
String arg

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/string_args.data/pack/sources/hello.move
+++ b/aptos-move/e2e-move-tests/src/tests/string_args.data/pack/sources/hello.move
@@ -66,9 +66,18 @@ module 0xCAFE::test {
         }
     }
 
+    public entry fun non_generic_call(sender: &signer, msg: String) acquires GenericModuleData {
+        let addr = signer::address_of(sender);
+        if (!exists<GenericModuleData<String>>(addr)) {
+            move_to<GenericModuleData<String>>(sender, GenericModuleData { state: msg });
+        } else {
+            borrow_global_mut<GenericModuleData<T>>(addr).state = msg;
+        }
+    }
+
     public entry fun generic_call<T: copy + drop + store>(sender: &signer, msg: T) acquires GenericModuleData {
         let addr = signer::address_of(sender);
-        if (!exists<ModuleData>(addr)) {
+        if (!exists<GenericModuleData<T>>(addr)) {
             move_to<GenericModuleData<T>>(sender, GenericModuleData { state: msg });
         } else {
             borrow_global_mut<GenericModuleData<T>>(addr).state = msg;

--- a/aptos-move/e2e-move-tests/src/tests/string_args.data/pack/sources/hello.move
+++ b/aptos-move/e2e-move-tests/src/tests/string_args.data/pack/sources/hello.move
@@ -66,6 +66,15 @@ module 0xCAFE::test {
         }
     }
 
+    public entry fun generic_call<T: copy + drop + store>(sender: &signer, msg: T) acquires GenericModuleData {
+        let addr = signer::address_of(sender);
+        if (!exists<ModuleData>(addr)) {
+            move_to<GenericModuleData<T>>(sender, GenericModuleData { state: msg });
+        } else {
+            borrow_global_mut<GenericModuleData<T>>(addr).state = msg;
+        }
+    }
+
     public entry fun generic_multi_vec<T: copy + drop + store, W: copy + drop + store>(
         sender: &signer,
         w_ies: vector<vector<W>>,

--- a/aptos-move/e2e-move-tests/src/tests/string_args.data/pack/sources/hello.move
+++ b/aptos-move/e2e-move-tests/src/tests/string_args.data/pack/sources/hello.move
@@ -4,40 +4,36 @@ module 0xCAFE::test {
     use std::string::String;
     use std::vector;
 
-    struct ModuleData has key, store {
-        state: String,
-    }
-
-    struct GenericModuleData<T: copy + store> has key, store {
+    struct ModuleData<T> has key, store {
         state: T,
     }
 
     public entry fun hi(sender: &signer, msg: String) acquires ModuleData {
         let addr = signer::address_of(sender);
-        if (!exists<ModuleData>(addr)) {
-            move_to(sender, ModuleData{state: msg});
+        if (!exists<ModuleData<String>>(addr)) {
+            move_to(sender, ModuleData<String>{state: msg});
         } else {
-            borrow_global_mut<ModuleData>(addr).state = msg;
+            borrow_global_mut<ModuleData<String>>(addr).state = msg;
         }
     }
 
     public entry fun str_vec(sender: &signer, msgs: vector<String>, i: u64) acquires ModuleData {
         find_hello_in_msgs(&msgs);
         let addr = signer::address_of(sender);
-        if (!exists<ModuleData>(addr)) {
-            move_to(sender, ModuleData{state: *vector::borrow(&msgs, i)});
+        if (!exists<ModuleData<String>>(addr)) {
+            move_to(sender, ModuleData<String>{state: *vector::borrow(&msgs, i)});
         } else {
-            borrow_global_mut<ModuleData>(addr).state = *vector::borrow(&msgs, i);
+            borrow_global_mut<ModuleData<String>>(addr).state = *vector::borrow(&msgs, i);
         }
     }
 
     public entry fun str_vec_vec(sender: &signer, msgs: vector<vector<String>>, i: u64, j: u64) acquires ModuleData {
         find_hello_in_msgs_of_msgs(&msgs);
         let addr = signer::address_of(sender);
-        if (!exists<ModuleData>(addr)) {
-            move_to(sender, ModuleData{state: *vector::borrow(vector::borrow(&msgs, i), j)});
+        if (!exists<ModuleData<String>>(addr)) {
+            move_to(sender, ModuleData<String>{state: *vector::borrow(vector::borrow(&msgs, i), j)});
         } else {
-            borrow_global_mut<ModuleData>(addr).state = *vector::borrow(vector::borrow(&msgs, i), j);
+            borrow_global_mut<ModuleData<String>>(addr).state = *vector::borrow(vector::borrow(&msgs, i), j);
         }
     }
 
@@ -59,28 +55,28 @@ module 0xCAFE::test {
 
         let addr = signer::address_of(sender);
         let msg = *vector::borrow(vector::borrow(&msgs, i), j);
-        if (!exists<ModuleData>(addr)) {
-            move_to(sender, ModuleData{state: msg});
+        if (!exists<ModuleData<String>>(addr)) {
+            move_to(sender, ModuleData<String>{state: msg});
         } else {
-            borrow_global_mut<ModuleData>(addr).state = msg;
+            borrow_global_mut<ModuleData<String>>(addr).state = msg;
         }
     }
 
-    public entry fun non_generic_call(sender: &signer, msg: String) acquires GenericModuleData {
+    public entry fun non_generic_call(sender: &signer, msg: String) acquires ModuleData {
         let addr = signer::address_of(sender);
-        if (!exists<GenericModuleData<String>>(addr)) {
-            move_to<GenericModuleData<String>>(sender, GenericModuleData { state: msg });
+        if (!exists<ModuleData<String>>(addr)) {
+            move_to<ModuleData<String>>(sender, ModuleData<String> { state: msg });
         } else {
-            borrow_global_mut<GenericModuleData<T>>(addr).state = msg;
+            borrow_global_mut<ModuleData<String>>(addr).state = msg;
         }
     }
 
-    public entry fun generic_call<T: copy + drop + store>(sender: &signer, msg: T) acquires GenericModuleData {
+    public entry fun generic_call<T: copy + drop + store>(sender: &signer, msg: T) acquires ModuleData {
         let addr = signer::address_of(sender);
-        if (!exists<GenericModuleData<T>>(addr)) {
-            move_to<GenericModuleData<T>>(sender, GenericModuleData { state: msg });
+        if (!exists<ModuleData<T>>(addr)) {
+            move_to<ModuleData<T>>(sender, ModuleData { state: msg });
         } else {
-            borrow_global_mut<GenericModuleData<T>>(addr).state = msg;
+            borrow_global_mut<ModuleData<T>>(addr).state = msg;
         }
     }
 
@@ -94,7 +90,7 @@ module 0xCAFE::test {
         val2: T,
         i: u64,
         j: u64,
-    ) acquires GenericModuleData {
+    ) acquires ModuleData {
         assert!(vector::length(&w_ies) > 0, 30);
         assert!(vector::length(&t_ies) > 0, 31);
         assert!(vector::length(&vec1) >= 0, 32);
@@ -105,16 +101,16 @@ module 0xCAFE::test {
         let v2 = *vector::borrow(vector::borrow(&t_ies, i), j);
         let check = (&v1 == &val1) || (&v2 == &val2);
         if (check) {
-            if (!exists<ModuleData>(addr)) {
-                move_to<GenericModuleData<T>>(sender, GenericModuleData { state: v2 });
+            if (!exists<ModuleData<T>>(addr)) {
+                move_to<ModuleData<T>>(sender, ModuleData { state: v2 });
             } else {
-                borrow_global_mut<GenericModuleData<T>>(addr).state = v2;
+                borrow_global_mut<ModuleData<T>>(addr).state = v2;
             }
         } else {
-            if (!exists<ModuleData>(addr)) {
-                move_to<GenericModuleData<T>>(sender, GenericModuleData { state: v2 });
+            if (!exists<ModuleData<T>>(addr)) {
+                move_to<ModuleData<T>>(sender, ModuleData { state: v2 });
             } else {
-                borrow_global_mut<GenericModuleData<T>>(addr).state = v2;
+                borrow_global_mut<ModuleData<T>>(addr).state = v2;
             }
         };
     }

--- a/aptos-move/e2e-move-tests/src/tests/string_args.rs
+++ b/aptos-move/e2e-move-tests/src/tests/string_args.rs
@@ -616,6 +616,7 @@ fn string_args_non_generic_call() {
     success_generic(vec![], tests);
 }
 
+#[ignore]
 #[test]
 fn string_args_generic_call() {
     let tests = vec![("0xcafe::test::generic_call", vec![(

--- a/aptos-move/e2e-move-tests/src/tests/string_args.rs
+++ b/aptos-move/e2e-move-tests/src/tests/string_args.rs
@@ -28,7 +28,15 @@ fn success_generic(ty_args: Vec<TypeTag>, tests: Vec<(&str, Vec<(Vec<Vec<u8>>, &
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
     assert_success!(h.publish_package(&acc, &common::test_dir_path("string_args.data/pack")));
 
-    let module_data = parse_struct_tag("0xCAFE::test::ModuleData").unwrap();
+    let mut module_data = parse_struct_tag("0xCAFE::test::ModuleData").unwrap();
+    let string_struct = StructTag {
+        address: AccountAddress::from_hex_literal("0x1").expect("valid address"),
+        module: Identifier::new("string").expect("valid identifier"),
+        name: Identifier::new("String").expect("valid identifier"),
+        type_params: vec![],
+    };
+    let string_type = TypeTag::Struct(Box::new(string_struct));
+    module_data.type_params.push(string_type);
 
     // Check in initial state, resource does not exist.
     assert!(!h.exists_resource(acc.address(), module_data.clone()));
@@ -599,13 +607,21 @@ fn string_args_bad_length() {
 }
 
 #[test]
+fn string_args_non_generic_call() {
+    let tests = vec![("0xcafe::test::non_generic_call", vec![(
+        vec![bcs::to_bytes("hi".as_bytes()).unwrap()],
+        "hi",
+    )])];
+
+    success_generic(vec![], tests);
+}
+
+#[test]
 fn string_args_generic_call() {
-    let tests = vec![
-        (
-            "0xcafe::test::non_generic_call",
-            vec![(vec![bcs::to_bytes("hi".as_bytes()).unwrap()], "hi")],
-        ),
-    ];
+    let tests = vec![("0xcafe::test::generic_call", vec![(
+        vec![bcs::to_bytes("hi".as_bytes()).unwrap()],
+        "hi",
+    )])];
 
     let string_struct = StructTag {
         address: AccountAddress::from_hex_literal("0x1").expect("valid address"),
@@ -615,7 +631,6 @@ fn string_args_generic_call() {
     };
     let string_type = TypeTag::Struct(Box::new(string_struct));
 
-    success_generic(vec![], tests);
     success_generic(vec![string_type], tests);
 }
 

--- a/aptos-move/e2e-move-tests/src/tests/string_args.rs
+++ b/aptos-move/e2e-move-tests/src/tests/string_args.rs
@@ -602,7 +602,7 @@ fn string_args_bad_length() {
 fn string_args_generic_call() {
     let tests = vec![
         (
-            "0xcafe::test::generic_call",
+            "0xcafe::test::non_generic_call",
             vec![(vec![bcs::to_bytes("hi".as_bytes()).unwrap()], "hi")],
         ),
     ];
@@ -615,6 +615,7 @@ fn string_args_generic_call() {
     };
     let string_type = TypeTag::Struct(Box::new(string_struct));
 
+    success_generic(vec![], tests);
     success_generic(vec![string_type], tests);
 }
 

--- a/aptos-move/e2e-move-tests/src/tests/string_args.rs
+++ b/aptos-move/e2e-move-tests/src/tests/string_args.rs
@@ -599,6 +599,26 @@ fn string_args_bad_length() {
 }
 
 #[test]
+fn string_args_generic_call() {
+    let tests = vec![
+        (
+            "0xcafe::test::generic_call",
+            vec![(vec![bcs::to_bytes("hi".as_bytes()).unwrap()], "hi")],
+        ),
+    ];
+
+    let string_struct = StructTag {
+        address: AccountAddress::from_hex_literal("0x1").expect("valid address"),
+        module: Identifier::new("string").expect("valid identifier"),
+        name: Identifier::new("String").expect("valid identifier"),
+        type_params: vec![],
+    };
+    let string_type = TypeTag::Struct(Box::new(string_struct));
+
+    success_generic(vec![string_type], tests);
+}
+
+#[test]
 fn string_args_generic_instantiation() {
     let mut tests = vec![];
     let long_addr = AccountAddress::from_hex_literal(


### PR DESCRIPTION
### Description

I realized that the current string argument implementation is broken for generic functions

ie,.

pub entry fun foo<T>(x:  T) { ... }

cannot be called with T=String as an entry function. This PR is adding a test case to show this

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
