### PR TITLE
[storage] Get metadata file list before syncing and downloading

### DIFF
--- a/storage/backup/backup-cli/src/coordinators/backup.rs
+++ b/storage/backup/backup-cli/src/coordinators/backup.rs
@@ -366,8 +366,7 @@ impl BackupCompactor {
         )
         .await?;
 
-        // Get a snapshot of remote metadata files before compaction
-        let files = self.storage.list_metadata_files().await?;
+        let files = metaview.get_file_handles();
 
         info!("Start compacting backup metadata files.");
         // Get all compacted chunks to be written back to storage

--- a/storage/backup/backup-cli/src/metadata/cache.rs
+++ b/storage/backup/backup-cli/src/metadata/cache.rs
@@ -115,7 +115,7 @@ pub async fn sync_and_load(
         remote_file_handles = storage.list_metadata_files().await?;
     }
     let remote_file_handle_by_hash: HashMap<_, _> = remote_file_handles
-        .into_iter()
+        .iter()
         .map(|file_handle| (file_handle.file_handle_hash(), file_handle))
         .collect();
     let remote_hashes: HashSet<_> = remote_file_handle_by_hash.keys().cloned().collect();
@@ -201,7 +201,8 @@ pub async fn sync_and_load(
         total_time = timer.elapsed().as_secs(),
         "Metadata cache loaded.",
     );
-    Ok(metadata_vec.into())
+
+    Ok(MetadataView::new(metadata_vec, remote_file_handles))
 }
 
 trait FileHandleHash {


### PR DESCRIPTION
### Description
Get a snapshot of remote metadata files before syncing the metadata file.

There is a corner case that syncing metadata file can run a long time and the snapshot of remote files can contain new files that are not covered by compaction

### Test Plan
Test on GCP with compaction job and backup verify