### PR TITLE
Add CLI support for multisig accounts (v2)

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.0.12]
+### Added
+* Support for creating and interacting with multisig accounts v2. More details can be found at [AIP 12](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-12.md).
+
 ## [1.0.11] - 2023/04/14
 ### Fixed
 * Fixed creating a new test account with `aptos init` would fail if the account didn't already exist

--- a/crates/aptos/src/account/mod.rs
+++ b/crates/aptos/src/account/mod.rs
@@ -10,6 +10,7 @@ pub mod derive_resource_account;
 pub mod fund;
 pub mod key_rotation;
 pub mod list;
+pub mod multisig_account;
 pub mod transfer;
 
 /// Tool for interacting with accounts
@@ -39,6 +40,30 @@ impl AccountTool {
             AccountTool::LookupAddress(tool) => tool.execute_serialized().await,
             AccountTool::RotateKey(tool) => tool.execute_serialized().await,
             AccountTool::Transfer(tool) => tool.execute_serialized().await,
+        }
+    }
+}
+
+/// Tool for interacting with multisig accounts
+#[derive(Debug, Subcommand)]
+pub enum MultisigAccountTool {
+    Approve(multisig_account::Approve),
+    Create(multisig_account::Create),
+    CreateTransaction(multisig_account::CreateTransaction),
+    Execute(multisig_account::Execute),
+    ExecuteReject(multisig_account::ExecuteReject),
+    Reject(multisig_account::Reject),
+}
+
+impl MultisigAccountTool {
+    pub async fn execute(self) -> CliResult {
+        match self {
+            MultisigAccountTool::Approve(tool) => tool.execute_serialized().await,
+            MultisigAccountTool::Create(tool) => tool.execute_serialized().await,
+            MultisigAccountTool::CreateTransaction(tool) => tool.execute_serialized().await,
+            MultisigAccountTool::Execute(tool) => tool.execute_serialized().await,
+            MultisigAccountTool::ExecuteReject(tool) => tool.execute_serialized().await,
+            MultisigAccountTool::Reject(tool) => tool.execute_serialized().await,
         }
     }
 }

--- a/crates/aptos/src/account/multisig_account.rs
+++ b/crates/aptos/src/account/multisig_account.rs
@@ -1,0 +1,257 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::types::{
+    CliCommand, CliTypedResult, EntryFunctionArguments, MultisigAccount, TransactionOptions,
+    TransactionSummary,
+};
+use aptos_cached_packages::aptos_stdlib;
+use aptos_rest_client::{
+    aptos_api_types::{WriteResource, WriteSetChange},
+    Transaction,
+};
+use aptos_types::{
+    account_address::AccountAddress,
+    transaction::{Multisig, MultisigTransactionPayload, TransactionPayload},
+};
+use async_trait::async_trait;
+use bcs::to_bytes;
+use clap::Parser;
+use serde::Serialize;
+
+/// Create a new multisig account (v2) on-chain.
+///
+/// This will create a new multisig account and make the sender one of the owners.
+#[derive(Debug, Parser)]
+pub struct Create {
+    /// Addresses of additional owners for the new multisig, beside the transaction sender.
+    #[clap(long, multiple_values = true, parse(try_from_str=crate::common::types::load_account_arg))]
+    pub(crate) additional_owners: Vec<AccountAddress>,
+    /// The number of signatures (approvals or rejections) required to execute or remove a proposed
+    /// transaction.
+    #[clap(long)]
+    pub(crate) num_signatures_required: u64,
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+}
+
+/// A shortened create multisig account output
+#[derive(Clone, Debug, Serialize)]
+pub struct CreateSummary {
+    #[serde(flatten)]
+    pub multisig_account: Option<MultisigAccount>,
+    #[serde(flatten)]
+    pub transaction_summary: TransactionSummary,
+}
+
+impl From<Transaction> for CreateSummary {
+    fn from(transaction: Transaction) -> Self {
+        let transaction_summary = TransactionSummary::from(&transaction);
+
+        let mut summary = CreateSummary {
+            transaction_summary,
+            multisig_account: None,
+        };
+
+        if let Transaction::UserTransaction(txn) = transaction {
+            summary.multisig_account = txn.info.changes.iter().find_map(|change| match change {
+                WriteSetChange::WriteResource(WriteResource { address, data, .. }) => {
+                    if data.typ.name.as_str() == "Account"
+                        && *address.inner().to_hex() != *txn.request.sender.inner().to_hex()
+                    {
+                        Some(MultisigAccount {
+                            multisig_address: *address.inner(),
+                        })
+                    } else {
+                        None
+                    }
+                },
+                _ => None,
+            });
+        }
+
+        summary
+    }
+}
+
+#[async_trait]
+impl CliCommand<CreateSummary> for Create {
+    fn command_name(&self) -> &'static str {
+        "CreateMultisig"
+    }
+
+    async fn execute(self) -> CliTypedResult<CreateSummary> {
+        self.txn_options
+            .submit_transaction(aptos_stdlib::multisig_account_create_with_owners(
+                self.additional_owners,
+                self.num_signatures_required,
+                // TODO: Support passing in custom metadata.
+                vec![],
+                vec![],
+            ))
+            .await
+            .map(CreateSummary::from)
+    }
+}
+
+/// Propose a new multisig transaction.
+///
+/// As one of the owners of the multisig, propose a new transaction. This also implicitly approves
+/// the created transaction so it has one approval initially. In order for the transaction to be
+/// executed, it needs as many approvals as the number of signatures required.
+#[derive(Debug, Parser)]
+pub struct CreateTransaction {
+    #[clap(flatten)]
+    pub(crate) multisig_account: MultisigAccount,
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+    #[clap(flatten)]
+    pub(crate) entry_function_args: EntryFunctionArguments,
+}
+
+#[async_trait]
+impl CliCommand<TransactionSummary> for CreateTransaction {
+    fn command_name(&self) -> &'static str {
+        "CreateTransactionMultisig"
+    }
+
+    async fn execute(self) -> CliTypedResult<TransactionSummary> {
+        let payload = MultisigTransactionPayload::EntryFunction(
+            self.entry_function_args.create_entry_function_payload()?,
+        );
+        self.txn_options
+            .submit_transaction(aptos_stdlib::multisig_account_create_transaction(
+                self.multisig_account.multisig_address,
+                to_bytes(&payload)?,
+            ))
+            .await
+            .map(|inner| inner.into())
+    }
+}
+
+/// Approve a multisig transaction.
+///
+/// As one of the owners of the multisig, approve a transaction proposed for the multisig.
+/// With enough approvals (as many as the number of signatures required), the transaction can be
+/// executed (See Execute).
+#[derive(Debug, Parser)]
+pub struct Approve {
+    #[clap(flatten)]
+    pub(crate) multisig_account: MultisigAccount,
+    /// The sequence number of the multisig transaction to approve. The sequence number increments
+    /// for every new multisig transaction.
+    #[clap(long)]
+    pub(crate) sequence_number: u64,
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+}
+
+#[async_trait]
+impl CliCommand<TransactionSummary> for Approve {
+    fn command_name(&self) -> &'static str {
+        "ApproveMultisig"
+    }
+
+    async fn execute(self) -> CliTypedResult<TransactionSummary> {
+        self.txn_options
+            .submit_transaction(aptos_stdlib::multisig_account_approve_transaction(
+                self.multisig_account.multisig_address,
+                self.sequence_number,
+            ))
+            .await
+            .map(|inner| inner.into())
+    }
+}
+
+/// Reject a multisig transaction.
+///
+/// As one of the owners of the multisig, reject a transaction proposed for the multisig.
+/// With enough rejections (as many as the number of signatures required), the transaction can be
+/// completely removed (See ExecuteReject).
+#[derive(Debug, Parser)]
+pub struct Reject {
+    #[clap(flatten)]
+    pub(crate) multisig_account: MultisigAccount,
+    /// The sequence number of the multisig transaction to reject. The sequence number increments
+    /// for every new multisig transaction.
+    #[clap(long)]
+    pub(crate) sequence_number: u64,
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+}
+
+#[async_trait]
+impl CliCommand<TransactionSummary> for Reject {
+    fn command_name(&self) -> &'static str {
+        "RejectMultisig"
+    }
+
+    async fn execute(self) -> CliTypedResult<TransactionSummary> {
+        self.txn_options
+            .submit_transaction(aptos_stdlib::multisig_account_reject_transaction(
+                self.multisig_account.multisig_address,
+                self.sequence_number,
+            ))
+            .await
+            .map(|inner| inner.into())
+    }
+}
+
+/// Execute a proposed multisig transaction.
+///
+/// The transaction to be executed needs to have as many approvals as the number of signatures
+/// required.
+#[derive(Debug, Parser)]
+pub struct Execute {
+    #[clap(flatten)]
+    pub(crate) multisig_account: MultisigAccount,
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+}
+
+#[async_trait]
+impl CliCommand<TransactionSummary> for Execute {
+    fn command_name(&self) -> &'static str {
+        "ExecuteMultisig"
+    }
+
+    async fn execute(self) -> CliTypedResult<TransactionSummary> {
+        let payload = TransactionPayload::Multisig(Multisig {
+            multisig_address: self.multisig_account.multisig_address,
+            // TODO: Support passing an explicit payload
+            transaction_payload: None,
+        });
+        self.txn_options
+            .submit_transaction(payload)
+            .await
+            .map(|inner| inner.into())
+    }
+}
+
+/// Remove a proposed multisig transaction.
+///
+/// The transaction to be removed needs to have as many rejections as the number of signatures
+/// required.
+#[derive(Debug, Parser)]
+pub struct ExecuteReject {
+    #[clap(flatten)]
+    pub(crate) multisig_account: MultisigAccount,
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+}
+
+#[async_trait]
+impl CliCommand<TransactionSummary> for ExecuteReject {
+    fn command_name(&self) -> &'static str {
+        "ExecuteRejectMultisig"
+    }
+
+    async fn execute(self) -> CliTypedResult<TransactionSummary> {
+        self.txn_options
+            .submit_transaction(aptos_stdlib::multisig_account_execute_rejected_transaction(
+                self.multisig_account.multisig_address,
+            ))
+            .await
+            .map(|inner| inner.into())
+    }
+}

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -43,6 +43,8 @@ pub enum Tool {
     #[clap(subcommand)]
     Move(move_tool::MoveTool),
     #[clap(subcommand)]
+    Multisig(account::MultisigAccountTool),
+    #[clap(subcommand)]
     Node(node::NodeTool),
     #[clap(subcommand)]
     Stake(stake::StakeTool),
@@ -62,6 +64,7 @@ impl Tool {
             Init(tool) => tool.execute_serialized_success().await,
             Key(tool) => tool.execute().await,
             Move(tool) => tool.execute().await,
+            Multisig(tool) => tool.execute().await,
             Node(tool) => tool.execute().await,
             Stake(tool) => tool.execute().await,
             Update(tool) => tool.execute_serialized().await,

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -13,10 +13,10 @@ use crate::{
         init::{InitTool, Network},
         types::{
             account_address_from_public_key, AccountAddressWrapper, CliError, CliTypedResult,
-            EncodingOptions, FaucetOptions, GasOptions, KeyType, MoveManifestAccountWrapper,
-            MovePackageDir, OptionalPoolAddressArgs, PoolAddressArgs, PrivateKeyInputOptions,
-            PromptOptions, PublicKeyInputOptions, RestOptions, RngArgs, SaveFile,
-            TransactionOptions, TransactionSummary,
+            EncodingOptions, EntryFunctionArguments, FaucetOptions, GasOptions, KeyType,
+            MoveManifestAccountWrapper, MovePackageDir, OptionalPoolAddressArgs, PoolAddressArgs,
+            PrivateKeyInputOptions, PromptOptions, PublicKeyInputOptions, RestOptions, RngArgs,
+            SaveFile, TransactionOptions, TransactionSummary,
         },
         utils::write_to_file,
     },
@@ -310,23 +310,25 @@ impl CliTestFramework {
         gas_options: Option<GasOptions>,
     ) -> CliTypedResult<TransactionSummary> {
         RunFunction {
-            function_id: MemberId {
-                module_id: ModuleId::new(
-                    AccountAddress::ONE,
-                    Identifier::from_str("coin").unwrap(),
-                ),
-                member_id: Identifier::from_str("transfer").unwrap(),
+            entry_function_args: EntryFunctionArguments {
+                function_id: MemberId {
+                    module_id: ModuleId::new(
+                        AccountAddress::ONE,
+                        Identifier::from_str("coin").unwrap(),
+                    ),
+                    member_id: Identifier::from_str("transfer").unwrap(),
+                },
+                args: vec![
+                    ArgWithType::from_str("address:0xdeadbeefcafebabe").unwrap(),
+                    ArgWithType::from_str(&format!("u64:{}", amount)).unwrap(),
+                ],
+                type_args: vec![MoveType::Struct(MoveStructTag::new(
+                    AccountAddress::ONE.into(),
+                    IdentifierWrapper::from_str("aptos_coin").unwrap(),
+                    IdentifierWrapper::from_str("AptosCoin").unwrap(),
+                    vec![],
+                ))],
             },
-            args: vec![
-                ArgWithType::from_str("address:0xdeadbeefcafebabe").unwrap(),
-                ArgWithType::from_str(&format!("u64:{}", amount)).unwrap(),
-            ],
-            type_args: vec![MoveType::Struct(MoveStructTag::new(
-                AccountAddress::ONE.into(),
-                IdentifierWrapper::from_str("aptos_coin").unwrap(),
-                IdentifierWrapper::from_str("AptosCoin").unwrap(),
-                vec![],
-            ))],
             txn_options: self.transaction_options(sender_index, gas_options),
         }
         .execute()
@@ -586,16 +588,18 @@ impl CliTestFramework {
         commission_percentage: u64,
     ) -> CliTypedResult<TransactionSummary> {
         RunFunction {
-            function_id: MemberId::from_str("0x1::staking_contract::create_staking_contract")
-                .unwrap(),
-            args: vec![
-                ArgWithType::address(self.account_id(operator_index)),
-                ArgWithType::address(self.account_id(voter_index)),
-                ArgWithType::u64(amount),
-                ArgWithType::u64(commission_percentage),
-                ArgWithType::bytes(vec![]),
-            ],
-            type_args: vec![],
+            entry_function_args: EntryFunctionArguments {
+                function_id: MemberId::from_str("0x1::staking_contract::create_staking_contract")
+                    .unwrap(),
+                args: vec![
+                    ArgWithType::address(self.account_id(operator_index)),
+                    ArgWithType::address(self.account_id(voter_index)),
+                    ArgWithType::u64(amount),
+                    ArgWithType::u64(commission_percentage),
+                    ArgWithType::bytes(vec![]),
+                ],
+                type_args: vec![],
+            },
             txn_options: self.transaction_options(owner_index, None),
         }
         .execute()
@@ -906,9 +910,11 @@ impl CliTestFramework {
 
         RunFunction {
             txn_options: self.transaction_options(index, gas_options),
-            function_id,
-            args: parsed_args,
-            type_args: parsed_type_args,
+            entry_function_args: EntryFunctionArguments {
+                function_id,
+                args: parsed_args,
+                type_args: parsed_type_args,
+            },
         }
         .execute()
         .await


### PR DESCRIPTION
### Description
This adds the CLI commands for interacting with multisig accounts v2. The commands are
1. aptos multisig create --addtional-owners owner1,owner2 --num-signatures-required 2
2. aptos multisig create-transaction --multisig-address <multisig address> --function-id 0x1::multisig_account::add_owners --args address:owner3
3. aptos multisig approve --multisig-address <multisig address> --sequence-number <sequence number of tx to approve>
aptos multisig reject --multisig-address <multisig address> --sequence-number <sequence number of tx to approve>
4. Execute the next tx that has enough approvals: aptos multisig execute --multisig-address <multisig address>
5. Execute (effectively remove) the next tx that has enough rejections: aptos multisig execute-reject --multisig-address <multisig address>

### Test Plan
Manual tests in mainnet
