### PR TITLE
[storage] add kv only option to statesnapshot restore

### DIFF
--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -60,6 +60,7 @@ impl RestoreHandler {
         &self,
         version: Version,
         expected_root_hash: HashValue,
+        kv_only: bool,
     ) -> Result<StateSnapshotRestore<StateKey, StateValue>> {
         StateSnapshotRestore::new(
             &self.state_store.state_merkle_db,
@@ -67,6 +68,7 @@ impl RestoreHandler {
             version,
             expected_root_hash,
             true, /* async_commit */
+            kv_only,
         )
     }
 

--- a/storage/aptosdb/src/state_restore/restore_test.rs
+++ b/storage/aptosdb/src/state_restore/restore_test.rs
@@ -187,7 +187,7 @@ proptest! {
         let restore_db = Arc::new(MockSnapshotStore::default());
         {
             let mut restore =
-                StateSnapshotRestore::new(&restore_db, &restore_db,  version, expected_root_hash, true /* async_commit */).unwrap();
+                StateSnapshotRestore::new(&restore_db, &restore_db,  version, expected_root_hash, true /* async_commit */, false).unwrap();
             let proof = tree
                 .get_range_proof(batch1.last().map(|(key, _value)| *key).unwrap(), version)
                 .unwrap();
@@ -199,7 +199,7 @@ proptest! {
             let remaining_accounts: Vec<_> = all.clone().into_iter().skip(batch1_size - overlap_size).collect();
 
             let mut restore =
-                StateSnapshotRestore::new(&restore_db, &restore_db,  version, expected_root_hash, true /* async commit */ ).unwrap();
+                StateSnapshotRestore::new(&restore_db, &restore_db,  version, expected_root_hash, true /* async commit */, false ).unwrap();
             let proof = tree
                 .get_range_proof(
                     remaining_accounts.last().map(|(h, _)| *h).unwrap(),
@@ -280,6 +280,7 @@ fn restore_without_interruption<V>(
             target_version,
             expected_root_hash,
             true, /* async_commit */
+            false,
         )
         .unwrap()
     } else {
@@ -288,6 +289,7 @@ fn restore_without_interruption<V>(
             target_db,
             target_version,
             expected_root_hash,
+            false,
         )
         .unwrap()
     };

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -840,6 +840,7 @@ impl StateStore {
             version,
             expected_root_hash,
             false, /* async_commit */
+            false,
         )?))
     }
 

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -332,7 +332,7 @@ proptest! {
         let store2 = &db2.state_store;
 
         let mut restore =
-            StateSnapshotRestore::new(&store2.state_merkle_db, store2, version, expected_root_hash, true /* async_commit */).unwrap();
+            StateSnapshotRestore::new(&store2.state_merkle_db, store2, version, expected_root_hash, true /* async_commit */, false).unwrap();
 
         let mut ordered_input: Vec<_> = input
             .into_iter()
@@ -430,7 +430,7 @@ proptest! {
         let store2 = &db2.state_store;
         let max_hash = HashValue::new([0xff; HashValue::LENGTH]);
         let mut restore =
-            StateSnapshotRestore::new(&store2.state_merkle_db, store2, version, expected_root_hash, true, /* async_commit */).unwrap();
+            StateSnapshotRestore::new(&store2.state_merkle_db, store2, version, expected_root_hash, true, /* async_commit */ false).unwrap();
 
         let dummy_state_key = StateKey::raw(vec![]);
         let (top_levels_batch, sharded_batches, _) = store2.state_merkle_db.merklize_value_set(vec![(max_hash, Some(&(HashValue::random(), dummy_state_key)))], None, 0, None, None).unwrap();

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
@@ -78,6 +78,7 @@ fn end_to_end() {
                 manifest_handle,
                 version,
                 validate_modules: false,
+                kv_only: false,
             },
             GlobalRestoreOpt {
                 dry_run: false,

--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -134,6 +134,7 @@ fn test_end_to_end_impl(d: TestData) {
                     manifest_handle: state_snapshot_manifest.unwrap(),
                     version,
                     validate_modules: false,
+                    kv_only: false,
                 },
                 global_restore_opt.clone(),
                 Arc::clone(&store),

--- a/storage/backup/backup-cli/src/coordinators/replay_verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/replay_verify.rs
@@ -142,6 +142,7 @@ impl ReplayVerifyCoordinator {
                     manifest_handle: backup.manifest,
                     version: backup.version,
                     validate_modules: self.validate_modules,
+                    kv_only: false,
                 },
                 global_opt.clone(),
                 Arc::clone(&self.storage),

--- a/storage/backup/backup-cli/src/coordinators/restore.rs
+++ b/storage/backup/backup-cli/src/coordinators/restore.rs
@@ -169,6 +169,7 @@ impl RestoreCoordinator {
                 manifest_handle: state_snapshot_backup.manifest,
                 version,
                 validate_modules: false,
+                kv_only: false,
             },
             self.global_opt.clone(),
             Arc::clone(&self.storage),

--- a/storage/backup/backup-cli/src/coordinators/verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/verify.rs
@@ -131,6 +131,7 @@ impl VerifyCoordinator {
                     manifest_handle: backup.manifest,
                     version: backup.version,
                     validate_modules: self.validate_modules,
+                    kv_only: false,
                 },
                 global_opt.clone(),
                 Arc::clone(&self.storage),

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -204,10 +204,11 @@ impl RestoreRunMode {
         &self,
         version: Version,
         expected_root_hash: HashValue,
+        kv_only: bool,
     ) -> Result<StateSnapshotRestore<StateKey, StateValue>> {
         match self {
             Self::Restore { restore_handler } => {
-                restore_handler.get_state_restore_receiver(version, expected_root_hash)
+                restore_handler.get_state_restore_receiver(version, expected_root_hash, kv_only)
             },
             Self::Verify => {
                 let mock_store = Arc::new(MockStore);
@@ -216,6 +217,7 @@ impl RestoreRunMode {
                     &mock_store,
                     version,
                     expected_root_hash,
+                    kv_only,
                 )
             },
         }


### PR DESCRIPTION
### Description
based on https://www.notion.so/aptoslabs/Enhanced-DB-Restore-cf86fbfacbb94eab8e155078f56cec34?pvs=4, we need to be able to recover a snapshot with kv only to speed up

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
use existing tests
will also jointly test with kv restore PR later
