### PR TITLE
[fungible_asset] rename ungated_transfer to frozen

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
+++ b/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
@@ -14,7 +14,7 @@ This defines the module for interacting with primary stores of accounts/objects,
 -  [Function `primary_store`](#0x1_primary_fungible_store_primary_store)
 -  [Function `primary_store_exists`](#0x1_primary_fungible_store_primary_store_exists)
 -  [Function `balance`](#0x1_primary_fungible_store_balance)
--  [Function `ungated_balance_transfer_allowed`](#0x1_primary_fungible_store_ungated_balance_transfer_allowed)
+-  [Function `is_frozen`](#0x1_primary_fungible_store_is_frozen)
 -  [Function `withdraw`](#0x1_primary_fungible_store_withdraw)
 -  [Function `deposit`](#0x1_primary_fungible_store_deposit)
 -  [Function `transfer`](#0x1_primary_fungible_store_transfer)
@@ -264,14 +264,14 @@ Get the balance of <code><a href="account.md#0x1_account">account</a></code>'s p
 
 </details>
 
-<a name="0x1_primary_fungible_store_ungated_balance_transfer_allowed"></a>
+<a name="0x1_primary_fungible_store_is_frozen"></a>
 
-## Function `ungated_balance_transfer_allowed`
+## Function `is_frozen`
 
-Return whether the given account's primary store can do direct transfers.
+Return whether the given account's primary store is frozen.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_ungated_balance_transfer_allowed">ungated_balance_transfer_allowed</a>&lt;T: key&gt;(<a href="account.md#0x1_account">account</a>: <b>address</b>, metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_is_frozen">is_frozen</a>&lt;T: key&gt;(<a href="account.md#0x1_account">account</a>: <b>address</b>, metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): bool
 </code></pre>
 
 
@@ -280,11 +280,11 @@ Return whether the given account's primary store can do direct transfers.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_ungated_balance_transfer_allowed">ungated_balance_transfer_allowed</a>&lt;T: key&gt;(<a href="account.md#0x1_account">account</a>: <b>address</b>, metadata: Object&lt;T&gt;): bool {
+<pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_is_frozen">is_frozen</a>&lt;T: key&gt;(<a href="account.md#0x1_account">account</a>: <b>address</b>, metadata: Object&lt;T&gt;): bool {
     <b>if</b> (<a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_exists">primary_store_exists</a>(<a href="account.md#0x1_account">account</a>, metadata)) {
-        <a href="fungible_asset.md#0x1_fungible_asset_ungated_balance_transfer_allowed">fungible_asset::ungated_balance_transfer_allowed</a>(<a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store">primary_store</a>(<a href="account.md#0x1_account">account</a>, metadata))
+        <a href="fungible_asset.md#0x1_fungible_asset_is_frozen">fungible_asset::is_frozen</a>(<a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store">primary_store</a>(<a href="account.md#0x1_account">account</a>, metadata))
     } <b>else</b> {
-        <b>true</b>
+        <b>false</b>
     }
 }
 </code></pre>

--- a/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
+++ b/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
@@ -84,12 +84,12 @@ module aptos_framework::primary_fungible_store {
     }
 
     #[view]
-    /// Return whether the given account's primary store can do direct transfers.
-    public fun ungated_balance_transfer_allowed<T: key>(account: address, metadata: Object<T>): bool {
+    /// Return whether the given account's primary store is frozen.
+    public fun is_frozen<T: key>(account: address, metadata: Object<T>): bool {
         if (primary_store_exists(account, metadata)) {
-            fungible_asset::ungated_balance_transfer_allowed(primary_store(account, metadata))
+            fungible_asset::is_frozen(primary_store(account, metadata))
         } else {
-            true
+            false
         }
     }
 
@@ -152,8 +152,8 @@ module aptos_framework::primary_fungible_store {
         assert!(!primary_store_exists(aaron_address, metadata), 2);
         assert!(balance(creator_address, metadata) == 0, 3);
         assert!(balance(aaron_address, metadata) == 0, 4);
-        assert!(ungated_balance_transfer_allowed(creator_address, metadata), 5);
-        assert!(ungated_balance_transfer_allowed(aaron_address, metadata), 6);
+        assert!(!is_frozen(creator_address, metadata), 5);
+        assert!(!is_frozen(aaron_address, metadata), 6);
         ensure_primary_store_exists(creator_address, metadata);
         ensure_primary_store_exists(aaron_address, metadata);
         assert!(primary_store_exists(creator_address, metadata), 7);

--- a/aptos-move/move-examples/fungible_asset/sources/coin_example.move
+++ b/aptos-move/move-examples/fungible_asset/sources/coin_example.move
@@ -33,7 +33,7 @@ module fungible_asset_extension::coin_example {
         managed_fungible_asset::mint(admin, get_metadata(), amount, to);
     }
 
-    /// Transfer as the owner of metadata object ignoring `allow_ungated_transfer` field.
+    /// Transfer as the owner of metadata object ignoring `frozen` field.
     public entry fun transfer(admin: &signer, from: address, to: address, amount: u64) {
         managed_fungible_asset::transfer(admin, get_metadata(), from, to, amount);
     }
@@ -53,12 +53,12 @@ module fungible_asset_extension::coin_example {
         managed_fungible_asset::unfreeze_account(admin, get_metadata(), account);
     }
 
-    /// Withdraw as the owner of metadata object ignoring `allow_ungated_transfer` field.
+    /// Withdraw as the owner of metadata object ignoring `frozen` field.
     public fun withdraw(admin: &signer, amount: u64, from: address): FungibleAsset {
         managed_fungible_asset::withdraw(admin, get_metadata(), amount, from)
     }
 
-    /// Deposit as the owner of metadata object ignoring `allow_ungated_transfer` field.
+    /// Deposit as the owner of metadata object ignoring `frozen` field.
     public fun deposit(admin: &signer, to: address, fa: FungibleAsset) {
         managed_fungible_asset::deposit(admin, get_metadata(), to, fa);
     }
@@ -78,12 +78,12 @@ module fungible_asset_extension::coin_example {
         let metadata = get_metadata();
         assert!(primary_fungible_store::balance(creator_address, metadata) == 100, 4);
         freeze_account(creator, creator_address);
-        assert!(!primary_fungible_store::ungated_balance_transfer_allowed(creator_address, metadata), 5);
+        assert!(primary_fungible_store::is_frozen(creator_address, metadata), 5);
         transfer(creator, creator_address, aaron_address, 10);
         assert!(primary_fungible_store::balance(aaron_address, metadata) == 10, 6);
 
         unfreeze_account(creator, creator_address);
-        assert!(primary_fungible_store::ungated_balance_transfer_allowed(creator_address, metadata), 7);
+        assert!(!primary_fungible_store::is_frozen(creator_address, metadata), 7);
         burn(creator, creator_address, 90);
     }
 


### PR DESCRIPTION
### Description
`ungated_balance_transfer` is long and counter intuitive. `frozen` is definitely much better as a name.
### Test Plan
ut
