### PR TITLE
[CANARY][gha] docker build conditional fix

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -20,7 +20,7 @@
 ## auto_merge).
 
 name: "Build+Test Docker Images"
-on: # build on main branch OR when a PR is labeled with `CICD:build-images`
+on: # build on main branch OR when a PR is labeled with `CICD:build-*images`
   # Allow us to run this specific workflow without a PR
   workflow_dispatch:
   pull_request_target:

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -69,15 +69,15 @@ permissions:
 # Note on the job-level `if` conditions:
 # This workflow is designed such that:
 # 1. Run ALL jobs when a 'push', 'workflow_dispatch' triggered the workflow or on 'pull_request's which have set auto_merge=true or have the label "CICD:run-e2e-tests".
-# 2. Run ONLY the docker image building jobs on PRs with the "CICD:build-images" label.
+# 2. Run ONLY the docker image building jobs on PRs with the "CICD:build[-<PROFILE/FEATURE>]-images" label.
 # 3. Run NOTHING when neither 1. or 2.'s conditions are satisfied.
 jobs:
   permission-check:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'CICD:build-images') ||
-      contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'CICD:build-') ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'CICD:run-') ||
       github.event.pull_request.auto_merge != null ||
       contains(github.event.pull_request.body, '#e2e')
     runs-on: ubuntu-latest
@@ -114,6 +114,10 @@ jobs:
   rust-images-indexer:
     needs: [permission-check, determine-docker-build-metadata]
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'CICD:build-indexer-images')
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -125,6 +129,10 @@ jobs:
   rust-images-failpoints:
     needs: [permission-check, determine-docker-build-metadata]
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'CICD:build-failpoints-images')
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -136,6 +144,10 @@ jobs:
   rust-images-performance:
     needs: [permission-check, determine-docker-build-metadata]
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'CICD:build-performance-images')
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -157,14 +169,48 @@ jobs:
       FEATURES: consensus-only-perf-test
       BUILD_ADDL_TESTING_IMAGES: true
 
+  rust-images-all:
+    needs:
+      [
+        determine-docker-build-metadata,
+        rust-images,
+        rust-images-indexer,
+        rust-images-failpoints,
+        rust-images-performance,
+        rust-images-consensus-only-perf-test,
+      ]
+    if: always() # this ensures that the job will run even if the previous jobs were skipped
+    runs-on: ubuntu-latest
+    steps:
+      - name: fail if rust-images job failed
+        if: ${{ needs.rust-images.result == 'failure' }}
+        run: exit 1
+      - name: fail if rust-images-indexer job failed
+        if: ${{ needs.rust-images-indexer.result == 'failure' }}
+        run: exit 1
+      - name: fail if rust-images-failpoints job failed
+        if: ${{ needs.rust-images-failpoints.result == 'failure' }}
+        run: exit 1
+      - name: fail if rust-images-performance job failed
+        if: ${{ needs.rust-images-performance.result == 'failure' }}
+        run: exit 1
+      - name: fail if rust-images-consensus-only-perf-test job failed
+        if: ${{ needs.rust-images-consensus-only-perf-test.result == 'failure' }}
+        run: exit 1
+    outputs:
+      rustImagesResult: ${{ needs.rust-images.result }}
+      rustImagesIndexerResult: ${{ needs.rust-images-indexer.result }}
+      rustImagesFailpointsResult: ${{ needs.rust-images-failpoints.result }}
+      rustImagesPerformanceResult: ${{ needs.rust-images-performance.result }}
+      rustImagesConsensusOnlyPerfTestResult: ${{ needs.rust-images-consensus-only-perf-test.result }}
+
   sdk-release:
-    needs: [rust-images, determine-docker-build-metadata]
+    needs: [rust-images-all]
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'CICD:skip-sdk-integration-test') && (
-      github.event_name == 'push' ||
+      (github.event_name == 'push' && github.ref_name != 'main') ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
-      github.event.pull_request.auto_merge != null) ||
+      github.event.pull_request.auto_merge != null ||
       contains(github.event.pull_request.body, '#e2e')
     uses: ./.github/workflows/sdk-release.yaml
     secrets: inherit
@@ -186,8 +232,7 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
 
   forge-e2e-test:
-    needs:
-      [rust-images, rust-images-failpoints, determine-docker-build-metadata]
+    needs: [rust-images-all, determine-docker-build-metadata]
     if: |
       !contains(github.event.pull_request.labels.*.name, 'CICD:skip-forge-e2e-test') && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
@@ -200,6 +245,9 @@ jobs:
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+      FORGE_TEST_SUITE: land_blocking
+      IMAGE_TAG: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+      FORGE_RUNNER_DURATION_SECS: 480
       COMMENT_HEADER: forge-e2e
       # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
       # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
@@ -208,57 +256,45 @@ jobs:
 
   # Run e2e compat test against testnet branch
   forge-compat-test:
-    needs:
-      [rust-images, rust-images-failpoints, determine-docker-build-metadata]
+    needs: [rust-images-all, determine-docker-build-metadata]
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'CICD:skip-forge-e2e-test') && (
-        (github.event_name == 'push' && github.ref_name != 'main') ||
-        github.event_name == 'workflow_dispatch' ||
-        contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
-        github.event.pull_request.auto_merge != null ||
-        contains(github.event.pull_request.body, '#e2e')
-      )
+      (github.event_name == 'push' && github.ref_name != 'main') ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+      github.event.pull_request.auto_merge != null ||
+      contains(github.event.pull_request.body, '#e2e')
+
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: compat
-      IMAGE_TAG: testnet_2d8b1b57553d869190f61df1aaf7f31a8fc19a7b # test against the latest build on testnet branch
+      IMAGE_TAG: testnet_2d8b1b57553d869190f61df1aaf7f31a8fc19a7b # test against a previous testnet release
       FORGE_RUNNER_DURATION_SECS: 300
       COMMENT_HEADER: forge-compat
-      # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
-      # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
-      # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
       FORGE_NAMESPACE: forge-compat-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
-  
+
   # Run forge framework upgradability test
   forge-framework-upgrade-test:
-    needs:
-      [rust-images, rust-images-failpoints, determine-docker-build-metadata]
+    needs: [rust-images-all, determine-docker-build-metadata]
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'CICD:skip-forge-e2e-test') && (
-        (github.event_name == 'push' && github.ref_name != 'main') ||
-        github.event_name == 'workflow_dispatch' ||
-        contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
-        github.event.pull_request.auto_merge != null ||
-        contains(github.event.pull_request.body, '#e2e')
-      )
+      (github.event_name == 'push' && github.ref_name != 'main') ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+      github.event.pull_request.auto_merge != null ||
+      contains(github.event.pull_request.body, '#e2e')
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: framework_upgrade
-      IMAGE_TAG: aptos-node-v1.3.0_3fc3d42b6cfe27460004f9a0326451bcda840a60  # This workflow will test the upgradability from the current tip of the release branch to the current main branch.
+      IMAGE_TAG: aptos-node-v1.3.0_3fc3d42b6cfe27460004f9a0326451bcda840a60 # This workflow will test the upgradability from the current tip of the release branch to the current main branch.
       FORGE_RUNNER_DURATION_SECS: 300
       COMMENT_HEADER: forge-framework-upgrade
-      # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
-      # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
-      # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
       FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
 
   forge-consensus-only-perf-test:
-    needs:
-      [rust-images-consensus-only-perf-test, determine-docker-build-metadata]
+    needs: [rust-images-all, determine-docker-build-metadata]
     if: |
       contains(github.event.pull_request.labels.*.name, 'CICD:run-consensus-only-perf-test')
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
@@ -269,7 +305,4 @@ jobs:
       IMAGE_TAG: consensus_only_perf_test_${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_RUNNER_DURATION_SECS: 300
       COMMENT_HEADER: forge-consensus-only-perf-test
-      # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
-      # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
-      # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
       FORGE_NAMESPACE: forge-consensus-only-perf-test-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -205,7 +205,7 @@ jobs:
       rustImagesConsensusOnlyPerfTestResult: ${{ needs.rust-images-consensus-only-perf-test.result }}
 
   sdk-release:
-    needs: [rust-images-all]
+    needs: [rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
     if: |
       (github.event_name == 'push' && github.ref_name != 'main') ||
       github.event_name == 'workflow_dispatch' ||
@@ -218,14 +218,15 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
 
   cli-e2e-tests:
-    needs: [rust-images, determine-docker-build-metadata]
+    needs: [rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
     if: |
       !contains(github.event.pull_request.labels.*.name, 'CICD:skip-sdk-integration-test') && (
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
-      github.event.pull_request.auto_merge != null) ||
-      contains(github.event.pull_request.body, '#e2e')
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+        github.event.pull_request.auto_merge != null) ||
+        contains(github.event.pull_request.body, '#e2e'
+      )
     uses: ./.github/workflows/cli-e2e-tests.yaml
     secrets: inherit
     with:
@@ -233,8 +234,8 @@ jobs:
 
   forge-e2e-test:
     needs: [rust-images-all, determine-docker-build-metadata]
-    if: |
-      !contains(github.event.pull_request.labels.*.name, 'CICD:skip-forge-e2e-test') && (
+    if: | # always() ensures that the job will run even if some of the previous docker variant build jobs were skipped https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
+      always() && needs.rust-images-all.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
@@ -257,13 +258,14 @@ jobs:
   # Run e2e compat test against testnet branch
   forge-compat-test:
     needs: [rust-images-all, determine-docker-build-metadata]
-    if: |
-      (github.event_name == 'push' && github.ref_name != 'main') ||
-      github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
-      github.event.pull_request.auto_merge != null ||
-      contains(github.event.pull_request.body, '#e2e')
-
+    if: | # always() ensures that the job will run even if some of the previous docker variant build jobs were skipped https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
+      always() && needs.rust-images-all.result == 'success' && (
+        (github.event_name == 'push' && github.ref_name != 'main') ||
+        github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+        github.event.pull_request.auto_merge != null ||
+        contains(github.event.pull_request.body, '#e2e')
+      )
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -277,12 +279,14 @@ jobs:
   # Run forge framework upgradability test
   forge-framework-upgrade-test:
     needs: [rust-images-all, determine-docker-build-metadata]
-    if: |
-      (github.event_name == 'push' && github.ref_name != 'main') ||
-      github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
-      github.event.pull_request.auto_merge != null ||
-      contains(github.event.pull_request.body, '#e2e')
+    if: | # always() ensures that the job will run even if some of the previous docker variant build jobs were skipped https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
+      always() && needs.rust-images-all.result == 'success' && (
+        (github.event_name == 'push' && github.ref_name != 'main') ||
+        github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+        github.event.pull_request.auto_merge != null ||
+        contains(github.event.pull_request.body, '#e2e')
+      )
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -295,7 +299,8 @@ jobs:
 
   forge-consensus-only-perf-test:
     needs: [rust-images-all, determine-docker-build-metadata]
-    if: |
+    if: | # always() ensures that the job will run even if some of the previous docker variant build jobs were skipped https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
+      always() && needs.rust-images-all.result == 'success' &&
       contains(github.event.pull_request.labels.*.name, 'CICD:run-consensus-only-perf-test')
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit

--- a/docker/experimental/docker-bake-rust-all.sh
+++ b/docker/experimental/docker-bake-rust-all.sh
@@ -31,6 +31,7 @@ if [ "$PROFILE" = "release" ]; then
 else
   # Builds for profiles other than "release" should be tagged with their profile name
   profile_prefix="${PROFILE}_"
+  exit 1 # force a failure
 fi
 
 if [ -n "$CUSTOM_IMAGE_TAG_PREFIX" ]; then
@@ -41,6 +42,7 @@ fi
 
 if [ -n "$FEATURES" ]; then
   export IMAGE_TAG_PREFIX="${IMAGE_TAG_PREFIX}${profile_prefix}${NORMALIZED_FEATURES_LIST}_"
+  exit 1 # force a failure
 else
   export IMAGE_TAG_PREFIX="${IMAGE_TAG_PREFIX}${profile_prefix}"
 fi


### PR DESCRIPTION
happy path: all builds succeed and subsequent tests are run after https://github.com/aptos-labs/aptos-core/actions/runs/4660306407
![image](https://user-images.githubusercontent.com/12578616/230995994-9c08371f-e4ce-4e1e-ba17-7408be076e16.png)

failure case: one build fails, so `rust-images-all` fails and blocks all subsequent tests: https://github.com/aptos-labs/aptos-core/actions/runs/4661829964?pr=7644
![image](https://user-images.githubusercontent.com/12578616/231537614-714c7f57-c07e-4510-af57-9d013997274f.png)


<!-- Please provide us with clear details for verifying that your changes work. -->
