### PR TITLE
Update aptos init in CLI to lookup onchain address based on public key

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,10 +3,10 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-* Update `aptos init` to fix an incorrect account address issue, when trying to init with a rotated private key. Right now it does an actual account lookup instead of deriving from public key
 
 ### Fixed
 * If `aptos init` is run with a faucet URL specified (which happens by default when using the local, devnet, or testnet network options) and funding the account fails, the account creation is considered a failure and nothing is persisted. Previously it would report success despite the account not being created on chain.
+* Update `aptos init` to fix an incorrect account address issue, when trying to init with a rotated private key. Right now it does an actual account lookup instead of deriving from public key
 
 ## [1.0.9] - 2023/03/29
 * `aptos move show abi` allows for viewing the ABI of a compiled move package

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+* Update `aptos init` to fix an incorrect account address issue, when trying to init with a rotated private key. Right now it does an actual account lookup instead of deriving from public key
+
 ### Fixed
 * If `aptos init` is run with a faucet URL specified (which happens by default when using the local, devnet, or testnet network options) and funding the account fails, the account creation is considered a failure and nothing is persisted. Previously it would report success despite the account not being created on chain.
 

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -3,7 +3,7 @@
 
 use crate::common::{
     types::{
-        account_address_from_public_key, CliCommand, CliConfig, CliError, CliTypedResult,
+        CliCommand, CliConfig, CliError, CliTypedResult,
         ConfigSearchMode, EncodingOptions, PrivateKeyInputOptions, ProfileConfig, ProfileOptions,
         PromptOptions, RngArgs, DEFAULT_PROFILE,
     },
@@ -19,6 +19,8 @@ use clap::Parser;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, str::FromStr};
+use crate::account::key_rotation::LookupAddress;
+use crate::common::types::{PublicKeyInputOptions, RestOptions};
 
 /// 1 APT (might not actually get that much, depending on the faucet)
 const NUM_DEFAULT_OCTAS: u64 = 100000000;
@@ -154,7 +156,17 @@ impl CliCommand<()> for InitTool {
             }
         };
         let public_key = private_key.public_key();
-        let address = account_address_from_public_key(&public_key);
+
+        // lookup the address from onchain instead of deriving it
+        // if this is the rotated key, deriving it will outputs an incorrect address
+        let rest_url = Url::parse(&*profile_config.rest_url.clone().unwrap());
+        let address = LookupAddress {
+            encoding_options: Default::default(),
+            public_key_options: PublicKeyInputOptions::from_key(&public_key),
+            profile_options: Default::default(),
+            rest_options: RestOptions::new(Option::from(rest_url.unwrap()), None),
+        }.execute().await?;
+
         profile_config.private_key = Some(private_key);
         profile_config.public_key = Some(public_key);
         profile_config.account = Some(address);

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -161,7 +161,6 @@ impl CliCommand<()> for InitTool {
 
         // lookup the address from onchain instead of deriving it
         // if this is the rotated key, deriving it will outputs an incorrect address
-        // let rest_url = Url::parse(&*profile_config.rest_url.clone().unwrap());
         let address = if let Some(rest_url) = &profile_config.rest_url {
             LookupAddress {
                 encoding_options: Default::default(),


### PR DESCRIPTION
### Description
After user rotated their pri/pub key, and they try to use `aptos init` with the updated rotated private key. The account address is incorrect, because it is derived from pub/pri key pair.

This PR updates it by lookup the account address from Public key instead.

Related feature request #6295 

### Test Plan
1. cargo build -p aptos
2. init with rotated key, and make sure account address is correct
`aptos-debug init --private-key 0x53f667f2b0aa149eb848023c919da16482855878ea9a0ac7cb131f7365612814 --profile rotation-test-3`
