### PR TITLE
[TEST ONLY] graceful overload on half of the nodes

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -54,6 +54,8 @@ pub struct QuorumStoreConfig {
     pub mempool_txn_pull_max_bytes: u64,
     pub back_pressure: QuorumStoreBackPressureConfig,
     pub num_workers_for_remote_batches: usize,
+    pub proof_max_in_future_usecs: u64,
+    pub proof_max_per_author: u64,
 }
 
 impl Default for QuorumStoreConfig {
@@ -77,6 +79,8 @@ impl Default for QuorumStoreConfig {
             back_pressure: QuorumStoreBackPressureConfig::default(),
             // number of batch coordinators to handle QS batch messages, should be >= 1
             num_workers_for_remote_batches: 10,
+            proof_max_in_future_usecs: Duration::from_secs(120).as_micros() as u64,
+            proof_max_per_author: 1000,
         }
     }
 }

--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -21,7 +21,7 @@ impl Default for QuorumStoreBackPressureConfig {
     fn default() -> QuorumStoreBackPressureConfig {
         QuorumStoreBackPressureConfig {
             // QS will be backpressured if the remaining total txns is more than this number
-            backlog_txn_limit_count: MAX_SENDING_BLOCK_TXNS_QUORUM_STORE_OVERRIDE * 8,
+            backlog_txn_limit_count: MAX_SENDING_BLOCK_TXNS_QUORUM_STORE_OVERRIDE * 20,
             // QS will create batches at the max rate until this number is reached
             backlog_per_validator_batch_limit_count: 4,
             decrease_duration_ms: 1000,

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -2,7 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::proof_of_store::ProofOfStore;
+use crate::proof_of_store::{BatchInfo, ProofOfStore};
 use aptos_crypto::HashValue;
 use aptos_executor_types::Error;
 use aptos_infallible::Mutex;
@@ -169,7 +169,7 @@ impl fmt::Display for Payload {
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub enum PayloadFilter {
     DirectMempool(Vec<TransactionSummary>),
-    InQuorumStore(HashSet<HashValue>),
+    InQuorumStore(HashSet<BatchInfo>),
     Empty,
 }
 
@@ -198,7 +198,7 @@ impl From<&Vec<&Payload>> for PayloadFilter {
             for payload in exclude_payloads {
                 if let Payload::InQuorumStore(proof_with_status) = payload {
                     for proof in &proof_with_status.proofs {
-                        exclude_proofs.insert(*proof.digest());
+                        exclude_proofs.insert(proof.info().clone());
                     }
                 }
             }
@@ -220,7 +220,7 @@ impl fmt::Display for PayloadFilter {
             PayloadFilter::InQuorumStore(excluded_proofs) => {
                 let mut proofs_str = "".to_string();
                 for proof in excluded_proofs.iter() {
-                    write!(proofs_str, "{} ", proof)?;
+                    write!(proofs_str, "{} ", proof.digest())?;
                 }
                 write!(f, "{}", proofs_str)
             },

--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -65,7 +65,17 @@ impl Display for BatchId {
 }
 
 #[derive(
-    Clone, Debug, Deserialize, Serialize, CryptoHasher, BCSCryptoHash, PartialEq, Eq, Hash,
+    Clone,
+    Debug,
+    Deserialize,
+    Serialize,
+    CryptoHasher,
+    BCSCryptoHash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
 )]
 pub struct BatchInfo {
     author: PeerId,
@@ -211,6 +221,10 @@ impl ProofOfStore {
             .get_voter_addresses(&validator.get_ordered_account_addresses());
         ret.shuffle(&mut thread_rng());
         ret
+    }
+
+    pub fn info(&self) -> &BatchInfo {
+        &self.info
     }
 }
 

--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -65,17 +65,7 @@ impl Display for BatchId {
 }
 
 #[derive(
-    Clone,
-    Debug,
-    Deserialize,
-    Serialize,
-    CryptoHasher,
-    BCSCryptoHash,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
+    Clone, Debug, Deserialize, Serialize, CryptoHasher, BCSCryptoHash, PartialEq, Eq, Hash,
 )]
 pub struct BatchInfo {
     author: PeerId,

--- a/consensus/src/payload_manager.rs
+++ b/consensus/src/payload_manager.rs
@@ -65,7 +65,7 @@ impl PayloadManager {
                     .update_certified_timestamp(block_timestamp)
                     .await;
 
-                let proofs: Vec<_> = payloads
+                let batches: Vec<_> = payloads
                     .into_iter()
                     .flat_map(|payload| match payload {
                         Payload::DirectMempool(_) => {
@@ -73,6 +73,7 @@ impl PayloadManager {
                         },
                         Payload::InQuorumStore(proof_with_status) => proof_with_status.proofs,
                     })
+                    .map(|proof| proof.info().clone())
                     .collect();
 
                 let mut tx = coordinator_tx.clone();
@@ -80,7 +81,7 @@ impl PayloadManager {
                 if let Err(e) = tx
                     .send(CoordinatorCommand::CommitNotification(
                         block_timestamp,
-                        proofs,
+                        batches,
                     ))
                     .await
                 {

--- a/consensus/src/payload_manager.rs
+++ b/consensus/src/payload_manager.rs
@@ -65,7 +65,7 @@ impl PayloadManager {
                     .update_certified_timestamp(block_timestamp)
                     .await;
 
-                let digests: Vec<HashValue> = payloads
+                let proofs: Vec<_> = payloads
                     .into_iter()
                     .flat_map(|payload| match payload {
                         Payload::DirectMempool(_) => {
@@ -73,7 +73,6 @@ impl PayloadManager {
                         },
                         Payload::InQuorumStore(proof_with_status) => proof_with_status.proofs,
                     })
-                    .map(|proof| *proof.digest())
                     .collect();
 
                 let mut tx = coordinator_tx.clone();
@@ -81,7 +80,7 @@ impl PayloadManager {
                 if let Err(e) = tx
                     .send(CoordinatorCommand::CommitNotification(
                         block_timestamp,
-                        digests,
+                        proofs,
                     ))
                     .await
                 {

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -195,7 +195,7 @@ impl BatchGenerator {
             / 2;
 
         loop {
-            let _timer = counters::WRAPPER_MAIN_LOOP.start_timer();
+            let _timer = counters::BATCH_GENERATOR_MAIN_LOOP.start_timer();
 
             tokio::select! {
                 biased;

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -54,11 +54,22 @@ pub static MAIN_LOOP: Lazy<DurationHistogram> = Lazy::new(|| {
 });
 
 /// Duration of each run of the event loop.
-pub static WRAPPER_MAIN_LOOP: Lazy<DurationHistogram> = Lazy::new(|| {
+pub static PROOF_MANAGER_MAIN_LOOP: Lazy<DurationHistogram> = Lazy::new(|| {
     DurationHistogram::new(
         register_histogram!(
-            "quorum_store_wrapper_main_loop",
-            "Duration of the each run of the event loop"
+            "quorum_store_proof_manager_main_loop",
+            "Duration of the each run of the proof manager event loop"
+        )
+        .unwrap(),
+    )
+});
+
+/// Duration of each run of the event loop.
+pub static BATCH_GENERATOR_MAIN_LOOP: Lazy<DurationHistogram> = Lazy::new(|| {
+    DurationHistogram::new(
+        register_histogram!(
+            "quorum_store_batch_generator_main_loop",
+            "Duration of the each run of the batch generator event loop"
         )
         .unwrap(),
     )

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -85,7 +85,7 @@ pub static NUM_TXN_PER_BATCH: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         "quorum_store_num_txn_per_batch",
         "Histogram for the number of transanctions per batch.",
-        // exponential_buckets(/*start=*/ 100.0, /*factor=*/ 1.1, /*count=*/ 100).unwrap(),
+        TRANSACTION_COUNT_BUCKETS.clone(),
     )
     .unwrap()
 });
@@ -120,14 +120,13 @@ pub static PROOF_SIZE_WHEN_PULL: Lazy<Histogram> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Histogram for the number of expired proof-of-store when pulled for consensus.
-pub static EXPIRED_PROOFS_WHEN_PULL: Lazy<Histogram> = Lazy::new(|| {
+pub static EXCLUDED_TXNS_WHEN_PULL: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
-        "quorum_store_expired_proof_size_when_pull",
-        "Histogram for the number of expired proof-of-store when pulled for consensus.",
+        "quorum_store_excluded_txns_when_pull",
+        "Histogram for the number of transactions were considered but excluded when pulled for consensus.",
         // exponential_buckets(/*start=*/ 5.0, /*factor=*/ 1.1, /*count=*/ 20).unwrap(),
     )
-    .unwrap()
+        .unwrap()
 });
 
 pub static GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_SAVE: Lazy<Histogram> = Lazy::new(
@@ -140,6 +139,14 @@ pub static GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_SAVE: Lazy<Histogr
     .unwrap()
     },
 );
+
+pub static NUM_PROOFS_EXPIRED_WHEN_COMMIT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "quorum_store_num_proofs_expired_when_commit",
+        "Number of proofs that were expired when commit is called"
+    )
+    .unwrap()
+});
 
 pub static NUM_BATCH_EXPIRED_WHEN_SAVE: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
@@ -179,33 +186,35 @@ pub static POS_TO_COMMIT: Lazy<Histogram> = Lazy::new(|| {
 });
 
 /// Histogram for the number of total txns left after cleaning up commit notifications.
-pub static NUM_TOTAL_TXNS_LEFT_ON_COMMIT: Lazy<Histogram> = Lazy::new(|| {
-    register_histogram!(
+pub static NUM_TOTAL_TXNS_LEFT_ON_COMMIT: Lazy<AverageIntCounter> = Lazy::new(|| {
+    AverageIntCounter::register(
         "quorum_store_num_total_txns_left_on_commit",
         "Histogram for the number of total txns left after cleaning up commit notifications.",
-        TRANSACTION_COUNT_BUCKETS.clone(),
     )
-    .unwrap()
 });
 
 /// Histogram for the number of total batches/PoS left after cleaning up commit notifications.
-pub static NUM_TOTAL_PROOFS_LEFT_ON_COMMIT: Lazy<Histogram> = Lazy::new(|| {
-    register_histogram!(
+pub static NUM_TOTAL_PROOFS_LEFT_ON_COMMIT: Lazy<AverageIntCounter> = Lazy::new(|| {
+    AverageIntCounter::register(
         "quorum_store_num_total_proofs_left_on_commit",
         "Histogram for the number of total batches/PoS left after cleaning up commit notifications.",
-        TRANSACTION_COUNT_BUCKETS.clone(),
     )
-        .unwrap()
+});
+
+/// Histogram for the number of local txns left after cleaning up commit notifications.
+pub static NUM_LOCAL_TXNS_LEFT_ON_COMMIT: Lazy<AverageIntCounter> = Lazy::new(|| {
+    AverageIntCounter::register(
+        "quorum_store_num_local_txns_left_on_commit",
+        "Histogram for the number of locally created txns left after cleaning up commit notifications.",
+    )
 });
 
 /// Histogram for the number of local batches/PoS left after cleaning up commit notifications.
-pub static NUM_LOCAL_PROOFS_LEFT_ON_COMMIT: Lazy<Histogram> = Lazy::new(|| {
-    register_histogram!(
+pub static NUM_LOCAL_PROOFS_LEFT_ON_COMMIT: Lazy<AverageIntCounter> = Lazy::new(|| {
+    AverageIntCounter::register(
         "quorum_store_num_local_proofs_left_on_commit",
         "Histogram for the number of locally created batches/PoS left after cleaning up commit notifications.",
-        TRANSACTION_COUNT_BUCKETS.clone(),
     )
-    .unwrap()
 });
 
 /// Counters
@@ -266,6 +275,15 @@ pub static REMOTE_POS_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
         "quorum_store_remote_PoS_count",
         "Count of the received PoS since last restart."
+    )
+    .unwrap()
+});
+
+pub static REJECTED_POS_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "quorum_store_rejected_PoS_count",
+        "Count of the rejected PoS since last restart, grouped by reason.",
+        &["reason"]
     )
     .unwrap()
 });

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -151,14 +151,6 @@ pub static GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_SAVE: Lazy<Histogr
     },
 );
 
-pub static NUM_PROOFS_EXPIRED_WHEN_COMMIT: Lazy<IntCounter> = Lazy::new(|| {
-    register_int_counter!(
-        "quorum_store_num_proofs_expired_when_commit",
-        "Number of proofs that were expired when commit is called"
-    )
-    .unwrap()
-});
-
 pub static NUM_BATCH_EXPIRED_WHEN_SAVE: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
         "quorum_store_num_batch_expired_when_save",
@@ -167,16 +159,25 @@ pub static NUM_BATCH_EXPIRED_WHEN_SAVE: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Histogram for the gaps between expiration round and the current round when pulling the proofs, and expiration round is lower.
-pub static GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_PULL_PROOFS: Lazy<Histogram> =
-    Lazy::new(|| {
+/// Histogram for the gaps between expiration time and the current block timestamp on commit, and expiration round is lower.
+pub static GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_COMMIT: Lazy<Histogram> = Lazy::new(
+    || {
         register_histogram!(
-        "quorum_store_gap_batch_expiration_and_current_round_when_pull",
-        "Histogram for the gaps between expiration round and the current round when pulling the proofs, and expiration round is lower.",
+        "quorum_store_gap_batch_expiration_and_current_time_when_commit",
+        "Histogram for the gaps between expiration time and the current block timestamp on commit, and expiration round is lower.",
         // exponential_buckets(/*start=*/ 100.0, /*factor=*/ 1.1, /*count=*/ 100).unwrap(),
     )
+            .unwrap()
+    },
+);
+
+pub static NUM_PROOFS_EXPIRED_WHEN_COMMIT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "quorum_store_num_proofs_expired_when_commit",
+        "Number of proofs that were expired when commit is called"
+    )
     .unwrap()
-    });
+});
 
 pub static POS_TO_PULL: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -36,9 +36,11 @@ impl ProofManager {
         my_peer_id: PeerId,
         back_pressure_total_txn_limit: u64,
         back_pressure_total_proof_limit: u64,
+        max_in_future_usecs: u64,
+        max_per_author: u64,
     ) -> Self {
         Self {
-            proofs_for_consensus: ProofQueue::new(my_peer_id),
+            proofs_for_consensus: ProofQueue::new(my_peer_id, max_in_future_usecs, max_per_author),
             back_pressure_total_txn_limit,
             remaining_total_txn_num: 0,
             back_pressure_total_proof_limit,

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -74,7 +74,6 @@ impl ProofManager {
 
     pub(crate) fn handle_proposal_request(&mut self, msg: GetPayloadCommand) {
         match msg {
-            // TODO: check what max_txns consensus is using
             GetPayloadCommand::GetPayloadRequest(
                 max_txns,
                 max_bytes,
@@ -82,7 +81,6 @@ impl ProofManager {
                 filter,
                 callback,
             ) => {
-                // TODO: Pass along to batch_store
                 let excluded_batches: HashSet<_> = match filter {
                     PayloadFilter::Empty => HashSet::new(),
                     PayloadFilter::DirectMempool(_) => {
@@ -138,8 +136,7 @@ impl ProofManager {
         };
 
         loop {
-            // TODO: additional main loop counter
-            let _timer = counters::WRAPPER_MAIN_LOOP.start_timer();
+            let _timer = counters::PROOF_MANAGER_MAIN_LOOP.start_timer();
 
             tokio::select! {
                     Some(msg) = proposal_rx.next() => monitor!("proof_manager_handle_proposal", {

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -338,6 +338,8 @@ impl InnerBuilder {
                 .back_pressure
                 .backlog_per_validator_batch_limit_count
                 * self.num_validators,
+            self.config.proof_max_in_future_usecs,
+            self.config.proof_max_per_author,
         );
         spawn_named!(
             "proof_manager",

--- a/consensus/src/quorum_store/quorum_store_coordinator.rs
+++ b/consensus/src/quorum_store/quorum_store_coordinator.rs
@@ -10,14 +10,14 @@ use crate::{
     round_manager::VerifiedEvent,
 };
 use aptos_channels::aptos_channel;
-use aptos_crypto::HashValue;
+use aptos_consensus_types::proof_of_store::ProofOfStore;
 use aptos_logger::prelude::*;
 use aptos_types::{account_address::AccountAddress, PeerId};
 use futures::StreamExt;
 use tokio::sync::{mpsc, oneshot};
 
 pub enum CoordinatorCommand {
-    CommitNotification(u64, Vec<HashValue>),
+    CommitNotification(u64, Vec<ProofOfStore>),
     Shutdown(futures_channel::oneshot::Sender<()>),
 }
 
@@ -53,11 +53,11 @@ impl QuorumStoreCoordinator {
         while let Some(cmd) = rx.next().await {
             monitor!("quorum_store_coordinator_loop", {
                 match cmd {
-                    CoordinatorCommand::CommitNotification(block_timestamp, digests) => {
+                    CoordinatorCommand::CommitNotification(block_timestamp, proofs) => {
                         self.proof_manager_cmd_tx
                             .send(ProofManagerCommand::CommitNotification(
                                 block_timestamp,
-                                digests,
+                                proofs,
                             ))
                             .await
                             .expect("Failed to send to ProofManager");

--- a/consensus/src/quorum_store/quorum_store_coordinator.rs
+++ b/consensus/src/quorum_store/quorum_store_coordinator.rs
@@ -10,14 +10,14 @@ use crate::{
     round_manager::VerifiedEvent,
 };
 use aptos_channels::aptos_channel;
-use aptos_consensus_types::proof_of_store::ProofOfStore;
+use aptos_consensus_types::proof_of_store::BatchInfo;
 use aptos_logger::prelude::*;
 use aptos_types::{account_address::AccountAddress, PeerId};
 use futures::StreamExt;
 use tokio::sync::{mpsc, oneshot};
 
 pub enum CoordinatorCommand {
-    CommitNotification(u64, Vec<ProofOfStore>),
+    CommitNotification(u64, Vec<BatchInfo>),
     Shutdown(futures_channel::oneshot::Sender<()>),
 }
 
@@ -53,11 +53,11 @@ impl QuorumStoreCoordinator {
         while let Some(cmd) = rx.next().await {
             monitor!("quorum_store_coordinator_loop", {
                 match cmd {
-                    CoordinatorCommand::CommitNotification(block_timestamp, proofs) => {
+                    CoordinatorCommand::CommitNotification(block_timestamp, batches) => {
                         self.proof_manager_cmd_tx
                             .send(ProofManagerCommand::CommitNotification(
                                 block_timestamp,
-                                proofs,
+                                batches,
                             ))
                             .await
                             .expect("Failed to send to ProofManager");

--- a/consensus/src/quorum_store/tests/proof_manager_test.rs
+++ b/consensus/src/quorum_store/tests/proof_manager_test.rs
@@ -42,3 +42,197 @@ async fn test_block_request() {
         panic!("Unexpected variant")
     }
 }
+
+#[tokio::test]
+async fn test_block_timestamp_expiration() {
+    let mut proof_manager = ProofManager::new(AccountAddress::random(), 10, 10);
+
+    let digest = HashValue::random();
+    let batch_id = BatchId::new_for_test(1);
+    let proof = ProofOfStore::new(
+        BatchInfo::new(PeerId::random(), batch_id, 0, 10, digest, 1, 1),
+        AggregateSignature::empty(),
+    );
+    proof_manager.receive_proof(proof.clone());
+
+    proof_manager.handle_commit_notification(1, vec![]);
+
+    let (callback_tx, callback_rx) = oneshot::channel();
+    let req = GetPayloadCommand::GetPayloadRequest(
+        100,
+        1000000,
+        true,
+        PayloadFilter::InQuorumStore(HashSet::new()),
+        callback_tx,
+    );
+    proof_manager.handle_proposal_request(req);
+    let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
+    if let Payload::InQuorumStore(proofs) = payload {
+        assert_eq!(proofs.proofs.len(), 1);
+        assert_eq!(proofs.proofs[0], proof);
+    } else {
+        panic!("Unexpected variant")
+    }
+
+    proof_manager.handle_commit_notification(20, vec![]);
+
+    let (callback_tx, callback_rx) = oneshot::channel();
+    let req = GetPayloadCommand::GetPayloadRequest(
+        100,
+        1000000,
+        true,
+        PayloadFilter::InQuorumStore(HashSet::new()),
+        callback_tx,
+    );
+    proof_manager.handle_proposal_request(req);
+    let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
+    if let Payload::InQuorumStore(proofs) = payload {
+        assert_eq!(proofs.proofs.len(), 0);
+    } else {
+        panic!("Unexpected variant")
+    }
+}
+
+#[tokio::test]
+async fn test_batch_commit() {
+    let mut proof_manager = ProofManager::new(AccountAddress::random(), 10, 10);
+
+    let digest = HashValue::random();
+    let batch_id = BatchId::new_for_test(1);
+    let proof0 = ProofOfStore::new(
+        BatchInfo::new(PeerId::random(), batch_id, 0, 10, digest, 1, 1),
+        AggregateSignature::empty(),
+    );
+    proof_manager.receive_proof(proof0.clone());
+
+    let digest = HashValue::random();
+    let batch_id = BatchId::new_for_test(1);
+    let proof1 = ProofOfStore::new(
+        BatchInfo::new(PeerId::random(), batch_id, 0, 11, digest, 1, 1),
+        AggregateSignature::empty(),
+    );
+    proof_manager.receive_proof(proof1.clone());
+
+    proof_manager.handle_commit_notification(1, vec![proof1.info().clone()]);
+
+    let (callback_tx, callback_rx) = oneshot::channel();
+    let req = GetPayloadCommand::GetPayloadRequest(
+        100,
+        1000000,
+        true,
+        PayloadFilter::InQuorumStore(HashSet::new()),
+        callback_tx,
+    );
+    proof_manager.handle_proposal_request(req);
+    let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
+    if let Payload::InQuorumStore(proofs) = payload {
+        assert_eq!(proofs.proofs.len(), 1);
+        assert!(proofs.proofs.contains(&proof0));
+    } else {
+        panic!("Unexpected variant")
+    }
+}
+
+fn create_proof(author: PeerId, expiration: u64, batch_sequence: u64) -> ProofOfStore {
+    let digest = HashValue::random();
+    let batch_id = BatchId::new_for_test(batch_sequence);
+    ProofOfStore::new(
+        BatchInfo::new(author, batch_id, 0, expiration, digest, 1, 1),
+        AggregateSignature::empty(),
+    )
+}
+
+#[tokio::test]
+async fn test_proposal_fairness() {
+    let mut proof_manager = ProofManager::new(AccountAddress::random(), 10, 10);
+    let peer0 = PeerId::random();
+    let peer1 = PeerId::random();
+
+    let mut peer0_proofs = vec![];
+    for i in 0..4 {
+        let proof = create_proof(peer0, 10 + i, 1 + i);
+        proof_manager.receive_proof(proof.clone());
+        peer0_proofs.push(proof);
+    }
+
+    let peer1_proof_0 = create_proof(peer1, 7, 1);
+    proof_manager.receive_proof(peer1_proof_0.clone());
+
+    // Without filter, and large max size, all proofs are retrieved
+    let (callback_tx, callback_rx) = oneshot::channel();
+    let req = GetPayloadCommand::GetPayloadRequest(
+        100,
+        1000000,
+        true,
+        PayloadFilter::InQuorumStore(HashSet::new()),
+        callback_tx,
+    );
+    proof_manager.handle_proposal_request(req);
+    let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
+    if let Payload::InQuorumStore(proofs) = payload {
+        assert_eq!(proofs.proofs.len(), 5);
+    } else {
+        panic!("Unexpected variant")
+    }
+
+    let (callback_tx, callback_rx) = oneshot::channel();
+    let req = GetPayloadCommand::GetPayloadRequest(
+        2,
+        1000000,
+        true,
+        PayloadFilter::InQuorumStore(HashSet::new()),
+        callback_tx,
+    );
+    proof_manager.handle_proposal_request(req);
+    let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
+    if let Payload::InQuorumStore(proofs) = payload {
+        assert_eq!(proofs.proofs.len(), 2);
+        assert!(proofs.proofs.contains(&peer0_proofs[0]));
+        assert!(proofs.proofs.contains(&peer1_proof_0));
+    } else {
+        panic!("Unexpected variant")
+    }
+
+    let mut filter = HashSet::new();
+    filter.insert(peer0_proofs[0].info().clone());
+    filter.insert(peer1_proof_0.info().clone());
+    let (callback_tx, callback_rx) = oneshot::channel();
+    let req = GetPayloadCommand::GetPayloadRequest(
+        2,
+        1000000,
+        true,
+        PayloadFilter::InQuorumStore(filter),
+        callback_tx,
+    );
+    proof_manager.handle_proposal_request(req);
+    let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
+    if let Payload::InQuorumStore(proofs) = payload {
+        assert_eq!(proofs.proofs.len(), 2);
+        assert!(proofs.proofs.contains(&peer0_proofs[1]));
+        assert!(proofs.proofs.contains(&peer0_proofs[2]));
+    } else {
+        panic!("Unexpected variant")
+    }
+
+    let mut filter = HashSet::new();
+    filter.insert(peer0_proofs[0].info().clone());
+    filter.insert(peer1_proof_0.info().clone());
+    filter.insert(peer0_proofs[1].info().clone());
+    filter.insert(peer0_proofs[2].info().clone());
+    let (callback_tx, callback_rx) = oneshot::channel();
+    let req = GetPayloadCommand::GetPayloadRequest(
+        2,
+        1000000,
+        true,
+        PayloadFilter::InQuorumStore(filter),
+        callback_tx,
+    );
+    proof_manager.handle_proposal_request(req);
+    let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
+    if let Payload::InQuorumStore(proofs) = payload {
+        assert_eq!(proofs.proofs.len(), 1);
+        assert!(proofs.proofs.contains(&peer0_proofs[3]));
+    } else {
+        panic!("Unexpected variant")
+    }
+}

--- a/consensus/src/quorum_store/tests/proof_manager_test.rs
+++ b/consensus/src/quorum_store/tests/proof_manager_test.rs
@@ -10,128 +10,7 @@ use aptos_consensus_types::{
 use aptos_crypto::HashValue;
 use aptos_types::{aggregate_signature::AggregateSignature, PeerId};
 use futures::channel::oneshot;
-use move_core_types::account_address::AccountAddress;
-use std::collections::HashSet;
-
-#[tokio::test]
-async fn test_block_request() {
-    let mut proof_manager = ProofManager::new(AccountAddress::random(), 10, 10);
-
-    let digest = HashValue::random();
-    let batch_id = BatchId::new_for_test(1);
-    let proof = ProofOfStore::new(
-        BatchInfo::new(PeerId::random(), batch_id, 0, 10, digest, 1, 1),
-        AggregateSignature::empty(),
-    );
-    proof_manager.receive_proof(proof.clone());
-
-    let (callback_tx, callback_rx) = oneshot::channel();
-    let req = GetPayloadCommand::GetPayloadRequest(
-        100,
-        1000000,
-        true,
-        PayloadFilter::InQuorumStore(HashSet::new()),
-        callback_tx,
-    );
-    proof_manager.handle_proposal_request(req);
-    let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
-    if let Payload::InQuorumStore(proofs) = payload {
-        assert_eq!(proofs.proofs.len(), 1);
-        assert_eq!(proofs.proofs[0], proof);
-    } else {
-        panic!("Unexpected variant")
-    }
-}
-
-#[tokio::test]
-async fn test_block_timestamp_expiration() {
-    let mut proof_manager = ProofManager::new(AccountAddress::random(), 10, 10);
-
-    let digest = HashValue::random();
-    let batch_id = BatchId::new_for_test(1);
-    let proof = ProofOfStore::new(
-        BatchInfo::new(PeerId::random(), batch_id, 0, 10, digest, 1, 1),
-        AggregateSignature::empty(),
-    );
-    proof_manager.receive_proof(proof.clone());
-
-    proof_manager.handle_commit_notification(1, vec![]);
-
-    let (callback_tx, callback_rx) = oneshot::channel();
-    let req = GetPayloadCommand::GetPayloadRequest(
-        100,
-        1000000,
-        true,
-        PayloadFilter::InQuorumStore(HashSet::new()),
-        callback_tx,
-    );
-    proof_manager.handle_proposal_request(req);
-    let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
-    if let Payload::InQuorumStore(proofs) = payload {
-        assert_eq!(proofs.proofs.len(), 1);
-        assert_eq!(proofs.proofs[0], proof);
-    } else {
-        panic!("Unexpected variant")
-    }
-
-    proof_manager.handle_commit_notification(20, vec![]);
-
-    let (callback_tx, callback_rx) = oneshot::channel();
-    let req = GetPayloadCommand::GetPayloadRequest(
-        100,
-        1000000,
-        true,
-        PayloadFilter::InQuorumStore(HashSet::new()),
-        callback_tx,
-    );
-    proof_manager.handle_proposal_request(req);
-    let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
-    if let Payload::InQuorumStore(proofs) = payload {
-        assert_eq!(proofs.proofs.len(), 0);
-    } else {
-        panic!("Unexpected variant")
-    }
-}
-
-#[tokio::test]
-async fn test_batch_commit() {
-    let mut proof_manager = ProofManager::new(AccountAddress::random(), 10, 10);
-
-    let digest = HashValue::random();
-    let batch_id = BatchId::new_for_test(1);
-    let proof0 = ProofOfStore::new(
-        BatchInfo::new(PeerId::random(), batch_id, 0, 10, digest, 1, 1),
-        AggregateSignature::empty(),
-    );
-    proof_manager.receive_proof(proof0.clone());
-
-    let digest = HashValue::random();
-    let batch_id = BatchId::new_for_test(1);
-    let proof1 = ProofOfStore::new(
-        BatchInfo::new(PeerId::random(), batch_id, 0, 11, digest, 1, 1),
-        AggregateSignature::empty(),
-    );
-    proof_manager.receive_proof(proof1.clone());
-
-    proof_manager.handle_commit_notification(1, vec![proof1.info().clone()]);
-
-    let (callback_tx, callback_rx) = oneshot::channel();
-    let req = GetPayloadCommand::GetPayloadRequest(
-        100,
-        1000000,
-        true,
-        PayloadFilter::InQuorumStore(HashSet::new()),
-        callback_tx,
-    );
-    proof_manager.handle_proposal_request(req);
-    let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
-    if let Payload::InQuorumStore(proofs) = payload {
-        assert_eq!(proofs.proofs.len(), 1);
-        assert!(proofs.proofs.contains(&proof0));
-    } else {
-        panic!("Unexpected variant")
-    }
-}
+use std::{collections::HashSet, time::Duration};
 
 fn create_proof(author: PeerId, expiration: u64, batch_sequence: u64) -> ProofOfStore {
     let digest = HashValue::random();
@@ -142,9 +21,98 @@ fn create_proof(author: PeerId, expiration: u64, batch_sequence: u64) -> ProofOf
     )
 }
 
+async fn get_proposal_and_assert(
+    proof_manager: &mut ProofManager,
+    max_txns: u64,
+    filter: &[BatchInfo],
+    expected: &[ProofOfStore],
+) {
+    let (callback_tx, callback_rx) = oneshot::channel();
+    let filter_set = HashSet::from_iter(filter.iter().cloned());
+    let req = GetPayloadCommand::GetPayloadRequest(
+        max_txns,
+        1000000,
+        true,
+        PayloadFilter::InQuorumStore(filter_set),
+        callback_tx,
+    );
+    proof_manager.handle_proposal_request(req);
+    let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
+    if let Payload::InQuorumStore(proofs) = payload {
+        assert_eq!(proofs.proofs.len(), expected.len());
+        for proof in proofs.proofs {
+            assert!(expected.contains(&proof));
+        }
+    } else {
+        panic!("Unexpected variant")
+    }
+}
+
+#[tokio::test]
+async fn test_block_request() {
+    let mut proof_manager = ProofManager::new(
+        PeerId::random(),
+        10,
+        10,
+        Duration::from_secs(60).as_micros() as u64,
+        100,
+    );
+
+    let proof = create_proof(PeerId::random(), 10, 1);
+    proof_manager.receive_proof(proof.clone());
+
+    get_proposal_and_assert(&mut proof_manager, 100, &vec![], &vec![proof.clone()]).await;
+}
+
+#[tokio::test]
+async fn test_block_timestamp_expiration() {
+    let mut proof_manager = ProofManager::new(
+        PeerId::random(),
+        10,
+        10,
+        Duration::from_secs(60).as_micros() as u64,
+        100,
+    );
+
+    let proof = create_proof(PeerId::random(), 10, 1);
+    proof_manager.receive_proof(proof.clone());
+
+    proof_manager.handle_commit_notification(1, vec![]);
+    get_proposal_and_assert(&mut proof_manager, 100, &vec![], &vec![proof]).await;
+
+    proof_manager.handle_commit_notification(20, vec![]);
+    get_proposal_and_assert(&mut proof_manager, 100, &vec![], &vec![]).await;
+}
+
+#[tokio::test]
+async fn test_batch_commit() {
+    let mut proof_manager = ProofManager::new(
+        PeerId::random(),
+        10,
+        10,
+        Duration::from_secs(60).as_micros() as u64,
+        100,
+    );
+
+    let proof0 = create_proof(PeerId::random(), 10, 1);
+    proof_manager.receive_proof(proof0.clone());
+
+    let proof1 = create_proof(PeerId::random(), 11, 2);
+    proof_manager.receive_proof(proof1.clone());
+
+    proof_manager.handle_commit_notification(1, vec![proof1.info().clone()]);
+    get_proposal_and_assert(&mut proof_manager, 100, &vec![], &vec![proof0]).await;
+}
+
 #[tokio::test]
 async fn test_proposal_fairness() {
-    let mut proof_manager = ProofManager::new(AccountAddress::random(), 10, 10);
+    let mut proof_manager = ProofManager::new(
+        PeerId::random(),
+        10,
+        10,
+        Duration::from_secs(60).as_micros() as u64,
+        100,
+    );
     let peer0 = PeerId::random();
     let peer1 = PeerId::random();
 
@@ -159,80 +127,116 @@ async fn test_proposal_fairness() {
     proof_manager.receive_proof(peer1_proof_0.clone());
 
     // Without filter, and large max size, all proofs are retrieved
-    let (callback_tx, callback_rx) = oneshot::channel();
-    let req = GetPayloadCommand::GetPayloadRequest(
+    let mut expected = peer0_proofs.clone();
+    expected.push(peer1_proof_0.clone());
+    get_proposal_and_assert(&mut proof_manager, 100, &vec![], &expected).await;
+
+    // The first two proofs are taken fairly from each peer
+    get_proposal_and_assert(&mut proof_manager, 2, &vec![], &vec![
+        peer0_proofs[0].clone(),
+        peer1_proof_0.clone(),
+    ])
+    .await;
+
+    // The next two proofs are taken from the remaining peer
+    let filter = vec![peer0_proofs[0].clone(), peer1_proof_0.clone()];
+    let filter: Vec<_> = filter.iter().map(ProofOfStore::info).cloned().collect();
+    get_proposal_and_assert(&mut proof_manager, 2, &filter, &peer0_proofs[1..3]).await;
+
+    // The last proof is also taken from the remaining peer
+    let mut filter = peer0_proofs[0..3].to_vec();
+    filter.push(peer1_proof_0.clone());
+    let filter: Vec<_> = filter.iter().map(ProofOfStore::info).cloned().collect();
+    get_proposal_and_assert(&mut proof_manager, 2, &filter, &peer0_proofs[3..4]).await;
+}
+
+#[tokio::test]
+async fn test_duplicate_batches_on_commit() {
+    let mut proof_manager = ProofManager::new(
+        PeerId::random(),
+        10,
+        10,
+        Duration::from_secs(60).as_micros() as u64,
         100,
-        1000000,
-        true,
-        PayloadFilter::InQuorumStore(HashSet::new()),
-        callback_tx,
     );
-    proof_manager.handle_proposal_request(req);
-    let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
-    if let Payload::InQuorumStore(proofs) = payload {
-        assert_eq!(proofs.proofs.len(), 5);
-    } else {
-        panic!("Unexpected variant")
+
+    let author = PeerId::random();
+    let digest = HashValue::random();
+    let batch_id = BatchId::new_for_test(1);
+    let batch = BatchInfo::new(author, batch_id, 0, 10, digest, 1, 1);
+    let proof0 = ProofOfStore::new(batch.clone(), AggregateSignature::empty());
+    let proof1 = ProofOfStore::new(batch.clone(), AggregateSignature::empty());
+    let proof2 = ProofOfStore::new(batch.clone(), AggregateSignature::empty());
+
+    proof_manager.receive_proof(proof0.clone());
+    proof_manager.receive_proof(proof1.clone());
+
+    // Only one copy of the batch exists
+    get_proposal_and_assert(&mut proof_manager, 10, &vec![], &vec![proof0.clone()]).await;
+
+    // Nothing goes wrong on commits
+    proof_manager.handle_commit_notification(4, vec![batch.clone()]);
+    get_proposal_and_assert(&mut proof_manager, 10, &vec![], &vec![]).await;
+
+    // Before expiration, still marked as committed
+    proof_manager.receive_proof(proof2.clone());
+    get_proposal_and_assert(&mut proof_manager, 10, &vec![], &vec![]).await;
+
+    // Nothing goes wrong on expiration
+    proof_manager.handle_commit_notification(5, vec![]);
+    get_proposal_and_assert(&mut proof_manager, 10, &vec![], &vec![]).await;
+    proof_manager.handle_commit_notification(12, vec![]);
+    get_proposal_and_assert(&mut proof_manager, 10, &vec![], &vec![]).await;
+}
+
+#[tokio::test]
+async fn test_duplicate_batches_on_expiration() {
+    let mut proof_manager = ProofManager::new(
+        PeerId::random(),
+        10,
+        10,
+        Duration::from_secs(60).as_micros() as u64,
+        100,
+    );
+
+    let author = PeerId::random();
+    let digest = HashValue::random();
+    let batch_id = BatchId::new_for_test(1);
+    let batch = BatchInfo::new(author, batch_id, 0, 10, digest, 1, 1);
+    let proof0 = ProofOfStore::new(batch.clone(), AggregateSignature::empty());
+    let proof1 = ProofOfStore::new(batch.clone(), AggregateSignature::empty());
+
+    proof_manager.receive_proof(proof0.clone());
+    proof_manager.receive_proof(proof1.clone());
+
+    // Only one copy of the batch exists
+    get_proposal_and_assert(&mut proof_manager, 10, &vec![], &vec![proof0.clone()]).await;
+
+    // Nothing goes wrong on expiration
+    proof_manager.handle_commit_notification(5, vec![]);
+    get_proposal_and_assert(&mut proof_manager, 10, &vec![], &vec![proof0.clone()]).await;
+    proof_manager.handle_commit_notification(12, vec![]);
+    get_proposal_and_assert(&mut proof_manager, 10, &vec![], &vec![]).await;
+}
+
+#[tokio::test]
+async fn test_max_per_author() {
+    let mut proof_manager = ProofManager::new(
+        PeerId::random(),
+        10,
+        10,
+        Duration::from_secs(60).as_micros() as u64,
+        10,
+    );
+
+    let author = PeerId::random();
+    let mut proofs = vec![];
+    for i in 0..20 {
+        let proof = create_proof(author, 10 + i, i);
+        proofs.push(proof.clone());
+        proof_manager.receive_proof(proof);
     }
 
-    let (callback_tx, callback_rx) = oneshot::channel();
-    let req = GetPayloadCommand::GetPayloadRequest(
-        2,
-        1000000,
-        true,
-        PayloadFilter::InQuorumStore(HashSet::new()),
-        callback_tx,
-    );
-    proof_manager.handle_proposal_request(req);
-    let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
-    if let Payload::InQuorumStore(proofs) = payload {
-        assert_eq!(proofs.proofs.len(), 2);
-        assert!(proofs.proofs.contains(&peer0_proofs[0]));
-        assert!(proofs.proofs.contains(&peer1_proof_0));
-    } else {
-        panic!("Unexpected variant")
-    }
-
-    let mut filter = HashSet::new();
-    filter.insert(peer0_proofs[0].info().clone());
-    filter.insert(peer1_proof_0.info().clone());
-    let (callback_tx, callback_rx) = oneshot::channel();
-    let req = GetPayloadCommand::GetPayloadRequest(
-        2,
-        1000000,
-        true,
-        PayloadFilter::InQuorumStore(filter),
-        callback_tx,
-    );
-    proof_manager.handle_proposal_request(req);
-    let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
-    if let Payload::InQuorumStore(proofs) = payload {
-        assert_eq!(proofs.proofs.len(), 2);
-        assert!(proofs.proofs.contains(&peer0_proofs[1]));
-        assert!(proofs.proofs.contains(&peer0_proofs[2]));
-    } else {
-        panic!("Unexpected variant")
-    }
-
-    let mut filter = HashSet::new();
-    filter.insert(peer0_proofs[0].info().clone());
-    filter.insert(peer1_proof_0.info().clone());
-    filter.insert(peer0_proofs[1].info().clone());
-    filter.insert(peer0_proofs[2].info().clone());
-    let (callback_tx, callback_rx) = oneshot::channel();
-    let req = GetPayloadCommand::GetPayloadRequest(
-        2,
-        1000000,
-        true,
-        PayloadFilter::InQuorumStore(filter),
-        callback_tx,
-    );
-    proof_manager.handle_proposal_request(req);
-    let GetPayloadResponse::GetPayloadResponse(payload) = callback_rx.await.unwrap().unwrap();
-    if let Payload::InQuorumStore(proofs) = payload {
-        assert_eq!(proofs.proofs.len(), 1);
-        assert!(proofs.proofs.contains(&peer0_proofs[3]));
-    } else {
-        panic!("Unexpected variant")
-    }
+    // Max per author restricts to first 10 proofs
+    get_proposal_and_assert(&mut proof_manager, 100, &vec![], &proofs[0..10]).await;
 }

--- a/consensus/src/quorum_store/tests/proof_manager_test.rs
+++ b/consensus/src/quorum_store/tests/proof_manager_test.rs
@@ -61,7 +61,7 @@ async fn test_block_request() {
     let proof = create_proof(PeerId::random(), 10, 1);
     proof_manager.receive_proof(proof.clone());
 
-    get_proposal_and_assert(&mut proof_manager, 100, &vec![], &vec![proof.clone()]).await;
+    get_proposal_and_assert(&mut proof_manager, 100, &[], &vec![proof.clone()]).await;
 }
 
 #[tokio::test]
@@ -78,10 +78,10 @@ async fn test_block_timestamp_expiration() {
     proof_manager.receive_proof(proof.clone());
 
     proof_manager.handle_commit_notification(1, vec![]);
-    get_proposal_and_assert(&mut proof_manager, 100, &vec![], &vec![proof]).await;
+    get_proposal_and_assert(&mut proof_manager, 100, &[], &vec![proof]).await;
 
     proof_manager.handle_commit_notification(20, vec![]);
-    get_proposal_and_assert(&mut proof_manager, 100, &vec![], &vec![]).await;
+    get_proposal_and_assert(&mut proof_manager, 100, &[], &[]).await;
 }
 
 #[tokio::test]
@@ -101,7 +101,7 @@ async fn test_batch_commit() {
     proof_manager.receive_proof(proof1.clone());
 
     proof_manager.handle_commit_notification(1, vec![proof1.info().clone()]);
-    get_proposal_and_assert(&mut proof_manager, 100, &vec![], &vec![proof0]).await;
+    get_proposal_and_assert(&mut proof_manager, 100, &[], &vec![proof0]).await;
 }
 
 #[tokio::test]
@@ -129,10 +129,10 @@ async fn test_proposal_fairness() {
     // Without filter, and large max size, all proofs are retrieved
     let mut expected = peer0_proofs.clone();
     expected.push(peer1_proof_0.clone());
-    get_proposal_and_assert(&mut proof_manager, 100, &vec![], &expected).await;
+    get_proposal_and_assert(&mut proof_manager, 100, &[], &expected).await;
 
     // The first two proofs are taken fairly from each peer
-    get_proposal_and_assert(&mut proof_manager, 2, &vec![], &vec![
+    get_proposal_and_assert(&mut proof_manager, 2, &[], &vec![
         peer0_proofs[0].clone(),
         peer1_proof_0.clone(),
     ])
@@ -172,21 +172,21 @@ async fn test_duplicate_batches_on_commit() {
     proof_manager.receive_proof(proof1.clone());
 
     // Only one copy of the batch exists
-    get_proposal_and_assert(&mut proof_manager, 10, &vec![], &vec![proof0.clone()]).await;
+    get_proposal_and_assert(&mut proof_manager, 10, &[], &vec![proof0.clone()]).await;
 
     // Nothing goes wrong on commits
     proof_manager.handle_commit_notification(4, vec![batch.clone()]);
-    get_proposal_and_assert(&mut proof_manager, 10, &vec![], &vec![]).await;
+    get_proposal_and_assert(&mut proof_manager, 10, &[], &[]).await;
 
     // Before expiration, still marked as committed
     proof_manager.receive_proof(proof2.clone());
-    get_proposal_and_assert(&mut proof_manager, 10, &vec![], &vec![]).await;
+    get_proposal_and_assert(&mut proof_manager, 10, &[], &[]).await;
 
     // Nothing goes wrong on expiration
     proof_manager.handle_commit_notification(5, vec![]);
-    get_proposal_and_assert(&mut proof_manager, 10, &vec![], &vec![]).await;
+    get_proposal_and_assert(&mut proof_manager, 10, &[], &[]).await;
     proof_manager.handle_commit_notification(12, vec![]);
-    get_proposal_and_assert(&mut proof_manager, 10, &vec![], &vec![]).await;
+    get_proposal_and_assert(&mut proof_manager, 10, &[], &[]).await;
 }
 
 #[tokio::test]
@@ -210,13 +210,13 @@ async fn test_duplicate_batches_on_expiration() {
     proof_manager.receive_proof(proof1.clone());
 
     // Only one copy of the batch exists
-    get_proposal_and_assert(&mut proof_manager, 10, &vec![], &vec![proof0.clone()]).await;
+    get_proposal_and_assert(&mut proof_manager, 10, &[], &vec![proof0.clone()]).await;
 
     // Nothing goes wrong on expiration
     proof_manager.handle_commit_notification(5, vec![]);
-    get_proposal_and_assert(&mut proof_manager, 10, &vec![], &vec![proof0.clone()]).await;
+    get_proposal_and_assert(&mut proof_manager, 10, &[], &vec![proof0.clone()]).await;
     proof_manager.handle_commit_notification(12, vec![]);
-    get_proposal_and_assert(&mut proof_manager, 10, &vec![], &vec![]).await;
+    get_proposal_and_assert(&mut proof_manager, 10, &[], &[]).await;
 }
 
 #[tokio::test]
@@ -238,5 +238,5 @@ async fn test_max_per_author() {
     }
 
     // Max per author restricts to first 10 proofs
-    get_proposal_and_assert(&mut proof_manager, 100, &vec![], &proofs[0..10]).await;
+    get_proposal_and_assert(&mut proof_manager, 100, &[], &proofs[0..10]).await;
 }

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{monitor, quorum_store::counters};
-use aptos_consensus_types::{common::TransactionSummary, proof_of_store::ProofOfStore};
-use aptos_crypto::HashValue;
+use aptos_consensus_types::{
+    common::TransactionSummary,
+    proof_of_store::{BatchInfo, ProofOfStore},
+};
 use aptos_logger::prelude::*;
 use aptos_mempool::{QuorumStoreRequest, QuorumStoreResponse};
-use aptos_types::transaction::SignedTransaction;
+use aptos_types::{transaction::SignedTransaction, PeerId};
 use chrono::Utc;
 use futures::channel::{mpsc::Sender, oneshot};
+use rand::{seq::SliceRandom, thread_rng};
 use std::{
     cmp::Reverse,
-    collections::{
-        hash_map::Entry::{Occupied, Vacant},
-        BinaryHeap, HashMap, HashSet, VecDeque,
-    },
+    collections::{BinaryHeap, HashMap, HashSet, VecDeque},
     hash::Hash,
     time::{Duration, Instant},
 };
@@ -142,43 +142,72 @@ impl MempoolProxy {
 
 // TODO: unitest
 pub struct ProofQueue {
-    digest_queue: VecDeque<(HashValue, u64)>, // queue of all proofs
-    local_digest_queue: VecDeque<(HashValue, u64)>, // queue of local proofs, to make back pressure update more efficient
-    digest_proof: HashMap<HashValue, Option<ProofOfStore>>, // None means committed
-    digest_insertion_time: HashMap<HashValue, Instant>,
+    my_peer_id: PeerId,
+    // Queue per peer to ensure fairness, includes insertion time
+    author_to_batches: HashMap<PeerId, Vec<BatchInfo>>,
+    // ProofOfStore and insertion_time. None if committed
+    batch_to_proof: HashMap<BatchInfo, Option<(ProofOfStore, Instant)>>,
+    latest_block_timestamp: u64,
+    max_in_future_usecs: u64,
+    max_queue_size_per_author: usize,
 }
 
 impl ProofQueue {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(my_peer_id: PeerId) -> Self {
         Self {
-            digest_queue: VecDeque::new(),
-            local_digest_queue: VecDeque::new(),
-            digest_proof: HashMap::new(),
-            digest_insertion_time: HashMap::new(),
+            my_peer_id,
+            author_to_batches: HashMap::new(),
+            batch_to_proof: HashMap::new(),
+            latest_block_timestamp: 0,
+            // TODO: move these to configs
+            max_in_future_usecs: Duration::from_secs(120).as_micros() as u64,
+            max_queue_size_per_author: 1000,
         }
     }
 
-    pub(crate) fn push(&mut self, proof: ProofOfStore, local: bool) {
-        match self.digest_proof.entry(*proof.digest()) {
-            Vacant(entry) => {
-                self.digest_queue
-                    .push_back((*proof.digest(), proof.expiration()));
-                entry.insert(Some(proof.clone()));
-                self.digest_insertion_time
-                    .insert(*proof.digest(), Instant::now());
-            },
-            Occupied(mut entry) => {
-                if entry.get().is_some()
-                    && entry.get().as_ref().unwrap().expiration() < proof.expiration()
-                {
-                    entry.insert(Some(proof.clone()));
-                }
-            },
+    pub(crate) fn push(&mut self, proof: ProofOfStore) {
+        if proof.expiration() < self.latest_block_timestamp {
+            counters::REJECTED_POS_COUNT
+                .with_label_values(&["expired"])
+                .inc();
+            return;
         }
-        if local {
+        if proof.expiration()
+            > aptos_infallible::duration_since_epoch().as_micros() as u64 + self.max_in_future_usecs
+        {
+            counters::REJECTED_POS_COUNT
+                .with_label_values(&["too_far_in_future"])
+                .inc();
+            return;
+        }
+        if self.batch_to_proof.get(proof.info()).is_some() {
+            counters::REJECTED_POS_COUNT
+                .with_label_values(&["duplicate"])
+                .inc();
+            return;
+        }
+
+        if let Some(queue) = self.author_to_batches.get(&proof.author()) {
+            if queue.len() >= self.max_queue_size_per_author {
+                sample!(
+                    SampleRate::Duration(Duration::from_secs(10)),
+                    warn!("Queue full for author {}", proof.author())
+                );
+                counters::REJECTED_POS_COUNT
+                    .with_label_values(&["queue_full"])
+                    .inc();
+                return;
+            }
+        }
+
+        let author = proof.author();
+        let queue = self.author_to_batches.entry(author).or_default();
+        queue.push(proof.info().clone());
+        self.batch_to_proof
+            .insert(proof.info().clone(), Some((proof, Instant::now())));
+
+        if author == self.my_peer_id {
             counters::LOCAL_POS_COUNT.inc();
-            self.local_digest_queue
-                .push_back((*proof.digest(), proof.expiration()));
         } else {
             counters::REMOTE_POS_COUNT.inc();
         }
@@ -188,159 +217,162 @@ impl ProofQueue {
     // return the vector of pulled PoS, and the size of the remaining PoS
     pub(crate) fn pull_proofs(
         &mut self,
-        excluded_proofs: &HashSet<HashValue>,
-        current_block_timestamp: u64,
+        excluded_batches: &HashSet<BatchInfo>,
         max_txns: u64,
         max_bytes: u64,
         return_non_full: bool,
     ) -> Vec<ProofOfStore> {
-        let num_expired = self
-            .digest_queue
-            .iter()
-            .take_while(|(_, expiration_time)| *expiration_time < current_block_timestamp)
-            .count();
-        let mut num_expired_but_not_committed = 0;
-        for (digest, expiration_time) in self.digest_queue.drain(0..num_expired) {
-            if self
-                .digest_proof
-                .get(&digest)
-                .expect("Entry for unexpired digest must exist")
-                .is_some()
-            {
-                // non-committed proof that is expired
-                num_expired_but_not_committed += 1;
-                if expiration_time < current_block_timestamp {
-                    counters::GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_PULL_PROOFS
-                        .observe((current_block_timestamp - expiration_time) as f64);
-                }
-            }
-            claims::assert_some!(self.digest_proof.remove(&digest));
-            self.digest_insertion_time.remove(&digest);
-        }
-
-        let mut ret = Vec::new();
+        let mut ret = vec![];
         let mut cur_bytes = 0;
         let mut cur_txns = 0;
-        let initial_size = self.digest_queue.len();
-        let mut size = self.digest_queue.len();
+        let mut excluded_txns = 0;
         let mut full = false;
 
-        for (digest, expiration) in self
-            .digest_queue
-            .iter()
-            .filter(|(digest, _)| !excluded_proofs.contains(digest))
-        {
-            if let Some(proof) = self
-                .digest_proof
-                .get(digest)
-                .expect("Entry for unexpired digest must exist")
-            {
-                if *expiration >= current_block_timestamp {
-                    // non-committed proof that has not expired
-                    cur_bytes += proof.num_bytes();
-                    cur_txns += proof.num_txns();
-                    if cur_bytes > max_bytes || cur_txns > max_txns {
-                        // Exceeded the limit for requested bytes or number of transactions.
-                        full = true;
+        let mut author_to_num_remaining = HashMap::new();
+        for (author, batches) in self.author_to_batches.iter() {
+            author_to_num_remaining.insert(*author, batches.len());
+        }
+
+        'outer: while !author_to_num_remaining.is_empty() {
+            let shuffled_peers: Vec<_> = {
+                let mut peers: Vec<_> = author_to_num_remaining.keys().cloned().collect();
+                peers.shuffle(&mut thread_rng());
+                peers
+            };
+
+            for peer in shuffled_peers {
+                let queue = self.author_to_batches.get(&peer).unwrap();
+                let num_remaining = author_to_num_remaining.remove(&peer).unwrap();
+
+                let mut num_read = 0;
+                for i in (queue.len() - num_remaining)..queue.len() {
+                    let batch = queue.get(i).unwrap();
+                    num_read += 1;
+                    if excluded_batches.contains(batch) {
+                        excluded_txns += batch.num_txns();
+                    } else if self.batch_to_proof.get(batch).unwrap().is_some() {
+                        cur_bytes += batch.num_bytes();
+                        cur_txns += batch.num_txns();
+                        if cur_bytes > max_bytes || cur_txns > max_txns {
+                            // Exceeded the limit for requested bytes or number of transactions.
+                            full = true;
+                            break 'outer;
+                        }
+                        let (proof, insertion_time) =
+                            self.batch_to_proof.get(batch).unwrap().clone().unwrap();
+                        ret.push(proof);
+                        counters::POS_TO_PULL.observe(insertion_time.elapsed().as_secs_f64());
                         break;
                     }
-                    ret.push(proof.clone());
-                    if let Some(insertion_time) = self.digest_insertion_time.get(digest) {
-                        counters::POS_TO_PULL.observe(insertion_time.elapsed().as_secs_f64());
-                    }
-                } else {
-                    // non-committed proof that is expired
-                    num_expired_but_not_committed += 1;
-                    if *expiration < current_block_timestamp {
-                        counters::GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_PULL_PROOFS
-                            .observe((current_block_timestamp - expiration) as f64);
-                    }
+                }
+                if num_remaining != num_read {
+                    author_to_num_remaining.insert(peer, num_remaining - num_read);
                 }
             }
-            size -= 1;
         }
         info!(
             // before non full check
             byte_size = cur_bytes,
             block_size = cur_txns,
             batch_count = ret.len(),
-            remaining_proof_num = size,
-            initial_remaining_proof_num = initial_size,
             full = full,
             return_non_full = return_non_full,
             "Pull payloads from QuorumStore: internal"
         );
 
         if full || return_non_full {
-            counters::EXPIRED_PROOFS_WHEN_PULL.observe(num_expired_but_not_committed as f64);
             counters::BLOCK_SIZE_WHEN_PULL.observe(cur_txns as f64);
             counters::BLOCK_BYTES_WHEN_PULL.observe(cur_bytes as f64);
             counters::PROOF_SIZE_WHEN_PULL.observe(ret.len() as f64);
+            counters::EXCLUDED_TXNS_WHEN_PULL.observe(excluded_txns as f64);
             ret
         } else {
             Vec::new()
         }
     }
 
+    pub(crate) fn handle_updated_block_timestamp(&mut self, block_timestamp: u64) {
+        assert!(
+            self.latest_block_timestamp <= block_timestamp,
+            "Decreasing block timestamp"
+        );
+        self.latest_block_timestamp = block_timestamp;
+
+        let peers: Vec<_> = self.author_to_batches.keys().cloned().collect();
+        let mut num_expired_but_not_committed = 0;
+
+        for peer in peers {
+            let mut queue = self.author_to_batches.remove(&peer).unwrap();
+            let num_expired = queue
+                .iter()
+                .take_while(|batch| batch.expiration() < block_timestamp)
+                .count();
+
+            for batch in queue.drain(0..num_expired) {
+                if self
+                    .batch_to_proof
+                    .get(&batch)
+                    .expect("Entry for unexpired batch must exist")
+                    .is_some()
+                {
+                    // non-committed proof that is expired
+                    num_expired_but_not_committed += 1;
+                    if batch.expiration() < block_timestamp {
+                        counters::GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_PULL_PROOFS
+                            .observe((block_timestamp - batch.expiration()) as f64);
+                    }
+                }
+                claims::assert_some!(self.batch_to_proof.remove(&batch));
+            }
+
+            if !queue.is_empty() {
+                self.author_to_batches.insert(peer, queue);
+            }
+        }
+        counters::NUM_PROOFS_EXPIRED_WHEN_COMMIT.inc_by(num_expired_but_not_committed);
+    }
+
     pub(crate) fn num_total_txns_and_proofs(&mut self, current_block_timestamp: u64) -> (u64, u64) {
         let mut remaining_txns = 0;
         let mut remaining_proofs = 0;
+        let mut remaining_local_txns = 0;
+        let mut remaining_local_proofs = 0;
+
         // TODO: if the digest_queue is large, this may be too inefficient
-        for (digest, expiration) in self.digest_queue.iter() {
-            // Not expired
-            if *expiration >= current_block_timestamp {
-                // Not committed
-                if let Some(Some(proof)) = self.digest_proof.get(digest) {
-                    remaining_txns += proof.num_txns();
-                    remaining_proofs += 1;
-                }
-            }
-        }
-        counters::NUM_TOTAL_TXNS_LEFT_ON_COMMIT.observe(remaining_txns as f64);
-        counters::NUM_TOTAL_PROOFS_LEFT_ON_COMMIT.observe(remaining_proofs as f64);
-
-        (remaining_txns, remaining_proofs)
-    }
-
-    // returns the number of unexpired local proofs
-    pub(crate) fn clean_local_proofs(&mut self, current_block_timestamp: u64) -> Option<u64> {
-        let num_expired = self
-            .local_digest_queue
-            .iter()
-            .take_while(|(_, expiration_time)| *expiration_time < current_block_timestamp)
-            .count();
-        self.local_digest_queue.drain(0..num_expired);
-
-        let mut remaining_local_proof_size = 0;
-
-        for (digest, expiration) in self.local_digest_queue.iter() {
-            // Not expired. It is possible that the proof entry in digest_proof was already removed
-            // when draining the digest_queue but local_digest_queue is not drained yet.
-            if *expiration >= current_block_timestamp {
-                if let Some(entry) = self.digest_proof.get(digest) {
+        let peers: Vec<_> = self.author_to_batches.keys().cloned().collect();
+        for peer in peers {
+            // TODO: queue direction!
+            let queue = self.author_to_batches.get(&peer).unwrap();
+            for batch in queue.iter() {
+                // Not expired
+                if batch.expiration() >= current_block_timestamp {
                     // Not committed
-                    if entry.is_some() {
-                        remaining_local_proof_size += 1;
+                    if let Some(Some((proof, _))) = self.batch_to_proof.get(batch) {
+                        remaining_txns += proof.num_txns();
+                        remaining_proofs += 1;
+                        if proof.author() == self.my_peer_id {
+                            remaining_local_txns += proof.num_txns();
+                            remaining_local_proofs += 1;
+                        }
                     }
                 }
             }
         }
-        counters::NUM_LOCAL_PROOFS_LEFT_ON_COMMIT.observe(remaining_local_proof_size as f64);
+        counters::NUM_TOTAL_TXNS_LEFT_ON_COMMIT.observe(remaining_txns);
+        counters::NUM_TOTAL_PROOFS_LEFT_ON_COMMIT.observe(remaining_proofs);
+        counters::NUM_LOCAL_TXNS_LEFT_ON_COMMIT.observe(remaining_local_txns);
+        counters::NUM_LOCAL_PROOFS_LEFT_ON_COMMIT.observe(remaining_local_proofs);
 
-        if let Some(&(_, time)) = self.local_digest_queue.iter().next() {
-            Some(time)
-        } else {
-            None
-        }
+        (remaining_txns, remaining_proofs)
     }
 
-    //mark in the hashmap committed PoS, but keep them until they expire
-    pub(crate) fn mark_committed(&mut self, proofs: Vec<ProofOfStore>) {
-        for digest in proofs.iter().map(|p| p.digest()) {
-            self.digest_proof.insert(*digest, None);
-            if let Some(insertion_time) = self.digest_insertion_time.get(digest) {
+    // Mark in the hashmap committed PoS, but keep them until they expire
+    pub(crate) fn mark_committed(&mut self, batches: Vec<BatchInfo>) {
+        for batch in batches {
+            if let Some(Some((_, insertion_time))) = self.batch_to_proof.get(&batch) {
                 counters::POS_TO_COMMIT.observe(insertion_time.elapsed().as_secs_f64());
             }
+            self.batch_to_proof.insert(batch, None);
         }
     }
 }

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -316,7 +316,7 @@ impl ProofQueue {
                     // non-committed proof that is expired
                     num_expired_but_not_committed += 1;
                     if batch.expiration() < block_timestamp {
-                        counters::GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_PULL_PROOFS
+                        counters::GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_COMMIT
                             .observe((block_timestamp - batch.expiration()) as f64);
                     }
                 }

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -335,10 +335,10 @@ impl ProofQueue {
     }
 
     //mark in the hashmap committed PoS, but keep them until they expire
-    pub(crate) fn mark_committed(&mut self, digests: Vec<HashValue>) {
-        for digest in digests {
-            self.digest_proof.insert(digest, None);
-            if let Some(insertion_time) = self.digest_insertion_time.get(&digest) {
+    pub(crate) fn mark_committed(&mut self, proofs: Vec<ProofOfStore>) {
+        for digest in proofs.iter().map(|p| p.digest()) {
+            self.digest_proof.insert(*digest, None);
+            if let Some(insertion_time) = self.digest_insertion_time.get(digest) {
                 counters::POS_TO_COMMIT.observe(insertion_time.elapsed().as_secs_f64());
             }
         }

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -400,7 +400,7 @@ fn get_changelog(prev_commit: Option<&String>, upstream_commit: &str) -> String 
 
 fn get_test_suite(suite_name: &str, duration: Duration) -> Result<ForgeConfig<'static>> {
     match suite_name {
-        "land_blocking" => Ok(land_blocking_test_suite(duration)),
+        "land_blocking" => single_test_suite("three_region_simulation_graceful_overload"),
         "local_test_suite" => Ok(local_test_suite()),
         "pre_release" => Ok(pre_release_suite()),
         "run_forever" => Ok(run_forever()),

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -804,6 +804,7 @@ fn graceful_overload(config: ForgeConfig) -> ForgeConfig {
             // don't regress, but something to investigate
             avg_tps: 3400,
             latency_thresholds: &[],
+            inner_destination_num_nodes: None,
         }])
         // First start higher gas-fee traffic, to not cause issues with TxnEmitter setup - account creation
         .with_emit_job(
@@ -852,6 +853,7 @@ fn three_region_sim_graceful_overload(config: ForgeConfig) -> ForgeConfig {
                 // don't regress, but something to investigate
                 avg_tps: 3400,
                 latency_thresholds: &[],
+                inner_destination_num_nodes: Some(10),
             },
             three_region_simulation_test: ThreeRegionSimulationTest {
                 add_execution_delay: None,

--- a/testsuite/testcases/src/two_traffics_test.rs
+++ b/testsuite/testcases/src/two_traffics_test.rs
@@ -20,6 +20,7 @@ pub struct TwoTrafficsTest {
     pub inner_tps: usize,
     pub inner_gas_price: u64,
     pub inner_init_gas_price_multiplier: u64,
+    pub inner_destination_num_nodes: Option<usize>,
 
     pub avg_tps: usize,
     pub latency_thresholds: &'static [(f32, LatencyType)],
@@ -38,6 +39,10 @@ impl NetworkLoadTest for TwoTrafficsTest {
             duration.as_secs_f32()
         );
         let nodes_to_send_load_to = LoadDestination::AllFullnodes.get_destination_nodes(swarm);
+        let num_nodes = match self.inner_destination_num_nodes {
+            None => nodes_to_send_load_to.len(),
+            Some(num) => num,
+        };
         let rng = ::rand::rngs::StdRng::from_seed(OsRng.gen());
 
         let (emitter, emit_job_request) = create_emitter_and_request(
@@ -48,7 +53,7 @@ impl NetworkLoadTest for TwoTrafficsTest {
                 })
                 .gas_price(self.inner_gas_price)
                 .init_gas_price_multiplier(self.inner_init_gas_price_multiplier),
-            &nodes_to_send_load_to,
+            &nodes_to_send_load_to[0..num_nodes],
             rng,
         )?;
 

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -70,7 +70,7 @@ impl OnChainConsensusConfig {
 
     pub fn quorum_store_enabled(&self) -> bool {
         match &self {
-            OnChainConsensusConfig::V1(_config) => false,
+            OnChainConsensusConfig::V1(_config) => true,
             OnChainConsensusConfig::V2(_config) => true,
         }
     }

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -70,7 +70,7 @@ impl OnChainConsensusConfig {
 
     pub fn quorum_store_enabled(&self) -> bool {
         match &self {
-            OnChainConsensusConfig::V1(_config) => true,
+            OnChainConsensusConfig::V1(_config) => false,
             OnChainConsensusConfig::V2(_config) => true,
         }
     }


### PR DESCRIPTION
- commit notifications to use proofs, not digest
- Implement the per-author queue in proof_manager
- [TEST BRANCH] hardcode quorum store enabled true
- Some cleanup of configs and adding more tests
- Pass around BatchInfo
- More cleanup
- Revert "[TEST BRANCH] hardcode quorum store enabled true"
- some cleanup
- change the test to overload only half
- three_region_simulation_graceful_overload

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
