### PR TITLE
[Commit Checker] Handle PR commit numbers

### DIFF
--- a/.github/actions/check-branch-commits/expected_on_devnet_not_main.txt
+++ b/.github/actions/check-branch-commits/expected_on_devnet_not_main.txt
@@ -3,4 +3,4 @@
 # hash should be on a new line, with a comment explaining why it is
 # not on the main branch.
 
-d883a7c1449b77688d2818cec20707ce4511c59b # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/66fb84a035f699e16a54aef0d11d19948b9a575f
+# This list is currently empty.

--- a/.github/actions/check-branch-commits/expected_on_mainnet_not_main.txt
+++ b/.github/actions/check-branch-commits/expected_on_mainnet_not_main.txt
@@ -3,9 +3,7 @@
 # hash should be on a new line, with a comment explaining why it is
 # not on the main branch.
 
-cb4ba0a57c998c60cbab65af31a64875d2588ca5 # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/d2a0d17164d978c025c04cc54be55ce08f069091
 f144de376c4c5bc04bcd945ff802c4d8ff499059 # Combines two cherry-picks into one: https://github.com/aptos-labs/aptos-core/pull/6480
-84a67d185df4a9c12947f6091d0c0dc3427703f1 # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/05eabd73b989fd733ca4b51e4f06c42088ea1e7c
 895ae28e4a105430d8b9d2ce2f6e48c3b2c7fcf0 # Included in https://github.com/aptos-labs/aptos-core/commit/e401d8fcb0105bcccb8ff7f2129088bf671b4644 and https://github.com/aptos-labs/aptos-core/commit/b4d48c23ac5eedfad707e975402c5a96cabd77ec
 a78970aa2a6fd6fa7db94d6d5700a902807102c7 # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/08ba4052c2e8b1de994706d1faf0f84e7c935ae1
 6aae9a3595da0321a8bda0220fcf593060d44941 # Included in https://github.com/aptos-labs/aptos-core/commit/7bd412edb762cbdc935f28f62a91fc69c8daf639
@@ -14,9 +12,7 @@ a78970aa2a6fd6fa7db94d6d5700a902807102c7 # Different commit hash and message: ht
 1a50f38d7989150c018c437abd5d037185afeee6 # Included in https://github.com/aptos-labs/aptos-core/commit/0ef3bf2631cd9c7c63ef6b7c9c444d9cb2cd1fd2
 88ce84b3dc1f48c2e044a91908b11914ef0abf40 # Included in https://github.com/aptos-labs/aptos-core/commit/7bd412edb762cbdc935f28f62a91fc69c8daf639
 e0514e55259890e1d51173ce6001a867edcf652f # Demangler removed in https://github.com/aptos-labs/aptos-core/commit/74c980f76d871a8ba38810e384f679ca99aeb29b
-30da7e46c037f974c668720a437726a9b2374445 # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/31ab7c69efafe19ca16af441682a3a5d1e0dcf0b
 b91762519bad24116a4f5fefb0fb1c780bbce560 # Unnecessary in main as it never included 8e137b70e8ce0b4f601b3db73a5971500235a913 (below)
-ac15be75a1d6a3ab68c7ff7f749f0cc98dc1fa98 # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/31ab7c69efafe19ca16af441682a3a5d1e0dcf0b
 8e137b70e8ce0b4f601b3db73a5971500235a913 # Not included, but when combined with b91762519bad24116a4f5fefb0fb1c780bbce560 (above), it's okay.
 79b087295f443d11d8ef69bb215cde6e116ea4cd # Contains a few commits merged into one: PRs 5849, 5898
 9bea4a9157e79453f2ecf5ee501ce611b3173b7c # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/abf10b4cafee32f9da22c8c85d526a3c70193d9c

--- a/.github/actions/check-branch-commits/expected_on_mainnet_not_testnet.txt
+++ b/.github/actions/check-branch-commits/expected_on_mainnet_not_testnet.txt
@@ -3,4 +3,16 @@
 # hash should be on a new line, with a comment explaining why it is
 # not on the testnet branch.
 
-# This list is currently empty.
+f144de376c4c5bc04bcd945ff802c4d8ff499059 # Combines two cherry-picks into one: https://github.com/aptos-labs/aptos-core/pull/6480
+895ae28e4a105430d8b9d2ce2f6e48c3b2c7fcf0 # Included in https://github.com/aptos-labs/aptos-core/commit/e401d8fcb0105bcccb8ff7f2129088bf671b4644 and https://github.com/aptos-labs/aptos-core/commit/b4d48c23ac5eedfad707e975402c5a96cabd77ec
+a78970aa2a6fd6fa7db94d6d5700a902807102c7 # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/08ba4052c2e8b1de994706d1faf0f84e7c935ae1
+6aae9a3595da0321a8bda0220fcf593060d44941 # Included in https://github.com/aptos-labs/aptos-core/commit/7bd412edb762cbdc935f28f62a91fc69c8daf639
+43ec117fb2fbf879d6e816fc77c7ed5ed5cd9d7c # Included in https://github.com/aptos-labs/aptos-core/commit/9df438a1eb6e6be9d97129781543196f03e7a812 and https://github.com/aptos-labs/aptos-core/commit/91797aacf83c7f668efa9ddee575139cb4ddbb42
+92e5409d1547d9168137824852a78e25bd83269e # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/ad5be501b44b98f6114dd617e6c904c48474199f
+1a50f38d7989150c018c437abd5d037185afeee6 # Included in https://github.com/aptos-labs/aptos-core/commit/0ef3bf2631cd9c7c63ef6b7c9c444d9cb2cd1fd2
+88ce84b3dc1f48c2e044a91908b11914ef0abf40 # Included in https://github.com/aptos-labs/aptos-core/commit/7bd412edb762cbdc935f28f62a91fc69c8daf639
+e0514e55259890e1d51173ce6001a867edcf652f # Demangler removed in https://github.com/aptos-labs/aptos-core/commit/74c980f76d871a8ba38810e384f679ca99aeb29b
+b91762519bad24116a4f5fefb0fb1c780bbce560 # Unnecessary in main as it never included 8e137b70e8ce0b4f601b3db73a5971500235a913 (below)
+8e137b70e8ce0b4f601b3db73a5971500235a913 # Not included, but when combined with b91762519bad24116a4f5fefb0fb1c780bbce560 (above), it's okay.
+79b087295f443d11d8ef69bb215cde6e116ea4cd # Contains a few commits merged into one: PRs 5849, 5898
+9bea4a9157e79453f2ecf5ee501ce611b3173b7c # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/abf10b4cafee32f9da22c8c85d526a3c70193d9c

--- a/.github/actions/check-branch-commits/expected_on_testnet_not_devnet.txt
+++ b/.github/actions/check-branch-commits/expected_on_testnet_not_devnet.txt
@@ -3,20 +3,4 @@
 # hash should be on a new line, with a comment explaining why it is
 # not on the devnet branch.
 
-cb4ba0a57c998c60cbab65af31a64875d2588ca5 # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/d2a0d17164d978c025c04cc54be55ce08f069091
-f144de376c4c5bc04bcd945ff802c4d8ff499059 # Contains a few commits merged into one: https://github.com/aptos-labs/aptos-core/pull/6480
-84a67d185df4a9c12947f6091d0c0dc3427703f1 # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/05eabd73b989fd733ca4b51e4f06c42088ea1e7c
-895ae28e4a105430d8b9d2ce2f6e48c3b2c7fcf0 # Contains a few commits merged into one: https://github.com/aptos-labs/aptos-core/pull/6436
-a78970aa2a6fd6fa7db94d6d5700a902807102c7 # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/08ba4052c2e8b1de994706d1faf0f84e7c935ae1
-6aae9a3595da0321a8bda0220fcf593060d44941 # Included in https://github.com/aptos-labs/aptos-core/commit/7bd412edb762cbdc935f28f62a91fc69c8daf639
-43ec117fb2fbf879d6e816fc77c7ed5ed5cd9d7c # Included in https://github.com/aptos-labs/aptos-core/commit/9df438a1eb6e6be9d97129781543196f03e7a812 and https://github.com/aptos-labs/aptos-core/commit/91797aacf83c7f668efa9ddee575139cb4ddbb42
-92e5409d1547d9168137824852a78e25bd83269e # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/ad5be501b44b98f6114dd617e6c904c48474199f
-1a50f38d7989150c018c437abd5d037185afeee6 # Included in https://github.com/aptos-labs/aptos-core/commit/0ef3bf2631cd9c7c63ef6b7c9c444d9cb2cd1fd2
-88ce84b3dc1f48c2e044a91908b11914ef0abf40 # Included in https://github.com/aptos-labs/aptos-core/commit/7bd412edb762cbdc935f28f62a91fc69c8daf639
-e0514e55259890e1d51173ce6001a867edcf652f # Demangler removed in https://github.com/aptos-labs/aptos-core/commit/74c980f76d871a8ba38810e384f679ca99aeb29b
-30da7e46c037f974c668720a437726a9b2374445 # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/31ab7c69efafe19ca16af441682a3a5d1e0dcf0b
-b91762519bad24116a4f5fefb0fb1c780bbce560 # Unnecessary in main as it never included 8e137b70e8ce0b4f601b3db73a5971500235a913 (below)
-ac15be75a1d6a3ab68c7ff7f749f0cc98dc1fa98 # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/31ab7c69efafe19ca16af441682a3a5d1e0dcf0b
-8e137b70e8ce0b4f601b3db73a5971500235a913 # Not included, but when combined with b91762519bad24116a4f5fefb0fb1c780bbce560 (above), it's okay.
-79b087295f443d11d8ef69bb215cde6e116ea4cd # Contains a few commits merged into one: PRs 5849, 5898
-9bea4a9157e79453f2ecf5ee501ce611b3173b7c # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/abf10b4cafee32f9da22c8c85d526a3c70193d9c
+c9a622ec93871baf3a0a07b077f3a370dbef852e # Temporary override to revert faucet changes

--- a/.github/actions/check-branch-commits/expected_on_testnet_not_main.txt
+++ b/.github/actions/check-branch-commits/expected_on_testnet_not_main.txt
@@ -3,20 +3,4 @@
 # hash should be on a new line, with a comment explaining why it is
 # not on the main branch.
 
-cb4ba0a57c998c60cbab65af31a64875d2588ca5 # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/d2a0d17164d978c025c04cc54be55ce08f069091
-f144de376c4c5bc04bcd945ff802c4d8ff499059 # Contains a few commits merged into one, see: https://github.com/aptos-labs/aptos-core/pull/6480
-84a67d185df4a9c12947f6091d0c0dc3427703f1 # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/05eabd73b989fd733ca4b51e4f06c42088ea1e7c
-895ae28e4a105430d8b9d2ce2f6e48c3b2c7fcf0 # Included in https://github.com/aptos-labs/aptos-core/commit/e401d8fcb0105bcccb8ff7f2129088bf671b4644 and https://github.com/aptos-labs/aptos-core/commit/b4d48c23ac5eedfad707e975402c5a96cabd77ec
-a78970aa2a6fd6fa7db94d6d5700a902807102c7 # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/08ba4052c2e8b1de994706d1faf0f84e7c935ae1
-6aae9a3595da0321a8bda0220fcf593060d44941 # Included in https://github.com/aptos-labs/aptos-core/commit/7bd412edb762cbdc935f28f62a91fc69c8daf639
-43ec117fb2fbf879d6e816fc77c7ed5ed5cd9d7c # Included in https://github.com/aptos-labs/aptos-core/commit/9df438a1eb6e6be9d97129781543196f03e7a812 and https://github.com/aptos-labs/aptos-core/commit/91797aacf83c7f668efa9ddee575139cb4ddbb42
-92e5409d1547d9168137824852a78e25bd83269e # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/ad5be501b44b98f6114dd617e6c904c48474199f
-1a50f38d7989150c018c437abd5d037185afeee6 # Included in https://github.com/aptos-labs/aptos-core/commit/0ef3bf2631cd9c7c63ef6b7c9c444d9cb2cd1fd2
-88ce84b3dc1f48c2e044a91908b11914ef0abf40 # Included in https://github.com/aptos-labs/aptos-core/commit/7bd412edb762cbdc935f28f62a91fc69c8daf639
-e0514e55259890e1d51173ce6001a867edcf652f # Demangler removed in https://github.com/aptos-labs/aptos-core/commit/74c980f76d871a8ba38810e384f679ca99aeb29b
-30da7e46c037f974c668720a437726a9b2374445 # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/31ab7c69efafe19ca16af441682a3a5d1e0dcf0b
-b91762519bad24116a4f5fefb0fb1c780bbce560 # Unnecessary in main as it never included 8e137b70e8ce0b4f601b3db73a5971500235a913 (below)
-ac15be75a1d6a3ab68c7ff7f749f0cc98dc1fa98 # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/31ab7c69efafe19ca16af441682a3a5d1e0dcf0b
-8e137b70e8ce0b4f601b3db73a5971500235a913 # Not included, but when combined with b91762519bad24116a4f5fefb0fb1c780bbce560 (above), it's okay.
-79b087295f443d11d8ef69bb215cde6e116ea4cd # Contains a few commits merged into one: PRs 5849, 5898
-9bea4a9157e79453f2ecf5ee501ce611b3173b7c # Different commit hash and message: https://github.com/aptos-labs/aptos-core/commit/abf10b4cafee32f9da22c8c85d526a3c70193d9c
+c9a622ec93871baf3a0a07b077f3a370dbef852e # Temporary override to revert faucet changes

--- a/.github/workflows/check-branch-commits.yaml
+++ b/.github/workflows/check-branch-commits.yaml
@@ -1,5 +1,5 @@
 # This workflow ensures that aptos-core branches do
-# not have inconsistent commits..
+# not have inconsistent commits.
 
 name: "check-branch-commits"
 on:


### PR DESCRIPTION
### Description

This PR updates the commit checker to handle PR commit numbers in the git commit messages. This typically occurs when a commit is cherry-picked across various branches (resulting in commit messages that are similar, but not identical due to the PR numbers). The PR also updates the exception lists.

### Test Plan
Existing test infrastructure.