### PR TITLE
Replace links to Move Book and Tutorial with Aptos variants

### DIFF
--- a/aptos-move/move-examples/mint_nft/4-Getting-Production-Ready/sources/create_nft_getting_production_ready.move
+++ b/aptos-move/move-examples/mint_nft/4-Getting-Production-Ready/sources/create_nft_getting_production_ready.move
@@ -24,7 +24,7 @@
 ///
 /// Move unit tests
 /// We added a few unit tests to make sure that our code is working as expected. For more information on how to write
-/// Move unit tests, see: https://move-language.github.io/move/unit-testing.html.
+/// Move unit tests, see: https://aptos.dev/guides/move-guides/book/unit-testing
 ///
 /// - How to interact with this module
 /// 1. Configure the admin account name address in Move.toml file.

--- a/developer-docs-site/docs/concepts/txns-states.md
+++ b/developer-docs-site/docs/concepts/txns-states.md
@@ -69,7 +69,7 @@ Currently the SDKs [Python](https://github.com/aptos-labs/aptos-core/blob/b0fe7e
 All operations on the Aptos blockchain should be available via entry point calls. While one could submit multiple transactions calling entry points in series, many such operations may benefit from being called atomically from a single transaction. A script payload transaction can call any entry point or public function defined within any module.
 
 :::tip Move book
-Currently there are no tutorials in this guide on script payloads, but the [Move book](https://move-language.github.io/move/modules-and-scripts.html?highlight=script#scripts) does go in some depth.
+Currently there are no tutorials in this guide on script payloads, but the [Move book](../guides/move-guides/book/modules-and-scripts.md) does go in some depth.
 :::
 
 :::tip Read more
@@ -122,5 +122,5 @@ In the figure:
 - Accounts **A** and **B**: Represent Alice's and Bob's accounts on the Aptos blockchain.
 - **S<sub>*i-1*</sub>** : Represents the (*i-1*)-the state of the blockchain. In this state, Alice's account **A** has a balance of 110 APT (Aptos coins), and Bob's account **B** has a balance of 52 APT.
 - **T<sub>*i*</sub>** : This is the *i*-th transaction executed on the blockchain. In this example, it represents Alice sending 10 APT to Bob.
-- **Apply()**: This is a deterministic function that always returns the same final state for a specific initial state and a specific transaction. If the current state of the blockchain is **S<sub>*i-1*</sub>**, and transaction **T<sub>*i*</sub>** is executed on the state **S<sub>*i-1*</sub>**, then the new state of the blockchain is always **S<sub>*i*</sub>**. The Aptos blockchain uses the [Move language](https://move-language.github.io/move/) to implement the deterministic execution function **Apply()**.
+- **Apply()**: This is a deterministic function that always returns the same final state for a specific initial state and a specific transaction. If the current state of the blockchain is **S<sub>*i-1*</sub>**, and transaction **T<sub>*i*</sub>** is executed on the state **S<sub>*i-1*</sub>**, then the new state of the blockchain is always **S<sub>*i*</sub>**. The Aptos blockchain uses the [Move language](../guides/move-guides/book/SUMMARY.md) to implement the deterministic execution function **Apply()**.
 - **S<sub>*i*</sub>** : This is the *i*-the state of the blockchain. When the transaction **T<sub>*i*</sub>** is applied to the blockchain, it generates the new state **S<sub>*i*</sub>** (an outcome of applying **Apply(S<sub>*i-1*</sub>, T<sub>*i*</sub>)** to **S<sub>*i-1*</sub>** and **T<sub>*i*</sub>**). This causes Alice’s account balance to be reduced by 10 to 100 APT and Bob’s account balance to be increased by 10 to 62 APT. The new state **S<sub>*i*</sub>** shows these updated balances.

--- a/developer-docs-site/docs/guides/move-guides/book/package-upgrades.md
+++ b/developer-docs-site/docs/guides/move-guides/book/package-upgrades.md
@@ -23,7 +23,7 @@ for more details.
 
 ## How it works
 
-Move code upgrades on the Aptos blockchain happen at the [Move package](https://move-language.github.io/move/packages.html)
+Move code upgrades on the Aptos blockchain happen at the [Move package](./packages.md)
 granularity. A package specifies an upgrade policy in the `Move.toml` manifest:
 
 ```toml
@@ -34,7 +34,7 @@ upgrade_policy = "compatible"
 ...
 ```
 :::tip Compatibility check
-Aptos checks compatibility at the time a [Move package](https://move-language.github.io/move/packages.html) is published via an Aptos transaction. This transaction will abort if deemed incompatible.
+Aptos checks compatibility at the time a Move package is published via an Aptos transaction. This transaction will abort if deemed incompatible.
 :::
 
 ## How to upgrade

--- a/developer-docs-site/docs/guides/move-guides/mint-nft-cli.md
+++ b/developer-docs-site/docs/guides/move-guides/mint-nft-cli.md
@@ -337,7 +337,7 @@ We prepare the module for production by:
 
 * adding a `TokenMintingEvent` to emit a custom event for tracking minting of tokens from this module.
 * enabling signature verification and ntroducing the concept of a proof challenge to prevent bot spamming.
-* including [unit tests](https://move-language.github.io/move/unit-testing.html) to make sure our code works as expected.
+* including [unit tests](./book/unit-testing.md) to make sure our code works as expected.
 
 
 ### Publish the module under a resource account

--- a/developer-docs-site/docs/guides/move-guides/move-scripts.md
+++ b/developer-docs-site/docs/guides/move-guides/move-scripts.md
@@ -5,7 +5,7 @@ slug: "move-scripts"
 
 # Move Scripts
 
-This tutorial explains how to write and execute a Move script. You can use Move scripts to execute a series of commands across published Move module interfaces.
+This tutorial explains how to write and execute a [Move script](./book/modules-and-scripts.md). You can use Move scripts to execute a series of commands across published Move module interfaces.
 
 ## Example use case
 

--- a/developer-docs-site/docs/guides/move-guides/move-structure.md
+++ b/developer-docs-site/docs/guides/move-guides/move-structure.md
@@ -13,7 +13,7 @@ Once published, the definition of a struct in Move is immutable. Structs themsel
 
 ## Abilities
 
-[Structures](https://move-language.github.io/move/structs-and-resources.html) in Move can be given different [abilities](https://move-language.github.io/move/abilities.html) that describe what can be done with that type. There are four different abilities that allow:
+[Structures](./book/structs-and-resources.md) in Move can be given different [abilities](./book/abilities.md) that describe what can be done with that type. There are four different abilities that allow:
 
 * copy: values of types with this ability to be copied. A geographic ID would be a good use case. NFTs should not have this ability.
 * drop: values of types with this ability to be popped/dropped.

--- a/developer-docs-site/docs/tutorials/first-move-module.md
+++ b/developer-docs-site/docs/tutorials/first-move-module.md
@@ -196,7 +196,7 @@ Upon success, the CLI will print out the following:
 }
 ```
 
-The `set_message` function modifies the `hello_blockchain` `MessageHolder` resource. A resource is a data structure that is stored in [global storage](https://move-language.github.io/move/structs-and-resources.html#storing-resources-in-global-storage). The resource can be read by querying the following REST API:
+The `set_message` function modifies the `hello_blockchain` `MessageHolder` resource. A resource is a data structure that is stored in [global storage](../guides/move-guides/book/structs-and-resources.md#storing-resources-in-global-storage). The resource can be read by querying the following REST API:
 
 ```bash
 


### PR DESCRIPTION
### Description

And Link from Move Scripts to Modules and Scripts page of Move Book

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
