### PR TITLE
[API] Log aptos client based on a custom header rather than user agent

### DIFF
--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -9,6 +9,7 @@ use crate::{
     view_function::ViewFunctionApi,
 };
 use anyhow::Context as AnyhowContext;
+use aptos_api_types::X_APTOS_CLIENT;
 use aptos_config::config::{ApiConfig, NodeConfig};
 use aptos_logger::info;
 use aptos_mempool::MempoolClientSender;
@@ -169,7 +170,11 @@ pub fn attach_poem_to_runtime(
             // https://stackoverflow.com/a/24689738/3846032
             .allow_credentials(true)
             .allow_methods(vec![Method::GET, Method::POST])
-            .allow_headers(vec![header::CONTENT_TYPE, header::ACCEPT]);
+            .allow_headers(vec![
+                header::HeaderName::from_static(X_APTOS_CLIENT),
+                header::CONTENT_TYPE,
+                header::ACCEPT,
+            ]);
 
         // Build routes for the API
         let route = Route::new()

--- a/api/types/src/headers.rs
+++ b/api/types/src/headers.rs
@@ -17,3 +17,5 @@ pub const X_APTOS_OLDEST_BLOCK_HEIGHT: &str = "X-Aptos-Oldest-Block-Height";
 pub const X_APTOS_LEDGER_TIMESTAMP: &str = "X-Aptos-Ledger-TimestampUsec";
 /// Cursor used for pagination.
 pub const X_APTOS_CURSOR: &str = "X-Aptos-Cursor";
+/// Provided by the client to identify what client it is.
+pub const X_APTOS_CLIENT: &str = "x-aptos-client";


### PR DESCRIPTION
### Description
Turns out some browsers don't let you modify the User-Agent string so we need to use our own header to identify the client.

See also the PR that originally added this using the User-Agent string: https://github.com/aptos-labs/aptos-core/pull/7037.

### Test Plan
Run local testnet:
```
cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes --with-faucet
```

Make a couple of requests with just curl:
```
curl http://127.0.0.1:8080/v1
curl http://127.0.0.1:8080/v1/accounts/0x1
```
Make a couple of requests with the header set, to which we just added the User-Agent stuff.
```
curl -H 'X-Aptos-Client: aptos-cli/1.0.11' http://127.0.0.1:8080/v1/accounts/0x1
```

See the metrics pushed appropriately, with `request-source-client-unknown` for the former and `aptos-cli/1.8.0` for the latter:
```
curl -s http://127.0.0.1:9101/metrics | grep -i request_source
```
```
aptos_api_request_source_client{operation_id="estimate_gas_price",request_source_client="unknown",status="200"} 1
aptos_api_request_source_client{operation_id="get_account",request_source_client="aptos-cli/1.0.11",status="200"} 1
aptos_api_request_source_client{operation_id="get_account",request_source_client="unknown",status="200"} 2
aptos_api_request_source_client{operation_id="get_account",request_source_client="unknown",status="404"} 1
aptos_api_request_source_client{operation_id="get_account_resources",request_source_client="unknown",status="200"} 1
aptos_api_request_source_client{operation_id="get_ledger_info",request_source_client="unknown",status="200"} 2
aptos_api_request_source_client{operation_id="get_transaction_by_hash",request_source_client="unknown",status="200"} 37
aptos_api_request_source_client{operation_id="submit_transaction",request_source_client="unknown",status="202"} 3
```
