### PR TITLE
[spec] Broken spec_pow function fix

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/math128.md
+++ b/aptos-move/framework/aptos-stdlib/doc/math128.md
@@ -469,7 +469,7 @@ to the most correct value up to last digit
 <a name="0x1_math128_spec_pow"></a>
 
 
-<pre><code><b>fun</b> <a href="math128.md#0x1_math128_spec_pow">spec_pow</a>(e: u128, n: u128): u128 {
+<pre><code><b>fun</b> <a href="math128.md#0x1_math128_spec_pow">spec_pow</a>(n: u128, e: u128): u128 {
    <b>if</b> (e == 0) {
        1
    }

--- a/aptos-move/framework/aptos-stdlib/doc/math64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/math64.md
@@ -424,7 +424,7 @@ to the most correct value up to last digit
 <a name="0x1_math64_spec_pow"></a>
 
 
-<pre><code><b>fun</b> <a href="math64.md#0x1_math64_spec_pow">spec_pow</a>(e: u64, n: u64): u64 {
+<pre><code><b>fun</b> <a href="math64.md#0x1_math64_spec_pow">spec_pow</a>(n: u64, e: u64): u64 {
    <b>if</b> (e == 0) {
        1
    }

--- a/aptos-move/framework/aptos-stdlib/sources/math128.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math128.spec.move
@@ -25,7 +25,7 @@ spec aptos_std::math128 {
         ensures [abstract] result == spec_pow(n, e);
     }
 
-    spec fun spec_pow(e: u128, n: u128): u128 {
+    spec fun spec_pow(n: u128, e: u128): u128 {
         if (e == 0) {
             1
         }

--- a/aptos-move/framework/aptos-stdlib/sources/math64.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math64.spec.move
@@ -25,7 +25,7 @@ spec aptos_std::math64 {
         ensures [abstract] result == spec_pow(n, e);
     }
 
-    spec fun spec_pow(e: u64, n: u64): u64 {
+    spec fun spec_pow(n: u64, e: u64): u64 {
         if (e == 0) {
             1
         }


### PR DESCRIPTION
### Description

The function spec_pow is not functioning as intended due to an incorrect ordering of its arguments.