### PR TITLE
[Peer Monitor] Add build info to the node info requests and max message sizes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,6 +2323,7 @@ version = "0.1.0"
 dependencies = [
  "aptos-config",
  "aptos-types",
+ "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "serde 1.0.149",
  "thiserror",
 ]

--- a/config/src/config/peer_monitoring_config.rs
+++ b/config/src/config/peer_monitoring_config.rs
@@ -10,6 +10,7 @@ pub struct PeerMonitoringServiceConfig {
     pub latency_monitoring: LatencyMonitoringConfig,
     pub max_concurrent_requests: u64, // Max num of concurrent server tasks
     pub max_network_channel_size: u64, // Max num of pending network messages
+    pub max_num_response_bytes: u64,  // Max num of bytes in a (serialized) response
     pub max_request_jitter_ms: u64, // Max amount of jitter (ms) that a request will be delayed for
     pub metadata_update_interval_ms: u64, // The interval (ms) between metadata updates
     pub network_monitoring: NetworkMonitoringConfig,
@@ -24,7 +25,8 @@ impl Default for PeerMonitoringServiceConfig {
             latency_monitoring: LatencyMonitoringConfig::default(),
             max_concurrent_requests: 1000,
             max_network_channel_size: 1000,
-            max_request_jitter_ms: 1000, // Monitoring requests are very infrequent
+            max_num_response_bytes: 100 * 1024, // 100 KB
+            max_request_jitter_ms: 1000,        // Monitoring requests are very infrequent
             metadata_update_interval_ms: 5000,
             network_monitoring: NetworkMonitoringConfig::default(),
             node_monitoring: NodeMonitoringConfig::default(),

--- a/network/peer-monitoring-service/client/src/peer_states/node_info.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/node_info.rs
@@ -154,7 +154,7 @@ mod test {
         // Handle several valid node info responses and verify the state
         for i in 0..10 {
             // Generate the test data
-            let git_hash = i.to_string();
+            let build_information = aptos_build_info::get_build_information();
             let highest_synced_epoch = i;
             let highest_synced_version = (i + 1) * 100;
             let ledger_timestamp_usecs = (i + 1) * 200;
@@ -163,7 +163,7 @@ mod test {
 
             // Create the service response
             let node_information_response = NodeInformationResponse {
-                git_hash,
+                build_information,
                 highest_synced_epoch,
                 highest_synced_version,
                 ledger_timestamp_usecs,

--- a/network/peer-monitoring-service/client/src/tests/single_peer.rs
+++ b/network/peer-monitoring-service/client/src/tests/single_peer.rs
@@ -514,6 +514,7 @@ async fn test_network_info_request_failures() {
             false,
             true,
             false,
+            false,
         )
         .await;
 
@@ -542,6 +543,28 @@ async fn test_network_info_request_failures() {
             true,
             false,
             false,
+            false,
+        )
+        .await;
+
+        // Wait until the network info state is updated with the failure
+        wait_for_network_info_request_failure(&peer_monitor_state, &validator_peer, i + 1).await;
+    }
+
+    // Handle several network info requests with responses that are too large
+    for i in 10..15 {
+        // Elapse enough time for a network info update
+        elapse_network_info_update_interval(node_config.clone(), mock_time.clone()).await;
+
+        // Verify that a single network info request is received and send a response that is too large
+        verify_network_info_request_and_respond(
+            &network_id,
+            &mut mock_monitoring_server,
+            create_random_network_info_response(),
+            false,
+            false,
+            true,
+            false,
         )
         .await;
 
@@ -554,7 +577,7 @@ async fn test_network_info_request_failures() {
         &peer_monitor_state,
         &validator_peer,
         network_info_response.clone(),
-        10,
+        15,
     );
 
     // Elapse enough time for a network info request and perform a successful execution
@@ -584,7 +607,7 @@ async fn test_network_info_request_failures() {
     );
 
     // Handle several network info requests without responses
-    for i in 11..16 {
+    for i in 16..21 {
         // Elapse enough time for a network info update
         elapse_network_info_update_interval(node_config.clone(), mock_time.clone()).await;
 
@@ -595,12 +618,13 @@ async fn test_network_info_request_failures() {
             create_random_network_info_response(),
             false,
             false,
+            false,
             true,
         )
         .await;
 
         // Wait until the network info state is updated with the failure
-        wait_for_network_info_request_failure(&peer_monitor_state, &validator_peer, i - 10).await;
+        wait_for_network_info_request_failure(&peer_monitor_state, &validator_peer, i - 15).await;
     }
 
     // Verify the new network info state of the peer monitor
@@ -732,6 +756,27 @@ async fn test_node_info_request_failures() {
             create_random_node_info_response(),
             true,
             false,
+            false,
+        )
+        .await;
+
+        // Wait until the node info state is updated with the failure
+        wait_for_node_info_request_failure(&peer_monitor_state, &validator_peer, i + 1).await;
+    }
+
+    // Handle several node info requests with responses that are too large
+    for i in 5..10 {
+        // Elapse enough time for a node info update
+        elapse_node_info_update_interval(node_config.clone(), mock_time.clone()).await;
+
+        // Verify that a single node info request is received and send a response that is too large
+        verify_node_info_request_and_respond(
+            &network_id,
+            &mut mock_monitoring_server,
+            create_random_node_info_response(),
+            false,
+            true,
+            false,
         )
         .await;
 
@@ -740,7 +785,7 @@ async fn test_node_info_request_failures() {
     }
 
     // Handle several node info requests without responses
-    for i in 5..10 {
+    for i in 10..15 {
         // Elapse enough time for a node info update
         elapse_node_info_update_interval(node_config.clone(), mock_time.clone()).await;
 
@@ -749,6 +794,7 @@ async fn test_node_info_request_failures() {
             &network_id,
             &mut mock_monitoring_server,
             create_random_node_info_response(),
+            false,
             false,
             true,
         )
@@ -763,7 +809,7 @@ async fn test_node_info_request_failures() {
         &peer_monitor_state,
         &validator_peer,
         node_info_response.clone(),
-        10,
+        15,
     );
 
     // Elapse enough time for a node info request and perform a successful execution

--- a/network/peer-monitoring-service/client/src/tests/utils.rs
+++ b/network/peer-monitoring-service/client/src/tests/utils.rs
@@ -25,10 +25,10 @@ use aptos_peer_monitoring_service_types::{
 };
 use aptos_time_service::{MockTimeService, TimeService, TimeServiceTrait};
 use aptos_types::{network_address::NetworkAddress, PeerId};
-use maplit::hashmap;
+use maplit::btreemap;
 use rand::{rngs::OsRng, Rng};
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     future::Future,
     sync::Arc,
     time::{Duration, Instant},
@@ -92,13 +92,13 @@ pub fn config_without_node_info_requests() -> NodeConfig {
 }
 
 /// Returns a simple connected peers map for testing purposes
-pub fn create_connected_peers_map() -> HashMap<PeerNetworkId, ConnectionMetadata> {
-    hashmap! { PeerNetworkId::random() => ConnectionMetadata::new(NetworkAddress::mock(), PeerId::random(), PeerRole::Unknown) }
+pub fn create_connected_peers_map() -> BTreeMap<PeerNetworkId, ConnectionMetadata> {
+    btreemap! { PeerNetworkId::random() => ConnectionMetadata::new(NetworkAddress::mock(), PeerId::random(), PeerRole::Unknown) }
 }
 
 /// Creates a network info response with the given data
 pub fn create_network_info_response(
-    connected_peers: &HashMap<PeerNetworkId, ConnectionMetadata>,
+    connected_peers: &BTreeMap<PeerNetworkId, ConnectionMetadata>,
     distance_from_validators: u64,
 ) -> NetworkInformationResponse {
     NetworkInformationResponse {
@@ -410,7 +410,7 @@ pub fn update_network_info_for_peer(
     peers_and_metadata: Arc<PeersAndMetadata>,
     peer_network_id: &PeerNetworkId,
     peer_state: &mut PeerState,
-    connected_peers: HashMap<PeerNetworkId, ConnectionMetadata>,
+    connected_peers: BTreeMap<PeerNetworkId, ConnectionMetadata>,
     distance_from_validators: u64,
     response_time_secs: f64,
 ) {

--- a/network/peer-monitoring-service/client/src/tests/utils.rs
+++ b/network/peer-monitoring-service/client/src/tests/utils.rs
@@ -28,7 +28,7 @@ use aptos_types::{network_address::NetworkAddress, PeerId};
 use maplit::hashmap;
 use rand::{rngs::OsRng, Rng};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     future::Future,
     sync::Arc,
     time::{Duration, Instant},
@@ -109,7 +109,7 @@ pub fn create_network_info_response(
 
 /// Creates a node info response with the given data
 pub fn create_node_info_response(
-    git_hash: String,
+    build_information: BTreeMap<String, String>,
     highest_synced_epoch: u64,
     highest_synced_version: u64,
     ledger_timestamp_usecs: u64,
@@ -117,7 +117,7 @@ pub fn create_node_info_response(
     uptime: Duration,
 ) -> NodeInformationResponse {
     NodeInformationResponse {
-        git_hash,
+        build_information,
         highest_synced_epoch,
         highest_synced_version,
         ledger_timestamp_usecs,
@@ -298,7 +298,7 @@ pub fn create_random_network_info_response() -> NetworkInformationResponse {
 /// Creates a new network info response with random values
 pub fn create_random_node_info_response() -> NodeInformationResponse {
     // Create the random values
-    let git_hash = aptos_build_info::get_git_hash();
+    let build_information = aptos_build_info::get_build_information();
     let highest_synced_epoch = get_random_u64();
     let highest_synced_version = get_random_u64();
     let ledger_timestamp_usecs = get_random_u64();
@@ -307,7 +307,7 @@ pub fn create_random_node_info_response() -> NodeInformationResponse {
 
     // Create and return the node info response
     create_node_info_response(
-        git_hash,
+        build_information,
         highest_synced_epoch,
         highest_synced_version,
         ledger_timestamp_usecs,

--- a/network/peer-monitoring-service/server/src/lib.rs
+++ b/network/peer-monitoring-service/server/src/lib.rs
@@ -253,7 +253,7 @@ impl<T: StorageReaderInterface> Handler<T> {
 
     fn get_node_information(&self) -> Result<PeerMonitoringServiceResponse, Error> {
         // Get the node information
-        let git_hash = aptos_build_info::get_git_hash();
+        let build_information = aptos_build_info::get_build_information();
         let current_time: Instant = self.time_service.now();
         let uptime = current_time.duration_since(self.start_time);
         let (highest_synced_epoch, highest_synced_version) =
@@ -263,7 +263,7 @@ impl<T: StorageReaderInterface> Handler<T> {
 
         // Create and return the response
         let node_information_response = NodeInformationResponse {
-            git_hash,
+            build_information,
             highest_synced_epoch,
             highest_synced_version,
             ledger_timestamp_usecs,

--- a/network/peer-monitoring-service/server/src/tests.rs
+++ b/network/peer-monitoring-service/server/src/tests.rs
@@ -442,7 +442,7 @@ async fn verify_node_information(
     // Verify the response is correct
     let expected_response =
         PeerMonitoringServiceResponse::NodeInformation(NodeInformationResponse {
-            git_hash: aptos_build_info::get_git_hash(),
+            build_information: aptos_build_info::get_build_information(),
             highest_synced_epoch,
             highest_synced_version,
             ledger_timestamp_usecs,

--- a/network/peer-monitoring-service/server/src/tests.rs
+++ b/network/peer-monitoring-service/server/src/tests.rs
@@ -59,10 +59,15 @@ use aptos_types::{
     PeerId,
 };
 use futures::channel::oneshot;
-use maplit::hashmap;
+use maplit::btreemap;
 use mockall::mock;
 use rand::{rngs::OsRng, Rng};
-use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    collections::{BTreeMap, HashMap},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 
 // Useful test constants
 const LOCAL_HOST_NET_ADDR: &str = "/ip4/127.0.0.1/tcp/8081";
@@ -99,7 +104,7 @@ async fn test_get_network_information_fullnode() {
     // Process a client request to fetch the network information and verify an empty response
     verify_network_information(
         &mut mock_client,
-        HashMap::new(),
+        BTreeMap::new(),
         MAX_DISTANCE_FROM_VALIDATORS,
     )
     .await;
@@ -113,7 +118,7 @@ async fn test_get_network_information_fullnode() {
         .unwrap();
 
     // Process a client request to fetch the network information and verify the response
-    let expected_peers = hashmap! {peer_network_id_1 => connection_metadata_1.clone()};
+    let expected_peers = btreemap! {peer_network_id_1 => connection_metadata_1.clone()};
     verify_network_information(
         &mut mock_client,
         expected_peers.clone(),
@@ -160,7 +165,7 @@ async fn test_get_network_information_fullnode() {
     // Process a client request to fetch the network information and verify the response
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => connection_metadata_1.clone()},
+        btreemap! {peer_network_id_1 => connection_metadata_1.clone()},
         peer_distance_1 + 1,
     )
     .await;
@@ -170,7 +175,7 @@ async fn test_get_network_information_fullnode() {
     let peer_network_id_2 = PeerNetworkId::new(NetworkId::Validator, peer_id_2);
     let peer_distance_2 = 0; // The peer is a validator
     let connection_metadata_2 = create_connection_metadata(peer_id_2);
-    let expected_peers = hashmap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2.clone()};
+    let expected_peers = btreemap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2.clone()};
     let latest_network_info_response = NetworkInformationResponse {
         connected_peers: transform_connection_metadata(expected_peers),
         distance_from_validators: peer_distance_2,
@@ -187,7 +192,7 @@ async fn test_get_network_information_fullnode() {
     // Process a client request to fetch the network information and verify the response
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2},
+        btreemap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2},
         peer_distance_2 + 1,
     )
     .await;
@@ -200,7 +205,7 @@ async fn test_get_network_information_fullnode() {
     // Process a request to fetch the network information and verify the response
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => connection_metadata_1},
+        btreemap! {peer_network_id_1 => connection_metadata_1},
         peer_distance_1 + 1,
     )
     .await;
@@ -218,7 +223,7 @@ async fn test_get_network_information_validator() {
     tokio::spawn(service.start());
 
     // Process a client request to fetch the network information and verify distance is 0
-    verify_network_information(&mut mock_client, HashMap::new(), 0).await;
+    verify_network_information(&mut mock_client, BTreeMap::new(), 0).await;
 
     // Connect a new peer to the validator (another validator)
     let peer_id_1 = PeerId::random();
@@ -229,7 +234,7 @@ async fn test_get_network_information_validator() {
         .unwrap();
 
     // Process a client request to fetch the network information and verify the response
-    let expected_peers = hashmap! {peer_network_id_1 => connection_metadata_1.clone()};
+    let expected_peers = btreemap! {peer_network_id_1 => connection_metadata_1.clone()};
     verify_network_information(&mut mock_client, expected_peers.clone(), 0).await;
 
     // Update the peer monitoring metadata for peer 1
@@ -252,7 +257,7 @@ async fn test_get_network_information_validator() {
     let peer_network_id_2 = PeerNetworkId::new(NetworkId::Vfn, peer_id_2);
     let peer_distance_2 = 1; // The peer is a VFN
     let connection_metadata_2 = create_connection_metadata(peer_id_2);
-    let expected_peers = hashmap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2.clone()};
+    let expected_peers = btreemap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2.clone()};
     let latest_network_info_response = NetworkInformationResponse {
         connected_peers: transform_connection_metadata(expected_peers.clone()),
         distance_from_validators: peer_distance_2,
@@ -277,7 +282,7 @@ async fn test_get_network_information_validator() {
     // Process a request to fetch the network information and verify the response
     verify_network_information(
         &mut mock_client,
-        hashmap! {peer_network_id_1 => connection_metadata_1},
+        btreemap! {peer_network_id_1 => connection_metadata_1},
         0,
     )
     .await;
@@ -390,7 +395,7 @@ fn create_connection_metadata(peer_id: AccountAddress) -> ConnectionMetadata {
 /// client, and verifies the response is correct.
 async fn verify_network_information(
     client: &mut MockClient,
-    expected_peers: HashMap<PeerNetworkId, ConnectionMetadata>,
+    expected_peers: BTreeMap<PeerNetworkId, ConnectionMetadata>,
     expected_distance_from_validators: u64,
 ) {
     // Send a request to fetch the network information
@@ -409,8 +414,8 @@ async fn verify_network_information(
 /// Transforms the connection metadata for the given peers into
 /// metadata expected by the peer monitoring service.
 fn transform_connection_metadata(
-    expected_peers: HashMap<PeerNetworkId, ConnectionMetadata>,
-) -> HashMap<PeerNetworkId, aptos_peer_monitoring_service_types::response::ConnectionMetadata> {
+    expected_peers: BTreeMap<PeerNetworkId, ConnectionMetadata>,
+) -> BTreeMap<PeerNetworkId, aptos_peer_monitoring_service_types::response::ConnectionMetadata> {
     expected_peers
         .into_iter()
         .map(|(peer_id, metadata)| {

--- a/network/peer-monitoring-service/types/Cargo.toml
+++ b/network/peer-monitoring-service/types/Cargo.toml
@@ -15,5 +15,6 @@ rust-version = { workspace = true }
 [dependencies]
 aptos-config = { workspace = true }
 aptos-types = { workspace = true }
+bcs = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/network/peer-monitoring-service/types/src/response.rs
+++ b/network/peer-monitoring-service/types/src/response.rs
@@ -4,7 +4,10 @@
 use aptos_config::{config::PeerRole, network_id::PeerNetworkId};
 use aptos_types::{network_address::NetworkAddress, PeerId};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::{BTreeMap, HashMap},
+    time::Duration,
+};
 use thiserror::Error;
 
 /// A peer monitoring service response
@@ -69,12 +72,12 @@ pub struct ServerProtocolVersionResponse {
 /// A response for the node information request
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct NodeInformationResponse {
-    pub git_hash: String, // The git hash of the build the peer is running on
-    pub highest_synced_epoch: u64, // The highest synced epoch of the node
-    pub highest_synced_version: u64, // The highest synced version of the node
+    pub build_information: BTreeMap<String, String>, // The build information of the node
+    pub highest_synced_epoch: u64,                   // The highest synced epoch of the node
+    pub highest_synced_version: u64,                 // The highest synced version of the node
     pub ledger_timestamp_usecs: u64, // The latest timestamp of the blockchain (in microseconds)
     pub lowest_available_version: u64, // The lowest stored version of the node (in storage)
-    pub uptime: Duration, // The amount of time the peer has been running
+    pub uptime: Duration,            // The amount of time the peer has been running
 }
 
 #[derive(Clone, Debug, Error)]

--- a/network/peer-monitoring-service/types/src/response.rs
+++ b/network/peer-monitoring-service/types/src/response.rs
@@ -4,10 +4,7 @@
 use aptos_config::{config::PeerRole, network_id::PeerNetworkId};
 use aptos_types::{network_address::NetworkAddress, PeerId};
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{BTreeMap, HashMap},
-    time::Duration,
-};
+use std::{collections::BTreeMap, time::Duration};
 use thiserror::Error;
 
 /// A peer monitoring service response
@@ -41,7 +38,7 @@ pub struct LatencyPingResponse {
 /// A response for the network information request
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct NetworkInformationResponse {
-    pub connected_peers: HashMap<PeerNetworkId, ConnectionMetadata>, // Connected peers
+    pub connected_peers: BTreeMap<PeerNetworkId, ConnectionMetadata>, // Connected peers
     pub distance_from_validators: u64, // The distance of the peer from the validator set
 }
 

--- a/network/peer-monitoring-service/types/src/response.rs
+++ b/network/peer-monitoring-service/types/src/response.rs
@@ -27,6 +27,18 @@ impl PeerMonitoringServiceResponse {
             Self::ServerProtocolVersion(_) => "server_protocol_version",
         }
     }
+
+    /// Returns the number of bytes in the serialized response
+    pub fn get_num_bytes(&self) -> Result<u64, UnexpectedResponseError> {
+        let serialized_bytes = bcs::to_bytes(&self).map_err(|error| {
+            UnexpectedResponseError(format!(
+                "Failed to serialize response: {}. Error: {:?}",
+                self.get_label(),
+                error
+            ))
+        })?;
+        Ok(serialized_bytes.len() as u64)
+    }
 }
 
 /// A response for the latency ping request


### PR DESCRIPTION
### Description
This PR makes several small improvements to the peer monitoring service (each in their own commit):
1. Update the peer monitoring service to share the build information for all peers (instead of just the git_hash). This should help improve build visibility in the wild west 😄 
2. Change the type of the connected peers map from HashMap to BTreeMap (not super necessary, but determinism makes life easier for debugging).
3. Add a message size limit on all peer monitoring messages to prevent malicious peers from forcing us to hold large messages in memory. The message limit is configurable (and defaults to 100KB), which should be more than enough for all messages (including the future messages for discovery).

### Test Plan
New and existing tests.