### PR TITLE
Use aggregators for p2p transactions in block-stm benchmarks

### DIFF
--- a/aptos-move/aptos-transaction-benchmarks/src/transactions.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/transactions.rs
@@ -5,7 +5,7 @@
 use aptos_bitvec::BitVec;
 use aptos_crypto::HashValue;
 use aptos_language_e2e_tests::{
-    account_universe::{log_balance_strategy, AUTransactionGen, AccountUniverseGen},
+    account_universe::{AUTransactionGen, AccountUniverseGen},
     executor::FakeExecutor,
     gas_costs::TXN_RESERVED,
 };
@@ -245,13 +245,12 @@ impl TransactionBenchState {
     }
 }
 
-/// Returns a strategy for the account universe customized for benchmarks.
+/// Returns a strategy for the account universe customized for benchmarks, i.e. having
+/// sufficiently large balance for gas.
 fn universe_strategy(
     num_accounts: usize,
     num_transactions: usize,
 ) -> impl Strategy<Value = AccountUniverseGen> {
-    // Multiply by 5 past the number of  to provide
-    let max_balance = TXN_RESERVED * num_transactions as u64 * 5;
-    let balance_strategy = log_balance_strategy(max_balance);
-    AccountUniverseGen::strategy(num_accounts, balance_strategy)
+    let balance = TXN_RESERVED * num_transactions as u64 * 5;
+    AccountUniverseGen::strategy(num_accounts, balance..(balance + 1))
 }

--- a/aptos-move/e2e-tests/src/account_universe/peer_to_peer.rs
+++ b/aptos-move/e2e-tests/src/account_universe/peer_to_peer.rs
@@ -46,6 +46,7 @@ impl AUTransactionGen for P2PTransferGen {
             receiver.account(),
             sender.sequence_number,
             self.amount,
+            1, // sets unit gas price, ensures an aggregator is used for total supply.
         );
 
         // Now figure out whether the transaction will actually work.

--- a/aptos-move/e2e-tests/src/common_transactions.rs
+++ b/aptos-move/e2e-tests/src/common_transactions.rs
@@ -54,13 +54,16 @@ pub fn create_account_txn(
         .sign()
 }
 
-/// Returns a transaction to transfer coin from one account to another (possibly new) one, with the
-/// given arguments.
+/// Returns a transaction to transfer coin from one account to another (possibly new) one,
+/// with the given arguments. Providing 0 as gas_unit_price generates transactions that
+/// don't use an aggregator for total supply tracking (due to logic in coin.move that
+/// doesn't generate a delta for total supply when gas is 0).
 pub fn peer_to_peer_txn(
     sender: &Account,
     receiver: &Account,
     seq_num: u64,
     transfer_amount: u64,
+    gas_unit_price: u64,
 ) -> SignedTransaction {
     // get a SignedTransaction
     sender
@@ -70,5 +73,6 @@ pub fn peer_to_peer_txn(
             transfer_amount,
         ))
         .sequence_number(seq_num)
+        .gas_unit_price(gas_unit_price)
         .sign()
 }

--- a/aptos-move/e2e-tests/src/gas_costs.rs
+++ b/aptos-move/e2e-tests/src/gas_costs.rs
@@ -138,7 +138,7 @@ pub static PEER_TO_PEER: Lazy<u64> = Lazy::new(|| {
     executor.add_account_data(&sender);
     executor.add_account_data(&receiver);
 
-    let txn = peer_to_peer_txn(sender.account(), receiver.account(), 10, 20_000);
+    let txn = peer_to_peer_txn(sender.account(), receiver.account(), 10, 20_000, 0);
     compute_gas_used(txn, &mut executor)
 });
 
@@ -155,7 +155,7 @@ pub static PEER_TO_PEER_TOO_LOW: Lazy<u64> = Lazy::new(|| {
     executor.add_account_data(&sender);
     executor.add_account_data(&receiver);
 
-    let txn = peer_to_peer_txn(sender.account(), receiver.account(), 10, balance + 1);
+    let txn = peer_to_peer_txn(sender.account(), receiver.account(), 10, balance + 1, 0);
     compute_gas_used(txn, &mut executor)
 });
 
@@ -171,7 +171,7 @@ pub static PEER_TO_PEER_NEW_RECEIVER_FIRST: Lazy<u64> = Lazy::new(|| {
     executor.add_account_data(&sender);
     let receiver = Account::new();
 
-    let txn = peer_to_peer_txn(sender.account(), &receiver, 10, 20_000);
+    let txn = peer_to_peer_txn(sender.account(), &receiver, 10, 20_000, 0);
     compute_gas_used(txn, &mut executor)
 });
 
@@ -186,8 +186,8 @@ pub static PEER_TO_PEER_NEW_RECEIVER_NEXT: Lazy<u64> = Lazy::new(|| {
     executor.add_account_data(&sender);
 
     let txns = vec![
-        peer_to_peer_txn(sender.account(), &Account::new(), 10, 20_000),
-        peer_to_peer_txn(sender.account(), &Account::new(), 11, 20_000),
+        peer_to_peer_txn(sender.account(), &Account::new(), 10, 20_000, 0),
+        peer_to_peer_txn(sender.account(), &Account::new(), 11, 20_000, 0),
     ];
     let output = &executor
         .execute_block(txns)
@@ -210,7 +210,7 @@ pub static PEER_TO_PEER_NEW_RECEIVER_TOO_LOW_FIRST: Lazy<u64> = Lazy::new(|| {
     executor.add_account_data(&sender);
     let receiver = Account::new();
 
-    let txn = peer_to_peer_txn(sender.account(), &receiver, 10, balance + 1);
+    let txn = peer_to_peer_txn(sender.account(), &receiver, 10, balance + 1, 0);
     compute_gas_used(txn, &mut executor)
 });
 
@@ -228,8 +228,8 @@ pub static PEER_TO_PEER_NEW_RECEIVER_TOO_LOW_NEXT: Lazy<u64> = Lazy::new(|| {
     executor.add_account_data(&sender);
 
     let txns = vec![
-        peer_to_peer_txn(sender.account(), &Account::new(), 10, 10_000),
-        peer_to_peer_txn(sender.account(), &Account::new(), 11, balance),
+        peer_to_peer_txn(sender.account(), &Account::new(), 10, 10_000, 0),
+        peer_to_peer_txn(sender.account(), &Account::new(), 11, balance, 0),
     ];
     let output = &executor
         .execute_block(txns)

--- a/aptos-move/e2e-testsuite/src/tests/failed_transaction_tests.rs
+++ b/aptos-move/e2e-testsuite/src/tests/failed_transaction_tests.rs
@@ -96,6 +96,7 @@ fn non_existent_sender() {
         receiver.account(),
         sequence_number,
         transfer_amount,
+        0,
     );
 
     let output = &executor.execute_transaction(txn);

--- a/aptos-move/e2e-testsuite/src/tests/genesis.rs
+++ b/aptos-move/e2e-testsuite/src/tests/genesis.rs
@@ -35,7 +35,7 @@ fn execute_genesis_and_drop_other_transaction() {
 
     let sender = executor.create_raw_account_data(1_000_000, 10);
     let receiver = executor.create_raw_account_data(100_000, 10);
-    let txn2 = peer_to_peer_txn(sender.account(), receiver.account(), 11, 1000);
+    let txn2 = peer_to_peer_txn(sender.account(), receiver.account(), 11, 1000, 0);
 
     let mut output = executor
         .execute_transaction_block(vec![txn, Transaction::UserTransaction(txn2)])

--- a/aptos-move/e2e-testsuite/src/tests/on_chain_configs.rs
+++ b/aptos-move/e2e-testsuite/src/tests/on_chain_configs.rs
@@ -50,7 +50,7 @@ fn drop_txn_after_reconfiguration() {
 
     let sender = executor.create_raw_account_data(1_000_000, 10);
     let receiver = executor.create_raw_account_data(100_000, 10);
-    let txn2 = peer_to_peer_txn(sender.account(), receiver.account(), 11, 1000);
+    let txn2 = peer_to_peer_txn(sender.account(), receiver.account(), 11, 1000, 0);
 
     let mut output = executor.execute_block(vec![txn, txn2]).unwrap();
     assert_eq!(output.pop().unwrap().status(), &TransactionStatus::Retry)

--- a/aptos-move/e2e-testsuite/src/tests/peer_to_peer.rs
+++ b/aptos-move/e2e-testsuite/src/tests/peer_to_peer.rs
@@ -22,7 +22,7 @@ fn single_peer_to_peer_with_event() {
     executor.add_account_data(&receiver);
 
     let transfer_amount = 1_000;
-    let txn = peer_to_peer_txn(sender.account(), receiver.account(), 10, transfer_amount);
+    let txn = peer_to_peer_txn(sender.account(), receiver.account(), 10, transfer_amount, 0);
 
     // execute transaction
     let output = executor.execute_transaction(txn);
@@ -72,10 +72,10 @@ fn few_peer_to_peer_with_event() {
 
     // execute transaction
     let txns: Vec<SignedTransaction> = vec![
-        peer_to_peer_txn(sender.account(), receiver.account(), 10, transfer_amount),
-        peer_to_peer_txn(sender.account(), receiver.account(), 11, transfer_amount),
-        peer_to_peer_txn(sender.account(), receiver.account(), 12, transfer_amount),
-        peer_to_peer_txn(sender.account(), receiver.account(), 13, transfer_amount),
+        peer_to_peer_txn(sender.account(), receiver.account(), 10, transfer_amount, 0),
+        peer_to_peer_txn(sender.account(), receiver.account(), 11, transfer_amount, 0),
+        peer_to_peer_txn(sender.account(), receiver.account(), 12, transfer_amount, 0),
+        peer_to_peer_txn(sender.account(), receiver.account(), 13, transfer_amount, 0),
     ];
     let output = executor.execute_block(txns).unwrap();
     for (idx, txn_output) in output.iter().enumerate() {
@@ -165,7 +165,7 @@ pub(crate) fn create_cyclic_transfers(
         let seq_num = sender_resource.sequence_number();
         let receiver = &accounts[(i + 1) % count];
 
-        let txn = peer_to_peer_txn(sender, receiver, seq_num, transfer_amount);
+        let txn = peer_to_peer_txn(sender, receiver, seq_num, transfer_amount, 0);
         txns.push(txn);
         txns_info.push(TxnInfo::new(sender, receiver, transfer_amount));
     }
@@ -192,7 +192,7 @@ fn create_one_to_many_transfers(
     for (i, receiver) in accounts.iter().enumerate().take(count).skip(1) {
         // let receiver = &accounts[i];
 
-        let txn = peer_to_peer_txn(sender, receiver, seq_num + i as u64 - 1, transfer_amount);
+        let txn = peer_to_peer_txn(sender, receiver, seq_num + i as u64 - 1, transfer_amount, 0);
         txns.push(txn);
         txns_info.push(TxnInfo::new(sender, receiver, transfer_amount));
     }
@@ -219,7 +219,7 @@ fn create_many_to_one_transfers(
             .expect("sender must exist");
         let seq_num = sender_resource.sequence_number();
 
-        let txn = peer_to_peer_txn(sender, receiver, seq_num, transfer_amount);
+        let txn = peer_to_peer_txn(sender, receiver, seq_num, transfer_amount, 0);
         txns.push(txn);
         txns_info.push(TxnInfo::new(sender, receiver, transfer_amount));
     }


### PR DESCRIPTION
We weren't using aggregator in the block-stm benchmark for total supply, like it is used in the real system. It makes sense to enable by default. It obviously slows down the benchmark, but comparably for sequential and parallel runs, i.e. it most likely comes from handling the extra write-set item.

We need this to confirm the numbers prior to landing https://github.com/aptos-labs/aptos-core/pull/7400 - and also makes sense for automated runs (@danielxiangzl / @perryjrandall).
