### PR TITLE
[Configs] Tiny tweak to chain ID logic.

### DIFF
--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -125,7 +125,7 @@ impl ConfigSanitizer for ApiConfig {
         }
 
         // Verify that failpoints are not enabled in mainnet
-        if chain_id.is_mainnet()? && api_config.failpoints_enabled {
+        if chain_id.is_mainnet() && api_config.failpoints_enabled {
             return Err(Error::ConfigSanitizerFailed(
                 sanitizer_name,
                 "Failpoints are not supported on mainnet nodes!".into(),

--- a/config/src/config/config_sanitizer.rs
+++ b/config/src/config/config_sanitizer.rs
@@ -94,7 +94,7 @@ fn sanitize_failpoints_config(
 
     // Verify that failpoints are not enabled in mainnet
     let failpoints_enabled = are_failpoints_enabled();
-    if chain_id.is_mainnet()? && failpoints_enabled {
+    if chain_id.is_mainnet() && failpoints_enabled {
         return Err(Error::ConfigSanitizerFailed(
             sanitizer_name,
             "Failpoints are not supported on mainnet nodes!".into(),

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -256,7 +256,7 @@ impl ConfigSanitizer for ConsensusConfig {
         SafetyRulesConfig::sanitize(node_config, node_role, chain_id)?;
 
         // Verify that the consensus-only feature is not enabled in mainnet
-        if chain_id.is_mainnet()? && is_consensus_only_perf_test_enabled() {
+        if chain_id.is_mainnet() && is_consensus_only_perf_test_enabled() {
             return Err(Error::ConfigSanitizerFailed(
                 sanitizer_name,
                 "consensus-only-perf-test should not be enabled in mainnet!".to_string(),

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -128,7 +128,7 @@ impl ConfigSanitizer for ExecutionConfig {
         let execution_config = &node_config.execution;
 
         // If this is a mainnet node, ensure that additional verifiers are enabled
-        if chain_id.is_mainnet()? {
+        if chain_id.is_mainnet() {
             if !execution_config.paranoid_hot_potato_verification {
                 return Err(Error::ConfigSanitizerFailed(
                     sanitizer_name,

--- a/config/src/config/inspection_service_config.rs
+++ b/config/src/config/inspection_service_config.rs
@@ -46,7 +46,7 @@ impl ConfigSanitizer for InspectionServiceConfig {
 
         // Verify that mainnet validators do not expose the configuration
         if node_role.is_validator()
-            && chain_id.is_mainnet()?
+            && chain_id.is_mainnet()
             && inspection_service_config.expose_configuration
         {
             return Err(Error::ConfigSanitizerFailed(

--- a/config/src/config/peer_monitoring_config.rs
+++ b/config/src/config/peer_monitoring_config.rs
@@ -100,7 +100,7 @@ impl ConfigSanitizer for PeerMonitoringServiceConfig {
         let peer_monitoring_config = &node_config.peer_monitoring_service;
 
         // Verify the peer monitoring service is not enabled in mainnet
-        if chain_id.is_mainnet()? && peer_monitoring_config.enable_peer_monitoring_client {
+        if chain_id.is_mainnet() && peer_monitoring_config.enable_peer_monitoring_client {
             return Err(Error::ConfigSanitizerFailed(
                 sanitizer_name,
                 "The peer monitoring service is not enabled in mainnet!".to_string(),

--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -86,7 +86,7 @@ impl ConfigSanitizer for SafetyRulesConfig {
         }
 
         // Verify that the secure backend is appropriate for mainnet validators
-        if chain_id.is_mainnet()? && node_role.is_validator() {
+        if chain_id.is_mainnet() && node_role.is_validator() {
             if safety_rules_config.backend.is_github() {
                 return Err(Error::ConfigSanitizerFailed(
                     sanitizer_name,
@@ -102,7 +102,7 @@ impl ConfigSanitizer for SafetyRulesConfig {
         }
 
         // Verify that the safety rules service is set to local for optimal performance
-        if chain_id.is_mainnet()? && !safety_rules_config.service.is_local() {
+        if chain_id.is_mainnet() && !safety_rules_config.service.is_local() {
             return Err(Error::ConfigSanitizerFailed(
                 sanitizer_name,
                 format!("The safety rules service should be set to local in mainnet for optimal performance! Given config: {:?}", &safety_rules_config.service)
@@ -110,7 +110,7 @@ impl ConfigSanitizer for SafetyRulesConfig {
         }
 
         // Verify that the safety rules test config is not enabled in mainnet
-        if chain_id.is_mainnet()? && safety_rules_config.test.is_some() {
+        if chain_id.is_mainnet() && safety_rules_config.test.is_some() {
             return Err(Error::ConfigSanitizerFailed(
                 sanitizer_name,
                 "The safety rules test config should not be used in mainnet!".to_string(),

--- a/types/src/chain_id.rs
+++ b/types/src/chain_id.rs
@@ -78,32 +78,27 @@ pub struct ChainId(u8);
 
 impl ChainId {
     /// Returns true iff the chain ID matches devnet
-    pub fn is_devnet(&self) -> Result<bool> {
-        let named_chain = self.get_named_chain()?;
-        Ok(named_chain == NamedChain::DEVNET)
+    pub fn is_devnet(&self) -> bool {
+        self.matches_named_chain(NamedChain::DEVNET)
     }
 
     /// Returns true iff the chain ID matches testnet
-    pub fn is_testnet(&self) -> Result<bool> {
-        let named_chain = self.get_named_chain()?;
-        Ok(named_chain == NamedChain::TESTNET)
+    pub fn is_testnet(&self) -> bool {
+        self.matches_named_chain(NamedChain::TESTNET)
     }
 
     /// Returns true iff the chain ID matches mainnet
-    pub fn is_mainnet(&self) -> Result<bool> {
-        let named_chain = self.get_named_chain()?;
-        Ok(named_chain == NamedChain::MAINNET)
+    pub fn is_mainnet(&self) -> bool {
+        self.matches_named_chain(NamedChain::MAINNET)
     }
 
-    /// Returns the named chain relating to the chain ID
-    fn get_named_chain(&self) -> Result<NamedChain> {
-        NamedChain::from_chain_id(self).map_err(|error| {
-            format_err!(
-                "Error fetching the named chain for chain id: {:?}, error: {:?}",
-                &self,
-                error
-            )
-        })
+    /// Returns true iff the chain ID matches the given named chain
+    fn matches_named_chain(&self, expected_chain: NamedChain) -> bool {
+        if let Ok(named_chain) = NamedChain::from_chain_id(self) {
+            named_chain == expected_chain
+        } else {
+            false
+        }
     }
 }
 


### PR DESCRIPTION
### Description
This PR makes a tiny tweak to the chain ID logic. Specifically, if a given chain ID does not match a named chain, we return `None` instead of throwing an error. This is helpful for node config sanitization in unknown chain ID environments.

### Test Plan
Existing test infrastructure.