### PR TITLE
[git config] Do not normalize .ps1 line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@
 *.txt text eol=lf 
 *.yaml text eol=lf 
 *.yml text eol=lf 
+*.ps1 text eol=crlf
 
 # Use Move syntax highlighter for Move IR code
 *.mvir linguist-language=Move


### PR DESCRIPTION
I experience some strange behavior with the .ps1 Windows powerscript files in our repo when using tools like copybara. It appears those files line endings are auto-normalized on checkout, and then create a diff. This adjusts .gitattributes to turn off autoconversion for those files, in hope that it helps (not sure it does).
