### PR TITLE
[Execution] Enable transaction shuffling in genesis for Forge

### DIFF
--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -69,8 +69,8 @@ use aptos_types::{
     epoch_change::EpochChangeProof,
     epoch_state::EpochState,
     on_chain_config::{
-        LeaderReputationType, OnChainConfigPayload, OnChainConsensusConfig, OnChainExecutionConfig,
-        ProposerElectionType, ValidatorSet,
+        ExecutionConfigV1, LeaderReputationType, OnChainConfigPayload, OnChainConsensusConfig,
+        OnChainExecutionConfig, ProposerElectionType, TransactionShufflerType, ValidatorSet,
     },
     validator_verifier::ValidatorVerifier,
 };
@@ -812,7 +812,11 @@ impl EpochManager {
         match self.storage.start() {
             LivenessStorageData::FullRecoveryData(initial_data) => {
                 let consensus_config = onchain_consensus_config.unwrap_or_default();
-                let execution_config = onchain_execution_config.unwrap_or_default();
+                let execution_config = onchain_execution_config.unwrap_or(
+                    OnChainExecutionConfig::V1(ExecutionConfigV1 {
+                        transaction_shuffler_type: TransactionShufflerType::NoShuffling,
+                    }),
+                );
                 self.quorum_store_enabled = self.enable_quorum_store(&consensus_config);
                 self.recovery_mode = false;
                 self.start_round_manager(

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -76,7 +76,7 @@ pub struct ExecutionConfigV1 {
 impl Default for ExecutionConfigV1 {
     fn default() -> Self {
         Self {
-            transaction_shuffler_type: TransactionShufflerType::NoShuffling,
+            transaction_shuffler_type: TransactionShufflerType::SenderAwareV1(32),
         }
     }
 }


### PR DESCRIPTION
### Description

Enabling this by default for Forge runs and any other tests. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
