### PR TITLE
fix all the collection_id to index

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/token_objects.rs
+++ b/aptos-move/e2e-move-tests/src/tests/token_objects.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize, Eq, PartialEq)]
 struct Token {
     collection: AccountAddress,
-    collection_id: u64,
+    index: u64,
     description: String,
     name: String,
     uri: String,

--- a/aptos-move/framework/aptos-token-objects/doc/collection.md
+++ b/aptos-move/framework/aptos-token-objects/doc/collection.md
@@ -285,7 +285,7 @@ Unlimited supply tracker, this is useful for adding events and supply tracking t
 
 <dl>
 <dt>
-<code>collection_id: u64</code>
+<code>index: u64</code>
 </dt>
 <dd>
 
@@ -318,7 +318,7 @@ Unlimited supply tracker, this is useful for adding events and supply tracking t
 
 <dl>
 <dt>
-<code>collection_id: u64</code>
+<code>index: u64</code>
 </dt>
 <dd>
 
@@ -660,7 +660,7 @@ Called by token on mint to increment supply if there's an appropriate Supply str
         );
         <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(&<b>mut</b> supply.mint_events,
             <a href="collection.md#0x4_collection_MintEvent">MintEvent</a> {
-                collection_id: supply.total_minted,
+                index: supply.total_minted,
                 <a href="token.md#0x4_token">token</a>,
             },
         );
@@ -672,7 +672,7 @@ Called by token on mint to increment supply if there's an appropriate Supply str
         <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
             &<b>mut</b> supply.mint_events,
             <a href="collection.md#0x4_collection_MintEvent">MintEvent</a> {
-                collection_id: supply.total_minted,
+                index: supply.total_minted,
                 <a href="token.md#0x4_token">token</a>,
             },
         );
@@ -694,7 +694,7 @@ Called by token on mint to increment supply if there's an appropriate Supply str
 Called by token on burn to decrement supply if there's an appropriate Supply struct.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="collection.md#0x4_collection_decrement_supply">decrement_supply</a>(<a href="collection.md#0x4_collection">collection</a>: &<a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="collection.md#0x4_collection_Collection">collection::Collection</a>&gt;, <a href="token.md#0x4_token">token</a>: <b>address</b>, collection_id: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="collection.md#0x4_collection_decrement_supply">decrement_supply</a>(<a href="collection.md#0x4_collection">collection</a>: &<a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="collection.md#0x4_collection_Collection">collection::Collection</a>&gt;, <a href="token.md#0x4_token">token</a>: <b>address</b>, index: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;)
 </code></pre>
 
 
@@ -706,7 +706,7 @@ Called by token on burn to decrement supply if there's an appropriate Supply str
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="collection.md#0x4_collection_decrement_supply">decrement_supply</a>(
     <a href="collection.md#0x4_collection">collection</a>: &Object&lt;<a href="collection.md#0x4_collection_Collection">Collection</a>&gt;,
     <a href="token.md#0x4_token">token</a>: <b>address</b>,
-    collection_id: Option&lt;u64&gt;,
+    index: Option&lt;u64&gt;,
 ) <b>acquires</b> <a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>, <a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a> {
     <b>let</b> collection_addr = <a href="../../aptos-framework/doc/object.md#0x1_object_object_address">object::object_address</a>(<a href="collection.md#0x4_collection">collection</a>);
     <b>if</b> (<b>exists</b>&lt;<a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>&gt;(collection_addr)) {
@@ -715,7 +715,7 @@ Called by token on burn to decrement supply if there's an appropriate Supply str
         <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
             &<b>mut</b> supply.mint_events,
             <a href="collection.md#0x4_collection_MintEvent">MintEvent</a> {
-                collection_id: *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&collection_id),
+                index: *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&index),
                 <a href="token.md#0x4_token">token</a>,
             },
         );
@@ -725,7 +725,7 @@ Called by token on burn to decrement supply if there's an appropriate Supply str
         <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
             &<b>mut</b> supply.mint_events,
             <a href="collection.md#0x4_collection_MintEvent">MintEvent</a> {
-                collection_id: *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&collection_id),
+                index: *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&index),
                 <a href="token.md#0x4_token">token</a>,
             },
         );

--- a/aptos-move/framework/aptos-token-objects/sources/collection.move
+++ b/aptos-move/framework/aptos-token-objects/sources/collection.move
@@ -98,12 +98,12 @@ module aptos_token_objects::collection {
     }
 
     struct BurnEvent has drop, store {
-        collection_id: u64,
+        index: u64,
         token: address,
     }
 
     struct MintEvent has drop, store {
-        collection_id: u64,
+        index: u64,
         token: address,
     }
 
@@ -266,7 +266,7 @@ module aptos_token_objects::collection {
             );
             event::emit_event(&mut supply.mint_events,
                 MintEvent {
-                    collection_id: supply.total_minted,
+                    index: supply.total_minted,
                     token,
                 },
             );
@@ -278,7 +278,7 @@ module aptos_token_objects::collection {
             event::emit_event(
                 &mut supply.mint_events,
                 MintEvent {
-                    collection_id: supply.total_minted,
+                    index: supply.total_minted,
                     token,
                 },
             );
@@ -292,7 +292,7 @@ module aptos_token_objects::collection {
     public(friend) fun decrement_supply(
         collection: &Object<Collection>,
         token: address,
-        collection_id: Option<u64>,
+        index: Option<u64>,
     ) acquires FixedSupply, UnlimitedSupply {
         let collection_addr = object::object_address(collection);
         if (exists<FixedSupply>(collection_addr)) {
@@ -301,7 +301,7 @@ module aptos_token_objects::collection {
             event::emit_event(
                 &mut supply.mint_events,
                 MintEvent {
-                    collection_id: *option::borrow(&collection_id),
+                    index: *option::borrow(&index),
                     token,
                 },
             );
@@ -311,7 +311,7 @@ module aptos_token_objects::collection {
             event::emit_event(
                 &mut supply.mint_events,
                 MintEvent {
-                    collection_id: *option::borrow(&collection_id),
+                    index: *option::borrow(&index),
                     token,
                 },
             );

--- a/ecosystem/python/sdk/aptos_sdk/aptos_token_client.py
+++ b/ecosystem/python/sdk/aptos_sdk/aptos_token_client.py
@@ -14,7 +14,6 @@ from .type_tag import StructTag, TypeTag
 
 
 class Object:
-
     allow_ungated_transfer: bool
     owner: AccountAddress
 
@@ -36,7 +35,6 @@ class Object:
 
 
 class Collection:
-
     creator: AccountAddress
     description: str
     name: str
@@ -64,7 +62,6 @@ class Collection:
 
 
 class Royalty:
-
     numerator: int
     denominator: int
     payee_address: AccountAddress
@@ -89,9 +86,8 @@ class Royalty:
 
 
 class Token:
-
     collection: AccountAddress
-    collection_id: int
+    index: int
     description: str
     name: str
     uri: str
@@ -101,25 +97,25 @@ class Token:
     def __init__(
         self,
         collection: AccountAddress,
-        collection_id: int,
+        index: int,
         description: str,
         name: str,
         uri: str,
     ):
         self.collection = collection
-        self.collection_id = collection_id
+        self.index = index
         self.description = description
         self.name = name
         self.uri = uri
 
     def __str__(self) -> str:
-        return f"Token[collection: {self.collection}, collection_id: {self.collection_id}, description: {self.description}, name: {self.name}, uri: {self.uri}]"
+        return f"Token[collection: {self.collection}, index: {self.index}, description: {self.description}, name: {self.name}, uri: {self.uri}]"
 
     @staticmethod
     def parse(resource: dict[str, Any]):
         return Token(
             AccountAddress.from_hex(resource["collection"]["inner"]),
-            int(resource["collection_id"]),
+            int(resource["index"]),
             resource["description"],
             resource["name"],
             resource["uri"],
@@ -138,7 +134,6 @@ class InvalidPropertyType(Exception):
 
 
 class Property:
-
     name: str
     property_type: str
     value: Any
@@ -259,7 +254,6 @@ class Property:
 
 
 class PropertyMap:
-
     properties: List[Property]
 
     struct_tag: str = "0x4::property_map::PropertyMap"


### PR DESCRIPTION
### Description

As it is called as `index` in token.move but not consistent with collection.move.
This PR has to be cherry-picked to v1.4

### Test Plan
ut
