### PR TITLE
[Config] Add Copy derive to Monitoring Config.

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -391,7 +391,7 @@ impl Default for NetworkMonitoringConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct NodeMonitoringConfig {
     pub node_info_request_interval_ms: u64, // The interval (ms) between node info requests


### PR DESCRIPTION
### Description
This PR adds the `Copy` derive to the `NodeMonitoringConfig` struct to fix a genuine CI/CD semantic merge conflict.

### Test Plan
Existing test infrastructure.