### PR TITLE
[storage] Restore state kv in historical range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,10 +894,13 @@ dependencies = [
  "aptos-executor-types",
  "aptos-logger",
  "aptos-push-metrics",
+ "aptos-state-view",
+ "aptos-storage-interface",
  "aptos-temppath",
  "aptos-types",
  "async-trait",
  "clap 3.2.23",
+ "itertools",
  "owo-colors",
  "tokio",
 ]

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -556,7 +556,7 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
         Ok(end_version)
     }
 
-    /// Consume end_version - begin_version txns from the mutable input arguments
+    /// Consume 'end_version - begin_version' txns from the mutable input arguments
     /// It's guaranteed that there's no known broken versions or epoch endings in the range.
     fn remove_and_apply(
         &self,

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -556,7 +556,7 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
         Ok(end_version)
     }
 
-    /// Consume 'end_version - begin_version' txns from the mutable input arguments
+    /// Consume `end_version - begin_version` txns from the mutable input arguments
     /// It's guaranteed that there's no known broken versions or epoch endings in the range.
     fn remove_and_apply(
         &self,

--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -128,14 +128,14 @@ impl RestoreHandler {
             .map_or(0, |(ver, _txn_info)| ver + 1))
     }
 
-    /// Returns the number of state leaves in the state merkel tree or 0 if no tree restored .
-    pub fn get_state_leaf_count(&self, version: Version) -> usize {
-        self.aptosdb
-            .get_state_leaf_count(version)
-            .unwrap_or(0_usize)
+    pub fn get_state_snapshot_before(
+        &self,
+        version: Version,
+    ) -> Result<Option<(Version, HashValue)>> {
+        self.aptosdb.get_state_snapshot_before(version)
     }
 
-    pub fn get_in_progress_state_snapshot_version(&self) -> Result<Option<Version>> {
+    pub fn get_in_progress_state_kv_snapshot_version(&self) -> Result<Option<Version>> {
         let mut iter = self
             .aptosdb
             .ledger_db

--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -7,7 +7,7 @@ use crate::{
     db_metadata::{DbMetadataKey, DbMetadataSchema},
     event_store::EventStore,
     ledger_store::LedgerStore,
-    state_restore::StateSnapshotRestore,
+    state_restore::{StateSnapshotRestore, StateSnapshotRestoreMode},
     state_store::StateStore,
     transaction_store::TransactionStore,
     AptosDB,
@@ -60,6 +60,7 @@ impl RestoreHandler {
         &self,
         version: Version,
         expected_root_hash: HashValue,
+        restore_mode: StateSnapshotRestoreMode,
     ) -> Result<StateSnapshotRestore<StateKey, StateValue>> {
         StateSnapshotRestore::new(
             &self.state_store.state_merkle_db,
@@ -67,6 +68,7 @@ impl RestoreHandler {
             version,
             expected_root_hash,
             true, /* async_commit */
+            restore_mode,
         )
     }
 
@@ -109,11 +111,13 @@ impl RestoreHandler {
             self.ledger_store.clone(),
             self.transaction_store.clone(),
             self.event_store.clone(),
+            self.state_store.clone(),
             first_version,
             txns,
             txn_infos,
             events,
             write_sets,
+            None,
             None,
         )
     }

--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -118,7 +118,6 @@ impl RestoreHandler {
             events,
             write_sets,
             None,
-            None,
         )
     }
 
@@ -127,6 +126,13 @@ impl RestoreHandler {
             .aptosdb
             .get_latest_transaction_info_option()?
             .map_or(0, |(ver, _txn_info)| ver + 1))
+    }
+
+    /// Returns the number of state leaves in the state merkel tree or 0 if no tree restored .
+    pub fn get_state_leaf_count(&self, version: Version) -> usize {
+        self.aptosdb
+            .get_state_leaf_count(version)
+            .unwrap_or(0_usize)
     }
 
     pub fn get_in_progress_state_snapshot_version(&self) -> Result<Option<Version>> {

--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -118,6 +118,31 @@ impl RestoreHandler {
             events,
             write_sets,
             None,
+            false,
+        )
+    }
+
+    pub fn save_transactions_and_replay_kv(
+        &self,
+        first_version: Version,
+        txns: &[Transaction],
+        txn_infos: &[TransactionInfo],
+        events: &[Vec<ContractEvent>],
+        write_sets: Vec<WriteSet>,
+    ) -> Result<()> {
+        restore_utils::save_transactions(
+            self.ledger_db.clone(),
+            self.ledger_store.clone(),
+            self.transaction_store.clone(),
+            self.event_store.clone(),
+            self.state_store.clone(),
+            first_version,
+            txns,
+            txn_infos,
+            events,
+            write_sets,
+            None,
+            true,
         )
     }
 

--- a/storage/aptosdb/src/backup/restore_utils.rs
+++ b/storage/aptosdb/src/backup/restore_utils.rs
@@ -1,13 +1,14 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::state_store::StateStore;
 ///! This file contains utilities that are helpful for performing
 ///! database restore operations, as required by restore and
 ///! state sync v2.
 use crate::{
-    event_store::EventStore, ledger_store::LedgerStore,
+    event_store::EventStore, ledger_store::LedgerStore, new_sharded_kv_schema_batch,
     schema::transaction_accumulator::TransactionAccumulatorSchema,
-    transaction_store::TransactionStore,
+    transaction_store::TransactionStore, ShardedStateKvSchemaBatch,
 };
 use anyhow::{ensure, Result};
 use aptos_crypto::HashValue;
@@ -91,44 +92,80 @@ pub fn confirm_or_save_frozen_subtrees(
 
 /// Saves the given transactions to the db. If a change set is provided, a batch
 /// of db alterations will be added to the change set without writing them to the db.
-pub fn save_transactions(
+pub(crate) fn save_transactions(
     db: Arc<DB>,
     ledger_store: Arc<LedgerStore>,
     transaction_store: Arc<TransactionStore>,
     event_store: Arc<EventStore>,
+    state_store: Arc<StateStore>,
     first_version: Version,
     txns: &[Transaction],
     txn_infos: &[TransactionInfo],
     events: &[Vec<ContractEvent>],
     write_sets: Vec<WriteSet>,
     existing_batch: Option<&mut SchemaBatch>,
+    sharded_kv_schema_batch: Option<&mut ShardedStateKvSchemaBatch>,
 ) -> Result<()> {
     if let Some(existing_batch) = existing_batch {
-        save_transactions_impl(
-            ledger_store,
-            transaction_store,
-            event_store,
-            first_version,
-            txns,
-            txn_infos,
-            events,
-            write_sets.as_ref(),
-            existing_batch,
-        )?;
+        if let Some(sharded_kv_schema_batch) = sharded_kv_schema_batch {
+            save_transactions_impl(
+                ledger_store,
+                transaction_store,
+                event_store,
+                state_store,
+                first_version,
+                txns,
+                txn_infos,
+                events,
+                write_sets.as_ref(),
+                existing_batch,
+                sharded_kv_schema_batch,
+            )?;
+        } else {
+            let mut sharded_kv_schema_batch = new_sharded_kv_schema_batch();
+            save_transactions_impl(
+                ledger_store,
+                transaction_store,
+                event_store,
+                Arc::clone(&state_store),
+                first_version,
+                txns,
+                txn_infos,
+                events,
+                write_sets.as_ref(),
+                existing_batch,
+                &mut sharded_kv_schema_batch,
+            )?;
+            // get the last version and commit to the state kv db
+            let last_version = first_version + txns.len() as u64 - 1;
+            state_store
+                .state_db
+                .state_kv_db
+                .commit(last_version, sharded_kv_schema_batch)?;
+        }
     } else {
         let mut batch = SchemaBatch::new();
+        let mut sharded_kv_schema_batch = new_sharded_kv_schema_batch();
         save_transactions_impl(
             ledger_store,
             transaction_store,
             event_store,
+            Arc::clone(&state_store),
             first_version,
             txns,
             txn_infos,
             events,
             write_sets.as_ref(),
             &mut batch,
+            &mut sharded_kv_schema_batch,
         )?;
         db.write_schemas(batch)?;
+        // get the last version and commit to the state kv db
+        let last_version = first_version + txns.len() as u64 - 1;
+        state_store
+            .state_db
+            .state_kv_db
+            .commit(last_version, sharded_kv_schema_batch)?;
     }
 
     Ok(())
@@ -179,16 +216,18 @@ fn save_ledger_infos_impl(
 }
 
 /// A helper function that saves the transactions to the given change set
-pub fn save_transactions_impl(
+pub(crate) fn save_transactions_impl(
     ledger_store: Arc<LedgerStore>,
     transaction_store: Arc<TransactionStore>,
     event_store: Arc<EventStore>,
+    state_store: Arc<StateStore>,
     first_version: Version,
     txns: &[Transaction],
     txn_infos: &[TransactionInfo],
     events: &[Vec<ContractEvent>],
     write_sets: &[WriteSet],
     batch: &mut SchemaBatch,
+    state_kv_batches: &mut ShardedStateKvSchemaBatch,
 ) -> Result<()> {
     for (idx, txn) in txns.iter().enumerate() {
         transaction_store.put_transaction(first_version + idx as Version, txn, batch)?;
@@ -199,6 +238,8 @@ pub fn save_transactions_impl(
     for (idx, ws) in write_sets.iter().enumerate() {
         transaction_store.put_write_set(first_version + idx as Version, ws, batch)?;
     }
+    // only write kv and not update the state tree
+    state_store.put_write_sets(write_sets.to_vec(), first_version, state_kv_batches)?;
 
     Ok(())
 }

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -302,6 +302,7 @@ impl AptosDB {
         pruner_config: PrunerConfig,
         buffered_state_target_items: usize,
         hack_for_tests: bool,
+        empty_buffered_state_for_restore: bool,
     ) -> Self {
         let state_merkle_db = Arc::new(state_merkle_db);
         let state_kv_db = Arc::new(state_kv_db);
@@ -324,6 +325,7 @@ impl AptosDB {
             state_kv_pruner,
             buffered_state_target_items,
             hack_for_tests,
+            empty_buffered_state_for_restore,
         ));
 
         let ledger_pruner = LedgerPrunerManager::new(
@@ -350,7 +352,7 @@ impl AptosDB {
         }
     }
 
-    pub fn open<P: AsRef<Path> + Clone>(
+    fn open_internal<P: AsRef<Path> + Clone>(
         db_root_path: P,
         readonly: bool,
         pruner_config: PrunerConfig,
@@ -358,6 +360,7 @@ impl AptosDB {
         enable_indexer: bool,
         buffered_state_target_items: usize,
         max_num_nodes_per_lru_cache_shard: usize,
+        empty_buffered_state_for_restore: bool,
     ) -> Result<Self> {
         ensure!(
             pruner_config.eq(&NO_OP_STORAGE_PRUNER_CONFIG) || !readonly,
@@ -378,6 +381,7 @@ impl AptosDB {
             pruner_config,
             buffered_state_target_items,
             readonly,
+            empty_buffered_state_for_restore,
         );
 
         if !readonly && enable_indexer {
@@ -385,6 +389,48 @@ impl AptosDB {
         }
 
         Ok(myself)
+    }
+
+    pub fn open<P: AsRef<Path> + Clone>(
+        db_root_path: P,
+        readonly: bool,
+        pruner_config: PrunerConfig,
+        rocksdb_configs: RocksdbConfigs,
+        enable_indexer: bool,
+        buffered_state_target_items: usize,
+        max_num_nodes_per_lru_cache_shard: usize,
+    ) -> Result<Self> {
+        Self::open_internal(
+            db_root_path,
+            readonly,
+            pruner_config,
+            rocksdb_configs,
+            enable_indexer,
+            buffered_state_target_items,
+            max_num_nodes_per_lru_cache_shard,
+            false,
+        )
+    }
+
+    pub fn open_kv_only<P: AsRef<Path> + Clone>(
+        db_root_path: P,
+        readonly: bool,
+        pruner_config: PrunerConfig,
+        rocksdb_configs: RocksdbConfigs,
+        enable_indexer: bool,
+        buffered_state_target_items: usize,
+        max_num_nodes_per_lru_cache_shard: usize,
+    ) -> Result<Self> {
+        Self::open_internal(
+            db_root_path,
+            readonly,
+            pruner_config,
+            rocksdb_configs,
+            enable_indexer,
+            buffered_state_target_items,
+            max_num_nodes_per_lru_cache_shard,
+            true,
+        )
     }
 
     pub fn open_dbs<P: AsRef<Path> + Clone>(
@@ -2102,6 +2148,7 @@ impl DbWriter for AptosDB {
                 &events,
                 wsets,
                 Option::Some((&mut batch, &mut sharded_kv_batch)),
+                false,
             )?;
 
             // Save the epoch ending ledger infos

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -2101,8 +2101,7 @@ impl DbWriter for AptosDB {
                 &transaction_infos,
                 &events,
                 wsets,
-                Some(&mut batch),
-                Some(&mut sharded_kv_batch), // we don't need to commit this batch since the key value should already be recovered from the snapshot
+                Option::Some((&mut batch, &mut sharded_kv_batch)),
             )?;
 
             // Save the epoch ending ledger infos

--- a/storage/aptosdb/src/state_restore/restore_test.rs
+++ b/storage/aptosdb/src/state_restore/restore_test.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::state_restore::{
-    StateSnapshotProgress, StateSnapshotRestore, StateValueBatch, StateValueWriter,
+    StateSnapshotProgress, StateSnapshotRestore, StateSnapshotRestoreMode, StateValueBatch,
+    StateValueWriter,
 };
 use anyhow::Result;
 use aptos_crypto::{hash::CryptoHash, HashValue};
@@ -187,7 +188,7 @@ proptest! {
         let restore_db = Arc::new(MockSnapshotStore::default());
         {
             let mut restore =
-                StateSnapshotRestore::new(&restore_db, &restore_db,  version, expected_root_hash, true /* async_commit */).unwrap();
+                StateSnapshotRestore::new(&restore_db, &restore_db,  version, expected_root_hash, true /* async_commit */, StateSnapshotRestoreMode::Default).unwrap();
             let proof = tree
                 .get_range_proof(batch1.last().map(|(key, _value)| *key).unwrap(), version)
                 .unwrap();
@@ -199,7 +200,7 @@ proptest! {
             let remaining_accounts: Vec<_> = all.clone().into_iter().skip(batch1_size - overlap_size).collect();
 
             let mut restore =
-                StateSnapshotRestore::new(&restore_db, &restore_db,  version, expected_root_hash, true /* async commit */ ).unwrap();
+                StateSnapshotRestore::new(&restore_db, &restore_db,  version, expected_root_hash, true /* async commit */, StateSnapshotRestoreMode::Default ).unwrap();
             let proof = tree
                 .get_range_proof(
                     remaining_accounts.last().map(|(h, _)| *h).unwrap(),
@@ -280,6 +281,7 @@ fn restore_without_interruption<V>(
             target_version,
             expected_root_hash,
             true, /* async_commit */
+            StateSnapshotRestoreMode::Default,
         )
         .unwrap()
     } else {
@@ -288,6 +290,7 @@ fn restore_without_interruption<V>(
             target_db,
             target_version,
             expected_root_hash,
+            StateSnapshotRestoreMode::Default,
         )
         .unwrap()
     };

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -597,7 +597,7 @@ impl StateStore {
         sharded_state_kv_batches: &ShardedStateKvSchemaBatch,
     ) -> Result<()> {
         let _timer = OTHER_TIMERS_SECONDS
-            .with_label_values(&["update_with_writesets"])
+            .with_label_values(&["put_writesets"])
             .start_timer();
 
         // convert value state sets to hash map reference
@@ -625,7 +625,7 @@ impl StateStore {
             sharded_state_kv_batches,
         )?;
 
-        self.put_state_value(value_state_sets, first_version, sharded_state_kv_batches)?;
+        self.put_state_values(value_state_sets, first_version, sharded_state_kv_batches)?;
 
         Ok(())
     }
@@ -657,10 +657,10 @@ impl StateStore {
             .with_label_values(&["add_state_kv_batch"])
             .start_timer();
 
-        self.put_state_value(value_state_sets, first_version, sharded_state_kv_batches)
+        self.put_state_values(value_state_sets, first_version, sharded_state_kv_batches)
     }
 
-    pub fn put_state_value(
+    pub fn put_state_values(
         &self,
         value_state_sets: Vec<&ShardedStateUpdates>,
         first_version: Version,

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -593,6 +593,7 @@ impl StateStore {
         &self,
         write_sets: Vec<WriteSet>,
         first_version: Version,
+        batch: &SchemaBatch,
         sharded_state_kv_batches: &ShardedStateKvSchemaBatch,
     ) -> Result<()> {
         let _timer = OTHER_TIMERS_SECONDS
@@ -615,6 +616,15 @@ impl StateStore {
 
         let value_state_sets =
             value_state_sets_raw.iter().collect();
+
+        self.put_stats_and_indices(
+            &value_state_sets,
+            first_version,
+            StateStorageUsage::new_untracked(),
+            batch,
+            sharded_state_kv_batches,
+        )?;
+
         self.put_state_value(value_state_sets, first_version, sharded_state_kv_batches)?;
 
         Ok(())

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -338,7 +338,7 @@ proptest! {
         let store2 = &db2.state_store;
 
         let mut restore =
-            StateSnapshotRestore::new(&store2.state_merkle_db, store2, version, expected_root_hash, true /* async_commit */).unwrap();
+            StateSnapshotRestore::new(&store2.state_merkle_db, store2, version, expected_root_hash, true /* async_commit */, StateSnapshotRestoreMode::Default).unwrap();
 
         let mut ordered_input: Vec<_> = input
             .into_iter()
@@ -436,7 +436,7 @@ proptest! {
         let store2 = &db2.state_store;
         let max_hash = HashValue::new([0xff; HashValue::LENGTH]);
         let mut restore =
-            StateSnapshotRestore::new(&store2.state_merkle_db, store2, version, expected_root_hash, true, /* async_commit */).unwrap();
+            StateSnapshotRestore::new(&store2.state_merkle_db, store2, version, expected_root_hash, true, /* async_commit */ StateSnapshotRestoreMode::Default).unwrap();
 
         let dummy_state_key = StateKey::raw(vec![]);
         let (top_levels_batch, sharded_batches, _) = store2.state_merkle_db.merklize_value_set(vec![(max_hash, Some(&(HashValue::random(), dummy_state_key)))], None, 0, None, None).unwrap();

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-backup-service = { workspace = true }
 aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-db = { workspace = true }
@@ -23,6 +24,7 @@ aptos-executor-types = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-jellyfish-merkle = { workspace = true }
 aptos-logger = { workspace = true }
+aptos-proptest-helpers = { workspace = true }
 aptos-push-metrics = { workspace = true }
 aptos-scratchpad = { workspace = true }
 aptos-storage-interface = { workspace = true }
@@ -63,4 +65,5 @@ proptest = { workspace = true }
 warp = { workspace = true }
 
 [features]
+testing = []
 fuzzing = ["aptos-db/fuzzing"]

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
@@ -15,7 +15,7 @@ use crate::{
         RocksdbOpt, TrustedWaypointOpt,
     },
 };
-use aptos_db::AptosDB;
+use aptos_db::{state_restore::StateSnapshotRestoreMode, AptosDB};
 use aptos_storage_interface::DbReader;
 use aptos_temppath::TempPath;
 use std::{convert::TryInto, sync::Arc};
@@ -78,6 +78,7 @@ fn end_to_end() {
                 manifest_handle,
                 version,
                 validate_modules: false,
+                restore_mode: StateSnapshotRestoreMode::Default,
             },
             GlobalRestoreOpt {
                 dry_run: false,

--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -20,7 +20,7 @@ use crate::{
         ReplayConcurrencyLevelOpt, RocksdbOpt, TrustedWaypointOpt,
     },
 };
-use aptos_db::AptosDB;
+use aptos_db::{state_restore::StateSnapshotRestoreMode, AptosDB};
 use aptos_executor_test_helpers::integration_test_impl::test_execution_with_storage_impl;
 use aptos_executor_types::VerifyExecutionMode;
 use aptos_storage_interface::DbReader;
@@ -134,6 +134,7 @@ fn test_end_to_end_impl(d: TestData) {
                     manifest_handle: state_snapshot_manifest.unwrap(),
                     version,
                     validate_modules: false,
+                    restore_mode: StateSnapshotRestoreMode::Default,
                 },
                 global_restore_opt.clone(),
                 Arc::clone(&store),

--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -151,6 +151,7 @@ fn test_end_to_end_impl(d: TestData) {
                 replay_from_version: Some(
                     d.state_snapshot_ver.unwrap_or(Version::max_value() - 1) + 1,
                 ),
+                kv_only_replay: Some(false),
             },
             global_restore_opt,
             store,

--- a/storage/backup/backup-cli/src/backup_types/transaction/manifest.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/manifest.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 /// A chunk of a transaction backup manifest to represent the
 /// [`first_version`, `last_version`] range (right side inclusive).
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct TransactionChunk {
     pub first_version: Version,
     pub last_version: Version,

--- a/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
@@ -425,7 +425,7 @@ impl TransactionRestoreBatchController {
                         first_version = global_first_version;
                     }
 
-                    // identify txn that to be saved before the first_to_replay version
+                    // identify txns to be saved before the first_to_replay version
                     if first_version < first_to_replay {
                         let num_to_save =
                             (min(first_to_replay, last_version + 1) - first_version) as usize;
@@ -454,6 +454,7 @@ impl TransactionRestoreBatchController {
                             "Transactions saved."
                         );
                     }
+
                     // create iterator of txn and its outputs to be replayed after the snapshot.
                     Ok(stream::iter(
                         izip!(txns, txn_infos, write_sets, event_vecs)

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -19,10 +19,7 @@ use aptos_db::AptosDB;
 use aptos_executor_types::VerifyExecutionMode;
 use aptos_storage_interface::DbReader;
 use aptos_temppath::TempPath;
-use aptos_types::{
-    state_store::{state_key::StateKeyTag, state_key_prefix::StateKeyPrefix},
-    transaction::Version,
-};
+use aptos_types::transaction::Version;
 use itertools::zip_eq;
 use std::{convert::TryInto, mem::size_of, sync::Arc};
 use tokio::time::Duration;
@@ -111,8 +108,8 @@ fn end_to_end() {
             backup_handles,
             None,
             None,
-            VerifyExecutionMode::verify_all(),
             None,
+            VerifyExecutionMode::verify_all(),
             None,
         )
         .run(),
@@ -139,28 +136,6 @@ fn end_to_end() {
             .map(|txn_to_commit| txn_to_commit.write_set().clone()),
     ) {
         assert_eq!(restore_ws, org_ws);
-    }
-
-    // Get all the key value pairs and compare if they are the same
-    let state_key_value_pairs_old = src_db
-        .get_prefixed_state_value_iterator(
-            &StateKeyPrefix::new(StateKeyTag::AccessPath, vec![]),
-            Option::None,
-            target_version,
-        )
-        .unwrap();
-    let state_key_value_pairs = tgt_db
-        .get_prefixed_state_value_iterator(
-            &StateKeyPrefix::new(StateKeyTag::AccessPath, vec![]),
-            Option::None,
-            target_version,
-        )
-        .unwrap();
-    for (old, new) in zip_eq(state_key_value_pairs_old, state_key_value_pairs) {
-        let (old_key, old_value) = old.unwrap();
-        let (new_key, new_value) = new.unwrap();
-        assert_eq!(old_key, new_key);
-        assert_eq!(old_value, new_value);
     }
 
     assert_eq!(

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -19,7 +19,10 @@ use aptos_db::AptosDB;
 use aptos_executor_types::VerifyExecutionMode;
 use aptos_storage_interface::DbReader;
 use aptos_temppath::TempPath;
-use aptos_types::transaction::Version;
+use aptos_types::{
+    state_store::{state_key::StateKeyTag, state_key_prefix::StateKeyPrefix},
+    transaction::Version,
+};
 use itertools::zip_eq;
 use std::{convert::TryInto, mem::size_of, sync::Arc};
 use tokio::time::Duration;
@@ -33,7 +36,7 @@ fn end_to_end() {
     backup_dir.create_as_dir().unwrap();
     let store: Arc<dyn BackupStorage> = Arc::new(LocalFs::new(backup_dir.path().to_path_buf()));
 
-    let (rt, port) = start_local_backup_service(src_db);
+    let (rt, port) = start_local_backup_service(Arc::clone(&src_db));
     let client = Arc::new(BackupServiceClient::new(format!(
         "http://localhost:{}",
         port
@@ -110,6 +113,7 @@ fn end_to_end() {
             None,
             VerifyExecutionMode::verify_all(),
             None,
+            None,
         )
         .run(),
     )
@@ -135,6 +139,27 @@ fn end_to_end() {
             .map(|txn_to_commit| txn_to_commit.write_set().clone()),
     ) {
         assert_eq!(restore_ws, org_ws);
+    }
+    // Get all the key value pairs and compare if they are the same
+    let state_key_value_pairs_old = src_db
+        .get_prefixed_state_value_iterator(
+            &StateKeyPrefix::new(StateKeyTag::AccessPath, vec![]),
+            Option::None,
+            target_version,
+        )
+        .unwrap();
+    let state_key_value_pairs = tgt_db
+        .get_prefixed_state_value_iterator(
+            &StateKeyPrefix::new(StateKeyTag::AccessPath, vec![]),
+            Option::None,
+            target_version,
+        )
+        .unwrap();
+    for (old, new) in zip_eq(state_key_value_pairs_old, state_key_value_pairs) {
+        let (old_key, old_value) = old.unwrap();
+        let (new_key, new_value) = new.unwrap();
+        assert_eq!(old_key, new_key);
+        assert_eq!(old_value, new_value);
     }
 
     assert_eq!(

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -140,6 +140,7 @@ fn end_to_end() {
     ) {
         assert_eq!(restore_ws, org_ws);
     }
+
     // Get all the key value pairs and compare if they are the same
     let state_key_value_pairs_old = src_db
         .get_prefixed_state_value_iterator(

--- a/storage/backup/backup-cli/src/coordinators/replay_verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/replay_verify.rs
@@ -142,6 +142,7 @@ impl ReplayVerifyCoordinator {
                     manifest_handle: backup.manifest,
                     version: backup.version,
                     validate_modules: self.validate_modules,
+                    restore_mode: Default::default(),
                 },
                 global_opt.clone(),
                 Arc::clone(&self.storage),
@@ -159,6 +160,7 @@ impl ReplayVerifyCoordinator {
             Some(replay_transactions_from_version), /* replay_from_version */
             None,                                   /* epoch_history */
             self.verify_execution_mode.clone(),
+            None,
             None,
         )
         .run()

--- a/storage/backup/backup-cli/src/coordinators/replay_verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/replay_verify.rs
@@ -103,7 +103,7 @@ impl ReplayVerifyCoordinator {
                 "DB already has non-empty State DB.",
             );
             (None, next_txn_version)
-        } else if let Some(version) = run_mode.get_in_progress_state_snapshot()? {
+        } else if let Some(version) = run_mode.get_in_progress_state_kv_snapshot()? {
             info!(
                 version = version,
                 "Found in progress state snapshot restore",
@@ -157,10 +157,10 @@ impl ReplayVerifyCoordinator {
             global_opt,
             self.storage,
             txn_manifests,
+            None,
             Some(replay_transactions_from_version), /* replay_from_version */
             None,                                   /* epoch_history */
             self.verify_execution_mode.clone(),
-            None,
             None,
         )
         .run()

--- a/storage/backup/backup-cli/src/coordinators/replay_verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/replay_verify.rs
@@ -158,8 +158,8 @@ impl ReplayVerifyCoordinator {
             self.storage,
             txn_manifests,
             None,
-            Some(replay_transactions_from_version), /* replay_from_version */
-            None,                                   /* epoch_history */
+            Some((replay_transactions_from_version, false)), /* replay_from_version */
+            None,                                            /* epoch_history */
             self.verify_execution_mode.clone(),
             None,
         )

--- a/storage/backup/backup-cli/src/coordinators/restore.rs
+++ b/storage/backup/backup-cli/src/coordinators/restore.rs
@@ -90,10 +90,20 @@ impl RestoreCoordinator {
     }
 
     /// Support two modes
-    /// 1. restore to target version
-    /// 2. restore a DB with all data ranging from start_version to target_version
-    /// We basically introduce a ledger history start version (lhs), a replay start version (rs) and target version
-    /// We directly store the write set and key values between (lhs, rs) and replay txn from (rs, target]
+    /// 1. restore to target version when do_phase_1 is false. We restore a closest snapshot and replay txns till the target version
+    /// 2. restore a DB with all data ranging from start_version to target_version with all KV restored between ledger_history_start_version and target_version along with the latest tree at target version.
+
+    /// The overall flow is as follows:
+    /// The first phase is restore till the tree snapshot before the target version. It includes the following work
+    /// a. restore the KV snapshot before ledger history start version, which also restore StateStorageUsage at the version
+    /// b. start from the first transaction of loaded chunk, save the txn accumualator, and apply transactions till the KV snapshot. We don't restore state KVs here since we can't calculate StateStorageUsage before the KV snapshot.
+    /// we start save transaction and restore KV after kv_snapshot version till the tree_snapshot before target version
+    ///
+    /// The second phase is restore the tree snapshot and replay txns till the target version
+    /// a. restore the tree snapshot
+    /// b. replay the txn till the target version
+    ///
+    /// we are support the resume from any point when the restore is interrupted.
     async fn run_impl(self) -> Result<()> {
         if self.replay_all {
             bail!("--replay--all not supported in this version.");
@@ -138,9 +148,12 @@ impl RestoreCoordinator {
             .run_mode
             .get_next_expected_transaction_version()?;
 
-        let kv_snapshot = if db_next_version == 0 {
-            match self.global_opt.run_mode.get_in_progress_state_kv_snapshot() {
-                Ok(Some(ver)) => {
+        let kv_snapshot = match self.global_opt.run_mode.get_in_progress_state_kv_snapshot() {
+            Ok(Some(ver)) => {
+                if db_next_version >= ver {
+                    // already restored the kv snapshot, no need to restore again
+                    None
+                } else {
                     let snapshot = metadata_view.select_state_snapshot(ver)?;
                     ensure!(
                         snapshot.is_some() && snapshot.as_ref().unwrap().version == ver,
@@ -148,67 +161,79 @@ impl RestoreCoordinator {
                         ver
                     );
                     snapshot
-                },
-                Ok(None) | Err(_) => {
-                    metadata_view.select_state_snapshot(std::cmp::min(lhs, max_txn_ver))?
-                },
-            }
-        } else {
-            None
+                }
+            },
+            Ok(None) | Err(_) => {
+                assert_eq!(
+                    db_next_version, 0,
+                    "DB should be empty if no in-progress state snapshot found"
+                );
+                metadata_view
+                    .select_state_snapshot(std::cmp::min(lhs, max_txn_ver))
+                    .expect("Cannot find any snapshot before ledger history start version")
+            },
         };
 
-        let tree_snapshot = metadata_view
-            .select_state_snapshot(std::cmp::min(self.target_version(), max_txn_ver))?
-            .expect("Cannot find tree snapshot before target version");
+        let tree_snapshot = if let Some((latest_tree_version, _)) = latest_tree_version {
+            let snapshot = metadata_view.select_state_snapshot(latest_tree_version)?;
 
-        let two_phase_restore = if let Some(kv_snapshot) = kv_snapshot.as_ref() {
+            ensure!(
+                snapshot.is_some() && snapshot.as_ref().unwrap().version == latest_tree_version,
+                "cannot find tree snapshot {}",
+                latest_tree_version
+            );
+            snapshot.unwrap()
+        } else {
+            metadata_view
+                .select_state_snapshot(std::cmp::min(self.target_version(), max_txn_ver))?
+                .expect("Cannot find tree snapshot before target version")
+        };
+
+        let do_phase_1 = if let Some(kv_snapshot) = kv_snapshot.as_ref() {
             // if we have a kv snapshot, we need to restore the state between lhs and rs
+            // if the version are equal, we don't need to restore phase 1. we can directly restore a snapshot with both tree and KV, and then replay txn till the target_version
             kv_snapshot.version < tree_snapshot.version
         } else {
             // if we don't have a kv snapshot, we need to restore the state between db_next_version and rs
-            db_next_version < tree_snapshot.version && db_next_version > 0
+            db_next_version < tree_snapshot.version
         };
-        let txn_start_version = if kv_snapshot.is_some() {
-            kv_snapshot.as_ref().unwrap().version
+        let txn_start_version = if let Some(kv_snapshot) = kv_snapshot.as_ref() {
+            kv_snapshot.version
         } else {
             db_next_version
         };
         let transaction_backups =
             metadata_view.select_transaction_backups(txn_start_version, target_version)?;
         let epoch_ending_backups = metadata_view.select_epoch_ending_backups(target_version)?;
+        let epoch_handles = epoch_ending_backups
+            .iter()
+            .filter(|e| e.first_version <= target_version)
+            .map(|backup| backup.manifest.clone())
+            .collect();
+        let epoch_history = if !self.skip_epoch_endings {
+            Some(Arc::new(
+                EpochHistoryRestoreController::new(
+                    epoch_handles,
+                    self.global_opt.clone(),
+                    self.storage.clone(),
+                )
+                .run()
+                .await?,
+            ))
+        } else {
+            None
+        };
 
         // Restore the the state kv between lhs and rs
-        if two_phase_restore {
-            let start_version = if let Some(ref kv_snapshot) = kv_snapshot {
-                kv_snapshot.version
-            } else {
-                db_next_version
-            };
+        if do_phase_1 {
             info!(
                 "Start restoring DB from version {} to tree snapshot version {}",
-                start_version, tree_snapshot.version,
+                txn_start_version, tree_snapshot.version,
             );
-            let epoch_handles = epoch_ending_backups
-                .iter()
-                .filter(|e| e.first_version <= tree_snapshot.version)
-                .map(|backup| backup.manifest.clone())
-                .collect();
-            let epoch_history = if !self.skip_epoch_endings {
-                Some(Arc::new(
-                    EpochHistoryRestoreController::new(
-                        epoch_handles,
-                        self.global_opt.clone(),
-                        self.storage.clone(),
-                    )
-                    .run()
-                    .await?,
-                ))
-            } else {
-                None
-            };
 
+            // phase 1.a: restore the kv snapshot
             if kv_snapshot.is_some() {
-                let kv_snapshot = kv_snapshot.unwrap();
+                let kv_snapshot = kv_snapshot.clone().unwrap();
                 info!("Start restoring KV snapshot at {}", kv_snapshot.version);
 
                 StateSnapshotRestoreController::new(
@@ -225,20 +250,40 @@ impl RestoreCoordinator {
                 .run()
                 .await?;
             }
+
+            // phase 1.b: save the txn between the first txn of the first chunk and the tree snapshot
             let txn_manifests = transaction_backups
                 .iter()
-                .filter(|e| e.first_version < tree_snapshot.version)
+                .filter(|e| {
+                    e.first_version <= tree_snapshot.version && e.last_version >= db_next_version
+                })
                 .map(|e| e.manifest.clone())
                 .collect();
+            assert!(
+                db_next_version == 0
+                    || transaction_backups.first().map_or(0, |t| t.first_version)
+                        <= db_next_version,
+                "Inconsistent state: first txn version {} is larger than db_next_version {}",
+                transaction_backups.first().map_or(0, |t| t.first_version),
+                db_next_version
+            );
             // update the kv to the kv db
+            // reset the global
             let mut transaction_restore_opt = self.global_opt.clone();
-            transaction_restore_opt.target_version = tree_snapshot.version - 1;
+            // We should replay kv to include the version of tree snapshot so that we can get correct storage usage at that version
+            // while restore tree only snapshots
+            let kv_replay_version = if let Some(kv_snapshot) = kv_snapshot.as_ref() {
+                kv_snapshot.version + 1
+            } else {
+                db_next_version
+            };
+            transaction_restore_opt.target_version = tree_snapshot.version;
             TransactionRestoreBatchController::new(
                 transaction_restore_opt,
                 Arc::clone(&self.storage),
                 txn_manifests,
-                None,
-                None,
+                Some(db_next_version),
+                Some((kv_replay_version, true /* only replay KV */)),
                 epoch_history.clone(),
                 VerifyExecutionMode::NoVerify,
                 None,
@@ -249,40 +294,17 @@ impl RestoreCoordinator {
             db_next_version = tree_snapshot.version;
         }
 
-        // Restore the full tree snapshot and replay till the target version
+        // Phase 2: restore the full tree snapshot and replay till the target version
         {
-            let epoch_handles = epoch_ending_backups
-                .iter()
-                .filter(|e| e.first_version <= target_version)
-                .map(|backup| backup.manifest.clone())
-                .collect();
-
-            let epoch_history = if !self.skip_epoch_endings {
-                Some(Arc::new(
-                    EpochHistoryRestoreController::new(
-                        epoch_handles,
-                        self.global_opt.clone(),
-                        self.storage.clone(),
-                    )
-                    .run()
-                    .await?,
-                ))
-            } else {
-                None
-            };
-
-            let first_version = if db_next_version == 0 {
-                None
-            } else {
-                Some(db_next_version)
-            };
-            let mut replay_version = first_version;
+            let first_version = (db_next_version > 0).then_some(db_next_version);
+            // we don't want to replay txn at exact tree snapshot version since the kv is restored either in phase 1 OR by snapshot restore in default mode
+            let mut replay_version = first_version.map(|v| (v, false));
 
             info!(
                 "Starting restore DB from version {} to target version {}",
                 db_next_version, target_version,
             );
-            // If the tree is not completed, we directly restore from the latest snapshot before target
+            // phase 2.a: if the tree is not completed, we directly restore from the latest snapshot before target
             if !tree_completed {
                 // For boostrap DB to latest version, we want to use default mode
                 let restore_mode = if db_next_version > 0 {
@@ -308,11 +330,13 @@ impl RestoreCoordinator {
                 )
                 .run()
                 .await?;
-                if restore_mode == StateSnapshotRestoreMode::Default {
-                    replay_version = Some(tree_snapshot.version + 1);
-                }
+                replay_version = Some((
+                    tree_snapshot.version + 1,
+                    false, /*replay entire txn including update tree and KV*/
+                ));
             }
 
+            // phase 2.b: restore the txn between the tree snapshot and the target version
             let txn_manifests = transaction_backups
                 .iter()
                 .filter(|e| e.last_version >= db_next_version)

--- a/storage/backup/backup-cli/src/coordinators/verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/verify.rs
@@ -17,6 +17,7 @@ use crate::{
     utils::{unix_timestamp_sec, GlobalRestoreOptions, RestoreRunMode, TrustedWaypointOpt},
 };
 use anyhow::Result;
+use aptos_db::state_restore::StateSnapshotRestoreMode;
 use aptos_executor_types::VerifyExecutionMode;
 use aptos_logger::prelude::*;
 use aptos_types::transaction::Version;
@@ -131,6 +132,7 @@ impl VerifyCoordinator {
                     manifest_handle: backup.manifest,
                     version: backup.version,
                     validate_modules: self.validate_modules,
+                    restore_mode: StateSnapshotRestoreMode::Default,
                 },
                 global_opt.clone(),
                 Arc::clone(&self.storage),
@@ -149,6 +151,7 @@ impl VerifyCoordinator {
             epoch_history,
             VerifyExecutionMode::NoVerify,
             self.output_transaction_analysis,
+            None,
         )
         .run()
         .await?;

--- a/storage/backup/backup-cli/src/coordinators/verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/verify.rs
@@ -147,11 +147,11 @@ impl VerifyCoordinator {
             global_opt,
             self.storage,
             txn_manifests,
+            None,
             None, /* replay_from_version */
             epoch_history,
             VerifyExecutionMode::NoVerify,
             self.output_transaction_analysis,
-            None,
         )
         .run()
         .await?;

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -8,7 +8,7 @@ pub mod read_record_bytes;
 pub mod storage_ext;
 pub(crate) mod stream;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 pub mod test_utils;
 
 use anyhow::{anyhow, Result};

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -20,7 +20,8 @@ use aptos_crypto::HashValue;
 use aptos_db::{
     backup::restore_handler::RestoreHandler,
     state_restore::{
-        StateSnapshotProgress, StateSnapshotRestore, StateValueBatch, StateValueWriter,
+        StateSnapshotProgress, StateSnapshotRestore, StateSnapshotRestoreMode, StateValueBatch,
+        StateValueWriter,
     },
     AptosDB, GetRestoreHandler,
 };
@@ -204,11 +205,14 @@ impl RestoreRunMode {
         &self,
         version: Version,
         expected_root_hash: HashValue,
+        restore_mode: StateSnapshotRestoreMode,
     ) -> Result<StateSnapshotRestore<StateKey, StateValue>> {
         match self {
-            Self::Restore { restore_handler } => {
-                restore_handler.get_state_restore_receiver(version, expected_root_hash)
-            },
+            Self::Restore { restore_handler } => restore_handler.get_state_restore_receiver(
+                version,
+                expected_root_hash,
+                restore_mode,
+            ),
             Self::Verify => {
                 let mock_store = Arc::new(MockStore);
                 StateSnapshotRestore::new_overwrite(
@@ -216,6 +220,7 @@ impl RestoreRunMode {
                     &mock_store,
                     version,
                     expected_root_hash,
+                    restore_mode,
                 )
             },
         }

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -247,6 +247,15 @@ impl RestoreRunMode {
         }
     }
 
+    pub fn get_state_leaf_count(&self, version: Version) -> usize {
+        match self {
+            RestoreRunMode::Restore { restore_handler } => {
+                restore_handler.get_state_leaf_count(version)
+            },
+            RestoreRunMode::Verify => 0,
+        }
+    }
+
     pub fn get_in_progress_state_snapshot(&self) -> Result<Option<Version>> {
         match self {
             RestoreRunMode::Restore { restore_handler } => {

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -283,16 +283,18 @@ impl TryFrom<GlobalRestoreOpt> for GlobalRestoreOptions {
         let concurrent_downloads = opt.concurrent_downloads.get();
         let replay_concurrency_level = opt.replay_concurrency_level.get();
         let run_mode = if let Some(db_dir) = &opt.db_dir {
-            let restore_handler = Arc::new(AptosDB::open(
+            // for restore, we can always start state store with empty buffered_state since we will restore
+            let restore_handler = Arc::new(AptosDB::open_kv_only(
                 db_dir,
                 false,                       /* read_only */
                 NO_OP_STORAGE_PRUNER_CONFIG, /* pruner config */
-                opt.rocksdb_opt.into(),
+                opt.rocksdb_opt.clone().into(),
                 false,
                 BUFFERED_STATE_TARGET_ITEMS,
                 DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
             )?)
             .get_restore_handler();
+
             RestoreRunMode::Restore { restore_handler }
         } else {
             RestoreRunMode::Verify

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -247,19 +247,19 @@ impl RestoreRunMode {
         }
     }
 
-    pub fn get_state_leaf_count(&self, version: Version) -> usize {
+    pub fn get_state_snapshot_before(&self, version: Version) -> Option<(Version, HashValue)> {
         match self {
-            RestoreRunMode::Restore { restore_handler } => {
-                restore_handler.get_state_leaf_count(version)
-            },
-            RestoreRunMode::Verify => 0,
+            RestoreRunMode::Restore { restore_handler } => restore_handler
+                .get_state_snapshot_before(version)
+                .unwrap_or(None),
+            RestoreRunMode::Verify => None,
         }
     }
 
-    pub fn get_in_progress_state_snapshot(&self) -> Result<Option<Version>> {
+    pub fn get_in_progress_state_kv_snapshot(&self) -> Result<Option<Version>> {
         match self {
             RestoreRunMode::Restore { restore_handler } => {
-                restore_handler.get_in_progress_state_snapshot_version()
+                restore_handler.get_in_progress_state_kv_snapshot_version()
             },
             RestoreRunMode::Verify => Ok(None),
         }

--- a/storage/db-tool/Cargo.toml
+++ b/storage/db-tool/Cargo.toml
@@ -20,10 +20,13 @@ aptos-db = { workspace = true, features = ["db-debugger"] }
 aptos-executor-types = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-push-metrics = { workspace = true }
+aptos-state-view = { workspace = true }
+aptos-storage-interface = { workspace = true }
 aptos-temppath = { workspace = true }
 aptos-types = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true }
+itertools = { workspace = true }
 owo-colors = { workspace = true }
 tokio = { workspace = true }
 

--- a/storage/db-tool/Cargo.toml
+++ b/storage/db-tool/Cargo.toml
@@ -31,5 +31,6 @@ owo-colors = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+aptos-backup-cli = { workspace = true, features = ["testing"] }
 aptos-backup-service = { workspace = true }
 aptos-executor-test-helpers = { workspace = true }

--- a/storage/db-tool/src/restore.rs
+++ b/storage/db-tool/src/restore.rs
@@ -60,6 +60,16 @@ pub enum Oneoff {
         #[clap(flatten)]
         global: GlobalRestoreOpt,
     },
+    /// Restore the db in a historical time frame with [ledger-history-start-version, target-version]
+    /// The restored the DB has both key-value and write sets restored
+    Bundle {
+        #[clap(flatten)]
+        storage: DBToolStorageOpt,
+        #[clap(flatten)]
+        opt: RestoreCoordinatorOpt,
+        #[clap(flatten)]
+        global: GlobalRestoreOpt,
+    },
 }
 
 impl Command {
@@ -105,6 +115,19 @@ impl Command {
                             storage.init_storage().await?,
                             None, /* epoch_history */
                             VerifyExecutionMode::NoVerify,
+                        )
+                        .run()
+                        .await?;
+                    },
+                    Oneoff::Bundle {
+                        storage,
+                        opt,
+                        global,
+                    } => {
+                        RestoreCoordinator::new(
+                            opt,
+                            global.try_into()?,
+                            storage.init_storage().await?,
                         )
                         .run()
                         .await?;

--- a/storage/db-tool/src/restore.rs
+++ b/storage/db-tool/src/restore.rs
@@ -60,16 +60,6 @@ pub enum Oneoff {
         #[clap(flatten)]
         global: GlobalRestoreOpt,
     },
-    /// Restore the db in a historical time frame with [ledger-history-start-version, target-version]
-    /// The restored the DB has both key-value and write sets restored
-    Bundle {
-        #[clap(flatten)]
-        storage: DBToolStorageOpt,
-        #[clap(flatten)]
-        opt: RestoreCoordinatorOpt,
-        #[clap(flatten)]
-        global: GlobalRestoreOpt,
-    },
 }
 
 impl Command {
@@ -115,19 +105,6 @@ impl Command {
                             storage.init_storage().await?,
                             None, /* epoch_history */
                             VerifyExecutionMode::NoVerify,
-                        )
-                        .run()
-                        .await?;
-                    },
-                    Oneoff::Bundle {
-                        storage,
-                        opt,
-                        global,
-                    } => {
-                        RestoreCoordinator::new(
-                            opt,
-                            global.try_into()?,
-                            storage.init_storage().await?,
                         )
                         .run()
                         .await?;

--- a/storage/db-tool/src/tests.rs
+++ b/storage/db-tool/src/tests.rs
@@ -7,8 +7,8 @@ use aptos_backup_cli::{
     metadata,
     metadata::{cache::MetadataCacheOpt, view::MetadataView},
     storage::{local_fs::LocalFs, BackupStorage},
+    utils::test_utils::start_local_backup_service,
 };
-use aptos_backup_service::start_backup_service;
 use aptos_config::config::RocksdbConfigs;
 use aptos_db::AptosDB;
 use aptos_executor_test_helpers::integration_test_impl::test_execution_with_storage_impl;
@@ -18,12 +18,7 @@ use aptos_types::{
     transaction::Version,
 };
 use clap::Parser;
-use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    ops::Deref,
-    sync::Arc,
-    time::Duration,
-};
+use std::{ops::Deref, sync::Arc, time::Duration};
 
 #[test]
 fn test_various_cmd_parsing() {
@@ -110,44 +105,165 @@ mod compaction_tests {
         sync::Arc,
         time::Duration,
     };
+    use itertools::Itertools;
 
     fn assert_metadata_view_eq(view1: &MetadataView, view2: &MetadataView) {
-        assert!(
-            view1.select_transaction_backups(0, Version::MAX).unwrap()
-                == view2.select_transaction_backups(0, Version::MAX).unwrap()
-                && view1.select_epoch_ending_backups(Version::MAX).unwrap()
-                    == view2.select_epoch_ending_backups(Version::MAX).unwrap()
-                && view1.select_state_snapshot(Version::MAX).unwrap()
-                    == view2.select_state_snapshot(Version::MAX).unwrap(),
-            "Metadata views are not equal"
-        );
-    }
+    assert!(
+        view1.select_transaction_backups(0, Version::MAX).unwrap()
+            == view2.select_transaction_backups(0, Version::MAX).unwrap()
+            && view1.select_epoch_ending_backups(Version::MAX).unwrap()
+                == view2.select_epoch_ending_backups(Version::MAX).unwrap()
+            && view1.select_state_snapshot(Version::MAX).unwrap()
+                == view2.select_state_snapshot(Version::MAX).unwrap(),
+        "Metadata views are not equal"
+    );
+}
 
-    #[test]
-    fn test_backup_compaction() {
-        let db = test_execution_with_storage_impl();
-        let backup_dir = TempPath::new();
-        backup_dir.create_as_dir().unwrap();
-        let local_fs = LocalFs::new(backup_dir.path().to_path_buf());
-        let store: Arc<dyn BackupStorage> = Arc::new(local_fs);
-        let rt = start_backup_service(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 6186), db);
-        // Backup the local_test DB
-        rt.block_on(
-            DBTool::try_parse_from([
-                "aptos-db-tool",
-                "backup",
-                "oneoff",
-                "epoch-ending",
-                "--start-epoch",
-                "0",
-                "--end-epoch",
-                "1",
-                "--local-fs-dir",
-                backup_dir.path().to_str().unwrap(),
-            ])
-            .unwrap()
-            .run(),
-        )
+#[test]
+fn test_backup_compaction() {
+    let db = test_execution_with_storage_impl();
+    let backup_dir = TempPath::new();
+    backup_dir.create_as_dir().unwrap();
+    let local_fs = LocalFs::new(backup_dir.path().to_path_buf());
+    let store: Arc<dyn BackupStorage> = Arc::new(local_fs);
+    let (rt, port) = start_local_backup_service(db);
+    let server_addr = format!(" http://localhost:{}", port);
+
+    // Backup the local_test DB
+    rt.block_on(
+        DBTool::try_parse_from([
+            "aptos-db-tool",
+            "backup",
+            "oneoff",
+            "--backup-service-address",
+            server_addr.as_str(),
+            "epoch-ending",
+            "--start-epoch",
+            "0",
+            "--end-epoch",
+            "1",
+            "--local-fs-dir",
+            backup_dir.path().to_str().unwrap(),
+        ])
+        .unwrap()
+        .run(),
+    )
+    .unwrap();
+
+    rt.block_on(
+        DBTool::try_parse_from([
+            "aptos-db-tool",
+            "backup",
+            "oneoff",
+            "--backup-service-address",
+            server_addr.as_str(),
+            "epoch-ending",
+            "--start-epoch",
+            "1",
+            "--end-epoch",
+            "2",
+            "--local-fs-dir",
+            backup_dir.path().to_str().unwrap(),
+        ])
+        .unwrap()
+        .run(),
+    )
+    .unwrap();
+
+    rt.block_on(
+        DBTool::try_parse_from([
+            "aptos-db-tool",
+            "backup",
+            "oneoff",
+            "--backup-service-address",
+            server_addr.as_str(),
+            "state-snapshot",
+            "--state-snapshot-epoch",
+            "1",
+            "--local-fs-dir",
+            backup_dir.path().to_str().unwrap(),
+        ])
+        .unwrap()
+        .run(),
+    )
+    .unwrap();
+
+    rt.block_on(
+        DBTool::try_parse_from([
+            "aptos-db-tool",
+            "backup",
+            "oneoff",
+            "--backup-service-address",
+            server_addr.as_str(),
+            "state-snapshot",
+            "--state-snapshot-epoch",
+            "2",
+            "--local-fs-dir",
+            backup_dir.path().to_str().unwrap(),
+        ])
+        .unwrap()
+        .run(),
+    )
+    .unwrap();
+    rt.block_on(
+        DBTool::try_parse_from([
+            "aptos-db-tool",
+            "backup",
+            "oneoff",
+            "--backup-service-address",
+            server_addr.as_str(),
+            "transaction",
+            "--start-version",
+            "0",
+            "--num_transactions",
+            "15",
+            "--local-fs-dir",
+            backup_dir.path().to_str().unwrap(),
+        ])
+        .unwrap()
+        .run(),
+    )
+    .unwrap();
+    rt.block_on(
+        DBTool::try_parse_from([
+            "aptos-db-tool",
+            "backup",
+            "oneoff",
+            "--backup-service-address",
+            server_addr.as_str(),
+            "transaction",
+            "--start-version",
+            "15",
+            "--num_transactions",
+            "15",
+            "--local-fs-dir",
+            backup_dir.path().to_str().unwrap(),
+        ])
+        .unwrap()
+        .run(),
+    )
+    .unwrap();
+    // assert the metadata views are same before and after compaction
+    let metadata_opt = MetadataCacheOpt::new(Some(TempPath::new().path().to_path_buf()));
+    let old_metaview = rt
+        .block_on(metadata::cache::sync_and_load(
+            &metadata_opt,
+            Arc::clone(&store),
+            1,
+        ))
+        .unwrap();
+    let compactor = BackupCompactor::new(2, 2, 2, metadata_opt.clone(), Arc::clone(&store), 1);
+    rt.block_on(compactor.run()).unwrap();
+
+    // run compaction again
+    rt.block_on(compactor.run()).unwrap();
+
+    let new_metaview = rt
+        .block_on(metadata::cache::sync_and_load(
+            &metadata_opt,
+            Arc::clone(&store),
+            1,
+        ))
         .unwrap();
 
         rt.block_on(
@@ -283,10 +399,8 @@ fn db_restore_test_setup(start: Version, end: Version) {
     let db = test_execution_with_storage_impl();
     let backup_dir = TempPath::new();
     backup_dir.create_as_dir().unwrap();
-    let rt = start_backup_service(
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 6186),
-        Arc::clone(&db),
-    );
+    let (rt, port) = start_local_backup_service(Arc::clone(&db));
+    let server_addr = format!(" http://localhost:{}", port);
 
     // Backup the local_test DB
     rt.block_on(
@@ -294,6 +408,8 @@ fn db_restore_test_setup(start: Version, end: Version) {
             "aptos-db-tool",
             "backup",
             "oneoff",
+            "--backup-service-address",
+            server_addr.as_str(),
             "epoch-ending",
             "--start-epoch",
             "0",
@@ -312,6 +428,8 @@ fn db_restore_test_setup(start: Version, end: Version) {
             "aptos-db-tool",
             "backup",
             "oneoff",
+            "--backup-service-address",
+            server_addr.as_str(),
             "epoch-ending",
             "--start-epoch",
             "1",
@@ -330,6 +448,8 @@ fn db_restore_test_setup(start: Version, end: Version) {
             "aptos-db-tool",
             "backup",
             "oneoff",
+            "--backup-service-address",
+            server_addr.as_str(),
             "state-snapshot",
             "--state-snapshot-epoch",
             "0",
@@ -346,6 +466,8 @@ fn db_restore_test_setup(start: Version, end: Version) {
             "aptos-db-tool",
             "backup",
             "oneoff",
+            "--backup-service-address",
+            server_addr.as_str(),
             "state-snapshot",
             "--state-snapshot-epoch",
             "1",
@@ -362,6 +484,8 @@ fn db_restore_test_setup(start: Version, end: Version) {
             "aptos-db-tool",
             "backup",
             "oneoff",
+            "--backup-service-address",
+            server_addr.as_str(),
             "state-snapshot",
             "--state-snapshot-epoch",
             "2",
@@ -377,6 +501,8 @@ fn db_restore_test_setup(start: Version, end: Version) {
             "aptos-db-tool",
             "backup",
             "oneoff",
+            "--backup-service-address",
+            server_addr.as_str(),
             "transaction",
             "--start-version",
             "0",
@@ -394,6 +520,8 @@ fn db_restore_test_setup(start: Version, end: Version) {
             "aptos-db-tool",
             "backup",
             "oneoff",
+            "--backup-service-address",
+            server_addr.as_str(),
             "transaction",
             "--start-version",
             "15",

--- a/storage/db-tool/src/tests.rs
+++ b/storage/db-tool/src/tests.rs
@@ -465,9 +465,9 @@ mod compaction_tests {
                 assert_eq!(new_value, old_value);
             });
         }
-        // first snapshot tree recovered
+        // first snapshot tree not recovered
         assert!(
-            tree_db.get_root_hash(0).is_err(),
+            tree_db.get_root_hash(0).is_err() || tree_db.get_leaf_count(0).unwrap() == 0,
             "tree at version 0 should not be restored"
         );
         // second snapshot tree recovered

--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -233,7 +233,7 @@ async fn test_genesis_transaction_flow() {
         (response.inner().epoch, response.inner().version)
     };
 
-    let backup_path = db_backup(
+    let (backup_path, snapshot_ver) = db_backup(
         env.validators()
             .next()
             .unwrap()
@@ -272,6 +272,7 @@ async fn test_genesis_transaction_flow() {
         db_dir.as_path(),
         &[waypoint],
         node.config().storage.rocksdb_configs.use_state_kv_db,
+        Some(snapshot_ver),
     );
 
     node.start().unwrap();

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -111,8 +111,7 @@ async fn test_db_restore() {
     // make a backup from node 1
     let node1_config = swarm.validator(validator_peer_ids[1]).unwrap().config();
     let port = node1_config.storage.backup_service_address.port();
-    let backup_path = db_backup(port, 5, 400, 200, 5, &[]);
-
+    let (backup_path, _) = db_backup(port, 5, 400, 200, 5, &[]);
     // take down node 0
     let node_to_restart = validator_peer_ids[0];
     swarm.validator_mut(node_to_restart).unwrap().stop();
@@ -133,6 +132,7 @@ async fn test_db_restore() {
         db_dir.as_path(),
         &[],
         node0_config.storage.rocksdb_configs.use_state_kv_db,
+        None,
     );
 
     expected_balance_0 -= 3;
@@ -187,7 +187,7 @@ fn db_backup_verify(backup_path: &Path, trusted_waypoints: &[Waypoint]) {
     metadata_cache_path.create_as_dir().unwrap();
 
     let mut cmd = Command::new(bin_path.as_path());
-
+    cmd.args(["backup", "verify"]);
     trusted_waypoints.iter().for_each(|w| {
         cmd.arg("--trust-waypoint");
         cmd.arg(&w.to_string());
@@ -195,8 +195,6 @@ fn db_backup_verify(backup_path: &Path, trusted_waypoints: &[Waypoint]) {
 
     let status = cmd
         .args([
-            "backup",
-            "verify",
             "--metadata-cache-dir",
             metadata_cache_path.path().to_str().unwrap(),
             "--concurrent-downloads",
@@ -261,7 +259,7 @@ fn wait_for_backups(
     metadata_cache_path: &Path,
     backup_path: &Path,
     trusted_waypoints: &[Waypoint],
-) -> Result<()> {
+) -> Result<Version> {
     for i in 0..120 {
         info!(
             "{}th wait for the backup to reach epoch {}, version {}.",
@@ -282,7 +280,7 @@ fn wait_for_backups(
                 now.elapsed().as_secs(),
                 state
             );
-            return Ok(());
+            return Ok(state.latest_state_snapshot_version.unwrap());
         }
         info!("Backup storage state: {}", state);
         if state.latest_transaction_version.is_some() {
@@ -325,7 +323,7 @@ pub(crate) fn db_backup(
     transaction_batch_size: usize,
     state_snapshot_interval_epochs: usize,
     trusted_waypoints: &[Waypoint],
-) -> TempPath {
+) -> (TempPath, Version) {
     info!("---------- running aptos db tool backup");
     let now = Instant::now();
     let bin_path = workspace_builder::get_bin("aptos-db-tool");
@@ -401,9 +399,9 @@ pub(crate) fn db_backup(
         std::str::from_utf8(&compaction.stderr).unwrap()
     );
     backup_coordinator.kill().unwrap();
-    wait_res.unwrap();
+    let snapshot_ver = wait_res.unwrap();
     replay_verify(backup_path.path(), trusted_waypoints);
-    backup_path
+    (backup_path, snapshot_ver)
 }
 
 pub(crate) fn db_restore(
@@ -411,6 +409,7 @@ pub(crate) fn db_restore(
     db_path: &Path,
     trusted_waypoints: &[Waypoint],
     use_state_kv_db: bool,
+    target_verion: Option<Version>, /* target version should be same as epoch ending version to start a node */
 ) {
     let now = Instant::now();
     let bin_path = workspace_builder::get_bin("aptos-db-tool");
@@ -427,6 +426,10 @@ pub(crate) fn db_restore(
 
     if use_state_kv_db {
         cmd.arg("--use-state-kv-db");
+    }
+    if let Some(version) = target_verion {
+        cmd.arg("--target-version");
+        cmd.arg(&version.to_string());
     }
 
     let status = cmd


### PR DESCRIPTION
### Description

### Requirements

To restore a database, provide a start version and end version with:

- All data restored, including state key values, write sets, state Merkle tree at the end version, and ledger info from genesis to generate a database with full data of a certain time frame.
- Fast, different from replaying transactions, decouple state key value commit from in-memory state Merkle tree updating.

### Approach

Enhance the existing DB bootstrap to support both the latest DB restore and archive DB restore.

The user provides the arguments in the CLI with (ledger_history_start_version, target_version), specifying the range of the historical database they want to restore.

Depending on the snapshot version's order with user provided arguments, two scenarios may occur:

**Scenario 1: [snapshot_a, lhs, snapshot_b, target]**

1. Calculate `snapshot_a`, restore the snapshot (only KVs are required) at `snapshot_a` to create a baseline.
2. Restore transactions in range [snapshot_a, snapshot_b].
    1. directly commit the write set as key value to KV CF
    2. snapshot_a and snapshot_b are inclusive since we need to restore txn Info at these two versions. 
3. Restore the snapshot at `snapshot_b` with both kv and tree.
4. Replay transactions from `snapshot_b` + 1 to `target`. 

**Scenario 2: [snapshot_a, lhs, target]**

1. Calculate `snapshot_a` and `snapshot_b` In this scenario, snapshot_a == snapshot_b
2. Directly replay transactions from `snapshot_a + 1` till `target`.

Lastly, if the user just wants to bootstrap the database to the latest version, lhs can be set to the same target version. We will just replay from the latest snapshot version to the latest target version

**Enable `TransactionRestoreBatchController`(TxnController) to restore with a start version**

We want to replay transactions between [snapshot_b, target]. However, the TxnController loads all transactions in a backup chunk file, which can contain more transactions than we need. These transaction are saved by default causing waste of computation. TxnController only support `target_version` to specify the range end. We need a `start_version` parameter to specify the exact range of Txns to avoid redundant computation

**Enable `StateSnapshotRestoreController` to restore KV only**

To restore `snapshot_a`, we do not need to restore the state tree since the tree will eventually be restored at `snapshot_b`. We can bypass the tree restore in the SnapshotController by disabling the thread for restoring the state tree using a flag.

Design doc here https://www.notion.so/aptoslabs/Enhanced-DB-Restore-cf86fbfacbb94eab8e155078f56cec34?pvs=4


### Test Plan
add a new unit test showing the KV restored, Tree restored only at the 2nd snapshot. 