### PR TITLE
[CLI] Update load_account_arg to pull  account address directly if exist

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -994,6 +994,11 @@ pub fn load_account_arg(str: &str) -> Result<AccountAddress, CliError> {
         })
     } else if let Ok(account_address) = AccountAddress::from_str(str) {
         Ok(account_address)
+    } else if let Some(Some(account_address)) =
+        CliConfig::load_profile(Some(str), ConfigSearchMode::CurrentDirAndParents)?
+            .map(|p| p.account)
+    {
+        Ok(account_address)
     } else if let Some(Some(private_key)) =
         CliConfig::load_profile(Some(str), ConfigSearchMode::CurrentDirAndParents)?
             .map(|p| p.private_key)


### PR DESCRIPTION
### Description
We should be pulling the account address directly from the profile specified if exist. Instead of derive the account_address from private key

For more detail of the issue, please refer to issue #6666 

resolve #6666 

### Test Plan
Tested locally to make sure it works even with key rotated. (Followed the same instruction from the issue described, and make sure publish successfully)

```
aptos-debug move publish --named-addresses TestCoinType=default2 --profile default2
Compiling, may take a little while to download git dependencies...
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING module_test
package size 970 bytes
Do you want to submit a transaction for a range of [17400 - 26100] Octas at a gas unit price of 100 Octas? [yes/no] >
yes
{
  "Result": {
    "transaction_hash": "0x4231bd0efaae519fa36c65e5e54ecac701e33c14ebfb8832ce6f0b1eede3e725",
    "gas_used": 174,
    "gas_unit_price": 100,
    "sender": "d53a65d05c8ca1160920573c54bb4ebaf06be19d6fcb540c5374a62003e65d79",
    "sequence_number": 4,
    "success": true,
    "timestamp_us": 1680592034050222,
    "version": 2828866,
    "vm_status": "Executed successfully"
  }
}
```

Double checked from the explore, and make sure transaction succeed on devnet - https://explorer.aptoslabs.com/txn/2828866/userTxnOverview 