### PR TITLE
[cli] Add more system information on telemetry and aptos info

### DIFF
--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -20,6 +20,7 @@ use crate::common::{
     types::{CliCommand, CliResult, CliTypedResult},
     utils::cli_build_information,
 };
+use aptos_telemetry::system_information::collect_limited_system_information;
 use async_trait::async_trait;
 use clap::Parser;
 use std::collections::BTreeMap;
@@ -85,6 +86,8 @@ impl CliCommand<BTreeMap<String, String>> for InfoTool {
     }
 
     async fn execute(self) -> CliTypedResult<BTreeMap<String, String>> {
-        Ok(cli_build_information())
+        let mut info = cli_build_information();
+        collect_limited_system_information(&mut info);
+        Ok(info)
     }
 }


### PR DESCRIPTION
### Description
This adds minimal and non-intrusive metrics for the CLI telemetry.  This will allow for tracking of CPU types and OS usage.

### Test Plan

Tested on my Windows desktop
```
$ aptos info
{
  "Result": {
    "build_branch": "node-startup-metrics",
    "build_cargo_version": "cargo 1.66.1 (ad779e08b 2023-01-10)",
    "build_clean_checkout": "true",
    "build_commit_hash": "e40cb0d288eec9b3cb01d83e68117d545b3f4f41",
    "build_is_release_build": "true",
    "build_os": "linux-x86_64",
    "build_pkg_version": "1.0.11",
    "build_profile_name": "release",
    "build_rust_channel": "1.66.1-x86_64-unknown-linux-gnu",
    "build_rust_version": "rustc 1.66.1 (90743e729 2023-01-10)",
    "build_tag": "",
    "build_time": "2023-04-19 16:57:39 -07:00",
    "build_using_tokio_unstable": "true",
    "cpu_brand": "AMD Ryzen 7 3700X 8-Core Processor",
    "cpu_core_count": "8",
    "cpu_count": "16",
    "cpu_vendor_id": "AuthenticAMD",
    "memory_total": "33567547",
    "system_kernel_version": "5.19.0-38-generic",
    "system_name": "Ubuntu",
    "system_os_version": "Linux 22.04 Ubuntu"
  }
}
```

Tested on my Macbook
```
$ aptos info 
{
  "Result": {
    "build_branch": "node-startup-metrics",
    "build_cargo_version": "cargo 1.66.1 (ad779e08b 2023-01-10)",
    "build_clean_checkout": "false",
    "build_commit_hash": "e40cb0d288eec9b3cb01d83e68117d545b3f4f41",
    "build_is_release_build": "false",
    "build_os": "macos-aarch64",
    "build_pkg_version": "1.0.11",
    "build_profile_name": "debug",
    "build_rust_channel": "1.66.1-aarch64-apple-darwin",
    "build_rust_version": "rustc 1.66.1 (90743e729 2023-01-10)",
    "build_tag": "",
    "build_time": "2023-04-19 14:53:45 -07:00",
    "build_using_tokio_unstable": "true",
    "cpu_brand": "Apple M1 Max",
    "cpu_core_count": "10",
    "cpu_count": "10",
    "cpu_vendor_id": "Apple",
    "memory_total": "68719476",
    "system_kernel_version": "22.4.0",
    "system_name": "Darwin",
    "system_os_version": "MacOS 13.3.1 "
  }
}

```