### PR TITLE
[Quorum Store] Turn quorum store onchain config on by default 

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1362,8 +1362,10 @@ fn changing_working_quorum_test_helper(
             let block_size = (target_tps / 4) as u64;
             helm_values["validator"]["config"]["consensus"]["max_sending_block_txns"] =
                 block_size.into();
-            helm_values["validator"]["config"]["consensus"]["max_receiving_block_txns"] =
-                block_size.into();
+            helm_values["validator"]["config"]["consensus"]
+                ["max_sending_block_txns_quorum_store_override"] = block_size.into();
+            helm_values["validator"]["config"]["consensus"]
+                ["max_receiving_block_txns_quorum_store_override"] = block_size.into();
             helm_values["validator"]["config"]["consensus"]["round_initial_timeout_ms"] =
                 500.into();
             helm_values["validator"]["config"]["consensus"]

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -11,7 +11,11 @@ use aptos_forge::{
 };
 use aptos_logger::Level;
 use aptos_rest_client::Client as RestClient;
-use aptos_sdk::{move_types::account_address::AccountAddress, transaction_builder::aptos_stdlib};
+use aptos_sdk::{
+    move_types::account_address::AccountAddress,
+    transaction_builder::aptos_stdlib,
+    types::on_chain_config::{ConsensusConfigV1, OnChainConsensusConfig},
+};
 use aptos_testcases::{
     compatibility_test::SimpleValidatorUpgrade,
     consensus_reliability_tests::ChangingWorkingQuorumTest,
@@ -402,7 +406,7 @@ fn get_changelog(prev_commit: Option<&String>, upstream_commit: &str) -> String 
 
 fn get_test_suite(suite_name: &str, duration: Duration) -> Result<ForgeConfig<'static>> {
     match suite_name {
-        "land_blocking" => Ok(land_blocking_test_suite(duration)),
+        "land_blocking" => Ok(land_blocking_three_region_test_suite(duration)),
         "local_test_suite" => Ok(local_test_suite()),
         "pre_release" => Ok(pre_release_suite()),
         "run_forever" => Ok(run_forever()),
@@ -1067,6 +1071,45 @@ fn three_region_simulation(config: ForgeConfig) -> ForgeConfig {
                     max_no_progress_secs: 20.0,
                     max_round_gap: 6,
                 }),
+        )
+}
+
+fn land_blocking_three_region_test_suite(duration: Duration) -> ForgeConfig<'static> {
+    ForgeConfig::default()
+        .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
+        .with_initial_fullnode_count(10)
+        .with_network_tests(vec![&ThreeRegionSameCloudSimulationTest])
+        .with_genesis_helm_config_fn(Arc::new(|helm_values| {
+            // Using V2 turns quorum store on by default
+            let consensus_config = OnChainConsensusConfig::V2(ConsensusConfigV1::default());
+            helm_values["chain"]["consensus_config"] =
+                serde_yaml::to_value(consensus_config).unwrap();
+            // Have single epoch change in land blocking
+            helm_values["chain"]["epoch_duration_secs"] = 300.into();
+        }))
+        .with_success_criteria(
+            SuccessCriteria::new(
+                if duration.as_secs() > 1200 {
+                    4500
+                } else {
+                    5000
+                },
+            )
+            .add_no_restarts()
+            .add_wait_for_catchup_s(
+                // Give at least 60s for catchup, give 10% of the run for longer durations.
+                (duration.as_secs() / 10).max(60),
+            )
+            .add_system_metrics_threshold(SystemMetricsThreshold::new(
+                // Check that we don't use more than 12 CPU cores for 30% of the time.
+                MetricsThreshold::new(12, 30),
+                // Check that we don't use more than 10 GB of memory for 30% of the time.
+                MetricsThreshold::new(10 * 1024 * 1024 * 1024, 30),
+            ))
+            .add_chain_progress(StateProgressThreshold {
+                max_no_progress_secs: 10.0,
+                max_round_gap: 4,
+            }),
         )
 }
 

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -402,7 +402,7 @@ fn get_changelog(prev_commit: Option<&String>, upstream_commit: &str) -> String 
 
 fn get_test_suite(suite_name: &str, duration: Duration) -> Result<ForgeConfig<'static>> {
     match suite_name {
-        "land_blocking" => single_test_suite("changing_working_quorum_test"),
+        "land_blocking" => Ok(land_blocking_test_suite(duration)),
         "local_test_suite" => Ok(local_test_suite()),
         "pre_release" => Ok(pre_release_suite()),
         "run_forever" => Ok(run_forever()),

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -991,6 +991,11 @@ fn validator_reboot_stress_test(config: ForgeConfig) -> ForgeConfig {
         }))
 }
 
+fn apply_quorum_store_configs_for_single_node(helm_values: &mut serde_yaml::Value) {
+    helm_values["validator"]["config"]["consensus"]["quorum_store"]["back_pressure"]
+        ["dynamic_max_txn_per_s"] = 5500.into();
+}
+
 fn single_vfn_perf(config: ForgeConfig) -> ForgeConfig {
     config
         .with_initial_validator_count(NonZeroUsize::new(1).unwrap())
@@ -1001,6 +1006,9 @@ fn single_vfn_perf(config: ForgeConfig) -> ForgeConfig {
                 .add_no_restarts()
                 .add_wait_for_catchup_s(240),
         )
+        .with_node_helm_config_fn(Arc::new(|helm_values| {
+            apply_quorum_store_configs_for_single_node(helm_values);
+        }))
 }
 
 fn setup_test(config: ForgeConfig) -> ForgeConfig {
@@ -1079,6 +1087,9 @@ fn network_partition(config: ForgeConfig) -> ForgeConfig {
                 .add_no_restarts()
                 .add_wait_for_catchup_s(240),
         )
+        .with_node_helm_config_fn(Arc::new(|helm_values| {
+            apply_quorum_store_configs_for_single_node(helm_values);
+        }))
 }
 
 fn compat(config: ForgeConfig) -> ForgeConfig {

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -11,11 +11,7 @@ use aptos_forge::{
 };
 use aptos_logger::Level;
 use aptos_rest_client::Client as RestClient;
-use aptos_sdk::{
-    move_types::account_address::AccountAddress,
-    transaction_builder::aptos_stdlib,
-    types::on_chain_config::{ConsensusConfigV1, OnChainConsensusConfig},
-};
+use aptos_sdk::{move_types::account_address::AccountAddress, transaction_builder::aptos_stdlib};
 use aptos_testcases::{
     compatibility_test::SimpleValidatorUpgrade,
     consensus_reliability_tests::ChangingWorkingQuorumTest,
@@ -1074,45 +1070,6 @@ fn three_region_simulation(config: ForgeConfig) -> ForgeConfig {
         )
 }
 
-fn land_blocking_three_region_test_suite(duration: Duration) -> ForgeConfig<'static> {
-    ForgeConfig::default()
-        .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
-        .with_initial_fullnode_count(10)
-        .with_network_tests(vec![&ThreeRegionSameCloudSimulationTest])
-        .with_genesis_helm_config_fn(Arc::new(|helm_values| {
-            // Using V2 turns quorum store on by default
-            let consensus_config = OnChainConsensusConfig::V2(ConsensusConfigV1::default());
-            helm_values["chain"]["consensus_config"] =
-                serde_yaml::to_value(consensus_config).unwrap();
-            // Have single epoch change in land blocking
-            helm_values["chain"]["epoch_duration_secs"] = 300.into();
-        }))
-        .with_success_criteria(
-            SuccessCriteria::new(
-                if duration.as_secs() > 1200 {
-                    4500
-                } else {
-                    5000
-                },
-            )
-            .add_no_restarts()
-            .add_wait_for_catchup_s(
-                // Give at least 60s for catchup, give 10% of the run for longer durations.
-                (duration.as_secs() / 10).max(60),
-            )
-            .add_system_metrics_threshold(SystemMetricsThreshold::new(
-                // Check that we don't use more than 12 CPU cores for 30% of the time.
-                MetricsThreshold::new(12, 30),
-                // Check that we don't use more than 10 GB of memory for 30% of the time.
-                MetricsThreshold::new(10 * 1024 * 1024 * 1024, 30),
-            ))
-            .add_chain_progress(StateProgressThreshold {
-                max_no_progress_secs: 10.0,
-                max_round_gap: 4,
-            }),
-        )
-}
-
 fn network_partition(config: ForgeConfig) -> ForgeConfig {
     config
         .with_initial_validator_count(NonZeroUsize::new(10).unwrap())
@@ -1266,11 +1223,47 @@ fn validators_join_and_leave(forge_config: ForgeConfig<'static>) -> ForgeConfig<
         )
 }
 
+#[allow(dead_code)]
 fn land_blocking_test_suite(duration: Duration) -> ForgeConfig<'static> {
     ForgeConfig::default()
         .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
         .with_initial_fullnode_count(10)
         .with_network_tests(vec![&PerformanceBenchmark])
+        .with_genesis_helm_config_fn(Arc::new(|helm_values| {
+            // Have single epoch change in land blocking
+            helm_values["chain"]["epoch_duration_secs"] = 300.into();
+        }))
+        .with_success_criteria(
+            SuccessCriteria::new(
+                if duration.as_secs() > 1200 {
+                    4500
+                } else {
+                    5000
+                },
+            )
+            .add_no_restarts()
+            .add_wait_for_catchup_s(
+                // Give at least 60s for catchup, give 10% of the run for longer durations.
+                (duration.as_secs() / 10).max(60),
+            )
+            .add_system_metrics_threshold(SystemMetricsThreshold::new(
+                // Check that we don't use more than 12 CPU cores for 30% of the time.
+                MetricsThreshold::new(12, 30),
+                // Check that we don't use more than 10 GB of memory for 30% of the time.
+                MetricsThreshold::new(10 * 1024 * 1024 * 1024, 30),
+            ))
+            .add_chain_progress(StateProgressThreshold {
+                max_no_progress_secs: 10.0,
+                max_round_gap: 4,
+            }),
+        )
+}
+
+fn land_blocking_three_region_test_suite(duration: Duration) -> ForgeConfig<'static> {
+    ForgeConfig::default()
+        .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
+        .with_initial_fullnode_count(10)
+        .with_network_tests(vec![&ThreeRegionSameCloudSimulationTest])
         .with_genesis_helm_config_fn(Arc::new(|helm_values| {
             // Have single epoch change in land blocking
             helm_values["chain"]["epoch_duration_secs"] = 300.into();

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -402,7 +402,7 @@ fn get_changelog(prev_commit: Option<&String>, upstream_commit: &str) -> String 
 
 fn get_test_suite(suite_name: &str, duration: Duration) -> Result<ForgeConfig<'static>> {
     match suite_name {
-        "land_blocking" => Ok(land_blocking_three_region_test_suite(duration)),
+        "land_blocking" => Ok(land_blocking_test_suite(duration)),
         "local_test_suite" => Ok(local_test_suite()),
         "pre_release" => Ok(pre_release_suite()),
         "run_forever" => Ok(run_forever()),
@@ -1223,7 +1223,6 @@ fn validators_join_and_leave(forge_config: ForgeConfig<'static>) -> ForgeConfig<
         )
 }
 
-#[allow(dead_code)]
 fn land_blocking_test_suite(duration: Duration) -> ForgeConfig<'static> {
     ForgeConfig::default()
         .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
@@ -1259,6 +1258,7 @@ fn land_blocking_test_suite(duration: Duration) -> ForgeConfig<'static> {
         )
 }
 
+#[allow(dead_code)]
 fn land_blocking_three_region_test_suite(duration: Duration) -> ForgeConfig<'static> {
     ForgeConfig::default()
         .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
@@ -1269,28 +1269,22 @@ fn land_blocking_three_region_test_suite(duration: Duration) -> ForgeConfig<'sta
             helm_values["chain"]["epoch_duration_secs"] = 300.into();
         }))
         .with_success_criteria(
-            SuccessCriteria::new(
-                if duration.as_secs() > 1200 {
-                    4500
-                } else {
-                    5000
-                },
-            )
-            .add_no_restarts()
-            .add_wait_for_catchup_s(
-                // Give at least 60s for catchup, give 10% of the run for longer durations.
-                (duration.as_secs() / 10).max(60),
-            )
-            .add_system_metrics_threshold(SystemMetricsThreshold::new(
-                // Check that we don't use more than 12 CPU cores for 30% of the time.
-                MetricsThreshold::new(12, 30),
-                // Check that we don't use more than 10 GB of memory for 30% of the time.
-                MetricsThreshold::new(10 * 1024 * 1024 * 1024, 30),
-            ))
-            .add_chain_progress(StateProgressThreshold {
-                max_no_progress_secs: 10.0,
-                max_round_gap: 4,
-            }),
+            SuccessCriteria::new(3500)
+                .add_no_restarts()
+                .add_wait_for_catchup_s(
+                    // Give at least 60s for catchup, give 10% of the run for longer durations.
+                    (duration.as_secs() / 10).max(60),
+                )
+                .add_system_metrics_threshold(SystemMetricsThreshold::new(
+                    // Check that we don't use more than 12 CPU cores for 30% of the time.
+                    MetricsThreshold::new(12, 30),
+                    // Check that we don't use more than 10 GB of memory for 30% of the time.
+                    MetricsThreshold::new(10 * 1024 * 1024 * 1024, 30),
+                ))
+                .add_chain_progress(StateProgressThreshold {
+                    max_no_progress_secs: 10.0,
+                    max_round_gap: 4,
+                }),
         )
 }
 

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -402,7 +402,7 @@ fn get_changelog(prev_commit: Option<&String>, upstream_commit: &str) -> String 
 
 fn get_test_suite(suite_name: &str, duration: Duration) -> Result<ForgeConfig<'static>> {
     match suite_name {
-        "land_blocking" => Ok(land_blocking_test_suite(duration)),
+        "land_blocking" => single_test_suite("changing_working_quorum_test"),
         "local_test_suite" => Ok(local_test_suite()),
         "pre_release" => Ok(pre_release_suite()),
         "run_forever" => Ok(run_forever()),

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -65,7 +65,7 @@ impl OnChainConsensusConfig {
 /// This is used when on-chain config is not initialized.
 impl Default for OnChainConsensusConfig {
     fn default() -> Self {
-        OnChainConsensusConfig::V1(ConsensusConfigV1::default())
+        OnChainConsensusConfig::V2(ConsensusConfigV1::default())
     }
 }
 


### PR DESCRIPTION
### Description

Change the default of onchain ConsensusConfig to use V2, which turns on quorum store. This will allow all tests (unit, smoke, forge) to use quorum store, and new networks that do a genesis (forge, next previewnet).

Adjust forge tests to pass with quorum store enabled. In particular:
* Bump up maximum allowed TPS in backpressure for single-node tests.
* Ensure at least one validator that is receiving transactions is not injected failures in stress tests. (Because quorum store cannot obtain proofs while in an earlier epoch.)
* Add a new `land_blocking_three_region_test_suite` that is not enabled yet. It currently gets ~4K TPS.

### Test Plan

Run continuous forge tests and ensure all previously passing tests still pass.
https://github.com/aptos-labs/aptos-core/actions/runs/4769819164
Note, `run-forge-different-node-speed-and-reliability-test` currently fails without quorum store as well.
