### PR TITLE
[SDK] Fix MultisigTransactionPayload deserialization

### DIFF
--- a/ecosystem/typescript/sdk/src/aptos_types/transaction.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/transaction.ts
@@ -225,6 +225,9 @@ export class MultiSigTransactionPayload {
   }
 
   static deserialize(deserializer: Deserializer): MultiSigTransactionPayload {
+    // TODO: Support other types of payload beside EntryFunction.
+    // This is the enum value indicating which type of payload the multisig tx contains.
+    deserializer.deserializeUleb128AsU32();
     return new MultiSigTransactionPayload(EntryFunction.deserialize(deserializer));
   }
 }


### PR DESCRIPTION
### Description
The serialized multisig sig transaction payload has an extra enum value that indicates which type of payload the multisig tx contains (currently only entry function is supported, but support for script payload can be added in the future). serialize() correctly takes this enum into value but deserialize currently doesn't.

