### PR TITLE
[docs] Update docs explaining how to use debug statement in Move code

### DIFF
--- a/developer-docs-site/docs/cli-tools/aptos-cli-tool/use-aptos-cli.md
+++ b/developer-docs-site/docs/cli-tools/aptos-cli-tool/use-aptos-cli.md
@@ -871,9 +871,7 @@ In this case, see [Install the dependencies of Move Prover](install-aptos-cli#st
 
 In this example, we will use `DebugDemo` in [debug-move-example](https://github.com/aptos-labs/aptos-core/tree/main/crates/aptos/debug-move-example).
 
-First, you need to include Move nursery in your Move [TOML file](https://github.com/aptos-labs/aptos-core/tree/main/crates/aptos/debug-move-example/Move.toml).
-
-Now, you can use `Debug::print` and `Debug::print_stack_trace` in your [DebugDemo Move file](https://github.com/aptos-labs/aptos-core/tree/main/crates/aptos/debug-move-example/sources/DebugDemo.move).
+Now, you can use `debug::print` and `debug::print_stack_trace` in your [DebugDemo Move file](https://github.com/aptos-labs/aptos-core/tree/main/crates/aptos/debug-move-example/sources/DebugDemo.move).
 
 You can run the following command:
 ```bash


### PR DESCRIPTION
### Description
It was incorrectly referring to the module as `Debug` instead of `debug` (used to be correct, no longer) as well as saying you need to use the nursery package, which you don't need to do now.

### Test Plan
CI.
