### PR TITLE
Code validation for multi-versioning

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -171,56 +171,21 @@ jobs:
       FEATURES: consensus-only-perf-test
       BUILD_ADDL_TESTING_IMAGES: true
 
-  rust-images-all:
-    needs:
-      [
-        determine-docker-build-metadata,
-        rust-images,
-        rust-images-indexer,
-        rust-images-failpoints,
-        rust-images-performance,
-        rust-images-consensus-only-perf-test,
-      ]
-    if: always() # this ensures that the job will run even if the previous jobs were skipped
-    runs-on: ubuntu-latest
-    steps:
-      - name: fail if rust-images job failed
-        if: ${{ needs.rust-images.result == 'failure' }}
-        run: exit 1
-      - name: fail if rust-images-indexer job failed
-        if: ${{ needs.rust-images-indexer.result == 'failure' }}
-        run: exit 1
-      - name: fail if rust-images-failpoints job failed
-        if: ${{ needs.rust-images-failpoints.result == 'failure' }}
-        run: exit 1
-      - name: fail if rust-images-performance job failed
-        if: ${{ needs.rust-images-performance.result == 'failure' }}
-        run: exit 1
-      - name: fail if rust-images-consensus-only-perf-test job failed
-        if: ${{ needs.rust-images-consensus-only-perf-test.result == 'failure' }}
-        run: exit 1
-    outputs:
-      rustImagesResult: ${{ needs.rust-images.result }}
-      rustImagesIndexerResult: ${{ needs.rust-images-indexer.result }}
-      rustImagesFailpointsResult: ${{ needs.rust-images-failpoints.result }}
-      rustImagesPerformanceResult: ${{ needs.rust-images-performance.result }}
-      rustImagesConsensusOnlyPerfTestResult: ${{ needs.rust-images-consensus-only-perf-test.result }}
-
   sdk-release:
-    needs: [rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
+    needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
     if: |
       (github.event_name == 'push' && github.ref_name != 'main') ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
       github.event.pull_request.auto_merge != null ||
       contains(github.event.pull_request.body, '#e2e')
-    uses: ./.github/workflows/sdk-release.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/sdk-release.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
 
   cli-e2e-tests:
-    needs: [rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
+    needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
     if: |
       !contains(github.event.pull_request.labels.*.name, 'CICD:skip-sdk-integration-test') && (
         github.event_name == 'push' ||
@@ -234,10 +199,30 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
 
+  indexer-grpc-e2e-tests:
+    needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
+    if: |
+      (github.event_name == 'push' && github.ref_name != 'main') ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+      github.event.pull_request.auto_merge != null ||
+      contains(github.event.pull_request.body, '#e2e')
+    uses: ./.github/workflows/docker-indexer-grpc-test.yaml
+    secrets: inherit
+    with:
+      GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+
   forge-e2e-test:
-    needs: [rust-images-all, determine-docker-build-metadata]
-    if: | # always() ensures that the job will run even if some of the previous docker variant build jobs were skipped https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
-      always() && needs.rust-images-all.result == 'success' && (
+    needs:
+      - permission-check
+      - determine-docker-build-metadata
+      - rust-images
+      - rust-images-indexer
+      - rust-images-failpoints
+      - rust-images-performance
+      - rust-images-consensus-only-perf-test
+    if: |
+      !failure() && !cancelled() && needs.permission-check.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
@@ -259,9 +244,16 @@ jobs:
 
   # Run e2e compat test against testnet branch
   forge-compat-test:
-    needs: [rust-images-all, determine-docker-build-metadata]
-    if: | # always() ensures that the job will run even if some of the previous docker variant build jobs were skipped https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
-      always() && needs.rust-images-all.result == 'success' && (
+    needs:
+      - permission-check
+      - determine-docker-build-metadata
+      - rust-images
+      - rust-images-indexer
+      - rust-images-failpoints
+      - rust-images-performance
+      - rust-images-consensus-only-perf-test
+    if: |
+      !failure() && !cancelled() && needs.permission-check.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
@@ -280,9 +272,16 @@ jobs:
 
   # Run forge framework upgradability test
   forge-framework-upgrade-test:
-    needs: [rust-images-all, determine-docker-build-metadata]
-    if: | # always() ensures that the job will run even if some of the previous docker variant build jobs were skipped https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
-      always() && needs.rust-images-all.result == 'success' && (
+    needs:
+      - permission-check
+      - determine-docker-build-metadata
+      - rust-images
+      - rust-images-indexer
+      - rust-images-failpoints
+      - rust-images-performance
+      - rust-images-consensus-only-perf-test
+    if: |
+      !failure() && !cancelled() && needs.permission-check.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
@@ -300,9 +299,16 @@ jobs:
       FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
 
   forge-consensus-only-perf-test:
-    needs: [rust-images-all, determine-docker-build-metadata]
-    if: | # always() ensures that the job will run even if some of the previous docker variant build jobs were skipped https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
-      always() && needs.rust-images-all.result == 'success' &&
+    needs:
+      - permission-check
+      - determine-docker-build-metadata
+      - rust-images
+      - rust-images-indexer
+      - rust-images-failpoints
+      - rust-images-performance
+      - rust-images-consensus-only-perf-test
+    if: |
+      !failure() && !cancelled() && needs.permission-check.result == 'success' &&
       contains(github.event.pull_request.labels.*.name, 'CICD:run-consensus-only-perf-test')
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -92,13 +92,13 @@ jobs:
   # Because the docker build happens in a reusable workflow, have a separate job that collects the right metadata
   # for the subsequent docker builds. Reusable workflows do not currently have the "env" context: https://github.com/orgs/community/discussions/26671
   determine-docker-build-metadata:
+    needs: [permission-check]
     runs-on: ubuntu-latest
     steps:
       - name: collect metadata
         run: |
-          echo "GIT_SHA: ${{ env.GIT_SHA }}"
-          echo "TARGET_CACHE_ID: ${{ env.TARGET_CACHE_ID }}"
-          echo "CONCURRENCY: ${{ github.workflow }}-${{ github.event_name }}-${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.sha || github.head_ref || github.ref }}"
+          echo "GIT_SHA: ${GIT_SHA}"
+          echo "TARGET_CACHE_ID: ${TARGET_CACHE_ID}"
     outputs:
       gitSha: ${{ env.GIT_SHA }}
       targetCacheId: ${{ env.TARGET_CACHE_ID }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
+ "aptos-executable-store",
  "aptos-infallible",
  "aptos-logger",
  "aptos-metrics-core",
@@ -907,6 +908,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-crypto",
+ "aptos-executable-store",
  "aptos-gas",
  "aptos-gas-profiling",
  "aptos-logger",
@@ -957,6 +959,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-executable-store"
+version = "0.1.0"
+dependencies = [
+ "aptos-crypto",
+ "aptos-infallible",
+ "aptos-logger",
+ "aptos-types",
+ "claims",
+ "dashmap",
+ "num-derive",
+ "num-traits 0.2.15",
+]
+
+[[package]]
 name = "aptos-executor"
 version = "0.1.0"
 dependencies = [
@@ -966,6 +982,7 @@ dependencies = [
  "aptos-consensus-types",
  "aptos-crypto",
  "aptos-db",
+ "aptos-executable-store",
  "aptos-executor-test-helpers",
  "aptos-executor-types",
  "aptos-gas",
@@ -1002,6 +1019,7 @@ dependencies = [
  "aptos-config",
  "aptos-crypto",
  "aptos-db",
+ "aptos-executable-store",
  "aptos-executor",
  "aptos-executor-types",
  "aptos-genesis",
@@ -1758,6 +1776,7 @@ dependencies = [
  "aptos-bitvec",
  "aptos-cached-packages",
  "aptos-crypto",
+ "aptos-executable-store",
  "aptos-framework",
  "aptos-gas",
  "aptos-keygen",
@@ -1952,6 +1971,7 @@ dependencies = [
  "anyhow",
  "aptos-aggregator",
  "aptos-crypto",
+ "aptos-executable-store",
  "aptos-infallible",
  "aptos-types",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -2983,6 +3003,7 @@ version = "0.1.0"
 dependencies = [
  "aptos-bitvec",
  "aptos-crypto",
+ "aptos-executable-store",
  "aptos-gas",
  "aptos-language-e2e-tests",
  "aptos-types",
@@ -3077,6 +3098,7 @@ dependencies = [
  "aptos-api-types",
  "aptos-cached-packages",
  "aptos-crypto",
+ "aptos-executable-store",
  "aptos-framework",
  "aptos-gas",
  "aptos-language-e2e-tests",
@@ -3183,6 +3205,7 @@ dependencies = [
  "aptos-block-executor",
  "aptos-crypto",
  "aptos-crypto-derive",
+ "aptos-executable-store",
  "aptos-framework",
  "aptos-gas",
  "aptos-infallible",
@@ -3261,6 +3284,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
+ "aptos-executable-store",
  "aptos-language-e2e-tests",
  "aptos-move-stdlib",
  "aptos-types",
@@ -5073,13 +5097,16 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.2.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8858831f7781322e539ea39e72449c46b059638250c14344fec8d0aa6e539c"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if",
- "num_cpus",
- "parking_lot 0.12.1",
+ "hashbrown 0.12.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.3",
+ "rayon",
 ]
 
 [[package]]
@@ -7373,10 +7400,11 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ members = [
     "storage/backup/backup-cli",
     "storage/backup/backup-service",
     "storage/db-tool",
+    "storage/executable-store",
     "storage/indexer",
     "storage/jellyfish-merkle",
     "storage/rocksdb-options",
@@ -270,6 +271,7 @@ aptos-event-notifications = { path = "state-sync/inter-component/event-notificat
 aptos-executor = { path = "execution/executor" }
 aptos-executor-test-helpers = { path = "execution/executor-test-helpers" }
 aptos-executor-types = { path = "execution/executor-types" }
+aptos-executable-store = { path = "storage/executable-store" }
 aptos-faucet-cli = { path = "crates/aptos-faucet/cli" }
 aptos-faucet-core = { path = "crates/aptos-faucet/core" }
 aptos-faucet-service = { path = "crates/aptos-faucet/service" }
@@ -412,7 +414,7 @@ crossbeam = "0.8.1"
 crossbeam-channel = "0.5.4"
 csv = "1.2.1"
 curve25519-dalek = "3"
-dashmap = "5.2.0"
+dashmap = { version = "5.4.0", features = ["rayon"] }
 datatest-stable = "0.1.1"
 debug-ignore = { version = "1.0.3", features = ["serde"] }
 derivative = "2.2.0"

--- a/aptos-move/aptos-debugger/Cargo.toml
+++ b/aptos-move/aptos-debugger/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 aptos-crypto = { workspace = true }
+aptos-executable-store = { workspace = true }
 aptos-gas = { workspace = true }
 aptos-gas-profiling = { workspace = true }
 aptos-logger = { workspace = true }

--- a/aptos-move/aptos-debugger/src/lib.rs
+++ b/aptos-move/aptos-debugger/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{format_err, Result};
+use aptos_executable_store::ExecutableStore;
 use aptos_gas::{
     AbstractValueSizeGasParameters, ChangeSetConfigs, NativeGasParameters, StandardGasMeter,
     LATEST_GAS_FEATURE_VERSION,
@@ -57,7 +58,7 @@ impl AptosDebugger {
         txns: Vec<Transaction>,
     ) -> Result<Vec<TransactionOutput>> {
         let state_view = DebuggerStateView::new(self.debugger.clone(), version);
-        AptosVM::execute_block(txns, &state_view)
+        AptosVM::execute_block(txns, &state_view, Arc::new(ExecutableStore::default()))
             .map_err(|err| format_err!("Unexpected VM Error: {:?}", err))
     }
 

--- a/aptos-move/aptos-debugger/src/main.rs
+++ b/aptos-move/aptos-debugger/src/main.rs
@@ -29,6 +29,10 @@ pub struct Argument {
 
     #[clap(long, default_value = "1")]
     concurrency_level: usize,
+
+    /// Default 0 disables executable caching across the blocks.
+    #[clap(long, default_value = "0")]
+    executable_cache_size: usize,
 }
 
 #[tokio::main]
@@ -36,6 +40,7 @@ async fn main() -> Result<()> {
     aptos_logger::Logger::new().init();
     let args = Argument::parse();
     AptosVM::set_concurrency_level_once(args.concurrency_level);
+    AptosVM::set_executable_cache_size_once(args.executable_cache_size as u64);
 
     let debugger = match args.target {
         Target::Rest { endpoint } => {

--- a/aptos-move/aptos-transaction-benchmarks/Cargo.toml
+++ b/aptos-move/aptos-transaction-benchmarks/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 aptos-bitvec = { workspace = true }
 aptos-crypto = { workspace = true }
+aptos-executable-store = { workspace = true }
 aptos-gas = { workspace = true, features = ["testing"] }
 aptos-language-e2e-tests = { workspace = true }
 aptos-types = { workspace = true }

--- a/aptos-move/aptos-transactional-test-harness/Cargo.toml
+++ b/aptos-move/aptos-transactional-test-harness/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true }
 aptos-api-types = { workspace = true }
 aptos-cached-packages = { workspace = true }
 aptos-crypto = { workspace = true }
+aptos-executable-store = { workspace = true }
 aptos-framework = { workspace = true }
 aptos-gas = { workspace = true }
 aptos-language-e2e-tests = { workspace = true }

--- a/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
+++ b/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
@@ -9,6 +9,7 @@ use aptos_crypto::{
     hash::HashValue,
     ValidCryptoMaterialStringExt,
 };
+use aptos_executable_store::ExecutableStore;
 use aptos_gas::{InitialGasSchedule, TransactionGasParameters};
 use aptos_language_e2e_tests::data_store::{FakeDataStore, GENESIS_CHANGE_SET_HEAD};
 use aptos_state_view::TStateView;
@@ -471,7 +472,11 @@ impl<'a> AptosTestAdapter<'a> {
     /// Should error if the transaction ends up being discarded, or having a status other than
     /// EXECUTED.
     fn run_transaction(&mut self, txn: Transaction) -> Result<TransactionOutput> {
-        let mut outputs = AptosVM::execute_block(vec![txn], &self.storage)?;
+        let mut outputs = AptosVM::execute_block(
+            vec![txn],
+            &self.storage,
+            Arc::new(ExecutableStore::default()),
+        )?;
 
         assert_eq!(outputs.len(), 1);
 

--- a/aptos-move/aptos-vm-profiling/Cargo.toml
+++ b/aptos-move/aptos-vm-profiling/Cargo.toml
@@ -18,6 +18,7 @@ once_cell = { workspace = true }
 smallvec = { workspace = true }
 
 aptos-cached-packages = { workspace = true }
+aptos-executable-store = { workspace = true }
 aptos-language-e2e-tests = { workspace = true }
 aptos-move-stdlib = { workspace = true }
 aptos-types = { workspace = true }

--- a/aptos-move/aptos-vm-profiling/src/bins/run_aptos_p2p.rs
+++ b/aptos-move/aptos-vm-profiling/src/bins/run_aptos_p2p.rs
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use aptos_executable_store::ExecutableStore;
 use aptos_language_e2e_tests::{account::AccountData, data_store::FakeDataStore};
-use aptos_types::{transaction::Transaction, write_set::WriteSet};
+use aptos_types::{
+    executable::ExecutableTestType, state_store::state_key::StateKey, transaction::Transaction,
+    write_set::WriteSet,
+};
 use aptos_vm::{AptosVM, VMExecutor};
 use std::{
     collections::HashMap,
     io::{self, Read},
+    sync::Arc,
 };
 
 fn main() -> Result<()> {
@@ -44,7 +49,11 @@ fn main() -> Result<()> {
         })
         .collect();
 
-    let res = AptosVM::execute_block(txns, &state_store)?;
+    let res = AptosVM::execute_block(
+        txns,
+        &state_store,
+        Arc::new(ExecutableStore::<StateKey, ExecutableTestType>::default()),
+    )?;
     for i in 0..NUM_TXNS {
         assert!(res[i as usize].status().status().unwrap().is_success());
     }

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -18,6 +18,7 @@ aptos-aggregator = { workspace = true }
 aptos-block-executor = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-crypto-derive = { workspace = true }
+aptos-executable-store = { workspace = true }
 aptos-framework =  { workspace = true }
 aptos-gas = { workspace = true }
 aptos-infallible = { workspace = true }

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -123,12 +123,15 @@ pub mod transaction_metadata;
 mod verifier;
 
 pub use crate::aptos_vm::AptosVM;
+use aptos_executable_store::ExecutableStore;
 use aptos_state_view::StateView;
 use aptos_types::{
+    executable::ExecutableTestType,
+    state_store::state_key::StateKey,
     transaction::{SignedTransaction, Transaction, TransactionOutput, VMValidatorResult},
     vm_status::VMStatus,
 };
-use std::marker::Sync;
+use std::{marker::Sync, sync::Arc};
 pub use verifier::view_function::determine_is_view;
 
 /// This trait describes the VM's validation interfaces.
@@ -152,6 +155,7 @@ pub trait VMExecutor: Send + Sync {
     fn execute_block(
         transactions: Vec<Transaction>,
         state_view: &(impl StateView + Sync),
+        executable_cache: Arc<ExecutableStore<StateKey, ExecutableTestType>>,
     ) -> Result<Vec<TransactionOutput>, VMStatus>;
 }
 

--- a/aptos-move/block-executor/Cargo.toml
+++ b/aptos-move/block-executor/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-aggregator = { workspace = true }
+aptos-executable-store = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }

--- a/aptos-move/block-executor/src/proptest_types/bencher.rs
+++ b/aptos-move/block-executor/src/proptest_types/bencher.rs
@@ -9,6 +9,8 @@ use crate::{
         TransactionGenParams, ValueType,
     },
 };
+use aptos_executable_store::ExecutableStore;
+use aptos_types::executable::ExecutableTestType;
 use criterion::{BatchSize, Bencher as CBencher};
 use num_cpus;
 use proptest::{
@@ -18,7 +20,7 @@ use proptest::{
     strategy::{Strategy, ValueTree},
     test_runner::TestRunner,
 };
-use std::{fmt::Debug, hash::Hash, marker::PhantomData};
+use std::{fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
 
 pub struct Bencher<K, V> {
     transaction_size: usize,
@@ -117,8 +119,14 @@ where
             Transaction<KeyType<K>, ValueType<V>>,
             Task<KeyType<K>, ValueType<V>>,
             EmptyDataView<KeyType<K>, ValueType<V>>,
+            ExecutableTestType,
         >::new(num_cpus::get())
-        .execute_transactions_parallel((), &self.transactions, &data_view);
+        .execute_transactions_parallel(
+            (),
+            &self.transactions,
+            &data_view,
+            Arc::new(ExecutableStore::<KeyType<K>, ExecutableTestType>::default()),
+        );
 
         self.expected_output.assert_output(&output);
     }

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -10,6 +10,8 @@ use crate::{
         TransactionGenParams, ValueType,
     },
 };
+use aptos_executable_store::ExecutableStore;
+use aptos_types::executable::ExecutableTestType;
 use claims::assert_ok;
 use num_cpus;
 use proptest::{
@@ -19,7 +21,7 @@ use proptest::{
     strategy::{Strategy, ValueTree},
     test_runner::TestRunner,
 };
-use std::{fmt::Debug, hash::Hash, marker::PhantomData};
+use std::{fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
 
 fn run_transactions<K, V>(
     key_universe: &[K],
@@ -55,8 +57,14 @@ fn run_transactions<K, V>(
             Transaction<KeyType<K>, ValueType<V>>,
             Task<KeyType<K>, ValueType<V>>,
             EmptyDataView<KeyType<K>, ValueType<V>>,
+            ExecutableTestType,
         >::new(num_cpus::get())
-        .execute_transactions_parallel((), &transactions, &data_view);
+        .execute_transactions_parallel(
+            (),
+            &transactions,
+            &data_view,
+            Arc::new(ExecutableStore::<KeyType<K>, ExecutableTestType>::default()),
+        );
 
         if module_access.0 && module_access.1 {
             assert_eq!(output.unwrap_err(), Error::ModulePathReadWrite);
@@ -179,8 +187,14 @@ fn deltas_writes_mixed() {
             Transaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             Task<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             DeltaDataView<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
+            ExecutableTestType,
         >::new(num_cpus::get())
-        .execute_transactions_parallel((), &transactions, &data_view);
+        .execute_transactions_parallel(
+            (),
+            &transactions,
+            &data_view,
+            Arc::new(ExecutableStore::<KeyType<[u8; 32]>, ExecutableTestType>::default()),
+        );
 
         let baseline = ExpectedOutput::generate_baseline(&transactions, None);
         baseline.assert_output(&output);
@@ -219,8 +233,14 @@ fn deltas_resolver() {
             Transaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             Task<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             DeltaDataView<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
+            ExecutableTestType,
         >::new(num_cpus::get())
-        .execute_transactions_parallel((), &transactions, &data_view);
+        .execute_transactions_parallel(
+            (),
+            &transactions,
+            &data_view,
+            Arc::new(ExecutableStore::<KeyType<[u8; 32]>, ExecutableTestType>::default()),
+        );
 
         let delta_writes = output
             .as_ref()
@@ -360,8 +380,14 @@ fn publishing_fixed_params() {
         Transaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
         Task<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
         DeltaDataView<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
+        ExecutableTestType,
     >::new(num_cpus::get())
-    .execute_transactions_parallel((), &transactions, &data_view);
+    .execute_transactions_parallel(
+        (),
+        &transactions,
+        &data_view,
+        Arc::new(ExecutableStore::<KeyType<[u8; 32]>, ExecutableTestType>::default()),
+    );
     assert_ok!(output);
 
     // Adjust the reads of txn indices[2] to contain module read to key 42.
@@ -396,8 +422,14 @@ fn publishing_fixed_params() {
             Transaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             Task<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             DeltaDataView<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
+            ExecutableTestType,
         >::new(num_cpus::get())
-        .execute_transactions_parallel((), &transactions, &data_view);
+        .execute_transactions_parallel(
+            (),
+            &transactions,
+            &data_view,
+            Arc::new(ExecutableStore::<KeyType<[u8; 32]>, ExecutableTestType>::default()),
+        );
 
         assert_eq!(output.unwrap_err(), Error::ModulePathReadWrite);
     }

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -28,13 +28,7 @@ pub enum ExecutionStatus<T, E> {
 /// transaction will write to a key value storage as their side effect.
 pub trait Transaction: Sync + Send + 'static {
     type Key: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug;
-    type Value: Send + Sync + TransactionWrite;
-}
-
-/// Inference result of a transaction.
-pub struct Accesses<K> {
-    pub keys_read: Vec<K>,
-    pub keys_written: Vec<K>,
+    type Value: Clone + Send + Sync + TransactionWrite;
 }
 
 /// Trait for single threaded transaction executor.

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -8,8 +8,12 @@ use crate::{
     scheduler::{Scheduler, SchedulerTask},
 };
 use aptos_aggregator::delta_change_set::{delta_add, delta_sub, DeltaOp, DeltaUpdate};
+use aptos_executable_store::ExecutableStore;
 use aptos_mvhashmap::types::TxnIndex;
-use aptos_types::{executable::ModulePath, write_set::TransactionWrite};
+use aptos_types::{
+    executable::{ExecutableTestType, ModulePath},
+    write_set::TransactionWrite,
+};
 use claims::{assert_matches, assert_some_eq};
 use rand::{prelude::*, random};
 use std::{
@@ -30,9 +34,18 @@ where
         phantom: PhantomData,
     };
 
-    let output =
-        BlockExecutor::<Transaction<K, V>, Task<K, V>, DeltaDataView<K, V>>::new(num_cpus::get())
-            .execute_transactions_parallel((), &transactions, &data_view);
+    let output = BlockExecutor::<
+        Transaction<K, V>,
+        Task<K, V>,
+        DeltaDataView<K, V>,
+        ExecutableTestType,
+    >::new(num_cpus::get())
+    .execute_transactions_parallel(
+        (),
+        &transactions,
+        &data_view,
+        Arc::new(ExecutableStore::<K, ExecutableTestType>::default()),
+    );
 
     let baseline = ExpectedOutput::generate_baseline(&transactions, None);
     baseline.assert_output(&output);

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -9,17 +9,18 @@ use aptos_aggregator::delta_change_set::{deserialize, serialize};
 use aptos_logger::error;
 use aptos_mvhashmap::{
     types::{MVCodeError, MVCodeOutput, MVDataError, MVDataOutput, TxnIndex},
+    unsync_map::UnsyncMap,
     MVHashMap,
 };
 use aptos_state_view::{StateViewId, TStateView};
 use aptos_types::{
-    executable::{ExecutableTestType, ModulePath},
+    executable::{Executable, ExecutableDescriptor, ExecutableView, FetchedModule, ModulePath},
     state_store::{state_storage_usage::StateStorageUsage, state_value::StateValue},
     vm_status::{StatusCode, VMStatus},
     write_set::TransactionWrite,
 };
 use aptos_vm_logging::{log_schema::AdapterLogSchema, prelude::*};
-use std::{cell::RefCell, collections::BTreeMap, fmt::Debug, hash::Hash, sync::Arc};
+use std::{cell::RefCell, fmt::Debug, hash::Hash, sync::Arc};
 
 /// A struct that is always used by a single thread performing an execution task. The struct is
 /// passed to the VM and acts as a proxy to resolve reads first in the shared multi-version
@@ -28,10 +29,16 @@ use std::{cell::RefCell, collections::BTreeMap, fmt::Debug, hash::Hash, sync::Ar
 /// TODO(issue 10177): MvHashMapView currently needs to be sync due to trait bounds, but should
 /// not be. In this case, the read_dependency member can have a RefCell<bool> type and the
 /// captured_reads member can have RefCell<Vec<ReadDescriptor<K>>> type.
-pub(crate) struct MVHashMapView<'a, K, V: TransactionWrite> {
-    versioned_map: &'a MVHashMap<K, V, ExecutableTestType>, // TODO: proper generic type
+pub(crate) struct MVHashMapView<
+    'a,
+    K: ModulePath + PartialOrd + Ord + Send + Clone + Hash + Eq + Sync + Debug,
+    V: TransactionWrite + Send + Sync,
+    X: Executable,
+> {
+    versioned_map: &'a MVHashMap<K, V, X>,
     scheduler: &'a Scheduler,
-    captured_reads: RefCell<Vec<ReadDescriptor<K>>>,
+    captured_reads: RefCell<Vec<(K, ReadDescriptor)>>,
+    captured_executables: RefCell<Vec<(K, ExecutableDescriptor)>>,
 }
 
 /// A struct which describes the result of the read from the proxy. The client
@@ -50,37 +57,76 @@ pub(crate) enum ReadResult<V> {
 
 impl<
         'a,
-        K: ModulePath + PartialOrd + Ord + Send + Clone + Debug + Hash + Eq,
+        K: ModulePath + PartialOrd + Ord + Send + Sync + Clone + Debug + Hash + Eq,
         V: TransactionWrite + Send + Sync,
-    > MVHashMapView<'a, K, V>
+        X: Executable,
+    > MVHashMapView<'a, K, V, X>
 {
-    pub(crate) fn new(
-        versioned_map: &'a MVHashMap<K, V, ExecutableTestType>,
-        scheduler: &'a Scheduler,
-    ) -> Self {
+    pub(crate) fn new(versioned_map: &'a MVHashMap<K, V, X>, scheduler: &'a Scheduler) -> Self {
         Self {
             versioned_map,
             scheduler,
             captured_reads: RefCell::new(Vec::new()),
+            captured_executables: RefCell::new(Vec::new()),
         }
     }
 
     /// Drains the captured reads.
-    pub(crate) fn take_reads(&self) -> Vec<ReadDescriptor<K>> {
-        self.captured_reads.take()
+    pub(crate) fn take_captured_inputs(
+        self,
+    ) -> (Vec<(K, ReadDescriptor)>, Vec<(K, ExecutableDescriptor)>) {
+        (self.captured_reads.take(), self.captured_executables.take())
     }
 
-    // TODO: Actually fill in the logic to record fetched executables, etc.
+    /// Captures a key, executable descriptor pair if an executable is returned,
+    /// otherwise, may return a module blob without capturing anything (for the
+    /// VM to produce executable), or None, indicating the module blob must be
+    /// returned from storage. May internally wait for a dependency.
     fn fetch_code(
         &self,
         key: &K,
         txn_idx: TxnIndex,
-    ) -> anyhow::Result<MVCodeOutput<V, ExecutableTestType>, MVCodeError> {
+    ) -> Option<(ExecutableDescriptor, FetchedModule<X>)> {
+        use MVCodeError::*;
+        use MVCodeOutput::*;
+
+        loop {
+            match self.versioned_map.fetch_code(key, txn_idx) {
+                Ok(Executable((executable, descriptor))) => {
+                    self.captured_executables
+                        .borrow_mut()
+                        .push((key.clone(), descriptor.clone()));
+                    return Some((descriptor, FetchedModule::Executable(executable)));
+                },
+                Ok(Module((v, hash))) => {
+                    return Some((
+                        ExecutableDescriptor::Published(hash),
+                        FetchedModule::Blob(
+                            v.extract_raw_bytes().expect("Module can't be deleted"),
+                        ),
+                    ));
+                },
+                Err(Dependency(dep_idx)) => {
+                    // `txn_idx` estimated to depend on a write from `dep_idx`.
+                    self.wait_for_dependency(txn_idx, dep_idx);
+                },
+                Err(NotFound) => return None,
+            }
+        }
+    }
+
+    // Legacy API to fetch modules as data via StateView interface.
+    // TODO: delete once executables are fetched via ExecutableView interface.
+    fn fetch_code_legacy(
+        &self,
+        key: &K,
+        txn_idx: TxnIndex,
+    ) -> anyhow::Result<MVCodeOutput<Arc<V>, X>, MVCodeError> {
         // Add a fake read from storage to register in reads for now in order
         // for the read / write path intersection fallback for modules to still work.
         self.captured_reads
             .borrow_mut()
-            .push(ReadDescriptor::from_storage(key.clone()));
+            .push((key.clone(), ReadDescriptor::Storage));
 
         self.versioned_map.fetch_code(key, txn_idx)
     }
@@ -91,6 +137,33 @@ impl<
 
     /// Captures a read from the VM execution, but not unresolved deltas, as in this case it is the
     /// callers responsibility to set the aggregator's base value and call fetch_data again.
+    fn wait_for_dependency(&self, txn_idx: TxnIndex, dep_idx: TxnIndex) {
+        if let Some(dep_condition) = self.scheduler.wait_for_dependency(txn_idx, dep_idx) {
+            let _timer = counters::DEPENDENCY_WAIT_SECONDS.start_timer();
+            // Wait on a condition variable corresponding to the encountered
+            // read dependency. Once the dep_idx finishes re-execution, scheduler
+            // will mark the dependency as resolved, and then the txn_idx will be
+            // scheduled for re-execution, which will re-awaken cvar here.
+            // A deadlock is not possible due to these condition variables:
+            // suppose all threads are waiting on read dependency, and consider
+            // one with lowest txn_idx. It observed a dependency, so some thread
+            // aborted dep_idx. If that abort returned execution task, by
+            // minimality (lower transactions aren't waiting), that thread would
+            // finish execution unblock txn_idx, contradiction. Otherwise,
+            // execution_idx in scheduler was lower at a time when at least the
+            // thread that aborted dep_idx was alive, and again, since lower txns
+            // than txn_idx are not blocked, so the execution of dep_idx will
+            // eventually finish and lead to unblocking txn_idx, contradiction.
+            let (lock, cvar) = &*dep_condition;
+            let mut dep_resolved = lock.lock();
+            while !*dep_resolved {
+                dep_resolved = cvar.wait(dep_resolved).unwrap();
+            }
+        }
+    }
+
+    /// Captures a read from the VM execution and returns ReadResult. May internally wait
+    /// for a dependency.
     fn fetch_data(&self, key: &K, txn_idx: TxnIndex) -> ReadResult<V> {
         use MVDataError::*;
         use MVDataOutput::*;
@@ -101,49 +174,25 @@ impl<
                     let (idx, incarnation) = version;
                     self.captured_reads
                         .borrow_mut()
-                        .push(ReadDescriptor::from_version(key.clone(), idx, incarnation));
+                        .push((key.clone(), ReadDescriptor::Version(idx, incarnation)));
                     return ReadResult::Value(v);
                 },
                 Ok(Resolved(value)) => {
                     self.captured_reads
                         .borrow_mut()
-                        .push(ReadDescriptor::from_resolved(key.clone(), value));
+                        .push((key.clone(), ReadDescriptor::Resolved(value)));
                     return ReadResult::U128(value);
                 },
                 Err(NotFound) => {
                     self.captured_reads
                         .borrow_mut()
-                        .push(ReadDescriptor::from_storage(key.clone()));
+                        .push((key.clone(), ReadDescriptor::Storage));
                     return ReadResult::None;
                 },
                 Err(Unresolved(_)) => return ReadResult::Unresolved,
                 Err(Dependency(dep_idx)) => {
-                    // `self.txn_idx` estimated to depend on a write from `dep_idx`.
-                    match self.scheduler.wait_for_dependency(txn_idx, dep_idx) {
-                        Some(dep_condition) => {
-                            let _timer = counters::DEPENDENCY_WAIT_SECONDS.start_timer();
-                            // Wait on a condition variable corresponding to the encountered
-                            // read dependency. Once the dep_idx finishes re-execution, scheduler
-                            // will mark the dependency as resolved, and then the txn_idx will be
-                            // scheduled for re-execution, which will re-awaken cvar here.
-                            // A deadlock is not possible due to these condition variables:
-                            // suppose all threads are waiting on read dependency, and consider
-                            // one with lowest txn_idx. It observed a dependency, so some thread
-                            // aborted dep_idx. If that abort returned execution task, by
-                            // minimality (lower transactions aren't waiting), that thread would
-                            // finish execution unblock txn_idx, contradiction. Otherwise,
-                            // execution_idx in scheduler was lower at a time when at least the
-                            // thread that aborted dep_idx was alive, and again, since lower txns
-                            // than txn_idx are not blocked, so the execution of dep_idx will
-                            // eventually finish and lead to unblocking txn_idx, contradiction.
-                            let (lock, cvar) = &*dep_condition;
-                            let mut dep_resolved = lock.lock();
-                            while !*dep_resolved {
-                                dep_resolved = cvar.wait(dep_resolved).unwrap();
-                            }
-                        },
-                        None => continue,
-                    }
+                    // `txn_idx` estimated to depend on a write from `dep_idx`.
+                    self.wait_for_dependency(txn_idx, dep_idx);
                 },
                 Err(DeltaApplicationFailure) => {
                     // Delta application failure currently should never happen. Here, we assume it
@@ -151,7 +200,7 @@ impl<
                     // ensure the transaction re-executes if 0 wasn't the right number.
                     self.captured_reads
                         .borrow_mut()
-                        .push(ReadDescriptor::from_delta_application_failure(key.clone()));
+                        .push((key.clone(), ReadDescriptor::DeltaApplicationFailure));
                     return ReadResult::U128(0);
                 },
             };
@@ -159,23 +208,23 @@ impl<
     }
 }
 
-enum ViewMapKind<'a, T: Transaction> {
-    MultiVersion(&'a MVHashMapView<'a, T::Key, T::Value>),
-    BTree(&'a BTreeMap<T::Key, T::Value>),
+enum ViewMapKind<'a, T: Transaction, X: Executable> {
+    MultiVersion(&'a MVHashMapView<'a, T::Key, T::Value, X>),
+    Unsync(&'a UnsyncMap<T::Key, T::Value, X>),
 }
 
-pub(crate) struct LatestView<'a, T: Transaction, S: TStateView<Key = T::Key>> {
+pub(crate) struct LatestView<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> {
     base_view: &'a S,
-    latest_view: ViewMapKind<'a, T>,
+    latest_view: ViewMapKind<'a, T, X>,
     txn_idx: TxnIndex,
 }
 
-impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
+impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<'a, T, S, X> {
     pub(crate) fn new_mv_view(
         base_view: &'a S,
-        map: &'a MVHashMapView<'a, T::Key, T::Value>,
+        map: &'a MVHashMapView<'a, T::Key, T::Value, X>,
         txn_idx: TxnIndex,
-    ) -> LatestView<'a, T, S> {
+    ) -> LatestView<'a, T, S, X> {
         LatestView {
             base_view,
             latest_view: ViewMapKind::MultiVersion(map),
@@ -183,46 +232,70 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
         }
     }
 
-    pub(crate) fn new_btree_view(
+    pub(crate) fn new_unsync_view(
         base_view: &'a S,
-        map: &'a BTreeMap<T::Key, T::Value>,
+        map: &'a UnsyncMap<T::Key, T::Value, X>,
         txn_idx: TxnIndex,
-    ) -> LatestView<'a, T, S> {
+    ) -> LatestView<'a, T, S, X> {
         LatestView {
             base_view,
-            latest_view: ViewMapKind::BTree(map),
+            latest_view: ViewMapKind::Unsync(map),
             txn_idx,
         }
     }
 
-    fn get_base_value(&self, state_key: &T::Key) -> anyhow::Result<Option<StateValue>> {
-        let ret = self.base_view.get_state_value(state_key);
+    fn log_storage_error(&self, key: &T::Key) {
+        // Even speculatively, reading from base view should not return an error.
+        // Thus, this critical error log and count does not need to be buffered.
+        let log_context = AdapterLogSchema::new(self.base_view.id(), self.txn_idx as usize);
+        alert!(
+            log_context,
+            "[VM, StateView] Error getting data from storage for {:?}",
+            key
+        );
+    }
 
-        if ret.is_err() {
-            // Even speculatively, reading from base view should not return an error.
-            // Thus, this critical error log and count does not need to be buffered.
-            let log_context = AdapterLogSchema::new(self.base_view.id(), self.txn_idx as usize);
-            alert!(
-                log_context,
-                "[VM, StateView] Error getting data from storage for {:?}",
-                state_key
-            );
-        }
-        ret
+    fn get_base_value(&self, key: &T::Key) -> anyhow::Result<Option<StateValue>> {
+        self.base_view.get_state_value(key).map_err(|e| {
+            self.log_storage_error(key);
+            e
+        })
+    }
+
+    fn get_base_module(
+        &self,
+        key: &T::Key,
+    ) -> anyhow::Result<(ExecutableDescriptor, FetchedModule<X>)> {
+        self.base_view.get_state_value_bytes(key).map_or_else(
+            |e| {
+                self.log_storage_error(key);
+                Err(e)
+            },
+            |maybe_bytes| {
+                Ok((
+                    ExecutableDescriptor::Storage,
+                    FetchedModule::Blob(maybe_bytes.expect("Module can't be deleted")),
+                ))
+            },
+        )
     }
 }
 
-impl<'a, T: Transaction, S: TStateView<Key = T::Key>> TStateView for LatestView<'a, T, S> {
+impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TStateView
+    for LatestView<'a, T, S, X>
+{
     type Key = T::Key;
 
     fn get_state_value(&self, state_key: &T::Key) -> anyhow::Result<Option<StateValue>> {
         match self.latest_view {
+            // TODO: get rid of the dispatch once caller statically dispatches data vs executable
+            // fetching via StateView or ExecutableView traits.
             ViewMapKind::MultiVersion(map) => match state_key.module_path() {
                 Some(_) => {
                     use MVCodeError::*;
                     use MVCodeOutput::*;
 
-                    match map.fetch_code(state_key, self.txn_idx) {
+                    match map.fetch_code_legacy(state_key, self.txn_idx) {
                         Ok(Executable(_)) => unreachable!("Versioned executable not implemented"),
                         Ok(Module((v, _))) => Ok(v.as_state_value()),
                         Err(Dependency(_)) => {
@@ -260,7 +333,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> TStateView for LatestView<
                     }
                 },
             },
-            ViewMapKind::BTree(map) => map.get(state_key).map_or_else(
+            ViewMapKind::Unsync(map) => map.fetch_data(state_key).map_or_else(
                 || self.get_base_value(state_key),
                 |v| Ok(v.as_state_value()),
             ),
@@ -277,5 +350,65 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> TStateView for LatestView<
 
     fn get_usage(&self) -> Result<StateStorageUsage> {
         self.base_view.get_usage()
+    }
+}
+
+impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> ExecutableView
+    for LatestView<'a, T, S, X>
+{
+    type Executable = X;
+    type Key = T::Key;
+
+    fn fetch_module(
+        &self,
+        key: &T::Key,
+    ) -> anyhow::Result<(ExecutableDescriptor, FetchedModule<X>)> {
+        match self.latest_view {
+            ViewMapKind::MultiVersion(map) => map
+                .fetch_code(key, self.txn_idx)
+                .map_or_else(|| self.get_base_module(key), Ok),
+            ViewMapKind::Unsync(map) => map.fetch_code(key).map_or_else(
+                || self.get_base_module(key),
+                |res| {
+                    Ok(match res {
+                        MVCodeOutput::Executable((executable, descriptor)) => {
+                            (descriptor, FetchedModule::Executable(executable))
+                        },
+                        MVCodeOutput::Module((v, hash)) => (
+                            ExecutableDescriptor::Published(hash),
+                            FetchedModule::Blob(
+                                v.extract_raw_bytes().expect("Module can't be deleted"),
+                            ),
+                        ),
+                    })
+                },
+            ),
+        }
+    }
+
+    fn store_executable(
+        &self,
+        key: &Self::Key,
+        descriptor: ExecutableDescriptor,
+        executable: Self::Executable,
+    ) {
+        match self.latest_view {
+            ViewMapKind::MultiVersion(map) => map
+                .versioned_map
+                .store_executable(key, descriptor, executable),
+            ViewMapKind::Unsync(map) => {
+                if !map.store_executable(key, descriptor.clone(), executable) {
+                    // Should not happen during sequential execution.
+                    let log_context =
+                        AdapterLogSchema::new(self.base_view.id(), self.txn_idx as usize);
+                    error!(
+                        log_context,
+                        "Executable w. descriptor = {:?} already stored for key = {:?}",
+                        descriptor,
+                        key
+                    );
+                }
+            },
+        }
     }
 }

--- a/aptos-move/e2e-tests/Cargo.toml
+++ b/aptos-move/e2e-tests/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true }
 aptos-bitvec = { workspace = true }
 aptos-cached-packages ={ workspace = true }
 aptos-crypto = { workspace = true, features = ["fuzzing"] }
+aptos-executable-store = { workspace = true }
 aptos-framework = { workspace = true }
 aptos-gas = { workspace = true }
 aptos-keygen = { workspace = true }

--- a/aptos-move/mvhashmap/src/types.rs
+++ b/aptos-move/mvhashmap/src/types.rs
@@ -3,7 +3,7 @@
 
 use aptos_aggregator::delta_change_set::DeltaOp;
 use aptos_crypto::hash::HashValue;
-use aptos_types::executable::ExecutableDescriptor;
+use aptos_types::executable::{Executable, ExecutableDescriptor};
 use std::sync::Arc;
 
 pub type TxnIndex = u32;
@@ -51,13 +51,14 @@ pub enum MVDataOutput<V> {
 
 /// Returned as Ok(..) when read successfully from the multi-version data-structure.
 #[derive(Debug, PartialEq, Eq)]
-pub enum MVCodeOutput<M, X> {
-    /// Arc to the executable corresponding to the latest module, and a descriptor
-    /// with either the module hash or indicator that the module is from storage.
-    Executable((Arc<X>, ExecutableDescriptor)),
-    /// Arc to the latest module, together with its (cryptographic) hash. Note that
+pub enum MVCodeOutput<M, X: Executable> {
+    /// Executable corresponding to the latest module, and a descriptor with either
+    /// the module hash or indicator that the module is from storage.
+    Executable((X, ExecutableDescriptor)),
+    /// The latest module, together with its (cryptographic) hash. Note that
     /// this can't be a storage-level module, as it's from multi-versioned code map.
-    /// The Option can be None if HashValue can't be computed, currently may happen
-    /// if the latest entry corresponded to the module deletion.
-    Module((Arc<M>, HashValue)),
+    // Note: currently used as Arc of type in multi-versioned, and directly in the
+    // simple (unsync) implementation. TODO: when the type is efficiently clonable
+    // and Arc wrapper will be deprecated anyway (both for modules and data).
+    Module((M, HashValue)),
 }

--- a/aptos-move/mvhashmap/src/unit_tests/mod.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/mod.rs
@@ -10,6 +10,7 @@ use aptos_aggregator::{
     delta_change_set::{delta_add, delta_sub, DeltaOp, DeltaUpdate},
     transaction::AggregatorValue,
 };
+use aptos_executable_store::ExecutableStore;
 use aptos_types::{
     access_path::AccessPath,
     executable::{ExecutableTestType, ModulePath},
@@ -89,7 +90,11 @@ fn create_write_read_placeholder_struct() {
     let ap2 = KeyType(b"/foo/c".to_vec());
     let ap3 = KeyType(b"/foo/d".to_vec());
 
-    let mvtbl: MVHashMap<KeyType<Vec<u8>>, Value, ExecutableTestType> = MVHashMap::new(None);
+    let mvtbl: MVHashMap<KeyType<Vec<u8>>, Value, ExecutableTestType> =
+        MVHashMap::new(Arc::new(ExecutableStore::<
+            KeyType<Vec<u8>>,
+            ExecutableTestType,
+        >::default()));
 
     // Reads that should go the DB return Err(NotFound)
     let r_db = mvtbl.fetch_data(&ap1, 5);

--- a/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
@@ -11,6 +11,7 @@ use aptos_aggregator::{
     delta_change_set::{delta_add, delta_sub, DeltaOp},
     transaction::AggregatorValue,
 };
+use aptos_executable_store::ExecutableStore;
 use aptos_types::{
     executable::ExecutableTestType, state_store::state_value::StateValue,
     write_set::TransactionWrite,
@@ -20,7 +21,10 @@ use std::{
     collections::{BTreeMap, HashMap},
     fmt::Debug,
     hash::Hash,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
 };
 
 const DEFAULT_TIMEOUT: u64 = 30;
@@ -190,7 +194,11 @@ where
 
     let baseline = Baseline::new(transactions.as_slice());
     // Only testing data, provide executable type ().
-    let map = MVHashMap::<KeyType<K>, Value<V>, ExecutableTestType>::new(None);
+    let map =
+        MVHashMap::<KeyType<K>, Value<V>, ExecutableTestType>::new(Arc::new(ExecutableStore::<
+            KeyType<K>,
+            ExecutableTestType,
+        >::default()));
 
     // make ESTIMATE placeholders for all versions to be updated.
     // allows to test that correct values appear at the end of concurrent execution.

--- a/aptos-move/mvhashmap/src/unsync_map.rs
+++ b/aptos-move/mvhashmap/src/unsync_map.rs
@@ -1,0 +1,145 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{types::MVCodeOutput, utils::module_hash};
+use aptos_crypto::hash::HashValue;
+use aptos_types::{
+    executable::{Executable, ExecutableDescriptor, ModulePath},
+    write_set::TransactionWrite,
+};
+use std::{
+    cell::RefCell,
+    collections::{
+        btree_map::Entry::{Occupied, Vacant},
+        BTreeMap, HashMap,
+    },
+    hash::Hash,
+};
+
+struct Entry<V: TransactionWrite, X: Executable> {
+    // data is Option since we may just use the entry to cache base (storage-version) executable.
+    data: Option<V>,
+    hash: Option<HashValue>,
+    maybe_base_executable: Option<X>,
+}
+
+impl<V: TransactionWrite + Clone, X: Executable> Entry<V, X> {
+    fn from_data(data: V) -> Self {
+        Self {
+            data: Some(data),
+            hash: None,
+            maybe_base_executable: None,
+        }
+    }
+
+    fn from_base_executable(executable: X) -> Self {
+        Self {
+            data: None,
+            hash: None,
+            maybe_base_executable: Some(executable),
+        }
+    }
+}
+
+/// UnsyncMap is designed to mimic the functionality of MVHashMap for sequential execution.
+/// In this case only the latest recorded version is relevant, simplifying the implementation.
+/// The functionality also includes Executable caching based on ExecutableDescriptor (i.e.
+/// module hash / storage version). Note that in the sequential mode, this cache is not re-used
+/// across blocks (to keep it simple, as such performance optimization isn't as relevant).
+/// UnsyncMap utilizes RefCell to provide access with interior mutability.
+pub struct UnsyncMap<K: ModulePath, V: TransactionWrite, X: Executable> {
+    data_map: RefCell<BTreeMap<K, Entry<V, X>>>,
+    executable_cache: RefCell<HashMap<HashValue, X>>,
+    executable_bytes: RefCell<usize>,
+}
+
+impl<K: ModulePath + Hash + Clone + Eq + Ord, V: TransactionWrite + Clone, X: Executable> Default
+    for UnsyncMap<K, V, X>
+{
+    fn default() -> Self {
+        Self {
+            data_map: RefCell::new(BTreeMap::new()),
+            executable_cache: RefCell::new(HashMap::new()),
+            executable_bytes: RefCell::new(0),
+        }
+    }
+}
+
+impl<K: ModulePath + Hash + Clone + Eq + Ord, V: TransactionWrite + Clone, X: Executable>
+    UnsyncMap<K, V, X>
+{
+    pub fn fetch_data(&self, key: &K) -> Option<V> {
+        self.data_map
+            .borrow()
+            .get(key)
+            .and_then(|entry| entry.data.clone())
+    }
+
+    pub fn fetch_code(&self, key: &K) -> Option<MVCodeOutput<V, X>> {
+        use MVCodeOutput::*;
+        debug_assert!(key.module_path().is_some());
+
+        self.data_map
+            .borrow_mut()
+            .get_mut(key)
+            .and_then(|entry| match &entry.data {
+                Some(module) => {
+                    let hash = entry.hash.get_or_insert(module_hash(module));
+
+                    Some(self.executable_cache.borrow().get(hash).map_or_else(
+                        || Module((module.clone(), *hash)),
+                        |x| Executable((x.clone(), ExecutableDescriptor::Published(*hash))),
+                    ))
+                },
+                None => entry
+                    .maybe_base_executable
+                    .as_ref()
+                    .map(|x| Executable((x.clone(), ExecutableDescriptor::Storage))),
+            })
+    }
+
+    pub fn insert(&self, key: K, value: V) {
+        self.data_map
+            .borrow_mut()
+            .insert(key, Entry::from_data(value));
+    }
+
+    /// We return false if the executable was already stored, as this isn't supposed to happen
+    /// during sequential execution (and the caller may choose to e.g. log a message).
+    pub fn store_executable(
+        &self,
+        key: &K,
+        descriptor: ExecutableDescriptor,
+        executable: X,
+    ) -> bool {
+        let size = executable.size_bytes();
+        let ret = match descriptor {
+            ExecutableDescriptor::Published(hash) => self
+                .executable_cache
+                .borrow_mut()
+                .insert(hash, executable)
+                .is_none(),
+            ExecutableDescriptor::Storage => match self.data_map.borrow_mut().entry(key.clone()) {
+                Occupied(mut entry) => entry
+                    .get_mut()
+                    .maybe_base_executable
+                    .replace(executable)
+                    .is_none(),
+                Vacant(entry) => {
+                    entry.insert(Entry::from_base_executable(executable));
+                    true
+                },
+            },
+        };
+
+        if ret {
+            *self.executable_bytes.borrow_mut() += size;
+        }
+
+        ret
+    }
+
+    pub fn executable_size(&self) -> usize {
+        *self.executable_bytes.borrow()
+    }
+}

--- a/aptos-move/mvhashmap/src/utils.rs
+++ b/aptos-move/mvhashmap/src/utils.rs
@@ -1,0 +1,16 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_crypto::hash::{DefaultHasher, HashValue};
+use aptos_types::write_set::TransactionWrite;
+
+pub(crate) fn module_hash<V: TransactionWrite>(module: &V) -> HashValue {
+    module
+        .extract_raw_bytes()
+        .map(|bytes| {
+            let mut hasher = DefaultHasher::new(b"Module");
+            hasher.update(&bytes);
+            hasher.finish()
+        })
+        .expect("Module can't be deleted")
+}

--- a/aptos-move/mvhashmap/src/versioned_code.rs
+++ b/aptos-move/mvhashmap/src/versioned_code.rs
@@ -1,14 +1,19 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::{Flag, MVCodeError, MVCodeOutput, TxnIndex};
-use aptos_crypto::hash::{DefaultHasher, HashValue};
+use crate::{
+    types::{Flag, MVCodeError, MVCodeOutput, TxnIndex},
+    utils::module_hash,
+};
+use aptos_crypto::hash::HashValue;
+use aptos_executable_store::ExecutableStore;
 use aptos_types::{
-    executable::{Executable, ExecutableDescriptor},
+    executable::{Executable, ExecutableDescriptor, ModulePath},
     write_set::TransactionWrite,
 };
 use crossbeam::utils::CachePadded;
 use dashmap::DashMap;
+use rayon::iter::ParallelIterator;
 use std::{
     collections::{btree_map::BTreeMap, HashMap},
     hash::Hash,
@@ -17,7 +22,7 @@ use std::{
 
 /// Every entry in shared multi-version data-structure has an "estimate" flag
 /// and some content.
-struct Entry<V: TransactionWrite> {
+struct Entry<V: TransactionWrite + Send + Sync> {
     /// Used to mark the entry as a "write estimate".
     flag: Flag,
 
@@ -32,30 +37,27 @@ struct Entry<V: TransactionWrite> {
 
 /// A VersionedValue internally contains a BTreeMap from indices of transactions
 /// that update the given access path alongside the corresponding entries.
-struct VersionedValue<V: TransactionWrite, X: Executable> {
+struct VersionedValue<V: TransactionWrite + Send + Sync, X: Executable> {
     versioned_map: BTreeMap<TxnIndex, CachePadded<Entry<V>>>,
 
-    /// Executable based on the storage version of the module.
-    base_executable: Option<Arc<X>>,
     /// Executables corresponding to published versions of the module, based on hash.
-    executables: HashMap<HashValue, Arc<X>>,
+    executables: HashMap<HashValue, X>,
 }
 
 /// Maps each key (access path) to an interal VersionedValue.
-pub struct VersionedCode<K, V: TransactionWrite, X: Executable> {
+pub struct VersionedCode<
+    K: ModulePath + Hash + Clone + Eq + Send + Sync,
+    V: TransactionWrite + Send + Sync,
+    X: Executable,
+> {
     values: DashMap<K, VersionedValue<V, X>>,
+    base_executables: Arc<ExecutableStore<K, X>>,
 }
 
-impl<V: TransactionWrite> Entry<V> {
+impl<V: TransactionWrite + Send + Sync> Entry<V> {
     pub fn new_write_from(module: V) -> Entry<V> {
-        let hash = module
-            .extract_raw_bytes()
-            .map(|bytes| {
-                let mut hasher = DefaultHasher::new(b"Module");
-                hasher.update(&bytes);
-                hasher.finish()
-            })
-            .expect("Module can't be deleted");
+        // Compute the module hash eagerly (Note: we could do it on access).
+        let hash = module_hash(&module);
 
         Entry {
             flag: Flag::Done,
@@ -73,15 +75,7 @@ impl<V: TransactionWrite> Entry<V> {
     }
 }
 
-impl<V: TransactionWrite, X: Executable> VersionedValue<V, X> {
-    pub fn new() -> Self {
-        Self {
-            versioned_map: BTreeMap::new(),
-            base_executable: None,
-            executables: HashMap::new(),
-        }
-    }
-
+impl<V: TransactionWrite + Send + Sync, X: Executable> VersionedValue<V, X> {
     fn read(&self, txn_idx: TxnIndex) -> anyhow::Result<(Arc<V>, HashValue), MVCodeError> {
         use MVCodeError::*;
 
@@ -98,16 +92,25 @@ impl<V: TransactionWrite, X: Executable> VersionedValue<V, X> {
     }
 }
 
-impl<V: TransactionWrite, X: Executable> Default for VersionedValue<V, X> {
+impl<V: TransactionWrite + Send + Sync, X: Executable> Default for VersionedValue<V, X> {
     fn default() -> Self {
-        VersionedValue::new()
+        Self {
+            versioned_map: BTreeMap::new(),
+            executables: HashMap::new(),
+        }
     }
 }
 
-impl<K: Hash + Clone + Eq, V: TransactionWrite, X: Executable> VersionedCode<K, V, X> {
-    pub(crate) fn new() -> Self {
+impl<
+        K: ModulePath + Hash + Clone + Eq + Send + Sync,
+        V: TransactionWrite + Send + Sync,
+        X: Executable,
+    > VersionedCode<K, V, X>
+{
+    pub(crate) fn new(base_executables: Arc<ExecutableStore<K, X>>) -> Self {
         Self {
             values: DashMap::new(),
+            base_executables,
         }
     }
 
@@ -131,15 +134,13 @@ impl<K: Hash + Clone + Eq, V: TransactionWrite, X: Executable> VersionedCode<K, 
         descriptor: ExecutableDescriptor,
         executable: X,
     ) {
-        let x = Arc::new(executable);
         match descriptor {
             ExecutableDescriptor::Published(hash) => {
                 let mut v = self.values.get_mut(key).expect("Path must exist");
-                v.executables.entry(hash).or_insert(x);
+                v.executables.entry(hash).or_insert(executable);
             },
             ExecutableDescriptor::Storage => {
-                let mut v = self.values.entry(key.clone()).or_default();
-                v.base_executable.get_or_insert(x);
+                self.base_executables.insert(key.clone(), executable);
             },
         };
     }
@@ -148,7 +149,7 @@ impl<K: Hash + Clone + Eq, V: TransactionWrite, X: Executable> VersionedCode<K, 
         &self,
         key: &K,
         txn_idx: TxnIndex,
-    ) -> anyhow::Result<MVCodeOutput<V, X>, MVCodeError> {
+    ) -> anyhow::Result<MVCodeOutput<Arc<V>, X>, MVCodeError> {
         use MVCodeError::*;
         use MVCodeOutput::*;
 
@@ -158,10 +159,10 @@ impl<K: Hash + Clone + Eq, V: TransactionWrite, X: Executable> VersionedCode<K, 
                     Some(x) => Executable((x.clone(), ExecutableDescriptor::Published(hash))),
                     None => Module((module, hash)),
                 }),
-                Err(NotFound) => v
-                    .base_executable
-                    .as_ref()
-                    .map(|x| Executable((x.clone(), ExecutableDescriptor::Storage)))
+                Err(NotFound) => self
+                    .base_executables
+                    .get(key)
+                    .map(|x| Executable((x, ExecutableDescriptor::Storage)))
                     .ok_or(NotFound),
                 Err(Dependency(idx)) => Err(Dependency(idx)),
             },
@@ -177,10 +178,26 @@ impl<K: Hash + Clone + Eq, V: TransactionWrite, X: Executable> VersionedCode<K, 
             "Entry must exist to be deleted"
         );
     }
-}
 
-impl<K: Hash + Clone + Eq, V: TransactionWrite, X: Executable> Default for VersionedCode<K, V, X> {
-    fn default() -> Self {
-        VersionedCode::new()
+    /// Prepares base_executables to be used by the next block, by processing the latest
+    /// written modules in the versioned_map. If an executable for latest module is available,
+    /// it is stored, and otherwise (executable isn't available for a module written during
+    /// the last block) any previous base_executable is cleared.
+    ///
+    /// Uses rayon for parallel processing the updates, so recommended to call with a rayon
+    /// threadpool installed.
+    pub(crate) fn update_base_executables(&self) {
+        self.values.par_iter_mut().for_each(|mut v| {
+            let new_base_hash = v.versioned_map.last_key_value().map(|(_, e)| e.hash);
+            if let Some(h) = new_base_hash {
+                match v.executables.remove(&h) {
+                    Some(x) => self.base_executables.insert(v.key().clone(), x),
+                    None => self.base_executables.remove(v.key()),
+                }
+            }
+        });
+
+        // Mark that the after block execution update has been completed on the cache.
+        self.base_executables.mark_updated();
     }
 }

--- a/aptos-move/mvhashmap/src/versioned_data.rs
+++ b/aptos-move/mvhashmap/src/versioned_data.rs
@@ -45,7 +45,7 @@ struct VersionedValue<V> {
 }
 
 /// Maps each key (access path) to an interal VersionedValue.
-pub struct VersionedData<K, V> {
+pub struct VersionedData<K: Hash + Clone + Eq + Send + Sync + Debug, V> {
     values: DashMap<K, VersionedValue<V>>,
 }
 
@@ -203,7 +203,7 @@ impl<V: TransactionWrite> Default for VersionedValue<V> {
     }
 }
 
-impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite> VersionedData<K, V> {
+impl<K: Hash + Clone + Debug + Eq + Send + Sync, V: TransactionWrite> VersionedData<K, V> {
     pub(crate) fn new() -> Self {
         Self {
             values: DashMap::new(),

--- a/aptos-node/src/utils.rs
+++ b/aptos-node/src/utils.rs
@@ -50,6 +50,7 @@ pub fn fetch_chain_id(db: &DbReaderWriter) -> anyhow::Result<ChainId> {
 pub fn set_aptos_vm_configurations(node_config: &NodeConfig) {
     AptosVM::set_paranoid_type_checks(node_config.execution.paranoid_type_verification);
     AptosVM::set_concurrency_level_once(node_config.execution.concurrency_level as usize);
+    AptosVM::set_executable_cache_size_once(node_config.execution.executable_cache_size);
     AptosVM::set_num_proof_reading_threads_once(
         node_config.execution.num_proof_reading_threads as usize,
     );

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -34,6 +34,7 @@ pub struct ExecutionConfig {
     pub paranoid_hot_potato_verification: bool,
     /// Enables enhanced metrics around processed transactions
     pub processed_transactions_detailed_counters: bool,
+    pub executable_cache_size: u64, // Cache size in bytes.
 }
 
 impl std::fmt::Debug for ExecutionConfig {
@@ -63,6 +64,8 @@ impl Default for ExecutionConfig {
             paranoid_type_verification: true,
             paranoid_hot_potato_verification: true,
             processed_transactions_detailed_counters: false,
+            // 100 mb default for executable cache. TODO: what makes sense.
+            executable_cache_size: 104857600,
         }
     }
 }

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -23,7 +23,10 @@ use aptos_backup_cli::{
     coordinators::restore::{RestoreCoordinator, RestoreCoordinatorOpt},
     metadata::cache::MetadataCacheOpt,
     storage::command_adapter::{config::CommandAdapterConfig, CommandAdapter},
-    utils::{ConcurrentDownloadsOpt, GlobalRestoreOpt, ReplayConcurrencyLevelOpt, RocksdbOpt},
+    utils::{
+        ConcurrentDownloadsOpt, GlobalRestoreOpt, ReplayConcurrencyLevelOpt,
+        ReplayExecutableCacheSizeOpt, RocksdbOpt,
+    },
 };
 use aptos_cached_packages::aptos_stdlib;
 use aptos_config::config::NodeConfig;
@@ -1501,6 +1504,9 @@ pub struct BootstrapDbFromBackup {
 
     #[clap(flatten)]
     pub replay_concurrency_level: ReplayConcurrencyLevelOpt,
+
+    #[clap(flatten)]
+    pub replay_executable_cache_size: ReplayExecutableCacheSizeOpt,
 }
 
 #[async_trait]
@@ -1524,6 +1530,7 @@ impl CliCommand<()> for BootstrapDbFromBackup {
             rocksdb_opt: RocksdbOpt::default(),
             concurrent_downloads: self.concurrent_downloads,
             replay_concurrency_level: self.replay_concurrency_level,
+            replay_executable_cache_size: self.replay_executable_cache_size,
         }
         .try_into()?;
         let storage = Arc::new(CommandAdapter::new(

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true }
 aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-db = { workspace = true }
+aptos-executable-store = { workspace = true }
 aptos-executor = { workspace = true }
 aptos-executor-types = { workspace = true }
 aptos-genesis = { workspace = true, features = ["testing"] }

--- a/execution/executor-benchmark/src/benchmark_transaction.rs
+++ b/execution/executor-benchmark/src/benchmark_transaction.rs
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use aptos_executable_store::ExecutableStore;
 use aptos_executor::{
     block_executor::TransactionBlockExecutor, components::chunk_output::ChunkOutput,
 };
 use aptos_storage_interface::cached_state_view::CachedStateView;
-use aptos_types::{account_address::AccountAddress, transaction::Transaction};
+use aptos_types::{
+    account_address::AccountAddress, executable::ExecutableTestType,
+    state_store::state_key::StateKey, transaction::Transaction,
+};
 use aptos_vm::AptosVM;
+use std::sync::Arc;
 
 pub struct TransferInfo {
     pub sender: AccountAddress,
@@ -73,6 +78,7 @@ impl TransactionBlockExecutor<BenchmarkTransaction> for AptosVM {
     fn execute_transaction_block(
         transactions: Vec<BenchmarkTransaction>,
         state_view: CachedStateView,
+        executable_cache: Arc<ExecutableStore<StateKey, ExecutableTestType>>,
     ) -> Result<ChunkOutput> {
         AptosVM::execute_transaction_block(
             transactions
@@ -80,6 +86,7 @@ impl TransactionBlockExecutor<BenchmarkTransaction> for AptosVM {
                 .map(|txn| txn.transaction)
                 .collect(),
             state_view,
+            executable_cache,
         )
     }
 }

--- a/execution/executor-benchmark/src/native_executor.rs
+++ b/execution/executor-benchmark/src/native_executor.rs
@@ -7,6 +7,7 @@ use crate::{
     metrics::TIMER,
 };
 use anyhow::Result;
+use aptos_executable_store::ExecutableStore;
 use aptos_executor::{
     block_executor::TransactionBlockExecutor, components::chunk_output::ChunkOutput,
 };
@@ -16,6 +17,7 @@ use aptos_types::{
     account_config::{deposit::DepositEvent, withdraw::WithdrawEvent},
     contract_event::ContractEvent,
     event::EventKey,
+    executable::ExecutableTestType,
     state_store::state_key::StateKey,
     transaction::{ExecutionStatus, Transaction, TransactionOutput, TransactionStatus},
     vm_status::AbortLocation,
@@ -28,7 +30,7 @@ use move_core_types::{
 };
 use once_cell::sync::{Lazy, OnceCell};
 use rayon::{prelude::*, ThreadPool, ThreadPoolBuilder};
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 struct IncrementalOutput {
     write_set: Vec<(StateKey, WriteOp)>,
@@ -339,6 +341,7 @@ impl TransactionBlockExecutor<BenchmarkTransaction> for NativeExecutor {
     fn execute_transaction_block(
         transactions: Vec<BenchmarkTransaction>,
         state_view: CachedStateView,
+        _executable_cache: Arc<ExecutableStore<StateKey, ExecutableTestType>>,
     ) -> Result<ChunkOutput> {
         let transaction_outputs = NATIVE_EXECUTOR_POOL.install(|| {
             transactions

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 aptos-consensus-types = { workspace = true }
 aptos-crypto = { workspace = true }
+aptos-executable-store = { workspace = true }
 aptos-executor-types = { workspace = true }
 aptos-gas = { workspace = true }
 aptos-infallible = { workspace = true }

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -17,6 +17,7 @@ use crate::{
     },
 };
 use anyhow::Result;
+use aptos_executable_store::ExecutableStore;
 use aptos_executor_types::{
     ChunkCommitNotification, ChunkExecutorTrait, ExecutedChunk, ParsedTransactionOutput,
     TransactionReplayer, VerifyExecutionMode,
@@ -30,7 +31,9 @@ use aptos_storage_interface::{
 };
 use aptos_types::{
     contract_event::ContractEvent,
+    executable::ExecutableTestType,
     ledger_info::LedgerInfoWithSignatures,
+    state_store::state_key::StateKey,
     transaction::{
         Transaction, TransactionInfo, TransactionListWithProof, TransactionOutput,
         TransactionOutputListWithProof, TransactionStatus, Version,
@@ -109,6 +112,7 @@ impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
     }
 }
 
+// TODO: consider adding executables cache here as well and re-using across chunk_executions.
 struct ChunkExecutorInner<V> {
     db: DbReaderWriter,
     commit_queue: Mutex<ChunkCommitQueue>,
@@ -203,7 +207,11 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
         let state_view = self.state_view(&latest_view)?;
         let chunk_output = {
             let _timer = APTOS_EXECUTOR_VM_EXECUTE_CHUNK_SECONDS.start_timer();
-            ChunkOutput::by_transaction_execution::<V>(transactions, state_view)?
+            ChunkOutput::by_transaction_execution::<V>(
+                transactions,
+                state_view,
+                Arc::new(ExecutableStore::<StateKey, ExecutableTestType>::default()),
+            )?
         };
         let executed_chunk = Self::apply_chunk_output_for_state_sync(
             verified_target_li,
@@ -526,7 +534,11 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
             .cloned()
             .collect();
 
-        let chunk_output = ChunkOutput::by_transaction_execution::<V>(txns, state_view)?;
+        let chunk_output = ChunkOutput::by_transaction_execution::<V>(
+            txns,
+            state_view,
+            Arc::new(ExecutableStore::<StateKey, ExecutableTestType>::default()),
+        )?;
         // not `zip_eq`, deliberately
         for (version, txn_out, txn_info, write_set, events) in multizip((
             begin_version..end_version,

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -8,17 +8,21 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
+use aptos_executable_store::ExecutableStore;
 use aptos_executor_types::BlockExecutorTrait;
 use aptos_state_view::StateView;
 use aptos_storage_interface::{
     cached_state_view::CachedStateView, state_delta::StateDelta, DbReader, DbReaderWriter, DbWriter,
 };
 use aptos_types::{
+    executable::ExecutableTestType,
     ledger_info::LedgerInfoWithSignatures,
+    state_store::state_key::StateKey,
     transaction::{Transaction, TransactionOutput, TransactionToCommit, Version},
     vm_status::VMStatus,
 };
 use aptos_vm::VMExecutor;
+use std::sync::Arc;
 
 fn create_test_executor() -> BlockExecutor<FakeVM, Transaction> {
     // setup fake db
@@ -51,8 +55,9 @@ impl TransactionBlockExecutor<Transaction> for FakeVM {
     fn execute_transaction_block(
         transactions: Vec<Transaction>,
         state_view: CachedStateView,
+        executable_cache: Arc<ExecutableStore<StateKey, ExecutableTestType>>,
     ) -> Result<ChunkOutput> {
-        ChunkOutput::by_transaction_execution::<FakeVM>(transactions, state_view)
+        ChunkOutput::by_transaction_execution::<FakeVM>(transactions, state_view, executable_cache)
     }
 }
 
@@ -60,6 +65,7 @@ impl VMExecutor for FakeVM {
     fn execute_block(
         _transactions: Vec<Transaction>,
         _state_view: &impl StateView,
+        _executable_cache: Arc<ExecutableStore<StateKey, ExecutableTestType>>,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         Ok(Vec::new())
     }

--- a/execution/executor/src/mock_vm/mock_vm_test.rs
+++ b/execution/executor/src/mock_vm/mock_vm_test.rs
@@ -4,16 +4,18 @@
 
 use super::{balance_ap, encode_mint_transaction, encode_transfer_transaction, seqnum_ap, MockVM};
 use anyhow::Result;
+use aptos_executable_store::ExecutableStore;
 use aptos_state_view::TStateView;
 use aptos_types::{
     account_address::AccountAddress,
+    executable::ExecutableTestType,
     state_store::{
         state_key::StateKey, state_storage_usage::StateStorageUsage, state_value::StateValue,
     },
     write_set::WriteOp,
 };
 use aptos_vm::VMExecutor;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 fn gen_address(index: u8) -> AccountAddress {
     AccountAddress::new([index; AccountAddress::LENGTH])
@@ -45,8 +47,12 @@ fn test_mock_vm_different_senders() {
         txns.push(encode_mint_transaction(gen_address(i), amount));
     }
 
-    let outputs = MockVM::execute_block(txns.clone(), &MockStateView)
-        .expect("MockVM should not fail to start");
+    let outputs = MockVM::execute_block(
+        txns.clone(),
+        &MockStateView,
+        Arc::new(ExecutableStore::<StateKey, ExecutableTestType>::default()),
+    )
+    .expect("MockVM should not fail to start");
 
     for (output, txn) in itertools::zip_eq(outputs.iter(), txns.iter()) {
         let sender = txn.try_as_signed_user_txn().unwrap().sender();
@@ -81,8 +87,12 @@ fn test_mock_vm_same_sender() {
         txns.push(encode_mint_transaction(sender, amount));
     }
 
-    let outputs =
-        MockVM::execute_block(txns, &MockStateView).expect("MockVM should not fail to start");
+    let outputs = MockVM::execute_block(
+        txns,
+        &MockStateView,
+        Arc::new(ExecutableStore::<StateKey, ExecutableTestType>::default()),
+    )
+    .expect("MockVM should not fail to start");
 
     for (i, output) in outputs.iter().enumerate() {
         assert_eq!(
@@ -115,8 +125,12 @@ fn test_mock_vm_payment() {
         encode_transfer_transaction(gen_address(0), gen_address(1), 50),
     ];
 
-    let output =
-        MockVM::execute_block(txns, &MockStateView).expect("MockVM should not fail to start");
+    let output = MockVM::execute_block(
+        txns,
+        &MockStateView,
+        Arc::new(ExecutableStore::<StateKey, ExecutableTestType>::default()),
+    )
+    .expect("MockVM should not fail to start");
 
     let mut output_iter = output.iter();
     output_iter.next();

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -15,6 +15,7 @@ use crate::{
 use anyhow::Result;
 use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, SigningKey, Uniform};
 use aptos_db::AptosDB;
+use aptos_executable_store::ExecutableStore;
 use aptos_executor_types::{
     BlockExecutorTrait, ChunkExecutorTrait, TransactionReplayer, VerifyExecutionMode,
 };
@@ -27,6 +28,7 @@ use aptos_types::{
     aggregate_signature::AggregateSignature,
     block_info::BlockInfo,
     chain_id::ChainId,
+    executable::ExecutableTestType,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     proof::definition::LeafCount,
     state_store::{state_key::StateKey, state_value::StateValue},
@@ -566,6 +568,7 @@ fn run_transactions_naive(transactions: Vec<Transaction>) -> HashValue {
                     Arc::new(AsyncProofFetcher::new(db.reader.clone())),
                 )
                 .unwrap(),
+            Arc::new(ExecutableStore::<StateKey, ExecutableTestType>::default()),
         )
         .unwrap();
         let (executed, _, _) = out.apply_to_ledger(&ledger_view).unwrap();

--- a/storage/backup/backup-cli/src/backup_types/epoch_ending/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/epoch_ending/tests.rs
@@ -13,7 +13,7 @@ use crate::{
     utils::{
         backup_service_client::BackupServiceClient, test_utils::tmp_db_with_random_content,
         ConcurrentDownloadsOpt, GlobalBackupOpt, GlobalRestoreOpt, ReplayConcurrencyLevelOpt,
-        RocksdbOpt, TrustedWaypointOpt,
+        ReplayExecutableCacheSizeOpt, RocksdbOpt, TrustedWaypointOpt,
     },
 };
 use aptos_backup_service::start_backup_service;
@@ -87,6 +87,7 @@ fn end_to_end() {
                 rocksdb_opt: RocksdbOpt::default(),
                 concurrent_downloads: ConcurrentDownloadsOpt::default(),
                 replay_concurrency_level: ReplayConcurrencyLevelOpt::default(),
+                replay_executable_cache_size: ReplayExecutableCacheSizeOpt::default(),
             }
             .try_into()
             .unwrap(),
@@ -219,6 +220,7 @@ async fn test_trusted_waypoints_impl(
             rocksdb_opt: RocksdbOpt::default(),
             concurrent_downloads: ConcurrentDownloadsOpt::default(),
             replay_concurrency_level: ReplayConcurrencyLevelOpt::default(),
+            replay_executable_cache_size: ReplayExecutableCacheSizeOpt::default(),
         }
         .try_into()
         .unwrap(),
@@ -240,6 +242,7 @@ async fn test_trusted_waypoints_impl(
             rocksdb_opt: RocksdbOpt::default(),
             concurrent_downloads: ConcurrentDownloadsOpt::default(),
             replay_concurrency_level: ReplayConcurrencyLevelOpt::default(),
+            replay_executable_cache_size: ReplayExecutableCacheSizeOpt::default(),
         }
         .try_into()
         .unwrap(),

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
@@ -12,7 +12,7 @@ use crate::{
         backup_service_client::BackupServiceClient,
         test_utils::{start_local_backup_service, tmp_db_with_random_content},
         ConcurrentDownloadsOpt, GlobalBackupOpt, GlobalRestoreOpt, ReplayConcurrencyLevelOpt,
-        RocksdbOpt, TrustedWaypointOpt,
+        ReplayExecutableCacheSizeOpt, RocksdbOpt, TrustedWaypointOpt,
     },
 };
 use aptos_db::AptosDB;
@@ -87,6 +87,7 @@ fn end_to_end() {
                 rocksdb_opt: RocksdbOpt::default(),
                 concurrent_downloads: ConcurrentDownloadsOpt::default(),
                 replay_concurrency_level: ReplayConcurrencyLevelOpt::default(),
+                replay_executable_cache_size: ReplayExecutableCacheSizeOpt::default(),
             }
             .try_into()
             .unwrap(),

--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -17,7 +17,7 @@ use crate::{
     utils::{
         backup_service_client::BackupServiceClient, test_utils::start_local_backup_service,
         ConcurrentDownloadsOpt, GlobalBackupOpt, GlobalRestoreOpt, GlobalRestoreOptions,
-        ReplayConcurrencyLevelOpt, RocksdbOpt, TrustedWaypointOpt,
+        ReplayConcurrencyLevelOpt, ReplayExecutableCacheSizeOpt, RocksdbOpt, TrustedWaypointOpt,
     },
 };
 use aptos_db::AptosDB;
@@ -124,6 +124,7 @@ fn test_end_to_end_impl(d: TestData) {
         rocksdb_opt: RocksdbOpt::default(),
         concurrent_downloads: ConcurrentDownloadsOpt::default(),
         replay_concurrency_level: ReplayConcurrencyLevelOpt::default(),
+        replay_executable_cache_size: ReplayExecutableCacheSizeOpt::default(),
     }
     .try_into()
     .unwrap();

--- a/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
@@ -269,6 +269,9 @@ impl TransactionRestoreBatchController {
                 "Bug: requested to output transaction output sizing info in restore mode.",
             );
             AptosVM::set_concurrency_level_once(self.global_opt.replay_concurrency_level);
+            AptosVM::set_executable_cache_size_once(
+                self.global_opt.replay_executable_cache_size as u64,
+            );
             let txns_to_execute_stream = self
                 .save_before_replay_version(first_version, loaded_chunk_stream, restore_handler)
                 .await?;

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -12,7 +12,7 @@ use crate::{
         backup_service_client::BackupServiceClient,
         test_utils::{start_local_backup_service, tmp_db_with_random_content},
         ConcurrentDownloadsOpt, GlobalBackupOpt, GlobalRestoreOpt, ReplayConcurrencyLevelOpt,
-        RocksdbOpt, TrustedWaypointOpt,
+        ReplayExecutableCacheSizeOpt, RocksdbOpt, TrustedWaypointOpt,
     },
 };
 use aptos_db::AptosDB;
@@ -101,6 +101,7 @@ fn end_to_end() {
                 rocksdb_opt: RocksdbOpt::default(),
                 concurrent_downloads: ConcurrentDownloadsOpt::default(),
                 replay_concurrency_level: ReplayConcurrencyLevelOpt::default(),
+                replay_executable_cache_size: ReplayExecutableCacheSizeOpt::default(),
             }
             .try_into()
             .unwrap(),

--- a/storage/backup/backup-cli/src/coordinators/replay_verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/replay_verify.rs
@@ -31,6 +31,7 @@ pub struct ReplayVerifyCoordinator {
     end_version: Version,
     validate_modules: bool,
     verify_execution_mode: VerifyExecutionMode,
+    replay_executable_cache_size: usize,
 }
 
 impl ReplayVerifyCoordinator {
@@ -45,6 +46,7 @@ impl ReplayVerifyCoordinator {
         end_version: Version,
         validate_modules: bool,
         verify_execution_mode: VerifyExecutionMode,
+        replay_executable_cache_size: usize,
     ) -> Result<Self> {
         Ok(Self {
             storage,
@@ -57,6 +59,7 @@ impl ReplayVerifyCoordinator {
             end_version,
             validate_modules,
             verify_execution_mode,
+            replay_executable_cache_size,
         })
     }
 
@@ -79,6 +82,7 @@ impl ReplayVerifyCoordinator {
 
     async fn run_impl(self) -> Result<()> {
         AptosVM::set_concurrency_level_once(self.replay_concurrency_level);
+        AptosVM::set_executable_cache_size_once(self.replay_executable_cache_size as u64);
         AptosVM::set_timed_feature_override(TimedFeatureOverride::Replay);
 
         let metadata_view = metadata::cache::sync_and_load(
@@ -134,6 +138,7 @@ impl ReplayVerifyCoordinator {
             run_mode,
             concurrent_downloads: self.concurrent_downloads,
             replay_concurrency_level: 0, // won't replay, doesn't matter
+            replay_executable_cache_size: 0, // won't replay, doesn't matter
         };
 
         if let Some(backup) = state_snapshot {

--- a/storage/backup/backup-cli/src/coordinators/verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/verify.rs
@@ -101,6 +101,7 @@ impl VerifyCoordinator {
             run_mode: Arc::new(RestoreRunMode::Verify),
             concurrent_downloads: self.concurrent_downloads,
             replay_concurrency_level: 0, // won't replay, doesn't matter
+            replay_executable_cache_size: 0, // won't replay, doesn't matter
         };
 
         let epoch_history = if self.skip_epoch_endings {

--- a/storage/db-tool/src/replay_verify.rs
+++ b/storage/db-tool/src/replay_verify.rs
@@ -6,7 +6,10 @@ use aptos_backup_cli::{
     coordinators::replay_verify::ReplayVerifyCoordinator,
     metadata::cache::MetadataCacheOpt,
     storage::DBToolStorageOpt,
-    utils::{ConcurrentDownloadsOpt, ReplayConcurrencyLevelOpt, RocksdbOpt, TrustedWaypointOpt},
+    utils::{
+        ConcurrentDownloadsOpt, ReplayConcurrencyLevelOpt, ReplayExecutableCacheSizeOpt,
+        RocksdbOpt, TrustedWaypointOpt,
+    },
 };
 use aptos_config::config::{
     BUFFERED_STATE_TARGET_ITEMS, DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
@@ -56,6 +59,8 @@ pub struct Opt {
     txns_to_skip: Vec<Version>,
     #[clap(long, help = "Do not quit right away when a replay issue is detected.")]
     lazy_quit: bool,
+    #[clap(flatten)]
+    replay_executable_cache_size: ReplayExecutableCacheSizeOpt,
 }
 
 impl Opt {
@@ -81,6 +86,7 @@ impl Opt {
             self.end_version.unwrap_or(Version::MAX),
             self.validate_modules,
             VerifyExecutionMode::verify_except(self.txns_to_skip).set_lazy_quit(self.lazy_quit),
+            self.replay_executable_cache_size.get(),
         )?
         .run()
         .await

--- a/storage/executable-store/Cargo.toml
+++ b/storage/executable-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "aptos-mvhashmap"
-description = "Move hash map"
+name = "aptos-executable-store"
+description = "Store for caching Move executables across blocks"
 version = "0.1.0"
 
 # Workspace inherited keys
@@ -13,19 +13,13 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = { workspace = true }
-aptos-aggregator = { workspace = true }
 aptos-crypto = { workspace = true }
-aptos-executable-store = { workspace = true }
 aptos-infallible = { workspace = true }
+aptos-logger = { workspace = true }
 aptos-types = { workspace = true }
-bcs = { workspace = true }
-crossbeam = { workspace = true }
-dashmap = { workspace = true, features = ["rayon"] }
-rayon = { workspace = true }
+dashmap = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
 
 [dev-dependencies]
 claims = { workspace = true }
-proptest = { workspace = true }
-proptest-derive = { workspace = true }
-rayon = { workspace = true }

--- a/storage/executable-store/src/lib.rs
+++ b/storage/executable-store/src/lib.rs
@@ -1,0 +1,365 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_crypto::HashValue;
+use aptos_infallible::Mutex;
+use aptos_logger::error;
+use aptos_types::executable::Executable;
+use dashmap::DashMap;
+use num_derive::FromPrimitive;
+use std::{
+    hash::Hash,
+    sync::atomic::{AtomicU8, AtomicUsize, Ordering},
+};
+
+/// Represents the state of the ExecutableStore. The goal is to catch errors in intended
+/// use, and reset the executable cache to an empty state if its state can't guarantee
+/// matching the state after the parent block id.
+///
+/// During the execution, the cache might get updated, i.e. if a new executable at storage
+/// version gets stored. After block execution, more updates may occur to align the cache
+/// contents to the new boundary: published modules may invalidated previously stored
+/// executables, and new corresponding executables may also be available. 'mark_updated'
+/// method can be called afterwards to mark state accordingly. Missing Updated state
+/// would indicate that the cache wasn't sychronized to the new block, and should not be
+/// re-used for the subsequent blocks. The Void state in such cases allows graceful
+/// handling by resetting / clearing the cache as needed.
+///
+/// Finally, ExecutableStore must be pruned, to control its size, and then the hash of the
+/// block that was executed needs to be set, marking it full circle in the Ready state.
+#[derive(Copy, Clone, FromPrimitive, PartialEq, Debug)]
+enum ExecutableStoreState {
+    Ready = 0,   // The cache is ready-to-use at a state after block id is recorded.
+    Updated = 1, // The cache is updated / synchronized after the block execution.
+    Pruned = 2,  // The cache is pruned (must record executed block id to become ready).
+    Void = 3,    // Unexpected state update order (expected: Ready -> Updated -> Pruned).
+}
+
+pub struct ExecutableStore<K: Eq + Hash, X: Executable> {
+    executables: DashMap<K, X>,
+    total_size: AtomicUsize,
+    state: AtomicU8,
+    block_id: Mutex<Option<HashValue>>,
+}
+
+impl<K: Eq + Hash, X: Executable> Default for ExecutableStore<K, X> {
+    fn default() -> Self {
+        Self {
+            executables: DashMap::new(),
+            total_size: AtomicUsize::new(0),
+            state: AtomicU8::new(ExecutableStoreState::Ready as u8),
+            block_id: Mutex::new(None),
+        }
+    }
+}
+
+impl<K: Eq + Hash, X: Executable> ExecutableStore<K, X> {
+    ///
+    /// The following methods should be called in quiescence. These are intended to
+    /// process the state and state of the Cache between block executions and be called
+    /// single-threaded. As such, no extra atomicity of ops within methods is needed.
+    ///
+
+    // Flushes the cache and marks state as Ready. This happens for error handling
+    // in cases when the empty cache is sufficient to proceed despite the error.
+    fn reset(&self) {
+        self.executables.clear();
+        self.total_size.store(0, Ordering::Relaxed);
+        self.block_id.lock().take();
+    }
+
+    /// Should be invoked after fully executing a new block w. block_id, and performing
+    /// required steps (updating & pruning the cache to align with the new block). If
+    /// the state was not updated in a proper order (Ready -> Updated -> Pruned),
+    /// then the cache will be cleared instead of recording the block_id.
+    pub fn mark_ready(&self, block_id: HashValue) {
+        let prev_state = self
+            .state
+            .swap(ExecutableStoreState::Ready as u8, Ordering::Relaxed);
+
+        if prev_state == ExecutableStoreState::Void as u8 {
+            self.reset();
+        } else {
+            self.block_id.lock().replace(block_id);
+        }
+    }
+
+    /// This method checks that the state is Ready, and either self.block_id is None
+    /// (corresponding to an empty cache), or matching block_id must be provided by the
+    /// caller for confirmation. This method panics if the state is not ready, as
+    /// mark_ready (or new ExecutableStore) must be used to ensure a proper state.
+    /// However, if the block_id does not match the provided parent block id, the cache
+    /// is cleared & error is logged for out of order execution.
+    pub fn check_ready(&self, parent_block_id: HashValue) {
+        assert!(
+            self.state.load(Ordering::Relaxed) == ExecutableStoreState::Ready as u8,
+            "Executable cache not Ready for block execution"
+        );
+
+        let block_id = *self.block_id.lock();
+        // Lock is released to avoid reset re-entry. Note: these calls are quiescent.
+
+        if block_id.map_or(false, |id| id != parent_block_id) {
+            self.reset();
+            error!(
+                "ExecutableStore block id {:?} != provided parent block id {:?}",
+                block_id, parent_block_id
+            );
+        }
+    }
+
+    /// If the state is observed to be expected_state, set it to new_state.
+    /// Otherwise, set state to Void.
+    fn set_state(&self, expected_state: ExecutableStoreState, new_state: ExecutableStoreState) {
+        let state = self.state.load(Ordering::Relaxed);
+
+        // Load and Store do not need to be atomic as the calling methods are supposed
+        // to only be used by a single thread in quiescence.
+        self.state.store(
+            if state == expected_state as u8 {
+                new_state as u8
+            } else {
+                ExecutableStoreState::Void as u8
+            },
+            Ordering::Relaxed,
+        );
+    }
+
+    /// Should be called when the cache is updated to be aligned with the state after
+    /// a block execution. Will set state to Void if the previous state wasn't Ready.
+    pub fn mark_updated(&self) {
+        self.set_state(ExecutableStoreState::Ready, ExecutableStoreState::Updated);
+    }
+
+    /// Must be called after block execution is complete, and the cache has been
+    /// updated accordingly (to contain base executables after the block execution).
+    /// Pruning is required to be able to update the block hash and re-use the
+    /// executable cache. If the cache isn't intended to be re-used, there is no
+    /// need to prune and new ExecutableStore can be created instead. If the previous
+    /// state isn't Updated, the Void state is set.
+    ///
+    /// Basic eviction policy: if total size > provided threshold, clear everything.
+    /// Returns true iff the cache was cleared.
+    /// TODO: more complex eviction policy.
+    pub fn prune(&self, size_threshold: usize) -> bool {
+        let ret = if self.size() > size_threshold {
+            self.reset();
+            true
+        } else {
+            false
+        };
+
+        self.set_state(ExecutableStoreState::Updated, ExecutableStoreState::Pruned);
+
+        ret
+    }
+
+    fn state(&self) -> ExecutableStoreState {
+        num_traits::FromPrimitive::from_u8(self.state.load(Ordering::Relaxed)).unwrap()
+    }
+
+    fn size(&self) -> usize {
+        self.total_size.load(Ordering::Relaxed)
+    }
+
+    ///
+    /// The following methods can be concurrent when invoked during the block execution.
+    ///
+
+    pub fn get(&self, key: &K) -> Option<X> {
+        debug_assert!(
+            self.state() == ExecutableStoreState::Ready,
+            "Getting from an Executable Cache in a not Ready state"
+        );
+
+        self.executables.get(key).map(|x| x.clone())
+    }
+
+    pub fn insert(&self, key: K, executable: X) {
+        debug_assert!(
+            self.state() == ExecutableStoreState::Ready,
+            "Inserting to an Executable Cache in a not Ready state"
+        );
+
+        // Add size first so subtract on concurrent remove does not underflow.
+        // Note: We could insert the executable first and then adjust the size and perform
+        // 1 atomic operation instead of 2 when an executable is already in the cache.
+        // However, (1) this requires signed type for size to avoid underflow (confusing),
+        // and (2) should not be frequent (caused only by a module upgrade, or by a race
+        // between parallel executor threads concurrently preparing the same executable).
+        self.total_size
+            .fetch_add(executable.size_bytes(), Ordering::Relaxed);
+
+        if let Some(x) = self.executables.insert(key, executable) {
+            // Adjust total size if the cache already contained an executable.
+            self.total_size.fetch_sub(x.size_bytes(), Ordering::Relaxed);
+        }
+    }
+
+    pub fn remove(&self, key: &K) {
+        debug_assert!(
+            self.state() == ExecutableStoreState::Ready,
+            "Removing from an Executable Cache in a not Ready state"
+        );
+
+        if let Some((_, x)) = self.executables.remove(key) {
+            // Since the size was added to total size
+            self.total_size.fetch_sub(x.size_bytes(), Ordering::Relaxed);
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ExecutableStore, ExecutableStoreState};
+    use aptos_crypto::HashValue;
+    use aptos_types::executable::Executable;
+    use claims::{assert_none, assert_some_eq};
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct MockExecutable(usize);
+
+    impl Executable for MockExecutable {
+        fn size_bytes(&self) -> usize {
+            self.0
+        }
+    }
+
+    #[test]
+    fn executable_store_state_loop() {
+        let store = ExecutableStore::<usize, MockExecutable>::default();
+
+        assert_eq!(store.state(), ExecutableStoreState::Ready);
+        store.insert(0, MockExecutable(3));
+
+        store.mark_updated();
+        assert_eq!(store.state(), ExecutableStoreState::Updated);
+
+        assert!(!store.prune(5));
+        assert_eq!(store.state(), ExecutableStoreState::Pruned);
+
+        // We will use the size of the cache as a proxy to know whether the flushing / reset
+        // has occurred, e.g. for unexpected state or block id.
+
+        let h = HashValue::random();
+        store.mark_ready(h);
+        store.check_ready(h);
+        assert_eq!(store.size(), 3);
+
+        // Checking readiness with wrong previous block ID must clear the cache.
+        let h1 = HashValue::random();
+        assert_ne!(h, h1);
+        store.check_ready(h1);
+        assert_eq!(store.size(), 0);
+    }
+
+    #[test]
+    fn executable_store_prune() {
+        let store = ExecutableStore::<usize, MockExecutable>::default();
+
+        store.insert(0, MockExecutable(3));
+        store.insert(1, MockExecutable(3));
+
+        store.mark_updated();
+
+        assert!(store.prune(5));
+        assert_eq!(store.size(), 0);
+    }
+
+    #[test]
+    fn executable_store_void() {
+        let store = ExecutableStore::<usize, MockExecutable>::default();
+
+        store.insert(0, MockExecutable(3));
+        // Pruning before marking updated should lead to the Void state.
+        assert!(!store.prune(5));
+
+        assert_eq!(store.state(), ExecutableStoreState::Void);
+
+        // Mark ready must reset the state to Ready & clear the cache.
+        assert_eq!(store.size(), 3);
+        store.mark_ready(HashValue::random());
+        assert_eq!(store.size(), 0);
+
+        assert_eq!(store.state(), ExecutableStoreState::Ready);
+
+        store.insert(0, MockExecutable(3));
+        store.mark_updated();
+        assert!(!store.prune(5));
+
+        // marking updated in non-ready state must also lead to the Void state.
+        store.mark_updated();
+        assert_eq!(store.state(), ExecutableStoreState::Void);
+
+        assert_eq!(store.size(), 3);
+        store.mark_ready(HashValue::random());
+        assert_eq!(store.size(), 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn insert_not_ready() {
+        let store = ExecutableStore::<usize, MockExecutable>::default();
+        store.mark_updated();
+        store.insert(0, MockExecutable(3));
+    }
+
+    #[test]
+    #[should_panic]
+    fn get_not_ready() {
+        let store = ExecutableStore::<usize, MockExecutable>::default();
+        store.mark_updated();
+        store.get(&0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn remove_not_ready() {
+        let store = ExecutableStore::<usize, MockExecutable>::default();
+        store.mark_updated();
+        store.remove(&0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn check_not_ready() {
+        let store = ExecutableStore::<usize, MockExecutable>::default();
+        store.mark_updated();
+        store.check_ready(HashValue::random());
+    }
+
+    #[test]
+    fn total_size_simple() {
+        let store = ExecutableStore::<usize, MockExecutable>::default();
+
+        // Insert to keys 0,1,2.
+        store.insert(0, MockExecutable(3));
+        store.insert(1, MockExecutable(10));
+        store.insert(2, MockExecutable(100));
+        assert_eq!(store.size(), 113);
+
+        // Remove keys 1 & 2.
+        store.remove(&1);
+        assert_eq!(store.size(), 103);
+        store.remove(&2);
+        assert_eq!(store.size(), 3);
+
+        // Should overwrite previously stored value at key 0.
+        store.insert(0, MockExecutable(4));
+        assert_eq!(store.size(), 4);
+
+        // Insert to key 3.
+        store.insert(3, MockExecutable(30));
+        assert_eq!(store.size(), 34);
+
+        // Re-insert key 2.
+        store.insert(2, MockExecutable(200));
+        assert_eq!(store.size(), 234);
+
+        // Actually check that the proper executables are stored (by size).
+        assert_some_eq!(store.get(&0), MockExecutable(4));
+        assert_none!(store.get(&1));
+        assert_some_eq!(store.get(&2), MockExecutable(200));
+        assert_some_eq!(store.get(&3), MockExecutable(30));
+    }
+}


### PR DESCRIPTION
This PR implements ExecutableView for LatestView used in executor, so any VM can utilize this dedicated trait for accessing modules & executables, and benefit from the shared-across blocks, memory managed (in a trivial way for the beginning - flush if larger than size in between blocks), multi-versioned executable (loader) cache.

A new parameter for the shared cache size configuration is added (like concurrency level) and cache prune (eviction) is implemented in Aptos_VM::execute_block (between blocks). ExecutableStore comes with logic to flush the cache if the blocks are not consecutive or updating at the block boundary / pruning didn't appear to happen in an expected order. 

WIP, currently left to push / update: 
(1) new tests: unit tests for all the new interfaces & cache re-use, and proptest integration w. fake VM (concurrency & multi-versioning in particular, but also interplay w. baseline cache).

Currently, the validation logic is straightforward, but in a follow-up PR we will add an optimization that doesn't abort a validation when a validating read observes code dependency. This is because for code / modules we have the hash, and it is likely not going to change upon re-execution (while for data we make a pessimistic assumption based on incarnation), so we can just store validation dependency (but unlike the execution, not put the thread to wait) and ensure validation re-runs after the dependency is resolved (execution finishes). We can couple these changes w. optimizing re-execution flow after dependency resolution (direct wake-up?).

We should also consider integrating different modes into benchmarks, as this PR for simplicity integrates in a way that our benchmarks will use empty cache over and over again (same behavior as today).

Another related discussion point is the AptosVM / AptosVMImpl design, seems like AptosVMImpl taking StateView and the way it is used, shouldn't be a member of AptosVM - instead these could be parameters that are currently hacked by static. The AptosVMImpl equivalent can be created on demand based on provided StateView (anyway how it seems to be used).

Edit: It seems like once we fix the loader issues and can share a single VM among executor threads, we can finally refactor aptos-vm and make it a lot cleaner. If it holds all across-block consecutive state, a lot of the ugliness in this PR will also get reverted.