### PR TITLE
Upgrade Poem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9263,9 +9263,9 @@ dependencies = [
 
 [[package]]
 name = "poem"
-version = "1.3.44"
+version = "1.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94ff00c513bee5c32ecbbf982f470e7e51e913330737dc40522ddc298954395"
+checksum = "c0608069d4999c3c02d49dff261663f2e73a8f7b00b7cd364fb5e93e419dafa1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -487,7 +487,7 @@ paste = "1.0.7"
 pbjson = "0.4.0"
 percent-encoding = "2.1.0"
 pin-project = "1.0.10"
-poem = { version = "=1.3.44", features = ["anyhow", "rustls"] }
+poem = { version = "=1.3.55", features = ["anyhow", "rustls"] }
 poem-openapi = { version = "2.0.10", features = ["swagger-ui", "url"] }
 pretty_assertions = "1.2.1"
 procfs = "0.14.1"

--- a/crates/aptos-protos/Cargo.lock
+++ b/crates/aptos-protos/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "a26fa4d7e3f2eebadf743988fc8aec9fa9a9e82611acafd77c1462ed6262440a"
 
 [[package]]
 name = "aptos-protos"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "pbjson",
  "prost",


### PR DESCRIPTION
### Description
The version of Poem we are using now is missing a few features that I think would be nice to have:
- The ability to use eliptic curve private keys when using the built-in TLS: https://github.com/poem-web/poem/pull/460.
- Improved SSE support, which we might want to experiment with.

### Test Plan
Running a local testnet and playing with that, as well as CI.
