### PR TITLE
fix principal calculation explanation

### DIFF
--- a/developer-docs-site/docs/nodes/validator-node/operator/delegation-pool-operations.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/delegation-pool-operations.md
@@ -166,8 +166,8 @@ Use this formula to calculate *rewards earned* for `active` and `pending_inactiv
 1. Get the amount of `active` and `pending_inactive` staking from the [`get_stake`](https://github.com/aptos-labs/aptos-core/blob/ed63ab756cda61439287304ed89bbb156fcbeaed/aptos-move/framework/aptos-framework/sources/delegation_pool.move#L321) view function.
 
 2. Calculate principal:
-    - "active principal" = **AddStakeEvent** - **UnlockStakeEvent** + **ReactivateStakeEvent**. If at any point during the iteration, "active principal" < 0, reset to 0. Negative principal could happen when the amount users `unlock` or `reactivate` include rewards earned from staking.
-    - "pending inactive principal" = **UnlockStakeEvent** - **ReactivateStakeEvent**. If at any point during the iteration, "pending inactive principal" < 0, reset to 0. Negative principal could happen when the amount users `unlock` or `reactivate` include rewards earned from staking.
+    - "active principal" = **AddStakeEvent** - **UnlockStakeEvent** + **ReactivateStakeEvent**. If at any point during the iteration, "active principal" < 0, reset to 0. Negative principal could happen when the amount users `unlock` include rewards earned from staking.
+    - "pending inactive principal" = **UnlockStakeEvent** - **ReactivateStakeEvent**. If at any point during the iteration, "pending inactive principal" < 0, reset to 0. Negative principal could happen when the amount users `reactivate` include rewards earned from staking.
 
 3. Compute rewards earned:
     - active_rewards = `active` - *active principal*.


### PR DESCRIPTION
active principal = add - unlock + reactivate. it can go negative only b/c unlock include rewards. reactivate doesn't contribute to the negativity.

likewise to pending inactive principal.

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad59998</samp>

Fix a typo in the documentation of the delegation pool rewards calculation algorithm. The change corrects the conditions for negative principal in `delegation-pool-operations.md`.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
