### PR TITLE
[gha] fix grafana-sync pnpm setup

### DIFF
--- a/.github/workflows/grafana-sync.yaml
+++ b/.github/workflows/grafana-sync.yaml
@@ -20,10 +20,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
       - uses: pnpm/action-setup@537643d491d20c2712d11533497cb47b2d0eb9d5 # pin https://github.com/pnpm/action-setup/releases/tag/v2.2.3
         with:
-          version: 7.13.4
-          run_install: |
-            - recursive: false
-              args: [--frozen-lockfile]
+          version: 8.2.0
       - name: Download current Grafana dashboards
         run: pnpm exec scripts/grafana-sync.mts download
       - name: Create Pull Request


### PR DESCRIPTION
### Description

Update the grafana sync job to use pnpm 8.2.0 and also remove install args.

This job has been failing for the last few days with the following error, likely due to changes in https://github.com/aptos-labs/aptos-core/pull/7890

```
Running pnpm install --frozen-lockfile...
   WARN  Ignoring not compatible lockfile at /home/runner/work/aptos-core/aptos-core/pnpm-lock.yaml
   ERROR  Headless installation requires a pnpm-lock.yaml file
  
  pnpm: Headless installation requires a pnpm-lock.yaml file
      at _install (/home/runner/setup-pnpm/node_modules/.pnpm/pnpm@7.13.4/node_modules/pnpm/dist/pnpm.cjs:138250:21)
      at mutateModules (/home/runner/setup-pnpm/node_modules/.pnpm/pnpm@7.13.4/node_modules/pnpm/dist/pnpm.cjs:138182:[29](https://github.com/aptos-labs/aptos-core/actions/runs/4768786690/jobs/8478504511#step:3:31))
      at async install (/home/runner/setup-pnpm/node_modules/.pnpm/pnpm@7.13.4/node_modules/pnpm/dist/pnpm.cjs:138137:24)
      at async handler (/home/runner/setup-pnpm/node_modules/.pnpm/pnpm@7.13.4/node_modules/pnpm/dist/pnpm.cjs:139884:[31](https://github.com/aptos-labs/aptos-core/actions/runs/4768786690/jobs/8478504511#step:3:33))
      at async /home/runner/setup-pnpm/node_modules/.pnpm/pnpm@7.13.4/node_modules/pnpm/dist/pnpm.cjs:209084:21
      at async run (/home/runner/setup-pnpm/node_modules/.pnpm/pnpm@7.13.4/node_modules/pnpm/dist/pnpm.cjs:209055:[34](https://github.com/aptos-labs/aptos-core/actions/runs/4768786690/jobs/8478504511#step:3:36))
      at async runPnpm (/home/runner/setup-pnpm/node_modules/.pnpm/pnpm@7.13.4/node_modules/pnpm/dist/pnpm.cjs:209280:5)
      at async /home/runner/setup-pnpm/node_modules/.pnpm/pnpm@7.13.4/node_modules/pnpm/dist/pnpm.cjs:209272:7
Error: Command pnpm install --frozen-lockfile (cwd: undefined) exits with status 1
```

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
