### PR TITLE
[Consensus][Cherry-pick] Create a seperate channel for buffer manager

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -603,6 +603,16 @@ pub static CONSENSUS_CHANNEL_MSGS: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Counters(queued,dequeued,dropped) related to buffer manager channel
+pub static BUFFER_MANAGER_CHANNEL_MSGS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_buffer_manager_channel_msgs_count",
+        "Counters(queued,dequeued,dropped) related to buffer manager channel",
+        &["state"]
+    )
+    .unwrap()
+});
+
 /// Counters for received consensus messages broken down by type
 pub static CONSENSUS_RECEIVED_MSGS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -497,7 +497,7 @@ impl EpochManager {
 
         let (commit_msg_tx, commit_msg_rx) = aptos_channel::new::<AccountAddress, VerifiedEvent>(
             QueueStyle::FIFO,
-            self.config.channel_size,
+            100,
             Some(&counters::BUFFER_MANAGER_MSGS),
         );
 

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1123,6 +1123,12 @@ impl EpochManager {
                         error!(epoch = self.epoch(), error = ?e, kind = error_kind(&e));
                     });
                 },
+                (peer, msg) = network_receivers.buffer_manager_messages.select_next_some() => {
+                    monitor!("epoch_manager_process_buffer_manager_messages",
+                    if let Err(e) = self.process_message(peer, msg).await {
+                        error!(epoch = self.epoch(), error = ?e, kind = error_kind(&e));
+                    });
+                },
                 (peer, msg) = network_receivers.quorum_store_messages.select_next_some() => {
                     monitor!("epoch_manager_process_quorum_store_messages",
                     if let Err(e) = self.process_message(peer, msg).await {

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -399,7 +399,7 @@ impl NetworkTask {
         self_receiver: aptos_channels::Receiver<Event<ConsensusMsg>>,
     ) -> (NetworkTask, NetworkReceivers) {
         let (consensus_messages_tx, consensus_messages) =
-            aptos_channel::new(QueueStyle::LIFO, 1, Some(&counters::CONSENSUS_CHANNEL_MSGS));
+            aptos_channel::new(QueueStyle::FIFO, 10, Some(&counters::CONSENSUS_CHANNEL_MSGS));
         let (buffer_manager_messages_tx, buffer_manager_messages) =
             aptos_channel::new(QueueStyle::FIFO, 100, Some(&counters::BUFFER_MANAGER_CHANNEL_MSGS));
         let (quorum_store_messages_tx, quorum_store_messages) = aptos_channel::new(

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -74,6 +74,10 @@ pub struct NetworkReceivers {
         (AccountAddress, Discriminant<ConsensusMsg>),
         (AccountAddress, ConsensusMsg),
     >,
+    pub buffer_manager_messages: aptos_channel::Receiver<
+        (AccountAddress, Discriminant<ConsensusMsg>),
+        (AccountAddress, ConsensusMsg),
+    >,
     pub quorum_store_messages: aptos_channel::Receiver<
         (AccountAddress, Discriminant<ConsensusMsg>),
         (AccountAddress, ConsensusMsg),
@@ -376,6 +380,10 @@ pub struct NetworkTask {
         (AccountAddress, Discriminant<ConsensusMsg>),
         (AccountAddress, ConsensusMsg),
     >,
+    buffer_manager_messages_tx: aptos_channel::Sender<
+    (AccountAddress, Discriminant<ConsensusMsg>),
+    (AccountAddress, ConsensusMsg),
+    >,
     quorum_store_messages_tx: aptos_channel::Sender<
         (AccountAddress, Discriminant<ConsensusMsg>),
         (AccountAddress, ConsensusMsg),
@@ -390,11 +398,10 @@ impl NetworkTask {
         network_service_events: NetworkServiceEvents<ConsensusMsg>,
         self_receiver: aptos_channels::Receiver<Event<ConsensusMsg>>,
     ) -> (NetworkTask, NetworkReceivers) {
-        let (consensus_messages_tx, consensus_messages) = aptos_channel::new(
-            QueueStyle::FIFO,
-            10,
-            Some(&counters::CONSENSUS_CHANNEL_MSGS),
-        );
+        let (consensus_messages_tx, consensus_messages) =
+            aptos_channel::new(QueueStyle::LIFO, 1, Some(&counters::CONSENSUS_CHANNEL_MSGS));
+        let (buffer_manager_messages_tx, buffer_manager_messages) =
+            aptos_channel::new(QueueStyle::FIFO, 100, Some(&counters::BUFFER_MANAGER_CHANNEL_MSGS));
         let (quorum_store_messages_tx, quorum_store_messages) = aptos_channel::new(
             QueueStyle::FIFO,
             // TODO: tune this value based on quorum store messages with backpressure
@@ -420,12 +427,14 @@ impl NetworkTask {
         (
             NetworkTask {
                 consensus_messages_tx,
+                buffer_manager_messages_tx,
                 quorum_store_messages_tx,
                 rpc_tx,
                 all_events,
             },
             NetworkReceivers {
                 consensus_messages,
+                buffer_manager_messages,
                 quorum_store_messages,
                 rpc_rx,
             },
@@ -466,6 +475,14 @@ impl NetworkTask {
                                 peer_id,
                                 quorum_store_msg,
                                 &self.quorum_store_messages_tx,
+                            );
+                        },
+                        buffer_manager_msg @ (ConsensusMsg::CommitVoteMsg(_)
+                        | ConsensusMsg::CommitDecisionMsg(_)) => {
+                            Self::push_msg(
+                                peer_id,
+                                buffer_manager_msg,
+                                &self.buffer_manager_messages_tx,
                             );
                         },
                         consensus_msg => {


### PR DESCRIPTION
Description
Currently, our consensus channel is a LIFO queue of size 1, which is because our consensus protocol only needs the latest message of any type from other peers. However, the buffer manager that receives the commit votes/decisions uses the same channel, which is problematic since there can be multiple messages for the buffer manager to receive.

This PR creates a separate channel (FIFO, larger size) for the buffer manager to receive the messages once the messages are received through the networking channel.

Test Plan
Existing smoke and forge tests.