### PR TITLE
[resource-viewer] Fix resolution of generics in move types

### DIFF
--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -188,7 +188,8 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
                 let (module, function, ty_args, args) = fun.into_inner();
                 let func_args = self
                     .inner
-                    .view_function_arguments(&module, &function, &args);
+                    .view_function_arguments(&module, &function, &ty_args, &args);
+
                 let json_args = match func_args {
                     Ok(values) => values
                         .into_iter()
@@ -218,7 +219,7 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
                             let (module, function, ty_args, args) = entry_function.into_inner();
                             let func_args = self
                                 .inner
-                                .view_function_arguments(&module, &function, &args);
+                                .view_function_arguments(&module, &function, &ty_args, &args);
                             let json_args = match func_args {
                                 Ok(values) => values
                                     .into_iter()

--- a/third_party/move/tools/move-resource-viewer/src/fat_type.rs
+++ b/third_party/move/tools/move-resource-viewer/src/fat_type.rs
@@ -172,6 +172,42 @@ impl FatType {
     }
 }
 
+impl From<&TypeTag> for FatType {
+    fn from(tag: &TypeTag) -> FatType {
+        use FatType::*;
+        match tag {
+            TypeTag::Bool => Bool,
+            TypeTag::U8 => U8,
+            TypeTag::U16 => U16,
+            TypeTag::U32 => U32,
+            TypeTag::U64 => U64,
+            TypeTag::U128 => U128,
+            TypeTag::Address => Address,
+            TypeTag::Signer => Signer,
+            TypeTag::Vector(inner) => Vector(Box::new(inner.as_ref().into())),
+            TypeTag::Struct(inner) => Struct(Box::new(inner.as_ref().into())),
+            TypeTag::U256 => U256,
+        }
+    }
+}
+
+impl From<&StructTag> for FatStructType {
+    fn from(struct_tag: &StructTag) -> FatStructType {
+        FatStructType {
+            address: struct_tag.address,
+            module: struct_tag.module.clone(),
+            name: struct_tag.name.clone(),
+            abilities: WrappedAbilitySet(AbilitySet::EMPTY), // We can't get abilities from a struct tag
+            ty_args: struct_tag
+                .type_params
+                .iter()
+                .map(|inner| inner.into())
+                .collect(),
+            layout: vec![], // We can't get field types from struct tag
+        }
+    }
+}
+
 impl TryInto<MoveStructLayout> for &FatStructType {
     type Error = PartialVMError;
 


### PR DESCRIPTION
### Description
If there's a generic, the Fat type parsing didn't use the type from the type arguments, which caused it to fail to parse.  Now, this will take in the type arguments to properly parse the inputs.

### Test Plan
I've done manual testing, I will add a unit test to properly test this.

Arguments now come out like this instead of hex encoded
```
"arguments":[{"inner":"0xb98022721f97da65950435386a5209be2fc54bed5f12fc8ea0a1c3d0c76f562f"},"Hello"]
```