### PR TITLE
[cli] Add update check once a day

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 ## [Unreleased]
 ### Fixed
 * If `aptos init` is run with a faucet URL specified (which happens by default when using the local, devnet, or testnet network options) and funding the account fails, the account creation is considered a failure and nothing is persisted. Previously it would report success despite the account not being created on chain.
+* Add check for updates once a day.  This will ensure to let people know when there is an update for the CLI.
 
 ## [1.0.8] - 2023/03/16
 ### Added

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -183,6 +183,12 @@ pub struct GlobalConfig {
     /// Prompt response type
     #[serde(default)]
     pub default_prompt_response: PromptResponseType,
+    /// Set to true to skip checking for updates
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skip_update_check: Option<bool>,
+    /// Last time updates were checked for
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_update_check_time: Option<u64>,
 }
 
 impl GlobalConfig {
@@ -222,7 +228,8 @@ impl GlobalConfig {
         }
     }
 
-    fn save(&self) -> CliTypedResult<()> {
+    /// Save the global config
+    pub fn save(&self) -> CliTypedResult<()> {
         let global_folder = global_folder()?;
         create_dir_if_not_exist(global_folder.as_path())?;
 

--- a/crates/aptos/src/main.rs
+++ b/crates/aptos/src/main.rs
@@ -54,7 +54,7 @@ pub async fn check_for_update() {
                 .await
                 {
                     if update_info.update_required {
-                        eprintln!("==UPDATE NOTICE==\n A new version of the Aptos CLI is out {}, please run `aptos update` to update\n", update_info.latest_version);
+                        eprintln!("== UPDATE NOTICE ==\nA new version of the Aptos CLI is out {}, please run `aptos update` to update\n", update_info.latest_version);
                     }
                 }
 

--- a/crates/aptos/src/main.rs
+++ b/crates/aptos/src/main.rs
@@ -9,17 +9,24 @@
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-use aptos::{move_tool, Tool};
+use aptos::{config, move_tool, update::helpers::check_if_update_required, Tool};
 use clap::Parser;
-use std::process::exit;
+use std::{
+    process::exit,
+    time::{Duration, SystemTime},
+};
+
+const ONE_DAY: Duration = Duration::from_secs(60 * 60 * 24);
 
 #[tokio::main]
 async fn main() {
+    // Check for updates
+    check_for_update().await;
+
     // Register hooks
     move_tool::register_package_hooks();
     // Run the corresponding tools
     let result = Tool::parse().execute().await;
-
     // At this point, we'll want to print and determine whether to exit for an error code
     match result {
         Ok(inner) => println!("{}", inner),
@@ -27,5 +34,34 @@ async fn main() {
             println!("{}", inner);
             exit(1);
         },
+    }
+}
+
+/// Check if there needs to be an update, ignoring errors so the CLI still works, updates aren't required
+pub async fn check_for_update() {
+    if let Ok(mut global_config) = config::GlobalConfig::load() {
+        // If this flag is set, skip the update check
+        if global_config.skip_update_check.unwrap_or(false) {
+            return;
+        }
+        let last_checked_time =
+            Duration::from_secs(global_config.last_update_check_time.unwrap_or(0));
+        if let Ok(now) = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+            if (now.saturating_sub(last_checked_time)) > ONE_DAY {
+                if let Ok(Ok(update_info)) = tokio::task::spawn_blocking(move || {
+                    check_if_update_required("aptos-labs", "aptos-core")
+                })
+                .await
+                {
+                    if update_info.update_required {
+                        eprintln!("==UPDATE NOTICE==\n A new version of the Aptos CLI is out {}, please run `aptos update` to update\n", update_info.latest_version);
+                    }
+                }
+
+                // We've checked so, we will update last update check_time
+                global_config.last_update_check_time = Some(now.as_secs());
+                let _ = global_config.save();
+            }
+        }
     }
 }

--- a/crates/aptos/src/update/mod.rs
+++ b/crates/aptos/src/update/mod.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-mod helpers;
+pub mod helpers;
 mod tool;
 
 use helpers::check_if_update_required;


### PR DESCRIPTION
### Description
This adds a check at the beginning of the CLI once a day that checks if there's an update.

This does unfortunately add extra loading time on the first run a day.  It can be disabled with a flag, but it probably needs to be documented better.

### Test Plan
I tested this by setting the local version to "1.0.6", and it checked accordingly.

```
./target/debug/aptos -h
==UPDATE NOTICE==
 A new version of the Aptos CLI is out 1.0.9, run `aptos update` to update

aptos 1.0.6
Aptos Labs <opensource@aptoslabs.com>
Command Line Interface (CLI) for developing and interacting with the Aptos blockchain

```