### PR TITLE
[scripts/docker] find latest validator-testing image and push remote

### DIFF
--- a/docker/experimental/docker-bake-rust-all.hcl
+++ b/docker/experimental/docker-bake-rust-all.hcl
@@ -24,6 +24,11 @@ variable "GCP_DOCKER_ARTIFACT_REPO" {}
 
 variable "AWS_ECR_ACCOUNT_NUM" {}
 
+variable "TARGET_REGISTRY" {
+  // must be "aws" | "remote" | "local", informs which docker tags are being generated
+  default = CI == "true" ? "remote" : "local"
+}
+
 variable "ecr_base" {
   default = "${AWS_ECR_ACCOUNT_NUM}.dkr.ecr.us-west-2.amazonaws.com/aptos"
 }
@@ -217,7 +222,7 @@ function "generate_cache_from" {
 
 function "generate_cache_to" {
   params = [target]
-  result = CI == "true" ? [
+  result = TARGET_REGISTRY == "remote" ? [
     "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-${IMAGE_TAG_PREFIX}${NORMALIZED_GIT_BRANCH_OR_PR}",
     "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-${IMAGE_TAG_PREFIX}${GIT_SHA}"
   ] : []
@@ -225,7 +230,7 @@ function "generate_cache_to" {
 
 function "generate_tags" {
   params = [target]
-  result = CI == "true" ? [
+  result = TARGET_REGISTRY == "remote" ? [
       "${GCP_DOCKER_ARTIFACT_REPO}/${target}:${IMAGE_TAG_PREFIX}${GIT_SHA}",
       "${GCP_DOCKER_ARTIFACT_REPO}/${target}:${IMAGE_TAG_PREFIX}${NORMALIZED_GIT_BRANCH_OR_PR}",
       "${ecr_base}/${target}:${IMAGE_TAG_PREFIX}${GIT_SHA}",

--- a/docker/experimental/docker-bake-rust-all.sh
+++ b/docker/experimental/docker-bake-rust-all.sh
@@ -45,11 +45,15 @@ else
   export IMAGE_TAG_PREFIX="${IMAGE_TAG_PREFIX}${profile_prefix}"
 fi
 
-BUILD_TARGET="${1:-forge-images}"
+BUILD_TARGET="${1:-all}"
+echo "Building target: ${BUILD_TARGET}"
+echo "To build only a specific target, run: docker/experimental/docker-bake-rust-all.sh <target>"
+echo "E.g. docker/experimental/docker-bake-rust-all.sh forge-images"
+
 if [ "$CI" == "true" ]; then
   TARGET_REGISTRY=remote docker buildx bake --progress=plain --file docker/experimental/docker-bake-rust-all.hcl --push $BUILD_TARGET
 else
-  TARGET_REGISTRY=local docker buildx bake --file docker/experimental/docker-bake-rust-all.hcl $BUILD_TARGET 
+  TARGET_REGISTRY=local docker buildx bake --file docker/experimental/docker-bake-rust-all.hcl $BUILD_TARGET
 fi
 
 echo "Build complete. Docker buildx cache usage:"


### PR DESCRIPTION
### Description

Update the image finding for continuous tests to search for `validator-testing` by default, which is used in the default build which only builds `forge-images`.

### Test Plan

Looks right based off of latest build and commit history:

```
$ python3 testsuite/find_latest_image.py --variant failpoints --variant performance                                                   
Finding latest aptos/validator-testing image with build variants: ['failpoints', 'performance']
With prefixes: ['failpoints_', 'performance_', '']
Found latest images: ['failpoints_6850dc44466f572a756b2ffac197db7befb12b87', 'performance_6850dc44466f572a756b2ffac197db7befb12b87', '6850dc44466f572a756b2ffac197db7befb12b87']
Exporting latest image as base GIT_SHA: 6850dc44466f572a756b2ffac197db7befb12b87
GITHUB_OUTPUT not set, not writing output. This may be an error with the action setup.
This may be an indication that you're running locally or the environment is not configured correctly
```

<!-- Please provide us with clear details for verifying that your changes work. -->
