### PR TITLE
[Forge] Add GCP auth to reusable Forge workflow

### DIFF
--- a/.github/workflows/workflow-run-forge.yaml
+++ b/.github/workflows/workflow-run-forge.yaml
@@ -72,6 +72,9 @@ env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+  GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+  GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
   AWS_REGION: us-west-2
   IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
   FORGE_IMAGE_TAG: ${{ inputs.FORGE_IMAGE_TAG }}
@@ -103,14 +106,52 @@ jobs:
           ref: ${{ inputs.GIT_SHA }}
           # get the last 10 commits if GIT_SHA is not specified
           fetch-depth: inputs.GIT_SHA != null && 0 || 10
+
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4
+
       - name: Install python deps
         run: pip3 install click==8.1.3 psutil==5.9.1
+
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+        id: docker-setup
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          # action/docker-setup logs in to GCP under project "aptos-ci", but this workflow
+          # runs kubectl under project "aptos-forge-gcp-0", to which the service account
+          # of "aptos-ci" has delegated access. The exported environment variables will
+          # still refer to "aptos-ci", which confuses the gcloud CLI, so we need to keep
+          # them out of the environment. That's ok, because gcloud will take configuration
+          # from the file-system anyway.
+          EXPORT_GCP_PROJECT_VARIABLES: "false"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+
+      - name: "Install GCloud SDK"
+        uses: "google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587" # pin@v1
+        with:
+          version: ">= 418.0.0"
+          install_components: "kubectl,gke-gcloud-auth-plugin"
+
+      - name: "Export GCloud auth token"
+        id: gcloud-auth
+        run: echo "CLOUDSDK_AUTH_ACCESS_TOKEN=${{ steps.docker-setup.outputs.CLOUDSDK_AUTH_ACCESS_TOKEN }}" >> $GITHUB_ENV
+        shell: bash
+
+      - name: "Setup GCloud project"
+        shell: bash
+        run: |
+          gcloud container clusters get-credentials aptos-forge-0 --zone us-central1-c --project aptos-forge-gcp-0
+          gcloud config set project aptos-forge-gcp-0
+
       - name: Run pre-Forge checks
         shell: bash
         env:
           FORGE_RUNNER_MODE: pre-forge
         run: testsuite/run_forge.sh
+
       - name: Post pre-Forge comment
         if: env.COMMENT_ON_PR == 'true' && github.event.number != null
         uses: marocchino/sticky-pull-request-comment@39c5b5dc7717447d0cba270cd115037d32d28443 # pin@39c5b5dc7717447d0cba270cd115037d32d2844
@@ -123,6 +164,7 @@ jobs:
       - name: Run Forge
         shell: bash
         run: testsuite/run_forge.sh
+
       - name: Post forge result comment
         # Post a Github comment if the run has not been cancelled and if we're running on a PR
         if: env.COMMENT_ON_PR == 'true' && github.event.number != null && !cancelled()
@@ -132,6 +174,7 @@ jobs:
           hide_and_recreate: true
           hide_classify: "OUTDATED"
           path: ${{ env.FORGE_COMMENT }}
+
       - name: Post to a Slack channel on failure
         # Post a Slack comment if the run has not been cancelled and the envs are set
         if: env.POST_TO_SLACK == 'true' && failure()


### PR DESCRIPTION
Depends on changes to actions/docker-setup that were already merged in https://github.com/aptos-labs/aptos-core/pull/7973.
Wrt. workflows dependencies, this commit does not affect development branches that are sync'd to commits prior to https://github.com/aptos-labs/aptos-core/pull/7973 because it references the workflows always at @main.
It *could* fail on dev branches which are so old that they lack #7646 (detect the cloud environment from the cluster name).

This is being tested in https://github.com/aptos-labs/aptos-core/pull/7971/commits, which adds a commit to redirect workflows to be PR-relative instead of @main.
A test run was manually triggered on [aptos-core](https://github.com/aptos-labs/aptos-core/actions/runs/4866458477/jobs/8678014311) and [aptos-core-private](https://github.com/aptos-labs/aptos-core-private/actions/runs/4866764023/jobs/8678631211).