### PR TITLE
[CLI] Add multisig account creation, vanity address support

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -503,13 +503,6 @@ impl EncodingType {
 }
 
 #[derive(Clone, Debug, Parser)]
-pub struct VanityPrefix {
-    /// Vanity prefix that resultant account address should start with, e.g. 0xaceface or d00d
-    #[clap(long)]
-    pub vanity_prefix: Option<String>,
-}
-
-#[derive(Clone, Debug, Parser)]
 pub struct RngArgs {
     /// The seed used for key generation, should be a 64 character hex string and only used for testing
     ///

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    common::types::{account_address_from_public_key, CliError, CliTypedResult, PromptOptions},
+    common::types::{
+        account_address_from_public_key, CliError, CliTypedResult, PromptOptions,
+        TransactionOptions, TransactionSummary,
+    },
     config::GlobalConfig,
     CliResult,
 };
@@ -12,7 +15,10 @@ use aptos_keygen::KeyGen;
 use aptos_logger::{debug, Level};
 use aptos_rest_client::{aptos_api_types::HashValue, Account, Client, State};
 use aptos_telemetry::service::telemetry_is_disabled;
-use aptos_types::{chain_id::ChainId, transaction::authenticator::AuthenticationKey};
+use aptos_types::{
+    chain_id::ChainId,
+    transaction::{authenticator::AuthenticationKey, TransactionPayload},
+};
 use itertools::Itertools;
 use move_core_types::account_address::AccountAddress;
 use reqwest::Url;
@@ -442,4 +448,21 @@ pub fn start_logger() {
     let mut logger = aptos_logger::Logger::new();
     logger.channel_size(1000).is_async(false).level(Level::Warn);
     logger.build();
+}
+
+/// For transaction payload, either get gas profile or submit for execution.
+pub async fn profile_or_submit(
+    payload: TransactionPayload,
+    txn_options: &TransactionOptions,
+) -> CliTypedResult<TransactionSummary> {
+    // Profile gas if needed.
+    if txn_options.profile_gas {
+        txn_options.profile_gas(payload).await
+    } else {
+        // Otherwise submit the transaction.
+        txn_options
+            .submit_transaction(payload)
+            .await
+            .map(TransactionSummary::from)
+    }
 }

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -16,6 +16,7 @@ use aptos_logger::{debug, Level};
 use aptos_rest_client::{aptos_api_types::HashValue, Account, Client, State};
 use aptos_telemetry::service::telemetry_is_disabled;
 use aptos_types::{
+    account_address::create_multisig_account_address,
     chain_id::ChainId,
     transaction::{authenticator::AuthenticationKey, TransactionPayload},
 };
@@ -314,24 +315,27 @@ where
     Ok(map)
 }
 
-/// Generate a vanity account for Ed25519 single signer scheme.
+/// Generate a vanity account for Ed25519 single signer scheme, either standard or multisig.
 ///
 /// The default authentication key for an Ed25519 account is the same as the account address. Hence
-/// this function generates Ed25519 private keys until finding one that has an authentication key
-/// that begins with the given vanity prefix. Note that while a valid hex string must have an even
-/// number of characters, a vanity prefix can have an odd number of characters since
-/// account addresses are human-readable.
+/// for a standard account, this function generates Ed25519 private keys until finding one that has
+/// an authentication key that begins with the given vanity prefix.
+///
+/// For a multisig account, this function generates private keys until finding one that can create
+/// a multisig account with the given vanity prefix as its first transaction (sequence number 0).
+///
+/// Note that while a valid hex string must have an even number of characters, a vanity prefix can
+/// have an odd number of characters since account addresses are human-readable.
 ///
 /// `vanity_prefix_ref` is a reference to a hex string vanity prefix, optionally prefixed with "0x".
 /// For example "0xaceface" or "d00d".
 pub fn generate_vanity_account_ed25519(
     vanity_prefix_ref: &str,
+    multisig: bool,
 ) -> CliTypedResult<Ed25519PrivateKey> {
-    // Optionally strip leading 0x from input string.
     let vanity_prefix_ref = vanity_prefix_ref
         .strip_prefix("0x")
-        .unwrap_or(vanity_prefix_ref);
-    // Get string instance to check if vanity prefix is valid hex (may need to add a 0 at end).
+        .unwrap_or(vanity_prefix_ref); // Optionally strip leading 0x from input string.
     let mut to_check_if_is_hex = String::from(vanity_prefix_ref);
     // If an odd number of characters append a 0 for verifying that prefix contains valid hex.
     if to_check_if_is_hex.len() % 2 != 0 {
@@ -340,19 +344,22 @@ pub fn generate_vanity_account_ed25519(
     hex::decode(to_check_if_is_hex).  // Check that the vanity prefix can be decoded into hex.
         map_err(|error| CliError::CommandArgumentError(format!(
             "The vanity prefix could not be decoded to hex: {}", error)))?;
-    // Create a random key generator based on OS random number generator.
-    let mut key_generator = KeyGen::from_os_rng();
-    // Randomly generate a new Ed25519 private key.
-    let mut private_key = key_generator.generate_ed25519_private_key();
-    // While the account address does not start with the vanity prefix:
-    while !account_address_from_public_key(&Ed25519PublicKey::from(&private_key))
-        .short_str_lossless()
-        .starts_with(vanity_prefix_ref)
-    {
-        // Generate a new account.
-        private_key = key_generator.generate_ed25519_private_key();
+    let mut key_generator = KeyGen::from_os_rng(); // Get random key generator.
+    loop {
+        // Generate new keys until finding a match against the vanity prefix.
+        let private_key = key_generator.generate_ed25519_private_key();
+        let mut account_address =
+            account_address_from_public_key(&Ed25519PublicKey::from(&private_key));
+        if multisig {
+            account_address = create_multisig_account_address(account_address, 0)
+        };
+        if account_address
+            .short_str_lossless()
+            .starts_with(vanity_prefix_ref)
+        {
+            return Ok(private_key);
+        };
     }
-    Ok(private_key) // Return the resulting private key.
 }
 
 pub fn current_dir() -> CliTypedResult<PathBuf> {
@@ -453,14 +460,14 @@ pub fn start_logger() {
 /// For transaction payload, either get gas profile or submit for execution.
 pub async fn profile_or_submit(
     payload: TransactionPayload,
-    txn_options: &TransactionOptions,
+    txn_options_ref: &TransactionOptions,
 ) -> CliTypedResult<TransactionSummary> {
     // Profile gas if needed.
-    if txn_options.profile_gas {
-        txn_options.profile_gas(payload).await
+    if txn_options_ref.profile_gas {
+        txn_options_ref.profile_gas(payload).await
     } else {
         // Otherwise submit the transaction.
-        txn_options
+        txn_options_ref
             .submit_transaction(payload)
             .await
             .map(TransactionSummary::from)

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod genesis;
 pub mod governance;
 pub mod move_tool;
+pub mod multisig;
 pub mod node;
 pub mod op;
 pub mod stake;
@@ -43,6 +44,8 @@ pub enum Tool {
     #[clap(subcommand)]
     Move(move_tool::MoveTool),
     #[clap(subcommand)]
+    Multisig(multisig::MultisigTool),
+    #[clap(subcommand)]
     Node(node::NodeTool),
     #[clap(subcommand)]
     Stake(stake::StakeTool),
@@ -62,6 +65,7 @@ impl Tool {
             Init(tool) => tool.execute_serialized_success().await,
             Key(tool) => tool.execute().await,
             Move(tool) => tool.execute().await,
+            Multisig(tool) => tool.execute().await,
             Node(tool) => tool.execute().await,
             Stake(tool) => tool.execute().await,
             Update(tool) => tool.execute_serialized().await,

--- a/crates/aptos/src/multisig/mod.rs
+++ b/crates/aptos/src/multisig/mod.rs
@@ -1,4 +1,5 @@
 // Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::{
     common::{
@@ -29,10 +30,10 @@ impl MultisigTool {
 #[derive(Debug, Parser)]
 pub struct CreateMultisig {
     /// Hex account address(es) to add as owners, each prefixed with "0x" and separated by spaces
-    #[clap(short, long, multiple(true), parse(try_from_str=crate::common::types::load_account_arg))]
+    #[clap(long, multiple(true), parse(try_from_str=crate::common::types::load_account_arg))]
     pub additional_owners: Vec<AccountAddress>,
     /// Number of signatures required to approve a transaction
-    #[clap(short, long)]
+    #[clap(long)]
     pub num_signatures_required: u64,
     #[clap(flatten)]
     pub txn_options: TransactionOptions,

--- a/crates/aptos/src/multisig/mod.rs
+++ b/crates/aptos/src/multisig/mod.rs
@@ -1,0 +1,61 @@
+use crate::{
+    common::types::{TransactionOptions, TransactionSummary},
+    CliCommand, CliResult, CliTypedResult,
+};
+use aptos_types::account_address::AccountAddress;
+use async_trait::async_trait;
+use clap::{Parser, Subcommand};
+
+/// Tool for multisig account operations.
+#[derive(Debug, Subcommand)]
+pub enum MultisigTool {
+    Create(CreateMultisig),
+}
+
+impl MultisigTool {
+    pub async fn execute(self) -> CliResult {
+        match self {
+            MultisigTool::Create(tool) => tool.execute_serialized().await,
+        }
+    }
+}
+
+/// Create a multisig account.
+#[derive(Debug, Parser)]
+pub struct CreateMultisig {
+    /// Hex account address(es) to add as owners, each prefixed with "0x" and separated by spaces
+    #[clap(short, long, multiple(true), parse(try_from_str=crate::common::types::load_account_arg))]
+    pub additional_owners: Vec<AccountAddress>,
+    /// Number of signatures required to approve a transaction
+    #[clap(short, long)]
+    pub num_signatures_required: u64,
+    #[clap(flatten)]
+    pub txn_options: TransactionOptions,
+}
+
+#[async_trait]
+impl CliCommand<TransactionSummary> for CreateMultisig {
+    fn command_name(&self) -> &'static str {
+        "CreateMultisig"
+    }
+
+    async fn execute(self) -> CliTypedResult<TransactionSummary> {
+        // Generate multisig account creation transaction payload, ignoring metadata map.
+        let payload = aptos_cached_packages::aptos_stdlib::multisig_account_create_with_owners(
+            self.additional_owners,
+            self.num_signatures_required,
+            vec![], // Metadata keys not supported here.
+            vec![], // Metadata values not supported here.
+        );
+        // Profile gas if needed.
+        if self.txn_options.profile_gas {
+            self.txn_options.profile_gas(payload).await
+        } else {
+            // Otherwise submit the transaction.
+            self.txn_options
+                .submit_transaction(payload)
+                .await
+                .map(TransactionSummary::from)
+        }
+    }
+}

--- a/crates/aptos/src/multisig/mod.rs
+++ b/crates/aptos/src/multisig/mod.rs
@@ -1,3 +1,5 @@
+// Copyright © Aptos Foundation
+
 use crate::{
     common::{
         types::{TransactionOptions, TransactionSummary},

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -200,9 +200,9 @@ impl CliCommand<HashMap<&'static str, PathBuf>> for GenerateKey {
             )));
         }
         if self.vanity_multisig && self.vanity_prefix.is_none() {
-            return Err(CliError::CommandArgumentError(format!(
-                "No vanity prefix provided"
-            )));
+            return Err(CliError::CommandArgumentError(
+                "No vanity prefix provided".to_string(),
+            ));
         }
         self.save_params.check_key_file()?;
         let mut keygen = self.rng_args.key_generator()?;

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -5,7 +5,7 @@ use crate::{
     common::{
         types::{
             account_address_from_public_key, CliError, CliTypedResult, EncodingOptions,
-            EncodingType, KeyType, RngArgs, SaveFile, VanityPrefix,
+            EncodingType, KeyType, RngArgs, SaveFile,
         },
         utils::{
             append_file_extension, check_if_file_exists, generate_vanity_account_ed25519,
@@ -17,7 +17,9 @@ use crate::{
 use aptos_config::config::{Peer, PeerRole};
 use aptos_crypto::{bls12381, ed25519, x25519, PrivateKey, ValidCryptoMaterial};
 use aptos_genesis::config::HostAndPort;
-use aptos_types::account_address::{from_identity_public_key, AccountAddress};
+use aptos_types::account_address::{
+    create_multisig_account_address, from_identity_public_key, AccountAddress,
+};
 use async_trait::async_trait;
 use clap::{Parser, Subcommand};
 use std::{
@@ -170,13 +172,18 @@ pub struct GenerateKey {
     /// Key type to generate. Must be one of [x25519, ed25519, bls12381]
     #[clap(long, default_value_t = KeyType::Ed25519)]
     pub(crate) key_type: KeyType,
-
+    /// Vanity prefix that resultant account address should start with, e.g. 0xaceface or d00d
+    #[clap(long, short('p'))]
+    pub vanity_prefix: Option<String>,
+    /// Use this flag when vanity prefix is for a multisig account. This mines a private key for
+    /// a single signer account that can, as its first transaction, create a multisig account with
+    /// the given vanity prefix
+    #[clap(long, short('m'))]
+    pub vanity_multisig: bool,
     #[clap(flatten)]
     pub rng_args: RngArgs,
     #[clap(flatten)]
     pub(crate) save_params: SaveKey,
-    #[clap(flatten)]
-    pub vanity_prefix: VanityPrefix,
 }
 
 #[async_trait]
@@ -186,16 +193,19 @@ impl CliCommand<HashMap<&'static str, PathBuf>> for GenerateKey {
     }
 
     async fn execute(self) -> CliTypedResult<HashMap<&'static str, PathBuf>> {
-        self.save_params.check_key_file()?;
-        let mut keygen = self.rng_args.key_generator()?;
-        // Verify key type is Ed25519 if a vanity prefix is specified.
-        if self.vanity_prefix.vanity_prefix.is_some() && !matches!(self.key_type, KeyType::Ed25519)
-        {
+        if self.vanity_prefix.is_some() && !matches!(self.key_type, KeyType::Ed25519) {
             return Err(CliError::CommandArgumentError(format!(
                 "Vanity prefixes are only accepted for {} keys",
                 KeyType::Ed25519
             )));
         }
+        if self.vanity_multisig && self.vanity_prefix.is_none() {
+            return Err(CliError::CommandArgumentError(format!(
+                "No vanity prefix provided"
+            )));
+        }
+        self.save_params.check_key_file()?;
+        let mut keygen = self.rng_args.key_generator()?;
         match self.key_type {
             KeyType::X25519 => {
                 let private_key = keygen.generate_x25519_private_key().map_err(|err| {
@@ -208,25 +218,34 @@ impl CliCommand<HashMap<&'static str, PathBuf>> for GenerateKey {
             },
             KeyType::Ed25519 => {
                 // If no vanity prefix specified, generate a standard Ed25519 private key.
-                let private_key = if self.vanity_prefix.vanity_prefix.is_none() {
+                let private_key = if self.vanity_prefix.is_none() {
                     keygen.generate_ed25519_private_key()
                 } else {
                     // If a vanity prefix is specified, generate vanity Ed25519 account from it.
                     generate_vanity_account_ed25519(
-                        self.vanity_prefix.vanity_prefix.clone().unwrap().as_str(),
+                        self.vanity_prefix.clone().unwrap().as_str(),
+                        self.vanity_multisig,
                     )?
                 };
-                // Store CLI result map from key save operation, to append vanity address if needed.
+                // Store CLI result from key save operation, to append vanity address(es) if needed.
                 let mut result_map = self.save_params.save_key(&private_key, "ed25519").unwrap();
-                // If a vanity prefix was specified:
-                if self.vanity_prefix.vanity_prefix.is_some() {
-                    // Get account address.
+                if self.vanity_prefix.is_some() {
                     let account_address = account_address_from_public_key(
                         &ed25519::Ed25519PublicKey::from(&private_key),
-                    )
-                    .to_hex_literal();
-                    // Put account address in PathBuf so it can be displayed from typed CLI result.
-                    result_map.insert("Account Address:", PathBuf::from(account_address));
+                    );
+                    // Store account address in a PathBuf so it can be displayed in CLI result.
+                    result_map.insert(
+                        "Account Address:",
+                        PathBuf::from(account_address.to_hex_literal()),
+                    );
+                    if self.vanity_multisig {
+                        let multisig_account_address =
+                            create_multisig_account_address(account_address, 0);
+                        result_map.insert(
+                            "Multisig Account Address:",
+                            PathBuf::from(multisig_account_address.to_hex_literal()),
+                        );
+                    }
                 }
                 return Ok(result_map);
             },

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -172,13 +172,16 @@ pub struct GenerateKey {
     /// Key type to generate. Must be one of [x25519, ed25519, bls12381]
     #[clap(long, default_value_t = KeyType::Ed25519)]
     pub(crate) key_type: KeyType,
-    /// Vanity prefix that resultant account address should start with, e.g. 0xaceface or d00d
-    #[clap(long, short('p'))]
+    /// Vanity prefix that resultant account address should start with, e.g. 0xaceface or d00d. Each
+    /// additional character multiplies by a factor of 16 the computational difficulty associated
+    /// with generating an address, so try out shorter prefixes first and be prepared to wait for
+    /// longer ones
+    #[clap(long)]
     pub vanity_prefix: Option<String>,
     /// Use this flag when vanity prefix is for a multisig account. This mines a private key for
     /// a single signer account that can, as its first transaction, create a multisig account with
     /// the given vanity prefix
-    #[clap(long, short('m'))]
+    #[clap(long)]
     pub vanity_multisig: bool,
     #[clap(flatten)]
     pub rng_args: RngArgs,

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -16,7 +16,7 @@ use crate::{
             EncodingOptions, FaucetOptions, GasOptions, KeyType, MoveManifestAccountWrapper,
             MovePackageDir, OptionalPoolAddressArgs, PoolAddressArgs, PrivateKeyInputOptions,
             PromptOptions, PublicKeyInputOptions, RestOptions, RngArgs, SaveFile,
-            TransactionOptions, TransactionSummary, VanityPrefix,
+            TransactionOptions, TransactionSummary,
         },
         utils::write_to_file,
     },
@@ -720,9 +720,8 @@ impl CliTestFramework {
                 },
                 encoding_options: Default::default(),
             },
-            vanity_prefix: VanityPrefix {
-                vanity_prefix: None,
-            },
+            vanity_prefix: None,
+            vanity_multisig: false,
         }
         .execute()
         .await

--- a/developer-docs-site/docs/cli-tools/aptos-cli-tool/use-aptos-cli.md
+++ b/developer-docs-site/docs/cli-tools/aptos-cli-tool/use-aptos-cli.md
@@ -29,6 +29,7 @@ SUBCOMMANDS:
     init          Tool to initialize current directory for the aptos tool
     key           Tool for generating, inspecting, and interacting with keys
     move          Tool for Move related operations
+    multisig      Tool for multisig account operations
     node          Tool for operations related to nodes
     stake         Tool for manipulating stake
 ```
@@ -714,6 +715,92 @@ The `peer_config.yaml` file will be created in your current working directory, w
 ```
 
 **Note:** In the addresses key, you should fill in your address.
+
+## Multisig examples
+
+### Create a vanity multisig account
+
+To create a multisig account use the `aptos multisig create` command.
+
+:::tip
+This example will create a vanity multisig account, but you do not have to use a vanity address.
+:::
+
+First generate a new private key file for the initiating owner:
+
+```bash
+# Generate private key file that can create vanity multisig on its first transaction.
+aptos key generate \
+    --output-file starts_with_d00d.key \
+    --vanity-prefix 0xd00d \
+    --vanity-multisig
+{
+  "Result": {
+    "PrivateKey Path": "starts_with_d00d.key",
+    "PublicKey Path": "starts_with_d00d.key.pub",
+    "Multisig Account Address:": "0xd00db2a7c10f8037af443cec1e2c2c82f419bcca2fd557de10fbc58c1635b432",
+    "Account Address:": "0xf2ac0ed090be51d067259101291d3aabca2a3b5e34a27c85da675cd6dbed9ada"
+  }
+}
+```
+
+Fund the owner (here we use the devnet faucet for illustrative purposes):
+
+```bash
+aptos account fund-with-faucet --account 0xf2ac0ed090be51d067259101291d3aabca2a3b5e34a27c85da675cd6dbed9ada
+{
+  "Result": "Added 100000000 Octas to account f2ac0ed090be51d067259101291d3aabca2a3b5e34a27c85da675cd6dbed9ada"
+}
+```
+
+Create the multisig account using the private key:
+
+```bash
+aptos multisig create \
+    --private-key-file starts_with_d00d.key \
+    --num-signatures-required 1
+{
+  "Result": {
+    "transaction_hash": "0x2aeb6f6443ef2a873e8fb3d4db11b923d46d9522f5724ff7d313ed5070f078ff",
+    "gas_used": 1520,
+    "gas_unit_price": 100,
+    "sender": "f2ac0ed090be51d067259101291d3aabca2a3b5e34a27c85da675cd6dbed9ada",
+    "sequence_number": 0,
+    "success": true,
+    "timestamp_us": 1680640710219543,
+    "version": 3202707,
+    "vm_status": "Executed successfully"
+  }
+}
+```
+
+Note that the initiating owner has sent a transaction, which created a new multisig account with the given vanity prefix:
+
+```
+aptos account list --account 0xd00db2a7c10f8037af443cec1e2c2c82f419bcca2fd557de10fbc58c1635b432
+{
+  "Result": [
+    ...
+    {
+      "0x1::multisig_account::MultisigAccount": {
+        "add_owners_events": {
+          "counter": "0",
+          "guid": {
+            "id": {
+              "addr": "0xd00db2a7c10f8037af443cec1e2c2c82f419bcca2fd557de10fbc58c1635b432",
+              "creation_num": "4"
+            }
+          }
+        ...
+        "signer_cap": {
+          "vec": [
+            {
+              "account": "0xd00db2a7c10f8037af443cec1e2c2c82f419bcca2fd557de10fbc58c1635b432"
+            }
+          ]
+        },
+        ...
+```
 
 ## Move examples
 


### PR DESCRIPTION
This PR adds multisig account creation and vanity address support to the `aptos` CLI, with documentation.

This PR extends #7521, which can be closed if this PR is landed.

I intend to submit more incremental PRs for the new CLI multisig subcommand, to support the new on-chain multisig account standard.

