### PR TITLE
update the doc for local testnet

### DIFF
--- a/developer-docs-site/docs/nodes/local-testnet/run-a-local-testnet.md
+++ b/developer-docs-site/docs/nodes/local-testnet/run-a-local-testnet.md
@@ -96,7 +96,7 @@ Faucets are stateless services that can be run in parallel with the testnet. A F
 3. Copy the _Aptos root key path_ from your terminal where you started the testnet, and use it to replace the `mint-key-file-path` in the below command.
 4. Run the following command to start a Faucet:
 ```
-cargo run --package aptos-faucet-service -- run-simple --mint-key-file-path "/tmp/694173aa3bbe019499bbd5cf3fe0e2fc/mint.key" --server-url http://127.0.0.1:8080
+cargo run --package aptos-faucet-service -- run-simple --key-file-path "/tmp/694173aa3bbe019499bbd5cf3fe0e2fc/mint.key" --node-url http://127.0.0.1:8080
 ```
 
 This will start a Faucet running locally without any restrictions to tokens that can be claimed and minted. This Faucet service will be as accessible as the testnet you started above.


### PR DESCRIPTION
### Description

It seems the faucet-service cmd args were renamed and the example command does not work... Updating.