### PR TITLE
Add hourly Forge-on-GCP continuous workflow

### DIFF
--- a/.github/workflows/forge-gcp.yaml
+++ b/.github/workflows/forge-gcp.yaml
@@ -1,0 +1,90 @@
+# Continuously run Forge tests on GCP against the main branch.
+name: Continuous Forge Tests - GCP
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+  id-token: write
+  actions: write #required for workflow cancellation via check-aptos-core
+
+on:
+  # Allow triggering manually
+  workflow_dispatch:
+    inputs:
+      IMAGE_TAG:
+        required: false
+        type: string
+        description: The docker image tag to test. This may be a git SHA1, or a tag like "<branch>_<git SHA1>". If not specified, Forge will find the latest build based on the git history (starting from GIT_SHA input)
+      GIT_SHA:
+        required: false
+        type: string
+        description: The git SHA1 to checkout. This affects the Forge test runner that is used. If not specified, the latest main will be used
+  schedule:
+    - cron: "37 * * * *" # the main branch cadence
+  pull_request:
+    paths:
+      - ".github/workflows/forge-gcp.yaml"
+
+env:
+  AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  IMAGE_TAG: ${{ inputs.IMAGE_TAG }} # this is only used for workflow_dispatch, otherwise defaults to empty
+  AWS_REGION: us-west-2
+
+jobs:
+  # This job determines the image tag and branch to test, and passes them to the other jobs
+  # NOTE: this may be better as a separate workflow as the logic is quite complex but generalizable
+  determine-test-metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      IMAGE_TAG: ${{ steps.determine-test-image-tag.outputs.IMAGE_TAG }}
+      BRANCH: ${{ steps.determine-test-branch.outputs.BRANCH }}
+    steps:
+      - name: Determine branch based on cadence
+        id: determine-test-branch
+        run: |
+          BRANCH=main
+          [[ -n "${{ inputs.GIT_SHA }}" ]] && BRANCH=${{ inputs.GIT_SHA }}
+          echo "BRANCH=$BRANCH" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          ref: ${{ steps.determine-test-branch.outputs.BRANCH }}
+          fetch-depth: 0
+
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
+        with:
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
+
+      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4
+
+      - name: Install python deps
+        run: pip3 install click==8.1.3 psutil==5.9.1
+
+      - name: Determine image tag
+        id: determine-test-image-tag
+        # forge relies on the default and failpoints variants
+        run: python3 testsuite/find_latest_image.py --variant failpoints --variant performance
+
+      - name: Write summary
+        run: |
+          IMAGE_TAG=${{ steps.determine-test-image-tag.outputs.IMAGE_TAG }}
+          BRANCH=${{ steps.determine-test-branch.outputs.BRANCH }}
+          if [ -n "${BRANCH}" ]; then
+            echo "BRANCH: [${BRANCH}](https://github.com/${{ github.repository }}/tree/${BRANCH})" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "IMAGE_TAG: [${IMAGE_TAG}](https://github.com/${{ github.repository }}/commit/${IMAGE_TAG})" >> $GITHUB_STEP_SUMMARY
+
+  forge-land-blocking:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      COMMENT_HEADER: forge-continuous
+      # This test suite is configured using the forge.py config test command
+      FORGE_TEST_SUITE: land_blocking
+      FORGE_CLUSTER_NAME: aptos-forge-0
+      FORGE_RUNNER_DURATION_SECS: 1800


### PR DESCRIPTION
### Description

Add workflow to run Forge tests on the GCP clusters.

### Test Plan

Test via cron and with manual invocation.