### PR TITLE
[framework-builder] Add Token v2 bindings to rust

### DIFF
--- a/aptos-move/aptos-sdk-builder/src/rust.rs
+++ b/aptos-move/aptos-sdk-builder/src/rust.rs
@@ -39,6 +39,7 @@ pub fn output(out: &mut dyn Write, abis: &[EntryABI], local_types: bool) -> Resu
     emitter.output_preamble()?;
     writeln!(emitter.out, "#![allow(dead_code)]")?;
     writeln!(emitter.out, "#![allow(unused_imports)]")?;
+    writeln!(emitter.out, "#![allow(clippy::too_many_arguments)]")?;
 
     emitter.output_script_call_enum_with_imports(abis)?;
 

--- a/aptos-move/framework/cached-packages/build.rs
+++ b/aptos-move/framework/cached-packages/build.rs
@@ -22,6 +22,20 @@ fn main() {
         );
         println!(
             "cargo:rerun-if-changed={}",
+            prev_dir
+                .join("aptos-token-objects")
+                .join("sources")
+                .display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            prev_dir
+                .join("aptos-token-objects")
+                .join("Move.toml")
+                .display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
             prev_dir.join("aptos-framework").join("sources").display()
         );
         println!(

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -12,6 +12,7 @@
 
 #![allow(dead_code)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 use aptos_types::{
     account_address::AccountAddress,
     transaction::{EntryFunction, TransactionPayload},

--- a/aptos-move/framework/cached-packages/src/aptos_stdlib.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_stdlib.rs
@@ -3,7 +3,10 @@
 
 #![allow(unused_imports)]
 
-pub use crate::{aptos_framework_sdk_builder::*, aptos_token_sdk_builder as aptos_token_stdlib};
+pub use crate::{
+    aptos_framework_sdk_builder::*, aptos_token_objects_sdk_builder as aptos_token_objects_stdlib,
+    aptos_token_sdk_builder as aptos_token_stdlib,
+};
 use aptos_types::{account_address::AccountAddress, transaction::TransactionPayload};
 
 pub fn aptos_coin_transfer(to: AccountAddress, amount: u64) -> TransactionPayload {

--- a/aptos-move/framework/cached-packages/src/aptos_token_objects_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_token_objects_sdk_builder.rs
@@ -12,6 +12,7 @@
 
 #![allow(dead_code)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 use aptos_types::{
     account_address::AccountAddress,
     transaction::{EntryFunction, TransactionPayload},

--- a/aptos-move/framework/cached-packages/src/aptos_token_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_token_sdk_builder.rs
@@ -12,6 +12,7 @@
 
 #![allow(dead_code)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 use aptos_types::{
     account_address::AccountAddress,
     transaction::{EntryFunction, TransactionPayload},

--- a/aptos-move/framework/cached-packages/src/lib.rs
+++ b/aptos-move/framework/cached-packages/src/lib.rs
@@ -6,6 +6,7 @@ use once_cell::sync::Lazy;
 
 pub mod aptos_framework_sdk_builder;
 pub mod aptos_stdlib;
+pub mod aptos_token_objects_sdk_builder;
 pub mod aptos_token_sdk_builder;
 
 #[cfg(unix)]


### PR DESCRIPTION
### Description
This adds token v2 bindings to Rust for usage elsewhere.

Additionally, I had to add `too many arguments` ignoring, because one of the functions has too many in token objects.
