### PR TITLE
[vm] propagate error message up instead of logging directly

### DIFF
--- a/third_party/move/move-bytecode-verifier/src/verifier.rs
+++ b/third_party/move/move-bytecode-verifier/src/verifier.rs
@@ -147,6 +147,7 @@ pub fn verify_script_with_config(config: &VerifierConfig, script: &CompiledScrip
     .unwrap_or_else(|_| {
         Err(
             PartialVMError::new(StatusCode::VERIFIER_INVARIANT_VIOLATION)
+                .with_message("[VM] bytecode verifier panicked for script".to_string())
                 .finish(Location::Undefined),
         )
     });

--- a/third_party/move/move-vm/runtime/src/loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader.rs
@@ -663,8 +663,7 @@ impl Loader {
         ) {
             Ok(script) => script,
             Err(err) => {
-                error!("[VM] deserializer for script returned error: {:?}", err,);
-                let msg = format!("Deserialization error: {:?}", err);
+                let msg = format!("[VM] deserializer for script returned error: {:?}", err);
                 return Err(PartialVMError::new(StatusCode::CODE_DESERIALIZATION_ERROR)
                     .with_message(msg)
                     .finish(Location::Script));
@@ -682,13 +681,7 @@ impl Loader {
                 self.verify_script_dependencies(&script, loaded_deps)?;
                 Ok(script)
             },
-            Err(err) => {
-                error!(
-                    "[VM] bytecode verifier returned errors for script: {:?}",
-                    err
-                );
-                Err(err)
-            },
+            Err(err) => Err(err),
         }
     }
 
@@ -1159,7 +1152,6 @@ impl Loader {
             Ok(bytes) => bytes,
             Err(err) if allow_loading_failure => return Err(err),
             Err(err) => {
-                error!("[VM] Error fetching module with id {:?}", id);
                 return Err(expect_no_verification_errors(err));
             },
         };

--- a/third_party/move/move-vm/runtime/src/logging.rs
+++ b/third_party/move/move-vm/runtime/src/logging.rs
@@ -4,7 +4,6 @@
 
 use move_binary_format::errors::{PartialVMError, VMError};
 use move_core_types::vm_status::{StatusCode, StatusType};
-use tracing::error;
 //
 // Utility functions
 //
@@ -32,7 +31,6 @@ pub fn expect_no_verification_errors(err: VMError) -> VMError {
                 _ => unreachable!(),
             };
 
-            error!("[VM] {}", message);
             PartialVMError::new(major_status)
                 .with_message(message)
                 .at_indices(indices)


### PR DESCRIPTION
To avoid speculative error logging, this commit only propagates the message back with the error type instead of directly print out. In following commit we'd need to make sure corresponding error messages are logged with speculative_error macro correctly.