### PR TITLE
Auto-detect Kubernetes version

### DIFF
--- a/terraform/aptos-node-testnet/aws/main.tf
+++ b/terraform/aptos-node-testnet/aws/main.tf
@@ -23,10 +23,9 @@ module "validator" {
 
   maximize_single_az_capacity = var.maximize_single_az_capacity
 
-  region             = var.region
-  kubernetes_version = var.kubernetes_version
-  iam_path           = var.iam_path
-  zone_id            = var.zone_id
+  region   = var.region
+  iam_path = var.iam_path
+  zone_id  = var.zone_id
   # do not create the main fullnode and validator DNS records
   # instead, rely on external-dns from the testnet-addons
   create_records = false

--- a/terraform/aptos-node-testnet/aws/variables.tf
+++ b/terraform/aptos-node-testnet/aws/variables.tf
@@ -4,11 +4,6 @@ variable "region" {
   description = "AWS region"
 }
 
-variable "kubernetes_version" {
-  description = "Version of Kubernetes to use for EKS cluster"
-  default     = "1.24"
-}
-
 variable "maximize_single_az_capacity" {
   description = "TEST ONLY: Whether to maximize the capacity of the cluster by allocating a large CIDR block to the first AZ"
   default     = false

--- a/terraform/aptos-node/gcp/security.tf
+++ b/terraform/aptos-node/gcp/security.tf
@@ -2,9 +2,18 @@
 
 data "kubernetes_all_namespaces" "all" {}
 
+locals {
+  kubernetes_master_version = substr(google_container_cluster.aptos.master_version, 0, 4)
+  baseline_pss_labels = {
+    "pod-security.kubernetes.io/audit"   = "baseline"
+    "pod-security.kubernetes.io/warn"    = "baseline"
+    "pod-security.kubernetes.io/enforce" = "privileged"
+  }
+}
+
 # FIXME: Remove when migrating to K8s 1.25
 resource "kubernetes_role_binding" "disable-psp" {
-  for_each = toset(var.kubernetes_version <= "1.24" ? data.kubernetes_all_namespaces.all.namespaces : [])
+  for_each = toset(local.kubernetes_master_version <= "1.24" ? data.kubernetes_all_namespaces.all.namespaces : [])
   metadata {
     name      = "privileged-psp"
     namespace = each.value
@@ -20,17 +29,6 @@ resource "kubernetes_role_binding" "disable-psp" {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Group"
     name      = "system:serviceaccounts:${each.value}"
-  }
-}
-
-locals {
-  baseline_pss_labels = {
-    "pod-security.kubernetes.io/audit"           = "baseline"
-    "pod-security.kubernetes.io/audit-version"   = "v${var.kubernetes_version}"
-    "pod-security.kubernetes.io/warn"            = "baseline"
-    "pod-security.kubernetes.io/warn-version"    = "v${var.kubernetes_version}"
-    "pod-security.kubernetes.io/enforce"         = "privileged"
-    "pod-security.kubernetes.io/enforce-version" = "v${var.kubernetes_version}"
   }
 }
 

--- a/terraform/aptos-node/gcp/variables.tf
+++ b/terraform/aptos-node/gcp/variables.tf
@@ -13,11 +13,6 @@ variable "zone" {
   type        = string
 }
 
-variable "kubernetes_version" {
-  description = "Version of Kubernetes to use for GKE clusters"
-  default     = "1.24"
-}
-
 variable "era" {
   description = "Chain era, used to start a clean chain"
   default     = 1

--- a/terraform/fullnode/aws/security.tf
+++ b/terraform/fullnode/aws/security.tf
@@ -2,9 +2,18 @@
 
 data "kubernetes_all_namespaces" "all" {}
 
+locals {
+  kubernetes_master_version = substr(aws_eks_cluster.aptos.version, 0, 4)
+  baseline_pss_labels = {
+    "pod-security.kubernetes.io/audit"   = "baseline"
+    "pod-security.kubernetes.io/warn"    = "baseline"
+    "pod-security.kubernetes.io/enforce" = "privileged"
+  }
+}
+
 # FIXME: Remove when migrating to K8s 1.25
 resource "kubernetes_role_binding" "disable-psp" {
-  for_each = toset(var.kubernetes_version <= "1.24" ? data.kubernetes_all_namespaces.all.namespaces : [])
+  for_each = toset(local.kubernetes_master_version <= "1.24" ? data.kubernetes_all_namespaces.all.namespaces : [])
   metadata {
     name      = "privileged-psp"
     namespace = each.value
@@ -20,17 +29,6 @@ resource "kubernetes_role_binding" "disable-psp" {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Group"
     name      = "system:serviceaccounts:${each.value}"
-  }
-}
-
-locals {
-  baseline_pss_labels = {
-    "pod-security.kubernetes.io/audit"           = "baseline"
-    "pod-security.kubernetes.io/audit-version"   = "v${var.kubernetes_version}"
-    "pod-security.kubernetes.io/warn"            = "baseline"
-    "pod-security.kubernetes.io/warn-version"    = "v${var.kubernetes_version}"
-    "pod-security.kubernetes.io/enforce"         = "privileged"
-    "pod-security.kubernetes.io/enforce-version" = "v${var.kubernetes_version}"
   }
 }
 

--- a/terraform/fullnode/aws/variables.tf
+++ b/terraform/fullnode/aws/variables.tf
@@ -2,11 +2,6 @@ variable "region" {
   description = "AWS region"
 }
 
-variable "kubernetes_version" {
-  description = "Version of Kubernetes to use for GKE clusters"
-  default     = "1.24"
-}
-
 variable "workspace_name_override" {
   description = "If specified, overrides the usage of Terraform workspace for naming purposes"
   default     = ""

--- a/terraform/fullnode/gcp/security.tf
+++ b/terraform/fullnode/gcp/security.tf
@@ -2,9 +2,18 @@
 
 data "kubernetes_all_namespaces" "all" {}
 
+locals {
+  kubernetes_master_version = substr(google_container_cluster.aptos.master_version, 0, 4)
+  baseline_pss_labels = {
+    "pod-security.kubernetes.io/audit"   = "baseline"
+    "pod-security.kubernetes.io/warn"    = "baseline"
+    "pod-security.kubernetes.io/enforce" = "privileged"
+  }
+}
+
 # FIXME: Remove when migrating to K8s 1.25
 resource "kubernetes_role_binding" "disable-psp" {
-  for_each = toset(var.kubernetes_version <= "1.24" ? data.kubernetes_all_namespaces.all.namespaces : [])
+  for_each = toset(local.kubernetes_master_version <= "1.24" ? data.kubernetes_all_namespaces.all.namespaces : [])
   metadata {
     name      = "privileged-psp"
     namespace = each.value
@@ -20,17 +29,6 @@ resource "kubernetes_role_binding" "disable-psp" {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Group"
     name      = "system:serviceaccounts:${each.value}"
-  }
-}
-
-locals {
-  baseline_pss_labels = {
-    "pod-security.kubernetes.io/audit"           = "baseline"
-    "pod-security.kubernetes.io/audit-version"   = "v${var.kubernetes_version}"
-    "pod-security.kubernetes.io/warn"            = "baseline"
-    "pod-security.kubernetes.io/warn-version"    = "v${var.kubernetes_version}"
-    "pod-security.kubernetes.io/enforce"         = "privileged"
-    "pod-security.kubernetes.io/enforce-version" = "v${var.kubernetes_version}"
   }
 }
 

--- a/terraform/fullnode/gcp/variables.tf
+++ b/terraform/fullnode/gcp/variables.tf
@@ -13,11 +13,6 @@ variable "zone" {
   type        = string
 }
 
-variable "kubernetes_version" {
-  description = "Version of Kubernetes to use for GKE clusters"
-  default     = "1.24"
-}
-
 variable "workspace_name_override" {
   description = "If specified, overrides the usage of Terraform workspace for naming purposes"
   default     = ""


### PR DESCRIPTION
### Description

Auto-detect Kubernetes version and stop pinning the PSS labels manually (they will default to the current Kubernetes version).

### Test plan

Tested on Rustienet and Previewnet.