### PR TITLE
[Indexer] Add delegator pool

### DIFF
--- a/crates/indexer/migrations/2023-04-02-032121_delegator_pools/down.sql
+++ b/crates/indexer/migrations/2023-04-02-032121_delegator_pools/down.sql
@@ -1,0 +1,6 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS delegated_staking_pools;
+DROP INDEX IF EXISTS dsp_oa_index;
+DROP INDEX IF EXISTS dsp_insat_index;
+ALTER TABLE current_staking_pool_voter
+DROP COLUMN IF EXISTS operator_address;

--- a/crates/indexer/migrations/2023-04-02-032121_delegator_pools/up.sql
+++ b/crates/indexer/migrations/2023-04-02-032121_delegator_pools/up.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+CREATE TABLE IF NOT EXISTS delegated_staking_pools (
+  staking_pool_address VARCHAR(66) UNIQUE PRIMARY KEY NOT NULL,
+  first_transaction_version BIGINT NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX dsp_insat_index ON delegated_staking_pools (inserted_at);
+ALTER TABLE current_staking_pool_voter
+ADD COLUMN IF NOT EXISTS operator_address VARCHAR(66) NOT NULL DEFAULT '';

--- a/crates/indexer/migrations/2023-04-02-032121_delegator_pools/up.sql
+++ b/crates/indexer/migrations/2023-04-02-032121_delegator_pools/up.sql
@@ -6,4 +6,4 @@ CREATE TABLE IF NOT EXISTS delegated_staking_pools (
 );
 CREATE INDEX dsp_insat_index ON delegated_staking_pools (inserted_at);
 ALTER TABLE current_staking_pool_voter
-ADD COLUMN IF NOT EXISTS operator_address VARCHAR(66) NOT NULL DEFAULT '';
+ADD COLUMN IF NOT EXISTS operator_address VARCHAR(66) NOT NULL;

--- a/crates/indexer/src/models/stake_models/delegator_pools.rs
+++ b/crates/indexer/src/models/stake_models/delegator_pools.rs
@@ -1,0 +1,60 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+
+use super::stake_utils::StakeResource;
+use crate::{schema::delegated_staking_pools, util::standardize_address};
+use aptos_api_types::{Transaction, WriteResource, WriteSetChange};
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+type StakingPoolAddress = String;
+pub type DelegatorPoolMap = HashMap<StakingPoolAddress, DelegatorPool>;
+
+// All pools
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(staking_pool_address))]
+#[diesel(table_name = delegated_staking_pools)]
+pub struct DelegatorPool {
+    pub staking_pool_address: String,
+    pub first_transaction_version: i64,
+}
+
+impl DelegatorPool {
+    pub fn from_transaction(transaction: &Transaction) -> anyhow::Result<DelegatorPoolMap> {
+        let mut delegator_pool_map = HashMap::new();
+        // Do a first pass to get the mapping of active_share table handles to staking pool addresses
+        if let Transaction::UserTransaction(user_txn) = transaction {
+            let txn_version = user_txn.info.version.0 as i64;
+            for wsc in &user_txn.info.changes {
+                if let WriteSetChange::WriteResource(write_resource) = wsc {
+                    let maybe_write_resource =
+                        Self::from_write_resource(write_resource, txn_version)?;
+                    if let Some(map) = maybe_write_resource {
+                        delegator_pool_map.insert(map.staking_pool_address.clone(), map);
+                    }
+                }
+            }
+        }
+        Ok(delegator_pool_map)
+    }
+
+    pub fn from_write_resource(
+        write_resource: &WriteResource,
+        txn_version: i64,
+    ) -> anyhow::Result<Option<Self>> {
+        if let Some(StakeResource::DelegationPool(_)) =
+            StakeResource::from_write_resource(write_resource, txn_version)?
+        {
+            let staking_pool_address = standardize_address(&write_resource.address.to_string());
+            return Ok(Some(Self {
+                staking_pool_address,
+                first_transaction_version: txn_version,
+            }));
+        }
+        Ok(None)
+    }
+}

--- a/crates/indexer/src/models/stake_models/mod.rs
+++ b/crates/indexer/src/models/stake_models/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod delegator_activities;
 pub mod delegator_balances;
+pub mod delegator_pools;
 pub mod proposal_votes;
 pub mod stake_utils;
 pub mod staking_pool_voter;

--- a/crates/indexer/src/models/stake_models/stake_utils.rs
+++ b/crates/indexer/src/models/stake_models/stake_utils.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StakePoolResource {
     pub delegated_voter: String,
+    pub operator_address: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/indexer/src/models/stake_models/staking_pool_voter.rs
+++ b/crates/indexer/src/models/stake_models/staking_pool_voter.rs
@@ -21,6 +21,7 @@ pub struct CurrentStakingPoolVoter {
     pub staking_pool_address: String,
     pub voter_address: String,
     pub last_transaction_version: i64,
+    pub operator_address: String,
 }
 
 impl CurrentStakingPoolVoter {
@@ -44,11 +45,13 @@ impl CurrentStakingPoolVoter {
                 {
                     let staking_pool_address =
                         standardize_address(&write_resource.address.to_string());
+                    let operator_address = standardize_address(&inner.operator_address);
                     let voter_address = standardize_address(&inner.delegated_voter);
                     staking_pool_voters.insert(staking_pool_address.clone(), Self {
                         staking_pool_address,
                         voter_address,
                         last_transaction_version: txn_version,
+                        operator_address,
                     });
                 }
             }

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -157,6 +157,7 @@ diesel::table! {
         voter_address -> Varchar,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
+        operator_address -> Varchar,
     }
 }
 
@@ -244,6 +245,14 @@ diesel::table! {
         pool_address -> Varchar,
         event_type -> Text,
         amount -> Numeric,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    delegated_staking_pools (staking_pool_address) {
+        staking_pool_address -> Varchar,
+        first_transaction_version -> Int8,
         inserted_at -> Timestamp,
     }
 }
@@ -547,6 +556,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     current_token_ownerships,
     current_token_pending_claims,
     delegated_staking_activities,
+    delegated_staking_pools,
     events,
     indexer_status,
     ledger_infos,


### PR DESCRIPTION
### Description
This is to get all delegated staking pools, even those that are empty. To get operator address, we'll take `delegated_staking_pools` and join to `current_staking_pool_voter`. 

### Test Plan
https://cloud.hasura.io/public/graphiql?endpoint=https%3A%2F%2Findexer-testnet.staging.gcp.aptosdev.com%2Fv1%2Fgraphql&query=query+DelegationPools+%7B%0A++delegated_staking_pools+%7B%0A++++staking_pool_address%0A++++current_staking_pool+%7B%0A++++++operator_address%0A++++%7D%0A++%7D%0A%7D%0A
<!-- Please provide us with clear details for verifying that your changes work. -->
