### PR TITLE
[release-tooling] Support input key as string (#7882)

### DIFF
--- a/aptos-move/aptos-release-builder/src/main.rs
+++ b/aptos-move/aptos-release-builder/src/main.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use aptos_crypto::{ed25519::Ed25519PrivateKey, ValidCryptoMaterialStringExt};
+use aptos_release_builder::validate::{DEFAULT_RESOLUTION_TIME, FAST_RESOLUTION_TIME};
+use aptos_types::{account_address::AccountAddress, chain_id::ChainId};
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
@@ -24,14 +27,38 @@ pub enum Commands {
         output_path: PathBuf,
     },
     ValidateProposals {
+        /// Path to the config to be released.
         #[clap(short, long)]
         release_config: PathBuf,
-        #[clap(short, long)]
-        test_dir: PathBuf,
         #[clap(short, long)]
         endpoint: url::Url,
         #[clap(long)]
         framework_git_rev: Option<String>,
+        #[clap(subcommand)]
+        input_option: InputOptions,
+        /// Mint to validator such that it has enough stake to allow fast voting resolution.
+        #[clap(long)]
+        mint_to_validator: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum InputOptions {
+    FromDirectory {
+        /// Path to the local testnet folder. If you are running local testnet via cli, it should be `.aptos/testnet`.
+        #[clap(short, long)]
+        test_dir: PathBuf,
+    },
+    FromArgs {
+        /// Hex encoded string for the root key of the network.
+        #[clap(long)]
+        root_key: String,
+        /// Hex encoded string for the address of a validator node.
+        #[clap(long)]
+        validator_address: String,
+        /// Hex encoded string for the private key of a validator node.
+        #[clap(long)]
+        validator_key: String,
     },
 }
 
@@ -51,21 +78,73 @@ async fn main() -> Result<()> {
         },
         Commands::ValidateProposals {
             release_config,
-            test_dir,
+            input_option,
             endpoint,
             framework_git_rev,
+            mint_to_validator,
         } => {
             let config =
                 aptos_release_builder::ReleaseConfig::load_config(release_config.as_path())?;
 
-            let mut network_config = aptos_release_builder::validate::NetworkConfig::new_from_dir(
-                endpoint,
-                test_dir.as_path(),
-            )?;
+            let root_key_path = aptos_temppath::TempPath::new();
+            root_key_path.create_as_file().unwrap();
+
+            let mut network_config = match input_option {
+                InputOptions::FromDirectory { test_dir } => {
+                    aptos_release_builder::validate::NetworkConfig::new_from_dir(
+                        endpoint.clone(),
+                        test_dir.as_path(),
+                    )?
+                },
+                InputOptions::FromArgs {
+                    root_key,
+                    validator_address,
+                    validator_key,
+                } => {
+                    let root_key = Ed25519PrivateKey::from_encoded_string(&root_key)?;
+                    let validator_key = Ed25519PrivateKey::from_encoded_string(&validator_key)?;
+                    let validator_account = AccountAddress::from_hex(validator_address.as_bytes())?;
+
+                    let mut root_key_path = root_key_path.path().to_path_buf();
+                    root_key_path.set_extension("key");
+
+                    std::fs::write(root_key_path.as_path(), bcs::to_bytes(&root_key)?)?;
+
+                    aptos_release_builder::validate::NetworkConfig {
+                        root_key_path,
+                        validator_account,
+                        validator_key,
+                        framework_git_rev: None,
+                        endpoint: endpoint.clone(),
+                    }
+                },
+            };
 
             network_config.framework_git_rev = framework_git_rev;
 
-            aptos_release_builder::validate::validate_config(config, network_config).await
+            if mint_to_validator {
+                let chain_id = aptos_rest_client::Client::new(endpoint)
+                    .get_ledger_information()
+                    .await?
+                    .inner()
+                    .chain_id;
+
+                if chain_id == ChainId::mainnet().id() || chain_id == ChainId::testnet().id() {
+                    anyhow::bail!("Mint to mainnet/testnet is not allowed");
+                }
+
+                network_config.mint_to_validator().await?;
+            }
+
+            network_config
+                .set_fast_resolve(FAST_RESOLUTION_TIME)
+                .await?;
+            aptos_release_builder::validate::validate_config(config, network_config.clone())
+                .await?;
+            // Reset resolution time back to normal after resolution
+            network_config
+                .set_fast_resolve(DEFAULT_RESOLUTION_TIME)
+                .await
         },
     }
 }

--- a/aptos-move/aptos-release-builder/src/validate.rs
+++ b/aptos-move/aptos-release-builder/src/validate.rs
@@ -24,6 +24,9 @@ use std::{
 };
 use url::Url;
 
+pub const FAST_RESOLUTION_TIME: u64 = 30;
+pub const DEFAULT_RESOLUTION_TIME: u64 = 43200;
+
 #[derive(Clone, Debug)]
 pub struct NetworkConfig {
     pub endpoint: Url,


### PR DESCRIPTION
* [release-tooling] Inputting keys as string

* fixup! [release-tooling] Inputting keys as string

### Description
Cherrypicking #7882  into 1.4 branch.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### AI-powered Walkthrough
<!-- Delete this section if you don't want the AI to create a detailed walkthrough of your PR -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3d3d67a</samp>

*  Add imports from `aptos_crypto` and `aptos_types` crates for proposal validation and minting features ([link](https://github.com/aptos-labs/aptos-core/pull/7999/files?diff=unified&w=0#diff-cff4e3e4830a868123dfd524d76081ec6c798abc23bf6d9e8476d966118bf5edR5-R7))
*  Modify `ValidateProposals` subcommand to accept different input options for network configuration and minting flag ([link](https://github.com/aptos-labs/aptos-core/pull/7999/files?diff=unified&w=0#diff-cff4e3e4830a868123dfd524d76081ec6c798abc23bf6d9e8476d966118bf5edL27-R64))
*  Implement logic for handling network configuration and minting in `src/main.rs` ([link](https://github.com/aptos-labs/aptos-core/pull/7999/files?diff=unified&w=0#diff-cff4e3e4830a868123dfd524d76081ec6c798abc23bf6d9e8476d966118bf5edL54-R147))
*  Define constants for voting resolution time in `src/validate.rs` ([link](https://github.com/aptos-labs/aptos-core/pull/7999/files?diff=unified&w=0#diff-4969e5623fb0d904ac9fae0ad19a8f8b1966f47f06f0bcbea796378300d9b191R27-R29))
