### PR TITLE
Expose aptos-move counters outside the module

### DIFF
--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -103,7 +103,7 @@
 
 mod access_path_cache;
 #[macro_use]
-mod counters;
+pub mod counters;
 pub mod data_cache;
 
 #[cfg(feature = "mirai-contracts")]


### PR DESCRIPTION
So that runtime (i.e. benchmark runtime) can get access to TXN_GAS_USAGE to monitor GAS consumption (as StateComputeResult doesn't have gas information)

used in a stacked PR

open to alternatives, but this seems simplest.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
