### PR TITLE
[Rust Lint] Fix cached-packages failure.

### DIFF
--- a/scripts/rust_lint.sh
+++ b/scripts/rust_lint.sh
@@ -39,7 +39,8 @@ cargo sort --grouped --workspace $CHECK_ARG
 # Ensure that aptos-cached-packages have been built correctly.
 cargo build -p aptos-cached-packages
 if [ -n "$CHECK_ARG" ]; then
-    if [ -n "$(git status --porcelain -uno)" ]; then
+    if [ -n "$(git status --porcelain -uno aptos-move)" ]; then
+      git diff
       echo "There are unstaged changes after running 'cargo build -p aptos-cached-packages'! Are you sure aptos-cached-packages is up-to-date?"
       exit 1
     fi


### PR DESCRIPTION
### Description
This PR fixes an edge-case in the rust_lint.sh script (where irrelevant untracked files are causing the lint to fail). This should hopefully fix it. 

### Test Plan
Existing test infrastructure.