### PR TITLE
Install git in the tools image

### DIFF
--- a/docker/experimental/tools.Dockerfile
+++ b/docker/experimental/tools.Dockerfile
@@ -10,6 +10,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     install \
     wget \
     curl \
+    perl-base=5.32.1-4+deb11u1 \
     git \
     libssl1.1 \
     ca-certificates \

--- a/docker/experimental/tools.Dockerfile
+++ b/docker/experimental/tools.Dockerfile
@@ -10,6 +10,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     install \
     wget \
     curl \
+    git \
     libssl1.1 \
     ca-certificates \
     socat \

--- a/docker/experimental/tools.Dockerfile
+++ b/docker/experimental/tools.Dockerfile
@@ -6,7 +6,7 @@ RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.lis
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && apt-get --no-install-recommends -y \
+    apt-get update && apt-get --no-install-recommends --allow-downgrades -y \
     install \
     wget \
     curl \

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -129,7 +129,7 @@ FROM debian-base AS tools
 RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.list.d/bullseye.list && \
     echo "Package: *\nPin: release n=bullseye\nPin-Priority: 50" > /etc/apt/preferences.d/bullseye
 
-RUN apt-get update && apt-get --no-install-recommends -y \
+RUN apt-get update && apt-get --no-install-recommends --allow-downgrades -y \
     install \
     wget \
     curl \

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -133,6 +133,7 @@ RUN apt-get update && apt-get --no-install-recommends -y \
     install \
     wget \
     curl \
+    perl-base=5.32.1-4+deb11u1 \
     git \
     libssl1.1 \
     ca-certificates \

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -133,6 +133,7 @@ RUN apt-get update && apt-get --no-install-recommends -y \
     install \
     wget \
     curl \
+    git \
     libssl1.1 \
     ca-certificates \
     socat \


### PR DESCRIPTION
### Description
The tools image contains, among other things, the CLI. In order to use certain features of the CLI, such as `aptos move compile` or `aptos move publish`, you must have `git` locally to download dependencies such as the framework. The tools image does not contain `git` currently so it fails with this obscure error:
```
FETCHING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
{
  "Error": "Unexpected error: Unable to resolve packages for package 'aptos_names'"
}
```
This PR fixes this issue by installing git in the image.

Note: I improve the situation with the error message in https://github.com/aptos-labs/aptos-core/pull/7585.

### Test Plan
TBD, pending resolution of these issues: https://aptos-org.slack.com/archives/C04SLLXCC4F/p1680692026091619.