### PR TITLE
[framework] improve token mint, burn tracking

### DIFF
--- a/api/src/tests/objects.rs
+++ b/api/src/tests/objects.rs
@@ -51,7 +51,16 @@ async fn test_gen_object() {
         )
         .await;
     let collection1 = context.gen_all_resources(&collection_addr).await;
-    assert_eq!(collection0, collection1);
+    let collection0_obj = to_object(collection0);
+    let collection1_obj = to_object(collection1);
+    assert_eq!(
+        collection0_obj["0x1::object::ObjectCore"],
+        collection1_obj["0x1::object::ObjectCore"]
+    );
+    assert_eq!(
+        collection0_obj["0x4::collection::Collection"],
+        collection1_obj["0x4::collection::Collection"]
+    );
 
     let hero = context.gen_all_resources(&token_addr).await;
     let hero_map = to_object(hero);

--- a/aptos-move/e2e-move-tests/src/tests/token_objects.rs
+++ b/aptos-move/e2e-move-tests/src/tests/token_objects.rs
@@ -15,7 +15,6 @@ struct Token {
     collection_id: u64,
     description: String,
     name: String,
-    creation_name: Option<String>,
     uri: String,
     mutation_events: EventHandle,
 }

--- a/aptos-move/framework/aptos-framework/doc/object.md
+++ b/aptos-move/framework/aptos-framework/doc/object.md
@@ -36,6 +36,7 @@ make it so that a reference to a global object can be returned from a function.
 -  [Function `is_object`](#0x1_object_is_object)
 -  [Function `create_object_address`](#0x1_object_create_object_address)
 -  [Function `create_user_derived_object_address`](#0x1_object_create_user_derived_object_address)
+-  [Function `create_guid_object_address`](#0x1_object_create_guid_object_address)
 -  [Function `exists_at`](#0x1_object_exists_at)
 -  [Function `object_address`](#0x1_object_object_address)
 -  [Function `convert`](#0x1_object_convert)
@@ -663,6 +664,34 @@ Derives an object address from the source address and an object: sha3_256([sourc
     <b>let</b> bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&source);
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&derive_from));
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> bytes, <a href="object.md#0x1_object_OBJECT_DERIVED_SCHEME">OBJECT_DERIVED_SCHEME</a>);
+    <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs_to_address">from_bcs::to_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash_sha3_256">hash::sha3_256</a>(bytes))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_object_create_guid_object_address"></a>
+
+## Function `create_guid_object_address`
+
+Derives an object from an Account GUID.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_guid_object_address">create_guid_object_address</a>(source: <b>address</b>, creation_num: u64): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_guid_object_address">create_guid_object_address</a>(source: <b>address</b>, creation_num: u64): <b>address</b> {
+    <b>let</b> id = <a href="guid.md#0x1_guid_create_id">guid::create_id</a>(source, creation_num);
+    <b>let</b> bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&id);
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> bytes, <a href="object.md#0x1_object_OBJECT_FROM_GUID_ADDRESS_SCHEME">OBJECT_FROM_GUID_ADDRESS_SCHEME</a>);
     <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs_to_address">from_bcs::to_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash_sha3_256">hash::sha3_256</a>(bytes))
 }
 </code></pre>

--- a/aptos-move/framework/aptos-framework/doc/object.md
+++ b/aptos-move/framework/aptos-framework/doc/object.md
@@ -33,6 +33,7 @@ make it so that a reference to a global object can be returned from a function.
 -  [Struct `TransferEvent`](#0x1_object_TransferEvent)
 -  [Constants](#@Constants_0)
 -  [Function `address_to_object`](#0x1_object_address_to_object)
+-  [Function `is_object`](#0x1_object_is_object)
 -  [Function `create_object_address`](#0x1_object_create_object_address)
 -  [Function `create_user_derived_object_address`](#0x1_object_create_user_derived_object_address)
 -  [Function `exists_at`](#0x1_object_exists_at)
@@ -582,6 +583,31 @@ Produces an ObjectId from the given address. This is not verified.
     <b>assert</b>!(<b>exists</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(<a href="object.md#0x1_object">object</a>), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="object.md#0x1_object_EOBJECT_DOES_NOT_EXIST">EOBJECT_DOES_NOT_EXIST</a>));
     <b>assert</b>!(<a href="object.md#0x1_object_exists_at">exists_at</a>&lt;T&gt;(<a href="object.md#0x1_object">object</a>), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="object.md#0x1_object_ERESOURCE_DOES_NOT_EXIST">ERESOURCE_DOES_NOT_EXIST</a>));
     <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;{ inner: <a href="object.md#0x1_object">object</a> }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_object_is_object"></a>
+
+## Function `is_object`
+
+Returns true if there exists an object or the remnants of an object.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_is_object">is_object</a>(<a href="object.md#0x1_object">object</a>: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_is_object">is_object</a>(<a href="object.md#0x1_object">object</a>: <b>address</b>): bool {
+    <b>exists</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(<a href="object.md#0x1_object">object</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/sources/object.move
+++ b/aptos-move/framework/aptos-framework/sources/object.move
@@ -152,6 +152,11 @@ module aptos_framework::object {
         Object<T>{ inner: object }
     }
 
+    /// Returns true if there exists an object or the remnants of an object.
+    public fun is_object(object: address): bool {
+        exists<ObjectCore>(object)
+    }
+
     /// Derives an object address from source material: sha3_256([creator address | seed | 0xFE]).
     public fun create_object_address(source: &address, seed: vector<u8>): address {
         let bytes = bcs::to_bytes(source);

--- a/aptos-move/framework/aptos-framework/sources/object.move
+++ b/aptos-move/framework/aptos-framework/sources/object.move
@@ -173,6 +173,14 @@ module aptos_framework::object {
         from_bcs::to_address(hash::sha3_256(bytes))
     }
 
+    /// Derives an object from an Account GUID.
+    public fun create_guid_object_address(source: address, creation_num: u64): address {
+        let id = guid::create_id(source, creation_num);
+        let bytes = bcs::to_bytes(&id);
+        vector::push_back(&mut bytes, OBJECT_FROM_GUID_ADDRESS_SCHEME);
+        from_bcs::to_address(hash::sha3_256(bytes))
+    }
+
     native fun exists_at<T: key>(object: address): bool;
 
     /// Returns the address of within an ObjectId.

--- a/aptos-move/framework/aptos-token-objects/doc/aptos_token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/aptos_token.md
@@ -462,7 +462,7 @@ With an existing collection, directly mint a soul bound token into the recipient
     property_types: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;String&gt;,
     property_values: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
 ): ConstructorRef <b>acquires</b> <a href="aptos_token.md#0x4_aptos_token_AptosCollection">AptosCollection</a> {
-    <b>let</b> constructor_ref = <a href="token.md#0x4_token_create_named_token">token::create_named_token</a>(
+    <b>let</b> constructor_ref = <a href="token.md#0x4_token_create_from_account">token::create_from_account</a>(
         creator,
         <a href="collection.md#0x4_collection">collection</a>,
         description,

--- a/aptos-move/framework/aptos-token-objects/doc/aptos_token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/aptos_token.md
@@ -462,7 +462,7 @@ With an existing collection, directly mint a soul bound token into the recipient
     property_types: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;String&gt;,
     property_values: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
 ): ConstructorRef <b>acquires</b> <a href="aptos_token.md#0x4_aptos_token_AptosCollection">AptosCollection</a> {
-    <b>let</b> constructor_ref = <a href="token.md#0x4_token_create">token::create</a>(
+    <b>let</b> constructor_ref = <a href="token.md#0x4_token_create_named_token">token::create_named_token</a>(
         creator,
         <a href="collection.md#0x4_collection">collection</a>,
         description,

--- a/aptos-move/framework/aptos-token-objects/doc/collection.md
+++ b/aptos-move/framework/aptos-token-objects/doc/collection.md
@@ -31,10 +31,12 @@ require adding the field original_name.
 -  [Struct `MutatorRef`](#0x4_collection_MutatorRef)
 -  [Struct `MutationEvent`](#0x4_collection_MutationEvent)
 -  [Resource `FixedSupply`](#0x4_collection_FixedSupply)
+-  [Resource `UnlimitedSupply`](#0x4_collection_UnlimitedSupply)
 -  [Struct `BurnEvent`](#0x4_collection_BurnEvent)
 -  [Struct `MintEvent`](#0x4_collection_MintEvent)
 -  [Constants](#@Constants_0)
 -  [Function `create_fixed_collection`](#0x4_collection_create_fixed_collection)
+-  [Function `create_unlimited_collection`](#0x4_collection_create_unlimited_collection)
 -  [Function `create_untracked_collection`](#0x4_collection_create_untracked_collection)
 -  [Function `create_collection_address`](#0x4_collection_create_collection_address)
 -  [Function `create_collection_seed`](#0x4_collection_create_collection_seed)
@@ -176,6 +178,7 @@ directly understand the behavior in a writeset.
 ## Resource `FixedSupply`
 
 Fixed supply tracker, this is useful for ensuring that a limited number of tokens are minted.
+and adding events and supply tracking to a collection.
 
 
 <pre><code><b>struct</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a> <b>has</b> key
@@ -196,6 +199,52 @@ Fixed supply tracker, this is useful for ensuring that a limited number of token
 </dd>
 <dt>
 <code>max_supply: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>total_minted: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>burn_events: <a href="../../aptos-framework/doc/event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="collection.md#0x4_collection_BurnEvent">collection::BurnEvent</a>&gt;</code>
+</dt>
+<dd>
+ Emitted upon burning a Token.
+</dd>
+<dt>
+<code>mint_events: <a href="../../aptos-framework/doc/event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="collection.md#0x4_collection_MintEvent">collection::MintEvent</a>&gt;</code>
+</dt>
+<dd>
+ Emitted upon minting an Token.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x4_collection_UnlimitedSupply"></a>
+
+## Resource `UnlimitedSupply`
+
+Unlimited supply tracker, this is useful for adding events and supply tracking to a collection.
+
+
+<pre><code><b>struct</b> <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>current_supply: u64</code>
 </dt>
 <dd>
 
@@ -322,6 +371,7 @@ Creates a fixed-sized collection, or a collection that supports a fixed amount o
 This is useful to create a guaranteed, limited supply on-chain digital asset. For example,
 a collection 1111 vicious vipers. Note, creating restrictions such as upward limits results
 in data structures that prevent Aptos from parallelizing mints of this collection type.
+Beyond that, it adds supply tracking with events.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_create_fixed_collection">create_fixed_collection</a>(creator: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, description: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, max_supply: u64, name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, <a href="royalty.md#0x4_royalty">royalty</a>: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="royalty.md#0x4_royalty_Royalty">royalty::Royalty</a>&gt;, uri: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <a href="../../aptos-framework/doc/object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>
@@ -369,6 +419,57 @@ in data structures that prevent Aptos from parallelizing mints of this collectio
 
 </details>
 
+<a name="0x4_collection_create_unlimited_collection"></a>
+
+## Function `create_unlimited_collection`
+
+Creates an unlimited collection. This has support for supply tracking but does not limit
+the supply of tokens.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_create_unlimited_collection">create_unlimited_collection</a>(creator: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, description: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, <a href="royalty.md#0x4_royalty">royalty</a>: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="royalty.md#0x4_royalty_Royalty">royalty::Royalty</a>&gt;, uri: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <a href="../../aptos-framework/doc/object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_create_unlimited_collection">create_unlimited_collection</a>(
+    creator: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    description: String,
+    name: String,
+    <a href="royalty.md#0x4_royalty">royalty</a>: Option&lt;Royalty&gt;,
+    uri: String,
+): ConstructorRef {
+    <b>let</b> collection_seed = <a href="collection.md#0x4_collection_create_collection_seed">create_collection_seed</a>(&name);
+    <b>let</b> constructor_ref = <a href="../../aptos-framework/doc/object.md#0x1_object_create_named_object">object::create_named_object</a>(creator, collection_seed);
+    <b>let</b> object_signer = <a href="../../aptos-framework/doc/object.md#0x1_object_generate_signer">object::generate_signer</a>(&constructor_ref);
+
+    <b>let</b> supply = <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a> {
+        current_supply: 0,
+        total_minted: 0,
+        burn_events: <a href="../../aptos-framework/doc/object.md#0x1_object_new_event_handle">object::new_event_handle</a>(&object_signer),
+        mint_events: <a href="../../aptos-framework/doc/object.md#0x1_object_new_event_handle">object::new_event_handle</a>(&object_signer),
+    };
+
+    create_collection_internal(
+        creator,
+        constructor_ref,
+        description,
+        name,
+        <a href="royalty.md#0x4_royalty">royalty</a>,
+        uri,
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(supply),
+    )
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x4_collection_create_untracked_collection"></a>
 
 ## Function `create_untracked_collection`
@@ -378,7 +479,7 @@ tokens. This is useful for mass airdrops that fully leverage Aptos parallelizati
 TODO: Hide this until we bring back meaningful way to enforce burns
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_create_untracked_collection">create_untracked_collection</a>(creator: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, description: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, <a href="royalty.md#0x4_royalty">royalty</a>: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="royalty.md#0x4_royalty_Royalty">royalty::Royalty</a>&gt;, uri: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <a href="../../aptos-framework/doc/object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>
+<pre><code><b>fun</b> <a href="collection.md#0x4_collection_create_untracked_collection">create_untracked_collection</a>(creator: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, description: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, <a href="royalty.md#0x4_royalty">royalty</a>: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="royalty.md#0x4_royalty_Royalty">royalty::Royalty</a>&gt;, uri: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <a href="../../aptos-framework/doc/object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>
 </code></pre>
 
 
@@ -387,7 +488,7 @@ TODO: Hide this until we bring back meaningful way to enforce burns
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_create_untracked_collection">create_untracked_collection</a>(
+<pre><code><b>fun</b> <a href="collection.md#0x4_collection_create_untracked_collection">create_untracked_collection</a>(
     creator: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     description: String,
     name: String,
@@ -482,7 +583,7 @@ Called by token on mint to increment supply if there's an appropriate Supply str
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="collection.md#0x4_collection_increment_supply">increment_supply</a>(
     <a href="collection.md#0x4_collection">collection</a>: &Object&lt;<a href="collection.md#0x4_collection_Collection">Collection</a>&gt;,
     <a href="token.md#0x4_token">token</a>: <b>address</b>,
-): Option&lt;u64&gt; <b>acquires</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a> {
+): Option&lt;u64&gt; <b>acquires</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>, <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a> {
     <b>let</b> collection_addr = <a href="../../aptos-framework/doc/object.md#0x1_object_object_address">object::object_address</a>(<a href="collection.md#0x4_collection">collection</a>);
     <b>if</b> (<b>exists</b>&lt;<a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>&gt;(collection_addr)) {
         <b>let</b> supply = <b>borrow_global_mut</b>&lt;<a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>&gt;(collection_addr);
@@ -492,6 +593,17 @@ Called by token on mint to increment supply if there's an appropriate Supply str
             supply.current_supply &lt;= supply.max_supply,
             <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="collection.md#0x4_collection_EEXCEEDS_MAX_SUPPLY">EEXCEEDS_MAX_SUPPLY</a>),
         );
+        <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(&<b>mut</b> supply.mint_events,
+            <a href="collection.md#0x4_collection_MintEvent">MintEvent</a> {
+                collection_id: supply.total_minted,
+                <a href="token.md#0x4_token">token</a>,
+            },
+        );
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(supply.total_minted)
+    } <b>else</b> <b>if</b> (<b>exists</b>&lt;<a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>&gt;(collection_addr)) {
+        <b>let</b> supply = <b>borrow_global_mut</b>&lt;<a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>&gt;(collection_addr);
+        supply.current_supply = supply.current_supply + 1;
+        supply.total_minted = supply.total_minted + 1;
         <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
             &<b>mut</b> supply.mint_events,
             <a href="collection.md#0x4_collection_MintEvent">MintEvent</a> {
@@ -530,10 +642,20 @@ Called by token on burn to decrement supply if there's an appropriate Supply str
     <a href="collection.md#0x4_collection">collection</a>: &Object&lt;<a href="collection.md#0x4_collection_Collection">Collection</a>&gt;,
     <a href="token.md#0x4_token">token</a>: <b>address</b>,
     collection_id: Option&lt;u64&gt;,
-) <b>acquires</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a> {
+) <b>acquires</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>, <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a> {
     <b>let</b> collection_addr = <a href="../../aptos-framework/doc/object.md#0x1_object_object_address">object::object_address</a>(<a href="collection.md#0x4_collection">collection</a>);
     <b>if</b> (<b>exists</b>&lt;<a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>&gt;(collection_addr)) {
         <b>let</b> supply = <b>borrow_global_mut</b>&lt;<a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>&gt;(collection_addr);
+        supply.current_supply = supply.current_supply - 1;
+        <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
+            &<b>mut</b> supply.mint_events,
+            <a href="collection.md#0x4_collection_MintEvent">MintEvent</a> {
+                collection_id: *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&collection_id),
+                <a href="token.md#0x4_token">token</a>,
+            },
+        );
+    } <b>else</b> <b>if</b> (<b>exists</b>&lt;<a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>&gt;(collection_addr)) {
+        <b>let</b> supply = <b>borrow_global_mut</b>&lt;<a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>&gt;(collection_addr);
         supply.current_supply = supply.current_supply - 1;
         <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
             &<b>mut</b> supply.mint_events,
@@ -591,7 +713,7 @@ Creates a MutatorRef, which gates the ability to mutate any fields that support 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_count">count</a>&lt;T: key&gt;(<a href="collection.md#0x4_collection">collection</a>: Object&lt;T&gt;): Option&lt;u64&gt; <b>acquires</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_count">count</a>&lt;T: key&gt;(<a href="collection.md#0x4_collection">collection</a>: Object&lt;T&gt;): Option&lt;u64&gt; <b>acquires</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>, <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a> {
     <b>let</b> collection_address = <a href="../../aptos-framework/doc/object.md#0x1_object_object_address">object::object_address</a>(&<a href="collection.md#0x4_collection">collection</a>);
     <b>assert</b>!(
         <b>exists</b>&lt;<a href="collection.md#0x4_collection_Collection">Collection</a>&gt;(collection_address),
@@ -600,6 +722,9 @@ Creates a MutatorRef, which gates the ability to mutate any fields that support 
 
     <b>if</b> (<b>exists</b>&lt;<a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>&gt;(collection_address)) {
         <b>let</b> supply = <b>borrow_global_mut</b>&lt;<a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>&gt;(collection_address);
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(supply.current_supply)
+    } <b>else</b> <b>if</b> (<b>exists</b>&lt;<a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>&gt;(collection_address)) {
+        <b>let</b> supply = <b>borrow_global_mut</b>&lt;<a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>&gt;(collection_address);
         <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(supply.current_supply)
     } <b>else</b> {
         <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>()

--- a/aptos-move/framework/aptos-token-objects/doc/token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/token.md
@@ -18,7 +18,7 @@ TODO:
 -  [Struct `MutatorRef`](#0x4_token_MutatorRef)
 -  [Struct `MutationEvent`](#0x4_token_MutationEvent)
 -  [Constants](#@Constants_0)
--  [Function `create`](#0x4_token_create)
+-  [Function `create_named_token`](#0x4_token_create_named_token)
 -  [Function `create_from_account`](#0x4_token_create_from_account)
 -  [Function `create_token_address`](#0x4_token_create_token_address)
 -  [Function `create_token_seed`](#0x4_token_create_token_seed)
@@ -238,15 +238,15 @@ The provided signer is not the creator
 
 
 
-<a name="0x4_token_create"></a>
+<a name="0x4_token_create_named_token"></a>
 
-## Function `create`
+## Function `create_named_token`
 
 Creates a new token object from a token name and returns the ConstructorRef for
 additional specialization.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_create">create</a>(creator: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, collection_name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, description: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, <a href="royalty.md#0x4_royalty">royalty</a>: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="royalty.md#0x4_royalty_Royalty">royalty::Royalty</a>&gt;, uri: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <a href="../../aptos-framework/doc/object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>
+<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_create_named_token">create_named_token</a>(creator: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, collection_name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, description: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, <a href="royalty.md#0x4_royalty">royalty</a>: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="royalty.md#0x4_royalty_Royalty">royalty::Royalty</a>&gt;, uri: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <a href="../../aptos-framework/doc/object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>
 </code></pre>
 
 
@@ -255,7 +255,7 @@ additional specialization.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_create">create</a>(
+<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_create_named_token">create_named_token</a>(
     creator: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     collection_name: String,
     description: String,
@@ -267,7 +267,7 @@ additional specialization.
     <b>let</b> seed = <a href="token.md#0x4_token_create_token_seed">create_token_seed</a>(&collection_name, &name);
 
     <b>let</b> constructor_ref = <a href="../../aptos-framework/doc/object.md#0x1_object_create_named_object">object::create_named_object</a>(creator, seed);
-    inline_create(&constructor_ref, creator_address, collection_name, description, name, <a href="royalty.md#0x4_royalty">royalty</a>, uri);
+    create_common(&constructor_ref, creator_address, collection_name, description, name, <a href="royalty.md#0x4_royalty">royalty</a>, uri);
     constructor_ref
 }
 </code></pre>
@@ -303,7 +303,7 @@ additional specialization.
 ): ConstructorRef {
     <b>let</b> creator_address = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(creator);
     <b>let</b> constructor_ref = <a href="../../aptos-framework/doc/object.md#0x1_object_create_object_from_account">object::create_object_from_account</a>(creator);
-    inline_create(&constructor_ref, creator_address, collection_name, description, name, <a href="royalty.md#0x4_royalty">royalty</a>, uri);
+    create_common(&constructor_ref, creator_address, collection_name, description, name, <a href="royalty.md#0x4_royalty">royalty</a>, uri);
     constructor_ref
 }
 </code></pre>

--- a/aptos-move/framework/aptos-token-objects/doc/token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/token.md
@@ -19,6 +19,7 @@ TODO:
 -  [Struct `MutationEvent`](#0x4_token_MutationEvent)
 -  [Constants](#@Constants_0)
 -  [Function `create`](#0x4_token_create)
+-  [Function `create_from_account`](#0x4_token_create_from_account)
 -  [Function `create_token_address`](#0x4_token_create_token_address)
 -  [Function `create_token_seed`](#0x4_token_create_token_seed)
 -  [Function `generate_mutator_ref`](#0x4_token_generate_mutator_ref)
@@ -241,7 +242,8 @@ The provided signer is not the creator
 
 ## Function `create`
 
-Creates a new token object and returns the ConstructorRef for additional specialization.
+Creates a new token object from a token name and returns the ConstructorRef for
+additional specialization.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_create">create</a>(creator: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, collection_name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, description: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, <a href="royalty.md#0x4_royalty">royalty</a>: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="royalty.md#0x4_royalty_Royalty">royalty::Royalty</a>&gt;, uri: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <a href="../../aptos-framework/doc/object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>
@@ -265,25 +267,43 @@ Creates a new token object and returns the ConstructorRef for additional special
     <b>let</b> seed = <a href="token.md#0x4_token_create_token_seed">create_token_seed</a>(&collection_name, &name);
 
     <b>let</b> constructor_ref = <a href="../../aptos-framework/doc/object.md#0x1_object_create_named_object">object::create_named_object</a>(creator, seed);
-    <b>let</b> object_signer = <a href="../../aptos-framework/doc/object.md#0x1_object_generate_signer">object::generate_signer</a>(&constructor_ref);
+    inline_create(&constructor_ref, creator_address, collection_name, description, name, <a href="royalty.md#0x4_royalty">royalty</a>, uri);
+    constructor_ref
+}
+</code></pre>
 
-    <b>let</b> collection_addr = <a href="collection.md#0x4_collection_create_collection_address">collection::create_collection_address</a>(&creator_address, &collection_name);
-    <b>let</b> <a href="collection.md#0x4_collection">collection</a> = <a href="../../aptos-framework/doc/object.md#0x1_object_address_to_object">object::address_to_object</a>&lt;Collection&gt;(collection_addr);
-    <b>let</b> id = <a href="collection.md#0x4_collection_increment_supply">collection::increment_supply</a>(&<a href="collection.md#0x4_collection">collection</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&object_signer));
 
-    <b>let</b> <a href="token.md#0x4_token">token</a> = <a href="token.md#0x4_token_Token">Token</a> {
-        <a href="collection.md#0x4_collection">collection</a>,
-        collection_id: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_get_with_default">option::get_with_default</a>(&<b>mut</b> id, 0),
-        description,
-        name,
-        uri,
-        mutation_events: <a href="../../aptos-framework/doc/object.md#0x1_object_new_event_handle">object::new_event_handle</a>(&object_signer),
-    };
-    <b>move_to</b>(&object_signer, <a href="token.md#0x4_token">token</a>);
 
-    <b>if</b> (<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&<a href="royalty.md#0x4_royalty">royalty</a>)) {
-        <a href="royalty.md#0x4_royalty_init">royalty::init</a>(&constructor_ref, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> <a href="royalty.md#0x4_royalty">royalty</a>))
-    };
+</details>
+
+<a name="0x4_token_create_from_account"></a>
+
+## Function `create_from_account`
+
+Creates a new token object from an account GUID and returns the ConstructorRef for
+additional specialization.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_create_from_account">create_from_account</a>(creator: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, collection_name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, description: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, <a href="royalty.md#0x4_royalty">royalty</a>: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="royalty.md#0x4_royalty_Royalty">royalty::Royalty</a>&gt;, uri: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <a href="../../aptos-framework/doc/object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_create_from_account">create_from_account</a>(
+    creator: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    collection_name: String,
+    description: String,
+    name: String,
+    <a href="royalty.md#0x4_royalty">royalty</a>: Option&lt;Royalty&gt;,
+    uri: String,
+): ConstructorRef {
+    <b>let</b> creator_address = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(creator);
+    <b>let</b> constructor_ref = <a href="../../aptos-framework/doc/object.md#0x1_object_create_object_from_account">object::create_object_from_account</a>(creator);
+    inline_create(&constructor_ref, creator_address, collection_name, description, name, <a href="royalty.md#0x4_royalty">royalty</a>, uri);
     constructor_ref
 }
 </code></pre>

--- a/aptos-move/framework/aptos-token-objects/doc/token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/token.md
@@ -27,7 +27,6 @@ TODO:
 -  [Function `creator`](#0x4_token_creator)
 -  [Function `collection`](#0x4_token_collection)
 -  [Function `collection_object`](#0x4_token_collection_object)
--  [Function `creation_name`](#0x4_token_creation_name)
 -  [Function `description`](#0x4_token_description)
 -  [Function `name`](#0x4_token_name)
 -  [Function `uri`](#0x4_token_uri)
@@ -92,13 +91,6 @@ Represents the common fields to all tokens.
 <dd>
  The name of the token, which should be unique within the collection; the length of name
  should be smaller than 128, characters, eg: "Aptos Animal #1234"
-</dd>
-<dt>
-<code>creation_name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;</code>
-</dt>
-<dd>
- The creation name of the token. Since tokens are created with the name as part of the
- object id generation.
 </dd>
 <dt>
 <code>uri: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a></code>
@@ -284,7 +276,6 @@ Creates a new token object and returns the ConstructorRef for additional special
         collection_id: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_get_with_default">option::get_with_default</a>(&<b>mut</b> id, 0),
         description,
         name,
-        creation_name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>(),
         uri,
         mutation_events: <a href="../../aptos-framework/doc/object.md#0x1_object_new_event_handle">object::new_event_handle</a>(&object_signer),
     };
@@ -513,35 +504,6 @@ Extracts the tokens address from a BurnRef.
 
 </details>
 
-<a name="0x4_token_creation_name"></a>
-
-## Function `creation_name`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_creation_name">creation_name</a>&lt;T: key&gt;(<a href="token.md#0x4_token">token</a>: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_creation_name">creation_name</a>&lt;T: key&gt;(<a href="token.md#0x4_token">token</a>: Object&lt;T&gt;): String <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a> {
-    <b>let</b> <a href="token.md#0x4_token">token</a> = borrow(&<a href="token.md#0x4_token">token</a>);
-    <b>if</b> (<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&<a href="token.md#0x4_token">token</a>.creation_name)) {
-        *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&<a href="token.md#0x4_token">token</a>.creation_name)
-    } <b>else</b> {
-        <a href="token.md#0x4_token">token</a>.name
-    }
-}
-</code></pre>
-
-
-
-</details>
-
 <a name="0x4_token_description"></a>
 
 ## Function `description`
@@ -682,7 +644,6 @@ Extracts the tokens address from a BurnRef.
         collection_id,
         description: _,
         name: _,
-        creation_name: _,
         uri: _,
         mutation_events,
     } = <b>move_from</b>&lt;<a href="token.md#0x4_token_Token">Token</a>&gt;(addr);
@@ -742,9 +703,6 @@ Extracts the tokens address from a BurnRef.
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_set_name">set_name</a>(mutator_ref: &<a href="token.md#0x4_token_MutatorRef">MutatorRef</a>, name: String) <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a> {
     <b>let</b> <a href="token.md#0x4_token">token</a> = borrow_mut(mutator_ref);
-    <b>if</b> (<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(&<a href="token.md#0x4_token">token</a>.creation_name)) {
-        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_fill">option::fill</a>(&<b>mut</b> <a href="token.md#0x4_token">token</a>.creation_name, <a href="token.md#0x4_token">token</a>.name)
-    };
     <a href="token.md#0x4_token">token</a>.name = name;
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
         &<b>mut</b> <a href="token.md#0x4_token">token</a>.mutation_events,

--- a/aptos-move/framework/aptos-token-objects/doc/token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/token.md
@@ -272,12 +272,12 @@ Creates a new token object and returns the ConstructorRef for additional special
     <b>let</b> creator_address = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(creator);
     <b>let</b> seed = <a href="token.md#0x4_token_create_token_seed">create_token_seed</a>(&collection_name, &name);
 
-    <b>let</b> collection_addr = <a href="collection.md#0x4_collection_create_collection_address">collection::create_collection_address</a>(&creator_address, &collection_name);
-    <b>let</b> <a href="collection.md#0x4_collection">collection</a> = <a href="../../aptos-framework/doc/object.md#0x1_object_address_to_object">object::address_to_object</a>&lt;Collection&gt;(collection_addr);
-    <b>let</b> id = <a href="collection.md#0x4_collection_increment_supply">collection::increment_supply</a>(&<a href="collection.md#0x4_collection">collection</a>);
-
     <b>let</b> constructor_ref = <a href="../../aptos-framework/doc/object.md#0x1_object_create_named_object">object::create_named_object</a>(creator, seed);
     <b>let</b> object_signer = <a href="../../aptos-framework/doc/object.md#0x1_object_generate_signer">object::generate_signer</a>(&constructor_ref);
+
+    <b>let</b> collection_addr = <a href="collection.md#0x4_collection_create_collection_address">collection::create_collection_address</a>(&creator_address, &collection_name);
+    <b>let</b> <a href="collection.md#0x4_collection">collection</a> = <a href="../../aptos-framework/doc/object.md#0x1_object_address_to_object">object::address_to_object</a>&lt;Collection&gt;(collection_addr);
+    <b>let</b> id = <a href="collection.md#0x4_collection_increment_supply">collection::increment_supply</a>(&<a href="collection.md#0x4_collection">collection</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&object_signer));
 
     <b>let</b> <a href="token.md#0x4_token">token</a> = <a href="token.md#0x4_token_Token">Token</a> {
         <a href="collection.md#0x4_collection">collection</a>,
@@ -679,7 +679,7 @@ Extracts the tokens address from a BurnRef.
 
     <b>let</b> <a href="token.md#0x4_token_Token">Token</a> {
         <a href="collection.md#0x4_collection">collection</a>,
-        collection_id: _,
+        collection_id,
         description: _,
         name: _,
         creation_name: _,
@@ -688,7 +688,7 @@ Extracts the tokens address from a BurnRef.
     } = <b>move_from</b>&lt;<a href="token.md#0x4_token_Token">Token</a>&gt;(addr);
 
     <a href="../../aptos-framework/doc/event.md#0x1_event_destroy_handle">event::destroy_handle</a>(mutation_events);
-    <a href="collection.md#0x4_collection_decrement_supply">collection::decrement_supply</a>(&<a href="collection.md#0x4_collection">collection</a>);
+    <a href="collection.md#0x4_collection_decrement_supply">collection::decrement_supply</a>(&<a href="collection.md#0x4_collection">collection</a>, addr, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(collection_id));
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-token-objects/sources/aptos_token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/aptos_token.move
@@ -201,7 +201,7 @@ module aptos_token_objects::aptos_token {
         property_types: vector<String>,
         property_values: vector<vector<u8>>,
     ): ConstructorRef acquires AptosCollection {
-        let constructor_ref = token::create(
+        let constructor_ref = token::create_named_token(
             creator,
             collection,
             description,

--- a/aptos-move/framework/aptos-token-objects/sources/collection.move
+++ b/aptos-move/framework/aptos-token-objects/sources/collection.move
@@ -67,9 +67,21 @@ module aptos_token_objects::collection {
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     /// Fixed supply tracker, this is useful for ensuring that a limited number of tokens are minted.
+    /// and adding events and supply tracking to a collection.
     struct FixedSupply has key {
         current_supply: u64,
         max_supply: u64,
+        total_minted: u64,
+        /// Emitted upon burning a Token.
+        burn_events: event::EventHandle<BurnEvent>,
+        /// Emitted upon minting an Token.
+        mint_events: event::EventHandle<MintEvent>,
+    }
+
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    /// Unlimited supply tracker, this is useful for adding events and supply tracking to a collection.
+    struct UnlimitedSupply has key {
+        current_supply: u64,
         total_minted: u64,
         /// Emitted upon burning a Token.
         burn_events: event::EventHandle<BurnEvent>,
@@ -91,6 +103,7 @@ module aptos_token_objects::collection {
     /// This is useful to create a guaranteed, limited supply on-chain digital asset. For example,
     /// a collection 1111 vicious vipers. Note, creating restrictions such as upward limits results
     /// in data structures that prevent Aptos from parallelizing mints of this collection type.
+    /// Beyond that, it adds supply tracking with events.
     public fun create_fixed_collection(
         creator: &signer,
         description: String,
@@ -122,10 +135,41 @@ module aptos_token_objects::collection {
         )
     }
 
+    /// Creates an unlimited collection. This has support for supply tracking but does not limit
+    /// the supply of tokens.
+    public fun create_unlimited_collection(
+        creator: &signer,
+        description: String,
+        name: String,
+        royalty: Option<Royalty>,
+        uri: String,
+    ): ConstructorRef {
+        let collection_seed = create_collection_seed(&name);
+        let constructor_ref = object::create_named_object(creator, collection_seed);
+        let object_signer = object::generate_signer(&constructor_ref);
+
+        let supply = UnlimitedSupply {
+            current_supply: 0,
+            total_minted: 0,
+            burn_events: object::new_event_handle(&object_signer),
+            mint_events: object::new_event_handle(&object_signer),
+        };
+
+        create_collection_internal(
+            creator,
+            constructor_ref,
+            description,
+            name,
+            royalty,
+            uri,
+            option::some(supply),
+        )
+    }
+
     /// Creates an untracked collection, or a collection that supports an arbitrary amount of
     /// tokens. This is useful for mass airdrops that fully leverage Aptos parallelization.
     /// TODO: Hide this until we bring back meaningful way to enforce burns
-    public fun create_untracked_collection(
+    fun create_untracked_collection(
         creator: &signer,
         description: String,
         name: String,
@@ -196,7 +240,7 @@ module aptos_token_objects::collection {
     public(friend) fun increment_supply(
         collection: &Object<Collection>,
         token: address,
-    ): Option<u64> acquires FixedSupply {
+    ): Option<u64> acquires FixedSupply, UnlimitedSupply {
         let collection_addr = object::object_address(collection);
         if (exists<FixedSupply>(collection_addr)) {
             let supply = borrow_global_mut<FixedSupply>(collection_addr);
@@ -206,6 +250,17 @@ module aptos_token_objects::collection {
                 supply.current_supply <= supply.max_supply,
                 error::out_of_range(EEXCEEDS_MAX_SUPPLY),
             );
+            event::emit_event(&mut supply.mint_events,
+                MintEvent {
+                    collection_id: supply.total_minted,
+                    token,
+                },
+            );
+            option::some(supply.total_minted)
+        } else if (exists<UnlimitedSupply>(collection_addr)) {
+            let supply = borrow_global_mut<UnlimitedSupply>(collection_addr);
+            supply.current_supply = supply.current_supply + 1;
+            supply.total_minted = supply.total_minted + 1;
             event::emit_event(
                 &mut supply.mint_events,
                 MintEvent {
@@ -224,10 +279,20 @@ module aptos_token_objects::collection {
         collection: &Object<Collection>,
         token: address,
         collection_id: Option<u64>,
-    ) acquires FixedSupply {
+    ) acquires FixedSupply, UnlimitedSupply {
         let collection_addr = object::object_address(collection);
         if (exists<FixedSupply>(collection_addr)) {
             let supply = borrow_global_mut<FixedSupply>(collection_addr);
+            supply.current_supply = supply.current_supply - 1;
+            event::emit_event(
+                &mut supply.mint_events,
+                MintEvent {
+                    collection_id: *option::borrow(&collection_id),
+                    token,
+                },
+            );
+        } else if (exists<UnlimitedSupply>(collection_addr)) {
+            let supply = borrow_global_mut<UnlimitedSupply>(collection_addr);
             supply.current_supply = supply.current_supply - 1;
             event::emit_event(
                 &mut supply.mint_events,
@@ -257,7 +322,7 @@ module aptos_token_objects::collection {
     }
 
     #[view]
-    public fun count<T: key>(collection: Object<T>): Option<u64> acquires FixedSupply {
+    public fun count<T: key>(collection: Object<T>): Option<u64> acquires FixedSupply, UnlimitedSupply {
         let collection_address = object::object_address(&collection);
         assert!(
             exists<Collection>(collection_address),
@@ -266,6 +331,9 @@ module aptos_token_objects::collection {
 
         if (exists<FixedSupply>(collection_address)) {
             let supply = borrow_global_mut<FixedSupply>(collection_address);
+            option::some(supply.current_supply)
+        } else if (exists<UnlimitedSupply>(collection_address)) {
+            let supply = borrow_global_mut<UnlimitedSupply>(collection_address);
             option::some(supply.current_supply)
         } else {
             option::none()
@@ -321,6 +389,36 @@ module aptos_token_objects::collection {
     }
 
     // Tests
+
+    #[test(creator = @0x123)]
+    fun test_create_mint_burn_for_unlimited(creator: &signer) acquires FixedSupply, UnlimitedSupply {
+        let creator_address = signer::address_of(creator);
+        let name = string::utf8(b"collection name");
+        create_unlimited_collection(creator, string::utf8(b""), name, option::none(), string::utf8(b""));
+        let collection = object::address_to_object<Collection>(
+            create_collection_address(&creator_address, &name),
+        );
+        assert!(count(collection) == option::some(0), 0);
+        let cid = increment_supply(&collection, creator_address);
+        assert!(count(collection) == option::some(1), 0);
+        decrement_supply(&collection, creator_address, cid);
+        assert!(count(collection) == option::some(0), 0);
+    }
+
+    #[test(creator = @0x123)]
+    fun test_create_mint_burn_for_fixed(creator: &signer) acquires FixedSupply, UnlimitedSupply {
+        let creator_address = signer::address_of(creator);
+        let name = string::utf8(b"collection name");
+        create_fixed_collection(creator, string::utf8(b""), 1, name, option::none(), string::utf8(b""));
+        let collection = object::address_to_object<Collection>(
+            create_collection_address(&creator_address, &name),
+        );
+        assert!(count(collection) == option::some(0), 0);
+        let cid = increment_supply(&collection, creator_address);
+        assert!(count(collection) == option::some(1), 0);
+        decrement_supply(&collection, creator_address, cid);
+        assert!(count(collection) == option::some(0), 0);
+    }
 
     #[test(creator = @0x123, trader = @0x456)]
     #[expected_failure(abort_code = 0x50003, location = aptos_framework::object)]

--- a/aptos-move/framework/aptos-token-objects/sources/token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/token.move
@@ -79,12 +79,12 @@ module aptos_token_objects::token {
         let creator_address = signer::address_of(creator);
         let seed = create_token_seed(&collection_name, &name);
 
-        let collection_addr = collection::create_collection_address(&creator_address, &collection_name);
-        let collection = object::address_to_object<Collection>(collection_addr);
-        let id = collection::increment_supply(&collection);
-
         let constructor_ref = object::create_named_object(creator, seed);
         let object_signer = object::generate_signer(&constructor_ref);
+
+        let collection_addr = collection::create_collection_address(&creator_address, &collection_name);
+        let collection = object::address_to_object<Collection>(collection_addr);
+        let id = collection::increment_supply(&collection, signer::address_of(&object_signer));
 
         let token = Token {
             collection,
@@ -235,7 +235,7 @@ module aptos_token_objects::token {
 
         let Token {
             collection,
-            collection_id: _,
+            collection_id,
             description: _,
             name: _,
             creation_name: _,
@@ -244,7 +244,7 @@ module aptos_token_objects::token {
         } = move_from<Token>(addr);
 
         event::destroy_handle(mutation_events);
-        collection::decrement_supply(&collection);
+        collection::decrement_supply(&collection, addr, option::some(collection_id));
     }
 
     public fun set_description(mutator_ref: &MutatorRef, description: String) acquires Token {

--- a/aptos-move/framework/aptos-token-objects/sources/token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/token.move
@@ -331,7 +331,7 @@ module aptos_token_objects::token {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
 
-        collection::create_untracked_collection(
+        collection::create_unlimited_collection(
             creator,
             string::utf8(b"collection description"),
             collection_name,

--- a/aptos-move/framework/aptos-token-objects/sources/token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/token.move
@@ -64,7 +64,7 @@ module aptos_token_objects::token {
         mutated_field_name: String,
     }
 
-    inline fun inline_create(
+    inline fun create_common(
         constructor_ref: &ConstructorRef,
         creator_address: address,
         collection_name: String,
@@ -96,7 +96,7 @@ module aptos_token_objects::token {
 
     /// Creates a new token object from a token name and returns the ConstructorRef for
     /// additional specialization.
-    public fun create(
+    public fun create_named_token(
         creator: &signer,
         collection_name: String,
         description: String,
@@ -108,7 +108,7 @@ module aptos_token_objects::token {
         let seed = create_token_seed(&collection_name, &name);
 
         let constructor_ref = object::create_named_object(creator, seed);
-        inline_create(&constructor_ref, creator_address, collection_name, description, name, royalty, uri);
+        create_common(&constructor_ref, creator_address, collection_name, description, name, royalty, uri);
         constructor_ref
     }
 
@@ -124,7 +124,7 @@ module aptos_token_objects::token {
     ): ConstructorRef {
         let creator_address = signer::address_of(creator);
         let constructor_ref = object::create_object_from_account(creator);
-        inline_create(&constructor_ref, creator_address, collection_name, description, name, royalty, uri);
+        create_common(&constructor_ref, creator_address, collection_name, description, name, royalty, uri);
         constructor_ref
     }
 
@@ -323,7 +323,7 @@ module aptos_token_objects::token {
             string::utf8(b"collection uri"),
         );
 
-        create(
+        create_named_token(
             creator,
             collection_name,
             string::utf8(b"token description"),
@@ -350,7 +350,7 @@ module aptos_token_objects::token {
             string::utf8(b"collection uri"),
         );
 
-        create(
+        create_named_token(
             creator,
             collection_name,
             string::utf8(b"token description"),
@@ -444,7 +444,7 @@ module aptos_token_objects::token {
         let token_name = string::utf8(b"token name");
 
         create_collection_helper(creator, *&collection_name, 1);
-        let constructor_ref = create(
+        let constructor_ref = create_named_token(
             creator,
             collection_name,
             string::utf8(b"token description"),
@@ -467,7 +467,7 @@ module aptos_token_objects::token {
         let token_name = string::utf8(b"token name");
 
         create_collection_helper(creator, *&collection_name, 1);
-        let constructor_ref = create(
+        let constructor_ref = create_named_token(
             creator,
             collection_name,
             string::utf8(b"token description"),
@@ -524,7 +524,7 @@ module aptos_token_objects::token {
 
     #[test_only]
     fun create_token_helper(creator: &signer, collection_name: String, token_name: String): ConstructorRef {
-        create(
+        create_named_token(
             creator,
             collection_name,
             string::utf8(b"token description"),

--- a/aptos-move/framework/cached-packages/build.rs
+++ b/aptos-move/framework/cached-packages/build.rs
@@ -14,6 +14,20 @@ fn main() {
         prev_dir.pop();
         println!(
             "cargo:rerun-if-changed={}",
+            prev_dir
+                .join("aptos-token-objects")
+                .join("Move.toml")
+                .display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            prev_dir
+                .join("aptos-token-objects")
+                .join("sources")
+                .display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
             prev_dir.join("aptos-token").join("sources").display()
         );
         println!(

--- a/aptos-move/move-examples/token_objects/sources/hero.move
+++ b/aptos-move/move-examples/token_objects/sources/hero.move
@@ -61,7 +61,7 @@ module token_objects::hero {
 
     fun init_module(account: &signer) {
         let collection = string::utf8(b"Hero Quest!");
-        collection::create_untracked_collection(
+        collection::create_unlimited_collection(
             account,
             string::utf8(b"collection description"),
             *&collection,

--- a/aptos-move/move-examples/token_objects/sources/hero.move
+++ b/aptos-move/move-examples/token_objects/sources/hero.move
@@ -82,7 +82,7 @@ module token_objects::hero {
         uri: String,
     ): ConstructorRef acquires OnChainConfig {
         let on_chain_config = borrow_global<OnChainConfig>(signer::address_of(creator));
-        token::create(
+        token::create_named_token(
             creator,
             *&on_chain_config.collection,
             description,

--- a/ecosystem/python/sdk/aptos_sdk/account_address.py
+++ b/ecosystem/python/sdk/aptos_sdk/account_address.py
@@ -75,6 +75,16 @@ class AccountAddress:
         return AccountAddress(hasher.digest())
 
     @staticmethod
+    def for_guid_object(creator: AccountAddress, creation_num: int) -> AccountAddress:
+        hasher = hashlib.sha3_256()
+        serializer = Serializer()
+        serializer.u64(creation_num)
+        hasher.update(serializer.output())
+        hasher.update(creator.address)
+        hasher.update(AuthKeyScheme.DeriveObjectAddressFromGuid)
+        return AccountAddress(hasher.digest())
+
+    @staticmethod
     def for_named_object(creator: AccountAddress, seed: bytes) -> AccountAddress:
         hasher = hashlib.sha3_256()
         hasher.update(creator.address)

--- a/ecosystem/python/sdk/aptos_sdk/aptos_token_client.py
+++ b/ecosystem/python/sdk/aptos_sdk/aptos_token_client.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Tuple
 
 from .account import Account
 from .account_address import AccountAddress
@@ -93,7 +93,6 @@ class Token:
 
     collection: AccountAddress
     collection_id: int
-    creation_name: Optional[str]
     description: str
     name: str
     uri: str
@@ -104,29 +103,24 @@ class Token:
         self,
         collection: AccountAddress,
         collection_id: int,
-        creation_name: Optional[str],
         description: str,
         name: str,
         uri: str,
     ):
         self.collection = collection
         self.collection_id = collection_id
-        self.creation_name = creation_name
         self.description = description
         self.name = name
         self.uri = uri
 
     def __str__(self) -> str:
-        return f"Token[collection: {self.collection}, collection_id: {self.collection_id}, creation_name: {self.creation_name}, description: {self.description}, name: {self.name}, uri: {self.uri}]"
+        return f"Token[collection: {self.collection}, collection_id: {self.collection_id}, description: {self.description}, name: {self.name}, uri: {self.uri}]"
 
     @staticmethod
     def parse(resource: dict[str, Any]):
         return Token(
             AccountAddress.from_hex(resource["collection"]["inner"]),
             int(resource["collection_id"]),
-            resource["creation_name"]["vec"][0]
-            if len(resource["creation_name"]["vec"]) == 1
-            else None,
             resource["description"],
             resource["name"],
             resource["uri"],

--- a/ecosystem/python/sdk/examples/async-aptos-token.py
+++ b/ecosystem/python/sdk/examples/async-aptos-token.py
@@ -59,6 +59,10 @@ async def main():
     )
     await rest_client.wait_for_transaction(txn_hash)
 
+    # This is a hack, once we add support for reading events or indexer, this will be easier
+    resp = await rest_client.account_resource(alice.address(), "0x1::account::Account")
+    creation_num = int(resp["data"]["guid_creation_num"])
+
     txn_hash = await token_client.mint_token(
         alice,
         collection_name,
@@ -72,9 +76,7 @@ async def main():
     collection_addr = AccountAddress.for_named_collection(
         alice.address(), collection_name
     )
-    token_addr = AccountAddress.for_named_token(
-        alice.address(), collection_name, token_name
-    )
+    token_addr = AccountAddress.for_guid_object(alice.address(), creation_num)
     """
     alice_address = AccountAddress.from_hex("0xa018017dc40fd081d2001acdb2660058ed2011f2790a42c2a40bab99909fbde5")
     collection_addr = AccountAddress.for_named_collection(alice_address, collection_name)


### PR DESCRIPTION
* Remove untracked collections from being public usage for now
* Add a mint and burn event for fixed supply
* Add tracking of both the collection id and the token's address to the events
* Add an unlimited supply to replace untracked
* Add support for minting deletable tokens


it is worth noting that untracked needs more thought:
* How to make them deletable as guid isn't parallelizable
* How to add events or create collection_ids

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
