### PR TITLE
[Quorum Store] remove continuous test quorum-store cadence

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -36,7 +36,6 @@ on: # build on main branch OR when a PR is labeled with `CICD:build-images`
       - aptos-release-v*
       # experimental branches
       - performance_benchmark
-      - quorum-store
       - preview
 
 # cancel redundant builds

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -36,6 +36,7 @@ on: # build on main branch OR when a PR is labeled with `CICD:build-images`
       - aptos-release-v*
       # experimental branches
       - performance_benchmark
+      - quorum-store
       - preview
 
 # cancel redundant builds

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -22,7 +22,6 @@ on:
         description: The git SHA1 to checkout. This affects the Forge test runner that is used. If not specified, the latest main will be used
   schedule:
     - cron: "0 9 * * *" # the main branch cadence
-    - cron: "0 21 * * *" # the QS "quorum-store" branch cadence
   pull_request:
     paths:
       - ".github/workflows/forge-stable.yaml"
@@ -54,9 +53,6 @@ jobs:
             if [[ "${{ github.event.schedule }}" == "0 9 * * *" ]]; then
               echo "Branch: main"
               echo "BRANCH=main" >> $GITHUB_OUTPUT
-            elif [[ "${{ github.event.schedule }}" == "0 21 * * *" ]]; then
-              echo "Branch: quorum-store"
-              echo "BRANCH=quorum-store" >> $GITHUB_OUTPUT
             else
               echo "Unknown schedule: ${{ github.event.schedule }}"
               exit 1


### PR DESCRIPTION
### Description

quorum-store branch no longer needs to be run continuously, as quorum store is now enabled by default.