### PR TITLE
Fix lint.py shell invocation

### DIFF
--- a/testsuite/lint.py
+++ b/testsuite/lint.py
@@ -15,7 +15,7 @@ def main() -> None:
 @main.command()
 @click.argument("paths", nargs=-1)
 def helm(paths: Tuple[str]) -> None:
-    shell = LocalShell(True)
+    shell = LocalShell()
 
     error = False
     for path in paths:


### PR DESCRIPTION
### Description

It was passing an obsolete argument (verbose) to LocalShell constructor.

### Test Plan

Tested manually.