### PR TITLE
[cli] Add more involved move init command

### DIFF
--- a/crates/aptos/src/move_tool/manifest.rs
+++ b/crates/aptos/src/move_tool/manifest.rs
@@ -25,6 +25,12 @@ pub struct ManifestNamedAddress {
     pub address: Option<AccountAddress>,
 }
 
+impl ManifestNamedAddress {
+    pub fn placeholder() -> Self {
+        ManifestNamedAddress { address: None }
+    }
+}
+
 impl From<Option<AccountAddress>> for ManifestNamedAddress {
     fn from(opt: Option<AccountAddress>) -> Self {
         ManifestNamedAddress { address: opt }


### PR DESCRIPTION
### Description
I was fixing some tests, and I realized that this kept pulling from `main`.  I've added it so it now pulls from `testnet` and made a little demo program so it can give some more info there.

Move init now provides a small program that's an example of what you can do along with how to test.  Additionally, shows best practices of naming and error messages

### Test Plan
```
$ ./target/debug/aptos move init --name test_all --package-dir test-all --assume-yes
{
  "Result": "Success"
}

$ aptos move test --package-dir test-all --named-addresses test_all=0x22            
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING test_all
Running Move unit tests
[ PASS    ] 0x22::test_all::test_authorization
[ PASS    ] 0x22::test_all::test_implementation
Test result: OK. Total tests: 2; passed: 2; failed: 0
{
  "Result": "Success"
}

$ aptos move publish --package-dir test-all --named-addresses test_all=devnet --profile devnet
Compiling, may take a little while to download git dependencies...
UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING test_all
package size 1378 bytes
Do you want to submit a transaction for a range of [97700 - 146500] Octas at a gas unit price of 100 Octas? [yes/no] >
yes
{
  "Result": {
    "transaction_hash": "0x7abd71cf2abc515e2b1d0d0ecda26e199d75d3a7aba149aa950efcb403cc0f8f",
    "gas_used": 977,
    "gas_unit_price": 100,
    "sender": "b11affd5c514bb969e988710ef57813d9556cc1e3fe6dc9aa6a82b56aee53d98",
    "sequence_number": 3,
    "success": true,
    "timestamp_us": 1682477528360497,
    "version": 193629,
    "vm_status": "Executed successfully"
  }
}
```