### PR TITLE
[tf/aws/gcp][testnet] add variables for toggling monitoring

### DIFF
--- a/terraform/aptos-node-testnet/aws/main.tf
+++ b/terraform/aptos-node-testnet/aws/main.tf
@@ -67,9 +67,9 @@ module "validator" {
   validator_instance_type = var.validator_instance_type
 
   # addons
-  enable_monitoring               = true
-  enable_prometheus_node_exporter = true
-  enable_kube_state_metrics       = true
+  enable_monitoring               = var.enable_monitoring
+  enable_prometheus_node_exporter = var.enable_prometheus_node_exporter
+  enable_kube_state_metrics       = var.enable_kube_state_metrics
   monitoring_helm_values          = var.monitoring_helm_values
   logger_helm_values              = var.logger_helm_values
 }

--- a/terraform/aptos-node-testnet/aws/variables.tf
+++ b/terraform/aptos-node-testnet/aws/variables.tf
@@ -112,10 +112,25 @@ variable "logger_helm_values" {
   default     = {}
 }
 
+variable "enable_monitoring" {
+  description = "Enable monitoring helm chart"
+  default     = true
+}
+
 variable "monitoring_helm_values" {
   description = "Map of values to pass to monitoring helm chart"
   type        = any
   default     = {}
+}
+
+variable "enable_prometheus_node_exporter" {
+  description = "Enable prometheus-node-exporter within monitoring helm chart"
+  default     = true
+}
+
+variable "enable_kube_state_metrics" {
+  description = "Enable kube-state-metrics within monitoring helm chart"
+  default     = true
 }
 
 variable "testnet_addons_helm_values" {

--- a/terraform/aptos-node-testnet/gcp/main.tf
+++ b/terraform/aptos-node-testnet/gcp/main.tf
@@ -60,8 +60,8 @@ module "validator" {
   validator_instance_type = var.validator_instance_type
 
   # addons
-  enable_monitoring      = true
-  enable_node_exporter   = true
+  enable_monitoring      = var.enable_monitoring
+  enable_node_exporter   = var.enable_node_exporter
   monitoring_helm_values = var.monitoring_helm_values
 }
 

--- a/terraform/aptos-node-testnet/gcp/variables.tf
+++ b/terraform/aptos-node-testnet/gcp/variables.tf
@@ -126,10 +126,20 @@ variable "enable_forge" {
   default     = false
 }
 
+variable "enable_monitoring" {
+  description = "Enable monitoring helm chart"
+  default     = true
+}
+
 variable "monitoring_helm_values" {
   description = "Map of values to pass to monitoring Helm"
   type        = any
   default     = {}
+}
+
+variable "enable_prometheus_node_exporter" {
+  description = "Enable prometheus-node-exporter within monitoring helm chart"
+  default     = true
 }
 
 ### Autoscaling


### PR DESCRIPTION
### Description

Propagate variables for toggling on and off monitoring features for testnets. Previously, these were available for `aptos-node`, and defaulted to `true` for all testnets.

### Test Plan

TF plan and remove monitoring resources

<!-- Please provide us with clear details for verifying that your changes work. -->
