### PR TITLE
Fix flag to skip fetching git deps in aptos move test

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+### Fixed
+* Previously `--skip-fetch-latest-git-deps` would not actually do anything when used with `aptos move test`. This has been fixed.
+
 ## [1.0.12] - 2023/04/25
 ### Added
 * Support for creating and interacting with multisig accounts v2. More details can be found at [AIP 12](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-12.md).

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -438,6 +438,7 @@ impl CliCommand<&'static str> for TestPackage {
             additional_named_addresses: self.move_options.named_addresses(),
             test_mode: true,
             install_dir: self.move_options.output_dir.clone(),
+            skip_fetch_latest_git_deps: self.move_options.skip_fetch_latest_git_deps,
             ..Default::default()
         };
 


### PR DESCRIPTION
### Description
This is a fun little PTO PR. While working on a side project on a plane I noticed that `aptos move test` doesn't work when you don't have internet because we don't actually respect the `--skip-fetch-latest-git-deps` flag. This PR fixes that.

### Test Plan
While offline.

Before:
```
$ aptos move test --skip-fetch-latest-git-deps --named-addresses addr=0x1
Compiling, may take a little while to download git dependencies...
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING tontine
{
  "Error": "Unexpected error: Unable to resolve packages for package 'tontine'"
}
```

After:
```
$ cargo run -p aptos -- move test --skip-fetch-latest-git-deps --named-addresses addr=0x1 --package-dir ~/github/aptos-tontine/move
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING tontine
Running Move unit tests
...
```
