### PR TITLE
Optimize the Aptos Names Service doc header

### DIFF
--- a/developer-docs-site/docs/guides/aptos-name-service-connector.md
+++ b/developer-docs-site/docs/guides/aptos-name-service-connector.md
@@ -1,8 +1,8 @@
 ---
-title: "Integrate Aptos Names Service"
+title: "Integrate with Aptos Names Service"
 id: "aptos-names-service-package"
 ---
-# Integrate with Aptos Names Service UI Package
+# Integrate with Aptos Names Service
 The Aptos Name Service provides a React UI package that offers developers a customizable button and modal to enable users to search for and mint Aptos names directly from their website.
 
 ## Prerequisites


### PR DESCRIPTION
I shortened the header since it takes up two lines instead of one like in the other docs.

![image](https://user-images.githubusercontent.com/125399153/228331961-11371030-a459-43f2-88f5-afda540ad111.png)
