### PR TITLE
[haproxy] Update haproxy 2.2 to latest

### DIFF
--- a/docker/compose/aptos-node/docker-compose-fullnode.yaml
+++ b/docker/compose/aptos-node/docker-compose-fullnode.yaml
@@ -4,7 +4,7 @@
 version: "3.8"
 services:
   haproxy:
-    image: haproxytech/haproxy-debian:2.2
+    image: haproxytech/haproxy-debian:2.2.29
     volumes:
       - type: bind
         source: ./haproxy-fullnode.cfg

--- a/docker/compose/aptos-node/docker-compose-src.yaml
+++ b/docker/compose/aptos-node/docker-compose-src.yaml
@@ -4,7 +4,7 @@
 version: "3.8"
 services:
   haproxy:
-    image: haproxytech/haproxy-debian:2.2
+    image: haproxytech/haproxy-debian:2.2.29
     volumes:
       - type: bind
         source: ./haproxy.cfg

--- a/docker/compose/aptos-node/docker-compose.yaml
+++ b/docker/compose/aptos-node/docker-compose.yaml
@@ -4,7 +4,7 @@
 version: "3.8"
 services:
   haproxy:
-    image: haproxytech/haproxy-debian:2.2
+    image: haproxytech/haproxy-debian:2.2.29
     volumes:
       - type: bind
         source: ./haproxy.cfg

--- a/terraform/helm/aptos-node/README.md
+++ b/terraform/helm/aptos-node/README.md
@@ -36,7 +36,7 @@ Aptos blockchain node deployment
 | haproxy.enabled | bool | `true` | Enable HAProxy deployment in front of validator and fullnodes |
 | haproxy.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy to use for HAProxy images |
 | haproxy.image.repo | string | `"haproxy"` | Image repo to use for HAProxy images |
-| haproxy.image.tag | string | `"2.2.14@sha256:36aa98fff27dcb2d12c93e68515a6686378c783ea9b1ab1d01ce993a5cbc73e1"` | Image tag to use for HAProxy images |
+| haproxy.image.tag | string | `"2.2.29@sha256:8019a233a37045a27970dbc990e9ea485799200c40f658e4620b7fdf55641a3c"` | Image tag to use for HAProxy images |
 | haproxy.limits.validator.connectionsPerIPPerMin | int | `12` | Limit the number of connections per IP address per min |
 | haproxy.limits.validator.maxBytesOutRate10sec | int | `134217728` |  |
 | haproxy.limits.validator.rateLimitSession | int | `256` |  |

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -29,7 +29,7 @@ haproxy:
     # -- Image repo to use for HAProxy images
     repo: haproxy
     # -- Image tag to use for HAProxy images
-    tag: 2.2.14@sha256:36aa98fff27dcb2d12c93e68515a6686378c783ea9b1ab1d01ce993a5cbc73e1
+    tag: 2.2.29@sha256:8019a233a37045a27970dbc990e9ea485799200c40f658e4620b7fdf55641a3c
     # -- Image pull policy to use for HAProxy images
     pullPolicy: IfNotPresent
   resources:

--- a/testsuite/dos/http_test/docker/docker-compose.yaml
+++ b/testsuite/dos/http_test/docker/docker-compose.yaml
@@ -4,7 +4,7 @@
 version: "3.8"
 services:
   haproxy:
-    image: haproxytech/haproxy-debian:2.2
+    image: haproxytech/haproxy-debian:2.2.29
     networks:
       - shared
     volumes:


### PR DESCRIPTION
Test Plan: docker compose / helm apply to testnets
