### PR TITLE
Run faucet tests for testnet on high-perf-docker

### DIFF
--- a/.github/workflows/faucet-tests.yaml
+++ b/.github/workflows/faucet-tests.yaml
@@ -27,7 +27,7 @@ jobs:
           NETWORK: devnet
           GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
   run-tests-testnet:
-    runs-on: ubuntu-latest
+    runs-on: high-perf-docker
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
### Description
I recently landed https://github.com/aptos-labs/aptos-core/pull/7446 to make the faucet tests run on our own runners right? Wrong, I cooked the goose and did it for devnet but missed testnet. This explains why the testnet tests take 4 times longer and fail sometimes while the devnet ones don't.

### Test Plan
CI.
