### PR TITLE
[ts-sdk] Fix output errors of publish ANS contract script

### DIFF
--- a/ecosystem/typescript/sdk/scripts/publish_ans_contract.ts
+++ b/ecosystem/typescript/sdk/scripts/publish_ans_contract.ts
@@ -51,8 +51,9 @@ try {
   deleteAnsFolder();
 } catch (error: any) {
   console.error("An error occurred:");
-  console.error("parsed stdout", error.stdout.toString("utf8"));
-  console.error("parsed stderr", error.stderr.toString("utf8"));
+  console.error("Status", error?.status);
+  console.error("parsed stdout", error?.stdout?.toString("utf8"));
+  console.error("parsed stderr", error?.stderr?.toString("utf8"));
   deleteAnsFolder();
   process.exit(1);
 }


### PR DESCRIPTION
### Description
The previous runs failed because they didn't parse the output errors correctly in the event there was no stdout / stderr.

```
 console.error("parsed stdout", error.stdout.toString("utf8"));
```

### Test Plan
Tested manually with
```
export APTOS_NODE_URL=http://127.0.0.1:8080/v1
export APTOS_FAUCET_URL=http://127.0.0.1:8081
pnpm test
```
