### PR TITLE
Add icon_uri to fungible asset and update comments

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/fungible_asset.md
@@ -149,6 +149,19 @@ Metadata of a Fungible asset
  For example, if <code>decimals</code> equals <code>2</code>, a balance of <code>505</code> coins should
  be displayed to a user as <code>5.05</code> (<code>505 / 10 ** 2</code>).
 </dd>
+<dt>
+<code>icon_uri: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a></code>
+</dt>
+<dd>
+ The Uniform Resource Identifier (uri) pointing to an image that can be used as the icon for this fungible
+ asset.
+</dd>
+<dt>
+<code>issuer: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a></code>
+</dt>
+<dd>
+ The entity who issued this fungible asset.
+</dd>
 </dl>
 
 
@@ -632,6 +645,16 @@ Transfer ref and store do not match.
 
 
 
+<a name="0x1_fungible_asset_EURI_TOO_LONG"></a>
+
+URI for the icon of the fungible asset metadata is too long
+
+
+<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_EURI_TOO_LONG">EURI_TOO_LONG</a>: u64 = 18;
+</code></pre>
+
+
+
 <a name="0x1_fungible_asset_MAX_DECIMALS"></a>
 
 
@@ -659,6 +682,15 @@ Transfer ref and store do not match.
 
 
 
+<a name="0x1_fungible_asset_MAX_URI_LENGTH"></a>
+
+
+
+<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_MAX_URI_LENGTH">MAX_URI_LENGTH</a>: u64 = 512;
+</code></pre>
+
+
+
 <a name="0x1_fungible_asset_add_fungibility"></a>
 
 ## Function `add_fungibility`
@@ -667,7 +699,7 @@ Make an existing object fungible by adding the Metadata resource.
 This returns the capabilities to mint, burn, and transfer.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_add_fungibility">add_fungibility</a>(constructor_ref: &<a href="object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>, monitoring_supply_with_maximum: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u128&gt;&gt;, name: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, symbol: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, decimals: u8): <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_add_fungibility">add_fungibility</a>(constructor_ref: &<a href="object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>, monitoring_supply_with_maximum: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u128&gt;&gt;, name: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, symbol: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, decimals: u8, icon_uri: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, issuer: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;
 </code></pre>
 
 
@@ -682,6 +714,8 @@ This returns the capabilities to mint, burn, and transfer.
     name: String,
     symbol: String,
     decimals: u8,
+    icon_uri: String,
+    issuer: String,
 ): Object&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a>&gt; {
     <b>assert</b>!(!<a href="object.md#0x1_object_can_generate_delete_ref">object::can_generate_delete_ref</a>(constructor_ref), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_EOBJECT_IS_DELETABLE">EOBJECT_IS_DELETABLE</a>));
     <b>let</b> metadata_object_signer = &<a href="object.md#0x1_object_generate_signer">object::generate_signer</a>(constructor_ref);
@@ -691,24 +725,18 @@ This returns the capabilities to mint, burn, and transfer.
             maximum
         }
     });
-    <b>assert</b>!(
-        <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&name) &lt;= <a href="fungible_asset.md#0x1_fungible_asset_MAX_NAME_LENGTH">MAX_NAME_LENGTH</a>,
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_ENAME_TOO_LONG">ENAME_TOO_LONG</a>)
-    );
-    <b>assert</b>!(
-        <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&symbol) &lt;= <a href="fungible_asset.md#0x1_fungible_asset_MAX_SYMBOL_LENGTH">MAX_SYMBOL_LENGTH</a>,
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_ESYMBOL_TOO_LONG">ESYMBOL_TOO_LONG</a>)
-    );
-    <b>assert</b>!(
-        <a href="fungible_asset.md#0x1_fungible_asset_decimals">decimals</a> &lt;= <a href="fungible_asset.md#0x1_fungible_asset_MAX_DECIMALS">MAX_DECIMALS</a>,
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_EDECIMALS_TOO_LARGE">EDECIMALS_TOO_LARGE</a>)
-    );
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&name) &lt;= <a href="fungible_asset.md#0x1_fungible_asset_MAX_NAME_LENGTH">MAX_NAME_LENGTH</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_ENAME_TOO_LONG">ENAME_TOO_LONG</a>));
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&symbol) &lt;= <a href="fungible_asset.md#0x1_fungible_asset_MAX_SYMBOL_LENGTH">MAX_SYMBOL_LENGTH</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_ESYMBOL_TOO_LONG">ESYMBOL_TOO_LONG</a>));
+    <b>assert</b>!(<a href="fungible_asset.md#0x1_fungible_asset_decimals">decimals</a> &lt;= <a href="fungible_asset.md#0x1_fungible_asset_MAX_DECIMALS">MAX_DECIMALS</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_EDECIMALS_TOO_LARGE">EDECIMALS_TOO_LARGE</a>));
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&icon_uri) &lt;= <a href="fungible_asset.md#0x1_fungible_asset_MAX_URI_LENGTH">MAX_URI_LENGTH</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="fungible_asset.md#0x1_fungible_asset_EURI_TOO_LONG">EURI_TOO_LONG</a>));
     <b>move_to</b>(metadata_object_signer,
         <a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a> {
             supply,
             name,
             symbol,
             decimals,
+            icon_uri,
+            issuer,
         }
     );
     <a href="object.md#0x1_object_object_from_constructor_ref">object::object_from_constructor_ref</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a>&gt;(constructor_ref)

--- a/aptos-move/framework/aptos-framework/doc/fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/fungible_asset.md
@@ -156,12 +156,6 @@ Metadata of a Fungible asset
  The Uniform Resource Identifier (uri) pointing to an image that can be used as the icon for this fungible
  asset.
 </dd>
-<dt>
-<code>issuer: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a></code>
-</dt>
-<dd>
- The entity who issued this fungible asset.
-</dd>
 </dl>
 
 
@@ -650,7 +644,7 @@ Transfer ref and store do not match.
 URI for the icon of the fungible asset metadata is too long
 
 
-<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_EURI_TOO_LONG">EURI_TOO_LONG</a>: u64 = 18;
+<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_EURI_TOO_LONG">EURI_TOO_LONG</a>: u64 = 19;
 </code></pre>
 
 
@@ -699,7 +693,7 @@ Make an existing object fungible by adding the Metadata resource.
 This returns the capabilities to mint, burn, and transfer.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_add_fungibility">add_fungibility</a>(constructor_ref: &<a href="object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>, monitoring_supply_with_maximum: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u128&gt;&gt;, name: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, symbol: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, decimals: u8, icon_uri: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, issuer: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_add_fungibility">add_fungibility</a>(constructor_ref: &<a href="object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>, monitoring_supply_with_maximum: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u128&gt;&gt;, name: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, symbol: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, decimals: u8, icon_uri: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;
 </code></pre>
 
 
@@ -715,7 +709,6 @@ This returns the capabilities to mint, burn, and transfer.
     symbol: String,
     decimals: u8,
     icon_uri: String,
-    issuer: String,
 ): Object&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a>&gt; {
     <b>assert</b>!(!<a href="object.md#0x1_object_can_generate_delete_ref">object::can_generate_delete_ref</a>(constructor_ref), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_EOBJECT_IS_DELETABLE">EOBJECT_IS_DELETABLE</a>));
     <b>let</b> metadata_object_signer = &<a href="object.md#0x1_object_generate_signer">object::generate_signer</a>(constructor_ref);
@@ -725,9 +718,9 @@ This returns the capabilities to mint, burn, and transfer.
             maximum
         }
     });
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&name) &lt;= <a href="fungible_asset.md#0x1_fungible_asset_MAX_NAME_LENGTH">MAX_NAME_LENGTH</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_ENAME_TOO_LONG">ENAME_TOO_LONG</a>));
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&symbol) &lt;= <a href="fungible_asset.md#0x1_fungible_asset_MAX_SYMBOL_LENGTH">MAX_SYMBOL_LENGTH</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_ESYMBOL_TOO_LONG">ESYMBOL_TOO_LONG</a>));
-    <b>assert</b>!(<a href="fungible_asset.md#0x1_fungible_asset_decimals">decimals</a> &lt;= <a href="fungible_asset.md#0x1_fungible_asset_MAX_DECIMALS">MAX_DECIMALS</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_EDECIMALS_TOO_LARGE">EDECIMALS_TOO_LARGE</a>));
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&name) &lt;= <a href="fungible_asset.md#0x1_fungible_asset_MAX_NAME_LENGTH">MAX_NAME_LENGTH</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="fungible_asset.md#0x1_fungible_asset_ENAME_TOO_LONG">ENAME_TOO_LONG</a>));
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&symbol) &lt;= <a href="fungible_asset.md#0x1_fungible_asset_MAX_SYMBOL_LENGTH">MAX_SYMBOL_LENGTH</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="fungible_asset.md#0x1_fungible_asset_ESYMBOL_TOO_LONG">ESYMBOL_TOO_LONG</a>));
+    <b>assert</b>!(<a href="fungible_asset.md#0x1_fungible_asset_decimals">decimals</a> &lt;= <a href="fungible_asset.md#0x1_fungible_asset_MAX_DECIMALS">MAX_DECIMALS</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="fungible_asset.md#0x1_fungible_asset_EDECIMALS_TOO_LARGE">EDECIMALS_TOO_LARGE</a>));
     <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&icon_uri) &lt;= <a href="fungible_asset.md#0x1_fungible_asset_MAX_URI_LENGTH">MAX_URI_LENGTH</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="fungible_asset.md#0x1_fungible_asset_EURI_TOO_LONG">EURI_TOO_LONG</a>));
     <b>move_to</b>(metadata_object_signer,
         <a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a> {
@@ -736,7 +729,6 @@ This returns the capabilities to mint, burn, and transfer.
             symbol,
             decimals,
             icon_uri,
-            issuer,
         }
     );
     <a href="object.md#0x1_object_object_from_constructor_ref">object::object_from_constructor_ref</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a>&gt;(constructor_ref)

--- a/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
+++ b/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
@@ -10,13 +10,11 @@ easily create a store for their account and deposit/withdraw/transfer fungible a
 The transfer flow works as below:
 1. The sender calls <code>transfer</code> on the fungible asset metadata object to transfer <code>amount</code> of fungible asset to
 <code>recipient</code>.
-2. The fungible asset metadata object calls <code>ensure_primary_store_exists</code> to ensure that the sender's primary store
-exists. If it doesn't, it creates it.
-3. The fungible asset metadata object calls <code>ensure_primary_store_exists</code> to ensure that the recipient's primary
-store exists. If it doesn't, it creates it.
-4. The fungible asset metadata object calls <code>withdraw</code> on the sender's primary store to withdraw <code>amount</code> of
+2. The fungible asset metadata object calls <code>ensure_primary_store_exists</code> to ensure that both the sender's and the
+recipient's primary stores exist. If either doesn't, it will be created.
+3. The fungible asset metadata object calls <code>withdraw</code> on the sender's primary store to withdraw <code>amount</code> of
 fungible asset from it. This emits an withdraw event.
-5. The fungible asset metadata object calls <code>deposit</code> on the recipient's primary store to deposit <code>amount</code> of
+4. The fungible asset metadata object calls <code>deposit</code> on the recipient's primary store to deposit <code>amount</code> of
 fungible asset to it. This emits an deposit event.
 
 
@@ -83,7 +81,7 @@ primary stores will be created automatically if they don't exist. Primary stores
 so that users can easily deposit/withdraw/transfer fungible assets.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_create_primary_store_enabled_fungible_asset">create_primary_store_enabled_fungible_asset</a>(constructor_ref: &<a href="object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>, monitoring_supply_with_maximum: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u128&gt;&gt;, name: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, symbol: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, decimals: u8, icon_uri: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, issuer: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_create_primary_store_enabled_fungible_asset">create_primary_store_enabled_fungible_asset</a>(constructor_ref: &<a href="object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>, monitoring_supply_with_maximum: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u128&gt;&gt;, name: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, symbol: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, decimals: u8, icon_uri: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>)
 </code></pre>
 
 
@@ -99,7 +97,6 @@ so that users can easily deposit/withdraw/transfer fungible assets.
     symbol: String,
     decimals: u8,
     icon_uri: String,
-    issuer: String,
 ) {
     <a href="fungible_asset.md#0x1_fungible_asset_add_fungibility">fungible_asset::add_fungibility</a>(
         constructor_ref,
@@ -108,7 +105,6 @@ so that users can easily deposit/withdraw/transfer fungible assets.
         symbol,
         decimals,
         icon_uri,
-        issuer,
     );
     <b>let</b> metadata_obj = &<a href="object.md#0x1_object_generate_signer">object::generate_signer</a>(constructor_ref);
     <b>move_to</b>(metadata_obj, <a href="primary_fungible_store.md#0x1_primary_fungible_store_DeriveRefPod">DeriveRefPod</a> {

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -47,6 +47,8 @@ module aptos_framework::fungible_asset {
     const EDECIMALS_TOO_LARGE: u64 = 17;
     /// Fungibility is only available for non-deletable objects.
     const EOBJECT_IS_DELETABLE: u64 = 18;
+    /// URI for the icon of the fungible asset metadata is too long
+    const EURI_TOO_LONG: u64 = 19;
 
     //
     // Constants
@@ -55,6 +57,7 @@ module aptos_framework::fungible_asset {
     const MAX_NAME_LENGTH: u64 = 32;
     const MAX_SYMBOL_LENGTH: u64 = 10;
     const MAX_DECIMALS: u8 = 32;
+    const MAX_URI_LENGTH: u64 = 512;
 
     /// Maximum possible coin supply.
     const MAX_U128: u128 = 340282366920938463463374607431768211455;
@@ -78,6 +81,11 @@ module aptos_framework::fungible_asset {
         /// For example, if `decimals` equals `2`, a balance of `505` coins should
         /// be displayed to a user as `5.05` (`505 / 10 ** 2`).
         decimals: u8,
+        /// The Uniform Resource Identifier (uri) pointing to an image that can be used as the icon for this fungible
+        /// asset.
+        icon_uri: String,
+        /// The entity who issued this fungible asset.
+        issuer: String,
     }
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
@@ -144,6 +152,8 @@ module aptos_framework::fungible_asset {
         name: String,
         symbol: String,
         decimals: u8,
+        icon_uri: String,
+        issuer: String,
     ): Object<Metadata> {
         assert!(!object::can_generate_delete_ref(constructor_ref), error::invalid_argument(EOBJECT_IS_DELETABLE));
         let metadata_object_signer = &object::generate_signer(constructor_ref);
@@ -153,24 +163,18 @@ module aptos_framework::fungible_asset {
                 maximum
             }
         });
-        assert!(
-            string::length(&name) <= MAX_NAME_LENGTH,
-            error::invalid_argument(ENAME_TOO_LONG)
-        );
-        assert!(
-            string::length(&symbol) <= MAX_SYMBOL_LENGTH,
-            error::invalid_argument(ESYMBOL_TOO_LONG)
-        );
-        assert!(
-            decimals <= MAX_DECIMALS,
-            error::invalid_argument(EDECIMALS_TOO_LARGE)
-        );
+        assert!(string::length(&name) <= MAX_NAME_LENGTH, error::invalid_argument(ENAME_TOO_LONG));
+        assert!(string::length(&symbol) <= MAX_SYMBOL_LENGTH, error::invalid_argument(ESYMBOL_TOO_LONG));
+        assert!(decimals <= MAX_DECIMALS, error::invalid_argument(EDECIMALS_TOO_LARGE));
+        assert!(string::length(&icon_uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
         move_to(metadata_object_signer,
             Metadata {
                 supply,
                 name,
                 symbol,
                 decimals,
+                icon_uri,
+                issuer,
             }
         );
         object::object_from_constructor_ref<Metadata>(constructor_ref)
@@ -587,7 +591,9 @@ module aptos_framework::fungible_asset {
             option::some(option::some(100)) /* max supply */,
             string::utf8(b"TEST"),
             string::utf8(b"@@"),
-            0
+            0,
+            string::utf8(b"http://www.example.com"),
+            string::utf8(b"native"),
         );
         let mint_ref = generate_mint_ref(constructor_ref);
         let burn_ref = generate_burn_ref(constructor_ref);

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -160,9 +160,9 @@ module aptos_framework::fungible_asset {
                 maximum
             }
         });
-        assert!(string::length(&name) <= MAX_NAME_LENGTH, error::invalid_argument(ENAME_TOO_LONG));
-        assert!(string::length(&symbol) <= MAX_SYMBOL_LENGTH, error::invalid_argument(ESYMBOL_TOO_LONG));
-        assert!(decimals <= MAX_DECIMALS, error::invalid_argument(EDECIMALS_TOO_LARGE));
+        assert!(string::length(&name) <= MAX_NAME_LENGTH, error::out_of_range(ENAME_TOO_LONG));
+        assert!(string::length(&symbol) <= MAX_SYMBOL_LENGTH, error::out_of_range(ESYMBOL_TOO_LONG));
+        assert!(decimals <= MAX_DECIMALS, error::out_of_range(EDECIMALS_TOO_LARGE));
         assert!(string::length(&icon_uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
         move_to(metadata_object_signer,
             Metadata {

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -84,8 +84,6 @@ module aptos_framework::fungible_asset {
         /// The Uniform Resource Identifier (uri) pointing to an image that can be used as the icon for this fungible
         /// asset.
         icon_uri: String,
-        /// The entity who issued this fungible asset.
-        issuer: String,
     }
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
@@ -153,7 +151,6 @@ module aptos_framework::fungible_asset {
         symbol: String,
         decimals: u8,
         icon_uri: String,
-        issuer: String,
     ): Object<Metadata> {
         assert!(!object::can_generate_delete_ref(constructor_ref), error::invalid_argument(EOBJECT_IS_DELETABLE));
         let metadata_object_signer = &object::generate_signer(constructor_ref);
@@ -174,7 +171,6 @@ module aptos_framework::fungible_asset {
                 symbol,
                 decimals,
                 icon_uri,
-                issuer,
             }
         );
         object::object_from_constructor_ref<Metadata>(constructor_ref)
@@ -592,8 +588,7 @@ module aptos_framework::fungible_asset {
             string::utf8(b"TEST"),
             string::utf8(b"@@"),
             0,
-            string::utf8(b"http://www.example.com"),
-            string::utf8(b"native"),
+            string::utf8(b"http://www.example.com/favicon.ico"),
         );
         let mint_ref = generate_mint_ref(constructor_ref);
         let burn_ref = generate_burn_ref(constructor_ref);

--- a/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
+++ b/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
@@ -21,14 +21,25 @@ module aptos_framework::primary_fungible_store {
         name: String,
         symbol: String,
         decimals: u8,
+        icon_uri: String,
+        issuer: String,
     ) {
-        fungible_asset::add_fungibility(constructor_ref, monitoring_supply_with_maximum, name, symbol, decimals);
+        fungible_asset::add_fungibility(
+            constructor_ref,
+            monitoring_supply_with_maximum,
+            name,
+            symbol,
+            decimals,
+            icon_uri,
+            issuer,
+        );
         let metadata_obj = &object::generate_signer(constructor_ref);
         move_to(metadata_obj, DeriveRefPod {
             metadata_derive_ref: object::generate_derive_ref(constructor_ref),
         });
     }
 
+    /// Ensure that the primary store object for the given address exists. If it doesn't, create it.
     public fun ensure_primary_store_exists<T: key>(
         owner: address,
         metadata: Object<T>,
@@ -57,18 +68,21 @@ module aptos_framework::primary_fungible_store {
     }
 
     #[view]
+    /// Get the address of the primary store for the given account.
     public fun primary_store_address<T: key>(owner: address, metadata: Object<T>): address {
         let metadata_addr = object::object_address(&metadata);
         object::create_user_derived_object_address(owner, metadata_addr)
     }
 
     #[view]
+    /// Get the primary store object for the given account.
     public fun primary_store<T: key>(owner: address, metadata: Object<T>): Object<FungibleStore> {
         let store = primary_store_address(owner, metadata);
         object::address_to_object<FungibleStore>(store)
     }
 
     #[view]
+    /// Return whether the given account's primary store exists.
     public fun primary_store_exists<T: key>(account: address, metadata: Object<T>): bool {
         fungible_asset::store_exists(primary_store_address(account, metadata))
     }
@@ -134,7 +148,9 @@ module aptos_framework::primary_fungible_store {
             option::some(option::some(100)), // max supply
             string::utf8(b"USDA"),
             string::utf8(b"$$$"),
-            0
+            0,
+            string::utf8(b"http://example.com/icon"),
+            string::utf8(b"native"),
         );
         let mint_ref = generate_mint_ref(constructor_ref);
         let burn_ref = generate_burn_ref(constructor_ref);

--- a/aptos-move/framework/aptos-token-objects/doc/collection.md
+++ b/aptos-move/framework/aptos-token-objects/doc/collection.md
@@ -339,6 +339,25 @@ Unlimited supply tracker, this is useful for adding events and supply tracking t
 ## Constants
 
 
+<a name="0x4_collection_EURI_TOO_LONG"></a>
+
+The URI is over the maximum length
+
+
+<pre><code><b>const</b> <a href="collection.md#0x4_collection_EURI_TOO_LONG">EURI_TOO_LONG</a>: u64 = 4;
+</code></pre>
+
+
+
+<a name="0x4_collection_MAX_URI_LENGTH"></a>
+
+
+
+<pre><code><b>const</b> <a href="collection.md#0x4_collection_MAX_URI_LENGTH">MAX_URI_LENGTH</a>: u64 = 512;
+</code></pre>
+
+
+
 <a name="0x4_collection_ECOLLECTION_DOES_NOT_EXIST"></a>
 
 The collection does not exist
@@ -389,16 +408,6 @@ The max supply must be positive
 
 
 
-<a name="0x4_collection_EURI_TOO_LONG"></a>
-
-The URI is over the maximum length
-
-
-<pre><code><b>const</b> <a href="collection.md#0x4_collection_EURI_TOO_LONG">EURI_TOO_LONG</a>: u64 = 4;
-</code></pre>
-
-
-
 <a name="0x4_collection_MAX_COLLECTION_NAME_LENGTH"></a>
 
 
@@ -413,15 +422,6 @@ The URI is over the maximum length
 
 
 <pre><code><b>const</b> <a href="collection.md#0x4_collection_MAX_DESCRIPTION_LENGTH">MAX_DESCRIPTION_LENGTH</a>: u64 = 2048;
-</code></pre>
-
-
-
-<a name="0x4_collection_MAX_URI_LENGTH"></a>
-
-
-
-<pre><code><b>const</b> <a href="collection.md#0x4_collection_MAX_URI_LENGTH">MAX_URI_LENGTH</a>: u64 = 512;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-token-objects/doc/token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/token.md
@@ -218,16 +218,6 @@ directly understand the behavior in a writeset.
 ## Constants
 
 
-<a name="0x4_token_EDESCRIPTION_TOO_LONG"></a>
-
-The description is over the maximum length
-
-
-<pre><code><b>const</b> <a href="token.md#0x4_token_EDESCRIPTION_TOO_LONG">EDESCRIPTION_TOO_LONG</a>: u64 = 6;
-</code></pre>
-
-
-
 <a name="0x4_token_EURI_TOO_LONG"></a>
 
 The URI is over the maximum length
@@ -238,20 +228,30 @@ The URI is over the maximum length
 
 
 
-<a name="0x4_token_MAX_DESCRIPTION_LENGTH"></a>
-
-
-
-<pre><code><b>const</b> <a href="token.md#0x4_token_MAX_DESCRIPTION_LENGTH">MAX_DESCRIPTION_LENGTH</a>: u64 = 2048;
-</code></pre>
-
-
-
 <a name="0x4_token_MAX_URI_LENGTH"></a>
 
 
 
 <pre><code><b>const</b> <a href="token.md#0x4_token_MAX_URI_LENGTH">MAX_URI_LENGTH</a>: u64 = 512;
+</code></pre>
+
+
+
+<a name="0x4_token_EDESCRIPTION_TOO_LONG"></a>
+
+The description is over the maximum length
+
+
+<pre><code><b>const</b> <a href="token.md#0x4_token_EDESCRIPTION_TOO_LONG">EDESCRIPTION_TOO_LONG</a>: u64 = 6;
+</code></pre>
+
+
+
+<a name="0x4_token_MAX_DESCRIPTION_LENGTH"></a>
+
+
+
+<pre><code><b>const</b> <a href="token.md#0x4_token_MAX_DESCRIPTION_LENGTH">MAX_DESCRIPTION_LENGTH</a>: u64 = 2048;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-token/doc/token.md
+++ b/aptos-move/framework/aptos-token/doc/token.md
@@ -1075,6 +1075,25 @@ Insufficient token balance
 
 
 
+<a name="0x3_token_EURI_TOO_LONG"></a>
+
+The URI is too long
+
+
+<pre><code><b>const</b> <a href="token.md#0x3_token_EURI_TOO_LONG">EURI_TOO_LONG</a>: u64 = 27;
+</code></pre>
+
+
+
+<a name="0x3_token_MAX_URI_LENGTH"></a>
+
+
+
+<pre><code><b>const</b> <a href="token.md#0x3_token_MAX_URI_LENGTH">MAX_URI_LENGTH</a>: u64 = 512;
+</code></pre>
+
+
+
 <a name="0x3_token_BURNABLE_BY_CREATOR"></a>
 
 
@@ -1431,16 +1450,6 @@ TokenStore doesn't exist
 
 
 
-<a name="0x3_token_EURI_TOO_LONG"></a>
-
-The URI is too long
-
-
-<pre><code><b>const</b> <a href="token.md#0x3_token_EURI_TOO_LONG">EURI_TOO_LONG</a>: u64 = 27;
-</code></pre>
-
-
-
 <a name="0x3_token_EUSER_NOT_OPT_IN_DIRECT_TRANSFER"></a>
 
 User didn't opt-in direct transfer
@@ -1485,15 +1494,6 @@ Cannot withdraw 0 token
 
 
 <pre><code><b>const</b> <a href="token.md#0x3_token_MAX_NFT_NAME_LENGTH">MAX_NFT_NAME_LENGTH</a>: u64 = 128;
-</code></pre>
-
-
-
-<a name="0x3_token_MAX_URI_LENGTH"></a>
-
-
-
-<pre><code><b>const</b> <a href="token.md#0x3_token_MAX_URI_LENGTH">MAX_URI_LENGTH</a>: u64 = 512;
 </code></pre>
 
 

--- a/aptos-move/move-examples/fungible_asset/sources/coin_example.move
+++ b/aptos-move/move-examples/fungible_asset/sources/coin_example.move
@@ -18,6 +18,8 @@ module fungible_asset_extension::coin_example {
             utf8(b"You only live once"), /* name */
             utf8(ASSET_SYMBOL), /* symbol */
             8, /* decimals */
+            utf8(b"http://example.com"), /* icon */
+            utf8(b"My issuer"), /* issuer */
         );
     }
 

--- a/aptos-move/move-examples/fungible_asset/sources/coin_example.move
+++ b/aptos-move/move-examples/fungible_asset/sources/coin_example.move
@@ -18,8 +18,7 @@ module fungible_asset_extension::coin_example {
             utf8(b"You only live once"), /* name */
             utf8(ASSET_SYMBOL), /* symbol */
             8, /* decimals */
-            utf8(b"http://example.com"), /* icon */
-            utf8(b"My issuer"), /* issuer */
+            utf8(b"http://example.com/favicon.ico"), /* icon */
         );
     }
 

--- a/aptos-move/move-examples/fungible_asset/sources/managed_coin.move
+++ b/aptos-move/move-examples/fungible_asset/sources/managed_coin.move
@@ -32,6 +32,8 @@ module fungible_asset_extension::managed_coin {
             utf8(b"Libra Coin"), /* name */
             utf8(ASSET_SYMBOL), /* symbol */
             8, /* decimals */
+            utf8(b"http://example.com"), /* icon */
+            utf8(b"My issuer"), /* issuer */
         );
 
         // Create mint/burn/transfer refs to allow creator to manage the fungible asset.

--- a/aptos-move/move-examples/fungible_asset/sources/managed_coin.move
+++ b/aptos-move/move-examples/fungible_asset/sources/managed_coin.move
@@ -32,8 +32,7 @@ module fungible_asset_extension::managed_coin {
             utf8(b"Libra Coin"), /* name */
             utf8(ASSET_SYMBOL), /* symbol */
             8, /* decimals */
-            utf8(b"http://example.com"), /* icon */
-            utf8(b"My issuer"), /* issuer */
+            utf8(b"http://example.com/favicon.ico"), /* icon */
         );
 
         // Create mint/burn/transfer refs to allow creator to manage the fungible asset.

--- a/aptos-move/move-examples/fungible_asset/sources/managed_fungible_asset.move
+++ b/aptos-move/move-examples/fungible_asset/sources/managed_fungible_asset.move
@@ -28,22 +28,27 @@ module fungible_asset_extension::managed_fungible_asset {
         maximum_supply: u128,
         name: String,
         symbol: String,
-        decimals: u8
+        decimals: u8,
+        icon_uri: String,
+        issuer: String,
     ) {
-        primary_fungible_store::create_primary_store_enabled_fungible_asset(
-            constructor_ref,
-            if (monitoring_supply) {
-                option::some(if (maximum_supply != 0) {
-                    option::some(maximum_supply)
-                } else {
-                    option::none()
-                })
+        let supply = if (monitoring_supply) {
+            option::some(if (maximum_supply != 0) {
+                option::some(maximum_supply)
             } else {
                 option::none()
-            },
+            })
+        } else {
+            option::none()
+        };
+        primary_fungible_store::create_primary_store_enabled_fungible_asset(
+            constructor_ref,
+            supply,
             name,
             symbol,
             decimals,
+            icon_uri,
+            issuer,
         );
 
         // Create mint/burn/transfer refs to allow creator to manage the fungible asset.
@@ -159,6 +164,8 @@ module fungible_asset_extension::managed_fungible_asset {
             utf8(b"Aptos Token"), /* name */
             utf8(b"APT"), /* symbol */
             8, /* decimals */
+            utf8(b"http://example.com"), /* icon */
+            utf8(b"My issuer"), /* issuer */
         );
         object_from_constructor_ref<Metadata>(constructor_ref)
     }

--- a/aptos-move/move-examples/fungible_asset/sources/managed_fungible_asset.move
+++ b/aptos-move/move-examples/fungible_asset/sources/managed_fungible_asset.move
@@ -1,6 +1,10 @@
-/// By deploying this module, the deployer provide an extension layer upon fungible asset that helps manage
-/// the refs for the deployer, who is set to be the initial admin that can mint/burn/freeze/unfreeze accounts.
-/// The admin can transfer the asset via object::transfer() at any point to set a new admin.
+/// This module provides a managed fungible asset that allows the owner of the metadata object to
+/// mint, transfer and burn fungible assets.
+///
+/// The functionalities offered by this module are:
+/// 1. Mint fungible assets as the owner of metadata object.
+/// 2. Transfer fungible assets as the owner of metadata object ignoring `frozen` field.
+/// 3. Burn fungible assets as the owner of metadata object.
 module fungible_asset_extension::managed_fungible_asset {
     use aptos_framework::fungible_asset::{Self, MintRef, TransferRef, BurnRef, FungibleAsset, Metadata};
     use aptos_framework::object::{Self, Object, ConstructorRef};
@@ -30,7 +34,6 @@ module fungible_asset_extension::managed_fungible_asset {
         symbol: String,
         decimals: u8,
         icon_uri: String,
-        issuer: String,
     ) {
         let supply = if (monitoring_supply) {
             option::some(if (maximum_supply != 0) {
@@ -48,7 +51,6 @@ module fungible_asset_extension::managed_fungible_asset {
             symbol,
             decimals,
             icon_uri,
-            issuer,
         );
 
         // Create mint/burn/transfer refs to allow creator to manage the fungible asset.
@@ -113,27 +115,35 @@ module fungible_asset_extension::managed_fungible_asset {
     }
 
     /// Unfreeze an account so it can transfer or receive fungible assets.
-    public entry fun unfreeze_account(admin: &signer,
-                                      metadata: Object<Metadata>,
-                                      account: address) acquires ManagedFungibleAsset {
+    public entry fun unfreeze_account(
+        admin: &signer,
+        metadata: Object<Metadata>,
+        account: address,
+    ) acquires ManagedFungibleAsset {
         let transfer_ref = &authorized_borrow_refs(admin, metadata).transfer_ref;
         let wallet = primary_fungible_store::ensure_primary_store_exists(account, metadata);
         fungible_asset::set_frozen_flag(transfer_ref, wallet, false);
     }
 
     /// Withdraw as the owner of metadata object ignoring `frozen` field.
-    public fun withdraw(admin: &signer,
-                        metadata: Object<Metadata>,
-                        amount: u64, from: address): FungibleAsset acquires ManagedFungibleAsset {
+    public fun withdraw(
+        admin: &signer,
+        metadata: Object<Metadata>,
+        amount: u64,
+        from: address,
+    ): FungibleAsset acquires ManagedFungibleAsset {
         let transfer_ref = &authorized_borrow_refs(admin, metadata).transfer_ref;
         let from_wallet = primary_fungible_store::ensure_primary_store_exists(from, metadata);
         fungible_asset::withdraw_with_ref(transfer_ref, from_wallet, amount)
     }
 
     /// Deposit as the owner of metadata object ignoring `frozen` field.
-    public fun deposit(admin: &signer,
-                       metadata: Object<Metadata>,
-                       to: address, fa: FungibleAsset) acquires ManagedFungibleAsset {
+    public fun deposit(
+        admin: &signer,
+        metadata: Object<Metadata>,
+        to: address,
+        fa: FungibleAsset,
+    ) acquires ManagedFungibleAsset {
         let transfer_ref = &authorized_borrow_refs(admin, metadata).transfer_ref;
         let to_wallet = primary_fungible_store::ensure_primary_store_exists(to, metadata);
         fungible_asset::deposit_with_ref(transfer_ref, to_wallet, fa);
@@ -164,8 +174,7 @@ module fungible_asset_extension::managed_fungible_asset {
             utf8(b"Aptos Token"), /* name */
             utf8(b"APT"), /* symbol */
             8, /* decimals */
-            utf8(b"http://example.com"), /* icon */
-            utf8(b"My issuer"), /* issuer */
+            utf8(b"http://example.com/favicon.ico"), /* icon */
         );
         object_from_constructor_ref<Metadata>(constructor_ref)
     }

--- a/aptos-move/move-examples/fungible_token/sources/managed_fungible_token.move
+++ b/aptos-move/move-examples/fungible_token/sources/managed_fungible_token.move
@@ -50,6 +50,7 @@ module fungible_token::managed_fungible_token {
             utf8(b"test fungible asset name"), /* name */
             utf8(ASSET_SYMBOL), /* symbol */
             2, /* decimals */
+            utf8(b"http://aptoslabs.com/favicon.ico")
         );
 
         // Create mint/burn/transfer refs to allow creator to manage the fungible asset.


### PR DESCRIPTION
### Description

This adds a useful field - icon uri to the fungible asset standard. 
1. icon_uri: This is different from the uri in fungible tokens. A fungible asset might not want to be listed as a token but still wants an icon. And token usually has full image not icon.

### Test Plan
Unit tests
