### PR TITLE
[Configs] Add a new ConfigSanitizer component.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,7 @@ dependencies = [
  "aptos-types",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "byteorder",
+ "cfg-if",
  "get_if_addrs",
  "mirai-annotations",
  "poem-openapi",

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -24,6 +24,7 @@ aptos-temppath = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
 byteorder = { workspace = true }
+cfg-if = { workspace = true }
 get_if_addrs = { workspace = true }
 mirai-annotations = { workspace = true }
 poem-openapi = { workspace = true }

--- a/config/src/config/base_config.rs
+++ b/config/src/config/base_config.rs
@@ -174,6 +174,38 @@ mod test {
     use super::*;
 
     #[test]
+    fn test_sanitize_valid_base_config() {
+        // Create a node config with a waypoint
+        let mut node_config = NodeConfig {
+            base: BaseConfig {
+                waypoint: WaypointConfig::FromConfig(Waypoint::default()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Sanitize the config and verify that it passes
+        BaseConfig::sanitize(&mut node_config, RoleType::Validator, ChainId::mainnet()).unwrap();
+    }
+
+    #[test]
+    fn test_sanitize_missing_waypoint() {
+        // Create a node config with a missing waypoint
+        let mut node_config = NodeConfig {
+            base: BaseConfig {
+                waypoint: WaypointConfig::None,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Sanitize the config and verify that it fails because of the missing waypoint
+        let error = BaseConfig::sanitize(&mut node_config, RoleType::Validator, ChainId::mainnet())
+            .unwrap_err();
+        assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+
+    #[test]
     fn verify_role_type_conversion() {
         // Verify relationship between RoleType and as_string() is reflexive
         let validator = RoleType::Validator;

--- a/config/src/config/config_sanitizer.rs
+++ b/config/src/config/config_sanitizer.rs
@@ -1,0 +1,215 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::config::{
+    ApiConfig, BaseConfig, ConsensusConfig, Error, ExecutionConfig, IndexerConfig,
+    IndexerGrpcConfig, InspectionServiceConfig, LoggerConfig, MempoolConfig, NodeConfig,
+    PeerMonitoringServiceConfig, RoleType, StateSyncConfig, StorageConfig,
+};
+use aptos_types::chain_id::ChainId;
+use cfg_if::cfg_if;
+use std::collections::HashSet;
+
+// Useful sanitizer constants
+const FAILPOINTS_SANITIZER_NAME: &str = "FailpointsConfigSanitizer";
+const FULLNODE_NETWORKS_SANITIZER_NAME: &str = "FullnodeNetworksConfigSanitizer";
+const SANITIZER_STRING: &str = "Sanitizer";
+const VALIDATOR_NETWORK_SANITIZER_NAME: &str = "ValidatorNetworkConfigSanitizer";
+
+/// A trait for validating and sanitizing node configs (and their sub-configs)
+pub trait ConfigSanitizer {
+    /// Get the name of the sanitizer (e.g., for logging and error strings)
+    fn get_sanitizer_name() -> String {
+        let config_name = get_config_name::<Self>().to_string();
+        config_name + SANITIZER_STRING
+    }
+
+    /// Validate and process the config according to the given node role and chain ID
+    fn sanitize(
+        _node_config: &mut NodeConfig,
+        _node_role: RoleType,
+        _chain_id: ChainId,
+    ) -> Result<(), Error> {
+        unimplemented!("sanitize() must be implemented for each sanitizer!");
+    }
+}
+
+impl ConfigSanitizer for NodeConfig {
+    fn sanitize(
+        node_config: &mut NodeConfig,
+        node_role: RoleType,
+        chain_id: ChainId,
+    ) -> Result<(), Error> {
+        // Sanitize all of the sub-configs
+        ApiConfig::sanitize(node_config, node_role, chain_id)?;
+        BaseConfig::sanitize(node_config, node_role, chain_id)?;
+        ConsensusConfig::sanitize(node_config, node_role, chain_id)?;
+        ExecutionConfig::sanitize(node_config, node_role, chain_id)?;
+        sanitize_failpoints_config(node_config, node_role, chain_id)?;
+        sanitize_fullnode_network_configs(node_config, node_role, chain_id)?;
+        IndexerConfig::sanitize(node_config, node_role, chain_id)?;
+        IndexerGrpcConfig::sanitize(node_config, node_role, chain_id)?;
+        InspectionServiceConfig::sanitize(node_config, node_role, chain_id)?;
+        LoggerConfig::sanitize(node_config, node_role, chain_id)?;
+        MempoolConfig::sanitize(node_config, node_role, chain_id)?;
+        PeerMonitoringServiceConfig::sanitize(node_config, node_role, chain_id)?;
+        StateSyncConfig::sanitize(node_config, node_role, chain_id)?;
+        StorageConfig::sanitize(node_config, node_role, chain_id)?;
+        sanitize_validator_network_config(node_config, node_role, chain_id)?;
+
+        Ok(()) // All configs passed validation
+    }
+}
+
+/// Returns true iff failpoints are enabled
+fn are_failpoints_enabled() -> bool {
+    cfg_if! {
+        if #[cfg(feature = "failpoints")] {
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Returns the name of the given config type
+fn get_config_name<T: ?Sized>() -> &'static str {
+    std::any::type_name::<T>()
+        .split("::")
+        .last()
+        .unwrap_or("UnknownConfig")
+}
+
+/// Validate and process the failpoints config according to the node role and chain ID
+fn sanitize_failpoints_config(
+    node_config: &mut NodeConfig,
+    _node_role: RoleType,
+    chain_id: ChainId,
+) -> Result<(), Error> {
+    let sanitizer_name = FAILPOINTS_SANITIZER_NAME.to_string();
+    let failpoints = &node_config.failpoints;
+
+    // Verify that failpoints are not enabled in mainnet
+    let failpoints_enabled = are_failpoints_enabled();
+    if chain_id.is_mainnet()? && failpoints_enabled {
+        return Err(Error::ConfigSanitizerFailed(
+            sanitizer_name,
+            "Failpoints are not supported on mainnet nodes!".into(),
+        ));
+    }
+
+    // Ensure that the failpoints config is populated appropriately
+    if let Some(failpoints) = failpoints {
+        if failpoints_enabled && failpoints.is_empty() {
+            return Err(Error::ConfigSanitizerFailed(
+                sanitizer_name,
+                "Failpoints are enabled, but the failpoints config is empty?".into(),
+            ));
+        } else if !failpoints_enabled && !failpoints.is_empty() {
+            return Err(Error::ConfigSanitizerFailed(
+                sanitizer_name,
+                "Failpoints are disabled, but the failpoints config is not empty!".into(),
+            ));
+        }
+    } else if failpoints_enabled {
+        return Err(Error::ConfigSanitizerFailed(
+            sanitizer_name,
+            "Failpoints are enabled, but the failpoints config is None!".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate and process the fullnode network configs according to the node role and chain ID
+fn sanitize_fullnode_network_configs(
+    node_config: &mut NodeConfig,
+    node_role: RoleType,
+    _chain_id: ChainId,
+) -> Result<(), Error> {
+    let sanitizer_name = FULLNODE_NETWORKS_SANITIZER_NAME.to_string();
+    let fullnode_networks = &mut node_config.full_node_networks;
+
+    // Verify that the fullnode network configs are not empty for fullnodes
+    if fullnode_networks.is_empty() && !node_role.is_validator() {
+        return Err(Error::ConfigSanitizerFailed(
+            sanitizer_name,
+            "Fullnode networks cannot be empty for fullnodes!".into(),
+        ));
+    }
+
+    // Check each fullnode network config and ensure uniqueness
+    let mut fullnode_network_ids = HashSet::new();
+    for fullnode_network_config in fullnode_networks {
+        let network_id = fullnode_network_config.network_id;
+
+        // Verify that the fullnode network config is not a validator network config
+        if network_id.is_validator_network() {
+            return Err(Error::ConfigSanitizerFailed(
+                sanitizer_name,
+                "Fullnode network configs cannot include a validator network!".into(),
+            ));
+        }
+
+        // Verify that the fullnode network config is unique
+        if !fullnode_network_ids.insert(network_id) {
+            return Err(Error::ConfigSanitizerFailed(
+                sanitizer_name,
+                format!(
+                    "Each fullnode network config must be unique! Found duplicate: {}",
+                    network_id
+                ),
+            ));
+        }
+
+        // Prepare the network id
+        fullnode_network_config.set_listen_address_and_prepare_identity()?;
+    }
+
+    Ok(())
+}
+
+/// Validate and process the validator network config according to the node role and chain ID
+fn sanitize_validator_network_config(
+    node_config: &mut NodeConfig,
+    node_role: RoleType,
+    _chain_id: ChainId,
+) -> Result<(), Error> {
+    let sanitizer_name = VALIDATOR_NETWORK_SANITIZER_NAME.to_string();
+    let validator_network = &mut node_config.validator_network;
+
+    // Verify that the validator network config is not empty for validators
+    if validator_network.is_none() && node_role.is_validator() {
+        return Err(Error::ConfigSanitizerFailed(
+            sanitizer_name,
+            "Validator network config cannot be empty for validators!".into(),
+        ));
+    }
+
+    // Check the validator network config
+    if let Some(validator_network_config) = validator_network {
+        let network_id = validator_network_config.network_id;
+        if !network_id.is_validator_network() {
+            return Err(Error::ConfigSanitizerFailed(
+                sanitizer_name,
+                format!(
+                    "Validator network config must have a validator network ID! Found ID: {}",
+                    network_id
+                ),
+            ));
+        }
+
+        // Verify that mutual authentication is enabled
+        if !validator_network_config.mutual_authentication {
+            return Err(Error::ConfigSanitizerFailed(
+                sanitizer_name,
+                "Mutual authentication must be enabled for the validator network!".into(),
+            ));
+        }
+
+        // Prepare the network id
+        validator_network_config.set_listen_address_and_prepare_identity()?;
+    }
+
+    Ok(())
+}

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -2,7 +2,11 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::config::{QuorumStoreConfig, SafetyRulesConfig};
+use crate::config::{
+    config_sanitizer::ConfigSanitizer, Error, NodeConfig, QuorumStoreConfig, RoleType,
+    SafetyRulesConfig,
+};
+use aptos_types::chain_id::ChainId;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -236,6 +240,21 @@ impl ConsensusConfig {
         } else {
             self.max_receiving_block_bytes
         }
+    }
+}
+
+impl ConfigSanitizer for ConsensusConfig {
+    /// Validate and process the consensus config according to the given node role and chain ID
+    fn sanitize(
+        node_config: &mut NodeConfig,
+        node_role: RoleType,
+        chain_id: ChainId,
+    ) -> Result<(), Error> {
+        // Verify that the safety rules config is valid
+        SafetyRulesConfig::sanitize(node_config, node_role, chain_id)?;
+
+        // TODO: should we add further verifications for consensus?
+        Ok(())
     }
 }
 

--- a/config/src/config/error.rs
+++ b/config/src/config/error.rs
@@ -6,6 +6,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("Failed to sanitize the node config! Sanitizer: {0}, Error: {1}")]
+    ConfigSanitizerFailed(String, String),
     #[error("Invariant violation: {0}")]
     InvariantViolation(String),
     #[error("Error accessing {0}: {1}")]
@@ -20,10 +22,8 @@ pub enum Error {
     Unexpected(String),
 }
 
-pub fn invariant(cond: bool, msg: String) -> Result<(), Error> {
-    if !cond {
-        Err(Error::InvariantViolation(msg))
-    } else {
-        Ok(())
+impl From<anyhow::Error> for Error {
+    fn from(error: anyhow::Error) -> Self {
+        Error::Unexpected(error.to_string())
     }
 }

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -157,6 +157,61 @@ mod test {
     };
 
     #[test]
+    fn test_sanitize_valid_execution_config() {
+        // Create a node config with a valid execution config
+        let mut node_config = NodeConfig {
+            execution: ExecutionConfig {
+                paranoid_hot_potato_verification: true,
+                paranoid_type_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Sanitize the config and verify that it succeeds
+        ExecutionConfig::sanitize(&mut node_config, RoleType::Validator, ChainId::mainnet())
+            .unwrap();
+    }
+
+    #[test]
+    fn test_sanitize_hot_potato_mainnet() {
+        // Create a node config with missing paranoid_hot_potato_verification on mainnet
+        let mut node_config = NodeConfig {
+            execution: ExecutionConfig {
+                paranoid_hot_potato_verification: false,
+                paranoid_type_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Sanitize the config and verify that it fails
+        let error =
+            ExecutionConfig::sanitize(&mut node_config, RoleType::Validator, ChainId::mainnet())
+                .unwrap_err();
+        assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+
+    #[test]
+    fn test_sanitize_paranoid_type_mainnet() {
+        // Create a node config with missing paranoid_type_verification on mainnet
+        let mut node_config = NodeConfig {
+            execution: ExecutionConfig {
+                paranoid_hot_potato_verification: true,
+                paranoid_type_verification: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Sanitize the config and verify that it fails
+        let error =
+            ExecutionConfig::sanitize(&mut node_config, RoleType::Validator, ChainId::mainnet())
+                .unwrap_err();
+        assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+
+    #[test]
     fn test_no_genesis() {
         let (mut config, path) = generate_config();
         assert_eq!(config.genesis, None);

--- a/config/src/config/identity_config.rs
+++ b/config/src/config/identity_config.rs
@@ -1,10 +1,16 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::{config::SecureBackend, keys::ConfigKey};
 use aptos_crypto::{bls12381, ed25519::Ed25519PrivateKey, x25519};
-use aptos_types::account_address::AccountAddress;
+use aptos_types::account_address::{AccountAddress, AccountAddress as PeerId};
 use serde::{Deserialize, Serialize};
-use std::{fs, fs::File, io::Write, path::Path};
+use std::{
+    fs,
+    fs::File,
+    io::Write,
+    path::{Path, PathBuf},
+};
 
 /// A single struct for reading / writing to a file for identity across configs
 #[derive(Deserialize, Serialize)]
@@ -31,4 +37,56 @@ impl IdentityBlob {
         let mut file = File::open(path)?;
         Ok(file.write_all(serde_yaml::to_string(self)?.as_bytes())?)
     }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum Identity {
+    FromConfig(IdentityFromConfig),
+    FromStorage(IdentityFromStorage),
+    FromFile(IdentityFromFile),
+    None,
+}
+
+impl Identity {
+    pub fn from_config(key: x25519::PrivateKey, peer_id: PeerId) -> Self {
+        let key = ConfigKey::new(key);
+        Identity::FromConfig(IdentityFromConfig { key, peer_id })
+    }
+
+    pub fn from_storage(key_name: String, peer_id_name: String, backend: SecureBackend) -> Self {
+        Identity::FromStorage(IdentityFromStorage {
+            backend,
+            key_name,
+            peer_id_name,
+        })
+    }
+
+    pub fn from_file(path: PathBuf) -> Self {
+        Identity::FromFile(IdentityFromFile { path })
+    }
+}
+
+/// The identity is stored within the config.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IdentityFromConfig {
+    #[serde(flatten)]
+    pub key: ConfigKey<x25519::PrivateKey>,
+    pub peer_id: PeerId,
+}
+
+/// This represents an identity in a secure-storage as defined in NodeConfig::secure.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IdentityFromStorage {
+    pub backend: SecureBackend,
+    pub key_name: String,
+    pub peer_id_name: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IdentityFromFile {
+    pub path: PathBuf,
 }

--- a/config/src/config/indexer_config.rs
+++ b/config/src/config/indexer_config.rs
@@ -1,9 +1,19 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::config::{config_sanitizer::ConfigSanitizer, Error, NodeConfig, RoleType};
+use aptos_logger::warn;
+use aptos_types::chain_id::ChainId;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
 
+// Useful indexer environment variables
+const GAP_LOOKBACK_VERSIONS: &str = "GAP_LOOKBACK_VERSIONS";
+const INDEXER_DATABASE_URL: &str = "INDEXER_DATABASE_URL";
+const PROCESSOR_NAME: &str = "PROCESSOR_NAME";
+const STARTING_VERSION: &str = "STARTING_VERSION";
+
+// Useful indexer defaults
 pub const DEFAULT_BATCH_SIZE: u16 = 500;
 pub const DEFAULT_FETCH_TASKS: u8 = 5;
 pub const DEFAULT_PROCESSOR_TASKS: u8 = 5;
@@ -103,7 +113,97 @@ impl Debug for IndexerConfig {
     }
 }
 
-pub fn env_or_default<T: std::str::FromStr>(
+impl ConfigSanitizer for IndexerConfig {
+    /// Validate and process the indexer config according to the given node role and chain ID
+    fn sanitize(
+        node_config: &mut NodeConfig,
+        _node_role: RoleType,
+        _chain_id: ChainId,
+    ) -> Result<(), Error> {
+        let indexer_config = &mut node_config.indexer;
+
+        // If the indexer is not enabled, there's nothing to validate
+        if !indexer_config.enabled {
+            return Ok(());
+        }
+
+        // Verify the postgres uri
+        indexer_config.postgres_uri = env_var_or_default(
+            INDEXER_DATABASE_URL,
+            indexer_config.postgres_uri.clone(),
+            Some(format!(
+                "Either 'config.indexer.postgres_uri' or '{}' must be set!",
+                INDEXER_DATABASE_URL
+            )),
+        );
+
+        // Verify the processor
+        indexer_config.processor = env_var_or_default(
+            PROCESSOR_NAME,
+            indexer_config
+                .processor
+                .clone()
+                .or_else(|| Some("default_processor".to_string())),
+            None,
+        );
+
+        // Verify the starting version
+        indexer_config.starting_version = match std::env::var(STARTING_VERSION).ok() {
+            None => indexer_config.starting_version,
+            Some(starting_version) => match starting_version.parse::<u64>() {
+                Ok(version) => Some(version),
+                Err(error) => {
+                    // This will allow a processor to have STARTING_VERSION undefined when deploying
+                    warn!(
+                        "Invalid STARTING_VERSION: {}. Error: {:?}. Using {:?} instead.",
+                        starting_version, error, indexer_config.starting_version
+                    );
+                    indexer_config.starting_version
+                },
+            },
+        };
+
+        // Set appropriate defaults
+        indexer_config.skip_migrations = indexer_config.skip_migrations.or(Some(false));
+        indexer_config.check_chain_id = indexer_config.check_chain_id.or(Some(true));
+        indexer_config.batch_size = default_if_zero(
+            indexer_config.batch_size.map(|v| v as u64),
+            DEFAULT_BATCH_SIZE as u64,
+        )
+        .map(|v| v as u16);
+        indexer_config.fetch_tasks = default_if_zero(
+            indexer_config.fetch_tasks.map(|v| v as u64),
+            DEFAULT_FETCH_TASKS as u64,
+        )
+        .map(|v| v as u8);
+        indexer_config.processor_tasks = default_if_zero(
+            indexer_config.processor_tasks.map(|v| v as u64),
+            DEFAULT_PROCESSOR_TASKS as u64,
+        )
+        .map(|value| value as u8);
+        indexer_config.emit_every = indexer_config.emit_every.or(Some(0));
+        indexer_config.gap_lookback_versions = env_var_or_default(
+            GAP_LOOKBACK_VERSIONS,
+            indexer_config.gap_lookback_versions.or(Some(1_500_000)),
+            None,
+        );
+
+        Ok(())
+    }
+}
+
+/// Returns the default if the value is 0, otherwise returns the value
+fn default_if_zero(value: Option<u64>, default: u64) -> Option<u64> {
+    match value {
+        None => Some(default),
+        Some(0) => Some(default),
+        Some(value) => Some(value),
+    }
+}
+
+/// Returns the value of the environment variable `env_var`
+/// if it is set, otherwise returns `default`.
+fn env_var_or_default<T: std::str::FromStr>(
     env_var: &'static str,
     default: Option<T>,
     expected_message: Option<String>,
@@ -119,28 +219,4 @@ pub fn env_or_default<T: std::str::FromStr>(
         }),
         Some(default_value) => partial.unwrap_or(Some(default_value)),
     }
-}
-
-pub fn default_if_zero_u8(value: Option<u8>, default: u8) -> Option<u8> {
-    default_if_zero(value.map(|v| v as u64), default as u64).map(|v| v as u8)
-}
-
-pub fn default_if_zero(value: Option<u64>, default: u64) -> Option<u64> {
-    match value {
-        None => Some(default),
-        Some(value) => {
-            if value == 0 {
-                Some(default)
-            } else {
-                Some(value)
-            }
-        },
-    }
-}
-
-pub fn must_be_set(config_var: &'static str, env_var: &'static str) -> Option<String> {
-    Some(format!(
-        "Either 'config.indexer.{}' or '{}' must be set!",
-        config_var, env_var
-    ))
 }

--- a/config/src/config/indexer_grpc_config.rs
+++ b/config/src/config/indexer_grpc_config.rs
@@ -1,12 +1,21 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::config::{config_sanitizer::ConfigSanitizer, Error, NodeConfig, RoleType};
+use aptos_types::chain_id::ChainId;
 use serde::{Deserialize, Serialize};
+
+// Useful indexer defaults
+pub const DEFAULT_ADDRESS: &str = "0.0.0.0:50051";
+pub const DEFAULT_OUTPUT_BATCH_SIZE: u16 = 100;
+pub const DEFAULT_PROCESSOR_BATCH_SIZE: u16 = 1000;
+pub const DEFAULT_PROCESSOR_TASK_COUNT: u16 = 20;
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct IndexerGrpcConfig {
     pub enabled: bool,
+
     /// The address that the grpc server will listen on
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub address: Option<String>,
@@ -22,4 +31,37 @@ pub struct IndexerGrpcConfig {
     /// Number of transactions returned in a single stream response
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_batch_size: Option<u16>,
+}
+
+impl ConfigSanitizer for IndexerGrpcConfig {
+    /// Validate and process the indexer grpc config according to the given node role and chain ID
+    fn sanitize(
+        node_config: &mut NodeConfig,
+        _node_role: RoleType,
+        _chain_id: ChainId,
+    ) -> Result<(), Error> {
+        let indexer_grpc_config = &mut node_config.indexer_grpc;
+
+        // If the indexer is not enabled, we don't need to do anything
+        if !indexer_grpc_config.enabled {
+            return Ok(());
+        }
+
+        // Set appropriate defaults
+        indexer_grpc_config.address = indexer_grpc_config
+            .address
+            .clone()
+            .or_else(|| Some(DEFAULT_ADDRESS.into()));
+        indexer_grpc_config.processor_task_count = indexer_grpc_config
+            .processor_task_count
+            .or(Some(DEFAULT_PROCESSOR_TASK_COUNT));
+        indexer_grpc_config.processor_batch_size = indexer_grpc_config
+            .processor_batch_size
+            .or(Some(DEFAULT_PROCESSOR_BATCH_SIZE));
+        indexer_grpc_config.output_batch_size = indexer_grpc_config
+            .output_batch_size
+            .or(Some(DEFAULT_OUTPUT_BATCH_SIZE));
+
+        Ok(())
+    }
 }

--- a/config/src/config/inspection_service_config.rs
+++ b/config/src/config/inspection_service_config.rs
@@ -1,7 +1,11 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::utils;
+use crate::{
+    config::{config_sanitizer::ConfigSanitizer, Error, NodeConfig, RoleType},
+    utils,
+};
+use aptos_types::chain_id::ChainId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
@@ -27,5 +31,32 @@ impl Default for InspectionServiceConfig {
 impl InspectionServiceConfig {
     pub fn randomize_ports(&mut self) {
         self.port = utils::get_available_port();
+    }
+}
+
+impl ConfigSanitizer for InspectionServiceConfig {
+    /// Validate and process the inspection service config according to the given node role and chain ID
+    fn sanitize(
+        node_config: &mut NodeConfig,
+        node_role: RoleType,
+        chain_id: ChainId,
+    ) -> Result<(), Error> {
+        let sanitizer_name = Self::get_sanitizer_name();
+        let inspection_service_config = &node_config.inspection_service;
+
+        // Verify that mainnet validators do not expose the configuration
+        if node_role.is_validator()
+            && chain_id.is_mainnet()?
+            && inspection_service_config.expose_configuration
+        {
+            return Err(Error::ConfigSanitizerFailed(
+                sanitizer_name,
+                "Mainnet validators should not expose the node configuration!".to_string(),
+            ));
+        }
+
+        // TODO: Verify that system information is not exposed for mainnet validators
+
+        Ok(())
     }
 }

--- a/config/src/config/inspection_service_config.rs
+++ b/config/src/config/inspection_service_config.rs
@@ -60,3 +60,45 @@ impl ConfigSanitizer for InspectionServiceConfig {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_valid_service_config() {
+        // Create an inspection service config with the configuration endpoint enabled
+        let mut node_config = NodeConfig {
+            inspection_service: InspectionServiceConfig {
+                expose_configuration: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Verify that the configuration is sanitized successfully
+        InspectionServiceConfig::sanitize(&mut node_config, RoleType::FullNode, ChainId::mainnet())
+            .unwrap()
+    }
+
+    #[test]
+    fn test_sanitize_config_mainnet() {
+        // Create an inspection service config with the configuration endpoint enabled
+        let mut node_config = NodeConfig {
+            inspection_service: InspectionServiceConfig {
+                expose_configuration: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Verify that sanitization fails for mainnet
+        let error = InspectionServiceConfig::sanitize(
+            &mut node_config,
+            RoleType::Validator,
+            ChainId::mainnet(),
+        )
+        .unwrap_err();
+        assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+}

--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -2,7 +2,10 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::config::MAX_APPLICATION_MESSAGE_SIZE;
+use crate::config::{
+    config_sanitizer::ConfigSanitizer, Error, NodeConfig, RoleType, MAX_APPLICATION_MESSAGE_SIZE,
+};
+use aptos_types::chain_id::ChainId;
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_BROADCAST_BUCKETS: &[u64] =
@@ -55,5 +58,16 @@ impl Default for MempoolConfig {
             eager_expire_threshold_ms: Some(10_000),
             eager_expire_time_ms: 3_000,
         }
+    }
+}
+
+impl ConfigSanitizer for MempoolConfig {
+    /// Validate and process the mempool config according to the given node role and chain ID
+    fn sanitize(
+        _node_config: &mut NodeConfig,
+        _node_role: RoleType,
+        _chain_id: ChainId,
+    ) -> Result<(), Error> {
+        Ok(()) // TODO: add reasonable verifications
     }
 }

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -5,6 +5,7 @@
 // All modules should be declared below
 mod api_config;
 mod base_config;
+mod config_sanitizer;
 mod consensus_config;
 mod error;
 mod execution_config;
@@ -16,6 +17,7 @@ mod logger_config;
 mod mempool_config;
 mod network_config;
 mod node_config;
+mod node_config_loader;
 mod peer_monitoring_config;
 mod persistable_config;
 mod quorum_store_config;

--- a/config/src/config/node_config_loader.rs
+++ b/config/src/config/node_config_loader.rs
@@ -1,0 +1,118 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    config::{
+        config_sanitizer::ConfigSanitizer, utils::RootPath, Error, NodeConfig, PersistableConfig,
+    },
+    utils::get_genesis_txn,
+};
+use aptos_types::{
+    chain_id::ChainId,
+    on_chain_config::OnChainConfig,
+    state_store::state_key::{StateKey, StateKeyInner},
+    transaction::{Transaction, WriteSetPayload},
+    write_set::WriteOp,
+};
+use std::path::Path;
+
+/// A simple node config loader that performs basic config
+/// sanitization and post-processing.
+pub struct NodeConfigLoader<P> {
+    node_config_path: P,
+}
+
+impl<P: AsRef<Path>> NodeConfigLoader<P> {
+    pub fn new(node_config_path: P) -> Self {
+        Self { node_config_path }
+    }
+
+    /// Load the node config, validate the configuration options
+    /// and process the config for the current environment.
+    pub fn load_and_sanitize_config(&self) -> Result<NodeConfig, Error> {
+        // Load the node config from disk
+        let mut node_config = NodeConfig::load_config(&self.node_config_path)?;
+
+        // Load the execution config
+        let input_dir = RootPath::new(&self.node_config_path);
+        node_config.execution.load_from_path(&input_dir)?;
+
+        // Sanitize the node config
+        sanitize_node_config(&mut node_config)?;
+
+        // TODO: post-process the config for the current environment
+
+        // Update the data directory
+        node_config.set_data_dir(node_config.get_data_dir().to_path_buf());
+        Ok(node_config)
+    }
+}
+
+/// Sanitize the node config for the current environment
+fn sanitize_node_config(node_config: &mut NodeConfig) -> Result<(), Error> {
+    // Get the role and chain_id for the node
+    let node_role = node_config.base.role;
+    let chain_id = get_chain_id(node_config)?;
+
+    // Sanitize the node config
+    NodeConfig::sanitize(node_config, node_role, chain_id)
+}
+
+/// Get the chain ID for the node
+fn get_chain_id(node_config: &NodeConfig) -> Result<ChainId, Error> {
+    // TODO: can we make this less hacky?
+
+    // Load the genesis transaction from disk
+    let genesis_txn = get_genesis_txn(node_config).ok_or(Error::InvariantViolation(
+        "The genesis transaction was not found!".to_string(),
+    ))?;
+
+    // Extract the chain ID from the genesis transaction
+    match genesis_txn {
+        Transaction::GenesisTransaction(WriteSetPayload::Direct(change_set)) => {
+            // Get the chain ID state key
+            let chain_id_access_path = ChainId::access_path().map_err(|error| {
+                Error::InvariantViolation(format!(
+                    "Failed to get the chain ID access path! Error: {:?}",
+                    error
+                ))
+            })?;
+            let chain_id_state_key =
+                StateKey::from(StateKeyInner::AccessPath(chain_id_access_path));
+
+            // Get the write op from the write set
+            let write_set_mut = change_set.clone().write_set().clone().into_mut();
+            let write_op = write_set_mut.get(&chain_id_state_key).ok_or_else(|| {
+                Error::InvariantViolation(
+                    "The genesis transaction does not contain the write op for the chain id!"
+                        .into(),
+                )
+            })?;
+
+            // Extract the chain ID from the write op
+            let write_op_bytes = match write_op {
+                WriteOp::Creation(bytes) => bytes,
+                WriteOp::Modification(bytes) => bytes,
+                WriteOp::CreationWithMetadata { data, metadata: _ } => data,
+                WriteOp::ModificationWithMetadata { data, metadata: _ } => data,
+                _ => {
+                    return Err(Error::InvariantViolation(
+                        "The genesis transaction does not contain the correct write op for the chain ID!".into(),
+                    ));
+                },
+            };
+            let chain_id = ChainId::deserialize_into_config(write_op_bytes).map_err(|error| {
+                Error::InvariantViolation(format!(
+                    "Failed to deserialize the chain ID: {:?}",
+                    error
+                ))
+            })?;
+
+            Ok(chain_id)
+        },
+        _ => Err(Error::InvariantViolation(format!(
+            "The genesis transaction has the incorrect type: {:?}!",
+            genesis_txn
+        ))),
+    }
+}

--- a/config/src/config/node_config_loader.rs
+++ b/config/src/config/node_config_loader.rs
@@ -52,7 +52,13 @@ impl<P: AsRef<Path>> NodeConfigLoader<P> {
 fn sanitize_node_config(node_config: &mut NodeConfig) -> Result<(), Error> {
     // Get the role and chain_id for the node
     let node_role = node_config.base.role;
-    let chain_id = get_chain_id(node_config)?;
+    let chain_id = match get_chain_id(node_config) {
+        Ok(chain_id) => chain_id,
+        Err(error) => {
+            println!("Failed to get the chain ID from the genesis blob! Skipping config sanitization. Error: {:?}", error);
+            return Ok(());
+        },
+    };
 
     // Sanitize the node config
     NodeConfig::sanitize(node_config, node_role, chain_id)

--- a/config/src/config/peer_monitoring_config.rs
+++ b/config/src/config/peer_monitoring_config.rs
@@ -110,3 +110,37 @@ impl ConfigSanitizer for PeerMonitoringServiceConfig {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_enabled_monitoring_config() {
+        // Create a monitoring config with an enabled monitoring client
+        let mut node_config = NodeConfig {
+            peer_monitoring_service: PeerMonitoringServiceConfig {
+                enable_peer_monitoring_client: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Verify the config passes sanitization for testnet
+        PeerMonitoringServiceConfig::sanitize(
+            &mut node_config,
+            RoleType::FullNode,
+            ChainId::testnet(),
+        )
+        .unwrap();
+
+        // Verify the config fails sanitization for mainnet
+        let error = PeerMonitoringServiceConfig::sanitize(
+            &mut node_config,
+            RoleType::FullNode,
+            ChainId::mainnet(),
+        )
+        .unwrap_err();
+        assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+}

--- a/config/src/config/secure_backend_config.rs
+++ b/config/src/config/secure_backend_config.rs
@@ -48,6 +48,16 @@ impl SecureBackend {
             SecureBackend::InMemoryStorage => {},
         }
     }
+
+    /// Returns true iff the backend is in memory
+    pub fn is_in_memory(&self) -> bool {
+        matches!(self, SecureBackend::InMemoryStorage)
+    }
+
+    /// Returns true iff the backend is github
+    pub fn is_github(&self) -> bool {
+        matches!(self, SecureBackend::GitHub(_))
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -2,6 +2,8 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::config::{config_sanitizer::ConfigSanitizer, Error, NodeConfig, RoleType};
+use aptos_types::chain_id::ChainId;
 use serde::{Deserialize, Serialize};
 
 // The maximum message size per state sync message
@@ -215,5 +217,16 @@ impl Default for AptosDataClientConfig {
             summary_poll_interval_ms: 200,
             use_compression: true,
         }
+    }
+}
+
+impl ConfigSanitizer for StateSyncConfig {
+    /// Validate and process the state sync config according to the given node role and chain ID
+    fn sanitize(
+        _node_config: &mut NodeConfig,
+        _node_role: RoleType,
+        _chain_id: ChainId,
+    ) -> Result<(), Error> {
+        Ok(()) // TODO: add validation of higher-level properties once we have variable configs
     }
 }

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -2,7 +2,11 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::utils;
+use crate::{
+    config::{config_sanitizer::ConfigSanitizer, Error, NodeConfig, RoleType},
+    utils,
+};
+use aptos_types::chain_id::ChainId;
 use serde::{Deserialize, Serialize};
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -269,6 +273,17 @@ impl StorageConfig {
     pub fn randomize_ports(&mut self) {
         self.backup_service_address
             .set_port(utils::get_available_port());
+    }
+}
+
+impl ConfigSanitizer for StorageConfig {
+    /// Validate and process the storage config according to the given node role and chain ID
+    fn sanitize(
+        _node_config: &mut NodeConfig,
+        _node_role: RoleType,
+        _chain_id: ChainId,
+    ) -> Result<(), Error> {
+        Ok(()) // TODO: add validation of higher-level properties once we have variable configs
     }
 }
 

--- a/config/src/config/test_data/validator.yaml
+++ b/config/src/config/test_data/validator.yaml
@@ -50,6 +50,7 @@ validator_network:
             ca_certificate: "/full/path/to/certificate"
             token:
                 from_disk: "/full/path/to/token"
+    network_id: "validator"
     ### Load keys from file
     # identity:
     #     type: "from_file"

--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -168,7 +168,7 @@ impl ValidatorNodeConfig {
     }
 
     fn save_config(&mut self) -> anyhow::Result<()> {
-        Ok(self.config.save(self.dir.join(CONFIG_FILE))?)
+        Ok(self.config.save_to_path(self.dir.join(CONFIG_FILE))?)
     }
 }
 
@@ -365,7 +365,9 @@ impl FullnodeNodeConfig {
     }
 
     fn save_config(&mut self) -> anyhow::Result<()> {
-        self.config.save(self.config_path()).map_err(Into::into)
+        self.config
+            .save_to_path(self.config_path())
+            .map_err(Into::into)
     }
 }
 

--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -62,8 +62,13 @@ impl LocalNode {
         account_private_key: Option<ConfigKey<Ed25519PrivateKey>>,
     ) -> Result<Self> {
         let config_path = directory.join("node.yaml");
-        let config = NodeConfig::load_from_path(&config_path)
-            .with_context(|| format!("Failed to load NodeConfig from file: {:?}", config_path))?;
+        let config = NodeConfig::load_from_path(&config_path).map_err(|error| {
+            anyhow!(
+                "Failed to load NodeConfig from file: {:?}. Error: {:?}",
+                config_path,
+                error
+            )
+        })?;
         let peer_id = config
             .get_peer_id()
             .ok_or_else(|| anyhow!("unable to retrieve PeerId from config"))?;

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -207,7 +207,7 @@ impl LocalSwarm {
                 };
 
                 // Since the validator's config has changed we need to save it
-                validator_config.save(validator.config_path())?;
+                validator_config.save_to_path(validator.config_path())?;
                 *validator.config_mut() = validator_config;
 
                 Ok((validator.peer_id(), public_network))

--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -13,7 +13,7 @@ use crate::{
     workspace_builder::workspace_root,
 };
 use anyhow::anyhow;
-use aptos_config::config::NodeConfig;
+use aptos_config::config::{InitialSafetyRulesConfig, NodeConfig};
 use aptos_forge::{get_highest_synced_version, LocalNode, Node, NodeExt, SwarmExt, Validator};
 use aptos_logger::prelude::*;
 use aptos_temppath::TempPath;
@@ -206,6 +206,10 @@ async fn test_genesis_transaction_flow() {
     for (expected_to_connect, node) in env.validators_mut().take(3).enumerate() {
         let mut node_config = node.config().clone();
         insert_waypoint(&mut node_config, waypoint);
+        node_config
+            .consensus
+            .safety_rules
+            .initial_safety_rules_config = InitialSafetyRulesConfig::None;
         node_config.execution.genesis = Some(genesis_transaction.clone());
         // reset the sync_only flag to false
         node_config.consensus.sync_only = false;

--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -31,7 +31,7 @@ use std::{
 fn update_node_config_restart(validator: &mut LocalNode, mut config: NodeConfig) {
     validator.stop();
     let node_path = validator.config_path();
-    config.save(node_path).unwrap();
+    config.save_to_path(node_path).unwrap();
     validator.start().unwrap();
 }
 
@@ -259,7 +259,7 @@ async fn test_genesis_transaction_flow() {
     node.stop();
     let mut node_config = node.config().clone();
     node_config.consensus.sync_only = false;
-    node_config.save(node.config_path()).unwrap();
+    node_config.save_to_path(node.config_path()).unwrap();
 
     let db_dir = node.config().storage.dir();
     fs::remove_dir_all(&db_dir).unwrap();

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -37,7 +37,7 @@ async fn test_full_node_bootstrap_state_snapshot() {
     let validator = swarm.validators_mut().next().unwrap();
     let mut config = validator.config().clone();
     config.state_sync.storage_service.max_state_chunk_size = 2;
-    config.save(validator.config_path()).unwrap();
+    config.save_to_path(validator.config_path()).unwrap();
     validator.restart().await.unwrap();
     validator
         .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_HEALTHY_WAIT_SECS))

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -122,7 +122,7 @@ async fn test_db_restore() {
     let mut node0_config = swarm.validator(node_to_restart).unwrap().config().clone();
     let genesis_waypoint = node0_config.base.waypoint.genesis_waypoint();
     insert_waypoint(&mut node0_config, genesis_waypoint);
-    node0_config.save(node0_config_path).unwrap();
+    node0_config.save_to_path(node0_config_path).unwrap();
     let db_dir = node0_config.storage.dir();
     fs::remove_dir_all(db_dir.clone()).unwrap();
 

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -85,18 +85,12 @@ pub async fn assert_balance(client: &RestClient, account: &LocalAccount, balance
 /// node swarm, or a public full node swarm.
 #[cfg(test)]
 pub mod swarm_utils {
-    use aptos_config::config::{
-        InitialSafetyRulesConfig, NodeConfig, SecureBackend, WaypointConfig,
-    };
+    use aptos_config::config::{NodeConfig, SecureBackend, WaypointConfig};
     use aptos_secure_storage::{KVStorage, Storage};
     use aptos_types::waypoint::Waypoint;
 
     pub fn insert_waypoint(node_config: &mut NodeConfig, waypoint: Waypoint) {
         node_config.base.waypoint = WaypointConfig::FromConfig(waypoint);
-        node_config
-            .consensus
-            .safety_rules
-            .initial_safety_rules_config = InitialSafetyRulesConfig::None;
 
         let f = |backend: &SecureBackend| {
             let mut storage: Storage = backend.into();


### PR DESCRIPTION
Note: this PR is based on: https://github.com/aptos-labs/aptos-core/pull/7781

### Description
This PR adds a simple `ConfigSanitizer` component to the node configs. The purpose of the `ConfigSanitizer` is to validate, sanity check and sanitize all configs on node startup, to help ensure configs are well-formed and consistent (e.g., that invariants hold across node types and networks).

To do this, we: (i) load the config from disk; (ii) extract the node role from the config; (iii) extract the chain ID from the genesis blob; and (iv) validate the config according to the node role, chain ID and compilation flags. This allows us to enforce various properties about the configs. Note: we're already doing some of these verifications today, but: (i) we're missing a lot of basic checks to prevent users from shooting themselves in the foot; and (ii) whatever checks we do have are spread throughout the code, making it difficult to reason about. The `ConfigSanitizer` will at least provide us a single source of truth regarding config quality.

The PR offers two commits:
1. Add the new sanitizer trait and implementations.
2. Add unit tests to verify sanitizer correctness.

Note:
- I haven't added all the checks we may want to add (only some obvious ones), but we can extend the checks once this lands.
- My next step is to add support for fine-grained node config defaults.

### Test Plan
New and existing test infrastructure.