### PR TITLE
[faucet] Allow for running in multiple threads

### DIFF
--- a/crates/aptos-faucet/core/src/server/run.rs
+++ b/crates/aptos-faucet/core/src/server/run.rs
@@ -72,10 +72,9 @@ impl RunConfig {
         info!("Starting server...");
 
         // Set whether we should use useful errors.
+        // If it's already set, then we'll carry on
         #[cfg(not(test))]
-        crate::endpoints::USE_HELPFUL_ERRORS
-            .set(self.handler_config.use_helpful_errors)
-            .expect("OnceCell somehow already set");
+        let _ = crate::endpoints::USE_HELPFUL_ERRORS.set(self.handler_config.use_helpful_errors);
 
         let concurrent_requests_semaphore = self
             .handler_config


### PR DESCRIPTION
### Description
This removes an assertion that prevents the faucet from being started twice in the same runtime.  Running the command `cargo test --package smoke-test --lib rosetta` locally prior to this change would fail every time on the `expect` statement.

### Test Plan
Tested locally with Rosetta tests

```
$ cargo test --package smoke-test --lib rosetta

running 6 tests
test rosetta::test_network ... ok
test rosetta::test_invalid_transaction_gas_charged ... ok
test rosetta::test_block_transactions ... ok
test rosetta::test_transfer ... ok
test rosetta::test_account_balance ... ok
test rosetta::test_block has been running for over 60 seconds
test rosetta::test_block ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 80 filtered out; finished in 78.66s
```