### PR TITLE
[gitattributes] Ensure that powerscript files are not line-ending-auto-converted

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,6 +19,9 @@
 *.yaml text eol=lf 
 *.yml text eol=lf 
 
+# Ensure that powerscript files are not auto-converted
+*.ps1 binary
+
 # Use Move syntax highlighter for Move IR code
 *.mvir linguist-language=Move
 


### PR DESCRIPTION
[Reopening as a branch]

This otherwise breaks flows like copybara.

Tested with a copybara migration that this prevents the problem.