### PR TITLE
Fix docker-update-images workflow

### DIFF
--- a/.github/workflows/docker-update-images.yaml
+++ b/.github/workflows/docker-update-images.yaml
@@ -14,14 +14,16 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v3
 
       - name: Check and pin updates (if any)
-        run: python3 scripts/update_docker_images.py
+        id: check_update
+        run: python3 scripts/update_docker_images.py >> $"GITHUB_OUTPUT"
 
       - name: Create Pull Request
-        if: ${{ success() }}
+        if: ${{ steps.check_update.outputs.NEEDS_UPDATE == "True" }}
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/docker-update-images.yaml
+++ b/.github/workflows/docker-update-images.yaml
@@ -23,7 +23,7 @@ jobs:
         run: python3 scripts/update_docker_images.py >> $"GITHUB_OUTPUT"
 
       - name: Create Pull Request
-        if: ${{ steps.check_update.outputs.NEEDS_UPDATE == "True" }}
+        if: ${{ steps.check_update.outputs.NEEDS_UPDATE == 'True' }}
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/docker-update-images.yaml
+++ b/.github/workflows/docker-update-images.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Check and pin updates (if any)
         id: check_update
-        run: python3 scripts/update_docker_images.py >> $GITHUB_OUTPUT
+        run: python3 scripts/update_docker_images.py >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         if: ${{ steps.check_update.outputs.NEEDS_UPDATE == 'True' }}

--- a/.github/workflows/docker-update-images.yaml
+++ b/.github/workflows/docker-update-images.yaml
@@ -42,3 +42,5 @@ jobs:
           team-reviewers: |
             aptos-labs/prod-eng
             aptos-labs/security
+          labels: |
+            CICD:run-e2e-tests

--- a/.github/workflows/docker-update-images.yaml
+++ b/.github/workflows/docker-update-images.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Check and pin updates (if any)
         id: check_update
-        run: python3 scripts/update_docker_images.py >> "$GITHUB_OUTPUT"
+        run: python3 scripts/update_docker_images.py
 
       - name: Create Pull Request
         if: ${{ steps.check_update.outputs.NEEDS_UPDATE == 'True' }}

--- a/.github/workflows/docker-update-images.yaml
+++ b/.github/workflows/docker-update-images.yaml
@@ -29,7 +29,7 @@ jobs:
         run: python3 scripts/update_docker_images.py
 
       - name: Create Pull Request
-        if: ${{ steps.check_update.outputs.NEEDS_UPDATE == 'True' }}
+        if: ${{ steps.check_update.outputs.NEED_UPDATE == 'True' }}
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/docker-update-images.yaml
+++ b/.github/workflows/docker-update-images.yaml
@@ -18,6 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}
+
       - name: Check and pin updates (if any)
         id: check_update
         run: python3 scripts/update_docker_images.py >> $"GITHUB_OUTPUT"

--- a/.github/workflows/docker-update-images.yaml
+++ b/.github/workflows/docker-update-images.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Check and pin updates (if any)
         id: check_update
-        run: python3 scripts/update_docker_images.py >> $"GITHUB_OUTPUT"
+        run: python3 scripts/update_docker_images.py >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
         if: ${{ steps.check_update.outputs.NEEDS_UPDATE == 'True' }}

--- a/scripts/update_docker_images.py
+++ b/scripts/update_docker_images.py
@@ -18,7 +18,7 @@ def update() -> int:
     script_dir = os.path.dirname(os.path.realpath(__file__))
     dockerfile_path = os.path.join(script_dir, "..", "docker", "rust-all.Dockerfile")
 
-    exit_code = 1  # 0 = an update exists, 1 = an update does not exist
+    update_exists = False
 
     for base_image, image_name in IMAGES.items():
         manifest = None
@@ -66,10 +66,11 @@ def update() -> int:
         with open(dockerfile_path, "w") as f:
             f.write(dockerfile_content)
 
-        exit_code = 0
+        update_exists = True
 
-    return exit_code
+    return update_exists
 
 
 if __name__ == "__main__":
-    exit(update())
+    print("NEEDS_UPDATE={}".format(update()))
+    exit()

--- a/scripts/update_docker_images.py
+++ b/scripts/update_docker_images.py
@@ -70,7 +70,16 @@ def update() -> int:
 
     return update_exists
 
+def write_github_output(key, value) -> None:
+    print(f"GITHUB_OUTPUT: {key}={value}")
+    try:
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            f.write(f"{key}={value}\n")
+    except KeyError:
+        print("GITHUB_OUTPUT environment variable not set")
+        exit()
+
 
 if __name__ == "__main__":
-    print("NEEDS_UPDATE={}".format(update()))
+    write_github_output("NEED_UPDATE", update())
     exit()


### PR DESCRIPTION
### Description

Fixes a bug in which the workflows exits with an error when it doesn't find new updates. This was caused by the python script returning an "error" exit code, which is interpreted by GHA as a failed action. The python script now always exits gracefully, and triggers the next step via its output.

### Test Plan
The workflow runs when a pull request includes its source or the related script, and will produce an error if it doesn't pass.