### PR TITLE
[storage] add timestamp to metadata for compaction and cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,7 @@ dependencies = [
  "aptos-push-metrics",
  "aptos-temppath",
  "aptos-types",
+ "async-trait",
  "clap 3.2.23",
  "owo-colors",
  "tokio",

--- a/storage/backup/backup-cli/src/storage/local_fs/mod.rs
+++ b/storage/backup/backup-cli/src/storage/local_fs/mod.rs
@@ -179,7 +179,9 @@ impl BackupStorage for LocalFs {
             },
             _ => bail!("Unexpected Error in saving metadata file {}", name.as_ref()),
         }
-
-        Ok(path.to_string_lossy().into_owned())
+        let fh = PathBuf::from(Self::METADATA_DIR)
+            .join(name.as_ref())
+            .path_to_string()?;
+        Ok(fh)
     }
 }

--- a/storage/db-tool/Cargo.toml
+++ b/storage/db-tool/Cargo.toml
@@ -22,6 +22,7 @@ aptos-logger = { workspace = true }
 aptos-push-metrics = { workspace = true }
 aptos-temppath = { workspace = true }
 aptos-types = { workspace = true }
+async-trait = { workspace = true }
 clap = { workspace = true }
 owo-colors = { workspace = true }
 tokio = { workspace = true }

--- a/storage/db-tool/src/backup_maintenance.rs
+++ b/storage/db-tool/src/backup_maintenance.rs
@@ -32,7 +32,14 @@ pub struct CompactionOpt {
     #[clap(flatten)]
     pub storage: DBToolStorageOpt,
     #[clap(flatten)]
-    concurrent_downloads: ConcurrentDownloadsOpt,
+    pub concurrent_downloads: ConcurrentDownloadsOpt,
+    /// Specify how many seconds to keep compacted metadata file before moving them to backup folder
+    #[clap(
+        long,
+        default_value = "86400",
+        help = "Remove metadata files replaced by compaction after specified seconds. They were not replaced right away after compaction in case they are being read then."
+    )]
+    pub remove_compacted_file_after: u64,
 }
 
 #[derive(Parser)]
@@ -52,6 +59,7 @@ impl Command {
                     opt.metadata_cache_opt,
                     opt.storage.init_storage().await?,
                     opt.concurrent_downloads.get(),
+                    opt.remove_compacted_file_after,
                 );
                 compactor.run().await?
             },

--- a/storage/db-tool/src/tests.rs
+++ b/storage/db-tool/src/tests.rs
@@ -2,22 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::DBTool;
-use aptos_backup_cli::{
-    coordinators::backup::BackupCompactor,
-    metadata,
-    metadata::{cache::MetadataCacheOpt, view::MetadataView},
-    storage::{local_fs::LocalFs, BackupStorage},
-};
-use aptos_backup_service::start_backup_service;
-use aptos_executor_test_helpers::integration_test_impl::test_execution_with_storage_impl;
-use aptos_temppath::TempPath;
-use aptos_types::transaction::Version;
 use clap::Parser;
-use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::Arc,
-    time::Duration,
-};
 
 #[test]
 fn test_various_cmd_parsing() {
@@ -85,152 +70,186 @@ fn run_cmd(args: &[&str]) {
     DBTool::try_parse_from(args).expect("command parse unsuccessful");
 }
 
-fn assert_metadata_view_eq(view1: &MetadataView, view2: &MetadataView) {
-    assert!(
-        view1.select_transaction_backups(0, Version::MAX).unwrap()
-            == view2.select_transaction_backups(0, Version::MAX).unwrap()
-            && view1.select_epoch_ending_backups(Version::MAX).unwrap()
-                == view2.select_epoch_ending_backups(Version::MAX).unwrap()
-            && view1.select_state_snapshot(Version::MAX).unwrap()
-                == view2.select_state_snapshot(Version::MAX).unwrap(),
-        "Metadata views are not equal"
-    );
-}
+#[cfg(test)]
+mod compaction_tests {
+    use crate::DBTool;
+    use aptos_backup_cli::{
+        coordinators::backup::BackupCompactor,
+        metadata,
+        metadata::{cache::MetadataCacheOpt, view::MetadataView},
+        storage::{local_fs::LocalFs, BackupStorage},
+    };
+    use aptos_backup_service::start_backup_service;
+    use aptos_executor_test_helpers::integration_test_impl::test_execution_with_storage_impl;
+    use aptos_temppath::TempPath;
+    use aptos_types::transaction::Version;
+    use clap::Parser;
+    use std::{
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+        sync::Arc,
+        time::Duration,
+    };
 
-#[test]
-fn test_backup_compaction() {
-    let db = test_execution_with_storage_impl();
-    let backup_dir = TempPath::new();
-    backup_dir.create_as_dir().unwrap();
-    let local_fs = LocalFs::new(backup_dir.path().to_path_buf());
-    let store: Arc<dyn BackupStorage> = Arc::new(local_fs);
-    let rt = start_backup_service(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 6186), db);
+    fn assert_metadata_view_eq(view1: &MetadataView, view2: &MetadataView) {
+        assert!(
+            view1.select_transaction_backups(0, Version::MAX).unwrap()
+                == view2.select_transaction_backups(0, Version::MAX).unwrap()
+                && view1.select_epoch_ending_backups(Version::MAX).unwrap()
+                    == view2.select_epoch_ending_backups(Version::MAX).unwrap()
+                && view1.select_state_snapshot(Version::MAX).unwrap()
+                    == view2.select_state_snapshot(Version::MAX).unwrap(),
+            "Metadata views are not equal"
+        );
+    }
 
-    // Backup the local_test DB
-    rt.block_on(
-        DBTool::try_parse_from([
-            "aptos-db-tool",
-            "backup",
-            "oneoff",
-            "epoch-ending",
-            "--start-epoch",
-            "0",
-            "--end-epoch",
-            "1",
-            "--local-fs-dir",
-            backup_dir.path().to_str().unwrap(),
-        ])
-        .unwrap()
-        .run(),
-    )
-    .unwrap();
-
-    rt.block_on(
-        DBTool::try_parse_from([
-            "aptos-db-tool",
-            "backup",
-            "oneoff",
-            "epoch-ending",
-            "--start-epoch",
-            "1",
-            "--end-epoch",
-            "2",
-            "--local-fs-dir",
-            backup_dir.path().to_str().unwrap(),
-        ])
-        .unwrap()
-        .run(),
-    )
-    .unwrap();
-
-    rt.block_on(
-        DBTool::try_parse_from([
-            "aptos-db-tool",
-            "backup",
-            "oneoff",
-            "state-snapshot",
-            "--state-snapshot-epoch",
-            "1",
-            "--local-fs-dir",
-            backup_dir.path().to_str().unwrap(),
-        ])
-        .unwrap()
-        .run(),
-    )
-    .unwrap();
-
-    rt.block_on(
-        DBTool::try_parse_from([
-            "aptos-db-tool",
-            "backup",
-            "oneoff",
-            "state-snapshot",
-            "--state-snapshot-epoch",
-            "2",
-            "--local-fs-dir",
-            backup_dir.path().to_str().unwrap(),
-        ])
-        .unwrap()
-        .run(),
-    )
-    .unwrap();
-    rt.block_on(
-        DBTool::try_parse_from([
-            "aptos-db-tool",
-            "backup",
-            "oneoff",
-            "transaction",
-            "--start-version",
-            "0",
-            "--num_transactions",
-            "15",
-            "--local-fs-dir",
-            backup_dir.path().to_str().unwrap(),
-        ])
-        .unwrap()
-        .run(),
-    )
-    .unwrap();
-    rt.block_on(
-        DBTool::try_parse_from([
-            "aptos-db-tool",
-            "backup",
-            "oneoff",
-            "transaction",
-            "--start-version",
-            "15",
-            "--num_transactions",
-            "15",
-            "--local-fs-dir",
-            backup_dir.path().to_str().unwrap(),
-        ])
-        .unwrap()
-        .run(),
-    )
-    .unwrap();
-    // assert the metadata views are same before and after compaction
-    let metadata_opt = MetadataCacheOpt::new(Some(TempPath::new().path().to_path_buf()));
-    let old_metaview = rt
-        .block_on(metadata::cache::sync_and_load(
-            &metadata_opt,
-            Arc::clone(&store),
-            1,
-        ))
-        .unwrap();
-    let compactor = BackupCompactor::new(2, 2, 2, metadata_opt.clone(), Arc::clone(&store), 1);
-    rt.block_on(compactor.run()).unwrap();
-
-    // run compaction again
-    rt.block_on(compactor.run()).unwrap();
-
-    let new_metaview = rt
-        .block_on(metadata::cache::sync_and_load(
-            &metadata_opt,
-            Arc::clone(&store),
-            1,
-        ))
+    #[test]
+    fn test_backup_compaction() {
+        let db = test_execution_with_storage_impl();
+        let backup_dir = TempPath::new();
+        backup_dir.create_as_dir().unwrap();
+        let local_fs = LocalFs::new(backup_dir.path().to_path_buf());
+        let store: Arc<dyn BackupStorage> = Arc::new(local_fs);
+        let rt = start_backup_service(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 6186), db);
+        // Backup the local_test DB
+        rt.block_on(
+            DBTool::try_parse_from([
+                "aptos-db-tool",
+                "backup",
+                "oneoff",
+                "epoch-ending",
+                "--start-epoch",
+                "0",
+                "--end-epoch",
+                "1",
+                "--local-fs-dir",
+                backup_dir.path().to_str().unwrap(),
+            ])
+            .unwrap()
+            .run(),
+        )
         .unwrap();
 
-    assert_metadata_view_eq(&old_metaview, &new_metaview);
-    rt.shutdown_timeout(Duration::from_secs(1));
+        rt.block_on(
+            DBTool::try_parse_from([
+                "aptos-db-tool",
+                "backup",
+                "oneoff",
+                "epoch-ending",
+                "--start-epoch",
+                "1",
+                "--end-epoch",
+                "2",
+                "--local-fs-dir",
+                backup_dir.path().to_str().unwrap(),
+            ])
+            .unwrap()
+            .run(),
+        )
+        .unwrap();
+
+        rt.block_on(
+            DBTool::try_parse_from([
+                "aptos-db-tool",
+                "backup",
+                "oneoff",
+                "state-snapshot",
+                "--state-snapshot-epoch",
+                "1",
+                "--local-fs-dir",
+                backup_dir.path().to_str().unwrap(),
+            ])
+            .unwrap()
+            .run(),
+        )
+        .unwrap();
+
+        rt.block_on(
+            DBTool::try_parse_from([
+                "aptos-db-tool",
+                "backup",
+                "oneoff",
+                "state-snapshot",
+                "--state-snapshot-epoch",
+                "2",
+                "--local-fs-dir",
+                backup_dir.path().to_str().unwrap(),
+            ])
+            .unwrap()
+            .run(),
+        )
+        .unwrap();
+        rt.block_on(
+            DBTool::try_parse_from([
+                "aptos-db-tool",
+                "backup",
+                "oneoff",
+                "transaction",
+                "--start-version",
+                "0",
+                "--num_transactions",
+                "15",
+                "--local-fs-dir",
+                backup_dir.path().to_str().unwrap(),
+            ])
+            .unwrap()
+            .run(),
+        )
+        .unwrap();
+        rt.block_on(
+            DBTool::try_parse_from([
+                "aptos-db-tool",
+                "backup",
+                "oneoff",
+                "transaction",
+                "--start-version",
+                "15",
+                "--num_transactions",
+                "15",
+                "--local-fs-dir",
+                backup_dir.path().to_str().unwrap(),
+            ])
+            .unwrap()
+            .run(),
+        )
+        .unwrap();
+
+        // assert the metadata views are same before and after compaction
+        let metadata_cache_dir = TempPath::new();
+        let metadata_opt = MetadataCacheOpt::new(Some(metadata_cache_dir.path().to_path_buf()));
+        let old_metaview = rt
+            .block_on(metadata::cache::sync_and_load(
+                &metadata_opt,
+                Arc::clone(&store),
+                1,
+            ))
+            .unwrap();
+        let og_list = rt.block_on(store.list_metadata_files()).unwrap();
+        let compactor =
+            BackupCompactor::new(2, 2, 2, metadata_opt.clone(), Arc::clone(&store), 1, 1);
+        rt.block_on(compactor.run()).unwrap();
+        // assert the original files are still present
+        let mut after_list = rt.block_on(store.list_metadata_files()).unwrap();
+        // remove any file matching str "compaction_timestamps" from after_list
+        after_list.retain(|x| !x.contains("compaction_timestamps"));
+        assert!(og_list.iter().all(|x| after_list.contains(x)));
+        // wait 2 seconds to ensure the compaction waiting time expires
+        std::thread::sleep(std::time::Duration::from_secs(2));
+        // run the compaction again
+        let compactor =
+            BackupCompactor::new(2, 2, 2, metadata_opt.clone(), Arc::clone(&store), 1, 1);
+        rt.block_on(compactor.run()).unwrap();
+        let final_list = rt.block_on(store.list_metadata_files()).unwrap();
+        // assert og list has no overlap with final list
+        assert!(!og_list.iter().any(|x| final_list.contains(x)));
+
+        let new_metaview = rt
+            .block_on(metadata::cache::sync_and_load(
+                &metadata_opt,
+                Arc::clone(&store),
+                1,
+            ))
+            .unwrap();
+        assert_metadata_view_eq(&old_metaview, &new_metaview);
+        rt.shutdown_timeout(Duration::from_secs(1));
+    }
 }


### PR DESCRIPTION
### Description
Make backup compaction transparent to clients.

when the client loads metadata files, it will try to create a view of remote metadata files.
However, it could be inconsistent when the compaction is in progress as the metadata files are moved to a backup folder.

we keep the original file initially.
we use a timestamp to determine if non compacted file or outdated compacted file could be safely deleted
### Test Plan
update test to show original files are kept and are eventually cleanup once the expiration date passed.