### PR TITLE
[indexer grpc] shrink the redis size.

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/cache_operator.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/cache_operator.rs
@@ -6,8 +6,9 @@ use redis::{AsyncCommands, RedisError, RedisResult};
 
 // Configurations for cache.
 // The cache size is estimated to be 10M transactions.
-// For 10M transactions, the cache size is about 40GB.
-const CACHE_SIZE_ESTIMATION: u64 = 10_000_000_u64;
+// For 3M transactions, the cache size is about 25GB.
+// At TPS 20k, it takes about 2.5 minutes to fill up the cache.
+const CACHE_SIZE_ESTIMATION: u64 = 3_000_000_u64;
 
 // Hard limit for cache lower bound. Only used for active eviction.
 // Cache worker actively evicts the cache entries if the cache entry version is

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/cache_operator.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/cache_operator.rs
@@ -5,7 +5,7 @@ use crate::constants::BLOB_STORAGE_SIZE;
 use redis::{AsyncCommands, RedisError, RedisResult};
 
 // Configurations for cache.
-// The cache size is estimated to be 10M transactions.
+// The cache size is estimated to be 3M transactions.
 // For 3M transactions, the cache size is about 25GB.
 // At TPS 20k, it takes about 2.5 minutes to fill up the cache.
 const CACHE_SIZE_ESTIMATION: u64 = 3_000_000_u64;


### PR DESCRIPTION
### Description

Shink the indexer grpc cache size

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### AI-powered Walkthrough
<!-- Delete this section if you don't want the AI to create a detailed walkthrough of your PR -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f8af351</samp>

* Reduce the cache size estimation for the indexer-grpc service to improve performance and memory usage ([link](https://github.com/aptos-labs/aptos-core/pull/7954/files?diff=unified&w=0#diff-c566c3bc9bfc6c73f3fae6e8d2759c61c529b1502c28a261499003ac59e91c76L9-R11))
* Update the comment to explain the new cache size and the cache fill-up time ([link](https://github.com/aptos-labs/aptos-core/pull/7954/files?diff=unified&w=0#diff-c566c3bc9bfc6c73f3fae6e8d2759c61c529b1502c28a261499003ac59e91c76L9-R11))
