### PR TITLE
remove unnecessary dependency in `aptos-move/framework/`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
- "aptos-cached-packages",
  "aptos-crypto",
  "aptos-gas",
  "aptos-gas-algebra-ext",

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -75,7 +75,6 @@ thiserror = { workspace = true }
 tiny-keccak = { workspace = true }
 
 [dev-dependencies]
-aptos-cached-packages = { workspace = true }
 aptos-gas = { workspace = true }
 aptos-vm = { workspace = true, features = ["testing"] }
 claims = { workspace = true }


### PR DESCRIPTION
### Description

**Problem:** Running `cargo test` inside `aptos-move/framework` is too slow due to the long build time of the `aptos-cached-packages` dependency.

**Bad solution:** Testing using the CLI is NOT faster than running `cargo test` when developing new Rust native functions because the entire CLI has to be recompiled to include the developed native functions.

**Proposed solution:** Remove `aptos-cached-packages` from `framework/`'s dependencies. What might go wrong? (No seriously, I actually don't know what might go wrong.)