### PR TITLE
add x-aptos-client header

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 
 ## Unreleased
 
+- Add `x-aptos-client` header to `AptosClient` requests
+
 ## 1.9.0 (2023-05-17)
 
 - Fix get number of delegators Indexer query

--- a/ecosystem/typescript/sdk/src/providers/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/providers/aptos_client.ts
@@ -86,7 +86,7 @@ export class AptosClient {
     } else {
       conf.WITH_CREDENTIALS = true;
     }
-    conf.HEADERS = { ...conf.HEADERS, "X-Aptos-Client": `aptos-ts-sdk/${VERSION}` };
+    conf.HEADERS = { ...conf.HEADERS, "x-aptos-client": `aptos-ts-sdk/${VERSION}` };
     this.client = new Gen.AptosGeneratedClient(conf);
   }
 

--- a/ecosystem/typescript/sdk/src/providers/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/providers/aptos_client.ts
@@ -35,6 +35,7 @@ import {
   AnyNumber,
 } from "../bcs";
 import { Ed25519PublicKey, MultiEd25519PublicKey } from "../aptos_types";
+import { VERSION } from "../version";
 
 export interface OptionalTransactionArgs {
   maxGasAmount?: Uint64;
@@ -85,6 +86,7 @@ export class AptosClient {
     } else {
       conf.WITH_CREDENTIALS = true;
     }
+    conf.HEADERS = { ...conf.HEADERS, "X-Aptos-Client": `aptos-ts-sdk/${VERSION}` };
     this.client = new Gen.AptosGeneratedClient(conf);
   }
 

--- a/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
@@ -16,12 +16,20 @@ import { bcsSerializeUint64, bcsToBytes } from "../../bcs";
 import { AccountAddress, Ed25519PublicKey, stringStructTag, TypeTagStruct } from "../../aptos_types";
 import { Provider } from "../../providers";
 import { BCS } from "../..";
+import { VERSION } from "../../version";
 
 const account = "0x1::account::Account";
 
 const aptosCoin = "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>";
 
 const coinTransferFunction = "0x1::coin::transfer";
+
+test.only("call should include X-Aptos-Client header", async () => {
+  const client = new AptosClient(NODE_URL, { HEADERS: { my: "header" } });
+  const heders = client.client.request.config.HEADERS;
+  expect(heders).toHaveProperty("X-Aptos-Client", `aptos-ts-sdk/${VERSION}`);
+  expect(heders).toHaveProperty("my", "header");
+});
 
 test("node url empty", () => {
   expect(() => {

--- a/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
@@ -24,7 +24,7 @@ const aptosCoin = "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>";
 
 const coinTransferFunction = "0x1::coin::transfer";
 
-test.only("call should include x-aptos-client header", async () => {
+test("call should include x-aptos-client header", async () => {
   const client = new AptosClient(NODE_URL, { HEADERS: { my: "header" } });
   const heders = client.client.request.config.HEADERS;
   expect(heders).toHaveProperty("x-aptos-client", `aptos-ts-sdk/${VERSION}`);

--- a/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
@@ -24,7 +24,7 @@ const aptosCoin = "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>";
 
 const coinTransferFunction = "0x1::coin::transfer";
 
-test.only("call should include X-Aptos-Client header", async () => {
+test.only("call should include x-aptos-client header", async () => {
   const client = new AptosClient(NODE_URL, { HEADERS: { my: "header" } });
   const heders = client.client.request.config.HEADERS;
   expect(heders).toHaveProperty("x-aptos-client", `aptos-ts-sdk/${VERSION}`);

--- a/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
@@ -27,7 +27,7 @@ const coinTransferFunction = "0x1::coin::transfer";
 test.only("call should include X-Aptos-Client header", async () => {
   const client = new AptosClient(NODE_URL, { HEADERS: { my: "header" } });
   const heders = client.client.request.config.HEADERS;
-  expect(heders).toHaveProperty("X-Aptos-Client", `aptos-ts-sdk/${VERSION}`);
+  expect(heders).toHaveProperty("x-aptos-client", `aptos-ts-sdk/${VERSION}`);
   expect(heders).toHaveProperty("my", "header");
 });
 


### PR DESCRIPTION
### Description
Adds `x-aptos-client` header to REST calls. 

**Needs to be merged after** https://github.com/aptos-labs/aptos-core/pull/7797
### Test Plan

- tested on Chrome, Safari, Brave and Edge browsers
<img width="492" alt="image" src="https://user-images.githubusercontent.com/29798064/233148101-4b23865b-7cd2-45d3-bd0e-dee0a0ee5174.png">
<img width="868" alt="image" src="https://user-images.githubusercontent.com/29798064/233148242-610dc15f-0a26-4d9e-868e-6c110f990b65.png">
<img width="754" alt="image" src="https://user-images.githubusercontent.com/29798064/233148379-9fce8bff-f6cf-4461-947f-3d9ae7474131.png">
<img width="1028" alt="image" src="https://user-images.githubusercontent.com/29798064/233149078-925b5f78-ce91-4528-a41c-323a11157f23.png">

- testes are passing

