### PR TITLE
[CLI e2e] update the e2e readme file for CLI

### DIFF
--- a/crates/aptos/e2e/README.md
+++ b/crates/aptos/e2e/README.md
@@ -23,6 +23,19 @@ For example:
 poetry run python main.py --base-network mainnet --test-cli-tag mainnet
 ```
 
+Note:
+
+1. If you are get an error message similar to ``docker: no matching manifest for linux/arm64/v8 in the manifest list entries.`` You can run your peotry command with env var ``DOCKER_DEFAULT_PLATFORM=linux/amd64``. For example:
+```
+DOCKER_DEFAULT_PLATFORM=linux/amd64 poetry run python main.py --base-network testnet --test-cli-path ~/aptos-core/target/debug/aptos
+```
+2. When running the e2e test using poetry locally, make sure you set your aptos config type to ``Workspace``, otherwise it won't be able to find the test account after ``aptos init``. You can change it back to ``Global`` afterward
+```
+aptos config set-global-config --config-type Workspace
+```
+
+
+
 ## Writing new test cases
 To write a new test case, follow these steps:
 1. (Optional) Make a new file in [cases/](cases/) if none of the existing files seem appropriate.

--- a/crates/aptos/e2e/README.md
+++ b/crates/aptos/e2e/README.md
@@ -23,18 +23,23 @@ For example:
 poetry run python main.py --base-network mainnet --test-cli-tag mainnet
 ```
 
-Note:
+## Debugging
 
-1. If you are get an error message similar to ``docker: no matching manifest for linux/arm64/v8 in the manifest list entries.`` You can run your peotry command with env var ``DOCKER_DEFAULT_PLATFORM=linux/amd64``. For example:
+If you are get an error message similar to this:
+```
+docker: no matching manifest for linux/arm64/v8 in the manifest list entries.
+```
+
+Try running the poetry command with this env var:
 ```
 DOCKER_DEFAULT_PLATFORM=linux/amd64 poetry run python main.py --base-network testnet --test-cli-path ~/aptos-core/target/debug/aptos
 ```
-2. When running the e2e test using poetry locally, make sure you set your aptos config type to ``Workspace``, otherwise it won't be able to find the test account after ``aptos init``. You can change it back to ``Global`` afterward
-```
-aptos config set-global-config --config-type Workspace
-```
+This makes the docker commands use the x86_64 images since we don't publish images for ARM.
 
-
+When running the e2e test using poetry locally, make sure you set your aptos config type to `workspace`, otherwise it won't be able to find the test account after `aptos init`. You can change it back to `global` afterward:
+```
+aptos config set-global-config --config-type workspace
+```
 
 ## Writing new test cases
 To write a new test case, follow these steps:


### PR DESCRIPTION
### Description
There were couple information missing from readme. This diff updates it so it unblock people who were testing it.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

```
➜  e2e git:(jin/add_account_lookup_by_auth_key) ✗ DOCKER_DEFAULT_PLATFORM=linux/amd64 poetry run python main.py --base-network testnet --test-cli-path ~/Projects/aptos-core/target/debug/aptos
2023-04-19 09:15:40,851 - INFO - Trying to run aptos CLI local testnet from image: aptoslabs/tools:testnet
testnet: Pulling from aptoslabs/tools
Digest: sha256:869c6981eb68858b3b71abf87cd488320caefce650721113422862badccdab78
Status: Image is up to date for aptoslabs/tools:testnet
2023-04-19 09:15:43,483 - INFO - Running aptos CLI local testnet from image: aptoslabs/tools:testnet
2023-04-19 09:15:43,484 - INFO - Waiting for node and faucet APIs for aptos-tools-testnet to come up
2023-04-19 09:15:58,718 - INFO - Node and faucet APIs for aptos-tools-testnet came up
2023-04-19 09:15:58,732 - INFO - Running test: test_init
2023-04-19 09:16:02,154 - INFO - Running test: test_account_fund_with_faucet
2023-04-19 09:16:32,686 - INFO - Running test: test_account_create
2023-04-19 09:16:38,517 - INFO - Stopping container: aptos-tools-testnet
2023-04-19 09:16:39,001 - INFO - Stopped container: aptos-tools-testnet
2023-04-19 09:16:39,001 - INFO - These tests passed:
2023-04-19 09:16:39,002 - INFO - test_init
2023-04-19 09:16:39,002 - INFO - test_account_fund_with_faucet
2023-04-19 09:16:39,002 - INFO - test_account_create
2023-04-19 09:16:39,002 - INFO - All tests passed!
```
