### PR TITLE
[Peer Monitoring Service] Add server-side support for node info requests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,6 +1995,7 @@ dependencies = [
  "aptos-metrics-core",
  "aptos-netcore",
  "aptos-num-variants",
+ "aptos-peer-monitoring-service-types",
  "aptos-proptest-helpers",
  "aptos-rate-limiter",
  "aptos-short-hex-str",
@@ -2293,14 +2294,18 @@ dependencies = [
 name = "aptos-peer-monitoring-service-server"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "aptos-bounded-executor",
+ "aptos-build-info",
  "aptos-channels",
  "aptos-config",
+ "aptos-crypto",
  "aptos-logger",
  "aptos-metrics-core",
  "aptos-netcore",
  "aptos-network",
  "aptos-peer-monitoring-service-types",
+ "aptos-storage-interface",
  "aptos-time-service",
  "aptos-types",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -2308,6 +2313,7 @@ dependencies = [
  "claims",
  "futures",
  "maplit",
+ "mockall",
  "once_cell",
  "rand 0.7.3",
  "serde 1.0.149",
@@ -2320,7 +2326,7 @@ name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
 dependencies = [
  "aptos-config",
- "aptos-network",
+ "aptos-types",
  "serde 1.0.149",
  "thiserror",
 ]

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -422,6 +422,7 @@ pub fn setup_environment_and_start_node(
     let peer_monitoring_service_runtime = services::start_peer_monitoring_service(
         &node_config,
         peer_monitoring_service_network_interfaces,
+        db_rw.reader.clone(),
     );
 
     // Start state sync and get the notification endpoints for mempool and consensus

--- a/aptos-node/src/services.rs
+++ b/aptos-node/src/services.rs
@@ -13,10 +13,12 @@ use aptos_mempool::{network::MempoolSyncMsg, MempoolClientRequest, QuorumStoreRe
 use aptos_mempool_notifications::MempoolNotificationListener;
 use aptos_network::application::interface::NetworkClientInterface;
 use aptos_peer_monitoring_service_server::{
-    network::PeerMonitoringServiceNetworkEvents, PeerMonitoringServiceServer,
+    network::PeerMonitoringServiceNetworkEvents, storage::StorageReader,
+    PeerMonitoringServiceServer,
 };
 use aptos_peer_monitoring_service_types::PeerMonitoringServiceMessage;
 use aptos_storage_interface::{DbReader, DbReaderWriter};
+use aptos_time_service::TimeService;
 use aptos_types::chain_id::ChainId;
 use futures::channel::{mpsc, mpsc::Sender};
 use std::{sync::Arc, thread, time::Instant};
@@ -139,6 +141,7 @@ pub fn start_node_inspection_service(node_config: &NodeConfig) {
 pub fn start_peer_monitoring_service(
     node_config: &NodeConfig,
     network_interfaces: ApplicationNetworkInterfaces<PeerMonitoringServiceMessage>,
+    db_reader: Arc<dyn DbReader>,
 ) -> Runtime {
     // Get the network client and events
     let network_client = network_interfaces.network_client;
@@ -156,6 +159,8 @@ pub fn start_peer_monitoring_service(
         peer_monitoring_service_runtime.handle().clone(),
         peer_monitoring_network_events,
         network_client.get_peers_and_metadata(),
+        StorageReader::new(db_reader),
+        TimeService::real(),
     );
     peer_monitoring_service_runtime.spawn(peer_monitoring_server.start());
 

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -335,6 +335,7 @@ pub struct PeerMonitoringServiceConfig {
     pub max_request_jitter_ms: u64, // Max amount of jitter (ms) that a request will be delayed for
     pub metadata_update_interval_ms: u64, // The interval (ms) between metadata updates
     pub network_monitoring: NetworkMonitoringConfig,
+    pub node_monitoring: NodeMonitoringConfig,
     pub peer_monitor_interval_ms: u64, // The interval (ms) between peer monitor executions
 }
 
@@ -348,6 +349,7 @@ impl Default for PeerMonitoringServiceConfig {
             max_request_jitter_ms: 1000, // Monitoring requests are very infrequent
             metadata_update_interval_ms: 5000,
             network_monitoring: NetworkMonitoringConfig::default(),
+            node_monitoring: NodeMonitoringConfig::default(),
             peer_monitor_interval_ms: 1000,
         }
     }
@@ -385,6 +387,22 @@ impl Default for NetworkMonitoringConfig {
         Self {
             network_info_request_interval_ms: 60_000, // 1 minute
             network_info_request_timeout_ms: 10_000,  // 10 seconds
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct NodeMonitoringConfig {
+    pub node_info_request_interval_ms: u64, // The interval (ms) between node info requests
+    pub node_info_request_timeout_ms: u64,  // The timeout (ms) for each node info request
+}
+
+impl Default for NodeMonitoringConfig {
+    fn default() -> Self {
+        Self {
+            node_info_request_interval_ms: 20_000, // 20 seconds
+            node_info_request_timeout_ms: 10_000,  // 10 seconds
         }
     }
 }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -27,6 +27,7 @@ aptos-memsocket = { workspace = true, optional = true }
 aptos-metrics-core = { workspace = true }
 aptos-netcore = { workspace = true }
 aptos-num-variants = { workspace = true }
+aptos-peer-monitoring-service-types = { workspace = true }
 aptos-proptest-helpers = { workspace = true, optional = true }
 aptos-rate-limiter = { workspace = true }
 aptos-short-hex-str = { workspace = true }

--- a/network/peer-monitoring-service/client/Cargo.toml
+++ b/network/peer-monitoring-service/client/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+aptos-config = { workspace = true }
 aptos-netcore = { workspace = true }
 aptos-network = { workspace = true, features = ["fuzzing"] }
 aptos-peer-monitoring-service-server = { workspace = true }

--- a/network/peer-monitoring-service/client/src/error.rs
+++ b/network/peer-monitoring-service/client/src/error.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_network::protocols::network::RpcError;
-use aptos_peer_monitoring_service_types::{PeerMonitoringServiceError, UnexpectedResponseError};
+use aptos_peer_monitoring_service_types::{
+    response::UnexpectedResponseError, PeerMonitoringServiceError,
+};
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/network/peer-monitoring-service/client/src/lib.rs
+++ b/network/peer-monitoring-service/client/src/lib.rs
@@ -11,10 +11,8 @@ use aptos_config::{
 use aptos_id_generator::U64IdGenerator;
 use aptos_infallible::RwLock;
 use aptos_logger::{info, warn};
-use aptos_network::application::{
-    interface::NetworkClient, metadata::PeerMonitoringMetadata, storage::PeersAndMetadata,
-};
-use aptos_peer_monitoring_service_types::PeerMonitoringServiceMessage;
+use aptos_network::application::{interface::NetworkClient, storage::PeersAndMetadata};
+use aptos_peer_monitoring_service_types::{PeerMonitoringMetadata, PeerMonitoringServiceMessage};
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use error::Error;
 use futures::StreamExt;

--- a/network/peer-monitoring-service/client/src/logging.rs
+++ b/network/peer-monitoring-service/client/src/logging.rs
@@ -4,7 +4,7 @@
 use crate::Error;
 use aptos_config::network_id::PeerNetworkId;
 use aptos_logger::Schema;
-use aptos_peer_monitoring_service_types::PeerMonitoringServiceRequest;
+use aptos_peer_monitoring_service_types::request::PeerMonitoringServiceRequest;
 use serde::Serialize;
 
 #[derive(Schema)]

--- a/network/peer-monitoring-service/client/src/network.rs
+++ b/network/peer-monitoring-service/client/src/network.rs
@@ -12,7 +12,8 @@ use aptos_network::application::{
     storage::PeersAndMetadata,
 };
 use aptos_peer_monitoring_service_types::{
-    PeerMonitoringServiceMessage, PeerMonitoringServiceRequest, PeerMonitoringServiceResponse,
+    request::PeerMonitoringServiceRequest, response::PeerMonitoringServiceResponse,
+    PeerMonitoringServiceMessage,
 };
 use std::{sync::Arc, time::Duration};
 

--- a/network/peer-monitoring-service/client/src/peer_states/key_value.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/key_value.rs
@@ -12,7 +12,8 @@ use aptos_config::{config::NodeConfig, network_id::PeerNetworkId};
 use aptos_infallible::RwLock;
 use aptos_network::application::metadata::PeerMetadata;
 use aptos_peer_monitoring_service_types::{
-    LatencyPingRequest, PeerMonitoringServiceRequest, PeerMonitoringServiceResponse,
+    request::{LatencyPingRequest, PeerMonitoringServiceRequest},
+    response::PeerMonitoringServiceResponse,
 };
 use aptos_time_service::TimeService;
 use enum_dispatch::enum_dispatch;

--- a/network/peer-monitoring-service/client/src/peer_states/latency_info.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/latency_info.rs
@@ -10,7 +10,8 @@ use aptos_infallible::RwLock;
 use aptos_logger::{error, warn};
 use aptos_network::application::metadata::PeerMetadata;
 use aptos_peer_monitoring_service_types::{
-    LatencyPingRequest, PeerMonitoringServiceRequest, PeerMonitoringServiceResponse,
+    request::{LatencyPingRequest, PeerMonitoringServiceRequest},
+    response::PeerMonitoringServiceResponse,
 };
 use aptos_time_service::TimeService;
 use std::{collections::BTreeMap, sync::Arc};
@@ -210,8 +211,8 @@ mod test {
         transport::{ConnectionId, ConnectionMetadata},
     };
     use aptos_peer_monitoring_service_types::{
-        LatencyPingRequest, LatencyPingResponse, PeerMonitoringServiceRequest,
-        PeerMonitoringServiceResponse,
+        request::{LatencyPingRequest, PeerMonitoringServiceRequest},
+        response::{LatencyPingResponse, PeerMonitoringServiceResponse},
     };
     use aptos_time_service::TimeService;
     use aptos_types::{network_address::NetworkAddress, PeerId};

--- a/network/peer-monitoring-service/client/src/peer_states/network_info.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/network_info.rs
@@ -13,7 +13,8 @@ use aptos_infallible::RwLock;
 use aptos_logger::warn;
 use aptos_network::application::metadata::PeerMetadata;
 use aptos_peer_monitoring_service_types::{
-    NetworkInformationResponse, PeerMonitoringServiceRequest, PeerMonitoringServiceResponse,
+    request::PeerMonitoringServiceRequest,
+    response::{NetworkInformationResponse, PeerMonitoringServiceResponse},
     MAX_DISTANCE_FROM_VALIDATORS,
 };
 use aptos_time_service::TimeService;
@@ -187,7 +188,8 @@ mod test {
         transport::{ConnectionId, ConnectionMetadata},
     };
     use aptos_peer_monitoring_service_types::{
-        NetworkInformationResponse, PeerMonitoringServiceRequest, PeerMonitoringServiceResponse,
+        request::PeerMonitoringServiceRequest,
+        response::{NetworkInformationResponse, PeerMonitoringServiceResponse},
     };
     use aptos_time_service::TimeService;
     use aptos_types::{network_address::NetworkAddress, PeerId};

--- a/network/peer-monitoring-service/client/src/peer_states/peer_state.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/peer_state.rs
@@ -156,18 +156,10 @@ impl PeerState {
         let average_latency_ping_secs = latency_info_state.get_average_latency_ping_secs();
         peer_monitoring_metadata.average_ping_latency_secs = average_latency_ping_secs;
 
-        // Get and store the depth from the validators
+        // Get and store the latest network info response
         let network_info_state = self.get_network_info_state()?;
         let network_info_response = network_info_state.get_latest_network_info_response();
-        let distance_from_validators = network_info_response
-            .as_ref()
-            .map(|network_info_response| network_info_response.distance_from_validators);
-        peer_monitoring_metadata.distance_from_validators = distance_from_validators;
-
-        // Get and store the connected peers and connection metadata
-        let connected_peers_and_metadata = network_info_response
-            .map(|network_info_response| network_info_response.connected_peers);
-        peer_monitoring_metadata.connected_peers = connected_peers_and_metadata;
+        peer_monitoring_metadata.latest_network_info_response = network_info_response;
 
         Ok(peer_monitoring_metadata)
     }

--- a/network/peer-monitoring-service/client/src/peer_states/peer_state.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/peer_state.rs
@@ -17,11 +17,8 @@ use aptos_config::{
 };
 use aptos_id_generator::{IdGenerator, U64IdGenerator};
 use aptos_infallible::RwLock;
-use aptos_network::application::{
-    interface::NetworkClient,
-    metadata::{PeerMetadata, PeerMonitoringMetadata},
-};
-use aptos_peer_monitoring_service_types::PeerMonitoringServiceMessage;
+use aptos_network::application::{interface::NetworkClient, metadata::PeerMetadata};
+use aptos_peer_monitoring_service_types::{PeerMonitoringMetadata, PeerMonitoringServiceMessage};
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use rand::{rngs::OsRng, Rng};
 use std::{collections::HashMap, sync::Arc, time::Duration};

--- a/network/peer-monitoring-service/client/src/tests/multiple_peers.rs
+++ b/network/peer-monitoring-service/client/src/tests/multiple_peers.rs
@@ -6,12 +6,12 @@ use crate::{
     tests::{
         mock::MockMonitoringServer,
         utils::{
-            elapse_latency_update_interval, elapse_metadata_updater_interval,
-            elapse_network_info_update_interval, get_config_without_latency_pings,
-            get_config_without_network_info_requests, get_distance_from_validators,
-            initialize_and_verify_peer_states, spawn_with_timeout, start_peer_metadata_updater,
-            start_peer_monitor, update_latency_info_for_peer, update_network_info_for_peer,
-            verify_and_handle_latency_ping, verify_empty_peer_states,
+            create_connected_peers_map, elapse_latency_update_interval,
+            elapse_metadata_updater_interval, elapse_network_info_update_interval,
+            get_config_without_latency_pings, get_config_without_network_info_requests,
+            get_distance_from_validators, initialize_and_verify_peer_states, spawn_with_timeout,
+            start_peer_metadata_updater, start_peer_monitor, update_latency_info_for_peer,
+            update_network_info_for_peer, verify_and_handle_latency_ping, verify_empty_peer_states,
             verify_latency_request_and_respond, wait_for_monitoring_latency_update,
             wait_for_monitoring_network_update, wait_for_peer_state_update,
         },
@@ -20,17 +20,14 @@ use crate::{
 };
 use aptos_config::{
     config::{NodeConfig, PeerRole},
-    network_id::{NetworkId, PeerNetworkId},
+    network_id::NetworkId,
 };
 use aptos_infallible::RwLock;
-use aptos_network::transport::ConnectionMetadata;
 use aptos_peer_monitoring_service_types::{
     request::PeerMonitoringServiceRequest,
     response::{LatencyPingResponse, NetworkInformationResponse, PeerMonitoringServiceResponse},
 };
 use aptos_time_service::TimeServiceTrait;
-use aptos_types::PeerId;
-use maplit::hashmap;
 use std::sync::Arc;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -107,8 +104,7 @@ async fn test_peer_updater_loop_multiple_peers() {
         let peer_state = peer_states.get_mut(peer).unwrap();
 
         // Update the network info
-        let connected_peers =
-            hashmap! { PeerNetworkId::random() => ConnectionMetadata::mock(PeerId::random()) };
+        let connected_peers = create_connected_peers_map();
         let distance_from_validators = get_distance_from_validators(peer);
         update_network_info_for_peer(
             peers_and_metadata.clone(),
@@ -392,8 +388,7 @@ async fn test_network_info() {
         let peer_monitor_state = peer_monitor_state.clone();
         let handle_requests = async move {
             // Create a response for the network info requests
-            let connected_peers =
-                hashmap! { PeerNetworkId::random() => ConnectionMetadata::mock(PeerId::random()) };
+            let connected_peers = create_connected_peers_map();
             let response =
                 PeerMonitoringServiceResponse::NetworkInformation(NetworkInformationResponse {
                     connected_peers: connected_peers.clone(),

--- a/network/peer-monitoring-service/client/src/tests/multiple_peers.rs
+++ b/network/peer-monitoring-service/client/src/tests/multiple_peers.rs
@@ -25,8 +25,8 @@ use aptos_config::{
 use aptos_infallible::RwLock;
 use aptos_network::transport::ConnectionMetadata;
 use aptos_peer_monitoring_service_types::{
-    LatencyPingResponse, NetworkInformationResponse, PeerMonitoringServiceRequest,
-    PeerMonitoringServiceResponse,
+    request::PeerMonitoringServiceRequest,
+    response::{LatencyPingResponse, NetworkInformationResponse, PeerMonitoringServiceResponse},
 };
 use aptos_time_service::TimeServiceTrait;
 use aptos_types::PeerId;

--- a/network/peer-monitoring-service/client/src/tests/single_peer.rs
+++ b/network/peer-monitoring-service/client/src/tests/single_peer.rs
@@ -6,29 +6,27 @@ use crate::{
     tests::{
         mock::MockMonitoringServer,
         utils::{
-            elapse_latency_update_interval, elapse_metadata_updater_interval,
-            elapse_network_info_update_interval, get_config_without_latency_pings,
-            get_config_without_network_info_requests, initialize_and_verify_peer_states,
-            start_peer_metadata_updater, start_peer_monitor, update_latency_info_for_peer,
-            update_network_info_for_peer, verify_all_requests_and_respond,
-            verify_and_handle_latency_ping, verify_and_handle_network_info_request,
-            verify_empty_peer_states, verify_latency_request_and_respond,
-            verify_network_info_request_and_respond, verify_peer_latency_state,
-            verify_peer_monitor_state, verify_peer_network_state, wait_for_latency_ping_failure,
-            wait_for_monitoring_latency_update, wait_for_monitoring_network_update,
-            wait_for_network_info_request_failure, wait_for_peer_state_update,
+            create_connected_peers_map, elapse_latency_update_interval,
+            elapse_metadata_updater_interval, elapse_network_info_update_interval,
+            get_config_without_latency_pings, get_config_without_network_info_requests,
+            initialize_and_verify_peer_states, start_peer_metadata_updater, start_peer_monitor,
+            update_latency_info_for_peer, update_network_info_for_peer,
+            verify_all_requests_and_respond, verify_and_handle_latency_ping,
+            verify_and_handle_network_info_request, verify_empty_peer_states,
+            verify_latency_request_and_respond, verify_network_info_request_and_respond,
+            verify_peer_latency_state, verify_peer_monitor_state, verify_peer_network_state,
+            wait_for_latency_ping_failure, wait_for_monitoring_latency_update,
+            wait_for_monitoring_network_update, wait_for_network_info_request_failure,
+            wait_for_peer_state_update,
         },
     },
     PeerState,
 };
 use aptos_config::{
     config::{NodeConfig, PeerRole},
-    network_id::{NetworkId, PeerNetworkId},
+    network_id::NetworkId,
 };
-use aptos_network::transport::ConnectionMetadata;
 use aptos_time_service::TimeServiceTrait;
-use aptos_types::PeerId;
-use maplit::hashmap;
 use std::cmp::min;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -196,8 +194,7 @@ async fn test_basic_peer_updater_loop() {
     // Update the network info for the fullnode several times
     for distance_from_validators in 2..10 {
         // Update the network info for the fullnode
-        let connected_peers =
-            hashmap! { PeerNetworkId::random() => ConnectionMetadata::mock(PeerId::random()) };
+        let connected_peers = create_connected_peers_map();
         update_network_info_for_peer(
             peers_and_metadata.clone(),
             &fullnode_peer,
@@ -450,8 +447,7 @@ async fn test_network_info_requests() {
     // Handle many network info requests and responses
     let distance_from_validators = 0;
     for _ in 0..20 {
-        let connected_peers =
-            hashmap! { PeerNetworkId::random() => ConnectionMetadata::mock(PeerId::random()) };
+        let connected_peers = create_connected_peers_map();
         verify_and_handle_network_info_request(
             &network_id,
             &mut mock_monitoring_server,
@@ -506,8 +502,7 @@ async fn test_network_info_request_failures() {
         elapse_network_info_update_interval(node_config.clone(), mock_time.clone()).await;
 
         // Verify that a single network info request is received and send a bad response
-        let connected_peers =
-            hashmap! { PeerNetworkId::random() => ConnectionMetadata::mock(PeerId::random()) };
+        let connected_peers = create_connected_peers_map();
         verify_network_info_request_and_respond(
             &network_id,
             &mut mock_monitoring_server,
@@ -538,8 +533,7 @@ async fn test_network_info_request_failures() {
         elapse_network_info_update_interval(node_config.clone(), mock_time.clone()).await;
 
         // Verify that a single network info request is received and send an invalid peer depth response
-        let connected_peers =
-            hashmap! { PeerNetworkId::random() => ConnectionMetadata::mock(PeerId::random()) };
+        let connected_peers = create_connected_peers_map();
         verify_network_info_request_and_respond(
             &network_id,
             &mut mock_monitoring_server,
@@ -565,8 +559,7 @@ async fn test_network_info_request_failures() {
     );
 
     // Elapse enough time for a network info request and perform a successful execution
-    let connected_peers =
-        hashmap! { PeerNetworkId::random() => ConnectionMetadata::mock(PeerId::random()) };
+    let connected_peers = create_connected_peers_map();
     verify_and_handle_network_info_request(
         &network_id,
         &mut mock_monitoring_server,
@@ -595,8 +588,7 @@ async fn test_network_info_request_failures() {
         elapse_network_info_update_interval(node_config.clone(), mock_time.clone()).await;
 
         // Verify that a single network info request is received and don't send a response
-        let connected_peers =
-            hashmap! { PeerNetworkId::random() => ConnectionMetadata::mock(PeerId::random()) };
+        let connected_peers = create_connected_peers_map();
         verify_network_info_request_and_respond(
             &network_id,
             &mut mock_monitoring_server,
@@ -622,8 +614,7 @@ async fn test_network_info_request_failures() {
     );
 
     // Elapse enough time for a latency ping and perform a successful execution
-    let connected_peers =
-        hashmap! { PeerNetworkId::random() => ConnectionMetadata::mock(PeerId::random()) };
+    let connected_peers = create_connected_peers_map();
     verify_and_handle_network_info_request(
         &network_id,
         &mut mock_monitoring_server,

--- a/network/peer-monitoring-service/client/src/tests/utils.rs
+++ b/network/peer-monitoring-service/client/src/tests/utils.rs
@@ -18,9 +18,12 @@ use aptos_network::{
     transport::ConnectionMetadata,
 };
 use aptos_peer_monitoring_service_types::{
-    LatencyPingRequest, LatencyPingResponse, NetworkInformationResponse,
-    PeerMonitoringServiceMessage, PeerMonitoringServiceRequest, PeerMonitoringServiceResponse,
-    ServerProtocolVersionResponse,
+    request::{LatencyPingRequest, PeerMonitoringServiceRequest},
+    response::{
+        LatencyPingResponse, NetworkInformationResponse, PeerMonitoringServiceResponse,
+        ServerProtocolVersionResponse,
+    },
+    PeerMonitoringServiceMessage,
 };
 use aptos_time_service::{MockTimeService, TimeService, TimeServiceTrait};
 use aptos_types::PeerId;

--- a/network/peer-monitoring-service/server/Cargo.toml
+++ b/network/peer-monitoring-service/server/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 aptos-bounded-executor = { workspace = true }
+aptos-build-info = { workspace = true }
 aptos-channels = { workspace = true }
 aptos-config = { workspace = true }
 aptos-logger = { workspace = true }
@@ -21,6 +22,7 @@ aptos-metrics-core = { workspace = true }
 aptos-netcore = { workspace = true }
 aptos-network = { workspace = true }
 aptos-peer-monitoring-service-types = { workspace = true }
+aptos-storage-interface = { workspace = true }
 aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
@@ -32,8 +34,11 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+anyhow = { workspace = true }
+aptos-crypto = { workspace = true }
 aptos-network = { workspace = true, features = ["fuzzing"] }
 aptos-time-service = { workspace = true, features = ["testing"] }
 claims = { workspace = true }
 maplit = { workspace = true }
+mockall = { workspace = true }
 rand = { workspace = true }

--- a/network/peer-monitoring-service/server/src/error.rs
+++ b/network/peer-monitoring-service/server/src/error.rs
@@ -8,6 +8,8 @@ use thiserror::Error;
 pub enum Error {
     #[error("Invalid request received: {0}")]
     InvalidRequest(String),
+    #[error("Storage error encountered: {0}")]
+    StorageErrorEncountered(String),
     #[error("Unexpected error encountered: {0}")]
     UnexpectedErrorEncountered(String),
 }
@@ -17,6 +19,7 @@ impl Error {
     pub fn get_label(&self) -> &'static str {
         match self {
             Error::InvalidRequest(_) => "invalid_request",
+            Error::StorageErrorEncountered(_) => "storage_error",
             Error::UnexpectedErrorEncountered(_) => "unexpected_error",
         }
     }

--- a/network/peer-monitoring-service/server/src/logging.rs
+++ b/network/peer-monitoring-service/server/src/logging.rs
@@ -3,7 +3,7 @@
 
 use crate::Error;
 use aptos_logger::Schema;
-use aptos_peer_monitoring_service_types::PeerMonitoringServiceRequest;
+use aptos_peer_monitoring_service_types::request::PeerMonitoringServiceRequest;
 use serde::Serialize;
 
 #[derive(Schema)]

--- a/network/peer-monitoring-service/server/src/network.rs
+++ b/network/peer-monitoring-service/server/src/network.rs
@@ -8,8 +8,8 @@ use aptos_network::{
     ProtocolId,
 };
 use aptos_peer_monitoring_service_types::{
-    PeerMonitoringServiceMessage, PeerMonitoringServiceRequest, PeerMonitoringServiceResponse,
-    Result,
+    request::PeerMonitoringServiceRequest, response::PeerMonitoringServiceResponse,
+    PeerMonitoringServiceMessage, Result,
 };
 use bytes::Bytes;
 use futures::{

--- a/network/peer-monitoring-service/server/src/storage.rs
+++ b/network/peer-monitoring-service/server/src/storage.rs
@@ -1,0 +1,64 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Error;
+use aptos_storage_interface::DbReader;
+use aptos_types::ledger_info::LedgerInfo;
+use std::sync::Arc;
+
+/// The interface into local storage (e.g., the Aptos DB) used by the peer
+/// monitoring server to handle client requests and responses.
+pub trait StorageReaderInterface: Clone + Send + 'static {
+    /// Returns the highest synced epoch and version
+    fn get_highest_synced_epoch_and_version(&self) -> Result<(u64, u64), Error>;
+
+    /// Returns the ledger timestamp of the blockchain in microseconds
+    fn get_ledger_timestamp_usecs(&self) -> Result<u64, Error>;
+
+    /// Returns the lowest available version in storage
+    fn get_lowest_available_version(&self) -> Result<u64, Error>;
+}
+
+/// The underlying implementation of the StorageReaderInterface, used by the
+/// storage server.
+#[derive(Clone)]
+pub struct StorageReader {
+    storage: Arc<dyn DbReader>,
+}
+
+impl StorageReader {
+    pub fn new(storage: Arc<dyn DbReader>) -> Self {
+        Self { storage }
+    }
+
+    /// Returns the latest ledger info in storage
+    fn get_latest_ledger_info(&self) -> Result<LedgerInfo, Error> {
+        let latest_ledger_info_with_sigs = self
+            .storage
+            .get_latest_ledger_info()
+            .map_err(|err| Error::StorageErrorEncountered(err.to_string()))?;
+        Ok(latest_ledger_info_with_sigs.ledger_info().clone())
+    }
+}
+
+impl StorageReaderInterface for StorageReader {
+    fn get_highest_synced_epoch_and_version(&self) -> Result<(u64, u64), Error> {
+        let latest_ledger_info = self.get_latest_ledger_info()?;
+        Ok((latest_ledger_info.epoch(), latest_ledger_info.version()))
+    }
+
+    fn get_ledger_timestamp_usecs(&self) -> Result<u64, Error> {
+        let latest_ledger_info = self.get_latest_ledger_info()?;
+        Ok(latest_ledger_info.timestamp_usecs())
+    }
+
+    fn get_lowest_available_version(&self) -> Result<u64, Error> {
+        let maybe_lowest_available_version = self
+            .storage
+            .get_first_txn_version()
+            .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
+        maybe_lowest_available_version.ok_or_else(|| {
+            Error::StorageErrorEncountered("get_first_txn_version() returned None!".into())
+        })
+    }
+}

--- a/network/peer-monitoring-service/server/src/tests.rs
+++ b/network/peer-monitoring-service/server/src/tests.rs
@@ -4,21 +4,20 @@
 #![forbid(unsafe_code)]
 
 use crate::{
-    metrics, PeerMonitoringServiceNetworkEvents, PeerMonitoringServiceServer,
-    MAX_DISTANCE_FROM_VALIDATORS, PEER_MONITORING_SERVER_VERSION,
+    metrics, storage::StorageReader, PeerMonitoringServiceNetworkEvents,
+    PeerMonitoringServiceServer, MAX_DISTANCE_FROM_VALIDATORS, PEER_MONITORING_SERVER_VERSION,
 };
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::{
     config::{BaseConfig, NodeConfig, PeerMonitoringServiceConfig, PeerRole, RoleType},
     network_id::{NetworkId, PeerNetworkId},
 };
+use aptos_crypto::HashValue;
 use aptos_logger::Level;
 use aptos_netcore::transport::ConnectionOrigin;
 use aptos_network::{
     application::{
-        interface::NetworkServiceEvents,
-        metadata::{ConnectionState, PeerMonitoringMetadata},
-        storage::PeersAndMetadata,
+        interface::NetworkServiceEvents, metadata::ConnectionState, storage::PeersAndMetadata,
     },
     peer_manager::PeerManagerNotification,
     protocols::{
@@ -29,16 +28,41 @@ use aptos_network::{
     transport::{ConnectionId, ConnectionMetadata},
 };
 use aptos_peer_monitoring_service_types::{
-    LatencyPingRequest, NetworkInformationResponse, PeerMonitoringServiceError,
-    PeerMonitoringServiceMessage, PeerMonitoringServiceRequest, PeerMonitoringServiceResponse,
-    ServerProtocolVersionResponse,
+    request::{LatencyPingRequest, PeerMonitoringServiceRequest},
+    response::{
+        NetworkInformationResponse, NodeInformationResponse, PeerMonitoringServiceResponse,
+        ServerProtocolVersionResponse,
+    },
+    PeerMonitoringMetadata, PeerMonitoringServiceError, PeerMonitoringServiceMessage,
 };
+use aptos_storage_interface::{DbReader, ExecutedTrees, Order};
 use aptos_time_service::{MockTimeService, TimeService};
-use aptos_types::{account_address::AccountAddress, network_address::NetworkAddress, PeerId};
+use aptos_types::{
+    account_address::AccountAddress,
+    aggregate_signature::AggregateSignature,
+    block_info::BlockInfo,
+    contract_event::EventWithVersion,
+    epoch_change::EpochChangeProof,
+    event::EventKey,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    network_address::NetworkAddress,
+    proof::{AccumulatorConsistencyProof, SparseMerkleProof, TransactionAccumulatorSummary},
+    state_proof::StateProof,
+    state_store::{
+        state_key::StateKey,
+        state_value::{StateValue, StateValueChunkWithProof},
+    },
+    transaction::{
+        AccountTransactionsWithProof, TransactionInfo, TransactionListWithProof,
+        TransactionOutputListWithProof, TransactionWithProof, Version,
+    },
+    PeerId,
+};
 use futures::channel::oneshot;
 use maplit::hashmap;
+use mockall::mock;
 use rand::{rngs::OsRng, Rng};
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
 // Useful test constants
 const LOCAL_HOST_NET_ADDR: &str = "/ip4/127.0.0.1/tcp/8081";
@@ -46,7 +70,7 @@ const LOCAL_HOST_NET_ADDR: &str = "/ip4/127.0.0.1/tcp/8081";
 #[tokio::test]
 async fn test_get_server_protocol_version() {
     // Create the peer monitoring client and server
-    let (mut mock_client, service, _, _) = MockClient::new(None, None);
+    let (mut mock_client, service, _, _) = MockClient::new(None, None, None);
     tokio::spawn(service.start());
 
     // Process a request to fetch the protocol version
@@ -69,7 +93,7 @@ async fn test_get_network_information_fullnode() {
         ..Default::default()
     };
     let (mut mock_client, service, _, peers_and_metadata) =
-        MockClient::new(Some(base_config), None);
+        MockClient::new(Some(base_config), None, None);
     tokio::spawn(service.start());
 
     // Process a client request to fetch the network information and verify an empty response
@@ -89,16 +113,22 @@ async fn test_get_network_information_fullnode() {
         .unwrap();
 
     // Process a client request to fetch the network information and verify the response
+    let expected_peers = hashmap! {peer_network_id_1 => connection_metadata_1.clone()};
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => connection_metadata_1.clone()},
+        expected_peers.clone(),
         MAX_DISTANCE_FROM_VALIDATORS,
     )
     .await;
 
     // Update the peer monitoring metadata for peer 1
     let peer_distance_1 = MAX_DISTANCE_FROM_VALIDATORS; // Peer 1 is not connected to anyone else
-    let peer_monitoring_metadata_1 = PeerMonitoringMetadata::new(None, None, Some(peer_distance_1));
+    let latest_network_info_response = NetworkInformationResponse {
+        connected_peers: transform_connection_metadata(expected_peers.clone()),
+        distance_from_validators: peer_distance_1,
+    };
+    let peer_monitoring_metadata_1 =
+        PeerMonitoringMetadata::new(None, Some(latest_network_info_response), None);
     peers_and_metadata
         .update_peer_monitoring_metadata(peer_network_id_1, peer_monitoring_metadata_1.clone())
         .unwrap();
@@ -106,14 +136,19 @@ async fn test_get_network_information_fullnode() {
     // Process a client request to fetch the network information and verify the response
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => connection_metadata_1.clone()},
+        expected_peers.clone(),
         MAX_DISTANCE_FROM_VALIDATORS,
     )
     .await;
 
     // Update the peer monitoring metadata and connection metadata for peer 1
     let peer_distance_1 = 2; // Peer 1 now has other connections
-    let peer_monitoring_metadata_1 = PeerMonitoringMetadata::new(None, None, Some(peer_distance_1));
+    let latest_network_info_response = NetworkInformationResponse {
+        connected_peers: transform_connection_metadata(expected_peers),
+        distance_from_validators: peer_distance_1,
+    };
+    let peer_monitoring_metadata_1 =
+        PeerMonitoringMetadata::new(None, Some(latest_network_info_response), None);
     peers_and_metadata
         .update_peer_monitoring_metadata(peer_network_id_1, peer_monitoring_metadata_1.clone())
         .unwrap();
@@ -135,7 +170,13 @@ async fn test_get_network_information_fullnode() {
     let peer_network_id_2 = PeerNetworkId::new(NetworkId::Validator, peer_id_2);
     let peer_distance_2 = 0; // The peer is a validator
     let connection_metadata_2 = create_connection_metadata(peer_id_2);
-    let peer_monitoring_metadata_2 = PeerMonitoringMetadata::new(None, None, Some(peer_distance_2));
+    let expected_peers = hashmap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2.clone()};
+    let latest_network_info_response = NetworkInformationResponse {
+        connected_peers: transform_connection_metadata(expected_peers),
+        distance_from_validators: peer_distance_2,
+    };
+    let peer_monitoring_metadata_2 =
+        PeerMonitoringMetadata::new(None, Some(latest_network_info_response), None);
     peers_and_metadata
         .insert_connection_metadata(peer_network_id_2, connection_metadata_2.clone())
         .unwrap();
@@ -173,7 +214,7 @@ async fn test_get_network_information_validator() {
         ..Default::default()
     };
     let (mut mock_client, service, _, peers_and_metadata) =
-        MockClient::new(Some(base_config), None);
+        MockClient::new(Some(base_config), None, None);
     tokio::spawn(service.start());
 
     // Process a client request to fetch the network information and verify distance is 0
@@ -188,34 +229,36 @@ async fn test_get_network_information_validator() {
         .unwrap();
 
     // Process a client request to fetch the network information and verify the response
-    verify_network_information(
-        &mut mock_client,
-        hashmap! {peer_network_id_1 => connection_metadata_1.clone()},
-        0,
-    )
-    .await;
+    let expected_peers = hashmap! {peer_network_id_1 => connection_metadata_1.clone()};
+    verify_network_information(&mut mock_client, expected_peers.clone(), 0).await;
 
     // Update the peer monitoring metadata for peer 1
     let peer_distance_1 = 0; // Peer 1 now has other connections
-    let peer_monitoring_metadata_1 = PeerMonitoringMetadata::new(None, None, Some(peer_distance_1));
+    let latest_network_info_response = NetworkInformationResponse {
+        connected_peers: transform_connection_metadata(expected_peers.clone()),
+        distance_from_validators: peer_distance_1,
+    };
+    let peer_monitoring_metadata_1 =
+        PeerMonitoringMetadata::new(None, Some(latest_network_info_response), None);
     peers_and_metadata
         .update_peer_monitoring_metadata(peer_network_id_1, peer_monitoring_metadata_1.clone())
         .unwrap();
 
     // Process a client request to fetch the network information and verify the response
-    verify_network_information(
-        &mut mock_client,
-        hashmap! {peer_network_id_1 => connection_metadata_1.clone()},
-        0,
-    )
-    .await;
+    verify_network_information(&mut mock_client, expected_peers, 0).await;
 
     // Connect another peer to the validator
     let peer_id_2 = PeerId::random();
     let peer_network_id_2 = PeerNetworkId::new(NetworkId::Vfn, peer_id_2);
     let peer_distance_2 = 1; // The peer is a VFN
     let connection_metadata_2 = create_connection_metadata(peer_id_2);
-    let peer_monitoring_metadata_2 = PeerMonitoringMetadata::new(None, None, Some(peer_distance_2));
+    let expected_peers = hashmap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2.clone()};
+    let latest_network_info_response = NetworkInformationResponse {
+        connected_peers: transform_connection_metadata(expected_peers.clone()),
+        distance_from_validators: peer_distance_2,
+    };
+    let peer_monitoring_metadata_2 =
+        PeerMonitoringMetadata::new(None, Some(latest_network_info_response), None);
     peers_and_metadata
         .insert_connection_metadata(peer_network_id_2, connection_metadata_2.clone())
         .unwrap();
@@ -224,12 +267,7 @@ async fn test_get_network_information_validator() {
         .unwrap();
 
     // Process a client request to fetch the network information and verify the response
-    verify_network_information(
-        &mut mock_client,
-        hashmap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2},
-        0,
-    )
-        .await;
+    verify_network_information(&mut mock_client, expected_peers, 0).await;
 
     // Disconnect peer 2
     peers_and_metadata
@@ -246,9 +284,79 @@ async fn test_get_network_information_validator() {
 }
 
 #[tokio::test]
+async fn test_get_node_information() {
+    // Setup the mock data
+    let highest_synced_epoch = 5;
+    let highest_synced_version = 1000;
+    let ledger_timestamp_usecs = 9734834;
+    let block_info = BlockInfo::new(
+        highest_synced_epoch,
+        0,
+        HashValue::zero(),
+        HashValue::zero(),
+        highest_synced_version,
+        ledger_timestamp_usecs,
+        None,
+    );
+    let latest_ledger_info = LedgerInfoWithSignatures::new(
+        LedgerInfo::new(block_info, HashValue::zero()),
+        AggregateSignature::empty(),
+    );
+    let lowest_available_version = 19;
+
+    // Create the mock storage reader
+    let mut mock_db_reader = create_mock_db_reader();
+
+    // Setup the mock expectations
+    mock_db_reader
+        .expect_get_latest_ledger_info()
+        .returning(move || Ok(latest_ledger_info.clone()));
+    mock_db_reader
+        .expect_get_first_txn_version()
+        .returning(move || Ok(Some(lowest_available_version)));
+
+    // Create the peer monitoring client and server
+    let storage_reader = StorageReader::new(Arc::new(mock_db_reader));
+    let (mut mock_client, service, time_service, _) =
+        MockClient::new(None, None, Some(storage_reader));
+    tokio::spawn(service.start());
+
+    // Process a client request to fetch the node information and verify the response
+    let mut total_uptime = Duration::from_millis(0);
+    verify_node_information(
+        &mut mock_client,
+        highest_synced_epoch,
+        highest_synced_version,
+        ledger_timestamp_usecs,
+        lowest_available_version,
+        total_uptime,
+    )
+    .await;
+
+    // Handle several more node information requests with new uptimes
+    for _ in 0..10 {
+        // Elapse a little bit of time
+        let duration_to_elapse = Duration::from_millis(100);
+        time_service.advance(duration_to_elapse);
+        total_uptime = total_uptime.saturating_add(duration_to_elapse);
+
+        // Process a client request to fetch the node information and verify the response
+        verify_node_information(
+            &mut mock_client,
+            highest_synced_epoch,
+            highest_synced_version,
+            ledger_timestamp_usecs,
+            lowest_available_version,
+            total_uptime,
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
 async fn test_latency_ping_request() {
     // Create the peer monitoring client and server
-    let (mut mock_client, service, _, _) = MockClient::new(None, None);
+    let (mut mock_client, service, _, _) = MockClient::new(None, None, None);
     tokio::spawn(service.start());
 
     // Process several requests to perform latency pings
@@ -292,8 +400,54 @@ async fn verify_network_information(
     // Verify the response is correct
     let expected_response =
         PeerMonitoringServiceResponse::NetworkInformation(NetworkInformationResponse {
-            connected_peers: expected_peers,
+            connected_peers: transform_connection_metadata(expected_peers),
             distance_from_validators: expected_distance_from_validators,
+        });
+    assert_eq!(response, expected_response);
+}
+
+/// Transforms the connection metadata for the given peers into
+/// metadata expected by the peer monitoring service.
+fn transform_connection_metadata(
+    expected_peers: HashMap<PeerNetworkId, ConnectionMetadata>,
+) -> HashMap<PeerNetworkId, aptos_peer_monitoring_service_types::response::ConnectionMetadata> {
+    expected_peers
+        .into_iter()
+        .map(|(peer_id, metadata)| {
+            let connection_metadata =
+                aptos_peer_monitoring_service_types::response::ConnectionMetadata::new(
+                    metadata.addr,
+                    metadata.remote_peer_id,
+                    metadata.role,
+                );
+            (peer_id, connection_metadata)
+        })
+        .collect()
+}
+
+/// A simple utility function that sends a request for node info using the given
+/// client, and verifies the response is correct.
+async fn verify_node_information(
+    client: &mut MockClient,
+    highest_synced_epoch: u64,
+    highest_synced_version: u64,
+    ledger_timestamp_usecs: u64,
+    lowest_available_version: u64,
+    uptime: Duration,
+) {
+    // Send a request to fetch the node information
+    let request = PeerMonitoringServiceRequest::GetNodeInformation;
+    let response = client.send_request(request).await.unwrap();
+
+    // Verify the response is correct
+    let expected_response =
+        PeerMonitoringServiceResponse::NodeInformation(NodeInformationResponse {
+            git_hash: aptos_build_info::get_git_hash(),
+            highest_synced_epoch,
+            highest_synced_version,
+            ledger_timestamp_usecs,
+            lowest_available_version,
+            uptime,
         });
     assert_eq!(response, expected_response);
 }
@@ -309,9 +463,10 @@ impl MockClient {
     fn new(
         base_config: Option<BaseConfig>,
         peer_monitoring_config: Option<PeerMonitoringServiceConfig>,
+        storage_reader: Option<StorageReader>,
     ) -> (
         Self,
-        PeerMonitoringServiceServer,
+        PeerMonitoringServiceServer<StorageReader>,
         MockTimeService,
         Arc<PeersAndMetadata>,
     ) {
@@ -353,11 +508,15 @@ impl MockClient {
         // Create the storage service
         let executor = tokio::runtime::Handle::current();
         let mock_time_service = TimeService::mock();
+        let storage_reader =
+            storage_reader.unwrap_or_else(|| StorageReader::new(Arc::new(create_mock_db_reader())));
         let peer_monitoring_server = PeerMonitoringServiceServer::new(
             node_config,
             executor,
             peer_monitoring_network_events,
             peers_and_metadata.clone(),
+            storage_reader,
+            mock_time_service.clone(),
         );
 
         // Create the client
@@ -430,5 +589,143 @@ fn get_random_network_id() -> NetworkId {
         1 => NetworkId::Vfn,
         2 => NetworkId::Public,
         num => panic!("This shouldn't be possible! Got num: {:?}", num),
+    }
+}
+
+/// Creates a mock database reader
+pub fn create_mock_db_reader() -> MockDatabaseReader {
+    MockDatabaseReader::new()
+}
+
+// This automatically creates a MockDatabaseReader.
+// TODO(joshlind): if we frequently use these mocks, we should define a single
+// mock test crate to be shared across the codebase.
+mock! {
+    pub DatabaseReader {}
+    impl DbReader for DatabaseReader {
+        fn get_epoch_ending_ledger_infos(
+            &self,
+            start_epoch: u64,
+            end_epoch: u64,
+        ) -> anyhow::Result<EpochChangeProof>;
+
+        fn get_transactions(
+            &self,
+            start_version: Version,
+            batch_size: u64,
+            ledger_version: Version,
+            fetch_events: bool,
+        ) -> anyhow::Result<TransactionListWithProof>;
+
+        fn get_transaction_by_hash(
+            &self,
+            hash: HashValue,
+            ledger_version: Version,
+            fetch_events: bool,
+        ) -> anyhow::Result<Option<TransactionWithProof>>;
+
+        fn get_transaction_by_version(
+            &self,
+            version: Version,
+            ledger_version: Version,
+            fetch_events: bool,
+        ) -> anyhow::Result<TransactionWithProof>;
+
+        fn get_first_txn_version(&self) -> anyhow::Result<Option<Version>>;
+
+        fn get_first_write_set_version(&self) -> anyhow::Result<Option<Version>>;
+
+        fn get_transaction_outputs(
+            &self,
+            start_version: Version,
+            limit: u64,
+            ledger_version: Version,
+        ) -> anyhow::Result<TransactionOutputListWithProof>;
+
+        fn get_events(
+            &self,
+            event_key: &EventKey,
+            start: u64,
+            order: Order,
+            limit: u64,
+            ledger_version: Version,
+        ) -> anyhow::Result<Vec<EventWithVersion>>;
+
+        fn get_block_timestamp(&self, version: u64) -> anyhow::Result<u64>;
+
+        fn get_last_version_before_timestamp(
+            &self,
+            _timestamp: u64,
+            _ledger_version: Version,
+        ) -> anyhow::Result<Version>;
+
+        fn get_latest_ledger_info_option(&self) -> anyhow::Result<Option<LedgerInfoWithSignatures>>;
+
+        fn get_latest_ledger_info(&self) -> anyhow::Result<LedgerInfoWithSignatures>;
+
+        fn get_latest_version(&self) -> anyhow::Result<Version>;
+
+        fn get_latest_commit_metadata(&self) -> anyhow::Result<(Version, u64)>;
+
+        fn get_account_transaction(
+            &self,
+            address: AccountAddress,
+            seq_num: u64,
+            include_events: bool,
+            ledger_version: Version,
+        ) -> anyhow::Result<Option<TransactionWithProof>>;
+
+        fn get_account_transactions(
+            &self,
+            address: AccountAddress,
+            seq_num: u64,
+            limit: u64,
+            include_events: bool,
+            ledger_version: Version,
+        ) -> anyhow::Result<AccountTransactionsWithProof>;
+
+        fn get_state_proof_with_ledger_info(
+            &self,
+            known_version: u64,
+            ledger_info: LedgerInfoWithSignatures,
+        ) -> anyhow::Result<StateProof>;
+
+        fn get_state_proof(&self, known_version: u64) -> anyhow::Result<StateProof>;
+
+        fn get_state_value_with_proof_by_version(
+            &self,
+            state_key: &StateKey,
+            version: Version,
+        ) -> anyhow::Result<(Option<StateValue>, SparseMerkleProof)>;
+
+        fn get_latest_executed_trees(&self) -> anyhow::Result<ExecutedTrees>;
+
+        fn get_epoch_ending_ledger_info(&self, known_version: u64) -> anyhow::Result<LedgerInfoWithSignatures>;
+
+        fn get_latest_transaction_info_option(&self) -> anyhow::Result<Option<(Version, TransactionInfo)>>;
+
+        fn get_accumulator_root_hash(&self, _version: Version) -> anyhow::Result<HashValue>;
+
+        fn get_accumulator_consistency_proof(
+            &self,
+            _client_known_version: Option<Version>,
+            _ledger_version: Version,
+        ) -> anyhow::Result<AccumulatorConsistencyProof>;
+
+        fn get_accumulator_summary(
+            &self,
+            ledger_version: Version,
+        ) -> anyhow::Result<TransactionAccumulatorSummary>;
+
+        fn get_state_leaf_count(&self, version: Version) -> anyhow::Result<usize>;
+
+        fn get_state_value_chunk_with_proof(
+            &self,
+            version: Version,
+            start_idx: usize,
+            chunk_size: usize,
+        ) -> anyhow::Result<StateValueChunkWithProof>;
+
+        fn get_epoch_snapshot_prune_window(&self) -> anyhow::Result<usize>;
     }
 }

--- a/network/peer-monitoring-service/types/Cargo.toml
+++ b/network/peer-monitoring-service/types/Cargo.toml
@@ -14,6 +14,6 @@ rust-version = { workspace = true }
 
 [dependencies]
 aptos-config = { workspace = true }
-aptos-network = { workspace = true }
+aptos-types = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/network/peer-monitoring-service/types/src/lib.rs
+++ b/network/peer-monitoring-service/types/src/lib.rs
@@ -3,11 +3,14 @@
 
 #![forbid(unsafe_code)]
 
-use aptos_config::network_id::PeerNetworkId;
-use aptos_network::transport::ConnectionMetadata;
+use crate::response::{NetworkInformationResponse, NodeInformationResponse};
+use request::PeerMonitoringServiceRequest;
+use response::PeerMonitoringServiceResponse;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, convert::TryFrom};
 use thiserror::Error;
+
+pub mod request;
+pub mod response;
 
 pub type Result<T, E = PeerMonitoringServiceError> = ::std::result::Result<T, E>;
 
@@ -33,113 +36,28 @@ pub enum PeerMonitoringServiceMessage {
     Response(Result<PeerMonitoringServiceResponse>),
 }
 
-/// A peer monitoring service request
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub enum PeerMonitoringServiceRequest {
-    GetNetworkInformation,    // Returns relevant network information for the peer
-    GetServerProtocolVersion, // Fetches the protocol version run by the server
-    LatencyPing(LatencyPingRequest), // A simple message used by the client to ensure liveness and measure latency
+/// The peer monitoring metadata for a peer
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct PeerMonitoringMetadata {
+    pub average_ping_latency_secs: Option<f64>, // The average latency ping for the peer
+    pub latest_network_info_response: Option<NetworkInformationResponse>, // The latest network info response
+    pub latest_node_info_response: Option<NodeInformationResponse>, // The latest node info response
 }
 
-impl PeerMonitoringServiceRequest {
-    /// Returns a summary label for the request
-    pub fn get_label(&self) -> &'static str {
-        match self {
-            Self::GetNetworkInformation => "get_network_information",
-            Self::GetServerProtocolVersion => "get_server_protocol_version",
-            Self::LatencyPing(_) => "latency_ping",
-        }
-    }
-}
+/// We must manually define this because f64 doesn't implement Eq. Instead,
+/// we rely on PartialEq (which is sufficient for our use-cases).
+impl Eq for PeerMonitoringMetadata {}
 
-/// The latency ping request
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct LatencyPingRequest {
-    pub ping_counter: u64, // A monotonically increasing counter to verify latency ping responses
-}
-
-/// A peer monitoring service response
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[allow(clippy::large_enum_variant)]
-pub enum PeerMonitoringServiceResponse {
-    LatencyPing(LatencyPingResponse), // A simple message to respond to latency checks (i.e., pings)
-    NetworkInformation(NetworkInformationResponse), // Holds the response for network information
-    ServerProtocolVersion(ServerProtocolVersionResponse), // Returns the current server protocol version
-}
-
-impl PeerMonitoringServiceResponse {
-    /// Returns a summary label for the response
-    pub fn get_label(&self) -> &'static str {
-        match self {
-            Self::LatencyPing(_) => "latency_ping",
-            Self::NetworkInformation(_) => "network_information",
-            Self::ServerProtocolVersion(_) => "server_protocol_version",
-        }
-    }
-}
-
-/// A response for the latency ping request
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct LatencyPingResponse {
-    pub ping_counter: u64, // A monotonically increasing counter to verify latency ping responses
-}
-
-/// A response for the network information request
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct NetworkInformationResponse {
-    pub connected_peers: HashMap<PeerNetworkId, ConnectionMetadata>, // Connected peers
-    pub distance_from_validators: u64, // The distance of the peer from the validator set
-                                       // TODO: add the rest of the information here!
-}
-
-/// A response for the server protocol version request
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct ServerProtocolVersionResponse {
-    pub version: u64, // The version of the peer monitoring service run by the server
-}
-
-#[derive(Clone, Debug, Error)]
-#[error("Unexpected response variant: {0}")]
-pub struct UnexpectedResponseError(pub String);
-
-impl TryFrom<PeerMonitoringServiceResponse> for LatencyPingResponse {
-    type Error = UnexpectedResponseError;
-
-    fn try_from(response: PeerMonitoringServiceResponse) -> Result<Self, Self::Error> {
-        match response {
-            PeerMonitoringServiceResponse::LatencyPing(inner) => Ok(inner),
-            _ => Err(UnexpectedResponseError(format!(
-                "expected latency_ping_response, found {}",
-                response.get_label()
-            ))),
-        }
-    }
-}
-
-impl TryFrom<PeerMonitoringServiceResponse> for NetworkInformationResponse {
-    type Error = UnexpectedResponseError;
-
-    fn try_from(response: PeerMonitoringServiceResponse) -> Result<Self, Self::Error> {
-        match response {
-            PeerMonitoringServiceResponse::NetworkInformation(inner) => Ok(inner),
-            _ => Err(UnexpectedResponseError(format!(
-                "expected network_information_response, found {}",
-                response.get_label()
-            ))),
-        }
-    }
-}
-
-impl TryFrom<PeerMonitoringServiceResponse> for ServerProtocolVersionResponse {
-    type Error = UnexpectedResponseError;
-
-    fn try_from(response: PeerMonitoringServiceResponse) -> Result<Self, Self::Error> {
-        match response {
-            PeerMonitoringServiceResponse::ServerProtocolVersion(inner) => Ok(inner),
-            _ => Err(UnexpectedResponseError(format!(
-                "expected server_protocol_version_response, found {}",
-                response.get_label()
-            ))),
+impl PeerMonitoringMetadata {
+    pub fn new(
+        average_ping_latency_secs: Option<f64>,
+        latest_network_info_response: Option<NetworkInformationResponse>,
+        latest_node_info_response: Option<NodeInformationResponse>,
+    ) -> Self {
+        PeerMonitoringMetadata {
+            average_ping_latency_secs,
+            latest_network_info_response,
+            latest_node_info_response,
         }
     }
 }

--- a/network/peer-monitoring-service/types/src/request.rs
+++ b/network/peer-monitoring-service/types/src/request.rs
@@ -1,0 +1,31 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+/// A peer monitoring service request
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum PeerMonitoringServiceRequest {
+    GetNetworkInformation,    // Returns relevant network information for the peer
+    GetNodeInformation,       // Returns relevant node information about the peer
+    GetServerProtocolVersion, // Fetches the protocol version run by the server
+    LatencyPing(LatencyPingRequest), // A simple message used by the client to ensure liveness and measure latency
+}
+
+impl PeerMonitoringServiceRequest {
+    /// Returns a summary label for the request
+    pub fn get_label(&self) -> &'static str {
+        match self {
+            Self::GetNetworkInformation => "get_network_information",
+            Self::GetNodeInformation => "get_node_information",
+            Self::GetServerProtocolVersion => "get_server_protocol_version",
+            Self::LatencyPing(_) => "latency_ping",
+        }
+    }
+}
+
+/// The latency ping request
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct LatencyPingRequest {
+    pub ping_counter: u64, // A monotonically increasing counter to verify latency ping responses
+}

--- a/network/peer-monitoring-service/types/src/response.rs
+++ b/network/peer-monitoring-service/types/src/response.rs
@@ -1,0 +1,138 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_config::{config::PeerRole, network_id::PeerNetworkId};
+use aptos_types::{network_address::NetworkAddress, PeerId};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, time::Duration};
+use thiserror::Error;
+
+/// A peer monitoring service response
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[allow(clippy::large_enum_variant)]
+pub enum PeerMonitoringServiceResponse {
+    LatencyPing(LatencyPingResponse), // A simple message to respond to latency checks (i.e., pings)
+    NetworkInformation(NetworkInformationResponse), // Holds the response for network information
+    NodeInformation(NodeInformationResponse), // Holds the response for node information
+    ServerProtocolVersion(ServerProtocolVersionResponse), // Returns the current server protocol version
+}
+
+impl PeerMonitoringServiceResponse {
+    /// Returns a summary label for the response
+    pub fn get_label(&self) -> &'static str {
+        match self {
+            Self::LatencyPing(_) => "latency_ping",
+            Self::NetworkInformation(_) => "network_information",
+            Self::NodeInformation(_) => "node_information",
+            Self::ServerProtocolVersion(_) => "server_protocol_version",
+        }
+    }
+}
+
+/// A response for the latency ping request
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct LatencyPingResponse {
+    pub ping_counter: u64, // A monotonically increasing counter to verify latency ping responses
+}
+
+/// A response for the network information request
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct NetworkInformationResponse {
+    pub connected_peers: HashMap<PeerNetworkId, ConnectionMetadata>, // Connected peers
+    pub distance_from_validators: u64, // The distance of the peer from the validator set
+}
+
+/// Simple connection metadata associated with each peer
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ConnectionMetadata {
+    pub network_address: NetworkAddress,
+    pub peer_id: PeerId,
+    pub peer_role: PeerRole,
+}
+
+impl ConnectionMetadata {
+    pub fn new(network_address: NetworkAddress, peer_id: PeerId, peer_role: PeerRole) -> Self {
+        Self {
+            network_address,
+            peer_id,
+            peer_role,
+        }
+    }
+}
+
+/// A response for the server protocol version request
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ServerProtocolVersionResponse {
+    pub version: u64, // The version of the peer monitoring service run by the server
+}
+
+/// A response for the node information request
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct NodeInformationResponse {
+    pub git_hash: String, // The git hash of the build the peer is running on
+    pub highest_synced_epoch: u64, // The highest synced epoch of the node
+    pub highest_synced_version: u64, // The highest synced version of the node
+    pub ledger_timestamp_usecs: u64, // The latest timestamp of the blockchain (in microseconds)
+    pub lowest_available_version: u64, // The lowest stored version of the node (in storage)
+    pub uptime: Duration, // The amount of time the peer has been running
+}
+
+#[derive(Clone, Debug, Error)]
+#[error("Unexpected response variant: {0}")]
+pub struct UnexpectedResponseError(pub String);
+
+impl TryFrom<PeerMonitoringServiceResponse> for LatencyPingResponse {
+    type Error = UnexpectedResponseError;
+
+    fn try_from(response: PeerMonitoringServiceResponse) -> crate::Result<Self, Self::Error> {
+        match response {
+            PeerMonitoringServiceResponse::LatencyPing(inner) => Ok(inner),
+            _ => Err(UnexpectedResponseError(format!(
+                "expected latency_ping_response, found {}",
+                response.get_label()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<PeerMonitoringServiceResponse> for NetworkInformationResponse {
+    type Error = UnexpectedResponseError;
+
+    fn try_from(response: PeerMonitoringServiceResponse) -> crate::Result<Self, Self::Error> {
+        match response {
+            PeerMonitoringServiceResponse::NetworkInformation(inner) => Ok(inner),
+            _ => Err(UnexpectedResponseError(format!(
+                "expected network_information_response, found {}",
+                response.get_label()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<PeerMonitoringServiceResponse> for ServerProtocolVersionResponse {
+    type Error = UnexpectedResponseError;
+
+    fn try_from(response: PeerMonitoringServiceResponse) -> crate::Result<Self, Self::Error> {
+        match response {
+            PeerMonitoringServiceResponse::ServerProtocolVersion(inner) => Ok(inner),
+            _ => Err(UnexpectedResponseError(format!(
+                "expected server_protocol_version_response, found {}",
+                response.get_label()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<PeerMonitoringServiceResponse> for NodeInformationResponse {
+    type Error = UnexpectedResponseError;
+
+    fn try_from(response: PeerMonitoringServiceResponse) -> crate::Result<Self, Self::Error> {
+        match response {
+            PeerMonitoringServiceResponse::NodeInformation(inner) => Ok(inner),
+            _ => Err(UnexpectedResponseError(format!(
+                "expected node_information_response, found {}",
+                response.get_label()
+            ))),
+        }
+    }
+}

--- a/network/src/application/metadata.rs
+++ b/network/src/application/metadata.rs
@@ -5,9 +5,8 @@ use crate::{
     protocols::wire::handshake::v1::{ProtocolId, ProtocolIdSet},
     transport::ConnectionMetadata,
 };
-use aptos_config::network_id::PeerNetworkId;
+use aptos_peer_monitoring_service_types::PeerMonitoringMetadata;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 /// The current connection state of a peer
 /// TODO: Allow nodes that are unhealthy to stay connected
@@ -16,32 +15,6 @@ pub enum ConnectionState {
     Connected,
     Disconnecting,
     Disconnected, // Currently unused (TODO: fix this!)
-}
-
-/// The peer monitoring metadata for a peer
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
-pub struct PeerMonitoringMetadata {
-    pub average_ping_latency_secs: Option<f64>, // The average latency ping for the peer
-    pub connected_peers: Option<HashMap<PeerNetworkId, ConnectionMetadata>>, // Connected peers and metadata
-    pub distance_from_validators: Option<u64>, // The known distance from the validator set
-}
-
-/// We must manually define this because f64 doesn't implement Eq. Instead,
-/// we rely on PartialEq (which is sufficient for our use-cases).
-impl Eq for PeerMonitoringMetadata {}
-
-impl PeerMonitoringMetadata {
-    pub fn new(
-        average_ping_latency_secs: Option<f64>,
-        connected_peers: Option<HashMap<PeerNetworkId, ConnectionMetadata>>,
-        distance_from_validators: Option<u64>,
-    ) -> Self {
-        PeerMonitoringMetadata {
-            average_ping_latency_secs,
-            connected_peers,
-            distance_from_validators,
-        }
-    }
 }
 
 /// A container holding all relevant metadata for the peer.

--- a/network/src/application/storage.rs
+++ b/network/src/application/storage.rs
@@ -5,7 +5,7 @@
 use crate::{
     application::{
         error::Error,
-        metadata::{ConnectionState, PeerMetadata, PeerMonitoringMetadata},
+        metadata::{ConnectionState, PeerMetadata},
     },
     transport::{ConnectionId, ConnectionMetadata},
     ProtocolId,
@@ -15,6 +15,7 @@ use aptos_config::{
     network_id::{NetworkId, PeerNetworkId},
 };
 use aptos_infallible::RwLock;
+use aptos_peer_monitoring_service_types::PeerMonitoringMetadata;
 use aptos_types::PeerId;
 use std::{
     collections::{hash_map::Entry, HashMap},


### PR DESCRIPTION
Note: this PR relates to: https://github.com/aptos-labs/aptos-core/issues/6789.

### Description
This PR adds server-side support for node information requests in the peer monitoring service. These requests gather basic peer information, including: (i) the git hash the peer is running on; (ii) the highest and lowest synced data versions; (iii) the latest ledger timestamp; and (iv) the peer uptime.

The PR offers two commits:
1. First, we add a new request and response type for node information data to the monitoring service. We also move some of the logic into different files to make it easier to find metadata, request data and response data.
2. Second, we add server-side support to handle node information requests, and add unit tests to verify the new functionality. Most of this commit is just boilerplate.

I'll follow this PR up with client-side support and more extensive tests.

### Test Plan
New and existing tests.