### PR TITLE
[CLI] Wait for the funding transactions in aptos init

### DIFF
--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -4,14 +4,13 @@
 use crate::{
     account::create::DEFAULT_FUNDED_COINS,
     common::{
-        types::{CliCommand, CliError, CliTypedResult, FaucetOptions, ProfileOptions, RestOptions},
-        utils::fund_account,
+        types::{CliCommand, CliTypedResult, FaucetOptions, ProfileOptions, RestOptions},
+        utils::{fund_account, wait_for_transactions},
     },
 };
 use aptos_types::account_address::AccountAddress;
 use async_trait::async_trait;
 use clap::Parser;
-use std::time::{Duration, SystemTime};
 
 /// Fund an account with tokens from a faucet
 ///
@@ -53,22 +52,8 @@ impl CliCommand<String> for FundWithFaucet {
             self.account,
         )
         .await?;
-        let sys_time = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .map_err(|e| CliError::UnexpectedError(e.to_string()))?
-            .as_secs()
-            + 30;
         let client = self.rest_options.client(&self.profile_options)?;
-        for hash in hashes {
-            client
-                .wait_for_transaction_by_hash(
-                    hash.into(),
-                    sys_time,
-                    Some(Duration::from_secs(60)),
-                    None,
-                )
-                .await?;
-        }
+        wait_for_transactions(&client, hashes).await?;
         return Ok(format!(
             "Added {} Octas to account {}",
             self.amount, self.account

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -7,7 +7,7 @@ use crate::common::{
         ConfigSearchMode, EncodingOptions, PrivateKeyInputOptions, ProfileConfig, ProfileOptions,
         PromptOptions, RngArgs, DEFAULT_PROFILE,
     },
-    utils::{fund_account, prompt_yes_with_override, read_line},
+    utils::{fund_account, prompt_yes_with_override, read_line, wait_for_transactions},
 };
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, ValidCryptoMaterialStringExt};
 use aptos_rest_client::{
@@ -211,13 +211,14 @@ impl CliCommand<()> for InitTool {
                     "Account {} doesn't exist, creating it and funding it with {} Octas",
                     address, NUM_DEFAULT_OCTAS
                 );
-                fund_account(
+                let hashes = fund_account(
                     Url::parse(faucet_url)
                         .map_err(|err| CliError::UnableToParse("rest_url", err.to_string()))?,
                     NUM_DEFAULT_OCTAS,
                     address,
                 )
                 .await?;
+                wait_for_transactions(&client, hashes).await?;
                 eprintln!("Account {} funded successfully", address);
             }
         } else if account_exists {

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -24,7 +24,7 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
     str::FromStr,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime},
 };
 
 /// Prompts for confirmation until a yes or no is given explicitly
@@ -370,6 +370,29 @@ pub async fn fund_account(
             response.status()
         )))
     }
+}
+
+/// Wait for transactions, returning an error if any of them fail.
+pub async fn wait_for_transactions(
+    client: &aptos_rest_client::Client,
+    hashes: Vec<HashValue>,
+) -> CliTypedResult<()> {
+    let sys_time = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_err(|e| CliError::UnexpectedError(e.to_string()))?
+        .as_secs()
+        + 30;
+    for hash in hashes {
+        client
+            .wait_for_transaction_by_hash(
+                hash.into(),
+                sys_time,
+                Some(Duration::from_secs(60)),
+                None,
+            )
+            .await?;
+    }
+    Ok(())
 }
 
 pub fn start_logger() {


### PR DESCRIPTION
### Description
Previously `aptos init` would say the account was funded successfully without actually waiting for and checking the success of the transactions. This PR makes it wait and check.

### Test Plan
See https://github.com/aptos-labs/aptos-core/pull/7561.
