### PR TITLE
Revert "[git config] Do not normalize .ps1 line endings"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,7 +18,6 @@
 *.txt text eol=lf 
 *.yaml text eol=lf 
 *.yml text eol=lf 
-*.ps1 text eol=crlf
 
 # Use Move syntax highlighter for Move IR code
 *.mvir linguist-language=Move


### PR DESCRIPTION
This reverts commit bcf4da937930872cd2a8b7f51232d887919af1f5.

### Description

The line ending normalization is causing GH checkouts to contain spurious diffs in one Powershell file, which are causing workflows to fail.
Example: https://github.com/aptos-labs/aptos-core/actions/runs/4726884758/jobs/8386904529?pr=7806