### PR TITLE
Cleanup tokenv2 collection

### DIFF
--- a/aptos-move/framework/aptos-token-objects/doc/aptos_token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/aptos_token.md
@@ -200,19 +200,20 @@ Storage state for managing the no-code Token.
 
 <a name="0x4_aptos_token_ECOLLECTION_DOES_NOT_EXIST"></a>
 
+The collection does not exist
 
 
-<pre><code><b>const</b> <a href="aptos_token.md#0x4_aptos_token_ECOLLECTION_DOES_NOT_EXIST">ECOLLECTION_DOES_NOT_EXIST</a>: u64 = 6;
+<pre><code><b>const</b> <a href="aptos_token.md#0x4_aptos_token_ECOLLECTION_DOES_NOT_EXIST">ECOLLECTION_DOES_NOT_EXIST</a>: u64 = 1;
 </code></pre>
 
 
 
 <a name="0x4_aptos_token_EFIELD_NOT_MUTABLE"></a>
 
-Attempted to mutate an immutable field
+The field being changed is not mutable
 
 
-<pre><code><b>const</b> <a href="aptos_token.md#0x4_aptos_token_EFIELD_NOT_MUTABLE">EFIELD_NOT_MUTABLE</a>: u64 = 3;
+<pre><code><b>const</b> <a href="aptos_token.md#0x4_aptos_token_EFIELD_NOT_MUTABLE">EFIELD_NOT_MUTABLE</a>: u64 = 4;
 </code></pre>
 
 
@@ -222,36 +223,37 @@ Attempted to mutate an immutable field
 The provided signer is not the creator
 
 
-<pre><code><b>const</b> <a href="aptos_token.md#0x4_aptos_token_ENOT_CREATOR">ENOT_CREATOR</a>: u64 = 2;
+<pre><code><b>const</b> <a href="aptos_token.md#0x4_aptos_token_ENOT_CREATOR">ENOT_CREATOR</a>: u64 = 3;
 </code></pre>
 
 
 
 <a name="0x4_aptos_token_ETOKEN_DOES_NOT_EXIST"></a>
 
+The token does not exist
 
 
-<pre><code><b>const</b> <a href="aptos_token.md#0x4_aptos_token_ETOKEN_DOES_NOT_EXIST">ETOKEN_DOES_NOT_EXIST</a>: u64 = 1;
+<pre><code><b>const</b> <a href="aptos_token.md#0x4_aptos_token_ETOKEN_DOES_NOT_EXIST">ETOKEN_DOES_NOT_EXIST</a>: u64 = 2;
 </code></pre>
 
 
 
 <a name="0x4_aptos_token_EPROPERTIES_NOT_MUTABLE"></a>
 
-Attempted to mutate a property map that is not mutable
+The property map being mutated is not mutable
 
 
-<pre><code><b>const</b> <a href="aptos_token.md#0x4_aptos_token_EPROPERTIES_NOT_MUTABLE">EPROPERTIES_NOT_MUTABLE</a>: u64 = 5;
+<pre><code><b>const</b> <a href="aptos_token.md#0x4_aptos_token_EPROPERTIES_NOT_MUTABLE">EPROPERTIES_NOT_MUTABLE</a>: u64 = 6;
 </code></pre>
 
 
 
 <a name="0x4_aptos_token_ETOKEN_NOT_BURNABLE"></a>
 
-Attempted to burn a non-burnable token
+The token being burned is not burnable
 
 
-<pre><code><b>const</b> <a href="aptos_token.md#0x4_aptos_token_ETOKEN_NOT_BURNABLE">ETOKEN_NOT_BURNABLE</a>: u64 = 4;
+<pre><code><b>const</b> <a href="aptos_token.md#0x4_aptos_token_ETOKEN_NOT_BURNABLE">ETOKEN_NOT_BURNABLE</a>: u64 = 5;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-token-objects/doc/collection.md
+++ b/aptos-move/framework/aptos-token-objects/doc/collection.md
@@ -359,22 +359,22 @@ The collection name is over the maximum length
 
 
 
+<a name="0x4_collection_ECOLLECTION_SUPPLY_EXCEEDED"></a>
+
+The collection has reached its supply and no more tokens can be minted, unless some are burned
+
+
+<pre><code><b>const</b> <a href="collection.md#0x4_collection_ECOLLECTION_SUPPLY_EXCEEDED">ECOLLECTION_SUPPLY_EXCEEDED</a>: u64 = 2;
+</code></pre>
+
+
+
 <a name="0x4_collection_EDESCRIPTION_TOO_LONG"></a>
 
 The description is over the maximum length
 
 
 <pre><code><b>const</b> <a href="collection.md#0x4_collection_EDESCRIPTION_TOO_LONG">EDESCRIPTION_TOO_LONG</a>: u64 = 5;
-</code></pre>
-
-
-
-<a name="0x4_collection_ETOO_MANY_TOKENS"></a>
-
-The collection has reached its supply and no more tokens can be minted
-
-
-<pre><code><b>const</b> <a href="collection.md#0x4_collection_ETOO_MANY_TOKENS">ETOO_MANY_TOKENS</a>: u64 = 2;
 </code></pre>
 
 
@@ -609,7 +609,7 @@ Named objects are derived from a seed, the collection's seed is its name.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_create_collection_seed">create_collection_seed</a>(name: &String): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(name) &lt; <a href="collection.md#0x4_collection_MAX_COLLECTION_NAME_LENGTH">MAX_COLLECTION_NAME_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="collection.md#0x4_collection_ECOLLECTION_NAME_TOO_LONG">ECOLLECTION_NAME_TOO_LONG</a>));
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(name) &lt;= <a href="collection.md#0x4_collection_MAX_COLLECTION_NAME_LENGTH">MAX_COLLECTION_NAME_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="collection.md#0x4_collection_ECOLLECTION_NAME_TOO_LONG">ECOLLECTION_NAME_TOO_LONG</a>));
     *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_bytes">string::bytes</a>(name)
 }
 </code></pre>
@@ -645,7 +645,7 @@ Called by token on mint to increment supply if there's an appropriate Supply str
         supply.total_minted = supply.total_minted + 1;
         <b>assert</b>!(
             supply.current_supply &lt;= supply.max_supply,
-            <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="collection.md#0x4_collection_ETOO_MANY_TOKENS">ETOO_MANY_TOKENS</a>),
+            <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="collection.md#0x4_collection_ECOLLECTION_SUPPLY_EXCEEDED">ECOLLECTION_SUPPLY_EXCEEDED</a>),
         );
         <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(&<b>mut</b> supply.mint_events,
             <a href="collection.md#0x4_collection_MintEvent">MintEvent</a> {
@@ -900,7 +900,7 @@ Provides the count of the current selection if supply tracking is used
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_set_description">set_description</a>(mutator_ref: &<a href="collection.md#0x4_collection_MutatorRef">MutatorRef</a>, description: String) <b>acquires</b> <a href="collection.md#0x4_collection_Collection">Collection</a> {
-    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&description) &lt; <a href="collection.md#0x4_collection_MAX_DESCRIPTION_LENGTH">MAX_DESCRIPTION_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="collection.md#0x4_collection_EDESCRIPTION_TOO_LONG">EDESCRIPTION_TOO_LONG</a>));
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&description) &lt;= <a href="collection.md#0x4_collection_MAX_DESCRIPTION_LENGTH">MAX_DESCRIPTION_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="collection.md#0x4_collection_EDESCRIPTION_TOO_LONG">EDESCRIPTION_TOO_LONG</a>));
     <b>let</b> <a href="collection.md#0x4_collection">collection</a> = borrow_mut(mutator_ref);
     <a href="collection.md#0x4_collection">collection</a>.description = description;
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
@@ -930,7 +930,7 @@ Provides the count of the current selection if supply tracking is used
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_set_uri">set_uri</a>(mutator_ref: &<a href="collection.md#0x4_collection_MutatorRef">MutatorRef</a>, uri: String) <b>acquires</b> <a href="collection.md#0x4_collection_Collection">Collection</a> {
-    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&uri) &lt; <a href="collection.md#0x4_collection_MAX_URI_LENGTH">MAX_URI_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="collection.md#0x4_collection_EURI_TOO_LONG">EURI_TOO_LONG</a>));
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&uri) &lt;= <a href="collection.md#0x4_collection_MAX_URI_LENGTH">MAX_URI_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="collection.md#0x4_collection_EURI_TOO_LONG">EURI_TOO_LONG</a>));
     <b>let</b> <a href="collection.md#0x4_collection">collection</a> = borrow_mut(mutator_ref);
     <a href="collection.md#0x4_collection">collection</a>.uri = uri;
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(

--- a/aptos-move/framework/aptos-token-objects/doc/collection.md
+++ b/aptos-move/framework/aptos-token-objects/doc/collection.md
@@ -609,7 +609,7 @@ Named objects are derived from a seed, the collection's seed is its name.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_create_collection_seed">create_collection_seed</a>(name: &String): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(name) &lt; <a href="collection.md#0x4_collection_MAX_COLLECTION_NAME_LENGTH">MAX_COLLECTION_NAME_LENGTH</a>, <a href="collection.md#0x4_collection_ECOLLECTION_NAME_TOO_LONG">ECOLLECTION_NAME_TOO_LONG</a>);
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(name) &lt; <a href="collection.md#0x4_collection_MAX_COLLECTION_NAME_LENGTH">MAX_COLLECTION_NAME_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="collection.md#0x4_collection_ECOLLECTION_NAME_TOO_LONG">ECOLLECTION_NAME_TOO_LONG</a>));
     *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_bytes">string::bytes</a>(name)
 }
 </code></pre>
@@ -900,7 +900,7 @@ Provides the count of the current selection if supply tracking is used
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_set_description">set_description</a>(mutator_ref: &<a href="collection.md#0x4_collection_MutatorRef">MutatorRef</a>, description: String) <b>acquires</b> <a href="collection.md#0x4_collection_Collection">Collection</a> {
-    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&description) &lt; <a href="collection.md#0x4_collection_MAX_DESCRIPTION_LENGTH">MAX_DESCRIPTION_LENGTH</a>, <a href="collection.md#0x4_collection_EDESCRIPTION_TOO_LONG">EDESCRIPTION_TOO_LONG</a>);
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&description) &lt; <a href="collection.md#0x4_collection_MAX_DESCRIPTION_LENGTH">MAX_DESCRIPTION_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="collection.md#0x4_collection_EDESCRIPTION_TOO_LONG">EDESCRIPTION_TOO_LONG</a>));
     <b>let</b> <a href="collection.md#0x4_collection">collection</a> = borrow_mut(mutator_ref);
     <a href="collection.md#0x4_collection">collection</a>.description = description;
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
@@ -930,7 +930,7 @@ Provides the count of the current selection if supply tracking is used
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_set_uri">set_uri</a>(mutator_ref: &<a href="collection.md#0x4_collection_MutatorRef">MutatorRef</a>, uri: String) <b>acquires</b> <a href="collection.md#0x4_collection_Collection">Collection</a> {
-    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&uri) &lt; <a href="collection.md#0x4_collection_MAX_URI_LENGTH">MAX_URI_LENGTH</a>, <a href="collection.md#0x4_collection_EURI_TOO_LONG">EURI_TOO_LONG</a>);
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&uri) &lt; <a href="collection.md#0x4_collection_MAX_URI_LENGTH">MAX_URI_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="collection.md#0x4_collection_EURI_TOO_LONG">EURI_TOO_LONG</a>));
     <b>let</b> <a href="collection.md#0x4_collection">collection</a> = borrow_mut(mutator_ref);
     <a href="collection.md#0x4_collection">collection</a>.uri = uri;
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(

--- a/aptos-move/framework/aptos-token-objects/doc/token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/token.md
@@ -421,7 +421,7 @@ Named objects are derived from a seed, the collection's seed is its name.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_create_token_seed">create_token_seed</a>(<a href="collection.md#0x4_collection">collection</a>: &String, name: &String): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(name) &lt; <a href="token.md#0x4_token_MAX_TOKEN_NAME_LENGTH">MAX_TOKEN_NAME_LENGTH</a>, <a href="token.md#0x4_token_ETOKEN_NAME_TOO_LONG">ETOKEN_NAME_TOO_LONG</a>);
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(name) &lt; <a href="token.md#0x4_token_MAX_TOKEN_NAME_LENGTH">MAX_TOKEN_NAME_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_ETOKEN_NAME_TOO_LONG">ETOKEN_NAME_TOO_LONG</a>));
     <b>let</b> seed = *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_bytes">string::bytes</a>(<a href="collection.md#0x4_collection">collection</a>);
     <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, b"::");
     <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_bytes">string::bytes</a>(name));
@@ -761,7 +761,7 @@ Extracts the tokens address from a BurnRef.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_set_description">set_description</a>(mutator_ref: &<a href="token.md#0x4_token_MutatorRef">MutatorRef</a>, description: String) <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a> {
-    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&description) &lt; <a href="token.md#0x4_token_MAX_DESCRIPTION_LENGTH">MAX_DESCRIPTION_LENGTH</a>, <a href="token.md#0x4_token_EDESCRIPTION_TOO_LONG">EDESCRIPTION_TOO_LONG</a>);
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&description) &lt; <a href="token.md#0x4_token_MAX_DESCRIPTION_LENGTH">MAX_DESCRIPTION_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_EDESCRIPTION_TOO_LONG">EDESCRIPTION_TOO_LONG</a>));
     <b>let</b> <a href="token.md#0x4_token">token</a> = borrow_mut(mutator_ref);
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
         &<b>mut</b> <a href="token.md#0x4_token">token</a>.mutation_events,
@@ -795,7 +795,7 @@ Extracts the tokens address from a BurnRef.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_set_name">set_name</a>(mutator_ref: &<a href="token.md#0x4_token_MutatorRef">MutatorRef</a>, name: String) <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a> {
-    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&name) &lt; <a href="token.md#0x4_token_MAX_TOKEN_NAME_LENGTH">MAX_TOKEN_NAME_LENGTH</a>, <a href="token.md#0x4_token_ETOKEN_NAME_TOO_LONG">ETOKEN_NAME_TOO_LONG</a>);
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&name) &lt; <a href="token.md#0x4_token_MAX_TOKEN_NAME_LENGTH">MAX_TOKEN_NAME_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_ETOKEN_NAME_TOO_LONG">ETOKEN_NAME_TOO_LONG</a>));
     <b>let</b> <a href="token.md#0x4_token">token</a> = borrow_mut(mutator_ref);
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
         &<b>mut</b> <a href="token.md#0x4_token">token</a>.mutation_events,
@@ -829,7 +829,7 @@ Extracts the tokens address from a BurnRef.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_set_uri">set_uri</a>(mutator_ref: &<a href="token.md#0x4_token_MutatorRef">MutatorRef</a>, uri: String) <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a> {
-    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&uri) &lt; <a href="token.md#0x4_token_MAX_URI_LENGTH">MAX_URI_LENGTH</a>, <a href="token.md#0x4_token_EURI_TOO_LONG">EURI_TOO_LONG</a>);
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&uri) &lt; <a href="token.md#0x4_token_MAX_URI_LENGTH">MAX_URI_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_EURI_TOO_LONG">EURI_TOO_LONG</a>));
     <b>let</b> <a href="token.md#0x4_token">token</a> = borrow_mut(mutator_ref);
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
         &<b>mut</b> <a href="token.md#0x4_token">token</a>.mutation_events,

--- a/aptos-move/framework/aptos-token-objects/doc/token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/token.md
@@ -5,7 +5,7 @@
 
 This defines an object-based Token. The key differentiating features from the Aptos standard
 token are:
-* Decouple token ownership from token data.
+* Decoupled token ownership from token data.
 * Explicit data model for token metadata via adjacent resources
 * Extensible framework for tokens
 
@@ -243,6 +243,7 @@ The provided signer is not the creator
 
 <a name="0x4_token_ETOKEN_DOES_NOT_EXIST"></a>
 
+The token does not exist
 
 
 <pre><code><b>const</b> <a href="token.md#0x4_token_ETOKEN_DOES_NOT_EXIST">ETOKEN_DOES_NOT_EXIST</a>: u64 = 1;

--- a/aptos-move/framework/aptos-token-objects/doc/token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/token.md
@@ -421,7 +421,7 @@ Named objects are derived from a seed, the collection's seed is its name.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_create_token_seed">create_token_seed</a>(<a href="collection.md#0x4_collection">collection</a>: &String, name: &String): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(name) &lt; <a href="token.md#0x4_token_MAX_TOKEN_NAME_LENGTH">MAX_TOKEN_NAME_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_ETOKEN_NAME_TOO_LONG">ETOKEN_NAME_TOO_LONG</a>));
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(name) &lt;= <a href="token.md#0x4_token_MAX_TOKEN_NAME_LENGTH">MAX_TOKEN_NAME_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_ETOKEN_NAME_TOO_LONG">ETOKEN_NAME_TOO_LONG</a>));
     <b>let</b> seed = *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_bytes">string::bytes</a>(<a href="collection.md#0x4_collection">collection</a>);
     <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, b"::");
     <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_bytes">string::bytes</a>(name));
@@ -761,7 +761,7 @@ Extracts the tokens address from a BurnRef.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_set_description">set_description</a>(mutator_ref: &<a href="token.md#0x4_token_MutatorRef">MutatorRef</a>, description: String) <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a> {
-    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&description) &lt; <a href="token.md#0x4_token_MAX_DESCRIPTION_LENGTH">MAX_DESCRIPTION_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_EDESCRIPTION_TOO_LONG">EDESCRIPTION_TOO_LONG</a>));
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&description) &lt;= <a href="token.md#0x4_token_MAX_DESCRIPTION_LENGTH">MAX_DESCRIPTION_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_EDESCRIPTION_TOO_LONG">EDESCRIPTION_TOO_LONG</a>));
     <b>let</b> <a href="token.md#0x4_token">token</a> = borrow_mut(mutator_ref);
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
         &<b>mut</b> <a href="token.md#0x4_token">token</a>.mutation_events,
@@ -795,7 +795,7 @@ Extracts the tokens address from a BurnRef.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_set_name">set_name</a>(mutator_ref: &<a href="token.md#0x4_token_MutatorRef">MutatorRef</a>, name: String) <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a> {
-    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&name) &lt; <a href="token.md#0x4_token_MAX_TOKEN_NAME_LENGTH">MAX_TOKEN_NAME_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_ETOKEN_NAME_TOO_LONG">ETOKEN_NAME_TOO_LONG</a>));
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&name) &lt;= <a href="token.md#0x4_token_MAX_TOKEN_NAME_LENGTH">MAX_TOKEN_NAME_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_ETOKEN_NAME_TOO_LONG">ETOKEN_NAME_TOO_LONG</a>));
     <b>let</b> <a href="token.md#0x4_token">token</a> = borrow_mut(mutator_ref);
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
         &<b>mut</b> <a href="token.md#0x4_token">token</a>.mutation_events,
@@ -829,7 +829,7 @@ Extracts the tokens address from a BurnRef.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_set_uri">set_uri</a>(mutator_ref: &<a href="token.md#0x4_token_MutatorRef">MutatorRef</a>, uri: String) <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a> {
-    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&uri) &lt; <a href="token.md#0x4_token_MAX_URI_LENGTH">MAX_URI_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_EURI_TOO_LONG">EURI_TOO_LONG</a>));
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&uri) &lt;= <a href="token.md#0x4_token_MAX_URI_LENGTH">MAX_URI_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="token.md#0x4_token_EURI_TOO_LONG">EURI_TOO_LONG</a>));
     <b>let</b> <a href="token.md#0x4_token">token</a> = borrow_mut(mutator_ref);
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
         &<b>mut</b> <a href="token.md#0x4_token">token</a>.mutation_events,

--- a/aptos-move/framework/aptos-token-objects/doc/token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/token.md
@@ -9,9 +9,6 @@ token are:
 * Explicit data model for token metadata via adjacent resources
 * Extensible framework for tokens
 
-TODO:
-* Update Object<T> to be a viable input as a transaction arg and then update all readers as view.
-
 
 -  [Resource `Token`](#0x4_token_Token)
 -  [Struct `BurnRef`](#0x4_token_BurnRef)
@@ -221,9 +218,47 @@ directly understand the behavior in a writeset.
 ## Constants
 
 
+<a name="0x4_token_EDESCRIPTION_TOO_LONG"></a>
+
+The description is over the maximum length
+
+
+<pre><code><b>const</b> <a href="token.md#0x4_token_EDESCRIPTION_TOO_LONG">EDESCRIPTION_TOO_LONG</a>: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x4_token_EURI_TOO_LONG"></a>
+
+The URI is over the maximum length
+
+
+<pre><code><b>const</b> <a href="token.md#0x4_token_EURI_TOO_LONG">EURI_TOO_LONG</a>: u64 = 5;
+</code></pre>
+
+
+
+<a name="0x4_token_MAX_DESCRIPTION_LENGTH"></a>
+
+
+
+<pre><code><b>const</b> <a href="token.md#0x4_token_MAX_DESCRIPTION_LENGTH">MAX_DESCRIPTION_LENGTH</a>: u64 = 2048;
+</code></pre>
+
+
+
+<a name="0x4_token_MAX_URI_LENGTH"></a>
+
+
+
+<pre><code><b>const</b> <a href="token.md#0x4_token_MAX_URI_LENGTH">MAX_URI_LENGTH</a>: u64 = 512;
+</code></pre>
+
+
+
 <a name="0x4_token_EFIELD_NOT_MUTABLE"></a>
 
-Attempted to mutate an immutable field
+The field being changed is not mutable
 
 
 <pre><code><b>const</b> <a href="token.md#0x4_token_EFIELD_NOT_MUTABLE">EFIELD_NOT_MUTABLE</a>: u64 = 3;
@@ -247,6 +282,25 @@ The token does not exist
 
 
 <pre><code><b>const</b> <a href="token.md#0x4_token_ETOKEN_DOES_NOT_EXIST">ETOKEN_DOES_NOT_EXIST</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x4_token_ETOKEN_NAME_TOO_LONG"></a>
+
+The token name is over the maximum length
+
+
+<pre><code><b>const</b> <a href="token.md#0x4_token_ETOKEN_NAME_TOO_LONG">ETOKEN_NAME_TOO_LONG</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x4_token_MAX_TOKEN_NAME_LENGTH"></a>
+
+
+
+<pre><code><b>const</b> <a href="token.md#0x4_token_MAX_TOKEN_NAME_LENGTH">MAX_TOKEN_NAME_LENGTH</a>: u64 = 128;
 </code></pre>
 
 
@@ -367,6 +421,7 @@ Named objects are derived from a seed, the collection's seed is its name.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_create_token_seed">create_token_seed</a>(<a href="collection.md#0x4_collection">collection</a>: &String, name: &String): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(name) &lt; <a href="token.md#0x4_token_MAX_TOKEN_NAME_LENGTH">MAX_TOKEN_NAME_LENGTH</a>, <a href="token.md#0x4_token_ETOKEN_NAME_TOO_LONG">ETOKEN_NAME_TOO_LONG</a>);
     <b>let</b> seed = *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_bytes">string::bytes</a>(<a href="collection.md#0x4_collection">collection</a>);
     <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, b"::");
     <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_bytes">string::bytes</a>(name));
@@ -706,6 +761,7 @@ Extracts the tokens address from a BurnRef.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_set_description">set_description</a>(mutator_ref: &<a href="token.md#0x4_token_MutatorRef">MutatorRef</a>, description: String) <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a> {
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&description) &lt; <a href="token.md#0x4_token_MAX_DESCRIPTION_LENGTH">MAX_DESCRIPTION_LENGTH</a>, <a href="token.md#0x4_token_EDESCRIPTION_TOO_LONG">EDESCRIPTION_TOO_LONG</a>);
     <b>let</b> <a href="token.md#0x4_token">token</a> = borrow_mut(mutator_ref);
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
         &<b>mut</b> <a href="token.md#0x4_token">token</a>.mutation_events,
@@ -739,6 +795,7 @@ Extracts the tokens address from a BurnRef.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_set_name">set_name</a>(mutator_ref: &<a href="token.md#0x4_token_MutatorRef">MutatorRef</a>, name: String) <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a> {
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&name) &lt; <a href="token.md#0x4_token_MAX_TOKEN_NAME_LENGTH">MAX_TOKEN_NAME_LENGTH</a>, <a href="token.md#0x4_token_ETOKEN_NAME_TOO_LONG">ETOKEN_NAME_TOO_LONG</a>);
     <b>let</b> <a href="token.md#0x4_token">token</a> = borrow_mut(mutator_ref);
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
         &<b>mut</b> <a href="token.md#0x4_token">token</a>.mutation_events,
@@ -772,6 +829,7 @@ Extracts the tokens address from a BurnRef.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_set_uri">set_uri</a>(mutator_ref: &<a href="token.md#0x4_token_MutatorRef">MutatorRef</a>, uri: String) <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a> {
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&uri) &lt; <a href="token.md#0x4_token_MAX_URI_LENGTH">MAX_URI_LENGTH</a>, <a href="token.md#0x4_token_EURI_TOO_LONG">EURI_TOO_LONG</a>);
     <b>let</b> <a href="token.md#0x4_token">token</a> = borrow_mut(mutator_ref);
     <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
         &<b>mut</b> <a href="token.md#0x4_token">token</a>.mutation_events,

--- a/aptos-move/framework/aptos-token-objects/sources/aptos_token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/aptos_token.move
@@ -11,26 +11,24 @@ module aptos_token_objects::aptos_token {
     use std::option::{Self, Option};
     use std::string::String;
     use std::signer;
-
     use aptos_framework::object::{Self, ConstructorRef, Object};
-
     use aptos_token_objects::collection;
     use aptos_token_objects::property_map;
     use aptos_token_objects::royalty;
     use aptos_token_objects::token;
 
-    // The token does not exist
-    const ETOKEN_DOES_NOT_EXIST: u64 = 1;
+    /// The collection does not exist
+    const ECOLLECTION_DOES_NOT_EXIST: u64 = 1;
+    /// The token does not exist
+    const ETOKEN_DOES_NOT_EXIST: u64 = 2;
     /// The provided signer is not the creator
-    const ENOT_CREATOR: u64 = 2;
-    /// Attempted to mutate an immutable field
-    const EFIELD_NOT_MUTABLE: u64 = 3;
-    /// Attempted to burn a non-burnable token
-    const ETOKEN_NOT_BURNABLE: u64 = 4;
-    /// Attempted to mutate a property map that is not mutable
-    const EPROPERTIES_NOT_MUTABLE: u64 = 5;
-    // The collection does not exist
-    const ECOLLECTION_DOES_NOT_EXIST: u64 = 6;
+    const ENOT_CREATOR: u64 = 3;
+    /// The field being changed is not mutable
+    const EFIELD_NOT_MUTABLE: u64 = 4;
+    /// The token being burned is not burnable
+    const ETOKEN_NOT_BURNABLE: u64 = 5;
+    /// The property map being mutated is not mutable
+    const EPROPERTIES_NOT_MUTABLE: u64 = 6;
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     /// Storage state for managing the no-code Collection.
@@ -665,7 +663,7 @@ module aptos_token_objects::aptos_token {
     }
 
     #[test(creator = @0x123, another = @0x456)]
-    #[expected_failure(abort_code = 0x50002, location = Self)]
+    #[expected_failure(abort_code = 0x50003, location = Self)]
     fun test_noncreator_freeze(creator: &signer, another: &signer) acquires AptosCollection, AptosToken {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
@@ -676,7 +674,7 @@ module aptos_token_objects::aptos_token {
     }
 
     #[test(creator = @0x123, another = @0x456)]
-    #[expected_failure(abort_code = 0x50002, location = Self)]
+    #[expected_failure(abort_code = 0x50003, location = Self)]
     fun test_noncreator_unfreeze(creator: &signer, another: &signer) acquires AptosCollection, AptosToken {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
@@ -702,7 +700,7 @@ module aptos_token_objects::aptos_token {
     }
 
     #[test(creator = @0x123)]
-    #[expected_failure(abort_code = 0x50003, location = Self)]
+    #[expected_failure(abort_code = 0x50004, location = Self)]
     fun test_set_immutable_description(creator: &signer) acquires AptosCollection, AptosToken {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
@@ -714,7 +712,7 @@ module aptos_token_objects::aptos_token {
     }
 
     #[test(creator = @0x123, noncreator = @0x456)]
-    #[expected_failure(abort_code = 0x50002, location = Self)]
+    #[expected_failure(abort_code = 0x50003, location = Self)]
     fun test_set_description_non_creator(
         creator: &signer,
         noncreator: &signer,
@@ -744,7 +742,7 @@ module aptos_token_objects::aptos_token {
     }
 
     #[test(creator = @0x123)]
-    #[expected_failure(abort_code = 0x50003, location = Self)]
+    #[expected_failure(abort_code = 0x50004, location = Self)]
     fun test_set_immutable_name(creator: &signer) acquires AptosCollection, AptosToken {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
@@ -756,7 +754,7 @@ module aptos_token_objects::aptos_token {
     }
 
     #[test(creator = @0x123, noncreator = @0x456)]
-    #[expected_failure(abort_code = 0x50002, location = Self)]
+    #[expected_failure(abort_code = 0x50003, location = Self)]
     fun test_set_name_non_creator(
         creator: &signer,
         noncreator: &signer,
@@ -786,7 +784,7 @@ module aptos_token_objects::aptos_token {
     }
 
     #[test(creator = @0x123)]
-    #[expected_failure(abort_code = 0x50003, location = Self)]
+    #[expected_failure(abort_code = 0x50004, location = Self)]
     fun test_set_immutable_uri(creator: &signer) acquires AptosCollection, AptosToken {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
@@ -798,7 +796,7 @@ module aptos_token_objects::aptos_token {
     }
 
     #[test(creator = @0x123, noncreator = @0x456)]
-    #[expected_failure(abort_code = 0x50002, location = Self)]
+    #[expected_failure(abort_code = 0x50003, location = Self)]
     fun test_set_uri_non_creator(
         creator: &signer,
         noncreator: &signer,
@@ -828,7 +826,7 @@ module aptos_token_objects::aptos_token {
     }
 
     #[test(creator = @0x123)]
-    #[expected_failure(abort_code = 0x50004, location = Self)]
+    #[expected_failure(abort_code = 0x50005, location = Self)]
     fun test_not_burnable(creator: &signer) acquires AptosCollection, AptosToken {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
@@ -840,7 +838,7 @@ module aptos_token_objects::aptos_token {
     }
 
     #[test(creator = @0x123, noncreator = @0x456)]
-    #[expected_failure(abort_code = 0x50002, location = Self)]
+    #[expected_failure(abort_code = 0x50003, location = Self)]
     fun test_burn_non_creator(
         creator: &signer,
         noncreator: &signer,
@@ -865,7 +863,7 @@ module aptos_token_objects::aptos_token {
     }
 
     #[test(creator = @0x123)]
-    #[expected_failure(abort_code = 0x50003, location = Self)]
+    #[expected_failure(abort_code = 0x50004, location = Self)]
     fun test_set_immutable_collection_description(creator: &signer) acquires AptosCollection {
         let collection_name = string::utf8(b"collection name");
         let collection = create_collection_helper(creator, collection_name, false);
@@ -873,7 +871,7 @@ module aptos_token_objects::aptos_token {
     }
 
     #[test(creator = @0x123, noncreator = @0x456)]
-    #[expected_failure(abort_code = 0x50002, location = Self)]
+    #[expected_failure(abort_code = 0x50003, location = Self)]
     fun test_set_collection_description_non_creator(
         creator: &signer,
         noncreator: &signer,
@@ -894,7 +892,7 @@ module aptos_token_objects::aptos_token {
     }
 
     #[test(creator = @0x123)]
-    #[expected_failure(abort_code = 0x50003, location = Self)]
+    #[expected_failure(abort_code = 0x50004, location = Self)]
     fun test_set_immutable_collection_uri(creator: &signer) acquires AptosCollection {
         let collection_name = string::utf8(b"collection name");
         let collection = create_collection_helper(creator, collection_name, false);
@@ -902,7 +900,7 @@ module aptos_token_objects::aptos_token {
     }
 
     #[test(creator = @0x123, noncreator = @0x456)]
-    #[expected_failure(abort_code = 0x50002, location = Self)]
+    #[expected_failure(abort_code = 0x50003, location = Self)]
     fun test_set_collection_uri_non_creator(
         creator: &signer,
         noncreator: &signer,

--- a/aptos-move/framework/aptos-token-objects/sources/collection.move
+++ b/aptos-move/framework/aptos-token-objects/sources/collection.move
@@ -205,9 +205,9 @@ module aptos_token_objects::collection {
         uri: String,
         supply: Option<Supply>,
     ): ConstructorRef {
-        assert!(string::length(&name) < MAX_COLLECTION_NAME_LENGTH, ECOLLECTION_NAME_TOO_LONG);
-        assert!(string::length(&uri) < MAX_URI_LENGTH, EURI_TOO_LONG);
-        assert!(string::length(&description) < MAX_DESCRIPTION_LENGTH, EDESCRIPTION_TOO_LONG);
+        assert!(string::length(&name) < MAX_COLLECTION_NAME_LENGTH, error::out_of_range(ECOLLECTION_NAME_TOO_LONG));
+        assert!(string::length(&uri) < MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
+        assert!(string::length(&description) < MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
 
         let object_signer = object::generate_signer(&constructor_ref);
 
@@ -243,7 +243,7 @@ module aptos_token_objects::collection {
 
     /// Named objects are derived from a seed, the collection's seed is its name.
     public fun create_collection_seed(name: &String): vector<u8> {
-        assert!(string::length(name) < MAX_COLLECTION_NAME_LENGTH, ECOLLECTION_NAME_TOO_LONG);
+        assert!(string::length(name) < MAX_COLLECTION_NAME_LENGTH, error::out_of_range(ECOLLECTION_NAME_TOO_LONG));
         *string::bytes(name)
     }
 
@@ -381,7 +381,7 @@ module aptos_token_objects::collection {
     }
 
     public fun set_description(mutator_ref: &MutatorRef, description: String) acquires Collection {
-        assert!(string::length(&description) < MAX_DESCRIPTION_LENGTH, EDESCRIPTION_TOO_LONG);
+        assert!(string::length(&description) < MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
         let collection = borrow_mut(mutator_ref);
         collection.description = description;
         event::emit_event(
@@ -391,7 +391,7 @@ module aptos_token_objects::collection {
     }
 
     public fun set_uri(mutator_ref: &MutatorRef, uri: String) acquires Collection {
-        assert!(string::length(&uri) < MAX_URI_LENGTH, EURI_TOO_LONG);
+        assert!(string::length(&uri) < MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
         let collection = borrow_mut(mutator_ref);
         collection.uri = uri;
         event::emit_event(

--- a/aptos-move/framework/aptos-token-objects/sources/collection.move
+++ b/aptos-move/framework/aptos-token-objects/sources/collection.move
@@ -205,9 +205,9 @@ module aptos_token_objects::collection {
         uri: String,
         supply: Option<Supply>,
     ): ConstructorRef {
-        assert!(string::length(&name) < MAX_COLLECTION_NAME_LENGTH, error::out_of_range(ECOLLECTION_NAME_TOO_LONG));
-        assert!(string::length(&uri) < MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
-        assert!(string::length(&description) < MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
+        assert!(string::length(&name) <= MAX_COLLECTION_NAME_LENGTH, error::out_of_range(ECOLLECTION_NAME_TOO_LONG));
+        assert!(string::length(&uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
+        assert!(string::length(&description) <= MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
 
         let object_signer = object::generate_signer(&constructor_ref);
 
@@ -243,7 +243,7 @@ module aptos_token_objects::collection {
 
     /// Named objects are derived from a seed, the collection's seed is its name.
     public fun create_collection_seed(name: &String): vector<u8> {
-        assert!(string::length(name) < MAX_COLLECTION_NAME_LENGTH, error::out_of_range(ECOLLECTION_NAME_TOO_LONG));
+        assert!(string::length(name) <= MAX_COLLECTION_NAME_LENGTH, error::out_of_range(ECOLLECTION_NAME_TOO_LONG));
         *string::bytes(name)
     }
 
@@ -381,7 +381,7 @@ module aptos_token_objects::collection {
     }
 
     public fun set_description(mutator_ref: &MutatorRef, description: String) acquires Collection {
-        assert!(string::length(&description) < MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
+        assert!(string::length(&description) <= MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
         let collection = borrow_mut(mutator_ref);
         collection.description = description;
         event::emit_event(
@@ -391,7 +391,7 @@ module aptos_token_objects::collection {
     }
 
     public fun set_uri(mutator_ref: &MutatorRef, uri: String) acquires Collection {
-        assert!(string::length(&uri) < MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
+        assert!(string::length(&uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
         let collection = borrow_mut(mutator_ref);
         collection.uri = uri;
         event::emit_event(

--- a/aptos-move/framework/aptos-token-objects/sources/collection.move
+++ b/aptos-move/framework/aptos-token-objects/sources/collection.move
@@ -30,8 +30,8 @@ module aptos_token_objects::collection {
 
     /// The collection does not exist
     const ECOLLECTION_DOES_NOT_EXIST: u64 = 1;
-    /// The collection has reached its supply and no more tokens can be minted
-    const ETOO_MANY_TOKENS: u64 = 2;
+    /// The collection has reached its supply and no more tokens can be minted, unless some are burned
+    const ECOLLECTION_SUPPLY_EXCEEDED: u64 = 2;
     /// The collection name is over the maximum length
     const ECOLLECTION_NAME_TOO_LONG: u64 = 3;
     /// The URI is over the maximum length
@@ -259,7 +259,7 @@ module aptos_token_objects::collection {
             supply.total_minted = supply.total_minted + 1;
             assert!(
                 supply.current_supply <= supply.max_supply,
-                error::out_of_range(ETOO_MANY_TOKENS),
+                error::out_of_range(ECOLLECTION_SUPPLY_EXCEEDED),
             );
             event::emit_event(&mut supply.mint_events,
                 MintEvent {

--- a/aptos-move/framework/aptos-token-objects/sources/token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/token.move
@@ -1,6 +1,6 @@
 /// This defines an object-based Token. The key differentiating features from the Aptos standard
 /// token are:
-/// * Decouple token ownership from token data.
+/// * Decoupled token ownership from token data.
 /// * Explicit data model for token metadata via adjacent resources
 /// * Extensible framework for tokens
 ///
@@ -12,14 +12,12 @@ module aptos_token_objects::token {
     use std::string::{Self, String};
     use std::signer;
     use std::vector;
-
     use aptos_framework::event;
     use aptos_framework::object::{Self, ConstructorRef, Object};
-
     use aptos_token_objects::collection::{Self, Collection};
     use aptos_token_objects::royalty::{Self, Royalty};
 
-    // The token does not exist
+    /// The token does not exist
     const ETOKEN_DOES_NOT_EXIST: u64 = 1;
     /// The provided signer is not the creator
     const ENOT_CREATOR: u64 = 2;
@@ -380,7 +378,7 @@ module aptos_token_objects::token {
     }
 
     #[test(creator = @0x123)]
-    #[expected_failure(abort_code = 0x20001, location = aptos_token_objects::collection)]
+    #[expected_failure(abort_code = 0x20002, location = aptos_token_objects::collection)]
     fun test_too_many_tokens(creator: &signer) {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");

--- a/aptos-move/framework/aptos-token-objects/sources/token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/token.move
@@ -81,9 +81,9 @@ module aptos_token_objects::token {
         royalty: Option<Royalty>,
         uri: String,
     ) {
-        assert!(string::length(&name) < MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
-        assert!(string::length(&description) < MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
-        assert!(string::length(&uri) < MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
+        assert!(string::length(&name) <= MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
+        assert!(string::length(&description) <= MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
+        assert!(string::length(&uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
 
         let object_signer = object::generate_signer(constructor_ref);
 
@@ -147,7 +147,7 @@ module aptos_token_objects::token {
 
     /// Named objects are derived from a seed, the collection's seed is its name.
     public fun create_token_seed(collection: &String, name: &String): vector<u8> {
-        assert!(string::length(name) < MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
+        assert!(string::length(name) <= MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
         let seed = *string::bytes(collection);
         vector::append(&mut seed, b"::");
         vector::append(&mut seed, *string::bytes(name));
@@ -275,7 +275,7 @@ module aptos_token_objects::token {
     }
 
     public fun set_description(mutator_ref: &MutatorRef, description: String) acquires Token {
-        assert!(string::length(&description) < MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
+        assert!(string::length(&description) <= MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
         let token = borrow_mut(mutator_ref);
         event::emit_event(
             &mut token.mutation_events,
@@ -289,7 +289,7 @@ module aptos_token_objects::token {
     }
 
     public fun set_name(mutator_ref: &MutatorRef, name: String) acquires Token {
-        assert!(string::length(&name) < MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
+        assert!(string::length(&name) <= MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
         let token = borrow_mut(mutator_ref);
         event::emit_event(
             &mut token.mutation_events,
@@ -303,7 +303,7 @@ module aptos_token_objects::token {
     }
 
     public fun set_uri(mutator_ref: &MutatorRef, uri: String) acquires Token {
-        assert!(string::length(&uri) < MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
+        assert!(string::length(&uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
         let token = borrow_mut(mutator_ref);
         event::emit_event(
             &mut token.mutation_events,

--- a/aptos-move/framework/aptos-token-objects/sources/token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/token.move
@@ -81,9 +81,9 @@ module aptos_token_objects::token {
         royalty: Option<Royalty>,
         uri: String,
     ) {
-        assert!(string::length(&name) < MAX_TOKEN_NAME_LENGTH, ETOKEN_NAME_TOO_LONG);
-        assert!(string::length(&description) < MAX_DESCRIPTION_LENGTH, EDESCRIPTION_TOO_LONG);
-        assert!(string::length(&uri) < MAX_URI_LENGTH, EURI_TOO_LONG);
+        assert!(string::length(&name) < MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
+        assert!(string::length(&description) < MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
+        assert!(string::length(&uri) < MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
 
         let object_signer = object::generate_signer(constructor_ref);
 
@@ -147,7 +147,7 @@ module aptos_token_objects::token {
 
     /// Named objects are derived from a seed, the collection's seed is its name.
     public fun create_token_seed(collection: &String, name: &String): vector<u8> {
-        assert!(string::length(name) < MAX_TOKEN_NAME_LENGTH, ETOKEN_NAME_TOO_LONG);
+        assert!(string::length(name) < MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
         let seed = *string::bytes(collection);
         vector::append(&mut seed, b"::");
         vector::append(&mut seed, *string::bytes(name));
@@ -275,7 +275,7 @@ module aptos_token_objects::token {
     }
 
     public fun set_description(mutator_ref: &MutatorRef, description: String) acquires Token {
-        assert!(string::length(&description) < MAX_DESCRIPTION_LENGTH, EDESCRIPTION_TOO_LONG);
+        assert!(string::length(&description) < MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
         let token = borrow_mut(mutator_ref);
         event::emit_event(
             &mut token.mutation_events,
@@ -289,7 +289,7 @@ module aptos_token_objects::token {
     }
 
     public fun set_name(mutator_ref: &MutatorRef, name: String) acquires Token {
-        assert!(string::length(&name) < MAX_TOKEN_NAME_LENGTH, ETOKEN_NAME_TOO_LONG);
+        assert!(string::length(&name) < MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
         let token = borrow_mut(mutator_ref);
         event::emit_event(
             &mut token.mutation_events,
@@ -303,7 +303,7 @@ module aptos_token_objects::token {
     }
 
     public fun set_uri(mutator_ref: &MutatorRef, uri: String) acquires Token {
-        assert!(string::length(&uri) < MAX_URI_LENGTH, EURI_TOO_LONG);
+        assert!(string::length(&uri) < MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
         let token = borrow_mut(mutator_ref);
         event::emit_event(
             &mut token.mutation_events,

--- a/aptos-move/framework/aptos-token-objects/sources/token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/token.move
@@ -4,8 +4,6 @@
 /// * Explicit data model for token metadata via adjacent resources
 /// * Extensible framework for tokens
 ///
-/// TODO:
-/// * Update Object<T> to be a viable input as a transaction arg and then update all readers as view.
 module aptos_token_objects::token {
     use std::error;
     use std::option::{Self, Option};
@@ -21,8 +19,18 @@ module aptos_token_objects::token {
     const ETOKEN_DOES_NOT_EXIST: u64 = 1;
     /// The provided signer is not the creator
     const ENOT_CREATOR: u64 = 2;
-    /// Attempted to mutate an immutable field
+    /// The field being changed is not mutable
     const EFIELD_NOT_MUTABLE: u64 = 3;
+    /// The token name is over the maximum length
+    const ETOKEN_NAME_TOO_LONG: u64 = 4;
+    /// The URI is over the maximum length
+    const EURI_TOO_LONG: u64 = 5;
+    /// The description is over the maximum length
+    const EDESCRIPTION_TOO_LONG: u64 = 6;
+
+    const MAX_TOKEN_NAME_LENGTH: u64 = 128;
+    const MAX_URI_LENGTH: u64 = 512;
+    const MAX_DESCRIPTION_LENGTH: u64 = 2048;
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     /// Represents the common fields to all tokens.
@@ -73,6 +81,10 @@ module aptos_token_objects::token {
         royalty: Option<Royalty>,
         uri: String,
     ) {
+        assert!(string::length(&name) < MAX_TOKEN_NAME_LENGTH, ETOKEN_NAME_TOO_LONG);
+        assert!(string::length(&description) < MAX_DESCRIPTION_LENGTH, EDESCRIPTION_TOO_LONG);
+        assert!(string::length(&uri) < MAX_URI_LENGTH, EURI_TOO_LONG);
+
         let object_signer = object::generate_signer(constructor_ref);
 
         let collection_addr = collection::create_collection_address(&creator_address, &collection_name);
@@ -135,6 +147,7 @@ module aptos_token_objects::token {
 
     /// Named objects are derived from a seed, the collection's seed is its name.
     public fun create_token_seed(collection: &String, name: &String): vector<u8> {
+        assert!(string::length(name) < MAX_TOKEN_NAME_LENGTH, ETOKEN_NAME_TOO_LONG);
         let seed = *string::bytes(collection);
         vector::append(&mut seed, b"::");
         vector::append(&mut seed, *string::bytes(name));
@@ -262,6 +275,7 @@ module aptos_token_objects::token {
     }
 
     public fun set_description(mutator_ref: &MutatorRef, description: String) acquires Token {
+        assert!(string::length(&description) < MAX_DESCRIPTION_LENGTH, EDESCRIPTION_TOO_LONG);
         let token = borrow_mut(mutator_ref);
         event::emit_event(
             &mut token.mutation_events,
@@ -275,6 +289,7 @@ module aptos_token_objects::token {
     }
 
     public fun set_name(mutator_ref: &MutatorRef, name: String) acquires Token {
+        assert!(string::length(&name) < MAX_TOKEN_NAME_LENGTH, ETOKEN_NAME_TOO_LONG);
         let token = borrow_mut(mutator_ref);
         event::emit_event(
             &mut token.mutation_events,
@@ -288,6 +303,7 @@ module aptos_token_objects::token {
     }
 
     public fun set_uri(mutator_ref: &MutatorRef, uri: String) acquires Token {
+        assert!(string::length(&uri) < MAX_URI_LENGTH, EURI_TOO_LONG);
         let token = borrow_mut(mutator_ref);
         event::emit_event(
             &mut token.mutation_events,


### PR DESCRIPTION
### Description
Adds max sizes to URI, Description, and Name for both token and collection.  Additionally, standardizes naming of errors and adds documentation

### Test Plan
```
Test result: OK. Total tests: 59; passed: 59; failed: 0
+-------------------------+
| Move Coverage Summary   |
+-------------------------+
Module 0000000000000000000000000000000000000000000000000000000000000004::royalty
>>> % Module coverage: 83.52
Module 0000000000000000000000000000000000000000000000000000000000000004::collection
>>> % Module coverage: 83.72
Module 0000000000000000000000000000000000000000000000000000000000000004::token
>>> % Module coverage: 81.29
Module 0000000000000000000000000000000000000000000000000000000000000004::property_map
>>> % Module coverage: 86.50
Module 0000000000000000000000000000000000000000000000000000000000000004::aptos_token
>>> % Module coverage: 77.05
+-------------------------+
| % Move Coverage: 82.36  |
+-------------------------+

```