### PR TITLE
[aptos-rosetta] Fix all simple maps to be vector rather than Btreemap

### DIFF
--- a/crates/aptos-rosetta/src/account.rs
+++ b/crates/aptos-rosetta/src/account.rs
@@ -93,7 +93,6 @@ async fn get_balances(
     maybe_filter_currencies: Option<Vec<Currency>>,
 ) -> ApiResult<(u64, Option<Vec<AccountAddress>>, Vec<Amount>)> {
     let owner_address = account.account_address()?;
-
     // Retrieve all account resources
     if let Ok(response) = rest_client
         .get_account_resources_at_version_bcs(owner_address, version)

--- a/crates/aptos-rosetta/src/construction.rs
+++ b/crates/aptos-rosetta/src/construction.rs
@@ -235,19 +235,22 @@ async fn fill_in_operator(
                     .get_account_resource_bcs::<Store>(op.owner, "0x1::staking_contract::Store")
                     .await?
                     .into_inner();
-                if store.staking_contracts.len() != 1 {
-                    let operators: Vec<_> = store.staking_contracts.keys().collect();
+                let staking_contracts = store.staking_contracts;
+                if staking_contracts.len() != 1 {
+                    let operators: Vec<_> = staking_contracts
+                        .iter()
+                        .map(|(address, _)| *address)
+                        .collect();
                     return Err(ApiError::InvalidInput(Some(format!(
                         "Account has more than one operator, operator must be specified from: {:?}",
                         operators
                     ))));
                 } else {
+                    // Take the only staking contract
                     op.old_operator = Some(
-                        *store
-                            .staking_contracts
-                            .iter()
-                            .next()
-                            .map(|inner| inner.0)
+                        staking_contracts
+                            .first()
+                            .map(|(address, _)| *address)
                             .unwrap(),
                     );
                 }
@@ -260,19 +263,22 @@ async fn fill_in_operator(
                     .get_account_resource_bcs::<Store>(op.owner, "0x1::staking_contract::Store")
                     .await?
                     .into_inner();
-                if store.staking_contracts.len() != 1 {
-                    let operators: Vec<_> = store.staking_contracts.keys().collect();
+                let staking_contracts = store.staking_contracts;
+                if staking_contracts.len() != 1 {
+                    let operators: Vec<_> = staking_contracts
+                        .iter()
+                        .map(|(address, _)| address)
+                        .collect();
                     return Err(ApiError::InvalidInput(Some(format!(
                         "Account has more than one operator, operator must be specified from: {:?}",
                         operators
                     ))));
                 } else {
+                    // Take the only staking contract
                     op.operator = Some(
-                        *store
-                            .staking_contracts
-                            .iter()
-                            .next()
-                            .map(|inner| inner.0)
+                        staking_contracts
+                            .first()
+                            .map(|(address, _)| *address)
                             .unwrap(),
                     );
                 }

--- a/crates/aptos-rosetta/src/lib.rs
+++ b/crates/aptos-rosetta/src/lib.rs
@@ -69,8 +69,8 @@ impl RosettaContext {
                     let store = store.into_inner();
                     let pool_addresses: Vec<_> = store
                         .staking_contracts
-                        .values()
-                        .map(|pool| pool.pool_address)
+                        .iter()
+                        .map(|(_, pool)| pool.pool_address)
                         .collect();
                     for pool_address in pool_addresses {
                         pool_address_to_owner.insert(pool_address, *owner_address);

--- a/crates/aptos-rosetta/src/types/move_types.rs
+++ b/crates/aptos-rosetta/src/types/move_types.rs
@@ -6,7 +6,6 @@
 use crate::AccountAddress;
 use aptos_types::event::EventHandle;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 
 pub const ACCOUNT_MODULE: &str = "account";
 pub const APTOS_ACCOUNT_MODULE: &str = "aptos_account";
@@ -43,7 +42,7 @@ pub const SET_OPERATOR_EVENTS_FIELD: &str = "set_operator_events";
 pub const SEQUENCE_NUMBER_FIELD: &str = "sequence_number";
 pub const SYMBOL_FIELD: &str = "symbol";
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StakingContract {
     pub principal: u64,
     pub pool_address: AccountAddress,
@@ -61,7 +60,7 @@ impl StakingContract {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Store {
-    pub staking_contracts: BTreeMap<AccountAddress, StakingContract>,
+    pub staking_contracts: Vec<(AccountAddress, StakingContract)>,
     pub create_staking_contract_events: EventHandle,
     pub update_voter_events: EventHandle,
     pub reset_lockup_events: EventHandle,
@@ -141,12 +140,12 @@ pub struct DistributeEvent {
     pub amount: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Pool {
     pub shareholders_limit: u64,
     pub total_coins: u64,
     pub total_shares: u64,
-    pub shares: BTreeMap<AccountAddress, u64>,
+    pub shares: Vec<(AccountAddress, u64)>,
     pub shareholders: Vec<AccountAddress>,
     pub scaling_factor: u64,
 }
@@ -154,12 +153,13 @@ pub struct Pool {
 impl Pool {
     pub fn get_balance(&self, account_address: &AccountAddress) -> Option<u64> {
         self.shares
-            .get(account_address)
-            .map(|inner| (*inner * self.total_coins) / self.total_shares)
+            .iter()
+            .find(|(address, _)| address == account_address)
+            .map(|(_, shares)| (*shares * self.total_coins) / self.total_shares)
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct Capability {
     pub pool_address: AccountAddress,
 }


### PR DESCRIPTION
### Description
BTreeMap only works if the input was ordered at first.  If it's not ordered, then it will fail at deserialization.  Simple map isn't guaranteed to be ordered.

### Test Plan
Tested directly against Rosetta