### PR TITLE
update cli release version and devnet release

### DIFF
--- a/developer-docs-site/docs/releases/devnet-release.md
+++ b/developer-docs-site/docs/releases/devnet-release.md
@@ -17,10 +17,10 @@ Aptos SDK Release v1.7.2
 
 |Release | Git Tag | Commit Hash|
 |---|---|---|
-|[Aptos CLI Release v1.0.11](https://github.com/aptos-labs/aptos-core/releases/tag/aptos-cli-v1.0.11)| `aptos-cli-v1.0.11` | `6b610f4fc36098662dd0742ecc16687b8b535bb3` |
+|[Aptos CLI Release v1.0.12](https://github.com/aptos-labs/aptos-core/releases/tag/aptos-cli-v1.0.12)| `aptos-cli-v1.0.12` | `36c557a2258d67f46f5c8d8500a07956f9e62ccc` |
 
 ## Aptos Node
 
 |Devnet Branch Commit | Docker Image Tag | Docker Image Digest | genesis.blob SHA-256 | Waypoint | Chain ID|
 |---|---|---|---|---|---|
-|`8eb3f0bb8f335f76abea8955e06bad213d81f502`| `devnet_8eb3f0bb8f335f76abea8955e06bad213d81f502` | `sha256:ef77a6dc0af552c8502079b3e1aea123e86a2669e95413610ca07c48155d9c51` | `sha256: 9177001b58d2033baeeeb9c45b0725f3e2fd5352bcac836c461d162bf99cff11`| `0:c1cedb4fad19385f1b3ba7abc5300fb8fd07315968b2b1c1d09165617b1ce93f` | 56 |
+|`57f8b499aead5adf38276acb585cd2c0de398568`| `devnet_57f8b499aead5adf38276acb585cd2c0de398568` | `sha256:d1e9adefdf8b7308008cea9d7cb5a791ac1936ba10363c14ca2cb18368078a1c` | `sha256: 3e71b9694e165b2f193d737c4b0eeb71129effa8338aa78f33be59daf8830a9a`| `0:5b7611a645bd3de8f884d41f60203a80f2fdc7f51f04558a12b71eb5e36c4ca8` | 58 |

--- a/developer-docs-site/docs/releases/mainnet-release.md
+++ b/developer-docs-site/docs/releases/mainnet-release.md
@@ -21,7 +21,7 @@ Aptos SDK Release v1.7.2
 
 |Release | Git Tag | Commit Hash|
 |---|---|---|
-|[Aptos CLI Release v1.0.11](https://github.com/aptos-labs/aptos-core/releases/tag/aptos-cli-v1.0.11)| `aptos-cli-v1.0.11` | `6b610f4fc36098662dd0742ecc16687b8b535bb3` |
+|[Aptos CLI Release v1.0.12](https://github.com/aptos-labs/aptos-core/releases/tag/aptos-cli-v1.0.12)| `aptos-cli-v1.0.12` | `36c557a2258d67f46f5c8d8500a07956f9e62ccc` |
 
 ## Aptos Node
 

--- a/developer-docs-site/docs/releases/testnet-release.md
+++ b/developer-docs-site/docs/releases/testnet-release.md
@@ -21,7 +21,7 @@ Aptos SDK Release v1.7.2
 
 |Release | Git Tag | Commit Hash|
 |---|---|---|
-|[Aptos CLI Release v1.0.11](https://github.com/aptos-labs/aptos-core/releases/tag/aptos-cli-v1.0.11)| `aptos-cli-v1.0.11` | `6b610f4fc36098662dd0742ecc16687b8b535bb3` |
+|[Aptos CLI Release v1.0.12](https://github.com/aptos-labs/aptos-core/releases/tag/aptos-cli-v1.0.12)| `aptos-cli-v1.0.12` | `36c557a2258d67f46f5c8d8500a07956f9e62ccc` |
 
 ## Aptos Node
 


### PR DESCRIPTION
### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9d459b1</samp>

This pull request updates the developer documentation for the Aptos CLI and the devnet node. It synchronizes the release information of the Aptos CLI with the different network environments: `devnet`, `testnet`, and `mainnet`.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### AI-powered Walkthrough
<!-- Delete this section if you don't want the AI to create a detailed walkthrough of your PR -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9d459b1</samp>

*  Update the Aptos CLI release information for devnet, testnet, and mainnet environments ([link](https://github.com/aptos-labs/aptos-core/pull/7972/files?diff=unified&w=0#diff-bd0408d6ed6244946ed1290a94e74fc272c027d8e310e28d8a2cd3b5e4869183L20-R20), [link](https://github.com/aptos-labs/aptos-core/pull/7972/files?diff=unified&w=0#diff-e0aa0bff73a7e4770cac62273214a1da9d45875bc652fd7a6e296e7d3d7931cbL24-R24), [link](https://github.com/aptos-labs/aptos-core/pull/7972/files?diff=unified&w=0#diff-e3d0f6951e12572bb3c3c1bb8bd74216e77d66fd6bbe4a4c9f06cb8379e62fe4L24-R24)) in the corresponding `devnet-release.md`, `testnet-release.md`, and `mainnet-release.md` files
