### PR TITLE
Delete the devtools directory

### DIFF
--- a/devtools/assets/license_header.txt
+++ b/devtools/assets/license_header.txt
@@ -1,1 +1,0 @@
-Copyright © Aptos Foundation


### PR DESCRIPTION
### Description
The only thing left in this directory was this `license_header.txt` file which is not used anywhere as far as I can tell. @JoshLind to confirm.

### Test Plan
CI.
