### PR TITLE
[TS SDK] add User-Agent header

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 ## Unreleased
 
 - Introduce `AnsClient` class to support ANS (Aptos Names Service) data fetching queries
+- Add `User-Agent` header to `AptosClient` queries
 
 ## 1.7.2 (2023-03-13)
 

--- a/ecosystem/typescript/sdk/README.md
+++ b/ecosystem/typescript/sdk/README.md
@@ -111,17 +111,17 @@ To release a new version of the SDK do the following.
 
 1. Check that the commit you're deploying from (likely just the latest commit of `main`) is green ln CI. Go to GitHub and make sure there is a green tick, specifically for the `sdk-release` release CI step. This ensures that the all tests, formatters, and linters passed, including server / client compatibility tests (within that commit) and tests to ensure the API, API spec, and client were all generated and match up.
 2. Bump the version in `package.json` according to [semver](https://semver.org/).
-3. Add an entry in the CHANGELOG for the version. We adhere to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Generally this means changing the "Unreleased" section to a version and then making a new "Unreleased" section.
-4. Once you're confident everything is correct, submit your PR. The CI will ensure that you have followed all the previous steps, specifically ensuring that the API, API spec, and SDK client are all compatible, that you've updated the changelog, that the tests pass, etc.
-5. Land the PR into the main branch. Make sure this commit comes up green in CI too.
-6. Check out the latest commit on main.
-7. Get the auth token from our password manager. Search for "npmjs". It should look like similar to this: `npm_cccaCVg0bWaaR741D5Gdsd12T4JpQre444aaaa`.
-8. Run `pnpm publish --dry-run`. From here, make some sanity checks:
-    a. Look closely at the output of the command. {ay close attention to what is packaged. Make sure we're not including some files that were included accidentally. For example `.aptos`. Add those to .npmignore if needed.
-    b. Compare the summary with the public npm package summary on npmjs. The number of files and sizes should not vary too much.
-9. Run `NODE_AUTH_TOKEN=<token> pnpm checked-publish`
-10. Double check that the release worked by visitng npmjs: https://www.npmjs.com/package/aptos
-
+3. Bump the version in `version.ts`
+4. Add an entry in the CHANGELOG for the version. We adhere to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Generally this means changing the "Unreleased" section to a version and then making a new "Unreleased" section.
+5. Once you're confident everything is correct, submit your PR. The CI will ensure that you have followed all the previous steps, specifically ensuring that the API, API spec, and SDK client are all compatible, that you've updated the changelog, that the tests pass, etc.
+6. Land the PR into the main branch. Make sure this commit comes up green in CI too.
+7. Check out the latest commit on main.
+8. Get the auth token from our password manager. Search for "npmjs". It should look like similar to this: `npm_cccaCVg0bWaaR741D5Gdsd12T4JpQre444aaaa`.
+9. Run `pnpm publish --dry-run`. From here, make some sanity checks:
+   a. Look closely at the output of the command. {ay close attention to what is packaged. Make sure we're not including some files that were included accidentally. For example `.aptos`. Add those to .npmignore if needed.
+   b. Compare the summary with the public npm package summary on npmjs. The number of files and sizes should not vary too much.
+10. Run `NODE_AUTH_TOKEN=<token> pnpm checked-publish`
+11. Double check that the release worked by visitng npmjs: https://www.npmjs.com/package/aptos
 
 [examples]: https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/typescript/sdk/examples/
 [repo]: https://github.com/aptos-labs/aptos-core
@@ -131,4 +131,3 @@ To release a new version of the SDK do the following.
 [discord-image]: https://img.shields.io/discord/945856774056083548?label=Discord&logo=discord&style=flat~~~~
 [discord-url]: https://discord.gg/aptoslabs
 [api-doc]: https://aptos-labs.github.io/ts-sdk-doc/
-

--- a/ecosystem/typescript/sdk/src/providers/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/providers/aptos_client.ts
@@ -86,7 +86,7 @@ export class AptosClient {
     } else {
       conf.WITH_CREDENTIALS = true;
     }
-    conf.HEADERS = { ...conf.HEADERS, "User-Agent": `aptos-ts-sdk / ${VERSION}` };
+    conf.HEADERS = { ...conf.HEADERS, "User-Agent": `aptos-ts-sdk/${VERSION}` };
 
     this.client = new Gen.AptosGeneratedClient(conf);
   }

--- a/ecosystem/typescript/sdk/src/providers/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/providers/aptos_client.ts
@@ -35,6 +35,7 @@ import {
   AnyNumber,
 } from "../bcs";
 import { Ed25519PublicKey, MultiEd25519PublicKey } from "../aptos_types";
+import { VERSION } from "../version";
 
 export interface OptionalTransactionArgs {
   maxGasAmount?: Uint64;
@@ -85,6 +86,7 @@ export class AptosClient {
     } else {
       conf.WITH_CREDENTIALS = true;
     }
+    conf.HEADERS = { ...conf.HEADERS, "User-Agent": `aptos-ts-sdk / ${VERSION}` };
 
     this.client = new Gen.AptosGeneratedClient(conf);
   }

--- a/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
@@ -14,6 +14,7 @@ import { HexString } from "../../utils";
 import { getFaucetClient, longTestTimeout, NODE_URL } from "../unit/test_helper.test";
 import { bcsSerializeUint64, bcsToBytes } from "../../bcs";
 import { Ed25519PublicKey } from "../../aptos_types";
+import { VERSION } from "../../version";
 
 const account = "0x1::account::Account";
 
@@ -26,6 +27,13 @@ test("node url empty", () => {
     const client = new AptosClient("");
     client.getAccount("0x1");
   }).toThrow("Node URL cannot be empty.");
+});
+
+test("call should include user-agent header", async () => {
+  const client = new AptosClient(NODE_URL, { HEADERS: { my: "header" } });
+  const heders = client.client.request.config.HEADERS;
+  expect(heders).toHaveProperty("User-Agent", `aptos-ts-sdk / ${VERSION}`);
+  expect(heders).toHaveProperty("my", "header");
 });
 
 test("gets genesis account", async () => {

--- a/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
@@ -32,7 +32,7 @@ test("node url empty", () => {
 test("call should include user-agent header", async () => {
   const client = new AptosClient(NODE_URL, { HEADERS: { my: "header" } });
   const heders = client.client.request.config.HEADERS;
-  expect(heders).toHaveProperty("User-Agent", `aptos-ts-sdk / ${VERSION}`);
+  expect(heders).toHaveProperty("User-Agent", `aptos-ts-sdk/${VERSION}`);
   expect(heders).toHaveProperty("my", "header");
 });
 

--- a/ecosystem/typescript/sdk/src/version.ts
+++ b/ecosystem/typescript/sdk/src/version.ts
@@ -1,0 +1,2 @@
+// hardcoded for now, we would want to have it injected dynamic
+export const VERSION = "1.7.2";

--- a/ecosystem/typescript/sdk/src/version.ts
+++ b/ecosystem/typescript/sdk/src/version.ts
@@ -1,2 +1,2 @@
-// hardcoded for now, we would want to have it injected dynamic
+// hardcoded for now, we would want to have it injected dynamically
 export const VERSION = "1.7.2";


### PR DESCRIPTION
### Description
Add User-Agent header to rest api calls 
### Test Plan
test are passing
and
```
2023-03-30T23:23:08.657964Z [api-18] DEBUG api/src/log.rs:53 {"elapsed":"835.083µs","method":"GET","path":"/v1/accounts/0x1","remote_addr":"127.0.0.1:65273","status":200,"user_agent":"aptos-ts-sdk / 1.7.2"}
```
