### PR TITLE
[Configs] Fix and update tokio-console features.

### DIFF
--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -76,9 +76,10 @@ url = { workspace = true }
 jemallocator = { workspace = true }
 
 [features]
-default = []
 assert-private-keys-not-cloneable = ["aptos-crypto/assert-private-keys-not-cloneable"]
-failpoints = ["fail/failpoints", "aptos-consensus/failpoints", "aptos-executor/failpoints", "aptos-mempool/failpoints", "aptos-api/failpoints"]
-indexer = ["aptos-indexer"]
 check-vm-features = []
 consensus-only-perf-test = ["aptos-executor/consensus-only-perf-test", "aptos-mempool/consensus-only-perf-test", "aptos-db/consensus-only-perf-test"]
+default = []
+failpoints = ["fail/failpoints", "aptos-consensus/failpoints", "aptos-executor/failpoints", "aptos-mempool/failpoints", "aptos-api/failpoints"]
+indexer = ["aptos-indexer"]
+tokio-console = ["aptos-logger/tokio-console"]

--- a/aptos-node/src/logger.rs
+++ b/aptos-node/src/logger.rs
@@ -40,7 +40,7 @@ pub fn create_logger(
         .level(node_config.logger.level)
         .telemetry_level(node_config.logger.telemetry_level)
         .enable_telemetry_flush(node_config.logger.enable_telemetry_flush)
-        .console_port(node_config.logger.console_port);
+        .tokio_console_port(node_config.logger.tokio_console_port);
     if node_config.logger.enable_backtrace {
         logger_builder.enable_backtrace();
     }

--- a/config/src/config/logger_config.rs
+++ b/config/src/config/logger_config.rs
@@ -17,11 +17,10 @@ pub struct LoggerConfig {
     pub is_async: bool,
     // The default logging level for slog.
     pub level: Level,
-    // tokio-console port
-    pub console_port: Option<u16>,
     pub enable_telemetry_remote_log: bool,
     pub enable_telemetry_flush: bool,
     pub telemetry_level: Level,
+    pub tokio_console_port: Option<u16>,
 }
 
 impl Default for LoggerConfig {
@@ -31,25 +30,24 @@ impl Default for LoggerConfig {
             enable_backtrace: false,
             is_async: true,
             level: Level::Info,
-            // This is the default port used by tokio-console
-            // setting console_port to None will disable tokio console even if aptos-console
-            // feature is enabled
-            console_port: Some(6669),
             enable_telemetry_remote_log: true,
             enable_telemetry_flush: true,
             telemetry_level: Level::Error,
+
+            // This is the default port used by tokio-console.
+            // Setting this to None will disable tokio-console
+            // even if the "tokio-console" feature is enabled.
+            tokio_console_port: None,
         }
     }
 }
 
 impl LoggerConfig {
-    pub fn disable_console(&mut self) {
-        self.console_port = None;
+    pub fn disable_tokio_console(&mut self) {
+        self.tokio_console_port = None;
     }
-}
 
-impl LoggerConfig {
     pub fn randomize_ports(&mut self) {
-        self.console_port = Some(utils::get_available_port());
+        self.tokio_console_port = Some(utils::get_available_port());
     }
 }

--- a/config/src/config/node_config.rs
+++ b/config/src/config/node_config.rs
@@ -263,7 +263,7 @@ impl NodeConfig {
         self.api.randomize_ports();
         self.inspection_service.randomize_ports();
         self.storage.randomize_ports();
-        self.logger.disable_console();
+        self.logger.disable_tokio_console();
 
         // Randomize the ports for the networks
         if let Some(network) = self.validator_network.as_mut() {

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -307,9 +307,9 @@ impl InnerBuilder {
                 self.config.max_batch_bytes as u64,
             );
             #[allow(unused_variables)]
-            let name = format!("batch_coordinator-{}", i).as_str();
+            let name = format!("batch_coordinator-{}", i);
             spawn_named!(
-                name,
+                name.as_str(),
                 batch_coordinator.start(remote_batch_coordinator_cmd_rx)
             );
         }

--- a/crates/aptos-logger/Cargo.toml
+++ b/crates/aptos-logger/Cargo.toml
@@ -39,4 +39,4 @@ pretty_assertions = { workspace = true }
 
 [features]
 default = []
-aptos-console = ["console-subscriber"]
+tokio-console = ["console-subscriber"]

--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -221,7 +221,7 @@ impl LogEntry {
 /// A builder for a `AptosData`, configures what, where, and how to write logs.
 pub struct AptosDataBuilder {
     channel_size: usize,
-    console_port: Option<u16>,
+    tokio_console_port: Option<u16>,
     enable_backtrace: bool,
     level: Level,
     remote_level: Level,
@@ -238,7 +238,7 @@ impl AptosDataBuilder {
     pub fn new() -> Self {
         Self {
             channel_size: CHANNEL_SIZE,
-            console_port: Some(6669),
+            tokio_console_port: None,
             enable_backtrace: false,
             level: Level::Info,
             remote_level: Level::Info,
@@ -281,8 +281,8 @@ impl AptosDataBuilder {
         self
     }
 
-    pub fn console_port(&mut self, console_port: Option<u16>) -> &mut Self {
-        self.console_port = console_port;
+    pub fn tokio_console_port(&mut self, tokio_console_port: Option<u16>) -> &mut Self {
+        self.tokio_console_port = tokio_console_port;
         self
     }
 
@@ -400,13 +400,13 @@ impl AptosDataBuilder {
     pub fn build(&mut self) -> Arc<AptosData> {
         let logger = self.build_logger();
 
-        let console_port = if cfg!(feature = "aptos-console") {
-            self.console_port
+        let tokio_console_port = if cfg!(feature = "tokio-console") {
+            self.tokio_console_port
         } else {
             None
         };
 
-        crate::logger::set_global_logger(logger.clone(), console_port);
+        crate::logger::set_global_logger(logger.clone(), tokio_console_port);
         logger
     }
 }

--- a/crates/aptos-logger/src/logger.rs
+++ b/crates/aptos-logger/src/logger.rs
@@ -41,36 +41,35 @@ pub(crate) fn enabled(metadata: &Metadata) -> bool {
 }
 
 /// Sets the global `Logger` exactly once
-pub fn set_global_logger(logger: Arc<dyn Logger>, console_port: Option<u16>) {
+pub fn set_global_logger(logger: Arc<dyn Logger>, tokio_console_port: Option<u16>) {
     if LOGGER.set(logger).is_err() {
         eprintln!("Global logger has already been set");
         error!("Global logger has already been set");
         return;
     }
 
-    /*
-     * if console_port is set all tracing::log are captured by the tokio-tracing infrastructure.
-     * else aptos-logger intercepts all tracing::log events
-     * In both scenarios *ALL* aptos-logger::log events are captured by aptos-logger as usual.
-     */
-    #[cfg(feature = "aptos-console")]
+    // If tokio-console is enabled, all tracing::log events are captured by the
+    // tokio-tracing infrastructure. Otherwise, aptos-logger intercepts all
+    // tracing::log events. In both scenarios *all* aptos-logger::log events are
+    // captured by the aptos-logger (as usual).
+    #[cfg(feature = "tokio-console")]
     {
-        if let Some(p) = console_port {
+        if let Some(tokio_console_port) = tokio_console_port {
             let console_layer = console_subscriber::ConsoleLayer::builder()
-                .server_addr(([0, 0, 0, 0], p))
+                .server_addr(([0, 0, 0, 0], tokio_console_port))
                 .spawn();
 
             tracing_subscriber::registry().with(console_layer).init();
             return;
         }
     }
-    if console_port.is_none() {
+    if tokio_console_port.is_none() {
         let _ = tracing::subscriber::set_global_default(
             crate::tracing_adapter::TracingToAptosDataLayer
                 .with_subscriber(tracing_subscriber::Registry::default()),
         );
     } else {
-        error!("console_port was set but has no effect, build with --cfg aptos-console");
+        error!("tokio_console_port was set but has no effect! Build the crate with the 'tokio-console' feature enabled!");
     }
 }
 

--- a/crates/aptos-logger/src/macros.rs
+++ b/crates/aptos-logger/src/macros.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Macros for sending logs at predetermined log `Level`s
-#[cfg(not(feature = "aptos-console"))]
+#[cfg(not(feature = "tokio-console"))]
 #[macro_export]
 macro_rules! spawn_named {
       ($name:expr, $func:expr) => { tokio::spawn($func); };
@@ -14,7 +14,7 @@ macro_rules! spawn_named {
       ($name:expr, $handler:expr, $async:ident = async ; $move:ident = move; $clojure:block) => { $handler.spawn( async move $clojure); };
   }
 
-#[cfg(feature = "aptos-console")]
+#[cfg(feature = "tokio-console")]
 #[macro_export]
 macro_rules! spawn_named {
       ($name:expr, $func:expr) => { tokio::task::Builder::new()

--- a/crates/aptos-logger/tests/tracing_translation_tests.rs
+++ b/crates/aptos-logger/tests/tracing_translation_tests.rs
@@ -42,7 +42,7 @@ fn verify_tracing_kvs() {
     let logs = writer.logs.clone();
     AptosData::builder()
         .is_async(false)
-        .console_port(None)
+        .tokio_console_port(None)
         .printer(Box::new(writer.write_to_stderr(false)))
         .build();
 


### PR DESCRIPTION
Note: this PR is based on: https://github.com/aptos-labs/aptos-core/pull/7706

### Description
This PR makes a few small fixes/tweaks to our configs and features for tokio-console. Specifically:
- Rename the `aptos-console` feature to `tokio-console` (this seems more descriptive, as all it's doing is enabling tokio console).
- Fix a build error with quorum store (i.e., trying to build with the console feature today results in an error). For example:
```
310 |             let name = format!("batch_coordinator-{}", i).as_str();
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         - temporary value is freed at the end of this statement
    |                        |
    |                        creates a temporary which is freed while still in use
```
- Rename `console_port` to `tokio_console_port` in the configs (again, this is more descriptive).
- Update the configs such that the `tokio_console_port` is None by default.

### Test Plan
Existing test infrastructure and running `cargo build -p aptos-node --features=tokio-console` now actually builds.