### PR TITLE
Explain gas based prioritization in greater detail

### DIFF
--- a/developer-docs-site/docs/concepts/gas-txn-fee.md
+++ b/developer-docs-site/docs/concepts/gas-txn-fee.md
@@ -25,7 +25,7 @@ Transactions can range from simple and inexpensive to complicated based upon the
 See [How Base Gas Works](./base-gas.md) for a detailed description of gas fee types and available optimizations.
 
 :::tip Unit of gas
-👉 A **unit of gas** is a dimensionless number, expressed as an integer. The total gas units consumed by your transaction depends on the complexity of your transaction. The **gas price**, on the other hand, is expressed in terms of Aptos blockchain’s native coin (Octas). Also see [Transactions and States](txns-states.md) for how a transaction submitted to the Aptos blockchain looks like.
+👉 A **unit of gas** is a dimensionless number or a unit that is not associated with any one item such as a coin, expressed as an integer. The total gas units consumed by your transaction depend on the complexity of your transaction. The **gas price**, on the other hand, is expressed in terms of Aptos blockchain’s native coin (Octas). Also see [Transactions and States](txns-states.md) for how a transaction submitted to the Aptos blockchain looks like.
 :::
 
 ## Gas price and prioritizing transactions
@@ -35,7 +35,7 @@ In the Aptos network, the Aptos governance sets the absolute minimum gas unit pr
 By specifying a higher gas unit price than the current market price, you can **increase** the priority level for your transaction on the blockchain by paying a larger processing fee. As part of consensus, when the leader selects transactions from its mempool to propose as part of the next block, it will prioritize selecting transactions with a higher gas unit price. While in most cases this is unnecessary, if the network is under load this measure can ensure your transaction is processed more quickly. See the `gas_unit_price` entry under [Estimating the gas units via simulation](#estimating-the-gas-units-via-simulation) for details.
 
 :::caution Increasing gas unit price with in-flight transactions
-👉 If you are increasing gas unit price, but have in-flight (uncommitted) transactions for the same account, you should resubmit all of those transactions with the higher gas unit price. This is because transactions within the same account always have to respect sequence number, so effectively the higher gas unit price transaction will only increase priority after the in-flight transactions are included in a block.
+👉 If you are increasing gas unit price, but have in-flight (uncommitted) transactions for the same account, you should resubmit all of those transactions with the higher gas unit price. This is because transactions within the same account always have to respect sequence number, so effectively the higher gas unit price transaction will increase priority only after the in-flight transactions are included in a block.
 :::
 
 ## Specifying gas fees within a transaction

--- a/developer-docs-site/docs/concepts/gas-txn-fee.md
+++ b/developer-docs-site/docs/concepts/gas-txn-fee.md
@@ -34,8 +34,8 @@ In the Aptos network, the Aptos governance sets the absolute minimum gas unit pr
 
 By specifying a higher gas unit price than the current market price, you can **increase** the priority level for your transaction on the blockchain by paying a larger processing fee. As part of consensus, when the leader selects transactions from its mempool to propose as part of the next block, it will prioritize selecting transactions with a higher gas unit price. While in most cases this is unnecessary, if the network is under load this measure can ensure your transaction is processed more quickly. See the `gas_unit_price` entry under [Estimating the gas units via simulation](#estimating-the-gas-units-via-simulation) for details.
 
-:::caution Transaction prioritzation
-👉 Specifying a higher gas unit price only influences propagation and selecting which transactions go into the next block, it does not influence the ordering of transactions _within_ a block.
+:::caution Increasing gas unit price with in-flight transactions
+👉 If you are increasing gas unit price, but have in-flight (uncommitted) transactions for the same account, you should resubmit all of those transactions with the higher gas unit price. This is because transactions within the same account always have to respect sequence number, so effectively the higher gas unit price transaction will only increase priority after the in-flight transactions are included in a block.
 :::
 
 ## Specifying gas fees within a transaction
@@ -115,5 +115,5 @@ The simulation steps for finding the correct amount of gas for a transaction are
 6. If you feel the need to prioritize or deprioritize your transaction, adjust the `gas_unit_price` of the transaction. Increase the value for higher priority, and decrease the value for lower priority.
 
 :::tip
-Prioritization is based upon buckets of `gas_unit_price`. The buckets are defined in [`mempool_config.rs`](https://github.com/aptos-labs/aptos-core/blob/30b385bf38d3dc8c4e8ee0ff045bc5d0d2f67a85/config/src/config/mempool_config.rs#L8). The current buckets are `[0, 150, 300, 500, 1000, 3000, 5000, 10000, 100000, 1000000]`. Therefore, a `gas_unit_price` of 150 and 299 would be priortized nearly the same.
+Prioritization is based upon buckets of `gas_unit_price`. The buckets are defined in [`mempool_config.rs`](https://github.com/aptos-labs/aptos-core/blob/30b385bf38d3dc8c4e8ee0ff045bc5d0d2f67a85/config/src/config/mempool_config.rs#L8). The current buckets are `[0, 150, 300, 500, 1000, 3000, 5000, 10000, 100000, 1000000]`. Therefore, a `gas_unit_price` of 150 and 299 would be prioritized nearly the same.
 :::

--- a/developer-docs-site/docs/concepts/gas-txn-fee.md
+++ b/developer-docs-site/docs/concepts/gas-txn-fee.md
@@ -24,14 +24,18 @@ Transactions can range from simple and inexpensive to complicated based upon the
 
 See [How Base Gas Works](./base-gas.md) for a detailed description of gas fee types and available optimizations.
 
-## Gas price and prioritizing transactions
-
-In the Aptos network, the Aptos governance sets the minimum gas unit price. However, the market determines the actual minimum gas unit price. See [Ethereum Gas Tracker](https://etherscan.io/gastracker), for example, which shows the market price movements of Ethereum gas price.
-
-By specifying a higher gas unit price than the current market price, you can **increase** the priority level for your transaction on the blockchain by paying a larger processing fee. While in most cases this is unnecessary, if the network is under load this measure can ensure your transaction is processed more quickly. See the `gas_unit_price` entry under [Estimating the gas units via simulation](#estimating-the-gas-units-via-simulation) for details.
-
 :::tip Unit of gas
 👉 A **unit of gas** is a dimensionless number, expressed as an integer. The total gas units consumed by your transaction depends on the complexity of your transaction. The **gas price**, on the other hand, is expressed in terms of Aptos blockchain’s native coin (Octas). Also see [Transactions and States](txns-states.md) for how a transaction submitted to the Aptos blockchain looks like.
+:::
+
+## Gas price and prioritizing transactions
+
+In the Aptos network, the Aptos governance sets the absolute minimum gas unit price. However, the market determines the actual minimum gas unit price. See [Ethereum Gas Tracker](https://etherscan.io/gastracker), for example, which shows the market price movements of Ethereum gas price.
+
+By specifying a higher gas unit price than the current market price, you can **increase** the priority level for your transaction on the blockchain by paying a larger processing fee. As part of consensus, when the leader selects transactions from its mempool to propose as part of the next block, it will prioritize selecting transactions with a higher gas unit price. While in most cases this is unnecessary, if the network is under load this measure can ensure your transaction is processed more quickly. See the `gas_unit_price` entry under [Estimating the gas units via simulation](#estimating-the-gas-units-via-simulation) for details.
+
+:::caution Transaction prioritzation
+👉 Specifying a higher gas unit price only influences propagation and selecting which transactions go into the next block, it does not influence the ordering of transactions _within_ a block.
 :::
 
 ## Specifying gas fees within a transaction

--- a/developer-docs-site/docs/concepts/gas-txn-fee.md
+++ b/developer-docs-site/docs/concepts/gas-txn-fee.md
@@ -30,7 +30,7 @@ See [How Base Gas Works](./base-gas.md) for a detailed description of gas fee ty
 
 ## Gas price and prioritizing transactions
 
-In the Aptos network, the Aptos governance sets the absolute minimum gas unit price. However, the market determines the actual minimum gas unit price. See [Ethereum Gas Tracker](https://etherscan.io/gastracker), for example, which shows the market price movements of Ethereum gas price.
+In the Aptos network, the Aptos governance sets the absolute minimum gas unit price. However, the market determines how quickly a transaction with a particular gas unit price is processed. See [Ethereum Gas Tracker](https://etherscan.io/gastracker), for example, which shows the market price movements of Ethereum gas price.
 
 By specifying a higher gas unit price than the current market price, you can **increase** the priority level for your transaction on the blockchain by paying a larger processing fee. As part of consensus, when the leader selects transactions from its mempool to propose as part of the next block, it will prioritize selecting transactions with a higher gas unit price. While in most cases this is unnecessary, if the network is under load this measure can ensure your transaction is processed more quickly. See the `gas_unit_price` entry under [Estimating the gas units via simulation](#estimating-the-gas-units-via-simulation) for details.
 


### PR DESCRIPTION
### Description
The docs mention that you can prioritize your txn by specifying a gas unit price, but it doesn't say what actually happens when you do that. This change clarifies that.

https://aptos-org.slack.com/archives/C03F71PU3B5/p1681464232985649

### Test Plan
Docs.
