### PR TITLE
Added support for --split-stages in executor benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,6 +1014,7 @@ dependencies = [
  "aptos-state-view",
  "aptos-storage-interface",
  "aptos-temppath",
+ "aptos-transaction-generator-lib",
  "aptos-types",
  "aptos-vm",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -570,7 +570,7 @@ impl TxnEmitter {
         let stats = Arc::new(DynamicStatsTracking::new(stats_tracking_phases));
         let tokio_handle = Handle::current();
 
-        let mut txn_generator_creator = create_txn_generator_creator(
+        let (mut txn_generator_creator, _, _) = create_txn_generator_creator(
             &req.transaction_mix_per_phase,
             num_workers,
             &mut all_accounts,

--- a/crates/transaction-emitter-lib/src/emitter/transaction_executor.rs
+++ b/crates/transaction-emitter-lib/src/emitter/transaction_executor.rs
@@ -13,7 +13,6 @@ use async_trait::async_trait;
 use futures::future::join_all;
 use rand::{rngs::StdRng, seq::SliceRandom, thread_rng, Rng, SeedableRng};
 use std::{
-    collections::HashMap,
     sync::atomic::AtomicUsize,
     time::{Duration, Instant},
 };
@@ -190,16 +189,6 @@ impl TransactionExecutor for RestApiTransactionExecutor {
             .await?
             .into_inner()
             .sequence_number())
-    }
-
-    async fn execute_transactions(&self, txns: &[SignedTransaction]) -> Result<()> {
-        self.execute_transactions_with_counter(txns, &CounterState {
-            submit_failures: vec![AtomicUsize::new(0)],
-            wait_failures: vec![AtomicUsize::new(0)],
-            successes: AtomicUsize::new(0),
-            by_client: HashMap::new(),
-        })
-        .await
     }
 
     async fn execute_transactions_with_counter(

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -30,6 +30,7 @@ aptos-scratchpad = { workspace = true }
 aptos-sdk = { workspace = true }
 aptos-state-view = { workspace = true }
 aptos-storage-interface = { workspace = true }
+aptos-transaction-generator-lib = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
 bcs = { workspace = true }

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -101,6 +101,9 @@ struct Opt {
     #[structopt(long)]
     use_sharded_state_merkle_db: bool,
 
+    #[structopt(long)]
+    split_stages: bool,
+
     #[structopt(subcommand)]
     cmd: Command,
 
@@ -207,6 +210,7 @@ where
                 opt.pruner_opt.pruner_config(),
                 opt.use_state_kv_db,
                 opt.use_sharded_state_merkle_db,
+                opt.split_stages,
             );
         },
         Command::AddAccounts {


### PR DESCRIPTION
added support for --split-stages, and preparing to add transaction-generator-lib for generating workload

This replaces PR #6761, without removing BenchmarkTransaction. But still adding support to deserialize transactions for execution, as I'll be passing all transactions from  transaction-generator-lib with empty extra info information.