### PR TITLE
[Spec] Fix specs in DPM example

### DIFF
--- a/third_party/move/documentation/examples/diem-framework/move-packages/DPN/sources/Diem.move
+++ b/third_party/move/documentation/examples/diem-framework/move-packages/DPN/sources/Diem.move
@@ -804,12 +804,12 @@ module DiemFramework::Diem {
     spec schema PreburnToEnsures<CoinType> {
         account: signer;
         amount: u64;
-        let account_addr = signer::address_of(account);
+        let account_addr_for_preburn = signer::address_of(account);
         /// Removes the preburn resource if it exists
-        modifies global<Preburn<CoinType>>(account_addr);
+        modifies global<Preburn<CoinType>>(account_addr_for_preburn);
         /// Publishes if it doesn't exists. Updates its state either way.
-        modifies global<PreburnQueue<CoinType>>(account_addr);
-        ensures exists<PreburnQueue<CoinType>>(account_addr);
+        modifies global<PreburnQueue<CoinType>>(account_addr_for_preburn);
+        ensures exists<PreburnQueue<CoinType>>(account_addr_for_preburn);
         // The preburn amount in the currency info can be updated.
         modifies global<CurrencyInfo<CoinType>>(@CurrencyInfo);
         include PreburnEnsures<CoinType>{preburn: spec_make_preburn(amount)};

--- a/third_party/move/documentation/examples/diem-framework/move-packages/DPN/sources/DiemAccount.move
+++ b/third_party/move/documentation/examples/diem-framework/move-packages/DPN/sources/DiemAccount.move
@@ -829,9 +829,13 @@ module DiemFramework::DiemAccount {
     spec pay_from {
         pragma opaque;
 
-        let payer = cap.account_address;
-        include PayFromWithoutDualAttestation<Token>;
-        include DualAttestation::AssertPaymentOkAbortsIf<Token>{value: amount};
+        include PayFromWithoutDualAttestation<Token>{
+            payer: cap.account_address
+        };
+        include DualAttestation::AssertPaymentOkAbortsIf<Token>{
+            payer: cap.account_address,
+            value: amount
+        };
     }
 
     spec pay_by_signers {


### PR DESCRIPTION
### Description

A recent [PR](https://github.com/aptos-labs/aptos-core/pull/7661) implements a more strict checking when inlining schema. This PR fixes existing specs that do not comply this checking. 

### Test Plan

run `move prove` in `third_party/move/documentation/examples/diem-framework/move-packages/DPN`.
