### PR TITLE
Add customizable to the list for the ANS UI doc

### DIFF
--- a/developer-docs-site/scripts/additional_dict.txt
+++ b/developer-docs-site/scripts/additional_dict.txt
@@ -293,6 +293,7 @@ clippy
 cn
 codebase
 config
+customizable
 configs
 const
 copyable


### PR DESCRIPTION
So [ANS UI library documentation](https://github.com/aptos-labs/aptos-core/pull/7212) can pass the docs-lint test.
