### PR TITLE
executor benchmark improvements for the different transaction types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,6 +1021,7 @@ dependencies = [
  "async-trait",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "chrono",
+ "clap 3.2.23",
  "criterion",
  "indicatif 0.15.0",
  "itertools",
@@ -1031,7 +1032,6 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde 1.0.149",
- "structopt",
  "tokio",
  "toml",
 ]

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -574,6 +574,7 @@ impl TxnEmitter {
             &req.transaction_mix_per_phase,
             num_workers,
             &mut all_accounts,
+            vec![],
             &txn_executor,
             &txn_factory,
             &init_txn_factory,

--- a/crates/transaction-generator-lib/src/args.rs
+++ b/crates/transaction-generator-lib/src/args.rs
@@ -9,12 +9,15 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Copy, Clone, ArgEnum, Deserialize, Parser, Serialize)]
 pub enum TransactionTypeArg {
     CoinTransfer,
+    CoinTransferWithInvalid,
     AccountGeneration,
     AccountGenerationLargePool,
     NftMintAndTransfer,
     PublishPackage,
     CustomFunctionLargeModuleWorkingSet,
     CreateNewResource,
+    ModifyGlobalResource,
+    ModifyTenGlobalResources,
     NoOp,
 }
 
@@ -29,6 +32,10 @@ impl TransactionTypeArg {
         match self {
             TransactionTypeArg::CoinTransfer => TransactionType::CoinTransfer {
                 invalid_transaction_ratio: 0,
+                sender_use_account_pool: false,
+            },
+            TransactionTypeArg::CoinTransferWithInvalid => TransactionType::CoinTransfer {
+                invalid_transaction_ratio: 10,
                 sender_use_account_pool: false,
             },
             TransactionTypeArg::AccountGeneration => TransactionType::default_account_generation(),
@@ -54,6 +61,16 @@ impl TransactionTypeArg {
                 },
                 num_modules: 1,
                 use_account_pool: true,
+            },
+            TransactionTypeArg::ModifyGlobalResource => TransactionType::CallCustomModules {
+                entry_point: EntryPoints::StepDst,
+                num_modules: 1,
+                use_account_pool: false,
+            },
+            TransactionTypeArg::ModifyTenGlobalResources => TransactionType::CallCustomModules {
+                entry_point: EntryPoints::StepDst,
+                num_modules: 10,
+                use_account_pool: false,
             },
             TransactionTypeArg::NoOp => TransactionType::CallCustomModules {
                 entry_point: EntryPoints::Nop,

--- a/crates/transaction-generator-lib/src/lib.rs
+++ b/crates/transaction-generator-lib/src/lib.rs
@@ -196,6 +196,7 @@ pub async fn create_txn_generator_creator(
     transaction_mix_per_phase: &[Vec<(TransactionType, usize)>],
     num_workers: usize,
     source_accounts: &mut [LocalAccount],
+    initial_burner_accounts: Vec<LocalAccount>,
     txn_executor: &dyn TransactionExecutor,
     txn_factory: &TransactionFactory,
     init_txn_factory: &TransactionFactory,
@@ -208,10 +209,11 @@ pub async fn create_txn_generator_creator(
     let addresses_pool = Arc::new(RwLock::new(
         source_accounts
             .iter()
+            .chain(initial_burner_accounts.iter())
             .map(|d| d.address())
             .collect::<Vec<_>>(),
     ));
-    let accounts_pool = Arc::new(RwLock::new(Vec::new()));
+    let accounts_pool = Arc::new(RwLock::new(initial_burner_accounts));
 
     let mut txn_generator_creator_mix_per_phase: Vec<
         Vec<(Box<dyn TransactionGeneratorCreator>, usize)>,

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -36,6 +36,7 @@ aptos-vm = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
 chrono = { workspace = true }
+clap = { workspace = true }
 criterion = { workspace = true }
 indicatif = { workspace = true }
 itertools = { workspace = true }
@@ -45,7 +46,6 @@ once_cell = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
-structopt = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 

--- a/execution/executor-benchmark/src/account_generator.rs
+++ b/execution/executor-benchmark/src/account_generator.rs
@@ -76,18 +76,17 @@ impl AccountCache {
         }
     }
 
+    pub fn split(mut self, index: usize) -> (Vec<LocalAccount>, Vec<LocalAccount>) {
+        let other = self.accounts.split_off(index);
+        (self.accounts.into(), other.into())
+    }
+
     pub fn len(&self) -> usize {
         self.accounts.len()
     }
 
     pub fn accounts(&self) -> &VecDeque<LocalAccount> {
         &self.accounts
-    }
-
-    pub fn accounts_mut(&mut self) -> &mut [LocalAccount] {
-        self.accounts.make_contiguous();
-
-        self.accounts.as_mut_slices().0
     }
 
     pub fn grow(&mut self, n: usize) {

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -2,7 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{add_accounts_impl, benchmark_transaction::BenchmarkTransaction};
+use crate::{add_accounts_impl, benchmark_transaction::BenchmarkTransaction, PipelineConfig};
 use aptos_config::{
     config::{
         PrunerConfig, RocksdbConfigs, BUFFERED_STATE_TARGET_ITEMS,
@@ -19,7 +19,7 @@ use aptos_storage_interface::DbReaderWriter;
 use aptos_vm::AptosVM;
 use std::{fs, path::Path};
 
-pub fn run<V>(
+pub fn create_db_with_accounts<V>(
     num_accounts: usize,
     init_account_balance: u64,
     block_size: usize,
@@ -28,6 +28,7 @@ pub fn run<V>(
     verify_sequence_numbers: bool,
     use_state_kv_db: bool,
     use_sharded_state_merkle_db: bool,
+    pipeline_config: PipelineConfig,
 ) where
     V: TransactionBlockExecutor<BenchmarkTransaction> + 'static,
 {
@@ -56,6 +57,7 @@ pub fn run<V>(
         verify_sequence_numbers,
         use_state_kv_db,
         use_sharded_state_merkle_db,
+        pipeline_config,
     );
 }
 

--- a/execution/executor-benchmark/src/fake_executor.rs
+++ b/execution/executor-benchmark/src/fake_executor.rs
@@ -240,6 +240,14 @@ impl TransactionBlockExecutor<BenchmarkTransaction> for FakeExecutor {
                                             &state_view,
                                         )
                                     },
+                                    (AccountAddress::ONE, "aptos_account", "create_account") => {
+                                        Self::handle_account_creation(
+                                            user_txn.sender(),
+                                            bcs::from_bytes(&f.args()[0]).unwrap(),
+                                            0,
+                                            &state_view,
+                                        )
+                                    },
                                     _ => unimplemented!(),
                                 }
                             },

--- a/execution/executor-benchmark/src/gen_executor.rs
+++ b/execution/executor-benchmark/src/gen_executor.rs
@@ -7,6 +7,7 @@ use crate::{
     db_access::{CoinStore, DbAccessUtil},
 };
 use anyhow::Result;
+use aptos_crypto::HashValue;
 use aptos_state_view::account_with_state_view::AsAccountWithStateView;
 use aptos_storage_interface::{state_view::LatestDbStateCheckpointView, DbReaderWriter};
 use aptos_transaction_generator_lib::{
@@ -20,6 +21,7 @@ use aptos_types::{
 use async_trait::async_trait;
 use std::{
     collections::HashMap,
+    iter::once,
     sync::{atomic::AtomicUsize, mpsc},
     time::Duration,
 };
@@ -62,6 +64,9 @@ impl GenInitTransactionExecutor for DbGenInitTransactionExecutor {
                     transaction: Transaction::UserTransaction(t.clone()),
                     extra_info: None,
                 })
+                .chain(once(
+                    Transaction::StateCheckpoint(HashValue::random()).into(),
+                ))
                 .collect(),
         )?;
 


### PR DESCRIPTION
* change executor benchmark from structopt to clap
* add --transaction-type flag to executor benchmark.
* add allow_discards and allow_aborts flags (asserting on those otherwise), and fixing commit to not panic when discards are present
* fixing to fetch sequence numbers for user accounts as well, and to fill accounts beyond main_signer_accounts to be used as burner accounts
* fixing GenInit executor to have StateCheckpoint as the last transaction for each block
