### PR TITLE
[cli] Fix vector<string> input in the CLI

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -1354,11 +1354,7 @@ impl FunctionArgType {
                     }),
                     // Note commas cannot be put into the strings.  But, this should be a less likely case,
                     // and the utility from having this available should be worth it.
-                    FunctionArgType::String => parse_vector_arg(arg, |arg| {
-                        bcs::to_bytes(arg).map_err(|err| {
-                            CliError::UnableToParse("vector<string>", err.to_string())
-                        })
-                    }),
+                    FunctionArgType::String => parse_vector_arg(arg, |arg| Ok(String::from(arg))),
                     FunctionArgType::U8 => parse_vector_arg(arg, |arg| {
                         u8::from_str(arg)
                             .map_err(|err| CliError::UnableToParse("vector<u8>", err.to_string()))
@@ -1565,7 +1561,6 @@ impl FromStr for ArgWithType {
                 "Arguments must be pairs of <type>:<arg> e.g. bool:true".to_string(),
             ));
         }
-
         let ty = FunctionArgType::from_str(parts.first().unwrap())?;
         let arg = parts.last().unwrap();
         let arg = ty.parse_arg(arg)?;


### PR DESCRIPTION
### Description
Strings were being double BCS encoded, this fixes this

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
This now works
```
aptos move run --function-id '0x4::aptos_token::mint' --args 'string:test collection' 'string:' 'string:normal token' 'string:uri' 'vector<string>:size' 'vector<string>:u8' 'hex_array:00' --profile local`

```