### PR TITLE
Add is_aggregator_enabled flag to NativeAggregatorContext

### DIFF
--- a/aptos-move/aptos-debugger/src/lib.rs
+++ b/aptos-move/aptos-debugger/src/lib.rs
@@ -234,7 +234,7 @@ impl AptosDebugger {
             TimedFeatures::enable_all(),
         )
         .unwrap();
-        let mut session = move_vm.new_session(&state_view_storage, SessionId::Void);
+        let mut session = move_vm.new_session(&state_view_storage, SessionId::Void, true);
         f(&mut session).map_err(|err| format_err!("Unexpected VM Error: {:?}", err))?;
         let change_set_ext = session
             .finish(

--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -613,8 +613,10 @@ impl AptosVMImpl {
         &self,
         r: &'r R,
         session_id: SessionId,
+        is_aggregator_enabled: bool,
     ) -> SessionExt<'r, '_> {
-        self.move_vm.new_session(r, session_id)
+        self.move_vm
+            .new_session(r, session_id, is_aggregator_enabled)
     }
 
     pub fn load_module<'r, R: MoveResolverExt>(

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -77,6 +77,7 @@ impl MoveVmExt {
         &self,
         remote: &'r S,
         session_id: SessionId,
+        is_aggregator_enabled: bool,
     ) -> SessionExt<'r, '_> {
         let mut extensions = NativeContextExtensions::default();
         let txn_hash: [u8; 32] = session_id
@@ -88,7 +89,11 @@ impl MoveVmExt {
         extensions.add(NativeTableContext::new(txn_hash, remote));
         extensions.add(NativeRistrettoPointContext::new());
         extensions.add(AlgebraContext::new());
-        extensions.add(NativeAggregatorContext::new(txn_hash, remote));
+        extensions.add(NativeAggregatorContext::new(
+            txn_hash,
+            remote,
+            is_aggregator_enabled,
+        ));
 
         let script_hash = match session_id {
             SessionId::Txn {

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -92,7 +92,11 @@ pub fn configure_for_unit_test() {
 fn unit_test_extensions_hook(exts: &mut NativeContextExtensions) {
     exts.add(NativeCodeContext::default());
     exts.add(NativeTransactionContext::new(vec![1], ChainId::test().id())); // We use the testing environment chain ID here
-    exts.add(NativeAggregatorContext::new([0; 32], &*DUMMY_RESOLVER));
+    exts.add(NativeAggregatorContext::new(
+        [0; 32],
+        &*DUMMY_RESOLVER,
+        true,
+    ));
     exts.add(NativeRistrettoPointContext::new());
     exts.add(AlgebraContext::new());
 }

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -593,7 +593,7 @@ impl FakeExecutor {
             )
             .unwrap();
             let remote_view = StorageAdapter::new(&self.data_store);
-            let mut session = vm.new_session(&remote_view, SessionId::void());
+            let mut session = vm.new_session(&remote_view, SessionId::void(), true);
             session
                 .execute_function_bypass_visibility(
                     &Self::module(module_name),
@@ -642,7 +642,7 @@ impl FakeExecutor {
         )
         .unwrap();
         let remote_view = StorageAdapter::new(&self.data_store);
-        let mut session = vm.new_session(&remote_view, SessionId::void());
+        let mut session = vm.new_session(&remote_view, SessionId::void(), true);
         session
             .execute_function_bypass_visibility(
                 &Self::module(module_name),

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -113,7 +113,7 @@ pub fn encode_aptos_mainnet_genesis_transaction(
     )
     .unwrap();
     let id1 = HashValue::zero();
-    let mut session = move_vm.new_session(&data_cache, SessionId::genesis(id1));
+    let mut session = move_vm.new_session(&data_cache, SessionId::genesis(id1), true);
 
     // On-chain genesis process.
     let consensus_config = OnChainConsensusConfig::default();
@@ -152,7 +152,7 @@ pub fn encode_aptos_mainnet_genesis_transaction(
     let mut id2_arr = [0u8; 32];
     id2_arr[31] = 1;
     let id2 = HashValue::new(id2_arr);
-    let mut session = move_vm.new_session(&data_cache, SessionId::genesis(id2));
+    let mut session = move_vm.new_session(&data_cache, SessionId::genesis(id2), true);
     publish_framework(&mut session, framework);
     let cs2 = session
         .finish(
@@ -230,7 +230,7 @@ pub fn encode_genesis_change_set(
     )
     .unwrap();
     let id1 = HashValue::zero();
-    let mut session = move_vm.new_session(&data_cache, SessionId::genesis(id1));
+    let mut session = move_vm.new_session(&data_cache, SessionId::genesis(id1), true);
 
     // On-chain genesis process.
     initialize(
@@ -271,7 +271,7 @@ pub fn encode_genesis_change_set(
     let mut id2_arr = [0u8; 32];
     id2_arr[31] = 1;
     let id2 = HashValue::new(id2_arr);
-    let mut session = move_vm.new_session(&data_cache, SessionId::genesis(id2));
+    let mut session = move_vm.new_session(&data_cache, SessionId::genesis(id2), true);
     publish_framework(&mut session, framework);
     let cs2 = session
         .finish(
@@ -906,7 +906,7 @@ pub fn test_genesis_module_publishing() {
     )
     .unwrap();
     let id1 = HashValue::zero();
-    let mut session = move_vm.new_session(&data_cache, SessionId::genesis(id1));
+    let mut session = move_vm.new_session(&data_cache, SessionId::genesis(id1), true);
     publish_framework(&mut session, aptos_cached_packages::head_release_bundle());
 }
 

--- a/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
+++ b/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
@@ -124,9 +124,11 @@ where
     let change_set_ext = {
         // TODO: specify an id by human and pass that in.
         let genesis_id = HashValue::zero();
-        let mut session = GenesisSession(
-            move_vm.new_session(&state_view_storage, SessionId::genesis(genesis_id)),
-        );
+        let mut session = GenesisSession(move_vm.new_session(
+            &state_view_storage,
+            SessionId::genesis(genesis_id),
+            true,
+        ));
         session.disable_reconfiguration();
         procedure(&mut session);
         session.enable_reconfiguration();


### PR DESCRIPTION
### Description
This is the first PR related to improving error handling for aggregators. Currently, if the value of an aggregator overflows, then the BlockSTM panics. Instead, we want the BlockSTM to re-execute the transaction by disabling the aggregators, and directly writing the aggregator values to the WriteSet. This PR adds a flag in the AggregatorContext to enable/disable aggregators. 