### PR TITLE
[rosetta] Add unlock_delegated_stake operation

### DIFF
--- a/crates/aptos-rosetta/src/client.rs
+++ b/crates/aptos-rosetta/src/client.rs
@@ -471,6 +471,45 @@ impl RosettaClient {
         .await
     }
 
+    pub async fn unlock_delegated_stake(
+        &self,
+        network_identifier: &NetworkIdentifier,
+        private_key: &Ed25519PrivateKey,
+        pool_address: AccountAddress,
+        amount: Option<u64>,
+        expiry_time_secs: u64,
+        sequence_number: Option<u64>,
+        max_gas: Option<u64>,
+        gas_unit_price: Option<u64>,
+    ) -> anyhow::Result<TransactionIdentifier> {
+        let delegator = self
+            .get_account_address(network_identifier.clone(), private_key)
+            .await?;
+        let mut keys = HashMap::new();
+        keys.insert(delegator, private_key);
+
+        let operations = vec![Operation::unlock_delegated_stake(
+            0,
+            None,
+            delegator,
+            AccountIdentifier::base_account(pool_address),
+            amount,
+        )];
+
+        self.submit_operations(
+            delegator,
+            network_identifier.clone(),
+            &keys,
+            operations,
+            expiry_time_secs,
+            sequence_number,
+            max_gas,
+            gas_unit_price,
+            true,
+        )
+        .await
+    }
+
     /// Retrieves the account address from the derivation path if there isn't an overriding account specified
     async fn get_account_address(
         &self,

--- a/crates/aptos-rosetta/src/construction.rs
+++ b/crates/aptos-rosetta/src/construction.rs
@@ -561,6 +561,11 @@ async fn construction_parse(
                     STAKING_CONTRACT_MODULE,
                     DISTRIBUTE_STAKING_REWARDS_FUNCTION,
                 ) => parse_distribute_staking_rewards_operation(sender, &type_args, &args)?,
+                (
+                    AccountAddress::ONE,
+                    DELEGATION_POOL_MODULE,
+                    UNLOCK_DELEGATED_STAKE_FUNCTION,
+                ) => parse_unlock_delegated_stake_operation(sender, &type_args, &args)?,
                 _ => {
                     return Err(ApiError::TransactionParseError(Some(format!(
                         "Unsupported entry function type {:x}::{}::{}",
@@ -885,6 +890,30 @@ pub fn parse_distribute_staking_rewards_operation(
     )])
 }
 
+pub fn parse_unlock_delegated_stake_operation(
+    delegator: AccountAddress,
+    type_args: &[TypeTag],
+    args: &[Vec<u8>],
+) -> ApiResult<Vec<Operation>> {
+    if !type_args.is_empty() {
+        return Err(ApiError::TransactionParseError(Some(format!(
+            "Unlock delegated stake should not have type arguments: {:?}",
+            type_args
+        ))));
+    }
+
+    let pool_address: AccountAddress = parse_function_arg("unlock_delegated_stake", args, 0)?;
+    let amount: u64 = parse_function_arg("unlock_delegated_stake", args, 1)?;
+
+    Ok(vec![Operation::unlock_delegated_stake(
+        0,
+        None,
+        delegator,
+        AccountIdentifier::base_account(pool_address),
+        Some(amount),
+    )])
+}
+
 /// Construction payloads command (OFFLINE)
 ///
 /// Constructs payloads for given known operations
@@ -1014,6 +1043,21 @@ async fn construction_payloads(
             } else {
                 return Err(ApiError::InvalidInput(Some(format!(
                     "Distribute staking rewards operation doesn't match metadata {:?} vs {:?}",
+                    inner, metadata.internal_operation
+                ))));
+            }
+        },
+        InternalOperation::UnlockDelegatedStake(inner) => {
+            if let InternalOperation::UnlockDelegatedStake(ref metadata_op) = metadata.internal_operation {
+                if inner.delegator != metadata_op.delegator || inner.pool_address != metadata_op.pool_address {
+                    return Err(ApiError::InvalidInput(Some(format!(
+                        "Unlock delegated stake operation doesn't match metadata {:?} vs {:?}",
+                        inner, metadata.internal_operation
+                    ))));
+                }
+            } else {
+                return Err(ApiError::InvalidInput(Some(format!(
+                    "Unlock delegated stake operation doesn't match metadata {:?} vs {:?}",
                     inner, metadata.internal_operation
                 ))));
             }

--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -103,6 +103,7 @@ pub enum OperationType {
     ResetLockup,
     UnlockStake,
     DistributeStakingRewards,
+    UnlockDelegatedStake,
     // Fee must always be last for ordering
     Fee,
 }
@@ -119,6 +120,7 @@ impl OperationType {
     const STAKING_REWARD: &'static str = "staking_reward";
     const UNLOCK_STAKE: &'static str = "unlock_stake";
     const WITHDRAW: &'static str = "withdraw";
+    const UNLOCK_DELEGATED_STAKE: &'static str = "unlock_delegated_stake";
 
     pub fn all() -> Vec<OperationType> {
         use OperationType::*;
@@ -134,6 +136,7 @@ impl OperationType {
             ResetLockup,
             UnlockStake,
             DistributeStakingRewards,
+            UnlockDelegatedStake,
         ]
     }
 }
@@ -154,6 +157,7 @@ impl FromStr for OperationType {
             Self::RESET_LOCKUP => Ok(OperationType::ResetLockup),
             Self::UNLOCK_STAKE => Ok(OperationType::UnlockStake),
             Self::DISTRIBUTE_STAKING_REWARDS => Ok(OperationType::DistributeStakingRewards),
+            Self::UNLOCK_DELEGATED_STAKE => Ok(OperationType::UnlockDelegatedStake),
             _ => Err(ApiError::DeserializationFailed(Some(format!(
                 "Invalid OperationType: {}",
                 s
@@ -176,6 +180,7 @@ impl Display for OperationType {
             ResetLockup => Self::RESET_LOCKUP,
             UnlockStake => Self::UNLOCK_STAKE,
             DistributeStakingRewards => Self::DISTRIBUTE_STAKING_REWARDS,
+            UnlockDelegatedStake => Self::UNLOCK_DELEGATED_STAKE,
             Fee => Self::FEE,
         })
     }


### PR DESCRIPTION
### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec6907e</samp>

This pull request adds a new feature to the `aptos-rosetta` crate that enables users to withdraw their delegated stake from a staking pool using the Rosetta API. It implements the `unlock_delegated_stake` transaction script and operation type, and adds a new method to the `RosettaClient` struct. It also updates the relevant types and functions in the `construction.rs`, `misc.rs`, and `objects.rs` files.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### AI-powered Walkthrough
<!-- Delete this section if you don't want the AI to create a detailed walkthrough of your PR -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ec6907e</samp>

*  Add support for unlocking delegated stake from a staking pool ([link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-ce42b16ed0cdee92985b9d18ad201cba238159f14347cd85e84d59ef521a5a8aR474-R512), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-15264510e439fd55802e559016531536a6201778a96ed322e1e9ad96d0ec5321R564-R568), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-15264510e439fd55802e559016531536a6201778a96ed322e1e9ad96d0ec5321R893-R916), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-15264510e439fd55802e559016531536a6201778a96ed322e1e9ad96d0ec5321R1050-R1064), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-381c4c1066b97c183db7f3d94d863e974242fafa6b8a0c0879e8afbe8d355478R106), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-381c4c1066b97c183db7f3d94d863e974242fafa6b8a0c0879e8afbe8d355478R123), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-381c4c1066b97c183db7f3d94d863e974242fafa6b8a0c0879e8afbe8d355478R139), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-381c4c1066b97c183db7f3d94d863e974242fafa6b8a0c0879e8afbe8d355478R160), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-381c4c1066b97c183db7f3d94d863e974242fafa6b8a0c0879e8afbe8d355478R183), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-4c3ba82cb1ca40eacbbd5e57918581177ace042aa8a97af48c2e51aef6190104L13-R13), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-4c3ba82cb1ca40eacbbd5e57918581177ace042aa8a97af48c2e51aef6190104R410-R426), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-4c3ba82cb1ca40eacbbd5e57918581177ace042aa8a97af48c2e51aef6190104R479-R480), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-4c3ba82cb1ca40eacbbd5e57918581177ace042aa8a97af48c2e51aef6190104R552-R559), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-4c3ba82cb1ca40eacbbd5e57918581177ace042aa8a97af48c2e51aef6190104R883-R895), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-4c3ba82cb1ca40eacbbd5e57918581177ace042aa8a97af48c2e51aef6190104R1518), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-4c3ba82cb1ca40eacbbd5e57918581177ace042aa8a97af48c2e51aef6190104R1682-R1698), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-4c3ba82cb1ca40eacbbd5e57918581177ace042aa8a97af48c2e51aef6190104R1728), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-4c3ba82cb1ca40eacbbd5e57918581177ace042aa8a97af48c2e51aef6190104R1803-R1809), [link](https://github.com/aptos-labs/aptos-core/pull/7963/files?diff=unified&w=0#diff-4c3ba82cb1ca40eacbbd5e57918581177ace042aa8a97af48c2e51aef6190104R1982-R1988))
