### PR TITLE
[CANARY][gha][docker] version docker-rust-build and enable workflow_dispatch

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -103,7 +103,7 @@ jobs:
 
   rust-images:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: ./.github/workflows/docker-rust-build.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -113,7 +113,7 @@ jobs:
 
   rust-images-indexer:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: ./.github/workflows/docker-rust-build.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -124,7 +124,7 @@ jobs:
 
   rust-images-failpoints:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: ./.github/workflows/docker-rust-build.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -135,7 +135,7 @@ jobs:
 
   rust-images-performance:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: ./.github/workflows/docker-rust-build.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -148,7 +148,7 @@ jobs:
     if: |
       contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image') ||
       contains(github.event.pull_request.labels.*.name, 'CICD:run-consensus-only-perf-test')
-    uses: ./.github/workflows/docker-rust-build.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -38,6 +38,8 @@ on: # build on main branch OR when a PR is labeled with `CICD:build-images`
       - performance_benchmark
       - quorum-store
       - preview
+      # CANARY
+      - rustielin/workflow-dispatch-build-canary
 
 # cancel redundant builds
 concurrency:
@@ -103,7 +105,7 @@ jobs:
 
   rust-images:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@rustielin/workflow-dispatch-build
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -113,7 +115,7 @@ jobs:
 
   rust-images-indexer:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@rustielin/workflow-dispatch-build
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -124,7 +126,7 @@ jobs:
 
   rust-images-failpoints:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@rustielin/workflow-dispatch-build
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -135,7 +137,7 @@ jobs:
 
   rust-images-performance:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@rustielin/workflow-dispatch-build
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -148,7 +150,7 @@ jobs:
     if: |
       contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image') ||
       contains(github.event.pull_request.labels.*.name, 'CICD:run-consensus-only-perf-test')
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@rustielin/workflow-dispatch-build
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -1,4 +1,4 @@
-name: "Build+Push Rust Docker Images"
+name: "*run Docker rust build reusable workflow"
 
 on:
   workflow_call:
@@ -25,10 +25,30 @@ on:
         required: false
         type: boolean
         description: Whether to build additional testing images. If not specified, only the base release images will be built
+  workflow_dispatch:
+    inputs:
+      GIT_SHA:
+        required: true
+        type: string
+        description: The git SHA1 to build. If not specified, the latest commit on the triggering branch will be built
+      FEATURES:
+        required: false
+        type: string
+        description: The cargo features to build. If not specified, none will be built other than those specified in cargo config
+      PROFILE:
+        default: release
+        required: false
+        type: string
+        description: The cargo profile to build. If not specified, the default release profile will be used
+      BUILD_ADDL_TESTING_IMAGES:
+        default: false
+        required: false
+        type: boolean
+        description: Whether to build additional testing images. If not specified, only the base release images will be built
 
 env:
   GIT_SHA: ${{ inputs.GIT_SHA }}
-  TARGET_CACHE_ID: ${{ inputs.TARGET_CACHE_ID }}
+  TARGET_CACHE_ID: ${{ inputs.TARGET_CACHE_ID || inputs.GIT_SHA }} # on workflow_dispatch, the build is one-off
   PROFILE: ${{ inputs.PROFILE }}
   FEATURES: ${{ inputs.FEATURES }}
   BUILD_ADDL_TESTING_IMAGES: ${{ inputs.BUILD_ADDL_TESTING_IMAGES }}


### PR DESCRIPTION
### Description

Trigger on push: https://github.com/aptos-labs/aptos-core/actions/runs/4494353867/jobs/7906736784?pr=7332

Log snippet from job setup shows that we're testing the reusable workflow that belongs on the branch in question from the PR:
```
Uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@refs/heads/rustielin/workflow-dispatch-build 
```

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
