### PR TITLE
[trivial] Make TransactionFactory fields public

### DIFF
--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -127,6 +127,18 @@ impl TransactionFactory {
         self
     }
 
+    pub fn get_max_gas_amount(&self) -> u64 {
+        self.max_gas_amount
+    }
+
+    pub fn get_gas_unit_price(&self) -> u64 {
+        self.gas_unit_price
+    }
+
+    pub fn get_transaction_expiration_time(&self) -> u64 {
+        self.transaction_expiration_time
+    }
+
     pub fn payload(&self, payload: TransactionPayload) -> TransactionBuilder {
         self.transaction_builder(payload)
     }


### PR DESCRIPTION
When creating multiple transactions, in order to compute needed funds in the account or the cost of transaction, on top of having TransactionFactory, I need to pass gas cost/max gas.

Having access to those fields, makes it easier to manage, I am not sure of any negatives though. I can also provide getters, instead of making fields public

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 28a61bd</samp>

Made some fields of `TransactionFactory` public and refactored transaction creation logic. This improves the flexibility and usability of the SDK for creating transactions.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
