### PR TITLE
[CANARY][gha] build all docker variants on push 

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -115,6 +115,8 @@ jobs:
     needs: [permission-check, determine-docker-build-metadata]
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'CICD:build-indexer-images')
     secrets: inherit
     with:
@@ -128,6 +130,8 @@ jobs:
     needs: [permission-check, determine-docker-build-metadata]
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'CICD:build-failpoints-images')
     secrets: inherit
     with:
@@ -141,6 +145,8 @@ jobs:
     needs: [permission-check, determine-docker-build-metadata]
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'CICD:build-performance-images')
     secrets: inherit
     with:

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -38,6 +38,8 @@ on: # build on main branch OR when a PR is labeled with `CICD:build-images`
       - performance_benchmark
       - quorum-store
       - preview
+      # canary
+      - rustielin/conditional-non-blocking-docker-builds-2-canary
 
 # cancel redundant builds
 concurrency:


### PR DESCRIPTION
### Description

canary build on push

### Test Plan

it does not skip the other build variants as before:

![image](https://user-images.githubusercontent.com/12578616/230466638-ce09b566-bbd4-4168-adb0-5d017cba4e8f.png)


<!-- Please provide us with clear details for verifying that your changes work. -->
