### PR TITLE
[txn emitter] Fix txn emitter client filtering

### DIFF
--- a/crates/transaction-emitter-lib/src/cluster.rs
+++ b/crates/transaction-emitter-lib/src/cluster.rs
@@ -12,9 +12,11 @@ use aptos_rest_client::Client as RestClient;
 use aptos_sdk::types::{
     account_config::aptos_test_root_address, chain_id::ChainId, AccountKey, LocalAccount,
 };
+use futures::{stream::FuturesUnordered, StreamExt};
 use rand::seq::SliceRandom;
 use std::convert::TryFrom;
 use url::Url;
+use std::time::Instant;
 
 #[derive(Debug)]
 pub struct Cluster {
@@ -42,6 +44,8 @@ impl Cluster {
 
         let mut instance_states = Vec::new();
         let mut errors = Vec::new();
+        let start = Instant::now();
+        let futures = FuturesUnordered::new();
         for url in &peers {
             let instance = Instance::new(
                 format!(
@@ -52,7 +56,16 @@ impl Cluster {
                 url.clone(),
                 None,
             );
-            match instance.rest_client().get_ledger_information().await {
+            futures.push(async move {
+                let result = instance.rest_client().get_ledger_information().await;
+                (instance, result)
+            });
+        }
+
+        let results: Vec<_> = futures.collect().await;
+        let fetch_time_s = start.elapsed().as_secs();
+        for (instance, result) in results {
+            match result {
                 Ok(v) => instance_states.push((instance, v.into_inner())),
                 Err(err) => {
                     warn!(
@@ -72,25 +85,27 @@ impl Cluster {
         }
 
         let mut instances = Vec::new();
-        let max_version = instance_states
+        let max_timestamp = instance_states
             .iter()
-            .map(|(_, s)| s.version)
+            .map(|(_, s)| s.timestamp_usecs / 1000000)
             .max()
             .unwrap();
 
         for (instance, state) in instance_states.into_iter() {
+            let state_timestamp = state.timestamp_usecs / 1000000;
             if state.chain_id != chain_id.id() {
                 warn!(
                     "Excluding client {} running wrong chain {}",
                     instance.peer_name(),
                     state.chain_id
                 );
-            } else if state.version + 100000 < max_version {
+            } else if state_timestamp + 20 + fetch_time_s < max_timestamp {
                 warn!(
-                    "Excluding Client {} too stale, {}, while chain at {}",
+                    "Excluding Client {} too stale, {}, while chain at {} (delta of {}s)",
                     instance.peer_name(),
-                    state.version,
-                    max_version
+                    state_timestamp,
+                    max_timestamp,
+                    max_timestamp - state_timestamp,
                 );
             } else {
                 info!(

--- a/crates/transaction-emitter-lib/src/cluster.rs
+++ b/crates/transaction-emitter-lib/src/cluster.rs
@@ -14,9 +14,8 @@ use aptos_sdk::types::{
 };
 use futures::{stream::FuturesUnordered, StreamExt};
 use rand::seq::SliceRandom;
-use std::convert::TryFrom;
+use std::{convert::TryFrom, time::Instant};
 use url::Url;
-use std::time::Instant;
 
 #[derive(Debug)]
 pub struct Cluster {

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -119,15 +119,20 @@ pub struct EmitJobRequest {
     rest_clients: Vec<RestClient>,
     mode: EmitJobMode,
 
-    gas_price: u64,
-    max_gas_per_txn: u64,
-    reuse_accounts: bool,
-    mint_to_root: bool,
-    init_gas_price_multiplier: u64,
-
     transaction_mix_per_phase: Vec<Vec<(TransactionType, usize)>>,
 
+    max_gas_per_txn: u64,
+    gas_price: u64,
+    init_gas_price_multiplier: u64,
+
+    reuse_accounts: bool,
+    mint_to_root: bool,
+
     txn_expiration_time_secs: u64,
+    init_expiration_multiplier: f64,
+
+    init_retry_interval: Duration,
+
     max_transactions_per_account: usize,
 
     expected_max_txns: u64,
@@ -135,9 +140,6 @@ pub struct EmitJobRequest {
     prompt_before_spending: bool,
 
     coordination_delay_between_instances: Duration,
-
-    init_retry_count: usize,
-    init_retry_interval: Duration,
 }
 
 impl Default for EmitJobRequest {
@@ -147,20 +149,20 @@ impl Default for EmitJobRequest {
             mode: EmitJobMode::MaxLoad {
                 mempool_backlog: 3000,
             },
-            gas_price: aptos_global_constants::GAS_UNIT_PRICE,
+            transaction_mix_per_phase: vec![vec![(TransactionType::default(), 1)]],
             max_gas_per_txn: aptos_global_constants::MAX_GAS_AMOUNT,
+            gas_price: aptos_global_constants::GAS_UNIT_PRICE,
+            init_gas_price_multiplier: 10,
             reuse_accounts: false,
             mint_to_root: false,
-            init_gas_price_multiplier: 10,
-            transaction_mix_per_phase: vec![vec![(TransactionType::default(), 1)]],
             txn_expiration_time_secs: 60,
+            init_expiration_multiplier: 3.0,
+            init_retry_interval: Duration::from_secs(10),
             max_transactions_per_account: 20,
             expected_max_txns: MAX_TXNS,
             expected_gas_per_txn: aptos_global_constants::MAX_GAS_AMOUNT,
             prompt_before_spending: false,
             coordination_delay_between_instances: Duration::from_secs(0),
-            init_retry_count: MAX_RETRIES,
-            init_retry_interval: Duration::from_secs(5),
         }
     }
 }
@@ -533,9 +535,12 @@ impl TxnEmitter {
             .with_transaction_expiration_time(mode_params.txn_expiration_time_secs)
             .with_gas_unit_price(req.gas_price)
             .with_max_gas_amount(req.max_gas_per_txn);
+        let init_expiration_time =
+            (mode_params.txn_expiration_time_secs as f64 * req.init_expiration_multiplier) as u64;
         let init_txn_factory = txn_factory
             .clone()
-            .with_gas_unit_price(req.gas_price * req.init_gas_price_multiplier);
+            .with_gas_unit_price(req.gas_price * req.init_gas_price_multiplier)
+            .with_transaction_expiration_time(init_expiration_time);
         let seed = self.rng.gen();
         info!(
             "AccountMinter Seed (can be passed in to reuse accounts): {:?}",
@@ -546,9 +551,16 @@ impl TxnEmitter {
             init_txn_factory.clone(),
             StdRng::from_seed(seed),
         );
+        let init_retries: usize =
+            usize::try_from(init_expiration_time / req.init_retry_interval.as_secs()).unwrap();
+        info!(
+            "Using reliable/retriable init transaction executor with {} retries, every {}s",
+            init_retries,
+            req.init_retry_interval.as_secs_f32()
+        );
         let txn_executor = RestApiTransactionExecutor {
             rest_clients: req.rest_clients.clone(),
-            max_retries: req.init_retry_count,
+            max_retries: init_retries,
             retry_after: req.init_retry_interval,
         };
         let mut all_accounts = account_minter

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -41,7 +41,7 @@ use tokio::{runtime::Handle, task::JoinHandle, time};
 // Max is 100k TPS for 3 hours
 const MAX_TXNS: u64 = 1_000_000_000;
 
-const MAX_RETRIES: usize = 8;
+const MAX_RETRIES: usize = 12;
 
 // This retry policy is used for important client calls necessary for setting
 // up the test (e.g. account creation) and collecting its results (e.g. checking

--- a/crates/transaction-emitter-lib/src/emitter/transaction_executor.rs
+++ b/crates/transaction-emitter-lib/src/emitter/transaction_executor.rs
@@ -3,16 +3,20 @@
 
 use super::RETRY_POLICY;
 use anyhow::{Context, Result};
-use aptos_logger::{sample, sample::SampleRate, warn};
+use aptos_logger::{debug, sample, sample::SampleRate, warn};
 use aptos_rest_client::Client as RestClient;
 use aptos_sdk::{
     move_types::account_address::AccountAddress, types::transaction::SignedTransaction,
 };
-use aptos_transaction_generator_lib::TransactionExecutor;
+use aptos_transaction_generator_lib::{CounterState, TransactionExecutor};
 use async_trait::async_trait;
 use futures::future::join_all;
 use rand::{rngs::StdRng, seq::SliceRandom, thread_rng, Rng, SeedableRng};
-use std::{sync::atomic::AtomicUsize, time::{Duration, Instant}};
+use std::{
+    collections::HashMap,
+    sync::atomic::AtomicUsize,
+    time::{Duration, Instant},
+};
 
 // Reliable/retrying transaction executor, used for initializing
 pub struct RestApiTransactionExecutor {
@@ -37,10 +41,18 @@ impl RestApiTransactionExecutor {
     async fn submit_check_and_retry(
         &self,
         txn: &SignedTransaction,
-        failure_counter: &[AtomicUsize],
+        counters: &CounterState,
         run_seed: u64,
     ) -> Result<()> {
         for i in 0..self.max_retries {
+            sample!(
+                SampleRate::Duration(Duration::from_secs(60)),
+                debug!(
+                    "Running reliable/retriable fetching, current state: {}",
+                    counters.show_detailed()
+                )
+            );
+
             // All transactions from the same sender, need to be submitted to the same client
             // in the same retry round, so that they are not placed in parking lot.
             // Do so by selecting a client via seeded random selection.
@@ -52,16 +64,54 @@ impl RestApiTransactionExecutor {
             .concat();
             let mut seeded_rng = StdRng::from_seed(*aptos_crypto::HashValue::sha3_256_of(&seed));
             let rest_client = self.random_rest_client_from_rng(&mut seeded_rng);
-            if submit_and_check(
+            let mut failed_submit = false;
+            let mut failed_wait = false;
+            let result = submit_and_check(
                 rest_client,
                 txn,
                 self.retry_after,
-                &failure_counter[(i * 2).min(failure_counter.len() - 1)],
-                &failure_counter[(i * 2 + 1).min(failure_counter.len() - 1)],
+                &mut failed_submit,
+                &mut failed_wait,
             )
-            .await
-            .is_ok()
-            {
+            .await;
+
+            if failed_submit {
+                counters.submit_failures[i.min(counters.submit_failures.len() - 1)]
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                if !counters.by_client.is_empty() {
+                    counters
+                        .by_client
+                        .get(&rest_client.path_prefix_string())
+                        .map(|(_, submit_failures, _)| {
+                            submit_failures.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                        });
+                }
+            }
+            if failed_wait {
+                counters.wait_failures[i.min(counters.wait_failures.len() - 1)]
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                if !counters.by_client.is_empty() {
+                    counters
+                        .by_client
+                        .get(&rest_client.path_prefix_string())
+                        .map(|(_, _, wait_failures)| {
+                            wait_failures.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                        });
+                }
+            }
+
+            if result.is_ok() {
+                counters
+                    .successes
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                if !counters.by_client.is_empty() {
+                    counters
+                        .by_client
+                        .get(&rest_client.path_prefix_string())
+                        .map(|(successes, _, _)| {
+                            successes.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                        });
+                }
                 return Ok(());
             };
         }
@@ -71,6 +121,9 @@ impl RestApiTransactionExecutor {
             .wait_for_signed_transaction_bcs(txn)
             .await?;
 
+        counters
+            .successes
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(())
     }
 }
@@ -79,8 +132,8 @@ async fn submit_and_check(
     rest_client: &RestClient,
     txn: &SignedTransaction,
     wait_duration: Duration,
-    submit_failure_counter: &AtomicUsize,
-    wait_failure_counter: &AtomicUsize,
+    failed_submit: &mut bool,
+    failed_wait: &mut bool,
 ) -> Result<()> {
     let start = Instant::now();
     if let Err(err) = rest_client.submit_bcs(txn).await {
@@ -92,7 +145,7 @@ async fn submit_and_check(
                 err,
             )
         );
-        submit_failure_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        *failed_submit = true;
         // even if txn fails submitting, it might get committed, so wait to see if that is the case.
     }
     if let Err(err) = rest_client
@@ -112,7 +165,7 @@ async fn submit_and_check(
                 err,
             )
         );
-        wait_failure_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        *failed_wait = true;
         Err(err)?;
     }
     Ok(())
@@ -140,32 +193,63 @@ impl TransactionExecutor for RestApiTransactionExecutor {
     }
 
     async fn execute_transactions(&self, txns: &[SignedTransaction]) -> Result<()> {
-        self.execute_transactions_with_counter(txns, &[AtomicUsize::new(0)])
-            .await
+        self.execute_transactions_with_counter(txns, &CounterState {
+            submit_failures: vec![AtomicUsize::new(0)],
+            wait_failures: vec![AtomicUsize::new(0)],
+            successes: AtomicUsize::new(0),
+            by_client: HashMap::new(),
+        })
+        .await
     }
 
     async fn execute_transactions_with_counter(
         &self,
         txns: &[SignedTransaction],
-        failure_counter: &[AtomicUsize],
+        counters: &CounterState,
     ) -> Result<()> {
         let run_seed: u64 = thread_rng().gen();
 
         join_all(
             txns.iter()
-                .map(|txn| self.submit_check_and_retry(txn, failure_counter, run_seed)),
+                .map(|txn| self.submit_check_and_retry(txn, counters, run_seed)),
         )
         .await
         .into_iter()
         .collect::<Result<Vec<()>, anyhow::Error>>()
         .with_context(|| {
             format!(
-                "Tried executing {} txns, failed by call by retry: {:?}",
+                "Tried executing {} txns, request counters: {:?}",
                 txns.len(),
-                failure_counter
+                counters.show_detailed()
             )
         })?;
 
         Ok(())
+    }
+
+    fn create_counter_state(&self) -> CounterState {
+        CounterState {
+            submit_failures: std::iter::repeat_with(|| AtomicUsize::new(0))
+                .take(self.max_retries)
+                .collect(),
+            wait_failures: std::iter::repeat_with(|| AtomicUsize::new(0))
+                .take(self.max_retries)
+                .collect(),
+            successes: AtomicUsize::new(0),
+            by_client: self
+                .rest_clients
+                .iter()
+                .map(|client| {
+                    (
+                        client.path_prefix_string(),
+                        (
+                            AtomicUsize::new(0),
+                            AtomicUsize::new(0),
+                            AtomicUsize::new(0),
+                        ),
+                    )
+                })
+                .collect(),
+        }
     }
 }

--- a/crates/transaction-emitter/src/main.rs
+++ b/crates/transaction-emitter/src/main.rs
@@ -64,7 +64,8 @@ pub async fn main() -> Result<()> {
         TxnEmitterCommand::EmitTx(args) => {
             let stats = emit_transactions(&args.cluster_args, &args.emit_args)
                 .await
-                .context("Emit transactions failed")?;
+                .map_err(|e| panic!("Emit transactions failed {:?}", e))
+                .unwrap();
             println!("Total stats: {}", stats);
             println!("Average rate: {}", stats.rate());
             Ok(())


### PR DESCRIPTION
We were pinging one client at a time, and so it can take 10s of seconds to fetch all. And we only allowing for 10s of 10k traffic in between (Because we were comparing versions)

- fetch all in parallel
- compare onchain timestamp, so it is not affected by traffic

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
