### PR TITLE
[cli] bugfix Lookup address on init 1.0.11 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "anyhow",
  "aptos-backup-cli",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [1.0.11] - 2023/04/14
 ### Fixed
 * Fixed creating a new test account with `aptos init` would fail if the account didn't already exist
 
-## [1.0.10]
+## [1.0.10] - 2023/04/13
 ### Fixed
 * If `aptos init` is run with a faucet URL specified (which happens by default when using the local, devnet, or testnet network options) and funding the account fails, the account creation is considered a failure and nothing is persisted. Previously it would report success despite the account not being created on chain.
 * When specifying a profile where the `AuthenticationKey` has been rotated, now the `AccountAddress` is properly used from the config file

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+### Fixed
+* Fixed creating a new test account with `aptos init` would fail if the account didn't already exist
+
 ## [1.0.10]
 ### Fixed
 * If `aptos init` is run with a faucet URL specified (which happens by default when using the local, devnet, or testnet network options) and funding the account fails, the account creation is considered a failure and nothing is persisted. Previously it would report success despite the account not being created on chain.

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "1.0.10"
+version = "1.0.11"
 
 # Workspace inherited keys
 authors = { workspace = true }

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    account::key_rotation::LookupAddress,
+    account::key_rotation::lookup_address,
     common::{
         types::{
             account_address_from_public_key, CliCommand, CliConfig, CliError, CliTypedResult,
             ConfigSearchMode, EncodingOptions, PrivateKeyInputOptions, ProfileConfig,
-            ProfileOptions, PromptOptions, PublicKeyInputOptions, RestOptions, RngArgs,
-            DEFAULT_PROFILE,
+            ProfileOptions, PromptOptions, RngArgs, DEFAULT_PROFILE,
         },
         utils::{fund_account, prompt_yes_with_override, read_line, wait_for_transactions},
     },
@@ -108,6 +107,7 @@ impl CliCommand<()> for InitTool {
             }
         };
 
+        // Ensure that there is at least a REST URL set for the network
         match network {
             Network::Mainnet => {
                 profile_config.rest_url =
@@ -159,34 +159,26 @@ impl CliCommand<()> for InitTool {
         };
         let public_key = private_key.public_key();
 
+        let client = aptos_rest_client::Client::new(
+            Url::parse(
+                profile_config
+                    .rest_url
+                    .as_ref()
+                    .expect("Must have rest client as created above"),
+            )
+            .map_err(|err| CliError::UnableToParse("rest_url", err.to_string()))?,
+        );
+
         // lookup the address from onchain instead of deriving it
         // if this is the rotated key, deriving it will outputs an incorrect address
-        let address = if let Some(rest_url) = &profile_config.rest_url {
-            LookupAddress {
-                encoding_options: Default::default(),
-                public_key_options: PublicKeyInputOptions::from_key(&public_key),
-                profile_options: Default::default(),
-                rest_options: RestOptions::new(
-                    Option::from(Url::parse(rest_url).expect("Failed to parse url")),
-                    None,
-                ),
-            }
-            .execute()
-            .await?
-        } else {
-            account_address_from_public_key(&public_key)
-        };
+        let derived_address = account_address_from_public_key(&public_key);
+        let address = lookup_address(&client, derived_address, false).await?;
 
         profile_config.private_key = Some(private_key);
         profile_config.public_key = Some(public_key);
         profile_config.account = Some(address);
 
         // Create account if it doesn't exist (and there's a faucet)
-        let client = aptos_rest_client::Client::new(
-            Url::parse(profile_config.rest_url.as_ref().unwrap())
-                .map_err(|err| CliError::UnableToParse("rest_url", err.to_string()))?,
-        );
-
         // Check if account exists
         let account_exists = match client.get_account(address).await {
             Ok(_) => true,
@@ -258,7 +250,7 @@ impl CliCommand<()> for InitTool {
         config
             .profiles
             .as_mut()
-            .unwrap()
+            .expect("Must have profiles, as created above")
             .insert(profile_name.to_string(), profile_config);
         config.save()?;
         eprintln!("\n---\nAptos CLI is now set up for account {} as profile {}!  Run `aptos --help` for more information about commands", address, self.profile_options.profile_name().unwrap_or(DEFAULT_PROFILE));
@@ -267,6 +259,7 @@ impl CliCommand<()> for InitTool {
 }
 
 impl InitTool {
+    /// Custom network created, which requires a REST URL
     fn custom_network(&self, profile_config: &mut ProfileConfig) -> CliTypedResult<()> {
         // Rest Endpoint
         let rest_url = if let Some(ref rest_url) = self.rest_url {
@@ -275,9 +268,9 @@ impl InitTool {
         } else {
             let current = profile_config.rest_url.as_deref();
             eprintln!(
-                "Enter your rest endpoint [Current: {} | No input: Exit (or keep the existing if present)]",
-                current.unwrap_or("None"),
-            );
+                    "Enter your rest endpoint [Current: {} | No input: Exit (or keep the existing if present)]",
+                    current.unwrap_or("None"),
+                );
             let input = read_line("Rest endpoint")?;
             let input = input.trim();
             if input.is_empty() {
@@ -308,10 +301,10 @@ impl InitTool {
         } else {
             let current = profile_config.faucet_url.as_deref();
             eprintln!(
-                "Enter your faucet endpoint [Current: {} | No input: Skip (or keep the existing one if present) | 'skip' to not use a faucet]",
-               current
-                    .unwrap_or("None"),
-            );
+                    "Enter your faucet endpoint [Current: {} | No input: Skip (or keep the existing one if present) | 'skip' to not use a faucet]",
+                    current
+                        .unwrap_or("None"),
+                );
             let input = read_line("Faucet endpoint")?;
             let input = input.trim();
             if input.is_empty() {
@@ -364,7 +357,7 @@ impl FromStr for Network {
                 return Err(CliError::CommandArgumentError(format!(
                     "Invalid network {}.  Must be one of [devnet, testnet, mainnet, local, custom]",
                     str
-                )))
+                )));
             },
         })
     }


### PR DESCRIPTION
### Description
Fixes a bug when `aptos init` for an account doesn't exist will fail immediately.


### Test Plan
Before:
```
./target/debug/aptos init --profile test-init2
Aptos already initialized for profile test-init2, do you want to overwrite the existing config? [yes/no] >
^C
 ✘ greg@jiggy  /opt/git/aptos-core   main  ./target/debug/aptos init --profile test-init3
Configuring for profile test-init3
Choose network from [devnet, testnet, mainnet, local, custom | defaults to devnet]

No network given, using devnet...
Enter your private key as a hex literal (0x...) [Current: None | No input: Generate new key (or keep one if present)]

No key given, generating key...
{
  "Error": "API error: API error Error(AccountNotFound): Account not found by Address(0x33c88b2eb0bee2dc483525b5b89a0bf5f0bb710f3f3027baeb3b337eda1fe582) and Ledger version(248990)"
}
```

After:
```
$ ./target/debug/aptos init --profile test-init2
Configuring for profile test-init2
Choose network from [devnet, testnet, mainnet, local, custom | defaults to devnet]

No network given, using devnet...
Enter your private key as a hex literal (0x...) [Current: None | No input: Generate new key (or keep one if present)]

No key given, generating key...
Account 21f9bffd0240b91627c3948b69ffdf51030965bcf7e58ce3e4768ee730838074 doesn't exist, creating it and funding it with 100000000 Octas
Account 21f9bffd0240b91627c3948b69ffdf51030965bcf7e58ce3e4768ee730838074 funded successfully

---
Aptos CLI is now set up for account 21f9bffd0240b91627c3948b69ffdf51030965bcf7e58ce3e4768ee730838074 as profile test-init2!  Run `aptos --help` for more information about commands
{
  "Result": "Success"
}

```

Lookup also still works where it gives an error if the account isn't on chain.
```
./target/debug/aptos account lookup-address --profile test-init
{
  "Result": "99e7ea90756cbe5760b0ea88ff3bfc2aab4902edca4972e4e6e05cc9af7ad194"
}

./target/debug/aptos account lookup-address --profile testnet --url https://fullnode.devnet.aptoslabs.com 
{
  "Error": "API error: API error Error(AccountNotFound): Account not found by Address(0x21dbfcef4bafda0a410050852d03e1924edb785e4ab98b19429ae1875e97a591) and Ledger version(252976)"
}
```