### PR TITLE
[transaction generator] Simplify txn-generator api to create transactions for a single account at a time

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/submission_worker.rs
+++ b/crates/transaction-emitter-lib/src/emitter/submission_worker.rs
@@ -275,8 +275,14 @@ impl SubmissionWorker {
             .accounts
             .iter_mut()
             .choose_multiple(&mut self.rng, batch_size);
-        self.txn_generator
-            .generate_transactions(accounts, self.params.transactions_per_account)
+
+        accounts
+            .into_iter()
+            .flat_map(|account| {
+                self.txn_generator
+                    .generate_transactions(account, self.params.transactions_per_account)
+            })
+            .collect()
     }
 }
 

--- a/crates/transaction-generator-lib/src/account_generator.rs
+++ b/crates/transaction-generator-lib/src/account_generator.rs
@@ -89,22 +89,19 @@ fn add_to_sized_pool<T>(
 impl TransactionGenerator for AccountGenerator {
     fn generate_transactions(
         &mut self,
-        accounts: Vec<&mut LocalAccount>,
-        transactions_per_account: usize,
+        account: &mut LocalAccount,
+        num_to_create: usize,
     ) -> Vec<SignedTransaction> {
-        let mut requests = Vec::with_capacity(accounts.len() * transactions_per_account);
-        let mut new_accounts = Vec::with_capacity(accounts.len() * transactions_per_account);
-        let mut new_account_addresses =
-            Vec::with_capacity(accounts.len() * transactions_per_account);
-        for account in accounts {
-            for _ in 0..transactions_per_account {
-                let receiver = LocalAccount::generate(&mut self.rng);
-                let receiver_address = receiver.address();
-                let request = self.gen_single_txn(account, receiver_address, &self.txn_factory);
-                requests.push(request);
-                new_accounts.push(receiver);
-                new_account_addresses.push(receiver_address);
-            }
+        let mut requests = Vec::with_capacity(num_to_create);
+        let mut new_accounts = Vec::with_capacity(num_to_create);
+        let mut new_account_addresses = Vec::with_capacity(num_to_create);
+        for _ in 0..num_to_create {
+            let receiver = LocalAccount::generate(&mut self.rng);
+            let receiver_address = receiver.address();
+            let request = self.gen_single_txn(account, receiver_address, &self.txn_factory);
+            requests.push(request);
+            new_accounts.push(receiver);
+            new_account_addresses.push(receiver_address);
         }
 
         if self.add_created_accounts_to_pool {

--- a/crates/transaction-generator-lib/src/accounts_pool_wrapper.rs
+++ b/crates/transaction-generator-lib/src/accounts_pool_wrapper.rs
@@ -31,17 +31,18 @@ impl AccountsPoolWrapperGenerator {
 impl TransactionGenerator for AccountsPoolWrapperGenerator {
     fn generate_transactions(
         &mut self,
-        accounts: Vec<&mut LocalAccount>,
-        transactions_per_account: usize,
+        _account: &mut LocalAccount,
+        num_to_create: usize,
     ) -> Vec<SignedTransaction> {
-        let needed = accounts.len() * transactions_per_account;
-
-        let mut accounts_to_burn = get_account_to_burn_from_pool(&self.accounts_pool, needed);
+        let mut accounts_to_burn =
+            get_account_to_burn_from_pool(&self.accounts_pool, num_to_create);
         if accounts_to_burn.is_empty() {
             return Vec::new();
         }
-        self.creator
-            .generate_transactions(accounts_to_burn.iter_mut().collect(), 1)
+        accounts_to_burn
+            .iter_mut()
+            .flat_map(|account| self.creator.generate_transactions(account, 1))
+            .collect()
     }
 }
 

--- a/crates/transaction-generator-lib/src/batch_transfer.rs
+++ b/crates/transaction-generator-lib/src/batch_transfer.rs
@@ -39,27 +39,25 @@ impl BatchTransferTransactionGenerator {
 impl TransactionGenerator for BatchTransferTransactionGenerator {
     fn generate_transactions(
         &mut self,
-        accounts: Vec<&mut LocalAccount>,
-        transactions_per_account: usize,
+        account: &mut LocalAccount,
+        num_to_create: usize,
     ) -> Vec<SignedTransaction> {
-        let mut requests = Vec::with_capacity(accounts.len() * transactions_per_account);
-        for sender in accounts {
-            for _ in 0..transactions_per_account {
-                let receivers = self
-                    .all_addresses
-                    .read()
-                    .choose_multiple(&mut self.rng, self.batch_size)
-                    .cloned()
-                    .collect::<Vec<_>>();
-                requests.push(
-                    sender.sign_with_transaction_builder(self.txn_factory.payload(
-                        aptos_stdlib::aptos_account_batch_transfer(receivers, vec![
-                            self.send_amount;
-                            self.batch_size
-                        ]),
-                    )),
-                );
-            }
+        let mut requests = Vec::with_capacity(num_to_create);
+        for _ in 0..num_to_create {
+            let receivers = self
+                .all_addresses
+                .read()
+                .choose_multiple(&mut self.rng, self.batch_size)
+                .cloned()
+                .collect::<Vec<_>>();
+            requests.push(
+                account.sign_with_transaction_builder(self.txn_factory.payload(
+                    aptos_stdlib::aptos_account_batch_transfer(receivers, vec![
+                        self.send_amount;
+                        self.batch_size
+                    ]),
+                )),
+            );
         }
 
         requests

--- a/crates/transaction-generator-lib/src/call_custom_modules.rs
+++ b/crates/transaction-generator-lib/src/call_custom_modules.rs
@@ -43,24 +43,21 @@ impl CallCustomModulesGenerator {
 impl TransactionGenerator for CallCustomModulesGenerator {
     fn generate_transactions(
         &mut self,
-        accounts: Vec<&mut LocalAccount>,
-        transactions_per_account: usize,
+        account: &mut LocalAccount,
+        num_to_create: usize,
     ) -> Vec<SignedTransaction> {
-        let needed = accounts.len() * transactions_per_account;
-        let mut requests = Vec::with_capacity(needed);
+        let mut requests = Vec::with_capacity(num_to_create);
 
-        for account in accounts {
-            for _ in 0..transactions_per_account {
-                let (package, publisher) = self.packages.choose(&mut self.rng).unwrap();
-                let request = package.use_specific_transaction(
-                    self.entry_point,
-                    account,
-                    &self.txn_factory,
-                    Some(&mut self.rng),
-                    Some(publisher),
-                );
-                requests.push(request);
-            }
+        for _ in 0..num_to_create {
+            let (package, publisher) = self.packages.choose(&mut self.rng).unwrap();
+            let request = package.use_specific_transaction(
+                self.entry_point,
+                account,
+                &self.txn_factory,
+                Some(&mut self.rng),
+                Some(publisher),
+            );
+            requests.push(request);
         }
         requests
     }

--- a/crates/transaction-generator-lib/src/lib.rs
+++ b/crates/transaction-generator-lib/src/lib.rs
@@ -113,8 +113,8 @@ impl Default for TransactionType {
 pub trait TransactionGenerator: Sync + Send {
     fn generate_transactions(
         &mut self,
-        accounts: Vec<&mut LocalAccount>,
-        transactions_per_account: usize,
+        account: &mut LocalAccount,
+        num_to_create: usize,
     ) -> Vec<SignedTransaction>;
 }
 

--- a/crates/transaction-generator-lib/src/nft_mint_and_transfer.rs
+++ b/crates/transaction-generator-lib/src/nft_mint_and_transfer.rs
@@ -52,52 +52,52 @@ impl NFTMintAndTransfer {
 impl TransactionGenerator for NFTMintAndTransfer {
     fn generate_transactions(
         &mut self,
-        accounts: Vec<&mut LocalAccount>,
-        transactions_per_account: usize,
+        account: &mut LocalAccount,
+        num_to_create: usize,
     ) -> Vec<SignedTransaction> {
-        let mut requests = Vec::with_capacity(accounts.len() * transactions_per_account);
-        for account in accounts {
-            let account_funded = self
-                .account_funded
-                .get(&account.address())
-                .cloned()
-                .unwrap_or(false);
-            for i in 0..transactions_per_account {
-                requests.push(
-                    if account_funded {
-                        create_nft_transfer_request(
-                            account,
-                            &self.distribution_account,
-                            self.creator_address,
-                            &self.collection_name,
-                            &self.token_name,
-                            &self.txn_factory,
-                            if i != transactions_per_account - 1 {
-                                1
-                            } else {
-                                INITIAL_NFT_BALANCE + 1 - transactions_per_account as u64
-                            },
-                        )
-                    } else {
-                        create_nft_transfer_request(
-                            &mut self.distribution_account,
-                            account,
-                            self.creator_address,
-                            &self.collection_name,
-                            &self.token_name,
-                            &self.txn_factory,
-                            if i != transactions_per_account - 1 {
-                                1
-                            } else {
-                                INITIAL_NFT_BALANCE + 1 - transactions_per_account as u64
-                            },
-                        )
-                    },
-                );
-            }
-            self.account_funded
-                .insert(account.address(), !account_funded);
+        let mut requests = Vec::with_capacity(num_to_create);
+
+        let account_funded = self
+            .account_funded
+            .get(&account.address())
+            .cloned()
+            .unwrap_or(false);
+        for i in 0..num_to_create {
+            requests.push(
+                if account_funded {
+                    create_nft_transfer_request(
+                        account,
+                        &self.distribution_account,
+                        self.creator_address,
+                        &self.collection_name,
+                        &self.token_name,
+                        &self.txn_factory,
+                        if i != num_to_create - 1 {
+                            1
+                        } else {
+                            INITIAL_NFT_BALANCE + 1 - num_to_create as u64
+                        },
+                    )
+                } else {
+                    create_nft_transfer_request(
+                        &mut self.distribution_account,
+                        account,
+                        self.creator_address,
+                        &self.collection_name,
+                        &self.token_name,
+                        &self.txn_factory,
+                        if i != num_to_create - 1 {
+                            1
+                        } else {
+                            INITIAL_NFT_BALANCE + 1 - num_to_create as u64
+                        },
+                    )
+                },
+            );
         }
+        self.account_funded
+            .insert(account.address(), !account_funded);
+
         requests
     }
 }

--- a/crates/transaction-generator-lib/src/publish_modules.rs
+++ b/crates/transaction-generator-lib/src/publish_modules.rs
@@ -34,33 +34,31 @@ impl PublishPackageGenerator {
 impl TransactionGenerator for PublishPackageGenerator {
     fn generate_transactions(
         &mut self,
-        accounts: Vec<&mut LocalAccount>,
-        transactions_per_account: usize,
+        account: &mut LocalAccount,
+        num_to_create: usize,
     ) -> Vec<SignedTransaction> {
-        let mut requests = Vec::with_capacity(accounts.len() * transactions_per_account);
-        for account in accounts {
-            // First publish the module and then use it
-            let package = self
-                .package_handler
-                .write()
-                .pick_package(&mut self.rng, account);
-            let txn = package.publish_transaction(account, &self.txn_factory);
-            requests.push(txn);
-            // use module published
-            // for _ in 1..transactions_per_account - 1 {
-            for _ in 1..transactions_per_account {
-                let request =
-                    package.use_random_transaction(&mut self.rng, account, &self.txn_factory);
-                requests.push(request);
-            }
-            // republish
-            // let package = self
-            //     .package_handler
-            //     .write()
-            //     .pick_package(&mut self.rng, account);
-            // let txn = package.publish_transaction(account, &self.txn_factory);
-            // requests.push(txn);
+        let mut requests = Vec::with_capacity(num_to_create);
+
+        // First publish the module and then use it
+        let package = self
+            .package_handler
+            .write()
+            .pick_package(&mut self.rng, account);
+        let txn = package.publish_transaction(account, &self.txn_factory);
+        requests.push(txn);
+        // use module published
+        // for _ in 1..transactions_per_account - 1 {
+        for _ in 1..num_to_create {
+            let request = package.use_random_transaction(&mut self.rng, account, &self.txn_factory);
+            requests.push(request);
         }
+        // republish
+        // let package = self
+        //     .package_handler
+        //     .write()
+        //     .pick_package(&mut self.rng, account);
+        // let txn = package.publish_transaction(account, &self.txn_factory);
+        // requests.push(txn);
         requests
     }
 }

--- a/crates/transaction-generator-lib/src/transaction_mix_generator.rs
+++ b/crates/transaction-generator-lib/src/transaction_mix_generator.rs
@@ -38,8 +38,8 @@ impl PhasedTxnMixGenerator {
 impl TransactionGenerator for PhasedTxnMixGenerator {
     fn generate_transactions(
         &mut self,
-        accounts: Vec<&mut LocalAccount>,
-        transactions_per_account: usize,
+        account: &mut LocalAccount,
+        num_to_create: usize,
     ) -> Vec<SignedTransaction> {
         let phase = if self.txn_mix_per_phase.len() == 1 {
             // when only single txn_mix is passed, use it for all phases, for simplicity
@@ -51,7 +51,7 @@ impl TransactionGenerator for PhasedTxnMixGenerator {
         let mut picked = self.rng.gen_range(0, self.total_weight_per_phase[phase]);
         for (gen, weight) in &mut self.txn_mix_per_phase[phase] {
             if picked < *weight {
-                return gen.generate_transactions(accounts, transactions_per_account);
+                return gen.generate_transactions(account, num_to_create);
             }
             picked -= *weight;
         }

--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -288,7 +288,7 @@ impl TransactionGenerator {
                 .flat_map(|_| {
                     let sender = self.main_signer_accounts.as_mut().unwrap().get_random();
                     transaction_generator
-                        .generate_transactions(vec![sender], transactions_per_sender)
+                        .generate_transactions(sender, transactions_per_sender)
                         .into_iter()
                         .map(|t| BenchmarkTransaction {
                             transaction: Transaction::UserTransaction(t),


### PR DESCRIPTION

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 720e036</samp>

This pull request refactors the transaction generation logic in the `transaction-generator-lib` and `transaction-emitter-lib` crates to use a single account instead of a vector of accounts as an input parameter for the `generate_transactions` method of the `TransactionGenerator` trait and its implementations. This simplifies the code, improves the performance, and avoids unnecessary cloning and looping. The pull request also updates the callers of the `generate_transactions` method in the `executor-benchmark` crate to match the new signature.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### AI-powered Walkthrough
<!-- Delete this section if you don't want the AI to create a detailed walkthrough of your PR -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 720e036</samp>

*  Simplify the `generate_transactions` method of the `SubmissionWorker` struct to use a flat_map instead of a nested loop ([link](https://github.com/aptos-labs/aptos-core/pull/8006/files?diff=unified&w=0#diff-ec01c783dc3863f36cc37dccc53aab9f48b7009490781efd805809c3199218a6L278-R285))
*  Change the signature of the `generate_transactions` method of the `TransactionGenerator` trait to take a single account instead of a vector of accounts as an argument ([link](https://github.com/aptos-labs/aptos-core/pull/8006/files?diff=unified&w=0#diff-278bbf7eb027ba51ad4530e7508c1f8fc7fbbd847d62b44867d08bb8331b5c1bL116-R117))
*  Update the implementations of the `TransactionGenerator` trait in `crates/transaction-generator-lib/src` to match the new signature and simplify the logic to generate transactions for each account ([link](https://github.com/aptos-labs/aptos-core/pull/8006/files?diff=unified&w=0#diff-d2677a07b714431e2dbed72ac48172126e689250ccb4b598f3be92299b4e5ce5L92-R104), [link](https://github.com/aptos-labs/aptos-core/pull/8006/files?diff=unified&w=0#diff-e2a6cd5f3c271ac6aa5f47a3b08ee50e66272cc0fd8037ada549fbe457df9a30L34-R45), [link](https://github.com/aptos-labs/aptos-core/pull/8006/files?diff=unified&w=0#diff-95a60faa4c54f3da5f269e529b8de163a1915bb645b846147c226105595d1d38L42-R60), [link](https://github.com/aptos-labs/aptos-core/pull/8006/files?diff=unified&w=0#diff-5af9b567e354b8e635872fd87d903eaff5d8e38361a13886ab110ee8847b679cL46-R60), [link](https://github.com/aptos-labs/aptos-core/pull/8006/files?diff=unified&w=0#diff-52717824600cc7ba0c7c0884d57129256951dea41bb2e9b384a85b310c96cdf7L55-R100), [link](https://github.com/aptos-labs/aptos-core/pull/8006/files?diff=unified&w=0#diff-97e71b2714734507c9cd8bd2fc0dbf214077e49e8fe769d8b0ed4f0fd9bd4e83L122-R159), [link](https://github.com/aptos-labs/aptos-core/pull/8006/files?diff=unified&w=0#diff-c56e270162f0cab06a7f530534793f5548cd15afdc61b7a19bb64dc91a6f9867L37-R61), [link](https://github.com/aptos-labs/aptos-core/pull/8006/files?diff=unified&w=0#diff-277a36e60e608c78d7059199e928ae3fb24ccf6256dcb51039ba6a0f379dfe1aL41-R42), [link](https://github.com/aptos-labs/aptos-core/pull/8006/files?diff=unified&w=0#diff-277a36e60e608c78d7059199e928ae3fb24ccf6256dcb51039ba6a0f379dfe1aL54-R54))
*  Update the call to the `generate_transactions` method of the transaction generator in `execution/executor-benchmark/src/transaction_generator.rs` to pass a single account instead of a vector of accounts as an argument ([link](https://github.com/aptos-labs/aptos-core/pull/8006/files?diff=unified&w=0#diff-eb266667f54a15df2f4b793020c24a7c9b37932260f609fbed76400425cb69d1L291-R291))
