### PR TITLE
[docs] Update link to the Move language tutorial

### DIFF
--- a/developer-docs-site/docs/move/book/creating-coins.md
+++ b/developer-docs-site/docs/move/book/creating-coins.md
@@ -1,3 +1,3 @@
 # Move Tutorial
 
-Please refer to the [Move Primitives Tutorial](https://github.com/aptos-labs/aptos-core/tree/main/third_party/move/documentation/tutorial).
+Please refer to the [Move Core Language Tutorial](https://github.com/aptos-labs/aptos-core/tree/main/aptos-move/move-examples/move-tutorial).


### PR DESCRIPTION
The book contained an outdated link to an older version of the language tutorial.

