### PR TITLE
[Peer Monitoring Service] Add garbage collection for peer states.

### DIFF
--- a/network/peer-monitoring-service/client/src/tests/utils.rs
+++ b/network/peer-monitoring-service/client/src/tests/utils.rs
@@ -208,6 +208,29 @@ fn get_random_u64() -> u64 {
     OsRng.gen()
 }
 
+/// Handle several latency ping requests and responses for the given peer
+pub async fn handle_several_latency_pings(
+    mock_monitoring_server: &mut MockMonitoringServer,
+    peer_monitor_state: &PeerMonitorState,
+    node_config: &NodeConfig,
+    mock_time: &MockTimeService,
+    peer_network_id: &PeerNetworkId,
+) {
+    for i in 0..5 {
+        verify_and_handle_latency_ping(
+            &peer_network_id.network_id(),
+            mock_monitoring_server,
+            peer_monitor_state,
+            node_config,
+            peer_network_id,
+            mock_time,
+            i + 1,
+            i + 2,
+        )
+        .await;
+    }
+}
+
 /// Initializes all the peer states by running the peer monitor loop
 /// once and ensuring the correct requests and responses are received.
 /// Returns the network info and node info responses used during execution.


### PR DESCRIPTION
Notes:
- This PR relates to: https://github.com/aptos-labs/aptos-core/issues/6789.
- This PR is built on: https://github.com/aptos-labs/aptos-core/pull/7459.

### Description
This PR adds garbage collection to the peer monitoring client. Specifically, we remove peer states for peers that are no longer connected. The PR offers several commits:
1. Add garbage collection to the peer monitoring client for peer states.
2. Small refactors to the tests. Nothing should change logically.

### Test Plan
New and existing unit tests.