### PR TITLE
[move compiler] Fix a bug with error messages introduced by inlining

### DIFF
--- a/third_party/move/move-compiler/src/inlining/translate.rs
+++ b/third_party/move/move-compiler/src/inlining/translate.rs
@@ -724,7 +724,7 @@ struct CheckerVisitor<'l, 'r> {
     seen: BTreeMap<StructName, Loc>,
 }
 
-fn post_inlining_check(inliner: &mut Inliner, _name: &str, fdef: &mut Function) {
+fn post_inlining_check(inliner: &mut Inliner, name: &str, fdef: &mut Function) {
     let mut visitor = CheckerVisitor {
         inliner,
         declared: fdef.acquires.clone(),
@@ -755,10 +755,11 @@ fn post_inlining_check(inliner: &mut Inliner, _name: &str, fdef: &mut Function) 
     for (s, l) in &seen {
         if !declared.contains_key(s) {
             let tmsg = format!(
-                "The call acquires '{}::{}', but the 'acquires' list for the current function does \
+                "The call acquires '{}::{}', but the 'acquires' list for the current function '{}` does \
              not contain this type. It must be present in the calling context's acquires list",
                 current_module,
-                s
+                s,
+                name
             );
             inliner
                 .env
@@ -786,8 +787,8 @@ impl<'l, 'r> Visitor for CheckerVisitor<'l, 'r> {
                     }
                 }
 
-                for (s, l) in &mcall.acquires {
-                    self.seen.insert(*s, *l);
+                for s in mcall.acquires.keys() {
+                    self.seen.insert(*s, ex.exp.loc);
                 }
                 VisitorContinuation::Descend
             },

--- a/third_party/move/move-compiler/tests/move_check/inlining/acquires_error_msg.exp
+++ b/third_party/move/move-compiler/tests/move_check/inlining/acquires_error_msg.exp
@@ -1,0 +1,6 @@
+error[E04020]: missing acquires annotation
+  ┌─ tests/move_check/inlining/acquires_error_msg.move:7:9
+  │
+7 │         modify(); // expect error message here
+  │         ^^^^^^^^ The call acquires '0x42::test::Test', but the 'acquires' list for the current function 'call_modify_without_acquire` does not contain this type. It must be present in the calling context's acquires list
+

--- a/third_party/move/move-compiler/tests/move_check/inlining/acquires_error_msg.move
+++ b/third_party/move/move-compiler/tests/move_check/inlining/acquires_error_msg.move
@@ -1,0 +1,13 @@
+module 0x42::test {
+    struct Test has key {
+        value: u64
+    }
+
+    public fun call_modify_without_acquire() {
+        modify(); // expect error message here
+    }
+
+    public fun modify() acquires Test {
+        borrow_global_mut<Test>(@0xcafe).value = 2;
+    }
+}

--- a/third_party/move/move-compiler/tests/move_check/inlining/resources_invalid.exp
+++ b/third_party/move/move-compiler/tests/move_check/inlining/resources_invalid.exp
@@ -2,7 +2,7 @@ error[E04020]: missing acquires annotation
   ┌─ tests/move_check/inlining/resources_invalid.move:8:9
   │
 8 │         borrow_global<T>(ref.addr)
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ The call acquires '0x42::token::Token', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ The call acquires '0x42::token::Token', but the 'acquires' list for the current function 'get_value` does not contain this type. It must be present in the calling context's acquires list
 
 error[E14002]: Inlined code invalid in this context
   ┌─ tests/move_check/inlining/resources_invalid.move:8:26

--- a/third_party/move/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/borrow_global_acquires_missing_annotation.exp
+++ b/third_party/move/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/borrow_global_acquires_missing_annotation.exp
@@ -2,5 +2,5 @@ error[E04020]: missing acquires annotation
   ┌─ tests/move_check/translated_ir_tests/move/borrow_tests/borrow_global_acquires_missing_annotation.move:6:9
   │
 6 │         borrow_global_mut<T1>(signer::address_of(account));
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The call acquires '0x8675309::A::T1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The call acquires '0x8675309::A::T1', but the 'acquires' list for the current function 'test` does not contain this type. It must be present in the calling context's acquires list
 

--- a/third_party/move/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/imm_borrow_global_requires_acquire.exp
+++ b/third_party/move/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/imm_borrow_global_requires_acquire.exp
@@ -2,5 +2,5 @@ error[E04020]: missing acquires annotation
   ┌─ tests/move_check/translated_ir_tests/move/borrow_tests/imm_borrow_global_requires_acquire.move:5:9
   │
 5 │         borrow_global<T1>(addr);
-  │         ^^^^^^^^^^^^^^^^^^^^^^^ The call acquires '0x8675309::A::T1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
+  │         ^^^^^^^^^^^^^^^^^^^^^^^ The call acquires '0x8675309::A::T1', but the 'acquires' list for the current function 'test` does not contain this type. It must be present in the calling context's acquires list
 

--- a/third_party/move/move-compiler/tests/move_check/typing/missing_acquire.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/missing_acquire.exp
@@ -2,5 +2,5 @@ error[E04020]: missing acquires annotation
    ┌─ tests/move_check/typing/missing_acquire.move:11:16
    │
 11 │         R1{} = move_from<R1>(a);
-   │                ^^^^^^^^^^^^^^^^ The call acquires '0x8675309::M::R1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
+   │                ^^^^^^^^^^^^^^^^ The call acquires '0x8675309::M::R1', but the 'acquires' list for the current function 't1` does not contain this type. It must be present in the calling context's acquires list
 


### PR DESCRIPTION
This was caused by a regression inlining introduced, and no previous test case. Fixes the issue and adds a test case. Closes #7412.

