### PR TITLE
[db-tool] do module-validation from backup-verify instead of replay-verify

### DIFF
--- a/.github/workflows/module-verify.yaml
+++ b/.github/workflows/module-verify.yaml
@@ -40,7 +40,7 @@ jobs:
       BACKUP_CONFIG_TEMPLATE_PATH: terraform/helm/fullnode/files/backup/s3-public.yaml
       # workflow config
       RUNS_ON: high-perf-docker-with-local-ssd
-      TIMEOUT_MINUTES: 10
+      TIMEOUT_MINUTES: 20
 
   verify-modules-mainnet:
     if: ${{ github.event_name == 'workflow_dispatch' && (inputs.CHAIN_NAME == 'mainnet' || inputs.CHAIN_NAME == 'all') }}
@@ -53,7 +53,7 @@ jobs:
       BACKUP_CONFIG_TEMPLATE_PATH: terraform/helm/fullnode/files/backup/s3-public.yaml
       # workflow config
       RUNS_ON: high-perf-docker-with-local-ssd
-      TIMEOUT_MINUTES: 720
+      TIMEOUT_MINUTES: 20
 
   test-verify-modules:
     if: ${{ github.event_name == 'pull_request' }}

--- a/storage/backup/backup-cli/src/coordinators/verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/verify.rs
@@ -27,6 +27,10 @@ pub struct VerifyCoordinator {
     metadata_cache_opt: MetadataCacheOpt,
     trusted_waypoints_opt: TrustedWaypointOpt,
     concurrent_downloads: usize,
+    start_version: Version,
+    end_version: Version,
+    state_snapshot_before_version: Version,
+    skip_epoch_endings: bool,
 }
 
 impl VerifyCoordinator {
@@ -35,12 +39,20 @@ impl VerifyCoordinator {
         metadata_cache_opt: MetadataCacheOpt,
         trusted_waypoints_opt: TrustedWaypointOpt,
         concurrent_downloads: usize,
+        start_version: Version,
+        end_version: Version,
+        state_snapshot_before_version: Version,
+        skip_epoch_endings: bool,
     ) -> Result<Self> {
         Ok(Self {
             storage,
             metadata_cache_opt,
             trusted_waypoints_opt,
             concurrent_downloads,
+            start_version,
+            end_version,
+            state_snapshot_before_version,
+            skip_epoch_endings,
         })
     }
 
@@ -71,8 +83,10 @@ impl VerifyCoordinator {
         )
         .await?;
         let ver_max = Version::max_value();
-        let state_snapshot = metadata_view.select_state_snapshot(ver_max)?;
-        let transactions = metadata_view.select_transaction_backups(0, ver_max)?;
+        let state_snapshot =
+            metadata_view.select_state_snapshot(self.state_snapshot_before_version)?;
+        let transactions =
+            metadata_view.select_transaction_backups(self.start_version, self.end_version)?;
         let epoch_endings = metadata_view.select_epoch_ending_backups(ver_max)?;
 
         let global_opt = GlobalRestoreOptions {
@@ -83,18 +97,22 @@ impl VerifyCoordinator {
             replay_concurrency_level: 0, // won't replay, doesn't matter
         };
 
-        let epoch_history = Arc::new(
-            EpochHistoryRestoreController::new(
-                epoch_endings
-                    .into_iter()
-                    .map(|backup| backup.manifest)
-                    .collect(),
-                global_opt.clone(),
-                self.storage.clone(),
-            )
-            .run()
-            .await?,
-        );
+        let epoch_history = if self.skip_epoch_endings {
+            None
+        } else {
+            Some(Arc::new(
+                EpochHistoryRestoreController::new(
+                    epoch_endings
+                        .into_iter()
+                        .map(|backup| backup.manifest)
+                        .collect(),
+                    global_opt.clone(),
+                    self.storage.clone(),
+                )
+                .run()
+                .await?,
+            ))
+        };
 
         if let Some(backup) = state_snapshot {
             StateSnapshotRestoreController::new(
@@ -105,7 +123,7 @@ impl VerifyCoordinator {
                 },
                 global_opt.clone(),
                 Arc::clone(&self.storage),
-                Some(Arc::clone(&epoch_history)),
+                epoch_history.clone(),
             )
             .run()
             .await?;
@@ -117,7 +135,7 @@ impl VerifyCoordinator {
             self.storage,
             txn_manifests,
             None, /* replay_from_version */
-            Some(epoch_history),
+            epoch_history,
             VerifyExecutionMode::NoVerify,
         )
         .run()

--- a/storage/backup/backup-cli/src/coordinators/verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/verify.rs
@@ -31,6 +31,7 @@ pub struct VerifyCoordinator {
     end_version: Version,
     state_snapshot_before_version: Version,
     skip_epoch_endings: bool,
+    validate_modules: bool,
 }
 
 impl VerifyCoordinator {
@@ -43,6 +44,7 @@ impl VerifyCoordinator {
         end_version: Version,
         state_snapshot_before_version: Version,
         skip_epoch_endings: bool,
+        validate_modules: bool,
     ) -> Result<Self> {
         Ok(Self {
             storage,
@@ -53,6 +55,7 @@ impl VerifyCoordinator {
             end_version,
             state_snapshot_before_version,
             skip_epoch_endings,
+            validate_modules,
         })
     }
 
@@ -115,11 +118,16 @@ impl VerifyCoordinator {
         };
 
         if let Some(backup) = state_snapshot {
+            info!(
+                epoch = backup.epoch,
+                version = backup.version,
+                "State snapshot selected for verification."
+            );
             StateSnapshotRestoreController::new(
                 StateSnapshotRestoreOpt {
                     manifest_handle: backup.manifest,
                     version: backup.version,
-                    validate_modules: false,
+                    validate_modules: self.validate_modules,
                 },
                 global_opt.clone(),
                 Arc::clone(&self.storage),

--- a/storage/db-tool/src/backup.rs
+++ b/storage/db-tool/src/backup.rs
@@ -152,6 +152,8 @@ pub struct VerifyOpt {
     state_snapshot_before_version: Option<Version>,
     #[clap(long, help = "Skip verifying epoch ending info.")]
     skip_epoch_endings: bool,
+    #[clap(long, help = "While verifying a snapshot, run module validation.")]
+    validate_modules: bool,
 }
 
 impl Command {
@@ -233,6 +235,7 @@ impl Command {
                     opt.end_version.unwrap_or(Version::MAX),
                     opt.state_snapshot_before_version.unwrap_or(Version::MAX),
                     opt.skip_epoch_endings,
+                    opt.validate_modules,
                 )?
                 .run()
                 .await?

--- a/storage/db-tool/src/lib.rs
+++ b/storage/db-tool/src/lib.rs
@@ -10,6 +10,7 @@ mod replay_verify;
 mod restore;
 #[cfg(test)]
 mod tests;
+mod utils;
 
 use anyhow::Result;
 use clap::Parser;

--- a/storage/db-tool/src/tests.rs
+++ b/storage/db-tool/src/tests.rs
@@ -70,6 +70,15 @@ fn test_various_cmd_parsing() {
         "--local-fs-dir",
         ".",
     ]);
+    run_cmd(&[
+        "aptos-db-tool",
+        "backup",
+        "verify",
+        "--local-fs-dir",
+        ".",
+        "--start-version",
+        "Max",
+    ]);
 }
 
 fn run_cmd(args: &[&str]) {

--- a/storage/db-tool/src/utils.rs
+++ b/storage/db-tool/src/utils.rs
@@ -1,0 +1,12 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+
+pub fn parse_maxable_u64(input: &str) -> Result<u64> {
+    if &input.to_lowercase() == "max" {
+        Ok(u64::MAX)
+    } else {
+        Ok(input.parse()?)
+    }
+}

--- a/testsuite/module_verify.py
+++ b/testsuite/module_verify.py
@@ -35,23 +35,18 @@ def main():
     else:
         print("[main process] skipping clearing backup artifacts")
 
-    LATEST_VERSION = query_backup_latest_version(BACKUP_CONFIG_TEMPLATE_PATH)
-
-    print(f"Latest version: {LATEST_VERSION}")
-
     # run verify-modules
     os.mkdir("local")
-    shutil.copytree("metadata-cache", "local/metadata-cache")
     subprocess.run(
         [
             "target/release/aptos-db-tool",
-            "replay-verify",
+            "backup",
+            "verify",
             "--validate-modules",
             "--concurrent-downloads=16",
-            "--replay-concurrency-level=4",
             "--metadata-cache-dir=./local/metadata-cache",
-            "--target-db-dir=./local/db",
-            f"--start-version={LATEST_VERSION}",
+            "--start-version=max",  # to disable transaction verification
+            "--skip-epoch-endings",
             "--command-adapter-config",
             f"{BACKUP_CONFIG_TEMPLATE_PATH}",
         ]


### PR DESCRIPTION
### Description

Avoids rebuilding the tree and writing to the DB, hence costs less / is faster.

### Test Plan

https://github.com/aptos-labs/aptos-core/actions/runs/4601955211/jobs/8130405414