### PR TITLE
[framework] Change step names, remove quorum store for now

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -1,7 +1,7 @@
 ---
 remote_endpoint: ~
 proposals:
-  - name: step_0
+  - name: enable_signature_checker
     metadata:
       title: "Enable the new signature checker"
       description: "This enables the improved signature checker implementation."
@@ -13,7 +13,7 @@ proposals:
         enabled:
           - signature_checker_v2
         disabled: []
-  - name: step_1
+  - name: enable_struct_constructor
     metadata:
       title: "Enable Struct Constructor Feature"
       description: "AIP-25: Enable some select set of structs as valid parameters to entry and view functions."
@@ -25,7 +25,7 @@ proposals:
         enabled:
           - struct_constructors
         disabled: []
-  - name: step_2
+  - name: upgrade_framework
     metadata:
       title: "Multi-step proposal to upgrade mainnet framework to v1.4.0"
       description: "This includes changes outlined in https://github.com/aptos-labs/aptos-core/releases/aptos-node-v1.4.0. Struct constructor, generic cryptography algebra, ed25519 returns false if wrong length, quorum store, and transaction shuffling will be enabled in separate proposals."
@@ -37,7 +37,7 @@ proposals:
       - Framework:
           bytecode_version: 6
           git_hash: ~
-  - name: step_3
+  - name: enable_ed25519_pubkey_validate_return_false_wrong_length
     metadata:
       title: "Enable ed25519_pubkey_validate_return_false_wrong_length"
       description: "AIP-23: Make ed25519 public key validation return none if key has the wrong length."
@@ -49,32 +49,7 @@ proposals:
         enabled:
           - ed25519_pubkey_validate_return_false_wrong_length
         disabled: []
-  - name: step_4
-    metadata:
-      title: "Enable Quorum Store"
-      description: "AIP-26: Quorum Store is a production-optimized implementation of Narwhal [1], that improves consensus throughput."
-      source_code_url: "TBD"
-      discussion_url: "https://github.com/aptos-foundation/AIPs/issues/108"
-    execution_mode: MultiStep
-    update_sequence:
-    - Consensus:
-        V2:
-          decoupled_execution: true
-          back_pressure_limit: 10
-          exclude_round: 40
-          proposer_election_type:
-            leader_reputation:
-              proposer_and_voter_v2:
-                active_weight: 1000
-                inactive_weight: 10
-                failed_weight: 1
-                failure_threshold_percent: 10
-                proposer_window_num_validators_multiplier: 10
-                voter_window_num_validators_multiplier: 1
-                weight_by_voting_power: true
-                use_history_from_previous_epoch_max_count: 5
-          max_failed_authors_to_store: 10
-  - name: step_5
+  - name: enable_transaction_shuffling
     metadata:
       title: "Enable Transaction Shuffling"
       description: "AIP-27: Sender Aware Transaction Shuffling"


### PR DESCRIPTION
[framework] Change step names, remove quorum store for now

    Test Plan: build with release builder
    
    ```
    cargo run -p aptos-release-builder -- generate-proposals --release-config aptos-move/aptos-release-builder/data/release.yaml --output-dir /tmp/banana
    ```