### PR TITLE
Remove unsafe

### DIFF
--- a/third_party/move/move-symbol-pool/src/pool.rs
+++ b/third_party/move/move-symbol-pool/src/pool.rs
@@ -62,8 +62,8 @@ impl Pool {
     /// Allocates a contiguous array of buckets on the heap. As strings are
     /// inserted into the pool, buckets in this array are filled with an entry.
     pub(crate) fn new() -> Self {
-        let vec = std::mem::ManuallyDrop::new(vec![0_usize; NB_BUCKETS]);
-        Self(unsafe { Box::from_raw(vec.as_ptr() as *mut [Bucket; NB_BUCKETS]) })
+        const INIT: Bucket = None;
+        Self(Box::new([INIT; NB_BUCKETS]))
     }
 
     /// Computes the hash value of a string, which is used to determine both

--- a/third_party/move/move-symbol-pool/src/pool.rs
+++ b/third_party/move/move-symbol-pool/src/pool.rs
@@ -62,6 +62,8 @@ impl Pool {
     /// Allocates a contiguous array of buckets on the heap. As strings are
     /// inserted into the pool, buckets in this array are filled with an entry.
     pub(crate) fn new() -> Self {
+        // Using const INIT, works around the fact that [None; NB_BUCKETS] not being possible
+        // because Bucket is not Copy.
         const INIT: Bucket = None;
         Self(Box::new([INIT; NB_BUCKETS]))
     }


### PR DESCRIPTION
### Description

Over the weekend I investigated some SIGSEGV I experienced and was looking at unsafe code in our code base as possible culprits. I encountered this which I initially thought must be wrong (Option<Box<Entry>> is type punned as an usize). It turns out that absolute compiler magic makes Option<Box<Entry>> the same size as usize, but I feel that kind of code is ridiculous.

The problem is that one cannot use [None, NB_BUCKETS] as Bucket == Option<Box<Entry>> is non-copyable, however one can simply work around that by using cont INIT: Bucket = None, and use INIT as initialization value.

This seems cleaner
