### PR TITLE
[Peer Monitor] Add performance monitoring support.

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -156,6 +156,22 @@ jobs:
         env:
           RUST_MIN_STACK: 4297152
 
+  rust-network-perf-unit-test:
+    runs-on: high-perf-docker
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - uses: taiki-e/install-action@v1.5.6
+        with:
+          tool: nextest
+      - run: | # Test the client and server
+          cargo nextest run --locked -p aptos-peer-monitoring-service-client --no-fail-fast -F network-perf-test
+          cargo nextest run --locked -p aptos-peer-monitoring-service-server --no-fail-fast -F network-perf-test
+
   rust-smoke-test:
     runs-on: high-perf-docker
     steps:
@@ -199,8 +215,33 @@ jobs:
           tool: nextest
       # prebuild aptos-node binary, so that tests don't start before node is built.
       # also prebuild aptos-node binary as a separate step to avoid feature unification issues
-      # --test-threads is intentionally set to reduce resource contention in ci jobs. Increasing this, increases job failures and retries.
       - run: cargo build --locked --package=aptos-node -F consensus-only-perf-test --release && LOCAL_SWARM_NODE_RELEASE=1 CONSENSUS_ONLY_PERF_TEST=1 cargo nextest run --release --package smoke-test -E "test(test_consensus_only_with_txn_emitter)" --run-ignored all
+
+      # We always try to create the artifact, but it only creates on flaky or failed smoke tests -- when the directories are empty.
+      - name: Upload smoke test logs for failed and flaky tests
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() || success() }}
+        with:
+          name: failed-consensus-only-smoke-test-logs
+          # Retain all smoke test data except for the db (which may be large).
+          path: |
+            /tmp/.tmp*
+            !/tmp/.tmp*/**/db/
+          retention-days: 14
+
+  rust-network-perf-smoke-test:
+    runs-on: high-perf-docker
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - uses: taiki-e/install-action@v1.5.6
+        with:
+          tool: nextest
+      # prebuild aptos-node binary, so that tests don't start before node is built.
+      # also prebuild aptos-node binary as a separate step to avoid feature unification issues
+      - run: cargo build --locked --package=aptos-node -F network-perf-test --release && LOCAL_SWARM_NODE_RELEASE=1 NETWORK_PERF_TEST=1 cargo nextest run --release --package smoke-test -E "test(test_network_performance_monitoring)" --run-ignored all
 
       # We always try to create the artifact, but it only creates on flaky or failed smoke tests -- when the directories are empty.
       - name: Upload smoke test logs for failed and flaky tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,6 +2313,7 @@ dependencies = [
  "aptos-types",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "bytes",
+ "cfg_block",
  "claims",
  "futures",
  "maplit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,7 @@ dependencies = [
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "byteorder",
  "cfg-if",
+ "cfg_block",
  "get_if_addrs",
  "mirai-annotations",
  "poem-openapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2331,6 +2331,7 @@ dependencies = [
  "aptos-config",
  "aptos-types",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
+ "cfg_block",
  "serde 1.0.149",
  "thiserror",
 ]
@@ -4316,6 +4317,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_block"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
 
 [[package]]
 name = "chrono"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -396,6 +396,7 @@ blst = "0.3.7"
 byteorder = "1.4.3"
 bytes = "1.1.0"
 chrono = { version = "0.4.19", features = ["clock", "serde"] }
+cfg_block = "0.1.1"
 cfg-if = "1.0.0"
 claims = "0.7"
 clap = { version = "3.2.23", features = ["derive", "env", "suggestions"] }

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -82,4 +82,5 @@ consensus-only-perf-test = ["aptos-executor/consensus-only-perf-test", "aptos-me
 default = []
 failpoints = ["fail/failpoints", "aptos-consensus/failpoints", "aptos-executor/failpoints", "aptos-mempool/failpoints", "aptos-api/failpoints"]
 indexer = ["aptos-indexer"]
+network-perf-test = ["aptos-peer-monitoring-service-client/network-perf-test", "aptos-peer-monitoring-service-server/network-perf-test", "aptos-peer-monitoring-service-types/network-perf-test"]
 tokio-console = ["aptos-logger/tokio-console"]

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -24,8 +24,8 @@ aptos-temppath = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
 byteorder = { workspace = true }
-cfg_block = { workspace = true }
 cfg-if = { workspace = true }
+cfg_block = { workspace = true }
 get_if_addrs = { workspace = true }
 mirai-annotations = { workspace = true }
 poem-openapi = { workspace = true }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -41,4 +41,5 @@ aptos-types = { workspace = true, features = ["fuzzing"] }
 [features]
 default = []
 fuzzing = ["aptos-crypto/fuzzing", "aptos-types/fuzzing"]
+network-perf-test = []
 testing = []

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -24,6 +24,7 @@ aptos-temppath = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
 byteorder = { workspace = true }
+cfg_block = { workspace = true }
 cfg-if = { workspace = true }
 get_if_addrs = { workspace = true }
 mirai-annotations = { workspace = true }

--- a/config/src/config/config_optimizer.rs
+++ b/config/src/config/config_optimizer.rs
@@ -4,7 +4,7 @@
 use crate::{
     config::{
         node_config_loader::NodeType, utils::get_config_name, Error, InspectionServiceConfig,
-        LoggerConfig, NodeConfig, StateSyncConfig,
+        LoggerConfig, NodeConfig, PeerMonitoringServiceConfig, StateSyncConfig,
     },
     network_id::NetworkId,
 };
@@ -63,6 +63,14 @@ impl ConfigOptimizer for NodeConfig {
         }
         if LoggerConfig::optimize(node_config, local_config_yaml, node_type, chain_id)? {
             optimizers_with_modifications.push(LoggerConfig::get_optimizer_name());
+        }
+        if PeerMonitoringServiceConfig::optimize(
+            node_config,
+            local_config_yaml,
+            node_type,
+            chain_id,
+        )? {
+            optimizers_with_modifications.push(PeerMonitoringServiceConfig::get_optimizer_name());
         }
         if StateSyncConfig::optimize(node_config, local_config_yaml, node_type, chain_id)? {
             optimizers_with_modifications.push(StateSyncConfig::get_optimizer_name());

--- a/config/src/config/peer_monitoring_config.rs
+++ b/config/src/config/peer_monitoring_config.rs
@@ -19,7 +19,7 @@ pub struct PeerMonitoringServiceConfig {
     pub metadata_update_interval_ms: u64, // The interval (ms) between metadata updates
     pub network_monitoring: NetworkMonitoringConfig,
     pub node_monitoring: NodeMonitoringConfig,
-    pub peer_monitor_interval_ms: u64, // The interval (ms) between peer monitor executions
+    pub peer_monitor_interval_usec: u64, // The interval (usec) between peer monitor executions
 }
 
 impl Default for PeerMonitoringServiceConfig {
@@ -34,7 +34,7 @@ impl Default for PeerMonitoringServiceConfig {
             metadata_update_interval_ms: 5000,
             network_monitoring: NetworkMonitoringConfig::default(),
             node_monitoring: NodeMonitoringConfig::default(),
-            peer_monitor_interval_ms: 1000,
+            peer_monitor_interval_usec: 1_000_000, // 1 second
         }
     }
 }

--- a/config/src/config/utils.rs
+++ b/config/src/config/utils.rs
@@ -65,3 +65,14 @@ pub fn is_tokio_console_enabled() -> bool {
         }
     }
 }
+
+/// Returns true iff the network-perf-test feature is enabled
+pub fn is_network_perf_test_enabled() -> bool {
+    cfg_if! {
+        if #[cfg(feature = "network-perf-test")] {
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/network/peer-monitoring-service/client/Cargo.toml
+++ b/network/peer-monitoring-service/client/Cargo.toml
@@ -43,4 +43,4 @@ maplit = { workspace = true }
 tokio-stream = { workspace = true }
 
 [features]
-network-perf-test = [ "aptos-peer-monitoring-service-server/network-perf-test", "aptos-peer-monitoring-service-types/network-perf-test" ]
+network-perf-test = ["aptos-peer-monitoring-service-server/network-perf-test", "aptos-peer-monitoring-service-types/network-perf-test"]

--- a/network/peer-monitoring-service/client/Cargo.toml
+++ b/network/peer-monitoring-service/client/Cargo.toml
@@ -41,3 +41,6 @@ aptos-peer-monitoring-service-server = { workspace = true }
 bcs = { workspace = true }
 maplit = { workspace = true }
 tokio-stream = { workspace = true }
+
+[features]
+network-perf-test = [ "aptos-peer-monitoring-service-server/network-perf-test", "aptos-peer-monitoring-service-types/network-perf-test" ]

--- a/network/peer-monitoring-service/client/src/lib.rs
+++ b/network/peer-monitoring-service/client/src/lib.rs
@@ -103,7 +103,7 @@ async fn start_peer_monitor_with_state(
     // Create an interval ticker for the monitor loop
     let monitoring_service_config = node_config.peer_monitoring_service;
     let peer_monitor_duration =
-        Duration::from_millis(monitoring_service_config.peer_monitor_interval_ms);
+        Duration::from_micros(monitoring_service_config.peer_monitor_interval_usec);
     let peer_monitor_ticker = time_service.interval(peer_monitor_duration);
     futures::pin_mut!(peer_monitor_ticker);
 

--- a/network/peer-monitoring-service/client/src/logging.rs
+++ b/network/peer-monitoring-service/client/src/logging.rs
@@ -46,6 +46,9 @@ pub enum LogEntry {
     NodeInfoRequest,
     PeerMonitorLoop,
     SendRequest,
+
+    #[cfg(feature = "network-perf-test")] // Disabled by default
+    PerformanceMonitoringRequest,
 }
 
 #[derive(Clone, Copy, Serialize)]

--- a/network/peer-monitoring-service/client/src/network.rs
+++ b/network/peer-monitoring-service/client/src/network.rs
@@ -93,7 +93,7 @@ pub async fn send_request_to_peer(
     let result = peer_monitoring_client
         .send_request(
             *peer_network_id,
-            request,
+            request.clone(),
             Duration::from_millis(request_timeout_ms),
         )
         .await;
@@ -108,7 +108,7 @@ pub async fn send_request_to_peer(
             );
             metrics::increment_request_counter(
                 &metrics::SUCCESS_RESPONSES,
-                request.get_label(),
+                request.clone().get_label(),
                 peer_network_id,
             );
             Ok(response)

--- a/network/peer-monitoring-service/client/src/peer_states/mod.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/mod.rs
@@ -17,6 +17,9 @@ pub mod node_info;
 pub mod peer_state;
 mod request_tracker;
 
+#[cfg(feature = "network-perf-test")] // Disabled by default
+mod performance_monitoring;
+
 /// Refreshes the states of the connected peers
 pub fn refresh_peer_states(
     monitoring_service_config: &PeerMonitoringServiceConfig,

--- a/network/peer-monitoring-service/client/src/peer_states/peer_state.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/peer_state.rs
@@ -243,6 +243,24 @@ impl PeerState {
             ))),
         }
     }
+
+    /// Returns a copy of the performance monitoring state
+    #[cfg(feature = "network-perf-test")] // Disabled by default
+    pub(crate) fn get_performance_monitoring_state(
+        &self,
+    ) -> Result<crate::peer_states::performance_monitoring::PerformanceMonitoringState, Error> {
+        let peer_state_value = self
+            .get_peer_state_value(&PeerStateKey::PerformanceMonitoring)?
+            .read()
+            .clone();
+        match peer_state_value {
+            PeerStateValue::PerformanceMonitoringState(performance_monitoring_state) => Ok(performance_monitoring_state),
+            peer_state_value => Err(Error::UnexpectedError(format!(
+                "Invalid peer state value found! Expected performance_monitoring_state but got: {:?}",
+                peer_state_value
+            ))),
+        }
+    }
 }
 
 /// Sanity checks that the monitoring service response size

--- a/network/peer-monitoring-service/client/src/peer_states/peer_state.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/peer_state.rs
@@ -102,7 +102,7 @@ impl PeerState {
                 peer_monitoring_client,
                 &peer_network_id,
                 request_id,
-                monitoring_service_request,
+                monitoring_service_request.clone(),
                 request_timeout_ms,
             )
             .await;
@@ -138,7 +138,7 @@ impl PeerState {
             peer_state_value.write().handle_monitoring_service_response(
                 &peer_network_id,
                 peer_metadata,
-                monitoring_service_request,
+                monitoring_service_request.clone(),
                 monitoring_service_response,
                 request_duration_secs,
             );

--- a/network/peer-monitoring-service/client/src/peer_states/performance_monitoring.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/performance_monitoring.rs
@@ -1,0 +1,334 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    peer_states::{key_value::StateValueInterface, request_tracker::RequestTracker},
+    Error, LogEntry, LogEvent, LogSchema,
+};
+use aptos_config::{config::PerformanceMonitoringConfig, network_id::PeerNetworkId};
+use aptos_infallible::RwLock;
+use aptos_logger::{error, warn};
+use aptos_network::application::metadata::PeerMetadata;
+use aptos_peer_monitoring_service_types::{
+    request::{PeerMonitoringServiceRequest, PerformanceMonitoringRequest},
+    response::{PeerMonitoringServiceResponse, PerformanceMonitoringResponse},
+};
+use aptos_time_service::TimeService;
+use std::sync::Arc;
+
+/// A simple container that holds a single peer's performance monitoring state
+#[derive(Clone, Debug)]
+pub struct PerformanceMonitoringState {
+    performance_monitoring_config: PerformanceMonitoringConfig, // The config for performance monitoring
+    recorded_performance_response: Option<PerformanceMonitoringResponse>, // The last performance response
+    request_counter: u64, // The monotonically increasing counter for each request
+    request_data: Vec<u8>, // The data to send in each request
+    request_tracker: Arc<RwLock<RequestTracker>>, // The request tracker for performance monitoring
+}
+
+impl PerformanceMonitoringState {
+    pub fn new(
+        performance_monitoring_config: PerformanceMonitoringConfig,
+        time_service: TimeService,
+    ) -> Self {
+        // Create the request tracker
+        let request_interval_usecs = performance_monitoring_config.rpc_interval_usec;
+        let request_tracker =
+            RequestTracker::new_with_microseconds(request_interval_usecs, time_service);
+
+        Self {
+            performance_monitoring_config,
+            recorded_performance_response: None,
+            request_counter: 0,
+            request_data: vec![],
+            request_tracker: Arc::new(RwLock::new(request_tracker)),
+        }
+    }
+
+    /// Returns the current request counter and increments it internally
+    pub fn get_and_increment_request_counter(&mut self) -> u64 {
+        let request_counter = self.request_counter;
+        self.request_counter += 1;
+        request_counter
+    }
+
+    /// Returns the latest performance response
+    pub fn get_latest_performance_monitoring_response(
+        &self,
+    ) -> Option<PerformanceMonitoringResponse> {
+        self.recorded_performance_response.clone()
+    }
+
+    /// Records the new performance response for the peer
+    pub fn record_performance_monitoring_response(
+        &mut self,
+        performance_response: PerformanceMonitoringResponse,
+    ) {
+        // Update the request tracker with a successful response
+        self.request_tracker.write().record_response_success();
+
+        // Save the response
+        self.recorded_performance_response = Some(performance_response);
+    }
+
+    /// Handles a request failure for the specified peer
+    fn handle_request_failure(&self) {
+        self.request_tracker.write().record_response_failure();
+    }
+
+    /// Returns the latest performance response
+    pub fn get_latest_performance_response(&self) -> Option<PerformanceMonitoringResponse> {
+        self.recorded_performance_response.clone()
+    }
+}
+
+impl StateValueInterface for PerformanceMonitoringState {
+    fn create_monitoring_service_request(&mut self) -> PeerMonitoringServiceRequest {
+        // Create the request data (if it hasn't already been created yet)
+        if self.request_data.is_empty() {
+            self.request_data = create_request_data(&self.performance_monitoring_config);
+        }
+
+        // Return the request
+        PeerMonitoringServiceRequest::PerformanceMonitoringRequest(PerformanceMonitoringRequest {
+            request_counter: self.get_and_increment_request_counter(),
+            data: self.request_data.clone(),
+        })
+    }
+
+    fn get_request_timeout_ms(&self) -> u64 {
+        self.performance_monitoring_config.rpc_timeout_ms
+    }
+
+    fn get_request_tracker(&self) -> Arc<RwLock<RequestTracker>> {
+        self.request_tracker.clone()
+    }
+
+    fn handle_monitoring_service_response(
+        &mut self,
+        peer_network_id: &PeerNetworkId,
+        _peer_metadata: PeerMetadata,
+        monitoring_service_request: PeerMonitoringServiceRequest,
+        monitoring_service_response: PeerMonitoringServiceResponse,
+        _response_time_secs: f64,
+    ) {
+        // Verify the request type is correctly formed
+        let monitoring_service_request = match monitoring_service_request {
+            PeerMonitoringServiceRequest::PerformanceMonitoringRequest(
+                monitoring_service_request,
+            ) => monitoring_service_request,
+            request => {
+                error!(LogSchema::new(LogEntry::SendRequest)
+                    .event(LogEvent::UnexpectedErrorEncountered)
+                    .peer(peer_network_id)
+                    .request(&request)
+                    .message("An unexpected request was sent instead of a performance monitoring request!"));
+                self.handle_request_failure();
+                return;
+            },
+        };
+
+        // Verify the response type is valid
+        let performance_monitoring_response = match monitoring_service_response {
+            PeerMonitoringServiceResponse::PerformanceMonitoring(
+                performance_monitoring_response,
+            ) => performance_monitoring_response,
+            _ => {
+                warn!(LogSchema::new(LogEntry::PerformanceMonitoringRequest)
+                    .event(LogEvent::ResponseError)
+                    .peer(peer_network_id)
+                    .message("An unexpected response was received instead of a performance monitoring response!"));
+                self.handle_request_failure();
+                return;
+            },
+        };
+
+        // Verify the request counter is correct
+        let request_counter = monitoring_service_request.request_counter;
+        let response_counter = performance_monitoring_response.response_counter;
+        if request_counter != response_counter {
+            warn!(LogSchema::new(LogEntry::PerformanceMonitoringRequest)
+                .event(LogEvent::ResponseError)
+                .peer(peer_network_id)
+                .message(&format!(
+                    "Peer responded with the incorrect request counter! Expected: {:?}, found: {:?}",
+                    request_counter, response_counter
+                )));
+            self.handle_request_failure();
+            return;
+        }
+
+        // Store the new performance response
+        self.record_performance_monitoring_response(performance_monitoring_response);
+    }
+
+    fn handle_monitoring_service_response_error(
+        &self,
+        peer_network_id: &PeerNetworkId,
+        error: Error,
+    ) {
+        // Handle the failure
+        self.handle_request_failure();
+
+        // Log the error
+        warn!(LogSchema::new(LogEntry::PerformanceMonitoringRequest)
+            .event(LogEvent::ResponseError)
+            .message("Error encountered when sending a performance request to the peer!")
+            .peer(peer_network_id)
+            .error(&error));
+    }
+}
+
+/// Creates the request data for the performance monitoring requests
+fn create_request_data(performance_monitoring_config: &PerformanceMonitoringConfig) -> Vec<u8> {
+    // Calculate the data size
+    let data_size = if performance_monitoring_config.enable_direct_send_testing {
+        performance_monitoring_config.direct_send_data_size
+    } else {
+        performance_monitoring_config.rpc_data_size
+    };
+
+    // Generate the random request data
+    (0..data_size).map(|_| rand::random::<u8>()).collect()
+}
+
+#[cfg(test)]
+mod test {
+    use crate::peer_states::{
+        key_value::StateValueInterface, performance_monitoring::PerformanceMonitoringState,
+    };
+    use aptos_config::{
+        config::{PeerRole, PerformanceMonitoringConfig},
+        network_id::{NetworkId, PeerNetworkId},
+    };
+    use aptos_netcore::transport::ConnectionOrigin;
+    use aptos_network::{
+        application::metadata::PeerMetadata,
+        protocols::wire::handshake::v1::{MessagingProtocolVersion, ProtocolIdSet},
+        transport::{ConnectionId, ConnectionMetadata},
+    };
+    use aptos_peer_monitoring_service_types::{
+        request::{PeerMonitoringServiceRequest, PerformanceMonitoringRequest},
+        response::{PeerMonitoringServiceResponse, PerformanceMonitoringResponse},
+    };
+    use aptos_time_service::TimeService;
+    use aptos_types::{network_address::NetworkAddress, PeerId};
+    use std::str::FromStr;
+
+    // Useful test constants
+    const TEST_NETWORK_ADDRESS: &str = "/ip4/127.0.0.1/tcp/8081";
+
+    #[test]
+    fn test_verify_performance_monitoring_state() {
+        // Create the performance monitoring state
+        let performance_monitoring_config = PerformanceMonitoringConfig::default();
+        let time_service = TimeService::mock();
+        let mut performance_monitoring_state =
+            PerformanceMonitoringState::new(performance_monitoring_config, time_service);
+
+        // Verify the initial performance monitoring state
+        verify_empty_performance_monitoring_response(&performance_monitoring_state);
+        assert_eq!(performance_monitoring_state.request_counter, 0);
+        assert!(performance_monitoring_state.request_data.is_empty());
+
+        // Attempt to handle an invalid monitoring response with mismatched request counters
+        let request_counter = performance_monitoring_state.get_and_increment_request_counter();
+        handle_monitoring_service_response(
+            &mut performance_monitoring_state,
+            request_counter,
+            request_counter + 1,
+        );
+
+        // Verify there is still no recorded response
+        verify_empty_performance_monitoring_response(&performance_monitoring_state);
+
+        // Handle several valid monitoring responses
+        let num_responses = 10;
+        for _ in 0..num_responses {
+            // Handle the monitoring response
+            let request_counter = performance_monitoring_state.get_and_increment_request_counter();
+            handle_monitoring_service_response(
+                &mut performance_monitoring_state,
+                request_counter,
+                request_counter,
+            );
+        }
+
+        // Verify the performance monitoring state
+        verify_performance_monitoring_state(&performance_monitoring_state, num_responses + 1);
+    }
+
+    /// Handles a monitoring service response from a peer
+    fn handle_monitoring_service_response(
+        performance_monitoring_state: &mut PerformanceMonitoringState,
+        request_counter: u64,
+        response_counter: u64,
+    ) {
+        // Create a new peer metadata entry
+        let peer_network_id = PeerNetworkId::new(NetworkId::Validator, PeerId::random());
+        let connection_metadata = ConnectionMetadata::new(
+            peer_network_id.peer_id(),
+            ConnectionId::default(),
+            NetworkAddress::from_str(TEST_NETWORK_ADDRESS).unwrap(),
+            ConnectionOrigin::Outbound,
+            MessagingProtocolVersion::V1,
+            ProtocolIdSet::empty(),
+            PeerRole::Validator,
+        );
+        let peer_metadata = PeerMetadata::new(connection_metadata);
+
+        // Create the service request
+        let peer_monitoring_service_request =
+            PeerMonitoringServiceRequest::PerformanceMonitoringRequest(
+                PerformanceMonitoringRequest {
+                    request_counter,
+                    data: vec![],
+                },
+            );
+
+        // Create the service response
+        let peer_monitoring_service_response =
+            PeerMonitoringServiceResponse::PerformanceMonitoring(PerformanceMonitoringResponse {
+                response_counter,
+            });
+
+        // Handle the response
+        performance_monitoring_state.handle_monitoring_service_response(
+            &peer_network_id,
+            peer_metadata,
+            peer_monitoring_service_request,
+            peer_monitoring_service_response,
+            0.0,
+        );
+    }
+
+    /// Verifies that there is no recorded performance monitoring response
+    fn verify_empty_performance_monitoring_response(
+        performance_monitoring_state: &PerformanceMonitoringState,
+    ) {
+        assert!(performance_monitoring_state
+            .recorded_performance_response
+            .is_none());
+    }
+
+    /// Verifies that the latest performance monitoring response is valid
+    fn verify_performance_monitoring_state(
+        performance_monitoring_state: &PerformanceMonitoringState,
+        expected_request_counter: u64,
+    ) {
+        // Verify the request counter matches the expected value
+        assert_eq!(
+            performance_monitoring_state.request_counter,
+            expected_request_counter
+        );
+
+        // Verify the latest performance monitoring response
+        let performance_monitoring_response = performance_monitoring_state
+            .get_latest_performance_monitoring_response()
+            .unwrap();
+        assert_eq!(
+            performance_monitoring_response.response_counter,
+            expected_request_counter - 1
+        );
+    }
+}

--- a/network/peer-monitoring-service/client/src/peer_states/request_tracker.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/request_tracker.rs
@@ -14,18 +14,25 @@ pub struct RequestTracker {
     last_request_time: Option<Instant>, // The most recent request time
     last_response_time: Option<Instant>, // The most recent response time
     num_consecutive_request_failures: u64, // The number of consecutive request failures
-    request_interval_ms: u64, // The interval (ms) between requests
+    request_interval_usec: u64, // The interval (usec) between requests
     time_service: TimeService, // The time service to use for duration calculation
 }
 
 impl RequestTracker {
+    /// Creates a new request tracker with the given request interval in ms
     pub fn new(request_interval_ms: u64, time_service: TimeService) -> Self {
+        let request_interval_usec = request_interval_ms * 1000;
+        RequestTracker::new_with_microseconds(request_interval_usec, time_service)
+    }
+
+    /// Creates a new request tracker with the given request interval in usec
+    pub fn new_with_microseconds(request_interval_usec: u64, time_service: TimeService) -> Self {
         Self {
             in_flight_request: false,
             last_request_time: None,
             last_response_time: None,
             num_consecutive_request_failures: 0,
-            request_interval_ms,
+            request_interval_usec,
             time_service,
         }
     }
@@ -76,7 +83,7 @@ impl RequestTracker {
         match self.last_request_time {
             Some(last_request_time) => {
                 self.time_service.now()
-                    > last_request_time.add(Duration::from_millis(self.request_interval_ms))
+                    > last_request_time.add(Duration::from_micros(self.request_interval_usec))
             },
             None => true, // A request should be sent immediately
         }

--- a/network/peer-monitoring-service/client/src/tests/mock.rs
+++ b/network/peer-monitoring-service/client/src/tests/mock.rs
@@ -167,10 +167,12 @@ impl MockMonitoringServer {
         let peer_manager_request_receiver = self.get_request_receiver(network_id);
 
         // Verify that there is no request pending
-        assert!(peer_manager_request_receiver
+        let pending_request = peer_manager_request_receiver
             .select_next_some()
-            .now_or_never()
-            .is_none());
+            .now_or_never();
+        if let Some(pending_request) = pending_request {
+            panic!("Unexpected pending request: {:?}", pending_request);
+        }
     }
 
     /// Gets the request receiver for the specified network

--- a/network/peer-monitoring-service/client/src/tests/mod.rs
+++ b/network/peer-monitoring-service/client/src/tests/mod.rs
@@ -5,3 +5,6 @@ mod mock;
 mod multiple_peers;
 mod single_peer;
 mod utils;
+
+#[cfg(feature = "network-perf-test")] // Disabled by default
+mod performance_monitoring;

--- a/network/peer-monitoring-service/client/src/tests/multiple_peers.rs
+++ b/network/peer-monitoring-service/client/src/tests/multiple_peers.rs
@@ -22,7 +22,7 @@ use crate::{
     PeerState,
 };
 use aptos_config::{
-    config::{NodeConfig, PeerRole},
+    config::{NodeConfig, PeerMonitoringServiceConfig, PeerRole},
     network_id::NetworkId,
 };
 use aptos_infallible::RwLock;
@@ -145,8 +145,14 @@ async fn test_initial_states() {
     let (peer_monitoring_client, mut mock_monitoring_server, peer_monitor_state, time_service) =
         MockMonitoringServer::new(all_network_ids.clone());
 
-    // Spawn the peer monitoring client
-    let node_config = NodeConfig::default();
+    // Spawn the peer monitoring client with a very low monitoring interval
+    let node_config = NodeConfig {
+        peer_monitoring_service: PeerMonitoringServiceConfig {
+            peer_monitor_interval_usec: 100,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
     start_peer_monitor(
         peer_monitoring_client,
         &peer_monitor_state,

--- a/network/peer-monitoring-service/client/src/tests/performance_monitoring.rs
+++ b/network/peer-monitoring-service/client/src/tests/performance_monitoring.rs
@@ -1,0 +1,448 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    peer_states::key_value::{PeerStateKey, StateValueInterface},
+    tests::{
+        mock::MockMonitoringServer,
+        utils::{
+            disabled_latency_monitoring_config, disabled_network_monitoring_config,
+            disabled_node_monitoring_config, initialize_and_verify_peer_states, spawn_with_timeout,
+            start_peer_monitor, verify_empty_peer_states, wait_for_peer_state_update,
+            wait_for_request_failure,
+        },
+    },
+    PeerMonitorState,
+};
+use aptos_config::{
+    config::{NodeConfig, PeerMonitoringServiceConfig, PeerRole, PerformanceMonitoringConfig},
+    network_id::{NetworkId, PeerNetworkId},
+};
+use aptos_infallible::RwLock;
+use aptos_peer_monitoring_service_types::{
+    request::PeerMonitoringServiceRequest,
+    response::{LatencyPingResponse, PeerMonitoringServiceResponse, PerformanceMonitoringResponse},
+};
+use aptos_time_service::{MockTimeService, TimeServiceTrait};
+use std::sync::Arc;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_performance_monitoring_multiple_peers() {
+    // Create the peer monitoring client and server
+    let all_network_ids = vec![NetworkId::Validator, NetworkId::Vfn, NetworkId::Public];
+    let (peer_monitoring_client, mut mock_monitoring_server, peer_monitor_state, time_service) =
+        MockMonitoringServer::new(all_network_ids.clone());
+
+    // Create a node config where only performance monitoring requests refresh
+    let node_config = config_with_performance_requests();
+
+    // Spawn the peer monitoring client
+    start_peer_monitor(
+        peer_monitoring_client,
+        &peer_monitor_state,
+        &time_service,
+        &node_config,
+    )
+    .await;
+
+    // Add a connected validator peer
+    let validator_peer_1 =
+        mock_monitoring_server.add_new_peer(NetworkId::Validator, PeerRole::Validator);
+
+    // Initialize all the validator states by running the peer monitor once
+    let mock_time = time_service.into_mock();
+    let _ = initialize_and_verify_peer_states(
+        &NetworkId::Validator,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer_1,
+        &mock_time,
+    )
+    .await;
+
+    // Add another connected validator peer
+    let validator_peer_2 =
+        mock_monitoring_server.add_new_peer(NetworkId::Validator, PeerRole::Validator);
+
+    // Initialize all the validator states by running the peer monitor once
+    let _ = initialize_and_verify_peer_states(
+        &NetworkId::Validator,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer_2,
+        &mock_time,
+    )
+    .await;
+
+    // Add another connected validator peer
+    let validator_peer_3 =
+        mock_monitoring_server.add_new_peer(NetworkId::Validator, PeerRole::Validator);
+
+    // Initialize all the validator states by running the peer monitor once
+    let _ = initialize_and_verify_peer_states(
+        &NetworkId::Validator,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer_3,
+        &mock_time,
+    )
+    .await;
+
+    // Handle several performance requests for the validators
+    let mock_monitoring_server = Arc::new(RwLock::new(mock_monitoring_server)).clone();
+    for _ in 0..10 {
+        // Elapse enough time for a performance update
+        let time_before_update = mock_time.now();
+        elapse_performance_update_interval(node_config.clone(), mock_time.clone()).await;
+
+        // Create a task that waits for the requests and sends responses
+        let mock_monitoring_server = mock_monitoring_server.clone();
+        let peer_monitor_state = peer_monitor_state.clone();
+        let handle_requests = async move {
+            // Verify that a performance monitoring request is received for each peer
+            for _ in 0..3 {
+                // Get the performance request
+                let network_request = mock_monitoring_server
+                    .write()
+                    .next_request(&NetworkId::Validator)
+                    .await
+                    .unwrap();
+
+                // Verify the request type and respond
+                match network_request.peer_monitoring_service_request {
+                    PeerMonitoringServiceRequest::PerformanceMonitoringRequest(request) => {
+                        // Create and send the performance monitoring response
+                        let response = PeerMonitoringServiceResponse::PerformanceMonitoring(
+                            PerformanceMonitoringResponse {
+                                response_counter: request.request_counter,
+                            },
+                        );
+                        network_request.response_sender.send(Ok(response.clone()));
+                    },
+                    request => panic!("Unexpected monitoring request received: {:?}", request),
+                }
+            }
+
+            // Wait for the peer states to update
+            for peer_network_id in &[validator_peer_1, validator_peer_2, validator_peer_3] {
+                wait_for_peer_state_update(
+                    time_before_update,
+                    &peer_monitor_state,
+                    peer_network_id,
+                    vec![PeerStateKey::PerformanceMonitoring],
+                )
+                .await;
+            }
+        };
+
+        // Spawn the task with a timeout
+        spawn_with_timeout(
+            handle_requests,
+            "Timed-out while waiting for the performance monitoring requests",
+        )
+        .await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_performance_monitoring_requests() {
+    // Create the peer monitoring client and server
+    let network_id = NetworkId::Validator;
+    let (peer_monitoring_client, mut mock_monitoring_server, peer_monitor_state, time_service) =
+        MockMonitoringServer::new(vec![network_id]);
+
+    // Create a node config where only performance monitoring requests refresh
+    let node_config = config_with_performance_requests();
+
+    // Spawn the peer monitoring client
+    start_peer_monitor(
+        peer_monitoring_client,
+        &peer_monitor_state,
+        &time_service,
+        &node_config,
+    )
+    .await;
+
+    // Verify the initial state of the peer monitor
+    verify_empty_peer_states(&peer_monitor_state);
+
+    // Add a connected validator peer
+    let validator_peer = mock_monitoring_server.add_new_peer(network_id, PeerRole::Validator);
+
+    // Initialize all the peer states by running the peer monitor once
+    let mock_time = time_service.into_mock();
+    let _ = initialize_and_verify_peer_states(
+        &network_id,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer,
+        &mock_time,
+    )
+    .await;
+
+    // Handle many performance requests and responses
+    for i in 0..20 {
+        verify_and_handle_performance_request(
+            &network_id,
+            &mut mock_monitoring_server,
+            &peer_monitor_state,
+            &node_config,
+            &validator_peer,
+            &mock_time,
+            i + 1,
+        )
+        .await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_performance_monitoring_request_failures() {
+    // Create the peer monitoring client and server
+    let network_id = NetworkId::Validator;
+    let (peer_monitoring_client, mut mock_monitoring_server, peer_monitor_state, time_service) =
+        MockMonitoringServer::new(vec![network_id]);
+
+    // Create a node config where only performance monitoring requests refresh
+    let node_config = config_with_performance_requests();
+
+    // Spawn the peer monitoring client
+    start_peer_monitor(
+        peer_monitoring_client,
+        &peer_monitor_state,
+        &time_service,
+        &node_config,
+    )
+    .await;
+
+    // Add a connected validator peer
+    let validator_peer = mock_monitoring_server.add_new_peer(network_id, PeerRole::Validator);
+
+    // Initialize all the peer states by running the peer monitor once
+    let mock_time = time_service.into_mock();
+    let _ = initialize_and_verify_peer_states(
+        &network_id,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer,
+        &mock_time,
+    )
+    .await;
+
+    // Handle several performance monitoring requests with bad responses
+    for i in 0..5 {
+        // Elapse enough time for a performance update
+        elapse_performance_update_interval(node_config.clone(), mock_time.clone()).await;
+
+        // Verify that a single performance monitoring request is received and send a bad response
+        // Create the test data
+        verify_performance_request_and_respond(
+            &network_id,
+            &mut mock_monitoring_server,
+            true,
+            false,
+        )
+        .await;
+
+        // Wait until the performance state is updated with the failure
+        wait_for_performance_request_failure(&peer_monitor_state, &validator_peer, i + 1).await;
+    }
+
+    // Handle several performance monitoring requests without responses
+    for i in 5..10 {
+        // Elapse enough time for a performance update
+        elapse_performance_update_interval(node_config.clone(), mock_time.clone()).await;
+
+        // Verify that a single performance monitoring request is received and send a bad response
+        // Create the test data
+        verify_performance_request_and_respond(
+            &network_id,
+            &mut mock_monitoring_server,
+            false,
+            true,
+        )
+        .await;
+
+        // Wait until the performance state is updated with the failure
+        wait_for_performance_request_failure(&peer_monitor_state, &validator_peer, i + 1).await;
+    }
+
+    // Verify the new performance state of the peer monitor
+    verify_performance_monitoring_state(&peer_monitor_state, &validator_peer, 0, 10);
+
+    // Elapse enough time for a performance update
+    verify_and_handle_performance_request(
+        &network_id,
+        &mut mock_monitoring_server,
+        &peer_monitor_state,
+        &node_config,
+        &validator_peer,
+        &mock_time,
+        11,
+    )
+    .await;
+
+    // Verify the new performance monitoring state of the peer monitor (the number
+    // of failures should have been reset).
+    verify_performance_monitoring_state(&peer_monitor_state, &validator_peer, 11, 0);
+}
+
+/// Returns a config where only performance infos are refreshed
+fn config_with_performance_requests() -> NodeConfig {
+    NodeConfig {
+        peer_monitoring_service: PeerMonitoringServiceConfig {
+            latency_monitoring: disabled_latency_monitoring_config(),
+            network_monitoring: disabled_network_monitoring_config(),
+            node_monitoring: disabled_node_monitoring_config(),
+            performance_monitoring: PerformanceMonitoringConfig {
+                direct_send_interval_usec: 10_000_000, // 10 seconds
+                rpc_interval_usec: 10_000_000,         // 10 seconds
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Elapses enough time for a performance update to occur
+async fn elapse_performance_update_interval(node_config: NodeConfig, mock_time: MockTimeService) {
+    let performance_monitoring_config = node_config.peer_monitoring_service.performance_monitoring;
+    let rpc_interval_ms = performance_monitoring_config.rpc_interval_usec / 1000;
+    mock_time.advance_ms_async(rpc_interval_ms + 1).await;
+}
+
+/// Elapses enough time for a performance request and handles the response
+async fn verify_and_handle_performance_request(
+    network_id: &NetworkId,
+    mock_monitoring_server: &mut MockMonitoringServer,
+    peer_monitor_state: &PeerMonitorState,
+    node_config: &NodeConfig,
+    peer_network_id: &PeerNetworkId,
+    mock_time: &MockTimeService,
+    expected_num_sent_requests: u64,
+) {
+    // Elapse enough time for a performance update
+    let time_before_update = mock_time.now();
+    elapse_performance_update_interval(node_config.clone(), mock_time.clone()).await;
+
+    // Verify that a single performance request is received and respond
+    verify_performance_request_and_respond(network_id, mock_monitoring_server, false, false).await;
+
+    // Wait until the performance monitoring state is updated by the client
+    wait_for_peer_state_update(
+        time_before_update,
+        peer_monitor_state,
+        peer_network_id,
+        vec![PeerStateKey::PerformanceMonitoring],
+    )
+    .await;
+
+    // Verify the performance monitoring state
+    verify_performance_monitoring_state(
+        peer_monitor_state,
+        peer_network_id,
+        expected_num_sent_requests,
+        0,
+    );
+}
+
+/// Verifies the performance monitoring state of the peer monitor
+fn verify_performance_monitoring_state(
+    peer_monitor_state: &PeerMonitorState,
+    peer_network_id: &PeerNetworkId,
+    expected_num_sent_requests: u64,
+    expected_num_consecutive_failures: u64,
+) {
+    // Fetch the peer monitoring metadata
+    let peer_states = peer_monitor_state.peer_states.read();
+    let peer_state = peer_states.get(peer_network_id).unwrap();
+
+    // Verify the performance monitoring state
+    let performance_monitoring_state = peer_state.get_performance_monitoring_state().unwrap();
+    let latest_performance_response = performance_monitoring_state
+        .get_latest_performance_response()
+        .unwrap();
+    assert_eq!(
+        latest_performance_response.response_counter,
+        expected_num_sent_requests,
+    );
+
+    // Verify the number of consecutive failures
+    assert_eq!(
+        performance_monitoring_state
+            .get_request_tracker()
+            .read()
+            .get_num_consecutive_failures(),
+        expected_num_consecutive_failures
+    );
+}
+
+/// Verifies that a performance monitoring request is received by the
+/// server and sends a response based on the given arguments.
+async fn verify_performance_request_and_respond(
+    network_id: &NetworkId,
+    mock_monitoring_server: &mut MockMonitoringServer,
+    respond_with_invalid_message: bool,
+    skip_sending_a_response: bool,
+) {
+    // Create a task that waits for the request and sends a response
+    let handle_request = async move {
+        // Process the performance request
+        let network_request = mock_monitoring_server
+            .next_request(network_id)
+            .await
+            .unwrap();
+        let response = match network_request.peer_monitoring_service_request {
+            PeerMonitoringServiceRequest::PerformanceMonitoringRequest(request) => {
+                if respond_with_invalid_message {
+                    // Respond with the wrong message type
+                    PeerMonitoringServiceResponse::LatencyPing(LatencyPingResponse {
+                        ping_counter: 10,
+                    })
+                } else {
+                    // Send a valid response
+                    let performance_monitoring_response = PerformanceMonitoringResponse {
+                        response_counter: request.request_counter,
+                    };
+                    PeerMonitoringServiceResponse::PerformanceMonitoring(
+                        performance_monitoring_response,
+                    )
+                }
+            },
+            request => panic!("Unexpected monitoring request received: {:?}", request),
+        };
+
+        // Send the response
+        if !skip_sending_a_response {
+            network_request.response_sender.send(Ok(response));
+        }
+    };
+
+    // Spawn the task with a timeout
+    spawn_with_timeout(
+        handle_request,
+        "Timed-out while waiting for a performance monitoring request",
+    )
+    .await;
+}
+
+/// Waits for the peer monitor state to be updated with
+/// a performance request failure.
+async fn wait_for_performance_request_failure(
+    peer_monitor_state: &PeerMonitorState,
+    peer_network_id: &PeerNetworkId,
+    num_expected_consecutive_failures: u64,
+) {
+    wait_for_request_failure(
+        peer_monitor_state,
+        peer_network_id,
+        PeerStateKey::PerformanceMonitoring,
+        num_expected_consecutive_failures,
+    )
+    .await;
+}

--- a/network/peer-monitoring-service/client/src/tests/single_peer.rs
+++ b/network/peer-monitoring-service/client/src/tests/single_peer.rs
@@ -7,7 +7,7 @@ use crate::{
         mock::MockMonitoringServer,
         utils::{
             config_with_latency_ping_requests, config_with_network_info_requests,
-            config_with_node_info_requests, config_without_node_info_requests,
+            config_with_node_info_requests, config_with_only_latency_and_network_requests,
             create_connected_peers_map, create_network_info_response,
             create_random_network_info_response, create_random_node_info_response,
             elapse_latency_update_interval, elapse_metadata_updater_interval,
@@ -40,8 +40,8 @@ async fn test_basic_peer_monitor_loop() {
     let (peer_monitoring_client, mut mock_monitoring_server, peer_monitor_state, time_service) =
         MockMonitoringServer::new(vec![network_id]);
 
-    // Create a node config where node info requests don't refresh
-    let node_config = config_without_node_info_requests();
+    // Create a node config where only latency and network requests are refreshed
+    let node_config = config_with_only_latency_and_network_requests();
 
     // Spawn the peer monitoring client
     start_peer_monitor(

--- a/network/peer-monitoring-service/client/src/tests/utils.rs
+++ b/network/peer-monitoring-service/client/src/tests/utils.rs
@@ -10,7 +10,7 @@ use crate::{
 use aptos_config::{
     config::{
         LatencyMonitoringConfig, NetworkMonitoringConfig, NodeConfig, NodeMonitoringConfig,
-        PeerMonitoringServiceConfig, PeerRole,
+        PeerMonitoringServiceConfig, PeerRole, PerformanceMonitoringConfig,
     },
     network_id::{NetworkId, PeerNetworkId},
 };
@@ -50,6 +50,7 @@ pub fn config_with_latency_ping_requests() -> NodeConfig {
         peer_monitoring_service: PeerMonitoringServiceConfig {
             network_monitoring: disabled_network_monitoring_config(),
             node_monitoring: disabled_node_monitoring_config(),
+            performance_monitoring: disabled_performance_monitoring_config(),
             ..Default::default()
         },
         ..Default::default()
@@ -62,6 +63,7 @@ pub fn config_with_network_info_requests() -> NodeConfig {
         peer_monitoring_service: PeerMonitoringServiceConfig {
             latency_monitoring: disabled_latency_monitoring_config(),
             node_monitoring: disabled_node_monitoring_config(),
+            performance_monitoring: disabled_performance_monitoring_config(),
             ..Default::default()
         },
         ..Default::default()
@@ -74,6 +76,7 @@ pub fn config_with_node_info_requests() -> NodeConfig {
         peer_monitoring_service: PeerMonitoringServiceConfig {
             latency_monitoring: disabled_latency_monitoring_config(),
             network_monitoring: disabled_network_monitoring_config(),
+            performance_monitoring: disabled_performance_monitoring_config(),
             ..Default::default()
         },
         ..Default::default()
@@ -81,10 +84,11 @@ pub fn config_with_node_info_requests() -> NodeConfig {
 }
 
 /// Returns a config where node info requests don't refresh
-pub fn config_without_node_info_requests() -> NodeConfig {
+pub fn config_with_only_latency_and_network_requests() -> NodeConfig {
     NodeConfig {
         peer_monitoring_service: PeerMonitoringServiceConfig {
             node_monitoring: disabled_node_monitoring_config(),
+            performance_monitoring: disabled_performance_monitoring_config(),
             ..Default::default()
         },
         ..Default::default()
@@ -148,7 +152,7 @@ pub fn create_node_info_response(
 }
 
 /// Returns a latency monitoring config where latency requests are disabled
-fn disabled_latency_monitoring_config() -> LatencyMonitoringConfig {
+pub fn disabled_latency_monitoring_config() -> LatencyMonitoringConfig {
     LatencyMonitoringConfig {
         latency_ping_interval_ms: UNREALISTIC_INTERVAL_MS,
         ..Default::default()
@@ -156,7 +160,7 @@ fn disabled_latency_monitoring_config() -> LatencyMonitoringConfig {
 }
 
 /// Returns a network monitoring config where network infos are disabled
-fn disabled_network_monitoring_config() -> NetworkMonitoringConfig {
+pub fn disabled_network_monitoring_config() -> NetworkMonitoringConfig {
     NetworkMonitoringConfig {
         network_info_request_interval_ms: UNREALISTIC_INTERVAL_MS,
         ..Default::default()
@@ -164,9 +168,18 @@ fn disabled_network_monitoring_config() -> NetworkMonitoringConfig {
 }
 
 /// Returns a node monitoring config where node infos are disabled
-fn disabled_node_monitoring_config() -> NodeMonitoringConfig {
+pub fn disabled_node_monitoring_config() -> NodeMonitoringConfig {
     NodeMonitoringConfig {
         node_info_request_interval_ms: UNREALISTIC_INTERVAL_MS,
+        ..Default::default()
+    }
+}
+
+/// Returns a performance monitoring config where performance monitoring is disabled
+pub fn disabled_performance_monitoring_config() -> PerformanceMonitoringConfig {
+    PerformanceMonitoringConfig {
+        direct_send_interval_usec: UNREALISTIC_INTERVAL_MS * 1000,
+        rpc_interval_usec: UNREALISTIC_INTERVAL_MS * 1000,
         ..Default::default()
     }
 }
@@ -277,10 +290,11 @@ pub async fn initialize_and_verify_peer_states(
     elapse_peer_monitor_interval(node_config.clone(), mock_time.clone()).await;
 
     // Verify the initial client requests and send responses
+    let num_expected_requests = PeerStateKey::get_all_keys().len() as u64;
     verify_all_requests_and_respond(
         network_id,
         mock_monitoring_server,
-        3,
+        num_expected_requests,
         Some(network_info_response.clone()),
         Some(node_info_response.clone()),
     )
@@ -639,6 +653,14 @@ pub async fn verify_all_requests_and_respond(
                     PeerMonitoringServiceResponse::LatencyPing(LatencyPingResponse {
                         ping_counter: latency_ping.ping_counter,
                     })
+                },
+                #[cfg(feature = "network-perf-test")] // Disabled by default
+                PeerMonitoringServiceRequest::PerformanceMonitoringRequest(request) => {
+                    PeerMonitoringServiceResponse::PerformanceMonitoring(
+                        aptos_peer_monitoring_service_types::response::PerformanceMonitoringResponse {
+                            response_counter: request.request_counter,
+                        },
+                    )
                 },
                 request => panic!("Unexpected monitoring request received: {:?}", request),
             };

--- a/network/peer-monitoring-service/client/src/tests/utils.rs
+++ b/network/peer-monitoring-service/client/src/tests/utils.rs
@@ -209,8 +209,9 @@ pub async fn elapse_node_info_update_interval(node_config: NodeConfig, mock_time
 /// Elapses enough time for the monitoring loop to execute
 pub async fn elapse_peer_monitor_interval(node_config: NodeConfig, mock_time: MockTimeService) {
     let peer_monitoring_config = node_config.peer_monitoring_service;
+    let peer_monitor_duration_ms = peer_monitoring_config.peer_monitor_interval_usec / 1000;
     mock_time
-        .advance_ms_async(peer_monitoring_config.peer_monitor_interval_ms + 1)
+        .advance_ms_async(peer_monitor_duration_ms + 1)
         .await;
 }
 

--- a/network/peer-monitoring-service/server/Cargo.toml
+++ b/network/peer-monitoring-service/server/Cargo.toml
@@ -27,6 +27,7 @@ aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
+cfg_block = { workspace = true }
 futures = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true }
@@ -42,3 +43,6 @@ claims = { workspace = true }
 maplit = { workspace = true }
 mockall = { workspace = true }
 rand = { workspace = true }
+
+[features]
+network-perf-test = [ "aptos-peer-monitoring-service-types/network-perf-test" ]

--- a/network/peer-monitoring-service/server/Cargo.toml
+++ b/network/peer-monitoring-service/server/Cargo.toml
@@ -45,4 +45,4 @@ mockall = { workspace = true }
 rand = { workspace = true }
 
 [features]
-network-perf-test = [ "aptos-peer-monitoring-service-types/network-perf-test" ]
+network-perf-test = ["aptos-peer-monitoring-service-types/network-perf-test"]

--- a/network/peer-monitoring-service/server/src/lib.rs
+++ b/network/peer-monitoring-service/server/src/lib.rs
@@ -13,10 +13,6 @@ use aptos_bounded_executor::BoundedExecutor;
 use aptos_config::config::{BaseConfig, NodeConfig, RoleType};
 use aptos_logger::prelude::*;
 use aptos_network::{application::storage::PeersAndMetadata, ProtocolId};
-#[cfg(feature = "network-perf-test")] // Disabled by default
-use aptos_peer_monitoring_service_types::{
-    request::PerformanceMonitoringRequest, response::PerformanceMonitoringResponse,
-};
 use aptos_peer_monitoring_service_types::{
     request::{LatencyPingRequest, PeerMonitoringServiceRequest},
     response::{
@@ -299,16 +295,15 @@ impl<T: StorageReaderInterface> Handler<T> {
     #[cfg(feature = "network-perf-test")] // Disabled by default
     fn handle_performance_monitoring_request(
         &self,
-        performance_monitoring_request: &PerformanceMonitoringRequest,
+        performance_monitoring_request: &aptos_peer_monitoring_service_types::request::PerformanceMonitoringRequest,
     ) -> Result<PeerMonitoringServiceResponse, Error> {
-        let performance_monitoring_response = PerformanceMonitoringResponse {
-            response_counter: performance_monitoring_request.request_counter,
-        };
-        Ok(
-            PeerMonitoringServiceResponse::PerformanceMonitoringResponse(
-                performance_monitoring_response,
-            ),
-        )
+        let performance_monitoring_response =
+            aptos_peer_monitoring_service_types::response::PerformanceMonitoringResponse {
+                response_counter: performance_monitoring_request.request_counter,
+            };
+        Ok(PeerMonitoringServiceResponse::PerformanceMonitoring(
+            performance_monitoring_response,
+        ))
     }
 }
 

--- a/network/peer-monitoring-service/server/src/lib.rs
+++ b/network/peer-monitoring-service/server/src/lib.rs
@@ -13,6 +13,10 @@ use aptos_bounded_executor::BoundedExecutor;
 use aptos_config::config::{BaseConfig, NodeConfig, RoleType};
 use aptos_logger::prelude::*;
 use aptos_network::{application::storage::PeersAndMetadata, ProtocolId};
+#[cfg(feature = "network-perf-test")] // Disabled by default
+use aptos_peer_monitoring_service_types::{
+    request::PerformanceMonitoringRequest, response::PerformanceMonitoringResponse,
+};
 use aptos_peer_monitoring_service_types::{
     request::{LatencyPingRequest, PeerMonitoringServiceRequest},
     response::{
@@ -174,6 +178,11 @@ impl<T: StorageReaderInterface> Handler<T> {
             },
             PeerMonitoringServiceRequest::GetNodeInformation => self.get_node_information(),
             PeerMonitoringServiceRequest::LatencyPing(request) => self.handle_latency_ping(request),
+
+            #[cfg(feature = "network-perf-test")] // Disabled by default
+            PeerMonitoringServiceRequest::PerformanceMonitoringRequest(request) => {
+                self.handle_performance_monitoring_request(request)
+            },
         };
 
         // Process the response and handle any errors
@@ -285,6 +294,21 @@ impl<T: StorageReaderInterface> Handler<T> {
         Ok(PeerMonitoringServiceResponse::LatencyPing(
             latency_ping_response,
         ))
+    }
+
+    #[cfg(feature = "network-perf-test")] // Disabled by default
+    fn handle_performance_monitoring_request(
+        &self,
+        performance_monitoring_request: &PerformanceMonitoringRequest,
+    ) -> Result<PeerMonitoringServiceResponse, Error> {
+        let performance_monitoring_response = PerformanceMonitoringResponse {
+            response_counter: performance_monitoring_request.request_counter,
+        };
+        Ok(
+            PeerMonitoringServiceResponse::PerformanceMonitoringResponse(
+                performance_monitoring_response,
+            ),
+        )
     }
 }
 

--- a/network/peer-monitoring-service/server/src/tests.rs
+++ b/network/peer-monitoring-service/server/src/tests.rs
@@ -27,6 +27,8 @@ use aptos_network::{
     },
     transport::{ConnectionId, ConnectionMetadata},
 };
+#[cfg(feature = "network-perf-test")] // Disabled by default
+use aptos_peer_monitoring_service_types::request::PerformanceMonitoringRequest;
 use aptos_peer_monitoring_service_types::{
     request::{LatencyPingRequest, PeerMonitoringServiceRequest},
     response::{
@@ -58,6 +60,7 @@ use aptos_types::{
     },
     PeerId,
 };
+use cfg_block::cfg_block;
 use futures::channel::oneshot;
 use maplit::btreemap;
 use mockall::mock;
@@ -374,6 +377,39 @@ async fn test_latency_ping_request() {
                 assert_eq!(latecy_ping_response.ping_counter, i);
             },
             _ => panic!("Expected latency ping response but got: {:?}", response),
+        }
+    }
+}
+
+cfg_block! {
+    #[cfg(feature = "network-perf-test")] { // Disabled by default
+        #[tokio::test]
+        async fn test_performance_monitoring_request() {
+            // Create the peer monitoring client and server
+            let (mut mock_client, service, _, _) = MockClient::new(None, None, None);
+            tokio::spawn(service.start());
+
+            // Process several performance monitoring requests
+            for i in 0..10 {
+                let request = PeerMonitoringServiceRequest::PerformanceMonitoringRequest(
+                    PerformanceMonitoringRequest {
+                        request_counter: i,
+                        data: [0; 100].to_vec(), // 100 bytes of zero's
+                    },
+                );
+                let response = mock_client.send_request(request).await.unwrap();
+                match response {
+                    PeerMonitoringServiceResponse::PerformanceMonitoringResponse(
+                        performance_monitoring_response,
+                    ) => {
+                        assert_eq!(performance_monitoring_response.response_counter, i);
+                    },
+                    _ => panic!(
+                        "Expected performance monitoring response but got: {:?}",
+                        response
+                    ),
+                }
+            }
         }
     }
 }

--- a/network/peer-monitoring-service/server/src/tests.rs
+++ b/network/peer-monitoring-service/server/src/tests.rs
@@ -27,8 +27,6 @@ use aptos_network::{
     },
     transport::{ConnectionId, ConnectionMetadata},
 };
-#[cfg(feature = "network-perf-test")] // Disabled by default
-use aptos_peer_monitoring_service_types::request::PerformanceMonitoringRequest;
 use aptos_peer_monitoring_service_types::{
     request::{LatencyPingRequest, PeerMonitoringServiceRequest},
     response::{
@@ -392,14 +390,14 @@ cfg_block! {
             // Process several performance monitoring requests
             for i in 0..10 {
                 let request = PeerMonitoringServiceRequest::PerformanceMonitoringRequest(
-                    PerformanceMonitoringRequest {
+                    aptos_peer_monitoring_service_types::request::PerformanceMonitoringRequest {
                         request_counter: i,
                         data: [0; 100].to_vec(), // 100 bytes of zero's
                     },
                 );
                 let response = mock_client.send_request(request).await.unwrap();
                 match response {
-                    PeerMonitoringServiceResponse::PerformanceMonitoringResponse(
+                    PeerMonitoringServiceResponse::PerformanceMonitoring(
                         performance_monitoring_response,
                     ) => {
                         assert_eq!(performance_monitoring_response.response_counter, i);

--- a/network/peer-monitoring-service/types/Cargo.toml
+++ b/network/peer-monitoring-service/types/Cargo.toml
@@ -16,5 +16,9 @@ rust-version = { workspace = true }
 aptos-config = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
+cfg_block = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
+
+[features]
+network-perf-test = []

--- a/network/peer-monitoring-service/types/src/request.rs
+++ b/network/peer-monitoring-service/types/src/request.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use cfg_block::cfg_block;
 use serde::{Deserialize, Serialize};
 
 /// A peer monitoring service request
@@ -10,6 +11,9 @@ pub enum PeerMonitoringServiceRequest {
     GetNodeInformation,       // Returns relevant node information about the peer
     GetServerProtocolVersion, // Fetches the protocol version run by the server
     LatencyPing(LatencyPingRequest), // A simple message used by the client to ensure liveness and measure latency
+
+    #[cfg(feature = "network-perf-test")] // Disabled by default
+    PerformanceMonitoringRequest(PerformanceMonitoringRequest), // A request to monitor network performance
 }
 
 impl PeerMonitoringServiceRequest {
@@ -20,6 +24,9 @@ impl PeerMonitoringServiceRequest {
             Self::GetNodeInformation => "get_node_information",
             Self::GetServerProtocolVersion => "get_server_protocol_version",
             Self::LatencyPing(_) => "latency_ping",
+
+            #[cfg(feature = "network-perf-test")] // Disabled by default
+            Self::PerformanceMonitoringRequest(_) => "performance_monitoring_request",
         }
     }
 }
@@ -28,4 +35,15 @@ impl PeerMonitoringServiceRequest {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct LatencyPingRequest {
     pub ping_counter: u64, // A monotonically increasing counter to verify latency ping responses
+}
+
+cfg_block! {
+    #[cfg(feature = "network-perf-test")] { // Disabled by default
+        /// The performance monitoring request
+        #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+        pub struct PerformanceMonitoringRequest {
+            pub request_counter: u64, // A monotonically increasing counter to verify responses
+            pub data: Vec<u8>, // A vector of bytes to send in the request
+        }
+    }
 }

--- a/network/peer-monitoring-service/types/src/request.rs
+++ b/network/peer-monitoring-service/types/src/request.rs
@@ -5,7 +5,7 @@ use cfg_block::cfg_block;
 use serde::{Deserialize, Serialize};
 
 /// A peer monitoring service request
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum PeerMonitoringServiceRequest {
     GetNetworkInformation,    // Returns relevant network information for the peer
     GetNodeInformation,       // Returns relevant node information about the peer
@@ -32,7 +32,7 @@ impl PeerMonitoringServiceRequest {
 }
 
 /// The latency ping request
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct LatencyPingRequest {
     pub ping_counter: u64, // A monotonically increasing counter to verify latency ping responses
 }

--- a/network/peer-monitoring-service/types/src/response.rs
+++ b/network/peer-monitoring-service/types/src/response.rs
@@ -18,7 +18,7 @@ pub enum PeerMonitoringServiceResponse {
     ServerProtocolVersion(ServerProtocolVersionResponse), // Returns the current server protocol version
 
     #[cfg(feature = "network-perf-test")] // Disabled by default
-    PerformanceMonitoringResponse(PerformanceMonitoringResponse), // A response for performance monitoring requests
+    PerformanceMonitoring(PerformanceMonitoringResponse), // A response for performance monitoring requests
 }
 
 impl PeerMonitoringServiceResponse {
@@ -31,7 +31,7 @@ impl PeerMonitoringServiceResponse {
             Self::ServerProtocolVersion(_) => "server_protocol_version",
 
             #[cfg(feature = "network-perf-test")] // Disabled by default
-            Self::PerformanceMonitoringResponse(_) => "performance_monitoring_response",
+            Self::PerformanceMonitoring(_) => "performance_monitoring_response",
         }
     }
 
@@ -169,7 +169,7 @@ cfg_block! {
 
             fn try_from(response: PeerMonitoringServiceResponse) -> crate::Result<Self, Self::Error> {
                 match response {
-                    PeerMonitoringServiceResponse::PerformanceMonitoringResponse(inner) => Ok(inner),
+                    PeerMonitoringServiceResponse::PerformanceMonitoring(inner) => Ok(inner),
                     _ => Err(UnexpectedResponseError(format!(
                         "expected performance_monitoring_response, found {}",
                         response.get_label()

--- a/testsuite/forge/src/backend/local/cargo.rs
+++ b/testsuite/forge/src/backend/local/cargo.rs
@@ -28,6 +28,10 @@ pub fn build_consensus_only_node() -> bool {
     option_env!("CONSENSUS_ONLY_PERF_TEST").is_some()
 }
 
+pub fn build_network_perf_test() -> bool {
+    option_env!("NETWORK_PERF_TEST").is_some()
+}
+
 pub fn metadata() -> Result<Metadata> {
     let output = Command::new("cargo")
         .arg("metadata")
@@ -160,9 +164,13 @@ pub fn git_merge_base<R: AsRef<str>>(rev: R) -> Result<String> {
 pub fn cargo_build_common_args() -> Vec<&'static str> {
     let use_release = use_release();
     let consensus_only = build_consensus_only_node();
+    let network_perf_test = build_network_perf_test();
     let mut args = vec!["build", "--features=failpoints,indexer"];
     if consensus_only {
         args.push("--features=consensus-only-perf-test");
+    }
+    if network_perf_test {
+        args.push("--features=network-perf-test");
     }
     if use_release {
         args.push("--release");

--- a/testsuite/smoke-test/src/network.rs
+++ b/testsuite/smoke-test/src/network.rs
@@ -211,11 +211,34 @@ async fn test_peer_monitoring_service_enabled() {
         .build()
         .await;
 
-    // Create a fullnode config that with peer monitoring enabled
-    let mut vfn_config = NodeConfig::get_default_vfn_config();
-    vfn_config
-        .peer_monitoring_service
-        .enable_peer_monitoring_client = true;
+    // Test the ability of the validators to sync
+    test_all_validator_failures(swarm).await;
+}
+
+#[ignore]
+#[tokio::test]
+// Requires that the network-perf-test feature is enabled
+async fn test_network_performance_monitoring() {
+    // Create a swarm of 4 validators with peer monitoring enabled
+    let swarm = SwarmBuilder::new_local(4)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
+            config.peer_monitoring_service.enable_peer_monitoring_client = true;
+            config
+                .peer_monitoring_service
+                .performance_monitoring
+                .enable_rpc_testing = true;
+            config
+                .peer_monitoring_service
+                .performance_monitoring
+                .rpc_interval_usec = 1_000_000; // 1 sec
+            config
+                .peer_monitoring_service
+                .performance_monitoring
+                .rpc_data_size = 1024; // 1 KB
+        }))
+        .build()
+        .await;
 
     // Test the ability of the validators to sync
     test_all_validator_failures(swarm).await;


### PR DESCRIPTION
Note: most of this PR is just tests.

### Description

This PR adds simple network performance benchmarking to the peer monitoring service. This allows us to run end-to-end benchmarks to test network stack performance. Right now, the benchmark is simple: the peer monitoring service has all nodes send RPC requests to all other nodes at a configurable frequency (e.g., every second), with a configurable message size of random bytes (e.g., 512 KB). We can then track latency and throughput using the metrics.

Performance monitoring is protected by a feature flag (`network-perf-test`) and the config sanitizer. Nodes without the feature flag enabled will be unable to recognize performance messages and will simply drop them (i.e., similar to a message serialization failure).

The PR offers the following commits (which, I'll just squash when I land):
- Change the peer monitoring interval to use microseconds instead of milliseconds (so we can run the monitor more frequently).
- Change the request tracker to use microseconds instead of milliseconds (again, so we have a finer granularity).
- Add a simple performance monitoring config to the peer monitoring config.
- Add new request and response types for performance monitoring (protected by the feature flag).
- Add server-side support for performance monitoring requests (the server simply acks the message).
- Add client-side support for performance monitoring requests (most of this is new tests and boilerplate).
- Add CI/CD checks for the performance monitor (e.g., smoke and unit tests).

Once this PR lands, I'll need to continue with: (i) supporting direct send messages through the config flags; (ii) updating the node inspection service to display the peer monitoring metadata; (iii) updating the performance monitoring logic to better expose throughput and latency; and (iv) adding a dedicated forge test so that we can run this in a realistic network environment and see how things go.

For those curious, the reason that I've rolled this into the peer monitoring service (and not just add a new dedicated performance monitor) is because the peer monitoring service is perfect for this. All I've needed to do is add a new dedicated request and response type. Everything else we get for free, e.g., metrics, latencies, logging, error support, test framework, etc.

### Test Plan
New and existing unit (and smoke) tests! I've already run this locally and things seem to work reasonable well.
