### PR TITLE
Fix logging init in lint.py and find_latest_image.py

### DIFF
--- a/testsuite/applogging.py
+++ b/testsuite/applogging.py
@@ -1,0 +1,28 @@
+# CLI logging.
+
+import logging
+import sys
+
+
+# Decorator that injects the global "log" into a function scope.
+def logger(func):
+    func.__globals__["log"] = logging.getLogger("")
+    return func
+
+
+def init_logging(
+    logger: logging.Logger,
+    level: int = logging.INFO,
+    print_metadata: bool = True,
+) -> None:
+    """Initialize logging."""
+    logger.setLevel(level)
+    sh = logging.StreamHandler(sys.stderr)
+    if print_metadata:
+        sh.setFormatter(
+            logging.Formatter(
+                "[%(asctime)s] %(levelname)s [%(filename)s.%(funcName)s:%(lineno)d] %(message)s",
+                datefmt="%a, %d %b %Y %H:%M:%S",
+            )
+        )
+    logger.addHandler(sh)

--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -30,6 +30,7 @@ from typing import (
     Union,
 )
 from urllib.parse import ParseResult, urlunparse, urlencode
+from applogging import logger, init_logging
 from forge_wrapper_core.filesystem import Filesystem, LocalFilesystem
 from forge_wrapper_core.git import Git
 from forge_wrapper_core.process import Processes, SystemProcesses
@@ -52,26 +53,6 @@ FORGE_IMAGE_NAME = "aptos/forge"
 
 DEFAULT_CONFIG = "forge-wrapper-config"
 DEFAULT_CONFIG_KEY = "forge-wrapper-config.json"
-
-
-# Decorator that injects the global "log" into a function scope.
-def logger(func):
-    func.__globals__["log"] = logging.getLogger("")
-    return func
-
-
-def init_logging(logger: logging.Logger, print_metadata: bool) -> None:
-    """Initialize logging."""
-    logger.setLevel(logging.INFO)
-    sh = logging.StreamHandler(sys.stdout)
-    if print_metadata:
-        sh.setFormatter(
-            logging.Formatter(
-                "[%(asctime)s] %(levelname)s [%(filename)s.%(funcName)s:%(lineno)d] %(message)s",
-                datefmt="%a, %d %b %Y %H:%M:%S",
-            )
-        )
-    logger.addHandler(sh)
 
 
 @dataclass
@@ -125,8 +106,6 @@ except ImportError:
 )
 @logger
 def main(log_metadata: bool) -> None:
-    # if sys.stdout.isatty():
-    #     log_metadata = True
     init_logging(logger=log, print_metadata=log_metadata)
     # Check that the current directory is the root of the repository.
     if not os.path.exists(".git"):

--- a/testsuite/lint.py
+++ b/testsuite/lint.py
@@ -1,19 +1,29 @@
-from forge import LocalShell
+# Helm linter.
 
+import logging
 import re
 from typing import Tuple
 from pathlib import Path
 
 import click
 
+from forge import LocalShell
+from applogging import logger, init_logging
+
 
 @click.group()
-def main() -> None:
-    pass
+@click.option(
+    "--log-metadata/--no-log-metadata",
+    default=True,
+)
+@logger
+def main(log_metadata: bool) -> None:
+    init_logging(logger=log, level=logging.DEBUG, print_metadata=log_metadata)
 
 
 @main.command()
 @click.argument("paths", nargs=-1)
+@logger
 def helm(paths: Tuple[str]) -> None:
     shell = LocalShell()
 
@@ -28,7 +38,7 @@ def helm(paths: Tuple[str]) -> None:
                 )
                 if match:
                     fullpath = Path(path).parent / match.group("filename")
-                    print(
+                    log.error(
                         "::error file={fullpath},line={line},col=1::{message}".format(
                             fullpath=fullpath, **match.groupdict()
                         )

--- a/testsuite/lint_test.py
+++ b/testsuite/lint_test.py
@@ -23,7 +23,9 @@ class HelmLintTestCase(unittest.TestCase):
         with patch.object(lint, "LocalShell", lambda *_: shell):
             runner = CliRunner()
             result = runner.invoke(
-                main, ["helm", "testsuite/fixtures/helm"], catch_exceptions=False
+                main,
+                ["--no-log-metadata", "helm", "testsuite/fixtures/helm"],
+                catch_exceptions=False,
             )
 
         shell.assert_commands(self)


### PR DESCRIPTION
### Description

Move init_logging() to separate file and import it into all the CLIs.

### Test Plan

Tested manually.

$ FORGE_TEST_SUITE=land_blocking VERBOSE=true python3 testsuite/forge.py test
$ python3 testsuite/lint.py helm terraform/helm/*
$ python3 testsuite/find_latest_image.py --variant failpoints --variant performance