### PR TITLE
move test filtering for aptos-framework

### DIFF
--- a/aptos-move/framework/README.md
+++ b/aptos-move/framework/README.md
@@ -47,3 +47,14 @@ The overall structure of the Aptos Framework is as follows:
 ├── releases                                    # Move release bundles
 └── tests
 ```
+
+## Move unit test selection
+In this package, unit test run triggered by `cargo test <filter>` will only select rust test wrappers
+(for example, those marked as `#[test]` in `tests/move_unit_test.rs`).
+
+To select the actual test cases in Move, use the following command.
+```bash
+MOVE_TEST_FILTER=<move-test-filter> cargo test <the-rest-params>
+```
+A test case is selected if and only if its full name (e.g. `0x1::ristretto255::test_point_neg`)
+contains the value of `MOVE_TEST_FILTER` as a substring.

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -14,8 +14,10 @@ use tempfile::tempdir;
 
 fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
     let pkg_path = path_in_crate(path_to_pkg);
-    let mut ut_config = UnitTestingConfig::default_with_bound(Some(100_000));
-    ut_config.filter = Some("ristretto".to_string());
+    // TODO(Gas): double check if this is correct
+    let bound = Some(100_000);
+    let mut ut_config = UnitTestingConfig::default_with_bound(bound);
+    ut_config.filter = std::env::var("MOVE_TEST_FILTER").ok();
     let ok = run_move_unit_tests(
         &pkg_path,
         move_package::BuildConfig {
@@ -23,7 +25,6 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
             install_dir: Some(tempdir().unwrap().path().to_path_buf()),
             ..Default::default()
         },
-        // TODO(Gas): double check if this is correct
         ut_config,
         aptos_test_natives(),
         /* cost_table */ None,

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -14,6 +14,8 @@ use tempfile::tempdir;
 
 fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
     let pkg_path = path_in_crate(path_to_pkg);
+    let mut ut_config = UnitTestingConfig::default_with_bound(Some(100_000));
+    ut_config.filter = Some("ristretto".to_string());
     let ok = run_move_unit_tests(
         &pkg_path,
         move_package::BuildConfig {
@@ -22,7 +24,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
             ..Default::default()
         },
         // TODO(Gas): double check if this is correct
-        UnitTestingConfig::default_with_bound(Some(100_000)),
+        ut_config,
         aptos_test_natives(),
         /* cost_table */ None,
         /* compute_coverage */ false,


### PR DESCRIPTION
A way to filter move unit tests and make aptos-framework development slightly easier.
