### PR TITLE
[docker] release images without crane

### DIFF
--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -28,7 +28,8 @@ permissions:
 
 jobs:
   copy-images:
-    runs-on: ubuntu-latest
+    # Run on a machine with more local storage for large docker images
+    runs-on: medium-perf-docker-with-local-ssd
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
 
@@ -46,6 +47,10 @@ jobs:
         with:
           username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
           password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .node-version
 
       - uses: pnpm/action-setup@537643d491d20c2712d11533497cb47b2d0eb9d5 # pin https://github.com/pnpm/action-setup/releases/tag/v2.2.3
         with:

--- a/docker/release-images.mjs
+++ b/docker/release-images.mjs
@@ -163,8 +163,11 @@ for (const [image, imageConfig] of Object.entries(IMAGES_TO_RELEASE)) {
         const imageTarget = `${targetRegistry}/${image}:${joinTagSegments(parsedArgs.IMAGE_TAG_PREFIX, profilePrefix, featureSuffix)}`;
         console.info(chalk.green(`INFO: copying ${imageSource} to ${imageTarget}`));
         await waitForImageToBecomeAvailable(imageSource, parsedArgs.WAIT_FOR_IMAGE_SECONDS);
-        await $`${crane} copy ${imageSource} ${imageTarget}`;
-        await $`${crane} copy ${imageSource} ${joinTagSegments(imageTarget, parsedArgs.GIT_SHA)}`;
+        // use docker pull/tag/push instead of crane copy for now to circumvent bug: https://github.com/google/go-containerregistry/issues/1679
+        await dockerMirrorRepo(imageSource, imageTarget);
+        await dockerMirrorRepo(imageSource, joinTagSegments(imageTarget, parsedArgs.GIT_SHA));
+        // await $`${crane} copy ${imageSource} ${imageTarget}`;
+        // await $`${crane} copy ${imageSource} ${joinTagSegments(imageTarget, parsedArgs.GIT_SHA)}`;
       }
     }
   }
@@ -173,6 +176,14 @@ for (const [image, imageConfig] of Object.entries(IMAGES_TO_RELEASE)) {
 // joinTagSegments joins tag segments with a dash, but only if the segment is not empty
 function joinTagSegments(...segments) {
   return segments.filter((s) => s).join("_");
+}
+
+// dockerMirrorRepo mirrors a docker image from one repo to another
+// Simply does what crane copy does, but with docker pull/tag/push
+async function dockerMirrorRepo(imageSource, imageTarget) {
+  await $`docker pull ${imageSource}`;
+  await $`docker tag ${imageSource} ${imageTarget}`;
+  await $`docker push ${imageTarget}`;
 }
 
 async function waitForImageToBecomeAvailable(imageToWaitFor, waitForImageSeconds) {


### PR DESCRIPTION
### Description

Cherry-pick https://github.com/aptos-labs/aptos-core/pull/7956

Fix the release to 1.4. It's currently blocked by an API change on the dockerhub side, and we've reverted from using `crane` to simply `docker pull && tag && push` to publish docker images

The failed job is here: https://github.com/aptos-labs/aptos-core/actions/runs/4832554942
