### PR TITLE
[aptos-framework] Cleanup framework doc comments

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/aptos_coin.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_coin.md
@@ -209,8 +209,8 @@ Can only called during genesis to initialize the Aptos coin.
         aptos_framework,
         <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(b"Aptos Coin"),
         <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(b"APT"),
-        8, /* decimals */
-        <b>true</b>, /* monitor_supply */
+        8, // decimals
+        <b>true</b>, // monitor_supply
     );
 
     // Aptos framework needs mint cap <b>to</b> mint coins <b>to</b> initial validators. This will be revoked once the validators

--- a/aptos-move/framework/aptos-framework/doc/aptos_governance.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_governance.md
@@ -4,18 +4,16 @@
 # Module `0x1::aptos_governance`
 
 
-* AptosGovernance represents the on-chain governance of the Aptos network. Voting power is calculated based on the
-* current epoch's voting power of the proposer or voter's backing stake pool. In addition, for it to count,
-* the stake pool's lockup needs to be at least as long as the proposal's duration.
-*
-* It provides the following flow:
-* 1. Proposers can create a proposal by calling AptosGovernance::create_proposal. The proposer's backing stake pool
-* needs to have the minimum proposer stake required. Off-chain components can subscribe to CreateProposalEvent to
-* track proposal creation and proposal ids.
-* 2. Voters can vote on a proposal. Their voting power is derived from the backing stake pool. Each stake pool can
-* only be used to vote on each proposal exactly once.
-*
+AptosGovernance represents the on-chain governance of the Aptos network. Voting power is calculated based on the
+current epoch's voting power of the proposer or voter's backing stake pool. In addition, for it to count,
+the stake pool's lockup needs to be at least as long as the proposal's duration.
 
+It provides the following flow:
+1. Proposers can create a proposal by calling AptosGovernance::create_proposal. The proposer's backing stake pool
+needs to have the minimum proposer stake required. Off-chain components can subscribe to CreateProposalEvent to
+track proposal creation and proposal ids.
+2. Voters can vote on a proposal. Their voting power is derived from the backing stake pool. Each stake pool can
+only be used to vote on each proposal exactly once.
 
 
 -  [Resource `GovernanceResponsbility`](#0x1_aptos_governance_GovernanceResponsbility)
@@ -1473,17 +1471,6 @@ Address @aptos_framework must exist GovernanceConfig and GovernanceEvents.
 
 
 <pre><code><b>include</b> <a href="aptos_governance.md#0x1_aptos_governance_AbortsIfNotGovernanceConfig">AbortsIfNotGovernanceConfig</a>;
-</code></pre>
-
-
-
-
-<a name="0x1_aptos_governance_AbortsIfNotGovernanceConfig"></a>
-
-
-<pre><code><b>schema</b> <a href="aptos_governance.md#0x1_aptos_governance_AbortsIfNotGovernanceConfig">AbortsIfNotGovernanceConfig</a> {
-    <b>aborts_if</b> !<b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_GovernanceConfig">GovernanceConfig</a>&gt;(@aptos_framework);
-}
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/stake.md
+++ b/aptos-move/framework/aptos-framework/doc/stake.md
@@ -4,24 +4,24 @@
 # Module `0x1::stake`
 
 
-* Validator lifecycle:
-* 1. Prepare a validator node set up and call stake::initialize_validator
-* 2. Once ready to deposit stake (or have funds assigned by a staking service in exchange for ownership capability),
-* call stake::add_stake (or *_with_cap versions if called from the staking service)
-* 3. Call stake::join_validator_set (or _with_cap version) to join the active validator set. Changes are effective in
-* the next epoch.
-* 4. Validate and gain rewards. The stake will automatically be locked up for a fixed duration (set by governance) and
-* automatically renewed at expiration.
-* 5. At any point, if the validator operator wants to update the consensus key or network/fullnode addresses, they can
-* call stake::rotate_consensus_key and stake::update_network_and_fullnode_addresses. Similar to changes to stake, the
-* changes to consensus key/network/fullnode addresses are only effective in the next epoch.
-* 6. Validator can request to unlock their stake at any time. However, their stake will only become withdrawable when
-* their current lockup expires. This can be at most as long as the fixed lockup duration.
-* 7. After exiting, the validator can either explicitly leave the validator set by calling stake::leave_validator_set
-* or if their stake drops below the min required, they would get removed at the end of the epoch.
-* 8. Validator can always rejoin the validator set by going through steps 2-3 again.
-* 9. An owner can always switch operators by calling stake::set_operator.
-* 10. An owner can always switch designated voter by calling stake::set_designated_voter.
+Validator lifecycle:
+1. Prepare a validator node set up and call stake::initialize_validator
+2. Once ready to deposit stake (or have funds assigned by a staking service in exchange for ownership capability),
+call stake::add_stake (or *_with_cap versions if called from the staking service)
+3. Call stake::join_validator_set (or _with_cap version) to join the active validator set. Changes are effective in
+the next epoch.
+4. Validate and gain rewards. The stake will automatically be locked up for a fixed duration (set by governance) and
+automatically renewed at expiration.
+5. At any point, if the validator operator wants to update the consensus key or network/fullnode addresses, they can
+call stake::rotate_consensus_key and stake::update_network_and_fullnode_addresses. Similar to changes to stake, the
+changes to consensus key/network/fullnode addresses are only effective in the next epoch.
+6. Validator can request to unlock their stake at any time. However, their stake will only become withdrawable when
+their current lockup expires. This can be at most as long as the fixed lockup duration.
+7. After exiting, the validator can either explicitly leave the validator set by calling stake::leave_validator_set
+or if their stake drops below the min required, they would get removed at the end of the epoch.
+8. Validator can always rejoin the validator set by going through steps 2-3 again.
+9. An owner can always switch operators by calling stake::set_operator.
+10. An owner can always switch designated voter by calling stake::set_designated_voter.
 
 
 -  [Resource `OwnerCapability`](#0x1_stake_OwnerCapability)

--- a/aptos-move/framework/aptos-framework/doc/staking_contract.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_contract.md
@@ -1690,6 +1690,7 @@ Distribute all unlocked (inactive) funds according to distribution shares.
 
 ## Function `assert_staking_contract_exists`
 
+Assert that a staking_contract exists for the staker/operator pair.
 
 
 <pre><code><b>fun</b> <a href="staking_contract.md#0x1_staking_contract_assert_staking_contract_exists">assert_staking_contract_exists</a>(staker: <b>address</b>, operator: <b>address</b>)
@@ -1719,6 +1720,7 @@ Distribute all unlocked (inactive) funds according to distribution shares.
 
 ## Function `add_distribution`
 
+Add a new distribution for <code>recipient</code> and <code>amount</code> to the staking contract's distributions list.
 
 
 <pre><code><b>fun</b> <a href="staking_contract.md#0x1_staking_contract_add_distribution">add_distribution</a>(operator: <b>address</b>, <a href="staking_contract.md#0x1_staking_contract">staking_contract</a>: &<b>mut</b> <a href="staking_contract.md#0x1_staking_contract_StakingContract">staking_contract::StakingContract</a>, recipient: <b>address</b>, coins_amount: u64, add_distribution_events: &<b>mut</b> <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="staking_contract.md#0x1_staking_contract_AddDistributionEvent">staking_contract::AddDistributionEvent</a>&gt;)
@@ -1759,6 +1761,7 @@ Distribute all unlocked (inactive) funds according to distribution shares.
 
 ## Function `get_staking_contract_amounts_internal`
 
+Calculate accumulated rewards and commissions since last update.
 
 
 <pre><code><b>fun</b> <a href="staking_contract.md#0x1_staking_contract_get_staking_contract_amounts_internal">get_staking_contract_amounts_internal</a>(<a href="staking_contract.md#0x1_staking_contract">staking_contract</a>: &<a href="staking_contract.md#0x1_staking_contract_StakingContract">staking_contract::StakingContract</a>): (u64, u64, u64)
@@ -1895,6 +1898,7 @@ Distribute all unlocked (inactive) funds according to distribution shares.
 
 ## Function `new_staking_contracts_holder`
 
+Create a new staking_contracts resource.
 
 
 <pre><code><b>fun</b> <a href="staking_contract.md#0x1_staking_contract_new_staking_contracts_holder">new_staking_contracts_holder</a>(staker: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>): <a href="staking_contract.md#0x1_staking_contract_Store">staking_contract::Store</a>

--- a/aptos-move/framework/aptos-framework/doc/voting.md
+++ b/aptos-move/framework/aptos-framework/doc/voting.md
@@ -4,27 +4,26 @@
 # Module `0x1::voting`
 
 
-* This is the general Voting module that can be used as part of a DAO Governance. Voting is designed to be used by
-* standalone governance modules, who has full control over the voting flow and is responsible for voting power
-* calculation and including proper capabilities when creating the proposal so resolution can go through.
-* On-chain governance of the Aptos network also uses Voting.
-*
-* The voting flow:
-* 1. The Voting module can be deployed at a known address (e.g. 0x1 for Aptos on-chain governance)
-* 2. The governance module, e.g. AptosGovernance, can be deployed later and define a GovernanceProposal resource type
-* that can also contain other information such as Capability resource for authorization.
-* 3. The governance module's owner can then register the ProposalType with Voting. This also hosts the proposal list
-* (forum) on the calling account.
-* 4. A proposer, through the governance module, can call Voting::create_proposal to create a proposal. create_proposal
-* cannot be called directly not through the governance module. A script hash of the resolution script that can later
-* be called to execute the proposal is required.
-* 5. A voter, through the governance module, can call Voting::vote on a proposal. vote requires passing a &ProposalType
-* and thus only the governance module that registers ProposalType can call vote.
-* 6. Once the proposal's expiration time has passed and more than the defined threshold has voted yes on the proposal,
-* anyone can call resolve which returns the content of the proposal (of type ProposalType) that can be used to execute.
-* 7. Only the resolution script with the same script hash specified in the proposal can call Voting::resolve as part of
-* the resolution process.
+This is the general Voting module that can be used as part of a DAO Governance. Voting is designed to be used by
+standalone governance modules, who has full control over the voting flow and is responsible for voting power
+calculation and including proper capabilities when creating the proposal so resolution can go through.
+On-chain governance of the Aptos network also uses Voting.
 
+The voting flow:
+1. The Voting module can be deployed at a known address (e.g. 0x1 for Aptos on-chain governance)
+2. The governance module, e.g. AptosGovernance, can be deployed later and define a GovernanceProposal resource type
+that can also contain other information such as Capability resource for authorization.
+3. The governance module's owner can then register the ProposalType with Voting. This also hosts the proposal list
+(forum) on the calling account.
+4. A proposer, through the governance module, can call Voting::create_proposal to create a proposal. create_proposal
+cannot be called directly not through the governance module. A script hash of the resolution script that can later
+be called to execute the proposal is required.
+5. A voter, through the governance module, can call Voting::vote on a proposal. vote requires passing a &ProposalType
+and thus only the governance module that registers ProposalType can call vote.
+6. Once the proposal's expiration time has passed and more than the defined threshold has voted yes on the proposal,
+anyone can call resolve which returns the content of the proposal (of type ProposalType) that can be used to execute.
+7. Only the resolution script with the same script hash specified in the proposal can call Voting::resolve as part of
+the resolution process.
 
 
 -  [Struct `Proposal`](#0x1_voting_Proposal)

--- a/aptos-move/framework/aptos-framework/sources/aptos_coin.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_coin.move
@@ -43,8 +43,8 @@ module aptos_framework::aptos_coin {
             aptos_framework,
             string::utf8(b"Aptos Coin"),
             string::utf8(b"APT"),
-            8, /* decimals */
-            true, /* monitor_supply */
+            8, // decimals
+            true, // monitor_supply
         );
 
         // Aptos framework needs mint cap to mint coins to initial validators. This will be revoked once the validators

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -1,16 +1,15 @@
-/**
- * AptosGovernance represents the on-chain governance of the Aptos network. Voting power is calculated based on the
- * current epoch's voting power of the proposer or voter's backing stake pool. In addition, for it to count,
- * the stake pool's lockup needs to be at least as long as the proposal's duration.
- *
- * It provides the following flow:
- * 1. Proposers can create a proposal by calling AptosGovernance::create_proposal. The proposer's backing stake pool
- * needs to have the minimum proposer stake required. Off-chain components can subscribe to CreateProposalEvent to
- * track proposal creation and proposal ids.
- * 2. Voters can vote on a proposal. Their voting power is derived from the backing stake pool. Each stake pool can
- * only be used to vote on each proposal exactly once.
- *
- */
+///
+/// AptosGovernance represents the on-chain governance of the Aptos network. Voting power is calculated based on the
+/// current epoch's voting power of the proposer or voter's backing stake pool. In addition, for it to count,
+/// the stake pool's lockup needs to be at least as long as the proposal's duration.
+///
+/// It provides the following flow:
+/// 1. Proposers can create a proposal by calling AptosGovernance::create_proposal. The proposer's backing stake pool
+/// needs to have the minimum proposer stake required. Off-chain components can subscribe to CreateProposalEvent to
+/// track proposal creation and proposal ids.
+/// 2. Voters can vote on a proposal. Their voting power is derived from the backing stake pool. Each stake pool can
+/// only be used to vote on each proposal exactly once.
+///
 module aptos_framework::aptos_governance {
     use std::error;
     use std::option;

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -585,7 +585,7 @@ module aptos_framework::fungible_asset {
     public fun init_test_metadata(constructor_ref: &ConstructorRef): (MintRef, TransferRef, BurnRef) {
         add_fungibility(
             constructor_ref,
-            option::some(option::some(100)) /* max supply */,
+            option::some(option::some(100)), // max supply
             string::utf8(b"USDA"),
             string::utf8(b"$$$"),
             0

--- a/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
+++ b/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
@@ -131,7 +131,7 @@ module aptos_framework::primary_fungible_store {
     ): (MintRef, TransferRef, BurnRef) {
         create_primary_store_enabled_fungible_asset(
             constructor_ref,
-            option::some(option::some(100)) /* max supply */,
+            option::some(option::some(100)), // max supply
             string::utf8(b"USDA"),
             string::utf8(b"$$$"),
             0

--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -1,23 +1,22 @@
-/**
- * Validator lifecycle:
- * 1. Prepare a validator node set up and call stake::initialize_validator
- * 2. Once ready to deposit stake (or have funds assigned by a staking service in exchange for ownership capability),
- * call stake::add_stake (or *_with_cap versions if called from the staking service)
- * 3. Call stake::join_validator_set (or _with_cap version) to join the active validator set. Changes are effective in
- * the next epoch.
- * 4. Validate and gain rewards. The stake will automatically be locked up for a fixed duration (set by governance) and
- * automatically renewed at expiration.
- * 5. At any point, if the validator operator wants to update the consensus key or network/fullnode addresses, they can
- * call stake::rotate_consensus_key and stake::update_network_and_fullnode_addresses. Similar to changes to stake, the
- * changes to consensus key/network/fullnode addresses are only effective in the next epoch.
- * 6. Validator can request to unlock their stake at any time. However, their stake will only become withdrawable when
- * their current lockup expires. This can be at most as long as the fixed lockup duration.
- * 7. After exiting, the validator can either explicitly leave the validator set by calling stake::leave_validator_set
- * or if their stake drops below the min required, they would get removed at the end of the epoch.
- * 8. Validator can always rejoin the validator set by going through steps 2-3 again.
- * 9. An owner can always switch operators by calling stake::set_operator.
- * 10. An owner can always switch designated voter by calling stake::set_designated_voter.
-*/
+///
+/// Validator lifecycle:
+/// 1. Prepare a validator node set up and call stake::initialize_validator
+/// 2. Once ready to deposit stake (or have funds assigned by a staking service in exchange for ownership capability),
+/// call stake::add_stake (or *_with_cap versions if called from the staking service)
+/// 3. Call stake::join_validator_set (or _with_cap version) to join the active validator set. Changes are effective in
+/// the next epoch.
+/// 4. Validate and gain rewards. The stake will automatically be locked up for a fixed duration (set by governance) and
+/// automatically renewed at expiration.
+/// 5. At any point, if the validator operator wants to update the consensus key or network/fullnode addresses, they can
+/// call stake::rotate_consensus_key and stake::update_network_and_fullnode_addresses. Similar to changes to stake, the
+/// changes to consensus key/network/fullnode addresses are only effective in the next epoch.
+/// 6. Validator can request to unlock their stake at any time. However, their stake will only become withdrawable when
+/// their current lockup expires. This can be at most as long as the fixed lockup duration.
+/// 7. After exiting, the validator can either explicitly leave the validator set by calling stake::leave_validator_set
+/// or if their stake drops below the min required, they would get removed at the end of the epoch.
+/// 8. Validator can always rejoin the validator set by going through steps 2-3 again.
+/// 9. An owner can always switch operators by calling stake::set_operator.
+/// 10. An owner can always switch designated voter by calling stake::set_designated_voter.
 module aptos_framework::stake {
     use std::error;
     use std::features;

--- a/aptos-move/framework/aptos-framework/sources/staking_contract.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.move
@@ -618,7 +618,7 @@ module aptos_framework::staking_contract {
         }
     }
 
-    // Assert that a staking_contract exists for the staker/operator pair.
+    /// Assert that a staking_contract exists for the staker/operator pair.
     fun assert_staking_contract_exists(staker: address, operator: address) acquires Store {
         assert!(exists<Store>(staker), error::not_found(ENO_STAKING_CONTRACT_FOUND_FOR_STAKER));
         let staking_contracts = &mut borrow_global_mut<Store>(staker).staking_contracts;
@@ -628,7 +628,7 @@ module aptos_framework::staking_contract {
         );
     }
 
-    // Add a new distribution for `recipient` and `amount` to the staking contract's distributions list.
+    /// Add a new distribution for `recipient` and `amount` to the staking contract's distributions list.
     fun add_distribution(
         operator: address,
         staking_contract: &mut StakingContract,
@@ -649,7 +649,7 @@ module aptos_framework::staking_contract {
         );
     }
 
-    // Calculate accumulated rewards and commissions since last update.
+    /// Calculate accumulated rewards and commissions since last update.
     fun get_staking_contract_amounts_internal(staking_contract: &StakingContract): (u64, u64, u64) {
         // Pending_inactive is not included in the calculation because pending_inactive can only come from:
         // 1. Outgoing commissions. This means commission has already been extracted.
@@ -726,7 +726,7 @@ module aptos_framework::staking_contract {
         pool_u64::update_total_coins(distribution_pool, updated_total_coins);
     }
 
-    // Create a new staking_contracts resource.
+    /// Create a new staking_contracts resource.
     fun new_staking_contracts_holder(staker: &signer): Store {
         Store {
             staking_contracts: simple_map::create<address, StakingContract>(),

--- a/aptos-move/framework/aptos-framework/sources/vesting.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.move
@@ -1,39 +1,38 @@
-/*
- * Simple vesting contract that allows specifying how much APT coins should be vesting in each fixed-size period. The
- * vesting contract also comes with staking and allows shareholders to withdraw rewards anytime.
- *
- * Vesting schedule is represented as a vector of distributions. For example, a vesting schedule of
- * [3/48, 3/48, 1/48] means that after the vesting starts:
- * 1. The first and second periods will vest 3/48 of the total original grant.
- * 2. The third period will vest 1/48.
- * 3. All subsequent periods will also vest 1/48 (last distribution in the schedule) until the original grant runs out.
- *
- * Shareholder flow:
- * 1. Admin calls create_vesting_contract with a schedule of [3/48, 3/48, 1/48] with a vesting cliff of 1 year and
- * vesting period of 1 month.
- * 2. After a month, a shareholder calls unlock_rewards to request rewards. They can also call vest() which would also
- * unlocks rewards but since the 1 year cliff has not passed (vesting has not started), vest() would not release any of
- * the original grant.
- * 3. After the unlocked rewards become fully withdrawable (as it's subject to staking lockup), shareholders can call
- * distribute() to send all withdrawable funds to all shareholders based on the original grant's shares structure.
- * 4. After 1 year and 1 month, the vesting schedule now starts. Shareholders call vest() to unlock vested coins. vest()
- * checks the schedule and unlocks 3/48 of the original grant in addition to any accumulated rewards since last
- * unlock_rewards(). Once the unlocked coins become withdrawable, shareholders can call distribute().
- * 5. Assuming the shareholders forgot to call vest() for 2 months, when they call vest() again, they will unlock vested
- * tokens for the next period since last vest. This would be for the first month they missed. They can call vest() a
- * second time to unlock for the second month they missed.
- *
- * Admin flow:
- * 1. After creating the vesting contract, admin cannot change the vesting schedule.
- * 2. Admin can call update_voter, update_operator, or reset_lockup at any time to update the underlying staking
- * contract.
- * 3. Admin can also call update_beneficiary for any shareholder. This would send all distributions (rewards, vested
- * coins) of that shareholder to the beneficiary account. By defalt, if a beneficiary is not set, the distributions are
- * send directly to the shareholder account.
- * 4. Admin can call terminate_vesting_contract to terminate the vesting. This would first finish any distribution but
- * will prevent any further rewards or vesting distributions from being created. Once the locked up stake becomes
- * withdrawable, admin can call admin_withdraw to withdraw all funds to the vesting contract's withdrawal address.
- */
+///
+/// Simple vesting contract that allows specifying how much APT coins should be vesting in each fixed-size period. The
+/// vesting contract also comes with staking and allows shareholders to withdraw rewards anytime.
+///
+/// Vesting schedule is represented as a vector of distributions. For example, a vesting schedule of
+/// [3/48, 3/48, 1/48] means that after the vesting starts:
+/// 1. The first and second periods will vest 3/48 of the total original grant.
+/// 2. The third period will vest 1/48.
+/// 3. All subsequent periods will also vest 1/48 (last distribution in the schedule) until the original grant runs out.
+///
+/// Shareholder flow:
+/// 1. Admin calls create_vesting_contract with a schedule of [3/48, 3/48, 1/48] with a vesting cliff of 1 year and
+/// vesting period of 1 month.
+/// 2. After a month, a shareholder calls unlock_rewards to request rewards. They can also call vest() which would also
+/// unlocks rewards but since the 1 year cliff has not passed (vesting has not started), vest() would not release any of
+/// the original grant.
+/// 3. After the unlocked rewards become fully withdrawable (as it's subject to staking lockup), shareholders can call
+/// distribute() to send all withdrawable funds to all shareholders based on the original grant's shares structure.
+/// 4. After 1 year and 1 month, the vesting schedule now starts. Shareholders call vest() to unlock vested coins. vest()
+/// checks the schedule and unlocks 3/48 of the original grant in addition to any accumulated rewards since last
+/// unlock_rewards(). Once the unlocked coins become withdrawable, shareholders can call distribute().
+/// 5. Assuming the shareholders forgot to call vest() for 2 months, when they call vest() again, they will unlock vested
+/// tokens for the next period since last vest. This would be for the first month they missed. They can call vest() a
+/// second time to unlock for the second month they missed.
+///
+/// Admin flow:
+/// 1. After creating the vesting contract, admin cannot change the vesting schedule.
+/// 2. Admin can call update_voter, update_operator, or reset_lockup at any time to update the underlying staking
+/// contract.
+/// 3. Admin can also call update_beneficiary for any shareholder. This would send all distributions (rewards, vested
+/// coins) of that shareholder to the beneficiary account. By defalt, if a beneficiary is not set, the distributions are
+/// send directly to the shareholder account.
+/// 4. Admin can call terminate_vesting_contract to terminate the vesting. This would first finish any distribution but
+/// will prevent any further rewards or vesting distributions from being created. Once the locked up stake becomes
+/// withdrawable, admin can call admin_withdraw to withdraw all funds to the vesting contract's withdrawal address.
 module aptos_framework::vesting {
     use std::bcs;
     use std::error;
@@ -926,8 +925,8 @@ module aptos_framework::vesting {
         account::create_signer_with_capability(&vesting_contract.signer_cap)
     }
 
-    // Create a salt for generating the resource accounts that will be holding the VestingContract.
-    // This address should be deterministic for the same admin and vesting contract creation nonce.
+    /// Create a salt for generating the resource accounts that will be holding the VestingContract.
+    /// This address should be deterministic for the same admin and vesting contract creation nonce.
     fun create_vesting_contract_account(
         admin: &signer,
         contract_creation_seed: vector<u8>,

--- a/aptos-move/framework/aptos-framework/sources/voting.move
+++ b/aptos-move/framework/aptos-framework/sources/voting.move
@@ -1,25 +1,24 @@
-/**
- * This is the general Voting module that can be used as part of a DAO Governance. Voting is designed to be used by
- * standalone governance modules, who has full control over the voting flow and is responsible for voting power
- * calculation and including proper capabilities when creating the proposal so resolution can go through.
- * On-chain governance of the Aptos network also uses Voting.
- *
- * The voting flow:
- * 1. The Voting module can be deployed at a known address (e.g. 0x1 for Aptos on-chain governance)
- * 2. The governance module, e.g. AptosGovernance, can be deployed later and define a GovernanceProposal resource type
- * that can also contain other information such as Capability resource for authorization.
- * 3. The governance module's owner can then register the ProposalType with Voting. This also hosts the proposal list
- * (forum) on the calling account.
- * 4. A proposer, through the governance module, can call Voting::create_proposal to create a proposal. create_proposal
- * cannot be called directly not through the governance module. A script hash of the resolution script that can later
- * be called to execute the proposal is required.
- * 5. A voter, through the governance module, can call Voting::vote on a proposal. vote requires passing a &ProposalType
- * and thus only the governance module that registers ProposalType can call vote.
- * 6. Once the proposal's expiration time has passed and more than the defined threshold has voted yes on the proposal,
- * anyone can call resolve which returns the content of the proposal (of type ProposalType) that can be used to execute.
- * 7. Only the resolution script with the same script hash specified in the proposal can call Voting::resolve as part of
- * the resolution process.
- */
+///
+/// This is the general Voting module that can be used as part of a DAO Governance. Voting is designed to be used by
+/// standalone governance modules, who has full control over the voting flow and is responsible for voting power
+/// calculation and including proper capabilities when creating the proposal so resolution can go through.
+/// On-chain governance of the Aptos network also uses Voting.
+///
+/// The voting flow:
+/// 1. The Voting module can be deployed at a known address (e.g. 0x1 for Aptos on-chain governance)
+/// 2. The governance module, e.g. AptosGovernance, can be deployed later and define a GovernanceProposal resource type
+/// that can also contain other information such as Capability resource for authorization.
+/// 3. The governance module's owner can then register the ProposalType with Voting. This also hosts the proposal list
+/// (forum) on the calling account.
+/// 4. A proposer, through the governance module, can call Voting::create_proposal to create a proposal. create_proposal
+/// cannot be called directly not through the governance module. A script hash of the resolution script that can later
+/// be called to execute the proposal is required.
+/// 5. A voter, through the governance module, can call Voting::vote on a proposal. vote requires passing a &ProposalType
+/// and thus only the governance module that registers ProposalType can call vote.
+/// 6. Once the proposal's expiration time has passed and more than the defined threshold has voted yes on the proposal,
+/// anyone can call resolve which returns the content of the proposal (of type ProposalType) that can be used to execute.
+/// 7. Only the resolution script with the same script hash specified in the proposal can call Voting::resolve as part of
+/// the resolution process.
 module aptos_framework::voting {
     use std::bcs::to_bytes;
     use std::error;

--- a/aptos-move/framework/aptos-stdlib/doc/pool_u64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/pool_u64.md
@@ -4,20 +4,19 @@
 # Module `0x1::pool_u64`
 
 
-* Simple module for tracking and calculating shares of a pool of coins. The shares are worth more as the total coins in
-* the pool increases. New shareholder can buy more shares or redeem their existing shares.
-*
-* Example flow:
-* 1. Pool start outs empty.
-* 2. Shareholder A buys in with 1000 coins. A will receive 1000 shares in the pool. Pool now has 1000 total coins and
-* 1000 total shares.
-* 3. Pool appreciates in value from rewards and now has 2000 coins. A's 1000 shares are now worth 2000 coins.
-* 4. Shareholder B now buys in with 1000 coins. Since before the buy in, each existing share is worth 2 coins, B will
-* receive 500 shares in exchange for 1000 coins. Pool now has 1500 shares and 3000 coins.
-* 5. Pool appreciates in value from rewards and now has 6000 coins.
-* 6. A redeems 500 shares. Each share is worth 6000 / 1500 = 4. A receives 2000 coins. Pool has 4000 coins and 1000
-* shares left.
+Simple module for tracking and calculating shares of a pool of coins. The shares are worth more as the total coins in
+the pool increases. New shareholder can buy more shares or redeem their existing shares.
 
+Example flow:
+1. Pool start outs empty.
+2. Shareholder A buys in with 1000 coins. A will receive 1000 shares in the pool. Pool now has 1000 total coins and
+1000 total shares.
+3. Pool appreciates in value from rewards and now has 2000 coins. A's 1000 shares are now worth 2000 coins.
+4. Shareholder B now buys in with 1000 coins. Since before the buy in, each existing share is worth 2 coins, B will
+receive 500 shares in exchange for 1000 coins. Pool now has 1500 shares and 3000 coins.
+5. Pool appreciates in value from rewards and now has 6000 coins.
+6. A redeems 500 shares. Each share is worth 6000 / 1500 = 4. A receives 2000 coins. Pool has 4000 coins and 1000
+shares left.
 
 
 -  [Struct `Pool`](#0x1_pool_u64_Pool)

--- a/aptos-move/framework/aptos-stdlib/doc/pool_u64_unbound.md
+++ b/aptos-move/framework/aptos-stdlib/doc/pool_u64_unbound.md
@@ -4,20 +4,19 @@
 # Module `0x1::pool_u64_unbound`
 
 
-* Simple module for tracking and calculating shares of a pool of coins. The shares are worth more as the total coins in
-* the pool increases. New shareholder can buy more shares or redeem their existing shares.
-*
-* Example flow:
-* 1. Pool start outs empty.
-* 2. Shareholder A buys in with 1000 coins. A will receive 1000 shares in the pool. Pool now has 1000 total coins and
-* 1000 total shares.
-* 3. Pool appreciates in value from rewards and now has 2000 coins. A's 1000 shares are now worth 2000 coins.
-* 4. Shareholder B now buys in with 1000 coins. Since before the buy in, each existing share is worth 2 coins, B will
-* receive 500 shares in exchange for 1000 coins. Pool now has 1500 shares and 3000 coins.
-* 5. Pool appreciates in value from rewards and now has 6000 coins.
-* 6. A redeems 500 shares. Each share is worth 6000 / 1500 = 4. A receives 2000 coins. Pool has 4000 coins and 1000
-* shares left.
+Simple module for tracking and calculating shares of a pool of coins. The shares are worth more as the total coins in
+the pool increases. New shareholder can buy more shares or redeem their existing shares.
 
+Example flow:
+1. Pool start outs empty.
+2. Shareholder A buys in with 1000 coins. A will receive 1000 shares in the pool. Pool now has 1000 total coins and
+1000 total shares.
+3. Pool appreciates in value from rewards and now has 2000 coins. A's 1000 shares are now worth 2000 coins.
+4. Shareholder B now buys in with 1000 coins. Since before the buy in, each existing share is worth 2 coins, B will
+receive 500 shares in exchange for 1000 coins. Pool now has 1500 shares and 3000 coins.
+5. Pool appreciates in value from rewards and now has 6000 coins.
+6. A redeems 500 shares. Each share is worth 6000 / 1500 = 4. A receives 2000 coins. Pool has 4000 coins and 1000
+shares left.
 
 
 -  [Struct `Pool`](#0x1_pool_u64_unbound_Pool)

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64.move
@@ -1,18 +1,18 @@
-/**
- * Simple module for tracking and calculating shares of a pool of coins. The shares are worth more as the total coins in
- * the pool increases. New shareholder can buy more shares or redeem their existing shares.
- *
- * Example flow:
- * 1. Pool start outs empty.
- * 2. Shareholder A buys in with 1000 coins. A will receive 1000 shares in the pool. Pool now has 1000 total coins and
- * 1000 total shares.
- * 3. Pool appreciates in value from rewards and now has 2000 coins. A's 1000 shares are now worth 2000 coins.
- * 4. Shareholder B now buys in with 1000 coins. Since before the buy in, each existing share is worth 2 coins, B will
- * receive 500 shares in exchange for 1000 coins. Pool now has 1500 shares and 3000 coins.
- * 5. Pool appreciates in value from rewards and now has 6000 coins.
- * 6. A redeems 500 shares. Each share is worth 6000 / 1500 = 4. A receives 2000 coins. Pool has 4000 coins and 1000
- * shares left.
- */
+///
+/// Simple module for tracking and calculating shares of a pool of coins. The shares are worth more as the total coins in
+/// the pool increases. New shareholder can buy more shares or redeem their existing shares.
+///
+/// Example flow:
+/// 1. Pool start outs empty.
+/// 2. Shareholder A buys in with 1000 coins. A will receive 1000 shares in the pool. Pool now has 1000 total coins and
+/// 1000 total shares.
+/// 3. Pool appreciates in value from rewards and now has 2000 coins. A's 1000 shares are now worth 2000 coins.
+/// 4. Shareholder B now buys in with 1000 coins. Since before the buy in, each existing share is worth 2 coins, B will
+/// receive 500 shares in exchange for 1000 coins. Pool now has 1500 shares and 3000 coins.
+/// 5. Pool appreciates in value from rewards and now has 6000 coins.
+/// 6. A redeems 500 shares. Each share is worth 6000 / 1500 = 4. A receives 2000 coins. Pool has 4000 coins and 1000
+/// shares left.
+///
 module aptos_std::pool_u64 {
     use aptos_std::simple_map::{Self, SimpleMap};
     use std::error;

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.move
@@ -1,18 +1,18 @@
-/**
- * Simple module for tracking and calculating shares of a pool of coins. The shares are worth more as the total coins in
- * the pool increases. New shareholder can buy more shares or redeem their existing shares.
- *
- * Example flow:
- * 1. Pool start outs empty.
- * 2. Shareholder A buys in with 1000 coins. A will receive 1000 shares in the pool. Pool now has 1000 total coins and
- * 1000 total shares.
- * 3. Pool appreciates in value from rewards and now has 2000 coins. A's 1000 shares are now worth 2000 coins.
- * 4. Shareholder B now buys in with 1000 coins. Since before the buy in, each existing share is worth 2 coins, B will
- * receive 500 shares in exchange for 1000 coins. Pool now has 1500 shares and 3000 coins.
- * 5. Pool appreciates in value from rewards and now has 6000 coins.
- * 6. A redeems 500 shares. Each share is worth 6000 / 1500 = 4. A receives 2000 coins. Pool has 4000 coins and 1000
- * shares left.
- */
+///
+/// Simple module for tracking and calculating shares of a pool of coins. The shares are worth more as the total coins in
+/// the pool increases. New shareholder can buy more shares or redeem their existing shares.
+///
+/// Example flow:
+/// 1. Pool start outs empty.
+/// 2. Shareholder A buys in with 1000 coins. A will receive 1000 shares in the pool. Pool now has 1000 total coins and
+/// 1000 total shares.
+/// 3. Pool appreciates in value from rewards and now has 2000 coins. A's 1000 shares are now worth 2000 coins.
+/// 4. Shareholder B now buys in with 1000 coins. Since before the buy in, each existing share is worth 2 coins, B will
+/// receive 500 shares in exchange for 1000 coins. Pool now has 1500 shares and 3000 coins.
+/// 5. Pool appreciates in value from rewards and now has 6000 coins.
+/// 6. A redeems 500 shares. Each share is worth 6000 / 1500 = 4. A receives 2000 coins. Pool has 4000 coins and 1000
+/// shares left.
+///
 module aptos_std::pool_u64_unbound {
     use aptos_std::table_with_length::{Self as table, TableWithLength as Table};
     use std::error;

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -6,6 +6,28 @@
 Defines feature flags for Aptos. Those are used in Aptos specific implementations of features in
 the Move stdlib, the Aptos stdlib, and the Aptos framework.
 
+============================================================================================
+Feature Flag Definitions
+
+Each feature flag should come with documentation which justifies the need of the flag.
+Introduction of a new feature flag requires approval of framework owners. Be frugal when
+introducing new feature flags, as too many can make it hard to understand the code.
+
+Each feature flag should come with a specification of a lifetime:
+
+- a *transient* feature flag is only needed until a related code rollout has happened. This
+is typically associated with the introduction of new native Move functions, and is only used
+from Move code. The owner of this feature is obliged to remove it once this can be done.
+
+- a *permanent* feature flag is required to stay around forever. Typically, those flags guard
+behavior in native code, and the behavior with or without the feature need to be preserved
+for playback.
+
+Note that removing a feature flag still requires the function which tests for the feature
+(like <code>code_dependency_check_enabled</code> below) to stay around for compatibility reasons, as it
+is a public function. However, once the feature flag is disabled, those functions can constantly
+return true.
+
 
 -  [Resource `Features`](#0x1_features_Features)
 -  [Constants](#@Constants_0)

--- a/aptos-move/framework/move-stdlib/doc/signer.md
+++ b/aptos-move/framework/move-stdlib/doc/signer.md
@@ -18,6 +18,13 @@
 
 ## Function `borrow_address`
 
+Borrows the address of the signer
+Conceptually, you can think of the <code><a href="signer.md#0x1_signer">signer</a></code> as being a struct wrapper arround an
+address
+```
+struct signer has drop { addr: address }
+```
+<code>borrow_address</code> borrows this inner field
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="signer.md#0x1_signer_borrow_address">borrow_address</a>(s: &<a href="signer.md#0x1_signer">signer</a>): &<b>address</b>

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -1,32 +1,31 @@
 /// Defines feature flags for Aptos. Those are used in Aptos specific implementations of features in
 /// the Move stdlib, the Aptos stdlib, and the Aptos framework.
+///
+/// ============================================================================================
+/// Feature Flag Definitions
+///
+/// Each feature flag should come with documentation which justifies the need of the flag.
+/// Introduction of a new feature flag requires approval of framework owners. Be frugal when
+/// introducing new feature flags, as too many can make it hard to understand the code.
+///
+/// Each feature flag should come with a specification of a lifetime:
+///
+/// - a *transient* feature flag is only needed until a related code rollout has happened. This
+///   is typically associated with the introduction of new native Move functions, and is only used
+///   from Move code. The owner of this feature is obliged to remove it once this can be done.
+///
+/// - a *permanent* feature flag is required to stay around forever. Typically, those flags guard
+///   behavior in native code, and the behavior with or without the feature need to be preserved
+///   for playback.
+///
+/// Note that removing a feature flag still requires the function which tests for the feature
+/// (like `code_dependency_check_enabled` below) to stay around for compatibility reasons, as it
+/// is a public function. However, once the feature flag is disabled, those functions can constantly
+/// return true.
 module std::features {
     use std::error;
     use std::signer;
     use std::vector;
-
-    // ============================================================================================
-    // Feature Flag Definitions
-
-    // Each feature flag should come with documentation which justifies the need of the flag.
-    // Introduction of a new feature flag requires approval of framework owners. Be frugal when
-    // introducing new feature flags, as too many can make it hard to understand the code.
-    //
-    // Each feature flag should come with a specification of a lifetime:
-    //
-    // - a *transient* feature flag is only needed until a related code rollout has happened. This
-    //   is typically associated with the introduction of new native Move functions, and is only used
-    //   from Move code. The owner of this feature is obliged to remove it once this can be done.
-    //
-    // - an *permanent* feature flag is required to stay around forever. Typically, those flags guard
-    //   behavior in native code, and the behavior with or without the feature need to be preserved
-    //   for playback.
-    //
-    // Note that removing a feature flag still requires the function which tests for the feature
-    // (like `code_dependency_check_enabled` below) to stay around for compatibility reasons, as it
-    // is a public function. However, once the feature flag is disabled, those functions can constantly
-    // return true.
-
 
     // --------------------------------------------------------------------------------------------
     // Code Publishing

--- a/aptos-move/framework/move-stdlib/sources/signer.move
+++ b/aptos-move/framework/move-stdlib/sources/signer.move
@@ -1,11 +1,11 @@
 module std::signer {
-    // Borrows the address of the signer
-    // Conceptually, you can think of the `signer` as being a struct wrapper arround an
-    // address
-    // ```
-    // struct signer has drop { addr: address }
-    // ```
-    // `borrow_address` borrows this inner field
+    /// Borrows the address of the signer
+    /// Conceptually, you can think of the `signer` as being a struct wrapper arround an
+    /// address
+    /// ```
+    /// struct signer has drop { addr: address }
+    /// ```
+    /// `borrow_address` borrows this inner field
     native public fun borrow_address(s: &signer): &address;
 
     // Copies the address of the signer


### PR DESCRIPTION
### Description

It was brought to my attention that the docs are illegible in the doc site for the framework, because comments were made like below:
```
/**
 * 
 *
 */
```

This adds a `*` at the beginning of every line, so every line is now a bullet.  I've converted them to
```
///
```

In addition to https://github.com/aptos-labs/aptos-core/pull/8012

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e984f5</samp>

This pull request makes various minor changes to the documentation and comment style of several modules and functions in the `aptos-core` repository. The main purpose of these changes is to improve the readability and consistency of the code documentation. The pull request also removes some random text and an incomplete comment line that seem to be errors or leftovers from previous edits. The pull request does not introduce any new features or modify any existing logic in the code.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### AI-powered Walkthrough
<!-- Delete this section if you don't want the AI to create a detailed walkthrough of your PR -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e984f5</samp>

*  Remove incomplete comment for `aptos_token` module in `aptos_token.md` and `aptos_token.move` files ([link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-0d23e2da03f67f6214d88ce2bfe1c2d5e04add0be068d3eba2456436b0c55166L6), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-14ec6c18b1a8576482c20058ad35591c0de51b8ba1dcde6b985a83f22a671490L1))
*  Add comments for various functions in `staking_contract.md` and `staking_contract.move` files, explaining their purposes and parameters ([link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-7397ddaab36b3379306c3c2d0e2b6ec1427f0640864554477cbdb68bd54e3d2fR1693), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-7397ddaab36b3379306c3c2d0e2b6ec1427f0640864554477cbdb68bd54e3d2fR1723), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-7397ddaab36b3379306c3c2d0e2b6ec1427f0640864554477cbdb68bd54e3d2fR1764), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-7397ddaab36b3379306c3c2d0e2b6ec1427f0640864554477cbdb68bd54e3d2fR1901), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-8d7b802c58c375726f1ab691afdec810cf833b5f2d1d64536c7d3e6ebd97e179L621-R621), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-8d7b802c58c375726f1ab691afdec810cf833b5f2d1d64536c7d3e6ebd97e179L631-R631), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-8d7b802c58c375726f1ab691afdec810cf833b5f2d1d64536c7d3e6ebd97e179L652-R652), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-8d7b802c58c375726f1ab691afdec810cf833b5f2d1d64536c7d3e6ebd97e179L729-R729))
*  Add comment for `create_vesting_contract_account` function in `vesting.md` and `vesting.move` files, explaining how it creates a salt and a deterministic address for the vesting contract ([link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-57ce0d8119f1900d14c1d96303b69146a7c2465fb6a7d7499d8ec6a6c8e83622R2513-R2514), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-7971d936b311002707ef91e060210f557b5fc9b2c7a4cb627367b8e8090f38f5L929-R929))
*  Remove `AbortsIfNotGovernanceConfig` schema from `aptos_governance.md` file, as it is not used anywhere else ([link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-8e1e34538e6c056b30196665ae9883eb427cfc9a50c4e02769d65f4d7f869297L1480-L1490))
*  Replace `/* */` comment syntax with `//` or `///` comment syntax for various arguments and modules in `aptos_coin.md`, `aptos_coin.move`, `fungible_asset.move`, `primary_fungible_store.move`, `vesting.md`, `vesting.move`, `voting.md`, and `voting.move` files, as a minor stylistic preference ([link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-6bb585cc1ca7f1101c9ff43108e915f23a00ac31610ed5ef5249b08e9cb31a40L212-R213), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-57ce0d8119f1900d14c1d96303b69146a7c2465fb6a7d7499d8ec6a6c8e83622L7-R42), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-256f845c0437c590166902125b82248aa6366beab4b1d7255dad785f5cb50fddL7-R26), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-623a03d904113f042c03986258f8e851c27cf2ba8430060c7da9d9591860c32fL46-R47), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-7026c328622536165825a6f5dcaf13764bd475489ecba30ba4716dfdc4acc1e9L588-R588), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-d54eaa290236079411e862eb7dcad89dc98d8320fc5bce2df663ecec0efb29b6L134-R134), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-7971d936b311002707ef91e060210f557b5fc9b2c7a4cb627367b8e8090f38f5L1-R35), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-5b53920d43083fa179b5920517df200f09135ca238f81d8971a45efd7ee5936eL1-R21))
*  Remove `*` symbols at the beginning of each line in comments for various modules in `aptos_governance.md`, `aptos_governance.move`, `stake.md`, `stake.move`, `pool_u64.md`, `pool_u64.move`, `pool_u64_unbound.md`, and `pool_u64_unbound.move` files, as a minor stylistic preference ([link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-8e1e34538e6c056b30196665ae9883eb427cfc9a50c4e02769d65f4d7f869297L7-R16), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-9673db78d20cddfca7df1ab5fe52f5fa2978b33e72c860eeca33a49d27a4f854L7-R24), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-605eb598a6bd6014775488e578257eca78570972f18c9b48181ca0acdec4ce1eL1-R12), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-b99b84dafe66e2c506df6498fac1ed9b4f2c3c8f96fc44e561a11ccd553a0376L1-R19), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-ccbee98c759a446750898570cb82ac54ceeebaef7dd8d67eab7b55a003ae335cL7-R19), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-3d8532ce14941085ac0029497e48bcff6eb5eddea5e59fe17b3de5a1fcf9f4bdL7-R19), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-f39782902f462efefb6b59d0a6efd316a0c0aa928b67f017c7bb46ec253114d1L1-R15), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-8fbcf5311fa3424ba3205fe3ea39891da5ed46f216dc72cca09e985f19dbb927L1-R15))
*  Add some random text to the end of the comment for `initialize` function in `aptos_coin.md` and `aptos_coin.move` files, which seems to be a mistake or a test and does not have any meaningful purpose or context ([link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-6bb585cc1ca7f1101c9ff43108e915f23a00ac31610ed5ef5249b08e9cb31a40L193-R193), [link](https://github.com/aptos-labs/aptos-core/pull/8016/files?diff=unified&w=0#diff-623a03d904113f042c03986258f8e851c27cf2ba8430060c7da9d9591860c32fL38-R38))
