### PR TITLE
Move debug to safe native + implement dummy to make old framework compatible

### DIFF
--- a/aptos-move/framework/src/natives/debug.rs
+++ b/aptos-move/framework/src/natives/debug.rs
@@ -135,7 +135,7 @@ pub fn make_all(
                 native_stack_trace,
             ),
         ),
-        // For replayability on-chain we need dummy implementations of these functions
+        // For re-playability on-chain we still implement the old versions of these functions
         (
             "print",
             make_safe_native(

--- a/aptos-move/framework/src/natives/debug.rs
+++ b/aptos-move/framework/src/natives/debug.rs
@@ -4,9 +4,18 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::natives::helpers::make_module_natives;
-use move_binary_format::errors::PartialVMResult;
-use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
+use crate::{
+    natives::{
+        helpers::{
+            make_module_natives, make_safe_native, SafeNativeContext, SafeNativeError,
+            SafeNativeResult,
+        },
+        string_utils::native_format_debug,
+    },
+    safely_pop_arg,
+};
+use aptos_types::on_chain_config::{Features, TimedFeatures};
+use move_vm_runtime::native_functions::NativeFunction;
 #[allow(unused_imports)]
 use move_vm_types::{
     loaded_data::runtime_types::Type,
@@ -14,7 +23,7 @@ use move_vm_types::{
     pop_arg,
     values::{Reference, Struct, Value},
 };
-use smallvec::smallvec;
+use smallvec::{smallvec, SmallVec};
 use std::{collections::VecDeque, sync::Arc};
 
 /***************************************************************************************************
@@ -22,12 +31,17 @@ use std::{collections::VecDeque, sync::Arc};
  *
  **************************************************************************************************/
 #[inline]
-fn native_print(ty_args: Vec<Type>, mut args: VecDeque<Value>) -> PartialVMResult<NativeResult> {
+fn native_print(
+    _: &(),
+    _: &mut SafeNativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
     if cfg!(feature = "testing") {
-        let val = pop_arg!(args, Struct);
+        let val = safely_pop_arg!(args, Struct);
         let bytes = val.unpack()?.next().unwrap();
 
         println!(
@@ -36,15 +50,7 @@ fn native_print(ty_args: Vec<Type>, mut args: VecDeque<Value>) -> PartialVMResul
         );
     }
 
-    Ok(NativeResult::ok(0.into(), smallvec![]))
-}
-
-pub fn make_native_print() -> NativeFunction {
-    Arc::new(
-        move |_context, ty_args, args| -> PartialVMResult<NativeResult> {
-            native_print(ty_args, args)
-        },
-    )
+    Ok(smallvec![])
 }
 
 /***************************************************************************************************
@@ -54,10 +60,11 @@ pub fn make_native_print() -> NativeFunction {
 #[allow(unused_variables)]
 #[inline]
 fn native_stack_trace(
-    context: &mut NativeContext,
+    _: &(),
+    context: &mut SafeNativeContext,
     ty_args: Vec<Type>,
     args: VecDeque<Value>,
-) -> PartialVMResult<NativeResult> {
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
@@ -68,35 +75,81 @@ fn native_stack_trace(
     }
 
     let move_str = Value::struct_(Struct::pack(vec![Value::vector_u8(s.into_bytes())]));
-    Ok(NativeResult::ok(0.into(), smallvec![move_str]))
+    Ok(smallvec![move_str])
 }
 
-pub fn make_native_stack_trace() -> NativeFunction {
-    Arc::new(
-        move |context, ty_args, args| -> PartialVMResult<NativeResult> {
-            native_stack_trace(context, ty_args, args)
-        },
-    )
+#[inline]
+fn native_old_debug_print(
+    _: &(),
+    context: &mut SafeNativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    if cfg!(feature = "testing") {
+        let x = safely_pop_arg!(args, Reference);
+        let val = x.read_ref().map_err(SafeNativeError::InvariantViolation)?;
+
+        println!(
+            "[debug] {}",
+            native_format_debug(context, &ty_args[0], val)?
+        );
+    }
+    Ok(smallvec![])
 }
 
-pub fn make_dummy() -> NativeFunction {
-    Arc::new(
-        move |_context, _ty_args, _args| -> PartialVMResult<NativeResult> {
-            Ok(NativeResult::ok(0.into(), smallvec![]))
-        },
-    )
+#[inline]
+fn native_old_print_stacktrace(
+    _: &(),
+    context: &mut SafeNativeContext,
+    ty_args: Vec<Type>,
+    args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.is_empty());
+
+    if cfg!(feature = "testing") {
+        let mut s = String::new();
+        context.print_stack_trace(&mut s)?;
+        println!("{}", s);
+    }
+    Ok(smallvec![])
 }
 
 /***************************************************************************************************
  * module
  **************************************************************************************************/
-pub fn make_all() -> impl Iterator<Item = (String, NativeFunction)> {
+pub fn make_all(
+    timed_features: TimedFeatures,
+    features: Arc<Features>,
+) -> impl Iterator<Item = (String, NativeFunction)> {
     let natives = [
-        ("native_print", make_native_print()),
-        ("native_stack_trace", make_native_stack_trace()),
+        (
+            "native_print",
+            make_safe_native((), timed_features.clone(), features.clone(), native_print),
+        ),
+        (
+            "native_stack_trace",
+            make_safe_native(
+                (),
+                timed_features.clone(),
+                features.clone(),
+                native_stack_trace,
+            ),
+        ),
         // For replayability on-chain we need dummy implementations of these functions
-        ("print", make_dummy()),
-        ("print_stack_trace", make_dummy()),
+        (
+            "print",
+            make_safe_native(
+                (),
+                timed_features.clone(),
+                features.clone(),
+                native_old_debug_print,
+            ),
+        ),
+        (
+            "print_stack_trace",
+            make_safe_native((), timed_features, features, native_old_print_stacktrace),
+        ),
     ];
 
     make_module_natives(natives)

--- a/aptos-move/framework/src/natives/debug.rs
+++ b/aptos-move/framework/src/natives/debug.rs
@@ -20,7 +20,6 @@ use move_vm_runtime::native_functions::NativeFunction;
 use move_vm_types::{
     loaded_data::runtime_types::Type,
     natives::function::NativeResult,
-    pop_arg,
     values::{Reference, Struct, Value},
 };
 use smallvec::{smallvec, SmallVec};

--- a/aptos-move/framework/src/natives/mod.rs
+++ b/aptos-move/framework/src/natives/mod.rs
@@ -429,7 +429,10 @@ pub fn all_natives(
         "object",
         object::make_all(gas_params.object, timed_features.clone(), features.clone())
     );
-    add_natives_from_module!("debug", debug::make_all());
+    add_natives_from_module!(
+        "debug",
+        debug::make_all(timed_features.clone(), features.clone())
+    );
     add_natives_from_module!(
         "string_utils",
         string_utils::make_all(gas_params.string_utils, timed_features, features)

--- a/aptos-move/framework/src/natives/string_utils.rs
+++ b/aptos-move/framework/src/natives/string_utils.rs
@@ -289,6 +289,30 @@ fn native_format_impl(
     Ok(())
 }
 
+/// For old debug implementation
+/// TODO: remove when old framework is completely removed
+pub(crate) fn native_format_debug(
+    context: &mut SafeNativeContext,
+    ty: &Type,
+    v: Value,
+) -> SafeNativeResult<String> {
+    let layout = context.deref().type_to_fully_annotated_layout(ty)?.unwrap();
+    let mut format_context = FormatContext {
+        context,
+        base_gas: 0.into(),
+        per_byte_gas: 0.into(),
+        max_depth: usize::MAX,
+        max_len: usize::MAX,
+        type_tag: true,
+        canonicalize: false,
+        single_line: false,
+        include_int_type: false,
+    };
+    let mut out = String::new();
+    native_format_impl(&mut format_context, &layout, v, 0, &mut out)?;
+    Ok(out)
+}
+
 fn native_format(
     gas_params: &GasParameters,
     context: &mut SafeNativeContext,


### PR DESCRIPTION
Solve the incompatibility issue with new binary + old framework

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c803a49</samp>

The pull request updates the debug module to use the new safe native function framework, which improves safety and flexibility of native functions. It also adds a new native_format_debug function to the string_utils module, which is used by the debug module to format values for debug output. The changes are compatible with the old debug functions for replayability on-chain.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### AI-powered Walkthrough
<!-- Delete this section if you don't want the AI to create a detailed walkthrough of your PR -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c803a49</samp>

*  Update imports, signatures, and implementations of native debug functions to use the new safe native function framework ([link](https://github.com/aptos-labs/aptos-core/pull/8017/files?diff=unified&w=0#diff-d0741d3f74fd704d43cafab775e97054a6e357541e7815621d4bce648d52c89cL7-R25), [link](https://github.com/aptos-labs/aptos-core/pull/8017/files?diff=unified&w=0#diff-d0741d3f74fd704d43cafab775e97054a6e357541e7815621d4bce648d52c89cL25-R43), [link](https://github.com/aptos-labs/aptos-core/pull/8017/files?diff=unified&w=0#diff-d0741d3f74fd704d43cafab775e97054a6e357541e7815621d4bce648d52c89cL39-R54), [link](https://github.com/aptos-labs/aptos-core/pull/8017/files?diff=unified&w=0#diff-d0741d3f74fd704d43cafab775e97054a6e357541e7815621d4bce648d52c89cL57-R66), [link](https://github.com/aptos-labs/aptos-core/pull/8017/files?diff=unified&w=0#diff-d0741d3f74fd704d43cafab775e97054a6e357541e7815621d4bce648d52c89cL71-R114))
*  Remove make_native_print and make_native_stack_trace functions, and replace them with make_safe_native macro calls that wrap the native functions and handle common logic and error handling ([link](https://github.com/aptos-labs/aptos-core/pull/8017/files?diff=unified&w=0#diff-d0741d3f74fd704d43cafab775e97054a6e357541e7815621d4bce648d52c89cL39-R54), [link](https://github.com/aptos-labs/aptos-core/pull/8017/files?diff=unified&w=0#diff-d0741d3f74fd704d43cafab775e97054a6e357541e7815621d4bce648d52c89cL71-R114))
*  Add native_old_debug_print and native_old_print_stacktrace functions to provide dummy implementations of the old debug functions for replayability on-chain, and check for testing feature flag to control debug output ([link](https://github.com/aptos-labs/aptos-core/pull/8017/files?diff=unified&w=0#diff-d0741d3f74fd704d43cafab775e97054a6e357541e7815621d4bce648d52c89cL71-R114))
*  Make native_format_debug function public and crate-visible in `string_utils.rs`, and use it to format values for debug output in the old debug functions ([link](https://github.com/aptos-labs/aptos-core/pull/8017/files?diff=unified&w=0#diff-98b1b9150f61f127f6a7e4c554a4866e149a716b5661ce2fffe7964110d1d093R292-R315), [link](https://github.com/aptos-labs/aptos-core/pull/8017/files?diff=unified&w=0#diff-d0741d3f74fd704d43cafab775e97054a6e357541e7815621d4bce648d52c89cL71-R114))
*  Pass timed features and features parameters to the make_all function in the debug module, and to the make_safe_native macro calls for each native function ([link](https://github.com/aptos-labs/aptos-core/pull/8017/files?diff=unified&w=0#diff-d0741d3f74fd704d43cafab775e97054a6e357541e7815621d4bce648d52c89cL39-R54), [link](https://github.com/aptos-labs/aptos-core/pull/8017/files?diff=unified&w=0#diff-d0741d3f74fd704d43cafab775e97054a6e357541e7815621d4bce648d52c89cL71-R114), [link](https://github.com/aptos-labs/aptos-core/pull/8017/files?diff=unified&w=0#diff-d0741d3f74fd704d43cafab775e97054a6e357541e7815621d4bce648d52c89cL93-R151), [link](https://github.com/aptos-labs/aptos-core/pull/8017/files?diff=unified&w=0#diff-c4be656b5e1494c79e37e28860af5cecf5c3351dd2541397ff6776cfe126177aL432-R436))
*  Move format_debug function from `string_utils.rs` to `debug.rs`, and rename it to native_format_debug ([link](https://github.com/aptos-labs/aptos-core/pull/8017/files?diff=unified&w=0#diff-98b1b9150f61f127f6a7e4c554a4866e149a716b5661ce2fffe7964110d1d093R292-R315), [link](https://github.com/aptos-labs/aptos-core/pull/8017/files?diff=unified&w=0#diff-d0741d3f74fd704d43cafab775e97054a6e357541e7815621d4bce648d52c89cL71-R114))
