### PR TITLE
use sha2 0.9.3 asm feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10888,6 +10888,7 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+ "sha2-asm",
 ]
 
 [[package]]
@@ -10899,6 +10900,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.5",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf27176fb5d15398e3a479c652c20459d9dac830dedd1fa55b42a77dbcdbfcea"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -519,7 +519,7 @@ rocksdb = { version = "0.20.1", features = ["lz4"] }
 rstest = "0.15.0"
 rusty-fork = "0.3.0"
 sha-1 = "0.10.0"
-sha2 = "0.9.3"
+sha2 = { version = "0.9.3", features = ["asm"] }
 sha2_0_10_6 = { package = "sha2", version = "0.10.6" }
 sha3 = "0.9.1"
 siphasher = "0.3.10"

--- a/crates/aptos-crypto/benches/hash.rs
+++ b/crates/aptos-crypto/benches/hash.rs
@@ -26,7 +26,7 @@ fn bench_group(c: &mut Criterion) {
 
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
 
-    group.sample_size(100);
+    group.sample_size(1000);
     group.plot_config(plot_config);
 
     let mut sizes = vec![0, 1];
@@ -37,40 +37,27 @@ fn bench_group(c: &mut Criterion) {
         sizes.push(size);
     }
 
-    // for n in sizes {
-    //     sha2_256(&mut group, n);
-    //     sha2_512(&mut group, n);
-    //     sha3_256(&mut group, n);
-    //     hash_to_g1(&mut group, n, DST_BLS_SIG_IN_G2_WITH_POP);
-    //     hash_to_g2(&mut group, n, DST_BLS_SIG_IN_G2_WITH_POP);
-    //     keccak256(&mut group, n);
-    //     blake2_blake2b_256(&mut group, n);
-    //     blake2_rfc_blake2b_256(&mut group, n);
-    // }
-
-    for n in [65536] {
-        let mut rng = thread_rng();
-        group.bench_function(BenchmarkId::new("sha2_0_9_3", n), move |b| {
-            b.iter_with_setup(
-            || random_bytes(&mut rng, n),
-                |bytes| {
-                    let mut hasher = sha2::Sha256::new();
-                    hasher.update(bytes);
-                    let output = hasher.finalize();
-                },
-            )
-        });
+    for n in sizes {
+        sha2_256(&mut group, n);
+        sha2_512(&mut group, n);
+        sha3_256(&mut group, n);
+        hash_to_g1(&mut group, n, DST_BLS_SIG_IN_G2_WITH_POP);
+        hash_to_g2(&mut group, n, DST_BLS_SIG_IN_G2_WITH_POP);
+        keccak256(&mut group, n);
+        blake2_blake2b_256(&mut group, n);
+        blake2_rfc_blake2b_256(&mut group, n);
     }
+
     group.finish();
 }
 
 /// Benchmarks the time to hash an arbitrary message of size n bytes using SHA2-256
-fn sha2_256<M: Measurement>(group: &mut BenchmarkGroup<M>, n: usize) {
+fn sha2_256<M: Measurement>(g: &mut BenchmarkGroup<M>, n: usize) {
     let mut rng = thread_rng();
 
-    group.throughput(Throughput::Bytes(n as u64));
+    g.throughput(Throughput::Bytes(n as u64));
 
-    group.bench_function(BenchmarkId::new("SHA2-256", n), move |b| {
+    g.bench_function(BenchmarkId::new("SHA2-256", n), move |b| {
         b.iter_with_setup(
             || random_bytes(&mut rng, n),
             |bytes| {

--- a/crates/aptos-crypto/benches/hash.rs
+++ b/crates/aptos-crypto/benches/hash.rs
@@ -26,7 +26,7 @@ fn bench_group(c: &mut Criterion) {
 
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
 
-    group.sample_size(1000);
+    group.sample_size(100);
     group.plot_config(plot_config);
 
     let mut sizes = vec![0, 1];
@@ -37,27 +37,40 @@ fn bench_group(c: &mut Criterion) {
         sizes.push(size);
     }
 
-    for n in sizes {
-        sha2_256(&mut group, n);
-        sha2_512(&mut group, n);
-        sha3_256(&mut group, n);
-        hash_to_g1(&mut group, n, DST_BLS_SIG_IN_G2_WITH_POP);
-        hash_to_g2(&mut group, n, DST_BLS_SIG_IN_G2_WITH_POP);
-        keccak256(&mut group, n);
-        blake2_blake2b_256(&mut group, n);
-        blake2_rfc_blake2b_256(&mut group, n);
-    }
+    // for n in sizes {
+    //     sha2_256(&mut group, n);
+    //     sha2_512(&mut group, n);
+    //     sha3_256(&mut group, n);
+    //     hash_to_g1(&mut group, n, DST_BLS_SIG_IN_G2_WITH_POP);
+    //     hash_to_g2(&mut group, n, DST_BLS_SIG_IN_G2_WITH_POP);
+    //     keccak256(&mut group, n);
+    //     blake2_blake2b_256(&mut group, n);
+    //     blake2_rfc_blake2b_256(&mut group, n);
+    // }
 
+    for n in [65536] {
+        let mut rng = thread_rng();
+        group.bench_function(BenchmarkId::new("sha2_0_9_3", n), move |b| {
+            b.iter_with_setup(
+            || random_bytes(&mut rng, n),
+                |bytes| {
+                    let mut hasher = sha2::Sha256::new();
+                    hasher.update(bytes);
+                    let output = hasher.finalize();
+                },
+            )
+        });
+    }
     group.finish();
 }
 
 /// Benchmarks the time to hash an arbitrary message of size n bytes using SHA2-256
-fn sha2_256<M: Measurement>(g: &mut BenchmarkGroup<M>, n: usize) {
+fn sha2_256<M: Measurement>(group: &mut BenchmarkGroup<M>, n: usize) {
     let mut rng = thread_rng();
 
-    g.throughput(Throughput::Bytes(n as u64));
+    group.throughput(Throughput::Bytes(n as u64));
 
-    g.bench_function(BenchmarkId::new("SHA2-256", n), move |b| {
+    group.bench_function(BenchmarkId::new("SHA2-256", n), move |b| {
         b.iter_with_setup(
             || random_bytes(&mut rng, n),
             |bytes| {


### PR DESCRIPTION
### Description

For `sha2_256(some_64_byte_msg)`, here is the latency diff on an GCP n2 machine.
```
hash/sha2_0_9_3/64      time:   [593.47 ns 593.77 ns 594.10 ns]                                
                        change: [-15.677% -15.612% -15.530%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
```

From the executor-benchmark results (machine: gcp/n2-32vcpu-64gb-epd40k, build profile: performance, block size: 10k, concurrency level: 32, workload: account creation),
the latency diff 
<img width="1443" alt="image" src="https://user-images.githubusercontent.com/4213569/236031814-5091a986-d93a-460a-8e0b-a25e9dc7701f.png">

The TPS diff TBD.
