### PR TITLE
[transaction-generator] Calling custom module code cleanup, and adding multisig transactions

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -69,7 +69,11 @@ impl<'t> AccountMinter<'t> {
         let coins_per_account = (req.expected_max_txns / total_requested_accounts as u64)
             .checked_mul(SEND_AMOUNT + req.expected_gas_per_txn * req.gas_price)
             .unwrap()
-            .checked_add(req.max_gas_per_txn * req.gas_price)
+            .checked_add(
+                req.max_gas_per_txn * req.gas_price
+                // for module publishing
+                + 2 * req.max_gas_per_txn * req.gas_price * req.init_gas_price_multiplier,
+            )
             .unwrap(); // extra coins for secure to pay none zero gas price
         let txn_factory = self.txn_factory.clone();
         let expected_children_per_seed_account =

--- a/crates/transaction-generator-lib/src/account_generator.rs
+++ b/crates/transaction-generator-lib/src/account_generator.rs
@@ -1,11 +1,11 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
-use crate::{TransactionGenerator, TransactionGeneratorCreator};
+use crate::{create_account_transaction, TransactionGenerator, TransactionGeneratorCreator};
 use aptos_infallible::RwLock;
 use aptos_logger::{info, sample, sample::SampleRate};
 use aptos_sdk::{
     move_types::account_address::AccountAddress,
-    transaction_builder::{aptos_stdlib, TransactionFactory},
+    transaction_builder::TransactionFactory,
     types::{transaction::SignedTransaction, LocalAccount},
 };
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -40,21 +40,6 @@ impl AccountGenerator {
             max_working_set,
             creation_balance,
         }
-    }
-
-    fn gen_single_txn(
-        &self,
-        from: &mut LocalAccount,
-        to: AccountAddress,
-        txn_factory: &TransactionFactory,
-    ) -> SignedTransaction {
-        from.sign_with_transaction_builder(txn_factory.payload(
-            if self.creation_balance > 0 {
-                aptos_stdlib::aptos_account_transfer(to, self.creation_balance)
-            } else {
-                aptos_stdlib::aptos_account_create_account(to)
-            },
-        ))
     }
 }
 
@@ -98,7 +83,12 @@ impl TransactionGenerator for AccountGenerator {
         for _ in 0..num_to_create {
             let receiver = LocalAccount::generate(&mut self.rng);
             let receiver_address = receiver.address();
-            let request = self.gen_single_txn(account, receiver_address, &self.txn_factory);
+            let request = create_account_transaction(
+                account,
+                receiver_address,
+                &self.txn_factory,
+                self.creation_balance,
+            );
             requests.push(request);
             new_accounts.push(receiver);
             new_account_addresses.push(receiver_address);

--- a/crates/transaction-generator-lib/src/args.rs
+++ b/crates/transaction-generator-lib/src/args.rs
@@ -9,6 +9,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Copy, Clone, ArgEnum, Deserialize, Parser, Serialize)]
 pub enum TransactionTypeArg {
     NoOp,
+    NoOp2Signers,
+    NoOp5Signers,
     CoinTransfer,
     CoinTransferWithInvalid,
     AccountGeneration,
@@ -80,6 +82,16 @@ impl TransactionTypeArg {
                 use_account_pool: false,
             },
             TransactionTypeArg::NoOp => TransactionType::CallCustomModules {
+                entry_point: EntryPoints::Nop,
+                num_modules: 1,
+                use_account_pool: false,
+            },
+            TransactionTypeArg::NoOp2Signers => TransactionType::CallCustomModules {
+                entry_point: EntryPoints::Nop,
+                num_modules: 1,
+                use_account_pool: false,
+            },
+            TransactionTypeArg::NoOp5Signers => TransactionType::CallCustomModules {
                 entry_point: EntryPoints::Nop,
                 num_modules: 1,
                 use_account_pool: false,

--- a/crates/transaction-generator-lib/src/entry_points.rs
+++ b/crates/transaction-generator-lib/src/entry_points.rs
@@ -1,0 +1,92 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    publishing::{module_simple::EntryPoints, publish_util::Package},
+    TransactionExecutor,
+};
+use crate::{
+    call_custom_modules::{TransactionGeneratorWorker, UserModuleTransactionGenerator},
+    create_account_transaction,
+};
+use aptos_sdk::{
+    transaction_builder::TransactionFactory,
+    types::{transaction::SignedTransaction, LocalAccount},
+};
+use async_trait::async_trait;
+use rand::rngs::StdRng;
+use std::sync::Arc;
+
+pub struct EntryPointTransactionGenerator {
+    pub entry_point: EntryPoints,
+}
+
+#[async_trait]
+impl UserModuleTransactionGenerator for EntryPointTransactionGenerator {
+    fn initialize_package(
+        &mut self,
+        package: &Package,
+        publisher: &mut LocalAccount,
+        txn_factory: &TransactionFactory,
+        rng: &mut StdRng,
+    ) -> Vec<SignedTransaction> {
+        if let Some(initial_entry_point) = self.entry_point.initialize_entry_point() {
+            let payload = initial_entry_point.create_payload(
+                package.get_module_id(initial_entry_point.module_name()),
+                Some(rng),
+                Some(&publisher.address()),
+            );
+            vec![publisher.sign_with_transaction_builder(txn_factory.payload(payload))]
+        } else {
+            vec![]
+        }
+    }
+
+    async fn create_generator_fn(
+        &self,
+        init_accounts: &mut [LocalAccount],
+        txn_factory: &TransactionFactory,
+        txn_executor: &dyn TransactionExecutor,
+        rng: &mut StdRng,
+    ) -> Arc<TransactionGeneratorWorker> {
+        let entry_point = self.entry_point;
+
+        let additional_signers = if let Some(num) = entry_point.multi_sig_additional_num() {
+            let new_accounts = Arc::new(
+                (0..num)
+                    .into_iter()
+                    .map(|_| LocalAccount::generate(rng))
+                    .collect::<Vec<_>>(),
+            );
+            let sender = init_accounts.get_mut(0).unwrap();
+            txn_executor
+                .execute_transactions(
+                    &new_accounts
+                        .iter()
+                        .map(|to| create_account_transaction(sender, to.address(), txn_factory, 0))
+                        .collect::<Vec<_>>(),
+                )
+                .await
+                .unwrap();
+            Some(new_accounts)
+        } else {
+            None
+        };
+
+        Arc::new(move |account, package, publisher, txn_factory, rng| {
+            let payload = entry_point.create_payload(
+                package.get_module_id(entry_point.module_name()),
+                Some(rng),
+                Some(&publisher.address()),
+            );
+            let builder = txn_factory.payload(payload);
+            match &additional_signers {
+                None => account.sign_with_transaction_builder(builder),
+                Some(additional_signers) => account.sign_multi_agent_with_transaction_builder(
+                    additional_signers.iter().collect(),
+                    builder,
+                ),
+            }
+        })
+    }
+}

--- a/crates/transaction-generator-lib/src/publishing/module_simple.rs
+++ b/crates/transaction-generator-lib/src/publishing/module_simple.rs
@@ -109,6 +109,10 @@ pub enum EntryPoints {
     // 0 args
     /// Empty (NoOp) function
     Nop,
+    /// Empty (NoOp) function, signed by 2 accounts
+    Nop2Signers,
+    /// Empty (NoOp) function, signed by 5 accounts
+    Nop5Signers,
     /// Increment signer resource - COUNTER_STEP
     Step,
     /// Fetch signer resource - COUNTER_STEP
@@ -165,6 +169,8 @@ impl EntryPoints {
     pub fn package_name(&self) -> &'static str {
         match self {
             EntryPoints::Nop
+            | EntryPoints::Nop2Signers
+            | EntryPoints::Nop5Signers
             | EntryPoints::Step
             | EntryPoints::GetCounter
             | EntryPoints::ResetData
@@ -192,6 +198,8 @@ impl EntryPoints {
     pub fn module_name(&self) -> &'static str {
         match self {
             EntryPoints::Nop
+            | EntryPoints::Nop2Signers
+            | EntryPoints::Nop5Signers
             | EntryPoints::Step
             | EntryPoints::GetCounter
             | EntryPoints::ResetData
@@ -225,6 +233,12 @@ impl EntryPoints {
         match self {
             // 0 args
             EntryPoints::Nop => get_payload_void(module_id, ident_str!("nop").to_owned()),
+            EntryPoints::Nop2Signers => {
+                get_payload_void(module_id, ident_str!("nop_2_signers").to_owned())
+            },
+            EntryPoints::Nop5Signers => {
+                get_payload_void(module_id, ident_str!("nop_5_signers").to_owned())
+            },
             EntryPoints::Step => get_payload_void(module_id, ident_str!("step").to_owned()),
             EntryPoints::GetCounter => {
                 get_payload_void(module_id, ident_str!("get_counter").to_owned())
@@ -308,14 +322,22 @@ impl EntryPoints {
 
     pub fn initialize_entry_point(&self) -> Option<EntryPoints> {
         match self {
-            EntryPoints::TokenV1MintAndStoreFT
-            | EntryPoints::TokenV1MintAndTransferFT
-            | EntryPoints::TokenV1MintAndStoreNFTParallel
+            EntryPoints::TokenV1MintAndStoreNFTParallel
             | EntryPoints::TokenV1MintAndStoreNFTSequential
             | EntryPoints::TokenV1MintAndTransferNFTParallel
-            | EntryPoints::TokenV1MintAndTransferNFTSequential => {
+            | EntryPoints::TokenV1MintAndTransferNFTSequential
+            | EntryPoints::TokenV1MintAndStoreFT
+            | EntryPoints::TokenV1MintAndTransferFT => {
                 Some(EntryPoints::TokenV1InitializeCollection)
             },
+            _ => None,
+        }
+    }
+
+    pub fn multi_sig_additional_num(&self) -> Option<usize> {
+        match self {
+            EntryPoints::Nop2Signers => Some(1),
+            EntryPoints::Nop5Signers => Some(4),
             _ => None,
         }
     }

--- a/crates/transaction-generator-lib/src/publishing/publish_util.rs
+++ b/crates/transaction-generator-lib/src/publishing/publish_util.rs
@@ -1,11 +1,11 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{publishing::module_simple, EntryPoints};
+use crate::publishing::module_simple;
 use aptos_framework::natives::code::PackageMetadata;
 use aptos_sdk::{
     bcs,
-    move_types::identifier::Identifier,
+    move_types::{identifier::Identifier, language_storage::ModuleId},
     transaction_builder::{aptos_stdlib, TransactionFactory},
     types::{account_address::AccountAddress, transaction::SignedTransaction, LocalAccount},
 };
@@ -162,30 +162,14 @@ impl Package {
         account: &mut LocalAccount,
         txn_factory: &TransactionFactory,
     ) -> SignedTransaction {
-        match self {
-            Self::Simple(modules, _) => {
-                let module_id = modules.get("simple").unwrap().self_id();
-                // let payload = module_simple::rand_gen_function(rng, module_id);
-                let payload = module_simple::rand_simple_function(rng, module_id);
-                account.sign_with_transaction_builder(txn_factory.payload(payload))
-            },
-        }
+        // let payload = module_simple::rand_gen_function(rng, module_id);
+        let payload = module_simple::rand_simple_function(rng, self.get_module_id("simple"));
+        account.sign_with_transaction_builder(txn_factory.payload(payload))
     }
 
-    pub fn use_specific_transaction(
-        &self,
-        fun: EntryPoints,
-        account: &mut LocalAccount,
-        txn_factory: &TransactionFactory,
-        rng: Option<&mut StdRng>,
-        other: Option<&AccountAddress>,
-    ) -> SignedTransaction {
+    pub fn get_module_id(&self, module_name: &str) -> ModuleId {
         match self {
-            Self::Simple(modules, _) => {
-                let module_id = modules.get(fun.module_name()).unwrap().self_id();
-                let payload = fun.create_payload(module_id, rng, other);
-                account.sign_with_transaction_builder(txn_factory.payload(payload))
-            },
+            Self::Simple(modules, _) => modules.get(module_name).unwrap().self_id(),
         }
     }
 }

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -127,6 +127,18 @@ impl TransactionFactory {
         self
     }
 
+    pub fn get_max_gas_amount(&self) -> u64 {
+        self.max_gas_amount
+    }
+
+    pub fn get_gas_unit_price(&self) -> u64 {
+        self.gas_unit_price
+    }
+
+    pub fn get_transaction_expiration_time(&self) -> u64 {
+        self.transaction_expiration_time
+    }
+
     pub fn payload(&self, payload: TransactionPayload) -> TransactionBuilder {
         self.transaction_builder(payload)
     }

--- a/testsuite/module-publish/src/packages/simple/sources/Simple.move
+++ b/testsuite/module-publish/src/packages/simple/sources/Simple.move
@@ -45,6 +45,12 @@ module 0xABCD::simple {
     public entry fun nop(_s: &signer) {
     }
 
+    public entry fun nop_2_signers(_s1: &signer, _s2: &signer) {
+    }
+
+    public entry fun nop_5_signers(_s1: &signer, _s2: &signer, _s3: &signer, _s4: &signer, _s5: &signer) {
+    }
+
     // Test simple CPU usage. Loop as defined by the input `count`.
     // Not a true test of CPU usage given the number of instructions
     // used, but a simple reference to computation with no data access.

--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -34,6 +34,8 @@ EXPECTED_TPS = {
     ("token-v1nft-mint-and-transfer-parallel", False): (1000.0, False),
     # ("token-v1nft-mint-and-store-sequential", False): 1000.0,
     # ("token-v1nft-mint-and-store-parallel", False): 1000.0,
+    ("no-op2-signers", False): (18200.0, False),
+    ("no-op5-signers", False): (18200.0, False),
 }
 
 NOISE_LOWER_LIMIT = 0.8


### PR DESCRIPTION
Extracting code, so that if anyone wants to test their module, and need a custom logic for what to pass in (beyond what EntryPoints can do), they have a simpler job - just to extend UserModuleTransactionGenerator, like I did here for EntryPointTransactionGenerator

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9b5597f</samp>

Add new test cases for transactions with multiple signers to `testsuite/single_node_performance.py`. The purpose is to measure the throughput of signature verification on different transaction types.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
