### PR TITLE
Revert "Auth to GCP in Forge-GCP workflow (#7689)"

### DIFF
--- a/.github/actions/docker-setup/action.yaml
+++ b/.github/actions/docker-setup/action.yaml
@@ -12,10 +12,6 @@ inputs:
   GCP_SERVICE_ACCOUNT_EMAIL:
     required: true
     description: "GCP service account email"
-  EXPORT_GCP_PROJECT_VARIABLES:
-    required: false
-    description: "Whether to export GCP credentials to the environment. Useful for running gcloud commands"
-    default: "true"
   # AWS auth
   AWS_ACCESS_KEY_ID:
     required: true
@@ -30,10 +26,6 @@ inputs:
   GIT_CREDENTIALS:
     description: "Optional credentials to pass to git. Useful if you need to pull private repos for dependencies"
     required: false
-outputs:
-  CLOUDSDK_AUTH_ACCESS_TOKEN:
-    description: "GCP access token"
-    value: ${{ steps.auth.outputs.access_token }}
 
 runs:
   using: composite
@@ -73,7 +65,6 @@ runs:
         access_token_lifetime: 5400 # setting this to 1.5h since sometimes docker builds (special performance builds etc.) take that long. Default is 1h.
         workload_identity_provider: ${{ inputs.GCP_WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ inputs.GCP_SERVICE_ACCOUNT_EMAIL }}
-        export_environment_variables: ${{ inputs.EXPORT_GCP_PROJECT_VARIABLES }}
 
     - name: Login to us-west1 Google Artifact Registry
       uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # pin@v2

--- a/.github/workflows/forge-gcp.yaml
+++ b/.github/workflows/forge-gcp.yaml
@@ -30,11 +30,8 @@ env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  AWS_REGION: us-west-2
-  GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-  GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-  GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
   IMAGE_TAG: ${{ inputs.IMAGE_TAG }} # this is only used for workflow_dispatch, otherwise defaults to empty
+  AWS_REGION: us-west-2
 
 jobs:
   # This job determines the image tag and branch to test, and passes them to the other jobs
@@ -83,7 +80,7 @@ jobs:
   forge-land-blocking:
     if: ${{ github.event_name != 'pull_request' }}
     needs: determine-test-metadata
-    uses: ./.github/workflows/workflow-run-forge.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       COMMENT_HEADER: forge-continuous

--- a/.github/workflows/workflow-run-forge.yaml
+++ b/.github/workflows/workflow-run-forge.yaml
@@ -72,9 +72,6 @@ env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-  GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-  GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
   AWS_REGION: us-west-2
   IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
   FORGE_IMAGE_TAG: ${{ inputs.FORGE_IMAGE_TAG }}
@@ -106,52 +103,14 @@ jobs:
           ref: ${{ inputs.GIT_SHA }}
           # get the last 10 commits if GIT_SHA is not specified
           fetch-depth: inputs.GIT_SHA != null && 0 || 10
-
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4
-
       - name: Install python deps
         run: pip3 install click==8.1.3 psutil==5.9.1
-
-      - uses: ./.github/actions/docker-setup
-        id: docker-setup
-        with:
-          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-          EXPORT_GCP_PROJECT_VARIABLES: "false"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
-          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
-
-      - name: "Set up Cloud SDK"
-        uses: "google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587" # pin@v1
-        with:
-          version: ">= 418.0.0"
-          install_components: "kubectl,gke-gcloud-auth-plugin"
-
-      - name: "Export gcloud auth token"
-        id: gcloud-auth
-        run: echo "CLOUDSDK_AUTH_ACCESS_TOKEN=${{ steps.docker-setup.outputs.CLOUDSDK_AUTH_ACCESS_TOKEN }}" >> $GITHUB_ENV
-        shell: bash
-
-      - name: "Use gcloud CLI"
-        shell: bash
-        run: |
-          gcloud container clusters get-credentials aptos-forge-0 --zone us-central1-c --project aptos-forge-gcp-0
-          kubectl get pods --all-namespaces
-
-      - name: "Set gcloud CLI to Forge GCP project"
-        shell: bash
-        run: |
-          unset CLOUDSDK_CORE_PROJECT
-          gcloud config set project aptos-forge-gcp-0
-
       - name: Run pre-Forge checks
         shell: bash
         env:
           FORGE_RUNNER_MODE: pre-forge
         run: testsuite/run_forge.sh
-
       - name: Post pre-Forge comment
         if: env.COMMENT_ON_PR == 'true' && github.event.number != null
         uses: marocchino/sticky-pull-request-comment@39c5b5dc7717447d0cba270cd115037d32d28443 # pin@39c5b5dc7717447d0cba270cd115037d32d2844
@@ -164,7 +123,6 @@ jobs:
       - name: Run Forge
         shell: bash
         run: testsuite/run_forge.sh
-
       - name: Post forge result comment
         # Post a Github comment if the run has not been cancelled and if we're running on a PR
         if: env.COMMENT_ON_PR == 'true' && github.event.number != null && !cancelled()
@@ -174,7 +132,6 @@ jobs:
           hide_and_recreate: true
           hide_classify: "OUTDATED"
           path: ${{ env.FORGE_COMMENT }}
-
       - name: Post to a Slack channel on failure
         # Post a Slack comment if the run has not been cancelled and the envs are set
         if: env.POST_TO_SLACK == 'true' && failure()

--- a/terraform/aptos-node-testnet/gcp/main.tf
+++ b/terraform/aptos-node-testnet/gcp/main.tf
@@ -61,7 +61,7 @@ module "validator" {
 
   # addons
   enable_monitoring      = var.enable_monitoring
-  enable_node_exporter   = var.enable_prometheus_node_exporter
+  enable_node_exporter   = var.enable_node_exporter
   monitoring_helm_values = var.monitoring_helm_values
 }
 


### PR DESCRIPTION
This reverts commit f9c9b1a7fe005ce6704f599665998f8549c7f9f1.

Fix issues with auth, e.g. https://github.com/aptos-labs/aptos-core/actions/runs/4834601494/jobs/8616447222: 

```
ERROR: (gcloud.container.clusters.get-credentials) You do not currently have an active account selected.
Please run:

  $ gcloud auth login

to obtain new credentials.

If you have already logged in with a different account:

    $ gcloud config set account ACCOUNT

to select an already authenticated account to use.
```

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 76dd83b</samp>

This pull request improves the GitHub actions and terraform modules for the `aptos-core` repository. It simplifies the `docker-setup` action by using an existing action for GCP authentication, refactors the `forge-gcp` and `workflow-run-forge` workflows to use common inputs and actions, and fixes a typo in the `aptos-node-testnet` module.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### AI-powered Walkthrough
<!-- Delete this section if you don't want the AI to create a detailed walkthrough of your PR -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 76dd83b</samp>

*  Remove unnecessary input and output parameters from `docker-setup` action and simplify `docker-login` step ([link](https://github.com/aptos-labs/aptos-core/pull/7969/files?diff=unified&w=0#diff-0edce50009da2543b6d20685bbacfb66edcbd679158322b1bb0dbde6eb38e4d0L15-L18), [link](https://github.com/aptos-labs/aptos-core/pull/7969/files?diff=unified&w=0#diff-0edce50009da2543b6d20685bbacfb66edcbd679158322b1bb0dbde6eb38e4d0L33-L36), [link](https://github.com/aptos-labs/aptos-core/pull/7969/files?diff=unified&w=0#diff-0edce50009da2543b6d20685bbacfb66edcbd679158322b1bb0dbde6eb38e4d0L76))
*  Move common input parameters from `forge-gcp` workflow to `docker-setup` action and update `run-forge` step to use latest version of `workflow-run-forge` action ([link](https://github.com/aptos-labs/aptos-core/pull/7969/files?diff=unified&w=0#diff-9ef4e10a72e7f6f32723ad83a14a22a38bb2bbfbd610b707656330670e34d2d9L33-R34), [link](https://github.com/aptos-labs/aptos-core/pull/7969/files?diff=unified&w=0#diff-9ef4e10a72e7f6f32723ad83a14a22a38bb2bbfbd610b707656330670e34d2d9L86-R83))
*  Remove unnecessary input parameters and steps from `workflow-run-forge` action and fix formatting ([link](https://github.com/aptos-labs/aptos-core/pull/7969/files?diff=unified&w=0#diff-6318df51379f74a4774d16e24116278b2641c32038db6cf11bff4ce827ce0bd2L75-L77), [link](https://github.com/aptos-labs/aptos-core/pull/7969/files?diff=unified&w=0#diff-6318df51379f74a4774d16e24116278b2641c32038db6cf11bff4ce827ce0bd2L109-R108), [link](https://github.com/aptos-labs/aptos-core/pull/7969/files?diff=unified&w=0#diff-6318df51379f74a4774d16e24116278b2641c32038db6cf11bff4ce827ce0bd2L154), [link](https://github.com/aptos-labs/aptos-core/pull/7969/files?diff=unified&w=0#diff-6318df51379f74a4774d16e24116278b2641c32038db6cf11bff4ce827ce0bd2L167), [link](https://github.com/aptos-labs/aptos-core/pull/7969/files?diff=unified&w=0#diff-6318df51379f74a4774d16e24116278b2641c32038db6cf11bff4ce827ce0bd2L177))
*  Fix typo in variable name in `aptos-node-testnet` terraform module ([link](https://github.com/aptos-labs/aptos-core/pull/7969/files?diff=unified&w=0#diff-929f0f0fa0993eb88f8fec978b7f6dfd577ccdb8e84463696f910a20bc3f8eebL64-R64))
