### PR TITLE
[gha] build all docker variants on push

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -115,6 +115,8 @@ jobs:
     needs: [permission-check, determine-docker-build-metadata]
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'CICD:build-indexer-images')
     secrets: inherit
     with:
@@ -128,6 +130,8 @@ jobs:
     needs: [permission-check, determine-docker-build-metadata]
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'CICD:build-failpoints-images')
     secrets: inherit
     with:
@@ -141,6 +145,8 @@ jobs:
     needs: [permission-check, determine-docker-build-metadata]
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'CICD:build-performance-images')
     secrets: inherit
     with:


### PR DESCRIPTION
### Description

bugfix for conditional docker builds. we still need to build all variants on push, since release uses it.

### Test Plan

canary on push: https://github.com/aptos-labs/aptos-core/pull/7614

<!-- Please provide us with clear details for verifying that your changes work. -->
