### PR TITLE
[Move-prover] Handling name conflict error when binding schema

### DIFF
--- a/third_party/move/move-prover/tests/sources/functional/schema_name.exp
+++ b/third_party/move/move-prover/tests/sources/functional/schema_name.exp
@@ -1,0 +1,6 @@
+Move prover returns: exiting with model building errors
+error: Variable `c` conflicts with a specification variable in the schema TestSchemaName::TestNameConflict
+  ┌─ tests/sources/functional/schema_name.move:9:16
+  │
+9 │             x: c + 3
+  │                ^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/schema_name.move
+++ b/third_party/move/move-prover/tests/sources/functional/schema_name.move
@@ -1,0 +1,29 @@
+module 0x42::TestSchemaName {
+
+    fun with_name_conflict(b: u64) {
+        assert!(b > 0, 1);
+    }
+    spec with_name_conflict {
+        let c = b;
+        include TestNameConflict {
+            x: c + 3
+        };
+    }
+
+    fun no_conflict(b: u64) {
+        assert!(b > 0, 1);
+    }
+    spec no_conflict {
+        let d = b;
+        include TestNameConflict {
+            x: d + 3
+        };
+    }
+
+    spec schema TestNameConflict {
+        x: u64;
+        let c = x > 3;
+        aborts_if !c;
+    }
+
+}


### PR DESCRIPTION
### Description

As pointed out by the issue #7559, the following code will generate a boogie internal error:

```
    fun with_name_conflict(b: u64) {
        assert!(b > 0, 1);
    }
    spec with_name_conflict {
        let c = b;
        include TestNameConflict {
            x: c + 3
        };
    }
  
    spec schema TestNameConflict {
        x: u64;
        let c = x > 3;
        aborts_if !c;
    }
```

The reason is that the prover cannot detect the name conflicts of `c` in  `with_name_conflict` and `TestNameConflict`. This PR checks the name conflicts between the specification and the schema to be included in it. 

Close #7559

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

A new test case `schema_name.move` is added.