### PR TITLE
Remove mypy from production dependencies.

### DIFF
--- a/ecosystem/python/sdk/pyproject.toml
+++ b/ecosystem/python/sdk/pyproject.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0"
 [tool.poetry.dependencies]
 h2 = "^4.1.0"
 httpx = "^0.23.0"
-mypy = "^0.982"
 PyNaCl = "^1.5.0"
 python = ">=3.7,<4.0"
 


### PR DESCRIPTION
### Description
Remove mypy as a regular dependency and leaving it only as a dev-dependency, to prevent constraining the mypy version that can be used by downstream projects.

### Test Plan
N/A