### PR TITLE
[Move-prover][Spec] Revive the pragma verify_duration_estimate 

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/staking_contract.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_contract.md
@@ -2001,7 +2001,7 @@ Staking_contract exists the stacker/operator pair.
 Staking_contract exists the stacker/operator pair.
 
 
-<pre><code><b>pragma</b> verify = <b>false</b>;
+<pre><code><b>pragma</b> verify_duration_estimate = 120;
 <b>let</b> staking_contracts = <b>global</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker).staking_contracts;
 <b>let</b> <a href="staking_contract.md#0x1_staking_contract">staking_contract</a> = <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(staking_contracts, operator);
 <b>include</b> <a href="staking_contract.md#0x1_staking_contract_StakingContractExistsAbortsIf">StakingContractExistsAbortsIf</a>;

--- a/aptos-move/framework/aptos-framework/doc/storage_gas.md
+++ b/aptos-move/framework/aptos-framework/doc/storage_gas.md
@@ -1461,7 +1461,7 @@ A non decreasing curve must ensure that next is greater than cur.
 
 
 <pre><code><b>pragma</b> opaque;
-<b>pragma</b> verify = <b>false</b>;
+<b>pragma</b> verify_duration_estimate = 120;
 <b>requires</b> max_usage &gt; 0;
 <b>requires</b> max_usage &lt;= <a href="storage_gas.md#0x1_storage_gas_MAX_U64">MAX_U64</a> / <a href="storage_gas.md#0x1_storage_gas_BASIS_POINT_DENOMINATION">BASIS_POINT_DENOMINATION</a>;
 <b>aborts_if</b> <b>false</b>;

--- a/aptos-move/framework/aptos-framework/doc/version.md
+++ b/aptos-move/framework/aptos-framework/doc/version.md
@@ -240,7 +240,8 @@ Abort if resource already exists in <code>@aptos_framwork</code> when initializi
 
 
 
-<pre><code><b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
+<pre><code><b>pragma</b> verify_duration_estimate = 120;
+<b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
 <b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
 <b>requires</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>();
 <b>requires</b> <a href="timestamp.md#0x1_timestamp_spec_now_microseconds">timestamp::spec_now_microseconds</a>() &gt;= <a href="reconfiguration.md#0x1_reconfiguration_last_reconfiguration_time">reconfiguration::last_reconfiguration_time</a>();

--- a/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.spec.move
@@ -84,9 +84,6 @@ spec aptos_framework::optional_aggregator {
         ensures is_parallelizable(old(optional_aggregator)) ==> !is_parallelizable(optional_aggregator);
         ensures !is_parallelizable(old(optional_aggregator)) ==> is_parallelizable(optional_aggregator);
         ensures optional_aggregator_value(optional_aggregator) == 0;
-        // ensures !is_parallelizable(optional_aggregator) ==> option::borrow(optional_aggregator.integer).value == 0;
-        // ensures is_parallelizable(optional_aggregator) ==> aggregator::spec_aggregator_get_val
-        //     (option::borrow(optional_aggregator.aggregator)) == 0;
     }
 
     /// The aggregator exists and the integer dosex not exist when Switches from parallelizable to non-parallelizable implementation.

--- a/aptos-move/framework/aptos-framework/sources/configs/version.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/version.spec.move
@@ -13,7 +13,8 @@ spec aptos_framework::version {
         use aptos_framework::aptos_coin::AptosCoin;
         use aptos_framework::transaction_fee;
         use aptos_framework::staking_config;
-
+        // Not verified when verify_duration_estimate > vc_timeout
+        pragma verify_duration_estimate = 120; // TODO: set because of timeout (property proved).
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
         include staking_config::StakingRewardsConfigRequirement;
         requires chain_status::is_operating();

--- a/aptos-move/framework/aptos-framework/sources/staking_contract.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.spec.move
@@ -20,7 +20,8 @@ spec aptos_framework::staking_contract {
 
     /// Staking_contract exists the stacker/operator pair.
     spec staking_contract_amounts(staker: address, operator: address): (u64, u64, u64) {
-        pragma verify = false; // TODO: set to false because of timeout (property proved).
+        // Not verified when verify_duration_estimate > vc_timeout
+        pragma verify_duration_estimate = 120; // TODO: set because of timeout (property proved).
         let staking_contracts = global<Store>(staker).staking_contracts;
         let staking_contract = simple_map::spec_get(staking_contracts, operator);
         include StakingContractExistsAbortsIf;

--- a/aptos-move/framework/aptos-framework/sources/storage_gas.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/storage_gas.spec.move
@@ -97,7 +97,8 @@ spec aptos_framework::storage_gas {
 
     spec calculate_gas(max_usage: u64, current_usage: u64, curve: &GasCurve): u64 {
         pragma opaque;
-        pragma verify = false; // TODO: set to false because of timeout (property proved).
+        // Not verified when verify_duration_estimate > vc_timeout
+        pragma verify_duration_estimate = 120; // TODO: set because of timeout (property proved).
         requires max_usage > 0;
         requires max_usage <= MAX_U64 / BASIS_POINT_DENOMINATION;
         aborts_if false;


### PR DESCRIPTION
### Description

This PR revives the function-level pragma `verify_duration_estimate`, which indicates an estimate how long verification takes. Verification of this function will be skipped if the its timeout value is smaller than this. 

Close #7321.
