### PR TITLE
[CLI] add account lookup by authentication key

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -621,6 +621,35 @@ pub struct EncodingOptions {
 }
 
 #[derive(Debug, Parser)]
+pub struct AuthenticationKeyInputOptions {
+    /// Authentication Key file input
+    #[clap(long, group = "authentication_key_input", parse(from_os_str))]
+    auth_key_file: Option<PathBuf>,
+
+    /// Authentication key input
+    #[clap(long, group = "authentication_key_input")]
+    auth_key: Option<String>,
+}
+
+impl AuthenticationKeyInputOptions {
+    pub fn extract_auth_key(
+        &self,
+        encoding: EncodingType,
+    ) -> CliTypedResult<Option<AuthenticationKey>> {
+        if let Some(ref file) = self.auth_key_file {
+            Ok(Some(
+                encoding.load_key("--auth-key-file", file.as_path())?,
+            ))
+        } else if let Some(ref key) = self.auth_key {
+            let key = key.as_bytes().to_vec();
+            Ok(Some(encoding.decode_key("--auth-key", key)?))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
 pub struct PublicKeyInputOptions {
     /// Ed25519 Public key input file name
     ///
@@ -834,6 +863,10 @@ pub trait ExtractPublicKey {
 
 pub fn account_address_from_public_key(public_key: &Ed25519PublicKey) -> AccountAddress {
     let auth_key = AuthenticationKey::ed25519(public_key);
+    account_address_from_auth_key(&auth_key)
+}
+
+pub fn account_address_from_auth_key(auth_key: &AuthenticationKey) -> AccountAddress {
     AccountAddress::new(*auth_key.derived_address())
 }
 

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -242,6 +242,7 @@ impl CliTestFramework {
             rest_options: self.rest_options(),
             encoding_options: Default::default(),
             profile_options: Default::default(),
+            authentication_key_options: Default::default(),
         }
         .execute()
         .await


### PR DESCRIPTION
### Description

Add the feature, which allow user to lookup address based on authentication key

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Manually test and make sure it works

```
➜  aptos-core git:(main) ✗ aptos-debug account lookup-address --auth-key 0xd53a65d05c8ca1160920573c54bb4ebaf06be19d6fcb540c5374a62003e65d79
Looking up address
auth key address found!
address is: d53a65d05c8ca1160920573c54bb4ebaf06be19d6fcb540c5374a62003e65d79
{
  "Result": "d53a65d05c8ca1160920573c54bb4ebaf06be19d6fcb540c5374a62003e65d79"
}
```
