### PR TITLE
[Pre-commit] Remove rust pre-commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,6 @@ repos:
       - id: check-added-large-files
         args:
           - --maxkb=2000
-  - repo: https://github.com/doublify/pre-commit-rust
-    rev: v1.0
-    hooks:
-      # - id: fmt // Not currently supported for the nightly build, e.g., https://github.com/doublify/pre-commit-rust/issues/15
-      - id: cargo-check
   # Once this issue is resolved, we can add the full license check: https://github.com/Lucas-C/pre-commit-hooks/issues/68
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.3.0


### PR DESCRIPTION
### Description

This PR removes the pre-commit checks for cargo-check. This can be expensive and we already verify it via `rust_lint.sh` (when landing), so, there's no need to do it twice 😄 

Note: `rust_lint.sh` runs `cargo xclippy`, which is a wrapper around `clippy` and ultimately calls `cargo check`, too. So, running `cargo check` separately seems redundant: https://stackoverflow.com/questions/57449356/is-cargo-clippy-a-superset-of-cargo-check.

### Test Plan
Existing test infrastructure.