### PR TITLE
persisted reliable broadcast state

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -171,56 +171,21 @@ jobs:
       FEATURES: consensus-only-perf-test
       BUILD_ADDL_TESTING_IMAGES: true
 
-  rust-images-all:
-    needs:
-      [
-        determine-docker-build-metadata,
-        rust-images,
-        rust-images-indexer,
-        rust-images-failpoints,
-        rust-images-performance,
-        rust-images-consensus-only-perf-test,
-      ]
-    if: always() # this ensures that the job will run even if the previous jobs were skipped
-    runs-on: ubuntu-latest
-    steps:
-      - name: fail if rust-images job failed
-        if: ${{ needs.rust-images.result == 'failure' }}
-        run: exit 1
-      - name: fail if rust-images-indexer job failed
-        if: ${{ needs.rust-images-indexer.result == 'failure' }}
-        run: exit 1
-      - name: fail if rust-images-failpoints job failed
-        if: ${{ needs.rust-images-failpoints.result == 'failure' }}
-        run: exit 1
-      - name: fail if rust-images-performance job failed
-        if: ${{ needs.rust-images-performance.result == 'failure' }}
-        run: exit 1
-      - name: fail if rust-images-consensus-only-perf-test job failed
-        if: ${{ needs.rust-images-consensus-only-perf-test.result == 'failure' }}
-        run: exit 1
-    outputs:
-      rustImagesResult: ${{ needs.rust-images.result }}
-      rustImagesIndexerResult: ${{ needs.rust-images-indexer.result }}
-      rustImagesFailpointsResult: ${{ needs.rust-images-failpoints.result }}
-      rustImagesPerformanceResult: ${{ needs.rust-images-performance.result }}
-      rustImagesConsensusOnlyPerfTestResult: ${{ needs.rust-images-consensus-only-perf-test.result }}
-
   sdk-release:
-    needs: [rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
+    needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
     if: |
       (github.event_name == 'push' && github.ref_name != 'main') ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
       github.event.pull_request.auto_merge != null ||
       contains(github.event.pull_request.body, '#e2e')
-    uses: ./.github/workflows/sdk-release.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/sdk-release.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
 
   cli-e2e-tests:
-    needs: [rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
+    needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
     if: |
       !contains(github.event.pull_request.labels.*.name, 'CICD:skip-sdk-integration-test') && (
         github.event_name == 'push' ||
@@ -234,10 +199,30 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
 
+  indexer-grpc-e2e-tests:
+    needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
+    if: |
+      (github.event_name == 'push' && github.ref_name != 'main') ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+      github.event.pull_request.auto_merge != null ||
+      contains(github.event.pull_request.body, '#e2e')
+    uses: ./.github/workflows/docker-indexer-grpc-test.yaml
+    secrets: inherit
+    with:
+      GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+
   forge-e2e-test:
-    needs: [rust-images-all, determine-docker-build-metadata]
-    if: | # always() ensures that the job will run even if some of the previous docker variant build jobs were skipped https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
-      always() && needs.rust-images-all.result == 'success' && (
+    needs:
+      - permission-check
+      - determine-docker-build-metadata
+      - rust-images
+      - rust-images-indexer
+      - rust-images-failpoints
+      - rust-images-performance
+      - rust-images-consensus-only-perf-test
+    if: |
+      !failure() && !cancelled() && needs.permission-check.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
@@ -259,9 +244,16 @@ jobs:
 
   # Run e2e compat test against testnet branch
   forge-compat-test:
-    needs: [rust-images-all, determine-docker-build-metadata]
-    if: | # always() ensures that the job will run even if some of the previous docker variant build jobs were skipped https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
-      always() && needs.rust-images-all.result == 'success' && (
+    needs:
+      - permission-check
+      - determine-docker-build-metadata
+      - rust-images
+      - rust-images-indexer
+      - rust-images-failpoints
+      - rust-images-performance
+      - rust-images-consensus-only-perf-test
+    if: |
+      !failure() && !cancelled() && needs.permission-check.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
@@ -280,9 +272,16 @@ jobs:
 
   # Run forge framework upgradability test
   forge-framework-upgrade-test:
-    needs: [rust-images-all, determine-docker-build-metadata]
-    if: | # always() ensures that the job will run even if some of the previous docker variant build jobs were skipped https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
-      always() && needs.rust-images-all.result == 'success' && (
+    needs:
+      - permission-check
+      - determine-docker-build-metadata
+      - rust-images
+      - rust-images-indexer
+      - rust-images-failpoints
+      - rust-images-performance
+      - rust-images-consensus-only-perf-test
+    if: |
+      !failure() && !cancelled() && needs.permission-check.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
@@ -300,9 +299,16 @@ jobs:
       FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
 
   forge-consensus-only-perf-test:
-    needs: [rust-images-all, determine-docker-build-metadata]
-    if: | # always() ensures that the job will run even if some of the previous docker variant build jobs were skipped https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
-      always() && needs.rust-images-all.result == 'success' &&
+    needs:
+      - permission-check
+      - determine-docker-build-metadata
+      - rust-images
+      - rust-images-indexer
+      - rust-images-failpoints
+      - rust-images-performance
+      - rust-images-consensus-only-perf-test
+    if: |
+      !failure() && !cancelled() && needs.permission-check.result == 'success' &&
       contains(github.event.pull_request.labels.*.name, 'CICD:run-consensus-only-perf-test')
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -92,13 +92,13 @@ jobs:
   # Because the docker build happens in a reusable workflow, have a separate job that collects the right metadata
   # for the subsequent docker builds. Reusable workflows do not currently have the "env" context: https://github.com/orgs/community/discussions/26671
   determine-docker-build-metadata:
+    needs: [permission-check]
     runs-on: ubuntu-latest
     steps:
       - name: collect metadata
         run: |
-          echo "GIT_SHA: ${{ env.GIT_SHA }}"
-          echo "TARGET_CACHE_ID: ${{ env.TARGET_CACHE_ID }}"
-          echo "CONCURRENCY: ${{ github.workflow }}-${{ github.event_name }}-${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.sha || github.head_ref || github.ref }}"
+          echo "GIT_SHA: ${GIT_SHA}"
+          echo "TARGET_CACHE_ID: ${TARGET_CACHE_ID}"
     outputs:
       gitSha: ${{ env.GIT_SHA }}
       targetCacheId: ${{ env.TARGET_CACHE_ID }}

--- a/consensus/consensus-types/src/node.rs
+++ b/consensus/consensus-types/src/node.rs
@@ -35,7 +35,7 @@ impl SignedNodeDigestInfo {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub struct SignedNodeDigest {
     epoch: u64,
     signed_node_digest_info: SignedNodeDigestInfo,
@@ -85,7 +85,7 @@ impl SignedNodeDigest {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq)]
 pub struct NodeCertificate {
     signed_node_digest_info: SignedNodeDigestInfo,
     multi_signature: AggregateSignature,
@@ -314,7 +314,7 @@ impl Node {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub struct CertifiedNode {
     header: Node,
     certificate: NodeCertificate,

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -27,6 +27,7 @@ use aptos_vm::AptosVM;
 use futures::channel::mpsc;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
+use crate::dag::reliable_broadcast::storage::NaiveReliableBroadcastDB;
 
 /// Helper function to start consensus based on configuration and return the runtime
 pub fn start_consensus(
@@ -41,7 +42,7 @@ pub fn start_consensus(
     let runtime = aptos_runtimes::spawn_named_runtime("consensus".into(), None);
     let storage = Arc::new(StorageWriteProxy::new(node_config, aptos_db.reader.clone()));
     let quorum_store_db = Arc::new(QuorumStoreDB::new(node_config.storage.dir()));
-
+    let reliable_broadcast_db = Arc::new(NaiveReliableBroadcastDB::new(node_config.storage.dir()));
     let txn_notifier = Arc::new(MempoolNotifier::new(
         consensus_to_mempool_sender.clone(),
         node_config.consensus.mempool_executed_txn_timeout_ms,
@@ -74,6 +75,7 @@ pub fn start_consensus(
         quorum_store_db,
         reconfig_events,
         bounded_executor,
+        reliable_broadcast_db,
     );
 
     let (network_task, network_receiver) = NetworkTask::new(network_service_events, self_receiver);

--- a/consensus/src/dag/dag.rs
+++ b/consensus/src/dag/dag.rs
@@ -327,6 +327,7 @@ impl MissingDagNodeStatus {
     }
 }
 
+
 // TODO: persist all every update
 #[allow(dead_code)]
 pub(crate) struct Dag {

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -34,6 +34,7 @@ use tokio::{
     sync::{mpsc::Sender, Mutex},
     time,
 };
+use crate::dag::reliable_broadcast::NaiveReliableBroadcastStorage;
 
 pub struct DagDriver {
     epoch: u64,
@@ -70,7 +71,7 @@ impl DagDriver {
     ) -> Self {
         let (rb_tx, rb_rx) = tokio::sync::mpsc::channel(config.channel_size);
 
-        let rb = ReliableBroadcast::new(
+        let rb = ReliableBroadcast::<NaiveReliableBroadcastStorage>::new(
             author,
             epoch,
             network_sender.clone(),

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -34,7 +34,7 @@ use tokio::{
     sync::{mpsc::Sender, Mutex},
     time,
 };
-use crate::dag::reliable_broadcast::NaiveReliableBroadcastStorage;
+use crate::dag::reliable_broadcast::storage::ReliableBroadcastStorage;
 
 pub struct DagDriver {
     epoch: u64,
@@ -58,6 +58,7 @@ impl DagDriver {
         epoch: u64,
         author: Author,
         config: DagConfig,
+        rb_storage: Arc<dyn ReliableBroadcastStorage>,
         payload_client: Arc<dyn PayloadClient>,
         network_sender: NetworkSender,
         verifier: ValidatorVerifier,
@@ -71,9 +72,10 @@ impl DagDriver {
     ) -> Self {
         let (rb_tx, rb_rx) = tokio::sync::mpsc::channel(config.channel_size);
 
-        let rb = ReliableBroadcast::<NaiveReliableBroadcastStorage>::new(
+        let rb = ReliableBroadcast::new(
             author,
             epoch,
+            rb_storage,
             network_sender.clone(),
             verifier.clone(),
             validator_signer,

--- a/consensus/src/dag/dag_driver_test.rs
+++ b/consensus/src/dag/dag_driver_test.rs
@@ -44,6 +44,7 @@ use futures_channel::oneshot;
 use maplit::hashmap;
 use std::{iter::FromIterator, sync::Arc};
 use tokio::runtime::Runtime;
+use crate::dag::reliable_broadcast::storage::MockReliableBroadcastDB;
 
 /// Auxiliary struct that is setting up node environment for the test.
 pub struct NodeSetup {
@@ -149,6 +150,7 @@ impl NodeSetup {
 
         let time_service = Arc::new(ClockTimeService::new(runtime.handle().clone()));
 
+        let rb_storage = Arc::new(MockReliableBroadcastDB::new());
         let payload_client = Arc::new(MockPayloadManager::new(None));
 
         let (rb_network_msg_tx, rb_network_msg_rx) = aptos_channel::new(QueueStyle::FIFO, 8, None);
@@ -158,6 +160,7 @@ impl NodeSetup {
             epoch_state.epoch,
             author,
             DagConfig::default(),
+            rb_storage,
             payload_client,
             network,
             epoch_state.verifier,

--- a/consensus/src/dag/mod.rs
+++ b/consensus/src/dag/mod.rs
@@ -1,3 +1,5 @@
+// Copyright © Aptos Foundation
+
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
@@ -5,7 +7,7 @@ mod anchor_election;
 mod bullshark;
 mod dag;
 pub(crate) mod dag_driver;
-mod reliable_broadcast;
+pub(crate) mod reliable_broadcast;
 mod types;
 
 #[cfg(test)]

--- a/consensus/src/dag/reliable_broadcast.rs
+++ b/consensus/src/dag/reliable_broadcast.rs
@@ -20,7 +20,16 @@ use aptos_types::{
 use futures::{FutureExt, StreamExt};
 use futures_channel::oneshot;
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
+use std::borrow::Borrow;
+use std::fmt::{Debug, Formatter};
+use std::path::Path;
 use tokio::{sync::mpsc::Receiver, time};
+use aptos_schemadb::{ColumnFamilyName, DB, define_schema, Options};
+use crate::dag::reliable_broadcast::Status::NothingToSend;
+use aptos_crypto::HashValue;
+use aptos_schemadb::schema::{KeyCodec, Schema, ValueCodec};
+use serde::{Deserialize, Serialize};
+use anyhow::Result;
 
 #[allow(dead_code)]
 #[derive(Debug)]
@@ -28,26 +37,122 @@ pub(crate) enum ReliableBroadcastCommand {
     BroadcastRequest(Node),
 }
 
-enum Status {
+pub trait ReliableBroadcastStorage {
+    fn new(peer_id: PeerId, epoch: u64) -> Self; // peer_id + epoch should be enough to identify?
+    fn load_all(&mut self) -> Option<ReliableBroadcastInMem>;
+    fn save_all(&mut self, in_mem: &ReliableBroadcastInMem);
+}
+
+pub struct NaiveReliableBroadcastStorage {
+    db: DB,
+}
+
+define_schema!(ReliableBroadcastStateSchema, HashValue, ReliableBroadcastInMem, "cf1");
+
+impl KeyCodec<ReliableBroadcastStateSchema> for HashValue {
+    fn encode_key(&self) -> Result<Vec<u8>> {
+        Ok(self.to_vec())
+    }
+
+    fn decode_key(data: &[u8]) -> Result<Self> {
+        Ok(HashValue::from_slice(data)?)
+    }
+}
+
+impl ValueCodec<ReliableBroadcastStateSchema> for ReliableBroadcastInMem {
+    fn encode_value(&self) -> Result<Vec<u8>> {
+        Ok(bcs::to_bytes(self)?)
+    }
+
+    fn decode_value(data: &[u8]) -> Result<Self> {
+        Ok(bcs::from_bytes(data)?)
+    }
+}
+
+impl ReliableBroadcastStorage for NaiveReliableBroadcastStorage {
+    fn new(peer_id: PeerId, epoch: u64) -> Self {
+        //TODO: a "session" as a DB/CF/key prefix?
+        //TODO: find a better path.
+        let db_path_str = format!("/tmp/reliable_broadcast_dbs/{peer_id}/{epoch}");
+        let db_path = Path::new(db_path_str.as_str());
+        let column_families = vec![ReliableBroadcastStateSchema::COLUMN_FAMILY_NAME];
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+        let db_name = "name1"; //TODO: better name
+        let db = DB::open(db_path, db_name, column_families, &opts).expect("ReliableBroadcast DB open failed");
+        Self {
+            db
+        }
+    }
+
+    fn load_all(&mut self) -> Option<ReliableBroadcastInMem> {
+        let k = HashValue::default();
+        self.db.get::<ReliableBroadcastStateSchema>(&k).expect("Failed in loading reliable broadcast state!");
+        //TODO: debugging
+        None
+    }
+
+    fn save_all(&mut self, in_mem: &ReliableBroadcastInMem) {
+        let k = HashValue::default();
+        self.db.put::<ReliableBroadcastStateSchema>(&k, in_mem).expect("Failed in saving reliable broadcast state!");
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub enum Status {
     NothingToSend,
     SendingNode(Node, IncrementalNodeCertificateState),
     SendingCertificate(CertifiedNode, AckSet),
 }
 
-// TODO: should we use the same message for node and certifade node -> create two verified events.
+// TODO: should we use the same message for node and certificate node -> create two verified events.
 
-pub struct ReliableBroadcast {
-    my_id: PeerId,
-    epoch: u64,
-    status: Status,
-    peer_round_signatures: BTreeMap<(Round, PeerId), SignedNodeDigest>,
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct ReliableBroadcastInMem {
+    pub my_id: PeerId,
+    pub epoch: u64,
+    pub status: Status,
+    pub peer_round_signatures: BTreeMap<(Round, PeerId), SignedNodeDigest>,
     // vs BTreeMap<Round, BTreeMap<PeerId, ConsensusMsg>> vs Hashset?
+}
+
+impl Default for ReliableBroadcastInMem {
+    fn default() -> Self {
+        Self {
+            my_id: PeerId::ONE,
+            epoch: 0,
+            status: Status::NothingToSend,
+            peer_round_signatures: BTreeMap::new(),
+        }
+    }
+}
+
+impl ReliableBroadcastInMem {
+    pub fn new(
+        my_id: PeerId,
+        epoch: u64,
+    ) -> Self {
+        let status = NothingToSend;
+        Self {
+            my_id,
+            epoch,
+            status,
+            // TODO: Do we need to clean memory inside an epoc? We need to DB between epochs.
+            peer_round_signatures: BTreeMap::new(),
+        }
+    }
+}
+
+pub struct ReliableBroadcast<T: ReliableBroadcastStorage> {
+    storage: T,
+    in_mem: ReliableBroadcastInMem,
     network_sender: NetworkSender,
     validator_verifier: ValidatorVerifier,
     validator_signer: Arc<ValidatorSigner>,
 }
 
-impl ReliableBroadcast {
+impl<T: ReliableBroadcastStorage> ReliableBroadcast<T> {
     pub fn new(
         my_id: PeerId,
         epoch: u64,
@@ -55,13 +160,10 @@ impl ReliableBroadcast {
         validator_verifier: ValidatorVerifier,
         validator_signer: Arc<ValidatorSigner>,
     ) -> Self {
+        let mut storage = T::new(my_id, epoch);
         Self {
-            my_id,
-            epoch,
-            status: Status::NothingToSend, // TODO status should be persisted.
-            // TODO: we need to persist the map and rebuild after crash
-            // TODO: Do we need to clean memory inside an epoc? We need to DB between epochs.
-            peer_round_signatures: BTreeMap::new(),
+            storage,
+            in_mem: ReliableBroadcastInMem::default(),
             network_sender,
             validator_verifier,
             validator_signer,
@@ -70,17 +172,19 @@ impl ReliableBroadcast {
 
     async fn handle_broadcast_request(&mut self, node: Node) {
         // It is live to stop broadcasting the previous node at this point.
-        self.status = Status::SendingNode(
+        self.in_mem.status = Status::SendingNode(
             node.clone(),
             IncrementalNodeCertificateState::new(node.digest()),
-        ); // TODO: should we persist?
+        );
+        self.persist_state(); //TODO: only write the part being changed.
+
         self.network_sender.send_node(node, None).await
     }
 
     // TODO: verify earlier that digest matches the node and epoch is right.
     // TODO: verify node has n-f parents(?).
     async fn handle_node_message(&mut self, node: Node) {
-        match self
+        match self.in_mem
             .peer_round_signatures
             .get(&(node.round(), node.source()))
         {
@@ -91,55 +195,58 @@ impl ReliableBroadcast {
             },
             None => {
                 let signed_node_digest =
-                    SignedNodeDigest::new(self.epoch, node.digest(), self.validator_signer.clone())
+                    SignedNodeDigest::new(self.in_mem.epoch, node.digest(), self.validator_signer.clone())
                         .unwrap();
-                self.peer_round_signatures
+                self.in_mem.peer_round_signatures
                     .insert((node.round(), node.source()), signed_node_digest.clone());
-                // TODO: persist
+                self.persist_state();  //TODO: only write the part being changed.
                 self.network_sender
                     .send_signed_node_digest(signed_node_digest, vec![node.source()])
                     .await;
             },
         }
     }
-
-    fn handle_signed_digest(
+    fn persist_state(&mut self) {
+        self.storage.save_all(&self.in_mem);
+    }
+    async fn handle_signed_digest(
         &mut self,
         signed_node_digest: SignedNodeDigest,
     ) -> Option<CertifiedNode> {
-        let mut certificate_done = false;
+        match &mut self.in_mem.status {
+            Status::SendingNode(node, incremental_node_certificate_state) => {
 
-        if let Status::SendingNode(_, incremental_node_certificate_state) = &mut self.status {
-            if let Err(e) = incremental_node_certificate_state.add_signature(signed_node_digest) {
-                info!("DAG: could not add signature, err = {:?}", e);
-            } else if incremental_node_certificate_state.ready(&self.validator_verifier) {
-                certificate_done = true;
+                if let Err(e) = incremental_node_certificate_state.add_signature(signed_node_digest.clone()) {
+                    info!("DAG: could not add signature, err = {:?}", e);
+                    None
+                } else {
+                    let maybe_node = if incremental_node_certificate_state.ready(&self.validator_verifier) {
+                        let node_certificate =
+                            incremental_node_certificate_state.take(&self.validator_verifier);
+                        let certified_node = CertifiedNode::new(node.clone(), node_certificate);
+                        let ack_set = AckSet::new(certified_node.node().digest());
+
+                        self.in_mem.status = Status::SendingCertificate(certified_node.clone(), ack_set);
+                        Some(certified_node)
+                    } else {
+                        None
+                    };
+                    self.persist_state();  //TODO: only write the part being changed.
+                    maybe_node
+                }
+            },
+            _ => {
+                None
             }
-        }
 
-        if certificate_done {
-            match std::mem::replace(&mut self.status, Status::NothingToSend) {
-                Status::SendingNode(node, incremental_node_certificate_state) => {
-                    let node_certificate =
-                        incremental_node_certificate_state.take(&self.validator_verifier);
-                    let certified_node = CertifiedNode::new(node, node_certificate);
-                    let ack_set = AckSet::new(certified_node.node().digest());
-
-                    self.status = Status::SendingCertificate(certified_node.clone(), ack_set); // TODO: should we persist status? probably yes.
-                    Some(certified_node)
-                },
-                _ => unreachable!("dag: status has to be SendingNode"),
-            }
-        } else {
-            None
         }
     }
 
     // TODO: consider marge node and certified node and use a trait to resend message.
     async fn handle_tick(&mut self) {
-        match &self.status {
+        match &self.in_mem.status {
             // Status::NothingToSend => info!("DAG: reliable broadcast has nothing to resend on tick peer_id {},", self.my_id),
-            Status::NothingToSend => info!("DAG: reliable broadcast has nothing to resend on tick"),
+            NothingToSend => info!("DAG: reliable broadcast has nothing to resend on tick"),
             Status::SendingNode(node, incremental_node_certificate_state) => {
                 self.network_sender
                     .send_node(
@@ -163,14 +270,15 @@ impl ReliableBroadcast {
         };
     }
 
-    fn handle_certified_node_ack_msg(&mut self, ack: CertifiedNodeAck) {
-        match &mut self.status {
+    async fn handle_certified_node_ack_msg(&mut self, ack: CertifiedNodeAck) {
+        match &mut self.in_mem.status {
             Status::SendingCertificate(certified_node, ack_set) => {
                 // TODO: check ack is up to date!
                 if ack.digest() == certified_node.digest() {
                     ack_set.add(ack);
                     if ack_set.missing_peers(&self.validator_verifier).is_empty() {
-                        self.status = Status::NothingToSend;
+                        self.in_mem.status = Status::NothingToSend;
+                        self.persist_state(); //TODO: only write the part being changed.
                     }
                 }
             },
@@ -184,6 +292,15 @@ impl ReliableBroadcast {
         mut command_rx: Receiver<ReliableBroadcastCommand>,
         close_rx: oneshot::Receiver<oneshot::Sender<()>>,
     ) {
+
+        let in_mem = if let Some(in_mem) = self.storage.load_all() {
+            in_mem
+        } else {
+            let in_mem = ReliableBroadcastInMem::new(self.in_mem.my_id, self.in_mem.epoch);
+            self.persist_state(); //TODO: only write the part being changed.
+            in_mem
+        };
+
         // TODO: think about tick readability and races.
         let mut interval = time::interval(Duration::from_millis(500)); // TODO: time out should be slightly more than one network round trip.
         let mut close_rx = close_rx.into_stream();
@@ -212,7 +329,7 @@ impl ReliableBroadcast {
                         },
 
                         VerifiedEvent::SignedNodeDigestMsg(signed_node_digest) => {
-                            if let Some(certified_node) = self.handle_signed_digest(*signed_node_digest) {
+                            if let Some(certified_node) = self.handle_signed_digest(*signed_node_digest).await {
                                 self.network_sender.send_certified_node(certified_node, None, true).await;
                                 interval.reset();
                             }
@@ -221,7 +338,7 @@ impl ReliableBroadcast {
 
 
                         VerifiedEvent::CertifiedNodeAckMsg(ack) => {
-                            self.handle_certified_node_ack_msg(*ack);
+                            self.handle_certified_node_ack_msg(*ack).await;
                         },
 
                         _ => unreachable!("reliable broadcast got wrong messsgae"),

--- a/consensus/src/dag/reliable_broadcast/mod.rs
+++ b/consensus/src/dag/reliable_broadcast/mod.rs
@@ -3,6 +3,8 @@
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod storage;
+
 use crate::{
     dag::types::{AckSet, IncrementalNodeCertificateState},
     network::{DagSender, NetworkSender},
@@ -15,21 +17,15 @@ use aptos_consensus_types::{
 };
 use aptos_logger::info;
 use aptos_types::{
-    validator_signer::ValidatorSigner, validator_verifier::ValidatorVerifier, PeerId,
+    PeerId, validator_signer::ValidatorSigner, validator_verifier::ValidatorVerifier,
 };
 use futures::{FutureExt, StreamExt};
 use futures_channel::oneshot;
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
-use std::borrow::Borrow;
-use std::fmt::{Debug, Formatter};
 use std::path::Path;
 use tokio::{sync::mpsc::Receiver, time};
-use aptos_schemadb::{ColumnFamilyName, DB, define_schema, Options};
-use crate::dag::reliable_broadcast::Status::NothingToSend;
-use aptos_crypto::HashValue;
-use aptos_schemadb::schema::{KeyCodec, Schema, ValueCodec};
-use serde::{Deserialize, Serialize};
-use anyhow::Result;
+use storage::ReliableBroadcastStorage;
+use serde::{Serialize, Deserialize};
 
 #[allow(dead_code)]
 #[derive(Debug)]
@@ -37,137 +33,68 @@ pub(crate) enum ReliableBroadcastCommand {
     BroadcastRequest(Node),
 }
 
-pub trait ReliableBroadcastStorage {
-    fn new(peer_id: PeerId, epoch: u64) -> Self; // peer_id + epoch should be enough to identify?
-    fn load_all(&mut self) -> Option<ReliableBroadcastInMem>;
-    fn save_all(&mut self, in_mem: &ReliableBroadcastInMem);
-}
-
-pub struct NaiveReliableBroadcastStorage {
-    db: DB,
-}
-
-define_schema!(ReliableBroadcastStateSchema, HashValue, ReliableBroadcastInMem, "cf1");
-
-impl KeyCodec<ReliableBroadcastStateSchema> for HashValue {
-    fn encode_key(&self) -> Result<Vec<u8>> {
-        Ok(self.to_vec())
-    }
-
-    fn decode_key(data: &[u8]) -> Result<Self> {
-        Ok(HashValue::from_slice(data)?)
-    }
-}
-
-impl ValueCodec<ReliableBroadcastStateSchema> for ReliableBroadcastInMem {
-    fn encode_value(&self) -> Result<Vec<u8>> {
-        Ok(bcs::to_bytes(self)?)
-    }
-
-    fn decode_value(data: &[u8]) -> Result<Self> {
-        Ok(bcs::from_bytes(data)?)
-    }
-}
-
-impl ReliableBroadcastStorage for NaiveReliableBroadcastStorage {
-    fn new(peer_id: PeerId, epoch: u64) -> Self {
-        //TODO: a "session" as a DB/CF/key prefix?
-        //TODO: find a better path.
-        let db_path_str = format!("/tmp/reliable_broadcast_dbs/{peer_id}/{epoch}");
-        let db_path = Path::new(db_path_str.as_str());
-        let column_families = vec![ReliableBroadcastStateSchema::COLUMN_FAMILY_NAME];
-        let mut opts = Options::default();
-        opts.create_if_missing(true);
-        opts.create_missing_column_families(true);
-        let db_name = "name1"; //TODO: better name
-        let db = DB::open(db_path, db_name, column_families, &opts).expect("ReliableBroadcast DB open failed");
-        Self {
-            db
-        }
-    }
-
-    fn load_all(&mut self) -> Option<ReliableBroadcastInMem> {
-        let k = HashValue::default();
-        self.db.get::<ReliableBroadcastStateSchema>(&k).expect("Failed in loading reliable broadcast state!");
-        //TODO: debugging
-        None
-    }
-
-    fn save_all(&mut self, in_mem: &ReliableBroadcastInMem) {
-        let k = HashValue::default();
-        self.db.put::<ReliableBroadcastStateSchema>(&k, in_mem).expect("Failed in saving reliable broadcast state!");
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
-pub enum Status {
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+enum Status {
     NothingToSend,
     SendingNode(Node, IncrementalNodeCertificateState),
     SendingCertificate(CertifiedNode, AckSet),
 }
 
-// TODO: should we use the same message for node and certificate node -> create two verified events.
-
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+/// The in-mem copy of a ReliableBroadcast state.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ReliableBroadcastInMem {
-    pub my_id: PeerId,
-    pub epoch: u64,
-    pub status: Status,
-    pub peer_round_signatures: BTreeMap<(Round, PeerId), SignedNodeDigest>,
+    my_id: PeerId,
+    epoch: u64,
+    status: Status,
+    peer_round_signatures: BTreeMap<(Round, PeerId), SignedNodeDigest>,
     // vs BTreeMap<Round, BTreeMap<PeerId, ConsensusMsg>> vs Hashset?
 }
 
-impl Default for ReliableBroadcastInMem {
-    fn default() -> Self {
-        Self {
-            my_id: PeerId::ONE,
-            epoch: 0,
-            status: Status::NothingToSend,
-            peer_round_signatures: BTreeMap::new(),
-        }
-    }
-}
+// TODO: should we use the same message for node and certifade node -> create two verified events.
 
-impl ReliableBroadcastInMem {
-    pub fn new(
-        my_id: PeerId,
-        epoch: u64,
-    ) -> Self {
-        let status = NothingToSend;
-        Self {
-            my_id,
-            epoch,
-            status,
-            // TODO: Do we need to clean memory inside an epoc? We need to DB between epochs.
-            peer_round_signatures: BTreeMap::new(),
-        }
-    }
-}
-
-pub struct ReliableBroadcast<T: ReliableBroadcastStorage> {
-    storage: T,
+pub struct ReliableBroadcast {
     in_mem: ReliableBroadcastInMem,
+    storage: Arc<dyn ReliableBroadcastStorage>,
     network_sender: NetworkSender,
     validator_verifier: ValidatorVerifier,
     validator_signer: Arc<ValidatorSigner>,
 }
 
-impl<T: ReliableBroadcastStorage> ReliableBroadcast<T> {
+impl ReliableBroadcast {
     pub fn new(
         my_id: PeerId,
         epoch: u64,
+        storage: Arc<dyn ReliableBroadcastStorage>,
         network_sender: NetworkSender,
         validator_verifier: ValidatorVerifier,
         validator_signer: Arc<ValidatorSigner>,
     ) -> Self {
-        let mut storage = T::new(my_id, epoch);
+        //TODO: is this a good time to clean up?
+        let in_mem = if let Some(in_mem) = storage.load_all(my_id, epoch) {
+            in_mem
+        } else {
+            let in_mem = ReliableBroadcastInMem {
+                my_id,
+                epoch,
+                status: Status::NothingToSend,
+                peer_round_signatures: BTreeMap::new(),
+            };
+            storage.save_all(my_id, epoch, &in_mem);
+            in_mem
+        };
         Self {
+            in_mem,
             storage,
-            in_mem: ReliableBroadcastInMem::default(),
+            // TODO: we need to persist the map and rebuild after crash
+            // TODO: Do we need to clean memory inside an epoc? We need to DB between epochs.
             network_sender,
             validator_verifier,
             validator_signer,
         }
+    }
+
+    fn persist_state(&mut self) {
+        self.storage.save_all(self.in_mem.my_id, self.in_mem.epoch, &self.in_mem);
     }
 
     async fn handle_broadcast_request(&mut self, node: Node) {
@@ -176,16 +103,15 @@ impl<T: ReliableBroadcastStorage> ReliableBroadcast<T> {
             node.clone(),
             IncrementalNodeCertificateState::new(node.digest()),
         );
-        self.persist_state(); //TODO: only write the part being changed.
-
+        self.persist_state();
         self.network_sender.send_node(node, None).await
     }
 
     // TODO: verify earlier that digest matches the node and epoch is right.
     // TODO: verify node has n-f parents(?).
     async fn handle_node_message(&mut self, node: Node) {
-        match self.in_mem
-            .peer_round_signatures
+        match self
+            .in_mem.peer_round_signatures
             .get(&(node.round(), node.source()))
         {
             Some(signed_node_digest) => {
@@ -199,46 +125,47 @@ impl<T: ReliableBroadcastStorage> ReliableBroadcast<T> {
                         .unwrap();
                 self.in_mem.peer_round_signatures
                     .insert((node.round(), node.source()), signed_node_digest.clone());
-                self.persist_state();  //TODO: only write the part being changed.
+                self.persist_state(); //TODO: only write the diff.
                 self.network_sender
                     .send_signed_node_digest(signed_node_digest, vec![node.source()])
                     .await;
             },
         }
     }
-    fn persist_state(&mut self) {
-        self.storage.save_all(&self.in_mem);
-    }
-    async fn handle_signed_digest(
+
+    fn handle_signed_digest(
         &mut self,
         signed_node_digest: SignedNodeDigest,
     ) -> Option<CertifiedNode> {
-        match &mut self.in_mem.status {
-            Status::SendingNode(node, incremental_node_certificate_state) => {
+        let mut certificate_done = false;
 
-                if let Err(e) = incremental_node_certificate_state.add_signature(signed_node_digest.clone()) {
-                    info!("DAG: could not add signature, err = {:?}", e);
-                    None
-                } else {
-                    let maybe_node = if incremental_node_certificate_state.ready(&self.validator_verifier) {
-                        let node_certificate =
-                            incremental_node_certificate_state.take(&self.validator_verifier);
-                        let certified_node = CertifiedNode::new(node.clone(), node_certificate);
-                        let ack_set = AckSet::new(certified_node.node().digest());
-
-                        self.in_mem.status = Status::SendingCertificate(certified_node.clone(), ack_set);
-                        Some(certified_node)
-                    } else {
-                        None
-                    };
-                    self.persist_state();  //TODO: only write the part being changed.
-                    maybe_node
+        if let Status::SendingNode(_, incremental_node_certificate_state) = &mut self.in_mem.status {
+            if let Err(e) = incremental_node_certificate_state.add_signature(signed_node_digest) {
+                info!("DAG: could not add signature, err = {:?}", e);
+            } else {
+                if incremental_node_certificate_state.ready(&self.validator_verifier) {
+                    certificate_done = true;
                 }
-            },
-            _ => {
-                None
+                self.persist_state();//TODO: only write the diff.
             }
+        }
 
+        if certificate_done {
+            match std::mem::replace(&mut self.in_mem.status, Status::NothingToSend) {
+                Status::SendingNode(node, incremental_node_certificate_state) => {
+                    let node_certificate =
+                        incremental_node_certificate_state.take(&self.validator_verifier);
+                    let certified_node = CertifiedNode::new(node, node_certificate);
+                    let ack_set = AckSet::new(certified_node.node().digest());
+
+                    self.in_mem.status = Status::SendingCertificate(certified_node.clone(), ack_set);
+                    self.persist_state(); //TODO: only write the diff.
+                    Some(certified_node)
+                },
+                _ => unreachable!("dag: status has to be SendingNode"),
+            }
+        } else {
+            None
         }
     }
 
@@ -246,7 +173,7 @@ impl<T: ReliableBroadcastStorage> ReliableBroadcast<T> {
     async fn handle_tick(&mut self) {
         match &self.in_mem.status {
             // Status::NothingToSend => info!("DAG: reliable broadcast has nothing to resend on tick peer_id {},", self.my_id),
-            NothingToSend => info!("DAG: reliable broadcast has nothing to resend on tick"),
+            Status::NothingToSend => info!("DAG: reliable broadcast has nothing to resend on tick"),
             Status::SendingNode(node, incremental_node_certificate_state) => {
                 self.network_sender
                     .send_node(
@@ -270,7 +197,7 @@ impl<T: ReliableBroadcastStorage> ReliableBroadcast<T> {
         };
     }
 
-    async fn handle_certified_node_ack_msg(&mut self, ack: CertifiedNodeAck) {
+    fn handle_certified_node_ack_msg(&mut self, ack: CertifiedNodeAck) {
         match &mut self.in_mem.status {
             Status::SendingCertificate(certified_node, ack_set) => {
                 // TODO: check ack is up to date!
@@ -278,8 +205,8 @@ impl<T: ReliableBroadcastStorage> ReliableBroadcast<T> {
                     ack_set.add(ack);
                     if ack_set.missing_peers(&self.validator_verifier).is_empty() {
                         self.in_mem.status = Status::NothingToSend;
-                        self.persist_state(); //TODO: only write the part being changed.
                     }
+                    self.persist_state(); //TODO: only write the diff.
                 }
             },
             _ => {},
@@ -292,15 +219,6 @@ impl<T: ReliableBroadcastStorage> ReliableBroadcast<T> {
         mut command_rx: Receiver<ReliableBroadcastCommand>,
         close_rx: oneshot::Receiver<oneshot::Sender<()>>,
     ) {
-
-        let in_mem = if let Some(in_mem) = self.storage.load_all() {
-            in_mem
-        } else {
-            let in_mem = ReliableBroadcastInMem::new(self.in_mem.my_id, self.in_mem.epoch);
-            self.persist_state(); //TODO: only write the part being changed.
-            in_mem
-        };
-
         // TODO: think about tick readability and races.
         let mut interval = time::interval(Duration::from_millis(500)); // TODO: time out should be slightly more than one network round trip.
         let mut close_rx = close_rx.into_stream();
@@ -329,7 +247,7 @@ impl<T: ReliableBroadcastStorage> ReliableBroadcast<T> {
                         },
 
                         VerifiedEvent::SignedNodeDigestMsg(signed_node_digest) => {
-                            if let Some(certified_node) = self.handle_signed_digest(*signed_node_digest).await {
+                            if let Some(certified_node) = self.handle_signed_digest(*signed_node_digest) {
                                 self.network_sender.send_certified_node(certified_node, None, true).await;
                                 interval.reset();
                             }
@@ -338,7 +256,7 @@ impl<T: ReliableBroadcastStorage> ReliableBroadcast<T> {
 
 
                         VerifiedEvent::CertifiedNodeAckMsg(ack) => {
-                            self.handle_certified_node_ack_msg(*ack).await;
+                            self.handle_certified_node_ack_msg(*ack);
                         },
 
                         _ => unreachable!("reliable broadcast got wrong messsgae"),

--- a/consensus/src/dag/reliable_broadcast/storage.rs
+++ b/consensus/src/dag/reliable_broadcast/storage.rs
@@ -1,0 +1,111 @@
+// Copyright © Aptos Foundation
+
+use std::path::Path;
+use aptos_logger::info;
+use aptos_schemadb::{DB, define_schema, Options};
+use aptos_schemadb::schema::{KeyCodec, ValueCodec};
+use aptos_types::PeerId;
+use crate::dag::reliable_broadcast::ReliableBroadcastInMem;
+use anyhow::{Error, Result};
+use move_core_types::account_address::AccountAddress;
+
+pub const RELIABLE_BROADCAST_DB_NAME: &str = "ReliableBroadcastDB";
+
+pub trait ReliableBroadcastStorage: Sync + Send {
+    fn load_all(&self, my_id: PeerId, epoch: u64) -> Option<ReliableBroadcastInMem>; //(peer_id, epoch) enough to identify?
+    fn save_all(&self, my_id: PeerId, epoch: u64, in_mem: &ReliableBroadcastInMem);
+}
+
+pub struct NaiveReliableBroadcastDB {
+    db: DB,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct NaiveKey {
+    id: PeerId,
+    epoch: u64,
+}
+
+define_schema!(ReliableBroadcastStateSchema, NaiveKey, ReliableBroadcastInMem, "cf1");
+
+impl KeyCodec<ReliableBroadcastStateSchema> for NaiveKey {
+    fn encode_key(&self) -> Result<Vec<u8>> {
+        let mut buf = Vec::with_capacity(AccountAddress::LENGTH + 8);
+        buf.extend_from_slice(self.id.as_slice());
+        let epoch_buf = self.epoch.to_be_bytes();
+        buf.extend_from_slice(epoch_buf.as_slice());
+        Ok(buf)
+    }
+
+    fn decode_key(data: &[u8]) -> Result<Self> {
+        if data.len() != AccountAddress::LENGTH + 8 {
+            return Err(Error::msg("Invalid key for ReliableBroadcastStateSchema"));
+        }
+        let id = PeerId::from_bytes(&data[0..AccountAddress::LENGTH])?;
+        let mut buf = [0_u8; 8];
+        buf.copy_from_slice(&data[AccountAddress::LENGTH..AccountAddress::LENGTH+8]);
+        let epoch= u64::from_le_bytes(buf);
+        Ok(NaiveKey{ id, epoch })
+    }
+}
+
+impl ValueCodec<ReliableBroadcastStateSchema> for ReliableBroadcastInMem {
+    fn encode_value(&self) -> Result<Vec<u8>> {
+        Ok(bcs::to_bytes(self)?)
+    }
+
+    fn decode_value(data: &[u8]) -> Result<Self> {
+        Ok(bcs::from_bytes(data)?)
+    }
+}
+
+impl NaiveReliableBroadcastDB {
+    pub fn new<P: AsRef<Path> + Clone>(db_root_path: P) -> Self {
+        let column_families = vec!["cf1"];
+
+        let path = db_root_path.as_ref().join(RELIABLE_BROADCAST_DB_NAME);
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+        let db = DB::open(path.clone(), RELIABLE_BROADCAST_DB_NAME, column_families, &opts)
+            .expect("ReliableBroadcastDB open failed; unable to continue");
+
+        info!(
+            "Opened ReliableBroadcastDB at {:?}",
+            path,
+        );
+
+        Self { db }
+    }
+}
+
+impl ReliableBroadcastStorage for NaiveReliableBroadcastDB {
+    fn load_all(&self, my_id: PeerId, epoch: u64) -> Option<ReliableBroadcastInMem> {
+        info!("NaiveReliableBroadcastDB::load_all(my_id={my_id}, epoch={epoch},in_mem=...)");
+        let key = NaiveKey{ id: my_id, epoch };
+        self.db.get::<ReliableBroadcastStateSchema>(&key).expect(format!("Failed in loading ReliableBroadcast state for id {my_id}, epoch {epoch} from NaiveReliableBroadcastDB.").as_str())
+    }
+
+    fn save_all(&self, my_id: PeerId, epoch: u64, in_mem: &ReliableBroadcastInMem) {
+        info!("NaiveReliableBroadcastDB::save_all(my_id={my_id}, epoch={epoch},in_mem=...)");
+        let key = NaiveKey{ id: my_id, epoch };
+        self.db.put::<ReliableBroadcastStateSchema>(&key, in_mem).expect(format!("Failed in saving ReliableBroadcast state for id {my_id}, epoch {epoch} into NaiveReliableBroadcastDB.").as_str());
+    }
+}
+
+pub struct MockReliableBroadcastDB {}
+
+impl MockReliableBroadcastDB {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ReliableBroadcastStorage for MockReliableBroadcastDB {
+    fn load_all(&self, my_id: PeerId, epoch: u64) -> Option<ReliableBroadcastInMem> {
+        None
+    }
+
+    fn save_all(&self, my_id: PeerId, epoch: u64, in_mem: &ReliableBroadcastInMem) {
+    }
+}

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -1,3 +1,5 @@
+// Copyright © Aptos Foundation
+
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,13 +12,14 @@ use aptos_types::{
     aggregate_signature::PartialSignatures, validator_verifier::ValidatorVerifier, PeerId,
 };
 use std::collections::{BTreeMap, HashSet};
-
+use serde::{Serialize, Deserialize};
 // pub(crate) trait MissingPeers {
 //     fn get_peers_signatures() -> HashSet<PeerId>;
 // }
 
 #[allow(dead_code)]
-pub(crate) struct IncrementalNodeCertificateState {
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct IncrementalNodeCertificateState {
     signed_node_digest_info: SignedNodeDigestInfo,
     aggregated_signature: BTreeMap<PeerId, bls12381::Signature>,
 }
@@ -69,18 +72,19 @@ impl IncrementalNodeCertificateState {
             .is_ok()
     }
 
-    pub(crate) fn take(self, validator_verifier: &ValidatorVerifier) -> NodeCertificate {
+    pub(crate) fn take(&self, validator_verifier: &ValidatorVerifier) -> NodeCertificate {
         let proof = match validator_verifier
-            .aggregate_signatures(&PartialSignatures::new(self.aggregated_signature))
+            .aggregate_signatures(&PartialSignatures::new(self.aggregated_signature.clone()))
         {
-            Ok(sig) => NodeCertificate::new(self.signed_node_digest_info, sig),
+            Ok(sig) => NodeCertificate::new(self.signed_node_digest_info.clone(), sig),
             Err(e) => unreachable!("Cannot aggregate signatures on digest err = {:?}", e),
         };
         proof
     }
 }
 
-pub(crate) struct AckSet {
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct AckSet {
     digest: HashValue,
     set: HashSet<PeerId>,
 }

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -96,6 +96,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
+use crate::dag::reliable_broadcast::storage::ReliableBroadcastStorage;
 
 /// Range of rounds (window) that we might be calling proposer election
 /// functions with at any given time, in addition to the proposer history length.
@@ -148,6 +149,7 @@ pub struct EpochManager {
     bounded_executor: BoundedExecutor,
     // recovery_mode is set to true when the recovery manager is spawned
     recovery_mode: bool,
+    rb_storage: Arc<dyn ReliableBroadcastStorage>,
 }
 
 #[allow(dead_code)]
@@ -164,6 +166,7 @@ impl EpochManager {
         quorum_store_storage: Arc<dyn QuorumStoreStorage>,
         reconfig_events: ReconfigNotificationListener,
         bounded_executor: BoundedExecutor,
+        rb_storage: Arc<dyn ReliableBroadcastStorage>,
     ) -> Self {
         let author = node_config.validator_network.as_ref().unwrap().peer_id();
         let config = node_config.consensus.clone();
@@ -198,6 +201,7 @@ impl EpochManager {
             batch_retrieval_tx: None,
             bounded_executor,
             recovery_mode: false,
+            rb_storage,
         }
     }
 
@@ -758,6 +762,7 @@ impl EpochManager {
             self.epoch(),
             self.author,
             self.config.dag_config.clone(),
+            self.rb_storage.clone(),
             payload_client,
             network_sender,
             epoch_state.verifier.clone(),

--- a/consensus/src/test_utils/mock_payload_manager.rs
+++ b/consensus/src/test_utils/mock_payload_manager.rs
@@ -17,6 +17,7 @@ use aptos_types::{
 use futures::{channel::mpsc, future::BoxFuture};
 use rand::Rng;
 use std::time::Duration;
+use crate::dag::reliable_broadcast::storage::ReliableBroadcastStorage;
 
 #[allow(dead_code)]
 pub struct MockPayloadManager {

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -50,6 +50,7 @@ use futures::{channel::mpsc, StreamExt};
 use maplit::hashmap;
 use std::{collections::HashMap, iter::FromIterator, sync::Arc};
 use tokio::runtime::Runtime;
+use crate::dag::reliable_broadcast::storage::MockReliableBroadcastDB;
 
 /// Auxiliary struct that is preparing SMR for the test
 pub struct SMRNode {
@@ -140,6 +141,7 @@ impl SMRNode {
 
         let quorum_store_storage = Arc::new(MockQuorumStoreDB::new());
         let bounded_executor = BoundedExecutor::new(2, playground.handle());
+        let mock_rb_db = Arc::new(MockReliableBroadcastDB::new());
 
         let epoch_mgr = EpochManager::new(
             &config,
@@ -153,6 +155,7 @@ impl SMRNode {
             quorum_store_storage,
             reconfig_listener,
             bounded_executor,
+            mock_rb_db,
         );
         let (network_task, network_receiver) =
             NetworkTask::new(network_service_events, self_receiver);


### PR DESCRIPTION
### TODO
- [ ] update schema so we can write diff only when writing

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 18212fb</samp>

This pull request enhances the reliable broadcast protocol in the consensus layer by adding persistent storage support, generic storage parameters, and testing utilities. It also improves the serialization and ownership handling of some consensus types and fixes some minor formatting issues.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### AI-powered Walkthrough
<!-- Delete this section if you don't want the AI to create a detailed walkthrough of your PR -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 18212fb</samp>

*  Add `Eq` and `PartialEq` traits to `SignedNodeDigest`, `NodeCertificate`, and `CertifiedNode` structs for comparison and testing ([link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-e56408e7d26b991c472271fbd867f4de0e5ed82fbc8fcf3fdd1e1cdfcabc5867L38-R38), [link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-e56408e7d26b991c472271fbd867f4de0e5ed82fbc8fcf3fdd1e1cdfcabc5867L88-R88), [link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-e56408e7d26b991c472271fbd867f4de0e5ed82fbc8fcf3fdd1e1cdfcabc5867L317-R317))
*  Add `Serialize` and `Deserialize` traits to `IncrementalNodeCertificateState`, `AckSet`, and `ReliableBroadcastInMem` structs for serialization and deserialization ([link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-c79d149558f9811365936e1f5ee1c9782824948885d96319957e537032ce3380L19-R22), [link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-c79d149558f9811365936e1f5ee1c9782824948885d96319957e537032ce3380L83-R87), [link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-52b1f018313908cd415e25d01b291c5f0d72e211601f7ec2e2f3c0bef141e554L37-R149))
*  Add `ReliableBroadcastStorage` trait and `NaiveReliableBroadcastStorage` struct to abstract and implement the storage logic for `ReliableBroadcast` ([link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-52b1f018313908cd415e25d01b291c5f0d72e211601f7ec2e2f3c0bef141e554L31-R103))
*  Add generic parameter `<T: ReliableBroadcastStorage>` to `ReliableBroadcast` struct and constructor to allow different storage implementations ([link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-52b1f018313908cd415e25d01b291c5f0d72e211601f7ec2e2f3c0bef141e554L50-R155), [link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-95423e57e1d4cbeeedb595e3d3831b9e834a4a80aad5ba84f78468a3a67edab2R37), [link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-95423e57e1d4cbeeedb595e3d3831b9e834a4a80aad5ba84f78468a3a67edab2L73-R74))
*  Replace multiple fields of `ReliableBroadcast` with a single `in_mem` field of type `ReliableBroadcastInMem` and add a `storage` field of type `T` ([link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-52b1f018313908cd415e25d01b291c5f0d72e211601f7ec2e2f3c0bef141e554L58-R166))
*  Add calls to `self.persist_state()` after updating the `in_mem` field of `ReliableBroadcast` in various methods to save the state to the storage ([link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-52b1f018313908cd415e25d01b291c5f0d72e211601f7ec2e2f3c0bef141e554L73-R180), [link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-52b1f018313908cd415e25d01b291c5f0d72e211601f7ec2e2f3c0bef141e554L94-R202), [link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-52b1f018313908cd415e25d01b291c5f0d72e211601f7ec2e2f3c0bef141e554L173-R281))
*  Make `handle_signed_digest` and `handle_certified_node_ack_msg` methods of `ReliableBroadcast` `async` and return `Option<CertifiedNode>` and `()` respectively ([link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-52b1f018313908cd415e25d01b291c5f0d72e211601f7ec2e2f3c0bef141e554L105-R241), [link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-52b1f018313908cd415e25d01b291c5f0d72e211601f7ec2e2f3c0bef141e554L166-R274))
*  Access the `in_mem` field of `ReliableBroadcast` instead of the removed fields in various methods to reflect the new structure ([link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-52b1f018313908cd415e25d01b291c5f0d72e211601f7ec2e2f3c0bef141e554L83-R187), [link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-52b1f018313908cd415e25d01b291c5f0d72e211601f7ec2e2f3c0bef141e554L140-R249))
*  Add `await` keywords to the calls to `handle_signed_digest` and `handle_certified_node_ack_msg` in the `run` method of `ReliableBroadcast` to reflect the new `async` signatures ([link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-52b1f018313908cd415e25d01b291c5f0d72e211601f7ec2e2f3c0bef141e554L215-R332), [link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-52b1f018313908cd415e25d01b291c5f0d72e211601f7ec2e2f3c0bef141e554L224-R341))
*  Add a block of code to the `run` method of `ReliableBroadcast` to load the `in_mem` state from the storage if it exists or create a new one and save it otherwise ([link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-52b1f018313908cd415e25d01b291c5f0d72e211601f7ec2e2f3c0bef141e554R295-R303))
*  Modify the `take` method of `IncrementalNodeCertificateState` to take a reference to `self` instead of consuming it and to clone the fields that are moved in the method to avoid ownership issues ([link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-c79d149558f9811365936e1f5ee1c9782824948885d96319957e537032ce3380L72-R79))
*  Add a blank line to `consensus/src/dag/dag.rs` for formatting purposes ([link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-9fce551236f22b2c42de31e164ea8cf62fcbf53655524a72db8c43ec5c768614R330))
*  Add a comment with the license notice to the top of `consensus/src/dag/types.rs` ([link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-c79d149558f9811365936e1f5ee1c9782824948885d96319957e537032ce3380R1-R2))
*  Add several imports of modules and traits to `consensus/src/dag/reliable_broadcast.rs` to use the `aptos_schemadb` crate and other dependencies ([link](https://github.com/aptos-labs/aptos-core/pull/7988/files?diff=unified&w=0#diff-52b1f018313908cd415e25d01b291c5f0d72e211601f7ec2e2f3c0bef141e554L23-R32))
