### PR TITLE
Correct erroneous module bundle comments

### DIFF
--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -185,9 +185,6 @@ impl RawTransaction {
     }
 
     /// Create a new `RawTransaction` with a module to publish.
-    ///
-    /// A module transaction is the only way to publish code. Only one module per transaction
-    /// can be published.
     pub fn new_module(
         sender: AccountAddress,
         sequence_number: u64,
@@ -210,8 +207,7 @@ impl RawTransaction {
 
     /// Create a new `RawTransaction` with a list of modules to publish.
     ///
-    /// A module transaction is the only way to publish code. Multiple modules per transaction
-    /// can be published.
+    /// Multiple modules per transaction can be published.
     pub fn new_module_bundle(
         sender: AccountAddress,
         sequence_number: u64,


### PR DESCRIPTION
Module bundles are not the only way to publish modules. Entry functions can publish modules too.