### PR TITLE
[Configs] Small clean ups and improvements to node configs.

### DIFF
--- a/aptos-node/src/state_sync.rs
+++ b/aptos-node/src/state_sync.rs
@@ -98,7 +98,7 @@ pub fn start_state_sync_and_get_notification_handles(
 
     // Start the data streaming service
     let (streaming_service_client, streaming_service_runtime) =
-        setup_data_streaming_service(node_config.state_sync.clone(), aptos_data_client.clone())?;
+        setup_data_streaming_service(node_config.state_sync, aptos_data_client.clone())?;
 
     // Create the chunk executor and persistent storage
     let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()));

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -35,6 +35,7 @@ url = { workspace = true }
 
 [dev-dependencies]
 aptos-crypto = { workspace = true }
+aptos-types = { workspace = true, features = ["fuzzing"] }
 
 [features]
 default = []

--- a/config/global-constants/src/lib.rs
+++ b/config/global-constants/src/lib.rs
@@ -10,21 +10,13 @@
 #![forbid(unsafe_code)]
 
 /// Definitions of global cryptographic keys (e.g., as held in secure storage)
-pub const APTOS_ROOT_KEY: &str = "aptos_root";
 pub const CONSENSUS_KEY: &str = "consensus";
-pub const FULLNODE_NETWORK_KEY: &str = "fullnode_network";
-pub const OPERATOR_ACCOUNT: &str = "operator_account";
-pub const OPERATOR_KEY: &str = "operator";
 pub const OWNER_ACCOUNT: &str = "owner_account";
-pub const OWNER_KEY: &str = "owner";
-pub const VALIDATOR_NETWORK_KEY: &str = "validator_network";
 
 /// Definitions of global data items (e.g., as held in secure storage)
 pub const SAFETY_DATA: &str = "safety_data";
 pub const WAYPOINT: &str = "waypoint";
 pub const GENESIS_WAYPOINT: &str = "genesis-waypoint";
-pub const MOVE_MODULES: &str = "move_modules";
-pub const MIN_PRICE_PER_GAS_UNIT: &str = "min_price_per_gas_unit";
 
 // TODO(Gas): double check if this right
 /// Definitions of global gas constants

--- a/config/src/config/base_config.rs
+++ b/config/src/config/base_config.rs
@@ -1,0 +1,174 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::config::SecureBackend;
+use aptos_secure_storage::{KVStorage, Storage};
+use aptos_types::waypoint::Waypoint;
+use poem_openapi::Enum as PoemEnum;
+use serde::{Deserialize, Serialize};
+use std::{fmt, fs, path::PathBuf, str::FromStr};
+use thiserror::Error;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct BaseConfig {
+    pub data_dir: PathBuf,
+    pub working_dir: Option<PathBuf>,
+    pub role: RoleType,
+    pub waypoint: WaypointConfig,
+}
+
+impl Default for BaseConfig {
+    fn default() -> BaseConfig {
+        BaseConfig {
+            data_dir: PathBuf::from("/opt/aptos/data"),
+            working_dir: None,
+            role: RoleType::Validator,
+            waypoint: WaypointConfig::None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WaypointConfig {
+    FromConfig(Waypoint),
+    FromFile(PathBuf),
+    FromStorage(SecureBackend),
+    None,
+}
+
+impl WaypointConfig {
+    pub fn waypoint_from_config(&self) -> Option<Waypoint> {
+        if let WaypointConfig::FromConfig(waypoint) = self {
+            Some(*waypoint)
+        } else {
+            None
+        }
+    }
+
+    pub fn waypoint(&self) -> Waypoint {
+        let waypoint = match &self {
+            WaypointConfig::FromConfig(waypoint) => Some(*waypoint),
+            WaypointConfig::FromFile(waypoint_path) => {
+                if !waypoint_path.exists() {
+                    panic!(
+                        "Waypoint file not found! Ensure the given path is correct: {:?}",
+                        waypoint_path.display()
+                    );
+                }
+                let content = fs::read_to_string(waypoint_path).unwrap_or_else(|error| {
+                    panic!(
+                        "Failed to read waypoint file {:?}. Error: {:?}",
+                        waypoint_path.display(),
+                        error
+                    )
+                });
+                Some(Waypoint::from_str(content.trim()).unwrap_or_else(|error| {
+                    panic!(
+                        "Failed to parse waypoint: {:?}. Error: {:?}",
+                        content.trim(),
+                        error
+                    )
+                }))
+            },
+            WaypointConfig::FromStorage(backend) => {
+                let storage: Storage = backend.into();
+                let waypoint = storage
+                    .get::<Waypoint>(aptos_global_constants::WAYPOINT)
+                    .expect("Unable to read waypoint")
+                    .value;
+                Some(waypoint)
+            },
+            WaypointConfig::None => None,
+        };
+        waypoint.expect("waypoint should be present")
+    }
+
+    pub fn genesis_waypoint(&self) -> Waypoint {
+        match &self {
+            WaypointConfig::FromStorage(backend) => {
+                let storage: Storage = backend.into();
+                storage
+                    .get::<Waypoint>(aptos_global_constants::GENESIS_WAYPOINT)
+                    .expect("Unable to read waypoint")
+                    .value
+            },
+            _ => self.waypoint(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Deserialize, Eq, PartialEq, PoemEnum, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[oai(rename_all = "snake_case")]
+pub enum RoleType {
+    Validator,
+    FullNode,
+}
+
+impl RoleType {
+    pub fn is_validator(self) -> bool {
+        self == RoleType::Validator
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RoleType::Validator => "validator",
+            RoleType::FullNode => "full_node",
+        }
+    }
+}
+
+impl FromStr for RoleType {
+    type Err = ParseRoleError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "validator" => Ok(RoleType::Validator),
+            "full_node" => Ok(RoleType::FullNode),
+            _ => Err(ParseRoleError(s.to_string())),
+        }
+    }
+}
+
+impl fmt::Debug for RoleType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl fmt::Display for RoleType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Invalid node role: {0}")]
+pub struct ParseRoleError(String);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn verify_role_type_conversion() {
+        // Verify relationship between RoleType and as_string() is reflexive
+        let validator = RoleType::Validator;
+        let full_node = RoleType::FullNode;
+        let converted_validator = RoleType::from_str(validator.as_str()).unwrap();
+        let converted_full_node = RoleType::from_str(full_node.as_str()).unwrap();
+        assert_eq!(converted_validator, validator);
+        assert_eq!(converted_full_node, full_node);
+    }
+
+    #[test]
+    fn verify_parse_role_error_on_invalid_role() {
+        let invalid_role_type = "this is not a valid role type";
+        assert!(matches!(
+            RoleType::from_str(invalid_role_type),
+            Err(ParseRoleError(_))
+        ));
+    }
+}

--- a/config/src/config/identity_config.rs
+++ b/config/src/config/identity_config.rs
@@ -1,0 +1,34 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_crypto::{bls12381, ed25519::Ed25519PrivateKey, x25519};
+use aptos_types::account_address::AccountAddress;
+use serde::{Deserialize, Serialize};
+use std::{fs, fs::File, io::Write, path::Path};
+
+/// A single struct for reading / writing to a file for identity across configs
+#[derive(Deserialize, Serialize)]
+pub struct IdentityBlob {
+    /// Optional account address. Used for validators and validator full nodes
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_address: Option<AccountAddress>,
+    /// Optional account key. Only used for validators
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_private_key: Option<Ed25519PrivateKey>,
+    /// Optional consensus key. Only used for validators
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub consensus_private_key: Option<bls12381::PrivateKey>,
+    /// Network private key. Peer id is derived from this if account address is not present
+    pub network_private_key: x25519::PrivateKey,
+}
+
+impl IdentityBlob {
+    pub fn from_file(path: &Path) -> anyhow::Result<IdentityBlob> {
+        Ok(serde_yaml::from_str(&fs::read_to_string(path)?)?)
+    }
+
+    pub fn to_file(&self, path: &Path) -> anyhow::Result<()> {
+        let mut file = File::open(path)?;
+        Ok(file.write_all(serde_yaml::to_string(self)?.as_bytes())?)
+    }
+}

--- a/config/src/config/logger_config.rs
+++ b/config/src/config/logger_config.rs
@@ -6,7 +6,7 @@ use crate::utils;
 use aptos_logger::{Level, CHANNEL_SIZE};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct LoggerConfig {
     // channel size for the asynchronous channel for node logging.

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -3,75 +3,81 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::network_id::NetworkId;
-use aptos_secure_storage::{KVStorage, Storage};
-use aptos_types::{waypoint::Waypoint, PeerId};
+use aptos_crypto::x25519;
+use aptos_types::PeerId;
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
     collections::HashMap,
-    fmt, fs,
     fs::File,
     io::{Read, Write},
     path::{Path, PathBuf},
-    str::FromStr,
 };
 use thiserror::Error;
 
-mod consensus_config;
-pub use consensus_config::*;
-mod quorum_store_config;
-pub use quorum_store_config::*;
-mod error;
-pub use error::*;
-mod execution_config;
-pub use execution_config::*;
-mod inspection_service_config;
-pub use inspection_service_config::*;
-mod logger_config;
-pub use logger_config::*;
-mod mempool_config;
-pub use mempool_config::*;
-mod network_config;
-pub use network_config::*;
-mod secure_backend_config;
-pub use secure_backend_config::*;
-mod state_sync_config;
-pub use state_sync_config::*;
-mod indexer_config;
-pub use indexer_config::*;
-mod indexer_grpc_config;
-pub use indexer_grpc_config::*;
-mod storage_config;
-pub use storage_config::*;
-mod safety_rules_config;
-pub use safety_rules_config::*;
-mod test_config;
-pub use test_config::*;
+// All modules should be declared below
 mod api_config;
+mod base_config;
+mod consensus_config;
+mod error;
+mod execution_config;
+mod identity_config;
+mod indexer_config;
+mod indexer_grpc_config;
+mod inspection_service_config;
+mod logger_config;
+mod mempool_config;
+mod network_config;
+mod quorum_store_config;
+mod safety_rules_config;
+mod secure_backend_config;
+mod state_sync_config;
+mod storage_config;
+mod test_config;
+
+// All public usage statements should be declared below
 pub use api_config::*;
-use aptos_crypto::{bls12381, ed25519::Ed25519PrivateKey, x25519};
-use aptos_types::account_address::AccountAddress;
-use poem_openapi::Enum as PoemEnum;
+pub use base_config::*;
+pub use consensus_config::*;
+pub use error::*;
+pub use execution_config::*;
+pub use identity_config::*;
+pub use indexer_config::*;
+pub use indexer_grpc_config::*;
+pub use inspection_service_config::*;
+pub use logger_config::*;
+pub use mempool_config::*;
+pub use network_config::*;
+pub use quorum_store_config::*;
+pub use safety_rules_config::*;
+pub use secure_backend_config::*;
+pub use state_sync_config::*;
+pub use storage_config::*;
+pub use test_config::*;
 
-/// Represents a deprecated config that provides no field verification.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
-pub struct DeprecatedConfig {}
-
-/// Config pulls in configuration information from the config file.
-/// This is used to set up the nodes and configure various parameters.
-/// The config file is broken up into sections for each module
-/// so that only that module can be passed around
+/// The node configuration defines the configuration for a single Aptos
+/// node (i.e., validator or fullnode). It is composed of module
+/// configurations for each of the modules that the node uses (e.g.,
+/// the API, indexer, mempool, state sync, etc.).
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct NodeConfig {
+    #[serde(default)]
+    pub api: ApiConfig,
     #[serde(default)]
     pub base: BaseConfig,
     #[serde(default)]
     pub consensus: ConsensusConfig,
     #[serde(default)]
     pub execution: ExecutionConfig,
+    #[serde(default)]
+    pub failpoints: Option<HashMap<String, String>>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub full_node_networks: Vec<NetworkConfig>,
+    #[serde(default)]
+    pub indexer: IndexerConfig,
+    #[serde(default)]
+    pub indexer_grpc: IndexerGrpcConfig,
     #[serde(default)]
     pub inspection_service: InspectionServiceConfig,
     #[serde(default)]
@@ -79,192 +85,16 @@ pub struct NodeConfig {
     #[serde(default)]
     pub mempool: MempoolConfig,
     #[serde(default)]
-    pub metrics: DeprecatedConfig,
-    #[serde(default)]
     pub peer_monitoring_service: PeerMonitoringServiceConfig,
     #[serde(default)]
-    pub api: ApiConfig,
-    #[serde(default)]
     pub state_sync: StateSyncConfig,
-    #[serde(default)]
-    pub indexer_grpc: IndexerGrpcConfig,
-    #[serde(default)]
-    pub indexer: IndexerConfig,
     #[serde(default)]
     pub storage: StorageConfig,
     #[serde(default)]
     pub test: Option<TestConfig>,
     #[serde(default)]
     pub validator_network: Option<NetworkConfig>,
-    #[serde(default)]
-    pub failpoints: Option<HashMap<String, String>>,
 }
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
-#[serde(default, deny_unknown_fields)]
-pub struct BaseConfig {
-    pub data_dir: PathBuf,
-    pub working_dir: Option<PathBuf>,
-    pub role: RoleType,
-    pub waypoint: WaypointConfig,
-}
-
-impl Default for BaseConfig {
-    fn default() -> BaseConfig {
-        BaseConfig {
-            data_dir: PathBuf::from("/opt/aptos/data"),
-            working_dir: None,
-            role: RoleType::Validator,
-            waypoint: WaypointConfig::None,
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum WaypointConfig {
-    FromConfig(Waypoint),
-    FromFile(PathBuf),
-    FromStorage(SecureBackend),
-    None,
-}
-
-impl WaypointConfig {
-    pub fn waypoint_from_config(&self) -> Option<Waypoint> {
-        if let WaypointConfig::FromConfig(waypoint) = self {
-            Some(*waypoint)
-        } else {
-            None
-        }
-    }
-
-    pub fn waypoint(&self) -> Waypoint {
-        let waypoint = match &self {
-            WaypointConfig::FromConfig(waypoint) => Some(*waypoint),
-            WaypointConfig::FromFile(waypoint_path) => {
-                if !waypoint_path.exists() {
-                    panic!(
-                        "Waypoint file not found! Ensure the given path is correct: {:?}",
-                        waypoint_path.display()
-                    );
-                }
-                let content = fs::read_to_string(waypoint_path).unwrap_or_else(|error| {
-                    panic!(
-                        "Failed to read waypoint file {:?}. Error: {:?}",
-                        waypoint_path.display(),
-                        error
-                    )
-                });
-                Some(Waypoint::from_str(content.trim()).unwrap_or_else(|error| {
-                    panic!(
-                        "Failed to parse waypoint: {:?}. Error: {:?}",
-                        content.trim(),
-                        error
-                    )
-                }))
-            },
-            WaypointConfig::FromStorage(backend) => {
-                let storage: Storage = backend.into();
-                let waypoint = storage
-                    .get::<Waypoint>(aptos_global_constants::WAYPOINT)
-                    .expect("Unable to read waypoint")
-                    .value;
-                Some(waypoint)
-            },
-            WaypointConfig::None => None,
-        };
-        waypoint.expect("waypoint should be present")
-    }
-
-    pub fn genesis_waypoint(&self) -> Waypoint {
-        match &self {
-            WaypointConfig::FromStorage(backend) => {
-                let storage: Storage = backend.into();
-                storage
-                    .get::<Waypoint>(aptos_global_constants::GENESIS_WAYPOINT)
-                    .expect("Unable to read waypoint")
-                    .value
-            },
-            _ => self.waypoint(),
-        }
-    }
-}
-
-/// A single struct for reading / writing to a file for identity across config
-#[derive(Deserialize, Serialize)]
-pub struct IdentityBlob {
-    /// Optional account address.  Used for validators and validator full nodes
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_address: Option<AccountAddress>,
-    /// Optional account key.  Only used for validators
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_private_key: Option<Ed25519PrivateKey>,
-    /// Optional consensus key.  Only used for validators
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub consensus_private_key: Option<bls12381::PrivateKey>,
-    /// Network private key.  Peer id is derived from this if account address is not present
-    pub network_private_key: x25519::PrivateKey,
-}
-
-impl IdentityBlob {
-    pub fn from_file(path: &Path) -> anyhow::Result<IdentityBlob> {
-        Ok(serde_yaml::from_str(&fs::read_to_string(path)?)?)
-    }
-
-    pub fn to_file(&self, path: &Path) -> anyhow::Result<()> {
-        let mut file = File::open(path)?;
-        Ok(file.write_all(serde_yaml::to_string(self)?.as_bytes())?)
-    }
-}
-
-#[derive(Clone, Copy, Deserialize, Eq, PartialEq, PoemEnum, Serialize)]
-#[serde(rename_all = "snake_case")]
-#[oai(rename_all = "snake_case")]
-pub enum RoleType {
-    Validator,
-    FullNode,
-}
-
-impl RoleType {
-    pub fn is_validator(self) -> bool {
-        self == RoleType::Validator
-    }
-
-    pub fn as_str(self) -> &'static str {
-        match self {
-            RoleType::Validator => "validator",
-            RoleType::FullNode => "full_node",
-        }
-    }
-}
-
-impl FromStr for RoleType {
-    type Err = ParseRoleError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "validator" => Ok(RoleType::Validator),
-            "full_node" => Ok(RoleType::FullNode),
-            _ => Err(ParseRoleError(s.to_string())),
-        }
-    }
-}
-
-impl fmt::Debug for RoleType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
-    }
-}
-
-impl fmt::Display for RoleType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
-#[derive(Debug, Error)]
-#[error("Invalid node role: {0}")]
-pub struct ParseRoleError(String);
 
 impl NodeConfig {
     pub fn data_dir(&self) -> &Path {
@@ -602,26 +432,6 @@ impl RootPath {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    #[test]
-    fn verify_role_type_conversion() {
-        // Verify relationship between RoleType and as_string() is reflexive
-        let validator = RoleType::Validator;
-        let full_node = RoleType::FullNode;
-        let converted_validator = RoleType::from_str(validator.as_str()).unwrap();
-        let converted_full_node = RoleType::from_str(full_node.as_str()).unwrap();
-        assert_eq!(converted_validator, validator);
-        assert_eq!(converted_full_node, full_node);
-    }
-
-    #[test]
-    fn verify_parse_role_error_on_invalid_role() {
-        let invalid_role_type = "this is not a valid role type";
-        assert!(matches!(
-            RoleType::from_str(invalid_role_type),
-            Err(ParseRoleError(_))
-        ));
-    }
 
     #[test]
     fn verify_configs() {

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -325,7 +325,7 @@ impl NetworkConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct PeerMonitoringServiceConfig {
     pub enable_peer_monitoring_client: bool, // Whether or not to spawn the monitoring client
@@ -353,7 +353,7 @@ impl Default for PeerMonitoringServiceConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct LatencyMonitoringConfig {
     pub latency_ping_interval_ms: u64, // The interval (ms) between latency pings for each peer
@@ -373,7 +373,7 @@ impl Default for LatencyMonitoringConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct NetworkMonitoringConfig {
     pub network_info_request_interval_ms: u64, // The interval (ms) between network info requests
@@ -464,7 +464,7 @@ pub struct IdentityFromFile {
     pub path: PathBuf,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RateLimitConfig {
     /// Maximum number of bytes/s for an IP

--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -5,7 +5,7 @@ use crate::config::MAX_SENDING_BLOCK_TXNS_QUORUM_STORE_OVERRIDE;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct QuorumStoreBackPressureConfig {
     pub backlog_txn_limit_count: u64,
@@ -33,7 +33,7 @@ impl Default for QuorumStoreBackPressureConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct QuorumStoreConfig {
     pub channel_size: usize,

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -13,7 +13,7 @@ const MAX_STATE_CHUNK_SIZE: u64 = 4000;
 const MAX_TRANSACTION_CHUNK_SIZE: u64 = 2000;
 const MAX_TRANSACTION_OUTPUT_CHUNK_SIZE: u64 = 1000;
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct StateSyncConfig {
     pub data_streaming_service: DataStreamingServiceConfig,
@@ -24,7 +24,7 @@ pub struct StateSyncConfig {
 
 /// The bootstrapping mode determines how the node will bootstrap to the latest
 /// blockchain state, e.g., directly download the latest states.
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub enum BootstrappingMode {
     ApplyTransactionOutputsFromGenesis, // Applies transaction outputs (starting at genesis)
     DownloadLatestStates, // Downloads the state keys and values (at the latest version)
@@ -50,7 +50,7 @@ impl BootstrappingMode {
 /// The continuous syncing mode determines how the node will stay up-to-date
 /// once it has bootstrapped and the blockchain continues to grow, e.g.,
 /// continuously executing all transactions.
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub enum ContinuousSyncingMode {
     ApplyTransactionOutputs, // Applies transaction outputs to stay up-to-date
     ExecuteTransactions,     // Executes transactions to stay up-to-date
@@ -69,7 +69,7 @@ impl ContinuousSyncingMode {
     }
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct StateSyncDriverConfig {
     pub bootstrapping_mode: BootstrappingMode, // The mode by which to bootstrap
@@ -107,7 +107,7 @@ impl Default for StateSyncDriverConfig {
     }
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct StorageServiceConfig {
     pub max_concurrent_requests: u64, // Max num of concurrent storage server tasks
@@ -139,7 +139,7 @@ impl Default for StorageServiceConfig {
     }
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct DataStreamingServiceConfig {
     // The interval (milliseconds) at which to refresh the global data summary.
@@ -182,7 +182,7 @@ impl Default for DataStreamingServiceConfig {
     }
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct AptosDataClientConfig {
     pub max_epoch_chunk_size: u64, // Max num of epoch ending ledger infos per chunk

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -17,7 +17,7 @@ pub const BUFFERED_STATE_TARGET_ITEMS: usize = 100_000;
 /// Port selected RocksDB options for tuning underlying rocksdb instance of AptosDB.
 /// see <https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h>
 /// for detailed explanations.
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct RocksdbConfig {
     pub max_open_files: i32,
@@ -49,7 +49,7 @@ impl Default for RocksdbConfig {
     }
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct RocksdbConfigs {
     pub ledger_db_config: RocksdbConfig,

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -650,7 +650,7 @@ impl EpochManager {
                 self.epoch(),
                 self.author,
                 epoch_state.verifier.len() as u64,
-                self.config.quorum_store_configs.clone(),
+                self.config.quorum_store_configs,
                 consensus_to_quorum_store_rx,
                 self.quorum_store_to_mempool_sender.clone(),
                 self.config.mempool_txn_pull_timeout_ms,

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -282,7 +282,7 @@ impl InnerBuilder {
         let batch_generator = BatchGenerator::new(
             self.epoch,
             self.author,
-            self.config.clone(),
+            self.config,
             self.quorum_store_storage.clone(),
             self.quorum_store_to_mempool_sender,
             self.mempool_txn_pull_timeout_ms,

--- a/network/peer-monitoring-service/client/src/lib.rs
+++ b/network/peer-monitoring-service/client/src/lib.rs
@@ -62,7 +62,7 @@ pub async fn start_peer_monitor(
     // Spawn the peer metadata updater
     let time_service = TimeService::real();
     spawn_peer_metadata_updater(
-        node_config.peer_monitoring_service.clone(),
+        node_config.peer_monitoring_service,
         peer_monitor_state.clone(),
         peer_monitoring_client.get_peers_and_metadata(),
         time_service.clone(),
@@ -95,7 +95,7 @@ async fn start_peer_monitor_with_state(
     let peers_and_metadata = peer_monitoring_client.get_peers_and_metadata();
 
     // Create an interval ticker for the monitor loop
-    let monitoring_service_config = node_config.peer_monitoring_service.clone();
+    let monitoring_service_config = node_config.peer_monitoring_service;
     let peer_monitor_duration =
         Duration::from_millis(monitoring_service_config.peer_monitor_interval_ms);
     let peer_monitor_ticker = time_service.interval(peer_monitor_duration);

--- a/network/peer-monitoring-service/client/src/peer_states/latency_info.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/latency_info.rs
@@ -226,8 +226,7 @@ mod test {
         // Create the latency info state
         let latency_monitoring_config = LatencyMonitoringConfig::default();
         let time_service = TimeService::mock();
-        let mut latency_info_state =
-            LatencyInfoState::new(latency_monitoring_config.clone(), time_service);
+        let mut latency_info_state = LatencyInfoState::new(latency_monitoring_config, time_service);
 
         // Verify the initial latency info state
         assert_eq!(latency_info_state.latency_ping_counter, 0);
@@ -273,8 +272,7 @@ mod test {
         // Create the latency info state
         let latency_monitoring_config = LatencyMonitoringConfig::default();
         let time_service = TimeService::mock();
-        let mut latency_info_state =
-            LatencyInfoState::new(latency_monitoring_config.clone(), time_service);
+        let mut latency_info_state = LatencyInfoState::new(latency_monitoring_config, time_service);
 
         // Verify the initial latency info state
         assert_eq!(latency_info_state.latency_ping_counter, 0);

--- a/network/peer-monitoring-service/client/src/tests/utils.rs
+++ b/network/peer-monitoring-service/client/src/tests/utils.rs
@@ -180,7 +180,7 @@ pub async fn start_peer_metadata_updater(
 ) {
     // Spawn the peer metadata updater
     tokio::spawn(spawn_peer_metadata_updater(
-        node_config.peer_monitoring_service.clone(),
+        node_config.peer_monitoring_service,
         peer_monitor_state.clone(),
         peers_and_metadata,
         time_service.clone(),

--- a/network/peer-monitoring-service/server/src/tests.rs
+++ b/network/peer-monitoring-service/server/src/tests.rs
@@ -322,7 +322,7 @@ impl MockClient {
         let peer_monitoring_config = peer_monitoring_config.unwrap_or_default();
         let node_config = NodeConfig {
             base: base_config,
-            peer_monitoring_service: peer_monitoring_config.clone(),
+            peer_monitoring_service: peer_monitoring_config,
             ..Default::default()
         };
 

--- a/network/src/noise/mod.rs
+++ b/network/src/noise/mod.rs
@@ -15,12 +15,13 @@
 //! use aptos_network::noise::{AntiReplayTimestamps, HandshakeAuthMode, NoiseUpgrader};
 //! use futures::{executor, future, io::{AsyncReadExt, AsyncWriteExt}};
 //! use aptos_memsocket::MemorySocket;
-//! use aptos_config::{config::{Peer, PeerRole, RoleType}, network_id::{NetworkContext, NetworkId}};
+//! use aptos_config::{config::{Peer, PeerRole}, network_id::{NetworkContext, NetworkId}};
 //! use aptos_crypto::{x25519, ed25519, Uniform, PrivateKey, test_utils::TEST_SEED};
 //! use aptos_infallible::RwLock;
 //! use rand::{rngs::StdRng, SeedableRng};
 //! use aptos_types::PeerId;
 //! use std::{collections::{HashSet, HashMap}, io, sync::Arc};
+//! use aptos_config::config::RoleType;
 //! use aptos_network::application::storage::PeersAndMetadata;
 //!
 //! fn example() -> io::Result<()> {


### PR DESCRIPTION
### Description

This PR makes several small cleanups to the node configs (each in their own commit):
1. Remove legacy and unused global constants.
2. Move the base and identity configs into their own files/modules.
4. Added copy derives for appropriate structs (to reduce clone calls) and small cleanups.

Note: nothing should logically change in this PR.

### Test Plan
Existing test infrastructure.