### PR TITLE
Confirm Docker is running in CLI and faucet e2e tests

### DIFF
--- a/crates/aptos-faucet/integration-tests/local_testnet.py
+++ b/crates/aptos-faucet/integration-tests/local_testnet.py
@@ -21,6 +21,18 @@ def run_node(network: Network, image_repo_with_project: str, external_test_dir: 
     internal_mount_path = "/mymount"
     LOG.info(f"Trying to run local testnet from image: {image_name}")
 
+    # Confirm that the Docker daemon is running.
+    try:
+        subprocess.run(
+            ["docker", "container", "ls"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+    except:
+        LOG.error("Failed to connect to Docker. Is it installed and running?")
+        raise
+
     # First delete the existing container if there is one with the same name.
     subprocess.run(
         ["docker", "rm", "-f", container_name],

--- a/crates/aptos/e2e/local_testnet.py
+++ b/crates/aptos/e2e/local_testnet.py
@@ -19,6 +19,18 @@ def run_node(network: Network, image_repo_with_project: str):
     container_name = f"aptos-tools-{network}"
     LOG.info(f"Trying to run aptos CLI local testnet from image: {image_name}")
 
+    # Confirm that the Docker daemon is running.
+    try:
+        subprocess.run(
+            ["docker", "container", "ls"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+    except:
+        LOG.error("Failed to connect to Docker. Is it installed and running?")
+        raise
+
     # First delete the existing container if there is one with the same name.
     subprocess.run(
         ["docker", "rm", "-f", container_name],


### PR DESCRIPTION
### Description
As it was it wasn't very clear why the local testnet setup was failing if Docker wasn't running. This makes it clearer.

### Test Plan
Turn off Docker, then:
```
$ poetry run python main.py --base-network devnet --test-cli-tag devnet
2023-04-19 17:27:02,547 - INFO - Trying to run aptos CLI local testnet from image: aptoslabs/tools:devnet
2023-04-19 17:27:02,585 - ERROR - Failed to connect to Docker. Is it installed and running?
Traceback (most recent call last):
  File "/Users/dport/a/core/crates/aptos/e2e/main.py", line 158, in <module>
    if main():
  File "/Users/dport/a/core/crates/aptos/e2e/main.py", line 117, in main
    container_name = run_node(args.base_network, args.image_repo_with_project)
  File "/Users/dport/a/core/crates/aptos/e2e/local_testnet.py", line 24, in run_node
    subprocess.run(
  File "/Users/dport/.pyenv/versions/3.9.13/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['docker', 'container', 'ls']' returned non-zero exit status 1.
```
