### PR TITLE
[network] cleanup unused rate limiter

### DIFF
--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -12,10 +12,10 @@
 //! long as the latter is in its trusted peers set.
 use aptos_config::{
     config::{
-        DiscoveryMethod, NetworkConfig, Peer, PeerRole, PeerSet, RateLimitConfig, RoleType,
-        CONNECTION_BACKOFF_BASE, CONNECTIVITY_CHECK_INTERVAL_MS, MAX_CONCURRENT_NETWORK_REQS,
-        MAX_CONNECTION_DELAY_MS, MAX_FRAME_SIZE, MAX_FULLNODE_OUTBOUND_CONNECTIONS,
-        MAX_INBOUND_CONNECTIONS, NETWORK_CHANNEL_SIZE,
+        DiscoveryMethod, NetworkConfig, Peer, PeerRole, PeerSet, RoleType, CONNECTION_BACKOFF_BASE,
+        CONNECTIVITY_CHECK_INTERVAL_MS, MAX_CONCURRENT_NETWORK_REQS, MAX_CONNECTION_DELAY_MS,
+        MAX_FRAME_SIZE, MAX_FULLNODE_OUTBOUND_CONNECTIONS, MAX_INBOUND_CONNECTIONS,
+        NETWORK_CHANNEL_SIZE,
     },
     network_id::NetworkContext,
 };
@@ -87,8 +87,6 @@ impl NetworkBuilder {
         network_channel_size: usize,
         max_concurrent_network_reqs: usize,
         inbound_connection_limit: usize,
-        inbound_rate_limit_config: Option<RateLimitConfig>,
-        outbound_rate_limit_config: Option<RateLimitConfig>,
         tcp_buffer_cfg: TCPBufferCfg,
     ) -> Self {
         // A network cannot exist without a PeerManager
@@ -106,8 +104,6 @@ impl NetworkBuilder {
             max_message_size,
             enable_proxy_protocol,
             inbound_connection_limit,
-            inbound_rate_limit_config,
-            outbound_rate_limit_config,
             tcp_buffer_cfg,
         );
 
@@ -148,8 +144,6 @@ impl NetworkBuilder {
             NETWORK_CHANNEL_SIZE,
             MAX_CONCURRENT_NETWORK_REQS,
             MAX_INBOUND_CONNECTIONS,
-            None,
-            None,
             TCPBufferCfg::default(),
         );
 
@@ -201,8 +195,6 @@ impl NetworkBuilder {
             config.network_channel_size,
             config.max_concurrent_network_reqs,
             config.max_inbound_connections,
-            config.inbound_rate_limit_config,
-            config.outbound_rate_limit_config,
             TCPBufferCfg::new_configs(
                 config.inbound_rx_buffer_size_bytes,
                 config.inbound_tx_buffer_size_bytes,

--- a/network/src/peer/fuzzing.rs
+++ b/network/src/peer/fuzzing.rs
@@ -29,7 +29,7 @@ pub fn generate_corpus(gen: &mut ValueGenerator) -> Vec<u8> {
     let network_msgs = gen.generate(vec(any::<MultiplexMessage>(), 1..20));
 
     let (write_socket, mut read_socket) = MemorySocket::new_pair();
-    let mut writer = MultiplexMessageSink::new(write_socket, constants::MAX_FRAME_SIZE, None);
+    let mut writer = MultiplexMessageSink::new(write_socket, constants::MAX_FRAME_SIZE);
 
     // Write the `MultiplexMessage`s to a fake socket
     let f_send = async move {
@@ -108,8 +108,6 @@ pub fn fuzz(data: &[u8]) {
         constants::MAX_CONCURRENT_OUTBOUND_RPCS,
         constants::MAX_FRAME_SIZE,
         constants::MAX_MESSAGE_SIZE,
-        None,
-        None,
     );
     executor.spawn(peer.start());
 

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -90,8 +90,6 @@ fn build_test_peer(
         MAX_CONCURRENT_OUTBOUND_RPCS,
         MAX_FRAME_SIZE,
         MAX_MESSAGE_SIZE,
-        None,
-        None,
     );
     let peer_handle = PeerHandle(peer_reqs_tx);
 
@@ -149,8 +147,8 @@ fn build_network_sink_stream(
     MultiplexMessageStream<impl AsyncRead + '_>,
 ) {
     let (read_half, write_half) = tokio::io::split(connection.compat());
-    let sink = MultiplexMessageSink::new(write_half.compat_write(), MAX_FRAME_SIZE, None);
-    let stream = MultiplexMessageStream::new(read_half.compat(), MAX_FRAME_SIZE, None);
+    let sink = MultiplexMessageSink::new(write_half.compat_write(), MAX_FRAME_SIZE);
+    let stream = MultiplexMessageStream::new(read_half.compat(), MAX_FRAME_SIZE);
     (sink, stream)
 }
 
@@ -263,7 +261,7 @@ fn peer_recv_message() {
     });
 
     let client = async move {
-        let mut connection = MultiplexMessageSink::new(connection, MAX_FRAME_SIZE, None);
+        let mut connection = MultiplexMessageSink::new(connection, MAX_FRAME_SIZE);
         for _ in 0..30 {
             // The client should then send the network message.
             connection.send(&send_msg).await.unwrap();

--- a/network/src/protocols/wire/messaging/v1/mod.rs
+++ b/network/src/protocols/wire/messaging/v1/mod.rs
@@ -11,7 +11,6 @@
 //! over-the-wire.
 
 use crate::protocols::{stream::StreamMessage, wire::handshake::v1::ProtocolId};
-use aptos_rate_limiter::{async_lib::AsyncRateLimiter, rate_limit::SharedBucket};
 use bytes::Bytes;
 use futures::{
     io::{AsyncRead, AsyncWrite},
@@ -178,14 +177,13 @@ pub fn network_message_frame_codec(max_frame_size: usize) -> LengthDelimitedCode
 #[pin_project]
 pub struct MultiplexMessageStream<TReadSocket: AsyncRead + Unpin> {
     #[pin]
-    framed_read: FramedRead<Compat<AsyncRateLimiter<TReadSocket>>, LengthDelimitedCodec>,
+    framed_read: FramedRead<Compat<TReadSocket>, LengthDelimitedCodec>,
 }
 
 impl<TReadSocket: AsyncRead + Unpin> MultiplexMessageStream<TReadSocket> {
-    pub fn new(socket: TReadSocket, max_frame_size: usize, bucket: Option<SharedBucket>) -> Self {
+    pub fn new(socket: TReadSocket, max_frame_size: usize) -> Self {
         let frame_codec = network_message_frame_codec(max_frame_size);
-        let rate_limited_socket = AsyncRateLimiter::new(socket, bucket);
-        let compat_socket = rate_limited_socket.compat();
+        let compat_socket = socket.compat();
         let framed_read = FramedRead::new(compat_socket, frame_codec);
         Self { framed_read }
     }
@@ -224,14 +222,13 @@ impl<TReadSocket: AsyncRead + Unpin> Stream for MultiplexMessageStream<TReadSock
 #[pin_project]
 pub struct MultiplexMessageSink<TWriteSocket: AsyncWrite> {
     #[pin]
-    framed_write: FramedWrite<Compat<AsyncRateLimiter<TWriteSocket>>, LengthDelimitedCodec>,
+    framed_write: FramedWrite<Compat<TWriteSocket>, LengthDelimitedCodec>,
 }
 
 impl<TWriteSocket: AsyncWrite> MultiplexMessageSink<TWriteSocket> {
-    pub fn new(socket: TWriteSocket, max_frame_size: usize, bucket: Option<SharedBucket>) -> Self {
+    pub fn new(socket: TWriteSocket, max_frame_size: usize) -> Self {
         let frame_codec = network_message_frame_codec(max_frame_size);
-        let rate_limited_socket = AsyncRateLimiter::new(socket, bucket);
-        let compat_socket = rate_limited_socket.compat_write();
+        let compat_socket = socket.compat_write();
         let framed_write = FramedWrite::new(compat_socket, frame_codec);
         Self { framed_write }
     }

--- a/network/src/protocols/wire/messaging/v1/test.rs
+++ b/network/src/protocols/wire/messaging/v1/test.rs
@@ -97,7 +97,7 @@ fn aptosnet_wire_test_vectors() {
     // test reading and deserializing gives us the expected message
 
     let socket_rx = ReadOnlyTestSocket::new(&message_bytes);
-    let message_rx = MultiplexMessageStream::new(socket_rx, 128, None);
+    let message_rx = MultiplexMessageStream::new(socket_rx, 128);
 
     let recv_messages = block_on(message_rx.collect::<Vec<_>>());
     let recv_messages = recv_messages
@@ -112,7 +112,7 @@ fn aptosnet_wire_test_vectors() {
     let mut write_buf = Vec::new();
     socket_tx.save_writing(&mut write_buf);
 
-    let mut message_tx = MultiplexMessageSink::new(socket_tx, 128, None);
+    let mut message_tx = MultiplexMessageSink::new(socket_tx, 128);
     block_on(message_tx.send(&message)).unwrap();
 
     assert_eq!(&write_buf, &message_bytes);
@@ -121,7 +121,7 @@ fn aptosnet_wire_test_vectors() {
 #[test]
 fn send_fails_when_larger_than_frame_limit() {
     let (memsocket_tx, _memsocket_rx) = MemorySocket::new_pair();
-    let mut message_tx = MultiplexMessageSink::new(memsocket_tx, 64, None);
+    let mut message_tx = MultiplexMessageSink::new(memsocket_tx, 64);
 
     // attempting to send an outbound message larger than your frame size will
     // return an Err
@@ -137,9 +137,9 @@ fn send_fails_when_larger_than_frame_limit() {
 fn recv_fails_when_larger_than_frame_limit() {
     let (memsocket_tx, memsocket_rx) = MemorySocket::new_pair();
     // sender won't error b/c their max frame size is larger
-    let mut message_tx = MultiplexMessageSink::new(memsocket_tx, 128, None);
+    let mut message_tx = MultiplexMessageSink::new(memsocket_tx, 128);
     // receiver will reject the message b/c the frame size is > 64 bytes max
-    let mut message_rx = MultiplexMessageStream::new(memsocket_rx, 64, None);
+    let mut message_rx = MultiplexMessageStream::new(memsocket_rx, 64);
 
     let message = MultiplexMessage::Message(NetworkMessage::DirectSendMsg(DirectSendMsg {
         protocol_id: ProtocolId::ConsensusRpcBcs,
@@ -233,8 +233,8 @@ proptest! {
             socket_tx.set_fragmented_write();
         }
 
-        let mut message_tx = MultiplexMessageSink::new(socket_tx, 128, None);
-        let message_rx = MultiplexMessageStream::new(socket_rx, 128, None);
+        let mut message_tx = MultiplexMessageSink::new(socket_tx, 128);
+        let message_rx = MultiplexMessageStream::new(socket_rx, 128);
         let (stream_tx, stream_rx) = aptos_channels::new_test(1024);
         let (mut msg_tx, msg_rx) = aptos_channels::new_test(1024);
         let mut outbound_stream = OutboundStream::new(128, 64 * 255, stream_tx);


### PR DESCRIPTION
Rate limiter is set to open, so essentially a no-op, but it relies on IpAddr for bucketing which means all the dns addr falls under the same bucket and would contend for the same mutex. This commit removes it from the stack.

