### PR TITLE
[tokenv2/hot-fix] correct burn_event

### DIFF
--- a/aptos-move/framework/aptos-token-objects/doc/collection.md
+++ b/aptos-move/framework/aptos-token-objects/doc/collection.md
@@ -713,8 +713,8 @@ Called by token on burn to decrement supply if there's an appropriate Supply str
         <b>let</b> supply = <b>borrow_global_mut</b>&lt;<a href="collection.md#0x4_collection_FixedSupply">FixedSupply</a>&gt;(collection_addr);
         supply.current_supply = supply.current_supply - 1;
         <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
-            &<b>mut</b> supply.mint_events,
-            <a href="collection.md#0x4_collection_MintEvent">MintEvent</a> {
+            &<b>mut</b> supply.burn_events,
+            <a href="collection.md#0x4_collection_BurnEvent">BurnEvent</a> {
                 index: *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&index),
                 <a href="token.md#0x4_token">token</a>,
             },
@@ -723,8 +723,8 @@ Called by token on burn to decrement supply if there's an appropriate Supply str
         <b>let</b> supply = <b>borrow_global_mut</b>&lt;<a href="collection.md#0x4_collection_UnlimitedSupply">UnlimitedSupply</a>&gt;(collection_addr);
         supply.current_supply = supply.current_supply - 1;
         <a href="../../aptos-framework/doc/event.md#0x1_event_emit_event">event::emit_event</a>(
-            &<b>mut</b> supply.mint_events,
-            <a href="collection.md#0x4_collection_MintEvent">MintEvent</a> {
+            &<b>mut</b> supply.burn_events,
+            <a href="collection.md#0x4_collection_BurnEvent">BurnEvent</a> {
                 index: *<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&index),
                 <a href="token.md#0x4_token">token</a>,
             },


### PR DESCRIPTION
### Description

thanks @bowenyang007 who found this. BurnEvent was mistakenly replaced by MintEvent.

### Test Plan
add ut

### AI-powered Walkthrough
<!-- Delete this section if you don't want the AI to create a detailed walkthrough of your PR -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d0b3355</samp>

*  Emit `BurnEvent` instead of `MintEvent` when tokens are burned from an unlimited collection in `collection.move` ([link](https://github.com/aptos-labs/aptos-core/pull/8007/files?diff=unified&w=0#diff-dcbdf830276ce9c3b9cb206fc7684a0710ae13d929a20e2b7140cd021da85932L302-R303), [link](https://github.com/aptos-labs/aptos-core/pull/8007/files?diff=unified&w=0#diff-dcbdf830276ce9c3b9cb206fc7684a0710ae13d929a20e2b7140cd021da85932L312-R313))
* Add tests for the new event features in `collection.move` by asserting the correct values of `mint_events` and `burn_events` counters for both unlimited and fixed collections ([link](https://github.com/aptos-labs/aptos-core/pull/8007/files?diff=unified&w=0#diff-dcbdf830276ce9c3b9cb206fc7684a0710ae13d929a20e2b7140cd021da85932L413-R421), [link](https://github.com/aptos-labs/aptos-core/pull/8007/files?diff=unified&w=0#diff-dcbdf830276ce9c3b9cb206fc7684a0710ae13d929a20e2b7140cd021da85932L428-R437))
