### PR TITLE
[docs] Look up email -> username map automatically

### DIFF
--- a/developer-docs-site/README.md
+++ b/developer-docs-site/README.md
@@ -99,12 +99,15 @@ Fix formatting issues by running:
 pnpm fmt
 ```
 
-## Re-generate contributors
+## Regenerating contributors
+The src/contributors.json file (which powers the list of Authors at the bottom of doc pages) needs to be manually generated.
 
-The src/contributors.json file (which powers the list of Authors at the bottom of doc pages) needs to be manually generated. Run the following command:
+In order to generate the contributor map you must authenticate with GitHub. The best way to do that is using GitHub CLI ([installation guide(https://github.com/cli/cli#installation)]). Once you have the GitHub CLI installed, you can run the following command to authenticate:
+```
+gh auth login --scopes read:user,user:email
+```
 
+Once that is done, you can generate the map with this command:
 ```
 pnpm contributors
 ```
-
-And then create a PR with the updated src/contributors.json.

--- a/developer-docs-site/package.json
+++ b/developer-docs-site/package.json
@@ -54,6 +54,8 @@
     "@docusaurus/module-type-aliases": "2.1.0",
     "@tsconfig/docusaurus": "1.0.6",
     "@types/node": "^18.11.9",
+    "command-exists": "^1.2.9",
+    "node-fetch": "^2.6.9",
     "prettier": "2.7.1",
     "typescript": "4.8.2",
     "webpack": "^5.74.0"

--- a/developer-docs-site/pnpm-lock.yaml
+++ b/developer-docs-site/pnpm-lock.yaml
@@ -19,8 +19,10 @@ specifiers:
   '@types/react': ^18.0.25
   buffer: ^6.0.3
   clsx: 1.2.1
+  command-exists: ^1.2.9
   hast-util-is-element: 1.1.0
   mkdirp: ^1.0.4
+  node-fetch: ^2.6.9
   path-to-regex: ^1.3.8
   prettier: 2.7.1
   prism-react-renderer: 1.2.1
@@ -49,7 +51,7 @@ dependencies:
   '@docusaurus/theme-common': 2.2.0_vwb7acela5jwz6tab56gfkhv7m
   '@docusaurus/types': 2.2.0_sfoxds7t5ydpegc3knd667wn6m
   '@mdx-js/react': 1.6.22_react@17.0.2
-  '@stoplight/elements': 7.7.4_7id2ld7otrrg3tr2tfabepoedi
+  '@stoplight/elements': 7.7.4_teljshmtnah3qfywcttd54pycq
   '@types/prop-types': 15.7.5
   '@types/react': 18.0.25
   buffer: 6.0.3
@@ -74,6 +76,8 @@ devDependencies:
   '@docusaurus/module-type-aliases': 2.1.0_sfoxds7t5ydpegc3knd667wn6m
   '@tsconfig/docusaurus': 1.0.6
   '@types/node': 18.11.9
+  command-exists: 1.2.9
+  node-fetch: 2.6.9
   prettier: 2.7.1
   typescript: 4.8.2
   webpack: 5.74.0
@@ -3431,7 +3435,7 @@ packages:
       webpack-sources: 3.2.3
     dev: false
 
-  /@stoplight/elements-core/7.7.4_7id2ld7otrrg3tr2tfabepoedi:
+  /@stoplight/elements-core/7.7.4_teljshmtnah3qfywcttd54pycq:
     resolution: {integrity: sha512-6Jr5wKLEzE4E/ut19Rohy0jc+7XswTIiih70qmuDNuMSyYoD0rc43B2m/dpYG6Hz9yuzAJRFCFrYm/wMAe0LzQ==}
     engines: {node: '>=14.13'}
     peerDependencies:
@@ -3441,7 +3445,7 @@ packages:
       '@stoplight/json': 3.20.1
       '@stoplight/json-schema-ref-parser': 9.2.2
       '@stoplight/json-schema-sampler': 0.2.2
-      '@stoplight/json-schema-viewer': 4.9.0_wr2bvqe2dst2ccbs7jvpixfusa
+      '@stoplight/json-schema-viewer': 4.9.0_l2hrl3ccsklbg4fm6zfi7xzvki
       '@stoplight/markdown-viewer': 5.5.1_bkghvto7wkjlzfiwpd6dc4h5xa
       '@stoplight/mosaic': 1.39.0_sfoxds7t5ydpegc3knd667wn6m
       '@stoplight/mosaic-code-editor': 1.39.0_sfoxds7t5ydpegc3knd667wn6m
@@ -3452,7 +3456,7 @@ packages:
       '@stoplight/yaml': 4.2.3
       classnames: 2.3.2
       httpsnippet: 2.0.0_mkdirp@1.0.4
-      jotai: 1.3.9_5sskk4kmcdrypng5czveb4tjzu
+      jotai: 1.3.9_25zasd7nezim5ffi22cvb7b3u4
       json-schema: 0.4.0
       lodash: 4.17.21
       nanoid: 3.3.4
@@ -3483,14 +3487,14 @@ packages:
       - xstate
     dev: false
 
-  /@stoplight/elements/7.7.4_7id2ld7otrrg3tr2tfabepoedi:
+  /@stoplight/elements/7.7.4_teljshmtnah3qfywcttd54pycq:
     resolution: {integrity: sha512-feEhqiEuz7PDcyh+0yO33bHC/SQWzxcy/KKZhYWWp4lndxWFkE97KrwPplqP60McEwyeDQMkDXlrlTvAEv8++Q==}
     engines: {node: '>=14.13'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@stoplight/elements-core': 7.7.4_7id2ld7otrrg3tr2tfabepoedi
+      '@stoplight/elements-core': 7.7.4_teljshmtnah3qfywcttd54pycq
       '@stoplight/http-spec': 5.5.2
       '@stoplight/json': 3.20.1
       '@stoplight/mosaic': 1.39.0_sfoxds7t5ydpegc3knd667wn6m
@@ -3591,7 +3595,7 @@ packages:
       magic-error: 0.0.1
     dev: false
 
-  /@stoplight/json-schema-viewer/4.9.0_wr2bvqe2dst2ccbs7jvpixfusa:
+  /@stoplight/json-schema-viewer/4.9.0_l2hrl3ccsklbg4fm6zfi7xzvki:
     resolution: {integrity: sha512-xuOt1FFeFxiy/bJrD0++9rjKY0NlaxH7y6jDZGCMGmH0y2vykpC2ZbHji+ol7/rB5TvVp7oE0NwlpK8TVizinw==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -3610,7 +3614,7 @@ packages:
       '@types/json-schema': 7.0.11
       classnames: 2.3.2
       fnv-plus: 1.3.1
-      jotai: 1.9.1_react@17.0.2
+      jotai: 1.9.1_7ennldyw5i24achwr433dtysxa
       lodash: 4.17.21
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -4422,8 +4426,10 @@ packages:
       indent-string: 4.0.0
     dev: false
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.11.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -5142,6 +5148,10 @@ packages:
   /comma-separated-tokens/2.0.2:
     resolution: {integrity: sha512-G5yTt3KQN4Yn7Yk4ed73hlZ1evrFKXeUW3086p3PRFNp7m2vIjI6Pg+Kgb+oyzhd9F2qdcoj67+y3SdxL5XWsg==}
     dev: false
+
+  /command-exists/1.2.9:
+    resolution: {integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==}
+    dev: true
 
   /commander/2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -7291,7 +7301,7 @@ packages:
   /isomorphic-fetch/3.0.0:
     resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
     dependencies:
-      node-fetch: 2.6.7
+      node-fetch: 2.6.9
       whatwg-fetch: 3.6.2
     transitivePeerDependencies:
       - encoding
@@ -7340,7 +7350,7 @@ packages:
       '@sideway/formula': 3.0.0
       '@sideway/pinpoint': 2.0.0
 
-  /jotai/1.3.9_5sskk4kmcdrypng5czveb4tjzu:
+  /jotai/1.3.9_25zasd7nezim5ffi22cvb7b3u4:
     resolution: {integrity: sha512-b6DvH9gf+7TfjaboCO54g+C0yhaakIaUBtjLf0dk1p15FWCzNw/93sezdXy9cCaZ8qcEdMLJcjBwQlORmIq29g==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
@@ -7374,11 +7384,12 @@ packages:
       xstate:
         optional: true
     dependencies:
+      '@babel/core': 7.12.9
       react: 17.0.2
       react-query: 3.39.2_sfoxds7t5ydpegc3knd667wn6m
     dev: false
 
-  /jotai/1.9.1_react@17.0.2:
+  /jotai/1.9.1_7ennldyw5i24achwr433dtysxa:
     resolution: {integrity: sha512-rDmmDL6owX4Kg5fAV0arjGVJmT1VYnkROwAx/PgpMkYCzvHEtABm8qnq/Ki5o5/GFGbvdfE11VNP1brDWP7+9w==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
@@ -7409,6 +7420,7 @@ packages:
       xstate:
         optional: true
     dependencies:
+      '@babel/core': 7.12.9
       react: 17.0.2
     dev: false
 
@@ -8156,6 +8168,17 @@ packages:
     dependencies:
       whatwg-url: 5.0.0
     dev: false
+
+  /node-fetch/2.6.9:
+    resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
 
   /node-forge/1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
@@ -9813,7 +9836,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       ajv-keywords: 5.1.0_ajv@8.11.0
     dev: false
 
@@ -10457,7 +10480,6 @@ packages:
 
   /tr46/0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: false
 
   /trim-trailing-lines/1.1.4:
     resolution: {integrity: sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==}
@@ -11012,7 +11034,6 @@ packages:
 
   /webidl-conversions/3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: false
 
   /webpack-bundle-analyzer/4.7.0:
     resolution: {integrity: sha512-j9b8ynpJS4K+zfO5GGwsAcQX4ZHpWV+yRiHDiL+bE0XHJ8NiPYLTNVQdlFYWxtpg9lfAQNlwJg16J9AJtFSXRg==}
@@ -11181,7 +11202,6 @@ packages:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    dev: false
 
   /which-typed-array/1.1.9:
     resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}

--- a/developer-docs-site/scripts/README.md
+++ b/developer-docs-site/scripts/README.md
@@ -8,3 +8,6 @@ pnpm spellcheck
 If you want to add a new word to the dictionary, you should add the word to `additional_dict.txt` and then run `sort -o additional_dict.txt additional_dict.txt`.
 
 Note that aspell, at least as it is configured now, does not support adding words with numbers in them, such as `MultiEd25519`. Instead you'd just want to add `MultiEd`.
+
+## Contributors
+See the top level README.

--- a/developer-docs-site/scripts/contributors.js
+++ b/developer-docs-site/scripts/contributors.js
@@ -1,45 +1,138 @@
 #!/usr/bin/env node
 
+const commandExists = require("command-exists");
 const fs = require("fs/promises");
 const path = require("path");
 const shell = require("shelljs");
+const fetch = require("node-fetch");
 
-// TODO: Generate this automatically.
-const EMAIL_TO_USERNAME = Object.freeze({
-  "raj@aptoslabs.com": "rajkaramchedu",
-  "isaac.wolinsky@gmail.com": "davidiw",
-  "sherryxiao.py@gmail.com": "sherry-x",
-  "kevin@aptoslabs.com": "movekevin",
-  "josh.lind@hotmail.com": "joshlind",
-  "bo@aptoslabs.com": "areshand",
-  "greg@gnazar.io": "gregnazario",
-  "christian@aptoslabs.com": "geekflyer",
-  "kent@aptoslabs.com": "kent-white",
-  "danielporteous1@gmail.com": "banool",
-  "jijunleng@gmail.com": "jjleng",
-  "msmouse@gmail.com": "msmouse",
-  "max@aptoslabs.com": "capcap",
-  "rustie117@gmail.com": "rustielin",
-  "z@chdenton.com": "zacharydenton",
-  "jacob@blient.com": "jacobadevore",
-  "davidmehi@google.com": "davidmehi",
-  "wgrieskamp@gmail.com": "wrwg",
+const PER_PAGE = 100;
+
+// This map contains contributor contributors that are not attributed to a GitHub
+// account. If you run `pnpm contributors` and notice that the username is `null`,
+// you might need to go find the contributor based on their email and ask what their
+// GitHub username is and add it to this map.
+const ADDITIONAL_EMAIL_TO_USERNAME = Object.freeze({
   "aching@calibra.com": "aching",
+  "bo@aptoslabs.com": "areshand",
+  "christian@aptoslabs.com": "geekflyer",
+  "jijunleng@gmail.com": "jjleng",
+  "josh.lind@hotmail.com": "joshlind",
+  "kent@aptoslabs.com": "kent-white",
+  "kevin@aptoslabs.com": "movekevin",
+  "max@aptoslabs.com": "capcap",
+  "msmouse@gmail.com": "msmouse",
+  "raj@aptoslabs.com": "rajkaramchedu",
+  "wgrieskamp@gmail.com": "wrwg",
 });
+
+// Fetch the token for using the GitHub GraphQL API. First try the environment (for CI)
+// and if that doesn't work, try to use the GH CLI (for local use).
+function getGitHubToken() {
+  const { GITHUB_TOKEN } = process.env;
+  if (GITHUB_TOKEN) {
+    console.log("Using token from the GITHUB_TOKEN environment variable");
+    return GITHUB_TOKEN;
+  }
+  // If no token was provided via the environment, try to use the GH CLI.
+  if (!commandExists.sync("gh")) {
+    throw new Error(
+      "The GITHUB_TOKEN environment variable is not set and the gh CLI is not installed, please read the README for instructions on how to fix this",
+    );
+  }
+  // Confirm that the GH auth token used for the CLI has the necessary scopes.
+  const status = shell.exec("gh auth status", { silent: true }).stderr;
+  if (status.includes("not logged in")) {
+    throw new Error("The GH CLI is not logged in, please run `gh auth login`");
+  }
+  if (!status.includes("read:user") || !status.includes("user:email")) {
+    // Initiate the flow to add the necessary scopes.
+    console.log("The GH CLI auth token does not have the necessary scopes. Refreshing token...");
+    shell.exec("gh auth refresh --scopes read:user,user:email --hostname github.com");
+  }
+  const ghToken = shell.exec("gh auth token", { silent: true }).stdout.trim();
+  return ghToken;
+}
+
+// Fetch the emails of all the contributors and look up their usernames. Note that it
+// is not possible to look up some usernames based on the contributor email, for example
+// because the contributor email no longer (or never did) map to a GitHub account, or
+// because the email they use for the GitHub contributions does not match the email on
+// their GitHub account. For those cases, we have a special additional mapping above.
+//
+// See here for where this code originally came from:
+// https://stackoverflow.com/questions/75868720/how-to-lookup-github-username-for-many-users-by-email
+async function fetchEmailToUsername() {
+  // Read contributor emails from the git log and store them in an array.
+  const out = shell.exec('git log --format="%ae" | sort -u', { silent: true });
+  const emailsUnfiltered = out.stdout.split("\n").filter(Boolean);
+
+  // Filter out emails ending with @users.noreply.github.com since the first part of
+  // that email is the username.
+  const emails = emailsUnfiltered.filter((email) => !email.endsWith("@users.noreply.github.com"));
+
+  // To use the GraphQL endpoint we need to provide an auth token.
+  const githubToken = getGitHubToken();
+
+  let emailUsernameMap = new Map();
+
+  // Break up the emails in page chunks since fetching them all at once causese
+  // the query to fail.
+  for (let page = 0; page < emails.length; page += PER_PAGE) {
+    const emailChunk = emails.slice(page, page + PER_PAGE);
+
+    // Build the GraphQL query string with one search query per email address in this
+    // chunk. See https://docs.github.com/en/graphql/reference/queries
+    let query = "query {";
+    for (const [idx, email] of emailChunk.entries()) {
+      query += ` query${idx}: search(query: "in:email ${email}", type: USER, first: 1) { nodes { ... on User { login email } } }`;
+    }
+    query += " }";
+
+    const fetchOptions = {
+      method: "POST",
+      headers: {
+        Authorization: `token ${githubToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query }),
+    };
+
+    const response = await fetch("https://api.github.com/graphql", fetchOptions);
+    const responseBody = await response.json();
+
+    // Parse the JSON response and append to the email => username map.
+    const nodes = Object.values(responseBody.data).flatMap((value) => value.nodes);
+
+    for (let i = 0; i < nodes.length; i++) {
+      const { email, login } = nodes[i];
+      if (!email) {
+        continue;
+      }
+      emailUsernameMap.set(email.toLowerCase(), login);
+    }
+
+    console.log(`Fetched ${page + emailChunk.length} usernames out of ${emails.length} emails`);
+  }
+
+  return emailUsernameMap;
+}
 
 const GITHUB_USERS_EMAIL_REGEX = /(\d+\+)?([^@]+)@users\.noreply\.github\.com/;
 
-const emailToUsername = (email) => {
+const lookupEmailToUsername = (email, emailToUsername) => {
   email = email.toLowerCase();
-  if (EMAIL_TO_USERNAME[email]) {
-    return EMAIL_TO_USERNAME[email];
+  if (ADDITIONAL_EMAIL_TO_USERNAME[email]) {
+    return ADDITIONAL_EMAIL_TO_USERNAME[email];
+  } else if (emailToUsername.has(email)) {
+    return emailToUsername.get(email);
   } else if (GITHUB_USERS_EMAIL_REGEX.test(email)) {
     return email.match(GITHUB_USERS_EMAIL_REGEX)[2];
   }
   return null;
 };
 
-const resolveContributors = (contributors) => {
+const resolveContributors = (contributors, emailToUsername) => {
   const result = [];
 
   // Group by email.
@@ -57,7 +150,7 @@ const resolveContributors = (contributors) => {
   for (const contributor of result.slice()) {
     if (names[contributor.name]) {
       if (names[contributor.name].username == null) {
-        names[contributor.name].username = emailToUsername(contributor.email);
+        names[contributor.name].username = lookupEmailToUsername(contributor.email, emailToUsername);
       }
       result.splice(result.indexOf(contributor), 1);
       continue;
@@ -68,7 +161,7 @@ const resolveContributors = (contributors) => {
   return result;
 };
 
-async function contributorsForFile(filePath) {
+async function contributorsForFile(filePath, emailToUsername) {
   const shortlog = shell.exec(`git shortlog -sne -- "${path.basename(filePath)}" < /dev/tty`, {
     cwd: path.dirname(filePath),
     silent: true,
@@ -85,11 +178,12 @@ async function contributorsForFile(filePath) {
       .map((line) => {
         line = line.trim();
         line = line.substring(line.indexOf("\t") + 1);
-        [name, email] = line.split(" <");
+        let [name, email] = line.split(" <");
         email = email.substring(0, email.length - 1);
-        const username = emailToUsername(email);
+        const username = lookupEmailToUsername(email, emailToUsername);
         return { name, email, username };
       }),
+    emailToUsername,
   );
 }
 
@@ -120,12 +214,15 @@ async function* docPaths(rootDir) {
 }
 
 (async function () {
+  const emailToUsername = await fetchEmailToUsername();
   const result = {};
   const docRoot = path.join(__dirname, "../docs");
   for await (const docPath of docPaths(docRoot)) {
     const url = await urlPath(docRoot, docPath);
-    result[url] = await contributorsForFile(docPath);
+    result[url] = await contributorsForFile(docPath, emailToUsername);
+    console.log("Determining contributors for", url);
   }
   const json = JSON.stringify(result, null, 2);
   await fs.writeFile(path.join(__dirname, "../src/contributors.json"), json);
+  console.log("Done!!");
 })();

--- a/developer-docs-site/src/contributors.json
+++ b/developer-docs-site/src/contributors.json
@@ -18,7 +18,7 @@
     {
       "name": "Junkil Park",
       "email": "jpark@aptoslabs.com",
-      "username": null
+      "username": "junkil-park"
     }
   ],
   "/aptos-white-paper/aptos-white-paper-index": [
@@ -136,6 +136,11 @@
       "username": null
     },
     {
+      "name": "Daniel Porteous (dport)",
+      "email": "danielporteous1@gmail.com",
+      "username": "banool"
+    },
+    {
       "name": "David Wolinsky",
       "email": "isaac.wolinsky@gmail.com",
       "username": "davidiw"
@@ -148,7 +153,7 @@
     {
       "name": "Jiege",
       "email": "stevekeol.x@gmail.com",
-      "username": null
+      "username": "stevekeol"
     },
     {
       "name": "Kevin",
@@ -178,7 +183,7 @@
     {
       "name": "铁哥",
       "email": "guotie.9@gmail.com",
-      "username": null
+      "username": "guotie"
     }
   ],
   "/cli-tools/build-from-brew": [
@@ -236,6 +241,11 @@
       "username": "clay-aptos"
     },
     {
+      "name": "0xhsy",
+      "email": "102006034+0xhsy@users.noreply.github.com",
+      "username": "0xhsy"
+    },
+    {
       "name": "Christian Sahar",
       "email": "125399153+saharct@users.noreply.github.com",
       "username": "saharct"
@@ -267,7 +277,7 @@
     {
       "name": "Eric Carlson",
       "email": "ecarls@gmail.com",
-      "username": null
+      "username": "ericjohncarlson"
     },
     {
       "name": "schultzie",
@@ -366,7 +376,7 @@
     {
       "name": "Neo",
       "email": "her_liu@qq.com",
-      "username": null
+      "username": "liuzemei"
     },
     {
       "name": "Raj Karamchedu",
@@ -405,7 +415,7 @@
     {
       "name": "Khac Vy",
       "email": "khacvy93@gmail.com",
-      "username": null
+      "username": "trankhacvy"
     },
     {
       "name": "Raj Karamchedu",
@@ -626,7 +636,7 @@
     {
       "name": "Jiege",
       "email": "stevekeol.x@gmail.com",
-      "username": null
+      "username": "stevekeol"
     },
     {
       "name": "Kevin",
@@ -722,6 +732,11 @@
       "name": "Angie Huang",
       "email": "123419931+angieyth@users.noreply.github.com",
       "username": "angieyth"
+    },
+    {
+      "name": "Christian Sahar",
+      "email": "125399153+saharct@users.noreply.github.com",
+      "username": "saharct"
     },
     {
       "name": "Clay Murphy",
@@ -849,12 +864,12 @@
     {
       "name": "Maksim Kurnikov",
       "email": "maxim.kurnikov@gmail.com",
-      "username": null
+      "username": "mkurnikov"
     },
     {
       "name": "Mason Hall",
       "email": "masonhall@gmail.com",
-      "username": null
+      "username": "fmhall"
     },
     {
       "name": "Sherry Xiao",
@@ -1028,7 +1043,7 @@
     {
       "name": "Junkil Park",
       "email": "jpark@aptoslabs.com",
-      "username": null
+      "username": "junkil-park"
     }
   ],
   "/guides/move-guides/book/abilities": [
@@ -1170,13 +1185,18 @@
       "name": "Clay Murphy",
       "email": "114445310+clay-aptos@users.noreply.github.com",
       "username": "clay-aptos"
+    },
+    {
+      "name": "Daniel Porteous (dport)",
+      "email": "danielporteous1@gmail.com",
+      "username": "banool"
     }
   ],
   "/guides/move-guides/book/package-upgrades": [
     {
       "name": "Junkil Park",
       "email": "jpark@aptoslabs.com",
-      "username": null
+      "username": "junkil-park"
     }
   ],
   "/guides/move-guides/book/packages": [
@@ -1302,7 +1322,7 @@
     {
       "name": "Junkil Park",
       "email": "jpark@aptoslabs.com",
-      "username": null
+      "username": "junkil-park"
     },
     {
       "name": "Kevin",
@@ -1351,7 +1371,7 @@
     {
       "name": "stephenLee",
       "email": "lxd.dlut@gmail.com",
-      "username": null
+      "username": "move-by-example"
     },
     {
       "name": "Christian Theilemann",
@@ -1376,7 +1396,7 @@
   ],
   "/guides/move-guides/move-scripts": [
     {
-      "name": "Daniel Porteous",
+      "name": "Daniel Porteous (dport)",
       "email": "danielporteous1@gmail.com",
       "username": "banool"
     }
@@ -1436,7 +1456,7 @@
     {
       "name": "Vivek",
       "email": "vivekascoder@gmail.com",
-      "username": null
+      "username": "vivekascoder"
     }
   ],
   "/guides/state-sync": [
@@ -1510,7 +1530,7 @@
     {
       "name": "mpoplavkov",
       "email": "mihail.poplavkov@gmail.com",
-      "username": null
+      "username": "mpoplavkov"
     },
     {
       "name": "traitmeta",
@@ -2051,7 +2071,7 @@
     {
       "name": "David Conroy",
       "email": "dconroy@gmail.com",
-      "username": null
+      "username": "dconroy"
     },
     {
       "name": "Raj Karamchedu",
@@ -2135,6 +2155,11 @@
       "name": "dorinbwr",
       "email": "98946433+dorinbwr@users.noreply.github.com",
       "username": "dorinbwr"
+    },
+    {
+      "name": "michelle-aptos",
+      "email": "120680608+michelle-aptos@users.noreply.github.com",
+      "username": "michelle-aptos"
     }
   ],
   "/nodes/validator-node/operator/index": [
@@ -2798,7 +2823,7 @@
     {
       "name": "Jacob Devore",
       "email": "jacob@blient.com",
-      "username": "jacobadevore"
+      "username": "JacobADevore"
     },
     {
       "name": "0xbe1",
@@ -2905,7 +2930,7 @@
     {
       "name": "Jacob Devore",
       "email": "jacob@blient.com",
-      "username": "jacobadevore"
+      "username": "JacobADevore"
     },
     {
       "name": "Maayan Savir",
@@ -3012,7 +3037,7 @@
     {
       "name": "铁哥",
       "email": "guotie.9@gmail.com",
-      "username": null
+      "username": "guotie"
     }
   ],
   "/tutorials/your-first-multisig": [
@@ -3071,7 +3096,7 @@
     {
       "name": "Jacob Devore",
       "email": "jacob@blient.com",
-      "username": "jacobadevore"
+      "username": "JacobADevore"
     },
     {
       "name": "Joshua Lind",
@@ -3150,7 +3175,7 @@
     {
       "name": "Junkil Park",
       "email": "jpark@aptoslabs.com",
-      "username": null
+      "username": "junkil-park"
     },
     {
       "name": "Wolfgang Grieskamp",
@@ -3237,7 +3262,7 @@
     {
       "name": "Junkil Park",
       "email": "jpark@aptoslabs.com",
-      "username": null
+      "username": "junkil-park"
     },
     {
       "name": "Kevin",


### PR DESCRIPTION
### Description
Previously to make contributors.js work we maintained a map of emails to usernames for cases where the contributor email couldn't be used to figure out the username (this is only possible if the email ends with @users.noreply.github.com). With this PR, in addition to this map (which is unfortunately still partially necessary due to reasons I explain the comments), we use the GitHub GraphQL API to lookup usernames based on the contributor emails.

As you can see, the hardcoded map has been pared down because some emails are returned by the GraphQL query. 

Thanks to this PR you can see in `src/contributors.js` that a lot of usernames that were previously null are now filled in.

### Test Plan
```
pnpm contributors
```
