### PR TITLE
[indexer] token v2 property map

### DIFF
--- a/crates/indexer/src/models/property_map.rs
+++ b/crates/indexer/src/models/property_map.rs
@@ -52,3 +52,53 @@ impl PropertyMap {
         serde_json::to_value(map).unwrap()
     }
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TokenObjectPropertyValue {
+    value: String,
+    typ: u8,
+}
+
+pub fn create_token_object_property_value(
+    typ: u8,
+    value: String,
+) -> Result<TokenObjectPropertyValue> {
+    Ok(TokenObjectPropertyValue {
+        value: util::convert_bcs_hex_new(typ, value.clone()).unwrap_or(value),
+        typ,
+    })
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TokenObjectPropertyMap {
+    data: HashMap<String, TokenObjectPropertyValue>,
+}
+
+impl TokenObjectPropertyMap {
+    /// Deserializes PropertyValue from bcs encoded json
+    pub fn from_bcs_encode_str(val: Value) -> Option<Value> {
+        let mut pm = TokenObjectPropertyMap {
+            data: HashMap::new(),
+        };
+        let records: &Vec<Value> = val.get("inner")?.get("data")?.as_array()?;
+        for entry in records {
+            let key = entry.get("key")?.as_str()?;
+            let val = entry.get("value")?.get("value")?.as_str()?;
+            let typ = entry.get("value")?.get("type")?.as_u64()?;
+            let pv = create_token_object_property_value(typ as u8, val.to_string()).ok()?;
+            pm.data.insert(key.to_string(), pv);
+        }
+        Some(Self::to_flat_json_new(pm))
+    }
+
+    /// Flattens PropertyMap which can't be easily consumable by downstream.
+    /// For example: Object {"data": Object {"creation_time_sec": Object {"value": String("1666125588")}}}
+    /// becomes Object {"creation_time_sec": "1666125588"}
+    fn to_flat_json_new(val: TokenObjectPropertyMap) -> Value {
+        let mut map = HashMap::new();
+        for (k, v) in val.data {
+            map.insert(k, v.value);
+        }
+        serde_json::to_value(map).unwrap()
+    }
+}

--- a/crates/indexer/src/util.rs
+++ b/crates/indexer/src/util.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::models::property_map::PropertyMap;
+use crate::models::property_map::{PropertyMap, TokenObjectPropertyMap};
 use aptos_api_types::Address;
 use bigdecimal::{BigDecimal, Signed, ToPrimitive, Zero};
 use serde::{Deserialize, Deserializer};
@@ -101,6 +101,20 @@ where
     Ok(convert_bcs_propertymap(s.clone()).unwrap_or(s))
 }
 
+/// convert the bcs encoded inner value of property_map to its original value in string format
+pub fn deserialize_token_object_property_map_from_bcs_hexstring<'de, D>(
+    deserializer: D,
+) -> core::result::Result<Value, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = serde_json::Value::deserialize(deserializer)?;
+    // iterate the json string to convert key-value pair
+    // assume the format of {“map”: {“data”: [{“key”: “Yuri”, “value”: {“type”: “String”, “value”: “0x42656e”}}, {“key”: “Tarded”, “value”: {“type”: “String”, “value”: “0x446f766572"}}]}}
+    // if successfully parsing we return the decoded property_map string otherwise return the original string
+    Ok(convert_bcs_token_object_propertymap(s.clone()).unwrap_or(s))
+}
+
 pub fn deserialize_string_from_hexstring<'de, D>(
     deserializer: D,
 ) -> core::result::Result<String, D::Error>
@@ -127,9 +141,39 @@ pub fn convert_bcs_hex(typ: String, value: String) -> Option<String> {
     .ok()
 }
 
+/// Convert the bcs serialized vector<u8> to its original string format for token v2 property map.
+pub fn convert_bcs_hex_new(typ: u8, value: String) -> Option<String> {
+    let decoded = hex::decode(value.strip_prefix("0x").unwrap_or(&*value)).ok()?;
+
+    match typ {
+        0 /* bool */ => bcs::from_bytes::<bool>(decoded.as_slice()).map(|e| format!("{}", e)),
+        1 /* u8 */ => bcs::from_bytes::<u8>(decoded.as_slice()).map(|e| format!("{}", e)),
+        2 /* u16 */ => bcs::from_bytes::<u16>(decoded.as_slice()).map(|e| format!("{}", e)),
+        3 /* u32 */ => bcs::from_bytes::<u32>(decoded.as_slice()).map(|e| format!("{}", e)),
+        4 /* u64 */ => bcs::from_bytes::<u64>(decoded.as_slice()).map(|e| format!("{}", e)),
+        5 /* u128 */ => bcs::from_bytes::<u128>(decoded.as_slice()).map(|e| format!("{}", e)),
+        6 /* u256 */ => bcs::from_bytes::<BigDecimal>(decoded.as_slice()).map(|e| format!("{}", e)),
+        7 /* address */ => bcs::from_bytes::<Address>(decoded.as_slice()).map(|e| format!("{}", e)),
+        8 /* byte_vector */ => bcs::from_bytes::<Vec<u8>>(decoded.as_slice()).map(|e| format!("0x{}", hex::encode(e))),
+        9 /* string */ => bcs::from_bytes::<String>(decoded.as_slice()).map(|e| format!("{}", e)),
+        _ => Ok(value),
+    }
+        .ok()
+}
+
 /// Convert the json serialized PropertyMap's inner BCS fields to their original value in string format
 pub fn convert_bcs_propertymap(s: Value) -> Option<Value> {
     match PropertyMap::from_bcs_encode_str(s) {
+        Some(e) => match serde_json::to_value(&e) {
+            Ok(val) => Some(val),
+            Err(_) => None,
+        },
+        None => None,
+    }
+}
+
+pub fn convert_bcs_token_object_propertymap(s: Value) -> Option<Value> {
+    match TokenObjectPropertyMap::from_bcs_encode_str(s) {
         Some(e) => match serde_json::to_value(&e) {
             Ok(val) => Some(val),
             Err(_) => None,
@@ -161,6 +205,12 @@ mod tests {
     #[derive(Serialize, Deserialize, Debug)]
     struct TokenDataMock {
         #[serde(deserialize_with = "deserialize_property_map_from_bcs_hexstring")]
+        pub default_properties: serde_json::Value,
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    struct TokenObjectDataMock {
+        #[serde(deserialize_with = "deserialize_token_object_property_map_from_bcs_hexstring")]
         pub default_properties: serde_json::Value,
     }
 
@@ -241,6 +291,72 @@ mod tests {
         };
         let val = serde_json::to_string(&test_struct).unwrap();
         let d: TokenDataMock = serde_json::from_str(val.as_str()).unwrap();
+        assert_eq!(d.default_properties, Value::Object(serde_json::Map::new()));
+    }
+
+    #[test]
+    fn test_deserialize_token_object_property_map() {
+        let test_property_json = r#"
+        {
+	"inner": {
+		"data": [{
+				"key": "Rank",
+				"value": {
+					"type": 9,
+					"value": "0x0642726f6e7a65"
+				}
+			},
+			{
+				"key": "address_property",
+				"value": {
+					"type": 7,
+					"value": "0x2b4d540735a4e128fda896f988415910a45cab41c9ddd802b32dd16e8f9ca3cd"
+				}
+			},
+			{
+				"key": "bytes_property",
+				"value": {
+					"type": 8,
+					"value": "0x0401020304"
+				}
+			},
+			{
+				"key": "u64_property",
+				"value": {
+					"type": 4,
+					"value": "0x0000000000000001"
+				}
+			}
+		]
+	}
+}
+        "#;
+        let test_property_json: serde_json::Value =
+            serde_json::from_str(test_property_json).unwrap();
+        let test_struct = TokenObjectDataMock {
+            default_properties: test_property_json,
+        };
+        let val = serde_json::to_string(&test_struct).unwrap();
+        let d: TokenObjectDataMock = serde_json::from_str(val.as_str()).unwrap();
+        assert_eq!(d.default_properties["Rank"], "Bronze");
+        assert_eq!(
+            d.default_properties["address_property"],
+            "0x2b4d540735a4e128fda896f988415910a45cab41c9ddd802b32dd16e8f9ca3cd"
+        );
+        assert_eq!(d.default_properties["bytes_property"], "0x01020304");
+        assert_eq!(d.default_properties["u64_property"], "72057594037927936");
+    }
+
+    #[test]
+    fn test_empty_token_object_property_map() {
+        let test_property_json = r#"{"inner": {"data": []}}"#;
+        let test_property_json: serde_json::Value =
+            serde_json::from_str(test_property_json).unwrap();
+        let test_struct = TokenObjectDataMock {
+            default_properties: test_property_json,
+        };
+        let val = serde_json::to_string(&test_struct).unwrap();
+        let d: TokenObjectDataMock = serde_json::from_str(val.as_str()).unwrap();
         assert_eq!(d.default_properties, Value::Object(serde_json::Map::new()));
     }
 }


### PR DESCRIPTION
### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 96e0116</samp>

This pull request adds new modules and functions to the `indexer` crate to handle the new token v2 standard. It introduces a new struct `TokenObjectPropertyValue` and a new module `util.rs` for deserializing and flattening bcs encoded property maps. It also updates the existing `property_map.rs` module to use the new structs and functions.

### Test Plan
ut
