### PR TITLE
[Indexer] Add delegator pool balances and fix delegator balances

### DIFF
--- a/crates/indexer/migrations/2023-04-27-233343_delegation_pool_balances/down.sql
+++ b/crates/indexer/migrations/2023-04-27-233343_delegation_pool_balances/down.sql
@@ -1,4 +1,14 @@
 -- This file should undo anything in `up.sql`
 DROP TABLE IF EXISTS delegated_staking_pool_balances;
+DROP TABLE IF EXISTS current_delegated_staking_pool_balances;
 DROP INDEX IF EXISTS dspb_insat_index;
+ALTER TABLE current_delegator_balances
+ADD COLUMN IF NOT EXISTS amount NUMERIC NOT NULL DEFAULT 0;
+-- need this for delegation staking, changing to amount
+CREATE OR REPLACE VIEW num_active_delegator_per_pool AS
+SELECT pool_address,
+  COUNT(DISTINCT delegator_address) AS num_active_delegator
+FROM current_delegator_balances
+WHERE amount > 0
+GROUP BY 1;
 ALTER TABLE current_delegator_balances DROP COLUMN IF EXISTS shares;

--- a/crates/indexer/migrations/2023-04-27-233343_delegation_pool_balances/down.sql
+++ b/crates/indexer/migrations/2023-04-27-233343_delegation_pool_balances/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS delegated_staking_pool_balances;
+DROP INDEX IF EXISTS dspb_insat_index;
+ALTER TABLE current_delegator_balances DROP COLUMN IF EXISTS shares;

--- a/crates/indexer/migrations/2023-04-27-233343_delegation_pool_balances/up.sql
+++ b/crates/indexer/migrations/2023-04-27-233343_delegation_pool_balances/up.sql
@@ -9,5 +9,21 @@ CREATE TABLE IF NOT EXISTS delegated_staking_pool_balances (
   PRIMARY KEY (transaction_version, staking_pool_address)
 );
 CREATE INDEX dspb_insat_index ON delegated_staking_pool_balances (inserted_at);
+CREATE TABLE IF NOT EXISTS current_delegated_staking_pool_balances (
+  staking_pool_address VARCHAR(66) UNIQUE PRIMARY KEY NOT NULL,
+  total_coins NUMERIC NOT NULL,
+  total_shares NUMERIC NOT NULL,
+  last_transaction_version BIGINT NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX cdspb_insat_index ON current_delegated_staking_pool_balances (inserted_at);
 ALTER TABLE current_delegator_balances
 ADD COLUMN IF NOT EXISTS shares NUMERIC NOT NULL;
+-- need this for delegation staking, changing to shares
+CREATE OR REPLACE VIEW num_active_delegator_per_pool AS
+SELECT pool_address,
+  COUNT(DISTINCT delegator_address) AS num_active_delegator
+FROM current_delegator_balances
+WHERE shares > 0
+GROUP BY 1;
+ALTER TABLE current_delegator_balances DROP COLUMN IF EXISTS amount;

--- a/crates/indexer/migrations/2023-04-27-233343_delegation_pool_balances/up.sql
+++ b/crates/indexer/migrations/2023-04-27-233343_delegation_pool_balances/up.sql
@@ -1,0 +1,13 @@
+-- Your SQL goes here
+CREATE TABLE IF NOT EXISTS delegated_staking_pool_balances (
+  transaction_version BIGINT NOT NULL,
+  staking_pool_address VARCHAR(66) NOT NULL,
+  total_coins NUMERIC NOT NULL,
+  total_shares NUMERIC NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  -- Constraints
+  PRIMARY KEY (transaction_version, staking_pool_address)
+);
+CREATE INDEX dspb_insat_index ON delegated_staking_pool_balances (inserted_at);
+ALTER TABLE current_delegator_balances
+ADD COLUMN IF NOT EXISTS shares NUMERIC NOT NULL DEFAULT 0;

--- a/crates/indexer/migrations/2023-04-27-233343_delegation_pool_balances/up.sql
+++ b/crates/indexer/migrations/2023-04-27-233343_delegation_pool_balances/up.sql
@@ -10,4 +10,4 @@ CREATE TABLE IF NOT EXISTS delegated_staking_pool_balances (
 );
 CREATE INDEX dspb_insat_index ON delegated_staking_pool_balances (inserted_at);
 ALTER TABLE current_delegator_balances
-ADD COLUMN IF NOT EXISTS shares NUMERIC NOT NULL DEFAULT 0;
+ADD COLUMN IF NOT EXISTS shares NUMERIC NOT NULL;

--- a/crates/indexer/src/models/stake_models/delegator_pools.rs
+++ b/crates/indexer/src/models/stake_models/delegator_pools.rs
@@ -6,7 +6,10 @@
 
 use super::stake_utils::StakeResource;
 use crate::{
-    schema::{delegated_staking_pool_balances, delegated_staking_pools},
+    schema::{
+        current_delegated_staking_pool_balances, delegated_staking_pool_balances,
+        delegated_staking_pools,
+    },
     util::standardize_address,
 };
 use aptos_api_types::{Transaction, WriteResource, WriteSetChange};
@@ -17,6 +20,7 @@ use std::collections::HashMap;
 
 type StakingPoolAddress = String;
 pub type DelegatorPoolMap = HashMap<StakingPoolAddress, DelegatorPool>;
+pub type DelegatorPoolBalanceMap = HashMap<StakingPoolAddress, CurrentDelegatorPoolBalance>;
 
 // All pools
 #[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
@@ -27,7 +31,7 @@ pub struct DelegatorPool {
     pub first_transaction_version: i64,
 }
 
-// All pools
+// Pools balances
 #[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(transaction_version, staking_pool_address))]
 #[diesel(table_name = delegated_staking_pool_balances)]
@@ -38,12 +42,28 @@ pub struct DelegatorPoolBalance {
     pub total_shares: BigDecimal,
 }
 
+// All pools w latest balances (really a more comprehensive version than DelegatorPool)
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(staking_pool_address))]
+#[diesel(table_name = current_delegated_staking_pool_balances)]
+pub struct CurrentDelegatorPoolBalance {
+    pub staking_pool_address: String,
+    pub total_coins: BigDecimal,
+    pub total_shares: BigDecimal,
+    last_transaction_version: i64,
+}
+
 impl DelegatorPool {
     pub fn from_transaction(
         transaction: &Transaction,
-    ) -> anyhow::Result<(DelegatorPoolMap, Vec<DelegatorPoolBalance>)> {
+    ) -> anyhow::Result<(
+        DelegatorPoolMap,
+        Vec<DelegatorPoolBalance>,
+        DelegatorPoolBalanceMap,
+    )> {
         let mut delegator_pool_map = HashMap::new();
         let mut delegator_pool_balances = vec![];
+        let mut delegator_pool_balances_map = HashMap::new();
         // Do a first pass to get the mapping of active_share table handles to staking pool addresses
         if let Transaction::UserTransaction(user_txn) = transaction {
             let txn_version = user_txn.info.version.0 as i64;
@@ -51,24 +71,43 @@ impl DelegatorPool {
                 if let WriteSetChange::WriteResource(write_resource) = wsc {
                     let maybe_write_resource =
                         Self::from_write_resource(write_resource, txn_version)?;
-                    if let Some((pool, pool_balances, _)) = maybe_write_resource {
-                        delegator_pool_map.insert(pool.staking_pool_address.clone(), pool);
+                    if let Some((pool, pool_balances, current_pool_balances, _)) =
+                        maybe_write_resource
+                    {
+                        let staking_pool_address = pool.staking_pool_address.clone();
+                        delegator_pool_map.insert(staking_pool_address.clone(), pool);
                         delegator_pool_balances.push(pool_balances);
+                        delegator_pool_balances_map
+                            .insert(staking_pool_address.clone(), current_pool_balances);
                     }
                 }
             }
         }
-        Ok((delegator_pool_map, delegator_pool_balances))
+        Ok((
+            delegator_pool_map,
+            delegator_pool_balances,
+            delegator_pool_balances_map,
+        ))
     }
 
     pub fn from_write_resource(
         write_resource: &WriteResource,
         txn_version: i64,
-    ) -> anyhow::Result<Option<(Self, DelegatorPoolBalance, String)>> {
+    ) -> anyhow::Result<
+        Option<(
+            Self,
+            DelegatorPoolBalance,
+            CurrentDelegatorPoolBalance,
+            String,
+        )>,
+    > {
         if let Some(StakeResource::DelegationPool(inner)) =
             StakeResource::from_write_resource(write_resource, txn_version)?
         {
             let staking_pool_address = standardize_address(&write_resource.address.to_string());
+            let total_coins = inner.active_shares.total_coins;
+            let total_shares =
+                inner.active_shares.total_shares / inner.active_shares.scaling_factor;
             Ok(Some((
                 Self {
                     staking_pool_address: staking_pool_address.clone(),
@@ -76,9 +115,15 @@ impl DelegatorPool {
                 },
                 DelegatorPoolBalance {
                     transaction_version: txn_version,
+                    staking_pool_address: staking_pool_address.clone(),
+                    total_coins: total_coins.clone(),
+                    total_shares: total_shares.clone(),
+                },
+                CurrentDelegatorPoolBalance {
                     staking_pool_address,
-                    total_coins: inner.active_shares.total_coins,
-                    total_shares: inner.active_shares.total_shares,
+                    total_coins,
+                    total_shares,
+                    last_transaction_version: txn_version,
                 },
                 standardize_address(&inner.active_shares.shares.inner.handle),
             )))

--- a/crates/indexer/src/models/stake_models/delegator_pools.rs
+++ b/crates/indexer/src/models/stake_models/delegator_pools.rs
@@ -5,8 +5,12 @@
 #![allow(clippy::extra_unused_lifetimes)]
 
 use super::stake_utils::StakeResource;
-use crate::{schema::delegated_staking_pools, util::standardize_address};
+use crate::{
+    schema::{delegated_staking_pools, delegated_staking_pool_balances},
+    util::standardize_address,
+};
 use aptos_api_types::{Transaction, WriteResource, WriteSetChange};
+use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -23,9 +27,23 @@ pub struct DelegatorPool {
     pub first_transaction_version: i64,
 }
 
+// All pools
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(transaction_version, staking_pool_address))]
+#[diesel(table_name = delegated_staking_pool_balances)]
+pub struct DelegatorPoolBalance {
+    pub transaction_version: i64,
+    pub staking_pool_address: String,
+    pub total_coins: BigDecimal,
+    pub total_shares: BigDecimal,
+}
+
 impl DelegatorPool {
-    pub fn from_transaction(transaction: &Transaction) -> anyhow::Result<DelegatorPoolMap> {
+    pub fn from_transaction(
+        transaction: &Transaction,
+    ) -> anyhow::Result<(DelegatorPoolMap, Vec<DelegatorPoolBalance>)> {
         let mut delegator_pool_map = HashMap::new();
+        let mut delegator_pool_balances = vec![];
         // Do a first pass to get the mapping of active_share table handles to staking pool addresses
         if let Transaction::UserTransaction(user_txn) = transaction {
             let txn_version = user_txn.info.version.0 as i64;
@@ -33,28 +51,39 @@ impl DelegatorPool {
                 if let WriteSetChange::WriteResource(write_resource) = wsc {
                     let maybe_write_resource =
                         Self::from_write_resource(write_resource, txn_version)?;
-                    if let Some(map) = maybe_write_resource {
-                        delegator_pool_map.insert(map.staking_pool_address.clone(), map);
+                    if let Some((pool, pool_balances, _)) = maybe_write_resource {
+                        delegator_pool_map.insert(pool.staking_pool_address.clone(), pool);
+                        delegator_pool_balances.push(pool_balances);
                     }
                 }
             }
         }
-        Ok(delegator_pool_map)
+        Ok((delegator_pool_map, delegator_pool_balances))
     }
 
     pub fn from_write_resource(
         write_resource: &WriteResource,
         txn_version: i64,
-    ) -> anyhow::Result<Option<Self>> {
-        if let Some(StakeResource::DelegationPool(_)) =
+    ) -> anyhow::Result<Option<(Self, DelegatorPoolBalance, String)>> {
+        if let Some(StakeResource::DelegationPool(inner)) =
             StakeResource::from_write_resource(write_resource, txn_version)?
         {
             let staking_pool_address = standardize_address(&write_resource.address.to_string());
-            return Ok(Some(Self {
-                staking_pool_address,
-                first_transaction_version: txn_version,
-            }));
+            Ok(Some((
+                Self {
+                    staking_pool_address: staking_pool_address.clone(),
+                    first_transaction_version: txn_version,
+                },
+                DelegatorPoolBalance {
+                    transaction_version: txn_version,
+                    staking_pool_address,
+                    total_coins: inner.active_shares.total_coins,
+                    total_shares: inner.active_shares.total_shares,
+                },
+                standardize_address(&inner.active_shares.shares.inner.handle),
+            )))
+        } else {
+            Ok(None)
         }
-        Ok(None)
     }
 }

--- a/crates/indexer/src/models/stake_models/delegator_pools.rs
+++ b/crates/indexer/src/models/stake_models/delegator_pools.rs
@@ -6,7 +6,7 @@
 
 use super::stake_utils::StakeResource;
 use crate::{
-    schema::{delegated_staking_pools, delegated_staking_pool_balances},
+    schema::{delegated_staking_pool_balances, delegated_staking_pools},
     util::standardize_address,
 };
 use aptos_api_types::{Transaction, WriteResource, WriteSetChange};

--- a/crates/indexer/src/models/stake_models/stake_utils.rs
+++ b/crates/indexer/src/models/stake_models/stake_utils.rs
@@ -25,6 +25,8 @@ pub struct SharesResource {
     pub total_coins: BigDecimal,
     #[serde(deserialize_with = "deserialize_from_string")]
     pub total_shares: BigDecimal,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub scaling_factor: BigDecimal,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/indexer/src/models/stake_models/stake_utils.rs
+++ b/crates/indexer/src/models/stake_models/stake_utils.rs
@@ -21,6 +21,10 @@ pub struct DelegationPoolResource {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SharesResource {
     pub shares: SharesInnerResource,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub total_coins: BigDecimal,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub total_shares: BigDecimal,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/indexer/src/processors/stake_processor.rs
+++ b/crates/indexer/src/processors/stake_processor.rs
@@ -12,7 +12,9 @@ use crate::{
     models::stake_models::{
         delegator_activities::DelegatedStakingActivity,
         delegator_balances::{CurrentDelegatorBalance, CurrentDelegatorBalanceMap},
-        delegator_pools::{DelegatorPool, DelegatorPoolBalance, DelegatorPoolMap},
+        delegator_pools::{
+            CurrentDelegatorPoolBalance, DelegatorPool, DelegatorPoolBalance, DelegatorPoolMap,
+        },
         proposal_votes::ProposalVote,
         staking_pool_voter::{CurrentStakingPoolVoter, StakingPoolVoterMap},
     },
@@ -54,6 +56,7 @@ fn insert_to_db_impl(
     delegator_balances: &[CurrentDelegatorBalance],
     delegator_pools: &[DelegatorPool],
     delegator_pool_balances: &[DelegatorPoolBalance],
+    current_delegator_pool_balances: &[CurrentDelegatorPoolBalance],
 ) -> Result<(), diesel::result::Error> {
     insert_current_stake_pool_voter(conn, current_stake_pool_voters)?;
     insert_proposal_votes(conn, proposal_votes)?;
@@ -61,6 +64,7 @@ fn insert_to_db_impl(
     insert_delegator_balances(conn, delegator_balances)?;
     insert_delegator_pools(conn, delegator_pools)?;
     insert_delegator_pool_balances(conn, delegator_pool_balances)?;
+    insert_current_delegator_pool_balances(conn, current_delegator_pool_balances)?;
     Ok(())
 }
 
@@ -75,6 +79,7 @@ fn insert_to_db(
     delegator_balances: Vec<CurrentDelegatorBalance>,
     delegator_pools: Vec<DelegatorPool>,
     delegator_pool_balances: Vec<DelegatorPoolBalance>,
+    current_delegator_pool_balances: Vec<CurrentDelegatorPoolBalance>,
 ) -> Result<(), diesel::result::Error> {
     aptos_logger::trace!(
         name = name,
@@ -94,6 +99,7 @@ fn insert_to_db(
                 &delegator_balances,
                 &delegator_pools,
                 &delegator_pool_balances,
+                &current_delegator_pool_balances,
             )
         }) {
         Ok(_) => Ok(()),
@@ -107,6 +113,8 @@ fn insert_to_db(
                 let delegator_balances = clean_data_for_db(delegator_balances, true);
                 let delegator_pools = clean_data_for_db(delegator_pools, true);
                 let delegator_pool_balances = clean_data_for_db(delegator_pool_balances, true);
+                let current_delegator_pool_balances =
+                    clean_data_for_db(current_delegator_pool_balances, true);
 
                 insert_to_db_impl(
                     pg_conn,
@@ -116,6 +124,7 @@ fn insert_to_db(
                     &delegator_balances,
                     &delegator_pools,
                     &delegator_pool_balances,
+                    &current_delegator_pool_balances,
                 )
             }),
     }
@@ -209,7 +218,6 @@ fn insert_delegator_balances(
                 .do_update()
                 .set((
                     table_handle.eq(excluded(table_handle)),
-                    amount.eq(excluded(amount)),
                     last_transaction_version.eq(excluded(last_transaction_version)),
                     inserted_at.eq(excluded(inserted_at)),
                     shares.eq(excluded(shares)),
@@ -268,6 +276,37 @@ fn insert_delegator_pool_balances(
     Ok(())
 }
 
+fn insert_current_delegator_pool_balances(
+    conn: &mut PgConnection,
+    item_to_insert: &[CurrentDelegatorPoolBalance],
+) -> Result<(), diesel::result::Error> {
+    use schema::current_delegated_staking_pool_balances::dsl::*;
+
+    let chunks = get_chunks(
+        item_to_insert.len(),
+        CurrentDelegatorPoolBalance::field_count(),
+    );
+    for (start_ind, end_ind) in chunks {
+        execute_with_better_error(
+            conn,
+            diesel::insert_into(schema::current_delegated_staking_pool_balances::table)
+                .values(&item_to_insert[start_ind..end_ind])
+                .on_conflict(staking_pool_address)
+                .do_update()
+                .set((
+                    total_coins.eq(excluded(total_coins)),
+                    total_shares.eq(excluded(total_shares)),
+                    last_transaction_version.eq(excluded(last_transaction_version)),
+                    inserted_at.eq(excluded(inserted_at)),
+                )),
+            Some(
+                " WHERE current_delegated_staking_pool_balances.last_transaction_version <= EXCLUDED.last_transaction_version ",
+            ),
+        )?;
+    }
+    Ok(())
+}
+
 #[async_trait]
 impl TransactionProcessor for StakeTransactionProcessor {
     fn name(&self) -> &'static str {
@@ -286,6 +325,7 @@ impl TransactionProcessor for StakeTransactionProcessor {
         let mut all_delegator_balances: CurrentDelegatorBalanceMap = HashMap::new();
         let mut all_delegator_pools: DelegatorPoolMap = HashMap::new();
         let mut all_delegator_pool_balances = vec![];
+        let mut all_current_delegator_pool_balances = HashMap::new();
 
         for txn in &transactions {
             // Add votes data
@@ -303,10 +343,11 @@ impl TransactionProcessor for StakeTransactionProcessor {
             all_delegator_balances.extend(delegator_balances);
 
             // Add delegator pools
-            let (delegator_pools, mut delegator_pool_balances) =
+            let (delegator_pools, mut delegator_pool_balances, current_delegator_pool_balances) =
                 DelegatorPool::from_transaction(txn).unwrap();
             all_delegator_pools.extend(delegator_pools);
             all_delegator_pool_balances.append(&mut delegator_pool_balances);
+            all_current_delegator_pool_balances.extend(current_delegator_pool_balances);
         }
 
         // Getting list of values and sorting by pk in order to avoid postgres deadlock since we're doing multi threaded db writes
@@ -319,6 +360,9 @@ impl TransactionProcessor for StakeTransactionProcessor {
         let mut all_delegator_pools = all_delegator_pools
             .into_values()
             .collect::<Vec<DelegatorPool>>();
+        let mut all_current_delegator_pool_balances = all_current_delegator_pool_balances
+            .into_values()
+            .collect::<Vec<CurrentDelegatorPoolBalance>>();
 
         // Sort by PK
         all_current_stake_pool_voters
@@ -331,6 +375,8 @@ impl TransactionProcessor for StakeTransactionProcessor {
             ))
         });
         all_delegator_pools.sort_by(|a, b| a.staking_pool_address.cmp(&b.staking_pool_address));
+        all_current_delegator_pool_balances
+            .sort_by(|a, b| a.staking_pool_address.cmp(&b.staking_pool_address));
 
         let mut conn = self.get_conn();
         let tx_result = insert_to_db(
@@ -344,6 +390,7 @@ impl TransactionProcessor for StakeTransactionProcessor {
             all_delegator_balances,
             all_delegator_pools,
             all_delegator_pool_balances,
+            all_current_delegator_pool_balances,
         );
         match tx_result {
             Ok(_) => Ok(ProcessingResult::new(

--- a/crates/indexer/src/processors/stake_processor.rs
+++ b/crates/indexer/src/processors/stake_processor.rs
@@ -269,7 +269,11 @@ fn insert_delegator_pool_balances(
             diesel::insert_into(schema::delegated_staking_pool_balances::table)
                 .values(&item_to_insert[start_ind..end_ind])
                 .on_conflict((transaction_version, staking_pool_address))
-                .do_nothing(),
+                .do_update()
+                .set((
+                    total_shares.eq(excluded(total_shares)),
+                    inserted_at.eq(excluded(inserted_at)),
+                )),
             None,
         )?;
     }

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -1,3 +1,5 @@
+// Copyright © Aptos Foundation
+
 // @generated automatically by Diesel CLI.
 
 diesel::table! {

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -1,5 +1,3 @@
-// Copyright © Aptos Foundation
-
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
@@ -148,6 +146,7 @@ diesel::table! {
         amount -> Numeric,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
+        shares -> Numeric,
     }
 }
 
@@ -245,6 +244,16 @@ diesel::table! {
         pool_address -> Varchar,
         event_type -> Text,
         amount -> Numeric,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    delegated_staking_pool_balances (transaction_version, staking_pool_address) {
+        transaction_version -> Int8,
+        staking_pool_address -> Varchar,
+        total_coins -> Numeric,
+        total_shares -> Numeric,
         inserted_at -> Timestamp,
     }
 }
@@ -556,6 +565,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     current_token_ownerships,
     current_token_pending_claims,
     delegated_staking_activities,
+    delegated_staking_pool_balances,
     delegated_staking_pools,
     events,
     indexer_status,

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -140,12 +140,21 @@ diesel::table! {
 }
 
 diesel::table! {
+    current_delegated_staking_pool_balances (staking_pool_address) {
+        staking_pool_address -> Varchar,
+        total_coins -> Numeric,
+        total_shares -> Numeric,
+        last_transaction_version -> Int8,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     current_delegator_balances (delegator_address, pool_address, pool_type) {
         delegator_address -> Varchar,
         pool_address -> Varchar,
         pool_type -> Varchar,
         table_handle -> Varchar,
-        amount -> Numeric,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
         shares -> Numeric,
@@ -560,6 +569,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     current_ans_lookup,
     current_coin_balances,
     current_collection_datas,
+    current_delegated_staking_pool_balances,
     current_delegator_balances,
     current_staking_pool_voter,
     current_table_items,


### PR DESCRIPTION
### Description
* Added delegator pool balances to track total delegated staking per period
* Added current delegator pool balances to track latest total coin / total shares per period (note that shares are divided by scaling_factor to avoid having ints that are too large for downstream services (e.g. bigquery)
* In delegator balances, rename amount to shares. To get amounts in APT we recommend joining against `current_delegated_staking_pool_balances` and doing the math of `shares / total shares * total coins` (to get latest balance)

### Testing
Number checks out now
<img width="996" alt="image" src="https://user-images.githubusercontent.com/11738325/235070813-37112a8b-c8d9-416d-9a4e-9d5d9abb96b4.png">

Also balances look legit
<img width="997" alt="image" src="https://user-images.githubusercontent.com/11738325/235070870-58db1533-bab9-484a-8f2d-6538cc2b216d.png">
