### PR TITLE
[storage] add cron backup compaction

### DIFF
--- a/terraform/helm/fullnode/templates/backup-compaction.yaml
+++ b/terraform/helm/fullnode/templates/backup-compaction.yaml
@@ -1,0 +1,100 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "backup.fullname" . }}-backup-compaction
+  labels:
+    {{- include "backup.labels" . | nindent 4 }}
+    app.kubernetes.io/name: backup-compaction
+spec:
+  concurrencyPolicy: Replace
+  suspend: {{ not .Values.backup.enable }}
+  schedule: {{ .Values.backup_compaction.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "backup.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/name: backup-compaction
+          annotations:
+            seccomp.security.alpha.kubernetes.io/pod: runtime/default
+        spec:
+          restartPolicy: Never
+          terminationGracePeriodSeconds: 0
+          containers:
+          - name: backup-compaction
+            # use the same image with the backup sts
+            image: {{ .Values.backup.image.repo }}:{{ .Values.backup.image.tag | default .Values.imageTag }}
+            imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
+            command:
+            - /usr/local/bin/aptos-db-tool
+            - backup-maintenance
+            - compact
+            - --state-snapshot-file-compact-factor
+            - 100
+            - --transaction-file-compact-factor
+            - 100
+            - --epoch-ending-file-compact-factor
+            - 100
+            - --metadata-cache-dir
+            - /tmp/aptos-backup-compaction-metadata
+            - --command-adapter-config
+            # use the same config with the backup sts
+            - /opt/aptos/etc/{{ .Values.backup.config.location }}.yaml
+            env:
+            - name: RUST_LOG
+              value: "info"
+            - name: RUST_BACKTRACE
+              value: "1"
+            {{- if (include "backup.pushMetricsEndpoint" $) }}
+            - name: KUBERNETES_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: PUSH_METRICS_ENDPOINT
+              value: "{{- include "backup.pushMetricsEndpoint" $ }}/api/v1/import/prometheus?extra_label=role={{- .jobName | default "db_backup_compaction" }}&extra_label=kubernetes_pod_name=$(KUBERNETES_POD_NAME)"
+            {{- end }}
+            {{- include "backup.backupEnvironment" (dict "config" $.Values.backup.config "era" $.Values.chain.era) | nindent 12 }}
+            {{- with .Values.backup_compaction }}
+            resources:
+            {{- toYaml .resources | nindent 14 }}
+            volumeMounts:
+            - name: backup-config
+              mountPath: /opt/aptos/etc
+            - name: tmp
+              mountPath: /tmp
+            securityContext:
+              readOnlyRootFilesystem: true
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 6180
+            runAsGroup: 6180
+            fsGroup: 6180
+          {{- with .nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          {{- with .affinity }}
+          affinity:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          {{- with .tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          {{- end }}
+          volumes:
+          - name: backup-config
+            configMap:
+              name: {{ include "backup.fullname" . }}-backup
+          - name: tmp
+            emptyDir: {}
+          serviceAccountName: {{ include "backup.serviceAccount" . }}
+          {{- if .Values.imagePullSecret }}
+          imagePullSecrets:
+          - name: {{.Values.imagePullSecret}}
+          {{- end }}

--- a/terraform/helm/fullnode/values.yaml
+++ b/terraform/helm/fullnode/values.yaml
@@ -147,6 +147,20 @@ backup_verify:
   tolerations: []
   affinity: {}
 
+backup_compaction:
+  # -- The schedule for backup compaction
+  schedule: "0 0 * * 3" # every Wednesday at midnight
+  resources:
+    limits:
+      cpu: 1
+      memory: 1Gi
+    requests:
+      cpu: 1
+      memory: 1Gi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
 restore:
   image:
     # -- Image repo to use for restore images


### PR DESCRIPTION
### Description

Currently, I did manual compaction for gcp and was testnet backup files.
Now, want to create a daily cron job to run manual compaction job in both gcp and aws backup fullnodes


### Test Plan
After the (1) v1.5 testnet release and  (2) terraform fix, the test will be
1. terraform apply the config file in this PR for testnet GCP cluster
2. check metadata folder to see if metadata files are compacted as expected, and check if the old metadata files are cleaned up from the metadata folder. 