### PR TITLE
[CLI] Exit if funding account fails when using aptos init with faucet

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+* If `aptos init` is run with a faucet URL specified (which happens by default when using the local, devnet, or testnet network options) and funding the account fails, the account creation is considered a failure and nothing is persisted. Previously it would report success despite the account not being created on chain.
 
 ## [1.0.8] - 2023/03/16
 ### Added

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -203,17 +203,14 @@ impl CliCommand<()> for InitTool {
                     "Account {} doesn't exist, creating it and funding it with {} Octas",
                     address, NUM_DEFAULT_OCTAS
                 );
-                match fund_account(
+                fund_account(
                     Url::parse(faucet_url)
                         .map_err(|err| CliError::UnableToParse("rest_url", err.to_string()))?,
                     NUM_DEFAULT_OCTAS,
                     address,
                 )
-                .await
-                {
-                    Ok(_) => eprintln!("Account {} funded successfully", address),
-                    Err(err) => eprintln!("Account {} failed to be funded: {:?}", address, err),
-                };
+                .await?;
+                eprintln!("Account {} funded successfully", address);
             }
         } else if account_exists {
             eprintln!("Account {} has been already found onchain", address);

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -355,7 +355,9 @@ pub async fn fund_account(
         .body("{}")
         .send()
         .await
-        .map_err(|err| CliError::ApiError(err.to_string()))?;
+        .map_err(|err| {
+            CliError::ApiError(format!("Failed to fund account with faucet: {:#}", err))
+        })?;
     if response.status() == 200 {
         let hashes: Vec<HashValue> = response
             .json()


### PR DESCRIPTION
### Description
If `aptos init` is run with a faucet URL specified (which happens by default when using the local, devnet, or testnet network options) and funding the account fails, the account creation is considered a failure and nothing is persisted. Previously it would report success despite the account not being created on chain.

### Test Plan
Before
```
$ aptos init
Configuring for profile default
Choose network from [devnet, testnet, mainnet, local, custom | defaults to devnet]
local
Enter your private key as a hex literal (0x...) [Current: None | No input: Generate new key (or keep one if present)]

No key given, generating key...
Account d43a9161565a1101ff11eb173de4eeebf9040b2365bc39e1fcbb2a24a0952395 doesn't exist, creating it and funding it with 100000000 Octas
Account d43a9161565a1101ff11eb173de4eeebf9040b2365bc39e1fcbb2a24a0952395 failed to be funded: ApiError("error sending request for url (http://localhost:8081/mint?amount=100000000&auth_key=d43a9161565a1101ff11eb173de4eeebf9040b2365bc39e1fcbb2a24a0952395): error trying to connect: tcp connect error: Connection refused (os error 61)")

---
Aptos CLI is now set up for account d43a9161565a1101ff11eb173de4eeebf9040b2365bc39e1fcbb2a24a0952395 as profile default!  Run `aptos --help` for more information about commands
{
  "Result": "Success"
}
```

After:
```
$ cargo run -p aptos -- init
Configuring for profile default
Choose network from [devnet, testnet, mainnet, local, custom | defaults to devnet]
local
Enter your private key as a hex literal (0x...) [Current: None | No input: Generate new key (or keep one if present)]

No key given, generating key...
Account 2ade820032635575c31dda4a6fb82910229d3dce79ea1a28be09f71294d216e6 doesn't exist, creating it and funding it with 100000000 Octas
{
  "Error": "API error: Failed to use faucet: error sending request for url (http://localhost:8081/mint?amount=100000000&auth_key=f8def665a40661b09b074254526a3bdf89bfe27f896aa56f8f870bafc9db3f27): error trying to connect: tcp connect error: Connection refused (os error 61)"
}
```
