### PR TITLE
[QuorumStore] BatchStore tests / bugfix + refactors

### DIFF
--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -76,9 +76,6 @@ impl BlockStore {
         sync_info: &SyncInfo,
         mut retriever: BlockRetriever,
     ) -> anyhow::Result<()> {
-        // // update the logical time for quorum store during state sync
-        // self.data_manager.notify_commit(LogicalTime::new(sync_info.highest_commit_cert().ledger_info().ledger_info().epoch(), sync_info.highest_commit_cert().ledger_info().ledger_info().round()), Vec::new()).await;
-
         self.sync_to_highest_commit_cert(
             sync_info.highest_commit_cert().ledger_info(),
             &retriever.network,

--- a/consensus/src/quorum_store/batch_store.rs
+++ b/consensus/src/quorum_store/batch_store.rs
@@ -26,7 +26,6 @@ use dashmap::{
 };
 use fail::fail_point;
 use once_cell::sync::OnceCell;
-use serde::{Deserialize, Serialize};
 use std::{
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -36,27 +35,24 @@ use std::{
 };
 use tokio::sync::oneshot;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct PersistRequest {
-    pub digest: HashValue,
-    pub value: PersistedValue,
-}
-struct QuotaManager {
+// Pub(crate) for testing only.
+pub(crate) struct QuotaManager {
     memory_balance: usize,
     db_balance: usize,
     batch_balance: usize,
+    // Recording the provided quotas for asserts.
     memory_quota: usize,
     db_quota: usize,
     batch_quota: usize,
 }
 
 impl QuotaManager {
-    fn new(db_quota: usize, memory_quota: usize, batch_quota: usize) -> Self {
+    pub(crate) fn new(db_quota: usize, memory_quota: usize, batch_quota: usize) -> Self {
         assert!(db_quota >= memory_quota);
         Self {
-            memory_balance: 0,
-            db_balance: 0,
-            batch_balance: 0,
+            memory_balance: memory_quota,
+            db_balance: db_quota,
+            batch_balance: batch_quota,
             memory_quota,
             db_quota,
             batch_quota,
@@ -64,34 +60,48 @@ impl QuotaManager {
     }
 
     pub(crate) fn update_quota(&mut self, num_bytes: usize) -> anyhow::Result<StorageMode> {
-        if self.batch_balance + 1 > self.batch_quota {
+        if self.batch_balance == 0 {
             counters::EXCEEDED_BATCH_QUOTA_COUNT.inc();
             bail!("Batch quota exceeded ");
         }
 
-        if self.memory_balance + num_bytes <= self.memory_quota {
-            self.memory_balance += num_bytes;
-            self.db_balance += num_bytes;
-            self.batch_balance += 1;
-            Ok(StorageMode::MemoryAndPersisted)
-        } else if self.db_balance + num_bytes <= self.db_quota {
-            self.db_balance += num_bytes;
-            self.batch_balance += 1;
-            Ok(StorageMode::PersistedOnly)
+        if self.db_balance >= num_bytes {
+            self.batch_balance -= 1;
+            self.db_balance -= num_bytes;
+
+            if self.memory_balance >= num_bytes {
+                self.memory_balance -= num_bytes;
+                Ok(StorageMode::MemoryAndPersisted)
+            } else {
+                Ok(StorageMode::PersistedOnly)
+            }
         } else {
             counters::EXCEEDED_STORAGE_QUOTA_COUNT.inc();
             bail!("Storage quota exceeded ");
         }
     }
 
+    fn assert_quota(balance: usize, to_free: usize, quota: usize, kind: &str) {
+        assert!(
+            balance + to_free <= quota,
+            "Balance {} + to_free {} more than {} quota {}",
+            balance,
+            to_free,
+            kind,
+            quota,
+        );
+    }
+
     pub(crate) fn free_quota(&mut self, num_bytes: usize, storage_mode: StorageMode) {
-        self.db_balance -= num_bytes;
-        self.batch_balance -= 1;
-        match storage_mode {
-            StorageMode::PersistedOnly => {},
-            StorageMode::MemoryAndPersisted => {
-                self.memory_balance -= num_bytes;
-            },
+        Self::assert_quota(self.batch_balance, 1, self.batch_quota, "Batch");
+        self.batch_balance += 1;
+
+        Self::assert_quota(self.db_balance, num_bytes, self.db_quota, "DB");
+        self.db_balance += num_bytes;
+
+        if matches!(storage_mode, StorageMode::MemoryAndPersisted) {
+            Self::assert_quota(self.memory_balance, num_bytes, self.memory_quota, "Memory");
+            self.memory_balance += num_bytes;
         }
     }
 }
@@ -163,7 +173,7 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
                 expired_keys.push(digest);
             } else {
                 batch_store
-                    .insert_to_cache(digest, value)
+                    .insert_to_cache(value)
                     .expect("Storage limit exceeded upon BatchReader construction");
             }
         }
@@ -180,15 +190,12 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
         *self.epoch.get().unwrap()
     }
 
-    fn free_quota(&self, persisted_value: PersistedValue) {
+    fn free_quota(&self, value: PersistedValue) {
         let mut quota_manager = self
             .peer_quota
-            .get_mut(&persisted_value.author())
+            .get_mut(&value.author())
             .expect("No QuotaManager for batch author");
-        quota_manager.free_quota(
-            persisted_value.num_bytes() as usize,
-            persisted_value.payload_storage_mode(),
-        );
+        quota_manager.free_quota(value.num_bytes() as usize, value.payload_storage_mode());
     }
 
     // Inserts a PersistedValue into the in-memory db_cache. If an entry with a higher
@@ -199,11 +206,8 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
     // Note: holds db_cache entry lock (due to DashMap), while accessing peer_quota
     // DashMap. Hence, peer_quota reference should never be held while accessing the
     // db_cache to avoid the deadlock (if needed, order is db_cache, then peer_quota).
-    pub(crate) fn insert_to_cache(
-        &self,
-        digest: HashValue,
-        mut value: PersistedValue,
-    ) -> anyhow::Result<bool> {
+    pub(crate) fn insert_to_cache(&self, mut value: PersistedValue) -> anyhow::Result<bool> {
+        let digest = *value.digest();
         let author = value.author();
         let expiration_time = value.expiration();
 
@@ -255,7 +259,7 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
         Ok(true)
     }
 
-    pub(crate) fn save(&self, digest: HashValue, value: PersistedValue) -> anyhow::Result<bool> {
+    pub(crate) fn save(&self, value: PersistedValue) -> anyhow::Result<bool> {
         let last_certified_time = self.last_certified_time();
         if value.expiration() > last_certified_time {
             fail_point!("quorum_store::save", |_| {
@@ -266,7 +270,7 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
                 Duration::from_micros(value.expiration() - last_certified_time).as_secs_f64(),
             );
 
-            return self.insert_to_cache(digest, value);
+            return self.insert_to_cache(value);
         }
         counters::NUM_BATCH_EXPIRED_WHEN_SAVE.inc();
         bail!(
@@ -304,14 +308,14 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
         ret
     }
 
-    pub fn persist(&self, persist_request: PersistRequest) -> Option<SignedBatchInfo> {
-        match self.save(persist_request.digest, persist_request.value.clone()) {
+    pub fn persist(&self, persist_request: PersistedValue) -> Option<SignedBatchInfo> {
+        match self.save(persist_request.clone()) {
             Ok(needs_db) => {
-                let batch_info = persist_request.value.batch_info().clone();
-                trace!("QS: sign digest {}", persist_request.digest);
+                let batch_info = persist_request.batch_info().clone();
+                trace!("QS: sign digest {}", persist_request.digest());
                 if needs_db {
                     self.db
-                        .save_batch(persist_request.digest, persist_request.value)
+                        .save_batch(persist_request)
                         .expect("Could not write to DB");
                 }
                 SignedBatchInfo::new(batch_info, &self.validator_signer).ok()
@@ -352,7 +356,7 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
         counters::GET_BATCH_FROM_DB_COUNT.inc();
 
         match self.db.get_batch(digest) {
-            Ok(Some(persisted_value)) => Ok(persisted_value),
+            Ok(Some(value)) => Ok(value),
             Ok(None) | Err(_) => {
                 error!("Could not get batch from db");
                 Err(Error::CouldNotGetData)
@@ -360,7 +364,7 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchStore<T> {
         }
     }
 
-    pub fn get_batch_from_local(&self, digest: &HashValue) -> Result<PersistedValue, Error> {
+    pub(crate) fn get_batch_from_local(&self, digest: &HashValue) -> Result<PersistedValue, Error> {
         if let Some(value) = self.db_cache.get(digest) {
             if value.payload_storage_mode() == StorageMode::PersistedOnly {
                 self.get_batch_from_db(digest)

--- a/consensus/src/quorum_store/quorum_store_db.rs
+++ b/consensus/src/quorum_store/quorum_store_db.rs
@@ -20,7 +20,7 @@ pub(crate) trait QuorumStoreStorage: Sync + Send {
 
     fn get_all_batches(&self) -> Result<HashMap<HashValue, PersistedValue>>;
 
-    fn save_batch(&self, digest: HashValue, batch: PersistedValue) -> Result<(), DbError>;
+    fn save_batch(&self, batch: PersistedValue) -> Result<(), DbError>;
 
     fn get_batch(&self, digest: &HashValue) -> Result<Option<PersistedValue>, DbError>;
 
@@ -78,13 +78,13 @@ impl QuorumStoreStorage for QuorumStoreDB {
         iter.collect::<Result<HashMap<HashValue, PersistedValue>>>()
     }
 
-    fn save_batch(&self, digest: HashValue, batch: PersistedValue) -> Result<(), DbError> {
+    fn save_batch(&self, batch: PersistedValue) -> Result<(), DbError> {
         trace!(
             "QS: db persists digest {} expiration {:?}",
-            digest,
+            batch.digest(),
             batch.expiration()
         );
-        Ok(self.db.put::<BatchSchema>(&digest, &batch)?)
+        Ok(self.db.put::<BatchSchema>(batch.digest(), &batch)?)
     }
 
     fn get_batch(&self, digest: &HashValue) -> Result<Option<PersistedValue>, DbError> {
@@ -138,7 +138,7 @@ impl QuorumStoreStorage for MockQuorumStoreDB {
         Ok(HashMap::new())
     }
 
-    fn save_batch(&self, _: HashValue, _: PersistedValue) -> Result<(), DbError> {
+    fn save_batch(&self, _: PersistedValue) -> Result<(), DbError> {
         Ok(())
     }
 

--- a/consensus/src/quorum_store/tests/batch_store_test.rs
+++ b/consensus/src/quorum_store/tests/batch_store_test.rs
@@ -4,25 +4,31 @@
 use crate::{
     quorum_store::{
         batch_requester::BatchRequester,
-        batch_store::{BatchStore, PersistRequest},
+        batch_store::{BatchStore, QuotaManager},
         quorum_store_db::QuorumStoreDB,
-        types::{Batch, PersistedValue},
+        types::{PersistedValue, StorageMode},
     },
     test_utils::mock_quorum_store_sender::MockQuorumStoreSender,
 };
-use aptos_consensus_types::proof_of_store::BatchId;
+use aptos_consensus_types::proof_of_store::{BatchId, BatchInfo};
 use aptos_crypto::HashValue;
 use aptos_temppath::TempPath;
-use aptos_types::{account_address::AccountAddress, validator_verifier::random_validator_verifier};
-use claims::assert_ok_eq;
+use aptos_types::{
+    account_address::AccountAddress, transaction::SignedTransaction,
+    validator_verifier::random_validator_verifier,
+};
+use claims::{assert_err, assert_none, assert_ok, assert_ok_eq, assert_some};
 use futures::executor::block_on;
+use once_cell::sync::Lazy;
 use std::sync::{
-    atomic::{AtomicUsize, Ordering},
+    atomic::{AtomicBool, AtomicUsize, Ordering},
     Arc,
 };
 use tokio::{sync::mpsc::channel, task::spawn_blocking};
 
-fn batch_store_for_test_no_db(memory_quota: usize) -> Arc<BatchStore<MockQuorumStoreSender>> {
+static TEST_REQUEST_ACCOUNT: Lazy<AccountAddress> = Lazy::new(AccountAddress::random);
+
+fn batch_store_for_test(memory_quota: usize) -> Arc<BatchStore<MockQuorumStoreSender>> {
     let tmp_dir = TempPath::new();
     let db = Arc::new(QuorumStoreDB::new(&tmp_dir));
     let (tx, _rx) = channel(10);
@@ -42,54 +48,51 @@ fn batch_store_for_test_no_db(memory_quota: usize) -> Arc<BatchStore<MockQuorumS
         10, // last committed round
         db,
         memory_quota, // memory_quota
-        1000,         // db quota
-        1000,         //batch quota
+        2001,         // db quota
+        2001,         // batch quota
         requester,
         signers[0].clone(),
         validator_verifier,
     ))
 }
 
+fn request_for_test(
+    digest: &HashValue,
+    round: u64,
+    num_bytes: u64,
+    maybe_payload: Option<Vec<SignedTransaction>>,
+) -> PersistedValue {
+    PersistedValue::new(
+        BatchInfo::new(
+            *TEST_REQUEST_ACCOUNT, // make sure all request come from the same account
+            BatchId::new_for_test(1),
+            10,
+            round,
+            *digest,
+            10,
+            num_bytes,
+        ),
+        maybe_payload,
+    )
+}
+
 #[test]
 fn test_insert_expire() {
-    let batch_store = batch_store_for_test_no_db(30);
+    let batch_store = batch_store_for_test(30);
 
     let digest = HashValue::random();
-    let batch = Batch::new(
-        BatchId::new_for_test(1),
-        vec![],
-        10,
-        15,
-        AccountAddress::random(),
-    );
-    let persisted_request: PersistRequest = batch.into();
+
     assert_ok_eq!(
-        batch_store.insert_to_cache(digest, persisted_request.value),
+        batch_store.insert_to_cache(request_for_test(&digest, 15, 10, None)),
         true
     );
-    let batch = Batch::new(
-        BatchId::new_for_test(1),
-        vec![],
-        10,
-        30,
-        AccountAddress::random(),
-    );
-    let persisted_request: PersistRequest = batch.into();
     assert_ok_eq!(
-        batch_store.insert_to_cache(digest, persisted_request.value),
+        batch_store.insert_to_cache(request_for_test(&digest, 30, 10, None)),
         true
     );
-    let batch = Batch::new(
-        BatchId::new_for_test(1),
-        vec![],
-        10,
-        25,
-        AccountAddress::random(),
-    );
-    let persisted_request: PersistRequest = batch.into();
     assert_ok_eq!(
-        batch_store.insert_to_cache(digest, persisted_request.value),
-        false,
+        batch_store.insert_to_cache(request_for_test(&digest, 25, 10, None)),
+        false
     );
     let expired = batch_store.clear_expired_payload(27);
     assert!(expired.is_empty());
@@ -101,38 +104,20 @@ fn test_insert_expire() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_extend_expiration_vs_save() {
     let num_experiments = 2000;
-    let batch_store = batch_store_for_test_no_db(0);
+    let batch_store = batch_store_for_test(2001);
 
     let batch_store_clone1 = batch_store.clone();
     let batch_store_clone2 = batch_store.clone();
 
     let digests: Vec<HashValue> = (0..num_experiments).map(|_| HashValue::random()).collect();
-    let later_exp_values: Vec<(HashValue, PersistedValue)> = (0..num_experiments)
+    let later_exp_values: Vec<PersistedValue> = (0..num_experiments)
         .map(|i| {
             // Pre-insert some of them.
             if i % 2 == 0 {
-                let batch = Batch::new(
-                    BatchId::new_for_test(1),
-                    vec![],
-                    10,
-                    i as u64 + 30,
-                    AccountAddress::random(),
-                );
-                let persisted_request: PersistRequest = batch.into();
-                batch_store
-                    .save(digests[i], persisted_request.value)
-                    .unwrap();
+                assert_ok!(batch_store.save(request_for_test(&digests[i], i as u64 + 30, 1, None)));
             }
-            let batch = Batch::new(
-                BatchId::new_for_test(1),
-                vec![],
-                10,
-                i as u64 + 40,
-                AccountAddress::random(),
-            );
-            let persisted_request: PersistRequest = batch.into();
 
-            (digests[i], persisted_request.value)
+            request_for_test(&digests[i], i as u64 + 40, 1, None)
         })
         .collect();
 
@@ -141,9 +126,13 @@ async fn test_extend_expiration_vs_save() {
     let start_clone1 = start_flag.clone();
     let start_clone2 = start_flag.clone();
 
+    let save_error = Arc::new(AtomicBool::new(false));
+    let save_error_clone1 = save_error.clone();
+    let save_error_clone2 = save_error.clone();
+
     // Thread that extends expiration by saving.
     spawn_blocking(move || {
-        for (i, (digest, later_exp_value)) in later_exp_values.into_iter().enumerate() {
+        for (i, later_exp_value) in later_exp_values.into_iter().enumerate() {
             // Wait until both threads are ready for next experiment.
             loop {
                 let flag_val = start_clone1.load(Ordering::Acquire);
@@ -152,7 +141,11 @@ async fn test_extend_expiration_vs_save() {
                 }
             }
 
-            batch_store_clone1.save(digest, later_exp_value).unwrap();
+            if batch_store_clone1.save(later_exp_value).is_err() {
+                // Save in a separate flag and break so test doesn't hang.
+                save_error_clone1.store(true, Ordering::Release);
+                break;
+            }
             start_clone1.fetch_add(1, Ordering::Relaxed);
         }
     });
@@ -163,7 +156,10 @@ async fn test_extend_expiration_vs_save() {
             // Wait until both threads are ready for next experiment.
             loop {
                 let flag_val = start_clone2.load(Ordering::Acquire);
-                if flag_val == 3 * i + 1 || flag_val == 3 * i + 2 {
+                if flag_val == 3 * i + 1
+                    || flag_val == 3 * i + 2
+                    || save_error_clone2.load(Ordering::Acquire)
+                {
                     break;
                 }
             }
@@ -175,18 +171,12 @@ async fn test_extend_expiration_vs_save() {
 
     for (i, &digest) in digests.iter().enumerate().take(num_experiments) {
         // Set the conditions for experiment (both threads waiting).
-        while start_flag.load(Ordering::Acquire) % 3 != 0 {}
+        while start_flag.load(Ordering::Acquire) % 3 != 0 {
+            assert!(!save_error.load(Ordering::Acquire));
+        }
 
         if i % 2 == 1 {
-            let batch = Batch::new(
-                BatchId::new_for_test(1),
-                vec![],
-                10,
-                i as u64 + 30,
-                AccountAddress::random(),
-            );
-            let persisted_request: PersistRequest = batch.into();
-            batch_store.save(digest, persisted_request.value).unwrap();
+            assert_ok!(batch_store.save(request_for_test(&digest, i as u64 + 30, 1, None)));
         }
 
         // Unleash the threads.
@@ -203,8 +193,104 @@ async fn test_extend_expiration_vs_save() {
     }
 }
 
-// TODO: last certified round.
-// TODO: check correct digests are returned.
-// TODO: check grace period.
-// TODO: check quota (cache vs persisted).
-// TODO: check the channels.
+#[test]
+fn test_quota_manager() {
+    let mut qm = QuotaManager::new(20, 10, 7);
+    assert_ok_eq!(qm.update_quota(5), StorageMode::MemoryAndPersisted);
+    assert_ok_eq!(qm.update_quota(3), StorageMode::MemoryAndPersisted);
+    assert_ok_eq!(qm.update_quota(2), StorageMode::MemoryAndPersisted);
+    assert_ok_eq!(qm.update_quota(1), StorageMode::PersistedOnly);
+    assert_ok_eq!(qm.update_quota(2), StorageMode::PersistedOnly);
+    assert_ok_eq!(qm.update_quota(7), StorageMode::PersistedOnly);
+    // 6 batches, fully used quotas
+
+    // exceed storage quota.
+    assert_err!(qm.update_quota(2));
+
+    qm.free_quota(5, StorageMode::MemoryAndPersisted);
+    // 5 batches, available memory and db quota: 5
+
+    // exceed storage quota
+    assert_err!(qm.update_quota(6));
+    assert_ok_eq!(qm.update_quota(3), StorageMode::MemoryAndPersisted);
+
+    // exceed storage quota
+    assert_err!(qm.update_quota(3));
+    assert_ok_eq!(qm.update_quota(1), StorageMode::MemoryAndPersisted);
+    // 7 batches, available memory and DB quota: 1
+
+    // Exceed batch quota
+    assert_err!(qm.update_quota(1));
+
+    qm.free_quota(1, StorageMode::PersistedOnly);
+    // 6 batches, available memory quota: 1, available DB quota: 2
+
+    // exceed storage quota
+    assert_err!(qm.update_quota(3));
+    assert_ok_eq!(qm.update_quota(2), StorageMode::PersistedOnly);
+    // 7 batches, available memory quota: 1, available DB quota: 0
+
+    qm.free_quota(2, StorageMode::MemoryAndPersisted);
+    // 6 batches, available memory quota: 3, available DB quota: 2
+
+    // while there is available memory quota, DB quota isn't enough.
+    assert_err!(qm.update_quota(3));
+    assert_ok_eq!(qm.update_quota(2), StorageMode::MemoryAndPersisted);
+}
+
+#[test]
+fn test_get_local_batch() {
+    let store = batch_store_for_test(30);
+
+    let digest_1 = HashValue::random();
+    let request_1 = request_for_test(&digest_1, 50, 20, Some(vec![]));
+    // Should be stored in memory and DB.
+    assert_some!(store.persist(request_1));
+
+    block_on(store.update_certified_timestamp(40));
+
+    let digest_2 = HashValue::random();
+    assert!(digest_2 != digest_1);
+    // Expiration is before 40.
+    let request_2_expired = request_for_test(&digest_2, 30, 20, Some(vec![]));
+    assert_none!(store.persist(request_2_expired));
+    // Proper (in the future) expiration.
+    let request_2 = request_for_test(&digest_2, 55, 20, Some(vec![]));
+    // Should be stored in DB only
+    assert_some!(store.persist(request_2));
+
+    let digest_3 = HashValue::random();
+    assert!(digest_3 != digest_1);
+    assert!(digest_3 != digest_2);
+    let request_3 = request_for_test(&digest_3, 56, 1970, Some(vec![]));
+    // Out of quota - should not be stored
+    assert_none!(store.persist(request_3.clone()));
+
+    assert_ok!(store.get_batch_from_local(&digest_1));
+    assert_ok!(store.get_batch_from_local(&digest_2));
+    block_on(store.update_certified_timestamp(51));
+    // Expired value w. digest_1.
+    assert_err!(store.get_batch_from_local(&digest_1));
+    assert_ok!(store.get_batch_from_local(&digest_2));
+
+    // Value w. digest_3 was never persisted
+    assert_err!(store.get_batch_from_local(&digest_3));
+    // Since payload is cleared, we can now persist value w. digest_3
+    assert_some!(store.persist(request_3));
+    assert_ok!(store.get_batch_from_local(&digest_3));
+
+    block_on(store.update_certified_timestamp(52));
+    assert_ok!(store.get_batch_from_local(&digest_2));
+    assert_ok!(store.get_batch_from_local(&digest_3));
+
+    block_on(store.update_certified_timestamp(55));
+    // Expired value w. digest_2
+    assert_err!(store.get_batch_from_local(&digest_2));
+    assert_ok!(store.get_batch_from_local(&digest_3));
+
+    block_on(store.update_certified_timestamp(56));
+    // Expired value w. digest_3
+    assert_err!(store.get_batch_from_local(&digest_1));
+    assert_err!(store.get_batch_from_local(&digest_2));
+    assert_err!(store.get_batch_from_local(&digest_3));
+}

--- a/consensus/src/quorum_store/tests/quorum_store_db_test.rs
+++ b/consensus/src/quorum_store/tests/quorum_store_db_test.rs
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::quorum_store::{
-    batch_store::PersistRequest,
     quorum_store_db::{QuorumStoreDB, QuorumStoreStorage},
     tests::utils::create_vec_signed_transactions,
-    types::Batch,
+    types::{Batch, PersistedValue},
 };
 use aptos_consensus_types::proof_of_store::BatchId;
 use aptos_temppath::TempPath;
 use aptos_types::account_address::AccountAddress;
+use claims::assert_ok;
 
 #[test]
 fn test_db_for_data() {
@@ -18,44 +18,42 @@ fn test_db_for_data() {
 
     let source = AccountAddress::random();
     let signed_txns = create_vec_signed_transactions(100);
-    let persist_request_1: PersistRequest =
+    let persist_request_1: PersistedValue =
         Batch::new(BatchId::new_for_test(1), signed_txns, 1, 20, source).into();
-    let digest_1 = persist_request_1.digest;
-    let value_1 = persist_request_1.value;
-    assert!(db.save_batch(digest_1, value_1.clone()).is_ok());
+    let clone_1 = persist_request_1.clone();
+    assert!(db.save_batch(clone_1).is_ok());
 
     assert_eq!(
-        db.get_batch(&digest_1)
+        db.get_batch(persist_request_1.digest())
             .expect("could not read from db")
             .unwrap(),
-        value_1
+        persist_request_1
     );
 
     let signed_txns = create_vec_signed_transactions(200);
-    let persist_request_2: PersistRequest =
+    let persist_request_2: PersistedValue =
         Batch::new(BatchId::new_for_test(1), signed_txns, 1, 20, source).into();
-    let digest_2 = persist_request_2.digest;
-    let value_2 = persist_request_2.value;
-    assert!(db.save_batch(digest_2, value_2).is_ok());
+    let clone_2 = persist_request_2.clone();
+    assert_ok!(db.save_batch(clone_2));
 
     let signed_txns = create_vec_signed_transactions(300);
-    let persist_request_3: PersistRequest =
+    let persist_request_3: PersistedValue =
         Batch::new(BatchId::new_for_test(1), signed_txns, 1, 20, source).into();
-    let digest_3 = persist_request_3.digest;
-    let value_3 = persist_request_3.value;
-    assert!(db.save_batch(digest_3, value_3).is_ok());
+    let clone_3 = persist_request_3.clone();
+    assert_ok!(db.save_batch(clone_3));
 
-    let batches = vec![digest_3];
-    assert!(db.delete_batches(batches).is_ok());
+    let batches = vec![*persist_request_3.digest()];
+    assert_ok!(db.delete_batches(batches));
     assert_eq!(
-        db.get_batch(&digest_3).expect("could not read from db"),
+        db.get_batch(persist_request_3.digest())
+            .expect("could not read from db"),
         None
     );
 
     let all_batches = db.get_all_batches().expect("could not read from db");
     assert_eq!(all_batches.len(), 2);
-    assert!(all_batches.contains_key(&digest_1));
-    assert!(all_batches.contains_key(&digest_2));
+    assert!(all_batches.contains_key(persist_request_1.digest()));
+    assert!(all_batches.contains_key(persist_request_2.digest()));
 }
 
 #[test]
@@ -67,16 +65,16 @@ fn test_db_for_batch_id() {
         .clean_and_get_batch_id(0)
         .expect("could not read from db")
         .is_none());
-    assert!(db.save_batch_id(0, BatchId::new_for_test(0)).is_ok());
-    assert!(db.save_batch_id(0, BatchId::new_for_test(4)).is_ok());
+    assert_ok!(db.save_batch_id(0, BatchId::new_for_test(0)));
+    assert_ok!(db.save_batch_id(0, BatchId::new_for_test(4)));
     assert_eq!(
         db.clean_and_get_batch_id(0)
             .expect("could not read from db")
             .unwrap(),
         BatchId::new_for_test(4)
     );
-    assert!(db.save_batch_id(1, BatchId::new_for_test(1)).is_ok());
-    assert!(db.save_batch_id(2, BatchId::new_for_test(2)).is_ok());
+    assert_ok!(db.save_batch_id(1, BatchId::new_for_test(1)));
+    assert_ok!(db.save_batch_id(2, BatchId::new_for_test(2)));
     assert_eq!(
         db.clean_and_get_batch_id(2)
             .expect("could not read from db")


### PR DESCRIPTION
Tests for QuotaManager and BatchStore interfaces for persisting & querying. Uncovered and fixed bug in QuotaManager (DB quota could have been exceeded by memory quota if requests arrived and freed in particular order).

Some refactoring to interfaces, e.g. seems like there is no need to have digest duplicated in PersistedRequest when it is already in BatchInfo, at which point PersistedRequest just becomes a type alias. Seems like simplifies code.