### PR TITLE
[TS SDK] Add support to generic params in entry functions

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 ## Unreleased
 
 - Add `AptosToken` plugin to support tokenv2
+- Add generic support to input params in move entry functions
 
 ## 1.8.4 (2023-04-13)
 

--- a/ecosystem/typescript/sdk/src/aptos_types/type_tag.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/type_tag.ts
@@ -218,6 +218,13 @@ export class StructTag {
   }
 }
 
+export const stringStructTag = new StructTag(
+  AccountAddress.fromHex("0x1"),
+  new Identifier("string"),
+  new Identifier("String"),
+  [],
+);
+
 function bail(message: string) {
   throw new TypeTagParserError(message);
 }
@@ -386,6 +393,9 @@ export class TypeTagParser {
       const res = this.parseTypeTag();
       this.consume(">");
       return new TypeTagVector(res);
+    }
+    if (tokenVal === "string") {
+      return new StructTag(AccountAddress.fromHex("0x1"), new Identifier("string"), new Identifier("String"), []);
     }
     if (tokenTy === "IDENT" && (tokenVal.startsWith("0x") || tokenVal.startsWith("0X"))) {
       const address = tokenVal;

--- a/ecosystem/typescript/sdk/src/aptos_types/type_tag.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/type_tag.ts
@@ -435,14 +435,14 @@ export class TypeTagParser {
       );
       return new TypeTagStruct(structTag);
     }
-    if (tokenTy == "GENERIC") {
+    if (tokenTy === "GENERIC") {
       if (this.typeTags.length === 0) {
         bail("Can't convert generic type to a tag type since typeTags array is empty.");
       }
       // a generic tokenVal has the format of `T<digit>`, for example `T1`.
       // The digit (i.e 1) indicates the the index of this type in the typeTags array.
       // For a tokenVal == T1, should be parsed as the type in typeTags[1]
-      const idx = parseInt(tokenVal.substring(1));
+      const idx = parseInt(tokenVal.substring(1), 10);
       return new TypeTagParser(this.typeTags[idx]).parseTypeTag();
     }
 

--- a/ecosystem/typescript/sdk/src/aptos_types/type_tag.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/type_tag.ts
@@ -436,9 +436,12 @@ export class TypeTagParser {
       return new TypeTagStruct(structTag);
     }
     if (tokenTy == "GENERIC") {
-      if (this.typeTags.length == 0) {
+      if (this.typeTags.length === 0) {
         bail("Can't convert generic type to a tag type since typeTags array is empty.");
       }
+      // a generic tokenVal has the format of `T<digit>`, for example `T1`.
+      // The digit (i.e 1) indicates the the index of this type in the typeTags array.
+      // For a tokenVal == T1, should be parsed as the type in typeTags[1]
       const idx = parseInt(tokenVal.substring(1));
       return new TypeTagParser(this.typeTags[idx]).parseTypeTag();
     }

--- a/ecosystem/typescript/sdk/src/plugins/aptos_token.ts
+++ b/ecosystem/typescript/sdk/src/plugins/aptos_token.ts
@@ -25,7 +25,6 @@ export interface CreateCollectionOptions {
   tokensBurnableByCreator?: boolean;
   tokensFreezableByCreator?: boolean;
 }
-type Generic = string | number | boolean | Uint8Array | Array<Generic>;
 
 const PropertyTypeMap = {
   BOOLEAN: "bool",
@@ -36,7 +35,7 @@ const PropertyTypeMap = {
   U128: "u128",
   U256: "u256",
   ADDRESS: "address",
-  U8VECTOR: "vector<u8>",
+  VECTOR: "vector<u8>",
   STRING: "string",
 };
 

--- a/ecosystem/typescript/sdk/src/plugins/aptos_token.ts
+++ b/ecosystem/typescript/sdk/src/plugins/aptos_token.ts
@@ -429,7 +429,7 @@ export class AptosToken {
     token: MaybeHexString,
     propertyKey: string,
     propertyType: PropertyType,
-    propertyValue: Generic,
+    propertyValue: string,
     tokenType?: string,
     extraArgs?: OptionalTransactionArgs,
   ) {
@@ -447,7 +447,7 @@ export class AptosToken {
     token: MaybeHexString,
     propertyKey: string,
     propertyType: PropertyType,
-    propertyValue: Generic,
+    propertyValue: string,
     tokenType?: string,
     extraArgs?: OptionalTransactionArgs,
   ) {

--- a/ecosystem/typescript/sdk/src/plugins/aptos_token.ts
+++ b/ecosystem/typescript/sdk/src/plugins/aptos_token.ts
@@ -36,8 +36,8 @@ const PropertyTypeMap = {
   U128: "u128",
   U256: "u256",
   ADDRESS: "address",
-  VECTORU8: "vector<u8>",
-  STRING: "0x1::string::String",
+  U8VECTOR: "vector<u8>",
+  STRING: "string",
 };
 
 export type PropertyType = keyof typeof PropertyTypeMap;

--- a/ecosystem/typescript/sdk/src/plugins/aptos_token.ts
+++ b/ecosystem/typescript/sdk/src/plugins/aptos_token.ts
@@ -25,14 +25,30 @@ export interface CreateCollectionOptions {
   tokensBurnableByCreator?: boolean;
   tokensFreezableByCreator?: boolean;
 }
+type Generic = string | number | boolean | Uint8Array | Array<Generic>;
+
+const PropertyTypeMap = {
+  BOOLEAN: "bool",
+  U8: "u8",
+  U16: "u16",
+  U32: "u32",
+  U64: "u64",
+  U128: "u128",
+  U256: "u256",
+  ADDRESS: "address",
+  VECTORU8: "vector<u8>",
+  STRING: "0x1::string::String",
+};
+
+export type PropertyType = keyof typeof PropertyTypeMap;
 
 /**
  * Class for managing aptos_token
  */
 export class AptosToken {
-  provider: Provider;
+  readonly provider: Provider;
 
-  tokenType: string = "0x4::token::Token";
+  private readonly tokenType: string = "0x4::token::Token";
 
   /**
    * Creates new AptosToken instance
@@ -50,13 +66,13 @@ export class AptosToken {
     args: any[],
     extraArgs?: OptionalTransactionArgs,
   ) {
-    const builder = new TransactionBuilderRemoteABI(this.provider.aptosClient, {
+    const builder = new TransactionBuilderRemoteABI(this.provider, {
       sender: account.address(),
       ...extraArgs,
     });
     const rawTxn = await builder.build(`0x4::aptos_token::${funcName}`, typeArgs, args);
     const bcsTxn = AptosClient.generateBCSTransaction(account, rawTxn);
-    const pendingTransaction = await this.provider.aptosClient.submitSignedBCSTransaction(bcsTxn);
+    const pendingTransaction = await this.provider.submitSignedBCSTransaction(bcsTxn);
     return pendingTransaction.hash;
   }
 
@@ -333,9 +349,9 @@ export class AptosToken {
   async addTokenProperty(
     creator: AptosAccount,
     token: MaybeHexString,
-    key: string,
-    type: string,
-    value: string,
+    propertyKey: string,
+    propertyType: PropertyType,
+    propertyValue: string,
     tokenType?: string,
     extraArgs?: OptionalTransactionArgs,
   ): Promise<string> {
@@ -343,7 +359,12 @@ export class AptosToken {
       creator,
       "add_property",
       [tokenType || this.tokenType],
-      [HexString.ensure(token).hex(), key, type, getSinglePropertyValueRaw(value, type)],
+      [
+        HexString.ensure(token).hex(),
+        propertyKey,
+        PropertyTypeMap[propertyType],
+        getSinglePropertyValueRaw(propertyValue, PropertyTypeMap[propertyType]),
+      ],
       extraArgs,
     );
   }
@@ -358,7 +379,7 @@ export class AptosToken {
   async removeTokenProperty(
     creator: AptosAccount,
     token: MaybeHexString,
-    key: string,
+    propertyKey: string,
     tokenType?: string,
     extraArgs?: OptionalTransactionArgs,
   ): Promise<string> {
@@ -366,7 +387,7 @@ export class AptosToken {
       creator,
       "remove_property",
       [tokenType || this.tokenType],
-      [HexString.ensure(token).hex(), key],
+      [HexString.ensure(token).hex(), propertyKey],
       extraArgs,
     );
   }
@@ -383,9 +404,9 @@ export class AptosToken {
   async updateTokenProperty(
     creator: AptosAccount,
     token: MaybeHexString,
-    key: string,
-    type: string,
-    value: string,
+    propertyKey: string,
+    propertyType: PropertyType,
+    propertyValue: string,
     tokenType?: string,
     extraArgs?: OptionalTransactionArgs,
   ): Promise<string> {
@@ -393,7 +414,48 @@ export class AptosToken {
       creator,
       "update_property",
       [tokenType || this.tokenType],
-      [HexString.ensure(token).hex(), key, type, getSinglePropertyValueRaw(value, type)],
+      [
+        HexString.ensure(token).hex(),
+        propertyKey,
+        PropertyTypeMap[propertyType],
+        getSinglePropertyValueRaw(propertyValue, PropertyTypeMap[propertyType]),
+      ],
+      extraArgs,
+    );
+  }
+
+  async addTypedProperty(
+    creator: AptosAccount,
+    token: MaybeHexString,
+    propertyKey: string,
+    propertyType: PropertyType,
+    propertyValue: Generic,
+    tokenType?: string,
+    extraArgs?: OptionalTransactionArgs,
+  ) {
+    return this.submitTransaction(
+      creator,
+      "add_typed_property",
+      [tokenType || this.tokenType, PropertyTypeMap[propertyType]],
+      [HexString.ensure(token).hex(), propertyKey, propertyValue],
+      extraArgs,
+    );
+  }
+
+  async updateTypedProperty(
+    creator: AptosAccount,
+    token: MaybeHexString,
+    propertyKey: string,
+    propertyType: PropertyType,
+    propertyValue: Generic,
+    tokenType?: string,
+    extraArgs?: OptionalTransactionArgs,
+  ) {
+    return this.submitTransaction(
+      creator,
+      "update_typed_property",
+      [tokenType || this.tokenType, PropertyTypeMap[propertyType]],
+      [HexString.ensure(token).hex(), propertyKey, propertyValue],
       extraArgs,
     );
   }

--- a/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
@@ -9,11 +9,13 @@ import {
   TransactionBuilderMultiEd25519,
   TransactionBuilderRemoteABI,
 } from "../../transaction_builder";
-import { TokenClient } from "../../plugins";
+import { AptosToken, TokenClient } from "../../plugins";
 import { HexString } from "../../utils";
-import { getFaucetClient, longTestTimeout, NODE_URL } from "../unit/test_helper.test";
+import { getFaucetClient, longTestTimeout, NODE_URL, PROVIDER_LOCAL_NETWORK_CONFIG } from "../unit/test_helper.test";
 import { bcsSerializeUint64, bcsToBytes } from "../../bcs";
-import { Ed25519PublicKey } from "../../aptos_types";
+import { AccountAddress, Ed25519PublicKey, stringStructTag, TypeTagStruct } from "../../aptos_types";
+import { Provider } from "../../providers";
+import { BCS } from "../..";
 
 const account = "0x1::account::Account";
 
@@ -113,6 +115,69 @@ test(
     resources = await client.getAccountResources(account2.address());
     accountResource = resources.find((r) => r.type === aptosCoin);
     expect((accountResource!.data as any).coin.value).toBe("717");
+  },
+  longTestTimeout,
+);
+
+test(
+  "submits generic type bcs transaction",
+  async () => {
+    const provider = new Provider(PROVIDER_LOCAL_NETWORK_CONFIG);
+    const aptosToken = new AptosToken(provider);
+    const account1 = new AptosAccount();
+    const faucetClient = getFaucetClient();
+
+    await faucetClient.fundAccount(account1.address(), 100_000_000);
+    let resources = await provider.getAccountResources(account1.address());
+    let accountResource = resources.find((r) => r.type === aptosCoin);
+    expect((accountResource!.data as any).coin.value).toBe("100000000");
+
+    let tokenAddress = "";
+
+    await provider.waitForTransaction(
+      await aptosToken.createCollection(
+        account1,
+        "Collection description",
+        "Collection Name",
+        "https://aptos.dev",
+        5,
+        10,
+        10,
+      ),
+    );
+    const txn = await provider.waitForTransactionWithResult(
+      await aptosToken.mint(
+        account1,
+        "Collection Name",
+        "Token Description",
+        "Token Name",
+        "https://aptos.dev/img/nyan.jpeg",
+        ["key"],
+        ["bool"],
+        ["true"],
+      ),
+      { checkSuccess: true },
+    );
+    tokenAddress = (txn as Gen.UserTransaction).events[0].data.token;
+    console.log(tokenAddress);
+
+    const token = new TxnBuilderTypes.TypeTagStruct(TxnBuilderTypes.StructTag.fromString("0x4::token::Token"));
+    const entryFunctionPayload = new TxnBuilderTypes.TransactionPayloadEntryFunction(
+      TxnBuilderTypes.EntryFunction.natural(
+        "0x4::aptos_token",
+        "add_typed_property",
+        [token, new TypeTagStruct(stringStructTag)],
+        [
+          BCS.bcsToBytes(AccountAddress.fromHex(tokenAddress)),
+          BCS.bcsSerializeStr("bcsKey"),
+          BCS.bcsSerializeStr("bcs value"),
+        ],
+      ),
+    );
+    const rawTxn = await provider.generateRawTransaction(account1.address(), entryFunctionPayload);
+    const bcsTxn = AptosClient.generateBCSTransaction(account1, rawTxn);
+    const transactionRes = await provider.submitSignedBCSTransaction(bcsTxn);
+    await provider.waitForTransaction(transactionRes.hash, { checkSuccess: true });
   },
   longTestTimeout,
 );

--- a/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
@@ -135,15 +135,10 @@ test(
     let tokenAddress = "";
 
     await provider.waitForTransaction(
-      await aptosToken.createCollection(
-        account1,
-        "Collection description",
-        "Collection Name",
-        "https://aptos.dev",
-        5,
-        10,
-        10,
-      ),
+      await aptosToken.createCollection(account1, "Collection description", "Collection Name", "https://aptos.dev", 5, {
+        royaltyNumerator: 10,
+        royaltyDenominator: 10,
+      }),
     );
     const txn = await provider.waitForTransactionWithResult(
       await aptosToken.mint(

--- a/ecosystem/typescript/sdk/src/tests/e2e/aptos_token.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/aptos_token.test.ts
@@ -2,9 +2,9 @@ import { AptosAccount } from "../../account";
 import { UserTransaction } from "../../generated";
 import { AptosToken } from "../../plugins";
 import { Provider } from "../../providers";
-import { NODE_URL, getFaucetClient, longTestTimeout } from "../unit/test_helper.test";
+import { PROVIDER_LOCAL_NETWORK_CONFIG, getFaucetClient, longTestTimeout } from "../unit/test_helper.test";
 
-const provider = new Provider({ fullnodeUrl: NODE_URL, indexerUrl: NODE_URL });
+const provider = new Provider(PROVIDER_LOCAL_NETWORK_CONFIG);
 const faucetClient = getFaucetClient();
 const aptosToken = new AptosToken(provider);
 
@@ -19,7 +19,6 @@ describe("token objects", () => {
   beforeAll(async () => {
     // Fund Alice's Account
     await faucetClient.fundAccount(alice.address(), 100000000);
-    console.log(alice);
   }, longTestTimeout);
 
   test(
@@ -53,7 +52,6 @@ describe("token objects", () => {
         { checkSuccess: true },
       );
       tokenAddress = (txn as UserTransaction).events[0].data.token;
-      console.log(tokenAddress);
     },
     longTestTimeout,
   );
@@ -157,13 +155,7 @@ describe("token objects", () => {
     "update typed property",
     async () => {
       await provider.waitForTransaction(
-        await aptosToken.updateTypedProperty(
-          alice,
-          tokenAddress,
-          "newTypedKey",
-          "VECTORU8",
-          new TextEncoder().encode(["hello", "World"].join("")),
-        ),
+        await aptosToken.updateTypedProperty(alice, tokenAddress, "newTypedKey", "U8", 2),
         { checkSuccess: true },
       );
     },

--- a/ecosystem/typescript/sdk/src/tests/e2e/aptos_token.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/aptos_token.test.ts
@@ -144,7 +144,7 @@ describe("token objects", () => {
     "add typed property",
     async () => {
       await provider.waitForTransaction(
-        await aptosToken.addTypedProperty(alice, tokenAddress, "newTypedKey", "U8", "5"),
+        await aptosToken.addTypedProperty(alice, tokenAddress, "newTypedKey", "U8VECTOR", "[hello,world]"),
         { checkSuccess: true },
       );
     },
@@ -155,7 +155,7 @@ describe("token objects", () => {
     "update typed property",
     async () => {
       await provider.waitForTransaction(
-        await aptosToken.updateTypedProperty(alice, tokenAddress, "newTypedKey", "U8", 2),
+        await aptosToken.updateTypedProperty(alice, tokenAddress, "newTypedKey", "U8", "2"),
         { checkSuccess: true },
       );
     },

--- a/ecosystem/typescript/sdk/src/tests/e2e/aptos_token.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/aptos_token.test.ts
@@ -19,6 +19,7 @@ describe("token objects", () => {
   beforeAll(async () => {
     // Fund Alice's Account
     await faucetClient.fundAccount(alice.address(), 100000000);
+    console.log(alice);
   }, longTestTimeout);
 
   test(
@@ -52,6 +53,7 @@ describe("token objects", () => {
         { checkSuccess: true },
       );
       tokenAddress = (txn as UserTransaction).events[0].data.token;
+      console.log(tokenAddress);
     },
     longTestTimeout,
   );
@@ -133,7 +135,35 @@ describe("token objects", () => {
     "add token property",
     async () => {
       await provider.waitForTransaction(
-        await aptosToken.addTokenProperty(alice, tokenAddress, "newKey", "bool", "true"),
+        await aptosToken.addTokenProperty(alice, tokenAddress, "newKey", "BOOLEAN", "true"),
+        { checkSuccess: true },
+      );
+    },
+    longTestTimeout,
+  );
+
+  test(
+    "add typed property",
+    async () => {
+      await provider.waitForTransaction(
+        await aptosToken.addTypedProperty(alice, tokenAddress, "newTypedKey", "U8", "5"),
+        { checkSuccess: true },
+      );
+    },
+    longTestTimeout,
+  );
+
+  test(
+    "update typed property",
+    async () => {
+      await provider.waitForTransaction(
+        await aptosToken.updateTypedProperty(
+          alice,
+          tokenAddress,
+          "newTypedKey",
+          "VECTORU8",
+          new TextEncoder().encode(["hello", "World"].join("")),
+        ),
         { checkSuccess: true },
       );
     },
@@ -144,7 +174,7 @@ describe("token objects", () => {
     "update token property",
     async () => {
       await provider.waitForTransaction(
-        await aptosToken.updateTokenProperty(alice, tokenAddress, "newKey", "u64", "0"),
+        await aptosToken.updateTokenProperty(alice, tokenAddress, "newKey", "U8", "5"),
         { checkSuccess: true },
       );
     },

--- a/ecosystem/typescript/sdk/src/tests/e2e/aptos_token.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/aptos_token.test.ts
@@ -144,7 +144,7 @@ describe("token objects", () => {
     "add typed property",
     async () => {
       await provider.waitForTransaction(
-        await aptosToken.addTypedProperty(alice, tokenAddress, "newTypedKey", "U8VECTOR", "[hello,world]"),
+        await aptosToken.addTypedProperty(alice, tokenAddress, "newTypedKey", "VECTOR", "[hello,world]"),
         { checkSuccess: true },
       );
     },

--- a/ecosystem/typescript/sdk/src/tests/unit/builder.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/unit/builder.test.ts
@@ -1,0 +1,234 @@
+import { TransactionBuilderRemoteABI } from "../../transaction_builder";
+import { AptosClient } from "../../providers";
+import { getFaucetClient, longTestTimeout, NODE_URL } from "./test_helper.test";
+import { AptosAccount } from "../../account";
+import {
+  RawTransaction,
+  TransactionPayloadEntryFunction,
+  TypeTagBool,
+  TypeTagStruct,
+  TypeTagU8,
+  TypeTagVector,
+} from "../../aptos_types";
+import { HexString } from "../../utils";
+
+describe.only("builder", () => {
+  test(
+    "generates raw txn from an entry function",
+    async () => {
+      const client = new AptosClient(NODE_URL);
+      const alice = new AptosAccount();
+      const faucetClient = getFaucetClient();
+      await faucetClient.fundAccount(alice.address(), 100000000);
+      // Create an instance of the class
+      const builder = new TransactionBuilderRemoteABI(client, { sender: alice.address() });
+
+      // Spy on the fetchABI method
+      const fetchABISpy = jest.spyOn(builder, "fetchABI");
+
+      // Mock the implementation of the fetchABI method to return a mock data
+      const abi = new Map();
+      abi.set("0x1::some_modules::SomeName", {
+        fullName: "0x1::some_modules::SomeName",
+        name: "SomeName",
+        is_entry: true,
+        is_view: false,
+        generic_type_params: [],
+        params: ["&signer", "0x1::string::String"],
+        return: [],
+        visibility: "public",
+      });
+      fetchABISpy.mockResolvedValue(abi);
+
+      // Call the build method with some arguments
+      const rawTxn = await builder.build("0x1::some_modules::SomeName", [], ["key"]);
+      expect(rawTxn instanceof RawTransaction).toBeTruthy();
+      expect(rawTxn.sender.address).toEqual(new HexString(alice.address().hex()).toUint8Array());
+      expect(rawTxn.payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.module_name.name.value).toBe("some_modules");
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.function_name.value).toBe("SomeName");
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.ty_args).toHaveLength(0);
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.args).toHaveLength(1);
+
+      // Restore the original implementation of the fetch method
+      fetchABISpy.mockRestore();
+    },
+    longTestTimeout,
+  );
+
+  test(
+    "generates raw txn from an entry function with Object type",
+    async () => {
+      const client = new AptosClient(NODE_URL);
+      const alice = new AptosAccount();
+      const faucetClient = getFaucetClient();
+      await faucetClient.fundAccount(alice.address(), 100000000);
+      // Create an instance of the class
+      const builder = new TransactionBuilderRemoteABI(client, { sender: alice.address() });
+
+      // Spy on the fetchABI method
+      const fetchABISpy = jest.spyOn(builder, "fetchABI");
+
+      // Mock the implementation of the fetchABI method to return a mock data
+      const abi = new Map();
+      abi.set("0x1::some_modules::SomeName", {
+        fullName: "0x1::some_modules::SomeName",
+        name: "SomeName",
+        is_entry: true,
+        is_view: false,
+        generic_type_params: [
+          {
+            constraints: ["key"],
+          },
+        ],
+        params: ["&signer", "0x1::object::Object<T>", "0x1::string::String"],
+        return: [],
+        visibility: "public",
+      });
+      fetchABISpy.mockResolvedValue(abi);
+
+      // Call the build method with some arguments
+      const rawTxn = await builder.build(
+        "0x1::some_modules::SomeName",
+        ["0x1::type::SomeType"],
+        ["0x2b4d540735a4e128fda896f988415910a45cab41c9ddd802b32dd16e8f9ca3cd", "key"],
+      );
+
+      expect(rawTxn instanceof RawTransaction).toBeTruthy();
+      expect(rawTxn.sender.address).toEqual(new HexString(alice.address().hex()).toUint8Array());
+      expect(rawTxn.payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.module_name.name.value).toBe("some_modules");
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.function_name.value).toBe("SomeName");
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.ty_args).toHaveLength(1);
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.args).toHaveLength(2);
+
+      // Restore the original implementation of the fetch method
+      fetchABISpy.mockRestore();
+    },
+    longTestTimeout,
+  );
+
+  test(
+    "generates raw txn from a generic entry function",
+    async () => {
+      const client = new AptosClient(NODE_URL);
+      const alice = new AptosAccount();
+      const faucetClient = getFaucetClient();
+      await faucetClient.fundAccount(alice.address(), 100000000);
+      // Create an instance of the class
+      const builder = new TransactionBuilderRemoteABI(client, { sender: alice.address() });
+
+      // Spy on the fetchABI method
+      const fetchABISpy = jest.spyOn(builder, "fetchABI");
+
+      // Mock the implementation of the fetchABI method to return a mock data
+      const abi = new Map();
+      abi.set("0x1::some_modules::SomeName", {
+        fullName: "0x1::some_modules::SomeName",
+        name: "SomeName",
+        is_entry: true,
+        is_view: false,
+        generic_type_params: [
+          {
+            constraints: ["key"],
+          },
+          {
+            constraints: ["drop"],
+          },
+        ],
+        params: ["&signer", "0x1::object::Object<T>", "0x1::string::String", "T1"],
+        return: [],
+        visibility: "public",
+      });
+      fetchABISpy.mockResolvedValue(abi);
+
+      // Call the build method with some arguments
+      const rawTxn = await builder.build(
+        "0x1::some_modules::SomeName",
+        ["0x1::type::SomeType", "vector<u8>"],
+        ["0x2b4d540735a4e128fda896f988415910a45cab41c9ddd802b32dd16e8f9ca3cd", "key", "[hello,world]"],
+      );
+
+      expect(rawTxn instanceof RawTransaction).toBeTruthy();
+      expect(rawTxn.sender.address).toEqual(new HexString(alice.address().hex()).toUint8Array());
+      expect(rawTxn.payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.module_name.name.value).toBe("some_modules");
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.function_name.value).toBe("SomeName");
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.ty_args).toHaveLength(2);
+      expect(
+        (rawTxn.payload as TransactionPayloadEntryFunction).value.ty_args[0] instanceof TypeTagStruct,
+      ).toBeTruthy();
+      expect(
+        (rawTxn.payload as TransactionPayloadEntryFunction).value.ty_args[1] instanceof TypeTagVector,
+      ).toBeTruthy();
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.args).toHaveLength(3);
+
+      // Restore the original implementation of the fetch method
+      fetchABISpy.mockRestore();
+    },
+    longTestTimeout,
+  );
+
+  test(
+    "generates raw txn from an entry function with multiple generic params",
+    async () => {
+      const client = new AptosClient(NODE_URL);
+      const alice = new AptosAccount();
+      const faucetClient = getFaucetClient();
+      await faucetClient.fundAccount(alice.address(), 100000000);
+      // Create an instance of the class
+      const builder = new TransactionBuilderRemoteABI(client, { sender: alice.address() });
+
+      // Spy on the fetchABI method
+      const fetchABISpy = jest.spyOn(builder, "fetchABI");
+
+      // Mock the implementation of the fetchABI method to return a mock data
+      const abi = new Map();
+      abi.set("0x1::some_modules::SomeName", {
+        fullName: "0x1::some_modules::SomeName",
+        name: "SomeName",
+        is_entry: true,
+        is_view: false,
+        generic_type_params: [
+          {
+            constraints: ["key"],
+          },
+          {
+            constraints: ["drop"],
+          },
+          {
+            constraints: ["key"],
+          },
+        ],
+        params: ["&signer", "T0", "0x1::string::String", "T1", "T2"],
+        return: [],
+        visibility: "public",
+      });
+      fetchABISpy.mockResolvedValue(abi);
+
+      // Call the build method with some arguments
+      const rawTxn = await builder.build(
+        "0x1::some_modules::SomeName",
+        ["bool", "vector<u8>", "u8"],
+        ["true", "key", "[hello,world]", "6"],
+      );
+
+      expect(rawTxn instanceof RawTransaction).toBeTruthy();
+      expect(rawTxn.sender.address).toEqual(new HexString(alice.address().hex()).toUint8Array());
+      expect(rawTxn.payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.module_name.name.value).toBe("some_modules");
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.function_name.value).toBe("SomeName");
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.ty_args).toHaveLength(3);
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.ty_args[0] instanceof TypeTagBool).toBeTruthy();
+      expect(
+        (rawTxn.payload as TransactionPayloadEntryFunction).value.ty_args[1] instanceof TypeTagVector,
+      ).toBeTruthy();
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.ty_args[2] instanceof TypeTagU8).toBeTruthy();
+      expect((rawTxn.payload as TransactionPayloadEntryFunction).value.args).toHaveLength(4);
+
+      // Restore the original implementation of the fetch method
+      fetchABISpy.mockRestore();
+    },
+    longTestTimeout,
+  );
+});

--- a/ecosystem/typescript/sdk/src/tests/unit/builder.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/unit/builder.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../../aptos_types";
 import { HexString } from "../../utils";
 
-describe.only("builder", () => {
+describe.only("TransactionBuilderRemoteABI", () => {
   test(
     "generates raw txn from an entry function",
     async () => {

--- a/ecosystem/typescript/sdk/src/tests/unit/test_helper.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/unit/test_helper.test.ts
@@ -1,10 +1,12 @@
 import { FaucetClient } from "../../plugins/faucet_client";
 import { OpenAPIConfig } from "../../generated";
+import { CustomEndpoints } from "../../utils/api-endpoints";
 
 export const NODE_URL = process.env.APTOS_NODE_URL!;
 export const FAUCET_URL = process.env.APTOS_FAUCET_URL!;
 export const API_TOKEN = process.env.API_TOKEN!;
 export const FAUCET_AUTH_TOKEN = process.env.FAUCET_AUTH_TOKEN!;
+export const PROVIDER_LOCAL_NETWORK_CONFIG: CustomEndpoints = { fullnodeUrl: NODE_URL, indexerUrl: NODE_URL };
 
 /**
  * Returns an instance of a FaucetClient with NODE_URL and FAUCET_URL from the

--- a/ecosystem/typescript/sdk/src/tests/unit/transaction_builder.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/unit/transaction_builder.test.ts
@@ -4,7 +4,7 @@
 /* eslint-disable max-len */
 import nacl from "tweetnacl";
 import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
-import { bcsSerializeUint64, bcsToBytes, Bytes } from "../../bcs";
+import { bcsSerializeBool, bcsSerializeUint64, bcsToBytes, Bytes } from "../../bcs";
 import { HexString } from "../../utils";
 
 import { TransactionBuilderEd25519, TransactionBuilder } from "../../transaction_builder/index";
@@ -25,6 +25,7 @@ import {
   TransactionArgumentU32,
   TransactionArgumentU256,
   AccountAddress,
+  TypeTagBool,
 } from "../../aptos_types";
 
 const ADDRESS_1 = "0x1222";
@@ -135,6 +136,35 @@ test("serialize entry function payload with type args but no function args", () 
 
   expect(hexSignedTxn(signedTxn)).toBe(
     "000000000000000000000000000000000000000000000000000000000a550c18000000000000000002000000000000000000000000000000000000000000000000000000000000122204636f696e0966616b655f66756e63010700000000000000000000000000000000000000000000000000000000000000010a6170746f735f636f696e094170746f73436f696e0000d0070000000000000000000000000000ffffffffffffffff040020b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200400e2d1cc4a27893cbae36d8b6a7150977c7620e065f359840413c5478a25f20a383250a9cdcb4fd71f7d171856f38972da30a9d10072e164614d96379004aa500",
+  );
+});
+
+test("serialize entry function payload with generic type args and function args", () => {
+  const token = new TypeTagStruct(StructTag.fromString(`0x14::token::Token`));
+
+  const entryFunctionPayload = new TransactionPayloadEntryFunction(
+    EntryFunction.natural(
+      `${ADDRESS_1}::aptos_token`,
+      "fake_typed_func",
+      [token, new TypeTagBool()],
+      [bcsToBytes(AccountAddress.fromHex(ADDRESS_2)), bcsSerializeBool(true)],
+    ),
+  );
+
+  const rawTxn = new RawTransaction(
+    AccountAddress.fromHex(ADDRESS_3),
+    BigInt(0),
+    entryFunctionPayload,
+    BigInt(2000),
+    BigInt(0),
+    BigInt(TXN_EXPIRE),
+    new ChainId(4),
+  );
+
+  const signedTxn = sign(rawTxn);
+
+  expect(hexSignedTxn(signedTxn)).toBe(
+    "000000000000000000000000000000000000000000000000000000000a550c1800000000000000000200000000000000000000000000000000000000000000000000000000000012220b6170746f735f746f6b656e0f66616b655f74797065645f66756e630207000000000000000000000000000000000000000000000000000000000000001405746f6b656e05546f6b656e0000022000000000000000000000000000000000000000000000000000000000000000dd0101d0070000000000000000000000000000ffffffffffffffff040020b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a4920040367085186aeef58a0256fc64ecb86b88a86f8a8e42151e0e9aae1ab6d426c4968f2cab664261ea6bb868869154fe6e946c082774741d5143e57a1d802fd1b700",
   );
 });
 

--- a/ecosystem/typescript/sdk/src/tests/unit/type_tag.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/unit/type_tag.test.ts
@@ -1,6 +1,7 @@
 import {
   StructTag,
   TypeTagAddress,
+  TypeTagBool,
   TypeTagParser,
   TypeTagParserError,
   TypeTagStruct,
@@ -116,6 +117,23 @@ describe("TypeTagParser", () => {
       expect(result.value.type_args.length).toEqual(2);
       expect(result.value.type_args[0] instanceof TypeTagAddress).toBeTruthy();
       expect(result.value.type_args[1] instanceof TypeTagStruct).toBeTruthy();
+    });
+  });
+
+  describe.only("supports generic types", () => {
+    test("throws an error when the type to use is not provided", () => {
+      const typeTag = "T0";
+      const parser = new TypeTagParser(typeTag);
+      expect(() => {
+        parser.parseTypeTag();
+      }).toThrow("Can't convert generic type to a tag type since typeTags array is empty.");
+    });
+
+    test("successfully parses a generic type tag to the provided type", () => {
+      const typeTag = "T0";
+      const parser = new TypeTagParser(typeTag, ["bool"]);
+      const result = parser.parseTypeTag();
+      expect(result instanceof TypeTagBool).toBeTruthy();
     });
   });
 });

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -397,10 +397,12 @@ export class TransactionBuilderRemoteABI {
     // Remove all `signer` and `&signer` from argument list because the Move VM injects those arguments. Clients do not
     // need to care about those args. `signer` and `&signer` are required be in the front of the argument list. But we
     // just loop through all arguments and filter out `signer` and `&signer`.
-    const originalArgs = funcAbi!.params.filter((param) => param !== "signer" && param !== "&signer");
+    const abiArgs = funcAbi!.params.filter((param) => param !== "signer" && param !== "&signer");
 
-    // Convert string arguments to TypeArgumentABI
-    const typeArgABIs = originalArgs.map((arg, i) => new ArgumentABI(`var${i}`, new TypeTagParser(arg).parseTypeTag()));
+    // Convert abi string arguments to TypeArgumentABI
+    const typeArgABIs = abiArgs.map(
+      (abiArg, i) => new ArgumentABI(`var${i}`, new TypeTagParser(abiArg, ty_tags).parseTypeTag()),
+    );
 
     const entryFunctionABI = new EntryFunctionABI(
       funcAbi!.name,

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.ts
@@ -15,8 +15,6 @@ import {
   AccountAddress,
   TypeTagVector,
   TypeTagStruct,
-  StructTag,
-  Identifier,
   TransactionArgument,
   TransactionArgumentBool,
   TransactionArgumentU16,
@@ -29,13 +27,6 @@ import {
   TransactionArgumentU8Vector,
 } from "../aptos_types";
 import { Serializer } from "../bcs";
-
-export const stringStructTag = new StructTag(
-  AccountAddress.fromHex("0x1"),
-  new Identifier("string"),
-  new Identifier("String"),
-  [],
-);
 
 function assertType(val: any, types: string[] | string, message?: string) {
   if (!types?.includes(typeof val)) {

--- a/ecosystem/typescript/sdk/src/utils/property_map_serde.ts
+++ b/ecosystem/typescript/sdk/src/utils/property_map_serde.ts
@@ -1,6 +1,7 @@
 import { Bytes, Deserializer, Serializer } from "../bcs";
-import { serializeArg, stringStructTag } from "../transaction_builder/builder_utils";
+import { serializeArg } from "../transaction_builder/builder_utils";
 import {
+  stringStructTag,
   TypeTag,
   TypeTagAddress,
   TypeTagBool,


### PR DESCRIPTION
### Description
Move supports generic input params, and specifically two generic functions in tokenv2 `add_typed_property` and `update_typed_property`.

This PR adds support for 
- generic params in the SDK for when we build a transaction based on remoteABI or when users pass in bcs transaction payload. This is the first step to support other input params such as Option.
- The 2 generic entry functions in TokenV2, `add_typed_property` and `update_typed_property`.

**This PR needs to be merged after** https://github.com/aptos-labs/aptos-core/pull/7486

### Test Plan
tests are passing
