### PR TITLE
[TS SDK] Add a script command to run tests without publishing ans contract

### DIFF
--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -23,6 +23,7 @@
     "_build:node": "tsup --format cjs,esm --dts",
     "lint": "eslint \"**/*.ts\"",
     "test": "pnpm run publish-ans-contract && jest",
+    "test_local": "jest",
     "_fmt": "prettier 'scripts/**/*.ts' 'src/**/*.ts' 'examples/**/*.js' 'examples/**/*.ts' '.eslintrc.js'",
     "fmt": "pnpm _fmt --write",
     "fmt:check": "pnpm _fmt --check",


### PR DESCRIPTION
### Description
Adding a script command to run sdk tests without publishing ANS contract. This can help when we want to run a single test file (i.e `pnpm run test_local -- src/tests/e2e/aptos_token.test.ts` ) and we dont need to pblish the ANS contract.
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
