### PR TITLE
[CLI] Fix e2e tests following change to `--skip-faucet`

### DIFF
--- a/crates/aptos/e2e/cases/init.py
+++ b/crates/aptos/e2e/cases/init.py
@@ -10,10 +10,13 @@ from test_results import test_case
 
 @test_case
 def test_init(run_helper: RunHelper, test_name=None):
-    # Init the CLI, which creates an account.
+    # Inititalize a profile for the CLI to use. Note that we do not set the
+    # --skip-faucet flag. This means that in addition to creating a profile locally,
+    # it will use the faucet to create the account on chain. This will fund the
+    # account with the default amount of 100000000 OCTA.
     run_helper.run_command(
         test_name,
-        ["aptos", "init", "--assume-yes", "--network", "local", "--skip-faucet"],
+        ["aptos", "init", "--assume-yes", "--network", "local"],
         input="\n",
     )
 

--- a/crates/aptos/e2e/common.py
+++ b/crates/aptos/e2e/common.py
@@ -26,6 +26,9 @@ class AccountInfo:
     account_address: str
 
 
+# This is an account that use for testing, for example to create it with the init
+# account, send funds to it, etc. This is not the account created by the `aptos init`
+# test. To get details about that account use get_account_info on the RunHelper.
 OTHER_ACCOUNT_ONE = AccountInfo(
     private_key="0x37368b46ce665362562c6d1d4ec01a08c8644c488690df5a17e13ba163e20221",
     public_key="0x25caf00522e4d4664ec0a27166a69e8a32b5078959d0fc398da70d40d2893e8f",
@@ -35,13 +38,6 @@ OTHER_ACCOUNT_ONE = AccountInfo(
 
 def build_image_name(image_repo_with_project: str, tag: str):
     return f"{image_repo_with_project}/tools:{tag}"
-
-
-def recursive_chmod(path, perms):
-    for dirpath, _, filenames in os.walk(path):
-        os.chmod(dirpath, perms)
-        for filename in filenames:
-            os.chmod(os.path.join(dirpath, filename), perms)
 
 
 # Exception to use when a test fails, for the CLI did something unexpected, an

--- a/crates/aptos/e2e/test_helpers.py
+++ b/crates/aptos/e2e/test_helpers.py
@@ -38,7 +38,7 @@ class RunHelper:
         self.host_working_directory = host_working_directory
         self.image_repo_with_project = image_repo_with_project
         self.image_tag = image_tag
-        self.cli_path = cli_path
+        self.cli_path = os.path.abspath(cli_path)
         self.test_count = 0
         self.api_client = RestClient(f"http://127.0.0.1:8080/v1")
 


### PR DESCRIPTION
### Description
In the tests we were using the `--skip-faucet` flag, which until https://github.com/aptos-labs/aptos-core/pull/7509 did not actually skip the faucet for a local network. Now that it works as intended, using it in these CLI tests is wrong.

Note: Even with this change, the tests are only fully correct if this PR also lands: https://github.com/aptos-labs/aptos-core/pull/7562.

### Test Plan
First, make sure this PR is stacked on top of https://github.com/aptos-labs/aptos-core/pull/7562.

Build a CLI:
```
cargo build -p aptos
```

Run the e2e tests using that CLI:
```
DOCKER_DEFAULT_PLATFORM=linux/amd64 poetry run python main.py --image-repo-with-project us-west1-docker.pkg.dev/aptos-global/aptos-internal --base-network devnet --test-cli-path ../../../target/debug/aptos
```

See that they all pass now:
```
2023-04-04 12:18:50,149 - INFO - Running aptos CLI local testnet from image: us-west1-docker.pkg.dev/aptos-global/aptos-internal/tools:devnet
2023-04-04 12:19:07,590 - INFO - Running test: test_init
2023-04-04 12:19:09,372 - INFO - Running test: test_account_fund_with_faucet
2023-04-04 12:19:11,159 - INFO - Running test: test_account_create
2023-04-04 12:19:13,104 - INFO - Stopping container: aptos-tools-devnet
2023-04-04 12:19:13,321 - INFO - Stopped container: aptos-tools-devnet
2023-04-04 12:19:13,321 - INFO - These tests passed:
2023-04-04 12:19:13,321 - INFO - test_init
2023-04-04 12:19:13,321 - INFO - test_account_fund_with_faucet
2023-04-04 12:19:13,321 - INFO - test_account_create
2023-04-04 12:19:13,321 - INFO - All tests passed!
```