### PR TITLE
Check CoinType is initialized in register

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/coin.md
+++ b/aptos-move/framework/aptos-framework/doc/coin.md
@@ -1636,6 +1636,8 @@ Returns minted <code><a href="coin.md#0x1_coin_Coin">Coin</a></code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x1_coin_register">register</a>&lt;CoinType&gt;(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <b>assert</b>!(<a href="coin.md#0x1_coin_is_coin_initialized">is_coin_initialized</a>&lt;CoinType&gt;(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="coin.md#0x1_coin_ECOIN_INFO_NOT_PUBLISHED">ECOIN_INFO_NOT_PUBLISHED</a>));
+
     <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
     // Short-circuit and do nothing <b>if</b> <a href="account.md#0x1_account">account</a> is already registered for CoinType.
     <b>if</b> (<a href="coin.md#0x1_coin_is_account_registered">is_account_registered</a>&lt;CoinType&gt;(account_addr)) {

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -536,6 +536,8 @@ module aptos_framework::coin {
     }
 
     public fun register<CoinType>(account: &signer) {
+        assert!(is_coin_initialized<CoinType>(), error::invalid_argument(ECOIN_INFO_NOT_PUBLISHED));
+
         let account_addr = signer::address_of(account);
         // Short-circuit and do nothing if account is already registered for CoinType.
         if (is_account_registered<CoinType>(account_addr)) {
@@ -618,6 +620,9 @@ module aptos_framework::coin {
     }
 
     #[test_only]
+    use std::string::String;
+
+    #[test_only]
     struct FakeMoney {}
 
     #[test_only]
@@ -674,6 +679,12 @@ module aptos_framework::coin {
             freeze_cap,
             mint_cap,
         });
+    }
+
+    #[test(account = @0x123)]
+    #[expected_failure(abort_code = 0x10003, location = Self)]
+    fun register_uninitialized_coin_should_fail(account: &signer) {
+        register<String>(account);
     }
 
     #[test(source = @0x1, destination = @0x2)]


### PR DESCRIPTION
### Description
This prevents accounts from registering arbitrary types that are not valid Coins.

### Test Plan
Unit tests