### PR TITLE
Make shareholder function handle both beneficiary and shareholder addresses to fix `accumulated_rewards` function

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/vesting.md
+++ b/aptos-move/framework/aptos-framework/doc/vesting.md
@@ -1499,12 +1499,13 @@ Return the list of all shareholders in the vesting contract.
 ## Function `shareholder`
 
 Return the shareholder address given the beneficiary address in a given vesting contract. If there are multiple
-shareholders with the same beneficiary address, only the first shareholder is returned.
+shareholders with the same beneficiary address, only the first shareholder is returned. If the given beneficiary
+address is actually a shareholder address, just return the address back.
 
-This returns 0x0 if no shareholder is found for the given beneficiary.
+This returns 0x0 if no shareholder is found for the given beneficiary / the address is not a shareholder itself.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vesting.md#0x1_vesting_shareholder">shareholder</a>(vesting_contract_address: <b>address</b>, beneficiary: <b>address</b>): <b>address</b>
+<pre><code><b>public</b> <b>fun</b> <a href="vesting.md#0x1_vesting_shareholder">shareholder</a>(vesting_contract_address: <b>address</b>, shareholder_or_beneficiary: <b>address</b>): <b>address</b>
 </code></pre>
 
 
@@ -1513,17 +1514,20 @@ This returns 0x0 if no shareholder is found for the given beneficiary.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vesting.md#0x1_vesting_shareholder">shareholder</a>(vesting_contract_address: <b>address</b>, beneficiary: <b>address</b>): <b>address</b> <b>acquires</b> <a href="vesting.md#0x1_vesting_VestingContract">VestingContract</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="vesting.md#0x1_vesting_shareholder">shareholder</a>(vesting_contract_address: <b>address</b>, shareholder_or_beneficiary: <b>address</b>): <b>address</b> <b>acquires</b> <a href="vesting.md#0x1_vesting_VestingContract">VestingContract</a> {
     <a href="vesting.md#0x1_vesting_assert_active_vesting_contract">assert_active_vesting_contract</a>(vesting_contract_address);
 
     <b>let</b> shareholders = &<a href="vesting.md#0x1_vesting_shareholders">shareholders</a>(vesting_contract_address);
+    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_contains">vector::contains</a>(shareholders, &shareholder_or_beneficiary)) {
+        <b>return</b> shareholder_or_beneficiary
+    };
     <b>let</b> vesting_contract = <b>borrow_global</b>&lt;<a href="vesting.md#0x1_vesting_VestingContract">VestingContract</a>&gt;(vesting_contract_address);
     <b>let</b> i = 0;
     <b>let</b> len = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(shareholders);
     <b>while</b> (i &lt; len) {
         <b>let</b> shareholder = *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(shareholders, i);
         // This will still <b>return</b> the shareholder <b>if</b> shareholder == beneficiary.
-        <b>if</b> (beneficiary == <a href="vesting.md#0x1_vesting_get_beneficiary">get_beneficiary</a>(vesting_contract, shareholder)) {
+        <b>if</b> (shareholder_or_beneficiary == <a href="vesting.md#0x1_vesting_get_beneficiary">get_beneficiary</a>(vesting_contract, shareholder)) {
             <b>return</b> shareholder
         };
         i = i + 1;
@@ -2910,7 +2914,7 @@ staking_contract and stake modules.
 ### Function `shareholder`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="vesting.md#0x1_vesting_shareholder">shareholder</a>(vesting_contract_address: <b>address</b>, beneficiary: <b>address</b>): <b>address</b>
+<pre><code><b>public</b> <b>fun</b> <a href="vesting.md#0x1_vesting_shareholder">shareholder</a>(vesting_contract_address: <b>address</b>, shareholder_or_beneficiary: <b>address</b>): <b>address</b>
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/vesting.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.spec.move
@@ -81,7 +81,7 @@ spec aptos_framework::vesting {
         include ActiveVestingContractAbortsIf<VestingContract>{contract_address: vesting_contract_address};
     }
 
-    spec shareholder(vesting_contract_address: address, beneficiary: address): address {
+    spec shareholder(vesting_contract_address: address, shareholder_or_beneficiary: address): address {
         include ActiveVestingContractAbortsIf<VestingContract>{contract_address: vesting_contract_address};
     }
 


### PR DESCRIPTION
## Description

In the vesting contract at this address:
```
0x3de72a2e5d6a330b919ee6de9a6f51f6250c32b1385107c7b2db02bc82bfd587
```

You see this entry in the beneficiaries map:
```
{
  key: "0x3168c3c9173a81f6923496649ef69995f79d10dee31cc5580b03057ce3a5b27f"
  value: "0x385c76d283c205a1ac3b117fe059d39ef80c5d67bcb1a3b73a2e220f67130512"
}
```

Where key is the shareholder and value is the beneficiary.

You can see that the `shareholder` function works as intended:
```
$ aptos move view --url https://fullnode.mainnet.aptoslabs.com --function-id 0x1::vesting::shareholder --args address:0x3de72a2e5d6a330b919ee6de9a6f51f6250c32b1385107c7b2db02bc82bfd587 address:0xd36d942f6cc900178f981e5196e4a1e4e9bdc7ed760afd33ca5553a4cad83126
{
  "Result": [
    "0x31711902c817a6b8cd83c999320da2c1e328695cd879f6115995c3fff7a29ac1"
  ]
}
```

So far so good. However, the `accumulated_rewards` function says it takes `shareholder_or_beneficiary`. If you pass in the beneficiary, the result looks good:
```
$ aptos move view --url https://fullnode.mainnet.aptoslabs.com --function-id 0x1::vesting::accumulated_rewards --args address:0x3de72a2e5d6a330b919ee6de9a6f51f6250c32b1385107c7b2db02bc82bfd587 address:0x385c76d283c205a1ac3b117fe059d39ef80c5d67bcb1a3b73a2e220f67130512
{
  "Result": [
    "22171919592"
  ]
}
```

If you pass in the shareholder however, it looks like this:
```
$ aptos move view --url https://fullnode.mainnet.aptoslabs.com --function-id 0x1::vesting::accumulated_rewards --args address:0x3de72a2e5d6a330b919ee6de9a6f51f6250c32b1385107c7b2db02bc82bfd587 address:0x3168c3c9173a81f6923496649ef69995f79d10dee31cc5580b03057ce3a5b27f
{
  "Result": [
    "0"
  ]
}
```

Meaning passing in the shareholder address doesn't actually work like the argument would imply for the `accumulated_rewards` function.

This PR fixes this problem by making the `shareholder` function just return the given address if the address is in the shareholders map as a key.

This is not the only way we could solve this, we could make `accumulated_rewards` figure this out instead. But I feel this is less error prone, and makes it match how the `beneficiary` function works.

## Test Plan
```
cd aptos-move/framework/aptos-framework
aptos move test
```