### PR TITLE
[framework] Create release config for 1.4

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,7 @@
 !**/*.errmap
 !config/src/config/test_data
 !aptos-move/aptos-release-builder/data/release.yaml
+!aptos-move/aptos-release-builder/data/proposals/
 !aptos-move/framework/
 !crates/aptos/src/move_tool/*.bpl
 !crates/aptos-faucet/doc/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,6 +2397,7 @@ dependencies = [
  "clap 3.2.23",
  "futures",
  "git2 0.16.1",
+ "handlebars",
  "hex",
  "move-binary-format",
  "move-core-types",
@@ -11213,6 +11214,7 @@ dependencies = [
  "aptos-types",
  "aptos-vault-client",
  "aptos-vm",
+ "aptos-vm-genesis",
  "aptos-writeset-generator",
  "async-trait",
  "base64 0.13.0",
@@ -11231,6 +11233,7 @@ dependencies = [
  "serde_yaml 0.8.26",
  "tokio",
  "url",
+ "walkdir",
 ]
 
 [[package]]

--- a/aptos-move/aptos-release-builder/Cargo.toml
+++ b/aptos-move/aptos-release-builder/Cargo.toml
@@ -29,6 +29,7 @@ bcs = { workspace = true }
 clap = { workspace = true }
 futures = { workspace = true }
 git2 = { workspace = true }
+handlebars = { workspace = true }
 hex = { workspace = true }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }

--- a/aptos-move/aptos-release-builder/data/example.yaml
+++ b/aptos-move/aptos-release-builder/data/example.yaml
@@ -1,42 +1,75 @@
 ---
-testnet: true
 remote_endpoint: ~
-is_multi_step: false
-update_sequence:
-  - Framework:
-      bytecode_version: 6
-      git_hash: ~
-  - DefaultGas
-  - FeatureFlag:
-      enabled:
-        - code_dependency_check
-        - treat_friend_as_private
-        - sha512_and_ripe_md160_natives
-        - aptos_std_chain_id_natives
-        - v_m_binary_format_v6
-        - multi_ed25519_pk_validate_v2_natives
-        - blake2b256_native
-        - resource_groups
-        - multisig_accounts
-        - delegation_pools
-        - cryptography_algebra_natives
-        - bls12381_structures
-        - ed25519_pubkey_validate_return_false_wrong_length
-      disabled: []
-  - Consensus:
-      V1:
-        decoupled_execution: true
-        back_pressure_limit: 10
-        exclude_round: 40
-        proposer_election_type:
-          leader_reputation:
-            proposer_and_voter_v2:
-              active_weight: 1000
-              inactive_weight: 10
-              failed_weight: 1
-              failure_threshold_percent: 10
-              proposer_window_num_validators_multiplier: 10
-              voter_window_num_validators_multiplier: 1
-              weight_by_voting_power: true
-              use_history_from_previous_epoch_max_count: 5
-        max_failed_authors_to_store: 10
+proposals:
+  - name: custom
+    metadata:
+      title: ""
+      description: ""
+      source_code_url: ""
+      discussion_url: ""
+    execution_mode: MultiStep
+    update_sequence:
+      - RawScript: data/proposals/empty.move
+  - name: framework
+    metadata:
+      title: ""
+      description: ""
+      source_code_url: ""
+      discussion_url: ""
+    execution_mode: MultiStep
+    update_sequence:
+      - Framework:
+          bytecode_version: 6
+          git_hash: ~
+  - name: gas
+    metadata:
+      title: ""
+      description: ""
+      source_code_url: ""
+      discussion_url: ""
+    execution_mode: MultiStep
+    update_sequence:
+      - DefaultGas
+  - name: feature_flags
+    metadata:
+      title: ""
+      description: ""
+      source_code_url: ""
+      discussion_url: ""
+    execution_mode: MultiStep
+    update_sequence:
+      - FeatureFlag:
+          enabled:
+            - code_dependency_check
+            - treat_friend_as_private
+            - sha512_and_ripe_md160_natives
+            - aptos_std_chain_id_natives
+            - v_m_binary_format_v6
+            - multi_ed25519_pk_validate_v2_natives
+            - blake2b256_native
+            - resource_groups
+            - multisig_accounts
+            - delegation_pools
+            - ed25519_pubkey_validate_return_false_wrong_length
+            - struct_constructors
+            - cryptography_algebra_natives
+            - bls12381_structures
+          disabled: []
+      - Consensus:
+          V1:
+            decoupled_execution: true
+            back_pressure_limit: 10
+            exclude_round: 40
+            proposer_election_type:
+              leader_reputation:
+                proposer_and_voter_v2:
+                  active_weight: 1000
+                  inactive_weight: 10
+                  failed_weight: 1
+                  failure_threshold_percent: 10
+                  proposer_window_num_validators_multiplier: 10
+                  voter_window_num_validators_multiplier: 1
+                  weight_by_voting_power: true
+                  use_history_from_previous_epoch_max_count: 5
+            max_failed_authors_to_store: 10
+      - RawScript: data/proposals/empty_multi_step.move

--- a/aptos-move/aptos-release-builder/data/proposals/empty.move
+++ b/aptos-move/aptos-release-builder/data/proposals/empty.move
@@ -1,0 +1,9 @@
+// Empty governance proposal to demonstrate functionality for including proposal in the release builder;
+//
+script {
+    use aptos_framework::aptos_governance;
+
+    fun main(proposal_id: u64) {
+        let _framework_signer = aptos_governance::resolve(proposal_id, @0x1);
+    }
+}

--- a/aptos-move/aptos-release-builder/data/proposals/empty_multi_step.move
+++ b/aptos-move/aptos-release-builder/data/proposals/empty_multi_step.move
@@ -1,0 +1,14 @@
+// Empty governance proposal to demonstrate functionality for including proposal in the release builder;
+//
+script {
+    use aptos_framework::aptos_governance;
+    use std::features;
+
+    fun main(proposal_id: u64) {
+         let _framework_signer = aptos_governance::resolve_multi_step_proposal(
+            proposal_id,
+            @0000000000000000000000000000000000000000000000000000000000000001,
+            {{ script_hash }},
+        );
+    }
+}

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -1,44 +1,77 @@
 ---
-testnet: true
 remote_endpoint: ~
-is_multi_step: true
-update_sequence:
-  - Framework:
-      bytecode_version: 6
-      git_hash: ~
-  - DefaultGas
-  - FeatureFlag:
-      enabled:
-        - code_dependency_check
-        - treat_friend_as_private
-        - sha512_and_ripe_md160_natives
-        - aptos_std_chain_id_natives
-        - v_m_binary_format_v6
-        - multi_ed25519_pk_validate_v2_natives
-        - blake2b256_native
-        - resource_groups
-        - multisig_accounts
-        - delegation_pools
-        - cryptography_algebra_natives
-        - bls12381_structures
-        - ed25519_pubkey_validate_return_false_wrong_length
-        - struct_constructors
-      disabled: []
-  - Consensus:
-      V1:
-        decoupled_execution: true
-        back_pressure_limit: 10
-        exclude_round: 40
-        proposer_election_type:
-          leader_reputation:
-            proposer_and_voter_v2:
-              active_weight: 1000
-              inactive_weight: 10
-              failed_weight: 1
-              failure_threshold_percent: 10
-              proposer_window_num_validators_multiplier: 10
-              voter_window_num_validators_multiplier: 1
-              weight_by_voting_power: true
-              use_history_from_previous_epoch_max_count: 5
-        max_failed_authors_to_store: 10
-
+proposals:
+  - name: step_1
+    metadata:
+      title: "Enable Struct Constructor Feature"
+      description: "TBD"
+      source_code_url: "TBD"
+      discussion_url: "TBD"
+    execution_mode: MultiStep
+    update_sequence:
+    - FeatureFlag:
+        enabled:
+          - struct_constructors
+        disabled: []
+  - name: step_2
+    metadata:
+      title: "Update to latest framework"
+      description: "TBD"
+      source_code_url: "TBD"
+      discussion_url: "TBD"
+    execution_mode: MultiStep
+    update_sequence:
+      - DefaultGas
+      - Framework:
+          bytecode_version: 6
+          git_hash: ~
+  - name: step_3
+    metadata:
+      title: "Enable bls12381"
+      description: "TBD"
+      source_code_url: "TBD"
+      discussion_url: "TBD"
+    execution_mode: MultiStep
+    update_sequence:
+    - FeatureFlag:
+        enabled:
+          - cryptography_algebra_natives
+          - bls12381_structures
+        disabled: []
+  - name: step_4
+    metadata:
+      title: "Enable ed25519_pubkey_validate_return_false_wrong_length"
+      description: "TBD"
+      source_code_url: "TBD"
+      discussion_url: "TBD"
+    execution_mode: MultiStep
+    update_sequence:
+    - FeatureFlag:
+        enabled:
+          - ed25519_pubkey_validate_return_false_wrong_length
+        disabled: []
+  - name: step_5
+    metadata:
+      title: "Enable Quorum Store"
+      description: "TBD"
+      source_code_url: "TBD"
+      discussion_url: "TBD"
+    execution_mode: MultiStep
+    update_sequence:
+    - Consensus:
+        V2:
+          decoupled_execution: true
+          back_pressure_limit: 10
+          exclude_round: 40
+          proposer_election_type:
+            leader_reputation:
+              proposer_and_voter_v2:
+                active_weight: 1000
+                inactive_weight: 10
+                failed_weight: 1
+                failure_threshold_percent: 10
+                proposer_window_num_validators_multiplier: 10
+                voter_window_num_validators_multiplier: 1
+                weight_by_voting_power: true
+                use_history_from_previous_epoch_max_count: 5
+          max_failed_authors_to_store: 10

--- a/aptos-move/aptos-release-builder/src/lib.rs
+++ b/aptos-move/aptos-release-builder/src/lib.rs
@@ -4,9 +4,10 @@
 pub mod components;
 mod utils;
 pub mod validate;
-pub use components::{ReleaseConfig, ReleaseEntry};
+pub use components::{ExecutionMode, ReleaseConfig, ReleaseEntry};
 use once_cell::sync::Lazy;
 
+// Update me after branch cut.
 const RELEASE_CONFIG: &str = include_str!("../data/release.yaml");
 
 static CURRENT_RELEASE_CONFIG: Lazy<ReleaseConfig> =
@@ -15,27 +16,4 @@ static CURRENT_RELEASE_CONFIG: Lazy<ReleaseConfig> =
 /// Returns the release bundle with which the last testnet was build or updated.
 pub fn current_release_config() -> &'static ReleaseConfig {
     &CURRENT_RELEASE_CONFIG
-}
-
-#[test]
-// Check that the feature flags enabled at genesis matches with the release config file.
-fn assert_feature_flags_eq() {
-    use crate::components::feature_flags::FeatureFlag;
-    use std::collections::HashSet;
-
-    let config = current_release_config();
-    let mut all_features = HashSet::new();
-    for feature in &config.update_sequence {
-        if let ReleaseEntry::FeatureFlag(features) = feature {
-            for feature in &features.enabled {
-                all_features.insert(feature.clone());
-            }
-        }
-    }
-    assert!(all_features.is_superset(
-        &aptos_vm_genesis::default_features()
-            .into_iter()
-            .map(FeatureFlag::from)
-            .collect::<HashSet<_>>()
-    ));
 }

--- a/aptos-move/aptos-release-builder/src/validate.rs
+++ b/aptos-move/aptos-release-builder/src/validate.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ReleaseConfig;
+use crate::{ExecutionMode, ReleaseConfig};
 use anyhow::Result;
 use aptos::{
     common::types::CliCommand,
@@ -38,20 +38,6 @@ struct CreateProposalEvent {
     proposal_id: U64,
 }
 
-const FAST_VOTE_SCRIPT: &str = r"
-script {
-    use aptos_framework::aptos_governance;
-
-    fun main(core_resources: &signer) {
-        let core_signer = aptos_governance::get_signer_testnet_only(core_resources, @0000000000000000000000000000000000000000000000000000000000000001);
-
-        let framework_signer = &core_signer;
-
-        aptos_governance::update_governance_config(framework_signer, 0, 0, 30);
-    }
-}
-";
-
 fn aptos_framework_path() -> PathBuf {
     let mut path = Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf();
     path.pop();
@@ -86,7 +72,6 @@ impl NetworkConfig {
     /// We expect all the scripts here to be single step governance proposal.
     pub async fn submit_and_execute_proposal(&self, script_path: Vec<PathBuf>) -> Result<()> {
         let mut proposals = vec![];
-        self.mint_to_validator().await?;
         for path in script_path.iter() {
             let proposal_id = self
                 .create_governance_proposal(path.as_path(), false)
@@ -116,7 +101,6 @@ impl NetworkConfig {
         script_path: Vec<PathBuf>,
     ) -> Result<()> {
         let first_script = script_path.first().unwrap();
-        self.mint_to_validator().await?;
         let proposal_id = self
             .create_governance_proposal(first_script.as_path(), true)
             .await?;
@@ -130,14 +114,26 @@ impl NetworkConfig {
         Ok(())
     }
 
-    /// Change the network to resolve governance proposal within 30 secs.
-    pub async fn set_fast_resolve(&self) -> Result<()> {
+    /// Change the time for a network to resolve governance proposal
+    pub async fn set_fast_resolve(&self, resolution_time: u64) -> Result<()> {
         let fast_resolve_script = aptos_temppath::TempPath::new();
         fast_resolve_script.create_as_file()?;
         let mut fas_script_path = fast_resolve_script.path().to_path_buf();
         fas_script_path.set_extension("move");
 
-        std::fs::write(fas_script_path.as_path(), FAST_VOTE_SCRIPT.as_bytes())?;
+        std::fs::write(fas_script_path.as_path(), format!(r#"
+        script {{
+            use aptos_framework::aptos_governance;
+
+            fun main(core_resources: &signer) {{
+                let core_signer = aptos_governance::get_signer_testnet_only(core_resources, @0000000000000000000000000000000000000000000000000000000000000001);
+
+                let framework_signer = &core_signer;
+
+                aptos_governance::update_governance_config(framework_signer, 0, 0, {});
+            }}
+        }}
+        "#, resolution_time).as_bytes())?;
 
         let mut args = vec![
             "",
@@ -357,62 +353,75 @@ async fn execute_release(
 
     release_config.generate_release_proposal_scripts(scripts_path.path())?;
 
-    let mut script_paths: Vec<PathBuf> = std::fs::read_dir(scripts_path.path())?
-        .filter_map(|entry| entry.ok())
-        .filter_map(|entry| {
-            let path = entry.path();
-            if path.extension().map(|s| s == "move").unwrap_or(false) {
-                Some(path)
-            } else {
-                None
-            }
-        })
-        .collect();
+    for proposal in release_config.proposals {
+        let mut proposal_path = scripts_path.path().to_path_buf();
+        proposal_path.push("sources");
+        proposal_path.push(proposal.name.as_str());
 
-    script_paths.sort();
+        let mut script_paths: Vec<PathBuf> = std::fs::read_dir(proposal_path.as_path())?
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| {
+                let path = entry.path();
+                if path.extension().map(|s| s == "move").unwrap_or(false) {
+                    Some(path)
+                } else {
+                    None
+                }
+            })
+            .collect();
 
-    if release_config.is_multi_step {
-        network_config.set_fast_resolve().await?;
-        network_config
-            .submit_and_execute_multi_step_proposal(script_paths)
-            .await?;
-    } else if release_config.testnet {
-        for entry in script_paths {
-            println!("Executing: {:?}", entry);
-            let mut args = vec![
-                "",
-                "--script-path",
-                entry.as_path().to_str().unwrap(),
-                "--sender-account",
-                "0xa550c18",
-                "--private-key-file",
-                network_config.root_key_path.as_path().to_str().unwrap(),
-                "--assume-yes",
-                "--encoding",
-                "bcs",
-                "--url",
-                network_config.endpoint.as_str(),
-            ];
+        script_paths.sort();
 
-            let rev = network_config.framework_git_rev.clone();
-            let framework_path = aptos_framework_path();
-            if let Some(rev) = &rev {
-                args.push("--framework-git-rev");
-                args.push(rev.as_str());
-            } else {
-                args.push("--framework-local-dir");
-                args.push(framework_path.as_os_str().to_str().unwrap());
-            };
+        match proposal.execution_mode {
+            ExecutionMode::MultiStep => {
+                network_config.set_fast_resolve(30).await?;
+                network_config
+                    .submit_and_execute_multi_step_proposal(script_paths)
+                    .await?;
 
-            RunScript::parse_from(args).execute().await?;
-        }
-    } else {
-        network_config.set_fast_resolve().await?;
-        // Single step governance proposal;
-        network_config
-            .submit_and_execute_proposal(script_paths)
-            .await?;
-    };
+                network_config.set_fast_resolve(43200).await?;
+            },
+            ExecutionMode::SingleStep => {
+                network_config.set_fast_resolve(30).await?;
+                // Single step governance proposal;
+                network_config
+                    .submit_and_execute_proposal(script_paths)
+                    .await?;
+                network_config.set_fast_resolve(43200).await?;
+            },
+            ExecutionMode::RootSigner => {
+                for entry in script_paths {
+                    println!("Executing: {:?}", entry);
+                    let mut args = vec![
+                        "",
+                        "--script-path",
+                        entry.as_path().to_str().unwrap(),
+                        "--sender-account",
+                        "0xa550c18",
+                        "--private-key-file",
+                        network_config.root_key_path.as_path().to_str().unwrap(),
+                        "--assume-yes",
+                        "--encoding",
+                        "bcs",
+                        "--url",
+                        network_config.endpoint.as_str(),
+                    ];
+
+                    let rev = network_config.framework_git_rev.clone();
+                    let framework_path = aptos_framework_path();
+                    if let Some(rev) = &rev {
+                        args.push("--framework-git-rev");
+                        args.push(rev.as_str());
+                    } else {
+                        args.push("--framework-local-dir");
+                        args.push(framework_path.as_os_str().to_str().unwrap());
+                    };
+
+                    RunScript::parse_from(args).execute().await?;
+                }
+            },
+        };
+    }
     Ok(())
 }
 

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -35,6 +35,7 @@ aptos-sdk = { workspace = true }
 aptos-temppath = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
+aptos-vm-genesis = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
 diesel = { workspace = true }
@@ -45,6 +46,7 @@ reqwest = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
+walkdir = { workspace = true }
 
 [dev-dependencies]
 aptos-backup-cli = { workspace = true }

--- a/testsuite/smoke-test/src/upgrade.rs
+++ b/testsuite/smoke-test/src/upgrade.rs
@@ -2,18 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    aptos::move_test_helpers, aptos_cli::validator::init_validator_account,
-    smoke_test_environment::SwarmBuilder, test_utils::check_create_mint_transfer,
-    workspace_builder, workspace_builder::workspace_root,
+    aptos::move_test_helpers, smoke_test_environment::SwarmBuilder,
+    test_utils::check_create_mint_transfer, workspace_builder, workspace_builder::workspace_root,
 };
-use aptos::move_tool::ArgWithType;
 use aptos_crypto::ValidCryptoMaterialStringExt;
 use aptos_forge::Swarm;
 use aptos_gas::{AptosGasParameters, GasQuantity, InitialGasSchedule, ToOnChainGasSchedule};
-use aptos_keygen::KeyGen;
-use aptos_release_builder::components::gas::generate_gas_upgrade_proposal;
+use aptos_release_builder::{
+    components::{
+        feature_flags::{FeatureFlag, Features},
+        framework::FrameworkReleaseConfig,
+        gas::generate_gas_upgrade_proposal,
+        ExecutionMode, Proposal, ProposalMetadata,
+    },
+    ReleaseEntry,
+};
 use aptos_temppath::TempPath;
-use std::{fs, path::PathBuf, process::Command, sync::Arc, thread, time::Duration};
+use aptos_types::on_chain_config::OnChainConsensusConfig;
+use std::{fs, path::PathBuf, process::Command, sync::Arc};
 
 // Ignored. This is redundant with the forge compat test but this test is easier to run locally and
 // could help debug much faster
@@ -94,14 +100,58 @@ async fn test_upgrade_flow() {
     let upgrade_scripts_folder = TempPath::new();
     upgrade_scripts_folder.create_as_dir().unwrap();
 
-    let config = aptos_release_builder::ReleaseConfig::default();
+    let config = aptos_release_builder::ReleaseConfig {
+        remote_endpoint: None,
+        proposals: vec![
+            Proposal {
+                execution_mode: ExecutionMode::RootSigner,
+                name: "framework".to_string(),
+                metadata: ProposalMetadata::default(),
+                update_sequence: vec![ReleaseEntry::Framework(FrameworkReleaseConfig {
+                    bytecode_version: 6, // TODO: remove explicit bytecode version from sources
+                    git_hash: None,
+                })],
+            },
+            Proposal {
+                execution_mode: ExecutionMode::RootSigner,
+                name: "gas".to_string(),
+                metadata: ProposalMetadata::default(),
+                update_sequence: vec![ReleaseEntry::DefaultGas],
+            },
+            Proposal {
+                execution_mode: ExecutionMode::RootSigner,
+                name: "feature_flags".to_string(),
+                metadata: ProposalMetadata::default(),
+                update_sequence: vec![
+                    ReleaseEntry::FeatureFlag(Features {
+                        enabled: aptos_vm_genesis::default_features()
+                            .into_iter()
+                            .map(FeatureFlag::from)
+                            .collect(),
+                        disabled: vec![],
+                    }),
+                    ReleaseEntry::Consensus(OnChainConsensusConfig::default()),
+                ],
+            },
+        ],
+    };
 
     config
         .generate_release_proposal_scripts(upgrade_scripts_folder.path())
         .unwrap();
-    let mut scripts = fs::read_dir(upgrade_scripts_folder.path())
-        .unwrap()
-        .map(|res| res.unwrap().path())
+    let mut scripts = walkdir::WalkDir::new(upgrade_scripts_folder.path())
+        .sort_by_file_name()
+        .into_iter()
+        .filter_map(|path| match path {
+            Ok(path) => {
+                if path.path().ends_with("move") {
+                    Some(path.path().to_path_buf())
+                } else {
+                    None
+                }
+            },
+            Err(_) => None,
+        })
         .collect::<Vec<_>>();
 
     scripts.sort();
@@ -152,122 +202,6 @@ async fn test_upgrade_flow() {
     check_create_mint_transfer(&mut env).await;
 }
 
-#[ignore]
-#[tokio::test]
-async fn test_upgrade_flow_multi_step() {
-    let (mut env, mut cli, _) = SwarmBuilder::new_local(1)
-        .with_init_config(Arc::new(|_, _, genesis_stake_amount| {
-            // make sure we have quorum
-            *genesis_stake_amount = 2000000000000000;
-        }))
-        .with_init_genesis_config(Arc::new(|genesis_config| {
-            genesis_config.allow_new_validators = true;
-            genesis_config.voting_duration_secs = 30;
-            genesis_config.voting_power_increase_limit = 50;
-            genesis_config.epoch_duration_secs = 4;
-        }))
-        .build_with_cli(2)
-        .await;
-
-    let upgrade_scripts_folder = TempPath::new();
-    upgrade_scripts_folder.create_as_dir().unwrap();
-
-    let config = aptos_release_builder::ReleaseConfig {
-        is_multi_step: true,
-        ..Default::default()
-    };
-
-    config
-        .generate_release_proposal_scripts(upgrade_scripts_folder.path())
-        .unwrap();
-    let mut scripts = fs::read_dir(upgrade_scripts_folder.path())
-        .unwrap()
-        .map(|res| res.unwrap().path())
-        .collect::<Vec<_>>();
-
-    scripts.sort();
-
-    // Create a proposal and vote for it to pass.
-    let mut i = 0;
-    while i < 2 {
-        let pool_address = cli.account_id(i);
-        cli.fund_account(i, Some(1000000000000000)).await.unwrap();
-
-        let mut keygen = KeyGen::from_os_rng();
-        let (validator_cli_index, _) =
-            init_validator_account(&mut cli, &mut keygen, Some(1000000000000000)).await;
-
-        cli.initialize_stake_owner(
-            i,
-            1000000000000000,
-            Some(validator_cli_index),
-            Some(validator_cli_index),
-        )
-        .await
-        .unwrap();
-
-        cli.increase_lockup(i).await.unwrap();
-
-        if i == 0 {
-            let first_script_path = PathBuf::from(scripts.get(0).unwrap());
-            cli.create_proposal(
-                validator_cli_index,
-                "https://raw.githubusercontent.com/aptos-labs/aptos-core/b4fb9acfc297327c43d030def2b59037c4376611/testsuite/smoke-test/src/upgrade_multi_step_test_metadata.txt",
-                first_script_path,
-                pool_address,
-                true,
-            ).await.unwrap();
-        };
-        cli.vote(validator_cli_index, 0, true, false, vec![pool_address])
-            .await;
-        i += 1;
-    }
-
-    // Sleep to pass voting_duration_secs
-    thread::sleep(Duration::from_secs(30));
-
-    let mut first_pass = true;
-    for path in scripts.iter() {
-        let verify_proposal_response = cli
-            .verify_proposal(0, path.to_str().unwrap())
-            .await
-            .unwrap();
-
-        assert!(verify_proposal_response.verified);
-
-        if first_pass {
-            // we don't necessarily have the hash in `aptos_governance::ApprovedExecutionHashes`
-            // in the first pass if we don't manually call add_approved_script_hash_script()
-            first_pass = false;
-        } else {
-            let approved_execution_hash = env
-                .aptos_public_info()
-                .get_approved_execution_hash_at_aptos_governance(0)
-                .await;
-            assert_eq!(
-                verify_proposal_response.computed_hash,
-                hex::encode(approved_execution_hash)
-            );
-        };
-
-        let args: Vec<ArgWithType> = vec![ArgWithType::u64(0)];
-        cli.run_script_with_script_path(3, path.to_str().unwrap(), args, Vec::new())
-            .await
-            .unwrap();
-    }
-
-    // Test the module publishing workflow
-    *env.aptos_public_info().root_account().sequence_number_mut() = 6;
-    let base_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let base_path_v1 = base_dir.join("src/aptos/package_publish_modules_v1/");
-
-    move_test_helpers::publish_package(&mut env.aptos_public_info(), base_path_v1)
-        .await
-        .unwrap();
-
-    check_create_mint_transfer(&mut env).await;
-}
-
 // This test is intentionally disabled because it's taking ~500s to execute right now.
 // The main reason is that compilation of scripts takes a bit too long, as the Move compiler will need
 // to repeatedly compile all the aptos framework pacakges as dependency
@@ -288,10 +222,7 @@ async fn test_release_validate_tool_multi_step() {
         }))
         .build_with_cli(2)
         .await;
-    let config = aptos_release_builder::ReleaseConfig {
-        is_multi_step: true,
-        ..Default::default()
-    };
+    let config = aptos_release_builder::ReleaseConfig::default();
 
     let root_key = TempPath::new();
     root_key.create_as_file().unwrap();
@@ -318,6 +249,8 @@ async fn test_release_validate_tool_multi_step() {
             .private_key(),
         framework_git_rev: None,
     };
+
+    network_config.mint_to_validator().await.unwrap();
 
     aptos_release_builder::validate::validate_config(config, network_config)
         .await

--- a/testsuite/testcases/src/framework_upgrade.rs
+++ b/testsuite/testcases/src/framework_upgrade.rs
@@ -90,6 +90,8 @@ impl NetworkTest for FrameworkUpgrade {
             framework_git_rev: None,
         };
 
+        runtime.block_on(network_info.mint_to_validator())?;
+
         let release_config = aptos_release_builder::current_release_config();
 
         runtime.block_on(aptos_release_builder::validate::validate_config(


### PR DESCRIPTION
### Description

Updated the yaml file to track release for 1.4. A few modifications were made in the PR:
1. The validate-proposal command no longer mint to the validator. Tests now need to manually mint to validators before executing the proposals. This allows the tooling to better mimic what the release process will look like in real life.
2. Added the full 1.4 release configuration. Tentatively we will have five different goverance proposals to vote. We are still waiting on finalizing the fifth one to enable transaction reshuffling cc @zekun000 
3. Change the release tooling to be able to handle multiple proposals in one release conifg.
4.  Add the ability to include a customize script for the release builder

### Test Plan

Framework upgrade test
