### PR TITLE
Rosetta testing fixes

### DIFF
--- a/testsuite/forge/src/interface/aptos.rs
+++ b/testsuite/forge/src/interface/aptos.rs
@@ -264,6 +264,19 @@ impl<'t> AptosPublicInfo<'t> {
         )
         .await
     }
+
+    /// Syncs the root account to it's sequence number in the event that a faucet changed it's value
+    pub async fn sync_root_account_sequence_number(&mut self) {
+        let root_address = self.root_account().address();
+        let root_sequence_number = self
+            .client()
+            .get_account_bcs(root_address)
+            .await
+            .unwrap()
+            .into_inner()
+            .sequence_number();
+        *self.root_account().sequence_number_mut() = root_sequence_number;
+    }
 }
 
 pub async fn reconfig(

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -53,8 +53,7 @@ const DEFAULT_INTERVAL_MS: u64 = 100;
 static DEFAULT_MAX_WAIT_DURATION: Duration = Duration::from_millis(DEFAULT_MAX_WAIT_MS);
 static DEFAULT_INTERVAL_DURATION: Duration = Duration::from_millis(DEFAULT_INTERVAL_MS);
 
-pub async fn setup_test(
-    num_nodes: usize,
+async fn setup_test(
     num_accounts: usize,
 ) -> (
     LocalSwarm,
@@ -62,7 +61,7 @@ pub async fn setup_test(
     JoinHandle<anyhow::Result<()>>,
     RosettaClient,
 ) {
-    let (swarm, cli, faucet) = SwarmBuilder::new_local(num_nodes)
+    let (swarm, cli, faucet) = SwarmBuilder::new_local(1)
         .with_init_genesis_config(Arc::new(|genesis_config| {
             genesis_config.epoch_duration_secs = 5;
         }))
@@ -198,7 +197,7 @@ async fn test_block_transactions() {
 
 #[tokio::test]
 async fn test_network() {
-    let (swarm, _, _, rosetta_client) = setup_test(1, 1).await;
+    let (swarm, _, _, rosetta_client) = setup_test(1).await;
     let chain_id = swarm.chain_id();
 
     // We only support one network, this network
@@ -261,7 +260,7 @@ async fn test_network() {
 
 #[tokio::test]
 async fn test_account_balance() {
-    let (mut swarm, cli, _faucet, rosetta_client) = setup_test(1, 3).await;
+    let (mut swarm, cli, _faucet, rosetta_client) = setup_test(3).await;
 
     let account_1 = cli.account_id(0);
     let account_2 = cli.account_id(1);
@@ -581,7 +580,7 @@ async fn get_balance(
 
 #[tokio::test]
 async fn test_transfer() {
-    let (mut swarm, cli, _faucet, rosetta_client) = setup_test(1, 1).await;
+    let (mut swarm, cli, _faucet, rosetta_client) = setup_test(1).await;
     let chain_id = swarm.chain_id();
     let public_info = swarm.aptos_public_info();
     let client = public_info.client();
@@ -718,7 +717,7 @@ async fn test_transfer() {
 /// it's block based and it needs time to run, we do all the checks in a single test.
 #[tokio::test]
 async fn test_block() {
-    let (swarm, cli, _faucet, rosetta_client) = setup_test(1, 5).await;
+    let (swarm, cli, _faucet, rosetta_client) = setup_test(5).await;
     let chain_id = swarm.chain_id();
     let validator = swarm.validators().next().unwrap();
     let rest_client = validator.rest_client();
@@ -1881,7 +1880,7 @@ async fn check_balances(
 
 #[tokio::test]
 async fn test_invalid_transaction_gas_charged() {
-    let (swarm, cli, _faucet, rosetta_client) = setup_test(1, 1).await;
+    let (swarm, cli, _faucet, rosetta_client) = setup_test(1).await;
     let chain_id = swarm.chain_id();
 
     // Make sure first that there's money to transfer

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -16,6 +16,7 @@ use aptos_crypto::{
 };
 use aptos_forge::{AptosPublicInfo, LocalSwarm, Node, NodeExt, Swarm};
 use aptos_gas::{AptosGasParameters, FromOnChainGasSchedule};
+use aptos_genesis::builder::InitConfigFn;
 use aptos_global_constants::GAS_UNIT_PRICE;
 use aptos_rest_client::{
     aptos_api_types::{TransactionOnChainData, UserTransaction},
@@ -27,8 +28,8 @@ use aptos_rosetta::{
     types::{
         AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, BlockIdentifier,
         BlockRequest, BlockResponse, NetworkIdentifier, NetworkRequest, Operation,
-        OperationStatusType, OperationType, PartialBlockIdentifier, TransactionType,
-        STAKING_CONTRACT_MODULE, SWITCH_OPERATOR_WITH_SAME_COMMISSION_FUNCTION,
+        OperationStatusType, OperationType, PartialBlockIdentifier, TransactionIdentifier,
+        TransactionType, STAKING_CONTRACT_MODULE, SWITCH_OPERATOR_WITH_SAME_COMMISSION_FUNCTION,
     },
     ROSETTA_VERSION,
 };
@@ -39,21 +40,21 @@ use aptos_types::{
 };
 use std::{
     collections::{BTreeMap, HashSet},
-    convert::TryFrom,
     future::Future,
     str::FromStr,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tokio::{task::JoinHandle, time::Instant};
-use aptos_rosetta::types::TransactionIdentifier;
 
-const DEFAULT_MAX_WAIT_MS: u64 = 5000;
+const EPOCH_DURATION_S: u64 = 5;
+const DEFAULT_TRANSFER_AMOUNT: u64 = 20;
+const DEFAULT_MAX_WAIT_S: u64 = 5;
 const DEFAULT_INTERVAL_MS: u64 = 100;
-static DEFAULT_MAX_WAIT_DURATION: Duration = Duration::from_millis(DEFAULT_MAX_WAIT_MS);
+static DEFAULT_MAX_WAIT_DURATION: Duration = Duration::from_secs(DEFAULT_MAX_WAIT_S);
 static DEFAULT_INTERVAL_DURATION: Duration = Duration::from_millis(DEFAULT_INTERVAL_MS);
 
-async fn setup_test(
+async fn setup_simple_test(
     num_accounts: usize,
 ) -> (
     LocalSwarm,
@@ -61,16 +62,30 @@ async fn setup_test(
     JoinHandle<anyhow::Result<()>>,
     RosettaClient,
 ) {
+    setup_test(num_accounts, Arc::new(|_, _, _| {})).await
+}
+
+async fn setup_test(
+    num_accounts: usize,
+    config_fn: InitConfigFn,
+) -> (
+    LocalSwarm,
+    CliTestFramework,
+    JoinHandle<anyhow::Result<()>>,
+    RosettaClient,
+) {
+    // Start the validator
     let (swarm, cli, faucet) = SwarmBuilder::new_local(1)
         .with_init_genesis_config(Arc::new(|genesis_config| {
-            genesis_config.epoch_duration_secs = 5;
+            genesis_config.epoch_duration_secs = EPOCH_DURATION_S;
         }))
+        .with_init_config(config_fn)
         .with_aptos()
         .build_with_cli(num_accounts)
         .await;
     let validator = swarm.validators().next().unwrap();
 
-    // And the client
+    // And the rosetta server
     let rosetta_port = get_available_port();
     let rosetta_socket_addr = format!("127.0.0.1:{}", rosetta_port);
     let rosetta_url = format!("http://{}", rosetta_socket_addr.clone())
@@ -95,8 +110,8 @@ async fn setup_test(
         )),
         cli.addresses(),
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     // Ensure rosetta can take requests
     try_until_ok_default(|| rosetta_client.network_list())
@@ -110,49 +125,11 @@ async fn setup_test(
 async fn test_block_transactions() {
     const NUM_TXNS_PER_PAGE: u16 = 2;
 
-    let (swarm, cli, _faucet) = SwarmBuilder::new_local(1)
-        .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
-            // Only one transaction will show up in a block no matter what
-            config.api.max_transactions_page_size = NUM_TXNS_PER_PAGE;
-        }))
-        .build_with_cli(2)
-        .await;
-    let validator = swarm.validators().next().unwrap();
-
-    // And the client
-    let rosetta_port = get_available_port();
-    let rosetta_socket_addr = format!("127.0.0.1:{}", rosetta_port);
-    let rosetta_url = format!("http://{}", rosetta_socket_addr.clone())
-        .parse()
-        .unwrap();
-    let rosetta_client = RosettaClient::new(rosetta_url);
-    let api_config = ApiConfig {
-        enabled: true,
-        address: rosetta_socket_addr.parse().unwrap(),
-        tls_cert_path: None,
-        tls_key_path: None,
-        content_length_limit: None,
-        max_transactions_page_size: NUM_TXNS_PER_PAGE,
-        ..Default::default()
-    };
-
-    // Start the server
-    let _rosetta = aptos_rosetta::bootstrap_async(
-        swarm.chain_id(),
-        api_config,
-        Some(aptos_rest_client::Client::new(
-            validator.rest_api_endpoint(),
-        )),
-        cli.addresses(),
+    let (swarm, cli, _faucet, rosetta_client) = setup_test(
+        2,
+        Arc::new(|_, config, _| config.api.max_transactions_page_size = NUM_TXNS_PER_PAGE),
     )
-        .await
-        .unwrap();
-
-    // Ensure rosetta can take requests
-    try_until_ok_default(|| rosetta_client.network_list())
-        .await
-        .unwrap();
+    .await;
 
     let account_1 = cli.account_id(0);
     let chain_id = swarm.chain_id();
@@ -164,8 +141,8 @@ async fn test_block_transactions() {
         AccountIdentifier::base_account(account_1),
         Some(0),
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
     assert_eq!(response.block_identifier, BlockIdentifier {
         index: 0,
         hash: BlockHash::new(chain_id, 0).to_string(),
@@ -197,7 +174,7 @@ async fn test_block_transactions() {
 
 #[tokio::test]
 async fn test_network() {
-    let (swarm, _, _, rosetta_client) = setup_test(1).await;
+    let (swarm, _, _, rosetta_client) = setup_simple_test(1).await;
     let chain_id = swarm.chain_id();
 
     // We only support one network, this network
@@ -260,25 +237,16 @@ async fn test_network() {
 
 #[tokio::test]
 async fn test_account_balance() {
-    let (mut swarm, cli, _faucet, rosetta_client) = setup_test(3).await;
+    let (mut swarm, cli, _faucet, rosetta_client) = setup_simple_test(3).await;
 
     let account_1 = cli.account_id(0);
     let account_2 = cli.account_id(1);
     let account_3 = cli.account_id(2);
     let chain_id = swarm.chain_id();
-    let root_address = swarm.aptos_public_info().root_account().address();
-    let root_sequence_number = swarm
+    swarm
         .aptos_public_info()
-        .client()
-        .get_account_bcs(root_address)
-        .await
-        .unwrap()
-        .into_inner()
-        .sequence_number();
-    *swarm
-        .aptos_public_info()
-        .root_account()
-        .sequence_number_mut() = root_sequence_number;
+        .sync_root_account_sequence_number()
+        .await;
 
     let mut account_4 = swarm
         .aptos_public_info()
@@ -293,8 +261,8 @@ async fn test_account_balance() {
         AccountIdentifier::base_account(account_1),
         Some(0),
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
     assert_eq!(response.block_identifier, BlockIdentifier {
         index: 0,
         hash: BlockHash::new(chain_id, 0).to_string(),
@@ -308,7 +276,7 @@ async fn test_account_balance() {
     let mut account_1_balance = DEFAULT_FUNDED_COINS * 3;
     let mut account_2_balance = DEFAULT_FUNDED_COINS;
     // At some time both accounts should exist with initial amounts
-    try_until_ok(Duration::from_secs(5), DEFAULT_INTERVAL_DURATION, || {
+    try_until_ok(DEFAULT_MAX_WAIT_DURATION, DEFAULT_INTERVAL_DURATION, || {
         account_has_balance(
             &rosetta_client,
             chain_id,
@@ -317,8 +285,8 @@ async fn test_account_balance() {
             0,
         )
     })
-        .await
-        .unwrap();
+    .await
+    .unwrap();
     try_until_ok_default(|| {
         account_has_balance(
             &rosetta_client,
@@ -328,8 +296,8 @@ async fn test_account_balance() {
             0,
         )
     })
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     // Send money, and expect the gas and fees to show up accordingly
     const TRANSFER_AMOUNT: u64 = 5000;
@@ -346,8 +314,8 @@ async fn test_account_balance() {
         account_1_balance,
         1,
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
     account_has_balance(
         &rosetta_client,
         chain_id,
@@ -355,8 +323,8 @@ async fn test_account_balance() {
         account_2_balance,
         0,
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     // Failed transaction spends gas
     let _ = cli
@@ -390,8 +358,8 @@ async fn test_account_balance() {
             account_1_balance,
             2,
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
     }
 
     // Check that the balance hasn't changed (and should be 0) in the invalid account
@@ -402,8 +370,8 @@ async fn test_account_balance() {
         0,
         0,
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     // Let's now check the staking balance with the original staking contract, it should not be supported
     cli.fund_account(2, Some(10_000_000)).await.unwrap();
@@ -417,8 +385,8 @@ async fn test_account_balance() {
         1_000_000,
         1,
     )
-        .await
-        .expect_err("Original staking contract is not supported");
+    .await
+    .expect_err("Original staking contract is not supported");
 
     create_staking_contract(
         &swarm.aptos_public_info(),
@@ -429,7 +397,7 @@ async fn test_account_balance() {
         10,
         1,
     )
-        .await;
+    .await;
 
     account_has_balance(
         &rosetta_client,
@@ -438,8 +406,8 @@ async fn test_account_balance() {
         1_000_000,
         1,
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     account_has_balance(
         &rosetta_client,
@@ -448,8 +416,8 @@ async fn test_account_balance() {
         1_000_000,
         1,
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     unlock_stake(
         &swarm.aptos_public_info(),
@@ -458,7 +426,7 @@ async fn test_account_balance() {
         1_000,
         2,
     )
-        .await;
+    .await;
 
     // Since unlock_stake was initiated, 1000 APT should be in pending inactive state until lockup ends
     account_has_balance(
@@ -468,8 +436,8 @@ async fn test_account_balance() {
         1_000,
         2,
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     account_has_balance(
         &rosetta_client,
@@ -478,8 +446,8 @@ async fn test_account_balance() {
         0,
         2,
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     /* TODO: Support operator stake account in the future
     account_has_balance(
@@ -578,12 +546,27 @@ async fn get_balance(
     try_until_ok_default(|| rosetta_client.account_balance(&request)).await
 }
 
+async fn wait_for_rosetta_block(node_clients: &NodeClients<'_>, block_height: u64) {
+    // Wait until the Rosetta service is ready
+    let request = NetworkRequest {
+        network_identifier: node_clients.network.clone(),
+    };
+
+    loop {
+        let status = try_until_ok_default(|| node_clients.rosetta_client.network_status(&request))
+            .await
+            .unwrap();
+        if status.current_block_identifier.index >= block_height {
+            break;
+        }
+    }
+}
+
 #[tokio::test]
 async fn test_transfer() {
-    let (mut swarm, cli, _faucet, rosetta_client) = setup_test(1).await;
+    let (mut swarm, cli, _faucet, rosetta_client) = setup_simple_test(1).await;
     let chain_id = swarm.chain_id();
-    let public_info = swarm.aptos_public_info();
-    let client = public_info.client();
+    let client = swarm.aptos_public_info().client().clone();
     let sender = cli.account_id(0);
     let receiver = AccountAddress::from_hex_literal("0xBEEF").unwrap();
     let sender_private_key = cli.private_key(0);
@@ -596,35 +579,22 @@ async fn test_transfer() {
         .value
         .0;
     let network = NetworkIdentifier::from(chain_id);
-
-    // Wait until the Rosetta service is ready
-    let request = NetworkRequest {
-        network_identifier: network.clone(),
+    let node_clients = NodeClients {
+        rosetta_client: &rosetta_client,
+        rest_client: &client,
+        network: &network,
     };
-
-    loop {
-        let status = try_until_ok_default(|| rosetta_client.network_status(&request))
-            .await
-            .unwrap();
-        if status.current_block_identifier.index >= 2 {
-            break;
-        }
-    }
+    wait_for_rosetta_block(&node_clients, 2).await;
 
     // Attempt to transfer more than balance to another user (should fail)
-    rosetta_client
-        .transfer(
-            &network,
-            sender_private_key,
-            receiver,
-            sender_balance + 200,
-            expiry_time(Duration::from_secs(5)).as_secs(),
-            None,
-            None,
-            None,
-        )
-        .await
-        .expect_err("Should fail simulation since we can't transfer more than balance coins");
+    simple_transfer_and_wait(
+        &node_clients,
+        sender_private_key,
+        receiver,
+        sender_balance + 200,
+    )
+    .await
+    .expect_err("Should fail simulation since we can't transfer more than balance coins");
 
     // Attempt to transfer more than balance to another user (should fail)
     let transaction_factory = TransactionFactory::new(chain_id)
@@ -642,7 +612,7 @@ async fn test_transfer() {
     let signed_transaction = SignedTransaction::new(
         unsigned_transaction,
         sender_private_key.public_key(),
-        Ed25519Signature::try_from([0u8; 64].as_ref()).unwrap(),
+        Ed25519Signature::dummy_signature(),
     );
 
     let simulation_txn = client
@@ -651,40 +621,22 @@ async fn test_transfer() {
         .expect("Should succeed getting gas estimate")
         .into_inner();
     let gas_usage = simulation_txn.info.gas_used() * GAS_UNIT_PRICE;
+    let max_sent = sender_balance - gas_usage;
 
     // Attempt to transfer more than balance - gas to another user (should fail)
-    rosetta_client
-        .transfer(
-            &network,
-            sender_private_key,
-            receiver,
-            sender_balance - gas_usage + 1,
-            expiry_time(Duration::from_secs(5)).as_secs(),
-            None,
-            None,
-            None,
-        )
+    simple_transfer_and_wait(&node_clients, sender_private_key, receiver, max_sent + 1)
         .await
         .expect_err("Should fail simulation since we can't transfer more than balance + gas coins");
 
-    // TODO(greg): Re-enable after fixing gas estimation.
-    /*
     // Attempt to transfer more than balance - gas to another user (should fail)
-    let transfer = transfer_and_wait(
-        &rosetta_client,
-        client,
-        &network,
-        sender_private_key,
-        receiver,
-        sender_balance - gas_usage,
-        Duration::from_secs(5),
-        None,
-        None,
-        None,
-    )
-    .await
-    .expect("Should succeed transfer");
-    assert_eq!(transfer.info.gas_used.0, gas_usage);
+    let node_clients = NodeClients {
+        rosetta_client: &rosetta_client,
+        rest_client: &client,
+        network: &network,
+    };
+    simple_transfer_and_wait(&node_clients, sender_private_key, receiver, max_sent)
+        .await
+        .expect("Should succeed transfer");
 
     // Sender balance should be 0
     assert_eq!(
@@ -708,16 +660,15 @@ async fn test_transfer() {
             .coin
             .value
             .0,
-        sender_balance - gas_usage
+        max_sent
     );
-    */
 }
 
 /// This test tests all of Rosetta's functionality from the read side in one go.  Since
 /// it's block based and it needs time to run, we do all the checks in a single test.
 #[tokio::test]
 async fn test_block() {
-    let (swarm, cli, _faucet, rosetta_client) = setup_test(5).await;
+    let (swarm, cli, _faucet, rosetta_client) = setup_simple_test(5).await;
     let chain_id = swarm.chain_id();
     let validator = swarm.validators().next().unwrap();
     let rest_client = validator.rest_client();
@@ -726,18 +677,13 @@ async fn test_block() {
     let mut balances = BTreeMap::<AccountAddress, BTreeMap<u64, i128>>::new();
 
     // Wait until the Rosetta service is ready
-    let request = NetworkRequest {
-        network_identifier: NetworkIdentifier::from(chain_id),
+    let network = NetworkIdentifier::from(chain_id);
+    let node_clients = NodeClients {
+        rosetta_client: &rosetta_client,
+        rest_client: &rest_client,
+        network: &network,
     };
-
-    loop {
-        let status = try_until_ok_default(|| rosetta_client.network_status(&request))
-            .await
-            .unwrap();
-        if status.current_block_identifier.index >= 2 {
-            break;
-        }
-    }
+    wait_for_rosetta_block(&node_clients, 2).await;
 
     // Do some transfers
     let account_id_0 = cli.account_id(0);
@@ -757,164 +703,129 @@ async fn test_block() {
         .await
         .unwrap()
         .into_inner();
-    let feaure_version = gas_schedule.feature_version;
+    let feature_version = gas_schedule.feature_version;
     let gas_params = AptosGasParameters::from_on_chain_gas_schedule(
         &gas_schedule.to_btree_map(),
-        feaure_version,
+        feature_version,
     )
-        .unwrap();
+    .unwrap();
     let min_gas_price = u64::from(gas_params.txn.min_price_per_gas_unit);
 
     let private_key_0 = cli.private_key(0);
     let private_key_1 = cli.private_key(1);
     let private_key_2 = cli.private_key(2);
     let private_key_3 = cli.private_key(3);
-    let network_identifier = chain_id.into();
-    let seq_no_0 = transfer_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
+
+    let seq_no_0 = simple_transfer_and_wait(
+        &node_clients,
         private_key_0,
         account_id_1,
-        20,
-        Duration::from_secs(5),
-        Some(0),
-        // TODO(greg): Revisit after fixing gas estimation.
-        Some(1000000),
-        None,
+        DEFAULT_TRANSFER_AMOUNT,
     )
-        .await
-        .unwrap()
-        .request
-        .sequence_number
-        .0;
-    transfer_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
+    .await
+    .unwrap()
+    .request
+    .sequence_number
+    .0;
+    simple_transfer_and_wait(
+        &node_clients,
         private_key_1,
         account_id_0,
-        20,
-        Duration::from_secs(5),
-        None,
-        // TODO(greg): Revisit after fixing gas estimation.
-        Some(1000000),
-        None,
+        DEFAULT_TRANSFER_AMOUNT,
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
     transfer_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
+        &node_clients,
         private_key_0,
         account_id_0,
-        20,
-        Duration::from_secs(5),
+        DEFAULT_TRANSFER_AMOUNT,
+        None,
         Some(seq_no_0 + 1),
-        // TODO(greg): revisit after fixing gas estimation
-        Some(1000000),
+        None,
         None,
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
     // Create a new account via transfer
-    transfer_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
+    simple_transfer_and_wait(
+        &node_clients,
         private_key_2,
         AccountAddress::from_hex_literal(INVALID_ACCOUNT).unwrap(),
-        20,
-        Duration::from_secs(5),
-        None,
-        // TODO(greg): Revisit after fixing gas estimation.
-        Some(1000000),
-        None,
+        DEFAULT_TRANSFER_AMOUNT,
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
     let seq_no_3 = transfer_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
+        &node_clients,
         private_key_3,
         account_id_0,
-        20,
-        Duration::from_secs(5),
+        DEFAULT_TRANSFER_AMOUNT,
+        None,
         None,
         Some(2000000),
         Some(min_gas_price),
     )
-        .await
-        .unwrap()
-        .request
-        .sequence_number
-        .0;
+    .await
+    .unwrap()
+    .request
+    .sequence_number
+    .0;
 
     // Create another account via command
     create_account_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
+        &node_clients,
         private_key_3,
         AccountAddress::from_hex_literal("0x99").unwrap(),
-        Duration::from_secs(5),
+        None,
         Some(seq_no_3 + 1),
         None,
         None,
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     transfer_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
+        &node_clients,
         private_key_1,
         account_id_3,
-        20,
-        Duration::from_secs(5),
+        DEFAULT_TRANSFER_AMOUNT,
+        None,
         // Test the default behavior
         None,
-        // TODO(greg): Revisit after fixing gas estimation.
-        Some(10000),
+        None,
         Some(min_gas_price + 1),
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     // This one will fail because expiration is in the past
     transfer_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
+        &node_clients,
         private_key_3,
         AccountAddress::ONE,
-        20,
-        Duration::from_secs(0),
+        DEFAULT_TRANSFER_AMOUNT,
+        Some(Duration::from_secs(0)),
         None,
         None,
         None,
     )
-        .await
-        .unwrap_err();
+    .await
+    .unwrap_err();
 
     // This one will fail because gas is too low
     transfer_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
+        &node_clients,
         private_key_3,
         AccountAddress::ONE,
-        20,
-        Duration::from_secs(5),
+        DEFAULT_TRANSFER_AMOUNT,
+        None,
         None,
         Some(1),
         None,
     )
-        .await
-        .unwrap_err();
+    .await
+    .unwrap_err();
 
     // Add a ton of coins, and set an operator
     cli.fund_account(3, Some(10_000_000)).await.unwrap();
@@ -922,148 +833,81 @@ async fn test_block() {
 
     // Set the operator
     set_operator_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
+        &node_clients,
         private_key_3,
         Some(account_id_3),
         account_id_1,
-        Duration::from_secs(5),
-        None,
-        None,
-        None,
     )
-        .await
-        .expect("Set operator should work!");
+    .await
+    .expect("Set operator should work!");
 
     // Also fail to set an operator (since the operator already changed)
     set_operator_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
+        &node_clients,
         private_key_3,
         Some(account_id_3),
         account_id_1,
-        Duration::from_secs(5),
-        None,
-        None,
-        None,
     )
-        .await
-        .unwrap_err();
+    .await
+    .unwrap_err();
 
     // Test native stake pool and reset lockup support
-    cli.fund_account(2, Some(1000000000000000)).await.unwrap();
+    const MIL_APT: u64 = 100000000000000;
+    cli.fund_account(2, Some(10 * MIL_APT)).await.unwrap();
     create_stake_pool_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
+        &node_clients,
         private_key_2,
         Some(account_id_3),
         Some(account_id_2),
-        Some(100000000000000),
+        Some(MIL_APT),
         Some(5),
-        Duration::from_secs(5),
-        None,
-        None,
-        None,
     )
-        .await
-        .expect("Should successfully create stake pool");
+    .await
+    .expect("Should successfully create stake pool");
 
     // TODO: Verify lockup time changes
 
     // Reset lockup
-    reset_lockup_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
-        private_key_2,
-        Some(account_id_3),
-        Duration::from_secs(5),
-        None,
-        None,
-        None,
-    )
+    reset_lockup_and_wait(&node_clients, private_key_2, Some(account_id_3))
         .await
         .expect("Should successfully reset lockup");
 
     // Successfully, and fail setting a voter
     set_voter_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
+        &node_clients,
         private_key_3,
         Some(account_id_3),
         account_id_1,
-        Duration::from_secs(5),
-        None,
-        None,
-        None,
     )
-        .await
-        .expect_err("Set voter shouldn't work with the wrong operator!");
+    .await
+    .expect_err("Set voter shouldn't work with the wrong operator!");
     set_voter_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
+        &node_clients,
         private_key_3,
         Some(account_id_1),
         account_id_1,
-        Duration::from_secs(5),
-        None,
-        None,
-        None,
     )
-        .await
-        .expect("Set voter should work!");
+    .await
+    .expect("Set voter should work!");
 
     // Unlock stake
-    unlock_stake_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
-        private_key_2,
-        Some(account_id_3),
-        Some(10),
-        Duration::from_secs(5),
-        None,
-        None,
-        None,
-    )
+    unlock_stake_and_wait(&node_clients, private_key_2, Some(account_id_3), Some(10))
         .await
         .expect("Should successfully unlock stake");
 
     // Failed distribution with wrong staker
-    distribute_staking_rewards_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
-        private_key_3,
-        account_id_2,
-        account_id_3,
-        Duration::from_secs(5),
-        None,
-        None,
-        None,
-    )
+    distribute_staking_rewards_and_wait(&node_clients, private_key_3, account_id_2, account_id_3)
         .await
         .expect_err("Staker has no staking contracts.");
 
     let final_txn = distribute_staking_rewards_and_wait(
-        &rosetta_client,
-        &rest_client,
-        &network_identifier,
+        &node_clients,
         private_key_3,
         account_id_3,
         account_id_2,
-        Duration::from_secs(5),
-        None,
-        None,
-        None,
     )
-        .await
-        .expect("Distribute staking rewards should work!");
+    .await
+    .expect("Distribute staking rewards should work!");
 
     let final_block_to_check = rest_client
         .get_block_by_version(final_txn.info.version.0, false)
@@ -1078,18 +922,7 @@ async fn test_block() {
     // TODO: Handle multiple coin types
 
     // Wait until the Rosetta service is ready
-    let request = NetworkRequest {
-        network_identifier: NetworkIdentifier::from(chain_id),
-    };
-
-    loop {
-        let status = try_until_ok_default(|| rosetta_client.network_status(&request))
-            .await
-            .unwrap();
-        if status.current_block_identifier.index >= final_block_height {
-            break;
-        }
-    }
+    wait_for_rosetta_block(&node_clients, final_block_height).await;
 
     // Now we have to watch all the changes
     let mut current_version = 0;
@@ -1215,7 +1048,7 @@ async fn parse_block_transactions(
                     actual_txn.transaction,
                     aptos_types::transaction::Transaction::GenesisTransaction(_)
                 ));
-            }
+            },
             TransactionType::User => {
                 assert!(matches!(
                     actual_txn.transaction,
@@ -1223,21 +1056,21 @@ async fn parse_block_transactions(
                 ));
                 // Must have a gas fee
                 assert!(!transaction.operations.is_empty());
-            }
+            },
             TransactionType::BlockMetadata => {
                 assert!(matches!(
                     actual_txn.transaction,
                     aptos_types::transaction::Transaction::BlockMetadata(_)
                 ));
                 assert!(transaction.operations.is_empty());
-            }
+            },
             TransactionType::StateCheckpoint => {
                 assert!(matches!(
                     actual_txn.transaction,
                     aptos_types::transaction::Transaction::StateCheckpoint(_)
                 ));
                 assert!(transaction.operations.is_empty());
-            }
+            },
         }
 
         parse_operations(
@@ -1246,7 +1079,7 @@ async fn parse_block_transactions(
             transaction,
             actual_txn,
         )
-            .await;
+        .await;
 
         for (_, account_balance) in balances.iter() {
             if let Some(amount) = account_balance.get(&cur_version) {
@@ -1272,14 +1105,9 @@ async fn parse_operations(
         assert_eq!(expected_index as u64, operation.operation_identifier.index);
 
         // Gas transaction is always last
-        let status = OperationStatusType::from_str(
-            operation
-                .status
-                .as_ref()
-                .expect("Should have an operation status"),
-        )
-            .expect("Operation status should be known");
-        let operation_type = OperationType::from_str(&operation.operation_type)
+        let status = operation.status().expect("Should have an operation status");
+        let operation_type = operation
+            .operation_type()
             .expect("Operation type should be known");
         let actual_successful = actual_txn.info.status().is_success();
 
@@ -1288,10 +1116,7 @@ async fn parse_operations(
             OperationType::CreateAccount => {
                 // Initialize state for a new account
                 let account = operation
-                    .account
-                    .as_ref()
-                    .expect("There should be an account in a create account operation")
-                    .account_address()
+                    .account()
                     .expect("Account address should be parsable");
 
                 if actual_successful {
@@ -1310,13 +1135,10 @@ async fn parse_operations(
                         "Failed transaction should have failed create account operation"
                     );
                 }
-            }
+            },
             OperationType::Deposit => {
                 let account = operation
-                    .account
-                    .as_ref()
-                    .expect("There should be an account in a deposit operation")
-                    .account_address()
+                    .account()
                     .expect("Account address should be parsable");
 
                 if actual_successful {
@@ -1327,22 +1149,15 @@ async fn parse_operations(
                         map
                     });
                     let (_, latest_balance) = account_balances.iter().last().unwrap();
-                    let amount = operation
-                        .amount
-                        .as_ref()
-                        .expect("Should have an amount in a deposit operation");
                     assert_eq!(
-                        amount.currency,
-                        native_coin(),
+                        operation.currency().unwrap(),
+                        &native_coin(),
                         "Balance should be the native coin"
                     );
-                    let delta = amount
-                        .value
-                        .parse::<u64>()
-                        .expect("Should be able to parse amount value");
+                    let delta = operation.amount().unwrap();
 
                     // Add with panic on overflow in case of too high of a balance
-                    let new_balance = *latest_balance + delta as i128;
+                    let new_balance = *latest_balance + delta;
                     account_balances.insert(block_height, new_balance);
                 } else {
                     assert_eq!(
@@ -1351,16 +1166,13 @@ async fn parse_operations(
                         "Failed transaction should have failed deposit operation"
                     );
                 }
-            }
+            },
             OperationType::Withdraw => {
                 // Gas is always successful
                 if actual_successful {
                     assert_eq!(OperationStatusType::Success, status);
                     let account = operation
-                        .account
-                        .as_ref()
-                        .expect("There should be an account in a withdraw operation")
-                        .account_address()
+                        .account()
                         .expect("Account address should be parsable");
 
                     let account_balances = balances.entry(account).or_insert_with(|| {
@@ -1369,24 +1181,13 @@ async fn parse_operations(
                         map
                     });
                     let (_, latest_balance) = account_balances.iter().last().unwrap();
-                    let amount = operation
-                        .amount
-                        .as_ref()
-                        .expect("Should have an amount in a deposit operation");
                     assert_eq!(
-                        amount.currency,
-                        native_coin(),
+                        operation.currency().unwrap(),
+                        &native_coin(),
                         "Balance should be the native coin"
                     );
-                    let delta = amount
-                        .value
-                        .strip_prefix('-')
-                        .expect("Should have a negative number")
-                        .parse::<u64>()
-                        .expect("Should be able to parse amount value");
-
-                    // Subtract with panic on overflow in case of a negative balance
-                    let new_balance = *latest_balance - delta as i128;
+                    let delta = operation.amount().unwrap();
+                    let new_balance = *latest_balance + delta;
                     account_balances.insert(block_height, new_balance);
                 } else {
                     assert_eq!(
@@ -1395,13 +1196,10 @@ async fn parse_operations(
                         "Failed transaction should have failed withdraw operation"
                     );
                 }
-            }
+            },
             OperationType::StakingReward => {
                 let account = operation
-                    .account
-                    .as_ref()
-                    .expect("There should be an account in a stake reward operation")
-                    .account_address()
+                    .account()
                     .expect("Account address should be parsable");
 
                 if actual_successful {
@@ -1412,22 +1210,15 @@ async fn parse_operations(
                         map
                     });
                     let (_, latest_balance) = account_balances.iter().last().unwrap();
-                    let amount = operation
-                        .amount
-                        .as_ref()
-                        .expect("Should have an amount in a stake reward operation");
                     assert_eq!(
-                        amount.currency,
-                        native_coin(),
+                        operation.currency().unwrap(),
+                        &native_coin(),
                         "Balance should be the native coin"
                     );
-                    let delta = amount
-                        .value
-                        .parse::<u64>()
-                        .expect("Should be able to parse amount value");
 
                     // Add with panic on overflow in case of too high of a balance
-                    let new_balance = *latest_balance + delta as i128;
+                    let delta = operation.amount().unwrap();
+                    let new_balance = *latest_balance + delta;
                     account_balances.insert(block_height, new_balance);
                 } else {
                     assert_eq!(
@@ -1436,7 +1227,7 @@ async fn parse_operations(
                         "Failed transaction should have failed stake reward operation"
                     );
                 }
-            }
+            },
             OperationType::SetOperator => {
                 if actual_successful {
                     assert_eq!(
@@ -1478,15 +1269,7 @@ async fn parse_operations(
                             _ => panic!("Unsupported entry function for set operator! {:?}", txn),
                         };
 
-                        let operator = operation
-                            .metadata
-                            .as_ref()
-                            .unwrap()
-                            .new_operator
-                            .as_ref()
-                            .unwrap()
-                            .account_address()
-                            .unwrap();
+                        let operator = operation.new_operator().unwrap();
                         assert_eq!(actual_operator_address, operator)
                     } else {
                         panic!("Not an entry function");
@@ -1494,7 +1277,7 @@ async fn parse_operations(
                 } else {
                     panic!("Not a user transaction");
                 }
-            }
+            },
             OperationType::SetVoter => {
                 if actual_successful {
                     assert_eq!(
@@ -1520,15 +1303,7 @@ async fn parse_operations(
                     {
                         let actual_voter_address: AccountAddress =
                             bcs::from_bytes(payload.args().first().unwrap()).unwrap();
-                        let voter = operation
-                            .metadata
-                            .as_ref()
-                            .unwrap()
-                            .new_voter
-                            .as_ref()
-                            .unwrap()
-                            .account_address()
-                            .unwrap();
+                        let voter = operation.new_voter().unwrap();
                         assert_eq!(actual_voter_address, voter)
                     } else {
                         panic!("Not an entry function");
@@ -1536,16 +1311,13 @@ async fn parse_operations(
                 } else {
                     panic!("Not a user transaction");
                 }
-            }
+            },
             OperationType::Fee => {
                 has_gas_op = true;
                 assert_eq!(OperationStatusType::Success, status);
                 let account = operation
-                    .account
-                    .as_ref()
-                    .expect("There should be an account in a fee operation")
-                    .account_address()
-                    .expect("Account address should be parsable");
+                    .account()
+                    .expect("There should be an account in a fee operation");
 
                 let account_balances = balances.entry(account).or_insert_with(|| {
                     let mut map = BTreeMap::new();
@@ -1553,24 +1325,15 @@ async fn parse_operations(
                     map
                 });
                 let (_, latest_balance) = account_balances.iter().last().unwrap();
-                let amount = operation
-                    .amount
-                    .as_ref()
-                    .expect("Should have an amount in a fee operation");
                 assert_eq!(
-                    amount.currency,
-                    native_coin(),
+                    operation.currency().unwrap(),
+                    &native_coin(),
                     "Balance should be the native coin"
                 );
-                let delta = amount
-                    .value
-                    .strip_prefix('-')
-                    .expect("Should have a negative number")
-                    .parse::<u64>()
-                    .expect("Should be able to parse amount value");
+                let delta = operation.amount().unwrap();
 
                 // Subtract with panic on overflow in case of a negative balance
-                let new_balance = *latest_balance - delta as i128;
+                let new_balance = *latest_balance + delta;
                 account_balances.insert(block_height, new_balance);
                 match actual_txn.transaction {
                     aptos_types::transaction::Transaction::UserTransaction(ref txn) => {
@@ -1579,15 +1342,15 @@ async fn parse_operations(
                                 .info
                                 .gas_used()
                                 .saturating_mul(txn.gas_unit_price()),
-                            delta,
+                            delta.unsigned_abs() as u64,
                             "Gas operation should always match gas used * gas unit price"
                         )
-                    }
+                    },
                     _ => {
                         panic!("Gas transactions should be user transactions!")
-                    }
+                    },
                 };
-            }
+            },
             OperationType::ResetLockup => {
                 if actual_successful {
                     assert_eq!(
@@ -1613,15 +1376,7 @@ async fn parse_operations(
                     {
                         let actual_operator_address: AccountAddress =
                             bcs::from_bytes(payload.args().first().unwrap()).unwrap();
-                        let operator = operation
-                            .metadata
-                            .as_ref()
-                            .unwrap()
-                            .operator
-                            .as_ref()
-                            .unwrap()
-                            .account_address()
-                            .unwrap();
+                        let operator = operation.operator().unwrap();
                         assert_eq!(actual_operator_address, operator)
                     } else {
                         panic!("Not an entry function");
@@ -1629,7 +1384,7 @@ async fn parse_operations(
                 } else {
                     panic!("Not a user transaction");
                 }
-            }
+            },
             OperationType::InitializeStakePool => {
                 if actual_successful {
                     assert_eq!(
@@ -1655,50 +1410,20 @@ async fn parse_operations(
                     {
                         let actual_operator_address: AccountAddress =
                             bcs::from_bytes(payload.args().get(0).unwrap()).unwrap();
-                        let operator = operation
-                            .metadata
-                            .as_ref()
-                            .unwrap()
-                            .new_operator
-                            .as_ref()
-                            .unwrap()
-                            .account_address()
-                            .unwrap();
+                        let operator = operation.new_operator().unwrap();
                         assert_eq!(actual_operator_address, operator);
 
                         let actual_voter_address: AccountAddress =
                             bcs::from_bytes(payload.args().get(1).unwrap()).unwrap();
-                        let voter = operation
-                            .metadata
-                            .as_ref()
-                            .unwrap()
-                            .new_voter
-                            .as_ref()
-                            .unwrap()
-                            .account_address()
-                            .unwrap();
+                        let voter = operation.new_voter().unwrap();
                         assert_eq!(actual_voter_address, voter);
 
                         let actual_stake_amount: u64 =
                             bcs::from_bytes(payload.args().get(2).unwrap()).unwrap();
-                        let stake = operation
-                            .metadata
-                            .as_ref()
-                            .unwrap()
-                            .staked_balance
-                            .as_ref()
-                            .unwrap()
-                            .0;
+                        let stake = operation.staked_balance().unwrap();
                         assert_eq!(actual_stake_amount, stake);
 
-                        let commission_percentage = operation
-                            .metadata
-                            .as_ref()
-                            .unwrap()
-                            .commission_percentage
-                            .as_ref()
-                            .unwrap()
-                            .0;
+                        let commission_percentage = operation.commission_percentage().unwrap();
                         let actual_commission: u64 =
                             bcs::from_bytes(payload.args().get(3).unwrap()).unwrap();
                         assert_eq!(actual_commission, commission_percentage);
@@ -1708,7 +1433,7 @@ async fn parse_operations(
                 } else {
                     panic!("Not a user transaction");
                 }
-            }
+            },
             OperationType::UnlockStake => {
                 if actual_successful {
                     assert_eq!(
@@ -1734,27 +1459,12 @@ async fn parse_operations(
                     {
                         let actual_operator_address: AccountAddress =
                             bcs::from_bytes(payload.args().first().unwrap()).unwrap();
-                        let operator = operation
-                            .metadata
-                            .as_ref()
-                            .unwrap()
-                            .operator
-                            .as_ref()
-                            .unwrap()
-                            .account_address()
-                            .unwrap();
+                        let operator = operation.operator().unwrap();
                         assert_eq!(actual_operator_address, operator);
 
                         let actual_amount: u64 =
                             bcs::from_bytes(payload.args().get(1).unwrap()).unwrap();
-                        let amount = operation
-                            .metadata
-                            .as_ref()
-                            .unwrap()
-                            .amount
-                            .as_ref()
-                            .unwrap()
-                            .0;
+                        let amount = operation.metadata_amount().unwrap();
                         assert_eq!(actual_amount, amount);
                     } else {
                         panic!("Not an entry function");
@@ -1762,7 +1472,7 @@ async fn parse_operations(
                 } else {
                     panic!("Not a user transaction");
                 }
-            }
+            },
             OperationType::DistributeStakingRewards => {
                 if actual_successful {
                     assert_eq!(
@@ -1788,28 +1498,12 @@ async fn parse_operations(
                     {
                         let actual_staker_address: AccountAddress =
                             bcs::from_bytes(payload.args().first().unwrap()).unwrap();
-                        let staker = operation
-                            .metadata
-                            .as_ref()
-                            .unwrap()
-                            .staker
-                            .as_ref()
-                            .unwrap()
-                            .account_address()
-                            .unwrap();
+                        let staker = operation.staker().unwrap();
                         assert_eq!(actual_staker_address, staker);
 
                         let actual_operator_address: AccountAddress =
                             bcs::from_bytes(payload.args().get(1).unwrap()).unwrap();
-                        let operator = operation
-                            .metadata
-                            .as_ref()
-                            .unwrap()
-                            .operator
-                            .as_ref()
-                            .unwrap()
-                            .account_address()
-                            .unwrap();
+                        let operator = operation.operator().unwrap();
                         assert_eq!(actual_operator_address, operator);
                     } else {
                         panic!("Not an entry function");
@@ -1817,7 +1511,7 @@ async fn parse_operations(
                 } else {
                     panic!("Not a user transaction");
                 }
-            }
+            },
         }
     }
 
@@ -1880,7 +1574,7 @@ async fn check_balances(
 
 #[tokio::test]
 async fn test_invalid_transaction_gas_charged() {
-    let (swarm, cli, _faucet, rosetta_client) = setup_test(1).await;
+    let (swarm, cli, _faucet, rosetta_client) = setup_simple_test(1).await;
     let chain_id = swarm.chain_id();
 
     // Make sure first that there's money to transfer
@@ -1981,11 +1675,11 @@ fn assert_failed_transfer_transaction(
                         receiver,
                         actual_txn.info.success,
                     );
-                }
+                },
                 OperationType::Withdraw => {
                     seen_withdraw = true;
                     assert_withdraw(operation, transfer_amount, sender, actual_txn.info.success);
-                }
+                },
                 _ => panic!("Shouldn't get any other operations"),
             }
         } else if !seen_deposit {
@@ -2071,22 +1765,22 @@ fn assert_transfer(
     } else {
         OperationStatusType::Failure
     }
-        .to_string();
+    .to_string();
     assert_eq!(&expected_status, operation.status.as_ref().unwrap());
 }
 
 /// Try for 2 seconds to get a response.  This handles the fact that it's starting async
 async fn try_until_ok_default<F, Fut, T>(function: F) -> anyhow::Result<T>
-    where
-        F: Fn() -> Fut,
-        Fut: Future<Output=anyhow::Result<T>>,
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = anyhow::Result<T>>,
 {
     try_until_ok(
         DEFAULT_MAX_WAIT_DURATION,
         DEFAULT_INTERVAL_DURATION,
         function,
     )
-        .await
+    .await
 }
 
 async fn try_until_ok<F, Fut, T>(
@@ -2094,9 +1788,9 @@ async fn try_until_ok<F, Fut, T>(
     interval: Duration,
     function: F,
 ) -> anyhow::Result<T>
-    where
-        F: Fn() -> Fut,
-        Fut: Future<Output=anyhow::Result<T>>,
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = anyhow::Result<T>>,
 {
     let mut result = Err(anyhow::Error::msg("Failed to get response"));
     let start = Instant::now();
@@ -2111,221 +1805,251 @@ async fn try_until_ok<F, Fut, T>(
     result
 }
 
+struct NodeClients<'a> {
+    pub rosetta_client: &'a RosettaClient,
+    pub rest_client: &'a aptos_rest_client::Client,
+    pub network: &'a NetworkIdentifier,
+}
+
 async fn create_account_and_wait(
-    rosetta_client: &RosettaClient,
-    rest_client: &aptos_rest_client::Client,
-    network_identifier: &NetworkIdentifier,
+    node_clients: &NodeClients<'_>,
     sender_key: &Ed25519PrivateKey,
     new_account: AccountAddress,
-    txn_expiry_duration: Duration,
+    txn_expiry_duration: Option<Duration>,
     sequence_number: Option<u64>,
     max_gas: Option<u64>,
     gas_unit_price: Option<u64>,
 ) -> Result<Box<UserTransaction>, ErrorWrapper> {
-    submit_transaction(rest_client, txn_expiry_duration, |expiry_time| rosetta_client
-        .create_account(
-            network_identifier,
-            sender_key,
-            new_account,
-            expiry_time,
-            sequence_number,
-            max_gas,
-            gas_unit_price,
-        ))
-        .await
+    submit_transaction(
+        node_clients.rest_client,
+        txn_expiry_duration.unwrap_or(DEFAULT_MAX_WAIT_DURATION),
+        |expiry_time| {
+            node_clients.rosetta_client.create_account(
+                node_clients.network,
+                sender_key,
+                new_account,
+                expiry_time,
+                sequence_number,
+                max_gas,
+                gas_unit_price,
+            )
+        },
+    )
+    .await
 }
 
-async fn transfer_and_wait(
-    rosetta_client: &RosettaClient,
-    rest_client: &aptos_rest_client::Client,
-    network_identifier: &NetworkIdentifier,
+async fn simple_transfer_and_wait(
+    node_clients: &NodeClients<'_>,
     sender_key: &Ed25519PrivateKey,
     receiver: AccountAddress,
     amount: u64,
-    txn_expiry_duration: Duration,
+) -> Result<Box<UserTransaction>, ErrorWrapper> {
+    transfer_and_wait(
+        node_clients,
+        sender_key,
+        receiver,
+        amount,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+}
+
+async fn transfer_and_wait(
+    node_clients: &NodeClients<'_>,
+    sender_key: &Ed25519PrivateKey,
+    receiver: AccountAddress,
+    amount: u64,
+    txn_expiry_duration: Option<Duration>,
     sequence_number: Option<u64>,
     max_gas: Option<u64>,
     gas_unit_price: Option<u64>,
 ) -> Result<Box<UserTransaction>, ErrorWrapper> {
-    submit_transaction(rest_client, txn_expiry_duration, |expiry_time| rosetta_client
-        .transfer(
-            network_identifier,
-            sender_key,
-            receiver,
-            amount,
-            expiry_time.as_secs(),
-            sequence_number,
-            max_gas,
-            gas_unit_price,
-        ))
-        .await
+    submit_transaction(
+        node_clients.rest_client,
+        txn_expiry_duration.unwrap_or(DEFAULT_MAX_WAIT_DURATION),
+        |expiry_time| {
+            node_clients.rosetta_client.transfer(
+                node_clients.network,
+                sender_key,
+                receiver,
+                amount,
+                expiry_time,
+                sequence_number,
+                max_gas,
+                gas_unit_price,
+            )
+        },
+    )
+    .await
 }
 
 async fn set_operator_and_wait(
-    rosetta_client: &RosettaClient,
-    rest_client: &aptos_rest_client::Client,
-    network_identifier: &NetworkIdentifier,
+    node_clients: &NodeClients<'_>,
     sender_key: &Ed25519PrivateKey,
     old_operator: Option<AccountAddress>,
     new_operator: AccountAddress,
-    txn_expiry_duration: Duration,
-    sequence_number: Option<u64>,
-    max_gas: Option<u64>,
-    gas_unit_price: Option<u64>,
 ) -> Result<Box<UserTransaction>, ErrorWrapper> {
-    submit_transaction(rest_client, txn_expiry_duration, |expiry_time| rosetta_client
-        .set_operator(
-            network_identifier,
-            sender_key,
-            old_operator,
-            new_operator,
-            expiry_time.as_secs(),
-            sequence_number,
-            max_gas,
-            gas_unit_price,
-        )).await
+    submit_transaction(
+        node_clients.rest_client,
+        DEFAULT_MAX_WAIT_DURATION,
+        |expiry_time| {
+            node_clients.rosetta_client.set_operator(
+                node_clients.network,
+                sender_key,
+                old_operator,
+                new_operator,
+                expiry_time,
+                None,
+                None,
+                None,
+            )
+        },
+    )
+    .await
 }
 
 async fn set_voter_and_wait(
-    rosetta_client: &RosettaClient,
-    rest_client: &aptos_rest_client::Client,
-    network_identifier: &NetworkIdentifier,
+    node_clients: &NodeClients<'_>,
     sender_key: &Ed25519PrivateKey,
     operator: Option<AccountAddress>,
     new_voter: AccountAddress,
-    txn_expiry_duration: Duration,
-    sequence_number: Option<u64>,
-    max_gas: Option<u64>,
-    gas_unit_price: Option<u64>,
 ) -> Result<Box<UserTransaction>, ErrorWrapper> {
-    submit_transaction(rest_client, txn_expiry_duration, |expiry_time| rosetta_client
-        .set_voter(
-            network_identifier,
-            sender_key,
-            operator,
-            new_voter,
-            expiry_time.as_secs(),
-            sequence_number,
-            max_gas,
-            gas_unit_price,
-        ))
-        .await
+    submit_transaction(
+        node_clients.rest_client,
+        DEFAULT_MAX_WAIT_DURATION,
+        |expiry_time| {
+            node_clients.rosetta_client.set_voter(
+                node_clients.network,
+                sender_key,
+                operator,
+                new_voter,
+                expiry_time,
+                None,
+                None,
+                None,
+            )
+        },
+    )
+    .await
 }
 
 async fn create_stake_pool_and_wait(
-    rosetta_client: &RosettaClient,
-    rest_client: &aptos_rest_client::Client,
-    network_identifier: &NetworkIdentifier,
+    node_clients: &NodeClients<'_>,
     sender_key: &Ed25519PrivateKey,
     operator: Option<AccountAddress>,
     voter: Option<AccountAddress>,
     stake_amount: Option<u64>,
     commission_percentage: Option<u64>,
-    txn_expiry_duration: Duration,
-    sequence_number: Option<u64>,
-    max_gas: Option<u64>,
-    gas_unit_price: Option<u64>,
 ) -> Result<Box<UserTransaction>, ErrorWrapper> {
-    submit_transaction(rest_client, txn_expiry_duration, |expiry_time| rosetta_client
-        .create_stake_pool(
-            network_identifier,
-            sender_key,
-            operator,
-            voter,
-            stake_amount,
-            commission_percentage,
-            expiry_time.as_secs(),
-            sequence_number,
-            max_gas,
-            gas_unit_price,
-        ))
-        .await
+    submit_transaction(
+        node_clients.rest_client,
+        DEFAULT_MAX_WAIT_DURATION,
+        |expiry_time| {
+            node_clients.rosetta_client.create_stake_pool(
+                node_clients.network,
+                sender_key,
+                operator,
+                voter,
+                stake_amount,
+                commission_percentage,
+                expiry_time,
+                None,
+                None,
+                None,
+            )
+        },
+    )
+    .await
 }
 
 async fn reset_lockup_and_wait(
-    rosetta_client: &RosettaClient,
-    rest_client: &aptos_rest_client::Client,
-    network_identifier: &NetworkIdentifier,
+    node_clients: &NodeClients<'_>,
     sender_key: &Ed25519PrivateKey,
     operator: Option<AccountAddress>,
-    txn_expiry_duration: Duration,
-    sequence_number: Option<u64>,
-    max_gas: Option<u64>,
-    gas_unit_price: Option<u64>,
 ) -> Result<Box<UserTransaction>, ErrorWrapper> {
-    submit_transaction(rest_client, txn_expiry_duration, |expiry_time| rosetta_client
-        .reset_lockup(
-            network_identifier,
-            sender_key,
-            operator,
-            expiry_time.as_secs(),
-            sequence_number,
-            max_gas,
-            gas_unit_price,
-        ))
-        .await
+    submit_transaction(
+        node_clients.rest_client,
+        DEFAULT_MAX_WAIT_DURATION,
+        |expiry_time| {
+            node_clients.rosetta_client.reset_lockup(
+                node_clients.network,
+                sender_key,
+                operator,
+                expiry_time,
+                None,
+                None,
+                None,
+            )
+        },
+    )
+    .await
 }
 
 async fn unlock_stake_and_wait(
-    rosetta_client: &RosettaClient,
-    rest_client: &aptos_rest_client::Client,
-    network_identifier: &NetworkIdentifier,
+    node_clients: &NodeClients<'_>,
     sender_key: &Ed25519PrivateKey,
     operator: Option<AccountAddress>,
     amount: Option<u64>,
-    txn_expiry_duration: Duration,
-    sequence_number: Option<u64>,
-    max_gas: Option<u64>,
-    gas_unit_price: Option<u64>,
 ) -> Result<Box<UserTransaction>, ErrorWrapper> {
-    submit_transaction(rest_client, txn_expiry_duration, |expiry_time| rosetta_client
-        .unlock_stake(
-            network_identifier,
-            sender_key,
-            operator,
-            amount,
-            expiry_time.as_secs(),
-            sequence_number,
-            max_gas,
-            gas_unit_price,
-        ))
-        .await
+    submit_transaction(
+        node_clients.rest_client,
+        DEFAULT_MAX_WAIT_DURATION,
+        |expiry_time| {
+            node_clients.rosetta_client.unlock_stake(
+                node_clients.network,
+                sender_key,
+                operator,
+                amount,
+                expiry_time,
+                None,
+                None,
+                None,
+            )
+        },
+    )
+    .await
 }
 
 async fn distribute_staking_rewards_and_wait(
-    rosetta_client: &RosettaClient,
-    rest_client: &aptos_rest_client::Client,
-    network_identifier: &NetworkIdentifier,
+    node_clients: &NodeClients<'_>,
     sender_key: &Ed25519PrivateKey,
     operator: AccountAddress,
     staker: AccountAddress,
-    txn_expiry_duration: Duration,
-    sequence_number: Option<u64>,
-    max_gas: Option<u64>,
-    gas_unit_price: Option<u64>,
 ) -> Result<Box<UserTransaction>, ErrorWrapper> {
-    submit_transaction(rest_client, txn_expiry_duration, |expiry_time| rosetta_client
-        .distribute_staking_rewards(
-            network_identifier,
-            sender_key,
-            operator,
-            staker,
-            expiry_time.as_secs(),
-            sequence_number,
-            max_gas,
-            gas_unit_price,
-        ))
-        .await
+    submit_transaction(
+        node_clients.rest_client,
+        DEFAULT_MAX_WAIT_DURATION,
+        |expiry_time| {
+            node_clients.rosetta_client.distribute_staking_rewards(
+                node_clients.network,
+                sender_key,
+                operator,
+                staker,
+                expiry_time,
+                None,
+                None,
+                None,
+            )
+        },
+    )
+    .await
 }
 
-async fn submit_transaction<Fut: Future<Output=anyhow::Result<TransactionIdentifier>>, F: FnOnce(u64) -> Fut>(
+async fn submit_transaction<
+    Fut: Future<Output = anyhow::Result<TransactionIdentifier>>,
+    F: FnOnce(u64) -> Fut,
+>(
     rest_client: &aptos_rest_client::Client,
     txn_expiry_duration: Duration,
     transaction_builder: F,
 ) -> Result<Box<UserTransaction>, ErrorWrapper> {
     let expiry_time = expiry_time(txn_expiry_duration);
 
-    let txn_hash = transaction_builder(expiry_time.as_secs()).await
+    let txn_hash = transaction_builder(expiry_time.as_secs())
+        .await
         .map_err(ErrorWrapper::BeforeSubmission)?
         .hash;
     wait_for_transaction(rest_client, expiry_time, txn_hash)
@@ -2343,7 +2067,7 @@ async fn wait_for_transaction(
         .wait_for_transaction_by_hash(
             hash_value,
             expiry_time.as_secs(),
-            Some(Duration::from_secs(60)),
+            Some(DEFAULT_MAX_WAIT_DURATION),
             None,
         )
         .await;
@@ -2354,7 +2078,7 @@ async fn wait_for_transaction(
             } else {
                 panic!("Transaction is supposed to be a UserTransaction!")
             }
-        }
+        },
         Err(_) => {
             if let Transaction::UserTransaction(txn) = rest_client
                 .get_transaction_by_hash(hash_value)
@@ -2366,7 +2090,7 @@ async fn wait_for_transaction(
             } else {
                 panic!("Failed transaction is supposed to be a UserTransaction!");
             }
-        }
+        },
     }
 }
 

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -46,6 +46,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tokio::{task::JoinHandle, time::Instant};
+use aptos_rosetta::types::TransactionIdentifier;
 
 const DEFAULT_MAX_WAIT_MS: u64 = 5000;
 const DEFAULT_INTERVAL_MS: u64 = 100;
@@ -95,8 +96,8 @@ pub async fn setup_test(
         )),
         cli.addresses(),
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
 
     // Ensure rosetta can take requests
     try_until_ok_default(|| rosetta_client.network_list())
@@ -146,8 +147,8 @@ async fn test_block_transactions() {
         )),
         cli.addresses(),
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
 
     // Ensure rosetta can take requests
     try_until_ok_default(|| rosetta_client.network_list())
@@ -164,11 +165,11 @@ async fn test_block_transactions() {
         AccountIdentifier::base_account(account_1),
         Some(0),
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
     assert_eq!(response.block_identifier, BlockIdentifier {
         index: 0,
-        hash: BlockHash::new(chain_id, 0).to_string()
+        hash: BlockHash::new(chain_id, 0).to_string(),
     });
 
     // First fund account 1 with lots more gas
@@ -227,7 +228,7 @@ async fn test_network() {
     assert_eq!(
         BlockIdentifier {
             index: 0,
-            hash: BlockHash::new(chain_id, 0).to_string()
+            hash: BlockHash::new(chain_id, 0).to_string(),
         },
         status.genesis_block_identifier
     );
@@ -293,11 +294,11 @@ async fn test_account_balance() {
         AccountIdentifier::base_account(account_1),
         Some(0),
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
     assert_eq!(response.block_identifier, BlockIdentifier {
         index: 0,
-        hash: BlockHash::new(chain_id, 0).to_string()
+        hash: BlockHash::new(chain_id, 0).to_string(),
     });
 
     // First fund account 1 with lots more gas
@@ -317,8 +318,8 @@ async fn test_account_balance() {
             0,
         )
     })
-    .await
-    .unwrap();
+        .await
+        .unwrap();
     try_until_ok_default(|| {
         account_has_balance(
             &rosetta_client,
@@ -328,8 +329,8 @@ async fn test_account_balance() {
             0,
         )
     })
-    .await
-    .unwrap();
+        .await
+        .unwrap();
 
     // Send money, and expect the gas and fees to show up accordingly
     const TRANSFER_AMOUNT: u64 = 5000;
@@ -346,8 +347,8 @@ async fn test_account_balance() {
         account_1_balance,
         1,
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
     account_has_balance(
         &rosetta_client,
         chain_id,
@@ -355,8 +356,8 @@ async fn test_account_balance() {
         account_2_balance,
         0,
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
 
     // Failed transaction spends gas
     let _ = cli
@@ -390,8 +391,8 @@ async fn test_account_balance() {
             account_1_balance,
             2,
         )
-        .await
-        .unwrap();
+            .await
+            .unwrap();
     }
 
     // Check that the balance hasn't changed (and should be 0) in the invalid account
@@ -402,8 +403,8 @@ async fn test_account_balance() {
         0,
         0,
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
 
     // Let's now check the staking balance with the original staking contract, it should not be supported
     cli.fund_account(2, Some(10_000_000)).await.unwrap();
@@ -417,8 +418,8 @@ async fn test_account_balance() {
         1_000_000,
         1,
     )
-    .await
-    .expect_err("Original staking contract is not supported");
+        .await
+        .expect_err("Original staking contract is not supported");
 
     create_staking_contract(
         &swarm.aptos_public_info(),
@@ -429,7 +430,7 @@ async fn test_account_balance() {
         10,
         1,
     )
-    .await;
+        .await;
 
     account_has_balance(
         &rosetta_client,
@@ -438,8 +439,8 @@ async fn test_account_balance() {
         1_000_000,
         1,
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
 
     account_has_balance(
         &rosetta_client,
@@ -448,8 +449,8 @@ async fn test_account_balance() {
         1_000_000,
         1,
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
 
     unlock_stake(
         &swarm.aptos_public_info(),
@@ -458,7 +459,7 @@ async fn test_account_balance() {
         1_000,
         2,
     )
-    .await;
+        .await;
 
     // Since unlock_stake was initiated, 1000 APT should be in pending inactive state until lockup ends
     account_has_balance(
@@ -468,8 +469,8 @@ async fn test_account_balance() {
         1_000,
         2,
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
 
     account_has_balance(
         &rosetta_client,
@@ -478,8 +479,8 @@ async fn test_account_balance() {
         0,
         2,
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
 
     /* TODO: Support operator stake account in the future
     account_has_balance(
@@ -762,7 +763,7 @@ async fn test_block() {
         &gas_schedule.to_btree_map(),
         feaure_version,
     )
-    .unwrap();
+        .unwrap();
     let min_gas_price = u64::from(gas_params.txn.min_price_per_gas_unit);
 
     let private_key_0 = cli.private_key(0);
@@ -783,11 +784,11 @@ async fn test_block() {
         Some(1000000),
         None,
     )
-    .await
-    .unwrap()
-    .request
-    .sequence_number
-    .0;
+        .await
+        .unwrap()
+        .request
+        .sequence_number
+        .0;
     transfer_and_wait(
         &rosetta_client,
         &rest_client,
@@ -801,8 +802,8 @@ async fn test_block() {
         Some(1000000),
         None,
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
     transfer_and_wait(
         &rosetta_client,
         &rest_client,
@@ -816,8 +817,8 @@ async fn test_block() {
         Some(1000000),
         None,
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
     // Create a new account via transfer
     transfer_and_wait(
         &rosetta_client,
@@ -832,8 +833,8 @@ async fn test_block() {
         Some(1000000),
         None,
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
     let seq_no_3 = transfer_and_wait(
         &rosetta_client,
         &rest_client,
@@ -846,11 +847,11 @@ async fn test_block() {
         Some(2000000),
         Some(min_gas_price),
     )
-    .await
-    .unwrap()
-    .request
-    .sequence_number
-    .0;
+        .await
+        .unwrap()
+        .request
+        .sequence_number
+        .0;
 
     // Create another account via command
     create_account_and_wait(
@@ -864,8 +865,8 @@ async fn test_block() {
         None,
         None,
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
 
     transfer_and_wait(
         &rosetta_client,
@@ -881,8 +882,8 @@ async fn test_block() {
         Some(10000),
         Some(min_gas_price + 1),
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
 
     // This one will fail because expiration is in the past
     transfer_and_wait(
@@ -897,8 +898,8 @@ async fn test_block() {
         None,
         None,
     )
-    .await
-    .unwrap_err();
+        .await
+        .unwrap_err();
 
     // This one will fail because gas is too low
     transfer_and_wait(
@@ -913,8 +914,8 @@ async fn test_block() {
         Some(1),
         None,
     )
-    .await
-    .unwrap_err();
+        .await
+        .unwrap_err();
 
     // Add a ton of coins, and set an operator
     cli.fund_account(3, Some(10_000_000)).await.unwrap();
@@ -933,8 +934,8 @@ async fn test_block() {
         None,
         None,
     )
-    .await
-    .expect("Set operator should work!");
+        .await
+        .expect("Set operator should work!");
 
     // Also fail to set an operator (since the operator already changed)
     set_operator_and_wait(
@@ -949,8 +950,8 @@ async fn test_block() {
         None,
         None,
     )
-    .await
-    .unwrap_err();
+        .await
+        .unwrap_err();
 
     // Test native stake pool and reset lockup support
     cli.fund_account(2, Some(1000000000000000)).await.unwrap();
@@ -968,8 +969,8 @@ async fn test_block() {
         None,
         None,
     )
-    .await
-    .expect("Should successfully create stake pool");
+        .await
+        .expect("Should successfully create stake pool");
 
     // TODO: Verify lockup time changes
 
@@ -985,8 +986,8 @@ async fn test_block() {
         None,
         None,
     )
-    .await
-    .expect("Should successfully reset lockup");
+        .await
+        .expect("Should successfully reset lockup");
 
     // Successfully, and fail setting a voter
     set_voter_and_wait(
@@ -1001,8 +1002,8 @@ async fn test_block() {
         None,
         None,
     )
-    .await
-    .expect_err("Set voter shouldn't work with the wrong operator!");
+        .await
+        .expect_err("Set voter shouldn't work with the wrong operator!");
     set_voter_and_wait(
         &rosetta_client,
         &rest_client,
@@ -1015,8 +1016,8 @@ async fn test_block() {
         None,
         None,
     )
-    .await
-    .expect("Set voter should work!");
+        .await
+        .expect("Set voter should work!");
 
     // Unlock stake
     unlock_stake_and_wait(
@@ -1031,8 +1032,8 @@ async fn test_block() {
         None,
         None,
     )
-    .await
-    .expect("Should successfully unlock stake");
+        .await
+        .expect("Should successfully unlock stake");
 
     // Failed distribution with wrong staker
     distribute_staking_rewards_and_wait(
@@ -1047,8 +1048,8 @@ async fn test_block() {
         None,
         None,
     )
-    .await
-    .expect_err("Staker has no staking contracts.");
+        .await
+        .expect_err("Staker has no staking contracts.");
 
     let final_txn = distribute_staking_rewards_and_wait(
         &rosetta_client,
@@ -1062,8 +1063,8 @@ async fn test_block() {
         None,
         None,
     )
-    .await
-    .expect("Distribute staking rewards should work!");
+        .await
+        .expect("Distribute staking rewards should work!");
 
     let final_block_to_check = rest_client
         .get_block_by_version(final_txn.info.version.0, false)
@@ -1215,7 +1216,7 @@ async fn parse_block_transactions(
                     actual_txn.transaction,
                     aptos_types::transaction::Transaction::GenesisTransaction(_)
                 ));
-            },
+            }
             TransactionType::User => {
                 assert!(matches!(
                     actual_txn.transaction,
@@ -1223,21 +1224,21 @@ async fn parse_block_transactions(
                 ));
                 // Must have a gas fee
                 assert!(!transaction.operations.is_empty());
-            },
+            }
             TransactionType::BlockMetadata => {
                 assert!(matches!(
                     actual_txn.transaction,
                     aptos_types::transaction::Transaction::BlockMetadata(_)
                 ));
                 assert!(transaction.operations.is_empty());
-            },
+            }
             TransactionType::StateCheckpoint => {
                 assert!(matches!(
                     actual_txn.transaction,
                     aptos_types::transaction::Transaction::StateCheckpoint(_)
                 ));
                 assert!(transaction.operations.is_empty());
-            },
+            }
         }
 
         parse_operations(
@@ -1246,7 +1247,7 @@ async fn parse_block_transactions(
             transaction,
             actual_txn,
         )
-        .await;
+            .await;
 
         for (_, account_balance) in balances.iter() {
             if let Some(amount) = account_balance.get(&cur_version) {
@@ -1278,7 +1279,7 @@ async fn parse_operations(
                 .as_ref()
                 .expect("Should have an operation status"),
         )
-        .expect("Operation status should be known");
+            .expect("Operation status should be known");
         let operation_type = OperationType::from_str(&operation.operation_type)
             .expect("Operation type should be known");
         let actual_successful = actual_txn.info.status().is_success();
@@ -1310,7 +1311,7 @@ async fn parse_operations(
                         "Failed transaction should have failed create account operation"
                     );
                 }
-            },
+            }
             OperationType::Deposit => {
                 let account = operation
                     .account
@@ -1351,7 +1352,7 @@ async fn parse_operations(
                         "Failed transaction should have failed deposit operation"
                     );
                 }
-            },
+            }
             OperationType::Withdraw => {
                 // Gas is always successful
                 if actual_successful {
@@ -1395,7 +1396,7 @@ async fn parse_operations(
                         "Failed transaction should have failed withdraw operation"
                     );
                 }
-            },
+            }
             OperationType::StakingReward => {
                 let account = operation
                     .account
@@ -1436,7 +1437,7 @@ async fn parse_operations(
                         "Failed transaction should have failed stake reward operation"
                     );
                 }
-            },
+            }
             OperationType::SetOperator => {
                 if actual_successful {
                     assert_eq!(
@@ -1494,7 +1495,7 @@ async fn parse_operations(
                 } else {
                     panic!("Not a user transaction");
                 }
-            },
+            }
             OperationType::SetVoter => {
                 if actual_successful {
                     assert_eq!(
@@ -1536,7 +1537,7 @@ async fn parse_operations(
                 } else {
                     panic!("Not a user transaction");
                 }
-            },
+            }
             OperationType::Fee => {
                 has_gas_op = true;
                 assert_eq!(OperationStatusType::Success, status);
@@ -1582,12 +1583,12 @@ async fn parse_operations(
                             delta,
                             "Gas operation should always match gas used * gas unit price"
                         )
-                    },
+                    }
                     _ => {
                         panic!("Gas transactions should be user transactions!")
-                    },
+                    }
                 };
-            },
+            }
             OperationType::ResetLockup => {
                 if actual_successful {
                     assert_eq!(
@@ -1629,7 +1630,7 @@ async fn parse_operations(
                 } else {
                     panic!("Not a user transaction");
                 }
-            },
+            }
             OperationType::InitializeStakePool => {
                 if actual_successful {
                     assert_eq!(
@@ -1708,7 +1709,7 @@ async fn parse_operations(
                 } else {
                     panic!("Not a user transaction");
                 }
-            },
+            }
             OperationType::UnlockStake => {
                 if actual_successful {
                     assert_eq!(
@@ -1762,7 +1763,7 @@ async fn parse_operations(
                 } else {
                     panic!("Not a user transaction");
                 }
-            },
+            }
             OperationType::DistributeStakingRewards => {
                 if actual_successful {
                     assert_eq!(
@@ -1817,7 +1818,7 @@ async fn parse_operations(
                 } else {
                     panic!("Not a user transaction");
                 }
-            },
+            }
         }
     }
 
@@ -1981,11 +1982,11 @@ fn assert_failed_transfer_transaction(
                         receiver,
                         actual_txn.info.success,
                     );
-                },
+                }
                 OperationType::Withdraw => {
                     seen_withdraw = true;
                     assert_withdraw(operation, transfer_amount, sender, actual_txn.info.success);
-                },
+                }
                 _ => panic!("Shouldn't get any other operations"),
             }
         } else if !seen_deposit {
@@ -2071,22 +2072,22 @@ fn assert_transfer(
     } else {
         OperationStatusType::Failure
     }
-    .to_string();
+        .to_string();
     assert_eq!(&expected_status, operation.status.as_ref().unwrap());
 }
 
 /// Try for 2 seconds to get a response.  This handles the fact that it's starting async
 async fn try_until_ok_default<F, Fut, T>(function: F) -> anyhow::Result<T>
-where
-    F: Fn() -> Fut,
-    Fut: Future<Output = anyhow::Result<T>>,
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output=anyhow::Result<T>>,
 {
     try_until_ok(
         DEFAULT_MAX_WAIT_DURATION,
         DEFAULT_INTERVAL_DURATION,
         function,
     )
-    .await
+        .await
 }
 
 async fn try_until_ok<F, Fut, T>(
@@ -2094,9 +2095,9 @@ async fn try_until_ok<F, Fut, T>(
     interval: Duration,
     function: F,
 ) -> anyhow::Result<T>
-where
-    F: Fn() -> Fut,
-    Fut: Future<Output = anyhow::Result<T>>,
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output=anyhow::Result<T>>,
 {
     let mut result = Err(anyhow::Error::msg("Failed to get response"));
     let start = Instant::now();
@@ -2121,22 +2122,18 @@ async fn create_account_and_wait(
     sequence_number: Option<u64>,
     max_gas: Option<u64>,
     gas_unit_price: Option<u64>,
-) -> Result<Box<UserTransaction>, Box<UserTransaction>> {
-    let expiry_time = expiry_time(txn_expiry_duration);
-    let txn_hash = rosetta_client
+) -> Result<Box<UserTransaction>, ErrorWrapper> {
+    submit_transaction(rest_client, txn_expiry_duration, |expiry_time| rosetta_client
         .create_account(
             network_identifier,
             sender_key,
             new_account,
-            expiry_time.as_secs(),
+            expiry_time,
             sequence_number,
             max_gas,
             gas_unit_price,
-        )
+        ))
         .await
-        .expect("Expect transfer to successfully submit to mempool")
-        .hash;
-    wait_for_transaction(rest_client, expiry_time, txn_hash).await
 }
 
 async fn transfer_and_wait(
@@ -2151,8 +2148,7 @@ async fn transfer_and_wait(
     max_gas: Option<u64>,
     gas_unit_price: Option<u64>,
 ) -> Result<Box<UserTransaction>, ErrorWrapper> {
-    let expiry_time = expiry_time(txn_expiry_duration);
-    let txn_hash = rosetta_client
+    submit_transaction(rest_client, txn_expiry_duration, |expiry_time| rosetta_client
         .transfer(
             network_identifier,
             sender_key,
@@ -2162,13 +2158,8 @@ async fn transfer_and_wait(
             sequence_number,
             max_gas,
             gas_unit_price,
-        )
+        ))
         .await
-        .map_err(ErrorWrapper::BeforeSubmission)?
-        .hash;
-    wait_for_transaction(rest_client, expiry_time, txn_hash)
-        .await
-        .map_err(ErrorWrapper::AfterSubmission)
 }
 
 async fn set_operator_and_wait(
@@ -2183,8 +2174,7 @@ async fn set_operator_and_wait(
     max_gas: Option<u64>,
     gas_unit_price: Option<u64>,
 ) -> Result<Box<UserTransaction>, ErrorWrapper> {
-    let expiry_time = expiry_time(txn_expiry_duration);
-    let txn_hash = rosetta_client
+    submit_transaction(rest_client, txn_expiry_duration, |expiry_time| rosetta_client
         .set_operator(
             network_identifier,
             sender_key,
@@ -2194,13 +2184,7 @@ async fn set_operator_and_wait(
             sequence_number,
             max_gas,
             gas_unit_price,
-        )
-        .await
-        .map_err(ErrorWrapper::BeforeSubmission)?
-        .hash;
-    wait_for_transaction(rest_client, expiry_time, txn_hash)
-        .await
-        .map_err(ErrorWrapper::AfterSubmission)
+        )).await
 }
 
 async fn set_voter_and_wait(
@@ -2215,8 +2199,7 @@ async fn set_voter_and_wait(
     max_gas: Option<u64>,
     gas_unit_price: Option<u64>,
 ) -> Result<Box<UserTransaction>, ErrorWrapper> {
-    let expiry_time = expiry_time(txn_expiry_duration);
-    let txn_hash = rosetta_client
+    submit_transaction(rest_client, txn_expiry_duration, |expiry_time| rosetta_client
         .set_voter(
             network_identifier,
             sender_key,
@@ -2226,13 +2209,8 @@ async fn set_voter_and_wait(
             sequence_number,
             max_gas,
             gas_unit_price,
-        )
+        ))
         .await
-        .map_err(ErrorWrapper::BeforeSubmission)?
-        .hash;
-    wait_for_transaction(rest_client, expiry_time, txn_hash)
-        .await
-        .map_err(ErrorWrapper::AfterSubmission)
 }
 
 async fn create_stake_pool_and_wait(
@@ -2249,8 +2227,7 @@ async fn create_stake_pool_and_wait(
     max_gas: Option<u64>,
     gas_unit_price: Option<u64>,
 ) -> Result<Box<UserTransaction>, ErrorWrapper> {
-    let expiry_time = expiry_time(txn_expiry_duration);
-    let txn_hash = rosetta_client
+    submit_transaction(rest_client, txn_expiry_duration, |expiry_time| rosetta_client
         .create_stake_pool(
             network_identifier,
             sender_key,
@@ -2262,13 +2239,8 @@ async fn create_stake_pool_and_wait(
             sequence_number,
             max_gas,
             gas_unit_price,
-        )
+        ))
         .await
-        .map_err(ErrorWrapper::BeforeSubmission)?
-        .hash;
-    wait_for_transaction(rest_client, expiry_time, txn_hash)
-        .await
-        .map_err(ErrorWrapper::AfterSubmission)
 }
 
 async fn reset_lockup_and_wait(
@@ -2282,8 +2254,7 @@ async fn reset_lockup_and_wait(
     max_gas: Option<u64>,
     gas_unit_price: Option<u64>,
 ) -> Result<Box<UserTransaction>, ErrorWrapper> {
-    let expiry_time = expiry_time(txn_expiry_duration);
-    let txn_hash = rosetta_client
+    submit_transaction(rest_client, txn_expiry_duration, |expiry_time| rosetta_client
         .reset_lockup(
             network_identifier,
             sender_key,
@@ -2292,13 +2263,8 @@ async fn reset_lockup_and_wait(
             sequence_number,
             max_gas,
             gas_unit_price,
-        )
+        ))
         .await
-        .map_err(ErrorWrapper::BeforeSubmission)?
-        .hash;
-    wait_for_transaction(rest_client, expiry_time, txn_hash)
-        .await
-        .map_err(ErrorWrapper::AfterSubmission)
 }
 
 async fn unlock_stake_and_wait(
@@ -2313,8 +2279,7 @@ async fn unlock_stake_and_wait(
     max_gas: Option<u64>,
     gas_unit_price: Option<u64>,
 ) -> Result<Box<UserTransaction>, ErrorWrapper> {
-    let expiry_time = expiry_time(txn_expiry_duration);
-    let txn_hash = rosetta_client
+    submit_transaction(rest_client, txn_expiry_duration, |expiry_time| rosetta_client
         .unlock_stake(
             network_identifier,
             sender_key,
@@ -2324,13 +2289,8 @@ async fn unlock_stake_and_wait(
             sequence_number,
             max_gas,
             gas_unit_price,
-        )
+        ))
         .await
-        .map_err(ErrorWrapper::BeforeSubmission)?
-        .hash;
-    wait_for_transaction(rest_client, expiry_time, txn_hash)
-        .await
-        .map_err(ErrorWrapper::AfterSubmission)
 }
 
 async fn distribute_staking_rewards_and_wait(
@@ -2345,8 +2305,7 @@ async fn distribute_staking_rewards_and_wait(
     max_gas: Option<u64>,
     gas_unit_price: Option<u64>,
 ) -> Result<Box<UserTransaction>, ErrorWrapper> {
-    let expiry_time = expiry_time(txn_expiry_duration);
-    let txn_hash = rosetta_client
+    submit_transaction(rest_client, txn_expiry_duration, |expiry_time| rosetta_client
         .distribute_staking_rewards(
             network_identifier,
             sender_key,
@@ -2356,8 +2315,18 @@ async fn distribute_staking_rewards_and_wait(
             sequence_number,
             max_gas,
             gas_unit_price,
-        )
+        ))
         .await
+}
+
+async fn submit_transaction<Fut: Future<Output=anyhow::Result<TransactionIdentifier>>, F: FnOnce(u64) -> Fut>(
+    rest_client: &aptos_rest_client::Client,
+    txn_expiry_duration: Duration,
+    transaction_builder: F,
+) -> Result<Box<UserTransaction>, ErrorWrapper> {
+    let expiry_time = expiry_time(txn_expiry_duration);
+
+    let txn_hash = transaction_builder(expiry_time.as_secs()).await
         .map_err(ErrorWrapper::BeforeSubmission)?
         .hash;
     wait_for_transaction(rest_client, expiry_time, txn_hash)
@@ -2386,7 +2355,7 @@ async fn wait_for_transaction(
             } else {
                 panic!("Transaction is supposed to be a UserTransaction!")
             }
-        },
+        }
         Err(_) => {
             if let Transaction::UserTransaction(txn) = rest_client
                 .get_transaction_by_hash(hash_value)
@@ -2398,7 +2367,7 @@ async fn wait_for_transaction(
             } else {
                 panic!("Failed transaction is supposed to be a UserTransaction!");
             }
-        },
+        }
     }
 }
 


### PR DESCRIPTION
### Description

This PR improves Rosetta's testing interface by refactoring a bunch of it.  This was work being done to debug an issue, and I've decided to commit it so it's more straightforward

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea01afb</samp>

This pull request enhances the rosetta types module with some utility methods and removes unnecessary serde attributes. It also adds a method to the aptos testing interface for syncing the root account sequence number with the client. These changes improve the usability and consistency of the aptos-core codebase.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### AI-powered Walkthrough
<!-- Delete this section if you don't want the AI to create a detailed walkthrough of your PR -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ea01afb</samp>

*  Add `value` method to `Amount` struct to parse the value field as an i128 integer and handle possible errors ([link](https://github.com/aptos-labs/aptos-core/pull/8014/files?diff=unified&w=0#diff-4c3ba82cb1ca40eacbbd5e57918581177ace042aa8a97af48c2e51aef6190104R94-R98))
*  Add methods to `Operation` struct to access optional fields and their inner values, and handle possible parsing errors ([link](https://github.com/aptos-labs/aptos-core/pull/8014/files?diff=unified&w=0#diff-4c3ba82cb1ca40eacbbd5e57918581177ace042aa8a97af48c2e51aef6190104R415-R510))
*  Remove `#[serde(rename_all = "camelCase")]` attribute from `Operation` and `OperationMetadata` structs to match the API naming convention ([link](https://github.com/aptos-labs/aptos-core/pull/8014/files?diff=unified&w=0#diff-4c3ba82cb1ca40eacbbd5e57918581177ace042aa8a97af48c2e51aef6190104R1480), [link](https://github.com/aptos-labs/aptos-core/pull/8014/files?diff=unified&w=0#diff-4c3ba82cb1ca40eacbbd5e57918581177ace042aa8a97af48c2e51aef6190104R1558))
*  Add `sync_root_account_sequence_number` method to `Aptos` struct in `testsuite/forge/src/interface/aptos.rs` to query and update the root account sequence number ([link](https://github.com/aptos-labs/aptos-core/pull/8014/files?diff=unified&w=0#diff-4d5b7e450338f886271f6c27433d567b074e5f4a8da1772c9f5e7777554665cfR267-R279))
