### PR TITLE
[Peer Monitoring Service] Add client-side support for node info messages.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,6 +2265,7 @@ dependencies = [
 name = "aptos-peer-monitoring-service-client"
 version = "0.1.0"
 dependencies = [
+ "aptos-build-info",
  "aptos-channels",
  "aptos-config",
  "aptos-id-generator",

--- a/network/peer-monitoring-service/client/Cargo.toml
+++ b/network/peer-monitoring-service/client/Cargo.toml
@@ -33,8 +33,8 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
-aptos-config = { workspace = true }
 aptos-build-info = { workspace = true }
+aptos-config = { workspace = true }
 aptos-netcore = { workspace = true }
 aptos-network = { workspace = true, features = ["fuzzing"] }
 aptos-peer-monitoring-service-server = { workspace = true }

--- a/network/peer-monitoring-service/client/Cargo.toml
+++ b/network/peer-monitoring-service/client/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 aptos-config = { workspace = true }
+aptos-build-info = { workspace = true }
 aptos-netcore = { workspace = true }
 aptos-network = { workspace = true, features = ["fuzzing"] }
 aptos-peer-monitoring-service-server = { workspace = true }

--- a/network/peer-monitoring-service/client/src/logging.rs
+++ b/network/peer-monitoring-service/client/src/logging.rs
@@ -43,6 +43,7 @@ pub enum LogEntry {
     LatencyPing,
     MetadataUpdateLoop,
     NetworkInfoRequest,
+    NodeInfoRequest,
     PeerMonitorLoop,
     SendRequest,
 }

--- a/network/peer-monitoring-service/client/src/peer_states/key_value.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/key_value.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     peer_states::{
-        latency_info::LatencyInfoState, network_info::NetworkInfoState,
+        latency_info::LatencyInfoState, network_info::NetworkInfoState, node_info::NodeInfoState,
         request_tracker::RequestTracker,
     },
     Error,
@@ -25,12 +25,17 @@ use std::sync::Arc;
 pub enum PeerStateKey {
     LatencyInfo,
     NetworkInfo,
+    NodeInfo,
 }
 
 impl PeerStateKey {
     /// A utility function for getting all peer state keys
     pub fn get_all_keys() -> Vec<PeerStateKey> {
-        vec![PeerStateKey::LatencyInfo, PeerStateKey::NetworkInfo]
+        vec![
+            PeerStateKey::LatencyInfo,
+            PeerStateKey::NetworkInfo,
+            PeerStateKey::NodeInfo,
+        ]
     }
 
     // TODO: Can we avoid exposing this label construction here?
@@ -44,6 +49,7 @@ impl PeerStateKey {
             PeerStateKey::NetworkInfo => {
                 PeerMonitoringServiceRequest::GetNetworkInformation.get_label()
             },
+            PeerStateKey::NodeInfo => PeerMonitoringServiceRequest::GetNodeInformation.get_label(),
         }
     }
 }
@@ -85,6 +91,7 @@ pub trait StateValueInterface {
 pub enum PeerStateValue {
     LatencyInfoState,
     NetworkInfoState,
+    NodeInfoState,
 }
 
 impl PeerStateValue {
@@ -100,6 +107,10 @@ impl PeerStateValue {
                 LatencyInfoState::new(latency_monitoring_config, time_service).into()
             },
             PeerStateKey::NetworkInfo => NetworkInfoState::new(node_config, time_service).into(),
+            PeerStateKey::NodeInfo => {
+                let node_monitoring_config = node_config.peer_monitoring_service.node_monitoring;
+                NodeInfoState::new(node_monitoring_config, time_service).into()
+            },
         }
     }
 }

--- a/network/peer-monitoring-service/client/src/peer_states/mod.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/mod.rs
@@ -11,8 +11,9 @@ use std::collections::HashMap;
 use tokio::runtime::Handle;
 
 pub mod key_value;
-mod latency_info;
-mod network_info;
+pub mod latency_info;
+pub mod network_info;
+pub mod node_info;
 pub mod peer_state;
 mod request_tracker;
 

--- a/network/peer-monitoring-service/client/src/peer_states/network_info.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/network_info.rs
@@ -204,7 +204,7 @@ mod test {
         let mut network_info_state = create_network_info_state(RoleType::Validator);
 
         // Verify there is no latest network info response
-        verify_empty_network_response(&mut network_info_state);
+        verify_empty_network_response(&network_info_state);
 
         // Attempt to store a network response with an invalid depth of
         // 0 (the peer is a VFN, not a validator).
@@ -216,7 +216,7 @@ mod test {
         );
 
         // Verify there is still no latest network info response
-        verify_empty_network_response(&mut network_info_state);
+        verify_empty_network_response(&network_info_state);
 
         // Attempt to store a network response with an invalid depth of
         // 1 (the peer is a validator, not a VFN).
@@ -228,7 +228,7 @@ mod test {
         );
 
         // Verify there is still no latest network info response
-        verify_empty_network_response(&mut network_info_state);
+        verify_empty_network_response(&network_info_state);
 
         // Attempt to store a network response with an invalid depth of
         // 10 (the peer is a VFN).
@@ -240,7 +240,7 @@ mod test {
         );
 
         // Verify there is still no latest network info response
-        verify_empty_network_response(&mut network_info_state);
+        verify_empty_network_response(&network_info_state);
 
         // Attempt to store a network response with a valid depth of
         // 1 (the peer is a VFN).
@@ -252,7 +252,7 @@ mod test {
         );
 
         // Verify the latest stored distance is correct
-        verify_network_response_distance(&mut network_info_state, 1);
+        verify_network_response_distance(&network_info_state, 1);
     }
 
     #[test]
@@ -261,7 +261,7 @@ mod test {
         let mut network_info_state = create_network_info_state(RoleType::FullNode);
 
         // Verify there is no latest network info response
-        verify_empty_network_response(&mut network_info_state);
+        verify_empty_network_response(&network_info_state);
 
         // Attempt to store a network response with an invalid depth of
         // 1 (the peer is a validator).
@@ -273,7 +273,7 @@ mod test {
         );
 
         // Verify there is still no latest network info response
-        verify_empty_network_response(&mut network_info_state);
+        verify_empty_network_response(&network_info_state);
 
         // Attempt to store a network response with an invalid depth of
         // 0 (the peer is a PFN, not a validator).
@@ -285,7 +285,7 @@ mod test {
         );
 
         // Verify there is still no latest network info response
-        verify_empty_network_response(&mut network_info_state);
+        verify_empty_network_response(&network_info_state);
 
         // Attempt to store a network response with an invalid depth of
         // 1 (the peer is a VFN, but VFNs can't connect to other VFN networks).
@@ -297,7 +297,7 @@ mod test {
         );
 
         // Verify there is still no latest network info response
-        verify_empty_network_response(&mut network_info_state);
+        verify_empty_network_response(&network_info_state);
 
         // Attempt to store a network response with a valid depth of
         // 2 (the peer is a public fullnode).
@@ -309,7 +309,7 @@ mod test {
         );
 
         // Verify the latest stored distance is correct
-        verify_network_response_distance(&mut network_info_state, 2);
+        verify_network_response_distance(&network_info_state, 2);
     }
 
     #[test]
@@ -318,7 +318,7 @@ mod test {
         let mut network_info_state = create_network_info_state(RoleType::FullNode);
 
         // Verify there is no latest network info response
-        verify_empty_network_response(&mut network_info_state);
+        verify_empty_network_response(&network_info_state);
 
         // Attempt to store a network response with an invalid depth of
         // 0 (the peer is a PFN, not a validator).
@@ -330,7 +330,7 @@ mod test {
         );
 
         // Verify there is still no latest network info response
-        verify_empty_network_response(&mut network_info_state);
+        verify_empty_network_response(&network_info_state);
 
         // Attempt to store a network response with an invalid depth of
         // 1 (the peer is a PFN, not a VFN).
@@ -342,7 +342,7 @@ mod test {
         );
 
         // Verify there is still no latest network info response
-        verify_empty_network_response(&mut network_info_state);
+        verify_empty_network_response(&network_info_state);
 
         // Attempt to store a network response with an invalid depth of
         // 2 (the peer is a VFN).
@@ -354,7 +354,7 @@ mod test {
         );
 
         // Verify there is still no latest network info response
-        verify_empty_network_response(&mut network_info_state);
+        verify_empty_network_response(&network_info_state);
 
         // Handle two correct responses
         for distance_from_validators in [2, 3] {
@@ -368,7 +368,7 @@ mod test {
             );
 
             // Verify the latest stored distance is correct
-            verify_network_response_distance(&mut network_info_state, distance_from_validators);
+            verify_network_response_distance(&network_info_state, distance_from_validators);
         }
     }
 
@@ -422,7 +422,7 @@ mod test {
     }
 
     /// Verifies that there is no latest network info response stored
-    fn verify_empty_network_response(network_info_state: &mut NetworkInfoState) {
+    fn verify_empty_network_response(network_info_state: &NetworkInfoState) {
         assert!(network_info_state
             .get_latest_network_info_response()
             .is_none());
@@ -430,7 +430,7 @@ mod test {
 
     /// Verifies that the latest network info response has a valid distance
     fn verify_network_response_distance(
-        network_info_state: &mut NetworkInfoState,
+        network_info_state: &NetworkInfoState,
         distance_from_validators: u64,
     ) {
         let network_info_response = network_info_state

--- a/network/peer-monitoring-service/client/src/peer_states/node_info.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/node_info.rs
@@ -1,0 +1,230 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    peer_states::{key_value::StateValueInterface, request_tracker::RequestTracker},
+    Error, LogEntry, LogEvent, LogSchema,
+};
+use aptos_config::{config::NodeMonitoringConfig, network_id::PeerNetworkId};
+use aptos_infallible::RwLock;
+use aptos_logger::warn;
+use aptos_network::application::metadata::PeerMetadata;
+use aptos_peer_monitoring_service_types::{
+    request::PeerMonitoringServiceRequest,
+    response::{NodeInformationResponse, PeerMonitoringServiceResponse},
+};
+use aptos_time_service::TimeService;
+use std::sync::Arc;
+
+/// A simple container that holds a single peer's node info
+#[derive(Clone, Debug)]
+pub struct NodeInfoState {
+    node_monitoring_config: NodeMonitoringConfig, // The config for node monitoring
+    recorded_node_info_response: Option<NodeInformationResponse>, // The last node info response
+    request_tracker: Arc<RwLock<RequestTracker>>, // The request tracker for node info requests
+}
+
+impl NodeInfoState {
+    pub fn new(node_monitoring_config: NodeMonitoringConfig, time_service: TimeService) -> Self {
+        let request_tracker = RequestTracker::new(
+            node_monitoring_config.node_info_request_interval_ms,
+            time_service,
+        );
+
+        Self {
+            node_monitoring_config,
+            recorded_node_info_response: None,
+            request_tracker: Arc::new(RwLock::new(request_tracker)),
+        }
+    }
+
+    /// Records the new node info response for the peer
+    pub fn record_node_info_response(&mut self, node_info_response: NodeInformationResponse) {
+        // Update the request tracker with a successful response
+        self.request_tracker.write().record_response_success();
+
+        // Save the node info
+        self.recorded_node_info_response = Some(node_info_response);
+    }
+
+    /// Handles a request failure for the specified peer
+    fn handle_request_failure(&self) {
+        self.request_tracker.write().record_response_failure();
+    }
+
+    /// Returns the latest node info response
+    pub fn get_latest_node_info_response(&self) -> Option<NodeInformationResponse> {
+        self.recorded_node_info_response.clone()
+    }
+}
+
+impl StateValueInterface for NodeInfoState {
+    fn create_monitoring_service_request(&mut self) -> PeerMonitoringServiceRequest {
+        PeerMonitoringServiceRequest::GetNodeInformation
+    }
+
+    fn get_request_timeout_ms(&self) -> u64 {
+        self.node_monitoring_config.node_info_request_timeout_ms
+    }
+
+    fn get_request_tracker(&self) -> Arc<RwLock<RequestTracker>> {
+        self.request_tracker.clone()
+    }
+
+    fn handle_monitoring_service_response(
+        &mut self,
+        peer_network_id: &PeerNetworkId,
+        _peer_metadata: PeerMetadata,
+        _monitoring_service_request: PeerMonitoringServiceRequest,
+        monitoring_service_response: PeerMonitoringServiceResponse,
+        _response_time_secs: f64,
+    ) {
+        // Verify the response type is valid
+        let node_info_response = match monitoring_service_response {
+            PeerMonitoringServiceResponse::NodeInformation(node_information_response) => {
+                node_information_response
+            },
+            _ => {
+                warn!(LogSchema::new(LogEntry::NodeInfoRequest)
+                    .event(LogEvent::ResponseError)
+                    .peer(peer_network_id)
+                    .message(
+                        "An unexpected response was received instead of a node info response!"
+                    ));
+                self.handle_request_failure();
+                return;
+            },
+        };
+
+        // Store the new latency ping result
+        self.record_node_info_response(node_info_response);
+    }
+
+    fn handle_monitoring_service_response_error(
+        &self,
+        peer_network_id: &PeerNetworkId,
+        error: Error,
+    ) {
+        // Handle the failure
+        self.handle_request_failure();
+
+        // Log the error
+        warn!(LogSchema::new(LogEntry::NodeInfoRequest)
+            .event(LogEvent::ResponseError)
+            .message("Error encountered when requesting node information from the peer!")
+            .peer(peer_network_id)
+            .error(&error));
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::peer_states::{key_value::StateValueInterface, node_info::NodeInfoState};
+    use aptos_config::{
+        config::{NodeMonitoringConfig, PeerRole},
+        network_id::PeerNetworkId,
+    };
+    use aptos_netcore::transport::ConnectionOrigin;
+    use aptos_network::{
+        application::metadata::PeerMetadata,
+        protocols::wire::handshake::v1::{MessagingProtocolVersion, ProtocolIdSet},
+        transport::{ConnectionId, ConnectionMetadata},
+    };
+    use aptos_peer_monitoring_service_types::{
+        request::PeerMonitoringServiceRequest,
+        response::{NodeInformationResponse, PeerMonitoringServiceResponse},
+    };
+    use aptos_time_service::TimeService;
+    use aptos_types::network_address::NetworkAddress;
+    use std::{str::FromStr, time::Duration};
+
+    // Useful test constants
+    const TEST_NETWORK_ADDRESS: &str = "/ip4/127.0.0.1/tcp/8081";
+
+    #[test]
+    fn test_verify_node_info_state() {
+        // Create the node info state
+        let node_monitoring_config = NodeMonitoringConfig::default();
+        let time_service = TimeService::mock();
+        let mut node_info_state = NodeInfoState::new(node_monitoring_config, time_service);
+
+        // Verify the initial node info state
+        verify_empty_node_response(&node_info_state);
+
+        // Handle several valid node info responses and verify the state
+        for i in 0..10 {
+            // Generate the test data
+            let git_hash = i.to_string();
+            let highest_synced_epoch = i;
+            let highest_synced_version = (i + 1) * 100;
+            let ledger_timestamp_usecs = (i + 1) * 200;
+            let lowest_available_version = highest_synced_version - 10;
+            let uptime = Duration::from_millis(i * 999);
+
+            // Create the service response
+            let node_information_response = NodeInformationResponse {
+                git_hash,
+                highest_synced_epoch,
+                highest_synced_version,
+                ledger_timestamp_usecs,
+                lowest_available_version,
+                uptime,
+            };
+
+            // Handle the node info response
+            handle_monitoring_service_response(
+                &mut node_info_state,
+                node_information_response.clone(),
+            );
+
+            // Verify the latest node info state
+            verify_node_info_state(&node_info_state, node_information_response);
+        }
+    }
+
+    /// Handles a monitoring service response from a peer
+    fn handle_monitoring_service_response(
+        node_info_state: &mut NodeInfoState,
+        node_information_response: NodeInformationResponse,
+    ) {
+        // Create a new peer metadata entry
+        let peer_network_id = PeerNetworkId::random();
+        let connection_metadata = ConnectionMetadata::new(
+            peer_network_id.peer_id(),
+            ConnectionId::default(),
+            NetworkAddress::from_str(TEST_NETWORK_ADDRESS).unwrap(),
+            ConnectionOrigin::Outbound,
+            MessagingProtocolVersion::V1,
+            ProtocolIdSet::empty(),
+            PeerRole::Validator,
+        );
+        let peer_metadata = PeerMetadata::new(connection_metadata);
+
+        // Create the service response
+        let peer_monitoring_service_response =
+            PeerMonitoringServiceResponse::NodeInformation(node_information_response);
+
+        // Handle the response
+        node_info_state.handle_monitoring_service_response(
+            &peer_network_id,
+            peer_metadata,
+            PeerMonitoringServiceRequest::GetNodeInformation,
+            peer_monitoring_service_response,
+            0.0,
+        );
+    }
+
+    /// Verifies that there is no latest node info response stored
+    fn verify_empty_node_response(node_info_state: &NodeInfoState) {
+        assert!(node_info_state.get_latest_node_info_response().is_none());
+    }
+
+    /// Verifies that the latest node info response is valid
+    fn verify_node_info_state(
+        node_info_state: &NodeInfoState,
+        expected_node_info_response: NodeInformationResponse,
+    ) {
+        let latest_node_info_response = node_info_state.get_latest_node_info_response().unwrap();
+        assert_eq!(latest_node_info_response, expected_node_info_response);
+    }
+}

--- a/network/peer-monitoring-service/client/src/tests/utils.rs
+++ b/network/peer-monitoring-service/client/src/tests/utils.rs
@@ -9,8 +9,8 @@ use crate::{
 };
 use aptos_config::{
     config::{
-        LatencyMonitoringConfig, NetworkMonitoringConfig, NodeConfig, PeerMonitoringServiceConfig,
-        PeerRole,
+        LatencyMonitoringConfig, NetworkMonitoringConfig, NodeConfig, NodeMonitoringConfig,
+        PeerMonitoringServiceConfig, PeerRole,
     },
     network_id::{NetworkId, PeerNetworkId},
 };
@@ -19,15 +19,16 @@ use aptos_peer_monitoring_service_types::{
     request::{LatencyPingRequest, PeerMonitoringServiceRequest},
     response::{
         ConnectionMetadata, LatencyPingResponse, NetworkInformationResponse,
-        PeerMonitoringServiceResponse, ServerProtocolVersionResponse,
+        NodeInformationResponse, PeerMonitoringServiceResponse, ServerProtocolVersionResponse,
     },
     PeerMonitoringServiceMessage,
 };
 use aptos_time_service::{MockTimeService, TimeService, TimeServiceTrait};
 use aptos_types::{network_address::NetworkAddress, PeerId};
 use maplit::hashmap;
+use rand::{rngs::OsRng, Rng};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     future::Future,
     sync::Arc,
     time::{Duration, Instant},
@@ -41,10 +42,112 @@ use tokio::{
 const PAUSE_FOR_SETUP_SECS: u64 = 1;
 const MAX_WAIT_TIME_SECS: u64 = 10;
 const SLEEP_DURATION_MS: u64 = 500;
+const UNREALISTIC_INTERVAL_MS: u64 = 1_000_000_000; // Unrealistically high interval
+
+/// Returns a config where only latency pings are refreshed
+pub fn config_with_latency_ping_requests() -> NodeConfig {
+    NodeConfig {
+        peer_monitoring_service: PeerMonitoringServiceConfig {
+            network_monitoring: disabled_network_monitoring_config(),
+            node_monitoring: disabled_node_monitoring_config(),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Returns a config where only network infos are refreshed
+pub fn config_with_network_info_requests() -> NodeConfig {
+    NodeConfig {
+        peer_monitoring_service: PeerMonitoringServiceConfig {
+            latency_monitoring: disabled_latency_monitoring_config(),
+            node_monitoring: disabled_node_monitoring_config(),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Returns a config where only node infos are refreshed
+pub fn config_with_node_info_requests() -> NodeConfig {
+    NodeConfig {
+        peer_monitoring_service: PeerMonitoringServiceConfig {
+            latency_monitoring: disabled_latency_monitoring_config(),
+            network_monitoring: disabled_network_monitoring_config(),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Returns a config where node info requests don't refresh
+pub fn config_without_node_info_requests() -> NodeConfig {
+    NodeConfig {
+        peer_monitoring_service: PeerMonitoringServiceConfig {
+            node_monitoring: disabled_node_monitoring_config(),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
 
 /// Returns a simple connected peers map for testing purposes
 pub fn create_connected_peers_map() -> HashMap<PeerNetworkId, ConnectionMetadata> {
     hashmap! { PeerNetworkId::random() => ConnectionMetadata::new(NetworkAddress::mock(), PeerId::random(), PeerRole::Unknown) }
+}
+
+/// Creates a network info response with the given data
+pub fn create_network_info_response(
+    connected_peers: &HashMap<PeerNetworkId, ConnectionMetadata>,
+    distance_from_validators: u64,
+) -> NetworkInformationResponse {
+    NetworkInformationResponse {
+        connected_peers: connected_peers.clone(),
+        distance_from_validators,
+    }
+}
+
+/// Creates a node info response with the given data
+pub fn create_node_info_response(
+    git_hash: String,
+    highest_synced_epoch: u64,
+    highest_synced_version: u64,
+    ledger_timestamp_usecs: u64,
+    lowest_available_version: u64,
+    uptime: Duration,
+) -> NodeInformationResponse {
+    NodeInformationResponse {
+        git_hash,
+        highest_synced_epoch,
+        highest_synced_version,
+        ledger_timestamp_usecs,
+        lowest_available_version,
+        uptime,
+    }
+}
+
+/// Returns a latency monitoring config where latency requests are disabled
+fn disabled_latency_monitoring_config() -> LatencyMonitoringConfig {
+    LatencyMonitoringConfig {
+        latency_ping_interval_ms: UNREALISTIC_INTERVAL_MS,
+        ..Default::default()
+    }
+}
+
+/// Returns a network monitoring config where network infos are disabled
+fn disabled_network_monitoring_config() -> NetworkMonitoringConfig {
+    NetworkMonitoringConfig {
+        network_info_request_interval_ms: UNREALISTIC_INTERVAL_MS,
+        ..Default::default()
+    }
+}
+
+/// Returns a node monitoring config where node infos are disabled
+fn disabled_node_monitoring_config() -> NodeMonitoringConfig {
+    NodeMonitoringConfig {
+        node_info_request_interval_ms: UNREALISTIC_INTERVAL_MS,
+        ..Default::default()
+    }
 }
 
 /// Elapses enough time for a latency update to occur
@@ -74,40 +177,20 @@ pub async fn elapse_network_info_update_interval(
         .await;
 }
 
+/// Elapses enough time for a node info update to occur
+pub async fn elapse_node_info_update_interval(node_config: NodeConfig, mock_time: MockTimeService) {
+    let node_monitoring_config = node_config.peer_monitoring_service.node_monitoring;
+    mock_time
+        .advance_ms_async(node_monitoring_config.node_info_request_interval_ms + 1)
+        .await;
+}
+
 /// Elapses enough time for the monitoring loop to execute
 pub async fn elapse_peer_monitor_interval(node_config: NodeConfig, mock_time: MockTimeService) {
     let peer_monitoring_config = node_config.peer_monitoring_service;
     mock_time
         .advance_ms_async(peer_monitoring_config.peer_monitor_interval_ms + 1)
         .await;
-}
-
-/// Returns a config where latency pings don't refresh
-pub fn get_config_without_latency_pings() -> NodeConfig {
-    NodeConfig {
-        peer_monitoring_service: PeerMonitoringServiceConfig {
-            latency_monitoring: LatencyMonitoringConfig {
-                latency_ping_interval_ms: 1_000_000_000, // Unrealistically high
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        ..Default::default()
-    }
-}
-
-/// Returns a config where network info requests don't refresh
-pub fn get_config_without_network_info_requests() -> NodeConfig {
-    NodeConfig {
-        peer_monitoring_service: PeerMonitoringServiceConfig {
-            network_monitoring: NetworkMonitoringConfig {
-                network_info_request_interval_ms: 1_000_000_000, // Unrealistically high
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        ..Default::default()
-    }
 }
 
 /// A simple helper function that returns a valid distance from
@@ -120,8 +203,14 @@ pub fn get_distance_from_validators(peer_network_id: &PeerNetworkId) -> u64 {
     }
 }
 
+/// Returns a random u64 for test purposes
+fn get_random_u64() -> u64 {
+    OsRng.gen()
+}
+
 /// Initializes all the peer states by running the peer monitor loop
 /// once and ensuring the correct requests and responses are received.
+/// Returns the network info and node info responses used during execution.
 pub async fn initialize_and_verify_peer_states(
     network_id: &NetworkId,
     mock_monitoring_server: &mut MockMonitoringServer,
@@ -129,21 +218,26 @@ pub async fn initialize_and_verify_peer_states(
     node_config: &NodeConfig,
     peer_network_id: &PeerNetworkId,
     mock_time: &MockTimeService,
-) -> (HashMap<PeerNetworkId, ConnectionMetadata>, u64) {
+) -> (NetworkInformationResponse, NodeInformationResponse) {
+    // Create the network info response
+    let distance_from_validators = get_distance_from_validators(peer_network_id);
+    let network_info_response =
+        create_network_info_response(&create_connected_peers_map(), distance_from_validators);
+
+    // Create the node info response
+    let node_info_response = create_random_node_info_response();
+
     // Elapse enough time for the peer monitor to execute
     let time_before_update = mock_time.now();
     elapse_peer_monitor_interval(node_config.clone(), mock_time.clone()).await;
-
-    // Create the test response data
-    let connected_peers = create_connected_peers_map();
-    let distance_from_validators = get_distance_from_validators(peer_network_id);
 
     // Verify the initial client requests and send responses
     verify_all_requests_and_respond(
         network_id,
         mock_monitoring_server,
-        &connected_peers,
-        distance_from_validators,
+        3,
+        Some(network_info_response.clone()),
+        Some(node_info_response.clone()),
     )
     .await;
 
@@ -160,12 +254,43 @@ pub async fn initialize_and_verify_peer_states(
     verify_peer_monitor_state(
         peer_monitor_state,
         peer_network_id,
-        &connected_peers,
-        distance_from_validators,
         1,
+        network_info_response.clone(),
+        node_info_response.clone(),
     );
 
-    (connected_peers, distance_from_validators)
+    (network_info_response, node_info_response)
+}
+
+/// Creates a new network info response with random values
+pub fn create_random_network_info_response() -> NetworkInformationResponse {
+    // Create the random values
+    let connected_peers = create_connected_peers_map();
+    let distance_from_validators = 0;
+
+    // Create and return the network info response
+    create_network_info_response(&connected_peers, distance_from_validators)
+}
+
+/// Creates a new network info response with random values
+pub fn create_random_node_info_response() -> NodeInformationResponse {
+    // Create the random values
+    let git_hash = aptos_build_info::get_git_hash();
+    let highest_synced_epoch = get_random_u64();
+    let highest_synced_version = get_random_u64();
+    let ledger_timestamp_usecs = get_random_u64();
+    let lowest_available_version = get_random_u64();
+    let uptime = Duration::from_millis(get_random_u64());
+
+    // Create and return the node info response
+    create_node_info_response(
+        git_hash,
+        highest_synced_epoch,
+        highest_synced_version,
+        ledger_timestamp_usecs,
+        lowest_available_version,
+        uptime,
+    )
 }
 
 /// Spawns the given task with a timeout
@@ -278,11 +403,9 @@ pub fn update_network_info_for_peer(
 
     // Create the network info request and response
     let network_info_request = PeerMonitoringServiceRequest::GetNetworkInformation;
-    let network_info_response =
-        PeerMonitoringServiceResponse::NetworkInformation(NetworkInformationResponse {
-            connected_peers,
-            distance_from_validators,
-        });
+    let network_info_response = PeerMonitoringServiceResponse::NetworkInformation(
+        create_network_info_response(&connected_peers, distance_from_validators),
+    );
 
     // Update the network info state
     network_info_state
@@ -348,8 +471,7 @@ pub async fn verify_and_handle_network_info_request(
     node_config: &NodeConfig,
     peer_network_id: &PeerNetworkId,
     mock_time: &MockTimeService,
-    connected_peers: &HashMap<PeerNetworkId, ConnectionMetadata>,
-    distance_from_validators: u64,
+    network_info_response: NetworkInformationResponse,
 ) {
     // Elapse enough time for a network info update
     let time_before_update = mock_time.now();
@@ -359,8 +481,7 @@ pub async fn verify_and_handle_network_info_request(
     verify_network_info_request_and_respond(
         network_id,
         mock_monitoring_server,
-        connected_peers,
-        distance_from_validators,
+        network_info_response.clone(),
         false,
         false,
         false,
@@ -380,10 +501,46 @@ pub async fn verify_and_handle_network_info_request(
     verify_peer_network_state(
         peer_monitor_state,
         peer_network_id,
-        connected_peers,
-        distance_from_validators,
+        network_info_response,
         0,
     );
+}
+
+/// Elapses enough time for a node info request and handles the response
+pub async fn verify_and_handle_node_info_request(
+    network_id: &NetworkId,
+    mock_monitoring_server: &mut MockMonitoringServer,
+    peer_monitor_state: &PeerMonitorState,
+    node_config: &NodeConfig,
+    peer_network_id: &PeerNetworkId,
+    mock_time: &MockTimeService,
+    node_info_response: NodeInformationResponse,
+) {
+    // Elapse enough time for a node info update
+    let time_before_update = mock_time.now();
+    elapse_node_info_update_interval(node_config.clone(), mock_time.clone()).await;
+
+    // Verify that a single node info request is received and respond
+    verify_node_info_request_and_respond(
+        network_id,
+        mock_monitoring_server,
+        node_info_response.clone(),
+        false,
+        false,
+    )
+    .await;
+
+    // Wait until the network info state is updated by the client
+    wait_for_peer_state_update(
+        time_before_update,
+        peer_monitor_state,
+        peer_network_id,
+        vec![PeerStateKey::NodeInfo],
+    )
+    .await;
+
+    // Verify the network info state
+    verify_peer_node_state(peer_monitor_state, peer_network_id, node_info_response, 0);
 }
 
 /// Verifies that all request types are received by the server
@@ -391,39 +548,47 @@ pub async fn verify_and_handle_network_info_request(
 pub async fn verify_all_requests_and_respond(
     network_id: &NetworkId,
     mock_monitoring_server: &mut MockMonitoringServer,
-    connected_peers: &HashMap<PeerNetworkId, ConnectionMetadata>,
-    distance_from_validators: u64,
+    num_expected_requests: u64,
+    network_information_response: Option<NetworkInformationResponse>,
+    node_information_response: Option<NodeInformationResponse>,
 ) {
     // Create a task that waits for all the requests and sends responses
     let handle_requests = async move {
-        // Counters to ensure we only receive one type of each request
-        let mut num_received_latency_pings = 0;
-        let mut num_received_network_requests = 0;
+        // The set of requests already seen to ensure we only receive one of each request type
+        let mut request_types_already_seen = HashSet::new();
 
-        // We expect a request to be sent for each peer state type
-        let num_state_types = PeerStateKey::get_all_keys().len();
-        for _ in 0..num_state_types {
-            // Process the peer monitoring request
+        // Handle each request
+        for _ in 0..num_expected_requests {
+            // Get the network request
             let network_request = mock_monitoring_server
                 .next_request(network_id)
                 .await
                 .unwrap();
+
+            // Verify we haven't seen a request of this type before
+            let request_type = network_request
+                .peer_monitoring_service_request
+                .get_label()
+                .to_string();
+            if request_types_already_seen.contains(&request_type) {
+                panic!("Received duplicate requests of type: {:?}", request_type);
+            } else {
+                request_types_already_seen.insert(request_type);
+            }
+
+            // Process the peer monitoring request
             let response = match network_request.peer_monitoring_service_request {
                 PeerMonitoringServiceRequest::GetNetworkInformation => {
-                    // Increment the counter
-                    num_received_network_requests += 1;
-
-                    // Return the response
-                    PeerMonitoringServiceResponse::NetworkInformation(NetworkInformationResponse {
-                        connected_peers: connected_peers.clone(),
-                        distance_from_validators,
-                    })
+                    PeerMonitoringServiceResponse::NetworkInformation(
+                        network_information_response.clone().unwrap(),
+                    )
+                },
+                PeerMonitoringServiceRequest::GetNodeInformation => {
+                    PeerMonitoringServiceResponse::NodeInformation(
+                        node_information_response.clone().unwrap(),
+                    )
                 },
                 PeerMonitoringServiceRequest::LatencyPing(latency_ping) => {
-                    // Increment the counter
-                    num_received_latency_pings += 1;
-
-                    // Return the response
                     PeerMonitoringServiceResponse::LatencyPing(LatencyPingResponse {
                         ping_counter: latency_ping.ping_counter,
                     })
@@ -433,11 +598,6 @@ pub async fn verify_all_requests_and_respond(
 
             // Send the response
             network_request.response_sender.send(Ok(response));
-        }
-
-        // Verify each request was received exactly once
-        if (num_received_latency_pings != 1) || (num_received_network_requests != 1) {
-            panic!("The requests were not received exactly once!");
         }
     };
 
@@ -512,19 +672,18 @@ pub async fn verify_latency_request_and_respond(
 }
 
 /// Verifies that a network info request is received by the
-/// server and sends a response.
+/// server and sends a response based on the given arguments.
 pub async fn verify_network_info_request_and_respond(
     network_id: &NetworkId,
     mock_monitoring_server: &mut MockMonitoringServer,
-    connected_peers: &HashMap<PeerNetworkId, ConnectionMetadata>,
-    distance_from_validators: u64,
+    network_info_response: NetworkInformationResponse,
     respond_with_invalid_distance: bool,
     respond_with_invalid_message: bool,
     skip_sending_a_response: bool,
 ) {
     // Create a task that waits for the request and sends a response
     let handle_request = async move {
-        // Process the latency ping request
+        // Process the network info request
         let network_request = mock_monitoring_server
             .next_request(network_id)
             .await
@@ -533,10 +692,10 @@ pub async fn verify_network_info_request_and_respond(
             PeerMonitoringServiceRequest::GetNetworkInformation => {
                 if respond_with_invalid_distance {
                     // Respond with an invalid distance
-                    PeerMonitoringServiceResponse::NetworkInformation(NetworkInformationResponse {
-                        connected_peers: connected_peers.clone(),
-                        distance_from_validators: 1,
-                    })
+                    PeerMonitoringServiceResponse::NetworkInformation(create_network_info_response(
+                        &create_connected_peers_map(),
+                        1,
+                    ))
                 } else if respond_with_invalid_message {
                     // Respond with the wrong message type
                     PeerMonitoringServiceResponse::LatencyPing(LatencyPingResponse {
@@ -544,10 +703,7 @@ pub async fn verify_network_info_request_and_respond(
                     })
                 } else {
                     // Send a valid response
-                    PeerMonitoringServiceResponse::NetworkInformation(NetworkInformationResponse {
-                        connected_peers: connected_peers.clone(),
-                        distance_from_validators,
-                    })
+                    PeerMonitoringServiceResponse::NetworkInformation(network_info_response)
                 }
             },
             request => panic!("Unexpected monitoring request received: {:?}", request),
@@ -563,6 +719,51 @@ pub async fn verify_network_info_request_and_respond(
     spawn_with_timeout(
         handle_request,
         "Timed-out while waiting for a network info request",
+    )
+    .await;
+}
+
+/// Verifies that a node info request is received by the
+/// server and sends a response based on the given arguments.
+pub async fn verify_node_info_request_and_respond(
+    network_id: &NetworkId,
+    mock_monitoring_server: &mut MockMonitoringServer,
+    node_info_response: NodeInformationResponse,
+    respond_with_invalid_message: bool,
+    skip_sending_a_response: bool,
+) {
+    // Create a task that waits for the request and sends a response
+    let handle_request = async move {
+        // Process the node info request
+        let network_request = mock_monitoring_server
+            .next_request(network_id)
+            .await
+            .unwrap();
+        let response = match network_request.peer_monitoring_service_request {
+            PeerMonitoringServiceRequest::GetNodeInformation => {
+                if respond_with_invalid_message {
+                    // Respond with the wrong message type
+                    PeerMonitoringServiceResponse::LatencyPing(LatencyPingResponse {
+                        ping_counter: 10,
+                    })
+                } else {
+                    // Send a valid response
+                    PeerMonitoringServiceResponse::NodeInformation(node_info_response)
+                }
+            },
+            request => panic!("Unexpected monitoring request received: {:?}", request),
+        };
+
+        // Send the response
+        if !skip_sending_a_response {
+            network_request.response_sender.send(Ok(response));
+        }
+    };
+
+    // Spawn the task with a timeout
+    spawn_with_timeout(
+        handle_request,
+        "Timed-out while waiting for a node info request",
     )
     .await;
 }
@@ -584,6 +785,8 @@ pub fn verify_peer_latency_state(
         latency_info_state.get_recorded_latency_pings().len(),
         expected_num_recorded_latency_pings as usize
     );
+
+    // Verify the number of consecutive failures
     assert_eq!(
         latency_info_state
             .get_request_tracker()
@@ -597,9 +800,9 @@ pub fn verify_peer_latency_state(
 pub fn verify_peer_monitor_state(
     peer_monitor_state: &PeerMonitorState,
     peer_network_id: &PeerNetworkId,
-    expected_connected_peers: &HashMap<PeerNetworkId, ConnectionMetadata>,
-    expected_distance_from_validators: u64,
     expected_num_recorded_latency_pings: u64,
+    expected_network_info_response: NetworkInformationResponse,
+    expected_node_info_response: NodeInformationResponse,
 ) {
     // Verify the latency ping state
     verify_peer_latency_state(
@@ -613,8 +816,15 @@ pub fn verify_peer_monitor_state(
     verify_peer_network_state(
         peer_monitor_state,
         peer_network_id,
-        expected_connected_peers,
-        expected_distance_from_validators,
+        expected_network_info_response,
+        0,
+    );
+
+    // Verify the node state
+    verify_peer_node_state(
+        peer_monitor_state,
+        peer_network_id,
+        expected_node_info_response,
         0,
     );
 }
@@ -623,29 +833,49 @@ pub fn verify_peer_monitor_state(
 pub fn verify_peer_network_state(
     peer_monitor_state: &PeerMonitorState,
     peer_network_id: &PeerNetworkId,
-    expected_connected_peers: &HashMap<PeerNetworkId, ConnectionMetadata>,
-    expected_distance_from_validators: u64,
+    expected_network_info_response: NetworkInformationResponse,
     expected_num_consecutive_failures: u64,
 ) {
     // Fetch the peer monitoring metadata
     let peer_states = peer_monitor_state.peer_states.read();
     let peer_state = peer_states.get(peer_network_id).unwrap();
 
-    // Verify the network state
+    // Verify the latest network info response
     let network_info_state = peer_state.get_network_info_state().unwrap();
     let latest_network_info_response = network_info_state
         .get_latest_network_info_response()
         .unwrap();
-    assert_eq!(
-        latest_network_info_response.connected_peers,
-        expected_connected_peers.clone()
-    );
-    assert_eq!(
-        latest_network_info_response.distance_from_validators,
-        expected_distance_from_validators
-    );
+    assert_eq!(latest_network_info_response, expected_network_info_response);
+
+    // Verify the number of consecutive failures
     assert_eq!(
         network_info_state
+            .get_request_tracker()
+            .read()
+            .get_num_consecutive_failures(),
+        expected_num_consecutive_failures
+    );
+}
+
+/// Verifies the node state of the peer monitor
+pub fn verify_peer_node_state(
+    peer_monitor_state: &PeerMonitorState,
+    peer_network_id: &PeerNetworkId,
+    expected_node_info_response: NodeInformationResponse,
+    expected_num_consecutive_failures: u64,
+) {
+    // Fetch the peer monitoring metadata
+    let peer_states = peer_monitor_state.peer_states.read();
+    let peer_state = peer_states.get(peer_network_id).unwrap();
+
+    // Verify the latest node info state
+    let node_info_state = peer_state.get_node_info_state().unwrap();
+    let latest_node_info_response = node_info_state.get_latest_node_info_response().unwrap();
+    assert_eq!(latest_node_info_response, expected_node_info_response);
+
+    // Verify the number of consecutive failures
+    assert_eq!(
+        node_info_state
             .get_request_tracker()
             .read()
             .get_num_consecutive_failures(),
@@ -660,32 +890,11 @@ pub async fn wait_for_latency_ping_failure(
     peer_network_id: &PeerNetworkId,
     num_expected_consecutive_failures: u64,
 ) {
-    // Create a task that waits for the updated states
-    let wait_for_update = async move {
-        loop {
-            // Fetch the request tracker for the latency state
-            let peers_states_lock = peer_monitor_state.peer_states.read();
-            let peer_state = peers_states_lock.get(peer_network_id).unwrap();
-            let request_tracker = peer_state
-                .get_request_tracker(&PeerStateKey::LatencyInfo)
-                .unwrap();
-            drop(peers_states_lock);
-
-            // Check if the request tracker failures matches the expected number
-            let num_consecutive_failures = request_tracker.read().get_num_consecutive_failures();
-            if num_consecutive_failures == num_expected_consecutive_failures {
-                return; // The peer state was updated!
-            }
-
-            // Sleep for some time before retrying
-            sleep(Duration::from_millis(SLEEP_DURATION_MS)).await;
-        }
-    };
-
-    // Spawn the task with a timeout
-    spawn_with_timeout(
-        wait_for_update,
-        "Timed-out while waiting for a latency ping failure!",
+    wait_for_request_failure(
+        peer_monitor_state,
+        peer_network_id,
+        PeerStateKey::LatencyInfo,
+        num_expected_consecutive_failures,
     )
     .await;
 }
@@ -751,7 +960,7 @@ pub async fn wait_for_monitoring_network_update(
                 if latest_network_info_response.distance_from_validators
                     == expected_distance_from_validators
                 {
-                    return; // The average latency info was updated!
+                    return; // The network info was updated!
                 }
             }
 
@@ -775,15 +984,46 @@ pub async fn wait_for_network_info_request_failure(
     peer_network_id: &PeerNetworkId,
     num_expected_consecutive_failures: u64,
 ) {
+    wait_for_request_failure(
+        peer_monitor_state,
+        peer_network_id,
+        PeerStateKey::NetworkInfo,
+        num_expected_consecutive_failures,
+    )
+    .await;
+}
+
+/// Waits for the peer monitor state to be updated with
+/// a node info request failure.
+pub async fn wait_for_node_info_request_failure(
+    peer_monitor_state: &PeerMonitorState,
+    peer_network_id: &PeerNetworkId,
+    num_expected_consecutive_failures: u64,
+) {
+    wait_for_request_failure(
+        peer_monitor_state,
+        peer_network_id,
+        PeerStateKey::NodeInfo,
+        num_expected_consecutive_failures,
+    )
+    .await;
+}
+
+/// Waits for the peer monitor state to be updated with
+/// the specified request failure.
+pub async fn wait_for_request_failure(
+    peer_monitor_state: &PeerMonitorState,
+    peer_network_id: &PeerNetworkId,
+    peer_state_key: PeerStateKey,
+    num_expected_consecutive_failures: u64,
+) {
     // Create a task that waits for the updated states
     let wait_for_update = async move {
         loop {
-            // Fetch the request tracker for the network info state
+            // Fetch the request tracker for the state
             let peers_states_lock = peer_monitor_state.peer_states.read();
             let peer_state = peers_states_lock.get(peer_network_id).unwrap();
-            let request_tracker = peer_state
-                .get_request_tracker(&PeerStateKey::NetworkInfo)
-                .unwrap();
+            let request_tracker = peer_state.get_request_tracker(&peer_state_key).unwrap();
             drop(peers_states_lock);
 
             // Check if the request tracker failures matches the expected number
@@ -800,7 +1040,7 @@ pub async fn wait_for_network_info_request_failure(
     // Spawn the task with a timeout
     spawn_with_timeout(
         wait_for_update,
-        "Timed-out while waiting for a network info failure!",
+        "Timed-out while waiting for a request failure!",
     )
     .await;
 }

--- a/network/peer-monitoring-service/server/src/storage.rs
+++ b/network/peer-monitoring-service/server/src/storage.rs
@@ -20,7 +20,7 @@ pub trait StorageReaderInterface: Clone + Send + 'static {
 }
 
 /// The underlying implementation of the StorageReaderInterface, used by the
-/// storage server.
+/// peer monitoring server.
 #[derive(Clone)]
 pub struct StorageReader {
     storage: Arc<dyn DbReader>,


### PR DESCRIPTION
Notes:
- This PR relates to: https://github.com/aptos-labs/aptos-core/issues/6789.
- Most of this PR is new tests.
- This PR is built on: https://github.com/aptos-labs/aptos-core/pull/7451.

### Description
This PR adds client-side support for node info messages. Specifically, it updates the peer monitoring loop to periodically send node info requests to peers to update their node metadata. The PR offers two commits:
1. Add client-side support for the node info messages to the peer monitor (this includes a new unit test).
2. Add more extensive integration tests for the node info messages (and perform various cleanups along the way).

Once this lands, we should have end-to-end support for node info messages.

### Test Plan
New and existing tests.