### PR TITLE
[bytecote verifier] fix the abstract interpreter bypass bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6792,9 +6792,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -7820,6 +7820,7 @@ version = "0.0.3"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
+ "indexmap",
  "move-core-types",
  "once_cell",
  "proptest",

--- a/third_party/move/move-binary-format/Cargo.toml
+++ b/third_party/move/move-binary-format/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.52"
 arbitrary = { version = "1.1.7", optional = true, features = ["derive"] }
+indexmap = "1.9.3"
 move-core-types = { path = "../move-core/types" }
 once_cell = "1.7.2"
 proptest = { version = "1.0.0", optional = true }

--- a/third_party/move/move-binary-format/src/control_flow_graph.rs
+++ b/third_party/move/move-binary-format/src/control_flow_graph.rs
@@ -4,10 +4,11 @@
 
 //! This module defines the control-flow graph uses for bytecode verification.
 use crate::file_format::{Bytecode, CodeOffset};
-use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
+use indexmap::{map::Entry, IndexMap};
+use std::collections::BTreeSet;
 
 // BTree/Hash agnostic type wrappers
-type Map<K, V> = BTreeMap<K, V>;
+type Map<K, V> = IndexMap<K, V>;
 type Set<V> = BTreeSet<V>;
 
 pub type BlockId = CodeOffset;
@@ -275,6 +276,15 @@ impl VMControlFlowGraph {
 
     pub fn reachable_from(&self, block_id: BlockId) -> Vec<BlockId> {
         self.traverse_by(block_id)
+    }
+
+    pub fn traversal_index(&self, block_id: u16) -> usize {
+        let index = self
+            .traversal_successors
+            .get_index_of(&block_id)
+            .unwrap_or_else(|| self.traversal_successors.len());
+        debug_assert!(index <= self.traversal_successors.len());
+        index
     }
 }
 

--- a/third_party/move/move-bytecode-verifier/transactional-tests/tests/control_flow/block_traversal_order_alias.exp
+++ b/third_party/move/move-bytecode-verifier/transactional-tests/tests/control_flow/block_traversal_order_alias.exp
@@ -1,0 +1,10 @@
+processed 1 task
+
+task 0 'publish'. lines 1-51:
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000001::Test'. Got VMError: {
+    major_status: CALL_BORROWED_MUTABLE_REFERENCE_ERROR,
+    sub_status: None,
+    location: 0x1::Test,
+    indices: [(FunctionDefinition, 1)],
+    offsets: [(FunctionDefinitionIndex(1), 16)],
+}

--- a/third_party/move/move-bytecode-verifier/transactional-tests/tests/control_flow/block_traversal_order_alias.mvir
+++ b/third_party/move/move-bytecode-verifier/transactional-tests/tests/control_flow/block_traversal_order_alias.mvir
@@ -1,0 +1,51 @@
+//# publish
+
+module 0x1.Test {
+	struct K has drop { x: u64 }
+
+	public no_alias(a: &mut Self.K, b: &mut Self.K) {
+		label start:
+		assert(!(*&copy(a).K::x == 100 && *&copy(b).K::x == 100), 123);
+		return;
+	}
+
+	public t() {
+		let x1: Self.K;
+		let x2: Self.K;
+		let ref: &mut Self.K;
+		let z: u64;
+		let p: u64;
+
+		// block start -> {loop_head}
+		label start:
+		x1 = K { x: 100 };
+		x2 = K { x: 200 };
+		ref = &mut x2;
+		z = 0;
+
+		// block loop_head -> {noalias_call, done}
+		label loop_head:
+		jump_if (copy(z) == 2) done;
+
+		// block noalias_call:
+		// NOTE: the verifier should realize that this block can be reached with ref set to &mut x1
+		//       and reject the module
+		Self.no_alias(&mut x1, copy(ref));
+		jump loop_back;
+
+		// block two_back_edges -> loop_back, loop_head
+		label two_back_edges:
+		p=1; // intentionally cause a change in state
+		ref = &mut x1;
+		jump_if (true) loop_head;
+
+		// block loop_back -> two_back_edges
+		label loop_back:
+		z = copy(z) + 1;
+		jump two_back_edges;
+
+		label done:
+		return;
+
+	}
+}

--- a/third_party/move/move-bytecode-verifier/transactional-tests/tests/control_flow/block_traversal_order_hot_potato.exp
+++ b/third_party/move/move-bytecode-verifier/transactional-tests/tests/control_flow/block_traversal_order_hot_potato.exp
@@ -1,0 +1,10 @@
+processed 1 task
+
+task 0 'publish'. lines 1-39:
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000001::Test'. Got VMError: {
+    major_status: STLOC_UNSAFE_TO_DESTROY_ERROR,
+    sub_status: None,
+    location: 0x1::Test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 8)],
+}

--- a/third_party/move/move-bytecode-verifier/transactional-tests/tests/control_flow/block_traversal_order_hot_potato.mvir
+++ b/third_party/move/move-bytecode-verifier/transactional-tests/tests/control_flow/block_traversal_order_hot_potato.mvir
@@ -1,0 +1,39 @@
+//# publish
+
+module 0x1.Test {
+	struct K { x: u64 }
+
+	public t() {
+		let hot_potato: Self.K;
+		let z: u64;
+		let p: u64;
+
+		// block start -> {loop_head}
+		label start:
+		z = 0;
+
+		// block loop_head -> {stloc_block, done}
+		label loop_head:
+		jump_if (copy(z) == 2) done;
+
+		// block stloc_block:
+		// NOTE: the verifier should realize that this block can be reached with `hot_potato` assigned
+		//       and reject the module
+		hot_potato = K { x: 100 }; // stloc should not work on second loop iteration
+		jump loop_back;
+
+		// block two_back_edges -> loop_back, loop_head
+		label two_back_edges:
+		p=1; // intentionally cause a change in state
+		jump_if (true) loop_head;
+
+		// block loop_back -> two_back_edges
+		label loop_back:
+		z = copy(z) + 1;
+		jump two_back_edges;
+
+		label done:
+		return;
+
+	}
+}


### PR DESCRIPTION
This ports the recent security patch that fixes the bug that would allow one to bypass the bytecode verifier partially. 