### PR TITLE
[Aptos Framework] Rewards Decrease over Time

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -32,6 +32,7 @@ pub enum FeatureFlag {
     Bls12381Structures,
     Ed25519PubkeyValidateReturnFalseWrongLength,
     StructConstructors,
+    RewardRateDecrease,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -140,6 +141,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
                 AptosFeatureFlag::ED25519_PUBKEY_VALIDATE_RETURN_FALSE_WRONG_LENGTH
             },
             FeatureFlag::StructConstructors => AptosFeatureFlag::STRUCT_CONSTRUCTORS,
+            FeatureFlag::RewardRateDecrease => AptosFeatureFlag::REWARD_RATE_DECREASE,
         }
     }
 }
@@ -173,6 +175,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::Ed25519PubkeyValidateReturnFalseWrongLength
             },
             AptosFeatureFlag::STRUCT_CONSTRUCTORS => FeatureFlag::StructConstructors,
+            AptosFeatureFlag::REWARD_RATE_DECREASE => FeatureFlag::RewardRateDecrease,
         }
     }
 }

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -32,7 +32,7 @@ pub enum FeatureFlag {
     Bls12381Structures,
     Ed25519PubkeyValidateReturnFalseWrongLength,
     StructConstructors,
-    RewardRateDecrease,
+    PeriodicalRewardRateReduction,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -141,7 +141,9 @@ impl From<FeatureFlag> for AptosFeatureFlag {
                 AptosFeatureFlag::ED25519_PUBKEY_VALIDATE_RETURN_FALSE_WRONG_LENGTH
             },
             FeatureFlag::StructConstructors => AptosFeatureFlag::STRUCT_CONSTRUCTORS,
-            FeatureFlag::RewardRateDecrease => AptosFeatureFlag::REWARD_RATE_DECREASE,
+            FeatureFlag::PeriodicalRewardRateReduction => {
+                AptosFeatureFlag::PERIODICAL_REWARD_RATE_DECREASE
+            },
         }
     }
 }
@@ -175,7 +177,9 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::Ed25519PubkeyValidateReturnFalseWrongLength
             },
             AptosFeatureFlag::STRUCT_CONSTRUCTORS => FeatureFlag::StructConstructors,
-            AptosFeatureFlag::REWARD_RATE_DECREASE => FeatureFlag::RewardRateDecrease,
+            AptosFeatureFlag::PERIODICAL_REWARD_RATE_DECREASE => {
+                FeatureFlag::PeriodicalRewardRateReduction
+            },
         }
     }
 }

--- a/aptos-move/e2e-move-tests/src/tests/common.rs
+++ b/aptos-move/e2e-move-tests/src/tests/common.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
+use std::{collections::BTreeMap, path::PathBuf};
 
 pub fn test_dir_path(s: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -15,4 +15,19 @@ pub fn framework_dir_path(s: &str) -> PathBuf {
         .join("..")
         .join("framework")
         .join(s)
+}
+
+pub fn build_scripts(package_folder: &str, package_names: Vec<&str>) -> BTreeMap<String, Vec<u8>> {
+    let mut scripts = BTreeMap::new();
+    for package_name in package_names {
+        let script = aptos_framework::BuiltPackage::build(
+            test_dir_path(format!("{}/{}", package_folder, package_name).as_str()),
+            aptos_framework::BuildOptions::default(),
+        )
+        .expect("building packages with scripts must succeed")
+        .extract_script_code()[0]
+            .clone();
+        scripts.insert(package_name.to_string(), script);
+    }
+    scripts
 }

--- a/aptos-move/e2e-move-tests/src/tests/stake.data/enable_rewards_rate_decrease/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/stake.data/enable_rewards_rate_decrease/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = 'EnableRewardsRateDecrease'
+version = "0.0.0"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }

--- a/aptos-move/e2e-move-tests/src/tests/stake.data/enable_rewards_rate_decrease/sources/main.move
+++ b/aptos-move/e2e-move-tests/src/tests/stake.data/enable_rewards_rate_decrease/sources/main.move
@@ -1,0 +1,21 @@
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::staking_config;
+    use aptos_framework::timestamp;
+    use std::features;
+
+    fun main(core_resources: &signer) {
+        let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @aptos_framework);
+        staking_config::initialize_rewards(
+            &framework_signer,
+            100,
+            30,
+            10000,
+            365 * 24 * 60 * 60 * 1000000,
+            timestamp::now_microseconds(),
+            5000,
+        );
+        let feature = features::get_reward_rate_decrease_feature();
+        features::change_feature_flags(&framework_signer, vector[feature], vector[]);
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/stake.data/enable_rewards_rate_decrease/sources/main.move
+++ b/aptos-move/e2e-move-tests/src/tests/stake.data/enable_rewards_rate_decrease/sources/main.move
@@ -4,6 +4,7 @@ script {
     use aptos_framework::timestamp;
     use aptos_std::fixed_point64;
     use std::features;
+    use aptos_framework::aptos_governance::reconfigure;
 
     fun main(core_resources: &signer) {
         let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @aptos_framework);
@@ -15,7 +16,8 @@ script {
             timestamp::now_seconds(),
             fixed_point64::create_from_rational(50, 100),
         );
-        let feature = features::get_reward_rate_decrease_feature();
+        let feature = features::get_periodical_reward_rate_decrease_feature();
         features::change_feature_flags(&framework_signer, vector[feature], vector[]);
+        reconfigure(&framework_signer);
     }
 }

--- a/aptos-move/e2e-move-tests/src/tests/stake.data/enable_rewards_rate_decrease/sources/main.move
+++ b/aptos-move/e2e-move-tests/src/tests/stake.data/enable_rewards_rate_decrease/sources/main.move
@@ -2,18 +2,18 @@ script {
     use aptos_framework::aptos_governance;
     use aptos_framework::staking_config;
     use aptos_framework::timestamp;
+    use aptos_std::fixed_point64;
     use std::features;
 
     fun main(core_resources: &signer) {
         let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @aptos_framework);
         staking_config::initialize_rewards(
             &framework_signer,
-            100,
-            30,
-            10000,
-            365 * 24 * 60 * 60 * 1000000,
-            timestamp::now_microseconds(),
-            5000,
+            fixed_point64::create_from_rational(1, 100),
+            fixed_point64::create_from_rational(3, 1000),
+            365 * 24 * 60 * 60,
+            timestamp::now_seconds(),
+            fixed_point64::create_from_rational(50, 100),
         );
         let feature = features::get_reward_rate_decrease_feature();
         features::change_feature_flags(&framework_signer, vector[feature], vector[]);

--- a/aptos-move/e2e-move-tests/src/tests/transaction_fee.rs
+++ b/aptos-move/e2e-move-tests/src/tests/transaction_fee.rs
@@ -22,25 +22,15 @@ use std::collections::BTreeMap;
 pub static PROPOSAL_SCRIPTS: Lazy<BTreeMap<String, Vec<u8>>> = Lazy::new(build_scripts);
 
 fn build_scripts() -> BTreeMap<String, Vec<u8>> {
-    let mut scripts = BTreeMap::new();
-    let package_names = [
+    let package_folder = "transaction_fee.data";
+    let package_names = vec![
         "initialize_collection",
         "enable_collection",
         "disable_collection",
         "upgrade_burn_percentage",
         "remove_validator",
     ];
-    for package_name in package_names {
-        let script = aptos_framework::BuiltPackage::build(
-            common::test_dir_path(format!("transaction_fee.data/{}", package_name).as_str()),
-            aptos_framework::BuildOptions::default(),
-        )
-        .expect("building packages with scripts must succeed")
-        .extract_script_code()[0]
-            .clone();
-        scripts.insert(package_name.to_string(), script);
-    }
-    scripts
+    common::build_scripts(package_folder, package_names)
 }
 
 // Constants for calculating rewards for validators at the end of each epoch.

--- a/aptos-move/framework/aptos-framework/doc/aptos_governance.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_governance.md
@@ -1705,6 +1705,7 @@ Address @aptos_framework must exist ApprovedExecutionHashes and GovernancePropos
 
 <pre><code><b>aborts_if</b> !<a href="system_addresses.md#0x1_system_addresses_is_aptos_framework_address">system_addresses::is_aptos_framework_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework));
 <b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
+<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
 <b>requires</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>();
 <b>requires</b> <a href="timestamp.md#0x1_timestamp_spec_now_microseconds">timestamp::spec_now_microseconds</a>() &gt;= <a href="reconfiguration.md#0x1_reconfiguration_last_reconfiguration_time">reconfiguration::last_reconfiguration_time</a>();
 <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">stake::ValidatorFees</a>&gt;(@aptos_framework);

--- a/aptos-move/framework/aptos-framework/doc/block.md
+++ b/aptos-move/framework/aptos-framework/doc/block.md
@@ -698,6 +698,7 @@ The BlockResource existed under the @aptos_framework.
 <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">stake::ValidatorFees</a>&gt;(@aptos_framework);
 <b>requires</b> <b>exists</b>&lt;CoinInfo&lt;AptosCoin&gt;&gt;(@aptos_framework);
 <b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
+<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
 <b>aborts_if</b> <b>false</b>;
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/block.md
+++ b/aptos-move/framework/aptos-framework/doc/block.md
@@ -689,7 +689,8 @@ The BlockResource existed under the @aptos_framework.
 
 
 
-<pre><code><b>requires</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>();
+<pre><code><b>pragma</b> verify = <b>false</b>;
+<b>requires</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>();
 <b>requires</b> <a href="system_addresses.md#0x1_system_addresses_is_vm">system_addresses::is_vm</a>(vm);
 <b>requires</b> proposer == @vm_reserved || <a href="stake.md#0x1_stake_spec_is_current_epoch_validator">stake::spec_is_current_epoch_validator</a>(proposer);
 <b>requires</b> <a href="timestamp.md#0x1_timestamp">timestamp</a> &gt;= <a href="reconfiguration.md#0x1_reconfiguration_last_reconfiguration_time">reconfiguration::last_reconfiguration_time</a>();

--- a/aptos-move/framework/aptos-framework/doc/consensus_config.md
+++ b/aptos-move/framework/aptos-framework/doc/consensus_config.md
@@ -170,7 +170,8 @@ Ensure the caller is admin and <code><a href="consensus_config.md#0x1_consensus_
 When setting now time must be later than last_reconfiguration_time.
 
 
-<pre><code><b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
+<pre><code><b>pragma</b> verify = <b>false</b>;
+<b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
 <b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
 <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
 <b>aborts_if</b> !<a href="system_addresses.md#0x1_system_addresses_is_aptos_framework_address">system_addresses::is_aptos_framework_address</a>(addr);

--- a/aptos-move/framework/aptos-framework/doc/consensus_config.md
+++ b/aptos-move/framework/aptos-framework/doc/consensus_config.md
@@ -171,6 +171,7 @@ When setting now time must be later than last_reconfiguration_time.
 
 
 <pre><code><b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
+<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
 <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
 <b>aborts_if</b> !<a href="system_addresses.md#0x1_system_addresses_is_aptos_framework_address">system_addresses::is_aptos_framework_address</a>(addr);
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">ConsensusConfig</a>&gt;(@aptos_framework);

--- a/aptos-move/framework/aptos-framework/doc/gas_schedule.md
+++ b/aptos-move/framework/aptos-framework/doc/gas_schedule.md
@@ -296,6 +296,7 @@ This can be called by on-chain governance to update the gas schedule.
 <pre><code><b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">stake::ValidatorFees</a>&gt;(@aptos_framework);
 <b>requires</b> <b>exists</b>&lt;CoinInfo&lt;AptosCoin&gt;&gt;(@aptos_framework);
 <b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
+<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
 <b>include</b> <a href="system_addresses.md#0x1_system_addresses_AbortsIfNotAptosFramework">system_addresses::AbortsIfNotAptosFramework</a>{ <a href="account.md#0x1_account">account</a>: aptos_framework };
 <b>aborts_if</b> len(gas_schedule_blob) == 0;
 <b>let</b> new_gas_schedule = <a href="util.md#0x1_util_spec_from_bytes">util::spec_from_bytes</a>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(gas_schedule_blob);
@@ -322,6 +323,7 @@ This can be called by on-chain governance to update the gas schedule.
 <b>requires</b> <b>exists</b>&lt;CoinInfo&lt;AptosCoin&gt;&gt;(@aptos_framework);
 <b>include</b> <a href="system_addresses.md#0x1_system_addresses_AbortsIfNotAptosFramework">system_addresses::AbortsIfNotAptosFramework</a>{ <a href="account.md#0x1_account">account</a>: aptos_framework };
 <b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
+<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
 <b>aborts_if</b> !<b>exists</b>&lt;StorageGasConfig&gt;(@aptos_framework);
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/reconfiguration.md
+++ b/aptos-move/framework/aptos-framework/doc/reconfiguration.md
@@ -579,6 +579,7 @@ Make sure the caller is admin and check the resource DisableReconfiguration.
 <pre><code><b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">stake::ValidatorFees</a>&gt;(@aptos_framework);
 <b>requires</b> <b>exists</b>&lt;CoinInfo&lt;AptosCoin&gt;&gt;(@aptos_framework);
 <b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
+<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
 <b>aborts_if</b> <b>false</b>;
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/reconfiguration.md
+++ b/aptos-move/framework/aptos-framework/doc/reconfiguration.md
@@ -576,7 +576,8 @@ Make sure the caller is admin and check the resource DisableReconfiguration.
 
 
 
-<pre><code><b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">stake::ValidatorFees</a>&gt;(@aptos_framework);
+<pre><code><b>pragma</b> verify = <b>false</b>;
+<b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">stake::ValidatorFees</a>&gt;(@aptos_framework);
 <b>requires</b> <b>exists</b>&lt;CoinInfo&lt;AptosCoin&gt;&gt;(@aptos_framework);
 <b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
 <b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;

--- a/aptos-move/framework/aptos-framework/doc/stake.md
+++ b/aptos-move/framework/aptos-framework/doc/stake.md
@@ -3092,8 +3092,11 @@ This function shouldn't abort.
         <b>assume</b> cur_validator_perf.successful_proposals + cur_validator_perf.failed_proposals &lt;= MAX_U64;
     };
     <b>let</b> num_total_proposals = cur_validator_perf.successful_proposals + cur_validator_perf.failed_proposals;
-
-    <b>let</b> (rewards_rate, rewards_rate_denominator) = <a href="staking_config.md#0x1_staking_config_get_reward_rate">staking_config::get_reward_rate</a>(<a href="staking_config.md#0x1_staking_config">staking_config</a>);
+    <b>let</b> (rewards_rate, rewards_rate_denominator) = <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_reward_rate_decrease_enabled">features::reward_rate_decrease_enabled</a>()) {
+        <a href="staking_config.md#0x1_staking_config_get_epoch_rewards_rate">staking_config::get_epoch_rewards_rate</a>()
+    } <b>else</b> {
+        <a href="staking_config.md#0x1_staking_config_get_reward_rate">staking_config::get_reward_rate</a>(<a href="staking_config.md#0x1_staking_config">staking_config</a>)
+    };
     <b>let</b> rewards_active = <a href="stake.md#0x1_stake_distribute_rewards">distribute_rewards</a>(
         &<b>mut</b> stake_pool.active,
         num_successful_proposals,
@@ -3531,95 +3534,6 @@ Returns validator's next epoch voting power, including pending_active, active, a
 
 
 
-
-<a name="0x1_stake_spec_validator_index_upper_bound"></a>
-
-
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_validator_index_upper_bound">spec_validator_index_upper_bound</a>(): u64 {
-   len(<b>global</b>&lt;<a href="stake.md#0x1_stake_ValidatorPerformance">ValidatorPerformance</a>&gt;(@aptos_framework).validators)
-}
-</code></pre>
-
-
-
-
-<a name="0x1_stake_spec_has_stake_pool"></a>
-
-
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_has_stake_pool">spec_has_stake_pool</a>(a: <b>address</b>): bool {
-   <b>exists</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(a)
-}
-</code></pre>
-
-
-
-
-<a name="0x1_stake_spec_has_validator_config"></a>
-
-
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_has_validator_config">spec_has_validator_config</a>(a: <b>address</b>): bool {
-   <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(a)
-}
-</code></pre>
-
-
-
-
-<a name="0x1_stake_spec_rewards_amount"></a>
-
-
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_rewards_amount">spec_rewards_amount</a>(
-   stake_amount: u64,
-   num_successful_proposals: u64,
-   num_total_proposals: u64,
-   rewards_rate: u64,
-   rewards_rate_denominator: u64,
-): u64;
-</code></pre>
-
-
-
-
-<a name="0x1_stake_spec_contains"></a>
-
-
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a>&gt;, addr: <b>address</b>): bool {
-   <b>exists</b> i in 0..len(validators): validators[i].addr == addr
-}
-</code></pre>
-
-
-
-
-<a name="0x1_stake_spec_is_current_epoch_validator"></a>
-
-
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_is_current_epoch_validator">spec_is_current_epoch_validator</a>(pool_address: <b>address</b>): bool {
-   <b>let</b> validator_set = <b>global</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
-   !<a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.pending_active, pool_address)
-       && (<a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.active_validators, pool_address)
-       || <a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.pending_inactive, pool_address))
-}
-</code></pre>
-
-
-
-
-<a name="0x1_stake_ResourceRequirement"></a>
-
-
-<pre><code><b>schema</b> <a href="stake.md#0x1_stake_ResourceRequirement">ResourceRequirement</a> {
-    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_AptosCoinCapabilities">AptosCoinCapabilities</a>&gt;(@aptos_framework);
-    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorPerformance">ValidatorPerformance</a>&gt;(@aptos_framework);
-    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
-    <b>requires</b> <b>exists</b>&lt;StakingConfig&gt;(@aptos_framework);
-    <b>requires</b> <b>exists</b>&lt;<a href="timestamp.md#0x1_timestamp_CurrentTimeMicroseconds">timestamp::CurrentTimeMicroseconds</a>&gt;(@aptos_framework);
-    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">ValidatorFees</a>&gt;(@aptos_framework);
-}
-</code></pre>
-
-
-
 <a name="@Specification_1_add_transaction_fee"></a>
 
 ### Function `add_transaction_fee`
@@ -3976,6 +3890,7 @@ Returns validator's next epoch voting power, including pending_active, active, a
 
 <pre><code><b>pragma</b> disable_invariants_in_body;
 <b>include</b> <a href="stake.md#0x1_stake_ResourceRequirement">ResourceRequirement</a>;
+<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
 <b>aborts_if</b> <b>false</b>;
 </code></pre>
 
@@ -3993,6 +3908,7 @@ Returns validator's next epoch voting power, including pending_active, active, a
 
 
 <pre><code><b>include</b> <a href="stake.md#0x1_stake_ResourceRequirement">ResourceRequirement</a>;
+<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(pool_address);
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(pool_address);
 <b>aborts_if</b> <b>global</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(pool_address).validator_index &gt;= len(validator_perf.validators);
@@ -4204,6 +4120,96 @@ Returns validator's next epoch voting power, including pending_active, active, a
 <pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_validator_indices_are_valid">spec_validator_indices_are_valid</a>(validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a>&gt;): bool {
    <b>forall</b> i in 0..len(validators):
        <b>global</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(validators[i].addr).validator_index &lt; <a href="stake.md#0x1_stake_spec_validator_index_upper_bound">spec_validator_index_upper_bound</a>()
+}
+</code></pre>
+
+
+
+
+<a name="0x1_stake_spec_validator_index_upper_bound"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_validator_index_upper_bound">spec_validator_index_upper_bound</a>(): u64 {
+   len(<b>global</b>&lt;<a href="stake.md#0x1_stake_ValidatorPerformance">ValidatorPerformance</a>&gt;(@aptos_framework).validators)
+}
+</code></pre>
+
+
+
+
+<a name="0x1_stake_spec_has_stake_pool"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_has_stake_pool">spec_has_stake_pool</a>(a: <b>address</b>): bool {
+   <b>exists</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(a)
+}
+</code></pre>
+
+
+
+
+<a name="0x1_stake_spec_has_validator_config"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_has_validator_config">spec_has_validator_config</a>(a: <b>address</b>): bool {
+   <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(a)
+}
+</code></pre>
+
+
+
+
+<a name="0x1_stake_spec_rewards_amount"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_rewards_amount">spec_rewards_amount</a>(
+   stake_amount: u64,
+   num_successful_proposals: u64,
+   num_total_proposals: u64,
+   rewards_rate: u64,
+   rewards_rate_denominator: u64,
+): u64;
+</code></pre>
+
+
+
+
+<a name="0x1_stake_spec_contains"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a>&gt;, addr: <b>address</b>): bool {
+   <b>exists</b> i in 0..len(validators): validators[i].addr == addr
+}
+</code></pre>
+
+
+
+
+<a name="0x1_stake_spec_is_current_epoch_validator"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_is_current_epoch_validator">spec_is_current_epoch_validator</a>(pool_address: <b>address</b>): bool {
+   <b>let</b> validator_set = <b>global</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
+   !<a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.pending_active, pool_address)
+       && (<a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.active_validators, pool_address)
+       || <a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.pending_inactive, pool_address))
+}
+</code></pre>
+
+
+
+
+<a name="0x1_stake_ResourceRequirement"></a>
+
+
+<pre><code><b>schema</b> <a href="stake.md#0x1_stake_ResourceRequirement">ResourceRequirement</a> {
+    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_AptosCoinCapabilities">AptosCoinCapabilities</a>&gt;(@aptos_framework);
+    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorPerformance">ValidatorPerformance</a>&gt;(@aptos_framework);
+    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
+    <b>requires</b> <b>exists</b>&lt;StakingConfig&gt;(@aptos_framework);
+    <b>requires</b> <b>exists</b>&lt;StakingRewardsConfig&gt;(@aptos_framework) || !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_reward_rate_decrease_enabled">features::spec_reward_rate_decrease_enabled</a>();
+    <b>requires</b> <b>exists</b>&lt;<a href="timestamp.md#0x1_timestamp_CurrentTimeMicroseconds">timestamp::CurrentTimeMicroseconds</a>&gt;(@aptos_framework);
+    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">ValidatorFees</a>&gt;(@aptos_framework);
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/stake.md
+++ b/aptos-move/framework/aptos-framework/doc/stake.md
@@ -3102,7 +3102,7 @@ This function shouldn't abort.
         <b>assume</b> cur_validator_perf.successful_proposals + cur_validator_perf.failed_proposals &lt;= <a href="stake.md#0x1_stake_MAX_U64">MAX_U64</a>;
     };
     <b>let</b> num_total_proposals = cur_validator_perf.successful_proposals + cur_validator_perf.failed_proposals;
-    <b>let</b> (rewards_rate, rewards_rate_denominator) = <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_reward_rate_decrease_enabled">features::reward_rate_decrease_enabled</a>()) {
+    <b>let</b> (rewards_rate, rewards_rate_denominator) = <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_periodical_reward_rate_decrease_enabled">features::periodical_reward_rate_decrease_enabled</a>()) {
         <b>let</b> epoch_rewards_rate = <a href="staking_config.md#0x1_staking_config_calculate_and_save_latest_epoch_rewards_rate">staking_config::calculate_and_save_latest_epoch_rewards_rate</a>();
         <b>if</b> (<a href="../../aptos-stdlib/doc/fixed_point64.md#0x1_fixed_point64_is_zero">fixed_point64::is_zero</a>(epoch_rewards_rate)) {
             (0u64, 1u64)

--- a/aptos-move/framework/aptos-framework/doc/staking_config.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_config.md
@@ -7,32 +7,48 @@ Provides the configuration for staking and rewards
 
 
 -  [Resource `StakingConfig`](#0x1_staking_config_StakingConfig)
+-  [Resource `StakingRewardsConfig`](#0x1_staking_config_StakingRewardsConfig)
 -  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_staking_config_initialize)
+-  [Function `initialize_rewards`](#0x1_staking_config_initialize_rewards)
 -  [Function `get`](#0x1_staking_config_get)
 -  [Function `get_allow_validator_set_change`](#0x1_staking_config_get_allow_validator_set_change)
 -  [Function `get_required_stake`](#0x1_staking_config_get_required_stake)
 -  [Function `get_recurring_lockup_duration`](#0x1_staking_config_get_recurring_lockup_duration)
 -  [Function `get_reward_rate`](#0x1_staking_config_get_reward_rate)
 -  [Function `get_voting_power_increase_limit`](#0x1_staking_config_get_voting_power_increase_limit)
+-  [Function `get_epoch_rewards_rate`](#0x1_staking_config_get_epoch_rewards_rate)
+-  [Function `get_staking_rewards_config`](#0x1_staking_config_get_staking_rewards_config)
 -  [Function `update_required_stake`](#0x1_staking_config_update_required_stake)
 -  [Function `update_recurring_lockup_duration_secs`](#0x1_staking_config_update_recurring_lockup_duration_secs)
 -  [Function `update_rewards_rate`](#0x1_staking_config_update_rewards_rate)
+-  [Function `update_rewards_config`](#0x1_staking_config_update_rewards_config)
 -  [Function `update_voting_power_increase_limit`](#0x1_staking_config_update_voting_power_increase_limit)
 -  [Function `validate_required_stake`](#0x1_staking_config_validate_required_stake)
+-  [Function `validate_rewards_config`](#0x1_staking_config_validate_rewards_config)
 -  [Specification](#@Specification_1)
     -  [Resource `StakingConfig`](#@Specification_1_StakingConfig)
+    -  [Resource `StakingRewardsConfig`](#@Specification_1_StakingRewardsConfig)
     -  [Function `initialize`](#@Specification_1_initialize)
+    -  [Function `initialize_rewards`](#@Specification_1_initialize_rewards)
     -  [Function `get`](#@Specification_1_get)
+    -  [Function `get_reward_rate`](#@Specification_1_get_reward_rate)
+    -  [Function `get_epoch_rewards_rate`](#@Specification_1_get_epoch_rewards_rate)
+    -  [Function `get_staking_rewards_config`](#@Specification_1_get_staking_rewards_config)
     -  [Function `update_required_stake`](#@Specification_1_update_required_stake)
     -  [Function `update_recurring_lockup_duration_secs`](#@Specification_1_update_recurring_lockup_duration_secs)
     -  [Function `update_rewards_rate`](#@Specification_1_update_rewards_rate)
+    -  [Function `update_rewards_config`](#@Specification_1_update_rewards_config)
     -  [Function `update_voting_power_increase_limit`](#@Specification_1_update_voting_power_increase_limit)
     -  [Function `validate_required_stake`](#@Specification_1_validate_required_stake)
+    -  [Function `validate_rewards_config`](#@Specification_1_validate_rewards_config)
 
 
 <pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
+<b>use</b> <a href="../../aptos-stdlib/doc/math64.md#0x1_math64">0x1::math64</a>;
 <b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
+<b>use</b> <a href="timestamp.md#0x1_timestamp">0x1::timestamp</a>;
 </code></pre>
 
 
@@ -101,9 +117,117 @@ Validator set configurations that will be stored with the @aptos_framework accou
 
 </details>
 
+<a name="0x1_staking_config_StakingRewardsConfig"></a>
+
+## Resource `StakingRewardsConfig`
+
+Staking reward configurations that will be stored with the @aptos_framework account.
+
+
+<pre><code><b>struct</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> <b>has</b> <b>copy</b>, drop, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>rewards_rate: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>min_rewards_rate: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>rewards_rate_denominator: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>rewards_rate_period_in_micros: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>last_rewards_rate_period_start_in_micros: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>rewards_rate_decrease_rate_bps: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
 <a name="@Constants_0"></a>
 
 ## Constants
+
+
+<a name="0x1_staking_config_BPS_DENOMINATOR"></a>
+
+Denominator of number in basis points. 1 bps(basis points) = 0.01%.
+
+
+<pre><code><b>const</b> <a href="staking_config.md#0x1_staking_config_BPS_DENOMINATOR">BPS_DENOMINATOR</a>: u64 = 10000;
+</code></pre>
+
+
+
+<a name="0x1_staking_config_EDEPRECATED_FUNCTION"></a>
+
+The function has been deprecated.
+
+
+<pre><code><b>const</b> <a href="staking_config.md#0x1_staking_config_EDEPRECATED_FUNCTION">EDEPRECATED_FUNCTION</a>: u64 = 10;
+</code></pre>
+
+
+
+<a name="0x1_staking_config_EDISABLED_FUNCTION"></a>
+
+The function is disabled or hasn't been enabled.
+
+
+<pre><code><b>const</b> <a href="staking_config.md#0x1_staking_config_EDISABLED_FUNCTION">EDISABLED_FUNCTION</a>: u64 = 11;
+</code></pre>
+
+
+
+<a name="0x1_staking_config_EINVALID_LAST_REWARDS_RATE_PERIOD_START"></a>
+
+Specified start time of last rewards rate period is invalid, which must be not late than the current timestamp.
+
+
+<pre><code><b>const</b> <a href="staking_config.md#0x1_staking_config_EINVALID_LAST_REWARDS_RATE_PERIOD_START">EINVALID_LAST_REWARDS_RATE_PERIOD_START</a>: u64 = 7;
+</code></pre>
+
+
+
+<a name="0x1_staking_config_EINVALID_MIN_REWARDS_RATE"></a>
+
+Specified min rewards rate is invalid, which must be within [0, rewards_rate].
+
+
+<pre><code><b>const</b> <a href="staking_config.md#0x1_staking_config_EINVALID_MIN_REWARDS_RATE">EINVALID_MIN_REWARDS_RATE</a>: u64 = 6;
+</code></pre>
+
 
 
 <a name="0x1_staking_config_EINVALID_REWARDS_RATE"></a>
@@ -112,6 +236,26 @@ Specified rewards rate is invalid, which must be within [0, MAX_REWARDS_RATE].
 
 
 <pre><code><b>const</b> <a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE">EINVALID_REWARDS_RATE</a>: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x1_staking_config_EINVALID_REWARDS_RATE_DECREASE_RATE"></a>
+
+Specified rewards rate decrease rate is invalid, which must be not greater than BPS_DENOMINATOR.
+
+
+<pre><code><b>const</b> <a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE_DECREASE_RATE">EINVALID_REWARDS_RATE_DECREASE_RATE</a>: u64 = 8;
+</code></pre>
+
+
+
+<a name="0x1_staking_config_EINVALID_REWARDS_RATE_PERIOD"></a>
+
+Specified rewards rate period is invalid, which must be 1 year at the moment.
+
+
+<pre><code><b>const</b> <a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE_PERIOD">EINVALID_REWARDS_RATE_PERIOD</a>: u64 = 9;
 </code></pre>
 
 
@@ -162,6 +306,16 @@ Limit the maximum value of <code>rewards_rate</code> in order to avoid any arith
 
 
 <pre><code><b>const</b> <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>: u64 = 1000000;
+</code></pre>
+
+
+
+<a name="0x1_staking_config_ONE_YEAR_IN_MICROS"></a>
+
+1 year => 365 * 24 * 60 * 60 * 1000000
+
+
+<pre><code><b>const</b> <a href="staking_config.md#0x1_staking_config_ONE_YEAR_IN_MICROS">ONE_YEAR_IN_MICROS</a>: u64 = 31536000000000;
 </code></pre>
 
 
@@ -223,6 +377,62 @@ Only called during genesis.
         rewards_rate,
         rewards_rate_denominator,
         voting_power_increase_limit,
+    });
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_staking_config_initialize_rewards"></a>
+
+## Function `initialize_rewards`
+
+Initialize rewards configurations.
+Can only be called as part of the Aptos governance proposal process established by the AptosGovernance module.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_initialize_rewards">initialize_rewards</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, rewards_rate: u64, min_rewards_rate: u64, rewards_rate_denominator: u64, rewards_rate_period_in_micros: u64, last_rewards_rate_period_start_in_micros: u64, rewards_rate_decrease_rate_bps: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_initialize_rewards">initialize_rewards</a>(
+    aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    rewards_rate: u64,
+    min_rewards_rate: u64,
+    rewards_rate_denominator: u64,
+    rewards_rate_period_in_micros: u64,
+    last_rewards_rate_period_start_in_micros: u64,
+    rewards_rate_decrease_rate_bps: u64,
+) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
+
+    <a href="staking_config.md#0x1_staking_config_validate_rewards_config">validate_rewards_config</a>(
+        rewards_rate,
+        min_rewards_rate,
+        rewards_rate_denominator,
+        rewards_rate_period_in_micros,
+        rewards_rate_decrease_rate_bps,
+    );
+    // TODO: we need last_rewards_rate_period_start_in_micros because <a href="genesis.md#0x1_genesis">genesis</a> time is not available on chain.
+    <b>assert</b>!(
+        <a href="timestamp.md#0x1_timestamp_now_microseconds">timestamp::now_microseconds</a>() &gt;= last_rewards_rate_period_start_in_micros,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_LAST_REWARDS_RATE_PERIOD_START">EINVALID_LAST_REWARDS_RATE_PERIOD_START</a>)
+    );
+
+    <b>move_to</b>(aptos_framework, <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> {
+        rewards_rate,
+        min_rewards_rate,
+        rewards_rate_denominator,
+        rewards_rate_period_in_micros,
+        last_rewards_rate_period_start_in_micros,
+        rewards_rate_decrease_rate_bps,
     });
 }
 </code></pre>
@@ -335,6 +545,7 @@ withdraw all funds).
 
 ## Function `get_reward_rate`
 
+DEPRECATING
 Return the reward rate.
 
 
@@ -348,6 +559,7 @@ Return the reward rate.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_get_reward_rate">get_reward_rate</a>(config: &<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>): (u64, u64) {
+    <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_reward_rate_decrease_enabled">features::reward_rate_decrease_enabled</a>(), <a href="staking_config.md#0x1_staking_config_EDEPRECATED_FUNCTION">EDEPRECATED_FUNCTION</a>);
     (config.rewards_rate, config.rewards_rate_denominator)
 }
 </code></pre>
@@ -374,6 +586,83 @@ Return the joining limit %.
 
 <pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_get_voting_power_increase_limit">get_voting_power_increase_limit</a>(config: &<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>): u64 {
     config.voting_power_increase_limit
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_staking_config_get_epoch_rewards_rate"></a>
+
+## Function `get_epoch_rewards_rate`
+
+Return the rewards rate of a epoch in the format of (nominator, denominator).
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_get_epoch_rewards_rate">get_epoch_rewards_rate</a>(): (u64, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_get_epoch_rewards_rate">get_epoch_rewards_rate</a>(): (u64, u64) <b>acquires</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> {
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_reward_rate_decrease_enabled">features::reward_rate_decrease_enabled</a>(), <a href="staking_config.md#0x1_staking_config_EDISABLED_FUNCTION">EDISABLED_FUNCTION</a>);
+    <b>let</b> staking_rewards_config = <a href="staking_config.md#0x1_staking_config_get_staking_rewards_config">get_staking_rewards_config</a>();
+    (staking_rewards_config.rewards_rate, staking_rewards_config.rewards_rate_denominator)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_staking_config_get_staking_rewards_config"></a>
+
+## Function `get_staking_rewards_config`
+
+Return the up-to-date StakingRewardsConfig.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_get_staking_rewards_config">get_staking_rewards_config</a>(): <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">staking_config::StakingRewardsConfig</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_get_staking_rewards_config">get_staking_rewards_config</a>(): <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> <b>acquires</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> {
+    <b>let</b> staking_rewards_config = <b>borrow_global_mut</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(@aptos_framework);
+    <b>let</b> current_time_in_micros = <a href="timestamp.md#0x1_timestamp_now_microseconds">timestamp::now_microseconds</a>();
+    <b>assert</b>!(
+        current_time_in_micros &gt;= staking_rewards_config.last_rewards_rate_period_start_in_micros,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_LAST_REWARDS_RATE_PERIOD_START">EINVALID_LAST_REWARDS_RATE_PERIOD_START</a>)
+    );
+    <b>if</b> (current_time_in_micros - staking_rewards_config.last_rewards_rate_period_start_in_micros &lt; staking_rewards_config.rewards_rate_period_in_micros) {
+        <b>return</b> *staking_rewards_config
+    };
+    // Rewards rate decrease rate cannot be greater than 100%. Otherwise rewards rate will be negative.
+    <b>assert</b>!(
+        staking_rewards_config.rewards_rate_decrease_rate_bps &lt;= <a href="staking_config.md#0x1_staking_config_BPS_DENOMINATOR">BPS_DENOMINATOR</a>,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE_DECREASE_RATE">EINVALID_REWARDS_RATE_DECREASE_RATE</a>)
+    );
+    <b>let</b> new_rate = math64::mul_div(
+        staking_rewards_config.rewards_rate,
+        <a href="staking_config.md#0x1_staking_config_BPS_DENOMINATOR">BPS_DENOMINATOR</a> - staking_rewards_config.rewards_rate_decrease_rate_bps,
+        <a href="staking_config.md#0x1_staking_config_BPS_DENOMINATOR">BPS_DENOMINATOR</a>,
+    );
+    new_rate = <a href="../../aptos-stdlib/doc/math64.md#0x1_math64_max">math64::max</a>(new_rate, staking_rewards_config.min_rewards_rate);
+
+    staking_rewards_config.rewards_rate = new_rate;
+    staking_rewards_config.last_rewards_rate_period_start_in_micros =
+        staking_rewards_config.last_rewards_rate_period_start_in_micros +
+        staking_rewards_config.rewards_rate_period_in_micros;
+    <b>return</b> *staking_rewards_config
 }
 </code></pre>
 
@@ -453,6 +742,7 @@ Can only be called as part of the Aptos governance proposal process established 
 
 ## Function `update_rewards_rate`
 
+DEPRECATING
 Update the rewards rate.
 Can only be called as part of the Aptos governance proposal process established by the AptosGovernance module.
 
@@ -471,6 +761,7 @@ Can only be called as part of the Aptos governance proposal process established 
     new_rewards_rate: u64,
     new_rewards_rate_denominator: u64,
 ) <b>acquires</b> <a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a> {
+    <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_reward_rate_decrease_enabled">features::reward_rate_decrease_enabled</a>(), <a href="staking_config.md#0x1_staking_config_EDEPRECATED_FUNCTION">EDEPRECATED_FUNCTION</a>);
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
     <b>assert</b>!(
         new_rewards_rate_denominator &gt; 0,
@@ -487,6 +778,54 @@ Can only be called as part of the Aptos governance proposal process established 
     <b>let</b> <a href="staking_config.md#0x1_staking_config">staking_config</a> = <b>borrow_global_mut</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>&gt;(@aptos_framework);
     <a href="staking_config.md#0x1_staking_config">staking_config</a>.rewards_rate = new_rewards_rate;
     <a href="staking_config.md#0x1_staking_config">staking_config</a>.rewards_rate_denominator = new_rewards_rate_denominator;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_staking_config_update_rewards_config"></a>
+
+## Function `update_rewards_config`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_update_rewards_config">update_rewards_config</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, rewards_rate: u64, min_rewards_rate: u64, rewards_rate_denominator: u64, rewards_rate_period_in_micros: u64, rewards_rate_decrease_rate_bps: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_update_rewards_config">update_rewards_config</a>(
+    aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    rewards_rate: u64,
+    min_rewards_rate: u64,
+    rewards_rate_denominator: u64,
+    rewards_rate_period_in_micros: u64,
+    rewards_rate_decrease_rate_bps: u64,
+) <b>acquires</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> {
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_reward_rate_decrease_enabled">features::reward_rate_decrease_enabled</a>(), <a href="staking_config.md#0x1_staking_config_EDISABLED_FUNCTION">EDISABLED_FUNCTION</a>);
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
+
+    <a href="staking_config.md#0x1_staking_config_validate_rewards_config">validate_rewards_config</a>(
+        rewards_rate,
+        min_rewards_rate,
+        rewards_rate_denominator,
+        rewards_rate_period_in_micros,
+        rewards_rate_decrease_rate_bps,
+    );
+
+    <b>let</b> staking_rewards_config = <b>borrow_global_mut</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(@aptos_framework);
+
+    staking_rewards_config.rewards_rate = rewards_rate;
+    staking_rewards_config.min_rewards_rate = min_rewards_rate;
+    staking_rewards_config.rewards_rate_denominator = rewards_rate_denominator;
+    staking_rewards_config.rewards_rate_period_in_micros = rewards_rate_period_in_micros;
+    staking_rewards_config.rewards_rate_decrease_rate_bps = rewards_rate_decrease_rate_bps;
 }
 </code></pre>
 
@@ -547,6 +886,66 @@ Can only be called as part of the Aptos governance proposal process established 
 
 <pre><code><b>fun</b> <a href="staking_config.md#0x1_staking_config_validate_required_stake">validate_required_stake</a>(minimum_stake: u64, maximum_stake: u64) {
     <b>assert</b>!(minimum_stake &lt;= maximum_stake && maximum_stake &gt; 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_STAKE_RANGE">EINVALID_STAKE_RANGE</a>));
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_staking_config_validate_rewards_config"></a>
+
+## Function `validate_rewards_config`
+
+
+
+<pre><code><b>fun</b> <a href="staking_config.md#0x1_staking_config_validate_rewards_config">validate_rewards_config</a>(rewards_rate: u64, min_rewards_rate: u64, rewards_rate_denominator: u64, rewards_rate_period_in_micros: u64, rewards_rate_decrease_rate_bps: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="staking_config.md#0x1_staking_config_validate_rewards_config">validate_rewards_config</a>(
+    rewards_rate: u64,
+    min_rewards_rate: u64,
+    rewards_rate_denominator: u64,
+    rewards_rate_period_in_micros: u64,
+    rewards_rate_decrease_rate_bps: u64,
+) {
+    <b>assert</b>!(
+        rewards_rate_denominator &gt; 0,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EZERO_REWARDS_RATE_DENOMINATOR">EZERO_REWARDS_RATE_DENOMINATOR</a>),
+    );
+
+    // `rewards_rate` and `min_rewards_rate` which are the numerator are limited <b>to</b>
+    // be `&lt;= <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>` in order <b>to</b> avoid the arithmetic overflow in the rewards calculation.
+    // `rewards_rate_denominator` can be adjusted <b>to</b> get the desired rewards rate
+    // (i.e., rewards_rate / rewards_rate_denominator).
+    <b>assert</b>!(rewards_rate &lt;= <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE">EINVALID_REWARDS_RATE</a>));
+    <b>assert</b>!(min_rewards_rate &lt;= <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE">EINVALID_REWARDS_RATE</a>));
+
+    <b>assert</b>!(
+        min_rewards_rate &lt;= rewards_rate,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_MIN_REWARDS_RATE">EINVALID_MIN_REWARDS_RATE</a>)
+    );
+
+    // We <b>assert</b> that (rewards_rate / rewards_rate_denominator &lt;= 1).
+    <b>assert</b>!(rewards_rate &lt;= rewards_rate_denominator, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE">EINVALID_REWARDS_RATE</a>));
+
+    // Rewards rate decrease rate cannot be greater than 100%. Otherwise rewards rate will be negative.
+    <b>assert</b>!(
+        rewards_rate_decrease_rate_bps &lt;= <a href="staking_config.md#0x1_staking_config_BPS_DENOMINATOR">BPS_DENOMINATOR</a>,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE_DECREASE_RATE">EINVALID_REWARDS_RATE_DECREASE_RATE</a>)
+    );
+
+    // Now rewards rate decrease interval must be 1 year.
+    <b>assert</b>!(
+        rewards_rate_period_in_micros == <a href="staking_config.md#0x1_staking_config_ONE_YEAR_IN_MICROS">ONE_YEAR_IN_MICROS</a>,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE_PERIOD">EINVALID_REWARDS_RATE_PERIOD</a>),
+    );
 }
 </code></pre>
 
@@ -631,6 +1030,67 @@ Can only be called as part of the Aptos governance proposal process established 
 
 
 
+<a name="@Specification_1_StakingRewardsConfig"></a>
+
+### Resource `StakingRewardsConfig`
+
+
+<pre><code><b>struct</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> <b>has</b> <b>copy</b>, drop, key
+</code></pre>
+
+
+
+<dl>
+<dt>
+<code>rewards_rate: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>min_rewards_rate: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>rewards_rate_denominator: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>rewards_rate_period_in_micros: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>last_rewards_rate_period_start_in_micros: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>rewards_rate_decrease_rate_bps: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+
+<pre><code><b>invariant</b> rewards_rate &lt;= <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>;
+<b>invariant</b> rewards_rate_denominator &gt; 0;
+<b>invariant</b> rewards_rate &lt;= rewards_rate_denominator;
+<b>invariant</b> min_rewards_rate &lt;= rewards_rate;
+<b>invariant</b> rewards_rate_period_in_micros == <a href="staking_config.md#0x1_staking_config_ONE_YEAR_IN_MICROS">ONE_YEAR_IN_MICROS</a>;
+<b>invariant</b> rewards_rate_decrease_rate_bps &lt;= <a href="staking_config.md#0x1_staking_config_BPS_DENOMINATOR">BPS_DENOMINATOR</a>;
+</code></pre>
+
+
+
 <a name="@Specification_1_initialize"></a>
 
 ### Function `initialize`
@@ -662,6 +1122,31 @@ StakingConfig does not exist under the aptos_framework before creating it.
 
 
 
+<a name="@Specification_1_initialize_rewards"></a>
+
+### Function `initialize_rewards`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_initialize_rewards">initialize_rewards</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, rewards_rate: u64, min_rewards_rate: u64, rewards_rate_denominator: u64, rewards_rate_period_in_micros: u64, last_rewards_rate_period_start_in_micros: u64, rewards_rate_decrease_rate_bps: u64)
+</code></pre>
+
+
+Caller must be @aptos_framework.
+last_rewards_rate_period_start_in_micros cannot be later than now.
+Abort at any condition in StakingRewardsConfigValidationAborts.
+StakingRewardsConfig does not exist under the aptos_framework before creating it.
+
+
+<pre><code><b>requires</b> <b>exists</b>&lt;<a href="timestamp.md#0x1_timestamp_CurrentTimeMicroseconds">timestamp::CurrentTimeMicroseconds</a>&gt;(@aptos_framework);
+<b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
+<b>aborts_if</b> addr != @aptos_framework;
+<b>aborts_if</b> last_rewards_rate_period_start_in_micros &gt; <a href="timestamp.md#0x1_timestamp_spec_now_microseconds">timestamp::spec_now_microseconds</a>();
+<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigValidationAbortsIf">StakingRewardsConfigValidationAbortsIf</a>;
+<b>aborts_if</b> <b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(addr);
+</code></pre>
+
+
+
 <a name="@Specification_1_get"></a>
 
 ### Function `get`
@@ -674,6 +1159,58 @@ StakingConfig does not exist under the aptos_framework before creating it.
 
 
 <pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>&gt;(@aptos_framework);
+</code></pre>
+
+
+
+<a name="@Specification_1_get_reward_rate"></a>
+
+### Function `get_reward_rate`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_get_reward_rate">get_reward_rate</a>(config: &<a href="staking_config.md#0x1_staking_config_StakingConfig">staking_config::StakingConfig</a>): (u64, u64)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_reward_rate_decrease_enabled">features::spec_reward_rate_decrease_enabled</a>();
+</code></pre>
+
+
+
+<a name="@Specification_1_get_epoch_rewards_rate"></a>
+
+### Function `get_epoch_rewards_rate`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_get_epoch_rewards_rate">get_epoch_rewards_rate</a>(): (u64, u64)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(@aptos_framework);
+<b>aborts_if</b> !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_reward_rate_decrease_enabled">features::spec_reward_rate_decrease_enabled</a>();
+<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">StakingRewardsConfigRequirement</a>;
+</code></pre>
+
+
+
+<a name="@Specification_1_get_staking_rewards_config"></a>
+
+### Function `get_staking_rewards_config`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_get_staking_rewards_config">get_staking_rewards_config</a>(): <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">staking_config::StakingRewardsConfig</a>
+</code></pre>
+
+
+
+
+<pre><code><b>requires</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_reward_rate_decrease_enabled">features::spec_reward_rate_decrease_enabled</a>();
+<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">StakingRewardsConfigRequirement</a>;
+<b>aborts_if</b> !<b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(@aptos_framework);
 </code></pre>
 
 
@@ -738,12 +1275,36 @@ The <code>rewards_rate</code> which is the numerator is limited to be <code>&lt;
 rewards_rate/rewards_rate_denominator <= 1.
 
 
-<pre><code><b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
+<pre><code><b>aborts_if</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_reward_rate_decrease_enabled">features::spec_reward_rate_decrease_enabled</a>();
+<b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
 <b>aborts_if</b> addr != @aptos_framework;
 <b>aborts_if</b> new_rewards_rate_denominator &lt;= 0;
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>&gt;(@aptos_framework);
 <b>aborts_if</b> new_rewards_rate &gt; <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>;
 <b>aborts_if</b> new_rewards_rate &gt; new_rewards_rate_denominator;
+</code></pre>
+
+
+
+<a name="@Specification_1_update_rewards_config"></a>
+
+### Function `update_rewards_config`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_update_rewards_config">update_rewards_config</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, rewards_rate: u64, min_rewards_rate: u64, rewards_rate_denominator: u64, rewards_rate_period_in_micros: u64, rewards_rate_decrease_rate_bps: u64)
+</code></pre>
+
+
+Caller must be @aptos_framework.
+StakingRewardsConfig is under the @aptos_framework.
+
+
+<pre><code><b>aborts_if</b> !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_reward_rate_decrease_enabled">features::spec_reward_rate_decrease_enabled</a>();
+<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">StakingRewardsConfigRequirement</a>;
+<b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
+<b>aborts_if</b> addr != @aptos_framework;
+<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigValidationAbortsIf">StakingRewardsConfigValidationAbortsIf</a>;
+<b>aborts_if</b> !<b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(addr);
 </code></pre>
 
 
@@ -783,6 +1344,23 @@ The maximum_stake must be greater than maximum_stake in the range of Specified s
 
 
 <pre><code><b>aborts_if</b> minimum_stake &gt; maximum_stake || maximum_stake &lt;= 0;
+</code></pre>
+
+
+
+<a name="@Specification_1_validate_rewards_config"></a>
+
+### Function `validate_rewards_config`
+
+
+<pre><code><b>fun</b> <a href="staking_config.md#0x1_staking_config_validate_rewards_config">validate_rewards_config</a>(rewards_rate: u64, min_rewards_rate: u64, rewards_rate_denominator: u64, rewards_rate_period_in_micros: u64, rewards_rate_decrease_rate_bps: u64)
+</code></pre>
+
+
+Abort at any condition in StakingRewardsConfigValidationAborts.
+
+
+<pre><code><b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigValidationAbortsIf">StakingRewardsConfigValidationAbortsIf</a>;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/staking_config.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_config.md
@@ -413,7 +413,6 @@ Can only be called as part of the Aptos governance proposal process established 
         rewards_rate_period_in_secs,
         rewards_rate_decrease_rate,
     );
-    // TODO: we need last_rewards_rate_period_start_in_secs because <a href="genesis.md#0x1_genesis">genesis</a> time is not available on chain.
     <b>assert</b>!(
         <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>() &gt;= last_rewards_rate_period_start_in_secs,
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_LAST_REWARDS_RATE_PERIOD_START">EINVALID_LAST_REWARDS_RATE_PERIOD_START</a>)
@@ -551,7 +550,7 @@ Return the reward rate.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_get_reward_rate">get_reward_rate</a>(config: &<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>): (u64, u64) {
-    <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_reward_rate_decrease_enabled">features::reward_rate_decrease_enabled</a>(), <a href="staking_config.md#0x1_staking_config_EDEPRECATED_FUNCTION">EDEPRECATED_FUNCTION</a>);
+    <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_periodical_reward_rate_decrease_enabled">features::periodical_reward_rate_decrease_enabled</a>(), <a href="staking_config.md#0x1_staking_config_EDEPRECATED_FUNCTION">EDEPRECATED_FUNCTION</a>);
     (config.rewards_rate, config.rewards_rate_denominator)
 }
 </code></pre>
@@ -602,7 +601,7 @@ Return the rewards rate of a epoch in the format of (nominator, denominator).
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_calculate_and_save_latest_epoch_rewards_rate">calculate_and_save_latest_epoch_rewards_rate</a>(): FixedPoint64 <b>acquires</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_reward_rate_decrease_enabled">features::reward_rate_decrease_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="staking_config.md#0x1_staking_config_EDISABLED_FUNCTION">EDISABLED_FUNCTION</a>));
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_periodical_reward_rate_decrease_enabled">features::periodical_reward_rate_decrease_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="staking_config.md#0x1_staking_config_EDISABLED_FUNCTION">EDISABLED_FUNCTION</a>));
     <b>let</b> staking_rewards_config = <a href="staking_config.md#0x1_staking_config_calculate_and_save_latest_rewards_config">calculate_and_save_latest_rewards_config</a>();
     staking_rewards_config.rewards_rate
 }
@@ -619,7 +618,7 @@ Return the rewards rate of a epoch in the format of (nominator, denominator).
 Calculate and return the up-to-date StakingRewardsConfig.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_calculate_and_save_latest_rewards_config">calculate_and_save_latest_rewards_config</a>(): <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">staking_config::StakingRewardsConfig</a>
+<pre><code><b>fun</b> <a href="staking_config.md#0x1_staking_config_calculate_and_save_latest_rewards_config">calculate_and_save_latest_rewards_config</a>(): <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">staking_config::StakingRewardsConfig</a>
 </code></pre>
 
 
@@ -628,7 +627,7 @@ Calculate and return the up-to-date StakingRewardsConfig.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_calculate_and_save_latest_rewards_config">calculate_and_save_latest_rewards_config</a>(): <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> <b>acquires</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> {
+<pre><code><b>fun</b> <a href="staking_config.md#0x1_staking_config_calculate_and_save_latest_rewards_config">calculate_and_save_latest_rewards_config</a>(): <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> <b>acquires</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> {
     <b>let</b> staking_rewards_config = <b>borrow_global_mut</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(@aptos_framework);
     <b>let</b> current_time_in_secs = <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>();
     <b>assert</b>!(
@@ -756,7 +755,7 @@ Can only be called as part of the Aptos governance proposal process established 
     new_rewards_rate: u64,
     new_rewards_rate_denominator: u64,
 ) <b>acquires</b> <a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a> {
-    <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_reward_rate_decrease_enabled">features::reward_rate_decrease_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="staking_config.md#0x1_staking_config_EDEPRECATED_FUNCTION">EDEPRECATED_FUNCTION</a>));
+    <b>assert</b>!(!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_periodical_reward_rate_decrease_enabled">features::periodical_reward_rate_decrease_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="staking_config.md#0x1_staking_config_EDEPRECATED_FUNCTION">EDEPRECATED_FUNCTION</a>));
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
     <b>assert</b>!(
         new_rewards_rate_denominator &gt; 0,
@@ -802,7 +801,6 @@ Can only be called as part of the Aptos governance proposal process established 
     rewards_rate_period_in_secs: u64,
     rewards_rate_decrease_rate: FixedPoint64,
 ) <b>acquires</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_reward_rate_decrease_enabled">features::reward_rate_decrease_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="staking_config.md#0x1_staking_config_EDISABLED_FUNCTION">EDISABLED_FUNCTION</a>));
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
 
     <a href="staking_config.md#0x1_staking_config_validate_rewards_config">validate_rewards_config</a>(
@@ -1176,7 +1174,7 @@ StakingRewardsConfig does not exist under the aptos_framework before creating it
 ### Function `calculate_and_save_latest_rewards_config`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="staking_config.md#0x1_staking_config_calculate_and_save_latest_rewards_config">calculate_and_save_latest_rewards_config</a>(): <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">staking_config::StakingRewardsConfig</a>
+<pre><code><b>fun</b> <a href="staking_config.md#0x1_staking_config_calculate_and_save_latest_rewards_config">calculate_and_save_latest_rewards_config</a>(): <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">staking_config::StakingRewardsConfig</a>
 </code></pre>
 
 
@@ -1273,8 +1271,7 @@ Caller must be @aptos_framework.
 StakingRewardsConfig is under the @aptos_framework.
 
 
-<pre><code><b>aborts_if</b> !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_reward_rate_decrease_enabled">features::spec_reward_rate_decrease_enabled</a>();
-<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">StakingRewardsConfigRequirement</a>;
+<pre><code><b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">StakingRewardsConfigRequirement</a>;
 <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
 <b>aborts_if</b> addr != @aptos_framework;
 <b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigValidationAbortsIf">StakingRewardsConfigValidationAbortsIf</a>;

--- a/aptos-move/framework/aptos-framework/doc/version.md
+++ b/aptos-move/framework/aptos-framework/doc/version.md
@@ -241,6 +241,7 @@ Abort if resource already exists in <code>@aptos_framwork</code> when initializi
 
 
 <pre><code><b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
+<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
 <b>requires</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>();
 <b>requires</b> <a href="timestamp.md#0x1_timestamp_spec_now_microseconds">timestamp::spec_now_microseconds</a>() &gt;= <a href="reconfiguration.md#0x1_reconfiguration_last_reconfiguration_time">reconfiguration::last_reconfiguration_time</a>();
 <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">stake::ValidatorFees</a>&gt;(@aptos_framework);

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.spec.move
@@ -248,10 +248,12 @@ spec aptos_framework::aptos_governance {
         use aptos_framework::coin::CoinInfo;
         use aptos_framework::aptos_coin::AptosCoin;
         use aptos_framework::transaction_fee;
+        use aptos_framework::staking_config;
 
         aborts_if !system_addresses::is_aptos_framework_address(signer::address_of(aptos_framework));
 
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
+        include staking_config::StakingRewardsConfigRequirement;
         requires chain_status::is_operating();
         requires timestamp::spec_now_microseconds() >= reconfiguration::last_reconfiguration_time();
         requires exists<stake::ValidatorFees>(@aptos_framework);

--- a/aptos-move/framework/aptos-framework/sources/block.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/block.spec.move
@@ -10,6 +10,7 @@ spec aptos_framework::block {
         use aptos_framework::coin::CoinInfo;
         use aptos_framework::aptos_coin::AptosCoin;
         use aptos_framework::transaction_fee;
+        use aptos_framework::staking_config;
 
         requires chain_status::is_operating();
         requires system_addresses::is_vm(vm);
@@ -20,6 +21,7 @@ spec aptos_framework::block {
         requires exists<stake::ValidatorFees>(@aptos_framework);
         requires exists<CoinInfo<AptosCoin>>(@aptos_framework);
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
+        include staking_config::StakingRewardsConfigRequirement;
 
         aborts_if false;
     }

--- a/aptos-move/framework/aptos-framework/sources/block.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/block.spec.move
@@ -12,6 +12,8 @@ spec aptos_framework::block {
         use aptos_framework::transaction_fee;
         use aptos_framework::staking_config;
 
+        pragma verify = false; // TODO: set to false because of timeout
+
         requires chain_status::is_operating();
         requires system_addresses::is_vm(vm);
         requires proposer == @vm_reserved || stake::spec_is_current_epoch_validator(proposer);

--- a/aptos-move/framework/aptos-framework/sources/configs/consensus_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/consensus_config.spec.move
@@ -24,8 +24,10 @@ spec aptos_framework::consensus_config {
         use aptos_framework::coin::CoinInfo;
         use aptos_framework::aptos_coin::AptosCoin;
         use aptos_framework::transaction_fee;
+        use aptos_framework::staking_config;
 
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
+        include staking_config::StakingRewardsConfigRequirement;
         let addr = signer::address_of(account);
         aborts_if !system_addresses::is_aptos_framework_address(addr);
         aborts_if !exists<ConsensusConfig>(@aptos_framework);

--- a/aptos-move/framework/aptos-framework/sources/configs/consensus_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/consensus_config.spec.move
@@ -26,6 +26,8 @@ spec aptos_framework::consensus_config {
         use aptos_framework::transaction_fee;
         use aptos_framework::staking_config;
 
+        pragma verify = false; // TODO: set to false because of timeout
+
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
         include staking_config::StakingRewardsConfigRequirement;
         let addr = signer::address_of(account);

--- a/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.spec.move
@@ -20,10 +20,12 @@ spec aptos_framework::gas_schedule {
         use aptos_framework::coin::CoinInfo;
         use aptos_framework::aptos_coin::AptosCoin;
         use aptos_framework::transaction_fee;
+        use aptos_framework::staking_config;
 
         requires exists<stake::ValidatorFees>(@aptos_framework);
         requires exists<CoinInfo<AptosCoin>>(@aptos_framework);
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
+        include staking_config::StakingRewardsConfigRequirement;
 
         include system_addresses::AbortsIfNotAptosFramework{ account: aptos_framework };
         aborts_if len(gas_schedule_blob) == 0;
@@ -38,6 +40,7 @@ spec aptos_framework::gas_schedule {
         use aptos_framework::coin::CoinInfo;
         use aptos_framework::aptos_coin::AptosCoin;
         use aptos_framework::transaction_fee;
+        use aptos_framework::staking_config;
 
         pragma timeout = 60;
 
@@ -45,6 +48,7 @@ spec aptos_framework::gas_schedule {
         requires exists<CoinInfo<AptosCoin>>(@aptos_framework);
         include system_addresses::AbortsIfNotAptosFramework{ account: aptos_framework };
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
+        include staking_config::StakingRewardsConfigRequirement;
         aborts_if !exists<StorageGasConfig>(@aptos_framework);
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
@@ -1,8 +1,12 @@
 /// Provides the configuration for staking and rewards
 module aptos_framework::staking_config {
     use std::error;
+    use std::features;
 
     use aptos_framework::system_addresses;
+    use aptos_framework::timestamp;
+
+    use aptos_std::math64;
 
     friend aptos_framework::genesis;
 
@@ -16,9 +20,26 @@ module aptos_framework::staking_config {
     const EINVALID_VOTING_POWER_INCREASE_LIMIT: u64 = 4;
     /// Specified rewards rate is invalid, which must be within [0, MAX_REWARDS_RATE].
     const EINVALID_REWARDS_RATE: u64 = 5;
+    /// Specified min rewards rate is invalid, which must be within [0, rewards_rate].
+    const EINVALID_MIN_REWARDS_RATE: u64 = 6;
+    /// Specified start time of last rewards rate period is invalid, which must be not late than the current timestamp.
+    const EINVALID_LAST_REWARDS_RATE_PERIOD_START: u64 = 7;
+    /// Specified rewards rate decrease rate is invalid, which must be not greater than BPS_DENOMINATOR.
+    const EINVALID_REWARDS_RATE_DECREASE_RATE: u64 = 8;
+    /// Specified rewards rate period is invalid, which must be 1 year at the moment.
+    const EINVALID_REWARDS_RATE_PERIOD: u64 = 9;
+    /// The function has been deprecated.
+    const EDEPRECATED_FUNCTION: u64 = 10;
+    /// The function is disabled or hasn't been enabled.
+    const EDISABLED_FUNCTION: u64 = 11;
 
     /// Limit the maximum value of `rewards_rate` in order to avoid any arithmetic overflow.
     const MAX_REWARDS_RATE: u64 = 1000000;
+    /// Denominator of number in basis points. 1 bps(basis points) = 0.01%.
+    const BPS_DENOMINATOR: u64 = 10000;
+    /// 1 year => 365 * 24 * 60 * 60 * 1000000
+    const ONE_YEAR_IN_MICROS: u64 = 31536000000000;
+
 
     /// Validator set configurations that will be stored with the @aptos_framework account.
     struct StakingConfig has copy, drop, key {
@@ -33,15 +54,35 @@ module aptos_framework::staking_config {
         recurring_lockup_duration_secs: u64,
         // Whether validators are allow to join/leave post genesis.
         allow_validator_set_change: bool,
+        // DEPRECATING: staking reward configurations will be in StakingRewardsConfig once REWARD_RATE_DECREASE flag is enabled.
         // The maximum rewards given out every epoch. This will be divided by the rewards rate denominator.
         // For example, 0.001% (0.00001) can be represented as 10 / 1000000.
         rewards_rate: u64,
+        // DEPRECATING: staking reward configurations will be in StakingRewardsConfig once REWARD_RATE_DECREASE flag is enabled.
         rewards_rate_denominator: u64,
         // Only this % of current total voting power is allowed to join the validator set in each epoch.
         // This is necessary to prevent a massive amount of new stake from joining that can potentially take down the
         // network if corresponding validators are not ready to participate in consensus in time.
         // This value is within (0, 50%), not inclusive.
         voting_power_increase_limit: u64,
+    }
+
+    /// Staking reward configurations that will be stored with the @aptos_framework account.
+    struct StakingRewardsConfig has copy, drop, key {
+        // The target rewards rate given out every epoch. This will be divided by the rewards rate denominator.
+        // For example, 0.001% (0.00001) can be represented as 10 / 1000000.
+        rewards_rate: u64,
+        // The minimum threshold for rewards_rate. rewards_rate won't be lower than this.
+        // This will be divided by the rewards rate denominator.
+        min_rewards_rate: u64,
+        rewards_rate_denominator: u64,
+        // Reward rate decreases every rewards_rate_period_in_micros microseconds.
+        // Currently it can only equal to 1 year. Keep this field in case we need to change the interval.
+        rewards_rate_period_in_micros: u64,
+        // Timestamp of start of last rewards period.
+        last_rewards_rate_period_start_in_micros: u64,
+        // Rate of reward rate decrease in BPS. 1 bps(basis points) = 0.01%.
+        rewards_rate_decrease_rate_bps: u64,
     }
 
     /// Only called during genesis.
@@ -89,6 +130,42 @@ module aptos_framework::staking_config {
         });
     }
 
+    /// Initialize rewards configurations.
+    /// Can only be called as part of the Aptos governance proposal process established by the AptosGovernance module.
+    public fun initialize_rewards(
+        aptos_framework: &signer,
+        rewards_rate: u64,
+        min_rewards_rate: u64,
+        rewards_rate_denominator: u64,
+        rewards_rate_period_in_micros: u64,
+        last_rewards_rate_period_start_in_micros: u64,
+        rewards_rate_decrease_rate_bps: u64,
+    ) {
+        system_addresses::assert_aptos_framework(aptos_framework);
+
+        validate_rewards_config(
+            rewards_rate,
+            min_rewards_rate,
+            rewards_rate_denominator,
+            rewards_rate_period_in_micros,
+            rewards_rate_decrease_rate_bps,
+        );
+        // TODO: we need last_rewards_rate_period_start_in_micros because genesis time is not available on chain.
+        assert!(
+            timestamp::now_microseconds() >= last_rewards_rate_period_start_in_micros,
+            error::invalid_argument(EINVALID_LAST_REWARDS_RATE_PERIOD_START)
+        );
+
+        move_to(aptos_framework, StakingRewardsConfig {
+            rewards_rate,
+            min_rewards_rate,
+            rewards_rate_denominator,
+            rewards_rate_period_in_micros,
+            last_rewards_rate_period_start_in_micros,
+            rewards_rate_decrease_rate_bps,
+        });
+    }
+
     public fun get(): StakingConfig acquires StakingConfig {
         *borrow_global<StakingConfig>(@aptos_framework)
     }
@@ -109,14 +186,53 @@ module aptos_framework::staking_config {
         config.recurring_lockup_duration_secs
     }
 
+    /// DEPRECATING
     /// Return the reward rate.
     public fun get_reward_rate(config: &StakingConfig): (u64, u64) {
+        assert!(!features::reward_rate_decrease_enabled(), EDEPRECATED_FUNCTION);
         (config.rewards_rate, config.rewards_rate_denominator)
     }
 
     /// Return the joining limit %.
     public fun get_voting_power_increase_limit(config: &StakingConfig): u64 {
         config.voting_power_increase_limit
+    }
+
+    /// Return the rewards rate of a epoch in the format of (nominator, denominator).
+    public fun get_epoch_rewards_rate(): (u64, u64) acquires StakingRewardsConfig {
+        assert!(features::reward_rate_decrease_enabled(), EDISABLED_FUNCTION);
+        let staking_rewards_config = get_staking_rewards_config();
+        (staking_rewards_config.rewards_rate, staking_rewards_config.rewards_rate_denominator)
+    }
+
+    /// Return the up-to-date StakingRewardsConfig.
+    public fun get_staking_rewards_config(): StakingRewardsConfig acquires StakingRewardsConfig {
+        let staking_rewards_config = borrow_global_mut<StakingRewardsConfig>(@aptos_framework);
+        let current_time_in_micros = timestamp::now_microseconds();
+        assert!(
+            current_time_in_micros >= staking_rewards_config.last_rewards_rate_period_start_in_micros,
+            error::invalid_argument(EINVALID_LAST_REWARDS_RATE_PERIOD_START)
+        );
+        if (current_time_in_micros - staking_rewards_config.last_rewards_rate_period_start_in_micros < staking_rewards_config.rewards_rate_period_in_micros) {
+            return *staking_rewards_config
+        };
+        // Rewards rate decrease rate cannot be greater than 100%. Otherwise rewards rate will be negative.
+        assert!(
+            staking_rewards_config.rewards_rate_decrease_rate_bps <= BPS_DENOMINATOR,
+            error::invalid_argument(EINVALID_REWARDS_RATE_DECREASE_RATE)
+        );
+        let new_rate = math64::mul_div(
+            staking_rewards_config.rewards_rate,
+            BPS_DENOMINATOR - staking_rewards_config.rewards_rate_decrease_rate_bps,
+            BPS_DENOMINATOR,
+        );
+        new_rate = math64::max(new_rate, staking_rewards_config.min_rewards_rate);
+
+        staking_rewards_config.rewards_rate = new_rate;
+        staking_rewards_config.last_rewards_rate_period_start_in_micros =
+            staking_rewards_config.last_rewards_rate_period_start_in_micros +
+            staking_rewards_config.rewards_rate_period_in_micros;
+        return *staking_rewards_config
     }
 
     /// Update the min and max stake amounts.
@@ -147,6 +263,7 @@ module aptos_framework::staking_config {
         staking_config.recurring_lockup_duration_secs = new_recurring_lockup_duration_secs;
     }
 
+    /// DEPRECATING
     /// Update the rewards rate.
     /// Can only be called as part of the Aptos governance proposal process established by the AptosGovernance module.
     public fun update_rewards_rate(
@@ -154,6 +271,7 @@ module aptos_framework::staking_config {
         new_rewards_rate: u64,
         new_rewards_rate_denominator: u64,
     ) acquires StakingConfig {
+        assert!(!features::reward_rate_decrease_enabled(), EDEPRECATED_FUNCTION);
         system_addresses::assert_aptos_framework(aptos_framework);
         assert!(
             new_rewards_rate_denominator > 0,
@@ -170,6 +288,34 @@ module aptos_framework::staking_config {
         let staking_config = borrow_global_mut<StakingConfig>(@aptos_framework);
         staking_config.rewards_rate = new_rewards_rate;
         staking_config.rewards_rate_denominator = new_rewards_rate_denominator;
+    }
+
+    public fun update_rewards_config(
+        aptos_framework: &signer,
+        rewards_rate: u64,
+        min_rewards_rate: u64,
+        rewards_rate_denominator: u64,
+        rewards_rate_period_in_micros: u64,
+        rewards_rate_decrease_rate_bps: u64,
+    ) acquires StakingRewardsConfig {
+        assert!(features::reward_rate_decrease_enabled(), EDISABLED_FUNCTION);
+        system_addresses::assert_aptos_framework(aptos_framework);
+
+        validate_rewards_config(
+            rewards_rate,
+            min_rewards_rate,
+            rewards_rate_denominator,
+            rewards_rate_period_in_micros,
+            rewards_rate_decrease_rate_bps,
+        );
+
+        let staking_rewards_config = borrow_global_mut<StakingRewardsConfig>(@aptos_framework);
+
+        staking_rewards_config.rewards_rate = rewards_rate;
+        staking_rewards_config.min_rewards_rate = min_rewards_rate;
+        staking_rewards_config.rewards_rate_denominator = rewards_rate_denominator;
+        staking_rewards_config.rewards_rate_period_in_micros = rewards_rate_period_in_micros;
+        staking_rewards_config.rewards_rate_decrease_rate_bps = rewards_rate_decrease_rate_bps;
     }
 
     /// Update the joining limit %.
@@ -192,6 +338,46 @@ module aptos_framework::staking_config {
         assert!(minimum_stake <= maximum_stake && maximum_stake > 0, error::invalid_argument(EINVALID_STAKE_RANGE));
     }
 
+    fun validate_rewards_config(
+        rewards_rate: u64,
+        min_rewards_rate: u64,
+        rewards_rate_denominator: u64,
+        rewards_rate_period_in_micros: u64,
+        rewards_rate_decrease_rate_bps: u64,
+    ) {
+        assert!(
+            rewards_rate_denominator > 0,
+            error::invalid_argument(EZERO_REWARDS_RATE_DENOMINATOR),
+        );
+
+        // `rewards_rate` and `min_rewards_rate` which are the numerator are limited to
+        // be `<= MAX_REWARDS_RATE` in order to avoid the arithmetic overflow in the rewards calculation.
+        // `rewards_rate_denominator` can be adjusted to get the desired rewards rate
+        // (i.e., rewards_rate / rewards_rate_denominator).
+        assert!(rewards_rate <= MAX_REWARDS_RATE, error::invalid_argument(EINVALID_REWARDS_RATE));
+        assert!(min_rewards_rate <= MAX_REWARDS_RATE, error::invalid_argument(EINVALID_REWARDS_RATE));
+
+        assert!(
+            min_rewards_rate <= rewards_rate,
+            error::invalid_argument(EINVALID_MIN_REWARDS_RATE)
+        );
+
+        // We assert that (rewards_rate / rewards_rate_denominator <= 1).
+        assert!(rewards_rate <= rewards_rate_denominator, error::invalid_argument(EINVALID_REWARDS_RATE));
+
+        // Rewards rate decrease rate cannot be greater than 100%. Otherwise rewards rate will be negative.
+        assert!(
+            rewards_rate_decrease_rate_bps <= BPS_DENOMINATOR,
+            error::invalid_argument(EINVALID_REWARDS_RATE_DECREASE_RATE)
+        );
+
+        // Now rewards rate decrease interval must be 1 year.
+        assert!(
+            rewards_rate_period_in_micros == ONE_YEAR_IN_MICROS,
+            error::invalid_argument(EINVALID_REWARDS_RATE_PERIOD),
+        );
+    }
+
     #[test(aptos_framework = @aptos_framework)]
     public entry fun test_change_staking_configs(aptos_framework: signer) acquires StakingConfig {
         initialize(&aptos_framework, 0, 1, 1, false, 1, 1, 1);
@@ -208,6 +394,73 @@ module aptos_framework::staking_config {
         assert!(config.rewards_rate == 10, 4);
         assert!(config.rewards_rate_denominator == 100, 4);
         assert!(config.voting_power_increase_limit == 10, 5);
+    }
+
+    #[test(aptos_framework = @aptos_framework)]
+    public entry fun test_staking_rewards_rate_decrease_over_time(aptos_framework: signer) acquires StakingRewardsConfig {
+        let start_time_in_micros: u64 = 100001000000;
+        initialize_rewards_for_test(
+            &aptos_framework,
+            100,
+            30,
+            10000,
+            ONE_YEAR_IN_MICROS,
+            start_time_in_micros,
+            5000
+        );
+
+        let (epoch_reward_rate, epoch_rewards_rate_denominator) = get_epoch_rewards_rate();
+        assert!(epoch_reward_rate == 100, 0);
+        assert!(epoch_rewards_rate_denominator == 10000, 1);
+        // Rewards rate should not change until the current reward rate period ends.
+        timestamp::fast_forward_seconds(ONE_YEAR_IN_MICROS / 1000000 / 2);
+        (epoch_reward_rate, epoch_rewards_rate_denominator) = get_epoch_rewards_rate();
+        assert!(epoch_reward_rate == 100, 3);
+        assert!(epoch_rewards_rate_denominator == 10000, 4);
+
+        // Rewards rate decreases to 100 * 5000 / 10000 = 50.
+        timestamp::fast_forward_seconds(ONE_YEAR_IN_MICROS / 1000000 / 2);
+        (epoch_reward_rate, epoch_rewards_rate_denominator) = get_epoch_rewards_rate();
+        assert!(epoch_reward_rate == 50, 5);
+        assert!(epoch_rewards_rate_denominator == 10000, 6);
+
+        // Rewards rate decreases to 50 * 5000 / 10000 = 25.
+        // But rewards_rate cannot be lower than min_rewards_rate = 30.
+        timestamp::fast_forward_seconds(ONE_YEAR_IN_MICROS / 1000000);
+        (epoch_reward_rate, epoch_rewards_rate_denominator) = get_epoch_rewards_rate();
+        assert!(epoch_reward_rate == 30, 7);
+        assert!(epoch_rewards_rate_denominator == 10000, 8);
+    }
+
+    #[test(aptos_framework = @aptos_framework)]
+    public entry fun test_change_staking_rewards_configs(aptos_framework: signer) acquires StakingRewardsConfig {
+        let start_time_in_micros: u64 = 100001000000;
+        initialize_rewards_for_test(
+            &aptos_framework,
+            100,
+            30,
+            10000,
+            ONE_YEAR_IN_MICROS,
+            start_time_in_micros,
+            5000
+        );
+
+        update_rewards_config(
+            &aptos_framework,
+            200,
+            60,
+            20000,
+            ONE_YEAR_IN_MICROS,
+            2500
+        );
+
+        let config = borrow_global<StakingRewardsConfig>(@aptos_framework);
+        assert!(config.rewards_rate == 200, 0);
+        assert!(config.min_rewards_rate == 60, 1);
+        assert!(config.rewards_rate_denominator == 20000, 3);
+        assert!(config.rewards_rate_period_in_micros == ONE_YEAR_IN_MICROS, 4);
+        assert!(config.last_rewards_rate_period_start_in_micros == start_time_in_micros, 4);
+        assert!(config.rewards_rate_decrease_rate_bps == 2500, 5);
     }
 
     #[test(account = @0x123)]
@@ -234,6 +487,13 @@ module aptos_framework::staking_config {
         update_voting_power_increase_limit(&account, 10);
     }
 
+    #[test(account = @0x123, aptos_framework = @aptos_framework)]
+    #[expected_failure(abort_code = 0x50003, location = aptos_framework::system_addresses)]
+    public entry fun test_update_rewards_config_unauthorized_should_fail(account: signer, aptos_framework: signer) acquires StakingRewardsConfig {
+        features::change_feature_flags(&aptos_framework, vector[features::get_reward_rate_decrease_feature()], vector[]);
+        update_rewards_config(&account, 1, 1, 1, ONE_YEAR_IN_MICROS, 1);
+    }
+
     #[test(aptos_framework = @aptos_framework)]
     #[expected_failure(abort_code = 0x10003, location = Self)]
     public entry fun test_update_required_stake_invalid_range_should_fail(aptos_framework: signer) acquires StakingConfig {
@@ -256,6 +516,91 @@ module aptos_framework::staking_config {
     #[expected_failure(abort_code = 0x10002, location = Self)]
     public entry fun test_update_rewards_invalid_denominator_should_fail(aptos_framework: signer) acquires StakingConfig {
         update_rewards_rate(&aptos_framework, 1, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework)]
+    #[expected_failure(abort_code = EDISABLED_FUNCTION, location = Self)]
+    public entry fun test_feature_flag_disabled_update_rewards_config_should_fail(aptos_framework: signer) acquires StakingRewardsConfig {
+        features::change_feature_flags(&aptos_framework, vector[], vector[features::get_reward_rate_decrease_feature()]);
+        update_rewards_config(&aptos_framework, 1, 1, 0, ONE_YEAR_IN_MICROS, 1);
+    }
+
+    #[test(aptos_framework = @aptos_framework)]
+    #[expected_failure(abort_code = 0x10002, location = Self)]
+    public entry fun test_update_rewards_config_invalid_denominator_should_fail(aptos_framework: signer) acquires StakingRewardsConfig {
+        features::change_feature_flags(&aptos_framework, vector[features::get_reward_rate_decrease_feature()], vector[]);
+        update_rewards_config(&aptos_framework, 1, 1, 0, ONE_YEAR_IN_MICROS, 1);
+    }
+
+    #[test(aptos_framework = @aptos_framework)]
+    #[expected_failure(abort_code = 0x10005, location = Self)]
+    public entry fun test_update_rewards_config_rewards_rate_greater_than_1000000_should_fail(aptos_framework: signer) acquires StakingRewardsConfig {
+        let start_time_in_micros: u64 = 100001000000;
+        initialize_rewards_for_test(
+            &aptos_framework,
+            15981,
+            7991,
+            1000000000,
+            ONE_YEAR_IN_MICROS,
+            start_time_in_micros,
+            150,
+        );
+        update_rewards_config(&aptos_framework, 1000001, 1, 10000000, ONE_YEAR_IN_MICROS, 1);
+    }
+
+    #[test(aptos_framework = @aptos_framework)]
+    #[expected_failure(abort_code = 0x10005, location = Self)]
+    public entry fun test_update_rewards_config_rewards_rate_greater_than_denominator_should_fail(aptos_framework: signer) acquires StakingRewardsConfig {
+        let start_time_in_micros: u64 = 100001000000;
+        initialize_rewards_for_test(
+            &aptos_framework,
+            15981,
+            7991,
+            1000000000,
+            ONE_YEAR_IN_MICROS,
+            start_time_in_micros,
+            150,
+        );
+        update_rewards_config(&aptos_framework, 10001, 1, 10000, ONE_YEAR_IN_MICROS, 1);
+    }
+
+    #[test(aptos_framework = @aptos_framework)]
+    #[expected_failure(abort_code = 0x10009, location = Self)]
+    public entry fun test_update_rewards_config_invalid_rewards_rate_period_should_fail(aptos_framework: signer) acquires StakingRewardsConfig {
+        let start_time_in_micros: u64 = 100001000000;
+        initialize_rewards_for_test(
+            &aptos_framework,
+            15981,
+            7991,
+            1000000000,
+            ONE_YEAR_IN_MICROS,
+            start_time_in_micros,
+            150,
+        );
+        update_rewards_config(&aptos_framework, 1001, 1, 10000, 100, 1);
+    }
+
+    #[test(aptos_framework = @aptos_framework)]
+    #[expected_failure(abort_code = 0x10008, location = Self)]
+    public entry fun test_update_rewards_config_invalid_rewards_rate_decrease_rate_should_fail(aptos_framework: signer) acquires StakingRewardsConfig {
+        let start_time_in_micros: u64 = 100001000000;
+        initialize_rewards_for_test(
+            &aptos_framework,
+            15981,
+            7991,
+            1000000000,
+            ONE_YEAR_IN_MICROS,
+            start_time_in_micros,
+            150,
+        );
+        update_rewards_config(&aptos_framework, 1001, 1, 10000, ONE_YEAR_IN_MICROS, 10001);
+    }
+
+    #[test(aptos_framework = @aptos_framework)]
+    #[expected_failure(abort_code = EDISABLED_FUNCTION, location = Self)]
+    public entry fun test_feature_flag_disabled_get_epoch_rewards_rate_should_fail(aptos_framework: signer) acquires StakingRewardsConfig {
+        features::change_feature_flags(&aptos_framework, vector[], vector[features::get_reward_rate_decrease_feature()]);
+        get_epoch_rewards_rate();
     }
 
     #[test(aptos_framework = @aptos_framework)]
@@ -297,5 +642,30 @@ module aptos_framework::staking_config {
                 voting_power_increase_limit,
             });
         };
+    }
+
+    // For tests to bypass all validations.
+    #[test_only]
+    public fun initialize_rewards_for_test(
+        aptos_framework: &signer,
+        rewards_rate: u64,
+        min_rewards_rate: u64,
+        rewards_rate_denominator: u64,
+        rewards_rate_period_in_micros: u64,
+        last_rewards_rate_period_start_in_micros: u64,
+        rewards_rate_decrease_rate_bps: u64,
+    ) {
+        features::change_feature_flags(aptos_framework, vector[features::get_reward_rate_decrease_feature()], vector[]);
+        timestamp::set_time_has_started_for_testing(aptos_framework);
+        timestamp::update_global_time_for_test(last_rewards_rate_period_start_in_micros);
+        initialize_rewards(
+            aptos_framework,
+            rewards_rate,
+            min_rewards_rate,
+            rewards_rate_denominator,
+            rewards_rate_period_in_micros,
+            last_rewards_rate_period_start_in_micros,
+            rewards_rate_decrease_rate_bps,
+        );
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
@@ -153,7 +153,6 @@ spec aptos_framework::staking_config {
         rewards_rate_decrease_rate: FixedPoint64,
     ) {
         use std::signer;
-        aborts_if !features::spec_reward_rate_decrease_enabled();
         include StakingRewardsConfigRequirement;
         let addr = signer::address_of(aptos_framework);
         aborts_if addr != @aptos_framework;

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
@@ -15,6 +15,15 @@ spec aptos_framework::staking_config {
         invariant rewards_rate <= rewards_rate_denominator;
     }
 
+    spec StakingRewardsConfig {
+        invariant rewards_rate <= MAX_REWARDS_RATE;
+        invariant rewards_rate_denominator > 0;
+        invariant rewards_rate <= rewards_rate_denominator;
+        invariant min_rewards_rate <= rewards_rate;
+        invariant rewards_rate_period_in_micros == ONE_YEAR_IN_MICROS;
+        invariant rewards_rate_decrease_rate_bps <= BPS_DENOMINATOR;
+    }
+
     /// Caller must be @aptos_framework.
     /// The maximum_stake must be greater than maximum_stake in the range of Specified stake and the maximum_stake greater than zero.
     /// The rewards_rate_denominator must greater than zero.
@@ -44,8 +53,46 @@ spec aptos_framework::staking_config {
         aborts_if exists<StakingConfig>(addr);
     }
 
+    /// Caller must be @aptos_framework.
+    /// last_rewards_rate_period_start_in_micros cannot be later than now.
+    /// Abort at any condition in StakingRewardsConfigValidationAborts.
+    /// StakingRewardsConfig does not exist under the aptos_framework before creating it.
+    spec initialize_rewards(
+        aptos_framework: &signer,
+        rewards_rate: u64,
+        min_rewards_rate: u64,
+        rewards_rate_denominator: u64,
+        rewards_rate_period_in_micros: u64,
+        last_rewards_rate_period_start_in_micros: u64,
+        rewards_rate_decrease_rate_bps: u64,
+    ) {
+        use std::signer;
+        requires exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
+        let addr = signer::address_of(aptos_framework);
+        aborts_if addr != @aptos_framework;
+        aborts_if last_rewards_rate_period_start_in_micros > timestamp::spec_now_microseconds();
+        include StakingRewardsConfigValidationAbortsIf;
+        aborts_if exists<StakingRewardsConfig>(addr);
+    }
+
     spec get(): StakingConfig {
         aborts_if !exists<StakingConfig>(@aptos_framework);
+    }
+
+    spec get_reward_rate(config: &StakingConfig): (u64, u64) {
+        aborts_if features::spec_reward_rate_decrease_enabled();
+    }
+
+    spec get_epoch_rewards_rate(): (u64, u64) {
+        aborts_if !exists<StakingRewardsConfig>(@aptos_framework);
+        aborts_if !features::spec_reward_rate_decrease_enabled();
+        include StakingRewardsConfigRequirement;
+    }
+
+    spec get_staking_rewards_config(): StakingRewardsConfig {
+        requires features::spec_reward_rate_decrease_enabled();
+        include StakingRewardsConfigRequirement;
+        aborts_if !exists<StakingRewardsConfig>(@aptos_framework);
     }
 
     /// Caller must be @aptos_framework.
@@ -88,12 +135,32 @@ spec aptos_framework::staking_config {
         new_rewards_rate_denominator: u64,
     ) {
         use std::signer;
+        aborts_if features::spec_reward_rate_decrease_enabled();
         let addr = signer::address_of(aptos_framework);
         aborts_if addr != @aptos_framework;
         aborts_if new_rewards_rate_denominator <= 0;
         aborts_if !exists<StakingConfig>(@aptos_framework);
         aborts_if new_rewards_rate > MAX_REWARDS_RATE;
         aborts_if new_rewards_rate > new_rewards_rate_denominator;
+    }
+
+    /// Caller must be @aptos_framework.
+    /// StakingRewardsConfig is under the @aptos_framework.
+    spec update_rewards_config(
+        aptos_framework: &signer,
+        rewards_rate: u64,
+        min_rewards_rate: u64,
+        rewards_rate_denominator: u64,
+        rewards_rate_period_in_micros: u64,
+        rewards_rate_decrease_rate_bps: u64,
+    ) {
+        use std::signer;
+        aborts_if !features::spec_reward_rate_decrease_enabled();
+        include StakingRewardsConfigRequirement;
+        let addr = signer::address_of(aptos_framework);
+        aborts_if addr != @aptos_framework;
+        include StakingRewardsConfigValidationAbortsIf;
+        aborts_if !exists<StakingRewardsConfig>(addr);
     }
 
     /// Caller must be @aptos_framework.
@@ -113,5 +180,61 @@ spec aptos_framework::staking_config {
     /// The maximum_stake must be greater than maximum_stake in the range of Specified stake and the maximum_stake greater than zero.
     spec validate_required_stake(minimum_stake: u64, maximum_stake: u64) {
         aborts_if minimum_stake > maximum_stake || maximum_stake <= 0;
+    }
+
+    /// Abort at any condition in StakingRewardsConfigValidationAborts.
+    spec validate_rewards_config(
+        rewards_rate: u64,
+        min_rewards_rate: u64,
+        rewards_rate_denominator: u64,
+        rewards_rate_period_in_micros: u64,
+        rewards_rate_decrease_rate_bps: u64,
+    ) {
+        include StakingRewardsConfigValidationAbortsIf;
+    }
+
+    /// rewards_rate must be within [0, MAX_REWARDS_RATE] in order to avoid the arithmetic overflow.
+    /// min_rewards_rate must be not greater than rewards_rate.
+    /// rewards_rate_denominator must be greater than 0.
+    /// rewards_rate / rewards_rate_denominator <= 1.
+    /// rewards_rate_period_in_micros must equal to 1 year.
+    /// rewards_rate_decrease_rate_bps / BPS_DENOMINATOR must be within [0,1].
+    spec schema StakingRewardsConfigValidationAbortsIf {
+        rewards_rate: u64;
+        min_rewards_rate: u64;
+        rewards_rate_denominator: u64;
+        rewards_rate_period_in_micros: u64;
+        rewards_rate_decrease_rate_bps: u64;
+
+        aborts_if rewards_rate < 0 || rewards_rate > MAX_REWARDS_RATE;
+        aborts_if min_rewards_rate > rewards_rate;
+        aborts_if rewards_rate_denominator <= 0;
+        aborts_if rewards_rate > rewards_rate_denominator;
+        aborts_if rewards_rate_period_in_micros != ONE_YEAR_IN_MICROS;
+        aborts_if rewards_rate_decrease_rate_bps < 0 || rewards_rate_decrease_rate_bps > BPS_DENOMINATOR;
+    }
+
+    spec schema StakingRewardsConfigRequirement {
+        requires exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
+        include features::spec_reward_rate_decrease_enabled() ==> StakingRewardsConfigEnabledRequirement;
+    }
+
+    spec schema StakingRewardsConfigEnabledRequirement {
+        requires exists<StakingRewardsConfig>(@aptos_framework);
+        let staking_rewards_config = global<StakingRewardsConfig>(@aptos_framework);
+        let rewards_rate = staking_rewards_config.rewards_rate;
+        let min_rewards_rate = staking_rewards_config.min_rewards_rate;
+        let rewards_rate_denominator = staking_rewards_config.rewards_rate_denominator;
+        let rewards_rate_period_in_micros = staking_rewards_config.rewards_rate_period_in_micros;
+        let last_rewards_rate_period_start_in_micros = staking_rewards_config.last_rewards_rate_period_start_in_micros;
+        let rewards_rate_decrease_rate_bps = staking_rewards_config.rewards_rate_decrease_rate_bps;
+
+        requires 0 <= rewards_rate && rewards_rate <= MAX_REWARDS_RATE;
+        requires min_rewards_rate <= rewards_rate;
+        requires rewards_rate_denominator > 0;
+        requires rewards_rate <= rewards_rate_denominator;
+        requires rewards_rate_period_in_micros == ONE_YEAR_IN_MICROS;
+        requires last_rewards_rate_period_start_in_micros <= timestamp::spec_now_microseconds();
+        requires 0 <= rewards_rate_decrease_rate_bps && rewards_rate_decrease_rate_bps <= BPS_DENOMINATOR;
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/configs/version.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/version.spec.move
@@ -12,8 +12,10 @@ spec aptos_framework::version {
         use aptos_framework::coin::CoinInfo;
         use aptos_framework::aptos_coin::AptosCoin;
         use aptos_framework::transaction_fee;
+        use aptos_framework::staking_config;
 
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
+        include staking_config::StakingRewardsConfigRequirement;
         requires chain_status::is_operating();
         requires timestamp::spec_now_microseconds() >= reconfiguration::last_reconfiguration_time();
         requires exists<stake::ValidatorFees>(@aptos_framework);

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.spec.move
@@ -67,6 +67,8 @@ spec aptos_framework::reconfiguration {
         use aptos_framework::transaction_fee;
         use aptos_framework::staking_config;
 
+        pragma verify = false; // TODO: set to false because of timeout
+
         requires exists<stake::ValidatorFees>(@aptos_framework);
         requires exists<CoinInfo<AptosCoin>>(@aptos_framework);
 

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.spec.move
@@ -65,11 +65,13 @@ spec aptos_framework::reconfiguration {
         use aptos_framework::coin::CoinInfo;
         use aptos_framework::aptos_coin::AptosCoin;
         use aptos_framework::transaction_fee;
+        use aptos_framework::staking_config;
 
         requires exists<stake::ValidatorFees>(@aptos_framework);
         requires exists<CoinInfo<AptosCoin>>(@aptos_framework);
 
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
+        include staking_config::StakingRewardsConfigRequirement;
         aborts_if false;
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -1163,7 +1163,7 @@ module aptos_framework::stake {
             assume cur_validator_perf.successful_proposals + cur_validator_perf.failed_proposals <= MAX_U64;
         };
         let num_total_proposals = cur_validator_perf.successful_proposals + cur_validator_perf.failed_proposals;
-        let (rewards_rate, rewards_rate_denominator) = if (features::reward_rate_decrease_enabled()) {
+        let (rewards_rate, rewards_rate_denominator) = if (features::periodical_reward_rate_decrease_enabled()) {
             let epoch_rewards_rate = staking_config::calculate_and_save_latest_epoch_rewards_rate();
             if (fixed_point64::is_zero(epoch_rewards_rate)) {
                 (0u64, 1u64)
@@ -2460,7 +2460,7 @@ module aptos_framework::stake {
             genesis_time_in_secs,
             fixed_point64::create_from_rational(50, 100),
         );
-        features::change_feature_flags(aptos_framework, vector[features::get_reward_rate_decrease_feature()], vector[]);
+        features::change_feature_flags(aptos_framework, vector[features::get_periodical_reward_rate_decrease_feature()], vector[]);
 
         // For some reason, this epoch is very long. It has been 1 year since genesis when the epoch ends.
         timestamp::fast_forward_seconds(one_year_in_secs - EPOCH_DURATION * 3);

--- a/aptos-move/framework/aptos-framework/sources/stake.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.spec.move
@@ -137,6 +137,7 @@ spec aptos_framework::stake {
         // The following resource requirement cannot be discharged by the global
         // invariants because this function is called during genesis.
         include ResourceRequirement;
+        include staking_config::StakingRewardsConfigRequirement;
         // This function should never abort.
         aborts_if false;
     }
@@ -150,6 +151,7 @@ spec aptos_framework::stake {
 
     spec update_stake_pool {
         include ResourceRequirement;
+        include staking_config::StakingRewardsConfigRequirement;
         aborts_if !exists<StakePool>(pool_address);
         aborts_if !exists<ValidatorConfig>(pool_address);
         aborts_if global<ValidatorConfig>(pool_address).validator_index >= len(validator_perf.validators);
@@ -346,6 +348,7 @@ spec aptos_framework::stake {
         requires exists<ValidatorPerformance>(@aptos_framework);
         requires exists<ValidatorSet>(@aptos_framework);
         requires exists<StakingConfig>(@aptos_framework);
+        requires exists<StakingRewardsConfig>(@aptos_framework) || !features::spec_reward_rate_decrease_enabled();
         requires exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
         requires exists<ValidatorFees>(@aptos_framework);
     }

--- a/aptos-move/framework/aptos-stdlib/doc/fixed_point64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/fixed_point64.md
@@ -9,6 +9,8 @@ a 64-bit fractional part.
 
 -  [Struct `FixedPoint64`](#0x1_fixed_point64_FixedPoint64)
 -  [Constants](#@Constants_0)
+-  [Function `sub`](#0x1_fixed_point64_sub)
+-  [Function `add`](#0x1_fixed_point64_add)
 -  [Function `multiply_u128`](#0x1_fixed_point64_multiply_u128)
 -  [Function `divide_u128`](#0x1_fixed_point64_divide_u128)
 -  [Function `create_from_rational`](#0x1_fixed_point64_create_from_rational)
@@ -17,17 +19,31 @@ a 64-bit fractional part.
 -  [Function `is_zero`](#0x1_fixed_point64_is_zero)
 -  [Function `min`](#0x1_fixed_point64_min)
 -  [Function `max`](#0x1_fixed_point64_max)
+-  [Function `less_or_equal`](#0x1_fixed_point64_less_or_equal)
+-  [Function `less`](#0x1_fixed_point64_less)
+-  [Function `greater_or_equal`](#0x1_fixed_point64_greater_or_equal)
+-  [Function `greater`](#0x1_fixed_point64_greater)
+-  [Function `equal`](#0x1_fixed_point64_equal)
+-  [Function `almost_equal`](#0x1_fixed_point64_almost_equal)
 -  [Function `create_from_u128`](#0x1_fixed_point64_create_from_u128)
 -  [Function `floor`](#0x1_fixed_point64_floor)
 -  [Function `ceil`](#0x1_fixed_point64_ceil)
 -  [Function `round`](#0x1_fixed_point64_round)
 -  [Specification](#@Specification_1)
+    -  [Function `sub`](#@Specification_1_sub)
+    -  [Function `add`](#@Specification_1_add)
     -  [Function `multiply_u128`](#@Specification_1_multiply_u128)
     -  [Function `divide_u128`](#@Specification_1_divide_u128)
     -  [Function `create_from_rational`](#@Specification_1_create_from_rational)
     -  [Function `create_from_raw_value`](#@Specification_1_create_from_raw_value)
     -  [Function `min`](#@Specification_1_min)
     -  [Function `max`](#@Specification_1_max)
+    -  [Function `less_or_equal`](#@Specification_1_less_or_equal)
+    -  [Function `less`](#@Specification_1_less)
+    -  [Function `greater_or_equal`](#@Specification_1_greater_or_equal)
+    -  [Function `greater`](#@Specification_1_greater)
+    -  [Function `equal`](#@Specification_1_equal)
+    -  [Function `almost_equal`](#@Specification_1_almost_equal)
     -  [Function `create_from_u128`](#@Specification_1_create_from_u128)
     -  [Function `floor`](#@Specification_1_floor)
     -  [Function `ceil`](#@Specification_1_ceil)
@@ -128,6 +144,16 @@ The multiplied value would be too large to be held in a <code>u128</code>
 
 
 
+<a name="0x1_fixed_point64_ENEGATIVE_RESULT"></a>
+
+Abort code on calculation result is negative.
+
+
+<pre><code><b>const</b> <a href="fixed_point64.md#0x1_fixed_point64_ENEGATIVE_RESULT">ENEGATIVE_RESULT</a>: u64 = 65542;
+</code></pre>
+
+
+
 <a name="0x1_fixed_point64_ERATIO_OUT_OF_RANGE"></a>
 
 The computed ratio when converting to a <code><a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a></code> would be unrepresentable
@@ -137,6 +163,63 @@ The computed ratio when converting to a <code><a href="fixed_point64.md#0x1_fixe
 </code></pre>
 
 
+
+<a name="0x1_fixed_point64_sub"></a>
+
+## Function `sub`
+
+Returns x - y. x must be not less than y.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_sub">sub</a>(x: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_sub">sub</a>(x: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {
+    <b>let</b> x_raw = <a href="fixed_point64.md#0x1_fixed_point64_get_raw_value">get_raw_value</a>(x);
+    <b>let</b> y_raw = <a href="fixed_point64.md#0x1_fixed_point64_get_raw_value">get_raw_value</a>(y);
+    <b>assert</b>!(x_raw &gt;= y_raw, <a href="fixed_point64.md#0x1_fixed_point64_ENEGATIVE_RESULT">ENEGATIVE_RESULT</a>);
+    <a href="fixed_point64.md#0x1_fixed_point64_create_from_raw_value">create_from_raw_value</a>(x_raw - y_raw)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_add"></a>
+
+## Function `add`
+
+Returns x + y. The result cannot be greater than MAX_U128.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_add">add</a>(x: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_add">add</a>(x: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a> {
+    <b>let</b> x_raw = <a href="fixed_point64.md#0x1_fixed_point64_get_raw_value">get_raw_value</a>(x);
+    <b>let</b> y_raw = <a href="fixed_point64.md#0x1_fixed_point64_get_raw_value">get_raw_value</a>(y);
+    <b>let</b> result = (x_raw <b>as</b> u256) + (y_raw <b>as</b> u256);
+    <b>assert</b>!(result &lt;= <a href="fixed_point64.md#0x1_fixed_point64_MAX_U128">MAX_U128</a>, <a href="fixed_point64.md#0x1_fixed_point64_ERATIO_OUT_OF_RANGE">ERATIO_OUT_OF_RANGE</a>);
+    <a href="fixed_point64.md#0x1_fixed_point64_create_from_raw_value">create_from_raw_value</a>((result <b>as</b> u128))
+}
+</code></pre>
+
+
+
+</details>
 
 <a name="0x1_fixed_point64_multiply_u128"></a>
 
@@ -390,6 +473,160 @@ Returns the larger of the two FixedPoint64 numbers.
 
 </details>
 
+<a name="0x1_fixed_point64_less_or_equal"></a>
+
+## Function `less_or_equal`
+
+Returns true if num1 <= num2
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less_or_equal">less_or_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less_or_equal">less_or_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+    num1.value &lt;= num2.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_less"></a>
+
+## Function `less`
+
+Returns true if num1 < num2
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less">less</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less">less</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+    num1.value &lt; num2.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_greater_or_equal"></a>
+
+## Function `greater_or_equal`
+
+Returns true if num1 >= num2
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater_or_equal">greater_or_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater_or_equal">greater_or_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+    num1.value &gt;= num2.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_greater"></a>
+
+## Function `greater`
+
+Returns true if num1 > num2
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater">greater</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater">greater</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+    num1.value &gt; num2.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_equal"></a>
+
+## Function `equal`
+
+Returns true if num1 = num2
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_equal">equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_equal">equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+    num1.value == num2.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_fixed_point64_almost_equal"></a>
+
+## Function `almost_equal`
+
+Returns true if num1 almost equals to num2, which means abs(num1-num2) <= precision
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_almost_equal">almost_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, precision: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_almost_equal">almost_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, precision: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+    <b>if</b> (num1.value &gt; num2.value) {
+        (num1.value - num2.value &lt;= precision.value)
+    } <b>else</b> {
+        (num2.value - num1.value &lt;= precision.value)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x1_fixed_point64_create_from_u128"></a>
 
 ## Function `create_from_u128`
@@ -511,6 +748,42 @@ Returns the value of a FixedPoint64 to the nearest integer.
 
 
 <pre><code><b>pragma</b> aborts_if_is_strict;
+</code></pre>
+
+
+
+<a name="@Specification_1_sub"></a>
+
+### Function `sub`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_sub">sub</a>(x: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> x.value &lt; y.value <b>with</b> <a href="fixed_point64.md#0x1_fixed_point64_ENEGATIVE_RESULT">ENEGATIVE_RESULT</a>;
+<b>ensures</b> result.value == x.value - y.value;
+</code></pre>
+
+
+
+<a name="@Specification_1_add"></a>
+
+### Function `add`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_add">add</a>(x: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, y: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> (x.value <b>as</b> u256) + (y.value <b>as</b> u256) &gt; <a href="fixed_point64.md#0x1_fixed_point64_MAX_U128">MAX_U128</a> <b>with</b> <a href="fixed_point64.md#0x1_fixed_point64_ERATIO_OUT_OF_RANGE">ERATIO_OUT_OF_RANGE</a>;
+<b>ensures</b> result.value == x.value + y.value;
 </code></pre>
 
 
@@ -726,6 +999,184 @@ Returns the value of a FixedPoint64 to the nearest integer.
        num1
    } <b>else</b> {
        num2
+   }
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_less_or_equal"></a>
+
+### Function `less_or_equal`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less_or_equal">less_or_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_less_or_equal">spec_less_or_equal</a>(num1, num2);
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_spec_less_or_equal"></a>
+
+
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_less_or_equal">spec_less_or_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+   num1.value &lt;= num2.value
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_less"></a>
+
+### Function `less`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_less">less</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_less">spec_less</a>(num1, num2);
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_spec_less"></a>
+
+
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_less">spec_less</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+   num1.value &lt; num2.value
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_greater_or_equal"></a>
+
+### Function `greater_or_equal`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater_or_equal">greater_or_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_greater_or_equal">spec_greater_or_equal</a>(num1, num2);
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_spec_greater_or_equal"></a>
+
+
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_greater_or_equal">spec_greater_or_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+   num1.value &gt;= num2.value
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_greater"></a>
+
+### Function `greater`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_greater">greater</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_greater">spec_greater</a>(num1, num2);
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_spec_greater"></a>
+
+
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_greater">spec_greater</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+   num1.value &gt; num2.value
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_equal"></a>
+
+### Function `equal`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_equal">equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_equal">spec_equal</a>(num1, num2);
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_spec_equal"></a>
+
+
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_equal">spec_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+   num1.value == num2.value
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_almost_equal"></a>
+
+### Function `almost_equal`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_almost_equal">almost_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>, precision: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">fixed_point64::FixedPoint64</a>): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == <a href="fixed_point64.md#0x1_fixed_point64_spec_almost_equal">spec_almost_equal</a>(num1, num2, precision);
+</code></pre>
+
+
+
+
+<a name="0x1_fixed_point64_spec_almost_equal"></a>
+
+
+<pre><code><b>fun</b> <a href="fixed_point64.md#0x1_fixed_point64_spec_almost_equal">spec_almost_equal</a>(num1: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, num2: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>, precision: <a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a>): bool {
+   <b>if</b> (num1.value &gt; num2.value) {
+       (num1.value - num2.value &lt;= precision.value)
+   } <b>else</b> {
+       (num2.value - num1.value &lt;= precision.value)
    }
 }
 </code></pre>

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -33,15 +33,15 @@ the Move stdlib, the Aptos stdlib, and the Aptos framework.
 -  [Function `cryptography_algebra_enabled`](#0x1_features_cryptography_algebra_enabled)
 -  [Function `get_bls12_381_strutures_feature`](#0x1_features_get_bls12_381_strutures_feature)
 -  [Function `bls12_381_structures_enabled`](#0x1_features_bls12_381_structures_enabled)
--  [Function `get_reward_rate_decrease_feature`](#0x1_features_get_reward_rate_decrease_feature)
--  [Function `reward_rate_decrease_enabled`](#0x1_features_reward_rate_decrease_enabled)
+-  [Function `get_periodical_reward_rate_decrease_feature`](#0x1_features_get_periodical_reward_rate_decrease_feature)
+-  [Function `periodical_reward_rate_decrease_enabled`](#0x1_features_periodical_reward_rate_decrease_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `is_enabled`](#0x1_features_is_enabled)
 -  [Function `set`](#0x1_features_set)
 -  [Function `contains`](#0x1_features_contains)
 -  [Specification](#@Specification_1)
     -  [Resource `Features`](#@Specification_1_Features)
-    -  [Function `reward_rate_decrease_enabled`](#@Specification_1_reward_rate_decrease_enabled)
+    -  [Function `periodical_reward_rate_decrease_enabled`](#@Specification_1_periodical_reward_rate_decrease_enabled)
     -  [Function `change_feature_flags`](#@Specification_1_change_feature_flags)
     -  [Function `is_enabled`](#@Specification_1_is_enabled)
     -  [Function `set`](#@Specification_1_set)
@@ -212,6 +212,17 @@ Lifetime: transient
 
 
 
+<a name="0x1_features_PERIODICAL_REWARD_RATE_DECREASE"></a>
+
+Whether reward rate decreases periodically.
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_PERIODICAL_REWARD_RATE_DECREASE">PERIODICAL_REWARD_RATE_DECREASE</a>: u64 = 16;
+</code></pre>
+
+
+
 <a name="0x1_features_RESOURCE_GROUPS"></a>
 
 Whether resource groups are enabled.
@@ -219,17 +230,6 @@ This is needed because of new attributes for structs and a change in storage rep
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_RESOURCE_GROUPS">RESOURCE_GROUPS</a>: u64 = 9;
-</code></pre>
-
-
-
-<a name="0x1_features_REWARD_RATE_DECREASE"></a>
-
-Whether reward rate decreases periodically.
-Lifetime: transient
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_REWARD_RATE_DECREASE">REWARD_RATE_DECREASE</a>: u64 = 16;
 </code></pre>
 
 
@@ -835,13 +835,13 @@ Lifetime: transient
 
 </details>
 
-<a name="0x1_features_get_reward_rate_decrease_feature"></a>
+<a name="0x1_features_get_periodical_reward_rate_decrease_feature"></a>
 
-## Function `get_reward_rate_decrease_feature`
+## Function `get_periodical_reward_rate_decrease_feature`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_reward_rate_decrease_feature">get_reward_rate_decrease_feature</a>(): u64
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_periodical_reward_rate_decrease_feature">get_periodical_reward_rate_decrease_feature</a>(): u64
 </code></pre>
 
 
@@ -850,20 +850,20 @@ Lifetime: transient
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_reward_rate_decrease_feature">get_reward_rate_decrease_feature</a>(): u64 { <a href="features.md#0x1_features_REWARD_RATE_DECREASE">REWARD_RATE_DECREASE</a> }
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_periodical_reward_rate_decrease_feature">get_periodical_reward_rate_decrease_feature</a>(): u64 { <a href="features.md#0x1_features_PERIODICAL_REWARD_RATE_DECREASE">PERIODICAL_REWARD_RATE_DECREASE</a> }
 </code></pre>
 
 
 
 </details>
 
-<a name="0x1_features_reward_rate_decrease_enabled"></a>
+<a name="0x1_features_periodical_reward_rate_decrease_enabled"></a>
 
-## Function `reward_rate_decrease_enabled`
+## Function `periodical_reward_rate_decrease_enabled`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_reward_rate_decrease_enabled">reward_rate_decrease_enabled</a>(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_periodical_reward_rate_decrease_enabled">periodical_reward_rate_decrease_enabled</a>(): bool
 </code></pre>
 
 
@@ -872,8 +872,8 @@ Lifetime: transient
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_reward_rate_decrease_enabled">reward_rate_decrease_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
-    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_REWARD_RATE_DECREASE">REWARD_RATE_DECREASE</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_periodical_reward_rate_decrease_enabled">periodical_reward_rate_decrease_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_PERIODICAL_REWARD_RATE_DECREASE">PERIODICAL_REWARD_RATE_DECREASE</a>)
 }
 </code></pre>
 
@@ -1041,12 +1041,12 @@ Helper to check whether a feature flag is enabled.
 
 
 
-<a name="@Specification_1_reward_rate_decrease_enabled"></a>
+<a name="@Specification_1_periodical_reward_rate_decrease_enabled"></a>
 
-### Function `reward_rate_decrease_enabled`
+### Function `periodical_reward_rate_decrease_enabled`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_reward_rate_decrease_enabled">reward_rate_decrease_enabled</a>(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_periodical_reward_rate_decrease_enabled">periodical_reward_rate_decrease_enabled</a>(): bool
 </code></pre>
 
 
@@ -1109,7 +1109,7 @@ Helper to check whether a feature flag is enabled.
 
 
 <pre><code><b>fun</b> <a href="features.md#0x1_features_spec_reward_rate_decrease_enabled">spec_reward_rate_decrease_enabled</a>(): bool {
-   <a href="features.md#0x1_features_spec_is_enabled">spec_is_enabled</a>(<a href="features.md#0x1_features_REWARD_RATE_DECREASE">REWARD_RATE_DECREASE</a>)
+   <a href="features.md#0x1_features_spec_is_enabled">spec_is_enabled</a>(<a href="features.md#0x1_features_PERIODICAL_REWARD_RATE_DECREASE">PERIODICAL_REWARD_RATE_DECREASE</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -33,12 +33,15 @@ the Move stdlib, the Aptos stdlib, and the Aptos framework.
 -  [Function `cryptography_algebra_enabled`](#0x1_features_cryptography_algebra_enabled)
 -  [Function `get_bls12_381_strutures_feature`](#0x1_features_get_bls12_381_strutures_feature)
 -  [Function `bls12_381_structures_enabled`](#0x1_features_bls12_381_structures_enabled)
+-  [Function `get_reward_rate_decrease_feature`](#0x1_features_get_reward_rate_decrease_feature)
+-  [Function `reward_rate_decrease_enabled`](#0x1_features_reward_rate_decrease_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `is_enabled`](#0x1_features_is_enabled)
 -  [Function `set`](#0x1_features_set)
 -  [Function `contains`](#0x1_features_contains)
 -  [Specification](#@Specification_1)
     -  [Resource `Features`](#@Specification_1_Features)
+    -  [Function `reward_rate_decrease_enabled`](#@Specification_1_reward_rate_decrease_enabled)
     -  [Function `change_feature_flags`](#@Specification_1_change_feature_flags)
     -  [Function `is_enabled`](#@Specification_1_is_enabled)
     -  [Function `set`](#@Specification_1_set)
@@ -216,6 +219,17 @@ This is needed because of new attributes for structs and a change in storage rep
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_RESOURCE_GROUPS">RESOURCE_GROUPS</a>: u64 = 9;
+</code></pre>
+
+
+
+<a name="0x1_features_REWARD_RATE_DECREASE"></a>
+
+Whether reward rate decreases periodically.
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_REWARD_RATE_DECREASE">REWARD_RATE_DECREASE</a>: u64 = 16;
 </code></pre>
 
 
@@ -821,6 +835,52 @@ Lifetime: transient
 
 </details>
 
+<a name="0x1_features_get_reward_rate_decrease_feature"></a>
+
+## Function `get_reward_rate_decrease_feature`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_reward_rate_decrease_feature">get_reward_rate_decrease_feature</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_reward_rate_decrease_feature">get_reward_rate_decrease_feature</a>(): u64 { <a href="features.md#0x1_features_REWARD_RATE_DECREASE">REWARD_RATE_DECREASE</a> }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_features_reward_rate_decrease_enabled"></a>
+
+## Function `reward_rate_decrease_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_reward_rate_decrease_enabled">reward_rate_decrease_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_reward_rate_decrease_enabled">reward_rate_decrease_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_REWARD_RATE_DECREASE">REWARD_RATE_DECREASE</a>)
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x1_features_change_feature_flags"></a>
 
 ## Function `change_feature_flags`
@@ -981,6 +1041,24 @@ Helper to check whether a feature flag is enabled.
 
 
 
+<a name="@Specification_1_reward_rate_decrease_enabled"></a>
+
+### Function `reward_rate_decrease_enabled`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_reward_rate_decrease_enabled">reward_rate_decrease_enabled</a>(): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>false</b>;
+<b>ensures</b> [abstract] result == <a href="features.md#0x1_features_spec_reward_rate_decrease_enabled">spec_reward_rate_decrease_enabled</a>();
+</code></pre>
+
+
+
 <a name="@Specification_1_change_feature_flags"></a>
 
 ### Function `change_feature_flags`
@@ -1022,6 +1100,17 @@ Helper to check whether a feature flag is enabled.
 
 
 <pre><code><b>fun</b> <a href="features.md#0x1_features_spec_is_enabled">spec_is_enabled</a>(feature: u64): bool;
+</code></pre>
+
+
+
+
+<a name="0x1_features_spec_reward_rate_decrease_enabled"></a>
+
+
+<pre><code><b>fun</b> <a href="features.md#0x1_features_spec_reward_rate_decrease_enabled">spec_reward_rate_decrease_enabled</a>(): bool {
+   <a href="features.md#0x1_features_spec_is_enabled">spec_is_enabled</a>(<a href="features.md#0x1_features_REWARD_RATE_DECREASE">REWARD_RATE_DECREASE</a>)
+}
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -169,10 +169,10 @@ module std::features {
 
     /// Whether reward rate decreases periodically.
     /// Lifetime: transient
-    const REWARD_RATE_DECREASE: u64 = 16;
-    public fun get_reward_rate_decrease_feature(): u64 { REWARD_RATE_DECREASE }
-    public fun reward_rate_decrease_enabled(): bool acquires Features {
-        is_enabled(REWARD_RATE_DECREASE)
+    const PERIODICAL_REWARD_RATE_DECREASE: u64 = 16;
+    public fun get_periodical_reward_rate_decrease_feature(): u64 { PERIODICAL_REWARD_RATE_DECREASE }
+    public fun periodical_reward_rate_decrease_enabled(): bool acquires Features {
+        is_enabled(PERIODICAL_REWARD_RATE_DECREASE)
     }
 
     // ============================================================================================

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -167,6 +167,14 @@ module std::features {
     /// Lifetime: transient
     const STRUCT_CONSTRUCTORS: u64 = 15;
 
+    /// Whether reward rate decreases periodically.
+    /// Lifetime: transient
+    const REWARD_RATE_DECREASE: u64 = 16;
+    public fun get_reward_rate_decrease_feature(): u64 { REWARD_RATE_DECREASE }
+    public fun reward_rate_decrease_enabled(): bool acquires Features {
+        is_enabled(REWARD_RATE_DECREASE)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
@@ -36,4 +36,14 @@ spec std::features {
     }
 
     spec fun spec_is_enabled(feature: u64): bool;
+
+    spec fun spec_reward_rate_decrease_enabled(): bool {
+        spec_is_enabled(REWARD_RATE_DECREASE)
+    }
+
+    spec reward_rate_decrease_enabled {
+        pragma opaque;
+        aborts_if [abstract] false;
+        ensures [abstract] result == spec_reward_rate_decrease_enabled();
+    }
 }

--- a/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
@@ -38,10 +38,10 @@ spec std::features {
     spec fun spec_is_enabled(feature: u64): bool;
 
     spec fun spec_reward_rate_decrease_enabled(): bool {
-        spec_is_enabled(REWARD_RATE_DECREASE)
+        spec_is_enabled(PERIODICAL_REWARD_RATE_DECREASE)
     }
 
-    spec reward_rate_decrease_enabled {
+    spec periodical_reward_rate_decrease_enabled {
         pragma opaque;
         aborts_if [abstract] false;
         ensures [abstract] result == spec_reward_rate_decrease_enabled();

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -23,6 +23,7 @@ pub enum FeatureFlag {
     BLS12_381_STRUCTURES = 13,
     ED25519_PUBKEY_VALIDATE_RETURN_FALSE_WRONG_LENGTH = 14,
     STRUCT_CONSTRUCTORS = 15,
+    REWARD_RATE_DECREASE = 16,
 }
 
 /// Representation of features on chain as a bitset.

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -23,7 +23,7 @@ pub enum FeatureFlag {
     BLS12_381_STRUCTURES = 13,
     ED25519_PUBKEY_VALIDATE_RETURN_FALSE_WRONG_LENGTH = 14,
     STRUCT_CONSTRUCTORS = 15,
-    REWARD_RATE_DECREASE = 16,
+    PERIODICAL_REWARD_RATE_DECREASE = 16,
 }
 
 /// Representation of features on chain as a bitset.


### PR DESCRIPTION
### Description
- Support rewards decrease over time in `stake.move` and `staking_config.move`. This feature is gated by flag `REWARDS_RATE_DECREASE`.
- In the beginning, we can specify `rewards rate` every epoch . Every `rewards rate period`(which can only be 1 year at the moment), `rewards rate` will decrease at a configurable `decrease rate`.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Unit testing, move prover testing and E2E testing.
Move unit tests coverage:
```
Module 0000000000000000000000000000000000000000000000000000000000000001::staking_contract
>>> % Module coverage: 93.90
Module 0000000000000000000000000000000000000000000000000000000000000001::stake
>>> % Module coverage: 89.65
```