### PR TITLE
ignore an example for `cargo test --doc` to pass

### DIFF
--- a/ecosystem/node-checker/src/provider/helpers.rs
+++ b/ecosystem/node-checker/src/provider/helpers.rs
@@ -9,7 +9,7 @@ pub const MISSING_PROVIDER_MESSAGE: &str = "Incomplete request";
 ///
 /// Example invocations:
 ///
-/// ```
+/// ```ignore
 /// # use std::io;
 /// let target_metrics_provider = aptos_node_checker_lib::get_provider!(
 ///     input.target_metrics_provider,


### PR DESCRIPTION
### Description

Code example would require unreasonable amount of context to actually work, ignore it so that `cargo test --doc` can pass.

### Test Plan

`cargo test --doc` passes now
