### PR TITLE
[TS SDK] Add function to compute the collection id hash

### DIFF
--- a/ecosystem/typescript/sdk/src/account/aptos_account.ts
+++ b/ecosystem/typescript/sdk/src/account/aptos_account.ts
@@ -4,6 +4,7 @@
 import nacl from "tweetnacl";
 import * as bip39 from "@scure/bip39";
 import { bytesToHex } from "@noble/hashes/utils";
+import { sha256 } from "@noble/hashes/sha256";
 import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
 import { derivePath } from "../utils/hd-key";
 import { HexString, MaybeHexString, Memoize } from "../utils";
@@ -111,7 +112,6 @@ export class AptosAccount {
    * @param seed The seed bytes
    * @returns The resource account address
    */
-
   static getResourceAccountAddress(sourceAddress: MaybeHexString, seed: Uint8Array): HexString {
     const source = bcsToBytes(AccountAddress.fromHex(sourceAddress));
 
@@ -120,6 +120,21 @@ export class AptosAccount {
     const hash = sha3Hash.create();
     hash.update(bytes);
 
+    return HexString.fromUint8Array(hash.digest());
+  }
+
+  /**
+   * Takes creator address and collection name and returns the collection id hash.
+   * Collection id hash are generated as sha256 hash of (`creator_address::collection_name`)
+   *
+   * @param creatorAddress Collection creator address
+   * @param collectionName The collection name
+   * @returns The collection id hash
+   */
+  static getCollectionID(creatorAddress: MaybeHexString, collectionName: string): HexString {
+    const seed = new TextEncoder().encode(`${creatorAddress}::${collectionName}`);
+    const hash = sha256.create();
+    hash.update(seed);
     return HexString.fromUint8Array(hash.digest());
   }
 

--- a/ecosystem/typescript/sdk/src/tests/unit/aptos_account.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/unit/aptos_account.test.ts
@@ -87,3 +87,11 @@ test("Test getAddressFromAccountOrAddress", () => {
   );
   expect(getAddressFromAccountOrAddress(account).toString()).toBe(aptosAccountObject.address);
 });
+
+test("Gets the collection id", async () => {
+  const creatorAddress = "0x28aa1624f8a8974c4158da696eea0e1c26af2cf7cacdb3564193ae817a44f908";
+  const collectionName = "AliceCollection";
+  expect(AptosAccount.getCollectionID(creatorAddress, collectionName).hex()).toBe(
+    "0x0524ffd0955d9c8c405315829ce896f5ced080cd15f146bbc690323d4d141b12",
+  );
+});


### PR DESCRIPTION
### Description
Per @moonclavedev's request, adding a function that computes a collection id by providing creator address and collection name.
### Test Plan
tests are passing

Also tested with
```
test("Gets the collection id", async () => {
  const creatorAddress = "0x043ec2cb158e3569842d537740fd53403e992b9e7349cc5d3dfaa5aff8faaef2";
  const collectionName = "Bruh Bears";
  expect(AptosAccount.getCollectionID(creatorAddress, collectionName).hex()).toBe(
    "0xda59e5f610419f274a20341fb198bf98415712de11a4468cfd45cbe495600c2a",
  );
});
```

that matches with Indexer
https://cloud.hasura.io/public/graphiql?endpoint=https%3A%2F%2Findexer.mainnet.aptoslabs.com%2Fv1%2Fgraphql&query=query+MyQuery+%7B%0A++current_collection_datas%28%0A++++where%3A+%7Bcollection_name%3A+%7B_eq%3A+%22Bruh+Bears%22%7D%2C+creator_address%3A+%7B_eq%3A+%220x043ec2cb158e3569842d537740fd53403e992b9e7349cc5d3dfaa5aff8faaef2%22%7D%7D%0A++%29+%7B%0A++++collection_data_id_hash%0A++%7D%0A%7D%0A
