### PR TITLE
[Peer Monitor] Add build info to the node info requests.

### DIFF
--- a/network/peer-monitoring-service/client/src/peer_states/node_info.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/node_info.rs
@@ -14,7 +14,11 @@ use aptos_peer_monitoring_service_types::{
     response::{NodeInformationResponse, PeerMonitoringServiceResponse},
 };
 use aptos_time_service::TimeService;
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
+
+// The maximum number of entries and string lengths in the build info map
+const MAX_BUILD_INFORMATION_ENTRIES: usize = 100;
+const MAX_BUILD_INFORMATION_STRING_LENGTH: usize = 200;
 
 /// A simple container that holds a single peer's node info
 #[derive(Clone, Debug)]
@@ -80,7 +84,7 @@ impl StateValueInterface for NodeInfoState {
         _response_time_secs: f64,
     ) {
         // Verify the response type is valid
-        let node_info_response = match monitoring_service_response {
+        let mut node_info_response = match monitoring_service_response {
             PeerMonitoringServiceResponse::NodeInformation(node_information_response) => {
                 node_information_response
             },
@@ -95,6 +99,27 @@ impl StateValueInterface for NodeInfoState {
                 return;
             },
         };
+
+        // Verify the build information does not have too many entries
+        let num_build_information_entries = node_info_response.build_information.len();
+        if num_build_information_entries > MAX_BUILD_INFORMATION_ENTRIES {
+            warn!(LogSchema::new(LogEntry::NodeInfoRequest)
+                .event(LogEvent::ResponseError)
+                .peer(peer_network_id)
+                .message(&format!(
+                    "The build information is too large! Got length {:?} but the max is {:?}!",
+                    num_build_information_entries, MAX_BUILD_INFORMATION_ENTRIES
+                )));
+            self.handle_request_failure();
+            return;
+        }
+
+        // Trim the entries of the build information (if they are too long)
+        let build_information = node_info_response
+            .build_information
+            .iter()
+            .map(|(key, value)| (trim_to_max_length(key), trim_to_max_length(value)));
+        node_info_response.build_information = BTreeMap::from_iter(build_information);
 
         // Store the new latency ping result
         self.record_node_info_response(node_info_response);
@@ -117,9 +142,25 @@ impl StateValueInterface for NodeInfoState {
     }
 }
 
+/// Trims the specified string to the maximum length
+/// allowed in the build info map and returns the
+/// (possibly) truncated string.
+fn trim_to_max_length(string_to_trim: &str) -> String {
+    if string_to_trim.len() > MAX_BUILD_INFORMATION_STRING_LENGTH {
+        string_to_trim[0..MAX_BUILD_INFORMATION_STRING_LENGTH].into()
+    } else {
+        string_to_trim.into()
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use crate::peer_states::{key_value::StateValueInterface, node_info::NodeInfoState};
+    use crate::peer_states::{
+        key_value::StateValueInterface,
+        node_info::{
+            NodeInfoState, MAX_BUILD_INFORMATION_ENTRIES, MAX_BUILD_INFORMATION_STRING_LENGTH,
+        },
+    };
     use aptos_config::{
         config::{NodeMonitoringConfig, PeerRole},
         network_id::PeerNetworkId,
@@ -136,10 +177,109 @@ mod test {
     };
     use aptos_time_service::TimeService;
     use aptos_types::network_address::NetworkAddress;
-    use std::{str::FromStr, time::Duration};
+    use std::{collections::BTreeMap, str::FromStr, time::Duration};
 
     // Useful test constants
     const TEST_NETWORK_ADDRESS: &str = "/ip4/127.0.0.1/tcp/8081";
+
+    #[test]
+    fn test_sanity_check_build_info() {
+        // Create the node info state
+        let node_monitoring_config = NodeMonitoringConfig::default();
+        let time_service = TimeService::mock();
+        let mut node_info_state = NodeInfoState::new(node_monitoring_config, time_service);
+
+        // Verify the initial node info state
+        verify_empty_node_response(&node_info_state);
+
+        // Generate the test data
+        let highest_synced_epoch = 0;
+        let highest_synced_version = 100;
+        let ledger_timestamp_usecs = 200;
+        let lowest_available_version = highest_synced_version - 10;
+        let uptime = Duration::from_millis(999);
+
+        // Create a build info map that has too many entries (with long strings)
+        let mut build_information = BTreeMap::new();
+        for i in 0..MAX_BUILD_INFORMATION_ENTRIES + 1 {
+            let counter_string = format!("{}", i);
+            let key = repeat_substring(&counter_string, MAX_BUILD_INFORMATION_STRING_LENGTH + 1);
+            let value = repeat_substring(&counter_string, MAX_BUILD_INFORMATION_STRING_LENGTH + 1);
+            build_information.insert(key, value);
+        }
+
+        // Create the service response
+        let node_information_response = NodeInformationResponse {
+            build_information: build_information.clone(),
+            highest_synced_epoch,
+            highest_synced_version,
+            ledger_timestamp_usecs,
+            lowest_available_version,
+            uptime,
+        };
+
+        // Handle the node info response
+        handle_monitoring_service_response(&mut node_info_state, node_information_response);
+
+        // Verify there is still no latest node info response
+        verify_empty_node_response(&node_info_state);
+
+        // Verify the number of consecutive request failures has increased
+        let num_consecutive_failures = node_info_state
+            .get_request_tracker()
+            .read()
+            .get_num_consecutive_failures();
+        assert_eq!(num_consecutive_failures, 1);
+
+        // Modify the build info map to be the correct size
+        build_information.pop_last().unwrap();
+
+        // Create the service response
+        let node_information_response = NodeInformationResponse {
+            build_information,
+            highest_synced_epoch,
+            highest_synced_version,
+            ledger_timestamp_usecs,
+            lowest_available_version,
+            uptime,
+        };
+
+        // Handle the node info response
+        handle_monitoring_service_response(&mut node_info_state, node_information_response);
+
+        // Verify the number of consecutive request failures has reset
+        let num_consecutive_failures = node_info_state
+            .get_request_tracker()
+            .read()
+            .get_num_consecutive_failures();
+        assert_eq!(num_consecutive_failures, 0);
+
+        // Verify the basic properties of the latest node info response
+        let latest_node_info_response = node_info_state.get_latest_node_info_response().unwrap();
+        assert_eq!(
+            latest_node_info_response.highest_synced_epoch,
+            highest_synced_epoch
+        );
+        assert_eq!(
+            latest_node_info_response.highest_synced_version,
+            highest_synced_version
+        );
+        assert_eq!(
+            latest_node_info_response.ledger_timestamp_usecs,
+            ledger_timestamp_usecs
+        );
+        assert_eq!(
+            latest_node_info_response.lowest_available_version,
+            lowest_available_version
+        );
+        assert_eq!(latest_node_info_response.uptime, uptime);
+
+        // Verify the latest node info response contains trimmed build info strings
+        for (key, value) in latest_node_info_response.build_information.iter() {
+            assert!(key.len() <= MAX_BUILD_INFORMATION_STRING_LENGTH);
+            assert!(value.len() <= MAX_BUILD_INFORMATION_STRING_LENGTH);
+        }
+    }
 
     #[test]
     fn test_verify_node_info_state() {
@@ -154,16 +294,19 @@ mod test {
         // Handle several valid node info responses and verify the state
         for i in 0..10 {
             // Generate the test data
-            let git_hash = i.to_string();
             let highest_synced_epoch = i;
             let highest_synced_version = (i + 1) * 100;
             let ledger_timestamp_usecs = (i + 1) * 200;
             let lowest_available_version = highest_synced_version - 10;
             let uptime = Duration::from_millis(i * 999);
 
+            // Generate the build info map
+            let mut build_information = BTreeMap::new();
+            build_information.insert(i.to_string(), i.to_string());
+
             // Create the service response
             let node_information_response = NodeInformationResponse {
-                git_hash,
+                build_information,
                 highest_synced_epoch,
                 highest_synced_version,
                 ledger_timestamp_usecs,
@@ -180,6 +323,16 @@ mod test {
             // Verify the latest node info state
             verify_node_info_state(&node_info_state, node_information_response);
         }
+    }
+
+    /// Repeats the given substring the specified number of times
+    /// and returns the resulting string.
+    fn repeat_substring(substring: &str, num_repeats: usize) -> String {
+        let mut result = String::new();
+        for _ in 0..num_repeats {
+            result.push_str(substring);
+        }
+        result
     }
 
     /// Handles a monitoring service response from a peer

--- a/network/peer-monitoring-service/client/src/tests/utils.rs
+++ b/network/peer-monitoring-service/client/src/tests/utils.rs
@@ -25,10 +25,10 @@ use aptos_peer_monitoring_service_types::{
 };
 use aptos_time_service::{MockTimeService, TimeService, TimeServiceTrait};
 use aptos_types::{network_address::NetworkAddress, PeerId};
-use maplit::hashmap;
+use maplit::btreemap;
 use rand::{rngs::OsRng, Rng};
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     future::Future,
     sync::Arc,
     time::{Duration, Instant},
@@ -92,13 +92,13 @@ pub fn config_without_node_info_requests() -> NodeConfig {
 }
 
 /// Returns a simple connected peers map for testing purposes
-pub fn create_connected_peers_map() -> HashMap<PeerNetworkId, ConnectionMetadata> {
-    hashmap! { PeerNetworkId::random() => ConnectionMetadata::new(NetworkAddress::mock(), PeerId::random(), PeerRole::Unknown) }
+pub fn create_connected_peers_map() -> BTreeMap<PeerNetworkId, ConnectionMetadata> {
+    btreemap! { PeerNetworkId::random() => ConnectionMetadata::new(NetworkAddress::mock(), PeerId::random(), PeerRole::Unknown) }
 }
 
 /// Creates a network info response with the given data
 pub fn create_network_info_response(
-    connected_peers: &HashMap<PeerNetworkId, ConnectionMetadata>,
+    connected_peers: &BTreeMap<PeerNetworkId, ConnectionMetadata>,
     distance_from_validators: u64,
 ) -> NetworkInformationResponse {
     NetworkInformationResponse {
@@ -410,7 +410,7 @@ pub fn update_network_info_for_peer(
     peers_and_metadata: Arc<PeersAndMetadata>,
     peer_network_id: &PeerNetworkId,
     peer_state: &mut PeerState,
-    connected_peers: HashMap<PeerNetworkId, ConnectionMetadata>,
+    connected_peers: BTreeMap<PeerNetworkId, ConnectionMetadata>,
     distance_from_validators: u64,
     response_time_secs: f64,
 ) {

--- a/network/peer-monitoring-service/client/src/tests/utils.rs
+++ b/network/peer-monitoring-service/client/src/tests/utils.rs
@@ -28,7 +28,7 @@ use aptos_types::{network_address::NetworkAddress, PeerId};
 use maplit::hashmap;
 use rand::{rngs::OsRng, Rng};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     future::Future,
     sync::Arc,
     time::{Duration, Instant},
@@ -109,7 +109,7 @@ pub fn create_network_info_response(
 
 /// Creates a node info response with the given data
 pub fn create_node_info_response(
-    git_hash: String,
+    build_information: BTreeMap<String, String>,
     highest_synced_epoch: u64,
     highest_synced_version: u64,
     ledger_timestamp_usecs: u64,
@@ -117,7 +117,7 @@ pub fn create_node_info_response(
     uptime: Duration,
 ) -> NodeInformationResponse {
     NodeInformationResponse {
-        git_hash,
+        build_information,
         highest_synced_epoch,
         highest_synced_version,
         ledger_timestamp_usecs,
@@ -298,7 +298,7 @@ pub fn create_random_network_info_response() -> NetworkInformationResponse {
 /// Creates a new network info response with random values
 pub fn create_random_node_info_response() -> NodeInformationResponse {
     // Create the random values
-    let git_hash = aptos_build_info::get_git_hash();
+    let build_information = aptos_build_info::get_build_information();
     let highest_synced_epoch = get_random_u64();
     let highest_synced_version = get_random_u64();
     let ledger_timestamp_usecs = get_random_u64();
@@ -307,7 +307,7 @@ pub fn create_random_node_info_response() -> NodeInformationResponse {
 
     // Create and return the node info response
     create_node_info_response(
-        git_hash,
+        build_information,
         highest_synced_epoch,
         highest_synced_version,
         ledger_timestamp_usecs,

--- a/network/peer-monitoring-service/server/src/lib.rs
+++ b/network/peer-monitoring-service/server/src/lib.rs
@@ -253,7 +253,7 @@ impl<T: StorageReaderInterface> Handler<T> {
 
     fn get_node_information(&self) -> Result<PeerMonitoringServiceResponse, Error> {
         // Get the node information
-        let git_hash = aptos_build_info::get_git_hash();
+        let build_information = aptos_build_info::get_build_information();
         let current_time: Instant = self.time_service.now();
         let uptime = current_time.duration_since(self.start_time);
         let (highest_synced_epoch, highest_synced_version) =
@@ -263,7 +263,7 @@ impl<T: StorageReaderInterface> Handler<T> {
 
         // Create and return the response
         let node_information_response = NodeInformationResponse {
-            git_hash,
+            build_information,
             highest_synced_epoch,
             highest_synced_version,
             ledger_timestamp_usecs,

--- a/network/peer-monitoring-service/server/src/tests.rs
+++ b/network/peer-monitoring-service/server/src/tests.rs
@@ -442,7 +442,7 @@ async fn verify_node_information(
     // Verify the response is correct
     let expected_response =
         PeerMonitoringServiceResponse::NodeInformation(NodeInformationResponse {
-            git_hash: aptos_build_info::get_git_hash(),
+            build_information: aptos_build_info::get_build_information(),
             highest_synced_epoch,
             highest_synced_version,
             ledger_timestamp_usecs,

--- a/network/peer-monitoring-service/server/src/tests.rs
+++ b/network/peer-monitoring-service/server/src/tests.rs
@@ -59,10 +59,15 @@ use aptos_types::{
     PeerId,
 };
 use futures::channel::oneshot;
-use maplit::hashmap;
+use maplit::btreemap;
 use mockall::mock;
 use rand::{rngs::OsRng, Rng};
-use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    collections::{BTreeMap, HashMap},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 
 // Useful test constants
 const LOCAL_HOST_NET_ADDR: &str = "/ip4/127.0.0.1/tcp/8081";
@@ -99,7 +104,7 @@ async fn test_get_network_information_fullnode() {
     // Process a client request to fetch the network information and verify an empty response
     verify_network_information(
         &mut mock_client,
-        HashMap::new(),
+        BTreeMap::new(),
         MAX_DISTANCE_FROM_VALIDATORS,
     )
     .await;
@@ -113,7 +118,7 @@ async fn test_get_network_information_fullnode() {
         .unwrap();
 
     // Process a client request to fetch the network information and verify the response
-    let expected_peers = hashmap! {peer_network_id_1 => connection_metadata_1.clone()};
+    let expected_peers = btreemap! {peer_network_id_1 => connection_metadata_1.clone()};
     verify_network_information(
         &mut mock_client,
         expected_peers.clone(),
@@ -160,7 +165,7 @@ async fn test_get_network_information_fullnode() {
     // Process a client request to fetch the network information and verify the response
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => connection_metadata_1.clone()},
+        btreemap! {peer_network_id_1 => connection_metadata_1.clone()},
         peer_distance_1 + 1,
     )
     .await;
@@ -170,7 +175,7 @@ async fn test_get_network_information_fullnode() {
     let peer_network_id_2 = PeerNetworkId::new(NetworkId::Validator, peer_id_2);
     let peer_distance_2 = 0; // The peer is a validator
     let connection_metadata_2 = create_connection_metadata(peer_id_2);
-    let expected_peers = hashmap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2.clone()};
+    let expected_peers = btreemap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2.clone()};
     let latest_network_info_response = NetworkInformationResponse {
         connected_peers: transform_connection_metadata(expected_peers),
         distance_from_validators: peer_distance_2,
@@ -187,7 +192,7 @@ async fn test_get_network_information_fullnode() {
     // Process a client request to fetch the network information and verify the response
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2},
+        btreemap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2},
         peer_distance_2 + 1,
     )
     .await;
@@ -200,7 +205,7 @@ async fn test_get_network_information_fullnode() {
     // Process a request to fetch the network information and verify the response
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => connection_metadata_1},
+        btreemap! {peer_network_id_1 => connection_metadata_1},
         peer_distance_1 + 1,
     )
     .await;
@@ -218,7 +223,7 @@ async fn test_get_network_information_validator() {
     tokio::spawn(service.start());
 
     // Process a client request to fetch the network information and verify distance is 0
-    verify_network_information(&mut mock_client, HashMap::new(), 0).await;
+    verify_network_information(&mut mock_client, BTreeMap::new(), 0).await;
 
     // Connect a new peer to the validator (another validator)
     let peer_id_1 = PeerId::random();
@@ -229,7 +234,7 @@ async fn test_get_network_information_validator() {
         .unwrap();
 
     // Process a client request to fetch the network information and verify the response
-    let expected_peers = hashmap! {peer_network_id_1 => connection_metadata_1.clone()};
+    let expected_peers = btreemap! {peer_network_id_1 => connection_metadata_1.clone()};
     verify_network_information(&mut mock_client, expected_peers.clone(), 0).await;
 
     // Update the peer monitoring metadata for peer 1
@@ -252,7 +257,7 @@ async fn test_get_network_information_validator() {
     let peer_network_id_2 = PeerNetworkId::new(NetworkId::Vfn, peer_id_2);
     let peer_distance_2 = 1; // The peer is a VFN
     let connection_metadata_2 = create_connection_metadata(peer_id_2);
-    let expected_peers = hashmap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2.clone()};
+    let expected_peers = btreemap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2.clone()};
     let latest_network_info_response = NetworkInformationResponse {
         connected_peers: transform_connection_metadata(expected_peers.clone()),
         distance_from_validators: peer_distance_2,
@@ -277,7 +282,7 @@ async fn test_get_network_information_validator() {
     // Process a request to fetch the network information and verify the response
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => connection_metadata_1},
+        btreemap! {peer_network_id_1 => connection_metadata_1},
         0,
     )
     .await;
@@ -390,7 +395,7 @@ fn create_connection_metadata(peer_id: AccountAddress) -> ConnectionMetadata {
 /// client, and verifies the response is correct.
 async fn verify_network_information(
     client: &mut MockClient,
-    expected_peers: HashMap<PeerNetworkId, ConnectionMetadata>,
+    expected_peers: BTreeMap<PeerNetworkId, ConnectionMetadata>,
     expected_distance_from_validators: u64,
 ) {
     // Send a request to fetch the network information
@@ -409,8 +414,8 @@ async fn verify_network_information(
 /// Transforms the connection metadata for the given peers into
 /// metadata expected by the peer monitoring service.
 fn transform_connection_metadata(
-    expected_peers: HashMap<PeerNetworkId, ConnectionMetadata>,
-) -> HashMap<PeerNetworkId, aptos_peer_monitoring_service_types::response::ConnectionMetadata> {
+    expected_peers: BTreeMap<PeerNetworkId, ConnectionMetadata>,
+) -> BTreeMap<PeerNetworkId, aptos_peer_monitoring_service_types::response::ConnectionMetadata> {
     expected_peers
         .into_iter()
         .map(|(peer_id, metadata)| {

--- a/network/peer-monitoring-service/types/src/response.rs
+++ b/network/peer-monitoring-service/types/src/response.rs
@@ -4,7 +4,10 @@
 use aptos_config::{config::PeerRole, network_id::PeerNetworkId};
 use aptos_types::{network_address::NetworkAddress, PeerId};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::{BTreeMap, HashMap},
+    time::Duration,
+};
 use thiserror::Error;
 
 /// A peer monitoring service response
@@ -69,12 +72,12 @@ pub struct ServerProtocolVersionResponse {
 /// A response for the node information request
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct NodeInformationResponse {
-    pub git_hash: String, // The git hash of the build the peer is running on
-    pub highest_synced_epoch: u64, // The highest synced epoch of the node
-    pub highest_synced_version: u64, // The highest synced version of the node
+    pub build_information: BTreeMap<String, String>, // The build information of the node
+    pub highest_synced_epoch: u64,                   // The highest synced epoch of the node
+    pub highest_synced_version: u64,                 // The highest synced version of the node
     pub ledger_timestamp_usecs: u64, // The latest timestamp of the blockchain (in microseconds)
     pub lowest_available_version: u64, // The lowest stored version of the node (in storage)
-    pub uptime: Duration, // The amount of time the peer has been running
+    pub uptime: Duration,            // The amount of time the peer has been running
 }
 
 #[derive(Clone, Debug, Error)]

--- a/network/peer-monitoring-service/types/src/response.rs
+++ b/network/peer-monitoring-service/types/src/response.rs
@@ -4,10 +4,7 @@
 use aptos_config::{config::PeerRole, network_id::PeerNetworkId};
 use aptos_types::{network_address::NetworkAddress, PeerId};
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{BTreeMap, HashMap},
-    time::Duration,
-};
+use std::{collections::BTreeMap, time::Duration};
 use thiserror::Error;
 
 /// A peer monitoring service response
@@ -41,7 +38,7 @@ pub struct LatencyPingResponse {
 /// A response for the network information request
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct NetworkInformationResponse {
-    pub connected_peers: HashMap<PeerNetworkId, ConnectionMetadata>, // Connected peers
+    pub connected_peers: BTreeMap<PeerNetworkId, ConnectionMetadata>, // Connected peers
     pub distance_from_validators: u64, // The distance of the peer from the validator set
 }
 


### PR DESCRIPTION
### Description
This PR updates the peer monitoring service to share the build information for all peers (instead of just the git_hash). This should help improve build visibility in the wild west 😄 

### Test Plan
New and existing tests.