### PR TITLE
[Storage service] Add peer IDs to error logs.

### DIFF
--- a/state-sync/storage-service/server/src/logging.rs
+++ b/state-sync/storage-service/server/src/logging.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::Error;
+use aptos_config::network_id::PeerNetworkId;
 use aptos_logger::Schema;
 use aptos_storage_service_types::requests::StorageServiceRequest;
 use serde::Serialize;
@@ -12,8 +13,10 @@ pub struct LogSchema<'a> {
     name: LogEntry,
     error: Option<&'a Error>,
     message: Option<&'a str>,
+    peer_network_id: Option<&'a PeerNetworkId>,
     response: Option<&'a str>,
     request: Option<&'a StorageServiceRequest>,
+    subscription_related: Option<bool>,
 }
 
 impl<'a> LogSchema<'a> {
@@ -22,8 +25,10 @@ impl<'a> LogSchema<'a> {
             name,
             error: None,
             message: None,
+            peer_network_id: None,
             response: None,
             request: None,
+            subscription_related: None,
         }
     }
 }
@@ -37,4 +42,5 @@ pub enum LogEntry {
     StorageSummaryRefresh,
     SubscriptionRefresh,
     SubscriptionResponse,
+    SubscriptionRequest,
 }

--- a/state-sync/storage-service/server/src/metrics.rs
+++ b/state-sync/storage-service/server/src/metrics.rs
@@ -11,6 +11,8 @@ use once_cell::sync::Lazy;
 /// Useful metric constants for the storage service
 pub const LRU_CACHE_HIT: &str = "lru_cache_hit";
 pub const LRU_CACHE_PROBE: &str = "lru_cache_probe";
+pub const SUBSCRIPTION_EVENT_ADD: &str = "subscription_event_add";
+pub const SUBSCRIPTION_EVENT_EXPIRE: &str = "subscription_event_expire";
 
 /// Counter for lru cache events in the storage service (server-side)
 pub static LRU_CACHE_EVENT: Lazy<IntCounterVec> = Lazy::new(|| {
@@ -79,6 +81,16 @@ pub static STORAGE_REQUEST_PROCESSING_LATENCY: Lazy<HistogramVec> = Lazy::new(||
         "aptos_storage_service_server_request_latency",
         "Time it takes to process a storage service request",
         &["protocol", "request_type"]
+    )
+    .unwrap()
+});
+
+/// Counter for subscription request events
+pub static SUBSCRIPTION_EVENT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_storage_service_server_subscription_event",
+        "Counters related to subscription events",
+        &["protocol", "event"]
     )
     .unwrap()
 });


### PR DESCRIPTION
### Description

This (tiny) PR adds peer network IDs to the error logs in the storage service. This will be helpful to better understand which peers are sending requests that may be invalid and/or fail.

### Test Plan
Existing test infrastructure.