### PR TITLE
[move-examples] Fix branch used by examples and the `aptos move init` command

### DIFF
--- a/aptos-move/move-examples/argument_example/Move.toml
+++ b/aptos-move/move-examples/argument_example/Move.toml
@@ -1,9 +1,9 @@
 [package]
 name = "ArgumentExample"
-version = "0.0.0"
+version = "1.0.0"
 
 [addresses]
-deploy_address = "_"
+argument_example = "_"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }

--- a/aptos-move/move-examples/argument_example/sources/arguments.move
+++ b/aptos-move/move-examples/argument_example/sources/arguments.move
@@ -1,4 +1,5 @@
-module deploy_address::number {
+/// Provides an example for inputs and outputs of all number types
+module argument_example::number {
     use std::error;
     use std::signer;
 

--- a/aptos-move/move-examples/dao/nft_dao/Move.toml
+++ b/aptos-move/move-examples/dao/nft_dao/Move.toml
@@ -1,12 +1,11 @@
 [package]
-name = "NFTDAO"
-version = "0.0.0"
+name = "NFTDaoExample"
+version = "1.0.0"
 upgrade_policy = "immutable"
 
 [addresses]
 dao_platform = "_"
-aptos_framework = "0x1"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosToken = { local = "../../../framework/aptos-token" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-token/", rev = "mainnet" }

--- a/aptos-move/move-examples/data_structures/Move.toml
+++ b/aptos-move/move-examples/data_structures/Move.toml
@@ -3,7 +3,7 @@ name = "DataStructure"
 version = "0.0.1"
 
 [dependencies]
-AptosStdlib = { local = "../../framework/aptos-stdlib" }
+AptosStdLib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-stdlib/", rev = "mainnet" }
 
 [addresses]
 std = "0x1"

--- a/aptos-move/move-examples/defi/Move.toml
+++ b/aptos-move/move-examples/defi/Move.toml
@@ -1,9 +1,9 @@
 [package]
-name = "Examples"
-version = "0.0.0"
+name = "DefiExamples"
+version = "1.0.0"
 
 [addresses]
 defi = "_"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }

--- a/aptos-move/move-examples/fungible_asset/Move.toml
+++ b/aptos-move/move-examples/fungible_asset/Move.toml
@@ -1,10 +1,9 @@
 [package]
-name = "FungibleAsset"
-version = "0.0.0"
+name = "FungibleAssetExample"
+version = "1.0.0"
 
 [addresses]
-aptos_framework = "0x1"
 fungible_asset = "_"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }

--- a/aptos-move/move-examples/governance/Move.toml
+++ b/aptos-move/move-examples/governance/Move.toml
@@ -1,9 +1,6 @@
 [package]
-name = "Examples"
-version = "0.0.0"
-
-[addresses]
-aptos_framework = "0x1"
+name = "GovernanceExamples"
+version = "1.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }

--- a/aptos-move/move-examples/hello_blockchain/Move.toml
+++ b/aptos-move/move-examples/hello_blockchain/Move.toml
@@ -1,9 +1,9 @@
 [package]
-name = "Examples"
-version = "0.0.0"
+name = "HelloBlockchainExample"
+version = "1.0.0"
 
 [addresses]
 hello_blockchain = "_"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }

--- a/aptos-move/move-examples/hello_prover/Move.toml
+++ b/aptos-move/move-examples/hello_prover/Move.toml
@@ -1,10 +1,6 @@
 [package]
-name = "hello_prover"
-version = "0.0.0"
+name = "HelloProverExample"
+version = "1.0.0"
 
 [dependencies]
-AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "main" }
-
-[addresses]
-
-
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }

--- a/aptos-move/move-examples/marketplace/Move.toml
+++ b/aptos-move/move-examples/marketplace/Move.toml
@@ -1,11 +1,10 @@
 [package]
-name = "MarketPlace"
-version = "0.0.1"
+name = "MarketplaceExample"
+version = "1.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
-AptosToken = { local = "../../framework/aptos-token" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-token/", rev = "mainnet" }
 
 [addresses]
-std = "0x1"
 marketplace = "_"

--- a/aptos-move/move-examples/message_board/Move.toml
+++ b/aptos-move/move-examples/message_board/Move.toml
@@ -1,10 +1,9 @@
 [package]
-name = "MessageBoard"
-version = "0.0.1"
+name = "MessageBoardExample"
+version = "1.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
 
 [addresses]
-std = "0x1"
 message_board = "_"

--- a/aptos-move/move-examples/mint_nft/1-Create-NFT/Move.toml
+++ b/aptos-move/move-examples/mint_nft/1-Create-NFT/Move.toml
@@ -1,10 +1,10 @@
 [package]
-name = "Examples"
-version = "0.0.0"
+name = "CreateNFTExample"
+version = "1.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosToken = { local = "../../../framework/aptos-token" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-token/", rev = "mainnet" }
 
 [addresses]
-aptos_framework = "0x1"
+mint_nft = "_"

--- a/aptos-move/move-examples/mint_nft/2-Using-Resource-Account/Move.toml
+++ b/aptos-move/move-examples/mint_nft/2-Using-Resource-Account/Move.toml
@@ -1,10 +1,10 @@
 [package]
-name = "Examples"
-version = "0.0.0"
+name = "CreateNFTWithResourceAccountExample"
+version = "1.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosToken = { local = "../../../framework/aptos-token" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-token/", rev = "mainnet" }
 
 [addresses]
-aptos_framework = "0x1"
+mint_nft = "_"

--- a/aptos-move/move-examples/mint_nft/3-Adding-Admin/Move.toml
+++ b/aptos-move/move-examples/mint_nft/3-Adding-Admin/Move.toml
@@ -1,12 +1,12 @@
 [package]
-name = "Examples"
-version = "0.0.0"
+name = "CreateNFTWithResourceAccountAdminExample"
+version = "1.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosToken = { local = "../../../framework/aptos-token" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-token/", rev = "mainnet" }
 
 [addresses]
-aptos_framework = "0x1"
+mint_nft = "_"
 # replace the admin_addr with the actual admin address we created using CLI
-admin_addr = "0xbeef"
+admin_addr = "_"

--- a/aptos-move/move-examples/mint_nft/4-Getting-Production-Ready/Move.toml
+++ b/aptos-move/move-examples/mint_nft/4-Getting-Production-Ready/Move.toml
@@ -1,12 +1,12 @@
 [package]
-name = "Examples"
-version = "0.0.0"
+name = "CreateNFTProductionReadyExample"
+version = "1.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosToken = { local = "../../../framework/aptos-token" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-token/", rev = "mainnet" }
 
 [addresses]
-aptos_framework = "0x1"
+mint_nft = "_"
 # replace the admin_addr with the actual admin address we created using CLI
 admin_addr = "0xbeef"

--- a/aptos-move/move-examples/moon_coin/Move.toml
+++ b/aptos-move/move-examples/moon_coin/Move.toml
@@ -1,9 +1,9 @@
 [package]
-name = "Examples"
-version = "0.0.0"
+name = "MoonCoinExample"
+version = "1.0.0"
 
 [addresses]
 MoonCoin = "_"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }

--- a/aptos-move/move-examples/move-tutorial/step_2/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_2/basic_coin/Move.toml
@@ -4,5 +4,5 @@ version = "0.0.0"
 
 [dependencies.AptosStdlib]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_2_sol/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_2_sol/basic_coin/Move.toml
@@ -7,5 +7,5 @@ named_addr = "0xCAFE"
 
 [dependencies.AptosStdlib]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_4/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_4/basic_coin/Move.toml
@@ -7,5 +7,5 @@ named_addr = "0xCAFE"
 
 [dependencies.AptosStdlib]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_4_sol/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_4_sol/basic_coin/Move.toml
@@ -7,5 +7,5 @@ named_addr = "0xCAFE"
 
 [dependencies.AptosStdlib]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_5/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_5/basic_coin/Move.toml
@@ -7,5 +7,5 @@ named_addr = "0xCAFE"
 
 [dependencies.AptosStdlib]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_5_sol/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_5_sol/basic_coin/Move.toml
@@ -7,5 +7,5 @@ named_addr = "0xCAFE"
 
 [dependencies.AptosStdlib]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_6/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_6/basic_coin/Move.toml
@@ -7,5 +7,5 @@ named_addr = "0xCAFE"
 
 [dependencies.AptosStdlib]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_7/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_7/basic_coin/Move.toml
@@ -7,5 +7,5 @@ named_addr = "0xCAFE"
 
 [dependencies.AptosStdlib]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_8/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_8/basic_coin/Move.toml
@@ -7,5 +7,5 @@ named_addr = "0xCAFE"
 
 [dependencies.AptosStdlib]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_8_sol/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_8_sol/basic_coin/Move.toml
@@ -7,5 +7,5 @@ named_addr = "0xDEADBEEF"
 
 [dependencies.AptosStdlib]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-stdlib'

--- a/aptos-move/move-examples/my_first_dapp/move/Move.toml
+++ b/aptos-move/move-examples/my_first_dapp/move/Move.toml
@@ -3,7 +3,7 @@ name = 'my_todo_list'
 version = '1.0.0'
 [dependencies.AptosFramework]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
+rev = 'mainnet'
 subdir = 'aptos-move/framework/aptos-framework'
 [addresses]
 todolist_addr='_'

--- a/aptos-move/move-examples/post_mint_reveal_nft/Move.toml
+++ b/aptos-move/move-examples/post_mint_reveal_nft/Move.toml
@@ -1,15 +1,13 @@
 [package]
-name = "test_package"
-version = "0.0.0"
-upgrade_policy = "compatible"
+name = "PostMintRevealExample"
+version = "1.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
-AptosToken = { local = "../../framework/aptos-token" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-token/", rev = "mainnet" }
 DataStructure = { local = "../data_structures" }
 
 [addresses]
-aptos_framework = "0x1"
 # the source_addr and post_mint_reveal_nft here are for unit test purposes.
 # in production, we should change them:
 # - the source_addr should be the address of the account that creates the resource account
@@ -17,5 +15,5 @@ aptos_framework = "0x1"
 # "aptos move create-resource-account-and-publish-package ..." because the CLI will automatically link
 # the address to the package. If we are not using the CLI, the post_mint_reveal_nft should be the address
 # of the resource account which is also the module publisher.
-source_addr = "0xcafe"
-post_mint_reveal_nft = "0xc3bb8488ab1a5815a9d543d7e41b0e0df46a7396f89b22821f07a4362f75ddc5"
+source_addr = "_"
+post_mint_reveal_nft = "_"

--- a/aptos-move/move-examples/resource_account/Move.toml
+++ b/aptos-move/move-examples/resource_account/Move.toml
@@ -1,11 +1,10 @@
 [package]
-name = "test_package"
-version = "0.0.0"
-upgrade_policy = "compatible"
+name = "ResourceAccountDefiExample"
+version = "1.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
 
 [addresses]
 # change it to `source_addr = "_" when calling `create-resource-account-and-publish-package` from the cli
-source_addr = "0xcafe"
+source_addr = "_"

--- a/aptos-move/move-examples/resource_groups/primary/Move.toml
+++ b/aptos-move/move-examples/resource_groups/primary/Move.toml
@@ -1,9 +1,9 @@
 [package]
-name = "ResourceGroupsPrimary"
-version = "0.0.0"
+name = "ResourceGroupsPrimaryExample"
+version = "1.0.0"
 
 [addresses]
 resource_groups_primary = "_"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }

--- a/aptos-move/move-examples/resource_groups/secondary/Move.toml
+++ b/aptos-move/move-examples/resource_groups/secondary/Move.toml
@@ -1,11 +1,11 @@
 [package]
-name = "ResourceGroupsSecondary"
-version = "0.0.0"
+name = "ResourceGroupsSecondaryExample"
+version = "1.0.0"
 
 [addresses]
 resource_groups_primary = "_"
 resource_groups_secondary = "_"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-ResourceGroupsPrimary = { local = "../primary" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+ResourceGroupsPrimaryExample = { local = "../primary" }

--- a/aptos-move/move-examples/scripts/minter/Move.toml
+++ b/aptos-move/move-examples/scripts/minter/Move.toml
@@ -1,6 +1,6 @@
 [package]
-name = "Minter"
-version = "0.0.0"
+name = "MinterExample"
+version = "1.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }

--- a/aptos-move/move-examples/scripts/two_by_two_transfer/Move.toml
+++ b/aptos-move/move-examples/scripts/two_by_two_transfer/Move.toml
@@ -1,6 +1,6 @@
 [package]
-name = "TwoByTwoTransfer"
-version = "0.0.0"
+name = "TwoByTwoTransferExample"
+version = "1.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }

--- a/aptos-move/move-examples/shared_account/Move.toml
+++ b/aptos-move/move-examples/shared_account/Move.toml
@@ -1,6 +1,6 @@
 [package]
-name = "Examples"
-version = "0.0.0"
+name = "SharedAccountExample"
+version = "1.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }

--- a/aptos-move/move-examples/split_transfer/Move.toml
+++ b/aptos-move/move-examples/split_transfer/Move.toml
@@ -1,6 +1,6 @@
 [package]
-name = "SplitTransfer"
-version = "0.0.0"
+name = "SplitTransferExample"
+version = "1.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }

--- a/aptos-move/move-examples/token_objects/Move.toml
+++ b/aptos-move/move-examples/token_objects/Move.toml
@@ -1,10 +1,10 @@
 [package]
-name = "TokenObjects"
-version = "0.0.0"
+name = "TokenObjectsExample"
+version = "1.0.0"
 
 [addresses]
 token_objects = "_"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
 AptosTokenObjects = { local = "../../framework/aptos-token-objects" }

--- a/aptos-move/move-examples/upgrade_and_govern/genesis/Move.toml
+++ b/aptos-move/move-examples/upgrade_and_govern/genesis/Move.toml
@@ -1,10 +1,11 @@
 # :!:>manifest
 [package]
-name = 'UpgradeAndGovern'
+name = 'UpgradeAndGovernExample'
 version = '1.0.0'
 
 [addresses]
 upgrade_and_govern = '_'
 
-[dependencies.AptosFramework]
-local = '../../../framework/aptos-framework' # <:!:manifest
+[dependencies]
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+# <:!:manifest

--- a/aptos-move/move-examples/upgrade_and_govern/upgrade/Move.toml
+++ b/aptos-move/move-examples/upgrade_and_govern/upgrade/Move.toml
@@ -1,10 +1,11 @@
 # :!:>manifest
 [package]
-name = 'UpgradeAndGovern'
+name = 'UpgradeAndGovernExample'
 version = '1.1.0'
 
 [addresses]
 upgrade_and_govern = '_'
 
-[dependencies.AptosFramework]
-local = '../../../framework/aptos-framework' # <:!:manifest
+[dependencies]
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "mainnet" }
+# <:!:manifest

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 ## [Unreleased]
 ### Fixed
 * If `aptos init` is run with a faucet URL specified (which happens by default when using the local, devnet, or testnet network options) and funding the account fails, the account creation is considered a failure and nothing is persisted. Previously it would report success despite the account not being created on chain.
+* Default `aptos move init` branch is now `mainnet` and not `main`, which caused more variability in the compilation.
 
 ## [1.0.8] - 2023/03/16
 ### Added

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -161,7 +161,7 @@ impl FrameworkPackageArgs {
         const APTOS_FRAMEWORK: &str = "AptosFramework";
         const APTOS_GIT_PATH: &str = "https://github.com/aptos-labs/aptos-core.git";
         const SUBDIR_PATH: &str = "aptos-move/framework/aptos-framework";
-        const DEFAULT_BRANCH: &str = "main";
+        const DEFAULT_BRANCH: &str = "mainnet";
 
         let move_toml = package_dir.join(SourcePackageLayout::Manifest.path());
         check_if_file_exists(move_toml.as_path(), prompt_options)?;


### PR DESCRIPTION
### Description
This should get rid of some confusion that people get into by using the `main` branch, by removing general usage of it.  We should only use predeployed versions for now until onchain dependencies are fully supported.

Additionally, this should prevent conflicts between deploying examples, and conflicts between packages that others may create.  We may want to also rename the address names, and the module names as well to prevent conflicts later.

### Test Plan
CI, will need to test each individually.
