### PR TITLE
[Quorum Store] bump up default min interval for batch generation

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -62,7 +62,7 @@ impl Default for QuorumStoreConfig {
             channel_size: 1000,
             proof_timeout_ms: 10000,
             batch_generation_poll_interval_ms: 25,
-            batch_generation_min_non_empty_interval_ms: 100,
+            batch_generation_min_non_empty_interval_ms: 200,
             batch_generation_max_interval_ms: 250,
             max_batch_bytes: 4 * 1024 * 1024,
             batch_request_num_peers: 3,


### PR DESCRIPTION
### Description

We saw the network behaving erratically when sending 10 batches/s. With 100 validators, this means processing 1000 votes/s, in addition to other messages. 5 batches/s seems more reasonable (500 votes/s).