### PR TITLE
[forge] Remove conflicting feature definition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -461,9 +461,7 @@ jemallocator = { version = "0.3.2", features = [
 ] }
 json-patch = "0.2.6"
 jsonwebtoken = "8.1"
-k8s-openapi = { version = "0.11.0", default-features = false, features = [
-    "v1_15",
-] }
+k8s-openapi = { version = "0.11.0", default-features = false }
 kube = { version = "0.51.0", features = ["jsonpatch"] }
 libfuzzer-sys = "=0.3.2"
 libsecp256k1 = "0.7.0"

--- a/testsuite/forge/Cargo.toml
+++ b/testsuite/forge/Cargo.toml
@@ -41,7 +41,9 @@ hyper = { workspace = true }
 hyper-tls = { workspace = true }
 itertools = { workspace = true }
 json-patch = { workspace = true }
-k8s-openapi = { workspace = true }
+k8s-openapi = { workspace = true, features = [
+    "v1_15",
+] }
 kube = { workspace = true }
 num_cpus = { workspace = true }
 once_cell = { workspace = true }


### PR DESCRIPTION
When pulling in a library from aptos-core, if you end up depending on k8s-openapi this will actually break the build with the following message

```
Library crates *must not* enable any features in their direct dependency on k8s-openapi, only in their dev-dependency. The choice of which Kubernetes version to support should be left to the final binary crate, so only binary crates should enable a specific feature. If library crates also enabled features, it could cause multiple features to be enabled simultaneously, which k8s-openapi does not support.
```

So this makes the features specified by the only binary that uses it forge, instead of making that decision for all libraries using it

Test Plan: cargo build + tests on PR pass

Try and pull from another project which has a k8s-openapi dep which previously failed, with this branch, does not fail
