### PR TITLE
[Dockerfile][Bug Fix] Fix indexer and failpoint builds

### DIFF
--- a/docker/experimental/build-node.sh
+++ b/docker/experimental/build-node.sh
@@ -14,7 +14,7 @@ echo "CARGO_TARGET_DIR: $CARGO_TARGET_DIR"
 # Build and overwrite the aptos-node binary with features if specified
 if [ -n "$FEATURES" ]; then
     echo "Building aptos-node with features ${FEATURES}"
-    (cd aptos-node && cargo build --profile=$PROFILE --features=$FEATURES "$@")
+    cargo build --profile=$PROFILE --features=$FEATURES -p aptos-node "$@"
 else 
     # Build aptos-node separately
     cargo build --locked --profile=$PROFILE \


### PR DESCRIPTION
### Description

cd-ing into aptos-core and building there creates target directory within the repo. Avoid the cd-ing.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Tested locally.
