### PR TITLE
[transaction-generator] Fix reliable executor client to check for VM status, not just sequence number

### DIFF
--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -120,6 +120,7 @@ pub fn run_benchmark<V>(
             db.clone(),
             &source_dir,
             // Initialization pipeline is temporary, so needs to be fully committed.
+            // No discards/aborts allowed during initialization, even if they are allowed later.
             PipelineConfig {
                 delay_execution_start: false,
                 split_stages: false,
@@ -434,7 +435,10 @@ mod tests {
 
     #[test]
     fn test_benchmark_transaction() {
-        test_generic_benchmark::<AptosVM>(Some(TransactionTypeArg::CreateNewAccountResource), true);
+        test_generic_benchmark::<AptosVM>(
+            Some(TransactionTypeArg::TokenV1NFTMintAndTransferSequential),
+            true,
+        );
     }
 
     #[test]


### PR DESCRIPTION

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77d31bf</samp>

This pull request enhances the error handling and logging of the transaction emitter and the executor benchmark, and updates the benchmark to use a new transaction type for non-fungible tokens. It uses the `TransactionInfo` type from the `aptos_rest_client` crate, the `anyhow` crate, and a new helper function `warn_detailed_error`. It also adds a comment to explain the benchmark assumption and modifies the files `transaction_executor.rs`, `gen_executor.rs`, and `lib.rs`.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
