### PR TITLE
[db-tool] backup-continuously: add read timeout to BackupServiceClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,7 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
+ "tokio-io-timeout",
  "tokio-stream",
  "tokio-util 0.7.3",
  "warp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -555,6 +555,7 @@ tracing = "0.1.34"
 tracing-subscriber = "0.3.11"
 trybuild = "1.0.41"
 tokio = { version = "1.21.0", features = ["full"] }
+tokio-io-timeout = "1.2.0"
 tokio-metrics = "0.1.0"
 tokio-retry = "0.3.0"
 tokio-stream = "0.1.8"

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -48,6 +48,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tokio = { workspace = true }
+tokio-io-timeout = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 

--- a/storage/backup/backup-cli/src/utils/backup_service_client.rs
+++ b/storage/backup/backup-cli/src/utils/backup_service_client.rs
@@ -9,7 +9,11 @@ use aptos_db::backup::backup_handler::DbState;
 use aptos_types::transaction::Version;
 use clap::Parser;
 use futures::TryStreamExt;
-use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt},
+    time::Duration,
+};
+use tokio_io_timeout::TimeoutReader;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 
 #[derive(Parser)]
@@ -29,6 +33,8 @@ pub struct BackupServiceClient {
 }
 
 impl BackupServiceClient {
+    const TIMEOUT_SECS: u64 = 60;
+
     pub fn new_with_opt(opt: BackupServiceClientOpt) -> Self {
         Self::new(opt.address)
     }
@@ -45,18 +51,23 @@ impl BackupServiceClient {
 
     async fn get(&self, path: &str) -> Result<impl AsyncRead> {
         let url = format!("{}/{}", self.address, path);
-        Ok(self
-            .client
-            .get(&url)
-            .send()
-            .await
+        let timeout = Duration::from_secs(Self::TIMEOUT_SECS);
+        let reader = tokio::time::timeout(timeout, self.client.get(&url).send())
+            .await?
             .err_notes(&url)?
             .error_for_status()
             .err_notes(&url)?
             .bytes_stream()
             .map_err(|e| futures::io::Error::new(futures::io::ErrorKind::Other, e))
             .into_async_read()
-            .compat())
+            .compat();
+
+        // Adding the timeout here instead of on the response because we do use long living
+        // connections. For example, we stream the entire state snapshot in one request.
+        let mut reader_with_read_timeout = TimeoutReader::new(reader);
+        reader_with_read_timeout.set_timeout(Some(timeout));
+
+        Ok(Box::pin(reader_with_read_timeout))
     }
 
     pub async fn get_db_state(&self) -> Result<Option<DbState>> {


### PR DESCRIPTION
### Description

Not reproduceable locally, but in our k8s deployments, whenever the fullnode is killed, the backup coordinator hangs on the http connection (that streams in state snapshot chunks), resulting in large gaps between state snapshots (until we restart the backup pod). 


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
built image and tested on testnet backup deployment in aws -- prolbem is gone