### PR TITLE
[gha][docker] version docker-rust-build and enable workflow_dispatch

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -103,7 +103,7 @@ jobs:
 
   rust-images:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: ./.github/workflows/docker-rust-build.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -113,7 +113,7 @@ jobs:
 
   rust-images-indexer:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: ./.github/workflows/docker-rust-build.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -124,7 +124,7 @@ jobs:
 
   rust-images-failpoints:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: ./.github/workflows/docker-rust-build.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -135,7 +135,7 @@ jobs:
 
   rust-images-performance:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: ./.github/workflows/docker-rust-build.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -148,7 +148,7 @@ jobs:
     if: |
       contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image') ||
       contains(github.event.pull_request.labels.*.name, 'CICD:run-consensus-only-perf-test')
-    uses: ./.github/workflows/docker-rust-build.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -1,4 +1,4 @@
-name: "Build+Push Rust Docker Images"
+name: "*run Docker rust build reusable workflow"
 
 on:
   workflow_call:
@@ -25,10 +25,30 @@ on:
         required: false
         type: boolean
         description: Whether to build additional testing images. If not specified, only the base release images will be built
+  workflow_dispatch:
+    inputs:
+      GIT_SHA:
+        required: true
+        type: string
+        description: The git SHA1 to build. If not specified, the latest commit on the triggering branch will be built
+      FEATURES:
+        required: false
+        type: string
+        description: The cargo features to build. If not specified, none will be built other than those specified in cargo config
+      PROFILE:
+        default: release
+        required: false
+        type: string
+        description: The cargo profile to build. If not specified, the default release profile will be used
+      BUILD_ADDL_TESTING_IMAGES:
+        default: false
+        required: false
+        type: boolean
+        description: Whether to build additional testing images. If not specified, only the base release images will be built
 
 env:
   GIT_SHA: ${{ inputs.GIT_SHA }}
-  TARGET_CACHE_ID: ${{ inputs.TARGET_CACHE_ID }}
+  TARGET_CACHE_ID: ${{ inputs.TARGET_CACHE_ID || inputs.GIT_SHA }} # on workflow_dispatch, the build is one-off, so use the git sha as the cache id instead of another key
   PROFILE: ${{ inputs.PROFILE }}
   FEATURES: ${{ inputs.FEATURES }}
   BUILD_ADDL_TESTING_IMAGES: ${{ inputs.BUILD_ADDL_TESTING_IMAGES }}


### PR DESCRIPTION
### Description

Version the docker rust build like the other reusable workflows (referring to `aptos-core@main`). Also enable the `workflow_dispatch` trigger, which will allow workflows such as forge to be able to trigger it separately. This unlocks some cost savings via not building all image variants at once

### Test Plan

Canary via separate PR: https://github.com/aptos-labs/aptos-core/pull/7332 to get around `pull_request_target`

<!-- Please provide us with clear details for verifying that your changes work. -->
