### PR TITLE
Improved Connection Balance and Committed Votes after Updating HAProxy Configuration

### DIFF
--- a/.github/workflows/copy-images-to-dockerhub-release.yaml
+++ b/.github/workflows/copy-images-to-dockerhub-release.yaml
@@ -1,4 +1,4 @@
-name: Copy images to dockerhub devnet/testnet
+name: Copy images to dockerhub on release
 on:
   push:
     branches:

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -47,6 +47,7 @@ on: # build on main branch OR when a PR is labeled with `CICD:build-images`
       # experimental branches
       - performance_benchmark
       - quorum-store
+      - preview
 
 # cancel redundant builds
 concurrency:

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -108,7 +108,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-consensus-stress-test
+      FORGE_NAMESPACE: forge-consensus-stress-test-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 2400
       FORGE_TEST_SUITE: consensus_stress_test
       POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
@@ -120,7 +120,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-account-creation-test
+      FORGE_NAMESPACE: forge-account-creation-test-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: account_creation
       POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
@@ -132,7 +132,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-performance
+      FORGE_NAMESPACE: forge-performance-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 7200
       FORGE_TEST_SUITE: land_blocking
       FORGE_ENABLE_PERFORMANCE: true
@@ -145,7 +145,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-continuous-e2e-single-vfn
+      FORGE_NAMESPACE: forge-continuous-e2e-single-vfn-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       # Run for 8 minutes
       FORGE_RUNNER_DURATION_SECS: 480
       FORGE_TEST_SUITE: single_vfn_perf
@@ -158,7 +158,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-haproxy
+      FORGE_NAMESPACE: forge-haproxy-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 600
       FORGE_ENABLE_HAPROXY: true
       FORGE_TEST_SUITE: land_blocking
@@ -172,7 +172,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
-      FORGE_NAMESPACE: forge-compat
+      FORGE_NAMESPACE: forge-compat-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       # Run for 5 minutes
       FORGE_RUNNER_DURATION_SECS: 300
       # This will upgrade from testnet branch to the latest main
@@ -190,7 +190,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-three-region
+      FORGE_NAMESPACE: forge-three-region-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 1800
       FORGE_TEST_SUITE: three_region_simulation
       POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
@@ -202,7 +202,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-fullnode-reboot-stress
+      FORGE_NAMESPACE: forge-fullnode-reboot-stress-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 1800
       FORGE_TEST_SUITE: fullnode_reboot_stress_test
       POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
@@ -214,7 +214,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-network-partition
+      FORGE_NAMESPACE: forge-network-partition-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       # Run for 15 minutes
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: network_partition
@@ -229,7 +229,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-changing-working-quorum-test
+      FORGE_NAMESPACE: forge-changing-working-quorum-test-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 1200
       FORGE_TEST_SUITE: changing_working_quorum_test
       POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
@@ -242,7 +242,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-different-node-speed-and-reliability-test
+      FORGE_NAMESPACE: forge-different-node-speed-and-reliability-test-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: different_node_speed_and_reliability_test
       POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
@@ -255,7 +255,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-changing-working-quorum-test-high-load
+      FORGE_NAMESPACE: forge-changing-working-quorum-test-high-load-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: changing_working_quorum_test_high_load
       POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch
@@ -270,7 +270,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-state-sync-perf-validator
+      FORGE_NAMESPACE: forge-state-sync-perf-validator-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       # Run for 40 minutes
       FORGE_RUNNER_DURATION_SECS: 2400
       FORGE_TEST_SUITE: state_sync_perf_validators
@@ -283,7 +283,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-execute
+      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-execute-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       # Run for 40 minutes
       FORGE_RUNNER_DURATION_SECS: 2400
       FORGE_TEST_SUITE: state_sync_perf_fullnodes_execute_transactions
@@ -296,7 +296,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-fast-sync
+      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-fast-sync-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       # Run for 40 minutes
       FORGE_RUNNER_DURATION_SECS: 2400
       FORGE_TEST_SUITE: state_sync_perf_fullnodes_fast_sync
@@ -309,7 +309,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-apply
+      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-apply-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 2400
       FORGE_TEST_SUITE: state_sync_perf_fullnodes_apply_outputs
       POST_TO_SLACK: ${{ needs.determine-test-metadata.outputs.BRANCH == 'main' }} # only post to slack on main branch

--- a/.github/workflows/forge-unstable.yaml
+++ b/.github/workflows/forge-unstable.yaml
@@ -106,7 +106,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-graceful-overload-test
+      FORGE_NAMESPACE: forge-graceful-overload-test-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 1800
       FORGE_TEST_SUITE: graceful_overload
       POST_TO_SLACK: true
@@ -118,7 +118,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-nft-mint-test
+      FORGE_NAMESPACE: forge-nft-mint-test-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: nft_mint
       POST_TO_SLACK: true
@@ -130,7 +130,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-state-sync-slow-processing-catching-up-test
+      FORGE_NAMESPACE: forge-state-sync-slow-processing-catching-up-test-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: state_sync_slow_processing_catching_up
       POST_TO_SLACK: true
@@ -143,7 +143,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-twin-validator
+      FORGE_NAMESPACE: forge-twin-validator-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: twin_validator_test
       POST_TO_SLACK: true
@@ -155,7 +155,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-three-region-with-different-node-speed
+      FORGE_NAMESPACE: forge-three-region-with-different-node-speed-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 3600
       FORGE_TEST_SUITE: three_region_simulation_with_different_node_speed
       FORGE_ENABLE_FAILPOINTS: true
@@ -168,7 +168,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-state-sync-failures-catching-up-test
+      FORGE_NAMESPACE: forge-state-sync-failures-catching-up-test-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: state_sync_failures_catching_up
       FORGE_ENABLE_FAILPOINTS: true
@@ -181,7 +181,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-validator-reboot-stress
+      FORGE_NAMESPACE: forge-validator-reboot-stress-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       # Run for 40 minutes
       FORGE_RUNNER_DURATION_SECS: 2400
       FORGE_TEST_SUITE: validator_reboot_stress_test

--- a/.github/workflows/run-gas-calibration.yaml
+++ b/.github/workflows/run-gas-calibration.yaml
@@ -29,6 +29,8 @@ jobs:
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - name: install Valgrind
         shell: bash
         run: sudo apt-get -y install valgrind

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
+ "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
  "aptos-consensus-notifications",

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -48,7 +48,6 @@ use aptos_vm::{
     move_vm_ext::MoveResolverExt,
 };
 use futures::{channel::oneshot, SinkExt};
-use itertools::Itertools;
 use move_core_types::language_storage::{ModuleId, StructTag};
 use std::{
     collections::HashMap,
@@ -62,7 +61,6 @@ pub struct Context {
     pub db: Arc<dyn DbReader>,
     mp_sender: MempoolClientSender,
     pub node_config: NodeConfig,
-    gas_estimation: Arc<RwLock<GasEstimationCache>>,
     gas_schedule_cache: Arc<RwLock<GasScheduleCache>>,
 }
 
@@ -84,13 +82,6 @@ impl Context {
             db,
             mp_sender,
             node_config,
-            gas_estimation: Arc::new(RwLock::new(GasEstimationCache {
-                last_updated_version: None,
-                last_updated_epoch: None,
-                deprioritized_gas_price: 0,
-                median_gas_price: 0,
-                prioritized_gas_price: 0,
-            })),
             gas_schedule_cache: Arc::new(RwLock::new(GasScheduleCache {
                 last_updated_epoch: None,
                 gas_schedule_params: None,
@@ -807,129 +798,13 @@ impl Context {
 
     pub fn estimate_gas_price<E: InternalError>(
         &self,
-        ledger_info: &LedgerInfo,
+        _ledger_info: &LedgerInfo,
     ) -> Result<GasEstimation, E> {
-        // The search size
-        const SEARCH_SIZE: u64 = 100_000;
-        let oldest_search_version = std::cmp::max(
-            ledger_info.ledger_version.0.saturating_sub(SEARCH_SIZE),
-            ledger_info.oldest_ledger_version.0,
-        );
-
-        // If it's cached, let's use that
-        {
-            let gas_estimation = self.gas_estimation.read().unwrap();
-            let (last_updated_epoch, _) = self.get_gas_schedule(ledger_info)?;
-
-            // Cache includes if there was an update on the gas schedule due to epoch changes
-            if gas_estimation.last_updated_version.is_some()
-                && gas_estimation.last_updated_version.unwrap() > oldest_search_version
-                && last_updated_epoch == gas_estimation.last_updated_epoch.unwrap_or_default()
-            {
-                return Ok(gas_estimation.gas_estimate());
-            }
-        }
-
-        // Otherwise, get the estimated amount from storage
-        {
-            let mut gas_estimation = self.gas_estimation.write().unwrap();
-            let (last_updated_epoch, gas_schedule) = self.get_gas_schedule(ledger_info)?;
-
-            // If this has been updated by a different thread, use that instead
-            if gas_estimation.last_updated_version.is_some()
-                && gas_estimation.last_updated_version.unwrap() > oldest_search_version
-                && last_updated_epoch == gas_estimation.last_updated_epoch.unwrap_or_default()
-            {
-                return Ok(gas_estimation.gas_estimate());
-            }
-            let mut gas_prices: Vec<u64> = self
-                .db
-                .get_gas_prices(
-                    oldest_search_version,
-                    SEARCH_SIZE,
-                    ledger_info.ledger_version.0,
-                )
-                .map_err(|err| {
-                    E::internal_with_code(err, AptosErrorCode::InternalError, ledger_info)
-                })?;
-
-            // When there's no gas prices in the last 100k transactions, we're going to set it to
-            // the lowest gas price because the transaction should get through with any amount
-            gas_estimation.last_updated_version = Some(ledger_info.ledger_version.0);
-            gas_estimation.last_updated_epoch = Some(last_updated_epoch);
-            let min_gas_price = gas_schedule.txn.min_price_per_gas_unit.into();
-            let max_gas_price = gas_schedule.txn.max_price_per_gas_unit.into();
-
-            let observed_gas_median = if gas_prices.is_empty() {
-                // This will make it always pick the minimum gas price
-                0
-            } else {
-                // Sort and take the median of the gas prices
-                gas_prices.sort();
-
-                // Median is the center if it's odd, average of the two middle if even
-                let mid = gas_prices.len() / 2;
-                if gas_prices.len() % 2 == 0 {
-                    let lower = gas_prices.get(mid.saturating_sub(1)).unwrap();
-                    let upper = gas_prices.get(mid).unwrap();
-
-                    upper.saturating_add(*lower).saturating_div(2)
-                } else {
-                    *gas_prices.get(mid).unwrap()
-                }
-            };
-
-            // Ensure the price is within the min/max bounds
-            gas_estimation.median_gas_price = std::cmp::min(
-                max_gas_price,
-                std::cmp::max(min_gas_price, observed_gas_median),
-            );
-
-            // Handle prices for "prioritized" and "deprioritized"
-            // There must be at least 1 buckets
-            assert!(!self.node_config.mempool.broadcast_buckets.is_empty());
-            let median_gas_price = gas_estimation.median_gas_price;
-
-            // TODO: Buckets are assumed to be ordered
-            let bucket_index = self
-                .node_config
-                .mempool
-                .broadcast_buckets
-                .iter()
-                .sorted()
-                .enumerate()
-                .find_map(|(index, current_bucket)| {
-                    if median_gas_price >= *current_bucket {
-                        Some(index)
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or_default();
-
-            // Previous bucket could be the same as the minimum price (if too low)
-            let previous_bucket_price = self
-                .node_config
-                .mempool
-                .broadcast_buckets
-                .get(bucket_index.saturating_sub(1))
-                .copied()
-                .unwrap_or(min_gas_price);
-            // Next bucket could be the same as the current gas price, but we increase by 1 for the estimation
-            let next_bucket_price = self
-                .node_config
-                .mempool
-                .broadcast_buckets
-                .get(bucket_index.saturating_add(1))
-                .copied()
-                .unwrap_or_else(|| median_gas_price.saturating_add(1));
-            // Ensure that bucket prices are within the bounds
-            gas_estimation.deprioritized_gas_price =
-                std::cmp::max(min_gas_price, previous_bucket_price);
-            gas_estimation.prioritized_gas_price = std::cmp::min(max_gas_price, next_bucket_price);
-
-            Ok(gas_estimation.gas_estimate())
-        }
+        Ok(GasEstimation {
+            deprioritized_gas_estimate: Some(100),
+            gas_estimate: 100,
+            prioritized_gas_estimate: Some(150),
+        })
     }
 
     pub fn get_gas_schedule<E: InternalError>(
@@ -1028,28 +903,6 @@ impl Context {
 
     pub fn last_updated_gas_schedule(&self) -> Option<u64> {
         self.gas_schedule_cache.read().unwrap().last_updated_epoch
-    }
-
-    pub fn last_updated_gas_estimation(&self) -> Option<u64> {
-        self.gas_estimation.read().unwrap().last_updated_version
-    }
-}
-
-pub struct GasEstimationCache {
-    last_updated_version: Option<u64>,
-    last_updated_epoch: Option<u64>,
-    deprioritized_gas_price: u64,
-    median_gas_price: u64,
-    prioritized_gas_price: u64,
-}
-
-impl GasEstimationCache {
-    pub fn gas_estimate(&self) -> GasEstimation {
-        GasEstimation {
-            deprioritized_gas_estimate: Some(self.deprioritized_gas_price),
-            gas_estimate: self.median_gas_price,
-            prioritized_gas_estimate: Some(self.prioritized_gas_price),
-        }
     }
 }
 

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -12,7 +12,8 @@ use crate::{
 };
 use anyhow::{bail, ensure, format_err, Context as AnyhowContext, Result};
 use aptos_api_types::{
-    AptosErrorCode, AsConverter, BcsBlock, GasEstimation, LedgerInfo, TransactionOnChainData,
+    AptosErrorCode, AsConverter, BcsBlock, GasEstimation, LedgerInfo, ResourceGroup,
+    TransactionOnChainData,
 };
 use aptos_config::config::{NodeConfig, RoleType};
 use aptos_crypto::HashValue;
@@ -50,7 +51,7 @@ use futures::{channel::oneshot, SinkExt};
 use itertools::Itertools;
 use move_core_types::language_storage::{ModuleId, StructTag};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     sync::{Arc, RwLock},
 };
 
@@ -344,7 +345,7 @@ impl Context {
             .map(|(key, value)| {
                 if resolver.is_resource_group(&key) {
                     // An error here means a storage invariant has been violated
-                    bcs::from_bytes::<BTreeMap<StructTag, Vec<u8>>>(&value)
+                    bcs::from_bytes::<ResourceGroup>(&value)
                         .map(|map| {
                             map.into_iter()
                                 .map(|(key, value)| (key, value))

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -1082,6 +1082,7 @@ async fn test_create_signing_message_rejects_no_content_length_request() {
     context.check_golden_output(resp);
 }
 
+#[ignore]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_gas_estimation() {
     let mut context = new_test_context(current_function_name!());

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -1088,7 +1088,6 @@ async fn test_gas_estimation() {
     let mut context = new_test_context(current_function_name!());
     let resp = context.get("/estimate_gas_price").await;
     assert!(context.last_updated_gas_schedule().is_some());
-    assert!(context.last_updated_gas_estimation().is_some());
     context.check_golden_output(resp);
 }
 

--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -230,7 +230,7 @@ impl TestContext {
     }
 
     pub fn last_updated_gas_estimation(&self) -> Option<u64> {
-        self.context.last_updated_gas_estimation()
+        Some(100)
     }
 
     /// Prune well-known excessively large entries from a resource array response.

--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -229,10 +229,6 @@ impl TestContext {
         self.context.last_updated_gas_schedule()
     }
 
-    pub fn last_updated_gas_estimation(&self) -> Option<u64> {
-        Some(100)
-    }
-
     /// Prune well-known excessively large entries from a resource array response.
     /// TODO: we can't dump all resources of an account as golden output. As functionality
     /// grows this becomes too much. Need a way to filter only the resources which folks want.

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -12,9 +12,9 @@ use crate::{
     view::ViewRequest,
     Bytecode, DirectWriteSet, EntryFunctionId, EntryFunctionPayload, Event, HexEncodedBytes,
     MoveFunction, MoveModuleBytecode, MoveResource, MoveScriptBytecode, MoveType, MoveValue,
-    PendingTransaction, ScriptPayload, ScriptWriteSet, SubmitTransactionRequest, Transaction,
-    TransactionInfo, TransactionOnChainData, TransactionPayload, UserTransactionRequest,
-    VersionedEvent, WriteSet, WriteSetChange, WriteSetPayload,
+    PendingTransaction, ResourceGroup, ScriptPayload, ScriptWriteSet, SubmitTransactionRequest,
+    Transaction, TransactionInfo, TransactionOnChainData, TransactionPayload,
+    UserTransactionRequest, VersionedEvent, WriteSet, WriteSetChange, WriteSetPayload,
 };
 use anyhow::{bail, ensure, format_err, Context as AnyhowContext, Result};
 use aptos_crypto::{hash::CryptoHash, HashValue};
@@ -77,6 +77,23 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
 
     pub fn try_into_resource<'b>(&self, typ: &StructTag, bytes: &'b [u8]) -> Result<MoveResource> {
         self.inner.view_resource(typ, bytes)?.try_into()
+    }
+
+    pub fn try_into_resources_from_resource_group(
+        &self,
+        bytes: &[u8],
+    ) -> Result<Vec<MoveResource>> {
+        let resources_with_tag: Vec<(StructTag, Vec<u8>)> = bcs::from_bytes::<ResourceGroup>(bytes)
+            .map(|map| {
+                map.into_iter()
+                    .map(|(key, value)| (key, value))
+                    .collect::<Vec<_>>()
+            })?;
+
+        resources_with_tag
+            .iter()
+            .map(|(struct_tag, value_bytes)| self.try_into_resource(struct_tag, value_bytes))
+            .collect::<Result<Vec<_>>>()
     }
 
     pub fn move_struct_fields<'b>(
@@ -152,7 +169,8 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
             // TODO: the resource value is interpreted by the type definition at the version of the converter, not the version of the tx: must be fixed before we allow module updates
             changes: write_set
                 .into_iter()
-                .filter_map(|(sk, wo)| self.try_into_write_set_change(sk, wo).ok())
+                .filter_map(|(sk, wo)| self.try_into_write_set_changes(sk, wo).ok())
+                .flatten()
                 .collect(),
             block_height: None,
             epoch: None,
@@ -261,13 +279,17 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
             },
             Direct(d) => {
                 let (write_set, events) = d.into_inner();
+                let nested_writeset_changes: Vec<Vec<WriteSetChange>> = write_set
+                    .into_iter()
+                    .map(|(state_key, op)| self.try_into_write_set_changes(state_key, op))
+                    .collect::<Result<Vec<Vec<_>>>>()?;
                 WriteSetPayload {
                     write_set: WriteSet::DirectWriteSet(DirectWriteSet {
                         // TODO: the resource value is interpreted by the type definition at the version of the converter, not the version of the tx: must be fixed before we allow module updates
-                        changes: write_set
+                        changes: nested_writeset_changes
                             .into_iter()
-                            .map(|(state_key, op)| self.try_into_write_set_change(state_key, op))
-                            .collect::<Result<_>>()?,
+                            .flatten()
+                            .collect::<Vec<WriteSetChange>>(),
                         events: self.try_into_events(&events)?,
                     }),
                 }
@@ -276,19 +298,21 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
         Ok(ret)
     }
 
-    pub fn try_into_write_set_change(
+    pub fn try_into_write_set_changes(
         &self,
         state_key: StateKey,
         op: WriteOp,
-    ) -> Result<WriteSetChange> {
+    ) -> Result<Vec<WriteSetChange>> {
         let hash = state_key.hash().to_hex_literal();
         let state_key = state_key.into_inner();
         match state_key {
             StateKeyInner::AccessPath(access_path) => {
-                self.try_access_path_into_write_set_change(hash, access_path, op)
+                self.try_access_path_into_write_set_changes(hash, access_path, op)
             },
             StateKeyInner::TableItem { handle, key } => {
-                self.try_table_item_into_write_set_change(hash, handle, key, op)
+                vec![self.try_table_item_into_write_set_change(hash, handle, key, op)]
+                    .into_iter()
+                    .collect()
             },
             StateKeyInner::Raw(_) => Err(format_err!(
                 "Can't convert account raw key {:?} to WriteSetChange",
@@ -297,47 +321,52 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
         }
     }
 
-    // TODO: Consider expanding ResourceGroup into Resource and returning Vec<WriteSetChange>
-    pub fn try_access_path_into_write_set_change(
+    pub fn try_access_path_into_write_set_changes(
         &self,
         state_key_hash: String,
         access_path: AccessPath,
         op: WriteOp,
-    ) -> Result<WriteSetChange> {
+    ) -> Result<Vec<WriteSetChange>> {
         let ret = match op.into_bytes() {
             None => match access_path.get_path() {
-                Path::Code(module_id) => WriteSetChange::DeleteModule(DeleteModule {
+                Path::Code(module_id) => vec![WriteSetChange::DeleteModule(DeleteModule {
                     address: access_path.address.into(),
                     state_key_hash,
                     module: module_id.into(),
-                }),
-                Path::Resource(typ) => WriteSetChange::DeleteResource(DeleteResource {
+                })],
+                Path::Resource(typ) => vec![WriteSetChange::DeleteResource(DeleteResource {
                     address: access_path.address.into(),
                     state_key_hash,
                     resource: typ.into(),
-                }),
-                Path::ResourceGroup(typ) => WriteSetChange::DeleteResource(DeleteResource {
+                })],
+                Path::ResourceGroup(typ) => vec![WriteSetChange::DeleteResource(DeleteResource {
                     address: access_path.address.into(),
                     state_key_hash,
                     resource: typ.into(),
-                }),
+                })],
             },
             Some(bytes) => match access_path.get_path() {
-                Path::Code(_) => WriteSetChange::WriteModule(WriteModule {
+                Path::Code(_) => vec![WriteSetChange::WriteModule(WriteModule {
                     address: access_path.address.into(),
                     state_key_hash,
                     data: MoveModuleBytecode::new(bytes).try_parse_abi()?,
-                }),
-                Path::Resource(typ) => WriteSetChange::WriteResource(WriteResource {
+                })],
+                Path::Resource(typ) => vec![WriteSetChange::WriteResource(WriteResource {
                     address: access_path.address.into(),
                     state_key_hash,
                     data: self.try_into_resource(&typ, &bytes)?,
-                }),
-                Path::ResourceGroup(typ) => WriteSetChange::WriteResource(WriteResource {
-                    address: access_path.address.into(),
-                    state_key_hash,
-                    data: self.try_into_resource(&typ, &bytes)?,
-                }),
+                })],
+                Path::ResourceGroup(_) => self
+                    .try_into_resources_from_resource_group(&bytes)?
+                    .into_iter()
+                    .map(|data| {
+                        WriteSetChange::WriteResource(WriteResource {
+                            address: access_path.address.into(),
+                            state_key_hash: state_key_hash.clone(),
+                            data,
+                        })
+                    })
+                    .collect::<Vec<_>>(),
             },
         };
         Ok(ret)

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -35,7 +35,7 @@ pub use move_types::{
     HexEncodedBytes, MoveAbility, MoveFunction, MoveFunctionGenericTypeParam,
     MoveFunctionVisibility, MoveModule, MoveModuleBytecode, MoveModuleId, MoveResource,
     MoveScriptBytecode, MoveStruct, MoveStructField, MoveStructTag, MoveType, MoveValue,
-    MAX_RECURSIVE_TYPES_ALLOWED, U128, U256, U64,
+    ResourceGroup, MAX_RECURSIVE_TYPES_ALLOWED, U128, U256, U64,
 };
 use serde::{Deserialize, Deserializer};
 use std::str::FromStr;

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -30,6 +30,8 @@ use std::{
     str::FromStr,
 };
 
+pub type ResourceGroup = BTreeMap<StructTag, Vec<u8>>;
+
 /// A parsed Move resource
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Object)]
 pub struct MoveResource {

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -15,6 +15,7 @@ feature_flags:
     - blake2b256_native
     - resource_groups
     - multisig_accounts
+    - delegation_pools
   disabled: []
 is_multi_step: true
 framework_release_at_end: true

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -27,6 +27,7 @@ pub enum FeatureFlag {
     Blake2b256Native,
     ResourceGroups,
     MultisigAccounts,
+    DelegationPools,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -126,6 +127,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::Blake2b256Native => AptosFeatureFlag::BLAKE2B_256_NATIVE,
             FeatureFlag::ResourceGroups => AptosFeatureFlag::RESOURCE_GROUPS,
             FeatureFlag::MultisigAccounts => AptosFeatureFlag::MULTISIG_ACCOUNTS,
+            FeatureFlag::DelegationPools => AptosFeatureFlag::DELEGATION_POOLS,
         }
     }
 }
@@ -150,6 +152,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::BLAKE2B_256_NATIVE => FeatureFlag::Blake2b256Native,
             AptosFeatureFlag::RESOURCE_GROUPS => FeatureFlag::ResourceGroups,
             AptosFeatureFlag::MULTISIG_ACCOUNTS => FeatureFlag::MultisigAccounts,
+            AptosFeatureFlag::DELEGATION_POOLS => FeatureFlag::DelegationPools,
         }
     }
 }

--- a/aptos-move/framework/aptos-framework/doc/delegation_pool.md
+++ b/aptos-move/framework/aptos-framework/doc/delegation_pool.md
@@ -1,0 +1,2258 @@
+
+<a name="0x1_delegation_pool"></a>
+
+# Module `0x1::delegation_pool`
+
+
+* Allow multiple delegators to participate in the same stake pool in order to collect the minimum
+* stake required to join the validator set. Delegators are rewarded out of the validator rewards
+* proportionally to their stake and provided the same stake-management API as the stake pool owner.
+*
+* The main accounting logic in the delegation pool contract handles the following:
+* 1. Tracks how much stake each delegator owns, privately deposited as well as earned.
+* Accounting individual delegator stakes is achieved through the shares-based pool defined at
+* <code>aptos_std::pool_u64</code>, hence delegators own shares rather than absolute stakes into the delegation pool.
+* 2. Tracks rewards earned by the stake pool, implicitly by the delegation one, in the meantime
+* and distribute them accordingly.
+* 3. Tracks lockup cycles on the stake pool in order to separate inactive stake (not earning rewards)
+* from pending_inactive stake (earning rewards) and allow its delegators to withdraw the former.
+* 4. Tracks how much commission fee has to be paid to the operator out of incoming rewards before
+* distributing them to the internal pool_u64 pools.
+*
+* In order to distinguish between stakes in different states and route rewards accordingly,
+* separate pool_u64 pools are used for individual stake states:
+*      1. one of <code>active</code> + <code>pending_active</code> stake
+*      2. one of <code>inactive</code> stake FOR each past observed lockup cycle (OLC) on the stake pool
+*      3. one of <code>pending_inactive</code> stake scheduled during this ongoing OLC
+*
+* As stake-state transitions and rewards are computed only at the stake pool level, the delegation pool
+* gets outdated. To mitigate this, at any interaction with the delegation pool, a process of synchronization
+* to the underlying stake pool is executed before the requested operation itself.
+*
+* At synchronization:
+*  - stake deviations between the two pools are actually the rewards produced in the meantime.
+*  - the commission fee is extracted from the rewards, the remaining stake is distributed to the internal
+* pool_u64 pools and then the commission stake used to buy shares for operator.
+*  - if detecting that the lockup expired on the stake pool, the delegation pool will isolate its
+* pending_inactive stake (now inactive) and create a new pool_u64 to host future pending_inactive stake
+* scheduled this newly started lockup.
+* Detecting a lockup expiration on the stake pool resumes to detecting new inactive stake.
+*
+* Accounting main invariants:
+*  - each stake-management operation (add/unlock/reactivate/withdraw) and operator change triggers
+* the synchronization process before executing its own function.
+*  - each OLC maps to one or more real lockups on the stake pool, but not the opposite. Actually, only a real
+* lockup with 'activity' (which inactivated some unlocking stake) triggers the creation of a new OLC.
+*  - unlocking and/or unlocked stake originating from different real lockups are never mixed together into
+* the same pool_u64. This invalidates the accounting of which rewards belong to whom.
+*  - no delegator can have unlocking and/or unlocked stake (pending withdrawals) in different OLCs. This ensures
+* delegators do not have to keep track of the OLCs when they unlocked. When creating a new pending withdrawal,
+* the existing one is executed (withdrawn) if is already inactive.
+*  - <code>add_stake</code> fees are always refunded, but only after the epoch when they have been charged ends.
+*  - withdrawing pending_inactive stake (when validator had gone inactive before its lockup expired)
+* does not inactivate any stake additional to the requested one to ensure OLC would not advance indefinitely.
+*  - the pending withdrawal exists at an OLC iff delegator owns some shares within the shares pool of that OLC.
+*
+* Example flow:
+* 1. A node operator creates a delegation pool by calling <code>initialize_delegation_pool</code> and sets
+* its commission fee to 0% (for simplicity). A stake pool is created with no initial stake and owned by
+* a resource account controlled by the delegation pool.
+* 2. Delegator A adds 100 stake which is converted to 100 shares into the active pool_u64
+* 3. Operator joins the validator set as the stake pool has now the minimum stake
+* 4. The stake pool earned rewards and now has 200 active stake. A's active shares are worth 200 coins as
+* the commission fee is 0%.
+* 5a. A requests <code>unlock</code> for 100 stake
+* 5b. Synchronization detects 200 - 100 active rewards which are entirely (0% commission) added to the active pool.
+* 5c. 100 coins = (100 * 100) / 200 = 50 shares are redeemed from the active pool and exchanged for 100 shares
+* into the pending_inactive one on A's behalf
+* 6. Delegator B adds 200 stake which is converted to (200 * 50) / 100 = 100 shares into the active pool
+* 7. The stake pool earned rewards and now has 600 active and 200 pending_inactive stake.
+* 8a. A requests <code>reactivate_stake</code> for 100 stake
+* 8b. Synchronization detects 600 - 300 active and 200 - 100 pending_inactive rewards which are both entirely
+* distributed to their corresponding pools
+* 8c. 100 coins = (100 * 100) / 200 = 50 shares are redeemed from the pending_inactive pool and exchanged for
+* (100 * 150) / 600 = 25 shares into the active one on A's behalf
+* 9. The lockup expires on the stake pool, inactivating the entire pending_inactive stake
+* 10a. B requests <code>unlock</code> for 100 stake
+* 10b. Synchronization detects no active or pending_inactive rewards, but 0 -> 100 inactive stake
+* on the stake pool, so it advances the observed lockup cycle and creates a pool_u64 for the new lockup,
+* hence allowing previous pending_inactive shares to be redeemed
+* 10c. 100 coins = (100 * 175) / 700 = 25 shares are redeemed from the active pool and exchanged for
+* 100 shares into the new pending_inactive one on B's behalf
+* 11. The stake pool earned rewards and now has some pending_inactive rewards.
+* 12a. A requests <code>withdraw</code> for its entire inactive stake
+* 12b. Synchronization detects no new inactive stake, but some pending_inactive rewards which are
+* distributed to the (2nd) pending_inactive pool
+* 12c. A's 50 shares = (50 * 100) / 50 = 100 coins are redeemed from the (1st) inactive pool and 100 stake
+* is transferred to A
+
+
+
+-  [Resource `DelegationPoolOwnership`](#0x1_delegation_pool_DelegationPoolOwnership)
+-  [Struct `ObservedLockupCycle`](#0x1_delegation_pool_ObservedLockupCycle)
+-  [Resource `DelegationPool`](#0x1_delegation_pool_DelegationPool)
+-  [Struct `AddStakeEvent`](#0x1_delegation_pool_AddStakeEvent)
+-  [Struct `ReactivateStakeEvent`](#0x1_delegation_pool_ReactivateStakeEvent)
+-  [Struct `UnlockStakeEvent`](#0x1_delegation_pool_UnlockStakeEvent)
+-  [Struct `WithdrawStakeEvent`](#0x1_delegation_pool_WithdrawStakeEvent)
+-  [Struct `DistributeCommissionEvent`](#0x1_delegation_pool_DistributeCommissionEvent)
+-  [Constants](#@Constants_0)
+-  [Function `owner_cap_exists`](#0x1_delegation_pool_owner_cap_exists)
+-  [Function `get_owned_pool_address`](#0x1_delegation_pool_get_owned_pool_address)
+-  [Function `delegation_pool_exists`](#0x1_delegation_pool_delegation_pool_exists)
+-  [Function `observed_lockup_cycle`](#0x1_delegation_pool_observed_lockup_cycle)
+-  [Function `operator_commission_percentage`](#0x1_delegation_pool_operator_commission_percentage)
+-  [Function `shareholders_count_active_pool`](#0x1_delegation_pool_shareholders_count_active_pool)
+-  [Function `get_delegation_pool_stake`](#0x1_delegation_pool_get_delegation_pool_stake)
+-  [Function `get_pending_withdrawal`](#0x1_delegation_pool_get_pending_withdrawal)
+-  [Function `get_stake`](#0x1_delegation_pool_get_stake)
+-  [Function `get_add_stake_fee`](#0x1_delegation_pool_get_add_stake_fee)
+-  [Function `can_withdraw_pending_inactive`](#0x1_delegation_pool_can_withdraw_pending_inactive)
+-  [Function `initialize_delegation_pool`](#0x1_delegation_pool_initialize_delegation_pool)
+-  [Function `assert_owner_cap_exists`](#0x1_delegation_pool_assert_owner_cap_exists)
+-  [Function `assert_delegation_pool_exists`](#0x1_delegation_pool_assert_delegation_pool_exists)
+-  [Function `assert_min_active_balance`](#0x1_delegation_pool_assert_min_active_balance)
+-  [Function `assert_min_pending_inactive_balance`](#0x1_delegation_pool_assert_min_pending_inactive_balance)
+-  [Function `coins_to_redeem_to_ensure_min_stake`](#0x1_delegation_pool_coins_to_redeem_to_ensure_min_stake)
+-  [Function `coins_to_transfer_to_ensure_min_stake`](#0x1_delegation_pool_coins_to_transfer_to_ensure_min_stake)
+-  [Function `retrieve_stake_pool_owner`](#0x1_delegation_pool_retrieve_stake_pool_owner)
+-  [Function `get_pool_address`](#0x1_delegation_pool_get_pool_address)
+-  [Function `olc_with_index`](#0x1_delegation_pool_olc_with_index)
+-  [Function `set_operator`](#0x1_delegation_pool_set_operator)
+-  [Function `set_delegated_voter`](#0x1_delegation_pool_set_delegated_voter)
+-  [Function `add_stake`](#0x1_delegation_pool_add_stake)
+-  [Function `unlock`](#0x1_delegation_pool_unlock)
+-  [Function `reactivate_stake`](#0x1_delegation_pool_reactivate_stake)
+-  [Function `withdraw`](#0x1_delegation_pool_withdraw)
+-  [Function `withdraw_internal`](#0x1_delegation_pool_withdraw_internal)
+-  [Function `pending_withdrawal_exists`](#0x1_delegation_pool_pending_withdrawal_exists)
+-  [Function `pending_inactive_shares_pool_mut`](#0x1_delegation_pool_pending_inactive_shares_pool_mut)
+-  [Function `pending_inactive_shares_pool`](#0x1_delegation_pool_pending_inactive_shares_pool)
+-  [Function `execute_pending_withdrawal`](#0x1_delegation_pool_execute_pending_withdrawal)
+-  [Function `buy_in_pending_inactive_shares`](#0x1_delegation_pool_buy_in_pending_inactive_shares)
+-  [Function `amount_to_shares_to_redeem`](#0x1_delegation_pool_amount_to_shares_to_redeem)
+-  [Function `redeem_active_shares`](#0x1_delegation_pool_redeem_active_shares)
+-  [Function `redeem_inactive_shares`](#0x1_delegation_pool_redeem_inactive_shares)
+-  [Function `calculate_stake_pool_drift`](#0x1_delegation_pool_calculate_stake_pool_drift)
+-  [Function `synchronize_delegation_pool`](#0x1_delegation_pool_synchronize_delegation_pool)
+-  [Function `multiply_then_divide`](#0x1_delegation_pool_multiply_then_divide)
+-  [Function `to_u128`](#0x1_delegation_pool_to_u128)
+
+
+<pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
+<b>use</b> <a href="aptos_coin.md#0x1_aptos_coin">0x1::aptos_coin</a>;
+<b>use</b> <a href="coin.md#0x1_coin">0x1::coin</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
+<b>use</b> <a href="../../aptos-stdlib/doc/pool_u64_unbound.md#0x1_pool_u64_unbound">0x1::pool_u64_unbound</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
+<b>use</b> <a href="stake.md#0x1_stake">0x1::stake</a>;
+<b>use</b> <a href="staking_config.md#0x1_staking_config">0x1::staking_config</a>;
+<b>use</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">0x1::table</a>;
+<b>use</b> <a href="timestamp.md#0x1_timestamp">0x1::timestamp</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_DelegationPoolOwnership"></a>
+
+## Resource `DelegationPoolOwnership`
+
+Capability that represents ownership over privileged operations on the underlying stake pool.
+
+
+<pre><code><b>struct</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolOwnership">DelegationPoolOwnership</a> <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>pool_address: <b>address</b></code>
+</dt>
+<dd>
+ equal to address of the resource account owning the stake pool
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_delegation_pool_ObservedLockupCycle"></a>
+
+## Struct `ObservedLockupCycle`
+
+
+
+<pre><code><b>struct</b> <a href="delegation_pool.md#0x1_delegation_pool_ObservedLockupCycle">ObservedLockupCycle</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>index: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_delegation_pool_DelegationPool"></a>
+
+## Resource `DelegationPool`
+
+
+
+<pre><code><b>struct</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>active_shares: <a href="../../aptos-stdlib/doc/pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>observed_lockup_cycle: <a href="delegation_pool.md#0x1_delegation_pool_ObservedLockupCycle">delegation_pool::ObservedLockupCycle</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>inactive_shares: <a href="../../aptos-stdlib/doc/table.md#0x1_table_Table">table::Table</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_ObservedLockupCycle">delegation_pool::ObservedLockupCycle</a>, <a href="../../aptos-stdlib/doc/pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>pending_withdrawals: <a href="../../aptos-stdlib/doc/table.md#0x1_table_Table">table::Table</a>&lt;<b>address</b>, <a href="delegation_pool.md#0x1_delegation_pool_ObservedLockupCycle">delegation_pool::ObservedLockupCycle</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>stake_pool_signer_cap: <a href="account.md#0x1_account_SignerCapability">account::SignerCapability</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>total_coins_inactive: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>operator_commission_percentage: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>add_stake_events: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_AddStakeEvent">delegation_pool::AddStakeEvent</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>reactivate_stake_events: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_ReactivateStakeEvent">delegation_pool::ReactivateStakeEvent</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>unlock_stake_events: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_UnlockStakeEvent">delegation_pool::UnlockStakeEvent</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>withdraw_stake_events: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_WithdrawStakeEvent">delegation_pool::WithdrawStakeEvent</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>distribute_commission_events: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DistributeCommissionEvent">delegation_pool::DistributeCommissionEvent</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_delegation_pool_AddStakeEvent"></a>
+
+## Struct `AddStakeEvent`
+
+
+
+<pre><code><b>struct</b> <a href="delegation_pool.md#0x1_delegation_pool_AddStakeEvent">AddStakeEvent</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>pool_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>delegator_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>amount_added: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>add_stake_fee: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_delegation_pool_ReactivateStakeEvent"></a>
+
+## Struct `ReactivateStakeEvent`
+
+
+
+<pre><code><b>struct</b> <a href="delegation_pool.md#0x1_delegation_pool_ReactivateStakeEvent">ReactivateStakeEvent</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>pool_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>delegator_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>amount_reactivated: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_delegation_pool_UnlockStakeEvent"></a>
+
+## Struct `UnlockStakeEvent`
+
+
+
+<pre><code><b>struct</b> <a href="delegation_pool.md#0x1_delegation_pool_UnlockStakeEvent">UnlockStakeEvent</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>pool_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>delegator_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>amount_unlocked: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_delegation_pool_WithdrawStakeEvent"></a>
+
+## Struct `WithdrawStakeEvent`
+
+
+
+<pre><code><b>struct</b> <a href="delegation_pool.md#0x1_delegation_pool_WithdrawStakeEvent">WithdrawStakeEvent</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>pool_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>delegator_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>amount_withdrawn: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x1_delegation_pool_DistributeCommissionEvent"></a>
+
+## Struct `DistributeCommissionEvent`
+
+
+
+<pre><code><b>struct</b> <a href="delegation_pool.md#0x1_delegation_pool_DistributeCommissionEvent">DistributeCommissionEvent</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>pool_address: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>operator: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>commission_active: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>commission_pending_inactive: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x1_delegation_pool_MAX_U64"></a>
+
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_MAX_U64">MAX_U64</a>: u64 = 18446744073709551615;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_EOWNER_CAP_ALREADY_EXISTS"></a>
+
+Account is already owning a delegation pool.
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_EOWNER_CAP_ALREADY_EXISTS">EOWNER_CAP_ALREADY_EXISTS</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_EOWNER_CAP_NOT_FOUND"></a>
+
+Delegation pool owner capability does not exist at the provided account.
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_EOWNER_CAP_NOT_FOUND">EOWNER_CAP_NOT_FOUND</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_VALIDATOR_STATUS_INACTIVE"></a>
+
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_VALIDATOR_STATUS_INACTIVE">VALIDATOR_STATUS_INACTIVE</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_EDELEGATION_POOLS_DISABLED"></a>
+
+Creating delegation pools is not enabled yet.
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_EDELEGATION_POOLS_DISABLED">EDELEGATION_POOLS_DISABLED</a>: u64 = 10;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_EDELEGATION_POOL_DOES_NOT_EXIST"></a>
+
+Delegation pool does not exist at the provided pool address.
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_EDELEGATION_POOL_DOES_NOT_EXIST">EDELEGATION_POOL_DOES_NOT_EXIST</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_EDELEGATOR_ACTIVE_BALANCE_TOO_LOW"></a>
+
+Delegator's active balance cannot be less than <code><a href="delegation_pool.md#0x1_delegation_pool_MIN_COINS_ON_SHARES_POOL">MIN_COINS_ON_SHARES_POOL</a></code>.
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_EDELEGATOR_ACTIVE_BALANCE_TOO_LOW">EDELEGATOR_ACTIVE_BALANCE_TOO_LOW</a>: u64 = 8;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_EDELEGATOR_PENDING_INACTIVE_BALANCE_TOO_LOW"></a>
+
+Delegator's pending_inactive balance cannot be less than <code><a href="delegation_pool.md#0x1_delegation_pool_MIN_COINS_ON_SHARES_POOL">MIN_COINS_ON_SHARES_POOL</a></code>.
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_EDELEGATOR_PENDING_INACTIVE_BALANCE_TOO_LOW">EDELEGATOR_PENDING_INACTIVE_BALANCE_TOO_LOW</a>: u64 = 9;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_EINVALID_COMMISSION_PERCENTAGE"></a>
+
+Commission percentage has to be between 0 and <code><a href="delegation_pool.md#0x1_delegation_pool_MAX_FEE">MAX_FEE</a></code> - 100%.
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_EINVALID_COMMISSION_PERCENTAGE">EINVALID_COMMISSION_PERCENTAGE</a>: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_ENOT_ENOUGH_ACTIVE_STAKE_TO_UNLOCK"></a>
+
+There is not enough <code>active</code> stake on the stake pool to <code>unlock</code>.
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_ENOT_ENOUGH_ACTIVE_STAKE_TO_UNLOCK">ENOT_ENOUGH_ACTIVE_STAKE_TO_UNLOCK</a>: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_EPENDING_WITHDRAWAL_EXISTS"></a>
+
+There is a pending withdrawal to be executed before <code>unlock</code>ing any new stake.
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_EPENDING_WITHDRAWAL_EXISTS">EPENDING_WITHDRAWAL_EXISTS</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_ESLASHED_INACTIVE_STAKE_ON_PAST_OLC"></a>
+
+Slashing (if implemented) should not be applied to already <code>inactive</code> stake.
+Not only it invalidates the accounting of past observed lockup cycles (OLC),
+but is also unfair to delegators whose stake has been inactive before validator started misbehaving.
+Additionally, the inactive stake does not count on the voting power of validator.
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_ESLASHED_INACTIVE_STAKE_ON_PAST_OLC">ESLASHED_INACTIVE_STAKE_ON_PAST_OLC</a>: u64 = 7;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_EWITHDRAW_ZERO_STAKE"></a>
+
+Cannot request to withdraw zero stake.
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_EWITHDRAW_ZERO_STAKE">EWITHDRAW_ZERO_STAKE</a>: u64 = 11;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_MAX_FEE"></a>
+
+Maximum operator percentage fee(of double digit precision): 22.85% is represented as 2285
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_MAX_FEE">MAX_FEE</a>: u64 = 10000;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_MIN_COINS_ON_SHARES_POOL"></a>
+
+Minimum coins to exist on a shares pool at all times.
+Enforced per delegator for both active and pending_inactive pools.
+This constraint ensures the share price cannot overly increase and lead to
+substantial loses when buying shares (can lose at most 1 share which may
+be worth a lot if current share price is high).
+This constraint is not enforced on inactive pools as they only allow redeems
+(can lose at most 1 coin regardless of current share price).
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_MIN_COINS_ON_SHARES_POOL">MIN_COINS_ON_SHARES_POOL</a>: u64 = 1000000000;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_MODULE_SALT"></a>
+
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_MODULE_SALT">MODULE_SALT</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; = [97, 112, 116, 111, 115, 95, 102, 114, 97, 109, 101, 119, 111, 114, 107, 58, 58, 100, 101, 108, 101, 103, 97, 116, 105, 111, 110, 95, 112, 111, 111, 108];
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_NULL_SHAREHOLDER"></a>
+
+Special shareholder temporarily owning the <code>add_stake</code> fees charged during this epoch.
+On each <code>add_stake</code> operation any resulted fee is used to buy active shares for this shareholder.
+First synchronization after this epoch ends will distribute accumulated fees to the rest of the pool as refunds.
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_NULL_SHAREHOLDER">NULL_SHAREHOLDER</a>: <b>address</b> = 0;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_SHARES_SCALING_FACTOR"></a>
+
+Scaling factor of shares pools used within the delegation pool
+
+
+<pre><code><b>const</b> <a href="delegation_pool.md#0x1_delegation_pool_SHARES_SCALING_FACTOR">SHARES_SCALING_FACTOR</a>: u64 = 10000000000000000;
+</code></pre>
+
+
+
+<a name="0x1_delegation_pool_owner_cap_exists"></a>
+
+## Function `owner_cap_exists`
+
+Return whether supplied address <code>addr</code> is owner of a delegation pool.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_owner_cap_exists">owner_cap_exists</a>(addr: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_owner_cap_exists">owner_cap_exists</a>(addr: <b>address</b>): bool {
+    <b>exists</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolOwnership">DelegationPoolOwnership</a>&gt;(addr)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_get_owned_pool_address"></a>
+
+## Function `get_owned_pool_address`
+
+Return address of the delegation pool owned by <code>owner</code> or fail if there is none.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(owner: <b>address</b>): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(owner: <b>address</b>): <b>address</b> <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolOwnership">DelegationPoolOwnership</a> {
+    <a href="delegation_pool.md#0x1_delegation_pool_assert_owner_cap_exists">assert_owner_cap_exists</a>(owner);
+    <b>borrow_global</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolOwnership">DelegationPoolOwnership</a>&gt;(owner).pool_address
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_delegation_pool_exists"></a>
+
+## Function `delegation_pool_exists`
+
+Return whether a delegation pool exists at supplied address <code>addr</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_delegation_pool_exists">delegation_pool_exists</a>(addr: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_delegation_pool_exists">delegation_pool_exists</a>(addr: <b>address</b>): bool {
+    <b>exists</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(addr)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_observed_lockup_cycle"></a>
+
+## Function `observed_lockup_cycle`
+
+Return the index of current observed lockup cycle on delegation pool <code>pool_address</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_observed_lockup_cycle">observed_lockup_cycle</a>(pool_address: <b>address</b>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_observed_lockup_cycle">observed_lockup_cycle</a>(pool_address: <b>address</b>): u64 <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a> {
+    <a href="delegation_pool.md#0x1_delegation_pool_assert_delegation_pool_exists">assert_delegation_pool_exists</a>(pool_address);
+    <b>borrow_global</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address).observed_lockup_cycle.index
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_operator_commission_percentage"></a>
+
+## Function `operator_commission_percentage`
+
+Return the operator commission percentage set on the delegation pool <code>pool_address</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_operator_commission_percentage">operator_commission_percentage</a>(pool_address: <b>address</b>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_operator_commission_percentage">operator_commission_percentage</a>(pool_address: <b>address</b>): u64 <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a> {
+    <a href="delegation_pool.md#0x1_delegation_pool_assert_delegation_pool_exists">assert_delegation_pool_exists</a>(pool_address);
+    <b>borrow_global</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address).operator_commission_percentage
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_shareholders_count_active_pool"></a>
+
+## Function `shareholders_count_active_pool`
+
+Return the number of delegators owning active stake within <code>pool_address</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_shareholders_count_active_pool">shareholders_count_active_pool</a>(pool_address: <b>address</b>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_shareholders_count_active_pool">shareholders_count_active_pool</a>(pool_address: <b>address</b>): u64 <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a> {
+    <a href="delegation_pool.md#0x1_delegation_pool_assert_delegation_pool_exists">assert_delegation_pool_exists</a>(pool_address);
+    <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_shareholders_count">pool_u64::shareholders_count</a>(&<b>borrow_global</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address).active_shares)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_get_delegation_pool_stake"></a>
+
+## Function `get_delegation_pool_stake`
+
+Return the stake amounts on <code>pool_address</code> in the different states:
+(<code>active</code>,<code>inactive</code>,<code>pending_active</code>,<code>pending_inactive</code>)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_get_delegation_pool_stake">get_delegation_pool_stake</a>(pool_address: <b>address</b>): (u64, u64, u64, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_get_delegation_pool_stake">get_delegation_pool_stake</a>(pool_address: <b>address</b>): (u64, u64, u64, u64) {
+    <a href="delegation_pool.md#0x1_delegation_pool_assert_delegation_pool_exists">assert_delegation_pool_exists</a>(pool_address);
+    <a href="stake.md#0x1_stake_get_stake">stake::get_stake</a>(pool_address)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_get_pending_withdrawal"></a>
+
+## Function `get_pending_withdrawal`
+
+Return whether the given delegator has any withdrawable stake. If they recently requested to unlock
+some stake and the stake pool's lockup cycle has not ended, their coins are not withdrawable yet.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_get_pending_withdrawal">get_pending_withdrawal</a>(pool_address: <b>address</b>, delegator_address: <b>address</b>): (bool, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_get_pending_withdrawal">get_pending_withdrawal</a>(
+    pool_address: <b>address</b>,
+    delegator_address: <b>address</b>
+): (bool, u64) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a> {
+    <a href="delegation_pool.md#0x1_delegation_pool_assert_delegation_pool_exists">assert_delegation_pool_exists</a>(pool_address);
+    <b>let</b> pool = <b>borrow_global</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address);
+    <b>let</b> (
+        lockup_cycle_ended,
+        _,
+        pending_inactive,
+        _,
+        commission_pending_inactive
+    ) = <a href="delegation_pool.md#0x1_delegation_pool_calculate_stake_pool_drift">calculate_stake_pool_drift</a>(pool);
+
+    <b>let</b> (withdrawal_exists, withdrawal_olc) = <a href="delegation_pool.md#0x1_delegation_pool_pending_withdrawal_exists">pending_withdrawal_exists</a>(pool, delegator_address);
+    <b>if</b> (!withdrawal_exists) {
+        // <b>if</b> no pending withdrawal, there is neither inactive nor pending_inactive <a href="stake.md#0x1_stake">stake</a>
+        (<b>false</b>, 0)
+    } <b>else</b> {
+        // delegator <b>has</b> either inactive or pending_inactive <a href="stake.md#0x1_stake">stake</a> due <b>to</b> automatic withdrawals
+        <b>let</b> inactive_shares = <a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow">table::borrow</a>(&pool.inactive_shares, withdrawal_olc);
+        <b>if</b> (withdrawal_olc.index &lt; pool.observed_lockup_cycle.index) {
+            // <b>if</b> withdrawal's lockup cycle ended on delegation pool then it is inactive
+            (<b>true</b>, <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_balance">pool_u64::balance</a>(inactive_shares, delegator_address))
+        } <b>else</b> {
+            pending_inactive = <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_shares_to_amount_with_total_coins">pool_u64::shares_to_amount_with_total_coins</a>(
+                inactive_shares,
+                <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_shares">pool_u64::shares</a>(inactive_shares, delegator_address),
+                // exclude operator pending_inactive rewards not converted <b>to</b> shares yet
+                pending_inactive - commission_pending_inactive
+            );
+            // <b>if</b> withdrawal's lockup cycle ended ONLY on <a href="stake.md#0x1_stake">stake</a> pool then it is also inactive
+            (lockup_cycle_ended, pending_inactive)
+        }
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_get_stake"></a>
+
+## Function `get_stake`
+
+Return total stake owned by <code>delegator_address</code> within delegation pool <code>pool_address</code>
+in each of its individual states: (<code>active</code>,<code>inactive</code>,<code>pending_inactive</code>)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_get_stake">get_stake</a>(pool_address: <b>address</b>, delegator_address: <b>address</b>): (u64, u64, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_get_stake">get_stake</a>(pool_address: <b>address</b>, delegator_address: <b>address</b>): (u64, u64, u64) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a> {
+    <a href="delegation_pool.md#0x1_delegation_pool_assert_delegation_pool_exists">assert_delegation_pool_exists</a>(pool_address);
+    <b>let</b> pool = <b>borrow_global</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address);
+    <b>let</b> (
+        lockup_cycle_ended,
+        active,
+        _,
+        commission_active,
+        commission_pending_inactive
+    ) = <a href="delegation_pool.md#0x1_delegation_pool_calculate_stake_pool_drift">calculate_stake_pool_drift</a>(pool);
+
+    <b>let</b> total_active_shares = <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_total_shares">pool_u64::total_shares</a>(&pool.active_shares);
+    <b>let</b> delegator_active_shares = <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_shares">pool_u64::shares</a>(&pool.active_shares, delegator_address);
+
+    <b>let</b> (_, _, pending_active, _) = <a href="stake.md#0x1_stake_get_stake">stake::get_stake</a>(pool_address);
+    <b>if</b> (pending_active == 0) {
+        // zero `pending_active` <a href="stake.md#0x1_stake">stake</a> indicates that either there are no `add_stake` fees or
+        // previous epoch <b>has</b> ended and should identify shares owning these fees <b>as</b> released
+        total_active_shares = total_active_shares - <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_shares">pool_u64::shares</a>(&pool.active_shares, <a href="delegation_pool.md#0x1_delegation_pool_NULL_SHAREHOLDER">NULL_SHAREHOLDER</a>);
+        <b>if</b> (delegator_address == <a href="delegation_pool.md#0x1_delegation_pool_NULL_SHAREHOLDER">NULL_SHAREHOLDER</a>) {
+            delegator_active_shares = 0
+        }
+    };
+    active = pool_u64::shares_to_amount_with_total_stats(
+        &pool.active_shares,
+        delegator_active_shares,
+        // exclude operator active rewards not converted <b>to</b> shares yet
+        active - commission_active,
+        total_active_shares
+    );
+
+    // get state and <a href="stake.md#0x1_stake">stake</a> (0 <b>if</b> there is none) of the pending withdrawal
+    <b>let</b> (withdrawal_inactive, withdrawal_stake) = <a href="delegation_pool.md#0x1_delegation_pool_get_pending_withdrawal">get_pending_withdrawal</a>(pool_address, delegator_address);
+    // report non-active stakes accordingly <b>to</b> the state of the pending withdrawal
+    <b>let</b> (inactive, pending_inactive) = <b>if</b> (withdrawal_inactive) (withdrawal_stake, 0) <b>else</b> (0, withdrawal_stake);
+
+    // should also <b>include</b> commission rewards in case of the operator <a href="account.md#0x1_account">account</a>
+    // operator rewards are actually used <b>to</b> buy shares which is introducing
+    // some imprecision (received <a href="stake.md#0x1_stake">stake</a> would be slightly less)
+    // but adding rewards onto the existing <a href="stake.md#0x1_stake">stake</a> is still a good approximation
+    <b>if</b> (delegator_address == <a href="stake.md#0x1_stake_get_operator">stake::get_operator</a>(pool_address)) {
+        active = active + commission_active;
+        // in-flight pending_inactive commission can coexist <b>with</b> already inactive withdrawal
+        <b>if</b> (lockup_cycle_ended) {
+            inactive = inactive + commission_pending_inactive
+        } <b>else</b> {
+            pending_inactive = pending_inactive + commission_pending_inactive
+        }
+    };
+
+    (active, inactive, pending_inactive)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_get_add_stake_fee"></a>
+
+## Function `get_add_stake_fee`
+
+Return refundable stake to be extracted from added <code>amount</code> at <code>add_stake</code> operation on pool <code>pool_address</code>.
+If the validator produces rewards this epoch, added stake goes directly to <code>pending_active</code> and
+does not earn rewards. However, all shares within a pool appreciate uniformly and when this epoch ends:
+- either added shares are still <code>pending_active</code> and steal from rewards of existing <code>active</code> stake
+- or have moved to <code>pending_inactive</code> and get full rewards (they displaced <code>active</code> stake at <code>unlock</code>)
+To mitigate this, some of the added stake is extracted and fed back into the pool as placeholder
+for the rewards the remaining stake would have earned if active:
+extracted-fee = (amount - extracted-fee) * reward-rate% * (100% - operator-commission%)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_get_add_stake_fee">get_add_stake_fee</a>(pool_address: <b>address</b>, amount: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_get_add_stake_fee">get_add_stake_fee</a>(pool_address: <b>address</b>, amount: u64): u64 <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a> {
+    <b>if</b> (<a href="stake.md#0x1_stake_is_current_epoch_validator">stake::is_current_epoch_validator</a>(pool_address)) {
+        <b>let</b> (rewards_rate, rewards_rate_denominator) = <a href="staking_config.md#0x1_staking_config_get_reward_rate">staking_config::get_reward_rate</a>(&<a href="staking_config.md#0x1_staking_config_get">staking_config::get</a>());
+        <b>if</b> (rewards_rate_denominator &gt; 0) {
+            <a href="delegation_pool.md#0x1_delegation_pool_assert_delegation_pool_exists">assert_delegation_pool_exists</a>(pool_address);
+            <b>let</b> pool = <b>borrow_global</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address);
+
+            rewards_rate = rewards_rate * (<a href="delegation_pool.md#0x1_delegation_pool_MAX_FEE">MAX_FEE</a> - pool.operator_commission_percentage);
+            rewards_rate_denominator = rewards_rate_denominator * <a href="delegation_pool.md#0x1_delegation_pool_MAX_FEE">MAX_FEE</a>;
+            ((((amount <b>as</b> u128) * (rewards_rate <b>as</b> u128)) / ((rewards_rate <b>as</b> u128) + (rewards_rate_denominator <b>as</b> u128))) <b>as</b> u64)
+        } <b>else</b> { 0 }
+    } <b>else</b> { 0 }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_can_withdraw_pending_inactive"></a>
+
+## Function `can_withdraw_pending_inactive`
+
+Return whether <code>pending_inactive</code> stake can be directly withdrawn from
+the delegation pool, implicitly its stake pool, in the special case
+the validator had gone inactive before its lockup expired.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_can_withdraw_pending_inactive">can_withdraw_pending_inactive</a>(pool_address: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_can_withdraw_pending_inactive">can_withdraw_pending_inactive</a>(pool_address: <b>address</b>): bool {
+    <a href="stake.md#0x1_stake_get_validator_state">stake::get_validator_state</a>(pool_address) == <a href="delegation_pool.md#0x1_delegation_pool_VALIDATOR_STATUS_INACTIVE">VALIDATOR_STATUS_INACTIVE</a> &&
+        <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>() &gt;= <a href="stake.md#0x1_stake_get_lockup_secs">stake::get_lockup_secs</a>(pool_address)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_initialize_delegation_pool"></a>
+
+## Function `initialize_delegation_pool`
+
+Initialize a delegation pool of custom fixed <code>operator_commission_percentage</code>.
+A resource account is created from <code>owner</code> signer and its supplied <code>delegation_pool_creation_seed</code>
+to host the delegation pool resource and own the underlying stake pool.
+Ownership over setting the operator/voter is granted to <code>owner</code> who has both roles initially.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_initialize_delegation_pool">initialize_delegation_pool</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, operator_commission_percentage: u64, delegation_pool_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_initialize_delegation_pool">initialize_delegation_pool</a>(
+    owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    operator_commission_percentage: u64,
+    delegation_pool_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+) {
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_delegation_pools_enabled">features::delegation_pools_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="delegation_pool.md#0x1_delegation_pool_EDELEGATION_POOLS_DISABLED">EDELEGATION_POOLS_DISABLED</a>));
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>assert</b>!(!<a href="delegation_pool.md#0x1_delegation_pool_owner_cap_exists">owner_cap_exists</a>(owner_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_already_exists">error::already_exists</a>(<a href="delegation_pool.md#0x1_delegation_pool_EOWNER_CAP_ALREADY_EXISTS">EOWNER_CAP_ALREADY_EXISTS</a>));
+    <b>assert</b>!(<a href="delegation_pool.md#0x1_delegation_pool_operator_commission_percentage">operator_commission_percentage</a> &lt;= <a href="delegation_pool.md#0x1_delegation_pool_MAX_FEE">MAX_FEE</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="delegation_pool.md#0x1_delegation_pool_EINVALID_COMMISSION_PERCENTAGE">EINVALID_COMMISSION_PERCENTAGE</a>));
+
+    // generate a seed <b>to</b> be used <b>to</b> create the resource <a href="account.md#0x1_account">account</a> hosting the delegation pool
+    <b>let</b> seed = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
+    // <b>include</b> <b>module</b> salt (before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> subseeds) <b>to</b> avoid conflicts <b>with</b> other modules creating resource accounts
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, <a href="delegation_pool.md#0x1_delegation_pool_MODULE_SALT">MODULE_SALT</a>);
+    // <b>include</b> an additional salt in case the same resource <a href="account.md#0x1_account">account</a> <b>has</b> already been created
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, delegation_pool_creation_seed);
+
+    <b>let</b> (stake_pool_signer, stake_pool_signer_cap) = <a href="account.md#0x1_account_create_resource_account">account::create_resource_account</a>(owner, seed);
+    <a href="coin.md#0x1_coin_register">coin::register</a>&lt;AptosCoin&gt;(&stake_pool_signer);
+
+    // stake_pool_signer will be owner of the <a href="stake.md#0x1_stake">stake</a> pool and have its `<a href="stake.md#0x1_stake_OwnerCapability">stake::OwnerCapability</a>`
+    <b>let</b> pool_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&stake_pool_signer);
+    <a href="stake.md#0x1_stake_initialize_stake_owner">stake::initialize_stake_owner</a>(&stake_pool_signer, 0, owner_address, owner_address);
+
+    <b>let</b> inactive_shares = <a href="../../aptos-stdlib/doc/table.md#0x1_table_new">table::new</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_ObservedLockupCycle">ObservedLockupCycle</a>, <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>&gt;();
+    <a href="../../aptos-stdlib/doc/table.md#0x1_table_add">table::add</a>(
+        &<b>mut</b> inactive_shares,
+        <a href="delegation_pool.md#0x1_delegation_pool_olc_with_index">olc_with_index</a>(0),
+        <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_create_with_scaling_factor">pool_u64::create_with_scaling_factor</a>(<a href="delegation_pool.md#0x1_delegation_pool_SHARES_SCALING_FACTOR">SHARES_SCALING_FACTOR</a>)
+    );
+
+    <b>move_to</b>(&stake_pool_signer, <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a> {
+        active_shares: <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_create_with_scaling_factor">pool_u64::create_with_scaling_factor</a>(<a href="delegation_pool.md#0x1_delegation_pool_SHARES_SCALING_FACTOR">SHARES_SCALING_FACTOR</a>),
+        observed_lockup_cycle: <a href="delegation_pool.md#0x1_delegation_pool_olc_with_index">olc_with_index</a>(0),
+        inactive_shares,
+        pending_withdrawals: <a href="../../aptos-stdlib/doc/table.md#0x1_table_new">table::new</a>&lt;<b>address</b>, <a href="delegation_pool.md#0x1_delegation_pool_ObservedLockupCycle">ObservedLockupCycle</a>&gt;(),
+        stake_pool_signer_cap,
+        total_coins_inactive: 0,
+        operator_commission_percentage,
+        add_stake_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_AddStakeEvent">AddStakeEvent</a>&gt;(&stake_pool_signer),
+        reactivate_stake_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_ReactivateStakeEvent">ReactivateStakeEvent</a>&gt;(&stake_pool_signer),
+        unlock_stake_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_UnlockStakeEvent">UnlockStakeEvent</a>&gt;(&stake_pool_signer),
+        withdraw_stake_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_WithdrawStakeEvent">WithdrawStakeEvent</a>&gt;(&stake_pool_signer),
+        distribute_commission_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DistributeCommissionEvent">DistributeCommissionEvent</a>&gt;(&stake_pool_signer),
+    });
+
+    // save delegation pool ownership and resource <a href="account.md#0x1_account">account</a> <b>address</b> (inner <a href="stake.md#0x1_stake">stake</a> pool <b>address</b>) on `owner`
+    <b>move_to</b>(owner, <a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolOwnership">DelegationPoolOwnership</a> { pool_address });
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_assert_owner_cap_exists"></a>
+
+## Function `assert_owner_cap_exists`
+
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_assert_owner_cap_exists">assert_owner_cap_exists</a>(owner: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_assert_owner_cap_exists">assert_owner_cap_exists</a>(owner: <b>address</b>) {
+    <b>assert</b>!(<a href="delegation_pool.md#0x1_delegation_pool_owner_cap_exists">owner_cap_exists</a>(owner), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="delegation_pool.md#0x1_delegation_pool_EOWNER_CAP_NOT_FOUND">EOWNER_CAP_NOT_FOUND</a>));
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_assert_delegation_pool_exists"></a>
+
+## Function `assert_delegation_pool_exists`
+
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_assert_delegation_pool_exists">assert_delegation_pool_exists</a>(pool_address: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_assert_delegation_pool_exists">assert_delegation_pool_exists</a>(pool_address: <b>address</b>) {
+    <b>assert</b>!(<a href="delegation_pool.md#0x1_delegation_pool_delegation_pool_exists">delegation_pool_exists</a>(pool_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="delegation_pool.md#0x1_delegation_pool_EDELEGATION_POOL_DOES_NOT_EXIST">EDELEGATION_POOL_DOES_NOT_EXIST</a>));
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_assert_min_active_balance"></a>
+
+## Function `assert_min_active_balance`
+
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_assert_min_active_balance">assert_min_active_balance</a>(pool: &<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">delegation_pool::DelegationPool</a>, delegator_address: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_assert_min_active_balance">assert_min_active_balance</a>(pool: &<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>, delegator_address: <b>address</b>) {
+    <b>let</b> balance = <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_balance">pool_u64::balance</a>(&pool.active_shares, delegator_address);
+    <b>assert</b>!(balance &gt;= <a href="delegation_pool.md#0x1_delegation_pool_MIN_COINS_ON_SHARES_POOL">MIN_COINS_ON_SHARES_POOL</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="delegation_pool.md#0x1_delegation_pool_EDELEGATOR_ACTIVE_BALANCE_TOO_LOW">EDELEGATOR_ACTIVE_BALANCE_TOO_LOW</a>));
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_assert_min_pending_inactive_balance"></a>
+
+## Function `assert_min_pending_inactive_balance`
+
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_assert_min_pending_inactive_balance">assert_min_pending_inactive_balance</a>(pool: &<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">delegation_pool::DelegationPool</a>, delegator_address: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_assert_min_pending_inactive_balance">assert_min_pending_inactive_balance</a>(pool: &<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>, delegator_address: <b>address</b>) {
+    <b>let</b> balance = <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_balance">pool_u64::balance</a>(<a href="delegation_pool.md#0x1_delegation_pool_pending_inactive_shares_pool">pending_inactive_shares_pool</a>(pool), delegator_address);
+    <b>assert</b>!(
+        balance &gt;= <a href="delegation_pool.md#0x1_delegation_pool_MIN_COINS_ON_SHARES_POOL">MIN_COINS_ON_SHARES_POOL</a>,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="delegation_pool.md#0x1_delegation_pool_EDELEGATOR_PENDING_INACTIVE_BALANCE_TOO_LOW">EDELEGATOR_PENDING_INACTIVE_BALANCE_TOO_LOW</a>)
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_coins_to_redeem_to_ensure_min_stake"></a>
+
+## Function `coins_to_redeem_to_ensure_min_stake`
+
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_coins_to_redeem_to_ensure_min_stake">coins_to_redeem_to_ensure_min_stake</a>(src_shares_pool: &<a href="../../aptos-stdlib/doc/pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, amount: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_coins_to_redeem_to_ensure_min_stake">coins_to_redeem_to_ensure_min_stake</a>(
+    src_shares_pool: &<a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>,
+    shareholder: <b>address</b>,
+    amount: u64,
+): u64 {
+    // find how many coins would be redeemed <b>if</b> supplying `amount`
+    <b>let</b> redeemed_coins = <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_shares_to_amount">pool_u64::shares_to_amount</a>(
+        src_shares_pool,
+        <a href="delegation_pool.md#0x1_delegation_pool_amount_to_shares_to_redeem">amount_to_shares_to_redeem</a>(src_shares_pool, shareholder, amount)
+    );
+    // <b>if</b> balance drops under threshold then redeem it entirely
+    <b>let</b> src_balance = <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_balance">pool_u64::balance</a>(src_shares_pool, shareholder);
+    <b>if</b> (src_balance - redeemed_coins &lt; <a href="delegation_pool.md#0x1_delegation_pool_MIN_COINS_ON_SHARES_POOL">MIN_COINS_ON_SHARES_POOL</a>) {
+        amount = src_balance;
+    };
+    amount
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_coins_to_transfer_to_ensure_min_stake"></a>
+
+## Function `coins_to_transfer_to_ensure_min_stake`
+
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_coins_to_transfer_to_ensure_min_stake">coins_to_transfer_to_ensure_min_stake</a>(src_shares_pool: &<a href="../../aptos-stdlib/doc/pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, dst_shares_pool: &<a href="../../aptos-stdlib/doc/pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, amount: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_coins_to_transfer_to_ensure_min_stake">coins_to_transfer_to_ensure_min_stake</a>(
+    src_shares_pool: &<a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>,
+    dst_shares_pool: &<a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>,
+    shareholder: <b>address</b>,
+    amount: u64,
+): u64 {
+    // find how many coins would be redeemed from source <b>if</b> supplying `amount`
+    <b>let</b> redeemed_coins = <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_shares_to_amount">pool_u64::shares_to_amount</a>(
+        src_shares_pool,
+        <a href="delegation_pool.md#0x1_delegation_pool_amount_to_shares_to_redeem">amount_to_shares_to_redeem</a>(src_shares_pool, shareholder, amount)
+    );
+    // <b>if</b> balance on destination would be less than threshold then redeem difference <b>to</b> threshold
+    <b>let</b> dst_balance = <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_balance">pool_u64::balance</a>(dst_shares_pool, shareholder);
+    <b>if</b> (dst_balance + redeemed_coins &lt; <a href="delegation_pool.md#0x1_delegation_pool_MIN_COINS_ON_SHARES_POOL">MIN_COINS_ON_SHARES_POOL</a>) {
+        // `redeemed_coins` &gt;= `amount` - 1 <b>as</b> redeem can lose at most 1 <a href="coin.md#0x1_coin">coin</a>
+        amount = <a href="delegation_pool.md#0x1_delegation_pool_MIN_COINS_ON_SHARES_POOL">MIN_COINS_ON_SHARES_POOL</a> - dst_balance + 1;
+    };
+    // check <b>if</b> new `amount` drops balance on source under threshold and adjust
+    <a href="delegation_pool.md#0x1_delegation_pool_coins_to_redeem_to_ensure_min_stake">coins_to_redeem_to_ensure_min_stake</a>(src_shares_pool, shareholder, amount)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_retrieve_stake_pool_owner"></a>
+
+## Function `retrieve_stake_pool_owner`
+
+Retrieves the shared resource account owning the stake pool in order
+to forward a stake-management operation to this underlying pool.
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_retrieve_stake_pool_owner">retrieve_stake_pool_owner</a>(pool: &<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">delegation_pool::DelegationPool</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_retrieve_stake_pool_owner">retrieve_stake_pool_owner</a>(pool: &<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> {
+    <a href="account.md#0x1_account_create_signer_with_capability">account::create_signer_with_capability</a>(&pool.stake_pool_signer_cap)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_get_pool_address"></a>
+
+## Function `get_pool_address`
+
+Get the address of delegation pool reference <code>pool</code>.
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_get_pool_address">get_pool_address</a>(pool: &<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">delegation_pool::DelegationPool</a>): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_get_pool_address">get_pool_address</a>(pool: &<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>): <b>address</b> {
+    <a href="account.md#0x1_account_get_signer_capability_address">account::get_signer_capability_address</a>(&pool.stake_pool_signer_cap)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_olc_with_index"></a>
+
+## Function `olc_with_index`
+
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_olc_with_index">olc_with_index</a>(index: u64): <a href="delegation_pool.md#0x1_delegation_pool_ObservedLockupCycle">delegation_pool::ObservedLockupCycle</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_olc_with_index">olc_with_index</a>(index: u64): <a href="delegation_pool.md#0x1_delegation_pool_ObservedLockupCycle">ObservedLockupCycle</a> {
+    <a href="delegation_pool.md#0x1_delegation_pool_ObservedLockupCycle">ObservedLockupCycle</a> { index }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_set_operator"></a>
+
+## Function `set_operator`
+
+Allows an owner to change the operator of the underlying stake pool.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_set_operator">set_operator</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_operator: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_set_operator">set_operator</a>(
+    owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    new_operator: <b>address</b>
+) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolOwnership">DelegationPoolOwnership</a>, <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a> {
+    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner));
+    // synchronize delegation and <a href="stake.md#0x1_stake">stake</a> pools before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> user operation
+    // ensure the <b>old</b> operator is paid its uncommitted commission rewards
+    <a href="delegation_pool.md#0x1_delegation_pool_synchronize_delegation_pool">synchronize_delegation_pool</a>(pool_address);
+    <a href="stake.md#0x1_stake_set_operator">stake::set_operator</a>(&<a href="delegation_pool.md#0x1_delegation_pool_retrieve_stake_pool_owner">retrieve_stake_pool_owner</a>(<b>borrow_global</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address)), new_operator);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_set_delegated_voter"></a>
+
+## Function `set_delegated_voter`
+
+Allows an owner to change the delegated voter of the underlying stake pool.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_set_delegated_voter">set_delegated_voter</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_voter: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_set_delegated_voter">set_delegated_voter</a>(
+    owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    new_voter: <b>address</b>
+) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolOwnership">DelegationPoolOwnership</a>, <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a> {
+    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner));
+    // synchronize delegation and <a href="stake.md#0x1_stake">stake</a> pools before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> user operation
+    <a href="delegation_pool.md#0x1_delegation_pool_synchronize_delegation_pool">synchronize_delegation_pool</a>(pool_address);
+    <a href="stake.md#0x1_stake_set_delegated_voter">stake::set_delegated_voter</a>(&<a href="delegation_pool.md#0x1_delegation_pool_retrieve_stake_pool_owner">retrieve_stake_pool_owner</a>(<b>borrow_global</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address)), new_voter);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_add_stake"></a>
+
+## Function `add_stake`
+
+Add <code>amount</code> of coins to the delegation pool <code>pool_address</code>.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_add_stake">add_stake</a>(delegator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, pool_address: <b>address</b>, amount: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_add_stake">add_stake</a>(delegator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, pool_address: <b>address</b>, amount: u64) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a> {
+    // short-circuit <b>if</b> amount <b>to</b> add is 0 so no <a href="event.md#0x1_event">event</a> is emitted
+    <b>if</b> (amount == 0) { <b>return</b> };
+    // synchronize delegation and <a href="stake.md#0x1_stake">stake</a> pools before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> user operation
+    <a href="delegation_pool.md#0x1_delegation_pool_synchronize_delegation_pool">synchronize_delegation_pool</a>(pool_address);
+
+    // fee <b>to</b> be charged for adding `amount` <a href="stake.md#0x1_stake">stake</a> on this delegation pool at this epoch
+    <b>let</b> add_stake_fee = <a href="delegation_pool.md#0x1_delegation_pool_get_add_stake_fee">get_add_stake_fee</a>(pool_address, amount);
+
+    <b>let</b> pool = <b>borrow_global_mut</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address);
+    <b>let</b> delegator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(delegator);
+
+    // <a href="stake.md#0x1_stake">stake</a> the entire amount <b>to</b> the <a href="stake.md#0x1_stake">stake</a> pool
+    <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;AptosCoin&gt;(delegator, pool_address, amount);
+    <a href="stake.md#0x1_stake_add_stake">stake::add_stake</a>(&<a href="delegation_pool.md#0x1_delegation_pool_retrieve_stake_pool_owner">retrieve_stake_pool_owner</a>(pool), amount);
+
+    // but buy shares for delegator just for the remaining amount after fee
+    <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_buy_in">pool_u64::buy_in</a>(&<b>mut</b> pool.active_shares, delegator_address, amount - add_stake_fee);
+    <a href="delegation_pool.md#0x1_delegation_pool_assert_min_active_balance">assert_min_active_balance</a>(pool, delegator_address);
+
+    // grant temporary ownership over `add_stake` fees <b>to</b> a separate shareholder in order <b>to</b>:
+    // - not mistake them for rewards <b>to</b> pay the operator from
+    // - distribute them together <b>with</b> the `active` rewards when this epoch ends
+    // in order <b>to</b> appreciate all shares on the active pool atomically
+    <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_buy_in">pool_u64::buy_in</a>(&<b>mut</b> pool.active_shares, <a href="delegation_pool.md#0x1_delegation_pool_NULL_SHAREHOLDER">NULL_SHAREHOLDER</a>, add_stake_fee);
+
+    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
+        &<b>mut</b> pool.add_stake_events,
+        <a href="delegation_pool.md#0x1_delegation_pool_AddStakeEvent">AddStakeEvent</a> {
+            pool_address,
+            delegator_address,
+            amount_added: amount,
+            add_stake_fee,
+        },
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_unlock"></a>
+
+## Function `unlock`
+
+Unlock <code>amount</code> from the active + pending_active stake of <code>delegator</code> or
+at most how much active stake there is on the stake pool.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_unlock">unlock</a>(delegator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, pool_address: <b>address</b>, amount: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_unlock">unlock</a>(delegator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, pool_address: <b>address</b>, amount: u64) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a> {
+    // short-circuit <b>if</b> amount <b>to</b> unlock is 0 so no <a href="event.md#0x1_event">event</a> is emitted
+    <b>if</b> (amount == 0) { <b>return</b> };
+
+    // fail unlock of more <a href="stake.md#0x1_stake">stake</a> than `active` on the <a href="stake.md#0x1_stake">stake</a> pool
+    <b>let</b> (active, _, _, _) = <a href="stake.md#0x1_stake_get_stake">stake::get_stake</a>(pool_address);
+    <b>assert</b>!(amount &lt;= active, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="delegation_pool.md#0x1_delegation_pool_ENOT_ENOUGH_ACTIVE_STAKE_TO_UNLOCK">ENOT_ENOUGH_ACTIVE_STAKE_TO_UNLOCK</a>));
+
+    // synchronize delegation and <a href="stake.md#0x1_stake">stake</a> pools before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> user operation
+    <a href="delegation_pool.md#0x1_delegation_pool_synchronize_delegation_pool">synchronize_delegation_pool</a>(pool_address);
+
+    <b>let</b> pool = <b>borrow_global_mut</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address);
+    <b>let</b> delegator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(delegator);
+
+    amount = <a href="delegation_pool.md#0x1_delegation_pool_coins_to_transfer_to_ensure_min_stake">coins_to_transfer_to_ensure_min_stake</a>(
+        &pool.active_shares,
+        <a href="delegation_pool.md#0x1_delegation_pool_pending_inactive_shares_pool">pending_inactive_shares_pool</a>(pool),
+        delegator_address,
+        amount,
+    );
+    amount = <a href="delegation_pool.md#0x1_delegation_pool_redeem_active_shares">redeem_active_shares</a>(pool, delegator_address, amount);
+
+    <a href="stake.md#0x1_stake_unlock">stake::unlock</a>(&<a href="delegation_pool.md#0x1_delegation_pool_retrieve_stake_pool_owner">retrieve_stake_pool_owner</a>(pool), amount);
+
+    <a href="delegation_pool.md#0x1_delegation_pool_buy_in_pending_inactive_shares">buy_in_pending_inactive_shares</a>(pool, delegator_address, amount);
+    <a href="delegation_pool.md#0x1_delegation_pool_assert_min_pending_inactive_balance">assert_min_pending_inactive_balance</a>(pool, delegator_address);
+
+    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
+        &<b>mut</b> pool.unlock_stake_events,
+        <a href="delegation_pool.md#0x1_delegation_pool_UnlockStakeEvent">UnlockStakeEvent</a> {
+            pool_address,
+            delegator_address,
+            amount_unlocked: amount,
+        },
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_reactivate_stake"></a>
+
+## Function `reactivate_stake`
+
+Move <code>amount</code> of coins from pending_inactive to active.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_reactivate_stake">reactivate_stake</a>(delegator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, pool_address: <b>address</b>, amount: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_reactivate_stake">reactivate_stake</a>(delegator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, pool_address: <b>address</b>, amount: u64) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a> {
+    // short-circuit <b>if</b> amount <b>to</b> reactivate is 0 so no <a href="event.md#0x1_event">event</a> is emitted
+    <b>if</b> (amount == 0) { <b>return</b> };
+    // synchronize delegation and <a href="stake.md#0x1_stake">stake</a> pools before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> user operation
+    <a href="delegation_pool.md#0x1_delegation_pool_synchronize_delegation_pool">synchronize_delegation_pool</a>(pool_address);
+
+    <b>let</b> pool = <b>borrow_global_mut</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address);
+    <b>let</b> delegator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(delegator);
+
+    amount = <a href="delegation_pool.md#0x1_delegation_pool_coins_to_transfer_to_ensure_min_stake">coins_to_transfer_to_ensure_min_stake</a>(
+        <a href="delegation_pool.md#0x1_delegation_pool_pending_inactive_shares_pool">pending_inactive_shares_pool</a>(pool),
+        &pool.active_shares,
+        delegator_address,
+        amount,
+    );
+    <b>let</b> observed_lockup_cycle = pool.observed_lockup_cycle;
+    amount = <a href="delegation_pool.md#0x1_delegation_pool_redeem_inactive_shares">redeem_inactive_shares</a>(pool, delegator_address, amount, observed_lockup_cycle);
+
+    <a href="stake.md#0x1_stake_reactivate_stake">stake::reactivate_stake</a>(&<a href="delegation_pool.md#0x1_delegation_pool_retrieve_stake_pool_owner">retrieve_stake_pool_owner</a>(pool), amount);
+
+    <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_buy_in">pool_u64::buy_in</a>(&<b>mut</b> pool.active_shares, delegator_address, amount);
+    <a href="delegation_pool.md#0x1_delegation_pool_assert_min_active_balance">assert_min_active_balance</a>(pool, delegator_address);
+
+    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
+        &<b>mut</b> pool.reactivate_stake_events,
+        <a href="delegation_pool.md#0x1_delegation_pool_ReactivateStakeEvent">ReactivateStakeEvent</a> {
+            pool_address,
+            delegator_address,
+            amount_reactivated: amount,
+        },
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_withdraw"></a>
+
+## Function `withdraw`
+
+Withdraw <code>amount</code> of owned inactive stake from the delegation pool at <code>pool_address</code>.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_withdraw">withdraw</a>(delegator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, pool_address: <b>address</b>, amount: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_withdraw">withdraw</a>(delegator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, pool_address: <b>address</b>, amount: u64) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a> {
+    <b>assert</b>!(amount &gt; 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="delegation_pool.md#0x1_delegation_pool_EWITHDRAW_ZERO_STAKE">EWITHDRAW_ZERO_STAKE</a>));
+    // synchronize delegation and <a href="stake.md#0x1_stake">stake</a> pools before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> user operation
+    <a href="delegation_pool.md#0x1_delegation_pool_synchronize_delegation_pool">synchronize_delegation_pool</a>(pool_address);
+    <a href="delegation_pool.md#0x1_delegation_pool_withdraw_internal">withdraw_internal</a>(<b>borrow_global_mut</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address), <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(delegator), amount);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_withdraw_internal"></a>
+
+## Function `withdraw_internal`
+
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_withdraw_internal">withdraw_internal</a>(pool: &<b>mut</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">delegation_pool::DelegationPool</a>, delegator_address: <b>address</b>, amount: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_withdraw_internal">withdraw_internal</a>(pool: &<b>mut</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>, delegator_address: <b>address</b>, amount: u64) {
+    // short-circuit <b>if</b> amount <b>to</b> withdraw is 0 so no <a href="event.md#0x1_event">event</a> is emitted
+    <b>if</b> (amount == 0) { <b>return</b> };
+
+    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_pool_address">get_pool_address</a>(pool);
+    <b>let</b> (withdrawal_exists, withdrawal_olc) = <a href="delegation_pool.md#0x1_delegation_pool_pending_withdrawal_exists">pending_withdrawal_exists</a>(pool, delegator_address);
+    // exit <b>if</b> no withdrawal or (it is pending and cannot withdraw pending_inactive <a href="stake.md#0x1_stake">stake</a> from <a href="stake.md#0x1_stake">stake</a> pool)
+    <b>if</b> (!(
+        withdrawal_exists &&
+            (withdrawal_olc.index &lt; pool.observed_lockup_cycle.index || <a href="delegation_pool.md#0x1_delegation_pool_can_withdraw_pending_inactive">can_withdraw_pending_inactive</a>(pool_address))
+    )) { <b>return</b> };
+
+    <b>if</b> (withdrawal_olc.index == pool.observed_lockup_cycle.index) {
+        amount = <a href="delegation_pool.md#0x1_delegation_pool_coins_to_redeem_to_ensure_min_stake">coins_to_redeem_to_ensure_min_stake</a>(
+            <a href="delegation_pool.md#0x1_delegation_pool_pending_inactive_shares_pool">pending_inactive_shares_pool</a>(pool),
+            delegator_address,
+            amount,
+        )
+    };
+    amount = <a href="delegation_pool.md#0x1_delegation_pool_redeem_inactive_shares">redeem_inactive_shares</a>(pool, delegator_address, amount, withdrawal_olc);
+
+    <b>let</b> stake_pool_owner = &<a href="delegation_pool.md#0x1_delegation_pool_retrieve_stake_pool_owner">retrieve_stake_pool_owner</a>(pool);
+    // <a href="stake.md#0x1_stake">stake</a> pool will inactivate entire pending_inactive <a href="stake.md#0x1_stake">stake</a> at `<a href="stake.md#0x1_stake_withdraw">stake::withdraw</a>` <b>to</b> make it withdrawable
+    // however, bypassing the inactivation of excess <a href="stake.md#0x1_stake">stake</a> (inactivated but not withdrawn) <b>ensures</b>
+    // the OLC is not advanced indefinitely on `unlock`-`withdraw` paired calls
+    <b>if</b> (<a href="delegation_pool.md#0x1_delegation_pool_can_withdraw_pending_inactive">can_withdraw_pending_inactive</a>(pool_address)) {
+        // get excess <a href="stake.md#0x1_stake">stake</a> before being entirely inactivated
+        <b>let</b> (_, _, _, pending_inactive) = <a href="stake.md#0x1_stake_get_stake">stake::get_stake</a>(pool_address);
+        <b>if</b> (withdrawal_olc.index == pool.observed_lockup_cycle.index) {
+            // `amount` less excess <b>if</b> withdrawing pending_inactive <a href="stake.md#0x1_stake">stake</a>
+            pending_inactive = pending_inactive - amount
+        };
+        // escape excess <a href="stake.md#0x1_stake">stake</a> from inactivation
+        <a href="stake.md#0x1_stake_reactivate_stake">stake::reactivate_stake</a>(stake_pool_owner, pending_inactive);
+        <a href="stake.md#0x1_stake_withdraw">stake::withdraw</a>(stake_pool_owner, amount);
+        // restore excess <a href="stake.md#0x1_stake">stake</a> <b>to</b> the pending_inactive state
+        <a href="stake.md#0x1_stake_unlock">stake::unlock</a>(stake_pool_owner, pending_inactive);
+    } <b>else</b> {
+        // no excess <a href="stake.md#0x1_stake">stake</a> <b>if</b> `<a href="stake.md#0x1_stake_withdraw">stake::withdraw</a>` does not inactivate at all
+        <a href="stake.md#0x1_stake_withdraw">stake::withdraw</a>(stake_pool_owner, amount);
+    };
+    <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;AptosCoin&gt;(stake_pool_owner, delegator_address, amount);
+
+    // commit withdrawal of possibly inactive <a href="stake.md#0x1_stake">stake</a> <b>to</b> the `total_coins_inactive`
+    // known by the delegation pool in order <b>to</b> not mistake it for slashing at next synchronization
+    <b>let</b> (_, inactive, _, _) = <a href="stake.md#0x1_stake_get_stake">stake::get_stake</a>(pool_address);
+    pool.total_coins_inactive = inactive;
+
+    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
+        &<b>mut</b> pool.withdraw_stake_events,
+        <a href="delegation_pool.md#0x1_delegation_pool_WithdrawStakeEvent">WithdrawStakeEvent</a> {
+            pool_address,
+            delegator_address,
+            amount_withdrawn: amount,
+        },
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_pending_withdrawal_exists"></a>
+
+## Function `pending_withdrawal_exists`
+
+Return the unique observed lockup cycle where delegator <code>delegator_address</code> may have
+unlocking (or already unlocked) stake to be withdrawn from delegation pool <code>pool</code>.
+A bool is returned to signal if a pending withdrawal exists at all.
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_pending_withdrawal_exists">pending_withdrawal_exists</a>(pool: &<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">delegation_pool::DelegationPool</a>, delegator_address: <b>address</b>): (bool, <a href="delegation_pool.md#0x1_delegation_pool_ObservedLockupCycle">delegation_pool::ObservedLockupCycle</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_pending_withdrawal_exists">pending_withdrawal_exists</a>(pool: &<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>, delegator_address: <b>address</b>): (bool, <a href="delegation_pool.md#0x1_delegation_pool_ObservedLockupCycle">ObservedLockupCycle</a>) {
+    <b>if</b> (<a href="../../aptos-stdlib/doc/table.md#0x1_table_contains">table::contains</a>(&pool.pending_withdrawals, delegator_address)) {
+        (<b>true</b>, *<a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow">table::borrow</a>(&pool.pending_withdrawals, delegator_address))
+    } <b>else</b> {
+        (<b>false</b>, <a href="delegation_pool.md#0x1_delegation_pool_olc_with_index">olc_with_index</a>(0))
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_pending_inactive_shares_pool_mut"></a>
+
+## Function `pending_inactive_shares_pool_mut`
+
+Return a mutable reference to the shares pool of <code>pending_inactive</code> stake on the
+delegation pool, always the last item in <code>inactive_shares</code>.
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_pending_inactive_shares_pool_mut">pending_inactive_shares_pool_mut</a>(pool: &<b>mut</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">delegation_pool::DelegationPool</a>): &<b>mut</b> <a href="../../aptos-stdlib/doc/pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_pending_inactive_shares_pool_mut">pending_inactive_shares_pool_mut</a>(pool: &<b>mut</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>): &<b>mut</b> <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a> {
+    <b>let</b> observed_lockup_cycle = pool.observed_lockup_cycle;
+    <a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> pool.inactive_shares, observed_lockup_cycle)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_pending_inactive_shares_pool"></a>
+
+## Function `pending_inactive_shares_pool`
+
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_pending_inactive_shares_pool">pending_inactive_shares_pool</a>(pool: &<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">delegation_pool::DelegationPool</a>): &<a href="../../aptos-stdlib/doc/pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_pending_inactive_shares_pool">pending_inactive_shares_pool</a>(pool: &<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>): &<a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a> {
+    <a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow">table::borrow</a>(&pool.inactive_shares, pool.observed_lockup_cycle)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_execute_pending_withdrawal"></a>
+
+## Function `execute_pending_withdrawal`
+
+Execute the pending withdrawal of <code>delegator_address</code> on delegation pool <code>pool</code>
+if existing and already inactive to allow the creation of a new one.
+<code>pending_inactive</code> stake would be left untouched even if withdrawable and should
+be explicitly withdrawn by delegator
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_execute_pending_withdrawal">execute_pending_withdrawal</a>(pool: &<b>mut</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">delegation_pool::DelegationPool</a>, delegator_address: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_execute_pending_withdrawal">execute_pending_withdrawal</a>(pool: &<b>mut</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>, delegator_address: <b>address</b>) {
+    <b>let</b> (withdrawal_exists, withdrawal_olc) = <a href="delegation_pool.md#0x1_delegation_pool_pending_withdrawal_exists">pending_withdrawal_exists</a>(pool, delegator_address);
+    <b>if</b> (withdrawal_exists && withdrawal_olc.index &lt; pool.observed_lockup_cycle.index) {
+        <a href="delegation_pool.md#0x1_delegation_pool_withdraw_internal">withdraw_internal</a>(pool, delegator_address, <a href="delegation_pool.md#0x1_delegation_pool_MAX_U64">MAX_U64</a>);
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_buy_in_pending_inactive_shares"></a>
+
+## Function `buy_in_pending_inactive_shares`
+
+Buy shares into the pending_inactive pool on behalf of delegator <code>shareholder</code> who
+redeemed <code>coins_amount</code> from the active pool to schedule it for unlocking.
+If delegator's pending withdrawal exists and has been inactivated, execute it firstly
+to ensure there is always only one withdrawal request.
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_buy_in_pending_inactive_shares">buy_in_pending_inactive_shares</a>(pool: &<b>mut</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">delegation_pool::DelegationPool</a>, shareholder: <b>address</b>, coins_amount: u64): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_buy_in_pending_inactive_shares">buy_in_pending_inactive_shares</a>(
+    pool: &<b>mut</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>,
+    shareholder: <b>address</b>,
+    coins_amount: u64,
+): u128 {
+    // cannot buy inactive shares, only pending_inactive at current lockup cycle
+    <b>let</b> new_shares = <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_buy_in">pool_u64::buy_in</a>(<a href="delegation_pool.md#0x1_delegation_pool_pending_inactive_shares_pool_mut">pending_inactive_shares_pool_mut</a>(pool), shareholder, coins_amount);
+    // never create a new pending withdrawal unless delegator owns some pending_inactive shares
+    <b>if</b> (new_shares == 0) { <b>return</b> 0 };
+
+    // execute the pending withdrawal <b>if</b> <b>exists</b> and is inactive before creating a new one
+    <a href="delegation_pool.md#0x1_delegation_pool_execute_pending_withdrawal">execute_pending_withdrawal</a>(pool, shareholder);
+
+    // save observed lockup cycle for the new pending withdrawal
+    <b>let</b> observed_lockup_cycle = pool.observed_lockup_cycle;
+    <b>assert</b>!(*<a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow_mut_with_default">table::borrow_mut_with_default</a>(
+        &<b>mut</b> pool.pending_withdrawals,
+        shareholder,
+        observed_lockup_cycle
+    ) == observed_lockup_cycle,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="delegation_pool.md#0x1_delegation_pool_EPENDING_WITHDRAWAL_EXISTS">EPENDING_WITHDRAWAL_EXISTS</a>)
+    );
+
+    new_shares
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_amount_to_shares_to_redeem"></a>
+
+## Function `amount_to_shares_to_redeem`
+
+Convert <code>coins_amount</code> of coins to be redeemed from shares pool <code>shares_pool</code>
+to the exact number of shares to redeem in order to achieve this.
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_amount_to_shares_to_redeem">amount_to_shares_to_redeem</a>(shares_pool: &<a href="../../aptos-stdlib/doc/pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, coins_amount: u64): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_amount_to_shares_to_redeem">amount_to_shares_to_redeem</a>(
+    shares_pool: &<a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>,
+    shareholder: <b>address</b>,
+    coins_amount: u64,
+): u128 {
+    <b>if</b> (coins_amount &gt;= <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_balance">pool_u64::balance</a>(shares_pool, shareholder)) {
+        // cap result at total shares of shareholder <b>to</b> pass `EINSUFFICIENT_SHARES` on subsequent redeem
+        <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_shares">pool_u64::shares</a>(shares_pool, shareholder)
+    } <b>else</b> {
+        <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_amount_to_shares">pool_u64::amount_to_shares</a>(shares_pool, coins_amount)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_redeem_active_shares"></a>
+
+## Function `redeem_active_shares`
+
+Redeem shares from the active pool on behalf of delegator <code>shareholder</code> who
+wants to unlock <code>coins_amount</code> of its active stake.
+Extracted coins will be used to buy shares into the pending_inactive pool and
+be available for withdrawal when current OLC ends.
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_redeem_active_shares">redeem_active_shares</a>(pool: &<b>mut</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">delegation_pool::DelegationPool</a>, shareholder: <b>address</b>, coins_amount: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_redeem_active_shares">redeem_active_shares</a>(
+    pool: &<b>mut</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>,
+    shareholder: <b>address</b>,
+    coins_amount: u64,
+): u64 {
+    <b>let</b> shares_to_redeem = <a href="delegation_pool.md#0x1_delegation_pool_amount_to_shares_to_redeem">amount_to_shares_to_redeem</a>(&pool.active_shares, shareholder, coins_amount);
+    // silently exit <b>if</b> not a shareholder otherwise redeem would fail <b>with</b> `ESHAREHOLDER_NOT_FOUND`
+    <b>if</b> (shares_to_redeem == 0) <b>return</b> 0;
+    <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_redeem_shares">pool_u64::redeem_shares</a>(&<b>mut</b> pool.active_shares, shareholder, shares_to_redeem)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_redeem_inactive_shares"></a>
+
+## Function `redeem_inactive_shares`
+
+Redeem shares from the inactive pool at <code>lockup_cycle</code> < current OLC on behalf of
+delegator <code>shareholder</code> who wants to withdraw <code>coins_amount</code> of its unlocked stake.
+Redeem shares from the pending_inactive pool at <code>lockup_cycle</code> == current OLC on behalf of
+delegator <code>shareholder</code> who wants to reactivate <code>coins_amount</code> of its unlocking stake.
+For latter case, extracted coins will be used to buy shares into the active pool and
+escape inactivation when current lockup ends.
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_redeem_inactive_shares">redeem_inactive_shares</a>(pool: &<b>mut</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">delegation_pool::DelegationPool</a>, shareholder: <b>address</b>, coins_amount: u64, lockup_cycle: <a href="delegation_pool.md#0x1_delegation_pool_ObservedLockupCycle">delegation_pool::ObservedLockupCycle</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_redeem_inactive_shares">redeem_inactive_shares</a>(
+    pool: &<b>mut</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>,
+    shareholder: <b>address</b>,
+    coins_amount: u64,
+    lockup_cycle: <a href="delegation_pool.md#0x1_delegation_pool_ObservedLockupCycle">ObservedLockupCycle</a>,
+): u64 {
+    <b>let</b> inactive_shares = <a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> pool.inactive_shares, lockup_cycle);
+    <b>let</b> shares_to_redeem = <a href="delegation_pool.md#0x1_delegation_pool_amount_to_shares_to_redeem">amount_to_shares_to_redeem</a>(inactive_shares, shareholder, coins_amount);
+    // silently exit <b>if</b> not a shareholder otherwise redeem would fail <b>with</b> `ESHAREHOLDER_NOT_FOUND`
+    <b>if</b> (shares_to_redeem == 0) <b>return</b> 0;
+    // 1. reaching here means delegator owns inactive/pending_inactive shares at OLC `lockup_cycle`
+    <b>let</b> redeemed_coins = <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_redeem_shares">pool_u64::redeem_shares</a>(inactive_shares, shareholder, shares_to_redeem);
+
+    // <b>if</b> entirely reactivated pending_inactive <a href="stake.md#0x1_stake">stake</a> or withdrawn inactive one,
+    // re-enable unlocking for delegator by deleting this pending withdrawal
+    <b>if</b> (<a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_shares">pool_u64::shares</a>(inactive_shares, shareholder) == 0) {
+        // 2. a delegator owns inactive/pending_inactive shares only at the OLC of its pending withdrawal
+        // 1 & 2: the pending withdrawal itself <b>has</b> been emptied of shares and can be safely deleted
+        <a href="../../aptos-stdlib/doc/table.md#0x1_table_remove">table::remove</a>(&<b>mut</b> pool.pending_withdrawals, shareholder);
+    };
+    // destroy inactive shares pool of past OLC <b>if</b> all its <a href="stake.md#0x1_stake">stake</a> <b>has</b> been withdrawn
+    <b>if</b> (lockup_cycle.index &lt; pool.observed_lockup_cycle.index && total_coins(inactive_shares) == 0) {
+        <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_destroy_empty">pool_u64::destroy_empty</a>(<a href="../../aptos-stdlib/doc/table.md#0x1_table_remove">table::remove</a>(&<b>mut</b> pool.inactive_shares, lockup_cycle));
+    };
+
+    redeemed_coins
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_calculate_stake_pool_drift"></a>
+
+## Function `calculate_stake_pool_drift`
+
+Calculate stake deviations between the delegation and stake pools in order to
+capture the rewards earned in the meantime, resulted operator commission and
+whether the lockup expired on the stake pool.
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_calculate_stake_pool_drift">calculate_stake_pool_drift</a>(pool: &<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">delegation_pool::DelegationPool</a>): (bool, u64, u64, u64, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_calculate_stake_pool_drift">calculate_stake_pool_drift</a>(pool: &<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>): (bool, u64, u64, u64, u64) {
+    <b>let</b> (active, inactive, pending_active, pending_inactive) = <a href="stake.md#0x1_stake_get_stake">stake::get_stake</a>(<a href="delegation_pool.md#0x1_delegation_pool_get_pool_address">get_pool_address</a>(pool));
+    <b>assert</b>!(
+        inactive &gt;= pool.total_coins_inactive,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="delegation_pool.md#0x1_delegation_pool_ESLASHED_INACTIVE_STAKE_ON_PAST_OLC">ESLASHED_INACTIVE_STAKE_ON_PAST_OLC</a>)
+    );
+    // determine whether a new lockup cycle <b>has</b> been ended on the <a href="stake.md#0x1_stake">stake</a> pool and
+    // inactivated SOME `pending_inactive` <a href="stake.md#0x1_stake">stake</a> which should stop earning rewards now,
+    // thus requiring separation of the `pending_inactive` <a href="stake.md#0x1_stake">stake</a> on current observed lockup
+    // and the future one on the newly started lockup
+    <b>let</b> lockup_cycle_ended = inactive &gt; pool.total_coins_inactive;
+
+    // actual coins on <a href="stake.md#0x1_stake">stake</a> pool belonging <b>to</b> the active shares pool
+    active = active + pending_active;
+    // actual coins on <a href="stake.md#0x1_stake">stake</a> pool belonging <b>to</b> the shares pool hosting `pending_inactive` <a href="stake.md#0x1_stake">stake</a>
+    // at current observed lockup cycle, either pending: `pending_inactive` or already inactivated:
+    <b>if</b> (lockup_cycle_ended) {
+        // `inactive` on <a href="stake.md#0x1_stake">stake</a> pool = <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> previous `inactive` <a href="stake.md#0x1_stake">stake</a> +
+        // <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> previous `pending_inactive` <a href="stake.md#0x1_stake">stake</a> and its rewards (both inactivated)
+        pending_inactive = inactive - pool.total_coins_inactive
+    };
+
+    // on <a href="stake.md#0x1_stake">stake</a>-management operations, total coins on the <b>internal</b> shares pools and individual
+    // stakes on the <a href="stake.md#0x1_stake">stake</a> pool are updated simultaneously, thus the only stakes becoming
+    // unsynced are rewards and slashes routed exclusively <b>to</b>/out the <a href="stake.md#0x1_stake">stake</a> pool
+
+    // operator `active` rewards not persisted yet <b>to</b> the active shares pool
+    <b>let</b> commission_active = total_coins(&pool.active_shares);
+    commission_active = <b>if</b> (active &gt; commission_active) {
+        <a href="delegation_pool.md#0x1_delegation_pool_multiply_then_divide">multiply_then_divide</a>(active - commission_active, pool.operator_commission_percentage, <a href="delegation_pool.md#0x1_delegation_pool_MAX_FEE">MAX_FEE</a>)
+    } <b>else</b> {
+        // handle <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> slashing applied <b>to</b> `active` <a href="stake.md#0x1_stake">stake</a>
+        0
+    };
+    // operator `pending_inactive` rewards not persisted yet <b>to</b> the pending_inactive shares pool
+    <b>let</b> commission_pending_inactive = total_coins(<a href="delegation_pool.md#0x1_delegation_pool_pending_inactive_shares_pool">pending_inactive_shares_pool</a>(pool));
+    commission_pending_inactive = <b>if</b> (pending_inactive &gt; commission_pending_inactive) {
+        <a href="delegation_pool.md#0x1_delegation_pool_multiply_then_divide">multiply_then_divide</a>(
+            pending_inactive - commission_pending_inactive,
+            pool.operator_commission_percentage,
+            <a href="delegation_pool.md#0x1_delegation_pool_MAX_FEE">MAX_FEE</a>
+        )
+    } <b>else</b> {
+        // handle <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> slashing applied <b>to</b> `pending_inactive` <a href="stake.md#0x1_stake">stake</a>
+        0
+    };
+
+    (lockup_cycle_ended, active, pending_inactive, commission_active, commission_pending_inactive)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_synchronize_delegation_pool"></a>
+
+## Function `synchronize_delegation_pool`
+
+Synchronize delegation and stake pools: distribute yet-undetected rewards to the corresponding internal
+shares pools, assign commission to operator and eventually prepare delegation pool for a new lockup cycle.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_synchronize_delegation_pool">synchronize_delegation_pool</a>(pool_address: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_synchronize_delegation_pool">synchronize_delegation_pool</a>(pool_address: <b>address</b>) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a> {
+    <a href="delegation_pool.md#0x1_delegation_pool_assert_delegation_pool_exists">assert_delegation_pool_exists</a>(pool_address);
+    <b>let</b> pool = <b>borrow_global_mut</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address);
+    <b>let</b> (
+        lockup_cycle_ended,
+        active,
+        pending_inactive,
+        commission_active,
+        commission_pending_inactive
+    ) = <a href="delegation_pool.md#0x1_delegation_pool_calculate_stake_pool_drift">calculate_stake_pool_drift</a>(pool);
+
+    // zero `pending_active` <a href="stake.md#0x1_stake">stake</a> indicates that either there are no `add_stake` fees or
+    // previous epoch <b>has</b> ended and should release the shares owning the existing fees
+    <b>let</b> (_, _, pending_active, _) = <a href="stake.md#0x1_stake_get_stake">stake::get_stake</a>(pool_address);
+    <b>if</b> (pending_active == 0) {
+        // renounce ownership over the `add_stake` fees by redeeming all shares of
+        // the special shareholder, implicitly their equivalent coins, out of the active shares pool
+        <a href="delegation_pool.md#0x1_delegation_pool_redeem_active_shares">redeem_active_shares</a>(pool, <a href="delegation_pool.md#0x1_delegation_pool_NULL_SHAREHOLDER">NULL_SHAREHOLDER</a>, <a href="delegation_pool.md#0x1_delegation_pool_MAX_U64">MAX_U64</a>);
+    };
+
+    // distribute rewards remaining after commission, <b>to</b> delegators (<b>to</b> already existing shares)
+    // before buying shares for the operator for its entire commission fee
+    // otherwise, operator's new shares would additionally appreciate from rewards it does not own
+
+    // <b>update</b> total coins accumulated by `active` + `pending_active` shares
+    // redeemed `add_stake` fees are restored and distributed <b>to</b> the rest of the pool <b>as</b> rewards
+    <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_update_total_coins">pool_u64::update_total_coins</a>(&<b>mut</b> pool.active_shares, active - commission_active);
+    // <b>update</b> total coins accumulated by `pending_inactive` shares at current observed lockup cycle
+    <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_update_total_coins">pool_u64::update_total_coins</a>(
+        <a href="delegation_pool.md#0x1_delegation_pool_pending_inactive_shares_pool_mut">pending_inactive_shares_pool_mut</a>(pool),
+        pending_inactive - commission_pending_inactive
+    );
+
+    // reward operator its commission out of uncommitted active rewards (`add_stake` fees already excluded)
+    <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_buy_in">pool_u64::buy_in</a>(&<b>mut</b> pool.active_shares, <a href="stake.md#0x1_stake_get_operator">stake::get_operator</a>(pool_address), commission_active);
+    // reward operator its commission out of uncommitted pending_inactive rewards
+    <a href="delegation_pool.md#0x1_delegation_pool_buy_in_pending_inactive_shares">buy_in_pending_inactive_shares</a>(pool, <a href="stake.md#0x1_stake_get_operator">stake::get_operator</a>(pool_address), commission_pending_inactive);
+
+    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
+        &<b>mut</b> pool.distribute_commission_events,
+        <a href="delegation_pool.md#0x1_delegation_pool_DistributeCommissionEvent">DistributeCommissionEvent</a> {
+            pool_address,
+            operator: <a href="stake.md#0x1_stake_get_operator">stake::get_operator</a>(pool_address),
+            commission_active,
+            commission_pending_inactive,
+        },
+    );
+
+    // advance lockup cycle on delegation pool <b>if</b> already ended on <a href="stake.md#0x1_stake">stake</a> pool (AND <a href="stake.md#0x1_stake">stake</a> explicitly inactivated)
+    <b>if</b> (lockup_cycle_ended) {
+        // capture inactive coins over all ended lockup cycles (including this ending one)
+        <b>let</b> (_, inactive, _, _) = <a href="stake.md#0x1_stake_get_stake">stake::get_stake</a>(pool_address);
+        pool.total_coins_inactive = inactive;
+
+        // advance lockup cycle on the delegation pool
+        pool.observed_lockup_cycle.index = pool.observed_lockup_cycle.index + 1;
+        // start new lockup cycle <b>with</b> a fresh shares pool for `pending_inactive` <a href="stake.md#0x1_stake">stake</a>
+        <a href="../../aptos-stdlib/doc/table.md#0x1_table_add">table::add</a>(
+            &<b>mut</b> pool.inactive_shares,
+            pool.observed_lockup_cycle,
+            <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_create_with_scaling_factor">pool_u64::create_with_scaling_factor</a>(<a href="delegation_pool.md#0x1_delegation_pool_SHARES_SCALING_FACTOR">SHARES_SCALING_FACTOR</a>)
+        );
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_multiply_then_divide"></a>
+
+## Function `multiply_then_divide`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_multiply_then_divide">multiply_then_divide</a>(x: u64, y: u64, z: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_multiply_then_divide">multiply_then_divide</a>(x: u64, y: u64, z: u64): u64 {
+    <b>let</b> result = (<a href="delegation_pool.md#0x1_delegation_pool_to_u128">to_u128</a>(x) * <a href="delegation_pool.md#0x1_delegation_pool_to_u128">to_u128</a>(y)) / <a href="delegation_pool.md#0x1_delegation_pool_to_u128">to_u128</a>(z);
+    (result <b>as</b> u64)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_to_u128"></a>
+
+## Function `to_u128`
+
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_to_u128">to_u128</a>(num: u64): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_to_u128">to_u128</a>(num: u64): u128 {
+    (num <b>as</b> u128)
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://move-language.github.io/move/introduction.html

--- a/aptos-move/framework/aptos-framework/doc/overview.md
+++ b/aptos-move/framework/aptos-framework/doc/overview.md
@@ -25,6 +25,7 @@ This is the reference documentation of the Aptos framework.
 -  [`0x1::coin`](coin.md#0x1_coin)
 -  [`0x1::consensus_config`](consensus_config.md#0x1_consensus_config)
 -  [`0x1::create_signer`](create_signer.md#0x1_create_signer)
+-  [`0x1::delegation_pool`](delegation_pool.md#0x1_delegation_pool)
 -  [`0x1::event`](event.md#0x1_event)
 -  [`0x1::gas_schedule`](gas_schedule.md#0x1_gas_schedule)
 -  [`0x1::genesis`](genesis.md#0x1_genesis)

--- a/aptos-move/framework/aptos-framework/doc/staking_contract.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_contract.md
@@ -740,6 +740,16 @@ pool.
 ## Constants
 
 
+<a name="0x1_staking_contract_EINVALID_COMMISSION_PERCENTAGE"></a>
+
+Commission percentage has to be between 0 and 100.
+
+
+<pre><code><b>const</b> <a href="staking_contract.md#0x1_staking_contract_EINVALID_COMMISSION_PERCENTAGE">EINVALID_COMMISSION_PERCENTAGE</a>: u64 = 2;
+</code></pre>
+
+
+
 <a name="0x1_staking_contract_ECANT_MERGE_STAKING_CONTRACTS"></a>
 
 Staking contracts can't be merged.
@@ -766,16 +776,6 @@ Store amount must be at least the min stake required for a stake pool to join th
 
 
 <pre><code><b>const</b> <a href="staking_contract.md#0x1_staking_contract_EINSUFFICIENT_STAKE_AMOUNT">EINSUFFICIENT_STAKE_AMOUNT</a>: u64 = 1;
-</code></pre>
-
-
-
-<a name="0x1_staking_contract_EINVALID_COMMISSION_PERCENTAGE"></a>
-
-Commission percentage has to be between 0 and 100.
-
-
-<pre><code><b>const</b> <a href="staking_contract.md#0x1_staking_contract_EINVALID_COMMISSION_PERCENTAGE">EINVALID_COMMISSION_PERCENTAGE</a>: u64 = 2;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/delegation_pool.move
+++ b/aptos-move/framework/aptos-framework/sources/delegation_pool.move
@@ -1,0 +1,2703 @@
+/**
+ * Allow multiple delegators to participate in the same stake pool in order to collect the minimum
+ * stake required to join the validator set. Delegators are rewarded out of the validator rewards
+ * proportionally to their stake and provided the same stake-management API as the stake pool owner.
+ *
+ * The main accounting logic in the delegation pool contract handles the following:
+ * 1. Tracks how much stake each delegator owns, privately deposited as well as earned.
+ * Accounting individual delegator stakes is achieved through the shares-based pool defined at
+ * `aptos_std::pool_u64`, hence delegators own shares rather than absolute stakes into the delegation pool.
+ * 2. Tracks rewards earned by the stake pool, implicitly by the delegation one, in the meantime
+ * and distribute them accordingly.
+ * 3. Tracks lockup cycles on the stake pool in order to separate inactive stake (not earning rewards)
+ * from pending_inactive stake (earning rewards) and allow its delegators to withdraw the former.
+ * 4. Tracks how much commission fee has to be paid to the operator out of incoming rewards before
+ * distributing them to the internal pool_u64 pools.
+ *
+ * In order to distinguish between stakes in different states and route rewards accordingly,
+ * separate pool_u64 pools are used for individual stake states:
+ *      1. one of `active` + `pending_active` stake
+ *      2. one of `inactive` stake FOR each past observed lockup cycle (OLC) on the stake pool
+ *      3. one of `pending_inactive` stake scheduled during this ongoing OLC
+ *
+ * As stake-state transitions and rewards are computed only at the stake pool level, the delegation pool
+ * gets outdated. To mitigate this, at any interaction with the delegation pool, a process of synchronization
+ * to the underlying stake pool is executed before the requested operation itself.
+ *
+ * At synchronization:
+ *  - stake deviations between the two pools are actually the rewards produced in the meantime.
+ *  - the commission fee is extracted from the rewards, the remaining stake is distributed to the internal
+ * pool_u64 pools and then the commission stake used to buy shares for operator.
+ *  - if detecting that the lockup expired on the stake pool, the delegation pool will isolate its
+ * pending_inactive stake (now inactive) and create a new pool_u64 to host future pending_inactive stake
+ * scheduled this newly started lockup.
+ * Detecting a lockup expiration on the stake pool resumes to detecting new inactive stake.
+ *
+ * Accounting main invariants:
+ *  - each stake-management operation (add/unlock/reactivate/withdraw) and operator change triggers
+ * the synchronization process before executing its own function.
+ *  - each OLC maps to one or more real lockups on the stake pool, but not the opposite. Actually, only a real
+ * lockup with 'activity' (which inactivated some unlocking stake) triggers the creation of a new OLC.
+ *  - unlocking and/or unlocked stake originating from different real lockups are never mixed together into
+ * the same pool_u64. This invalidates the accounting of which rewards belong to whom.
+ *  - no delegator can have unlocking and/or unlocked stake (pending withdrawals) in different OLCs. This ensures
+ * delegators do not have to keep track of the OLCs when they unlocked. When creating a new pending withdrawal,
+ * the existing one is executed (withdrawn) if is already inactive.
+ *  - `add_stake` fees are always refunded, but only after the epoch when they have been charged ends.
+ *  - withdrawing pending_inactive stake (when validator had gone inactive before its lockup expired)
+ * does not inactivate any stake additional to the requested one to ensure OLC would not advance indefinitely.
+ *  - the pending withdrawal exists at an OLC iff delegator owns some shares within the shares pool of that OLC.
+ *
+ * Example flow:
+ * 1. A node operator creates a delegation pool by calling `initialize_delegation_pool` and sets
+ * its commission fee to 0% (for simplicity). A stake pool is created with no initial stake and owned by
+ * a resource account controlled by the delegation pool.
+ * 2. Delegator A adds 100 stake which is converted to 100 shares into the active pool_u64
+ * 3. Operator joins the validator set as the stake pool has now the minimum stake
+ * 4. The stake pool earned rewards and now has 200 active stake. A's active shares are worth 200 coins as
+ * the commission fee is 0%.
+ * 5a. A requests `unlock` for 100 stake
+ * 5b. Synchronization detects 200 - 100 active rewards which are entirely (0% commission) added to the active pool.
+ * 5c. 100 coins = (100 * 100) / 200 = 50 shares are redeemed from the active pool and exchanged for 100 shares
+ * into the pending_inactive one on A's behalf
+ * 6. Delegator B adds 200 stake which is converted to (200 * 50) / 100 = 100 shares into the active pool
+ * 7. The stake pool earned rewards and now has 600 active and 200 pending_inactive stake.
+ * 8a. A requests `reactivate_stake` for 100 stake
+ * 8b. Synchronization detects 600 - 300 active and 200 - 100 pending_inactive rewards which are both entirely
+ * distributed to their corresponding pools
+ * 8c. 100 coins = (100 * 100) / 200 = 50 shares are redeemed from the pending_inactive pool and exchanged for
+ * (100 * 150) / 600 = 25 shares into the active one on A's behalf
+ * 9. The lockup expires on the stake pool, inactivating the entire pending_inactive stake
+ * 10a. B requests `unlock` for 100 stake
+ * 10b. Synchronization detects no active or pending_inactive rewards, but 0 -> 100 inactive stake
+ * on the stake pool, so it advances the observed lockup cycle and creates a pool_u64 for the new lockup,
+ * hence allowing previous pending_inactive shares to be redeemed
+ * 10c. 100 coins = (100 * 175) / 700 = 25 shares are redeemed from the active pool and exchanged for
+ * 100 shares into the new pending_inactive one on B's behalf
+ * 11. The stake pool earned rewards and now has some pending_inactive rewards.
+ * 12a. A requests `withdraw` for its entire inactive stake
+ * 12b. Synchronization detects no new inactive stake, but some pending_inactive rewards which are
+ * distributed to the (2nd) pending_inactive pool
+ * 12c. A's 50 shares = (50 * 100) / 50 = 100 coins are redeemed from the (1st) inactive pool and 100 stake
+ * is transferred to A
+ */
+module aptos_framework::delegation_pool {
+    use std::error;
+    use std::features;
+    use std::signer;
+    use std::vector;
+
+    use aptos_std::pool_u64_unbound::{Self as pool_u64, total_coins};
+    use aptos_std::table::{Self, Table};
+
+    use aptos_framework::account;
+    use aptos_framework::aptos_coin::AptosCoin;
+    use aptos_framework::coin;
+    use aptos_framework::event::{Self, EventHandle};
+    use aptos_framework::stake;
+    use aptos_framework::staking_config;
+    use aptos_framework::timestamp;
+
+    const MODULE_SALT: vector<u8> = b"aptos_framework::delegation_pool";
+
+    /// Delegation pool owner capability does not exist at the provided account.
+    const EOWNER_CAP_NOT_FOUND: u64 = 1;
+
+    /// Account is already owning a delegation pool.
+    const EOWNER_CAP_ALREADY_EXISTS: u64 = 2;
+
+    /// Delegation pool does not exist at the provided pool address.
+    const EDELEGATION_POOL_DOES_NOT_EXIST: u64 = 3;
+
+    /// There is a pending withdrawal to be executed before `unlock`ing any new stake.
+    const EPENDING_WITHDRAWAL_EXISTS: u64 = 4;
+
+    /// Commission percentage has to be between 0 and `MAX_FEE` - 100%.
+    const EINVALID_COMMISSION_PERCENTAGE: u64 = 5;
+
+    /// There is not enough `active` stake on the stake pool to `unlock`.
+    const ENOT_ENOUGH_ACTIVE_STAKE_TO_UNLOCK: u64 = 6;
+
+    /// Slashing (if implemented) should not be applied to already `inactive` stake.
+    /// Not only it invalidates the accounting of past observed lockup cycles (OLC),
+    /// but is also unfair to delegators whose stake has been inactive before validator started misbehaving.
+    /// Additionally, the inactive stake does not count on the voting power of validator.
+    const ESLASHED_INACTIVE_STAKE_ON_PAST_OLC: u64 = 7;
+
+    /// Delegator's active balance cannot be less than `MIN_COINS_ON_SHARES_POOL`.
+    const EDELEGATOR_ACTIVE_BALANCE_TOO_LOW: u64 = 8;
+
+    /// Delegator's pending_inactive balance cannot be less than `MIN_COINS_ON_SHARES_POOL`.
+    const EDELEGATOR_PENDING_INACTIVE_BALANCE_TOO_LOW: u64 = 9;
+
+    /// Creating delegation pools is not enabled yet.
+    const EDELEGATION_POOLS_DISABLED: u64 = 10;
+
+    /// Cannot request to withdraw zero stake.
+    const EWITHDRAW_ZERO_STAKE: u64 = 11;
+
+    const MAX_U64: u64 = 18446744073709551615;
+
+    /// Maximum operator percentage fee(of double digit precision): 22.85% is represented as 2285
+    const MAX_FEE: u64 = 10000;
+
+    const VALIDATOR_STATUS_INACTIVE: u64 = 4;
+
+    /// Special shareholder temporarily owning the `add_stake` fees charged during this epoch.
+    /// On each `add_stake` operation any resulted fee is used to buy active shares for this shareholder.
+    /// First synchronization after this epoch ends will distribute accumulated fees to the rest of the pool as refunds.
+    const NULL_SHAREHOLDER: address = @0x0;
+
+    /// Minimum coins to exist on a shares pool at all times.
+    /// Enforced per delegator for both active and pending_inactive pools.
+    /// This constraint ensures the share price cannot overly increase and lead to
+    /// substantial loses when buying shares (can lose at most 1 share which may
+    /// be worth a lot if current share price is high).
+    /// This constraint is not enforced on inactive pools as they only allow redeems
+    /// (can lose at most 1 coin regardless of current share price).
+    const MIN_COINS_ON_SHARES_POOL: u64 = 1000000000;
+
+    /// Scaling factor of shares pools used within the delegation pool
+    const SHARES_SCALING_FACTOR: u64 = 10000000000000000;
+
+    /// Capability that represents ownership over privileged operations on the underlying stake pool.
+    struct DelegationPoolOwnership has key, store {
+        /// equal to address of the resource account owning the stake pool
+        pool_address: address,
+    }
+
+    struct ObservedLockupCycle has copy, drop, store {
+        index: u64,
+    }
+
+    struct DelegationPool has key {
+        // Shares pool of `active` + `pending_active` stake
+        active_shares: pool_u64::Pool,
+        // Index of current observed lockup cycle on the delegation pool since its creation
+        observed_lockup_cycle: ObservedLockupCycle,
+        // Shares pools of `inactive` stake on each ended OLC and `pending_inactive` stake on the current one.
+        // Tracks shares of delegators who requested withdrawals in each OLC
+        inactive_shares: Table<ObservedLockupCycle, pool_u64::Pool>,
+        // Mapping from delegator address to the OLC of its pending withdrawal if having one
+        pending_withdrawals: Table<address, ObservedLockupCycle>,
+        // Signer capability of the resource account owning the stake pool
+        stake_pool_signer_cap: account::SignerCapability,
+        // Total (inactive) coins on the shares pools over all ended OLCs
+        total_coins_inactive: u64,
+        // Commission fee paid to the node operator out of pool rewards
+        operator_commission_percentage: u64,
+
+        // The events emitted by stake-management operations on the delegation pool
+        add_stake_events: EventHandle<AddStakeEvent>,
+        reactivate_stake_events: EventHandle<ReactivateStakeEvent>,
+        unlock_stake_events: EventHandle<UnlockStakeEvent>,
+        withdraw_stake_events: EventHandle<WithdrawStakeEvent>,
+        distribute_commission_events: EventHandle<DistributeCommissionEvent>,
+    }
+
+    struct AddStakeEvent has drop, store {
+        pool_address: address,
+        delegator_address: address,
+        amount_added: u64,
+        add_stake_fee: u64,
+    }
+
+    struct ReactivateStakeEvent has drop, store {
+        pool_address: address,
+        delegator_address: address,
+        amount_reactivated: u64,
+    }
+
+    struct UnlockStakeEvent has drop, store {
+        pool_address: address,
+        delegator_address: address,
+        amount_unlocked: u64,
+    }
+
+    struct WithdrawStakeEvent has drop, store {
+        pool_address: address,
+        delegator_address: address,
+        amount_withdrawn: u64,
+    }
+
+    struct DistributeCommissionEvent has drop, store {
+        pool_address: address,
+        operator: address,
+        commission_active: u64,
+        commission_pending_inactive: u64,
+    }
+
+    #[view]
+    /// Return whether supplied address `addr` is owner of a delegation pool.
+    public fun owner_cap_exists(addr: address): bool {
+        exists<DelegationPoolOwnership>(addr)
+    }
+
+    #[view]
+    /// Return address of the delegation pool owned by `owner` or fail if there is none.
+    public fun get_owned_pool_address(owner: address): address acquires DelegationPoolOwnership {
+        assert_owner_cap_exists(owner);
+        borrow_global<DelegationPoolOwnership>(owner).pool_address
+    }
+
+    #[view]
+    /// Return whether a delegation pool exists at supplied address `addr`.
+    public fun delegation_pool_exists(addr: address): bool {
+        exists<DelegationPool>(addr)
+    }
+
+    #[view]
+    /// Return the index of current observed lockup cycle on delegation pool `pool_address`.
+    public fun observed_lockup_cycle(pool_address: address): u64 acquires DelegationPool {
+        assert_delegation_pool_exists(pool_address);
+        borrow_global<DelegationPool>(pool_address).observed_lockup_cycle.index
+    }
+
+    #[view]
+    /// Return the operator commission percentage set on the delegation pool `pool_address`.
+    public fun operator_commission_percentage(pool_address: address): u64 acquires DelegationPool {
+        assert_delegation_pool_exists(pool_address);
+        borrow_global<DelegationPool>(pool_address).operator_commission_percentage
+    }
+
+    #[view]
+    /// Return the number of delegators owning active stake within `pool_address`.
+    public fun shareholders_count_active_pool(pool_address: address): u64 acquires DelegationPool {
+        assert_delegation_pool_exists(pool_address);
+        pool_u64::shareholders_count(&borrow_global<DelegationPool>(pool_address).active_shares)
+    }
+
+    #[view]
+    /// Return the stake amounts on `pool_address` in the different states:
+    /// (`active`,`inactive`,`pending_active`,`pending_inactive`)
+    public fun get_delegation_pool_stake(pool_address: address): (u64, u64, u64, u64) {
+        assert_delegation_pool_exists(pool_address);
+        stake::get_stake(pool_address)
+    }
+
+    #[view]
+    /// Return whether the given delegator has any withdrawable stake. If they recently requested to unlock
+    /// some stake and the stake pool's lockup cycle has not ended, their coins are not withdrawable yet.
+    public fun get_pending_withdrawal(
+        pool_address: address,
+        delegator_address: address
+    ): (bool, u64) acquires DelegationPool {
+        assert_delegation_pool_exists(pool_address);
+        let pool = borrow_global<DelegationPool>(pool_address);
+        let (
+            lockup_cycle_ended,
+            _,
+            pending_inactive,
+            _,
+            commission_pending_inactive
+        ) = calculate_stake_pool_drift(pool);
+
+        let (withdrawal_exists, withdrawal_olc) = pending_withdrawal_exists(pool, delegator_address);
+        if (!withdrawal_exists) {
+            // if no pending withdrawal, there is neither inactive nor pending_inactive stake
+            (false, 0)
+        } else {
+            // delegator has either inactive or pending_inactive stake due to automatic withdrawals
+            let inactive_shares = table::borrow(&pool.inactive_shares, withdrawal_olc);
+            if (withdrawal_olc.index < pool.observed_lockup_cycle.index) {
+                // if withdrawal's lockup cycle ended on delegation pool then it is inactive
+                (true, pool_u64::balance(inactive_shares, delegator_address))
+            } else {
+                pending_inactive = pool_u64::shares_to_amount_with_total_coins(
+                    inactive_shares,
+                    pool_u64::shares(inactive_shares, delegator_address),
+                    // exclude operator pending_inactive rewards not converted to shares yet
+                    pending_inactive - commission_pending_inactive
+                );
+                // if withdrawal's lockup cycle ended ONLY on stake pool then it is also inactive
+                (lockup_cycle_ended, pending_inactive)
+            }
+        }
+    }
+
+    #[view]
+    /// Return total stake owned by `delegator_address` within delegation pool `pool_address`
+    /// in each of its individual states: (`active`,`inactive`,`pending_inactive`)
+    public fun get_stake(pool_address: address, delegator_address: address): (u64, u64, u64) acquires DelegationPool {
+        assert_delegation_pool_exists(pool_address);
+        let pool = borrow_global<DelegationPool>(pool_address);
+        let (
+            lockup_cycle_ended,
+            active,
+            _,
+            commission_active,
+            commission_pending_inactive
+        ) = calculate_stake_pool_drift(pool);
+
+        let total_active_shares = pool_u64::total_shares(&pool.active_shares);
+        let delegator_active_shares = pool_u64::shares(&pool.active_shares, delegator_address);
+
+        let (_, _, pending_active, _) = stake::get_stake(pool_address);
+        if (pending_active == 0) {
+            // zero `pending_active` stake indicates that either there are no `add_stake` fees or
+            // previous epoch has ended and should identify shares owning these fees as released
+            total_active_shares = total_active_shares - pool_u64::shares(&pool.active_shares, NULL_SHAREHOLDER);
+            if (delegator_address == NULL_SHAREHOLDER) {
+                delegator_active_shares = 0
+            }
+        };
+        active = pool_u64::shares_to_amount_with_total_stats(
+            &pool.active_shares,
+            delegator_active_shares,
+            // exclude operator active rewards not converted to shares yet
+            active - commission_active,
+            total_active_shares
+        );
+
+        // get state and stake (0 if there is none) of the pending withdrawal
+        let (withdrawal_inactive, withdrawal_stake) = get_pending_withdrawal(pool_address, delegator_address);
+        // report non-active stakes accordingly to the state of the pending withdrawal
+        let (inactive, pending_inactive) = if (withdrawal_inactive) (withdrawal_stake, 0) else (0, withdrawal_stake);
+
+        // should also include commission rewards in case of the operator account
+        // operator rewards are actually used to buy shares which is introducing
+        // some imprecision (received stake would be slightly less)
+        // but adding rewards onto the existing stake is still a good approximation
+        if (delegator_address == stake::get_operator(pool_address)) {
+            active = active + commission_active;
+            // in-flight pending_inactive commission can coexist with already inactive withdrawal
+            if (lockup_cycle_ended) {
+                inactive = inactive + commission_pending_inactive
+            } else {
+                pending_inactive = pending_inactive + commission_pending_inactive
+            }
+        };
+
+        (active, inactive, pending_inactive)
+    }
+
+    #[view]
+    /// Return refundable stake to be extracted from added `amount` at `add_stake` operation on pool `pool_address`.
+    /// If the validator produces rewards this epoch, added stake goes directly to `pending_active` and
+    /// does not earn rewards. However, all shares within a pool appreciate uniformly and when this epoch ends:
+    /// - either added shares are still `pending_active` and steal from rewards of existing `active` stake
+    /// - or have moved to `pending_inactive` and get full rewards (they displaced `active` stake at `unlock`)
+    /// To mitigate this, some of the added stake is extracted and fed back into the pool as placeholder
+    /// for the rewards the remaining stake would have earned if active:
+    /// extracted-fee = (amount - extracted-fee) * reward-rate% * (100% - operator-commission%)
+    public fun get_add_stake_fee(pool_address: address, amount: u64): u64 acquires DelegationPool {
+        if (stake::is_current_epoch_validator(pool_address)) {
+            let (rewards_rate, rewards_rate_denominator) = staking_config::get_reward_rate(&staking_config::get());
+            if (rewards_rate_denominator > 0) {
+                assert_delegation_pool_exists(pool_address);
+                let pool = borrow_global<DelegationPool>(pool_address);
+
+                rewards_rate = rewards_rate * (MAX_FEE - pool.operator_commission_percentage);
+                rewards_rate_denominator = rewards_rate_denominator * MAX_FEE;
+                ((((amount as u128) * (rewards_rate as u128)) / ((rewards_rate as u128) + (rewards_rate_denominator as u128))) as u64)
+            } else { 0 }
+        } else { 0 }
+    }
+
+    #[view]
+    /// Return whether `pending_inactive` stake can be directly withdrawn from
+    /// the delegation pool, implicitly its stake pool, in the special case
+    /// the validator had gone inactive before its lockup expired.
+    public fun can_withdraw_pending_inactive(pool_address: address): bool {
+        stake::get_validator_state(pool_address) == VALIDATOR_STATUS_INACTIVE &&
+            timestamp::now_seconds() >= stake::get_lockup_secs(pool_address)
+    }
+
+    /// Initialize a delegation pool of custom fixed `operator_commission_percentage`.
+    /// A resource account is created from `owner` signer and its supplied `delegation_pool_creation_seed`
+    /// to host the delegation pool resource and own the underlying stake pool.
+    /// Ownership over setting the operator/voter is granted to `owner` who has both roles initially.
+    public entry fun initialize_delegation_pool(
+        owner: &signer,
+        operator_commission_percentage: u64,
+        delegation_pool_creation_seed: vector<u8>,
+    ) {
+        assert!(features::delegation_pools_enabled(), error::invalid_state(EDELEGATION_POOLS_DISABLED));
+        let owner_address = signer::address_of(owner);
+        assert!(!owner_cap_exists(owner_address), error::already_exists(EOWNER_CAP_ALREADY_EXISTS));
+        assert!(operator_commission_percentage <= MAX_FEE, error::invalid_argument(EINVALID_COMMISSION_PERCENTAGE));
+
+        // generate a seed to be used to create the resource account hosting the delegation pool
+        let seed = vector::empty<u8>();
+        // include module salt (before any subseeds) to avoid conflicts with other modules creating resource accounts
+        vector::append(&mut seed, MODULE_SALT);
+        // include an additional salt in case the same resource account has already been created
+        vector::append(&mut seed, delegation_pool_creation_seed);
+
+        let (stake_pool_signer, stake_pool_signer_cap) = account::create_resource_account(owner, seed);
+        coin::register<AptosCoin>(&stake_pool_signer);
+
+        // stake_pool_signer will be owner of the stake pool and have its `stake::OwnerCapability`
+        let pool_address = signer::address_of(&stake_pool_signer);
+        stake::initialize_stake_owner(&stake_pool_signer, 0, owner_address, owner_address);
+
+        let inactive_shares = table::new<ObservedLockupCycle, pool_u64::Pool>();
+        table::add(
+            &mut inactive_shares,
+            olc_with_index(0),
+            pool_u64::create_with_scaling_factor(SHARES_SCALING_FACTOR)
+        );
+
+        move_to(&stake_pool_signer, DelegationPool {
+            active_shares: pool_u64::create_with_scaling_factor(SHARES_SCALING_FACTOR),
+            observed_lockup_cycle: olc_with_index(0),
+            inactive_shares,
+            pending_withdrawals: table::new<address, ObservedLockupCycle>(),
+            stake_pool_signer_cap,
+            total_coins_inactive: 0,
+            operator_commission_percentage,
+            add_stake_events: account::new_event_handle<AddStakeEvent>(&stake_pool_signer),
+            reactivate_stake_events: account::new_event_handle<ReactivateStakeEvent>(&stake_pool_signer),
+            unlock_stake_events: account::new_event_handle<UnlockStakeEvent>(&stake_pool_signer),
+            withdraw_stake_events: account::new_event_handle<WithdrawStakeEvent>(&stake_pool_signer),
+            distribute_commission_events: account::new_event_handle<DistributeCommissionEvent>(&stake_pool_signer),
+        });
+
+        // save delegation pool ownership and resource account address (inner stake pool address) on `owner`
+        move_to(owner, DelegationPoolOwnership { pool_address });
+    }
+
+    fun assert_owner_cap_exists(owner: address) {
+        assert!(owner_cap_exists(owner), error::not_found(EOWNER_CAP_NOT_FOUND));
+    }
+
+    fun assert_delegation_pool_exists(pool_address: address) {
+        assert!(delegation_pool_exists(pool_address), error::invalid_argument(EDELEGATION_POOL_DOES_NOT_EXIST));
+    }
+
+    fun assert_min_active_balance(pool: &DelegationPool, delegator_address: address) {
+        let balance = pool_u64::balance(&pool.active_shares, delegator_address);
+        assert!(balance >= MIN_COINS_ON_SHARES_POOL, error::invalid_argument(EDELEGATOR_ACTIVE_BALANCE_TOO_LOW));
+    }
+
+    fun assert_min_pending_inactive_balance(pool: &DelegationPool, delegator_address: address) {
+        let balance = pool_u64::balance(pending_inactive_shares_pool(pool), delegator_address);
+        assert!(
+            balance >= MIN_COINS_ON_SHARES_POOL,
+            error::invalid_argument(EDELEGATOR_PENDING_INACTIVE_BALANCE_TOO_LOW)
+        );
+    }
+
+    fun coins_to_redeem_to_ensure_min_stake(
+        src_shares_pool: &pool_u64::Pool,
+        shareholder: address,
+        amount: u64,
+    ): u64 {
+        // find how many coins would be redeemed if supplying `amount`
+        let redeemed_coins = pool_u64::shares_to_amount(
+            src_shares_pool,
+            amount_to_shares_to_redeem(src_shares_pool, shareholder, amount)
+        );
+        // if balance drops under threshold then redeem it entirely
+        let src_balance = pool_u64::balance(src_shares_pool, shareholder);
+        if (src_balance - redeemed_coins < MIN_COINS_ON_SHARES_POOL) {
+            amount = src_balance;
+        };
+        amount
+    }
+
+    fun coins_to_transfer_to_ensure_min_stake(
+        src_shares_pool: &pool_u64::Pool,
+        dst_shares_pool: &pool_u64::Pool,
+        shareholder: address,
+        amount: u64,
+    ): u64 {
+        // find how many coins would be redeemed from source if supplying `amount`
+        let redeemed_coins = pool_u64::shares_to_amount(
+            src_shares_pool,
+            amount_to_shares_to_redeem(src_shares_pool, shareholder, amount)
+        );
+        // if balance on destination would be less than threshold then redeem difference to threshold
+        let dst_balance = pool_u64::balance(dst_shares_pool, shareholder);
+        if (dst_balance + redeemed_coins < MIN_COINS_ON_SHARES_POOL) {
+            // `redeemed_coins` >= `amount` - 1 as redeem can lose at most 1 coin
+            amount = MIN_COINS_ON_SHARES_POOL - dst_balance + 1;
+        };
+        // check if new `amount` drops balance on source under threshold and adjust
+        coins_to_redeem_to_ensure_min_stake(src_shares_pool, shareholder, amount)
+    }
+
+    /// Retrieves the shared resource account owning the stake pool in order
+    /// to forward a stake-management operation to this underlying pool.
+    fun retrieve_stake_pool_owner(pool: &DelegationPool): signer {
+        account::create_signer_with_capability(&pool.stake_pool_signer_cap)
+    }
+
+    /// Get the address of delegation pool reference `pool`.
+    fun get_pool_address(pool: &DelegationPool): address {
+        account::get_signer_capability_address(&pool.stake_pool_signer_cap)
+    }
+
+    fun olc_with_index(index: u64): ObservedLockupCycle {
+        ObservedLockupCycle { index }
+    }
+
+    /// Allows an owner to change the operator of the underlying stake pool.
+    public entry fun set_operator(
+        owner: &signer,
+        new_operator: address
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        let pool_address = get_owned_pool_address(signer::address_of(owner));
+        // synchronize delegation and stake pools before any user operation
+        // ensure the old operator is paid its uncommitted commission rewards
+        synchronize_delegation_pool(pool_address);
+        stake::set_operator(&retrieve_stake_pool_owner(borrow_global<DelegationPool>(pool_address)), new_operator);
+    }
+
+    /// Allows an owner to change the delegated voter of the underlying stake pool.
+    public entry fun set_delegated_voter(
+        owner: &signer,
+        new_voter: address
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        let pool_address = get_owned_pool_address(signer::address_of(owner));
+        // synchronize delegation and stake pools before any user operation
+        synchronize_delegation_pool(pool_address);
+        stake::set_delegated_voter(&retrieve_stake_pool_owner(borrow_global<DelegationPool>(pool_address)), new_voter);
+    }
+
+    /// Add `amount` of coins to the delegation pool `pool_address`.
+    public entry fun add_stake(delegator: &signer, pool_address: address, amount: u64) acquires DelegationPool {
+        // short-circuit if amount to add is 0 so no event is emitted
+        if (amount == 0) { return };
+        // synchronize delegation and stake pools before any user operation
+        synchronize_delegation_pool(pool_address);
+
+        // fee to be charged for adding `amount` stake on this delegation pool at this epoch
+        let add_stake_fee = get_add_stake_fee(pool_address, amount);
+
+        let pool = borrow_global_mut<DelegationPool>(pool_address);
+        let delegator_address = signer::address_of(delegator);
+
+        // stake the entire amount to the stake pool
+        coin::transfer<AptosCoin>(delegator, pool_address, amount);
+        stake::add_stake(&retrieve_stake_pool_owner(pool), amount);
+
+        // but buy shares for delegator just for the remaining amount after fee
+        pool_u64::buy_in(&mut pool.active_shares, delegator_address, amount - add_stake_fee);
+        assert_min_active_balance(pool, delegator_address);
+
+        // grant temporary ownership over `add_stake` fees to a separate shareholder in order to:
+        // - not mistake them for rewards to pay the operator from
+        // - distribute them together with the `active` rewards when this epoch ends
+        // in order to appreciate all shares on the active pool atomically
+        pool_u64::buy_in(&mut pool.active_shares, NULL_SHAREHOLDER, add_stake_fee);
+
+        event::emit_event(
+            &mut pool.add_stake_events,
+            AddStakeEvent {
+                pool_address,
+                delegator_address,
+                amount_added: amount,
+                add_stake_fee,
+            },
+        );
+    }
+
+    /// Unlock `amount` from the active + pending_active stake of `delegator` or
+    /// at most how much active stake there is on the stake pool.
+    public entry fun unlock(delegator: &signer, pool_address: address, amount: u64) acquires DelegationPool {
+        // short-circuit if amount to unlock is 0 so no event is emitted
+        if (amount == 0) { return };
+
+        // fail unlock of more stake than `active` on the stake pool
+        let (active, _, _, _) = stake::get_stake(pool_address);
+        assert!(amount <= active, error::invalid_argument(ENOT_ENOUGH_ACTIVE_STAKE_TO_UNLOCK));
+
+        // synchronize delegation and stake pools before any user operation
+        synchronize_delegation_pool(pool_address);
+
+        let pool = borrow_global_mut<DelegationPool>(pool_address);
+        let delegator_address = signer::address_of(delegator);
+
+        amount = coins_to_transfer_to_ensure_min_stake(
+            &pool.active_shares,
+            pending_inactive_shares_pool(pool),
+            delegator_address,
+            amount,
+        );
+        amount = redeem_active_shares(pool, delegator_address, amount);
+
+        stake::unlock(&retrieve_stake_pool_owner(pool), amount);
+
+        buy_in_pending_inactive_shares(pool, delegator_address, amount);
+        assert_min_pending_inactive_balance(pool, delegator_address);
+
+        event::emit_event(
+            &mut pool.unlock_stake_events,
+            UnlockStakeEvent {
+                pool_address,
+                delegator_address,
+                amount_unlocked: amount,
+            },
+        );
+    }
+
+    /// Move `amount` of coins from pending_inactive to active.
+    public entry fun reactivate_stake(delegator: &signer, pool_address: address, amount: u64) acquires DelegationPool {
+        // short-circuit if amount to reactivate is 0 so no event is emitted
+        if (amount == 0) { return };
+        // synchronize delegation and stake pools before any user operation
+        synchronize_delegation_pool(pool_address);
+
+        let pool = borrow_global_mut<DelegationPool>(pool_address);
+        let delegator_address = signer::address_of(delegator);
+
+        amount = coins_to_transfer_to_ensure_min_stake(
+            pending_inactive_shares_pool(pool),
+            &pool.active_shares,
+            delegator_address,
+            amount,
+        );
+        let observed_lockup_cycle = pool.observed_lockup_cycle;
+        amount = redeem_inactive_shares(pool, delegator_address, amount, observed_lockup_cycle);
+
+        stake::reactivate_stake(&retrieve_stake_pool_owner(pool), amount);
+
+        pool_u64::buy_in(&mut pool.active_shares, delegator_address, amount);
+        assert_min_active_balance(pool, delegator_address);
+
+        event::emit_event(
+            &mut pool.reactivate_stake_events,
+            ReactivateStakeEvent {
+                pool_address,
+                delegator_address,
+                amount_reactivated: amount,
+            },
+        );
+    }
+
+    /// Withdraw `amount` of owned inactive stake from the delegation pool at `pool_address`.
+    public entry fun withdraw(delegator: &signer, pool_address: address, amount: u64) acquires DelegationPool {
+        assert!(amount > 0, error::invalid_argument(EWITHDRAW_ZERO_STAKE));
+        // synchronize delegation and stake pools before any user operation
+        synchronize_delegation_pool(pool_address);
+        withdraw_internal(borrow_global_mut<DelegationPool>(pool_address), signer::address_of(delegator), amount);
+    }
+
+    fun withdraw_internal(pool: &mut DelegationPool, delegator_address: address, amount: u64) {
+        // short-circuit if amount to withdraw is 0 so no event is emitted
+        if (amount == 0) { return };
+
+        let pool_address = get_pool_address(pool);
+        let (withdrawal_exists, withdrawal_olc) = pending_withdrawal_exists(pool, delegator_address);
+        // exit if no withdrawal or (it is pending and cannot withdraw pending_inactive stake from stake pool)
+        if (!(
+            withdrawal_exists &&
+                (withdrawal_olc.index < pool.observed_lockup_cycle.index || can_withdraw_pending_inactive(pool_address))
+        )) { return };
+
+        if (withdrawal_olc.index == pool.observed_lockup_cycle.index) {
+            amount = coins_to_redeem_to_ensure_min_stake(
+                pending_inactive_shares_pool(pool),
+                delegator_address,
+                amount,
+            )
+        };
+        amount = redeem_inactive_shares(pool, delegator_address, amount, withdrawal_olc);
+
+        let stake_pool_owner = &retrieve_stake_pool_owner(pool);
+        // stake pool will inactivate entire pending_inactive stake at `stake::withdraw` to make it withdrawable
+        // however, bypassing the inactivation of excess stake (inactivated but not withdrawn) ensures
+        // the OLC is not advanced indefinitely on `unlock`-`withdraw` paired calls
+        if (can_withdraw_pending_inactive(pool_address)) {
+            // get excess stake before being entirely inactivated
+            let (_, _, _, pending_inactive) = stake::get_stake(pool_address);
+            if (withdrawal_olc.index == pool.observed_lockup_cycle.index) {
+                // `amount` less excess if withdrawing pending_inactive stake
+                pending_inactive = pending_inactive - amount
+            };
+            // escape excess stake from inactivation
+            stake::reactivate_stake(stake_pool_owner, pending_inactive);
+            stake::withdraw(stake_pool_owner, amount);
+            // restore excess stake to the pending_inactive state
+            stake::unlock(stake_pool_owner, pending_inactive);
+        } else {
+            // no excess stake if `stake::withdraw` does not inactivate at all
+            stake::withdraw(stake_pool_owner, amount);
+        };
+        coin::transfer<AptosCoin>(stake_pool_owner, delegator_address, amount);
+
+        // commit withdrawal of possibly inactive stake to the `total_coins_inactive`
+        // known by the delegation pool in order to not mistake it for slashing at next synchronization
+        let (_, inactive, _, _) = stake::get_stake(pool_address);
+        pool.total_coins_inactive = inactive;
+
+        event::emit_event(
+            &mut pool.withdraw_stake_events,
+            WithdrawStakeEvent {
+                pool_address,
+                delegator_address,
+                amount_withdrawn: amount,
+            },
+        );
+    }
+
+    /// Return the unique observed lockup cycle where delegator `delegator_address` may have
+    /// unlocking (or already unlocked) stake to be withdrawn from delegation pool `pool`.
+    /// A bool is returned to signal if a pending withdrawal exists at all.
+    fun pending_withdrawal_exists(pool: &DelegationPool, delegator_address: address): (bool, ObservedLockupCycle) {
+        if (table::contains(&pool.pending_withdrawals, delegator_address)) {
+            (true, *table::borrow(&pool.pending_withdrawals, delegator_address))
+        } else {
+            (false, olc_with_index(0))
+        }
+    }
+
+    /// Return a mutable reference to the shares pool of `pending_inactive` stake on the
+    /// delegation pool, always the last item in `inactive_shares`.
+    fun pending_inactive_shares_pool_mut(pool: &mut DelegationPool): &mut pool_u64::Pool {
+        let observed_lockup_cycle = pool.observed_lockup_cycle;
+        table::borrow_mut(&mut pool.inactive_shares, observed_lockup_cycle)
+    }
+
+    fun pending_inactive_shares_pool(pool: &DelegationPool): &pool_u64::Pool {
+        table::borrow(&pool.inactive_shares, pool.observed_lockup_cycle)
+    }
+
+    /// Execute the pending withdrawal of `delegator_address` on delegation pool `pool`
+    /// if existing and already inactive to allow the creation of a new one.
+    /// `pending_inactive` stake would be left untouched even if withdrawable and should
+    /// be explicitly withdrawn by delegator
+    fun execute_pending_withdrawal(pool: &mut DelegationPool, delegator_address: address) {
+        let (withdrawal_exists, withdrawal_olc) = pending_withdrawal_exists(pool, delegator_address);
+        if (withdrawal_exists && withdrawal_olc.index < pool.observed_lockup_cycle.index) {
+            withdraw_internal(pool, delegator_address, MAX_U64);
+        }
+    }
+
+    /// Buy shares into the pending_inactive pool on behalf of delegator `shareholder` who
+    /// redeemed `coins_amount` from the active pool to schedule it for unlocking.
+    /// If delegator's pending withdrawal exists and has been inactivated, execute it firstly
+    /// to ensure there is always only one withdrawal request.
+    fun buy_in_pending_inactive_shares(
+        pool: &mut DelegationPool,
+        shareholder: address,
+        coins_amount: u64,
+    ): u128 {
+        // cannot buy inactive shares, only pending_inactive at current lockup cycle
+        let new_shares = pool_u64::buy_in(pending_inactive_shares_pool_mut(pool), shareholder, coins_amount);
+        // never create a new pending withdrawal unless delegator owns some pending_inactive shares
+        if (new_shares == 0) { return 0 };
+
+        // execute the pending withdrawal if exists and is inactive before creating a new one
+        execute_pending_withdrawal(pool, shareholder);
+
+        // save observed lockup cycle for the new pending withdrawal
+        let observed_lockup_cycle = pool.observed_lockup_cycle;
+        assert!(*table::borrow_mut_with_default(
+            &mut pool.pending_withdrawals,
+            shareholder,
+            observed_lockup_cycle
+        ) == observed_lockup_cycle,
+            error::invalid_state(EPENDING_WITHDRAWAL_EXISTS)
+        );
+
+        new_shares
+    }
+
+    /// Convert `coins_amount` of coins to be redeemed from shares pool `shares_pool`
+    /// to the exact number of shares to redeem in order to achieve this.
+    fun amount_to_shares_to_redeem(
+        shares_pool: &pool_u64::Pool,
+        shareholder: address,
+        coins_amount: u64,
+    ): u128 {
+        if (coins_amount >= pool_u64::balance(shares_pool, shareholder)) {
+            // cap result at total shares of shareholder to pass `EINSUFFICIENT_SHARES` on subsequent redeem
+            pool_u64::shares(shares_pool, shareholder)
+        } else {
+            pool_u64::amount_to_shares(shares_pool, coins_amount)
+        }
+    }
+
+    /// Redeem shares from the active pool on behalf of delegator `shareholder` who
+    /// wants to unlock `coins_amount` of its active stake.
+    /// Extracted coins will be used to buy shares into the pending_inactive pool and
+    /// be available for withdrawal when current OLC ends.
+    fun redeem_active_shares(
+        pool: &mut DelegationPool,
+        shareholder: address,
+        coins_amount: u64,
+    ): u64 {
+        let shares_to_redeem = amount_to_shares_to_redeem(&pool.active_shares, shareholder, coins_amount);
+        // silently exit if not a shareholder otherwise redeem would fail with `ESHAREHOLDER_NOT_FOUND`
+        if (shares_to_redeem == 0) return 0;
+        pool_u64::redeem_shares(&mut pool.active_shares, shareholder, shares_to_redeem)
+    }
+
+    /// Redeem shares from the inactive pool at `lockup_cycle` < current OLC on behalf of
+    /// delegator `shareholder` who wants to withdraw `coins_amount` of its unlocked stake.
+    /// Redeem shares from the pending_inactive pool at `lockup_cycle` == current OLC on behalf of
+    /// delegator `shareholder` who wants to reactivate `coins_amount` of its unlocking stake.
+    /// For latter case, extracted coins will be used to buy shares into the active pool and
+    /// escape inactivation when current lockup ends.
+    fun redeem_inactive_shares(
+        pool: &mut DelegationPool,
+        shareholder: address,
+        coins_amount: u64,
+        lockup_cycle: ObservedLockupCycle,
+    ): u64 {
+        let inactive_shares = table::borrow_mut(&mut pool.inactive_shares, lockup_cycle);
+        let shares_to_redeem = amount_to_shares_to_redeem(inactive_shares, shareholder, coins_amount);
+        // silently exit if not a shareholder otherwise redeem would fail with `ESHAREHOLDER_NOT_FOUND`
+        if (shares_to_redeem == 0) return 0;
+        // 1. reaching here means delegator owns inactive/pending_inactive shares at OLC `lockup_cycle`
+        let redeemed_coins = pool_u64::redeem_shares(inactive_shares, shareholder, shares_to_redeem);
+
+        // if entirely reactivated pending_inactive stake or withdrawn inactive one,
+        // re-enable unlocking for delegator by deleting this pending withdrawal
+        if (pool_u64::shares(inactive_shares, shareholder) == 0) {
+            // 2. a delegator owns inactive/pending_inactive shares only at the OLC of its pending withdrawal
+            // 1 & 2: the pending withdrawal itself has been emptied of shares and can be safely deleted
+            table::remove(&mut pool.pending_withdrawals, shareholder);
+        };
+        // destroy inactive shares pool of past OLC if all its stake has been withdrawn
+        if (lockup_cycle.index < pool.observed_lockup_cycle.index && total_coins(inactive_shares) == 0) {
+            pool_u64::destroy_empty(table::remove(&mut pool.inactive_shares, lockup_cycle));
+        };
+
+        redeemed_coins
+    }
+
+    /// Calculate stake deviations between the delegation and stake pools in order to
+    /// capture the rewards earned in the meantime, resulted operator commission and
+    /// whether the lockup expired on the stake pool.
+    fun calculate_stake_pool_drift(pool: &DelegationPool): (bool, u64, u64, u64, u64) {
+        let (active, inactive, pending_active, pending_inactive) = stake::get_stake(get_pool_address(pool));
+        assert!(
+            inactive >= pool.total_coins_inactive,
+            error::invalid_state(ESLASHED_INACTIVE_STAKE_ON_PAST_OLC)
+        );
+        // determine whether a new lockup cycle has been ended on the stake pool and
+        // inactivated SOME `pending_inactive` stake which should stop earning rewards now,
+        // thus requiring separation of the `pending_inactive` stake on current observed lockup
+        // and the future one on the newly started lockup
+        let lockup_cycle_ended = inactive > pool.total_coins_inactive;
+
+        // actual coins on stake pool belonging to the active shares pool
+        active = active + pending_active;
+        // actual coins on stake pool belonging to the shares pool hosting `pending_inactive` stake
+        // at current observed lockup cycle, either pending: `pending_inactive` or already inactivated:
+        if (lockup_cycle_ended) {
+            // `inactive` on stake pool = any previous `inactive` stake +
+            // any previous `pending_inactive` stake and its rewards (both inactivated)
+            pending_inactive = inactive - pool.total_coins_inactive
+        };
+
+        // on stake-management operations, total coins on the internal shares pools and individual
+        // stakes on the stake pool are updated simultaneously, thus the only stakes becoming
+        // unsynced are rewards and slashes routed exclusively to/out the stake pool
+
+        // operator `active` rewards not persisted yet to the active shares pool
+        let commission_active = total_coins(&pool.active_shares);
+        commission_active = if (active > commission_active) {
+            multiply_then_divide(active - commission_active, pool.operator_commission_percentage, MAX_FEE)
+        } else {
+            // handle any slashing applied to `active` stake
+            0
+        };
+        // operator `pending_inactive` rewards not persisted yet to the pending_inactive shares pool
+        let commission_pending_inactive = total_coins(pending_inactive_shares_pool(pool));
+        commission_pending_inactive = if (pending_inactive > commission_pending_inactive) {
+            multiply_then_divide(
+                pending_inactive - commission_pending_inactive,
+                pool.operator_commission_percentage,
+                MAX_FEE
+            )
+        } else {
+            // handle any slashing applied to `pending_inactive` stake
+            0
+        };
+
+        (lockup_cycle_ended, active, pending_inactive, commission_active, commission_pending_inactive)
+    }
+
+    /// Synchronize delegation and stake pools: distribute yet-undetected rewards to the corresponding internal
+    /// shares pools, assign commission to operator and eventually prepare delegation pool for a new lockup cycle.
+    public entry fun synchronize_delegation_pool(pool_address: address) acquires DelegationPool {
+        assert_delegation_pool_exists(pool_address);
+        let pool = borrow_global_mut<DelegationPool>(pool_address);
+        let (
+            lockup_cycle_ended,
+            active,
+            pending_inactive,
+            commission_active,
+            commission_pending_inactive
+        ) = calculate_stake_pool_drift(pool);
+
+        // zero `pending_active` stake indicates that either there are no `add_stake` fees or
+        // previous epoch has ended and should release the shares owning the existing fees
+        let (_, _, pending_active, _) = stake::get_stake(pool_address);
+        if (pending_active == 0) {
+            // renounce ownership over the `add_stake` fees by redeeming all shares of
+            // the special shareholder, implicitly their equivalent coins, out of the active shares pool
+            redeem_active_shares(pool, NULL_SHAREHOLDER, MAX_U64);
+        };
+
+        // distribute rewards remaining after commission, to delegators (to already existing shares)
+        // before buying shares for the operator for its entire commission fee
+        // otherwise, operator's new shares would additionally appreciate from rewards it does not own
+
+        // update total coins accumulated by `active` + `pending_active` shares
+        // redeemed `add_stake` fees are restored and distributed to the rest of the pool as rewards
+        pool_u64::update_total_coins(&mut pool.active_shares, active - commission_active);
+        // update total coins accumulated by `pending_inactive` shares at current observed lockup cycle
+        pool_u64::update_total_coins(
+            pending_inactive_shares_pool_mut(pool),
+            pending_inactive - commission_pending_inactive
+        );
+
+        // reward operator its commission out of uncommitted active rewards (`add_stake` fees already excluded)
+        pool_u64::buy_in(&mut pool.active_shares, stake::get_operator(pool_address), commission_active);
+        // reward operator its commission out of uncommitted pending_inactive rewards
+        buy_in_pending_inactive_shares(pool, stake::get_operator(pool_address), commission_pending_inactive);
+
+        event::emit_event(
+            &mut pool.distribute_commission_events,
+            DistributeCommissionEvent {
+                pool_address,
+                operator: stake::get_operator(pool_address),
+                commission_active,
+                commission_pending_inactive,
+            },
+        );
+
+        // advance lockup cycle on delegation pool if already ended on stake pool (AND stake explicitly inactivated)
+        if (lockup_cycle_ended) {
+            // capture inactive coins over all ended lockup cycles (including this ending one)
+            let (_, inactive, _, _) = stake::get_stake(pool_address);
+            pool.total_coins_inactive = inactive;
+
+            // advance lockup cycle on the delegation pool
+            pool.observed_lockup_cycle.index = pool.observed_lockup_cycle.index + 1;
+            // start new lockup cycle with a fresh shares pool for `pending_inactive` stake
+            table::add(
+                &mut pool.inactive_shares,
+                pool.observed_lockup_cycle,
+                pool_u64::create_with_scaling_factor(SHARES_SCALING_FACTOR)
+            );
+        }
+    }
+
+    public fun multiply_then_divide(x: u64, y: u64, z: u64): u64 {
+        let result = (to_u128(x) * to_u128(y)) / to_u128(z);
+        (result as u64)
+    }
+
+    fun to_u128(num: u64): u128 {
+        (num as u128)
+    }
+
+    #[test_only]
+    use aptos_framework::reconfiguration;
+
+    #[test_only]
+    const CONSENSUS_KEY_1: vector<u8> = x"8a54b92288d4ba5073d3a52e80cc00ae9fbbc1cc5b433b46089b7804c38a76f00fc64746c7685ee628fc2d0b929c2294";
+    #[test_only]
+    const CONSENSUS_POP_1: vector<u8> = x"a9d6c1f1270f2d1454c89a83a4099f813a56dc7db55591d46aa4e6ccae7898b234029ba7052f18755e6fa5e6b73e235f14efc4e2eb402ca2b8f56bad69f965fc11b7b25eb1c95a06f83ddfd023eac4559b6582696cfea97b227f4ce5bdfdfed0";
+
+    #[test_only]
+    const EPOCH_DURATION: u64 = 60;
+    #[test_only]
+    const LOCKUP_CYCLE_SECONDS: u64 = 3600;
+
+    #[test_only]
+    const ONE_APT: u64 = 100000000;
+
+    #[test_only]
+    const VALIDATOR_STATUS_PENDING_ACTIVE: u64 = 1;
+    #[test_only]
+    const VALIDATOR_STATUS_ACTIVE: u64 = 2;
+    #[test_only]
+    const VALIDATOR_STATUS_PENDING_INACTIVE: u64 = 3;
+
+    #[test_only]
+    const DELEGATION_POOLS: u64 = 11;
+
+    #[test_only]
+    public fun end_aptos_epoch() {
+        stake::end_epoch(); // additionally forwards EPOCH_DURATION seconds
+        reconfiguration::reconfigure_for_test_custom();
+    }
+
+    #[test_only]
+    public fun initialize_for_test(aptos_framework: &signer) {
+        initialize_for_test_custom(
+            aptos_framework,
+            100 * ONE_APT,
+            10000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            100,
+            1000000
+        );
+    }
+
+    #[test_only]
+    public fun initialize_for_test_custom(
+        aptos_framework: &signer,
+        minimum_stake: u64,
+        maximum_stake: u64,
+        recurring_lockup_secs: u64,
+        allow_validator_set_change: bool,
+        rewards_rate_numerator: u64,
+        rewards_rate_denominator: u64,
+        voting_power_increase_limit: u64,
+    ) {
+        account::create_account_for_test(signer::address_of(aptos_framework));
+        stake::initialize_for_test_custom(
+            aptos_framework,
+            minimum_stake,
+            maximum_stake,
+            recurring_lockup_secs,
+            allow_validator_set_change,
+            rewards_rate_numerator,
+            rewards_rate_denominator,
+            voting_power_increase_limit,
+        );
+        reconfiguration::initialize_for_test(aptos_framework);
+        features::change_feature_flags(aptos_framework, vector[DELEGATION_POOLS], vector[]);
+    }
+
+    #[test_only]
+    public fun initialize_test_validator(
+        validator: &signer,
+        amount: u64,
+        should_join_validator_set: bool,
+        should_end_epoch: bool,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        let validator_address = signer::address_of(validator);
+        if (!account::exists_at(validator_address)) {
+            account::create_account_for_test(validator_address);
+        };
+
+        initialize_delegation_pool(validator, 0, vector::empty<u8>());
+        let pool_address = get_owned_pool_address(validator_address);
+
+        stake::rotate_consensus_key(validator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1);
+
+        if (amount > 0) {
+            stake::mint(validator, amount);
+            add_stake(validator, pool_address, amount);
+        };
+
+        if (should_join_validator_set) {
+            stake::join_validator_set(validator, pool_address);
+        };
+
+        if (should_end_epoch) {
+            end_aptos_epoch();
+        };
+    }
+
+    #[test_only]
+    fun unlock_with_min_stake_disabled(
+        delegator: &signer,
+        pool_address: address,
+        amount: u64
+    ) acquires DelegationPool {
+        synchronize_delegation_pool(pool_address);
+
+        let pool = borrow_global_mut<DelegationPool>(pool_address);
+        let delegator_address = signer::address_of(delegator);
+
+        amount = redeem_active_shares(pool, delegator_address, amount);
+        stake::unlock(&retrieve_stake_pool_owner(pool), amount);
+        buy_in_pending_inactive_shares(pool, delegator_address, amount);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    #[expected_failure(abort_code = 0x3000A, location = Self)]
+    public entry fun test_delegation_pools_disabled(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        features::change_feature_flags(aptos_framework, vector[], vector[DELEGATION_POOLS]);
+
+        initialize_delegation_pool(validator, 0, vector::empty<u8>());
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    public entry fun test_set_operator_and_delegated_voter(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+
+        let validator_address = signer::address_of(validator);
+        initialize_delegation_pool(validator, 0, vector::empty<u8>());
+        let pool_address = get_owned_pool_address(validator_address);
+
+        assert!(stake::get_operator(pool_address) == @0x123, 1);
+        assert!(stake::get_delegated_voter(pool_address) == @0x123, 1);
+
+        set_operator(validator, @0x111);
+        assert!(stake::get_operator(pool_address) == @0x111, 2);
+
+        set_delegated_voter(validator, @0x112);
+        assert!(stake::get_delegated_voter(pool_address) == @0x112, 2);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    #[expected_failure(abort_code = 0x60001, location = Self)]
+    public entry fun test_cannot_set_operator(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        // account does not own any delegation pool
+        set_operator(validator, @0x111);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    #[expected_failure(abort_code = 0x60001, location = Self)]
+    public entry fun test_cannot_set_delegated_voter(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        // account does not own any delegation pool
+        set_delegated_voter(validator, @0x112);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    #[expected_failure(abort_code = 0x80002, location = Self)]
+    public entry fun test_already_owns_delegation_pool(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        initialize_delegation_pool(validator, 0, x"00");
+        initialize_delegation_pool(validator, 0, x"01");
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    #[expected_failure(abort_code = 0x1000B, location = Self)]
+    public entry fun test_cannot_withdraw_zero_stake(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        initialize_delegation_pool(validator, 0, x"00");
+        withdraw(validator, get_owned_pool_address(signer::address_of(validator)), 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    public entry fun test_initialize_delegation_pool(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+
+        let validator_address = signer::address_of(validator);
+        initialize_delegation_pool(validator, 1234, vector::empty<u8>());
+
+        assert_owner_cap_exists(validator_address);
+        let pool_address = get_owned_pool_address(validator_address);
+        assert_delegation_pool_exists(pool_address);
+
+        assert!(stake::stake_pool_exists(pool_address), 0);
+        assert!(stake::get_operator(pool_address) == validator_address, 0);
+        assert!(stake::get_delegated_voter(pool_address) == validator_address, 0);
+
+        assert!(observed_lockup_cycle(pool_address) == 0, 0);
+        assert!(total_coins_inactive(pool_address) == 0, 0);
+        assert!(operator_commission_percentage(pool_address) == 1234, 0);
+        assert_inactive_shares_pool(pool_address, 0, true, 0);
+        stake::assert_stake_pool(pool_address, 0, 0, 0, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator1 = @0x010, delegator2 = @0x020)]
+    public entry fun test_add_stake_fee(
+        aptos_framework: &signer,
+        validator: &signer,
+        delegator1: &signer,
+        delegator2: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test_custom(
+            aptos_framework,
+            100 * ONE_APT,
+            10000000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            100,
+            1000000
+        );
+
+        let validator_address = signer::address_of(validator);
+        account::create_account_for_test(validator_address);
+
+        // create delegation pool with 37.35% operator commission
+        initialize_delegation_pool(validator, 3735, vector::empty<u8>());
+        let pool_address = get_owned_pool_address(validator_address);
+
+        stake::rotate_consensus_key(validator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1);
+
+        // zero `add_stake` fee as validator is not producing rewards this epoch
+        assert!(get_add_stake_fee(pool_address, 1000000 * ONE_APT) == 0, 0);
+
+        // add 1M APT, join the validator set and activate this stake
+        stake::mint(validator, 1000000 * ONE_APT);
+        add_stake(validator, pool_address, 1000000 * ONE_APT);
+
+        stake::join_validator_set(validator, pool_address);
+        end_aptos_epoch();
+
+        let delegator1_address = signer::address_of(delegator1);
+        account::create_account_for_test(delegator1_address);
+
+        let delegator2_address = signer::address_of(delegator2);
+        account::create_account_for_test(delegator2_address);
+
+        // `add_stake` fee for 100000 coins: 100000 * 0.006265 / (1 + 0.006265)
+        assert!(get_add_stake_fee(pool_address, 100000 * ONE_APT) == 62259941466, 0);
+
+        // add pending_active stake from multiple delegators
+        stake::mint(delegator1, 100000 * ONE_APT);
+        add_stake(delegator1, pool_address, 100000 * ONE_APT);
+        stake::mint(delegator2, 10000 * ONE_APT);
+        add_stake(delegator2, pool_address, 10000 * ONE_APT);
+
+        end_aptos_epoch();
+        // delegators should own the same amount as initially deposited
+        assert_delegation(delegator1_address, pool_address, 10000000000000, 0, 0);
+        assert_delegation(delegator2_address, pool_address, 1000000000000, 0, 0);
+
+        // add more stake from delegator 1
+        stake::mint(delegator1, 10000 * ONE_APT);
+        let (delegator1_active, _, _) = get_stake(pool_address, delegator1_address);
+        add_stake(delegator1, pool_address, 10000 * ONE_APT);
+
+        let fee = get_add_stake_fee(pool_address, 10000 * ONE_APT);
+        assert_delegation(delegator1_address, pool_address, delegator1_active + 10000 * ONE_APT - fee, 0, 0);
+
+        // delegator 2 should not benefit in any way from this new stake
+        assert_delegation(delegator2_address, pool_address, 1000000000000, 0, 0);
+
+        // add more stake from delegator 2
+        stake::mint(delegator2, 100000 * ONE_APT);
+        add_stake(delegator2, pool_address, 100000 * ONE_APT);
+
+        end_aptos_epoch();
+        // delegators should own the same amount as initially deposited + any rewards produced
+        // 10000000000000 * 1% * (100 - 37.35)%
+        assert_delegation(delegator1_address, pool_address, 11062650000001, 0, 0);
+        // 1000000000000 * 1% * (100 - 37.35)%
+        assert_delegation(delegator2_address, pool_address, 11006265000001, 0, 0);
+
+        // in-flight operator commission rewards do not automatically restake/compound
+        synchronize_delegation_pool(pool_address);
+
+        // stakes should remain the same - `Self::get_stake` correctly calculates them
+        assert_delegation(delegator1_address, pool_address, 11062650000001, 0, 0);
+        assert_delegation(delegator2_address, pool_address, 11006265000001, 0, 0);
+
+        end_aptos_epoch();
+        // delegators should own previous stake * 1.006265
+        assert_delegation(delegator1_address, pool_address, 11131957502251, 0, 0);
+        assert_delegation(delegator2_address, pool_address, 11075219250226, 0, 0);
+
+        // add more stake from delegator 1
+        stake::mint(delegator1, 20000 * ONE_APT);
+        (delegator1_active, _, _) = get_stake(pool_address, delegator1_address);
+        add_stake(delegator1, pool_address, 20000 * ONE_APT);
+
+        fee = get_add_stake_fee(pool_address, 20000 * ONE_APT);
+        assert_delegation(delegator1_address, pool_address, delegator1_active + 20000 * ONE_APT - fee, 0, 0);
+
+        // delegator 1 unlocks his entire newly added stake
+        unlock(delegator1, pool_address, 20000 * ONE_APT - fee);
+        end_aptos_epoch();
+        // delegator 1 should own previous 11131957502250 active * 1.006265 and 20000 coins pending_inactive
+        assert_delegation(delegator1_address, pool_address, 11201699216002, 0, 2000000000000);
+
+        // stakes should remain the same - `Self::get_stake` correctly calculates them
+        synchronize_delegation_pool(pool_address);
+        assert_delegation(delegator1_address, pool_address, 11201699216002, 0, 2000000000000);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator = @0x010)]
+    public entry fun test_never_create_pending_withdrawal_if_no_shares_bought(
+        aptos_framework: &signer,
+        validator: &signer,
+        delegator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        initialize_test_validator(validator, 1000 * ONE_APT, true, false);
+
+        let validator_address = signer::address_of(validator);
+        let pool_address = get_owned_pool_address(validator_address);
+
+        let delegator_address = signer::address_of(delegator);
+        account::create_account_for_test(delegator_address);
+
+        // add stake without fees as validator is not active yet
+        stake::mint(delegator, 10 * ONE_APT);
+        add_stake(delegator, pool_address, 10 * ONE_APT);
+        end_aptos_epoch();
+
+        unlock(validator, pool_address, 100 * ONE_APT);
+
+        stake::assert_stake_pool(pool_address, 91000000000, 0, 0, 10000000000);
+        end_aptos_epoch();
+        stake::assert_stake_pool(pool_address, 91910000000, 0, 0, 10100000000);
+
+        unlock_with_min_stake_disabled(delegator, pool_address, 1);
+        // request 1 coins * 910 / 919.1 = 0.99 shares to redeem * 1.01 price -> 0 coins out
+        // 1 coins lost at redeem due to 0.99 shares being burned
+        assert_delegation(delegator_address, pool_address, 1009999999, 0, 0);
+        assert_pending_withdrawal(delegator_address, pool_address, false, 0, false, 0);
+
+        unlock_with_min_stake_disabled(delegator, pool_address, 2);
+        // request 2 coins * 909.99 / 919.1 = 1.98 shares to redeem * 1.01 price -> 1 coins out
+        // with 1 coins buy 1 * 100 / 101 = 0.99 shares in pending_inactive pool * 1.01 -> 0 coins in
+        // 1 coins lost at redeem due to 1.98 - 1.01 shares being burned + 1 coins extracted
+        synchronize_delegation_pool(pool_address);
+        assert_delegation(delegator_address, pool_address, 1009999997, 0, 0);
+        // the pending withdrawal has been created as > 0 pending_inactive shares have been bought
+        assert_pending_withdrawal(delegator_address, pool_address, true, 0, false, 0);
+
+        // successfully delete the pending withdrawal (redeem all owned shares even worth 0 coins)
+        reactivate_stake(delegator, pool_address, 1);
+        assert_delegation(delegator_address, pool_address, 1009999997, 0, 0);
+        assert_pending_withdrawal(delegator_address, pool_address, false, 0, false, 0);
+
+        // unlock min coins to own some pending_inactive balance (have to disable min-balance checks)
+        unlock_with_min_stake_disabled(delegator, pool_address, 3);
+        // request 3 coins * 909.99 / 919.09 = 2.97 shares to redeem * 1.01 price -> 2 coins out
+        // with 2 coins buy 2 * 100 / 101 = 1.98 shares in pending_inactive pool * 1.01 -> 1 coins in
+        // 1 coins lost at redeem due to 2.97 - 2 * 1.01 shares being burned + 2 coins extracted
+        synchronize_delegation_pool(pool_address);
+        assert_delegation(delegator_address, pool_address, 1009999994, 0, 1);
+        // the pending withdrawal has been created as > 0 pending_inactive shares have been bought
+        assert_pending_withdrawal(delegator_address, pool_address, true, 0, false, 1);
+
+        reactivate_stake(delegator, pool_address, 1);
+        // redeem 1 coins >= delegator balance -> all shares are redeemed and pending withdrawal is deleted
+        assert_delegation(delegator_address, pool_address, 1009999995, 0, 0);
+        // the pending withdrawal has been deleted as delegator has 0 pending_inactive shares now
+        assert_pending_withdrawal(delegator_address, pool_address, false, 0, false, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    #[expected_failure(abort_code = 0x10008, location = Self)]
+    public entry fun test_add_stake_min_amount(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        initialize_test_validator(validator, MIN_COINS_ON_SHARES_POOL - 1, false, false);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    public entry fun test_add_stake_single(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        initialize_test_validator(validator, 1000 * ONE_APT, false, false);
+
+        let validator_address = signer::address_of(validator);
+        let pool_address = get_owned_pool_address(validator_address);
+
+        // validator is inactive => added stake is `active` by default
+        stake::assert_stake_pool(pool_address, 1000 * ONE_APT, 0, 0, 0);
+        assert_delegation(validator_address, pool_address, 1000 * ONE_APT, 0, 0);
+
+        // zero `add_stake` fee as validator is not producing rewards this epoch
+        assert!(get_add_stake_fee(pool_address, 250 * ONE_APT) == 0, 0);
+
+        // check `add_stake` increases `active` stakes of delegator and stake pool
+        stake::mint(validator, 300 * ONE_APT);
+        let balance = coin::balance<AptosCoin>(validator_address);
+        add_stake(validator, pool_address, 250 * ONE_APT);
+
+        // check added stake have been transferred out of delegator account
+        assert!(coin::balance<AptosCoin>(validator_address) == balance - 250 * ONE_APT, 0);
+        // zero `add_stake` fee charged from added stake
+        assert_delegation(validator_address, pool_address, 1250 * ONE_APT, 0, 0);
+        // zero `add_stake` fee transferred to null shareholder
+        assert_delegation(NULL_SHAREHOLDER, pool_address, 0, 0, 0);
+        // added stake is automatically `active` on inactive validator
+        stake::assert_stake_pool(pool_address, 1250 * ONE_APT, 0, 0, 0);
+
+        // activate validator
+        stake::join_validator_set(validator, pool_address);
+        end_aptos_epoch();
+
+        // add 250 coins being pending_active until next epoch
+        stake::mint(validator, 250 * ONE_APT);
+        add_stake(validator, pool_address, 250 * ONE_APT);
+
+        let fee1 = get_add_stake_fee(pool_address, 250 * ONE_APT);
+        assert_delegation(validator_address, pool_address, 1500 * ONE_APT - fee1, 0, 0);
+        // check `add_stake` fee has been transferred to the null shareholder
+        assert_delegation(NULL_SHAREHOLDER, pool_address, fee1, 0, 0);
+        stake::assert_stake_pool(pool_address, 1250 * ONE_APT, 0, 250 * ONE_APT, 0);
+
+        // add 100 additional coins being pending_active until next epoch
+        stake::mint(validator, 100 * ONE_APT);
+        add_stake(validator, pool_address, 100 * ONE_APT);
+
+        let fee2 = get_add_stake_fee(pool_address, 100 * ONE_APT);
+        assert_delegation(validator_address, pool_address, 1600 * ONE_APT - fee1 - fee2, 0, 0);
+        // check `add_stake` fee has been transferred to the null shareholder
+        assert_delegation(NULL_SHAREHOLDER, pool_address, fee1 + fee2, 0, 0);
+        stake::assert_stake_pool(pool_address, 1250 * ONE_APT, 0, 350 * ONE_APT, 0);
+
+        end_aptos_epoch();
+        // delegator got its `add_stake` fees back + 1250 * 1% * (100% - 0%) active rewards
+        assert_delegation(validator_address, pool_address, 161250000000, 0, 0);
+        stake::assert_stake_pool(pool_address, 161250000000, 0, 0, 0);
+
+        // check that shares of null shareholder have been released
+        assert_delegation(NULL_SHAREHOLDER, pool_address, 0, 0, 0);
+        synchronize_delegation_pool(pool_address);
+        assert!(pool_u64::shares(&borrow_global<DelegationPool>(pool_address).active_shares, NULL_SHAREHOLDER) == 0, 0);
+        assert_delegation(NULL_SHAREHOLDER, pool_address, 0, 0, 0);
+
+        // add 200 coins being pending_active until next epoch
+        stake::mint(validator, 200 * ONE_APT);
+        add_stake(validator, pool_address, 200 * ONE_APT);
+
+        fee1 = get_add_stake_fee(pool_address, 200 * ONE_APT);
+        assert_delegation(validator_address, pool_address, 181250000000 - fee1, 0, 0);
+        // check `add_stake` fee has been transferred to the null shareholder
+        assert_delegation(NULL_SHAREHOLDER, pool_address, fee1 - 1, 0, 0);
+        stake::assert_stake_pool(pool_address, 161250000000, 0, 20000000000, 0);
+
+        end_aptos_epoch();
+        // delegator got its `add_stake` fee back + 161250000000 * 1% active rewards
+        assert_delegation(validator_address, pool_address, 182862500000, 0, 0);
+        stake::assert_stake_pool(pool_address, 182862500000, 0, 0, 0);
+
+        // check that shares of null shareholder have been released
+        assert_delegation(NULL_SHAREHOLDER, pool_address, 0, 0, 0);
+        synchronize_delegation_pool(pool_address);
+        assert!(pool_u64::shares(&borrow_global<DelegationPool>(pool_address).active_shares, NULL_SHAREHOLDER) == 0, 0);
+        assert_delegation(NULL_SHAREHOLDER, pool_address, 0, 0, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator = @0x010)]
+    public entry fun test_add_stake_many(
+        aptos_framework: &signer,
+        validator: &signer,
+        delegator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        initialize_test_validator(validator, 1000 * ONE_APT, true, true);
+
+        let validator_address = signer::address_of(validator);
+        let pool_address = get_owned_pool_address(validator_address);
+
+        let delegator_address = signer::address_of(delegator);
+        account::create_account_for_test(delegator_address);
+
+        stake::assert_stake_pool(pool_address, 1000 * ONE_APT, 0, 0, 0);
+        assert_delegation(validator_address, pool_address, 1000 * ONE_APT, 0, 0);
+
+        // add 250 coins from second account
+        stake::mint(delegator, 250 * ONE_APT);
+        add_stake(delegator, pool_address, 250 * ONE_APT);
+
+        let fee1 = get_add_stake_fee(pool_address, 250 * ONE_APT);
+        assert_delegation(delegator_address, pool_address, 250 * ONE_APT - fee1, 0, 0);
+        assert_delegation(validator_address, pool_address, 1000 * ONE_APT, 0, 0);
+        stake::assert_stake_pool(pool_address, 1000 * ONE_APT, 0, 250 * ONE_APT, 0);
+
+        end_aptos_epoch();
+        // 1000 * 1.01 active stake + 250 pending_active stake
+        stake::assert_stake_pool(pool_address, 1260 * ONE_APT, 0, 0, 0);
+        // delegator got its `add_stake` fee back
+        assert_delegation(delegator_address, pool_address, 250 * ONE_APT, 0, 0);
+        // actual active rewards have been distributed to their earner(s)
+        assert_delegation(validator_address, pool_address, 100999999999, 0, 0);
+
+        // add another 250 coins from first account
+        stake::mint(validator, 250 * ONE_APT);
+        add_stake(validator, pool_address, 250 * ONE_APT);
+
+        fee1 = get_add_stake_fee(pool_address, 250 * ONE_APT);
+        assert_delegation(validator_address, pool_address, 125999999999 - fee1, 0, 0);
+        assert_delegation(delegator_address, pool_address, 250 * ONE_APT, 0, 0);
+        stake::assert_stake_pool(pool_address, 1260 * ONE_APT, 0, 250 * ONE_APT, 0);
+
+        // add another 100 coins from second account
+        stake::mint(delegator, 100 * ONE_APT);
+        add_stake(delegator, pool_address, 100 * ONE_APT);
+
+        let fee2 = get_add_stake_fee(pool_address, 100 * ONE_APT);
+        assert_delegation(delegator_address, pool_address, 350 * ONE_APT - fee2, 0, 0);
+        assert_delegation(validator_address, pool_address, 125999999999 - fee1, 0, 0);
+        stake::assert_stake_pool(pool_address, 1260 * ONE_APT, 0, 350 * ONE_APT, 0);
+
+        end_aptos_epoch();
+        // both delegators got their `add_stake` fees back
+        // 250 * 1.01 active stake + 100 pending_active stake
+        assert_delegation(delegator_address, pool_address, 35250000001, 0, 0);
+        // 1010 * 1.01 active stake + 250 pending_active stake
+        assert_delegation(validator_address, pool_address, 127009999998, 0, 0);
+        stake::assert_stake_pool(pool_address, 162260000000, 0, 0, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator = @0x010)]
+    public entry fun test_unlock_single(
+        aptos_framework: &signer,
+        validator: &signer,
+        delegator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        initialize_test_validator(validator, 100 * ONE_APT, true, true);
+
+        let validator_address = signer::address_of(validator);
+        let pool_address = get_owned_pool_address(validator_address);
+
+        let delegator_address = signer::address_of(delegator);
+        account::create_account_for_test(delegator_address);
+
+        // add 200 coins pending_active until next epoch
+        stake::mint(validator, 200 * ONE_APT);
+        add_stake(validator, pool_address, 200 * ONE_APT);
+
+        let fee = get_add_stake_fee(pool_address, 200 * ONE_APT);
+        assert_delegation(validator_address, pool_address, 300 * ONE_APT - fee, 0, 0);
+        stake::assert_stake_pool(pool_address, 100 * ONE_APT, 0, 200 * ONE_APT, 0);
+
+        // cannot unlock pending_active stake (only 100/300 stake can be displaced)
+        unlock(validator, pool_address, 100 * ONE_APT);
+        assert_delegation(validator_address, pool_address, 200 * ONE_APT - fee, 0, 100 * ONE_APT);
+        assert_pending_withdrawal(validator_address, pool_address, true, 0, false, 100 * ONE_APT);
+        stake::assert_stake_pool(pool_address, 0, 0, 200 * ONE_APT, 100 * ONE_APT);
+        assert_inactive_shares_pool(pool_address, 0, true, 100 * ONE_APT);
+
+        // reactivate entire pending_inactive stake progressively
+        reactivate_stake(validator, pool_address, 50 * ONE_APT);
+
+        assert_delegation(validator_address, pool_address, 250 * ONE_APT - fee, 0, 50 * ONE_APT);
+        assert_pending_withdrawal(validator_address, pool_address, true, 0, false, 50 * ONE_APT);
+        stake::assert_stake_pool(pool_address, 50 * ONE_APT, 0, 200 * ONE_APT, 50 * ONE_APT);
+
+        reactivate_stake(validator, pool_address, 50 * ONE_APT);
+
+        assert_delegation(validator_address, pool_address, 300 * ONE_APT - fee, 0, 0);
+        assert_pending_withdrawal(validator_address, pool_address, false, 0, false, 0);
+        stake::assert_stake_pool(pool_address, 100 * ONE_APT, 0, 200 * ONE_APT, 0);
+        // pending_inactive shares pool has not been deleted (as can still `unlock` this OLC)
+        assert_inactive_shares_pool(pool_address, 0, true, 0);
+
+        end_aptos_epoch();
+        // 10000000000 * 1.01 active stake + 20000000000 pending_active stake
+        assert_delegation(validator_address, pool_address, 301 * ONE_APT, 0, 0);
+        stake::assert_stake_pool(pool_address, 301 * ONE_APT, 0, 0, 0);
+
+        // can unlock more than at previous epoch as the pending_active stake became active
+        unlock(validator, pool_address, 150 * ONE_APT);
+        assert_delegation(validator_address, pool_address, 15100000001, 0, 14999999999);
+        stake::assert_stake_pool(pool_address, 15100000001, 0, 0, 14999999999);
+        assert_pending_withdrawal(validator_address, pool_address, true, 0, false, 14999999999);
+
+        assert!(stake::get_remaining_lockup_secs(pool_address) == LOCKUP_CYCLE_SECONDS - EPOCH_DURATION, 0);
+        end_aptos_epoch(); // additionally forwards EPOCH_DURATION seconds
+
+        // pending_inactive stake should have not been inactivated
+        // 15100000001 * 1.01 active stake + 14999999999 pending_inactive * 1.01 stake
+        assert_delegation(validator_address, pool_address, 15251000001, 0, 15149999998);
+        assert_pending_withdrawal(validator_address, pool_address, true, 0, false, 15149999998);
+        stake::assert_stake_pool(pool_address, 15251000001, 0, 0, 15149999998);
+
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS - 3 * EPOCH_DURATION);
+        end_aptos_epoch(); // additionally forwards EPOCH_DURATION seconds and expires lockup cycle
+
+        // 15251000001 * 1.01 active stake + 15149999998 * 1.01 pending_inactive(now inactive) stake
+        assert_delegation(validator_address, pool_address, 15403510001, 15301499997, 0);
+        assert_pending_withdrawal(validator_address, pool_address, true, 0, true, 15301499997);
+        stake::assert_stake_pool(pool_address, 15403510001, 15301499997, 0, 0);
+
+        // add 50 coins from another account
+        stake::mint(delegator, 50 * ONE_APT);
+        add_stake(delegator, pool_address, 50 * ONE_APT);
+
+        // observed lockup cycle should have advanced at `add_stake`(on synchronization)
+        assert!(observed_lockup_cycle(pool_address) == 1, 0);
+
+        fee = get_add_stake_fee(pool_address, 50 * ONE_APT);
+        assert_delegation(delegator_address, pool_address, 4999999999 - fee, 0, 0);
+        assert_delegation(validator_address, pool_address, 15403510001, 15301499997, 0);
+        stake::assert_stake_pool(pool_address, 15403510001, 15301499997, 50 * ONE_APT, 0);
+
+        // cannot withdraw stake unlocked by others
+        withdraw(delegator, pool_address, 50 * ONE_APT);
+        assert!(coin::balance<AptosCoin>(delegator_address) == 0, 0);
+
+        // withdraw own unlocked stake
+        withdraw(validator, pool_address, 15301499997);
+        assert!(coin::balance<AptosCoin>(validator_address) == 15301499997, 0);
+        assert_delegation(validator_address, pool_address, 15403510001, 0, 0);
+        // pending withdrawal has been executed and deleted
+        assert_pending_withdrawal(validator_address, pool_address, false, 0, false, 0);
+        // inactive shares pool on OLC 0 has been deleted because its stake has been withdrawn
+        assert_inactive_shares_pool(pool_address, 0, false, 0);
+
+        // new pending withdrawal can be created on lockup cycle 1
+        unlock(validator, pool_address, 5403510001);
+        assert_delegation(validator_address, pool_address, 10000000000, 0, 5403510000);
+        assert_pending_withdrawal(validator_address, pool_address, true, 1, false, 5403510000);
+
+        // end lockup cycle 1
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_aptos_epoch();
+
+        // 10000000000 * 1.01 active stake + 5403510000 * 1.01 pending_inactive(now inactive) stake
+        assert_delegation(validator_address, pool_address, 10100000000, 5457545100, 0);
+        assert_pending_withdrawal(validator_address, pool_address, true, 1, true, 5457545100);
+
+        // unlock when the pending withdrawal exists and gets automatically executed
+        let balance = coin::balance<AptosCoin>(validator_address);
+        unlock(validator, pool_address, 10100000000);
+        assert!(coin::balance<AptosCoin>(validator_address) == balance + 5457545100, 0);
+        assert_delegation(validator_address, pool_address, 0, 0, 10100000000);
+        // this is the new pending withdrawal replacing the executed one
+        assert_pending_withdrawal(validator_address, pool_address, true, 2, false, 10100000000);
+
+        // create dummy validator to ensure the existing validator can leave the set
+        initialize_test_validator(delegator, 100 * ONE_APT, true, true);
+        // inactivate validator
+        stake::leave_validator_set(validator, pool_address);
+        end_aptos_epoch();
+
+        // expire lockup cycle on the stake pool
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        let observed_lockup_cycle = observed_lockup_cycle(pool_address);
+        end_aptos_epoch();
+
+        // observed lockup cycle should be unchanged as no stake has been inactivated
+        synchronize_delegation_pool(pool_address);
+        assert!(observed_lockup_cycle(pool_address) == observed_lockup_cycle, 0);
+
+        // stake is pending_inactive as it has not been inactivated
+        stake::assert_stake_pool(pool_address, 5100500001, 0, 0, 10303010000);
+        // 10100000000 * 1.01 * 1.01 pending_inactive stake
+        assert_delegation(validator_address, pool_address, 0, 0, 10303010000);
+        // the pending withdrawal should be reported as still pending
+        assert_pending_withdrawal(validator_address, pool_address, true, 2, false, 10303010000);
+
+        // validator is inactive and lockup expired => pending_inactive stake is withdrawable
+        balance = coin::balance<AptosCoin>(validator_address);
+        withdraw(validator, pool_address, 10303010000);
+
+        assert!(coin::balance<AptosCoin>(validator_address) == balance + 10303010000, 0);
+        assert_delegation(validator_address, pool_address, 0, 0, 0);
+        assert_pending_withdrawal(validator_address, pool_address, false, 0, false, 0);
+        stake::assert_stake_pool(pool_address, 5100500001, 0, 0, 0);
+        // pending_inactive shares pool has not been deleted (as can still `unlock` this OLC)
+        assert_inactive_shares_pool(pool_address, observed_lockup_cycle(pool_address), true, 0);
+
+        stake::mint(validator, 30 * ONE_APT);
+        add_stake(validator, pool_address, 30 * ONE_APT);
+        unlock(validator, pool_address, 10 * ONE_APT);
+
+        assert_delegation(validator_address, pool_address, 1999999999, 0, 1000000000);
+        // the pending withdrawal should be reported as still pending
+        assert_pending_withdrawal(validator_address, pool_address, true, 2, false, 1000000000);
+
+        balance = coin::balance<AptosCoin>(validator_address);
+        // pending_inactive balance would be under threshold => redeem entire balance
+        withdraw(validator, pool_address, 1);
+        // pending_inactive balance has been withdrawn and the pending withdrawal executed
+        assert_delegation(validator_address, pool_address, 1999999999, 0, 0);
+        assert_pending_withdrawal(validator_address, pool_address, false, 0, false, 0);
+        assert!(coin::balance<AptosCoin>(validator_address) == balance + 1000000000, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator1 = @0x010, delegator2 = @0x020)]
+    public entry fun test_total_coins_inactive(
+        aptos_framework: &signer,
+        validator: &signer,
+        delegator1: &signer,
+        delegator2: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        initialize_test_validator(validator, 200 * ONE_APT, true, true);
+
+        let validator_address = signer::address_of(validator);
+        let pool_address = get_owned_pool_address(validator_address);
+
+        let delegator1_address = signer::address_of(delegator1);
+        account::create_account_for_test(delegator1_address);
+
+        let delegator2_address = signer::address_of(delegator2);
+        account::create_account_for_test(delegator2_address);
+
+        stake::mint(delegator1, 100 * ONE_APT);
+        stake::mint(delegator2, 200 * ONE_APT);
+        add_stake(delegator1, pool_address, 100 * ONE_APT);
+        add_stake(delegator2, pool_address, 200 * ONE_APT);
+        end_aptos_epoch();
+
+        assert_delegation(delegator1_address, pool_address, 100 * ONE_APT, 0, 0);
+        assert_delegation(delegator2_address, pool_address, 200 * ONE_APT, 0, 0);
+
+        // unlock some stake from delegator 1
+        unlock(delegator1, pool_address, 50 * ONE_APT);
+        assert_delegation(delegator1_address, pool_address, 5000000000, 0, 4999999999);
+
+        // move to lockup cycle 1
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_aptos_epoch();
+
+        // delegator 1 pending_inactive stake has been inactivated
+        assert_delegation(delegator1_address, pool_address, 5050000000, 5049999998, 0);
+        assert_delegation(delegator2_address, pool_address, 202 * ONE_APT, 0, 0);
+
+        synchronize_delegation_pool(pool_address);
+        assert!(total_coins_inactive(pool_address) == 5049999998, 0);
+
+        // unlock some stake from delegator 2
+        unlock(delegator2, pool_address, 50 * ONE_APT);
+        assert_delegation(delegator2_address, pool_address, 15200000001, 0, 4999999999);
+
+        // withdraw some of inactive stake of delegator 1
+        withdraw(delegator1, pool_address, 2049999998);
+        assert_delegation(delegator1_address, pool_address, 5050000000, 3000000001, 0);
+        assert!(total_coins_inactive(pool_address) == 3000000001, 0);
+
+        // move to lockup cycle 2
+        let (_, inactive, _, pending_inactive) = stake::get_stake(pool_address);
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_aptos_epoch();
+
+        // delegator 2 pending_inactive stake has been inactivated
+        assert_delegation(delegator1_address, pool_address, 5100500000, 3000000001, 0);
+        assert_delegation(delegator2_address, pool_address, 15352000001, 5049999998, 0);
+
+        // total_coins_inactive remains unchanged in the absence of user operations
+        assert!(total_coins_inactive(pool_address) == inactive, 0);
+        synchronize_delegation_pool(pool_address);
+        // total_coins_inactive == previous inactive stake + previous pending_inactive stake and its rewards
+        assert!(total_coins_inactive(pool_address) == inactive + pending_inactive + pending_inactive / 100, 0);
+
+        // withdraw some of inactive stake of delegator 2
+        let total_coins_inactive = total_coins_inactive(pool_address);
+        withdraw(delegator2, pool_address, 3049999998);
+        assert!(total_coins_inactive(pool_address) == total_coins_inactive - 3049999997, 0);
+
+        // unlock some stake from delegator `validator`
+        unlock(validator, pool_address, 50 * ONE_APT);
+
+        // create dummy validator to ensure the existing validator can leave the set
+        initialize_test_validator(delegator1, 100 * ONE_APT, true, true);
+        // inactivate validator
+        stake::leave_validator_set(validator, pool_address);
+        end_aptos_epoch();
+
+        // move to lockup cycle 3
+        (_, inactive, _, pending_inactive) = stake::get_stake(pool_address);
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_aptos_epoch();
+
+        // pending_inactive stake has not been inactivated as validator is inactive
+        let (_, inactive_now, _, pending_inactive_now) = stake::get_stake(pool_address);
+        assert!(inactive_now == inactive, inactive_now);
+        assert!(pending_inactive_now == pending_inactive, pending_inactive_now);
+
+        // total_coins_inactive remains unchanged in the absence of a new OLC
+        synchronize_delegation_pool(pool_address);
+        assert!(total_coins_inactive(pool_address) == inactive, 0);
+
+        // withdraw entire pending_inactive stake
+        withdraw(validator, pool_address, MAX_U64);
+        assert!(total_coins_inactive(pool_address) == inactive, 0);
+        (_, _, _, pending_inactive) = stake::get_stake(pool_address);
+        assert!(pending_inactive == 0, pending_inactive);
+
+        // withdraw entire inactive stake
+        withdraw(delegator1, pool_address, MAX_U64);
+        withdraw(delegator2, pool_address, MAX_U64);
+        assert!(total_coins_inactive(pool_address) == 0, 0);
+        (_, inactive, _, _) = stake::get_stake(pool_address);
+        assert!(inactive == 0, inactive);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    public entry fun test_reactivate_stake_single(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        initialize_test_validator(validator, 200 * ONE_APT, true, true);
+
+        let validator_address = signer::address_of(validator);
+        let pool_address = get_owned_pool_address(validator_address);
+
+        // unlock some stake from the active one
+        unlock(validator, pool_address, 100 * ONE_APT);
+        assert_delegation(validator_address, pool_address, 100 * ONE_APT, 0, 100 * ONE_APT);
+        stake::assert_stake_pool(pool_address, 100 * ONE_APT, 0, 0, 100 * ONE_APT);
+        assert_pending_withdrawal(validator_address, pool_address, true, 0, false, 100 * ONE_APT);
+
+        // add some stake to pending_active state
+        stake::mint(validator, 150 * ONE_APT);
+        add_stake(validator, pool_address, 150 * ONE_APT);
+
+        let fee = get_add_stake_fee(pool_address, 150 * ONE_APT);
+        assert_delegation(validator_address, pool_address, 250 * ONE_APT - fee, 0, 100 * ONE_APT);
+        stake::assert_stake_pool(pool_address, 100 * ONE_APT, 0, 150 * ONE_APT, 100 * ONE_APT);
+
+        // can reactivate only pending_inactive stake
+        reactivate_stake(validator, pool_address, 150 * ONE_APT);
+
+        assert_delegation(validator_address, pool_address, 350 * ONE_APT - fee, 0, 0);
+        stake::assert_stake_pool(pool_address, 200 * ONE_APT, 0, 150 * ONE_APT, 0);
+        assert_pending_withdrawal(validator_address, pool_address, false, 0, false, 0);
+
+        end_aptos_epoch();
+        // 20000000000 active stake * 1.01 + 15000000000 pending_active stake
+        assert_delegation(validator_address, pool_address, 35200000000, 0, 0);
+
+        // unlock stake added at previous epoch (expect some imprecision when moving shares)
+        unlock(validator, pool_address, 150 * ONE_APT);
+        assert_delegation(validator_address, pool_address, 20200000001, 0, 14999999999);
+        stake::assert_stake_pool(pool_address, 20200000001, 0, 0, 14999999999);
+
+        // inactivate pending_inactive stake
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_aptos_epoch();
+
+        // 20200000001 active stake * 1.01 + 14999999999 pending_inactive stake * 1.01
+        assert_delegation(validator_address, pool_address, 20402000001, 15149999998, 0);
+        assert_pending_withdrawal(validator_address, pool_address, true, 0, true, 15149999998);
+
+        // cannot reactivate inactive stake
+        reactivate_stake(validator, pool_address, 15149999998);
+        assert_delegation(validator_address, pool_address, 20402000001, 15149999998, 0);
+
+        // unlock stake in the new lockup cycle (the pending withdrawal is executed)
+        unlock(validator, pool_address, 100 * ONE_APT);
+        assert!(coin::balance<AptosCoin>(validator_address) == 15149999998, 0);
+        assert_delegation(validator_address, pool_address, 10402000002, 0, 9999999999);
+        assert_pending_withdrawal(validator_address, pool_address, true, 1, false, 9999999999);
+
+        // reactivate the new pending withdrawal almost entirely
+        reactivate_stake(validator, pool_address, 8999999999);
+        assert_pending_withdrawal(validator_address, pool_address, true, 1, false, 1000000000);
+        // reactivate remaining stake of the new pending withdrawal
+        reactivate_stake(validator, pool_address, 1000000000);
+        assert_pending_withdrawal(validator_address, pool_address, false, 0, false, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator = @0x010)]
+    public entry fun test_withdraw_many(
+        aptos_framework: &signer,
+        validator: &signer,
+        delegator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        initialize_test_validator(validator, 1000 * ONE_APT, true, true);
+
+        let validator_address = signer::address_of(validator);
+        let pool_address = get_owned_pool_address(validator_address);
+
+        let delegator_address = signer::address_of(delegator);
+        account::create_account_for_test(delegator_address);
+
+        stake::mint(delegator, 200 * ONE_APT);
+        add_stake(delegator, pool_address, 200 * ONE_APT);
+
+        unlock(validator, pool_address, 100 * ONE_APT);
+        assert_pending_withdrawal(validator_address, pool_address, true, 0, false, 100 * ONE_APT);
+
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_aptos_epoch();
+
+        assert_delegation(delegator_address, pool_address, 200 * ONE_APT, 0, 0);
+        assert_delegation(validator_address, pool_address, 90899999999, 10100000000, 0);
+        assert_pending_withdrawal(validator_address, pool_address, true, 0, true, 10100000000);
+        assert_inactive_shares_pool(pool_address, 0, true, 100 * ONE_APT);
+
+        // check cannot withdraw inactive stake unlocked by others
+        withdraw(delegator, pool_address, MAX_U64);
+        assert_delegation(delegator_address, pool_address, 200 * ONE_APT, 0, 0);
+        assert_delegation(validator_address, pool_address, 90899999999, 10100000000, 0);
+
+        unlock(delegator, pool_address, 100 * ONE_APT);
+        assert_delegation(delegator_address, pool_address, 10000000000, 0, 9999999999);
+        assert_delegation(validator_address, pool_address, 90900000000, 10100000000, 0);
+        assert_pending_withdrawal(delegator_address, pool_address, true, 1, false, 9999999999);
+
+        // check cannot withdraw inactive stake unlocked by others even if owning pending_inactive
+        withdraw(delegator, pool_address, MAX_U64);
+        assert_delegation(delegator_address, pool_address, 10000000000, 0, 9999999999);
+        assert_delegation(validator_address, pool_address, 90900000000, 10100000000, 0);
+
+        // withdraw entire owned inactive stake
+        let balance = coin::balance<AptosCoin>(validator_address);
+        withdraw(validator, pool_address, MAX_U64);
+        assert!(coin::balance<AptosCoin>(validator_address) == balance + 10100000000, 0);
+        assert_pending_withdrawal(validator_address, pool_address, false, 0, false, 0);
+        assert_inactive_shares_pool(pool_address, 0, false, 0);
+
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_aptos_epoch();
+
+        assert_delegation(delegator_address, pool_address, 10100000000, 10099999998, 0);
+        assert_pending_withdrawal(delegator_address, pool_address, true, 1, true, 10099999998);
+        assert_inactive_shares_pool(pool_address, 1, true, 9999999999);
+
+        // use too small of an unlock amount to actually transfer shares to the pending_inactive pool
+        // check that no leftovers have been produced on the stake or delegation pools
+        stake::assert_stake_pool(pool_address, 101909000001, 10099999998, 0, 0);
+        unlock_with_min_stake_disabled(delegator, pool_address, 1);
+        stake::assert_stake_pool(pool_address, 101909000001, 10099999998, 0, 0);
+        assert_delegation(delegator_address, pool_address, 10100000000, 10099999998, 0);
+        assert_pending_withdrawal(delegator_address, pool_address, true, 1, true, 10099999998);
+
+        // implicitly execute the pending withdrawal by unlocking min stake to buy 1 share
+        unlock_with_min_stake_disabled(delegator, pool_address, 2);
+        stake::assert_stake_pool(pool_address, 101909000000, 0, 0, 1);
+        assert_delegation(delegator_address, pool_address, 10099999998, 0, 1);
+        // old pending withdrawal has been replaced
+        assert_pending_withdrawal(delegator_address, pool_address, true, 2, false, 1);
+        assert_inactive_shares_pool(pool_address, 1, false, 0);
+        assert_inactive_shares_pool(pool_address, 2, true, 1);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator = @0x010)]
+    public entry fun test_inactivate_no_excess_stake(
+        aptos_framework: &signer,
+        validator: &signer,
+        delegator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        initialize_test_validator(validator, 1200 * ONE_APT, true, true);
+
+        let validator_address = signer::address_of(validator);
+        let pool_address = get_owned_pool_address(validator_address);
+
+        let delegator_address = signer::address_of(delegator);
+        account::create_account_for_test(delegator_address);
+
+        stake::mint(delegator, 200 * ONE_APT);
+        add_stake(delegator, pool_address, 200 * ONE_APT);
+
+        // create inactive and pending_inactive stakes on the stake pool
+        unlock(validator, pool_address, 200 * ONE_APT);
+
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_aptos_epoch();
+
+        unlock(delegator, pool_address, 100 * ONE_APT);
+
+        // check no excess pending_inactive is inactivated in the special case
+        // the validator had gone inactive before its lockup expired
+
+        let observed_lockup_cycle = observed_lockup_cycle(pool_address);
+
+        // create dummy validator to ensure the existing validator can leave the set
+        initialize_test_validator(delegator, 100 * ONE_APT, true, true);
+        // inactivate validator
+        stake::leave_validator_set(validator, pool_address);
+        end_aptos_epoch();
+        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_INACTIVE, 0);
+
+        // expire lockup afterwards
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_aptos_epoch();
+
+        synchronize_delegation_pool(pool_address);
+        // no new inactive stake detected => OLC does not advance
+        assert!(observed_lockup_cycle(pool_address) == observed_lockup_cycle, 0);
+
+        // pending_inactive stake has not been inactivated
+        stake::assert_stake_pool(pool_address, 113231100001, 20200000000, 0, 10200999997);
+        assert_delegation(delegator_address, pool_address, 10201000000, 0, 10200999997);
+        assert_delegation(validator_address, pool_address, 103030100000, 20200000000, 0);
+
+        // withdraw some inactive stake (remaining pending_inactive is not inactivated)
+        withdraw(validator, pool_address, 200000000);
+        stake::assert_stake_pool(pool_address, 113231100001, 20000000001, 0, 10200999997);
+        assert_delegation(delegator_address, pool_address, 10201000000, 0, 10200999997);
+        assert_delegation(validator_address, pool_address, 103030100000, 20000000001, 0);
+
+        // withdraw some pending_inactive stake (remaining pending_inactive is not inactivated)
+        withdraw(delegator, pool_address, 200999997);
+        stake::assert_stake_pool(pool_address, 113231100001, 20000000001, 0, 10000000001);
+        assert_delegation(delegator_address, pool_address, 10201000000, 0, 10000000001);
+        assert_delegation(validator_address, pool_address, 103030100000, 20000000001, 0);
+
+        // no new inactive stake detected => OLC does not advance
+        assert!(observed_lockup_cycle(pool_address) == observed_lockup_cycle, 0);
+
+        unlock(delegator, pool_address, 10201000000);
+        withdraw(delegator, pool_address, 10201000000);
+        assert!(observed_lockup_cycle(pool_address) == observed_lockup_cycle, 0);
+
+        assert_delegation(delegator_address, pool_address, 0, 0, 10000000002);
+        assert_delegation(validator_address, pool_address, 103030100001, 20000000001, 0);
+        assert_pending_withdrawal(validator_address, pool_address, true, 0, true, 20000000001);
+        assert_pending_withdrawal(delegator_address, pool_address, true, 1, false, 10000000002);
+        stake::assert_stake_pool(pool_address, 103030100001, 20000000001, 0, 10000000002);
+
+        // reactivate validator
+        stake::join_validator_set(validator, pool_address);
+        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 0);
+        end_aptos_epoch();
+
+        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_ACTIVE, 0);
+        // no rewards have been produced yet and no stake inactivated as lockup has been refreshed
+        stake::assert_stake_pool(pool_address, 103030100001, 20000000001, 0, 10000000002);
+
+        synchronize_delegation_pool(pool_address);
+        assert_pending_withdrawal(validator_address, pool_address, true, 0, true, 20000000001);
+        assert_pending_withdrawal(delegator_address, pool_address, true, 1, false, 10000000002);
+        assert!(observed_lockup_cycle(pool_address) == observed_lockup_cycle, 0);
+
+        // cannot withdraw pending_inactive stake anymore
+        withdraw(delegator, pool_address, 10000000002);
+        assert_pending_withdrawal(delegator_address, pool_address, true, 1, false, 10000000002);
+
+        // earning rewards is resumed from this epoch on
+        end_aptos_epoch();
+        stake::assert_stake_pool(pool_address, 104060401001, 20000000001, 0, 10100000002);
+
+        // new pending_inactive stake earns rewards but so does the old one
+        unlock(validator, pool_address, 104060401001);
+        assert_pending_withdrawal(validator_address, pool_address, true, 1, false, 104060401000);
+        assert_pending_withdrawal(delegator_address, pool_address, true, 1, false, 10100000002);
+        end_aptos_epoch();
+        assert_pending_withdrawal(validator_address, pool_address, true, 1, false, 105101005010);
+        assert_pending_withdrawal(delegator_address, pool_address, true, 1, false, 10201000002);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    public entry fun test_active_stake_rewards(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        initialize_test_validator(validator, 1000 * ONE_APT, true, true);
+
+        let validator_address = signer::address_of(validator);
+        let pool_address = get_owned_pool_address(validator_address);
+
+        end_aptos_epoch();
+        // 100000000000 active stake * 1.01
+        assert_delegation(validator_address, pool_address, 1010 * ONE_APT, 0, 0);
+
+        // add stake in pending_active state
+        stake::mint(validator, 200 * ONE_APT);
+        add_stake(validator, pool_address, 200 * ONE_APT);
+
+        let fee = get_add_stake_fee(pool_address, 200 * ONE_APT);
+        assert_delegation(validator_address, pool_address, 1210 * ONE_APT - fee, 0, 0);
+
+        end_aptos_epoch();
+        // 101000000000 active stake * 1.01 + 20000000000 pending_active stake with no rewards
+        assert_delegation(validator_address, pool_address, 122010000000, 0, 0);
+
+        end_aptos_epoch();
+        // 122010000000 active stake * 1.01
+        assert_delegation(validator_address, pool_address, 123230100000, 0, 0);
+
+        // 123230100000 active stake * 1.01
+        end_aptos_epoch();
+        // 124462401000 active stake * 1.01
+        end_aptos_epoch();
+        // 125707025010 active stake * 1.01
+        end_aptos_epoch();
+        // 126964095260 active stake * 1.01
+        end_aptos_epoch();
+        // 128233736212 active stake * 1.01
+        end_aptos_epoch();
+        assert_delegation(validator_address, pool_address, 129516073574, 0, 0);
+
+        // unlock 200 coins from delegator `validator`
+        unlock(validator, pool_address, 200 * ONE_APT);
+        assert_delegation(validator_address, pool_address, 109516073575, 0, 19999999999);
+
+        // end this lockup cycle
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_aptos_epoch();
+        // 109516073575 active stake * 1.01 + 19999999999 pending_inactive stake * 1.01
+        assert_delegation(validator_address, pool_address, 110611234310, 20199999998, 0);
+
+        end_aptos_epoch();
+        // 110611234310 active stake * 1.01 + 20199999998 inactive stake
+        assert_delegation(validator_address, pool_address, 111717346653, 20199999998, 0);
+
+        // add stake in pending_active state
+        stake::mint(validator, 1000 * ONE_APT);
+        add_stake(validator, pool_address, 1000 * ONE_APT);
+
+        fee = get_add_stake_fee(pool_address, 1000 * ONE_APT);
+        assert_delegation(validator_address, pool_address, 211717346653 - fee, 20199999998, 0);
+
+        end_aptos_epoch();
+        // 111717346653 active stake * 1.01 + 100000000000 pending_active stake + 20199999998 inactive stake
+        assert_delegation(validator_address, pool_address, 212834520119, 20199999998, 0);
+
+        end_aptos_epoch();
+        // 212834520119 active stake * 1.01 + 20199999998 inactive stake
+        assert_delegation(validator_address, pool_address, 214962865320, 20199999998, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator = @0x010)]
+    public entry fun test_active_stake_rewards_multiple(
+        aptos_framework: &signer,
+        validator: &signer,
+        delegator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        initialize_test_validator(validator, 200 * ONE_APT, true, true);
+
+        let validator_address = signer::address_of(validator);
+        let pool_address = get_owned_pool_address(validator_address);
+
+        let delegator_address = signer::address_of(delegator);
+        account::create_account_for_test(delegator_address);
+
+        // add stake in pending_active state
+        stake::mint(delegator, 300 * ONE_APT);
+        add_stake(delegator, pool_address, 300 * ONE_APT);
+
+        let fee = get_add_stake_fee(pool_address, 300 * ONE_APT);
+        assert_delegation(delegator_address, pool_address, 300 * ONE_APT - fee, 0, 0);
+        assert_delegation(validator_address, pool_address, 200 * ONE_APT, 0, 0);
+        stake::assert_stake_pool(pool_address, 200 * ONE_APT, 0, 300 * ONE_APT, 0);
+
+        end_aptos_epoch();
+        // `delegator` got its `add_stake` fee back and `validator` its active stake rewards
+        assert_delegation(delegator_address, pool_address, 300 * ONE_APT, 0, 0);
+        assert_delegation(validator_address, pool_address, 20199999999, 0, 0);
+        stake::assert_stake_pool(pool_address, 502 * ONE_APT, 0, 0, 0);
+
+        // delegators earn their own rewards from now on
+        end_aptos_epoch();
+        assert_delegation(delegator_address, pool_address, 303 * ONE_APT, 0, 0);
+        assert_delegation(validator_address, pool_address, 20401999999, 0, 0);
+        stake::assert_stake_pool(pool_address, 50702000000, 0, 0, 0);
+
+        end_aptos_epoch();
+        assert_delegation(delegator_address, pool_address, 30603000000, 0, 0);
+        assert_delegation(validator_address, pool_address, 20606019999, 0, 0);
+        stake::assert_stake_pool(pool_address, 51209020000, 0, 0, 0);
+
+        end_aptos_epoch();
+        assert_delegation(delegator_address, pool_address, 30909030000, 0, 0);
+        assert_delegation(validator_address, pool_address, 20812080199, 0, 0);
+        stake::assert_stake_pool(pool_address, 51721110200, 0, 0, 0);
+
+        // add more stake in pending_active state than currently active
+        stake::mint(delegator, 1000 * ONE_APT);
+        add_stake(delegator, pool_address, 1000 * ONE_APT);
+
+        fee = get_add_stake_fee(pool_address, 1000 * ONE_APT);
+        assert_delegation(delegator_address, pool_address, 130909030000 - fee, 0, 0);
+        assert_delegation(validator_address, pool_address, 20812080199, 0, 0);
+
+        end_aptos_epoch();
+        // `delegator` got its `add_stake` fee back and `validator` its active stake rewards
+        assert_delegation(delegator_address, pool_address, 131218120300, 0, 0);
+        assert_delegation(validator_address, pool_address, 21020201001, 0, 0);
+        stake::assert_stake_pool(pool_address, 152238321302, 0, 0, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    public entry fun test_pending_inactive_stake_rewards(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        initialize_test_validator(validator, 1000 * ONE_APT, true, true);
+
+        let validator_address = signer::address_of(validator);
+        let pool_address = get_owned_pool_address(validator_address);
+
+        end_aptos_epoch();
+        assert_delegation(validator_address, pool_address, 1010 * ONE_APT, 0, 0);
+
+        // unlock 200 coins from delegator `validator`
+        unlock(validator, pool_address, 200 * ONE_APT);
+        assert_delegation(validator_address, pool_address, 81000000001, 0, 19999999999);
+
+        end_aptos_epoch(); // 81000000001 active stake * 1.01 + 19999999999 pending_inactive stake * 1.01
+        end_aptos_epoch(); // 81810000001 active stake * 1.01 + 20199999998 pending_inactive stake * 1.01
+
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_aptos_epoch(); // 82628100001 active stake * 1.01 + 20401999997 pending_inactive stake * 1.01
+        end_aptos_epoch(); // 83454381001 active stake * 1.01 + 20606019996 pending_inactive stake(now inactive)
+        assert_delegation(validator_address, pool_address, 84288924811, 20606019996, 0);
+
+        // unlock 200 coins from delegator `validator` which implicitly executes its pending withdrawal
+        unlock(validator, pool_address, 200 * ONE_APT);
+        assert!(coin::balance<AptosCoin>(validator_address) == 20606019996, 0);
+        assert_delegation(validator_address, pool_address, 64288924812, 0, 19999999999);
+
+        // lockup cycle is not ended, pending_inactive stake is still earning
+        end_aptos_epoch(); // 64288924812 active stake * 1.01 + 19999999999 pending_inactive stake * 1.01
+        end_aptos_epoch(); // 64931814060 active stake * 1.01 + 20199999998 pending_inactive stake * 1.01
+        end_aptos_epoch(); // 65581132200 active stake * 1.01 + 20401999997 pending_inactive stake * 1.01
+        end_aptos_epoch(); // 66236943522 active stake * 1.01 + 20606019996 pending_inactive stake * 1.01
+        assert_delegation(validator_address, pool_address, 66899312957, 0, 20812080195);
+
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_aptos_epoch(); // 66899312957 active stake * 1.01 + 20812080195 pending_inactive stake * 1.01
+        end_aptos_epoch(); // 67568306086 active stake * 1.01 + 21020200996 pending_inactive stake(now inactive)
+        end_aptos_epoch(); // 68243989147 active stake * 1.01 + 21020200996 inactive stake
+        assert_delegation(validator_address, pool_address, 68926429037, 21020200996, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator1 = @0x010, delegator2 = @0x020)]
+    public entry fun test_out_of_order_redeem(
+        aptos_framework: &signer,
+        validator: &signer,
+        delegator1: &signer,
+        delegator2: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        initialize_test_validator(validator, 1000 * ONE_APT, true, true);
+
+        let validator_address = signer::address_of(validator);
+        let pool_address = get_owned_pool_address(validator_address);
+
+        let delegator1_address = signer::address_of(delegator1);
+        account::create_account_for_test(delegator1_address);
+
+        let delegator2_address = signer::address_of(delegator2);
+        account::create_account_for_test(delegator2_address);
+
+        stake::mint(delegator1, 300 * ONE_APT);
+        add_stake(delegator1, pool_address, 300 * ONE_APT);
+
+        stake::mint(delegator2, 300 * ONE_APT);
+        add_stake(delegator2, pool_address, 300 * ONE_APT);
+
+        end_aptos_epoch();
+
+        // create the pending withdrawal of delegator 1 in lockup cycle 0
+        unlock(delegator1, pool_address, 150 * ONE_APT);
+        assert_pending_withdrawal(delegator1_address, pool_address, true, 0, false, 14999999999);
+
+        // move to lockup cycle 1
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_aptos_epoch();
+
+        // create the pending withdrawal of delegator 2 in lockup cycle 1
+        unlock(delegator2, pool_address, 150 * ONE_APT);
+        assert_pending_withdrawal(delegator2_address, pool_address, true, 1, false, 14999999999);
+        // 14999999999 pending_inactive stake * 1.01
+        assert_pending_withdrawal(delegator1_address, pool_address, true, 0, true, 15149999998);
+
+        // move to lockup cycle 2
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_aptos_epoch();
+
+        assert_pending_withdrawal(delegator2_address, pool_address, true, 1, true, 15149999998);
+        assert_pending_withdrawal(delegator1_address, pool_address, true, 0, true, 15149999998);
+
+        // both delegators who unlocked at different lockup cycles should be able to withdraw their stakes
+        withdraw(delegator1, pool_address, 15149999998);
+        withdraw(delegator2, pool_address, 5149999998);
+
+        assert_pending_withdrawal(delegator2_address, pool_address, true, 1, true, 10000000001);
+        assert_pending_withdrawal(delegator1_address, pool_address, false, 0, false, 0);
+        assert!(coin::balance<AptosCoin>(delegator1_address) == 15149999998, 0);
+        assert!(coin::balance<AptosCoin>(delegator2_address) == 5149999997, 0);
+
+        // recreate the pending withdrawal of delegator 1 in lockup cycle 2
+        unlock(delegator1, pool_address, 100 * ONE_APT);
+
+        // move to lockup cycle 3
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_aptos_epoch();
+
+        assert_pending_withdrawal(delegator2_address, pool_address, true, 1, true, 10000000001);
+        // 9999999999 pending_inactive stake * 1.01
+        assert_pending_withdrawal(delegator1_address, pool_address, true, 2, true, 10099999998);
+
+        // withdraw inactive stake of delegator 2 left from lockup cycle 1 in cycle 3
+        withdraw(delegator2, pool_address, 10000000001);
+        assert!(coin::balance<AptosCoin>(delegator2_address) == 15149999998, 0);
+        assert_pending_withdrawal(delegator2_address, pool_address, false, 0, false, 0);
+
+        // withdraw inactive stake of delegator 1 left from previous lockup cycle
+        withdraw(delegator1, pool_address, 10099999998);
+        assert!(coin::balance<AptosCoin>(delegator1_address) == 15149999998 + 10099999998, 0);
+        assert_pending_withdrawal(delegator1_address, pool_address, false, 0, false, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator1 = @0x010, delegator2 = @0x020)]
+    public entry fun test_operator_fee(
+        aptos_framework: &signer,
+        validator: &signer,
+        delegator1: &signer,
+        delegator2: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+
+        let validator_address = signer::address_of(validator);
+        account::create_account_for_test(validator_address);
+
+        // create delegation pool of commission fee 12.65%
+        initialize_delegation_pool(validator, 1265, vector::empty<u8>());
+        let pool_address = get_owned_pool_address(validator_address);
+        assert!(stake::get_operator(pool_address) == validator_address, 0);
+
+        let delegator1_address = signer::address_of(delegator1);
+        account::create_account_for_test(delegator1_address);
+
+        let delegator2_address = signer::address_of(delegator2);
+        account::create_account_for_test(delegator2_address);
+
+        stake::mint(delegator1, 100 * ONE_APT);
+        add_stake(delegator1, pool_address, 100 * ONE_APT);
+
+        stake::mint(delegator2, 200 * ONE_APT);
+        add_stake(delegator2, pool_address, 200 * ONE_APT);
+
+        // validator is inactive and added stake is instantly `active`
+        stake::assert_stake_pool(pool_address, 300 * ONE_APT, 0, 0, 0);
+
+        // validator does not produce rewards yet
+        end_aptos_epoch();
+        stake::assert_stake_pool(pool_address, 300 * ONE_APT, 0, 0, 0);
+
+        // therefore, there are no operator commission rewards yet
+        assert_delegation(validator_address, pool_address, 0, 0, 0);
+
+        // activate validator
+        stake::rotate_consensus_key(validator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1);
+        stake::join_validator_set(validator, pool_address);
+        end_aptos_epoch();
+
+        // produce active rewards
+        end_aptos_epoch();
+        stake::assert_stake_pool(pool_address, 30300000000, 0, 0, 0);
+
+        // 300000000 active rewards * 0.1265
+        assert_delegation(validator_address, pool_address, 37950000, 0, 0);
+        // 10000000000 active stake * (1 + 1% reward-rate * 0.8735)
+        assert_delegation(delegator1_address, pool_address, 10087350000, 0, 0);
+        // 20000000000 active stake * 1.008735
+        assert_delegation(delegator2_address, pool_address, 20174700000, 0, 0);
+
+        end_aptos_epoch();
+        stake::assert_stake_pool(pool_address, 30603000000, 0, 0, 0);
+
+        // 603000000 active rewards * 0.1265 instead of
+        // 303000000 active rewards * 0.1265 + 37950000 active stake * 1.008735
+        // because operator commission rewards are not automatically restaked compared to already owned stake
+        assert_delegation(validator_address, pool_address, 76279500, 0, 0);
+        // 10087350000 active stake * 1.008735 + some of the rewards of previous commission if restaked
+        assert_delegation(delegator1_address, pool_address, 10175573500, 0, 0);
+        // 20174700000 active stake * 1.008735 + some of the rewards of previous commission if restaked
+        assert_delegation(delegator2_address, pool_address, 20351147000, 0, 0);
+
+        // restake operator commission rewards
+        synchronize_delegation_pool(pool_address);
+
+        end_aptos_epoch();
+        stake::assert_stake_pool(pool_address, 30909030000, 0, 0, 0);
+
+        // 306030000 active rewards * 0.1265 + 76279500 active stake * 1.008735
+        assert_delegation(validator_address, pool_address, 115658596, 0, 0);
+        // 10175573500 active stake * 1.008735
+        assert_delegation(delegator1_address, pool_address, 10264457134, 0, 0);
+        // 20351147000 active stake * 1.008735
+        assert_delegation(delegator2_address, pool_address, 20528914269, 0, 0);
+
+        // check operator is rewarded by pending_inactive stake too
+        unlock(delegator2, pool_address, 100 * ONE_APT);
+        stake::assert_stake_pool(pool_address, 20909030001, 0, 0, 9999999999);
+
+        end_aptos_epoch();
+        stake::assert_stake_pool(pool_address, 21118120301, 0, 0, 10099999998);
+
+        assert_pending_withdrawal(validator_address, pool_address, false, 0, false, 0);
+        // distribute operator pending_inactive commission rewards
+        synchronize_delegation_pool(pool_address);
+        // 99999999 pending_inactive rewards * 0.1265
+        assert_pending_withdrawal(validator_address, pool_address, true, 0, false, 12649998);
+
+        // 209090300 active rewards * 0.1265 + 115658596 active stake * 1.008735
+        // 99999999 pending_inactive rewards * 0.1265
+        assert_delegation(validator_address, pool_address, 143118796, 0, 12649998);
+        // 10264457134 active stake * 1.008735
+        assert_delegation(delegator1_address, pool_address, 10354117168, 0, 0);
+        // 10528914270 active stake * 1.008735
+        // 9999999999 pending_inactive stake * 1.008735
+        assert_delegation(delegator2_address, pool_address, 10620884336, 0, 10087349999);
+
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_aptos_epoch();
+        stake::assert_stake_pool(pool_address, 21329301504, 10200999997, 0, 0);
+
+        // operator pending_inactive rewards on previous epoch have been inactivated
+        // 211181203 active rewards * 0.1265 + 143118796 active stake * 1.008735
+        // 100999999 pending_inactive rewards * 0.1265 + 12649998 pending_inactive stake * 1.008735
+        assert_delegation(validator_address, pool_address, 171083360, 25536995, 0);
+        // distribute operator pending_inactive commission rewards
+        synchronize_delegation_pool(pool_address);
+        assert_pending_withdrawal(validator_address, pool_address, true, 0, true, 25536995);
+
+        // check operator is not rewarded by `add_stake` fees
+        stake::mint(delegator1, 100 * ONE_APT);
+        assert!(get_add_stake_fee(pool_address, 100 * ONE_APT) > 0, 0);
+        add_stake(delegator1, pool_address, 100 * ONE_APT);
+
+        end_aptos_epoch();
+        stake::assert_stake_pool(pool_address, 31542594519, 10200999997, 0, 0);
+
+        // 213293015 active rewards * 0.1265 + 171083360 active stake * 1.008735
+        assert_delegation(validator_address, pool_address, 199559340, 25536995, 0);
+
+        // unlock some more stake to produce pending_inactive commission
+        // 10620884336 active stake * (1.008735 ^ 2 epochs)
+        // 10087349999 pending_inactive stake * 1.008735
+        assert_delegation(delegator2_address, pool_address, 10807241561, 10175463001, 0);
+        unlock(delegator2, pool_address, 100 * ONE_APT);
+        // 10807241561 - 100 APT < `MIN_COINS_ON_SHARES_POOL` thus active stake is entirely unlocked
+        assert_delegation(delegator2_address, pool_address, 0, 0, 10807241561);
+        end_aptos_epoch();
+
+        // in-flight pending_inactive commission can coexist with previous inactive commission
+        assert_delegation(validator_address, pool_address, 227532711, 25536996, 13671160);
+        assert_pending_withdrawal(validator_address, pool_address, true, 0, true, 25536996);
+
+        // distribute in-flight pending_inactive commission, implicitly executing the inactive withdrawal of operator
+        coin::register<AptosCoin>(validator);
+        synchronize_delegation_pool(pool_address);
+        assert!(coin::balance<AptosCoin>(validator_address) == 25536996, 0);
+
+        // in-flight commission has been synced, implicitly used to buy shares for operator
+        // expect operator stake to be slightly less than previously reported by `Self::get_stake`
+        assert_delegation(validator_address, pool_address, 227532711, 0, 13671159);
+        assert_pending_withdrawal(validator_address, pool_address, true, 1, false, 13671159);
+    }
+
+    #[test(aptos_framework = @aptos_framework, old_operator = @0x123, delegator = @0x010, new_operator = @0x020)]
+    public entry fun test_change_operator(
+        aptos_framework: &signer,
+        old_operator: &signer,
+        delegator: &signer,
+        new_operator: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+
+        let old_operator_address = signer::address_of(old_operator);
+        account::create_account_for_test(old_operator_address);
+
+        let new_operator_address = signer::address_of(new_operator);
+        account::create_account_for_test(new_operator_address);
+
+        // create delegation pool of commission fee 12.65%
+        initialize_delegation_pool(old_operator, 1265, vector::empty<u8>());
+        let pool_address = get_owned_pool_address(old_operator_address);
+        assert!(stake::get_operator(pool_address) == old_operator_address, 0);
+
+        let delegator_address = signer::address_of(delegator);
+        account::create_account_for_test(delegator_address);
+
+        stake::mint(delegator, 200 * ONE_APT);
+        add_stake(delegator, pool_address, 200 * ONE_APT);
+        unlock(delegator, pool_address, 100 * ONE_APT);
+
+        // activate validator
+        stake::rotate_consensus_key(old_operator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1);
+        stake::join_validator_set(old_operator, pool_address);
+        end_aptos_epoch();
+
+        // produce active and pending_inactive rewards
+        end_aptos_epoch();
+        stake::assert_stake_pool(pool_address, 10100000000, 0, 0, 10100000000);
+        assert_delegation(old_operator_address, pool_address, 12650000, 0, 12650000);
+        end_aptos_epoch();
+        stake::assert_stake_pool(pool_address, 10201000000, 0, 0, 10201000000);
+        assert_delegation(old_operator_address, pool_address, 25426500, 0, 25426500);
+
+        // change operator
+        set_operator(old_operator, new_operator_address);
+
+        end_aptos_epoch();
+        stake::assert_stake_pool(pool_address, 10303010000, 0, 0, 10303010000);
+        // 25426500 active stake * 1.008735 and 25426500 pending_inactive stake * 1.008735
+        assert_delegation(old_operator_address, pool_address, 25648600, 0, 25648600);
+        // 102010000 active rewards * 0.1265 and 102010000 pending_inactive rewards * 0.1265
+        assert_delegation(new_operator_address, pool_address, 12904265, 0, 12904265);
+
+        // restake `new_operator` commission rewards
+        synchronize_delegation_pool(pool_address);
+
+        end_aptos_epoch();
+        stake::assert_stake_pool(pool_address, 10406040100, 0, 0, 10406040100);
+        // 25648600 active stake * 1.008735 and 25648600 pending_inactive stake * 1.008735
+        assert_delegation(old_operator_address, pool_address, 25872641, 0, 25872641);
+        // 103030100 active rewards * 0.1265 and 12904265 active stake * 1.008735
+        // 103030100 pending_inactive rewards * 0.1265 and 12904265 pending_inactive stake * 1.008735
+        assert_delegation(new_operator_address, pool_address, 26050290, 0, 26050290);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator1 = @0x010, delegator2 = @0x020)]
+    public entry fun test_min_stake_is_preserved(
+        aptos_framework: &signer,
+        validator: &signer,
+        delegator1: &signer,
+        delegator2: &signer,
+    ) acquires DelegationPoolOwnership, DelegationPool {
+        initialize_for_test(aptos_framework);
+        initialize_test_validator(validator, 100 * ONE_APT, true, false);
+
+        let validator_address = signer::address_of(validator);
+        let pool_address = get_owned_pool_address(validator_address);
+
+        let delegator1_address = signer::address_of(delegator1);
+        account::create_account_for_test(delegator1_address);
+
+        let delegator2_address = signer::address_of(delegator2);
+        account::create_account_for_test(delegator2_address);
+
+        // add stake without fees as validator is not active yet
+        stake::mint(delegator1, 50 * ONE_APT);
+        add_stake(delegator1, pool_address, 50 * ONE_APT);
+        stake::mint(delegator2, 16 * ONE_APT);
+        add_stake(delegator2, pool_address, 16 * ONE_APT);
+
+        // validator becomes active and share price is 1
+        end_aptos_epoch();
+
+        assert_delegation(delegator1_address, pool_address, 5000000000, 0, 0);
+        // pending_inactive balance would be under threshold => move MIN_COINS_ON_SHARES_POOL coins
+        unlock(delegator1, pool_address, MIN_COINS_ON_SHARES_POOL - 1);
+        assert_delegation(delegator1_address, pool_address, 3999999999, 0, 1000000001);
+
+        // pending_inactive balance is over threshold
+        reactivate_stake(delegator1, pool_address, 1);
+        assert_delegation(delegator1_address, pool_address, 4000000000, 0, 1000000000);
+
+        // pending_inactive balance would be under threshold => move entire balance
+        reactivate_stake(delegator1, pool_address, 1);
+        assert_delegation(delegator1_address, pool_address, 5000000000, 0, 0);
+
+        // active balance would be under threshold => move entire balance
+        unlock(delegator1, pool_address, 5000000000 - (MIN_COINS_ON_SHARES_POOL - 1));
+        assert_delegation(delegator1_address, pool_address, 0, 0, 5000000000);
+
+        // active balance would be under threshold => move MIN_COINS_ON_SHARES_POOL coins
+        reactivate_stake(delegator1, pool_address, 1);
+        assert_delegation(delegator1_address, pool_address, 1000000001, 0, 3999999999);
+
+        // active balance is over threshold
+        unlock(delegator1, pool_address, 1);
+        assert_delegation(delegator1_address, pool_address, 1000000000, 0, 4000000000);
+
+        // pending_inactive balance would be under threshold => move entire balance
+        reactivate_stake(delegator1, pool_address, 4000000000 - (MIN_COINS_ON_SHARES_POOL - 1));
+        assert_delegation(delegator1_address, pool_address, 5000000000, 0, 0);
+
+        // active + pending_inactive balance < 2 * MIN_COINS_ON_SHARES_POOL
+        // stake can live on only one of the shares pools
+        assert_delegation(delegator2_address, pool_address, 16 * ONE_APT, 0, 0);
+        unlock(delegator2, pool_address, 1);
+        assert_delegation(delegator2_address, pool_address, 0, 0, 16 * ONE_APT);
+        reactivate_stake(delegator2, pool_address, 1);
+        assert_delegation(delegator2_address, pool_address, 16 * ONE_APT, 0, 0);
+
+        unlock(delegator2, pool_address, ONE_APT);
+        assert_delegation(delegator2_address, pool_address, 0, 0, 16 * ONE_APT);
+        reactivate_stake(delegator2, pool_address, 2 * ONE_APT);
+        assert_delegation(delegator2_address, pool_address, 16 * ONE_APT, 0, 0);
+
+        // share price becomes 1.01 on both pools
+        unlock(delegator1, pool_address, 1);
+        assert_delegation(delegator1_address, pool_address, 3999999999, 0, 1000000001);
+        end_aptos_epoch();
+        assert_delegation(delegator1_address, pool_address, 4039999998, 0, 1010000001);
+
+        // pending_inactive balance is over threshold
+        reactivate_stake(delegator1, pool_address, 10000001);
+        assert_delegation(delegator1_address, pool_address, 4049999998, 0, 1000000001);
+
+        // 1 coin < 1.01 so no shares are redeemed
+        reactivate_stake(delegator1, pool_address, 1);
+        assert_delegation(delegator1_address, pool_address, 4049999998, 0, 1000000001);
+
+        // pending_inactive balance is over threshold
+        // requesting 2 coins actually redeems 1 coin from pending_inactive pool
+        reactivate_stake(delegator1, pool_address, 2);
+        assert_delegation(delegator1_address, pool_address, 4049999999, 0, 1000000000);
+
+        // 1 coin < 1.01 so no shares are redeemed
+        reactivate_stake(delegator1, pool_address, 1);
+        assert_delegation(delegator1_address, pool_address, 4049999999, 0, 1000000000);
+
+        // pending_inactive balance would be under threshold => move entire balance
+        reactivate_stake(delegator1, pool_address, 2);
+        assert_delegation(delegator1_address, pool_address, 5049999999, 0, 0);
+
+        // pending_inactive balance would be under threshold => move MIN_COINS_ON_SHARES_POOL coins
+        unlock(delegator1, pool_address, MIN_COINS_ON_SHARES_POOL - 1);
+        assert_delegation(delegator1_address, pool_address, 4049999998, 0, 1000000000);
+
+        // pending_inactive balance would be under threshold => move entire balance
+        reactivate_stake(delegator1, pool_address, 1);
+        assert_delegation(delegator1_address, pool_address, 5049999998, 0, 0);
+    }
+
+    #[test_only]
+    public fun assert_delegation(
+        delegator_address: address,
+        pool_address: address,
+        active_stake: u64,
+        inactive_stake: u64,
+        pending_inactive_stake: u64,
+    ) acquires DelegationPool {
+        let (actual_active, actual_inactive, actual_pending_inactive) = get_stake(pool_address, delegator_address);
+        assert!(actual_active == active_stake, actual_active);
+        assert!(actual_inactive == inactive_stake, actual_inactive);
+        assert!(actual_pending_inactive == pending_inactive_stake, actual_pending_inactive);
+    }
+
+    #[test_only]
+    public fun assert_pending_withdrawal(
+        delegator_address: address,
+        pool_address: address,
+        exists: bool,
+        olc: u64,
+        inactive: bool,
+        stake: u64,
+    ) acquires DelegationPool {
+        assert_delegation_pool_exists(pool_address);
+        let pool = borrow_global<DelegationPool>(pool_address);
+        let (withdrawal_exists, withdrawal_olc) = pending_withdrawal_exists(pool, delegator_address);
+        assert!(withdrawal_exists == exists, 0);
+        assert!(withdrawal_olc.index == olc, withdrawal_olc.index);
+        let (withdrawal_inactive, withdrawal_stake) = get_pending_withdrawal(pool_address, delegator_address);
+        assert!(withdrawal_inactive == inactive, 0);
+        assert!(withdrawal_stake == stake, withdrawal_stake);
+    }
+
+    #[test_only]
+    public fun assert_inactive_shares_pool(
+        pool_address: address,
+        olc: u64,
+        exists: bool,
+        stake: u64,
+    ) acquires DelegationPool {
+        assert_delegation_pool_exists(pool_address);
+        let pool = borrow_global<DelegationPool>(pool_address);
+        assert!(table::contains(&pool.inactive_shares, olc_with_index(olc)) == exists, 0);
+        if (exists) {
+            let actual_stake = total_coins(table::borrow(&pool.inactive_shares, olc_with_index(olc)));
+            assert!(actual_stake == stake, actual_stake);
+        } else {
+            assert!(0 == stake, 0);
+        }
+    }
+
+    #[test_only]
+    public fun total_coins_inactive(pool_address: address): u64 acquires DelegationPool {
+        borrow_global<DelegationPool>(pool_address).total_coins_inactive
+    }
+}

--- a/aptos-move/framework/aptos-framework/tests/delegation_pool_integration_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/delegation_pool_integration_tests.move
@@ -1,0 +1,1078 @@
+#[test_only]
+module aptos_framework::delegation_pool_integration_tests {
+    use std::features;
+    use std::signer;
+
+    use aptos_std::bls12381;
+    use aptos_std::stake;
+    use aptos_std::vector;
+
+    use aptos_framework::account;
+    use aptos_framework::aptos_coin::AptosCoin;
+    use aptos_framework::coin;
+    use aptos_framework::reconfiguration;
+    use aptos_framework::delegation_pool as dp;
+    use aptos_framework::timestamp;
+
+    #[test_only]
+    const EPOCH_DURATION: u64 = 60;
+
+    #[test_only]
+    const LOCKUP_CYCLE_SECONDS: u64 = 3600;
+
+    #[test_only]
+    const ONE_APT: u64 = 100000000;
+
+    #[test_only]
+    const VALIDATOR_STATUS_PENDING_ACTIVE: u64 = 1;
+    const VALIDATOR_STATUS_ACTIVE: u64 = 2;
+    const VALIDATOR_STATUS_PENDING_INACTIVE: u64 = 3;
+    const VALIDATOR_STATUS_INACTIVE: u64 = 4;
+
+    #[test_only]
+    const DELEGATION_POOLS: u64 = 11;
+
+    #[test_only]
+    public fun initialize_for_test(aptos_framework: &signer) {
+        initialize_for_test_custom(
+            aptos_framework,
+            100 * ONE_APT,
+            10000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            100,
+            1000000
+        );
+    }
+
+    #[test_only]
+    public fun end_epoch() {
+        stake::end_epoch();
+        reconfiguration::reconfigure_for_test_custom();
+    }
+
+    // Convenient function for setting up all required stake initializations.
+    #[test_only]
+    public fun initialize_for_test_custom(
+        aptos_framework: &signer,
+        minimum_stake: u64,
+        maximum_stake: u64,
+        recurring_lockup_secs: u64,
+        allow_validator_set_change: bool,
+        rewards_rate_numerator: u64,
+        rewards_rate_denominator: u64,
+        voting_power_increase_limit: u64,
+    ) {
+        account::create_account_for_test(signer::address_of(aptos_framework));
+        stake::initialize_for_test_custom(
+            aptos_framework,
+            minimum_stake,
+            maximum_stake,
+            recurring_lockup_secs,
+            allow_validator_set_change,
+            rewards_rate_numerator,
+            rewards_rate_denominator,
+            voting_power_increase_limit
+        );
+        reconfiguration::initialize_for_test(aptos_framework);
+        features::change_feature_flags(aptos_framework, vector[DELEGATION_POOLS], vector[]);
+    }
+
+    #[test_only]
+    public fun mint_and_add_stake(account: &signer, amount: u64) {
+        stake::mint(account, amount);
+        dp::add_stake(account, dp::get_owned_pool_address(signer::address_of(account)), amount);
+    }
+
+    #[test_only]
+    public fun initialize_test_validator(
+        public_key: &bls12381::PublicKey,
+        proof_of_possession: &bls12381::ProofOfPossession,
+        validator: &signer,
+        amount: u64,
+        should_join_validator_set: bool,
+        should_end_epoch: bool,
+    ) {
+        let validator_address = signer::address_of(validator);
+        if (!account::exists_at(signer::address_of(validator))) {
+            account::create_account_for_test(validator_address);
+        };
+
+        dp::initialize_delegation_pool(validator, 0, vector::empty<u8>());
+        validator_address = dp::get_owned_pool_address(validator_address);
+
+        let pk_bytes = bls12381::public_key_to_bytes(public_key);
+        let pop_bytes = bls12381::proof_of_possession_to_bytes(proof_of_possession);
+        stake::rotate_consensus_key(validator, validator_address, pk_bytes, pop_bytes);
+
+        if (amount > 0) {
+            mint_and_add_stake(validator, amount);
+        };
+
+        if (should_join_validator_set) {
+            stake::join_validator_set(validator, validator_address);
+        };
+        if (should_end_epoch) {
+            end_epoch();
+        };
+    }
+
+    #[test_only]
+    public fun generate_identity(): (bls12381::SecretKey, bls12381::PublicKey, bls12381::ProofOfPossession) {
+        let (sk, pkpop) = bls12381::generate_keys();
+        let pop = bls12381::generate_proof_of_possession(&sk);
+        let unvalidated_pk = bls12381::public_key_with_pop_to_normal(&pkpop);
+        (sk, unvalidated_pk, pop)
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    #[expected_failure(abort_code = 0x10007, location = aptos_framework::stake)]
+    public entry fun test_inactive_validator_can_add_stake_if_exceeding_max_allowed(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, false, false);
+
+        // Add more stake to exceed max. This should fail.
+        mint_and_add_stake(validator, 9900 * ONE_APT + 1);
+    }
+
+    #[test(aptos_framework = @0x1, validator_1 = @0x123, validator_2 = @0x234)]
+    #[expected_failure(abort_code = 0x10007, location = aptos_framework::stake)]
+    public entry fun test_pending_active_validator_cannot_add_stake_if_exceeding_max_allowed(
+        aptos_framework: &signer,
+        validator_1: &signer,
+        validator_2: &signer,
+    ) {
+        initialize_for_test_custom(
+            aptos_framework,
+            50 * ONE_APT,
+            10000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            10,
+            100000
+        );
+        // Have one validator join the set to ensure the validator set is not empty when main validator joins.
+        let (_sk_1, pk_1, pop_1) = generate_identity();
+        initialize_test_validator(&pk_1, &pop_1, validator_1, 100 * ONE_APT, true, true);
+
+        // Validator 2 joins validator set but epoch has not ended so validator is in pending_active state.
+        let (_sk_2, pk_2, pop_2) = generate_identity();
+        initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, true, false);
+
+        // Add more stake to exceed max. This should fail.
+        mint_and_add_stake(validator_2, 9900 * ONE_APT + 1);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    #[expected_failure(abort_code = 0x10007, location = aptos_framework::stake)]
+    public entry fun test_active_validator_cannot_add_stake_if_exceeding_max_allowed(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        // Validator joins validator set and waits for epoch end so it's in the validator set.
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, true);
+
+        // Add more stake to exceed max. This should fail.
+        mint_and_add_stake(validator, 9900 * ONE_APT + 1);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    #[expected_failure(abort_code = 0x10007, location = aptos_framework::stake)]
+    public entry fun test_active_validator_with_pending_inactive_stake_cannot_add_stake_if_exceeding_max_allowed(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        // Validator joins validator set and waits for epoch end so it's in the validator set.
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, true);
+
+        // Request to unlock 50 coins, which go to pending_inactive. Validator has 50 remaining in active.
+        let pool_address = dp::get_owned_pool_address(signer::address_of(validator));
+        dp::unlock(validator, pool_address, 50 * ONE_APT);
+        stake::assert_validator_state(pool_address, 50 * ONE_APT, 0, 0, 50 * ONE_APT, 0);
+
+        // Add 9900 APT + 1 more. Total stake is 50 (active) + 50 (pending_inactive) + 9900 APT + 1 > 10000 so still exceeding max.
+        mint_and_add_stake(validator, 9900 * ONE_APT + 1);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator_1 = @0x123, validator_2 = @0x234)]
+    #[expected_failure(abort_code = 0x10007, location = aptos_framework::stake)]
+    public entry fun test_pending_inactive_cannot_add_stake_if_exceeding_max_allowed(
+        aptos_framework: &signer,
+        validator_1: &signer,
+        validator_2: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        let (_sk_1, pk_1, pop_1) = generate_identity();
+        let (_sk_2, pk_2, pop_2) = generate_identity();
+        initialize_test_validator(&pk_1, &pop_1, validator_1, 100 * ONE_APT, true, false);
+        initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, true, true);
+
+        // Leave validator set so validator is in pending_inactive state.
+        stake::leave_validator_set(validator_1, dp::get_owned_pool_address(signer::address_of(validator_1)));
+
+        // Add 9900 APT + 1 more. Total stake is 50 (active) + 50 (pending_inactive) + 9900 APT + 1 > 10000 so still exceeding max.
+        mint_and_add_stake(validator_1, 9900 * ONE_APT + 1);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    public entry fun test_end_to_end(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, true);
+
+        // Validator has a lockup now that they've joined the validator set.
+        let validator_address = signer::address_of(validator);
+        let pool_address = dp::get_owned_pool_address(validator_address);
+        assert!(stake::get_remaining_lockup_secs(pool_address) == LOCKUP_CYCLE_SECONDS, 1);
+
+        // Validator adds more stake while already being active.
+        // The added stake should go to pending_active to wait for activation when next epoch starts.
+        stake::mint(validator, 900 * ONE_APT);
+        dp::add_stake(validator, pool_address, 100 * ONE_APT);
+        assert!(coin::balance<AptosCoin>(validator_address) == 800 * ONE_APT, 2);
+        stake::assert_validator_state(pool_address, 100 * ONE_APT, 0, 100 * ONE_APT, 0, 0);
+
+        // Pending_active stake is activated in the new epoch.
+        // Rewards of 1 coin are also distributed for the existing active stake of 100 coins.
+        end_epoch();
+        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_ACTIVE, 3);
+        stake::assert_validator_state(pool_address, 201 * ONE_APT, 0, 0, 0, 0);
+
+        // Request unlock of 100 coins. These 100 coins are moved to pending_inactive and will be unlocked when the
+        // current lockup expires.
+        dp::unlock(validator, pool_address, 100 * ONE_APT);
+        stake::assert_validator_state(pool_address, 10100000001, 0, 0, 9999999999, 0);
+
+        // Enough time has passed so the current lockup cycle should have ended.
+        // The first epoch after the lockup cycle ended should automatically move unlocked (pending_inactive) stake
+        // to inactive.
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_epoch();
+        // Rewards were also minted to pending_inactive, which got all moved to inactive.
+        stake::assert_validator_state(pool_address, 10201000001, 10099999998, 0, 0, 0);
+        // Lockup is renewed and validator is still active.
+        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_ACTIVE, 4);
+        assert!(stake::get_remaining_lockup_secs(pool_address) == LOCKUP_CYCLE_SECONDS, 5);
+
+        // Validator withdraws from inactive stake multiple times.
+        dp::withdraw(validator, pool_address, 50 * ONE_APT);
+        assert!(coin::balance<AptosCoin>(validator_address) == 84999999999, 6);
+        stake::assert_validator_state(pool_address, 10201000001, 5099999999, 0, 0, 0);
+        dp::withdraw(validator, pool_address, 51 * ONE_APT);
+        assert!(coin::balance<AptosCoin>(validator_address) == 90099999998, 7);
+        stake::assert_validator_state(pool_address, 10201000001, 0, 0, 0, 0);
+
+        // Enough time has passed again and the validator's lockup is renewed once more. Validator is still active.
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_epoch();
+
+        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_ACTIVE, 8);
+        assert!(stake::get_remaining_lockup_secs(pool_address) == LOCKUP_CYCLE_SECONDS, 9);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator_1 = @0x123, validator_2 = @0x234)]
+    #[expected_failure(abort_code = 0x1000D, location = aptos_framework::stake)]
+    public entry fun test_inactive_validator_cannot_join_if_exceed_increase_limit(
+        aptos_framework: &signer,
+        validator_1: &signer,
+        validator_2: &signer,
+    ) {
+        // Only 50% voting power increase is allowed in each epoch.
+        initialize_for_test_custom(
+            aptos_framework,
+            50 * ONE_APT,
+            10000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            10,
+            50
+        );
+        let (_sk_1, pk_1, pop_1) = generate_identity();
+        let (_sk_2, pk_2, pop_2) = generate_identity();
+        initialize_test_validator(&pk_1, &pop_1, validator_1, 100 * ONE_APT, false, false);
+        initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, false, false);
+
+        // Validator 1 needs to be in the set so validator 2's added stake counts against the limit.
+        stake::join_validator_set(validator_1, dp::get_owned_pool_address(signer::address_of(validator_1)));
+        end_epoch();
+
+        // Validator 2 joins the validator set but their stake would lead to exceeding the voting power increase limit.
+        // Therefore, this should fail.
+        stake::join_validator_set(validator_2, dp::get_owned_pool_address(signer::address_of(validator_2)));
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator_1 = @0x123, validator_2 = @0x234)]
+    public entry fun test_pending_active_validator_can_add_more_stake(
+        aptos_framework: &signer,
+        validator_1: &signer,
+        validator_2: &signer,
+    ) {
+        initialize_for_test_custom(
+            aptos_framework,
+            50 * ONE_APT,
+            10000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            10,
+            10000
+        );
+        // Need 1 validator to be in the active validator set so joining limit works.
+        let (_sk_1, pk_1, pop_1) = generate_identity();
+        let (_sk_2, pk_2, pop_2) = generate_identity();
+        initialize_test_validator(&pk_1, &pop_1, validator_1, 100 * ONE_APT, false, true);
+        initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, false, false);
+
+        // Add more stake while still pending_active.
+        let validator_2_address = dp::get_owned_pool_address(signer::address_of(validator_2));
+        stake::join_validator_set(validator_2, validator_2_address);
+        assert!(stake::get_validator_state(validator_2_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 0);
+        mint_and_add_stake(validator_2, 100 * ONE_APT);
+        stake::assert_validator_state(validator_2_address, 200 * ONE_APT, 0, 0, 0, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator_1 = @0x123, validator_2 = @0x234)]
+    #[expected_failure(abort_code = 0x1000D, location = aptos_framework::stake)]
+    public entry fun test_pending_active_validator_cannot_add_more_stake_than_limit(
+        aptos_framework: &signer,
+        validator_1: &signer,
+        validator_2: &signer,
+    ) {
+        // 100% voting power increase is allowed in each epoch.
+        initialize_for_test_custom(
+            aptos_framework,
+            50 * ONE_APT,
+            10000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            10,
+            100
+        );
+        // Need 1 validator to be in the active validator set so joining limit works.
+        let (_sk_1, pk_1, pop_1) = generate_identity();
+        initialize_test_validator(&pk_1, &pop_1, validator_1, 100 * ONE_APT, true, true);
+
+        // Validator 2 joins the validator set but epoch has not ended so they're still pending_active.
+        // Current voting power increase is already 100%. This is not failing yet.
+        let (_sk_2, pk_2, pop_2) = generate_identity();
+        initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, true, false);
+
+        // Add more stake, which now exceeds the 100% limit. This should fail.
+        mint_and_add_stake(validator_2, ONE_APT);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    public entry fun test_pending_active_validator_leaves_validator_set(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        // Validator joins but epoch hasn't ended, so the validator is still pending_active.
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, false);
+        let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
+        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 0);
+
+        // Leave the validator set immediately.
+        stake::leave_validator_set(validator, validator_address);
+        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_INACTIVE, 1);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    #[expected_failure(abort_code = 0x1000D, location = aptos_framework::stake)]
+    public entry fun test_active_validator_cannot_add_more_stake_than_limit_in_multiple_epochs(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        // Only 50% voting power increase is allowed in each epoch.
+        initialize_for_test_custom(
+            aptos_framework,
+            50 * ONE_APT,
+            10000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            10,
+            50
+        );
+        // Add initial stake and join the validator set.
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, true);
+
+        let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
+        stake::assert_validator_state(validator_address, 100 * ONE_APT, 0, 0, 0, 0);
+        end_epoch();
+        stake::assert_validator_state(validator_address, 110 * ONE_APT, 0, 0, 0, 0);
+        end_epoch();
+        stake::assert_validator_state(validator_address, 121 * ONE_APT, 0, 0, 0, 0);
+        // Add more than 50% limit. The following line should fail.
+        mint_and_add_stake(validator, 99 * ONE_APT);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    #[expected_failure(abort_code = 0x1000D, location = aptos_framework::stake)]
+    public entry fun test_active_validator_cannot_add_more_stake_than_limit(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        // Only 50% voting power increase is allowed in each epoch.
+        initialize_for_test_custom(
+            aptos_framework,
+            50 * ONE_APT,
+            10000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            10,
+            50
+        );
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, true);
+
+        // Add more than 50% limit. This should fail.
+        mint_and_add_stake(validator, 50 * ONE_APT + 1);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    public entry fun test_active_validator_unlock_partial_stake(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        // Reward rate = 10%.
+        initialize_for_test_custom(
+            aptos_framework,
+            50 * ONE_APT,
+            10000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            10,
+            100
+        );
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, true);
+
+        // Unlock half of the coins.
+        let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
+        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 1);
+        dp::unlock(validator, validator_address, 50 * ONE_APT);
+        stake::assert_validator_state(validator_address, 50 * ONE_APT, 0, 0, 50 * ONE_APT, 0);
+
+        // Enough time has passed so the current lockup cycle should have ended.
+        // 50 coins should have unlocked while the remaining 51 (50 + rewards) should stay locked for another cycle.
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_epoch();
+        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_ACTIVE, 2);
+        // Validator received rewards in both active and pending inactive.
+        stake::assert_validator_state(validator_address, 55 * ONE_APT, 55 * ONE_APT, 0, 0, 0);
+        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 3);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    public entry fun test_active_validator_can_withdraw_all_stake_and_rewards_at_once(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, true);
+        let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
+        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 0);
+
+        // One more epoch passes to generate rewards.
+        end_epoch();
+        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_ACTIVE, 1);
+        stake::assert_validator_state(validator_address, 101 * ONE_APT, 0, 0, 0, 0);
+
+        // Unlock all coins while still having a lockup.
+        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS - EPOCH_DURATION, 2);
+        dp::unlock(validator, validator_address, 101 * ONE_APT);
+        stake::assert_validator_state(validator_address, 0, 0, 0, 101 * ONE_APT, 0);
+
+        // One more epoch passes while the current lockup cycle (3600 secs) has not ended.
+        timestamp::fast_forward_seconds(1000);
+        end_epoch();
+        // Validator should not be removed from the validator set since their 100 coins in pending_inactive state should
+        // still count toward voting power.
+        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_ACTIVE, 3);
+        stake::assert_validator_state(validator_address, 0, 0, 0, 10201000000, 0);
+
+        // Enough time has passed so the current lockup cycle should have ended. Funds are now fully unlocked.
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_epoch();
+        stake::assert_validator_state(validator_address, 0, 10303010000, 0, 0, 0);
+        // Validator has been kicked out of the validator set as their stake is 0 now.
+        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_INACTIVE, 4);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    #[expected_failure(abort_code = 0x10006, location = aptos_framework::delegation_pool)]
+    public entry fun test_active_validator_unlocking_more_than_available_stake_should_cap(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, false, false);
+
+        // Validator unlocks more stake than they have active. This should limit the unlock to 100.
+        let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
+        dp::unlock(validator, validator_address, 200 * ONE_APT);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    public entry fun test_active_validator_withdraw_should_cap_by_inactive_stake(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        // Initial balance = 900 (idle) + 100 (staked) = 1000.
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, true);
+        stake::mint(validator, 900 * ONE_APT);
+
+        // Validator unlocks stake.
+        let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
+        dp::unlock(validator, validator_address, 100 * ONE_APT);
+        // Enough time has passed so the stake is fully unlocked.
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_epoch();
+
+        // Validator can only withdraw a max of 100 unlocked coins even if they request to withdraw more than 100.
+        dp::withdraw(validator, validator_address, 200 * ONE_APT);
+
+        // Receive back all coins with an extra 1 for rewards.
+        assert!(coin::balance<AptosCoin>(signer::address_of(validator)) == 100100000000, 2);
+        stake::assert_validator_state(validator_address, 0, 0, 0, 0, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    public entry fun test_active_validator_can_reactivate_pending_inactive_stake(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, true);
+
+        // Validator unlocks stake, which gets moved into pending_inactive.
+        let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
+        dp::unlock(validator, validator_address, 50 * ONE_APT);
+        stake::assert_validator_state(validator_address, 50 * ONE_APT, 0, 0, 50 * ONE_APT, 0);
+
+        // Validator can reactivate pending_inactive stake.
+        dp::reactivate_stake(validator, validator_address, 50 * ONE_APT);
+        stake::assert_validator_state(validator_address, 100 * ONE_APT, 0, 0, 0, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    public entry fun test_active_validator_reactivate_more_than_available_pending_inactive_stake_should_cap(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, true);
+
+        // Validator tries to reactivate more than available pending_inactive stake, which should limit to 50.
+        let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
+        dp::unlock(validator, validator_address, 50 * ONE_APT);
+        stake::assert_validator_state(validator_address, 50 * ONE_APT, 0, 0, 50 * ONE_APT, 0);
+        dp::reactivate_stake(validator, validator_address, 51 * ONE_APT);
+        stake::assert_validator_state(validator_address, 100 * ONE_APT, 0, 0, 0, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    public entry fun test_active_validator_having_insufficient_remaining_stake_after_withdrawal_gets_kicked(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, true);
+
+        // Unlock enough coins that the remaining is not enough to meet the min required.
+        let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
+        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 1);
+        dp::unlock(validator, validator_address, 50 * ONE_APT);
+        stake::assert_validator_state(validator_address, 50 * ONE_APT, 0, 0, 50 * ONE_APT, 0);
+
+        // Enough time has passed so the current lockup cycle should have ended.
+        // 50 coins should have unlocked while the remaining 51 (50 + rewards) is not enough so the validator is kicked
+        // from the validator set.
+        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_ACTIVE, 2);
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_epoch();
+        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_INACTIVE, 2);
+        stake::assert_validator_state(validator_address, 5050000000, 5050000000, 0, 0, 0);
+        // Lockup is no longer renewed since the validator is no longer a part of the validator set.
+        assert!(stake::get_remaining_lockup_secs(validator_address) == 0, 3);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, validator_2 = @0x234)]
+    public entry fun test_active_validator_leaves_staking_but_still_has_a_lockup(
+        aptos_framework: &signer,
+        validator: &signer,
+        validator_2: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        let (_sk_1, pk_1, pop_1) = generate_identity();
+        let (_sk_2, pk_2, pop_2) = generate_identity();
+        initialize_test_validator(&pk_1, &pop_1, validator, 100 * ONE_APT, true, false);
+        // We need a second validator here just so the first validator can leave.
+        initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, true, true);
+
+        // Leave the validator set while still having a lockup.
+        let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
+        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 0);
+        stake::leave_validator_set(validator, validator_address);
+        // Validator is in pending_inactive state but is technically still part of the validator set.
+        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_PENDING_INACTIVE, 2);
+        stake::assert_validator_state(validator_address, 100 * ONE_APT, 0, 0, 0, 1);
+        end_epoch();
+
+        // Epoch has ended so validator is no longer part of the validator set.
+        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_INACTIVE, 3);
+        // However, their stake, including rewards, should still subject to the existing lockup.
+        stake::assert_validator_state(validator_address, 101 * ONE_APT, 0, 0, 0, 1);
+        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS - EPOCH_DURATION, 4);
+
+        // If they try to unlock, their stake is moved to pending_inactive and would only be withdrawable after the
+        // lockup has expired.
+        dp::unlock(validator, validator_address, 50 * ONE_APT);
+        stake::assert_validator_state(validator_address, 5100000001, 0, 0, 4999999999, 1);
+        // A couple of epochs passed but lockup has not expired so the validator's stake remains the same.
+        end_epoch();
+        end_epoch();
+        end_epoch();
+        stake::assert_validator_state(validator_address, 5100000001, 0, 0, 4999999999, 1);
+        // Fast forward enough so the lockup expires. Now the validator can just call withdraw directly to withdraw
+        // pending_inactive stakes.
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+
+        // an epoch passes but validator is inactive and its pending_inactive stake is not explicitly inactivated
+        end_epoch();
+        // pending_inactive stake should not be inactivated
+        stake::assert_validator_state(validator_address, 5100000001, 0, 0, 4999999999, 1);
+        // delegator's stake should be in sync with states reported by stake pool
+        dp::assert_delegation(signer::address_of(validator), validator_address, 5100000001, 0, 4999999999);
+
+        dp::withdraw(validator, validator_address, 4999999999);
+        stake::assert_validator_state(validator_address, 5100000001, 0, 0, 0, 1);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, validator_2 = @0x234)]
+    public entry fun test_active_validator_leaves_staking_and_rejoins_with_expired_lockup_should_be_renewed(
+        aptos_framework: &signer,
+        validator: &signer,
+        validator_2: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        let (_sk_1, pk_1, pop_1) = generate_identity();
+        let (_sk_2, pk_2, pop_2) = generate_identity();
+        initialize_test_validator(&pk_1, &pop_1, validator, 100 * ONE_APT, true, false);
+        // We need a second validator here just so the first validator can leave.
+        initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, true, true);
+
+        // Leave the validator set while still having a lockup.
+        let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
+        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 0);
+        stake::leave_validator_set(validator, validator_address);
+        end_epoch();
+
+        // Fast forward enough so the lockup expires.
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        assert!(stake::get_remaining_lockup_secs(validator_address) == 0, 1);
+
+        // Validator rejoins the validator set. Once the current epoch ends, their lockup should be automatically
+        // renewed.
+        stake::join_validator_set(validator, validator_address);
+        end_epoch();
+        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_ACTIVE, 2);
+        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 2);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator_1 = @0x123, validator_2 = @0x234)]
+    public entry fun test_pending_inactive_validator_does_not_count_in_increase_limit(
+        aptos_framework: &signer,
+        validator_1: &signer,
+        validator_2: &signer,
+    ) {
+        // Only 50% voting power increase is allowed in each epoch.
+        initialize_for_test_custom(
+            aptos_framework,
+            50 * ONE_APT,
+            10000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            10,
+            50
+        );
+        let (_sk_1, pk_1, pop_1) = generate_identity();
+        let (_sk_2, pk_2, pop_2) = generate_identity();
+        initialize_test_validator(&pk_1, &pop_1, validator_1, 100 * ONE_APT, true, false);
+        // We need a second validator here just so the first validator can leave.
+        initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, true, true);
+
+        // Validator 1 leaves the validator set. Epoch has not ended so they're still pending_inactive.
+        stake::leave_validator_set(validator_1, dp::get_owned_pool_address(signer::address_of(validator_1)));
+        // Validator 1 adds more stake. This should not succeed as it should not count as a voting power increase.
+        mint_and_add_stake(validator_1, 51 * ONE_APT);
+    }
+
+    #[test(aptos_framework = @0x1, validator_1 = @0x123, validator_2 = @0x234, validator_3 = @0x345)]
+    public entry fun test_multiple_validators_join_and_leave(
+        aptos_framework: &signer,
+        validator_1: &signer,
+        validator_2: &signer,
+        validator_3: &signer
+    ) {
+        initialize_for_test_custom(
+            aptos_framework,
+            100 * ONE_APT,
+            10000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            100,
+            100
+        );
+        let (_sk_1, pk_1, pop_1) = generate_identity();
+        let (_sk_2, pk_2, pop_2) = generate_identity();
+        let (_sk_3, pk_3, pop_3) = generate_identity();
+        initialize_test_validator(&pk_1, &pop_1, validator_1, 100 * ONE_APT, false, false);
+        initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, false, false);
+        initialize_test_validator(&pk_3, &pop_3, validator_3, 100 * ONE_APT, false, false);
+
+        let validator_1_address = dp::get_owned_pool_address(signer::address_of(validator_1));
+        let validator_2_address = dp::get_owned_pool_address(signer::address_of(validator_2));
+        let validator_3_address = dp::get_owned_pool_address(signer::address_of(validator_3));
+
+        // Validator 1 and 2 join the validator set.
+        stake::join_validator_set(validator_2, validator_2_address);
+        stake::join_validator_set(validator_1, validator_1_address);
+        end_epoch();
+        assert!(stake::get_validator_state(validator_1_address) == VALIDATOR_STATUS_ACTIVE, 0);
+        assert!(stake::get_validator_state(validator_2_address) == VALIDATOR_STATUS_ACTIVE, 1);
+
+        // Validator indices is the reverse order of the joining order.
+        stake::assert_validator_state(validator_1_address, 100 * ONE_APT, 0, 0, 0, 0);
+        stake::assert_validator_state(validator_2_address, 100 * ONE_APT, 0, 0, 0, 1);
+
+        // Validator 1 rotates consensus key. Validator 2 leaves. Validator 3 joins.
+        let (_sk_1b, pk_1b, pop_1b) = generate_identity();
+        let pk_1b_bytes = bls12381::public_key_to_bytes(&pk_1b);
+        let pop_1b_bytes = bls12381::proof_of_possession_to_bytes(&pop_1b);
+        stake::rotate_consensus_key(validator_1, validator_1_address, pk_1b_bytes, pop_1b_bytes);
+        stake::leave_validator_set(validator_2, validator_2_address);
+        stake::join_validator_set(validator_3, validator_3_address);
+        // Validator 2 is not effectively removed until next epoch.
+        assert!(stake::get_validator_state(validator_2_address) == VALIDATOR_STATUS_PENDING_INACTIVE, 6);
+
+        // Validator 3 is not effectively added until next epoch.
+        assert!(stake::get_validator_state(validator_3_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 7);
+
+        // Changes applied after new epoch
+        end_epoch();
+        assert!(stake::get_validator_state(validator_1_address) == VALIDATOR_STATUS_ACTIVE, 8);
+        stake::assert_validator_state(validator_1_address, 101 * ONE_APT, 0, 0, 0, 0);
+        assert!(stake::get_validator_state(validator_2_address) == VALIDATOR_STATUS_INACTIVE, 9);
+        // The validator index of validator 2 stays the same but this doesn't matter as the next time they rejoin the
+        // validator set, their index will get set correctly.
+        stake::assert_validator_state(validator_2_address, 101 * ONE_APT, 0, 0, 0, 1);
+        assert!(stake::get_validator_state(validator_3_address) == VALIDATOR_STATUS_ACTIVE, 10);
+        stake::assert_validator_state(validator_3_address, 100 * ONE_APT, 0, 0, 0, 1);
+
+        // Validators without enough stake will be removed.
+        dp::unlock(validator_1, validator_1_address, 50 * ONE_APT);
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_epoch();
+        assert!(stake::get_validator_state(validator_1_address) == VALIDATOR_STATUS_INACTIVE, 11);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    public entry fun test_delegated_staking_with_owner_cap(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test_custom(
+            aptos_framework,
+            100 * ONE_APT,
+            10000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            100,
+            100
+        );
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 0, false, false);
+
+        // Add stake when the validator is not yet activated.
+        mint_and_add_stake(validator, 100 * ONE_APT);
+        let pool_address = dp::get_owned_pool_address(signer::address_of(validator));
+        stake::assert_validator_state(pool_address, 100 * ONE_APT, 0, 0, 0, 0);
+
+        // Join the validator set with enough stake.
+        stake::join_validator_set(validator, pool_address);
+        end_epoch();
+        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_ACTIVE, 0);
+
+        // Unlock the entire stake.
+        dp::unlock(validator, pool_address, 100 * ONE_APT);
+        stake::assert_validator_state(pool_address, 0, 0, 0, 100 * ONE_APT, 0);
+        timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
+        end_epoch();
+
+        // Withdraw stake + rewards.
+        stake::assert_validator_state(pool_address, 0, 101 * ONE_APT, 0, 0, 0);
+        dp::withdraw(validator, pool_address, 101 * ONE_APT);
+        assert!(coin::balance<AptosCoin>(signer::address_of(validator)) == 101 * ONE_APT, 1);
+        stake::assert_validator_state(pool_address, 0, 0, 0, 0, 0);
+
+        // Operator can separately rotate consensus key.
+        let (_sk_new, pk_new, pop_new) = generate_identity();
+        let pk_new_bytes = bls12381::public_key_to_bytes(&pk_new);
+        let pop_new_bytes = bls12381::proof_of_possession_to_bytes(&pop_new);
+        stake::rotate_consensus_key(validator, pool_address, pk_new_bytes, pop_new_bytes);
+        let (consensus_pubkey, _, _) = stake::get_validator_config(pool_address);
+        assert!(consensus_pubkey == pk_new_bytes, 2);
+
+        // Operator can update network and fullnode addresses.
+        stake::update_network_and_fullnode_addresses(validator, pool_address, b"1", b"2");
+        let (_, network_addresses, fullnode_addresses) = stake::get_validator_config(pool_address);
+        assert!(network_addresses == b"1", 3);
+        assert!(fullnode_addresses == b"2", 4);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    #[expected_failure(abort_code = 0x1000A, location = aptos_framework::stake)]
+    public entry fun test_validator_cannot_join_post_genesis(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test_custom(
+            aptos_framework,
+            100 * ONE_APT,
+            10000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            false,
+            1,
+            100,
+            100
+        );
+
+        // Joining the validator set should fail as post genesis validator set change is not allowed.
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, true);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    #[expected_failure(abort_code = 0x1000E, location = aptos_framework::stake)]
+    public entry fun test_invalid_pool_address(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, true);
+        stake::join_validator_set(validator, @0x234);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    #[expected_failure(abort_code = 0x1000A, location = aptos_framework::stake)]
+    public entry fun test_validator_cannot_leave_post_genesis(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test_custom(
+            aptos_framework,
+            100 * ONE_APT,
+            10000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            false,
+            1,
+            100,
+            100
+        );
+        let (_sk, pk, pop) = generate_identity();
+        initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, false, false);
+
+        // Bypass the check to join. This is the same function called during Genesis.
+        let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
+        stake::join_validator_set(validator, validator_address);
+        end_epoch();
+
+        // Leaving the validator set should fail as post genesis validator set change is not allowed.
+        stake::leave_validator_set(validator, validator_address);
+    }
+
+    #[test(
+        aptos_framework = @aptos_framework,
+        validator_1 = @aptos_framework,
+        validator_2 = @0x2,
+        validator_3 = @0x3,
+        validator_4 = @0x4,
+        validator_5 = @0x5
+    )]
+    public entry fun test_staking_validator_index(
+        aptos_framework: &signer,
+        validator_1: &signer,
+        validator_2: &signer,
+        validator_3: &signer,
+        validator_4: &signer,
+        validator_5: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+
+        let (_sk_1, pk_1, pop_1) = generate_identity();
+        let (_sk_2, pk_2, pop_2) = generate_identity();
+        let (_sk_3, pk_3, pop_3) = generate_identity();
+        let (_sk_4, pk_4, pop_4) = generate_identity();
+        let (_sk_5, pk_5, pop_5) = generate_identity();
+
+        initialize_test_validator(&pk_1, &pop_1, validator_1, 100 * ONE_APT, false, false);
+        initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, false, false);
+        initialize_test_validator(&pk_3, &pop_3, validator_3, 100 * ONE_APT, false, false);
+        initialize_test_validator(&pk_4, &pop_4, validator_4, 100 * ONE_APT, false, false);
+        initialize_test_validator(&pk_5, &pop_5, validator_5, 100 * ONE_APT, false, false);
+
+        let v1_addr = dp::get_owned_pool_address(signer::address_of(validator_1));
+        let v2_addr = dp::get_owned_pool_address(signer::address_of(validator_2));
+        let v3_addr = dp::get_owned_pool_address(signer::address_of(validator_3));
+        let v4_addr = dp::get_owned_pool_address(signer::address_of(validator_4));
+        let v5_addr = dp::get_owned_pool_address(signer::address_of(validator_5));
+
+        stake::join_validator_set(validator_3, v3_addr);
+        end_epoch();
+        assert!(stake::get_validator_index(v3_addr) == 0, 0);
+
+        stake::join_validator_set(validator_4, v4_addr);
+        end_epoch();
+        assert!(stake::get_validator_index(v3_addr) == 0, 1);
+        assert!(stake::get_validator_index(v4_addr) == 1, 2);
+
+        stake::join_validator_set(validator_1, v1_addr);
+        stake::join_validator_set(validator_2, v2_addr);
+        // pending_inactive is appended in reverse order
+        end_epoch();
+        assert!(stake::get_validator_index(v3_addr) == 0, 6);
+        assert!(stake::get_validator_index(v4_addr) == 1, 7);
+        assert!(stake::get_validator_index(v2_addr) == 2, 8);
+        assert!(stake::get_validator_index(v1_addr) == 3, 9);
+
+        stake::join_validator_set(validator_5, v5_addr);
+        end_epoch();
+        assert!(stake::get_validator_index(v3_addr) == 0, 10);
+        assert!(stake::get_validator_index(v4_addr) == 1, 11);
+        assert!(stake::get_validator_index(v2_addr) == 2, 12);
+        assert!(stake::get_validator_index(v1_addr) == 3, 13);
+        assert!(stake::get_validator_index(v5_addr) == 4, 14);
+
+        // after swap remove, it's 3,4,2,5
+        stake::leave_validator_set(validator_1, v1_addr);
+        // after swap remove, it's 5,4,2
+        stake::leave_validator_set(validator_3, v3_addr);
+        end_epoch();
+
+        assert!(stake::get_validator_index(v5_addr) == 0, 15);
+        assert!(stake::get_validator_index(v4_addr) == 1, 16);
+        assert!(stake::get_validator_index(v2_addr) == 2, 17);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    #[expected_failure(abort_code = 0x1000B, location = aptos_framework::stake)]
+    public entry fun test_invalid_config(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test_custom(
+            aptos_framework,
+            50 * ONE_APT,
+            10000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            100,
+            100
+        );
+
+        // Call initialize_stake_owner, which only initializes the stake pool but not validator config.
+        let validator_address = signer::address_of(validator);
+        account::create_account_for_test(validator_address);
+        dp::initialize_delegation_pool(validator, 0, vector::empty<u8>());
+        validator_address = dp::get_owned_pool_address(validator_address);
+        mint_and_add_stake(validator, 100 * ONE_APT);
+
+        // Join the validator set with enough stake. This should fail because the validator didn't initialize validator
+        // config.
+        stake::join_validator_set(validator, validator_address);
+    }
+
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
+    public entry fun test_valid_config(
+        aptos_framework: &signer,
+        validator: &signer,
+    ) {
+        initialize_for_test_custom(
+            aptos_framework,
+            50 * ONE_APT,
+            10000 * ONE_APT,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            100,
+            100
+        );
+
+        // Call initialize_stake_owner, which only initializes the stake pool but not validator config.
+        let validator_address = signer::address_of(validator);
+        account::create_account_for_test(validator_address);
+        dp::initialize_delegation_pool(validator, 0, vector::empty<u8>());
+        validator_address = dp::get_owned_pool_address(validator_address);
+        mint_and_add_stake(validator, 100 * ONE_APT);
+
+        // Initialize validator config.
+        let (_sk_new, pk_new, pop_new) = generate_identity();
+        let pk_new_bytes = bls12381::public_key_to_bytes(&pk_new);
+        let pop_new_bytes = bls12381::proof_of_possession_to_bytes(&pop_new);
+        stake::rotate_consensus_key(validator, validator_address, pk_new_bytes, pop_new_bytes);
+
+        // Join the validator set with enough stake. This now wouldn't fail since the validator config already exists.
+        stake::join_validator_set(validator, validator_address);
+    }
+
+    #[test(aptos_framework = @0x1, validator_1 = @0x123, validator_2 = @0x234)]
+    public entry fun test_removing_validator_from_active_set(
+        aptos_framework: &signer,
+        validator_1: &signer,
+        validator_2: &signer,
+    ) {
+        initialize_for_test(aptos_framework);
+        let (_sk_1, pk_1, pop_1) = generate_identity();
+        let (_sk_2, pk_2, pop_2) = generate_identity();
+        initialize_test_validator(&pk_1, &pop_1, validator_1, 100 * ONE_APT, true, false);
+        initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, true, true);
+
+        // Remove validator 1 from the active validator set. Only validator 2 remains.
+        let validator_to_remove = dp::get_owned_pool_address(signer::address_of(validator_1));
+        stake::remove_validators(aptos_framework, &vector[validator_to_remove]);
+        assert!(stake::get_validator_state(validator_to_remove) == VALIDATOR_STATUS_PENDING_INACTIVE, 1);
+    }
+}

--- a/aptos-move/framework/aptos-stdlib/doc/overview.md
+++ b/aptos-move/framework/aptos-stdlib/doc/overview.md
@@ -27,6 +27,7 @@ This is the reference documentation of the Aptos standard library.
 -  [`0x1::math_fixed`](math_fixed.md#0x1_math_fixed)
 -  [`0x1::multi_ed25519`](multi_ed25519.md#0x1_multi_ed25519)
 -  [`0x1::pool_u64`](pool_u64.md#0x1_pool_u64)
+-  [`0x1::pool_u64_unbound`](pool_u64_unbound.md#0x1_pool_u64_unbound)
 -  [`0x1::ristretto255`](ristretto255.md#0x1_ristretto255)
 -  [`0x1::secp256k1`](secp256k1.md#0x1_secp256k1)
 -  [`0x1::simple_map`](simple_map.md#0x1_simple_map)

--- a/aptos-move/framework/aptos-stdlib/doc/pool_u64_unbound.md
+++ b/aptos-move/framework/aptos-stdlib/doc/pool_u64_unbound.md
@@ -1,0 +1,871 @@
+
+<a name="0x1_pool_u64_unbound"></a>
+
+# Module `0x1::pool_u64_unbound`
+
+
+* Simple module for tracking and calculating shares of a pool of coins. The shares are worth more as the total coins in
+* the pool increases. New shareholder can buy more shares or redeem their existing shares.
+*
+* Example flow:
+* 1. Pool start outs empty.
+* 2. Shareholder A buys in with 1000 coins. A will receive 1000 shares in the pool. Pool now has 1000 total coins and
+* 1000 total shares.
+* 3. Pool appreciates in value from rewards and now has 2000 coins. A's 1000 shares are now worth 2000 coins.
+* 4. Shareholder B now buys in with 1000 coins. Since before the buy in, each existing share is worth 2 coins, B will
+* receive 500 shares in exchange for 1000 coins. Pool now has 1500 shares and 3000 coins.
+* 5. Pool appreciates in value from rewards and now has 6000 coins.
+* 6. A redeems 500 shares. Each share is worth 6000 / 1500 = 4. A receives 2000 coins. Pool has 4000 coins and 1000
+* shares left.
+
+
+
+-  [Struct `Pool`](#0x1_pool_u64_unbound_Pool)
+-  [Constants](#@Constants_0)
+-  [Function `create`](#0x1_pool_u64_unbound_create)
+-  [Function `create_with_scaling_factor`](#0x1_pool_u64_unbound_create_with_scaling_factor)
+-  [Function `destroy_empty`](#0x1_pool_u64_unbound_destroy_empty)
+-  [Function `total_coins`](#0x1_pool_u64_unbound_total_coins)
+-  [Function `total_shares`](#0x1_pool_u64_unbound_total_shares)
+-  [Function `contains`](#0x1_pool_u64_unbound_contains)
+-  [Function `shares`](#0x1_pool_u64_unbound_shares)
+-  [Function `balance`](#0x1_pool_u64_unbound_balance)
+-  [Function `shareholders_count`](#0x1_pool_u64_unbound_shareholders_count)
+-  [Function `update_total_coins`](#0x1_pool_u64_unbound_update_total_coins)
+-  [Function `buy_in`](#0x1_pool_u64_unbound_buy_in)
+-  [Function `add_shares`](#0x1_pool_u64_unbound_add_shares)
+-  [Function `redeem_shares`](#0x1_pool_u64_unbound_redeem_shares)
+-  [Function `transfer_shares`](#0x1_pool_u64_unbound_transfer_shares)
+-  [Function `deduct_shares`](#0x1_pool_u64_unbound_deduct_shares)
+-  [Function `amount_to_shares`](#0x1_pool_u64_unbound_amount_to_shares)
+-  [Function `amount_to_shares_with_total_coins`](#0x1_pool_u64_unbound_amount_to_shares_with_total_coins)
+-  [Function `shares_to_amount`](#0x1_pool_u64_unbound_shares_to_amount)
+-  [Function `shares_to_amount_with_total_coins`](#0x1_pool_u64_unbound_shares_to_amount_with_total_coins)
+-  [Function `shares_to_amount_with_total_stats`](#0x1_pool_u64_unbound_shares_to_amount_with_total_stats)
+-  [Function `multiply_then_divide`](#0x1_pool_u64_unbound_multiply_then_divide)
+-  [Function `to_u128`](#0x1_pool_u64_unbound_to_u128)
+-  [Function `to_u256`](#0x1_pool_u64_unbound_to_u256)
+
+
+<pre><code><b>use</b> <a href="../../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<b>use</b> <a href="table_with_length.md#0x1_table_with_length">0x1::table_with_length</a>;
+</code></pre>
+
+
+
+<a name="0x1_pool_u64_unbound_Pool"></a>
+
+## Struct `Pool`
+
+
+
+<pre><code><b>struct</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a> <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>total_coins: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>total_shares: u128</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>shares: <a href="table_with_length.md#0x1_table_with_length_TableWithLength">table_with_length::TableWithLength</a>&lt;<b>address</b>, u128&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>scaling_factor: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x1_pool_u64_unbound_MAX_U64"></a>
+
+
+
+<pre><code><b>const</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U64">MAX_U64</a>: u64 = 18446744073709551615;
+</code></pre>
+
+
+
+<a name="0x1_pool_u64_unbound_MAX_U128"></a>
+
+
+
+<pre><code><b>const</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U128">MAX_U128</a>: u128 = 340282366920938463463374607431768211455;
+</code></pre>
+
+
+
+<a name="0x1_pool_u64_unbound_EINSUFFICIENT_SHARES"></a>
+
+Cannot redeem more shares than the shareholder has in the pool.
+
+
+<pre><code><b>const</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x1_pool_u64_unbound_EPOOL_IS_NOT_EMPTY"></a>
+
+Cannot destroy non-empty pool.
+
+
+<pre><code><b>const</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EPOOL_IS_NOT_EMPTY">EPOOL_IS_NOT_EMPTY</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_pool_u64_unbound_EPOOL_TOTAL_COINS_OVERFLOW"></a>
+
+Pool's total coins cannot exceed u64.max.
+
+
+<pre><code><b>const</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EPOOL_TOTAL_COINS_OVERFLOW">EPOOL_TOTAL_COINS_OVERFLOW</a>: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x1_pool_u64_unbound_EPOOL_TOTAL_SHARES_OVERFLOW"></a>
+
+Pool's total shares cannot exceed u64.max.
+
+
+<pre><code><b>const</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EPOOL_TOTAL_SHARES_OVERFLOW">EPOOL_TOTAL_SHARES_OVERFLOW</a>: u64 = 7;
+</code></pre>
+
+
+
+<a name="0x1_pool_u64_unbound_ESHAREHOLDER_NOT_FOUND"></a>
+
+Shareholder not present in pool.
+
+
+<pre><code><b>const</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_pool_u64_unbound_ESHAREHOLDER_SHARES_OVERFLOW"></a>
+
+Shareholder cannot have more than u64.max shares.
+
+
+<pre><code><b>const</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_ESHAREHOLDER_SHARES_OVERFLOW">ESHAREHOLDER_SHARES_OVERFLOW</a>: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x1_pool_u64_unbound_ETOO_MANY_SHAREHOLDERS"></a>
+
+There are too many shareholders in the pool.
+
+
+<pre><code><b>const</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_ETOO_MANY_SHAREHOLDERS">ETOO_MANY_SHAREHOLDERS</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_pool_u64_unbound_create"></a>
+
+## Function `create`
+
+Create a new pool.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_create">create</a>(): <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_create">create</a>(): <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a> {
+    // Default <b>to</b> a scaling factor of 1 (effectively no scaling).
+    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_create_with_scaling_factor">create_with_scaling_factor</a>(1)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_create_with_scaling_factor"></a>
+
+## Function `create_with_scaling_factor`
+
+Create a new pool with custom <code>scaling_factor</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_create_with_scaling_factor">create_with_scaling_factor</a>(scaling_factor: u64): <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_create_with_scaling_factor">create_with_scaling_factor</a>(scaling_factor: u64): <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a> {
+    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a> {
+        total_coins: 0,
+        total_shares: 0,
+        shares: <a href="table.md#0x1_table_new">table::new</a>&lt;<b>address</b>, u128&gt;(),
+        scaling_factor,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_destroy_empty"></a>
+
+## Function `destroy_empty`
+
+Destroy an empty pool. This will fail if the pool has any balance of coins.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_destroy_empty">destroy_empty</a>(pool: <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_destroy_empty">destroy_empty</a>(pool: <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>) {
+    <b>assert</b>!(pool.total_coins == 0, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EPOOL_IS_NOT_EMPTY">EPOOL_IS_NOT_EMPTY</a>));
+    <b>let</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a> {
+        total_coins: _,
+        total_shares: _,
+        shares,
+        scaling_factor: _,
+    } = pool;
+    table::destroy_empty&lt;<b>address</b>, u128&gt;(shares);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_total_coins"></a>
+
+## Function `total_coins`
+
+Return <code>pool</code>'s total balance of coins.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_total_coins">total_coins</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_total_coins">total_coins</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>): u64 {
+    pool.total_coins
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_total_shares"></a>
+
+## Function `total_shares`
+
+Return the total number of shares across all shareholders in <code>pool</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_total_shares">total_shares</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_total_shares">total_shares</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>): u128 {
+    pool.total_shares
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_contains"></a>
+
+## Function `contains`
+
+Return true if <code>shareholder</code> is in <code>pool</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>): bool {
+    <a href="table.md#0x1_table_contains">table::contains</a>(&pool.shares, shareholder)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_shares"></a>
+
+## Function `shares`
+
+Return the number of shares of <code>stakeholder</code> in <code>pool</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>): u128 {
+    <b>if</b> (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(pool, shareholder)) {
+        *<a href="table.md#0x1_table_borrow">table::borrow</a>(&pool.shares, shareholder)
+    } <b>else</b> {
+        0
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_balance"></a>
+
+## Function `balance`
+
+Return the balance in coins of <code>shareholder</code> in <code>pool.</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_balance">balance</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_balance">balance</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>): u64 {
+    <b>let</b> num_shares = <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(pool, shareholder);
+    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount">shares_to_amount</a>(pool, num_shares)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_shareholders_count"></a>
+
+## Function `shareholders_count`
+
+Return the number of shareholders in <code>pool</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shareholders_count">shareholders_count</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shareholders_count">shareholders_count</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>): u64 {
+    table::length(&pool.shares)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_update_total_coins"></a>
+
+## Function `update_total_coins`
+
+Update <code>pool</code>'s total balance of coins.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_update_total_coins">update_total_coins</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, new_total_coins: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_update_total_coins">update_total_coins</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, new_total_coins: u64) {
+    pool.total_coins = new_total_coins;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_buy_in"></a>
+
+## Function `buy_in`
+
+Allow an existing or new shareholder to add their coins to the pool in exchange for new shares.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_buy_in">buy_in</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, coins_amount: u64): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_buy_in">buy_in</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>, coins_amount: u64): u128 {
+    <b>if</b> (coins_amount == 0) <b>return</b> 0;
+
+    <b>let</b> new_shares = <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares">amount_to_shares</a>(pool, coins_amount);
+    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U64">MAX_U64</a> - pool.total_coins &gt;= coins_amount, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EPOOL_TOTAL_COINS_OVERFLOW">EPOOL_TOTAL_COINS_OVERFLOW</a>));
+    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U128">MAX_U128</a> - pool.total_shares &gt;= new_shares, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EPOOL_TOTAL_SHARES_OVERFLOW">EPOOL_TOTAL_SHARES_OVERFLOW</a>));
+
+    pool.total_coins = pool.total_coins + coins_amount;
+    pool.total_shares = pool.total_shares + new_shares;
+    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_add_shares">add_shares</a>(pool, shareholder, new_shares);
+    new_shares
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_add_shares"></a>
+
+## Function `add_shares`
+
+Add the number of shares directly for <code>shareholder</code> in <code>pool</code>.
+This would dilute other shareholders if the pool's balance of coins didn't change.
+
+
+<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_add_shares">add_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, new_shares: u128): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_add_shares">add_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>, new_shares: u128): u128 {
+    <b>if</b> (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(pool, shareholder)) {
+        <b>let</b> existing_shares = <a href="table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> pool.shares, shareholder);
+        <b>let</b> current_shares = *existing_shares;
+        <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_MAX_U128">MAX_U128</a> - current_shares &gt;= new_shares, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_ESHAREHOLDER_SHARES_OVERFLOW">ESHAREHOLDER_SHARES_OVERFLOW</a>));
+
+        *existing_shares = current_shares + new_shares;
+        *existing_shares
+    } <b>else</b> <b>if</b> (new_shares &gt; 0) {
+        <a href="table.md#0x1_table_add">table::add</a>(&<b>mut</b> pool.shares, shareholder, new_shares);
+        new_shares
+    } <b>else</b> {
+        new_shares
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_redeem_shares"></a>
+
+## Function `redeem_shares`
+
+Allow <code>shareholder</code> to redeem their shares in <code>pool</code> for coins.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_redeem_shares">redeem_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, shares_to_redeem: u128): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_redeem_shares">redeem_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>, shares_to_redeem: u128): u64 {
+    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(pool, shareholder), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
+    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(pool, shareholder) &gt;= shares_to_redeem, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
+
+    <b>if</b> (shares_to_redeem == 0) <b>return</b> 0;
+
+    <b>let</b> redeemed_coins = <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount">shares_to_amount</a>(pool, shares_to_redeem);
+    pool.total_coins = pool.total_coins - redeemed_coins;
+    pool.total_shares = pool.total_shares - shares_to_redeem;
+    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(pool, shareholder, shares_to_redeem);
+
+    redeemed_coins
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_transfer_shares"></a>
+
+## Function `transfer_shares`
+
+Transfer shares from <code>shareholder_1</code> to <code>shareholder_2</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_transfer_shares">transfer_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder_1: <b>address</b>, shareholder_2: <b>address</b>, shares_to_transfer: u128)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_transfer_shares">transfer_shares</a>(
+    pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>,
+    shareholder_1: <b>address</b>,
+    shareholder_2: <b>address</b>,
+    shares_to_transfer: u128,
+) {
+    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(pool, shareholder_1), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
+    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(pool, shareholder_1) &gt;= shares_to_transfer, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
+    <b>if</b> (shares_to_transfer == 0) <b>return</b>;
+
+    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(pool, shareholder_1, shares_to_transfer);
+    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_add_shares">add_shares</a>(pool, shareholder_2, shares_to_transfer);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_deduct_shares"></a>
+
+## Function `deduct_shares`
+
+Directly deduct <code>shareholder</code>'s number of shares in <code>pool</code> and return the number of remaining shares.
+
+
+<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, num_shares: u128): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(pool: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>, num_shares: u128): u128 {
+    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(pool, shareholder), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
+    <b>assert</b>!(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(pool, shareholder) &gt;= num_shares, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
+
+    <b>let</b> existing_shares = <a href="table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> pool.shares, shareholder);
+    *existing_shares = *existing_shares - num_shares;
+
+    // Remove the shareholder completely <b>if</b> they have no shares left.
+    <b>let</b> remaining_shares = *existing_shares;
+    <b>if</b> (remaining_shares == 0) {
+        <a href="table.md#0x1_table_remove">table::remove</a>(&<b>mut</b> pool.shares, shareholder);
+    };
+
+    remaining_shares
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_amount_to_shares"></a>
+
+## Function `amount_to_shares`
+
+Return the number of new shares <code>coins_amount</code> can buy in <code>pool</code>.
+<code>amount</code> needs to big enough to avoid rounding number.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares">amount_to_shares</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, coins_amount: u64): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares">amount_to_shares</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, coins_amount: u64): u128 {
+    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(pool, coins_amount, pool.total_coins)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_amount_to_shares_with_total_coins"></a>
+
+## Function `amount_to_shares_with_total_coins`
+
+Return the number of new shares <code>coins_amount</code> can buy in <code>pool</code> with a custom total coins number.
+<code>amount</code> needs to big enough to avoid rounding number.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, coins_amount: u64, total_coins: u64): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_amount_to_shares_with_total_coins">amount_to_shares_with_total_coins</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, coins_amount: u64, total_coins: u64): u128 {
+    // No shares yet so amount is worth the same number of shares.
+    <b>if</b> (pool.total_coins == 0 || pool.total_shares == 0) {
+        // Multiply by scaling factor <b>to</b> minimize rounding errors during <b>internal</b> calculations for buy ins/redeems.
+        // This can overflow but scaling factor is expected <b>to</b> be chosen carefully so this would not overflow.
+        <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(coins_amount) * <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(pool.scaling_factor)
+    } <b>else</b> {
+        // Shares price = total_coins / total existing shares.
+        // New number of shares = new_amount / shares_price = new_amount * existing_shares / total_amount.
+        // We rearrange the calc and do multiplication first <b>to</b> avoid rounding errors.
+        <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(pool, <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(coins_amount), pool.total_shares, <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(total_coins))
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_shares_to_amount"></a>
+
+## Function `shares_to_amount`
+
+Return the number of coins <code>shares</code> are worth in <code>pool</code>.
+<code>shares</code> needs to big enough to avoid rounding number.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount">shares_to_amount</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shares: u128): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount">shares_to_amount</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shares: u128): u64 {
+    <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(pool, shares, pool.total_coins)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_shares_to_amount_with_total_coins"></a>
+
+## Function `shares_to_amount_with_total_coins`
+
+Return the number of coins <code>shares</code> are worth in <code>pool</code> with a custom total coins number.
+<code>shares</code> needs to big enough to avoid rounding number.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shares: u128, total_coins: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount_with_total_coins">shares_to_amount_with_total_coins</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shares: u128, total_coins: u64): u64 {
+    // No shares or coins yet so shares are worthless.
+    <b>if</b> (pool.total_coins == 0 || pool.total_shares == 0) {
+        0
+    } <b>else</b> {
+        // Shares price = total_coins / total existing shares.
+        // Shares worth = shares * shares price = shares * total_coins / total existing shares.
+        // We rearrange the calc and do multiplication first <b>to</b> avoid rounding errors.
+        (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(pool, shares, <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(total_coins), pool.total_shares) <b>as</b> u64)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_shares_to_amount_with_total_stats"></a>
+
+## Function `shares_to_amount_with_total_stats`
+
+Return the number of coins <code>shares</code> are worth in <code>pool</code> with custom total coins and shares numbers.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount_with_total_stats">shares_to_amount_with_total_stats</a>(pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shares: u128, total_coins: u64, total_shares: u128): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares_to_amount_with_total_stats">shares_to_amount_with_total_stats</a>(
+    pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>,
+    shares: u128,
+    total_coins: u64,
+    total_shares: u128,
+): u64 {
+    <b>if</b> (pool.total_coins == 0 || total_shares == 0) {
+        0
+    } <b>else</b> {
+        (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(pool, shares, <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(total_coins), total_shares) <b>as</b> u64)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_multiply_then_divide"></a>
+
+## Function `multiply_then_divide`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(_pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, x: u128, y: u128, z: u128): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_multiply_then_divide">multiply_then_divide</a>(_pool: &<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, x: u128, y: u128, z: u128): u128 {
+    <b>let</b> result = (<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u256">to_u256</a>(x) * <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u256">to_u256</a>(y)) / <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u256">to_u256</a>(z);
+    (result <b>as</b> u128)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_to_u128"></a>
+
+## Function `to_u128`
+
+
+
+<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(num: u64): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u128">to_u128</a>(num: u64): u128 {
+    (num <b>as</b> u128)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_pool_u64_unbound_to_u256"></a>
+
+## Function `to_u256`
+
+
+
+<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u256">to_u256</a>(num: u128): u256
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_to_u256">to_u256</a>(num: u128): u256 {
+    (num <b>as</b> u256)
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://move-language.github.io/move/introduction.html

--- a/aptos-move/framework/aptos-stdlib/doc/smart_vector.md
+++ b/aptos-move/framework/aptos-stdlib/doc/smart_vector.md
@@ -41,8 +41,8 @@
 ## Struct `SmartVector`
 
 A Scalable vector implementation based on tables, elements are grouped into buckets with <code>bucket_size</code>.
-The vector wrapping BigVector represents an option w/o <code>Drop</code> ability requirement of T to save space in the
-metadata associated with BigVector when smart_vector is so small that inline_vec vector can hold all the data.
+The option wrapping BigVector saves space in the metadata associated with BigVector when smart_vector is
+so small that inline_vec vector can hold all the data.
 
 
 <pre><code><b>struct</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt; <b>has</b> store
@@ -62,7 +62,7 @@ metadata associated with BigVector when smart_vector is so small that inline_vec
 
 </dd>
 <dt>
-<code>big_vec: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;&gt;</code>
+<code>big_vec: <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="big_vector.md#0x1_big_vector_BigVector">big_vector::BigVector</a>&lt;T&gt;&gt;</code>
 </dt>
 <dd>
 
@@ -150,7 +150,7 @@ inaccurate.
 <pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_empty">empty</a>&lt;T: store&gt;(): <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt; {
     <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a> {
         inline_vec: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
-        big_vec: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
+        big_vec: <a href="../../move-stdlib/doc/option.md#0x1_option_none">option::none</a>(),
         inline_capacity: <a href="../../move-stdlib/doc/option.md#0x1_option_none">option::none</a>(),
         bucket_size: <a href="../../move-stdlib/doc/option.md#0x1_option_none">option::none</a>(),
     }
@@ -182,7 +182,7 @@ When inline_capacity = 0, SmartVector degrades to a wrapper of BigVector.
     <b>assert</b>!(bucket_size &gt; 0, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_vector.md#0x1_smart_vector_EZERO_BUCKET_SIZE">EZERO_BUCKET_SIZE</a>));
     <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a> {
         inline_vec: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
-        big_vec: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>[],
+        big_vec: <a href="../../move-stdlib/doc/option.md#0x1_option_none">option::none</a>(),
         inline_capacity: <a href="../../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(inline_capacity),
         bucket_size: <a href="../../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(bucket_size),
     }
@@ -241,7 +241,7 @@ Aborts if <code>v</code> is not empty.
     <b>assert</b>!(<a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>(&v), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_vector.md#0x1_smart_vector_EVECTOR_NOT_EMPTY">EVECTOR_NOT_EMPTY</a>));
     <b>let</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a> { inline_vec, big_vec, inline_capacity: _, bucket_size: _} = v;
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(inline_vec);
-    <a href="../../move-stdlib/doc/vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(big_vec);
+    <a href="../../move-stdlib/doc/option.md#0x1_option_destroy_none">option::destroy_none</a>(big_vec);
 }
 </code></pre>
 
@@ -272,7 +272,7 @@ Aborts if <code>i</code> is out of bounds.
     <b>if</b> (i &lt; inline_len) {
         <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&v.inline_vec, i)
     } <b>else</b> {
-        <a href="big_vector.md#0x1_big_vector_borrow">big_vector::borrow</a>(<a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&v.big_vec, 0), i - inline_len)
+        <a href="big_vector.md#0x1_big_vector_borrow">big_vector::borrow</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&v.big_vec), i - inline_len)
     }
 }
 </code></pre>
@@ -304,7 +304,7 @@ Aborts if <code>i</code> is out of bounds.
     <b>if</b> (i &lt; inline_len) {
         <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> v.inline_vec, i)
     } <b>else</b> {
-        <a href="big_vector.md#0x1_big_vector_borrow_mut">big_vector::borrow_mut</a>(<a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> v.big_vec, 0), i - inline_len)
+        <a href="big_vector.md#0x1_big_vector_borrow_mut">big_vector::borrow_mut</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow_mut">option::borrow_mut</a>(&<b>mut</b> v.big_vec), i - inline_len)
     }
 }
 </code></pre>
@@ -387,9 +387,9 @@ This operation will cost more gas when it adds new bucket.
             <b>let</b> estimated_avg_size = max((size_of_val(&v.inline_vec) + val_size) / (inline_len + 1), 1);
             max(1024 /* free_write_quota */ / estimated_avg_size, 1)
         };
-        <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> v.big_vec, <a href="big_vector.md#0x1_big_vector_empty">big_vector::empty</a>(bucket_size));
+        <a href="../../move-stdlib/doc/option.md#0x1_option_fill">option::fill</a>(&<b>mut</b> v.big_vec, <a href="big_vector.md#0x1_big_vector_empty">big_vector::empty</a>(bucket_size));
     };
-    <a href="big_vector.md#0x1_big_vector_push_back">big_vector::push_back</a>(<a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> v.big_vec, 0), val);
+    <a href="big_vector.md#0x1_big_vector_push_back">big_vector::push_back</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow_mut">option::borrow_mut</a>(&<b>mut</b> v.big_vec), val);
 }
 </code></pre>
 
@@ -417,13 +417,13 @@ Aborts if <code>v</code> is empty.
 <pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_pop_back">pop_back</a>&lt;T&gt;(v: &<b>mut</b> <a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;): T {
     <b>assert</b>!(!<a href="smart_vector.md#0x1_smart_vector_is_empty">is_empty</a>(v), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="smart_vector.md#0x1_smart_vector_EVECTOR_EMPTY">EVECTOR_EMPTY</a>));
     <b>let</b> big_vec_wrapper = &<b>mut</b> v.big_vec;
-    <b>if</b> (<a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(big_vec_wrapper) != 0) {
-        <b>let</b> big_vec = <a href="../../move-stdlib/doc/vector.md#0x1_vector_pop_back">vector::pop_back</a>(big_vec_wrapper);
+    <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(big_vec_wrapper)) {
+        <b>let</b> big_vec = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(big_vec_wrapper);
         <b>let</b> val = <a href="big_vector.md#0x1_big_vector_pop_back">big_vector::pop_back</a>(&<b>mut</b> big_vec);
         <b>if</b> (<a href="big_vector.md#0x1_big_vector_is_empty">big_vector::is_empty</a>(&big_vec)) {
             <a href="big_vector.md#0x1_big_vector_destroy_empty">big_vector::destroy_empty</a>(big_vec)
         } <b>else</b> {
-            <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(big_vec_wrapper, big_vec);
+            <a href="../../move-stdlib/doc/option.md#0x1_option_fill">option::fill</a>(big_vec_wrapper, big_vec);
         };
         val
     } <b>else</b> {
@@ -462,12 +462,12 @@ Disclaimer: This function may be costly. Use it at your own discretion.
         <a href="../../move-stdlib/doc/vector.md#0x1_vector_remove">vector::remove</a>(&<b>mut</b> v.inline_vec, i)
     } <b>else</b> {
         <b>let</b> big_vec_wrapper = &<b>mut</b> v.big_vec;
-        <b>let</b> big_vec = <a href="../../move-stdlib/doc/vector.md#0x1_vector_pop_back">vector::pop_back</a>(big_vec_wrapper);
+        <b>let</b> big_vec = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(big_vec_wrapper);
         <b>let</b> val = <a href="big_vector.md#0x1_big_vector_remove">big_vector::remove</a>(&<b>mut</b> big_vec, i - inline_len);
         <b>if</b> (<a href="big_vector.md#0x1_big_vector_is_empty">big_vector::is_empty</a>(&big_vec)) {
             <a href="big_vector.md#0x1_big_vector_destroy_empty">big_vector::destroy_empty</a>(big_vec)
         } <b>else</b> {
-            <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(big_vec_wrapper, big_vec);
+            <a href="../../move-stdlib/doc/option.md#0x1_option_fill">option::fill</a>(big_vec_wrapper, big_vec);
         };
         val
     }
@@ -503,22 +503,22 @@ Aborts if <code>i</code> is out of bounds.
     <b>let</b> big_vec_wrapper = &<b>mut</b> v.big_vec;
     <b>let</b> inline_vec = &<b>mut</b> v.inline_vec;
     <b>if</b> (i &gt;= inline_len) {
-        <b>let</b> big_vec = <a href="../../move-stdlib/doc/vector.md#0x1_vector_pop_back">vector::pop_back</a>(big_vec_wrapper);
+        <b>let</b> big_vec = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(big_vec_wrapper);
         <b>let</b> val = <a href="big_vector.md#0x1_big_vector_swap_remove">big_vector::swap_remove</a>(&<b>mut</b> big_vec, i - inline_len);
         <b>if</b> (<a href="big_vector.md#0x1_big_vector_is_empty">big_vector::is_empty</a>(&big_vec)) {
             <a href="big_vector.md#0x1_big_vector_destroy_empty">big_vector::destroy_empty</a>(big_vec)
         } <b>else</b> {
-            <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(big_vec_wrapper, big_vec);
+            <a href="../../move-stdlib/doc/option.md#0x1_option_fill">option::fill</a>(big_vec_wrapper, big_vec);
         };
         val
     } <b>else</b> {
         <b>if</b> (inline_len &lt; len) {
-            <b>let</b> big_vec = <a href="../../move-stdlib/doc/vector.md#0x1_vector_pop_back">vector::pop_back</a>(big_vec_wrapper);
+            <b>let</b> big_vec = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(big_vec_wrapper);
             <b>let</b> last_from_big_vec = <a href="big_vector.md#0x1_big_vector_pop_back">big_vector::pop_back</a>(&<b>mut</b> big_vec);
             <b>if</b> (<a href="big_vector.md#0x1_big_vector_is_empty">big_vector::is_empty</a>(&big_vec)) {
                 <a href="big_vector.md#0x1_big_vector_destroy_empty">big_vector::destroy_empty</a>(big_vec)
             } <b>else</b> {
-                <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(big_vec_wrapper, big_vec);
+                <a href="../../move-stdlib/doc/option.md#0x1_option_fill">option::fill</a>(big_vec_wrapper, big_vec);
             };
             <a href="../../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(inline_vec, last_from_big_vec);
         };
@@ -556,11 +556,11 @@ for v.
     <b>assert</b>!(j &lt; len, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="smart_vector.md#0x1_smart_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>));
     <b>let</b> inline_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&v.inline_vec);
     <b>if</b> (i &gt;= inline_len) {
-        <a href="big_vector.md#0x1_big_vector_swap">big_vector::swap</a>(<a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> v.big_vec, 0), i - inline_len, j - inline_len);
+        <a href="big_vector.md#0x1_big_vector_swap">big_vector::swap</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow_mut">option::borrow_mut</a>(&<b>mut</b> v.big_vec), i - inline_len, j - inline_len);
     } <b>else</b> <b>if</b> (j &lt; inline_len) {
         <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap">vector::swap</a>(&<b>mut</b> v.inline_vec, i, j);
     } <b>else</b> {
-        <b>let</b> big_vec = <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> v.big_vec, 0);
+        <b>let</b> big_vec = <a href="../../move-stdlib/doc/option.md#0x1_option_borrow_mut">option::borrow_mut</a>(&<b>mut</b> v.big_vec);
         <b>let</b> inline_vec = &<b>mut</b> v.inline_vec;
         <b>let</b> element_i = <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap_remove">vector::swap_remove</a>(inline_vec, i);
         <b>let</b> element_j = <a href="big_vector.md#0x1_big_vector_swap_remove">big_vector::swap_remove</a>(big_vec, j - inline_len);
@@ -604,8 +604,8 @@ Disclaimer: This function may be costly. Use it at your own discretion.
     };
     <a href="../../move-stdlib/doc/vector.md#0x1_vector_reverse">vector::reverse</a>(&<b>mut</b> new_inline_vec);
     // Reverse the <a href="big_vector.md#0x1_big_vector">big_vector</a> left <b>if</b> <b>exists</b>.
-    <b>if</b> (!<a href="../../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&v.big_vec)) {
-        <a href="big_vector.md#0x1_big_vector_reverse">big_vector::reverse</a>(<a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> v.big_vec, 0));
+    <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&v.big_vec)) {
+        <a href="big_vector.md#0x1_big_vector_reverse">big_vector::reverse</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow_mut">option::borrow_mut</a>(&<b>mut</b> v.big_vec));
     };
     // Mem::swap the two vectors.
     <b>let</b> temp_vec = <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
@@ -651,8 +651,8 @@ Disclaimer: This function may be costly. Use it at your own discretion.
     <b>let</b> (found, i) = <a href="../../move-stdlib/doc/vector.md#0x1_vector_index_of">vector::index_of</a>(&v.inline_vec, val);
     <b>if</b> (found) {
         (<b>true</b>, i)
-    } <b>else</b> <b>if</b> (!<a href="../../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&v.big_vec)) {
-        <b>let</b> (found, i) = <a href="big_vector.md#0x1_big_vector_index_of">big_vector::index_of</a>(<a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&v.big_vec, 0), val);
+    } <b>else</b> <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&v.big_vec)) {
+        <b>let</b> (found, i) = <a href="big_vector.md#0x1_big_vector_index_of">big_vector::index_of</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&v.big_vec), val);
         (found, i + <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&v.inline_vec))
     } <b>else</b> {
         (<b>false</b>, 0)
@@ -709,10 +709,10 @@ Return the length of the vector.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="smart_vector.md#0x1_smart_vector_length">length</a>&lt;T&gt;(v: &<a href="smart_vector.md#0x1_smart_vector_SmartVector">SmartVector</a>&lt;T&gt;): u64 {
-    <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&v.inline_vec) + <b>if</b> (<a href="../../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&v.big_vec)) {
+    <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&v.inline_vec) + <b>if</b> (<a href="../../move-stdlib/doc/option.md#0x1_option_is_none">option::is_none</a>(&v.big_vec)) {
         0
     } <b>else</b> {
-        <a href="big_vector.md#0x1_big_vector_length">big_vector::length</a>(<a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&v.big_vec, 0))
+        <a href="big_vector.md#0x1_big_vector_length">big_vector::length</a>(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&v.big_vec))
     }
 }
 </code></pre>

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.move
@@ -1,0 +1,263 @@
+/**
+ * Simple module for tracking and calculating shares of a pool of coins. The shares are worth more as the total coins in
+ * the pool increases. New shareholder can buy more shares or redeem their existing shares.
+ *
+ * Example flow:
+ * 1. Pool start outs empty.
+ * 2. Shareholder A buys in with 1000 coins. A will receive 1000 shares in the pool. Pool now has 1000 total coins and
+ * 1000 total shares.
+ * 3. Pool appreciates in value from rewards and now has 2000 coins. A's 1000 shares are now worth 2000 coins.
+ * 4. Shareholder B now buys in with 1000 coins. Since before the buy in, each existing share is worth 2 coins, B will
+ * receive 500 shares in exchange for 1000 coins. Pool now has 1500 shares and 3000 coins.
+ * 5. Pool appreciates in value from rewards and now has 6000 coins.
+ * 6. A redeems 500 shares. Each share is worth 6000 / 1500 = 4. A receives 2000 coins. Pool has 4000 coins and 1000
+ * shares left.
+ */
+module aptos_std::pool_u64_unbound {
+    use aptos_std::table_with_length::{Self as table, TableWithLength as Table};
+    use std::error;
+
+    /// Shareholder not present in pool.
+    const ESHAREHOLDER_NOT_FOUND: u64 = 1;
+    /// There are too many shareholders in the pool.
+    const ETOO_MANY_SHAREHOLDERS: u64 = 2;
+    /// Cannot destroy non-empty pool.
+    const EPOOL_IS_NOT_EMPTY: u64 = 3;
+    /// Cannot redeem more shares than the shareholder has in the pool.
+    const EINSUFFICIENT_SHARES: u64 = 4;
+    /// Shareholder cannot have more than u64.max shares.
+    const ESHAREHOLDER_SHARES_OVERFLOW: u64 = 5;
+    /// Pool's total coins cannot exceed u64.max.
+    const EPOOL_TOTAL_COINS_OVERFLOW: u64 = 6;
+    /// Pool's total shares cannot exceed u64.max.
+    const EPOOL_TOTAL_SHARES_OVERFLOW: u64 = 7;
+
+    const MAX_U64: u64 = 18446744073709551615;
+
+    const MAX_U128: u128 = 340282366920938463463374607431768211455;
+
+    struct Pool has store {
+        total_coins: u64,
+        total_shares: u128,
+        shares: Table<address, u128>,
+        // Default to 1. This can be used to minimize rounding errors when computing shares and coins amount.
+        // However, users need to make sure the coins amount don't overflow when multiplied by the scaling factor.
+        scaling_factor: u64,
+    }
+
+    /// Create a new pool.
+    public fun create(): Pool {
+        // Default to a scaling factor of 1 (effectively no scaling).
+        create_with_scaling_factor(1)
+    }
+
+    /// Create a new pool with custom `scaling_factor`.
+    public fun create_with_scaling_factor(scaling_factor: u64): Pool {
+        Pool {
+            total_coins: 0,
+            total_shares: 0,
+            shares: table::new<address, u128>(),
+            scaling_factor,
+        }
+    }
+
+    /// Destroy an empty pool. This will fail if the pool has any balance of coins.
+    public fun destroy_empty(pool: Pool) {
+        assert!(pool.total_coins == 0, error::invalid_state(EPOOL_IS_NOT_EMPTY));
+        let Pool {
+            total_coins: _,
+            total_shares: _,
+            shares,
+            scaling_factor: _,
+        } = pool;
+        table::destroy_empty<address, u128>(shares);
+    }
+
+    /// Return `pool`'s total balance of coins.
+    public fun total_coins(pool: &Pool): u64 {
+        pool.total_coins
+    }
+
+    /// Return the total number of shares across all shareholders in `pool`.
+    public fun total_shares(pool: &Pool): u128 {
+        pool.total_shares
+    }
+
+    /// Return true if `shareholder` is in `pool`.
+    public fun contains(pool: &Pool, shareholder: address): bool {
+        table::contains(&pool.shares, shareholder)
+    }
+
+    /// Return the number of shares of `stakeholder` in `pool`.
+    public fun shares(pool: &Pool, shareholder: address): u128 {
+        if (contains(pool, shareholder)) {
+            *table::borrow(&pool.shares, shareholder)
+        } else {
+            0
+        }
+    }
+
+    /// Return the balance in coins of `shareholder` in `pool.`
+    public fun balance(pool: &Pool, shareholder: address): u64 {
+        let num_shares = shares(pool, shareholder);
+        shares_to_amount(pool, num_shares)
+    }
+
+    /// Return the number of shareholders in `pool`.
+    public fun shareholders_count(pool: &Pool): u64 {
+        table::length(&pool.shares)
+    }
+
+    /// Update `pool`'s total balance of coins.
+    public fun update_total_coins(pool: &mut Pool, new_total_coins: u64) {
+        pool.total_coins = new_total_coins;
+    }
+
+    /// Allow an existing or new shareholder to add their coins to the pool in exchange for new shares.
+    public fun buy_in(pool: &mut Pool, shareholder: address, coins_amount: u64): u128 {
+        if (coins_amount == 0) return 0;
+
+        let new_shares = amount_to_shares(pool, coins_amount);
+        assert!(MAX_U64 - pool.total_coins >= coins_amount, error::invalid_argument(EPOOL_TOTAL_COINS_OVERFLOW));
+        assert!(MAX_U128 - pool.total_shares >= new_shares, error::invalid_argument(EPOOL_TOTAL_SHARES_OVERFLOW));
+
+        pool.total_coins = pool.total_coins + coins_amount;
+        pool.total_shares = pool.total_shares + new_shares;
+        add_shares(pool, shareholder, new_shares);
+        new_shares
+    }
+
+    /// Add the number of shares directly for `shareholder` in `pool`.
+    /// This would dilute other shareholders if the pool's balance of coins didn't change.
+    fun add_shares(pool: &mut Pool, shareholder: address, new_shares: u128): u128 {
+        if (contains(pool, shareholder)) {
+            let existing_shares = table::borrow_mut(&mut pool.shares, shareholder);
+            let current_shares = *existing_shares;
+            assert!(MAX_U128 - current_shares >= new_shares, error::invalid_argument(ESHAREHOLDER_SHARES_OVERFLOW));
+
+            *existing_shares = current_shares + new_shares;
+            *existing_shares
+        } else if (new_shares > 0) {
+            table::add(&mut pool.shares, shareholder, new_shares);
+            new_shares
+        } else {
+            new_shares
+        }
+    }
+
+    /// Allow `shareholder` to redeem their shares in `pool` for coins.
+    public fun redeem_shares(pool: &mut Pool, shareholder: address, shares_to_redeem: u128): u64 {
+        assert!(contains(pool, shareholder), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
+        assert!(shares(pool, shareholder) >= shares_to_redeem, error::invalid_argument(EINSUFFICIENT_SHARES));
+
+        if (shares_to_redeem == 0) return 0;
+
+        let redeemed_coins = shares_to_amount(pool, shares_to_redeem);
+        pool.total_coins = pool.total_coins - redeemed_coins;
+        pool.total_shares = pool.total_shares - shares_to_redeem;
+        deduct_shares(pool, shareholder, shares_to_redeem);
+
+        redeemed_coins
+    }
+
+    /// Transfer shares from `shareholder_1` to `shareholder_2`.
+    public fun transfer_shares(
+        pool: &mut Pool,
+        shareholder_1: address,
+        shareholder_2: address,
+        shares_to_transfer: u128,
+    ) {
+        assert!(contains(pool, shareholder_1), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
+        assert!(shares(pool, shareholder_1) >= shares_to_transfer, error::invalid_argument(EINSUFFICIENT_SHARES));
+        if (shares_to_transfer == 0) return;
+
+        deduct_shares(pool, shareholder_1, shares_to_transfer);
+        add_shares(pool, shareholder_2, shares_to_transfer);
+    }
+
+    /// Directly deduct `shareholder`'s number of shares in `pool` and return the number of remaining shares.
+    fun deduct_shares(pool: &mut Pool, shareholder: address, num_shares: u128): u128 {
+        assert!(contains(pool, shareholder), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
+        assert!(shares(pool, shareholder) >= num_shares, error::invalid_argument(EINSUFFICIENT_SHARES));
+
+        let existing_shares = table::borrow_mut(&mut pool.shares, shareholder);
+        *existing_shares = *existing_shares - num_shares;
+
+        // Remove the shareholder completely if they have no shares left.
+        let remaining_shares = *existing_shares;
+        if (remaining_shares == 0) {
+            table::remove(&mut pool.shares, shareholder);
+        };
+
+        remaining_shares
+    }
+
+    /// Return the number of new shares `coins_amount` can buy in `pool`.
+    /// `amount` needs to big enough to avoid rounding number.
+    public fun amount_to_shares(pool: &Pool, coins_amount: u64): u128 {
+        amount_to_shares_with_total_coins(pool, coins_amount, pool.total_coins)
+    }
+
+    /// Return the number of new shares `coins_amount` can buy in `pool` with a custom total coins number.
+    /// `amount` needs to big enough to avoid rounding number.
+    public fun amount_to_shares_with_total_coins(pool: &Pool, coins_amount: u64, total_coins: u64): u128 {
+        // No shares yet so amount is worth the same number of shares.
+        if (pool.total_coins == 0 || pool.total_shares == 0) {
+            // Multiply by scaling factor to minimize rounding errors during internal calculations for buy ins/redeems.
+            // This can overflow but scaling factor is expected to be chosen carefully so this would not overflow.
+            to_u128(coins_amount) * to_u128(pool.scaling_factor)
+        } else {
+            // Shares price = total_coins / total existing shares.
+            // New number of shares = new_amount / shares_price = new_amount * existing_shares / total_amount.
+            // We rearrange the calc and do multiplication first to avoid rounding errors.
+            multiply_then_divide(pool, to_u128(coins_amount), pool.total_shares, to_u128(total_coins))
+        }
+    }
+
+    /// Return the number of coins `shares` are worth in `pool`.
+    /// `shares` needs to big enough to avoid rounding number.
+    public fun shares_to_amount(pool: &Pool, shares: u128): u64 {
+        shares_to_amount_with_total_coins(pool, shares, pool.total_coins)
+    }
+
+    /// Return the number of coins `shares` are worth in `pool` with a custom total coins number.
+    /// `shares` needs to big enough to avoid rounding number.
+    public fun shares_to_amount_with_total_coins(pool: &Pool, shares: u128, total_coins: u64): u64 {
+        // No shares or coins yet so shares are worthless.
+        if (pool.total_coins == 0 || pool.total_shares == 0) {
+            0
+        } else {
+            // Shares price = total_coins / total existing shares.
+            // Shares worth = shares * shares price = shares * total_coins / total existing shares.
+            // We rearrange the calc and do multiplication first to avoid rounding errors.
+            (multiply_then_divide(pool, shares, to_u128(total_coins), pool.total_shares) as u64)
+        }
+    }
+
+    /// Return the number of coins `shares` are worth in `pool` with custom total coins and shares numbers.
+    public fun shares_to_amount_with_total_stats(
+        pool: &Pool,
+        shares: u128,
+        total_coins: u64,
+        total_shares: u128,
+    ): u64 {
+        if (pool.total_coins == 0 || total_shares == 0) {
+            0
+        } else {
+            (multiply_then_divide(pool, shares, to_u128(total_coins), total_shares) as u64)
+        }
+    }
+
+    public fun multiply_then_divide(_pool: &Pool, x: u128, y: u128, z: u128): u128 {
+        let result = (to_u256(x) * to_u256(y)) / to_u256(z);
+        (result as u128)
+    }
+
+    fun to_u128(num: u64): u128 {
+        (num as u128)
+    }
+
+    fun to_u256(num: u128): u256 {
+        (num as u256)
+    }
+}

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -27,6 +27,8 @@ the Move stdlib, the Aptos stdlib, and the Aptos framework.
 -  [Function `resource_groups_enabled`](#0x1_features_resource_groups_enabled)
 -  [Function `get_multisig_accounts_feature`](#0x1_features_get_multisig_accounts_feature)
 -  [Function `multisig_accounts_enabled`](#0x1_features_multisig_accounts_enabled)
+-  [Function `get_delegation_pools_feature`](#0x1_features_get_delegation_pools_feature)
+-  [Function `delegation_pools_enabled`](#0x1_features_delegation_pools_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `is_enabled`](#0x1_features_is_enabled)
 -  [Function `set`](#0x1_features_set)
@@ -121,6 +123,17 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_COLLECT_AND_DISTRIBUTE_GAS_FEES">COLLECT_AND_DISTRIBUTE_GAS_FEES</a>: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x1_features_DELEGATION_POOLS"></a>
+
+Whether delegation pools are enabled.
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_DELEGATION_POOLS">DELEGATION_POOLS</a>: u64 = 11;
 </code></pre>
 
 
@@ -612,6 +625,52 @@ Lifetime: transient
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_multisig_accounts_enabled">multisig_accounts_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_MULTISIG_ACCOUNTS">MULTISIG_ACCOUNTS</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_features_get_delegation_pools_feature"></a>
+
+## Function `get_delegation_pools_feature`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_delegation_pools_feature">get_delegation_pools_feature</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_delegation_pools_feature">get_delegation_pools_feature</a>(): u64 { <a href="features.md#0x1_features_DELEGATION_POOLS">DELEGATION_POOLS</a> }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_features_delegation_pools_enabled"></a>
+
+## Function `delegation_pools_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_delegation_pools_enabled">delegation_pools_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_delegation_pools_enabled">delegation_pools_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_DELEGATION_POOLS">DELEGATION_POOLS</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -130,6 +130,16 @@ module std::features {
         is_enabled(MULTISIG_ACCOUNTS)
     }
 
+    /// Whether delegation pools are enabled.
+    /// Lifetime: transient
+    const DELEGATION_POOLS: u64 = 11;
+
+    public fun get_delegation_pools_feature(): u64 { DELEGATION_POOLS }
+
+    public fun delegation_pools_enabled(): bool acquires Features {
+        is_enabled(DELEGATION_POOLS)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -418,6 +418,7 @@ pub fn default_features() -> Vec<FeatureFlag> {
         FeatureFlag::BLAKE2B_256_NATIVE,
         FeatureFlag::RESOURCE_GROUPS,
         FeatureFlag::MULTISIG_ACCOUNTS,
+        FeatureFlag::DELEGATION_POOLS,
     ]
 }
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-bitvec = { workspace = true }
+aptos-bounded-executor = { workspace = true }
 aptos-channels = { workspace = true }
 aptos-config = { workspace = true }
 aptos-consensus-notifications = { workspace = true }

--- a/consensus/src/block_storage/block_store_test.rs
+++ b/consensus/src/block_storage/block_store_test.rs
@@ -473,7 +473,7 @@ async fn test_need_sync_for_ledger_info() {
     assert!(block_store.need_sync_for_ledger_info(&ordered_too_far));
 
     let committed_round_too_far =
-        block_store.commit_root().round() + block_store.back_pressure_limit * 2 + 1;
+        block_store.commit_root().round() + block_store.back_pressure_limit * 3 + 1;
     let committed_too_far = create_ledger_info(committed_round_too_far);
     assert!(block_store.need_sync_for_ledger_info(&committed_too_far));
 

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -47,7 +47,7 @@ impl BlockStore {
     pub fn need_sync_for_ledger_info(&self, li: &LedgerInfoWithSignatures) -> bool {
         (self.ordered_root().round() < li.commit_info().round()
             && !self.block_exists(li.commit_info().id()))
-            || self.commit_root().round() + 2 * self.back_pressure_limit < li.commit_info().round()
+            || self.commit_root().round() + 3 * self.back_pressure_limit < li.commit_info().round()
     }
 
     /// Checks if quorum certificate can be inserted in block store without RPC

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -12,6 +12,7 @@ use crate::{
     txn_notifier::MempoolNotifier,
     util::time_service::ClockTimeService,
 };
+use aptos_bounded_executor::BoundedExecutor;
 use aptos_config::config::NodeConfig;
 use aptos_consensus_notifications::ConsensusNotificationSender;
 use aptos_event_notifications::ReconfigNotificationListener;
@@ -57,6 +58,7 @@ pub fn start_consensus(
     let (self_sender, self_receiver) = aptos_channels::new(1_024, &counters::PENDING_SELF_MESSAGES);
 
     let consensus_network_client = ConsensusNetworkClient::new(network_client);
+    let bounded_executor = BoundedExecutor::new(4, runtime.handle().clone());
     let epoch_mgr = EpochManager::new(
         node_config,
         time_service,
@@ -67,6 +69,7 @@ pub fn start_consensus(
         state_computer,
         storage,
         reconfig_events,
+        bounded_executor,
     );
 
     let (network_task, network_receiver) = NetworkTask::new(network_service_events, self_receiver);

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -43,6 +43,7 @@ use crate::{
     util::time_service::TimeService,
 };
 use anyhow::{bail, ensure, Context};
+use aptos_bounded_executor::BoundedExecutor;
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::config::{ConsensusConfig, NodeConfig};
 use aptos_consensus_types::{
@@ -78,6 +79,7 @@ use itertools::Itertools;
 use std::{
     cmp::Ordering,
     collections::HashMap,
+    hash::Hash,
     mem::{discriminant, Discriminant},
     path::PathBuf,
     sync::Arc,
@@ -120,12 +122,13 @@ pub struct EpochManager {
         aptos_channel::Sender<(Author, Discriminant<VerifiedEvent>), (Author, VerifiedEvent)>,
     >,
     round_manager_close_tx: Option<oneshot::Sender<oneshot::Sender<()>>>,
-    epoch_state: Option<EpochState>,
+    epoch_state: Option<Arc<EpochState>>,
     block_retrieval_tx:
         Option<aptos_channel::Sender<AccountAddress, IncomingBlockRetrievalRequest>>,
     quorum_store_storage_path: PathBuf,
     quorum_store_msg_tx: Option<aptos_channel::Sender<AccountAddress, VerifiedEvent>>,
     quorum_store_coordinator_tx: Option<Sender<CoordinatorCommand>>,
+    bounded_executor: BoundedExecutor,
 }
 
 impl EpochManager {
@@ -139,6 +142,7 @@ impl EpochManager {
         commit_state_computer: Arc<dyn StateComputer>,
         storage: Arc<dyn PersistentLivenessStorage>,
         reconfig_events: ReconfigNotificationListener,
+        bounded_executor: BoundedExecutor,
     ) -> Self {
         let author = node_config.validator_network.as_ref().unwrap().peer_id();
         let config = node_config.consensus.clone();
@@ -167,6 +171,7 @@ impl EpochManager {
             quorum_store_storage_path: node_config.storage.dir(),
             quorum_store_msg_tx: None,
             quorum_store_coordinator_tx: None,
+            bounded_executor,
         }
     }
 
@@ -440,7 +445,7 @@ impl EpochManager {
 
     fn spawn_block_retrieval_task(&mut self, epoch: u64, block_store: Arc<BlockStore>) {
         let (request_tx, mut request_rx) = aptos_channel::new(
-            QueueStyle::LIFO,
+            QueueStyle::FIFO,
             1,
             Some(&counters::BLOCK_RETRIEVAL_TASK_MSGS),
         );
@@ -759,7 +764,7 @@ impl EpochManager {
             error!("Failed to read on-chain consensus config {}", error);
         }
 
-        self.epoch_state = Some(epoch_state.clone());
+        self.epoch_state = Some(Arc::new(epoch_state.clone()));
 
         match self.storage.start() {
             LivenessStorageData::FullRecoveryData(initial_data) => {
@@ -800,27 +805,43 @@ impl EpochManager {
             self.filter_quorum_store_events(peer_id, &unverified_event)?;
 
             // same epoch -> run well-formedness + signature check
-            let verified_event = monitor!(
-                "verify_message",
-                unverified_event.clone().verify(
-                    peer_id,
-                    &self.epoch_state().verifier,
-                    self.quorum_store_enabled
-                )
-            )
-            .context("[EpochManager] Verify event")
-            .map_err(|err| {
-                error!(
-                    SecurityEvent::ConsensusInvalidMessage,
-                    remote_peer = peer_id,
-                    error = ?err,
-                    unverified_event = unverified_event
-                );
-                err
-            })?;
-
-            // process the verified event
-            self.process_event(peer_id, verified_event)?;
+            let epoch_state = self.epoch_state.clone().unwrap();
+            let quorum_store_enabled = self.quorum_store_enabled;
+            let quorum_store_msg_tx = self.quorum_store_msg_tx.clone();
+            let buffer_manager_msg_tx = self.buffer_manager_msg_tx.clone();
+            let round_manager_tx = self.round_manager_tx.clone();
+            let my_peer_id = self.author;
+            self.bounded_executor
+                .spawn(async move {
+                    match monitor!(
+                        "verify_message",
+                        unverified_event.clone().verify(
+                            peer_id,
+                            &epoch_state.verifier,
+                            quorum_store_enabled,
+                            peer_id == my_peer_id,
+                        )
+                    ) {
+                        Ok(verified_event) => {
+                            Self::forward_event(
+                                quorum_store_msg_tx,
+                                buffer_manager_msg_tx,
+                                round_manager_tx,
+                                peer_id,
+                                verified_event,
+                            );
+                        },
+                        Err(e) => {
+                            error!(
+                                SecurityEvent::ConsensusInvalidMessage,
+                                remote_peer = peer_id,
+                                error = ?e,
+                                unverified_event = unverified_event
+                            );
+                        },
+                    }
+                })
+                .await;
         }
         Ok(())
     }
@@ -910,49 +931,55 @@ impl EpochManager {
         }
     }
 
-    fn process_event(
-        &mut self,
+    fn forward_event_to<K: Eq + Hash + Clone, V>(
+        mut maybe_tx: Option<aptos_channel::Sender<K, V>>,
+        key: K,
+        value: V,
+    ) -> anyhow::Result<()> {
+        if let Some(tx) = &mut maybe_tx {
+            tx.push(key, value)
+        } else {
+            bail!("channel not initialized");
+        }
+    }
+
+    fn forward_event(
+        quorum_store_msg_tx: Option<aptos_channel::Sender<AccountAddress, VerifiedEvent>>,
+        buffer_manager_msg_tx: Option<aptos_channel::Sender<AccountAddress, VerifiedEvent>>,
+        round_manager_tx: Option<
+            aptos_channel::Sender<(Author, Discriminant<VerifiedEvent>), (Author, VerifiedEvent)>,
+        >,
         peer_id: AccountAddress,
         event: VerifiedEvent,
-    ) -> anyhow::Result<()> {
+    ) {
         if let VerifiedEvent::ProposalMsg(proposal) = &event {
             observe_block(
                 proposal.proposal().timestamp_usecs(),
                 BlockStage::EPOCH_MANAGER_VERIFIED,
             );
         }
-        match event {
+        if let Err(e) = match event {
             quorum_store_event @ (VerifiedEvent::BatchRequestMsg(_)
             | VerifiedEvent::UnverifiedBatchMsg(_)
             | VerifiedEvent::SignedDigestMsg(_)
             | VerifiedEvent::ProofOfStoreMsg(_)
             | VerifiedEvent::FragmentMsg(_)) => {
-                if let Some(sender) = &mut self.quorum_store_msg_tx {
-                    sender.push(peer_id, quorum_store_event)?;
-                }
+                Self::forward_event_to(quorum_store_msg_tx, peer_id, quorum_store_event)
+                    .context("quorum store sender")
             },
             buffer_manager_event @ (VerifiedEvent::CommitVote(_)
             | VerifiedEvent::CommitDecision(_)) => {
-                if let Some(sender) = &mut self.buffer_manager_msg_tx {
-                    sender.push(peer_id, buffer_manager_event)?;
-                } else {
-                    bail!("Commit Phase not started but received Commit Message (CommitVote/CommitDecision)");
-                }
+                Self::forward_event_to(buffer_manager_msg_tx, peer_id, buffer_manager_event)
+                    .context("buffer manager sender")
             },
-            round_manager_event => {
-                self.forward_to_round_manager(peer_id, round_manager_event);
-            },
-        }
-        Ok(())
-    }
-
-    fn forward_to_round_manager(&mut self, peer_id: Author, event: VerifiedEvent) {
-        let sender = self
-            .round_manager_tx
-            .as_mut()
-            .expect("RoundManager not started");
-        if let Err(e) = sender.push((peer_id, discriminant(&event)), (peer_id, event)) {
-            error!("Failed to send event to round manager {:?}", e);
+            round_manager_event => Self::forward_event_to(
+                round_manager_tx,
+                (peer_id, discriminant(&round_manager_event)),
+                (peer_id, round_manager_event),
+            )
+            .context("round manager sender"),
+        } {
+            warn!("Failed to forward event: {}", e);
         }
     }
 
@@ -972,7 +999,15 @@ impl EpochManager {
     }
 
     fn process_local_timeout(&mut self, round: u64) {
-        self.forward_to_round_manager(self.author, VerifiedEvent::LocalTimeout(round));
+        let peer_id = self.author;
+        let event = VerifiedEvent::LocalTimeout(round);
+        let sender = self
+            .round_manager_tx
+            .as_mut()
+            .expect("RoundManager not started");
+        if let Err(e) = sender.push((peer_id, discriminant(&event)), (peer_id, event)) {
+            error!("Failed to send event to round manager {:?}", e);
+        }
     }
 
     async fn await_reconfig_notification(&mut self) {
@@ -993,7 +1028,7 @@ impl EpochManager {
         // initial start of the processor
         self.await_reconfig_notification().await;
         loop {
-            ::futures::select! {
+            tokio::select! {
                 (peer, msg) = network_receivers.consensus_messages.select_next_some() => {
                     if let Err(e) = self.process_message(peer, msg).await {
                         error!(epoch = self.epoch(), error = ?e, kind = error_kind(&e));

--- a/consensus/src/experimental/tests/buffer_manager_tests.rs
+++ b/consensus/src/experimental/tests/buffer_manager_tests.rs
@@ -224,7 +224,10 @@ async fn loopback_commit_vote(
                 let event: UnverifiedEvent = msg.into();
                 // verify the message and send the message into self loop
                 msg_tx
-                    .push(author, event.verify(author, verifier, false).unwrap())
+                    .push(
+                        author,
+                        event.verify(author, verifier, false, false).unwrap(),
+                    )
                     .ok();
             }
         },

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -104,6 +104,10 @@ impl NetworkPlayground {
         }
     }
 
+    pub fn handle(&self) -> Handle {
+        self.executor.clone()
+    }
+
     /// HashMap of supported protocols to initialize ConsensusNetworkClient.
     pub fn peer_protocols(&self) -> Arc<PeersAndMetadata> {
         self.peers_and_metadata.clone()

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -83,29 +83,40 @@ impl UnverifiedEvent {
         peer_id: PeerId,
         validator: &ValidatorVerifier,
         quorum_store_enabled: bool,
+        self_message: bool,
     ) -> Result<VerifiedEvent, VerifyError> {
         Ok(match self {
             //TODO: no need to sign and verify the proposal
             UnverifiedEvent::ProposalMsg(p) => {
-                p.verify(validator, quorum_store_enabled)?;
+                if !self_message {
+                    p.verify(validator, quorum_store_enabled)?;
+                }
                 VerifiedEvent::ProposalMsg(p)
             },
             UnverifiedEvent::VoteMsg(v) => {
-                v.verify(validator)?;
+                if !self_message {
+                    v.verify(validator)?;
+                }
                 VerifiedEvent::VoteMsg(v)
             },
             // sync info verification is on-demand (verified when it's used)
             UnverifiedEvent::SyncInfo(s) => VerifiedEvent::UnverifiedSyncInfo(s),
             UnverifiedEvent::CommitVote(cv) => {
-                cv.verify(validator)?;
+                if !self_message {
+                    cv.verify(validator)?;
+                }
                 VerifiedEvent::CommitVote(cv)
             },
             UnverifiedEvent::CommitDecision(cd) => {
-                cd.verify(validator)?;
+                if !self_message {
+                    cd.verify(validator)?;
+                }
                 VerifiedEvent::CommitDecision(cd)
             },
             UnverifiedEvent::FragmentMsg(f) => {
-                f.verify(peer_id)?;
+                if !self_message {
+                    f.verify(peer_id)?;
+                }
                 VerifiedEvent::FragmentMsg(f)
             },
             UnverifiedEvent::BatchRequestMsg(br) => {
@@ -118,11 +129,15 @@ impl UnverifiedEvent {
                 VerifiedEvent::UnverifiedBatchMsg(b)
             },
             UnverifiedEvent::SignedDigestMsg(sd) => {
-                sd.verify(validator)?;
+                if !self_message {
+                    sd.verify(validator)?;
+                }
                 VerifiedEvent::SignedDigestMsg(sd)
             },
             UnverifiedEvent::ProofOfStoreMsg(p) => {
-                p.verify(validator)?;
+                if !self_message {
+                    p.verify(validator)?;
+                }
                 VerifiedEvent::ProofOfStoreMsg(p)
             },
         })

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -13,6 +13,7 @@ use crate::{
     test_utils::{MockStateComputer, MockStorage},
     util::time_service::ClockTimeService,
 };
+use aptos_bounded_executor::BoundedExecutor;
 use aptos_channels::{self, aptos_channel, message_queues::QueueStyle};
 use aptos_config::{
     config::{NodeConfig, WaypointConfig},
@@ -136,6 +137,8 @@ impl SMRNode {
         let (self_sender, self_receiver) =
             aptos_channels::new(1_024, &counters::PENDING_SELF_MESSAGES);
 
+        let bounded_executor = BoundedExecutor::new(2, playground.handle());
+
         let epoch_mgr = EpochManager::new(
             &config,
             time_service,
@@ -146,6 +149,7 @@ impl SMRNode {
             state_computer.clone(),
             storage.clone(),
             reconfig_listener,
+            bounded_executor,
         );
         let (network_task, network_receiver) =
             NetworkTask::new(network_service_events, self_receiver);

--- a/crates/aptos-rosetta/src/account.rs
+++ b/crates/aptos-rosetta/src/account.rs
@@ -93,7 +93,6 @@ async fn get_balances(
     maybe_filter_currencies: Option<Vec<Currency>>,
 ) -> ApiResult<(u64, Option<Vec<AccountAddress>>, Vec<Amount>)> {
     let owner_address = account.account_address()?;
-
     // Retrieve all account resources
     if let Ok(response) = rest_client
         .get_account_resources_at_version_bcs(owner_address, version)

--- a/crates/aptos-rosetta/src/client.rs
+++ b/crates/aptos-rosetta/src/client.rs
@@ -348,6 +348,84 @@ impl RosettaClient {
         .await
     }
 
+    pub async fn unlock_stake(
+        &self,
+        network_identifier: &NetworkIdentifier,
+        private_key: &Ed25519PrivateKey,
+        operator: Option<AccountAddress>,
+        amount: Option<u64>,
+        expiry_time_secs: u64,
+        sequence_number: Option<u64>,
+        max_gas: Option<u64>,
+        gas_unit_price: Option<u64>,
+    ) -> anyhow::Result<TransactionIdentifier> {
+        let sender = self
+            .get_account_address(network_identifier.clone(), private_key)
+            .await?;
+        let mut keys = HashMap::new();
+        keys.insert(sender, private_key);
+
+        let operations = vec![Operation::unlock_stake(
+            0,
+            None,
+            sender,
+            operator.map(AccountIdentifier::base_account),
+            amount,
+        )];
+
+        self.submit_operations(
+            sender,
+            network_identifier.clone(),
+            &keys,
+            operations,
+            expiry_time_secs,
+            sequence_number,
+            max_gas,
+            gas_unit_price,
+            operator.is_none(),
+        )
+        .await
+    }
+
+    pub async fn distribute_staking_rewards(
+        &self,
+        network_identifier: &NetworkIdentifier,
+        private_key: &Ed25519PrivateKey,
+        operator: AccountAddress,
+        staker: AccountAddress,
+        expiry_time_secs: u64,
+        sequence_number: Option<u64>,
+        max_gas: Option<u64>,
+        gas_unit_price: Option<u64>,
+    ) -> anyhow::Result<TransactionIdentifier> {
+        let sender = self
+            .get_account_address(network_identifier.clone(), private_key)
+            .await?;
+        let mut keys = HashMap::new();
+        keys.insert(sender, private_key);
+
+        let operations = vec![Operation::distribute_staking_rewards(
+            0,
+            None,
+            sender,
+            AccountIdentifier::base_account(operator),
+            AccountIdentifier::base_account(staker),
+        )];
+
+        self.submit_operations(
+            sender,
+            network_identifier.clone(),
+            &keys,
+            operations,
+            expiry_time_secs,
+            sequence_number,
+            max_gas,
+            gas_unit_price,
+            false,
+        )
+        .await
+    }
+
     pub async fn create_stake_pool(
         &self,
         network_identifier: &NetworkIdentifier,

--- a/crates/aptos-rosetta/src/construction.rs
+++ b/crates/aptos-rosetta/src/construction.rs
@@ -235,19 +235,22 @@ async fn fill_in_operator(
                     .get_account_resource_bcs::<Store>(op.owner, "0x1::staking_contract::Store")
                     .await?
                     .into_inner();
-                if store.staking_contracts.len() != 1 {
-                    let operators: Vec<_> = store.staking_contracts.keys().collect();
+                let staking_contracts = store.staking_contracts;
+                if staking_contracts.len() != 1 {
+                    let operators: Vec<_> = staking_contracts
+                        .iter()
+                        .map(|(address, _)| *address)
+                        .collect();
                     return Err(ApiError::InvalidInput(Some(format!(
                         "Account has more than one operator, operator must be specified from: {:?}",
                         operators
                     ))));
                 } else {
+                    // Take the only staking contract
                     op.old_operator = Some(
-                        *store
-                            .staking_contracts
-                            .iter()
-                            .next()
-                            .map(|inner| inner.0)
+                        staking_contracts
+                            .first()
+                            .map(|(address, _)| *address)
                             .unwrap(),
                     );
                 }
@@ -260,19 +263,22 @@ async fn fill_in_operator(
                     .get_account_resource_bcs::<Store>(op.owner, "0x1::staking_contract::Store")
                     .await?
                     .into_inner();
-                if store.staking_contracts.len() != 1 {
-                    let operators: Vec<_> = store.staking_contracts.keys().collect();
+                let staking_contracts = store.staking_contracts;
+                if staking_contracts.len() != 1 {
+                    let operators: Vec<_> = staking_contracts
+                        .iter()
+                        .map(|(address, _)| address)
+                        .collect();
                     return Err(ApiError::InvalidInput(Some(format!(
                         "Account has more than one operator, operator must be specified from: {:?}",
                         operators
                     ))));
                 } else {
+                    // Take the only staking contract
                     op.operator = Some(
-                        *store
-                            .staking_contracts
-                            .iter()
-                            .next()
-                            .map(|inner| inner.0)
+                        staking_contracts
+                            .first()
+                            .map(|(address, _)| *address)
                             .unwrap(),
                     );
                 }

--- a/crates/aptos-rosetta/src/construction.rs
+++ b/crates/aptos-rosetta/src/construction.rs
@@ -547,6 +547,14 @@ async fn construction_parse(
                 (AccountAddress::ONE, STAKING_CONTRACT_MODULE, RESET_LOCKUP_FUNCTION) => {
                     parse_reset_lockup_operation(sender, &type_args, &args)?
                 },
+                (AccountAddress::ONE, STAKING_CONTRACT_MODULE, UNLOCK_STAKE_FUNCTION) => {
+                    parse_unlock_stake_operation(sender, &type_args, &args)?
+                },
+                (
+                    AccountAddress::ONE,
+                    STAKING_CONTRACT_MODULE,
+                    DISTRIBUTE_STAKING_REWARDS_FUNCTION,
+                ) => parse_distribute_staking_rewards_operation(sender, &type_args, &args)?,
                 _ => {
                     return Err(ApiError::TransactionParseError(Some(format!(
                         "Unsupported entry function type {:x}::{}::{}",
@@ -823,6 +831,54 @@ pub fn parse_reset_lockup_operation(
     )])
 }
 
+pub fn parse_unlock_stake_operation(
+    sender: AccountAddress,
+    type_args: &[TypeTag],
+    args: &[Vec<u8>],
+) -> ApiResult<Vec<Operation>> {
+    if !type_args.is_empty() {
+        return Err(ApiError::TransactionParseError(Some(format!(
+            "Unlock stake should not have type arguments: {:?}",
+            type_args
+        ))));
+    }
+
+    let operator: AccountAddress = parse_function_arg("unlock_stake", args, 0)?;
+    let amount: u64 = parse_function_arg("unlock_stake", args, 1)?;
+
+    Ok(vec![Operation::unlock_stake(
+        0,
+        None,
+        sender,
+        Some(AccountIdentifier::base_account(operator)),
+        Some(amount),
+    )])
+}
+
+pub fn parse_distribute_staking_rewards_operation(
+    sender: AccountAddress,
+    type_args: &[TypeTag],
+    args: &[Vec<u8>],
+) -> ApiResult<Vec<Operation>> {
+    if !type_args.is_empty() {
+        return Err(ApiError::TransactionParseError(Some(format!(
+            "Distribute should not have type arguments: {:?}",
+            type_args
+        ))));
+    }
+
+    let staker: AccountAddress = parse_function_arg("distribute_staking_rewards", args, 0)?;
+    let operator: AccountAddress = parse_function_arg("distribute_staking_rewards", args, 1)?;
+
+    Ok(vec![Operation::distribute_staking_rewards(
+        0,
+        None,
+        sender,
+        AccountIdentifier::base_account(operator),
+        AccountIdentifier::base_account(staker),
+    )])
+}
+
 /// Construction payloads command (OFFLINE)
 ///
 /// Constructs payloads for given known operations
@@ -920,6 +976,38 @@ async fn construction_payloads(
             } else {
                 return Err(ApiError::InvalidInput(Some(format!(
                     "Reset lockup operation doesn't match metadata {:?} vs {:?}",
+                    inner, metadata.internal_operation
+                ))));
+            }
+        },
+        InternalOperation::UnlockStake(inner) => {
+            if let InternalOperation::UnlockStake(ref metadata_op) = metadata.internal_operation {
+                if inner.owner != metadata_op.owner || inner.operator != metadata_op.operator {
+                    return Err(ApiError::InvalidInput(Some(format!(
+                        "Unlock stake operation doesn't match metadata {:?} vs {:?}",
+                        inner, metadata.internal_operation
+                    ))));
+                }
+            } else {
+                return Err(ApiError::InvalidInput(Some(format!(
+                    "Unlock stake operation doesn't match metadata {:?} vs {:?}",
+                    inner, metadata.internal_operation
+                ))));
+            }
+        },
+        InternalOperation::DistributeStakingRewards(inner) => {
+            if let InternalOperation::DistributeStakingRewards(ref metadata_op) =
+                metadata.internal_operation
+            {
+                if inner.operator != metadata_op.operator || inner.staker != metadata_op.staker {
+                    return Err(ApiError::InvalidInput(Some(format!(
+                        "Distribute staking rewards operation doesn't match metadata {:?} vs {:?}",
+                        inner, metadata.internal_operation
+                    ))));
+                }
+            } else {
+                return Err(ApiError::InvalidInput(Some(format!(
+                    "Distribute staking rewards operation doesn't match metadata {:?} vs {:?}",
                     inner, metadata.internal_operation
                 ))));
             }

--- a/crates/aptos-rosetta/src/lib.rs
+++ b/crates/aptos-rosetta/src/lib.rs
@@ -69,8 +69,8 @@ impl RosettaContext {
                     let store = store.into_inner();
                     let pool_addresses: Vec<_> = store
                         .staking_contracts
-                        .values()
-                        .map(|pool| pool.pool_address)
+                        .iter()
+                        .map(|(_, pool)| pool.pool_address)
                         .collect();
                     for pool_address in pool_addresses {
                         pool_address_to_owner.insert(pool_address, *owner_address);

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -50,6 +50,34 @@ impl AccountIdentifier {
         }
     }
 
+    pub fn pending_active_stake_account(address: AccountAddress) -> Self {
+        AccountIdentifier {
+            address: to_hex_lower(&address),
+            sub_account: Some(SubAccountIdentifier::new_pending_active_stake()),
+        }
+    }
+
+    pub fn active_stake_account(address: AccountAddress) -> Self {
+        AccountIdentifier {
+            address: to_hex_lower(&address),
+            sub_account: Some(SubAccountIdentifier::new_active_stake()),
+        }
+    }
+
+    pub fn pending_inactive_stake_account(address: AccountAddress) -> Self {
+        AccountIdentifier {
+            address: to_hex_lower(&address),
+            sub_account: Some(SubAccountIdentifier::new_pending_inactive_stake()),
+        }
+    }
+
+    pub fn inactive_stake_account(address: AccountAddress) -> Self {
+        AccountIdentifier {
+            address: to_hex_lower(&address),
+            sub_account: Some(SubAccountIdentifier::new_inactive_stake()),
+        }
+    }
+
     pub fn operator_stake_account(
         address: AccountAddress,
         operator_address: AccountAddress,
@@ -72,9 +100,45 @@ impl AccountIdentifier {
         }
     }
 
+    pub fn is_pending_active_stake(&self) -> bool {
+        if let Some(ref inner) = self.sub_account {
+            inner.is_pending_active_stake()
+        } else {
+            false
+        }
+    }
+
+    pub fn is_active_stake(&self) -> bool {
+        if let Some(ref inner) = self.sub_account {
+            inner.is_active_stake()
+        } else {
+            false
+        }
+    }
+
+    pub fn is_pending_inactive_stake(&self) -> bool {
+        if let Some(ref inner) = self.sub_account {
+            inner.is_pending_inactive_stake()
+        } else {
+            false
+        }
+    }
+
+    pub fn is_inactive_stake(&self) -> bool {
+        if let Some(ref inner) = self.sub_account {
+            inner.is_inactive_stake()
+        } else {
+            false
+        }
+    }
+
     pub fn is_operator_stake(&self) -> bool {
         if let Some(ref inner) = self.sub_account {
-            !inner.is_total_stake()
+            !(inner.is_total_stake()
+                || inner.is_active_stake()
+                || inner.is_pending_active_stake()
+                || inner.is_inactive_stake()
+                || inner.is_pending_inactive_stake())
         } else {
             false
         }
@@ -106,12 +170,40 @@ pub struct SubAccountIdentifier {
 }
 
 const STAKE: &str = "stake";
+const PENDING_ACTIVE_STAKE: &str = "pending_active_stake";
+const ACTIVE_STAKE: &str = "active_stake";
+const PENDING_INACTIVE_STAKE: &str = "pending_inactive_stake";
+const INACTIVE_STAKE: &str = "inactive_stake";
 const ACCOUNT_SEPARATOR: char = '-';
 
 impl SubAccountIdentifier {
     pub fn new_total_stake() -> SubAccountIdentifier {
         SubAccountIdentifier {
             address: STAKE.to_string(),
+        }
+    }
+
+    pub fn new_pending_active_stake() -> SubAccountIdentifier {
+        SubAccountIdentifier {
+            address: PENDING_ACTIVE_STAKE.to_string(),
+        }
+    }
+
+    pub fn new_active_stake() -> SubAccountIdentifier {
+        SubAccountIdentifier {
+            address: ACTIVE_STAKE.to_string(),
+        }
+    }
+
+    pub fn new_pending_inactive_stake() -> SubAccountIdentifier {
+        SubAccountIdentifier {
+            address: PENDING_INACTIVE_STAKE.to_string(),
+        }
+    }
+
+    pub fn new_inactive_stake() -> SubAccountIdentifier {
+        SubAccountIdentifier {
+            address: INACTIVE_STAKE.to_string(),
         }
     }
 
@@ -123,6 +215,22 @@ impl SubAccountIdentifier {
 
     pub fn is_total_stake(&self) -> bool {
         self.address.as_str() == STAKE
+    }
+
+    pub fn is_pending_active_stake(&self) -> bool {
+        self.address.as_str() == PENDING_ACTIVE_STAKE
+    }
+
+    pub fn is_active_stake(&self) -> bool {
+        self.address.as_str() == ACTIVE_STAKE
+    }
+
+    pub fn is_pending_inactive_stake(&self) -> bool {
+        self.address.as_str() == PENDING_INACTIVE_STAKE
+    }
+
+    pub fn is_inactive_stake(&self) -> bool {
+        self.address.as_str() == INACTIVE_STAKE
     }
 
     pub fn operator_address(&self) -> ApiResult<AccountAddress> {
@@ -287,10 +395,19 @@ mod test {
         let base_account = AccountIdentifier::base_account(account);
         let total_stake_account = AccountIdentifier::total_stake_account(account);
         let operator_stake_account = AccountIdentifier::operator_stake_account(account, operator);
+        let active_stake_account = AccountIdentifier::active_stake_account(account);
+        let pending_active_stake_account = AccountIdentifier::pending_active_stake_account(account);
+        let inactive_stake_account = AccountIdentifier::inactive_stake_account(account);
+        let pending_inactive_stake_account =
+            AccountIdentifier::pending_inactive_stake_account(account);
 
         assert!(base_account.is_base_account());
         assert!(!operator_stake_account.is_base_account());
         assert!(!total_stake_account.is_base_account());
+        assert!(!active_stake_account.is_base_account());
+        assert!(!pending_active_stake_account.is_base_account());
+        assert!(!inactive_stake_account.is_base_account());
+        assert!(!pending_inactive_stake_account.is_base_account());
 
         assert!(!base_account.is_operator_stake());
         assert!(operator_stake_account.is_operator_stake());
@@ -300,9 +417,21 @@ mod test {
         assert!(!operator_stake_account.is_total_stake());
         assert!(total_stake_account.is_total_stake());
 
+        assert!(active_stake_account.is_active_stake());
+        assert!(pending_active_stake_account.is_pending_active_stake());
+        assert!(inactive_stake_account.is_inactive_stake());
+        assert!(pending_inactive_stake_account.is_pending_inactive_stake());
+
         assert_eq!(Ok(account), base_account.account_address());
         assert_eq!(Ok(account), operator_stake_account.account_address());
         assert_eq!(Ok(account), total_stake_account.account_address());
+        assert_eq!(Ok(account), active_stake_account.account_address());
+        assert_eq!(Ok(account), pending_active_stake_account.account_address());
+        assert_eq!(Ok(account), inactive_stake_account.account_address());
+        assert_eq!(
+            Ok(account),
+            pending_inactive_stake_account.account_address()
+        );
 
         assert!(base_account.operator_address().is_err());
         assert_eq!(Ok(operator), operator_stake_account.operator_address());

--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -93,6 +93,8 @@ pub enum OperationType {
     SetVoter,
     InitializeStakePool,
     ResetLockup,
+    UnlockStake,
+    DistributeStakingRewards,
     // Fee must always be last for ordering
     Fee,
 }
@@ -100,12 +102,14 @@ pub enum OperationType {
 impl OperationType {
     const CREATE_ACCOUNT: &'static str = "create_account";
     const DEPOSIT: &'static str = "deposit";
+    const DISTRIBUTE_STAKING_REWARDS: &'static str = "distribute_staking_rewards";
     const FEE: &'static str = "fee";
     const INITIALIZE_STAKE_POOL: &'static str = "initialize_stake_pool";
     const RESET_LOCKUP: &'static str = "reset_lockup";
     const SET_OPERATOR: &'static str = "set_operator";
     const SET_VOTER: &'static str = "set_voter";
     const STAKING_REWARD: &'static str = "staking_reward";
+    const UNLOCK_STAKE: &'static str = "unlock_stake";
     const WITHDRAW: &'static str = "withdraw";
 
     pub fn all() -> Vec<OperationType> {
@@ -120,6 +124,8 @@ impl OperationType {
             StakingReward,
             InitializeStakePool,
             ResetLockup,
+            UnlockStake,
+            DistributeStakingRewards,
         ]
     }
 }
@@ -138,6 +144,8 @@ impl FromStr for OperationType {
             Self::SET_VOTER => Ok(OperationType::SetVoter),
             Self::INITIALIZE_STAKE_POOL => Ok(OperationType::InitializeStakePool),
             Self::RESET_LOCKUP => Ok(OperationType::ResetLockup),
+            Self::UNLOCK_STAKE => Ok(OperationType::UnlockStake),
+            Self::DISTRIBUTE_STAKING_REWARDS => Ok(OperationType::DistributeStakingRewards),
             _ => Err(ApiError::DeserializationFailed(Some(format!(
                 "Invalid OperationType: {}",
                 s
@@ -158,6 +166,8 @@ impl Display for OperationType {
             SetVoter => Self::SET_VOTER,
             InitializeStakePool => Self::INITIALIZE_STAKE_POOL,
             ResetLockup => Self::RESET_LOCKUP,
+            UnlockStake => Self::UNLOCK_STAKE,
+            DistributeStakingRewards => Self::DISTRIBUTE_STAKING_REWARDS,
             Fee => Self::FEE,
         })
     }
@@ -227,7 +237,7 @@ impl Display for OperationStatusType {
     }
 }
 
-pub async fn get_total_stake(
+pub async fn get_stake_balances(
     rest_client: &aptos_rest_client::Client,
     owner_account: &AccountIdentifier,
     pool_address: AccountAddress,
@@ -240,36 +250,46 @@ pub async fn get_total_stake(
     {
         let stake_pool = response.into_inner();
 
-        // Any stake pools that match, retrieve that.  Then update the total
-        let balance = get_stake_balance_from_stake_pool(&stake_pool, owner_account)?;
-        Ok(Some(balance))
+        // Stake isn't allowed for base accounts
+        if owner_account.is_base_account() {
+            return Err(ApiError::InvalidInput(Some(
+                "Stake pool not supported for base account".to_string(),
+            )));
+        }
+
+        // If the operator address is different, skip
+        if owner_account.is_operator_stake()
+            && owner_account.operator_address()? != stake_pool.operator_address
+        {
+            return Err(ApiError::InvalidInput(Some(
+                "Stake pool not for matching operator".to_string(),
+            )));
+        }
+
+        // Any stake pools that match, retrieve that.
+        let mut requested_balance: Option<String> = None;
+
+        if owner_account.is_active_stake() {
+            requested_balance = Some(stake_pool.active.to_string());
+        } else if owner_account.is_pending_active_stake() {
+            requested_balance = Some(stake_pool.pending_active.to_string());
+        } else if owner_account.is_inactive_stake() {
+            requested_balance = Some(stake_pool.inactive.to_string());
+        } else if owner_account.is_pending_inactive_stake() {
+            requested_balance = Some(stake_pool.pending_inactive.to_string());
+        } else if owner_account.is_total_stake() {
+            requested_balance = Some(stake_pool.get_total_staked_amount().to_string());
+        }
+
+        if let Some(balance) = requested_balance {
+            Ok(Some(Amount {
+                value: balance,
+                currency: native_coin(),
+            }))
+        } else {
+            Ok(None)
+        }
     } else {
         Ok(None)
     }
-}
-
-/// Retrieves total stake balances from an individual stake pool
-fn get_stake_balance_from_stake_pool(
-    stake_pool: &StakePool,
-    account: &AccountIdentifier,
-) -> ApiResult<Amount> {
-    // Stake isn't allowed for base accounts
-    if account.is_base_account() {
-        return Err(ApiError::InvalidInput(Some(
-            "Stake pool not supported for base account".to_string(),
-        )));
-    }
-
-    // If the operator address is different, skip
-    if account.is_operator_stake() && account.operator_address()? != stake_pool.operator_address {
-        return Err(ApiError::InvalidInput(Some(
-            "Stake pool not for matching operator".to_string(),
-        )));
-    }
-
-    // TODO: Represent inactive, and pending as separate?
-    Ok(Amount {
-        value: stake_pool.get_total_staked_amount().to_string(),
-        currency: native_coin(),
-    })
 }

--- a/crates/aptos-rosetta/src/types/move_types.rs
+++ b/crates/aptos-rosetta/src/types/move_types.rs
@@ -33,6 +33,8 @@ pub const CREATE_STAKING_CONTRACT_FUNCTION: &str = "create_staking_contract";
 pub const SWITCH_OPERATOR_WITH_SAME_COMMISSION_FUNCTION: &str =
     "switch_operator_with_same_commission";
 pub const UPDATE_VOTER_FUNCTION: &str = "update_voter";
+pub const UNLOCK_STAKE_FUNCTION: &str = "unlock_stake";
+pub const DISTRIBUTE_STAKING_REWARDS_FUNCTION: &str = "distribute";
 
 pub const DECIMALS_FIELD: &str = "decimal";
 pub const DEPOSIT_EVENTS_FIELD: &str = "deposit_events";

--- a/crates/aptos-rosetta/src/types/move_types.rs
+++ b/crates/aptos-rosetta/src/types/move_types.rs
@@ -6,7 +6,6 @@
 use crate::AccountAddress;
 use aptos_types::event::EventHandle;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 
 pub const ACCOUNT_MODULE: &str = "account";
 pub const APTOS_ACCOUNT_MODULE: &str = "aptos_account";
@@ -43,7 +42,7 @@ pub const SET_OPERATOR_EVENTS_FIELD: &str = "set_operator_events";
 pub const SEQUENCE_NUMBER_FIELD: &str = "sequence_number";
 pub const SYMBOL_FIELD: &str = "symbol";
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StakingContract {
     pub principal: u64,
     pub pool_address: AccountAddress,
@@ -61,7 +60,7 @@ impl StakingContract {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Store {
-    pub staking_contracts: BTreeMap<AccountAddress, StakingContract>,
+    pub staking_contracts: Vec<(AccountAddress, StakingContract)>,
     pub create_staking_contract_events: EventHandle,
     pub update_voter_events: EventHandle,
     pub reset_lockup_events: EventHandle,
@@ -141,12 +140,12 @@ pub struct DistributeEvent {
     pub amount: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Pool {
     pub shareholders_limit: u64,
     pub total_coins: u64,
     pub total_shares: u64,
-    pub shares: BTreeMap<AccountAddress, u64>,
+    pub shares: Vec<(AccountAddress, u64)>,
     pub shareholders: Vec<AccountAddress>,
     pub scaling_factor: u64,
 }
@@ -154,12 +153,13 @@ pub struct Pool {
 impl Pool {
     pub fn get_balance(&self, account_address: &AccountAddress) -> Option<u64> {
         self.shares
-            .get(account_address)
-            .map(|inner| (*inner * self.total_coins) / self.total_shares)
+            .iter()
+            .find(|(address, _)| address == account_address)
+            .map(|(_, shares)| (*shares * self.total_coins) / self.total_shares)
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct Capability {
     pub pool_address: AccountAddress,
 }

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -8,8 +8,9 @@
 use crate::{
     common::{is_native_coin, native_coin, native_coin_tag},
     construction::{
-        parse_create_stake_pool_operation, parse_reset_lockup_operation,
-        parse_set_operator_operation, parse_set_voter_operation,
+        parse_create_stake_pool_operation, parse_distribute_staking_rewards_operation,
+        parse_reset_lockup_operation, parse_set_operator_operation, parse_set_voter_operation,
+        parse_unlock_stake_operation,
     },
     error::ApiResult,
     types::{
@@ -370,6 +371,42 @@ impl Operation {
             Some(OperationMetadata::reset_lockup(operator)),
         )
     }
+
+    pub fn unlock_stake(
+        operation_index: u64,
+        status: Option<OperationStatusType>,
+        owner: AccountAddress,
+        operator: Option<AccountIdentifier>,
+        amount: Option<u64>,
+    ) -> Operation {
+        Operation::new(
+            OperationType::UnlockStake,
+            operation_index,
+            status,
+            AccountIdentifier::base_account(owner),
+            None,
+            Some(OperationMetadata::unlock_stake(operator, amount)),
+        )
+    }
+
+    pub fn distribute_staking_rewards(
+        operation_index: u64,
+        status: Option<OperationStatusType>,
+        account: AccountAddress,
+        operator: AccountIdentifier,
+        staker: AccountIdentifier,
+    ) -> Operation {
+        Operation::new(
+            OperationType::DistributeStakingRewards,
+            operation_index,
+            status,
+            AccountIdentifier::base_account(account),
+            None,
+            Some(OperationMetadata::distribute_staking_rewards(
+                operator, staker,
+            )),
+        )
+    }
 }
 
 impl std::cmp::PartialOrd for Operation {
@@ -418,6 +455,10 @@ pub struct OperationMetadata {
     pub staked_balance: Option<U64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub commission_percentage: Option<U64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub amount: Option<U64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub staker: Option<AccountIdentifier>,
 }
 
 impl OperationMetadata {
@@ -467,6 +508,25 @@ impl OperationMetadata {
     pub fn reset_lockup(operator: Option<AccountIdentifier>) -> Self {
         OperationMetadata {
             operator,
+            ..Default::default()
+        }
+    }
+
+    pub fn unlock_stake(operator: Option<AccountIdentifier>, amount: Option<u64>) -> Self {
+        OperationMetadata {
+            operator,
+            amount: amount.map(U64::from),
+            ..Default::default()
+        }
+    }
+
+    pub fn distribute_staking_rewards(
+        operator: AccountIdentifier,
+        staker: AccountIdentifier,
+    ) -> Self {
+        OperationMetadata {
+            operator: Some(operator),
+            staker: Some(staker),
             ..Default::default()
         }
     }
@@ -767,6 +827,30 @@ fn parse_failed_operations_from_txn_payload(
                     }
                 } else {
                     warn!("Failed to parse create staking pool {:?}", inner);
+                }
+            },
+            (AccountAddress::ONE, STAKING_CONTRACT_MODULE, UNLOCK_STAKE_FUNCTION) => {
+                if let Ok(mut ops) =
+                    parse_unlock_stake_operation(sender, inner.ty_args(), inner.args())
+                {
+                    if let Some(operation) = ops.get_mut(0) {
+                        operation.status = Some(OperationStatusType::Failure.to_string());
+                    }
+                } else {
+                    warn!("Failed to parse unlock stake {:?}", inner);
+                }
+            },
+            (AccountAddress::ONE, STAKING_CONTRACT_MODULE, DISTRIBUTE_STAKING_REWARDS_FUNCTION) => {
+                if let Ok(mut ops) = parse_distribute_staking_rewards_operation(
+                    sender,
+                    inner.ty_args(),
+                    inner.args(),
+                ) {
+                    if let Some(operation) = ops.get_mut(0) {
+                        operation.status = Some(OperationStatusType::Failure.to_string());
+                    }
+                } else {
+                    warn!("Failed to parse distribute staking rewards {:?}", inner);
                 }
             },
             _ => {
@@ -1260,6 +1344,34 @@ async fn parse_staking_contract_resource_changes(
             }
             operations.push(operation);
         }
+
+        // Handle distribute events, there are no events on the stake pool
+        let distribute_staking_rewards_events =
+            filter_events(events, store.distribute_events.key(), |event_key, event| {
+                if let Ok(event) = bcs::from_bytes::<DistributeEvent>(event.event_data()) {
+                    Some(event)
+                } else {
+                    // If we can't parse the withdraw event, then there's nothing
+                    warn!(
+                        "Failed to parse distribute event!  Skipping for {}:{}",
+                        event_key.get_creator_address(),
+                        event_key.get_creation_number()
+                    );
+                    None
+                }
+            });
+
+        // For every distribute events, add staking reward operation
+        for event in distribute_staking_rewards_events {
+            operations.push(Operation::staking_reward(
+                operation_index,
+                Some(OperationStatusType::Success),
+                AccountIdentifier::base_account(event.recipient),
+                native_coin(),
+                event.amount,
+            ));
+            operation_index += 1;
+        }
     }
 
     Ok(operations)
@@ -1361,6 +1473,8 @@ pub enum InternalOperation {
     SetVoter(SetVoter),
     InitializeStakePool(InitializeStakePool),
     ResetLockup(ResetLockup),
+    UnlockStake(UnlockStake),
+    DistributeStakingRewards(DistributeStakingRewards),
 }
 
 impl InternalOperation {
@@ -1483,6 +1597,47 @@ impl InternalOperation {
                                 }));
                             }
                         },
+                        Ok(OperationType::UnlockStake) => {
+                            if let (
+                                Some(OperationMetadata {
+                                    operator, amount, ..
+                                }),
+                                Some(account),
+                            ) = (&operation.metadata, &operation.account)
+                            {
+                                let operator = if let Some(operator) = operator {
+                                    operator.account_address()?
+                                } else {
+                                    return Err(ApiError::InvalidInput(Some(
+                                        "Unlock Stake missing operator field".to_string(),
+                                    )));
+                                };
+                                return Ok(Self::UnlockStake(UnlockStake {
+                                    owner: account.account_address()?,
+                                    operator,
+                                    amount: amount.map(u64::from).unwrap_or_default(),
+                                }));
+                            }
+                        },
+                        Ok(OperationType::DistributeStakingRewards) => {
+                            if let (
+                                Some(OperationMetadata {
+                                    operator: Some(operator),
+                                    staker: Some(staker),
+                                    ..
+                                }),
+                                Some(account),
+                            ) = (&operation.metadata, &operation.account)
+                            {
+                                return Ok(Self::DistributeStakingRewards(
+                                    DistributeStakingRewards {
+                                        sender: account.account_address()?,
+                                        operator: operator.account_address()?,
+                                        staker: staker.account_address()?,
+                                    },
+                                ));
+                            }
+                        },
                         _ => {},
                     }
                 }
@@ -1510,6 +1665,8 @@ impl InternalOperation {
             Self::SetVoter(inner) => inner.owner,
             Self::InitializeStakePool(inner) => inner.owner,
             Self::ResetLockup(inner) => inner.owner,
+            Self::UnlockStake(inner) => inner.owner,
+            Self::DistributeStakingRewards(inner) => inner.sender,
         }
     }
 
@@ -1569,6 +1726,20 @@ impl InternalOperation {
             InternalOperation::ResetLockup(reset_lockup) => (
                 aptos_stdlib::staking_contract_reset_lockup(reset_lockup.operator),
                 reset_lockup.owner,
+            ),
+            InternalOperation::UnlockStake(unlock_stake) => (
+                aptos_stdlib::staking_contract_unlock_stake(
+                    unlock_stake.operator,
+                    unlock_stake.amount,
+                ),
+                unlock_stake.owner,
+            ),
+            InternalOperation::DistributeStakingRewards(distribute_staking_rewards) => (
+                aptos_stdlib::staking_contract_distribute(
+                    distribute_staking_rewards.staker,
+                    distribute_staking_rewards.operator,
+                ),
+                distribute_staking_rewards.sender,
             ),
         })
     }
@@ -1727,4 +1898,18 @@ pub struct InitializeStakePool {
 pub struct ResetLockup {
     pub owner: AccountAddress,
     pub operator: AccountAddress,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct UnlockStake {
+    pub owner: AccountAddress,
+    pub operator: AccountAddress,
+    pub amount: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DistributeStakingRewards {
+    pub sender: AccountAddress,
+    pub operator: AccountAddress,
+    pub staker: AccountAddress,
 }

--- a/crates/channel/src/aptos_channel.rs
+++ b/crates/channel/src/aptos_channel.rs
@@ -11,7 +11,6 @@
 use crate::message_queues::{PerKeyQueue, QueueStyle};
 use anyhow::{ensure, Result};
 use aptos_infallible::{Mutex, NonZeroUsize};
-use aptos_logger::debug;
 use aptos_metrics_core::IntCounterVec;
 use futures::{
     channel::oneshot,
@@ -105,7 +104,6 @@ impl<K: Eq + Hash + Clone, M> Sender<K, M> {
         // notify the corresponding status channel if it was registered.
         if let Some((dropped_val, Some(dropped_status_ch))) = dropped {
             // Ignore errors.
-            debug!("QS: dropped message in aptos channel");
             let _err = dropped_status_ch.send(ElementStatus::Dropped(dropped_val));
         }
         if let Some(w) = shared_state.waker.take() {

--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -960,7 +960,7 @@ def sanitize_forge_resource_name(forge_resource: str) -> str:
     """
     Sanitize the intended forge resource name to be a valid k8s resource name
     """
-    max_length = 64
+    max_length = 63
     sanitized_namespace = ""
     for i, c in enumerate(forge_resource):
         if i >= max_length:

--- a/testsuite/forge_test.py
+++ b/testsuite/forge_test.py
@@ -751,7 +751,7 @@ class ForgeFormattingTests(unittest.TestCase, AssertFixtureMixin):
         namespace = sanitize_forge_resource_name(namespace_too_long)
         self.assertEqual(
             namespace,
-            "forge-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "forge-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         )
 
 

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -18,6 +18,7 @@ pub enum FeatureFlag {
     BLAKE2B_256_NATIVE = 8,
     RESOURCE_GROUPS = 9,
     MULTISIG_ACCOUNTS = 10,
+    DELEGATION_POOLS = 11,
 }
 
 /// Representation of features on chain as a bitset.


### PR DESCRIPTION
I wanted to share a recent experience I had with my validator server. Before the last update, my server had a connection parameter distribution of approximately 50/50. However, after the update, the distribution shifted to around 80/20 and remained that way for about two weeks. Normally, the distribution would revert within the first 3-4 days after an update.
After discussing the issue with some fellow community members, I decided to make changes to my haproxy.cfg file. I updated the following parameters:
nbthread 8 
timeout queue 10s 
timeout connect 10s 
timeout server 120s 
timeout client 120s 
And also changed the backend validator-fn configuration( belive that this is the key):
default-server maxconn 128 
To my delight, within minutes, the connection rate adjusted to approximately 40/60. Additionally, my committed_votes metric improved from an average of 60/12h to 70.
@rustielin 