### PR TITLE
[gha] Add debug line to check if concurrency is conflictingo

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -98,6 +98,7 @@ jobs:
         run: |
           echo "GIT_SHA: ${{ env.GIT_SHA }}"
           echo "TARGET_CACHE_ID: ${{ env.TARGET_CACHE_ID }}"
+          echo "CONCURRENCY: ${{ github.workflow }}-${{ github.event_name }}-${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.sha || github.head_ref || github.ref }}"
     outputs:
       gitSha: ${{ env.GIT_SHA }}
       targetCacheId: ${{ env.TARGET_CACHE_ID }}


### PR DESCRIPTION
I suspect that performance builds on main are being canceled because this complex concurrency group name is not working as intended but it seems very difficult to actually tell without logging it

So this logs that value so that we can see if it does what is intended on PR and main

Test plan: These is not a great way to test this afaik
