### PR TITLE
[CLI] Add nested vector arg support, docs (#7709)

### DIFF
--- a/aptos-move/move-examples/cli_args/Move.toml
+++ b/aptos-move/move-examples/cli_args/Move.toml
@@ -1,0 +1,12 @@
+[package]
+name = "CliArgs"
+version = "0.1.0"
+upgrade_policy = "compatible"
+
+[addresses]
+deploy_address = "_"
+std = "0x1"
+aptos_framework = "0x1"
+
+[dependencies]
+AptosFramework = { local = "../../framework/aptos-framework" }

--- a/aptos-move/move-examples/cli_args/sources/cli_args.move
+++ b/aptos-move/move-examples/cli_args/sources/cli_args.move
@@ -1,0 +1,37 @@
+module deploy_address::cli_args {
+    use std::signer;
+
+    struct Holder has key {
+        u8_solo: u8,
+        bool_vec: vector<bool>,
+        address_vec_vec: vector<vector<address>>,
+    }
+
+
+    #[view]
+    public fun reveal(host: address): (u8, vector<bool>, vector<vector<address>>) acquires Holder {
+        let holder_ref = borrow_global<Holder>(host);
+        (holder_ref.u8_solo, holder_ref.bool_vec, holder_ref.address_vec_vec)
+    }
+
+    public entry fun set_vals(
+        account: signer,
+        u8_solo: u8,
+        bool_vec: vector<bool>,
+        address_vec_vec: vector<vector<address>>,
+    ) acquires Holder {
+        let account_addr = signer::address_of(&account);
+        if (!exists<Holder>(account_addr)) {
+            move_to(&account, Holder {
+                u8_solo,
+                bool_vec,
+                address_vec_vec,
+            })
+        } else {
+            let old_holder = borrow_global_mut<Holder>(account_addr);
+            old_holder.u8_solo = u8_solo;
+            old_holder.bool_vec = bool_vec;
+            old_holder.address_vec_vec = address_vec_vec;
+        }
+    }
+}

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -12,11 +12,11 @@ use crate::{
     common::{
         init::{InitTool, Network},
         types::{
-            account_address_from_public_key, AccountAddressWrapper, CliError, CliTypedResult,
-            EncodingOptions, EntryFunctionArguments, FaucetOptions, GasOptions, KeyType,
-            MoveManifestAccountWrapper, MovePackageDir, OptionalPoolAddressArgs, PoolAddressArgs,
-            PrivateKeyInputOptions, PromptOptions, PublicKeyInputOptions, RestOptions, RngArgs,
-            SaveFile, TransactionOptions, TransactionSummary,
+            account_address_from_public_key, AccountAddressWrapper, ArgWithTypeVec, CliError,
+            CliTypedResult, EncodingOptions, EntryFunctionArguments, FaucetOptions, GasOptions,
+            KeyType, MoveManifestAccountWrapper, MovePackageDir, OptionalPoolAddressArgs,
+            PoolAddressArgs, PrivateKeyInputOptions, PromptOptions, PublicKeyInputOptions,
+            RestOptions, RngArgs, SaveFile, TransactionOptions, TransactionSummary,
         },
         utils::write_to_file,
     },
@@ -318,10 +318,12 @@ impl CliTestFramework {
                     ),
                     member_id: Identifier::from_str("transfer").unwrap(),
                 },
-                args: vec![
-                    ArgWithType::from_str("address:0xdeadbeefcafebabe").unwrap(),
-                    ArgWithType::from_str(&format!("u64:{}", amount)).unwrap(),
-                ],
+                arg_vec: ArgWithTypeVec {
+                    args: vec![
+                        ArgWithType::from_str("address:0xdeadbeefcafebabe").unwrap(),
+                        ArgWithType::from_str(&format!("u64:{}", amount)).unwrap(),
+                    ],
+                },
                 type_args: vec![MoveType::Struct(MoveStructTag::new(
                     AccountAddress::ONE.into(),
                     IdentifierWrapper::from_str("aptos_coin").unwrap(),
@@ -591,13 +593,15 @@ impl CliTestFramework {
             entry_function_args: EntryFunctionArguments {
                 function_id: MemberId::from_str("0x1::staking_contract::create_staking_contract")
                     .unwrap(),
-                args: vec![
-                    ArgWithType::address(self.account_id(operator_index)),
-                    ArgWithType::address(self.account_id(voter_index)),
-                    ArgWithType::u64(amount),
-                    ArgWithType::u64(commission_percentage),
-                    ArgWithType::bytes(vec![]),
-                ],
+                arg_vec: ArgWithTypeVec {
+                    args: vec![
+                        ArgWithType::address(self.account_id(operator_index)),
+                        ArgWithType::address(self.account_id(voter_index)),
+                        ArgWithType::u64(amount),
+                        ArgWithType::u64(commission_percentage),
+                        ArgWithType::bytes(vec![]),
+                    ],
+                },
                 type_args: vec![],
             },
             txn_options: self.transaction_options(owner_index, None),
@@ -912,7 +916,7 @@ impl CliTestFramework {
             txn_options: self.transaction_options(index, gas_options),
             entry_function_args: EntryFunctionArguments {
                 function_id,
-                args: parsed_args,
+                arg_vec: ArgWithTypeVec { args: parsed_args },
                 type_args: parsed_type_args,
             },
         }
@@ -976,7 +980,7 @@ impl CliTestFramework {
                 framework_package_args,
                 bytecode_version: None,
             },
-            args: Vec::new(),
+            arg_vec: ArgWithTypeVec { args: Vec::new() },
             type_args: Vec::new(),
         }
         .execute()
@@ -1002,7 +1006,7 @@ impl CliTestFramework {
                 },
                 bytecode_version: None,
             },
-            args,
+            arg_vec: ArgWithTypeVec { args },
             type_args,
         }
         .execute()

--- a/developer-docs-site/docs/tools/aptos-cli-tool/use-aptos-cli.md
+++ b/developer-docs-site/docs/tools/aptos-cli-tool/use-aptos-cli.md
@@ -750,6 +750,54 @@ The `peer_config.yaml` file will be created in your current working directory, w
 
 Move examples can be found in the [Move section](../../move/move-on-aptos/cli).
 
+You can also pass multi-nested vector arguments, like in the `cli_args` example from [move-examples](https://github.com/aptos-labs/aptos-core/tree/main/aptos-move/move-examples):
+
+:::tip
+To pass vectors (including nested vectors) as arguments, use JSON syntax escaped with quotes!
+:::
+
+```zsh
+aptos move run \
+    --function-id <deployer_address>::cli_args::set_vals \
+    --private-key-file <your-key-file> \
+    --args \
+        u8:123 \
+        "bool:[false, true, false, false]" \
+        'address:[["0xace", "0xbee"], ["0xcad"], ["0xdee"], []]'
+```
+
+Then you can call the view function to see your arguments persisted on-chain!
+
+```zsh
+aptos move view \
+    --function-id <deployer_address>::cli_args::reveal \
+    --args address:<deployer_address>
+{
+  "Result": [
+    123,
+    [
+      false,
+      true,
+      false,
+      false
+    ],
+    [
+      [
+        "0xace",
+        "0xbee"
+      ],
+      [
+        "0xcad"
+      ],
+      [
+        "0xdee"
+      ],
+      []
+    ]
+  ]
+}
+```
+
 ## Node command examples
 
 This section summarizes how to run a local testnet with Aptos CLI. See [Run a Local Testnet with Aptos CLI](../../nodes/local-testnet/using-cli-to-run-a-local-testnet.md) for more details.


### PR DESCRIPTION
@davidiw @gregnazario @movekevin

Addresses #7709 

# Summary of changes

* Implement recursive vector parsing for `ArgWithType`
* Abstract out `ArgWithTypeVec` field in accordance with [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) design principles
* Add Move example with multiple nested vector permutations
* Add CLI docs for running example Move code

# Vector syntax

Previously, the CLI was restricted to vector arguments with a maximum depth of 1, per the below syntax:

`vector<u8>:2,5,3`

Notably, this schema does *not* support doubly nested vectors of the form `vector<vector<u8>>`, as there is no way to delimit inner vectors.

However, since Move vectors must all use the same inner type, the new schema employs JSON array syntax of the form:

`"u8:[[1, 2], [], [4, 5, 6]]"`

Note here the use of quotes to escape spaces and square braces, as required for typical shell interpreters like `zsh`.

Hence as described in the docs example from this PR, a Move function can be invoked via syntax of the form:

```zsh
aptos move run \
    --function-id <deploy_address>::cli_args::set_vals \
    --private-key-file <keyfile> \
    --args \
        u8:123 \
        "bool:[false, true, false, false]" \
        'address:[["0xace", "0xbee"], ["0xcad"], ["0xdee"], []]'
```

# Additional example

See also testnet transaction [499639189](https://explorer.aptoslabs.com/txn/499639189/payload?network=testnet) for a public entry function invocation with a `vector<vector<u64>>` argument, run from the CLI via:

```zsh
aptos move run \
    --function-id $testnet_address::incentives::update_incentives \
    --private-key-file tesnet_account.key \
    --type-args 0x1::aptos_coin::AptosCoin \
    --args \
        u64:1 \
        u64:1 \
        u64:1 \
        u64:2000 \
        "u64:[[10000, 0, 7], [8333, 1, 6], [7692, 2, 5], [7143, 3, 4], [6667, 4, 3], [6250, 5, 2], [5882, 6, 1]]"
```

# Local checks

The following commands were run in the below directories:

* `aptos-core/`

    ```zsh
    pre-commit run --all-files
    scripts/rust_lint.sh
    ```

* `aptos-core/crates/aptos/`

    ```zsh
    cargo test
    ```

* `aptos-core/developer-docs-site/`

    ```
    pnpm spellcheck
    pnpm lint
    ```

