### PR TITLE
Add `TypeAccessor`

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -91,12 +91,13 @@ jobs:
   # Because the docker build happens in a reusable workflow, have a separate job that collects the right metadata
   # for the subsequent docker builds. Reusable workflows do not currently have the "env" context: https://github.com/orgs/community/discussions/26671
   determine-docker-build-metadata:
+    needs: [permission-check]
     runs-on: ubuntu-latest
     steps:
       - name: collect metadata
         run: |
-          echo "GIT_SHA: ${{ env.GIT_SHA }}"
-          echo "TARGET_CACHE_ID: ${{ env.TARGET_CACHE_ID }}"
+          echo "GIT_SHA: ${GIT_SHA}"
+          echo "TARGET_CACHE_ID: ${TARGET_CACHE_ID}"
     outputs:
       gitSha: ${{ env.GIT_SHA }}
       targetCacheId: ${{ env.TARGET_CACHE_ID }}

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -48,6 +48,7 @@ concurrency:
 
 env:
   GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
+  GCP_DOCKER_ARTIFACT_REPO_US: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO_US }}
   AWS_ECR_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
   # In case of pull_request events by default github actions merges main into the PR branch and then runs the tests etc
   # on the prospective merge result instead of only on the tip of the PR.
@@ -69,15 +70,15 @@ permissions:
 # Note on the job-level `if` conditions:
 # This workflow is designed such that:
 # 1. Run ALL jobs when a 'push', 'workflow_dispatch' triggered the workflow or on 'pull_request's which have set auto_merge=true or have the label "CICD:run-e2e-tests".
-# 2. Run ONLY the docker image building jobs on PRs with the "CICD:build-images" label.
+# 2. Run ONLY the docker image building jobs on PRs with the "CICD:build[-<PROFILE/FEATURE>]-images" label.
 # 3. Run NOTHING when neither 1. or 2.'s conditions are satisfied.
 jobs:
   permission-check:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'CICD:build-images') ||
-      contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'CICD:build-') ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'CICD:run-') ||
       github.event.pull_request.auto_merge != null ||
       contains(github.event.pull_request.body, '#e2e')
     runs-on: ubuntu-latest
@@ -115,6 +116,10 @@ jobs:
   rust-images-indexer:
     needs: [permission-check, determine-docker-build-metadata]
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'CICD:build-indexer-images')
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -126,6 +131,10 @@ jobs:
   rust-images-failpoints:
     needs: [permission-check, determine-docker-build-metadata]
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'CICD:build-failpoints-images')
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -137,6 +146,10 @@ jobs:
   rust-images-performance:
     needs: [permission-check, determine-docker-build-metadata]
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'CICD:build-performance-images')
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -159,38 +172,57 @@ jobs:
       BUILD_ADDL_TESTING_IMAGES: true
 
   sdk-release:
-    needs: [rust-images, determine-docker-build-metadata]
+    needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'CICD:skip-sdk-integration-test') && (
-      github.event_name == 'push' ||
+      (github.event_name == 'push' && github.ref_name != 'main') ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
-      github.event.pull_request.auto_merge != null) ||
+      github.event.pull_request.auto_merge != null ||
       contains(github.event.pull_request.body, '#e2e')
-    uses: ./.github/workflows/sdk-release.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/sdk-release.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
 
   cli-e2e-tests:
-    needs: [rust-images, determine-docker-build-metadata]
+    needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
     if: |
       !contains(github.event.pull_request.labels.*.name, 'CICD:skip-sdk-integration-test') && (
-      github.event_name == 'push' ||
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+        github.event.pull_request.auto_merge != null) ||
+        contains(github.event.pull_request.body, '#e2e'
+      )
+    uses: ./.github/workflows/cli-e2e-tests.yaml
+    secrets: inherit
+    with:
+      GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+
+  indexer-grpc-e2e-tests:
+    needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
+    if: |
+      (github.event_name == 'push' && github.ref_name != 'main') ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
-      github.event.pull_request.auto_merge != null) ||
+      github.event.pull_request.auto_merge != null ||
       contains(github.event.pull_request.body, '#e2e')
-    uses: ./.github/workflows/cli-e2e-tests.yaml
+    uses: ./.github/workflows/docker-indexer-grpc-test.yaml
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
 
   forge-e2e-test:
     needs:
-      [rust-images, rust-images-failpoints, determine-docker-build-metadata]
+      - permission-check
+      - determine-docker-build-metadata
+      - rust-images
+      - rust-images-indexer
+      - rust-images-failpoints
+      - rust-images-performance
+      - rust-images-consensus-only-perf-test
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'CICD:skip-forge-e2e-test') && (
+      !failure() && !cancelled() && needs.permission-check.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
@@ -201,6 +233,9 @@ jobs:
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+      FORGE_TEST_SUITE: land_blocking
+      IMAGE_TAG: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+      FORGE_RUNNER_DURATION_SECS: 480
       COMMENT_HEADER: forge-e2e
       # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
       # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
@@ -210,9 +245,15 @@ jobs:
   # Run e2e compat test against testnet branch
   forge-compat-test:
     needs:
-      [rust-images, rust-images-failpoints, determine-docker-build-metadata]
+      - permission-check
+      - determine-docker-build-metadata
+      - rust-images
+      - rust-images-indexer
+      - rust-images-failpoints
+      - rust-images-performance
+      - rust-images-consensus-only-perf-test
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'CICD:skip-forge-e2e-test') && (
+      !failure() && !cancelled() && needs.permission-check.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
@@ -224,20 +265,23 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: compat
-      IMAGE_TAG: testnet_2d8b1b57553d869190f61df1aaf7f31a8fc19a7b # test against the latest build on testnet branch
+      IMAGE_TAG: testnet_2d8b1b57553d869190f61df1aaf7f31a8fc19a7b # test against a previous testnet release
       FORGE_RUNNER_DURATION_SECS: 300
       COMMENT_HEADER: forge-compat
-      # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
-      # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
-      # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
       FORGE_NAMESPACE: forge-compat-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
-  
+
   # Run forge framework upgradability test
   forge-framework-upgrade-test:
     needs:
-      [rust-images, rust-images-failpoints, determine-docker-build-metadata]
+      - permission-check
+      - determine-docker-build-metadata
+      - rust-images
+      - rust-images-indexer
+      - rust-images-failpoints
+      - rust-images-performance
+      - rust-images-consensus-only-perf-test
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'CICD:skip-forge-e2e-test') && (
+      !failure() && !cancelled() && needs.permission-check.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
@@ -249,18 +293,22 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: framework_upgrade
-      IMAGE_TAG: aptos-node-v1.3.0_3fc3d42b6cfe27460004f9a0326451bcda840a60  # This workflow will test the upgradability from the current tip of the release branch to the current main branch.
+      IMAGE_TAG: aptos-node-v1.3.0_3fc3d42b6cfe27460004f9a0326451bcda840a60 # This workflow will test the upgradability from the current tip of the release branch to the current main branch.
       FORGE_RUNNER_DURATION_SECS: 300
       COMMENT_HEADER: forge-framework-upgrade
-      # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
-      # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
-      # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
       FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
 
   forge-consensus-only-perf-test:
     needs:
-      [rust-images-consensus-only-perf-test, determine-docker-build-metadata]
+      - permission-check
+      - determine-docker-build-metadata
+      - rust-images
+      - rust-images-indexer
+      - rust-images-failpoints
+      - rust-images-performance
+      - rust-images-consensus-only-perf-test
     if: |
+      !failure() && !cancelled() && needs.permission-check.result == 'success' &&
       contains(github.event.pull_request.labels.*.name, 'CICD:run-consensus-only-perf-test')
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
@@ -270,7 +318,4 @@ jobs:
       IMAGE_TAG: consensus_only_perf_test_${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_RUNNER_DURATION_SECS: 300
       COMMENT_HEADER: forge-consensus-only-perf-test
-      # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
-      # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
-      # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
       FORGE_NAMESPACE: forge-consensus-only-perf-test-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3092,6 +3092,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-type-accessor"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "aptos-api-types",
+ "aptos-framework",
+ "aptos-rest-client",
+ "aptos-types",
+ "move-binary-format",
+ "move-core-types",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "aptos-types"
 version = "0.0.3"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ members = [
     "crates/aptos-telemetry-service",
     "crates/aptos-temppath",
     "crates/aptos-time-service",
+    "crates/aptos-type-accessor",
     "crates/aptos-warp-webserver",
     "crates/bounded-executor",
     "crates/channel",
@@ -248,6 +249,7 @@ aptos-aggregator = { path = "aptos-move/aptos-aggregator" }
 aptos-api = { path = "api" }
 aptos-api-test-context = { path = "api/test-context" }
 aptos-api-types = { path = "api/types" }
+aptos-type-accessor = { path = "crates/aptos-type-accessor" }
 aptos-backup-cli = { path = "storage/backup/backup-cli" }
 aptos-backup-service = { path = "storage/backup/backup-service" }
 aptos-bounded-executor = { path = "crates/bounded-executor" }

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -348,7 +348,7 @@ impl Serialize for MoveValue {
 }
 
 /// A Move struct tag for referencing an onchain struct type
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct MoveStructTag {
     pub address: Address,
     pub module: IdentifierWrapper,
@@ -397,6 +397,10 @@ impl MoveStructTag {
             name,
             generic_type_params,
         }
+    }
+
+    pub fn module_id(&self) -> ModuleId {
+        ModuleId::new(self.address.into(), self.module.clone().into())
     }
 }
 
@@ -479,7 +483,7 @@ impl TryFrom<MoveStructTag> for StructTag {
 }
 
 /// An enum of Move's possible types on-chain
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum MoveType {
     /// A bool type
     Bool,

--- a/crates/aptos-type-accessor/Cargo.toml
+++ b/crates/aptos-type-accessor/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "aptos-type-accessor"
+description = "Aptos Type Accessor"
+version = "0.0.1"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+aptos-api-types = { workspace = true }
+aptos-rest-client = { workspace = true }
+aptos-types = { workspace = true }
+move-binary-format = { workspace = true }
+move-core-types = { workspace = true }
+
+[dev-dependencies]
+anyhow = { workspace = true, features = ["backtrace"] }
+aptos-framework = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }

--- a/crates/aptos-type-accessor/move/food/Move.toml
+++ b/crates/aptos-type-accessor/move/food/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "food"
+version = "0.0.1"
+
+[dependencies]
+AptosFramework = { local = "../../../../aptos-move/framework/aptos-framework" }
+
+[addresses]
+addr = "_"

--- a/crates/aptos-type-accessor/move/food/README.md
+++ b/crates/aptos-type-accessor/move/food/README.md
@@ -1,0 +1,1 @@
+This is a module used for testing the type accessor.

--- a/crates/aptos-type-accessor/move/food/sources/food.move
+++ b/crates/aptos-type-accessor/move/food/sources/food.move
@@ -1,0 +1,35 @@
+module addr::food {
+    use aptos_std::simple_map::SimpleMap;
+    use aptos_std::table::Table;
+    use std::string::String;
+
+    struct Color has store {
+        red: u8,
+        blue: u8,
+        green: u8,
+    }
+
+    struct Fruit has store {
+        name: String,
+        color: Color,
+    }
+
+    struct Buyer has store {
+        name: String,
+        address: address,
+    }
+
+    struct FruitManager has key {
+        // The key is just an incrementing counter. This tracks all the fruit we have.
+        fruit_inventory: Table<u64, Fruit>,
+
+        // A map from fruit name to price.
+        prices: SimpleMap<String, u64>,
+
+        // A list of addresses authorized to buy the fruit.
+        authorized_buyers: vector<Buyer>,
+
+        // The last time a piece of fruit was sold.
+        last_sale_time: u64,
+    }
+}

--- a/crates/aptos-type-accessor/src/accessor.rs
+++ b/crates/aptos-type-accessor/src/accessor.rs
@@ -1,0 +1,285 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::path::{parse_path, PathComponent};
+use anyhow::{bail, Context, Result};
+use aptos_api_types::MoveType;
+use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+use std::collections::BTreeMap;
+
+/// [`TypeAccessor`] is a utility for looking up the types of fields in Move data at runtime.
+///
+#[derive(Clone, Debug)]
+pub struct TypeAccessor {
+    /// This is a map of ModuleId (address, name) to a map of struct name to a map of field name to field type.
+    field_info: BTreeMap<
+        // Module address + name.
+        ModuleId,
+        BTreeMap<
+            // Struct name.
+            Identifier,
+            BTreeMap<
+                // Field name.
+                Identifier,
+                // Field type.
+                MoveType,
+            >,
+        >,
+    >,
+}
+
+impl TypeAccessor {
+    /// Create a new [`TypeAccessor`]
+    ///
+    /// **Note**: You should not use this function directly but rather make use of a
+    /// builder. See the [crate level documentation](crate) for more information about builders.
+    pub fn new(
+        field_info: BTreeMap<ModuleId, BTreeMap<Identifier, BTreeMap<Identifier, MoveType>>>,
+    ) -> Self {
+        Self { field_info }
+    }
+
+    /// Look up the type of a field at a given path in a struct. You can see examples
+    /// of how to use this function in the [crate level documentation](crate).
+    pub fn get_type(
+        &self,
+        module_id: &ModuleId,
+        struct_name: &Identifier,
+        path: &str,
+    ) -> Result<&MoveType> {
+        self.get_type_structured(
+            module_id,
+            struct_name,
+            parse_path(path)
+                .with_context(|| format!("Failed to parse path {}", path))?
+                .as_slice(),
+        )
+        .with_context(|| {
+            format!(
+                "Failed to get type at path {} of struct {} in module {}",
+                path, struct_name, module_id
+            )
+        })
+    }
+
+    pub fn get_type_structured(
+        &self,
+        module_id: &ModuleId,
+        struct_name: &Identifier,
+        path: &[PathComponent],
+    ) -> Result<&MoveType> {
+        if path.is_empty() {
+            bail!("Path cannot be empty");
+        }
+
+        // Get the type of the first field of the requested struct.
+        let fields = self.get_fields(module_id, struct_name)?;
+        let mut typ = match &path[0] {
+            PathComponent::Field(field_name) => fields.get(field_name).with_context(|| {
+                format!(
+                    "Could not find top level field {} in struct {} in module {}",
+                    field_name, struct_name, module_id
+                )
+            })?,
+            _ => {
+                bail!("First component of path must be a field");
+            },
+        };
+
+        for (i, component) in path[1..].iter().enumerate() {
+            match component {
+                PathComponent::Field(field_name) => {
+                    if let MoveType::Struct(struct_tag) = typ {
+                        let fields =
+                            self.get_fields(&struct_tag.module_id(), &struct_tag.name.0)?;
+                        typ = fields.get(field_name).with_context(|| {
+                            format!(
+                                "Could not find field {} in struct {} in module {}",
+                                field_name, struct_name, module_id
+                            )
+                        })?;
+                    } else {
+                        bail!(
+                            "Tried to access field {} of non-struct type {} at path {:?}",
+                            field_name,
+                            typ,
+                            &path[..i]
+                        );
+                    }
+                },
+                PathComponent::GenericTypeParamIndex(index) => {
+                    if let MoveType::Struct(struct_tag) = typ {
+                        typ = struct_tag
+                            .generic_type_params
+                            .get(*index as usize)
+                            .with_context(|| {
+                                format!(
+                                    "Tried to access generic type param at index {} but there are only {} generic type params",
+                                    index, struct_tag.generic_type_params.len()
+                                )
+                            })?;
+                    } else {
+                        bail!(
+                            "Tried to access generic type param of non-struct type {} at path {:?}",
+                            typ,
+                            &path[..i]
+                        );
+                    }
+                },
+                PathComponent::EnterArray => {
+                    if let MoveType::Vector { items: inner_typ } = typ {
+                        typ = inner_typ;
+                    } else {
+                        bail!(
+                            "Tried to access array element of non-array type {} at path {:?}",
+                            typ,
+                            &path[..i]
+                        );
+                    }
+                },
+            }
+        }
+
+        Ok(typ)
+    }
+
+    fn get_fields(
+        &self,
+        module_id: &ModuleId,
+        struct_name: &Identifier,
+    ) -> Result<&BTreeMap<Identifier, MoveType>> {
+        let structs = self
+            .field_info
+            .get(module_id)
+            .with_context(|| format!("Could not find module {}", module_id))?;
+        let fields = structs.get(struct_name).with_context(|| {
+            format!(
+                "Could not find struct {} in module {}",
+                struct_name, module_id
+            )
+        })?;
+        Ok(fields)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        builder::TypeAccessorBuilderTrait, test_helpers::compile_package, TypeAccessorBuilderLocal,
+    };
+    use aptos_types::account_address::AccountAddress;
+    use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn test_food_get_type() -> Result<()> {
+        // Compile the food package and all the packages we know it recursively depends on.
+        let mut modules = Vec::new();
+        for name in &["aptos-framework", "aptos-stdlib", "move-stdlib"] {
+            let path = PathBuf::try_from(format!("../../aptos-move/framework/{}", name)).unwrap();
+            modules.extend(compile_package(path)?);
+        }
+        modules.extend(compile_package(PathBuf::try_from("move/food").unwrap())?);
+
+        // Build the TypeAccessor.
+        let type_accessor = TypeAccessorBuilderLocal::new()
+            .add_modules(modules)
+            .build()
+            .context("Failed to build TypeAccessor with all the modules")?;
+
+        let module_name = "food";
+        let module_id = ModuleId::new(AccountAddress::TWO, Identifier::new(module_name).unwrap());
+        let struct_name = Identifier::new("FruitManager").unwrap();
+
+        // Confirm that we can access a leaf type.
+        assert_eq!(
+            type_accessor
+                .get_type(&module_id, &struct_name, "fruit_inventory.handle")
+                .context("Failed to get type")?,
+            &MoveType::Address,
+        );
+
+        // Confirm that we can access a leaf type with a generic type param in the
+        // path.
+        assert_eq!(
+            type_accessor
+                .get_type(&module_id, &struct_name, "fruit_inventory.1.color.red")
+                .context("Failed to get type")?,
+            &MoveType::U8,
+        );
+
+        // Confirm that we can access a type with a generic type param at the end of
+        // the path.
+        let fruit_inventory_value_type = type_accessor
+            .get_type(&module_id, &struct_name, "fruit_inventory.1")
+            .context("Failed to get type")?;
+        match fruit_inventory_value_type {
+            MoveType::Struct(struct_tag) => {
+                assert_eq!(struct_tag.address.inner(), &AccountAddress::TWO);
+                assert_eq!(struct_tag.module.0.as_str(), module_name);
+                assert_eq!(struct_tag.name.0.as_str(), "Fruit");
+            },
+            _ => bail!("Expected type to be a struct"),
+        }
+
+        // Confirm that we can access the type of a top level field in the struct.
+        assert_eq!(
+            type_accessor
+                .get_type(&module_id, &struct_name, "last_sale_time")
+                .context("Failed to get type")?,
+            &MoveType::U64,
+        );
+
+        // Confirm that we can access the type of a vector.
+        assert!(matches!(
+            type_accessor
+                .get_type(&module_id, &struct_name, "authorized_buyers")
+                .context("Failed to get type")?,
+            &MoveType::Vector { items: _ }
+        ));
+
+        // Confirm that we can access the type of the thing inside a vector.
+        assert!(matches!(
+            type_accessor
+                .get_type(&module_id, &struct_name, "authorized_buyers.[]")
+                .context("Failed to get type")?,
+            &MoveType::Struct(_)
+        ));
+
+        // Confirm that we can access a field of a type of the thing inside a vector.
+        assert!(matches!(
+            type_accessor
+                .get_type(&module_id, &struct_name, "authorized_buyers.[].address")
+                .context("Failed to get type")?,
+            &MoveType::Address
+        ));
+
+        // Confirm that using an empty path is an error.
+        assert!(type_accessor
+            .get_type(&module_id, &struct_name, "")
+            .is_err());
+
+        // Confirm that it is an error to try access a field that doesn't exist.
+        assert!(type_accessor
+            .get_type(&module_id, &struct_name, "fruit_inventory.1.color.orange")
+            .is_err());
+
+        // Confirm that it is an error to keep trying to access fields when the
+        // type is not a struct.
+        assert!(type_accessor
+            .get_type(
+                &module_id,
+                &struct_name,
+                "fruit_inventory.1.color.red.something"
+            )
+            .is_err());
+
+        // Confirm that it is an error to try to use a generic path param as the first
+        // part of the path.
+        assert!(type_accessor
+            .get_type(&module_id, &struct_name, "1.color.red.something")
+            .is_err());
+
+        Ok(())
+    }
+}

--- a/crates/aptos-type-accessor/src/builder/common.rs
+++ b/crates/aptos-type-accessor/src/builder/common.rs
@@ -1,0 +1,74 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_api_types::{MoveModule, MoveType};
+use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+/// Defines functions common to all `TypeAccessorBuilder`s.
+pub trait TypeAccessorBuilderTrait {
+    /// Add modules that we have already retrieved.
+    fn add_modules(self, modules: Vec<MoveModule>) -> Self;
+
+    /// Add a module that we have already retreived.
+    fn add_module(self, module: MoveModule) -> Self;
+}
+
+pub(crate) fn parse_module(
+    module: MoveModule,
+) -> (
+    // The map of struct to field to field type.
+    BTreeMap<Identifier, BTreeMap<Identifier, MoveType>>,
+    // Any new Move modules we need to retrieve.
+    BTreeSet<ModuleId>,
+) {
+    let mut structs_info = BTreeMap::new();
+    let mut modules_to_retrieve = BTreeSet::new();
+
+    // For each struct in the module look through the types of the fields and
+    // determine any more modules we need to look up.
+    for struc in module.structs.into_iter() {
+        let mut types_to_resolve = Vec::new();
+        let mut types_seen = HashSet::new();
+
+        for field in struc.fields {
+            types_to_resolve.push(field.typ.clone());
+            structs_info
+                .entry(struc.name.clone().into())
+                .or_insert_with(BTreeMap::new)
+                .insert(field.name.into(), field.typ);
+        }
+
+        // Go through the types recursively until we hit leaf types. As we do so,
+        // we add more modules to `modules_to_retrieve`. This way, we can ensure
+        // that we look up the types for all modules relevant to this struct.
+        while let Some(typ) = types_to_resolve.pop() {
+            if types_seen.contains(&typ) {
+                continue;
+            }
+            types_seen.insert(typ.clone());
+
+            // For types that refer to other types, add those to the list of
+            // types. This continues until we hit leaves / a cycle.
+            match typ {
+                MoveType::Vector { items: typ } => {
+                    types_to_resolve.push(*typ);
+                },
+                MoveType::Reference {
+                    mutable: _,
+                    to: typ,
+                } => {
+                    types_to_resolve.push(*typ);
+                },
+                MoveType::Struct(struct_tag) => {
+                    let module_id =
+                        ModuleId::new(struct_tag.address.into(), struct_tag.module.into());
+                    modules_to_retrieve.insert(module_id);
+                },
+                _other => {},
+            }
+        }
+    }
+
+    (structs_info, modules_to_retrieve)
+}

--- a/crates/aptos-type-accessor/src/builder/local.rs
+++ b/crates/aptos-type-accessor/src/builder/local.rs
@@ -1,0 +1,137 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::common::{parse_module, TypeAccessorBuilderTrait};
+use crate::accessor::TypeAccessor;
+use anyhow::{bail, Result};
+use aptos_api_types::{MoveModule, MoveType};
+use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+/// This builder operates only with modules provided to it directly. It is not able to
+/// look up modules, so `build` will fail if it encounters a module that wasn't
+/// registered in advance. If you want a TypeAccessorBuilder that can look up modules
+/// as it encounters them, use [`crate::TypeAccessorBuilderRemote`].
+#[derive(Clone, Debug)]
+pub struct TypeAccessorBuilderLocal {
+    modules: BTreeMap<ModuleId, MoveModule>,
+}
+
+impl TypeAccessorBuilderLocal {
+    pub fn new() -> Self {
+        Self {
+            modules: BTreeMap::new(),
+        }
+    }
+
+    pub fn build(mut self) -> Result<TypeAccessor> {
+        if self.modules.is_empty() {
+            bail!("Cannot build TypeAccessor without any modules to lookup or add");
+        }
+
+        let mut field_info: BTreeMap<
+            ModuleId,
+            BTreeMap<Identifier, BTreeMap<Identifier, MoveType>>,
+        > = BTreeMap::new();
+
+        let mut modules_processed = BTreeSet::new();
+
+        while let Some((module_id, module)) = self.modules.pop_first() {
+            if modules_processed.contains(&module_id) {
+                continue;
+            }
+            modules_processed.insert(module_id.clone());
+            let (structs_info, modules_to_retrieve) = parse_module(module);
+
+            // Filter out modules we already have / have processed.
+            let modules_to_retrieve: HashSet<_> = modules_to_retrieve
+                .into_iter()
+                .filter(|module_id| {
+                    !self.modules.contains_key(module_id) && !modules_processed.contains(module_id)
+                })
+                .collect();
+
+            if !modules_to_retrieve.is_empty() {
+                bail!(
+                    "While processing {} references to modules not available \
+                    to the builder were found: {:?}. This makes it impossible \
+                    to comprehensively resolve types, and this builder is \
+                    unable to look up new modules, so it is impossible to \
+                    build a complete TypeAccessor.",
+                    module_id,
+                    modules_to_retrieve
+                );
+            }
+
+            field_info.insert(module_id, structs_info);
+        }
+
+        Ok(TypeAccessor::new(field_info))
+    }
+}
+
+impl TypeAccessorBuilderTrait for TypeAccessorBuilderLocal {
+    fn add_modules(mut self, modules: Vec<MoveModule>) -> Self {
+        for module in modules {
+            self.modules.insert(
+                ModuleId::new(module.address.into(), module.name.clone().into()),
+                module,
+            );
+        }
+        self
+    }
+
+    fn add_module(self, module: MoveModule) -> Self {
+        self.add_modules(vec![module])
+    }
+}
+
+impl Default for TypeAccessorBuilderLocal {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::compile_package;
+    use anyhow::Context;
+    use std::path::PathBuf;
+
+    /// Test that the TypeAccessor works as expected in DoNotLookup mode.
+    #[tokio::test]
+    async fn test_food_no_lookup() -> Result<()> {
+        // First just build the top level module in move/food.
+        let food_modules = compile_package(PathBuf::try_from("move/food").unwrap())?;
+
+        // Build a TypeAccessor with just that module. We expect this to fail, because
+        // while the TypeAccessorBuilder is building it will find references to
+        // modules that it doesn't know about and because it is in DoNotLookup mode,
+        // it will return an error.
+        let type_accessor_result = TypeAccessorBuilderLocal::new()
+            .add_modules(food_modules.clone())
+            .build();
+        assert!(
+            type_accessor_result.is_err(),
+            "Expected TypeAccessorBuilder to fail because we didn't give it all the modules it needs"
+        );
+
+        let mut modules = food_modules;
+
+        // Compile the modules that we know food recursively depends on.
+        for name in &["aptos-framework", "aptos-stdlib", "move-stdlib"] {
+            let path = PathBuf::try_from(format!("../../aptos-move/framework/{}", name)).unwrap();
+            modules.extend(compile_package(path)?);
+        }
+        modules.extend(compile_package(PathBuf::try_from("move/food").unwrap())?);
+
+        // Build a new type accessor with all of those modules, which we expect to succeed.
+        TypeAccessorBuilderLocal::new()
+            .add_modules(modules)
+            .build()
+            .context("Failed to build TypeAccessor with all the modules")?;
+
+        Ok(())
+    }
+}

--- a/crates/aptos-type-accessor/src/builder/mod.rs
+++ b/crates/aptos-type-accessor/src/builder/mod.rs
@@ -1,0 +1,10 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+mod common;
+mod local;
+mod remote;
+
+pub use common::TypeAccessorBuilderTrait;
+pub use local::TypeAccessorBuilderLocal;
+pub use remote::TypeAccessorBuilderRemote;

--- a/crates/aptos-type-accessor/src/builder/remote.rs
+++ b/crates/aptos-type-accessor/src/builder/remote.rs
@@ -1,0 +1,126 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::common::{parse_module, TypeAccessorBuilderTrait};
+use crate::accessor::TypeAccessor;
+use anyhow::{bail, Context, Result};
+use aptos_api_types::{MoveModule, MoveType};
+use aptos_rest_client::Client as RestClient;
+use move_binary_format::file_format::CompiledModule;
+use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+
+/// This builder is able to look up modules as it encounters them. This way we can
+/// ensure that the resulting TypeAccessor will be able to resolve information about
+/// every type that recursively appears in the types of the modules that were initially
+/// registered with the builder.
+#[derive(Clone, Debug)]
+pub struct TypeAccessorBuilderRemote {
+    modules_to_retrieve: BTreeSet<ModuleId>,
+    modules: BTreeMap<ModuleId, MoveModule>,
+    rest_client: Arc<RestClient>,
+}
+
+impl TypeAccessorBuilderRemote {
+    pub fn new(rest_client: Arc<RestClient>) -> Self {
+        Self {
+            modules_to_retrieve: BTreeSet::new(),
+            modules: BTreeMap::new(),
+            rest_client,
+        }
+    }
+
+    pub async fn build(mut self) -> anyhow::Result<TypeAccessor> {
+        if self.modules_to_retrieve.is_empty() && self.modules.is_empty() {
+            bail!("Cannot build TypeAccessor without any modules to lookup or add");
+        }
+
+        let mut field_info: BTreeMap<
+            ModuleId,
+            BTreeMap<Identifier, BTreeMap<Identifier, MoveType>>,
+        > = BTreeMap::new();
+
+        let mut modules_processed = BTreeSet::new();
+
+        loop {
+            if !self.modules_to_retrieve.is_empty() {
+                while let Some(module_id) = self.modules_to_retrieve.pop_first() {
+                    if self.modules.contains_key(&module_id) {
+                        continue;
+                    }
+                    self.modules
+                        .insert(module_id.clone(), self.retrieve_module(module_id).await?);
+                }
+            } else if !self.modules.is_empty() {
+                while let Some((module_id, module)) = self.modules.pop_first() {
+                    if modules_processed.contains(&module_id) {
+                        continue;
+                    }
+                    modules_processed.insert(module_id.clone());
+                    let (structs_info, modules_to_retrieve) = parse_module(module);
+
+                    self.modules_to_retrieve.extend(modules_to_retrieve);
+
+                    field_info.insert(module_id, structs_info);
+                }
+            } else {
+                break;
+            }
+        }
+
+        Ok(TypeAccessor::new(field_info))
+    }
+
+    async fn retrieve_module(&self, module_id: ModuleId) -> Result<MoveModule> {
+        let module_bytecode = self
+            .rest_client
+            .get_account_module_bcs(*module_id.address(), module_id.name().as_str())
+            .await
+            .context(format!(
+                "Failed to get module {}::{}",
+                module_id.address(),
+                module_id.name()
+            ))?
+            .into_inner();
+
+        let module: MoveModule = CompiledModule::deserialize(&module_bytecode)
+            .context(format!(
+                "Failed to deserialize module {}::{}",
+                module_id.address(),
+                module_id.name()
+            ))?
+            .into();
+
+        Ok(module)
+    }
+
+    /// Add modules to look up.
+    pub fn lookup_modules(mut self, module_ids: Vec<ModuleId>) -> Self {
+        self.modules_to_retrieve.extend(module_ids);
+        self
+    }
+
+    /// Add a module to look up.
+    pub fn lookup_module(self, module_id: ModuleId) -> Self {
+        self.lookup_modules(vec![module_id])
+    }
+}
+
+impl TypeAccessorBuilderTrait for TypeAccessorBuilderRemote {
+    fn add_modules(mut self, modules: Vec<MoveModule>) -> Self {
+        for module in modules {
+            self.modules.insert(
+                ModuleId::new(module.address.into(), module.name.clone().into()),
+                module,
+            );
+        }
+        self
+    }
+
+    fn add_module(self, module: MoveModule) -> Self {
+        self.add_modules(vec![module])
+    }
+}

--- a/crates/aptos-type-accessor/src/lib.rs
+++ b/crates/aptos-type-accessor/src/lib.rs
@@ -1,0 +1,246 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Aptos Type Accessor
+//!
+//! This crate provides the [`TypeAccessor`], which allows you to query the types of fields
+//! in Move resources at runtime. This is best explained with an example.
+//!
+//! Say you have this Move module:
+//!
+//! ```move
+//! module addr::food {
+//!     use aptos_std::simple_map::SimpleMap;
+//!     use aptos_std::table::Table;
+//!     use std::string::String;
+//!
+//!     struct Color has store {
+//!         red: u8,
+//!         blue: u8,
+//!         green: u8,
+//!     }
+//!
+//!     struct Fruit has store {
+//!         name: String,
+//!         color: Color,
+//!     }
+//!
+//!     struct Buyer has store {
+//!         name: String,
+//!         address: address,
+//!     }
+//!
+//!     struct FruitManager has key {
+//!         // The key is just an incrementing counter. This tracks all the fruit we have.
+//!         fruit_inventory: Table<u64, Fruit>,
+//!
+//!         // A map from fruit name to price.
+//!         prices: SimpleMap<String, u64>,
+//!
+//!         // A list of addresses authorized to buy the fruit.
+//!         authorized_buyers: vector<Buyer>,
+//!
+//!         // The last time a piece of fruit was sold.
+//!         last_sale_time: u64,
+//!     }
+//! }
+//! ```
+//!
+//! If you fetch the `FruitManager` resource, it might look like this (where some
+//! fields are skipped for conciseness):
+//!
+//! ```json
+//! {
+//!     "last_sale_time": "1681320398",
+//!     "authorized_buyers": ["0x321"],
+//!     "prices": [],
+//! }
+//! ```
+//!
+//! This leaves you guessing what `prices` is, since all you see is an empty vec. Using the `TypeAccessor` you can figure this out:
+//!
+//! ```no_run
+//! use aptos_api_types::MoveStructTag;
+//! use aptos_rest_client::Client as RestClient;
+//! use aptos_types::account_address::AccountAddress;
+//! use aptos_type_accessor::TypeAccessorBuilderRemote;
+//! use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+//! use std::sync::Arc;
+//! # use std::str::FromStr;
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     # let url = url::Url::from_str("https://fullnode.mainnet.aptoslabs.com").unwrap();
+//!     let aptos_client = Arc::new(RestClient::new(url));
+//!
+//!     let account_address = AccountAddress::from_hex_literal("0x123")?;
+//!     let module_name = Identifier::new("food")?;
+//!     let module_id = ModuleId::new(account_address, module_name);
+//!     let type_accessor = TypeAccessorBuilderRemote::new(aptos_client)
+//!         .lookup_module(module_id.clone())
+//!         .build()
+//!         .await?;
+//!
+//!     let struct_name = Identifier::new("FruitManager")?;
+//!     type_accessor.get_type(&module_id, &struct_name, "prices");
+//!     #
+//!     # Ok(())
+//! }
+//! ```
+//!
+//! Output:
+//!
+//! ```text
+//! MoveStructTag {
+//!     address: Address(
+//!         0000000000000000000000000000000000000000000000000000000000000001,
+//!     ),
+//!     module: IdentifierWrapper(
+//!         Identifier(
+//!             "simple_map",
+//!         ),
+//!     ),
+//!     name: IdentifierWrapper(
+//!         Identifier(
+//!             "SimpleMap",
+//!         ),
+//!     ),
+//!     generic_type_params: [
+//!         Struct(
+//!             MoveStructTag {
+//!                 address: Address(
+//!                     0000000000000000000000000000000000000000000000000000000000000001,
+//!                 ),
+//!                 module: IdentifierWrapper(
+//!                     Identifier(
+//!                         "string",
+//!                     ),
+//!                 ),
+//!                 name: IdentifierWrapper(
+//!                     Identifier(
+//!                         "String",
+//!                     ),
+//!                 ),
+//!                 generic_type_params: [],
+//!             },
+//!         ),
+//!         U64,
+//!     ],
+//! }
+//! ```
+//!
+//! Now you know that it is a `SimpleMap`, great!
+//!
+//! You can use the `TypeAccessor` to resolve other similar issues with this output:
+//! - With the output alone you cannot determine what type `last_sale_time` is since
+//! it is represented as a string. Using the [`TypeAccessor`] you can determine that
+//! it is a `u64`.
+//! - With the output alone you cannot determine what type the items in
+//! `authorized_buyers` are. Just because it is a string that looks like an address
+//! does not guarantee that it is one. Using the [`TypeAccessor`] you can determine
+//! that it is indeed an `address`.
+//!
+//! The [`TypeAccessor`] also supports nested queries:
+//!
+//! ```no_run
+//! #
+//! # use aptos_types::account_address::AccountAddress;
+//! # use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+//! # use aptos_type_accessor::TypeAccessorBuilderLocal;
+//! #
+//! # let type_accessor = TypeAccessorBuilderLocal::new().build()?;
+//! #
+//! # let account_address = AccountAddress::from_hex_literal("0x123")?;
+//! # let module_name = Identifier::new("food")?;
+//! # let module_id = ModuleId::new(account_address, module_name);
+//! # let struct_name = Identifier::new("FruitManager")?;
+//! #
+//! type_accessor.get_type(&module_id, &struct_name, "fruit_inventory.1.color.red")?;
+//! #
+//! # Ok::<(), anyhow::Error>(())
+//! ```
+//!
+//! Output:
+//! ```text
+//! MoveType::U64
+//! ```
+//!
+//! ## Path Syntax
+//!
+//! In its raw format, a path is defined as a vec of [`PathComponent`].
+//!
+//! ```
+//! # use aptos_type_accessor::PathComponent;
+//! # use move_core_types::identifier::Identifier;
+//! #
+//! let path = vec![
+//!    PathComponent::Field(Identifier::new("fruit_inventory").unwrap()),
+//!    PathComponent::GenericTypeParamIndex(1),
+//!    PathComponent::Field(Identifier::new("color").unwrap()),
+//!    PathComponent::Field(Identifier::new("red").unwrap()),
+//! ];
+//! ```
+//! This means get the `fruit_inventory` field, then the 1st generic type param
+//! (0-indexed), then the `color` field, then the `red` field.
+//!
+//! This is a bit verbose, so we also provide a syntax for specifying paths as a string.
+//! The syntax is inspired by [jq](https://stedolan.github.io/jq/), though it is not
+//! identical.
+//!
+//! These are some examples of path strings and what they get parsed to:
+//!
+//! An example that uses `.1` to access the 1st (0-indexed) generic type param:
+//! ```
+//! "fruit_inventory.1.color.red";
+//! # ()
+//! ```
+//! ```
+//! # use aptos_type_accessor::PathComponent;
+//! # use move_core_types::identifier::Identifier;
+//! #
+//! vec![
+//!    PathComponent::Field(Identifier::new("fruit_inventory").unwrap()),
+//!    PathComponent::GenericTypeParamIndex(1),
+//!    PathComponent::Field(Identifier::new("color").unwrap()),
+//!    PathComponent::Field(Identifier::new("red").unwrap()),
+//! ];
+//! ```
+//!
+//! An example that uses `.[]` to access the type of the thing inside a vector:
+//! ```
+//! "authorized_buyers.[].address";
+//! # ()
+//! ```
+//! ```
+//! # use aptos_type_accessor::PathComponent;
+//! # use move_core_types::identifier::Identifier;
+//! #
+//! vec![
+//!   PathComponent::Field(Identifier::new("authorized_buyers").unwrap()),
+//!   PathComponent::EnterArray,
+//!   PathComponent::Field(Identifier::new("address").unwrap()),
+//! ];
+//! ```
+//!
+//! You can read more about this syntax in the documentation for [`parse_path`].
+//!
+//! ## Builder Types
+//!
+//! This crate offers two types of builders for building a [`TypeAccessor`]:
+//! - [`TypeAccessorBuilderLocal`]: Use this when you have all the modules you need
+//! locally already.
+//! - [`TypeAccessorBuilderRemote`]: Use this when you want to fetch modules from the
+//! API as part of building the TypeAccessor.
+//!
+//! The documentation for each of these builders will help you decide which one is
+//! appropriate for your use case.
+
+mod accessor;
+mod builder;
+mod path;
+#[cfg(test)]
+mod test_helpers;
+
+pub use accessor::TypeAccessor;
+pub use builder::{TypeAccessorBuilderLocal, TypeAccessorBuilderRemote, TypeAccessorBuilderTrait};
+pub use path::{parse_path, PathComponent};

--- a/crates/aptos-type-accessor/src/path.rs
+++ b/crates/aptos-type-accessor/src/path.rs
@@ -1,0 +1,101 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use move_core_types::identifier::Identifier;
+use std::str::FromStr;
+
+/// Parse a path into a vector of [`PathComponent`]s.
+///
+/// For example, the path:
+/// ```
+/// "fruit_inventory.1.color.red";
+/// # ()
+/// ```
+/// would be parsed into:
+/// ```
+/// # use aptos_type_accessor::PathComponent;
+/// # use move_core_types::identifier::Identifier;
+/// #
+/// [
+///     PathComponent::Field(Identifier::new("fruit_inventory")?),
+///     PathComponent::GenericTypeParamIndex(1),
+///     PathComponent::Field(Identifier::new("color")?),
+///     PathComponent::Field(Identifier::new("red")?),
+/// ];
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+///
+/// Similarly, the path:
+/// ```
+/// "authorized_buyers.[].address";
+/// # ()
+/// ```
+/// would be parsed into:
+/// ```
+/// # use aptos_type_accessor::PathComponent;
+/// # use move_core_types::identifier::Identifier;
+/// #
+/// [
+///     PathComponent::Field(Identifier::new("authorized_buyers")?),
+///     PathComponent::EnterArray,
+///     PathComponent::Field(Identifier::new("address")?),
+/// ];
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+///
+/// This syntax exploits known restrictions on Move field names. Making use of
+/// `.`, `.<number>`, and `.[]` is safe because, in the case of `.` and `.[]`,
+/// Move field names can't contain those characters, and in the case of
+/// `.<number>`, Move field names can't start with a number.
+pub fn parse_path(path: &str) -> Result<Vec<PathComponent>> {
+    path.split('.').map(PathComponent::from_str).collect()
+}
+
+/// A single component of a path specifier to be used with [`crate::TypeAccessor`].
+/// See more in the documentation for [`parse_path`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PathComponent {
+    /// Access a field of a struct.
+    Field(Identifier),
+    /// Access a generic type parameter of a type.
+    GenericTypeParamIndex(u16),
+    /// Access the type inside an array.
+    EnterArray,
+}
+
+impl FromStr for PathComponent {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(index) = s.parse::<u16>() {
+            Ok(PathComponent::GenericTypeParamIndex(index))
+        } else if s == "[]" {
+            Ok(PathComponent::EnterArray)
+        } else {
+            Ok(PathComponent::Field(Identifier::new(s).with_context(
+                || format!("String {} is not a valid identifier", s),
+            )?))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_path() {
+        assert_eq!(parse_path("fruit_inventory.1.color.red").unwrap(), vec![
+            PathComponent::Field(Identifier::new("fruit_inventory").unwrap()),
+            PathComponent::GenericTypeParamIndex(1),
+            PathComponent::Field(Identifier::new("color").unwrap()),
+            PathComponent::Field(Identifier::new("red").unwrap()),
+        ]);
+        assert_eq!(parse_path("authorized_buyers.[].address").unwrap(), vec![
+            PathComponent::Field(Identifier::new("authorized_buyers").unwrap()),
+            PathComponent::EnterArray,
+            PathComponent::Field(Identifier::new("address").unwrap()),
+        ]);
+    }
+}

--- a/crates/aptos-type-accessor/src/test_helpers.rs
+++ b/crates/aptos-type-accessor/src/test_helpers.rs
@@ -1,0 +1,32 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use aptos_api_types::MoveModule;
+use aptos_framework::{BuildOptions, BuiltPackage};
+use aptos_types::account_address::AccountAddress;
+use std::{collections::BTreeMap, path::PathBuf};
+
+// Given the name of a Move package directory, compile it and return the compiled modules.
+// TODO: Consider making something that memoizes this so we don't have to recompile the
+// same stuff for each test.
+pub(crate) fn compile_package(path: PathBuf) -> Result<Vec<MoveModule>> {
+    let mut named_addresses = BTreeMap::new();
+    named_addresses.insert("addr".to_string(), AccountAddress::TWO);
+    let build_options = BuildOptions {
+        with_abis: true,
+        named_addresses,
+        ..Default::default()
+    };
+    let pack = BuiltPackage::build(path.clone(), build_options)
+        .with_context(|| format!("Failed to build package at {}", path.to_string_lossy()))?;
+    pack.extract_metadata_and_save()
+        .context("Failed to extract metadata and save")?;
+    let modules: Vec<MoveModule> = pack
+        .modules()
+        .cloned()
+        .into_iter()
+        .map(|m| m.into())
+        .collect();
+    Ok(modules)
+}


### PR DESCRIPTION
### Description
This PR adds the `TypeAccessor` described in this doc: https://www.notion.so/aptoslabs/Leveraging-ABIs-Understanding-Data-382f4768e5a24ccfb115bf99bcf361b0?pvs=4#bf382620d7924bca9921b86796a6460b.

The best summary of this PR is provided by the crate level documentation. Check it out here: https://dport.me/rustdoc/aptos_type_accessor/.

You can see more examples of how this works in the tests in the PR.

Open work:
- If the user of the `TypeAccessor` is long-lived, e.g. an indexer processor, it is possible that the modules in the `TypeAccessor` will become stale. If that happens, it's possible that a new struct will appear but the `TypeAccessor` won't know about it. In this case, likely what the user would want to do is refetch the stale module and rebuild. This logic is not provided.
    - For this we'd likely want to use a transparent error type from thiserror and we could catch this "missing module / struct / field" case.
    - Some kind of manager would then sit on top of this and rebuild as needed.
- There are no tests for the `TypeAccessorBuilderRemote` remote now.
- Currently I'm using types from the API types (MoveModule, MoveType, etc). It might be best to use inner types, though those are admittedly harder to work with.
- The builder currently fetches full modules wholesale. This is necessary because this is all the API offers, but it would need to change if wanted to leverage more targeted reads if we make it possible.
- Currently the processing logic resolves all structs in modules that the top level structs depend on. This isn't necessary since those top level structs only depend on a subset of the structs in those modules, we only need to process some of the structs. This is an optimization though.
- In `TypeAccessorBuilderRemote` I shouldn't take in an `AptosClient`, but something that implements a trait. This adds more options for how you'd fetch modules beyond just the REST client.

### Test Plan
```
cd crates/aptos-type-accessor
cargo test
```
