### PR TITLE
[framework] Add rewards view functions to vesting

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/stake.md
+++ b/aptos-move/framework/aptos-framework/doc/stake.md
@@ -106,6 +106,7 @@
 -  [Function `assert_owner_cap_exists`](#0x1_stake_assert_owner_cap_exists)
 -  [Specification](#@Specification_1)
     -  [Function `add_transaction_fee`](#@Specification_1_add_transaction_fee)
+    -  [Function `get_stake`](#@Specification_1_get_stake)
     -  [Function `get_validator_state`](#@Specification_1_get_validator_state)
     -  [Function `initialize`](#@Specification_1_initialize)
     -  [Function `remove_validators`](#@Specification_1_remove_validators)
@@ -3545,6 +3546,63 @@ Returns validator's next epoch voting power, including pending_active, active, a
 
 
 
+
+<a name="0x1_stake_spec_rewards_amount"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_rewards_amount">spec_rewards_amount</a>(
+   stake_amount: u64,
+   num_successful_proposals: u64,
+   num_total_proposals: u64,
+   rewards_rate: u64,
+   rewards_rate_denominator: u64,
+): u64;
+</code></pre>
+
+
+
+
+<a name="0x1_stake_spec_contains"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a>&gt;, addr: <b>address</b>): bool {
+   <b>exists</b> i in 0..len(validators): validators[i].addr == addr
+}
+</code></pre>
+
+
+
+
+<a name="0x1_stake_spec_is_current_epoch_validator"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_is_current_epoch_validator">spec_is_current_epoch_validator</a>(pool_address: <b>address</b>): bool {
+   <b>let</b> validator_set = <b>global</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
+   !<a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.pending_active, pool_address)
+       && (<a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.active_validators, pool_address)
+       || <a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.pending_inactive, pool_address))
+}
+</code></pre>
+
+
+
+
+<a name="0x1_stake_ResourceRequirement"></a>
+
+
+<pre><code><b>schema</b> <a href="stake.md#0x1_stake_ResourceRequirement">ResourceRequirement</a> {
+    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_AptosCoinCapabilities">AptosCoinCapabilities</a>&gt;(@aptos_framework);
+    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorPerformance">ValidatorPerformance</a>&gt;(@aptos_framework);
+    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
+    <b>requires</b> <b>exists</b>&lt;StakingConfig&gt;(@aptos_framework);
+    <b>requires</b> <b>exists</b>&lt;StakingRewardsConfig&gt;(@aptos_framework) || !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_periodical_reward_rate_decrease_enabled">features::spec_periodical_reward_rate_decrease_enabled</a>();
+    <b>requires</b> <b>exists</b>&lt;<a href="timestamp.md#0x1_timestamp_CurrentTimeMicroseconds">timestamp::CurrentTimeMicroseconds</a>&gt;(@aptos_framework);
+    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">ValidatorFees</a>&gt;(@aptos_framework);
+}
+</code></pre>
+
+
+
 <a name="@Specification_1_add_transaction_fee"></a>
 
 ### Function `add_transaction_fee`
@@ -3557,6 +3615,22 @@ Returns validator's next epoch voting power, including pending_active, active, a
 
 
 <pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">ValidatorFees</a>&gt;(@aptos_framework);
+</code></pre>
+
+
+
+<a name="@Specification_1_get_stake"></a>
+
+### Function `get_stake`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="stake.md#0x1_stake_get_stake">get_stake</a>(pool_address: <b>address</b>): (u64, u64, u64, u64)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !<a href="stake.md#0x1_stake_stake_pool_exists">stake_pool_exists</a>(pool_address);
 </code></pre>
 
 
@@ -4164,63 +4238,6 @@ Returns validator's next epoch voting power, including pending_active, active, a
 
 <pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_has_validator_config">spec_has_validator_config</a>(a: <b>address</b>): bool {
    <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(a)
-}
-</code></pre>
-
-
-
-
-<a name="0x1_stake_spec_rewards_amount"></a>
-
-
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_rewards_amount">spec_rewards_amount</a>(
-   stake_amount: u64,
-   num_successful_proposals: u64,
-   num_total_proposals: u64,
-   rewards_rate: u64,
-   rewards_rate_denominator: u64,
-): u64;
-</code></pre>
-
-
-
-
-<a name="0x1_stake_spec_contains"></a>
-
-
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a>&gt;, addr: <b>address</b>): bool {
-   <b>exists</b> i in 0..len(validators): validators[i].addr == addr
-}
-</code></pre>
-
-
-
-
-<a name="0x1_stake_spec_is_current_epoch_validator"></a>
-
-
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_is_current_epoch_validator">spec_is_current_epoch_validator</a>(pool_address: <b>address</b>): bool {
-   <b>let</b> validator_set = <b>global</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
-   !<a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.pending_active, pool_address)
-       && (<a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.active_validators, pool_address)
-       || <a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.pending_inactive, pool_address))
-}
-</code></pre>
-
-
-
-
-<a name="0x1_stake_ResourceRequirement"></a>
-
-
-<pre><code><b>schema</b> <a href="stake.md#0x1_stake_ResourceRequirement">ResourceRequirement</a> {
-    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_AptosCoinCapabilities">AptosCoinCapabilities</a>&gt;(@aptos_framework);
-    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorPerformance">ValidatorPerformance</a>&gt;(@aptos_framework);
-    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
-    <b>requires</b> <b>exists</b>&lt;StakingConfig&gt;(@aptos_framework);
-    <b>requires</b> <b>exists</b>&lt;StakingRewardsConfig&gt;(@aptos_framework) || !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_periodical_reward_rate_decrease_enabled">features::spec_periodical_reward_rate_decrease_enabled</a>();
-    <b>requires</b> <b>exists</b>&lt;<a href="timestamp.md#0x1_timestamp_CurrentTimeMicroseconds">timestamp::CurrentTimeMicroseconds</a>&gt;(@aptos_framework);
-    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">ValidatorFees</a>&gt;(@aptos_framework);
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/staking_contract.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_contract.md
@@ -51,6 +51,7 @@ pool.
 -  [Function `commission_percentage`](#0x1_staking_contract_commission_percentage)
 -  [Function `staking_contract_amounts`](#0x1_staking_contract_staking_contract_amounts)
 -  [Function `pending_distribution_counts`](#0x1_staking_contract_pending_distribution_counts)
+-  [Function `total_distributable_amount`](#0x1_staking_contract_total_distributable_amount)
 -  [Function `staking_contract_exists`](#0x1_staking_contract_staking_contract_exists)
 -  [Function `create_staking_contract`](#0x1_staking_contract_create_staking_contract)
 -  [Function `create_staking_contract_with_coins`](#0x1_staking_contract_create_staking_contract_with_coins)
@@ -78,6 +79,7 @@ pool.
     -  [Function `commission_percentage`](#@Specification_1_commission_percentage)
     -  [Function `staking_contract_amounts`](#@Specification_1_staking_contract_amounts)
     -  [Function `pending_distribution_counts`](#@Specification_1_pending_distribution_counts)
+    -  [Function `total_distributable_amount`](#@Specification_1_total_distributable_amount)
     -  [Function `staking_contract_exists`](#@Specification_1_staking_contract_exists)
     -  [Function `create_staking_contract`](#@Specification_1_create_staking_contract)
     -  [Function `create_staking_contract_with_coins`](#@Specification_1_create_staking_contract_with_coins)
@@ -968,7 +970,7 @@ This errors out the staking contract with the provided staker and operator doesn
 
 Return the number of pending distributions (e.g. commission, withdrawals from stakers).
 
-This errors out the staking contract with the provided staker and operator doesn't exist.
+This errors out if the staking contract with the provided staker and operator doesn't exist.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="staking_contract.md#0x1_staking_contract_pending_distribution_counts">pending_distribution_counts</a>(staker: <b>address</b>, operator: <b>address</b>): u64
@@ -984,6 +986,38 @@ This errors out the staking contract with the provided staker and operator doesn
     <a href="staking_contract.md#0x1_staking_contract_assert_staking_contract_exists">assert_staking_contract_exists</a>(staker, operator);
     <b>let</b> staking_contracts = &<b>borrow_global</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker).staking_contracts;
     <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_shareholders_count">pool_u64::shareholders_count</a>(&<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_borrow">simple_map::borrow</a>(staking_contracts, &operator).distribution_pool)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_staking_contract_total_distributable_amount"></a>
+
+## Function `total_distributable_amount`
+
+Return the amount that will be split between all stakers the next time distribute() is called.
+
+This errors out if the staking contract with the provided staker and operator doesn't exist.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_contract.md#0x1_staking_contract_total_distributable_amount">total_distributable_amount</a>(staker: <b>address</b>, operator: <b>address</b>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_contract.md#0x1_staking_contract_total_distributable_amount">total_distributable_amount</a>(staker: <b>address</b>, operator: <b>address</b>): u64 <b>acquires</b> <a href="staking_contract.md#0x1_staking_contract_Store">Store</a> {
+    <a href="staking_contract.md#0x1_staking_contract_assert_staking_contract_exists">assert_staking_contract_exists</a>(staker, operator);
+    <b>let</b> store = <b>borrow_global_mut</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker);
+    <b>let</b> <a href="staking_contract.md#0x1_staking_contract">staking_contract</a> = <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_borrow">simple_map::borrow</a>(&store.staking_contracts, &operator);
+    <b>let</b> pool_address = <a href="staking_contract.md#0x1_staking_contract">staking_contract</a>.pool_address;
+    <b>let</b> (_, inactive, _, pending_inactive) = <a href="stake.md#0x1_stake_get_stake">stake::get_stake</a>(pool_address);
+    inactive + pending_inactive
 }
 </code></pre>
 
@@ -2023,6 +2057,31 @@ Staking_contract exists the stacker/operator pair.
 
 
 <pre><code><b>include</b> <a href="staking_contract.md#0x1_staking_contract_StakingContractExistsAbortsIf">StakingContractExistsAbortsIf</a>;
+</code></pre>
+
+
+
+<a name="@Specification_1_total_distributable_amount"></a>
+
+### Function `total_distributable_amount`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_contract.md#0x1_staking_contract_total_distributable_amount">total_distributable_amount</a>(staker: <b>address</b>, operator: <b>address</b>): u64
+</code></pre>
+
+
+
+
+<pre><code><b>let</b> staking_contracts = <b>global</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker).staking_contracts;
+<b>let</b> <a href="staking_contract.md#0x1_staking_contract">staking_contract</a> = <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(staking_contracts, operator);
+<b>let</b> pool_address = <a href="staking_contract.md#0x1_staking_contract">staking_contract</a>.pool_address;
+<b>let</b> stake_pool = <b>global</b>&lt;<a href="stake.md#0x1_stake_StakePool">stake::StakePool</a>&gt;(pool_address);
+<b>let</b> pending_active = <a href="coin.md#0x1_coin_value">coin::value</a>(stake_pool.pending_inactive);
+<b>let</b> inactive = <a href="coin.md#0x1_coin_value">coin::value</a>(stake_pool.inactive);
+<b>aborts_if</b> !<b>exists</b>&lt;<a href="stake.md#0x1_stake_StakePool">stake::StakePool</a>&gt;(pool_address);
+<b>aborts_if</b> !<b>exists</b>&lt;<a href="stake.md#0x1_stake_StakePool">stake::StakePool</a>&gt;(pool_address);
+<b>aborts_if</b> inactive + pending_active &gt; MAX_U64;
+<b>include</b> <a href="staking_contract.md#0x1_staking_contract_StakingContractExistsAbortsIf">StakingContractExistsAbortsIf</a>;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/vesting.md
+++ b/aptos-move/framework/aptos-framework/doc/vesting.md
@@ -33,6 +33,10 @@
 -  [Function `vesting_schedule`](#0x1_vesting_vesting_schedule)
 -  [Function `total_accumulated_rewards`](#0x1_vesting_total_accumulated_rewards)
 -  [Function `accumulated_rewards`](#0x1_vesting_accumulated_rewards)
+-  [Function `total_distributable_rewards`](#0x1_vesting_total_distributable_rewards)
+-  [Function `distributable_rewards`](#0x1_vesting_distributable_rewards)
+-  [Function `total_upcoming_rewards`](#0x1_vesting_total_upcoming_rewards)
+-  [Function `upcoming_rewards`](#0x1_vesting_upcoming_rewards)
 -  [Function `shareholders`](#0x1_vesting_shareholders)
 -  [Function `shareholder`](#0x1_vesting_shareholder)
 -  [Function `create_vesting_schedule`](#0x1_vesting_create_vesting_schedule)
@@ -1402,8 +1406,9 @@ This errors out if the vesting contract with the provided address doesn't exist.
 
 ## Function `total_accumulated_rewards`
 
-Return the total accumulated rewards that have not been distributed to shareholders of the vesting contract.
+Return the total accumulated rewards that can be unlocked for distribution to shareholders of the vesting contract.
 This excludes any unpaid commission that the operator has not collected.
+Calling unlock_stake() will allow these rewards to be distributed.
 
 This errors out if the vesting contract with the provided address doesn't exist.
 
@@ -1435,7 +1440,8 @@ This errors out if the vesting contract with the provided address doesn't exist.
 
 ## Function `accumulated_rewards`
 
-Return the accumulated rewards that have not been distributed to the provided shareholder. Caller can also pass
+Return the accumulated rewards that can be unlocked for shareholder distribution.
+Calling unlock_stake() will allow these rewards to be distributed. Caller can also pass
 the beneficiary address instead of shareholder address.
 
 This errors out if the vesting contract with the provided address doesn't exist.
@@ -1459,6 +1465,134 @@ This errors out if the vesting contract with the provided address doesn't exist.
     <b>let</b> vesting_contract = <b>borrow_global</b>&lt;<a href="vesting.md#0x1_vesting_VestingContract">VestingContract</a>&gt;(vesting_contract_address);
     <b>let</b> shares = <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_shares">pool_u64::shares</a>(&vesting_contract.grant_pool, shareholder);
     <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_shares_to_amount_with_total_coins">pool_u64::shares_to_amount_with_total_coins</a>(&vesting_contract.grant_pool, shares, total_accumulated_rewards)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vesting_total_distributable_rewards"></a>
+
+## Function `total_distributable_rewards`
+
+Return the total amount of rewards that will be disbursed the next time distribute() is called.
+
+This errors out if the vesting contract with the provided address doesn't exist.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vesting.md#0x1_vesting_total_distributable_rewards">total_distributable_rewards</a>(vesting_contract_address: <b>address</b>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vesting.md#0x1_vesting_total_distributable_rewards">total_distributable_rewards</a>(vesting_contract_address: <b>address</b>): u64 <b>acquires</b> <a href="vesting.md#0x1_vesting_VestingContract">VestingContract</a> {
+    <a href="vesting.md#0x1_vesting_assert_active_vesting_contract">assert_active_vesting_contract</a>(vesting_contract_address);
+
+    <b>let</b> vesting_contract = <b>borrow_global</b>&lt;<a href="vesting.md#0x1_vesting_VestingContract">VestingContract</a>&gt;(vesting_contract_address);
+    <a href="staking_contract.md#0x1_staking_contract_total_distributable_amount">staking_contract::total_distributable_amount</a>(vesting_contract_address, vesting_contract.staking.operator)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vesting_distributable_rewards"></a>
+
+## Function `distributable_rewards`
+
+Return the amount of rewards that will be disbursed the next time distribute() is called. Caller can pass in
+the beneficiary address or the shareholder address.
+
+This errors out if the vesting contract with the provided address doesn't exist.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vesting.md#0x1_vesting_distributable_rewards">distributable_rewards</a>(vesting_contract_address: <b>address</b>, shareholder_or_beneficiary: <b>address</b>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vesting.md#0x1_vesting_distributable_rewards">distributable_rewards</a>(
+    vesting_contract_address: <b>address</b>, shareholder_or_beneficiary: <b>address</b>): u64 <b>acquires</b> <a href="vesting.md#0x1_vesting_VestingContract">VestingContract</a> {
+    <a href="vesting.md#0x1_vesting_assert_active_vesting_contract">assert_active_vesting_contract</a>(vesting_contract_address);
+
+    <b>let</b> total_distributable_rewards = <a href="vesting.md#0x1_vesting_total_distributable_rewards">total_distributable_rewards</a>(vesting_contract_address); // minus commission ???
+    <b>let</b> shareholder = <a href="vesting.md#0x1_vesting_shareholder">shareholder</a>(vesting_contract_address, shareholder_or_beneficiary);
+    <b>let</b> vesting_contract = <b>borrow_global</b>&lt;<a href="vesting.md#0x1_vesting_VestingContract">VestingContract</a>&gt;(vesting_contract_address);
+    <b>let</b> shares = <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_shares">pool_u64::shares</a>(&vesting_contract.grant_pool, shareholder);
+    <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_shares_to_amount_with_total_coins">pool_u64::shares_to_amount_with_total_coins</a>(&vesting_contract.grant_pool, shares, total_distributable_rewards)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vesting_total_upcoming_rewards"></a>
+
+## Function `total_upcoming_rewards`
+
+Return the total amount of upcoming rewards.
+In order to receive all upcoming rewards, the rewards may need to be unlocked via unlock_rewards(),
+and will need to be distributed via distribute().
+
+This errors out if the vesting contract with the provided address doesn't exist.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vesting.md#0x1_vesting_total_upcoming_rewards">total_upcoming_rewards</a>(vesting_contract_address: <b>address</b>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vesting.md#0x1_vesting_total_upcoming_rewards">total_upcoming_rewards</a>(vesting_contract_address: <b>address</b>): u64 <b>acquires</b> <a href="vesting.md#0x1_vesting_VestingContract">VestingContract</a> {
+    <b>let</b> total_distributable_rewards = <a href="vesting.md#0x1_vesting_total_distributable_rewards">total_distributable_rewards</a>(vesting_contract_address);
+    <b>let</b> total_accumulated_rewards = <a href="vesting.md#0x1_vesting_total_accumulated_rewards">total_accumulated_rewards</a>(vesting_contract_address);
+    total_distributable_rewards + total_accumulated_rewards
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vesting_upcoming_rewards"></a>
+
+## Function `upcoming_rewards`
+
+Return the amount of upcoming rewards that can be received by the sharholder/beneficiary.
+In order to receive all upcoming rewards, the rewards may need to be unlocked via unlock_rewards(),
+and will need to be distributed via distribute().
+
+This errors out if the vesting contract with the provided address doesn't exist.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vesting.md#0x1_vesting_upcoming_rewards">upcoming_rewards</a>(vesting_contract_address: <b>address</b>, shareholder_or_beneficiary: <b>address</b>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vesting.md#0x1_vesting_upcoming_rewards">upcoming_rewards</a>(
+    vesting_contract_address: <b>address</b>, shareholder_or_beneficiary: <b>address</b>): u64 <b>acquires</b> <a href="vesting.md#0x1_vesting_VestingContract">VestingContract</a> {
+    <b>let</b> distributable_rewards = <a href="vesting.md#0x1_vesting_distributable_rewards">distributable_rewards</a>(vesting_contract_address, shareholder_or_beneficiary);
+    <b>let</b> accumulated_rewards = <a href="vesting.md#0x1_vesting_accumulated_rewards">accumulated_rewards</a>(vesting_contract_address, shareholder_or_beneficiary);
+    distributable_rewards + accumulated_rewards
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/sources/stake.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.spec.move
@@ -225,6 +225,10 @@ spec aptos_framework::stake {
         ensures (forall i in old(len(v1))..len(v1): v1[i] == old(v2[len(v2) - (i - len(v1)) - 1]));
     }
 
+    spec get_stake(pool_address: address): (u64, u64, u64, u64) {
+        aborts_if !stake_pool_exists(pool_address);
+    }
+
     spec remove_validators {
         requires chain_status::is_operating();
     }

--- a/aptos-move/framework/aptos-framework/sources/vesting.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.move
@@ -415,6 +415,31 @@ module aptos_framework::vesting {
     }
 
     #[view]
+    /// Return the total amount of upcoming rewards.
+    /// In order to receive all upcoming rewards, the rewards may need to be unlocked via unlock_rewards(), 
+    /// and will need to be distributed via distribute().
+    /// 
+    /// This errors out if the vesting contract with the provided address doesn't exist.
+    public fun total_upcoming_rewards(vesting_contract_address: address): u64 acquires VestingContract {
+        let total_distributable_rewards = total_distributable_rewards(vesting_contract_address);
+        let total_accumulated_rewards = total_accumulated_rewards(vesting_contract_address);
+        total_distributable_rewards + total_accumulated_rewards
+    }
+
+    #[view]
+    /// Return the amount of upcoming rewards that can be received by the sharholder/beneficiary.
+    /// In order to receive all upcoming rewards, the rewards may need to be unlocked via unlock_rewards(), 
+    /// and will need to be distributed via distribute().
+    /// 
+    /// This errors out if the vesting contract with the provided address doesn't exist.
+    public fun upcoming_rewards(
+        vesting_contract_address: address, shareholder_or_beneficiary: address): u64 acquires VestingContract {
+        let distributable_rewards = distributable_rewards(vesting_contract_address, shareholder_or_beneficiary);
+        let accumulated_rewards = accumulated_rewards(vesting_contract_address, shareholder_or_beneficiary);
+        distributable_rewards + accumulated_rewards
+    }
+
+    #[view]
     /// Return the list of all shareholders in the vesting contract.
     public fun shareholders(vesting_contract_address: address): vector<address> acquires VestingContract {
         assert_active_vesting_contract(vesting_contract_address);

--- a/aptos-move/framework/aptos-framework/sources/vesting.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.move
@@ -350,8 +350,9 @@ module aptos_framework::vesting {
     }
 
     #[view]
-    /// Return the total accumulated rewards that have not been distributed to shareholders of the vesting contract.
-    /// This excludes any unpaid commission that the operator has not collected.
+    /// Return the total accumulated rewards that can be unlocked for distribution to shareholders of the vesting contract.
+    /// This excludes any unpaid commission that the operator has not collected. 
+    /// Calling unlock_stake() will allow these rewards to be distributed.
     ///
     /// This errors out if the vesting contract with the provided address doesn't exist.
     public fun total_accumulated_rewards(vesting_contract_address: address): u64 acquires VestingContract {
@@ -364,7 +365,8 @@ module aptos_framework::vesting {
     }
 
     #[view]
-    /// Return the accumulated rewards that have not been distributed to the provided shareholder. Caller can also pass
+    /// Return the accumulated rewards that can be unlocked for shareholder distribution. 
+    /// Calling unlock_stake() will allow these rewards to be distributed. Caller can also pass
     /// the beneficiary address instead of shareholder address.
     ///
     /// This errors out if the vesting contract with the provided address doesn't exist.


### PR DESCRIPTION
### Description
This PR adds `upcoming_rewards` functions as specified in #7741, `distributable_rewards` functions as specified in #7740, and changes the comments of the `accumulated_rewards` functions for greater clarity as specified in #7739

### Test Plan
The `get_stake` and `total_distributable_amount` spec can be tested with `aptos move prove -f staking_contract`. 

I have also added a unit test titled`test_distributable_rewards_with_multiple_stakers` to demonstrate how the `distributable_rewards` functions work
