### PR TITLE
[forge tests] Unbreak forge consensus stress tests

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1327,7 +1327,8 @@ fn changing_working_quorum_test_helper(
                 500.into();
             helm_values["validator"]["config"]["consensus"]
                 ["round_timeout_backoff_exponent_base"] = 1.0.into();
-            helm_values["validator"]["config"]["consensus"]["quorum_store_poll_count"] = 1.into();
+            helm_values["validator"]["config"]["consensus"]["quorum_store_poll_time_ms"] =
+                100.into();
 
             let mut min_block_txns = block_size;
             let mut chain_health_backoff = ConsensusConfig::default().chain_health_backoff;


### PR DESCRIPTION
### Description

The config was replaced, but the helm_values was not updated leading to the validators crash-looping during these forge tests.
