### PR TITLE
show faucet endpoint with http scheme

### DIFF
--- a/crates/aptos-faucet/core/src/server/run.rs
+++ b/crates/aptos-faucet/core/src/server/run.rs
@@ -214,7 +214,7 @@ impl RunConfig {
         }
 
         println!(
-            "Faucet is running. Faucet endpoint: {}:{}",
+            "Faucet is running. Faucet endpoint: http://{}:{}",
             self.server_config.listen_address, self.server_config.listen_port
         );
 

--- a/developer-docs-site/docs/nodes/local-testnet/using-cli-to-run-a-local-testnet.md
+++ b/developer-docs-site/docs/nodes/local-testnet/using-cli-to-run-a-local-testnet.md
@@ -38,7 +38,7 @@ Completed generating configuration:
 
 Aptos is running, press ctrl-c to exit
 
-Faucet is running.  Faucet endpoint: 0.0.0.0:8081
+Faucet is running.  Faucet endpoint: http://0.0.0.0:8081
 ```
 
 The above command will use the default configuration for the validator node.


### PR DESCRIPTION
### Description

`aptos init --faucet-url` wants http:// , so we should print it in node startup status

### Test Plan

Ran a local node, was able to copy & paste faucet endpoint into `aptos init`
