### PR TITLE
[CLI] Improve error message when local testnet node fails to start

### DIFF
--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -1181,9 +1181,10 @@ impl CliCommand<()> for RunLocalTestnet {
             }
 
             if !started_successfully {
-                return Err(CliError::UnexpectedError(
-                    "Failed to startup local node before faucet".to_string(),
-                ));
+                return Err(CliError::UnexpectedError(format!(
+                    "Local node at {} did not start up before faucet",
+                    rest_url
+                )));
             }
 
             // Build the config for the faucet service.


### PR DESCRIPTION
### Description
Improving the error message to make it more obvious.

### Test Plan
```
cargo build
```