### PR TITLE
Revert "Revert "refactor a bit (#7918)""

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,6 +3133,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-utils"
+version = "0.1.0"
+
+[[package]]
 name = "aptos-validator-interface"
 version = "0.1.0"
 dependencies = [
@@ -3187,6 +3191,7 @@ dependencies = [
  "aptos-mvhashmap",
  "aptos-state-view",
  "aptos-types",
+ "aptos-utils",
  "aptos-vm-logging",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "aptos-move/vm-genesis",
     "aptos-move/writeset-transaction-generator",
     "aptos-node",
+    "aptos-utils",
     "config",
     "config/global-constants",
     "consensus",
@@ -358,6 +359,7 @@ aptos-transaction-emitter-lib = { path = "crates/transaction-emitter-lib" }
 aptos-transaction-generator-lib = { path = "crates/transaction-generator-lib" }
 aptos-transactional-test-harness = { path = "aptos-move/aptos-transactional-test-harness" }
 aptos-types = { path = "types" }
+aptos-utils = { path = "aptos-utils" }
 aptos-validator-interface = { path = "aptos-move/aptos-validator-interface" }
 aptos-vault-client = { path = "secure/storage/vault" }
 aptos-vm = { path = "aptos-move/aptos-vm" }

--- a/aptos-move/aptos-debugger/src/lib.rs
+++ b/aptos-move/aptos-debugger/src/lib.rs
@@ -220,7 +220,7 @@ impl AptosDebugger {
 
     pub fn run_session_at_version<F>(&self, version: Version, f: F) -> Result<ChangeSet>
     where
-        F: FnOnce(&mut SessionExt<StorageAdapter<DebuggerStateView>>) -> VMResult<()>,
+        F: FnOnce(&mut SessionExt) -> VMResult<()>,
     {
         let state_view = DebuggerStateView::new(self.debugger.clone(), version);
         let state_view_storage = StorageAdapter::new(&state_view);

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -27,6 +27,7 @@ aptos-move-stdlib = { workspace = true }
 aptos-mvhashmap = { workspace = true }
 aptos-state-view = { workspace = true }
 aptos-types = { workspace = true }
+aptos-utils = { workspace = true }
 aptos-vm-logging = { workspace = true }
 bcs = { workspace = true }
 dashmap = { workspace = true }

--- a/aptos-move/aptos-vm/src/adapter_common.rs
+++ b/aptos-move/aptos-vm/src/adapter_common.rs
@@ -18,15 +18,15 @@ use aptos_vm_logging::log_schema::AdapterLogSchema;
 
 /// This trait describes the VM adapter's interface.
 /// TODO: bring more of the execution logic in aptos_vm into this file.
-pub trait VMAdapter {
+pub(crate) trait VMAdapter {
     /// Creates a new Session backed by the given storage.
     /// TODO: this doesn't belong in this trait. We should be able to remove
     /// this after redesigning cache ownership model.
-    fn new_session<'r, R: MoveResolverExt>(
+    fn new_session<'r>(
         &self,
-        remote: &'r R,
+        remote: &'r impl MoveResolverExt,
         session_id: SessionId,
-    ) -> SessionExt<'r, '_, R>;
+    ) -> SessionExt<'r, '_>;
 
     /// Checks the signature of the given signed transaction and returns
     /// `Ok(SignatureCheckedTransaction)` if the signature is valid.
@@ -36,10 +36,10 @@ pub trait VMAdapter {
     fn check_transaction_format(&self, txn: &SignedTransaction) -> Result<(), VMStatus>;
 
     /// Runs the prologue for the given transaction.
-    fn run_prologue<S: MoveResolverExt, SS: MoveResolverExt>(
+    fn run_prologue(
         &self,
-        session: &mut SessionExt<SS>,
-        storage: &S,
+        session: &mut SessionExt,
+        storage: &impl MoveResolverExt,
         transaction: &SignatureCheckedTransaction,
         log_context: &AdapterLogSchema,
     ) -> Result<(), VMStatus>;
@@ -48,17 +48,17 @@ pub trait VMAdapter {
     fn should_restart_execution(output: &TransactionOutput) -> bool;
 
     /// Execute a single transaction.
-    fn execute_single_transaction<S: MoveResolverExt>(
+    fn execute_single_transaction(
         &self,
         txn: &PreprocessedTransaction,
-        data_cache: &S,
+        data_cache: &impl MoveResolverExt,
         log_context: &AdapterLogSchema,
     ) -> Result<(VMStatus, TransactionOutputExt, Option<String>), VMStatus>;
 
-    fn validate_signature_checked_transaction<S: MoveResolverExt, SS: MoveResolverExt>(
+    fn validate_signature_checked_transaction(
         &self,
-        session: &mut SessionExt<SS>,
-        storage: &S,
+        session: &mut SessionExt,
+        storage: &impl MoveResolverExt,
         transaction: &SignatureCheckedTransaction,
         allow_too_new: bool,
         log_context: &AdapterLogSchema,

--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -22,8 +22,8 @@ use aptos_types::{
     account_config::{TransactionValidation, APTOS_TRANSACTION_VALIDATION, CORE_CODE_ADDRESS},
     chain_id::ChainId,
     on_chain_config::{
-        ApprovedExecutionHashes, ConfigurationResource, Features, GasSchedule, GasScheduleV2,
-        OnChainConfig, StorageGasSchedule, TimedFeatures, Version,
+        ApprovedExecutionHashes, ConfigurationResource, FeatureFlag, Features, GasSchedule,
+        GasScheduleV2, OnChainConfig, StorageGasSchedule, TimedFeatures, Version,
     },
     transaction::{AbortInfo, ExecutionStatus, Multisig, TransactionOutput, TransactionStatus},
     vm_status::{StatusCode, VMStatus},
@@ -599,7 +599,11 @@ impl AptosVMImpl {
         &self,
         module: &ModuleId,
     ) -> Option<RuntimeModuleMetadataV1> {
-        aptos_framework::get_vm_metadata(&self.move_vm, module.clone())
+        if self.features.is_enabled(FeatureFlag::VM_BINARY_FORMAT_V6) {
+            aptos_framework::get_vm_metadata(&self.move_vm, module.clone())
+        } else {
+            aptos_framework::get_vm_metadata_v0(&self.move_vm, module.clone())
+        }
     }
 
     pub fn new_move_resolver<'r, R: MoveResolverExt>(

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -66,9 +66,7 @@ impl<'a, 'm, S: MoveResolverExt> MoveResolverWithVMMetadata<'a, 'm, S> {
 
 impl<'a, 'm, S: MoveResolverExt> MoveResolverExt for MoveResolverWithVMMetadata<'a, 'm, S> {
     fn get_module_metadata(&self, module_id: ModuleId) -> Option<RuntimeModuleMetadataV1> {
-        aptos_framework::get_vm_metadata(self.move_vm, module_id.clone()).or_else(|| {
-            self.move_resolver.get_module_metadata(module_id)
-        })
+        aptos_framework::get_vm_metadata(self.move_vm, module_id)
     }
 
     fn get_resource_group_data(

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -66,7 +66,9 @@ impl<'a, 'm, S: MoveResolverExt> MoveResolverWithVMMetadata<'a, 'm, S> {
 
 impl<'a, 'm, S: MoveResolverExt> MoveResolverExt for MoveResolverWithVMMetadata<'a, 'm, S> {
     fn get_module_metadata(&self, module_id: ModuleId) -> Option<RuntimeModuleMetadataV1> {
-        aptos_framework::get_vm_metadata(self.move_vm, module_id)
+        aptos_framework::get_vm_metadata(self.move_vm, module_id.clone()).or_else(|| {
+            self.move_resolver.get_module_metadata(module_id)
+        })
     }
 
     fn get_resource_group_data(

--- a/aptos-move/aptos-vm/src/move_vm_ext/resolver.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/resolver.rs
@@ -4,15 +4,25 @@
 use aptos_framework::{natives::state_storage::StateStorageUsageResolver, RuntimeModuleMetadataV1};
 use aptos_state_view::StateView;
 use aptos_types::on_chain_config::ConfigStorage;
-use move_binary_format::errors::{Location, PartialVMError, VMError};
+use aptos_utils::{aptos_try, return_on_failure};
+use move_binary_format::errors::VMError;
 use move_core_types::{
     account_address::AccountAddress,
     language_storage::{ModuleId, StructTag},
     resolver::MoveResolver,
-    vm_status::StatusCode,
 };
 use move_table_extension::TableResolver;
-use std::collections::BTreeMap;
+
+fn get_resource_group_from_metadata(
+    struct_tag: &StructTag,
+    metadata: Option<aptos_framework::RuntimeModuleMetadataV1>,
+) -> Option<StructTag> {
+    metadata?
+        .struct_attributes
+        .get(struct_tag.name.as_ident_str().as_str())?
+        .iter()
+        .find_map(|attr| attr.get_resource_group_member())
+}
 
 pub trait MoveResolverExt:
     MoveResolver + TableResolver + StateStorageUsageResolver + ConfigStorage + StateView
@@ -31,74 +41,22 @@ pub trait MoveResolverExt:
         struct_tag: &StructTag,
     ) -> Result<Option<Vec<u8>>, VMError>;
 
-    fn get_any_resource(
-        &self,
-        address: &AccountAddress,
-        struct_tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, VMError> {
+    fn get_resource_group(&self, struct_tag: &StructTag) -> Option<StructTag> {
         let metadata = self.get_module_metadata(struct_tag.module_id());
-        let resource_group = Self::get_resource_group_from_metadata(struct_tag, metadata);
-        if let Some(resource_group) = resource_group {
-            self.get_resource_from_group(address, struct_tag, &resource_group)
-        } else {
-            self.get_standard_resource(address, struct_tag)
-        }
+        get_resource_group_from_metadata(struct_tag, metadata)
     }
 
-    fn get_resource_from_group(
-        &self,
-        address: &AccountAddress,
-        struct_tag: &StructTag,
-        resource_group: &StructTag,
-    ) -> Result<Option<Vec<u8>>, VMError> {
-        let group_data = self.get_resource_group_data(address, resource_group)?;
-        if let Some(group_data) = group_data {
-            let mut group_data: BTreeMap<StructTag, Vec<u8>> = bcs::from_bytes(&group_data)
-                .map_err(|_| {
-                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                        .finish(Location::Undefined)
-                })?;
-            Ok(group_data.remove(struct_tag))
-        } else {
-            Ok(None)
-        }
-    }
-
-    fn get_resource_group(&self, struct_tag: &StructTag) -> Result<Option<StructTag>, VMError> {
-        let metadata = self.get_module_metadata(struct_tag.module_id());
-        Ok(Self::get_resource_group_from_metadata(struct_tag, metadata))
-    }
-
-    fn get_resource_group_from_metadata(
-        struct_tag: &StructTag,
-        metadata: Option<aptos_framework::RuntimeModuleMetadataV1>,
-    ) -> Option<StructTag> {
-        metadata.and_then(|metadata| {
-            metadata
-                .struct_attributes
-                .get(struct_tag.name.as_ident_str().as_str())
-                .and_then(|attrs| {
-                    attrs
-                        .iter()
-                        .find_map(|attr| attr.get_resource_group_member())
-                })
-        })
-    }
-
+    // Move to API does not belong here
     fn is_resource_group(&self, struct_tag: &StructTag) -> bool {
-        let metadata = self.get_module_metadata(struct_tag.module_id());
-        metadata
-            .and_then(|metadata| {
-                metadata
-                    .struct_attributes
-                    .get(struct_tag.name.as_ident_str().as_str())
-                    .and_then(|attrs| {
-                        attrs
-                            .iter()
-                            .map(|attr| Some(attr.is_resource_group()))
-                            .next()
-                    })
-            })
-            .is_some()
+        aptos_try!({
+            return_on_failure!(self
+                .get_module_metadata(struct_tag.module_id())?
+                .struct_attributes
+                .get(struct_tag.name.as_ident_str().as_str())?
+                .iter()
+                .find(|attr| attr.is_resource_group()));
+            Some(())
+        })
+        .is_some()
     }
 }

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -77,7 +77,7 @@ impl MoveVmExt {
         &self,
         remote: &'r S,
         session_id: SessionId,
-    ) -> SessionExt<'r, '_, S> {
+    ) -> SessionExt<'r, '_> {
         let mut extensions = NativeContextExtensions::default();
         let txn_hash: [u8; 32] = session_id
             .as_uuid()
@@ -109,7 +109,6 @@ impl MoveVmExt {
 
         SessionExt::new(
             self.inner.new_session_with_extensions(remote, extensions),
-            self,
             remote,
         )
     }

--- a/aptos-move/aptos-vm/src/verifier/resource_groups.rs
+++ b/aptos-move/aptos-vm/src/verifier/resource_groups.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::move_vm_ext::{MoveResolverExt, SessionExt};
+use crate::move_vm_ext::SessionExt;
 use aptos_framework::{ResourceGroupScope, RuntimeModuleMetadataV1};
 use move_binary_format::{
     errors::{Location, PartialVMError, VMError, VMResult},
@@ -29,8 +29,8 @@ fn metadata_validation_error(msg: &str) -> VMError {
 /// * Ensure that each member has a membership and it does not change
 /// * Ensure that each group has a scope and that it does not become more restrictive
 /// * For any new members, verify that they are in a valid resource group
-pub(crate) fn validate_resource_groups<S: MoveResolverExt>(
-    session: &mut SessionExt<S>,
+pub(crate) fn validate_resource_groups(
+    session: &mut SessionExt,
     modules: &[CompiledModule],
 ) -> Result<(), VMError> {
     let mut groups = BTreeMap::new();
@@ -72,8 +72,8 @@ pub(crate) fn validate_resource_groups<S: MoveResolverExt>(
 /// * Extract the resource group metadata
 /// * Verify all changes are compatible upgrades
 /// * Return any new members to validate correctness and all groups to assist in validation
-pub(crate) fn validate_module_and_extract_new_entries<S: MoveResolverExt>(
-    session: &mut SessionExt<S>,
+pub(crate) fn validate_module_and_extract_new_entries(
+    session: &mut SessionExt,
     module: &CompiledModule,
 ) -> VMResult<(
     BTreeMap<String, ResourceGroupScope>,
@@ -111,8 +111,8 @@ pub(crate) fn validate_module_and_extract_new_entries<S: MoveResolverExt>(
 }
 
 /// Given a module id extract all resource group metadata
-pub(crate) fn extract_resource_group_metadata_from_module<S: MoveResolverExt>(
-    session: &mut SessionExt<S>,
+pub(crate) fn extract_resource_group_metadata_from_module(
+    session: &mut SessionExt,
     module_id: &ModuleId,
 ) -> VMResult<(
     BTreeMap<String, ResourceGroupScope>,

--- a/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
+++ b/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
@@ -6,10 +6,7 @@
 //! TODO: we should not only validate the types but also the actual values, e.g.
 //! for strings whether they consist of correct characters.
 
-use crate::{
-    move_vm_ext::{MoveResolverExt, SessionExt},
-    VMStatus,
-};
+use crate::{move_vm_ext::SessionExt, VMStatus};
 use move_binary_format::{errors::VMError, file_format_common::read_uleb128_as_u64};
 use move_core_types::{
     account_address::AccountAddress,
@@ -97,8 +94,8 @@ pub(crate) fn get_allowed_structs(
 /// 3. check arg types are allowed after signers
 ///
 /// after validation, add senders and non-signer arguments to generate the final args
-pub(crate) fn validate_combine_signer_and_txn_args<S: MoveResolverExt>(
-    session: &mut SessionExt<S>,
+pub(crate) fn validate_combine_signer_and_txn_args(
+    session: &mut SessionExt,
     senders: Vec<AccountAddress>,
     args: Vec<Vec<u8>>,
     func: &LoadedFunctionInstantiation,
@@ -183,8 +180,8 @@ pub(crate) fn validate_combine_signer_and_txn_args<S: MoveResolverExt>(
 }
 
 // Return whether the argument is valid/allowed and whether it needs construction.
-pub(crate) fn is_valid_txn_arg<S: MoveResolverExt>(
-    session: &SessionExt<S>,
+pub(crate) fn is_valid_txn_arg(
+    session: &SessionExt,
     typ: &Type,
     allowed_structs: &ConstructorMap,
 ) -> (bool, bool) {
@@ -208,8 +205,8 @@ pub(crate) fn is_valid_txn_arg<S: MoveResolverExt>(
 // Construct arguments. Walk through the arguments and according to the signature
 // construct arguments that require so.
 // TODO: This needs a more solid story and a tighter integration with the VM.
-pub(crate) fn construct_args<S: MoveResolverExt>(
-    session: &mut SessionExt<S>,
+pub(crate) fn construct_args(
+    session: &mut SessionExt,
     idxs: &[usize],
     args: &mut [Vec<u8>],
     func: &LoadedFunctionInstantiation,
@@ -250,8 +247,8 @@ pub(crate) fn construct_args<S: MoveResolverExt>(
 // A Cursor is used to recursively walk the serialized arg manually and correctly. In effect we
 // are parsing the BCS serialized implicit constructor invocation tree, while serializing the
 // constructed types into the output parameter arg.
-pub(crate) fn recursively_construct_arg<S: MoveResolverExt>(
-    session: &mut SessionExt<S>,
+pub(crate) fn recursively_construct_arg(
+    session: &mut SessionExt,
     ty: &Type,
     allowed_structs: &ConstructorMap,
     cursor: &mut Cursor<&[u8]>,
@@ -309,8 +306,8 @@ pub(crate) fn recursively_construct_arg<S: MoveResolverExt>(
 // constructed value. This is the correct data to pass as the argument to a function taking
 // said struct as a parameter. In this function we execute the constructor constructing the
 // value and returning the BCS serialized representation.
-fn validate_and_construct<S: MoveResolverExt>(
-    session: &mut SessionExt<S>,
+fn validate_and_construct(
+    session: &mut SessionExt,
     expected_type: &Type,
     constructor: &FunctionId,
     allowed_structs: &ConstructorMap,

--- a/aptos-move/aptos-vm/src/verifier/view_function.rs
+++ b/aptos-move/aptos-vm/src/verifier/view_function.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    move_vm_ext::{MoveResolverExt, SessionExt},
+    move_vm_ext::SessionExt,
     verifier::{transaction_arg_validation, transaction_arg_validation::get_allowed_structs},
 };
 use aptos_framework::RuntimeModuleMetadataV1;
@@ -29,8 +29,8 @@ pub fn determine_is_view(
 
 /// Validate view function call. This checks whether the function is marked as a view
 /// function, and validates the arguments.
-pub(crate) fn validate_view_function<S: MoveResolverExt>(
-    session: &mut SessionExt<S>,
+pub(crate) fn validate_view_function(
+    session: &mut SessionExt,
     mut args: Vec<Vec<u8>>,
     fun_name: &IdentStr,
     fun_inst: &LoadedFunctionInstantiation,

--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -362,7 +362,7 @@ fn inject_runtime_metadata(
                             let serialized_metadata = bcs::to_bytes(&module_metadata)
                                 .expect("BCS for RuntimeModuleMetadata");
                             named_module.module.metadata.push(Metadata {
-                                key: APTOS_METADATA_KEY_V1.clone(),
+                                key: APTOS_METADATA_KEY_V1.to_vec(),
                                 value: serialized_metadata,
                             });
                         } else {
@@ -370,7 +370,7 @@ fn inject_runtime_metadata(
                                 bcs::to_bytes(&module_metadata.clone().downgrade())
                                     .expect("BCS for RuntimeModuleMetadata");
                             named_module.module.metadata.push(Metadata {
-                                key: APTOS_METADATA_KEY.clone(),
+                                key: APTOS_METADATA_KEY.to_vec(),
                                 value: serialized_metadata,
                             });
                         }

--- a/aptos-move/framework/src/module_metadata.rs
+++ b/aptos-move/framework/src/module_metadata.rs
@@ -15,7 +15,6 @@ use move_core_types::{
     metadata::Metadata,
 };
 use move_vm_runtime::move_vm::MoveVM;
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use thiserror::Error;
@@ -26,10 +25,8 @@ pub const METADATA_V1_MIN_FILE_FORMAT_VERSION: u32 = 6;
 /// The keys used to identify the metadata in the metadata section of the module bytecode.
 /// This is more or less arbitrary, besides we should use some unique key to identify
 /// Aptos specific metadata (`aptos::` here).
-pub static APTOS_METADATA_KEY: Lazy<Vec<u8>> =
-    Lazy::new(|| "aptos::metadata_v0".as_bytes().to_vec());
-pub static APTOS_METADATA_KEY_V1: Lazy<Vec<u8>> =
-    Lazy::new(|| "aptos::metadata_v1".as_bytes().to_vec());
+pub static APTOS_METADATA_KEY: &[u8] = "aptos::metadata_v0".as_bytes();
+pub static APTOS_METADATA_KEY_V1: &[u8] = "aptos::metadata_v1".as_bytes();
 
 /// Aptos specific metadata attached to the metadata section of file_format.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -112,7 +109,7 @@ impl KnownAttribute {
 
     pub fn get_resource_group_member(&self) -> Option<StructTag> {
         if self.kind == KnownAttributeKind::ResourceGroupMember as u8 {
-            self.args.get(0).and_then(|group| str::parse(group).ok())
+            self.args.get(0)?.parse().ok()
         } else {
             None
         }
@@ -125,20 +122,16 @@ impl KnownAttribute {
 
 /// Extract metadata from the VM, upgrading V0 to V1 representation as needed
 pub fn get_vm_metadata(vm: &MoveVM, module_id: ModuleId) -> Option<RuntimeModuleMetadataV1> {
-    if let Some(data) = vm.get_module_metadata(module_id.clone(), &APTOS_METADATA_KEY_V1) {
+    if let Some(data) = vm.get_module_metadata(module_id.clone(), APTOS_METADATA_KEY_V1) {
         bcs::from_bytes::<RuntimeModuleMetadataV1>(&data.value).ok()
-    } else if let Some(data) = vm.get_module_metadata(module_id, &APTOS_METADATA_KEY) {
-        // Old format available, upgrade to new one on the fly
-        let data_v0 = bcs::from_bytes::<RuntimeModuleMetadata>(&data.value).ok()?;
-        Some(data_v0.upgrade())
     } else {
-        None
+        get_vm_metadata_v0(vm, module_id)
     }
 }
 
 /// Extract metadata from the VM, legacy V0 format upgraded to V1
-pub fn get_vm_metadata_v0(vm: &MoveVM, module_id: ModuleId) -> Option<RuntimeModuleMetadataV1> {
-    if let Some(data) = vm.get_module_metadata(module_id, &APTOS_METADATA_KEY) {
+fn get_vm_metadata_v0(vm: &MoveVM, module_id: ModuleId) -> Option<RuntimeModuleMetadataV1> {
+    if let Some(data) = vm.get_module_metadata(module_id, APTOS_METADATA_KEY) {
         let data_v0 = bcs::from_bytes::<RuntimeModuleMetadata>(&data.value).ok()?;
         Some(data_v0.upgrade())
     } else {
@@ -175,7 +168,7 @@ pub fn check_metadata_format(module: &CompiledModule) -> Result<(), MalformedErr
 pub fn get_metadata_from_compiled_module(
     module: &CompiledModule,
 ) -> Option<RuntimeModuleMetadataV1> {
-    if let Some(data) = find_metadata(module, &APTOS_METADATA_KEY_V1) {
+    if let Some(data) = find_metadata(module, APTOS_METADATA_KEY_V1) {
         let mut metadata = bcs::from_bytes::<RuntimeModuleMetadataV1>(&data.value).ok();
         // Clear out metadata for v5, since it shouldn't have existed in the first place and isn't
         // being used. Note, this should have been gated in the verify module metadata.
@@ -186,7 +179,7 @@ pub fn get_metadata_from_compiled_module(
             }
         }
         metadata
-    } else if let Some(data) = find_metadata(module, &APTOS_METADATA_KEY) {
+    } else if let Some(data) = find_metadata(module, APTOS_METADATA_KEY) {
         // Old format available, upgrade to new one on the fly
         let data_v0 = bcs::from_bytes::<RuntimeModuleMetadata>(&data.value).ok()?;
         Some(data_v0.upgrade())
@@ -208,7 +201,7 @@ pub fn get_metadata_from_compiled_module(
 pub fn get_metadata_from_compiled_script(
     script: &CompiledScript,
 ) -> Option<RuntimeModuleMetadataV1> {
-    if let Some(data) = find_metadata_in_script(script, &APTOS_METADATA_KEY_V1) {
+    if let Some(data) = find_metadata_in_script(script, APTOS_METADATA_KEY_V1) {
         let mut metadata = bcs::from_bytes::<RuntimeModuleMetadataV1>(&data.value).ok();
         // Clear out metadata for v5, since it shouldn't have existed in the first place and isn't
         // being used. Note, this should have been gated in the verify module metadata.
@@ -219,7 +212,7 @@ pub fn get_metadata_from_compiled_script(
             }
         }
         metadata
-    } else if let Some(data) = find_metadata_in_script(script, &APTOS_METADATA_KEY) {
+    } else if let Some(data) = find_metadata_in_script(script, APTOS_METADATA_KEY) {
         // Old format available, upgrade to new one on the fly
         let data_v0 = bcs::from_bytes::<RuntimeModuleMetadata>(&data.value).ok()?;
         Some(data_v0.upgrade())

--- a/aptos-move/framework/src/module_metadata.rs
+++ b/aptos-move/framework/src/module_metadata.rs
@@ -130,7 +130,7 @@ pub fn get_vm_metadata(vm: &MoveVM, module_id: ModuleId) -> Option<RuntimeModule
 }
 
 /// Extract metadata from the VM, legacy V0 format upgraded to V1
-fn get_vm_metadata_v0(vm: &MoveVM, module_id: ModuleId) -> Option<RuntimeModuleMetadataV1> {
+pub fn get_vm_metadata_v0(vm: &MoveVM, module_id: ModuleId) -> Option<RuntimeModuleMetadataV1> {
     if let Some(data) = vm.get_module_metadata(module_id, APTOS_METADATA_KEY) {
         let data_v0 = bcs::from_bytes::<RuntimeModuleMetadata>(&data.value).ok()?;
         Some(data_v0.upgrade())

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -35,7 +35,6 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
-    resolver::MoveResolver,
     value::{serialize_values, MoveValue},
 };
 use move_vm_types::gas::UnmeteredGasMeter;
@@ -338,7 +337,7 @@ fn validate_genesis_config(genesis_config: &GenesisConfiguration) {
 }
 
 fn exec_function(
-    session: &mut SessionExt<impl MoveResolver>,
+    session: &mut SessionExt,
     module_name: &str,
     function_name: &str,
     ty_args: Vec<TypeTag>,
@@ -367,7 +366,7 @@ fn exec_function(
 }
 
 fn initialize(
-    session: &mut SessionExt<impl MoveResolver>,
+    session: &mut SessionExt,
     chain_id: ChainId,
     genesis_config: &GenesisConfiguration,
     consensus_config: &OnChainConsensusConfig,
@@ -437,7 +436,7 @@ pub fn default_features() -> Vec<FeatureFlag> {
     ]
 }
 
-fn initialize_features(session: &mut SessionExt<impl MoveResolver>) {
+fn initialize_features(session: &mut SessionExt) {
     let features: Vec<u64> = default_features()
         .into_iter()
         .map(|feature| feature as u64)
@@ -456,7 +455,7 @@ fn initialize_features(session: &mut SessionExt<impl MoveResolver>) {
     );
 }
 
-fn initialize_aptos_coin(session: &mut SessionExt<impl MoveResolver>) {
+fn initialize_aptos_coin(session: &mut SessionExt) {
     exec_function(
         session,
         GENESIS_MODULE_NAME,
@@ -466,7 +465,7 @@ fn initialize_aptos_coin(session: &mut SessionExt<impl MoveResolver>) {
     );
 }
 
-fn set_genesis_end(session: &mut SessionExt<impl MoveResolver>) {
+fn set_genesis_end(session: &mut SessionExt) {
     exec_function(
         session,
         GENESIS_MODULE_NAME,
@@ -477,7 +476,7 @@ fn set_genesis_end(session: &mut SessionExt<impl MoveResolver>) {
 }
 
 fn initialize_core_resources_and_aptos_coin(
-    session: &mut SessionExt<impl MoveResolver>,
+    session: &mut SessionExt,
     core_resources_key: &Ed25519PublicKey,
 ) {
     let core_resources_auth_key = AuthenticationKey::ed25519(core_resources_key);
@@ -494,10 +493,7 @@ fn initialize_core_resources_and_aptos_coin(
 }
 
 /// Create and initialize Association and Core Code accounts.
-fn initialize_on_chain_governance(
-    session: &mut SessionExt<impl MoveResolver>,
-    genesis_config: &GenesisConfiguration,
-) {
+fn initialize_on_chain_governance(session: &mut SessionExt, genesis_config: &GenesisConfiguration) {
     exec_function(
         session,
         GOVERNANCE_MODULE_NAME,
@@ -512,7 +508,7 @@ fn initialize_on_chain_governance(
     );
 }
 
-fn create_accounts(session: &mut SessionExt<impl MoveResolver>, accounts: &[AccountBalance]) {
+fn create_accounts(session: &mut SessionExt, accounts: &[AccountBalance]) {
     let accounts_bytes = bcs::to_bytes(accounts).expect("AccountMaps can be serialized");
     let mut serialized_values = serialize_values(&vec![MoveValue::Signer(CORE_CODE_ADDRESS)]);
     serialized_values.push(accounts_bytes);
@@ -526,7 +522,7 @@ fn create_accounts(session: &mut SessionExt<impl MoveResolver>, accounts: &[Acco
 }
 
 fn create_employee_validators(
-    session: &mut SessionExt<impl MoveResolver>,
+    session: &mut SessionExt,
     employees: &[EmployeePool],
     genesis_config: &GenesisConfiguration,
 ) {
@@ -549,10 +545,7 @@ fn create_employee_validators(
 /// Creates and initializes each validator owner and validator operator. This method creates all
 /// the required accounts, sets the validator operators for each validator owner, and sets the
 /// validator config on-chain.
-fn create_and_initialize_validators(
-    session: &mut SessionExt<impl MoveResolver>,
-    validators: &[Validator],
-) {
+fn create_and_initialize_validators(session: &mut SessionExt, validators: &[Validator]) {
     let validators_bytes = bcs::to_bytes(validators).expect("Validators can be serialized");
     let mut serialized_values = serialize_values(&vec![MoveValue::Signer(CORE_CODE_ADDRESS)]);
     serialized_values.push(validators_bytes);
@@ -566,7 +559,7 @@ fn create_and_initialize_validators(
 }
 
 fn create_and_initialize_validators_with_commission(
-    session: &mut SessionExt<impl MoveResolver>,
+    session: &mut SessionExt,
     validators: &[ValidatorWithCommissionRate],
 ) {
     let validators_bytes = bcs::to_bytes(validators).expect("Validators can be serialized");
@@ -584,7 +577,7 @@ fn create_and_initialize_validators_with_commission(
     );
 }
 
-fn allow_core_resources_to_set_version(session: &mut SessionExt<impl MoveResolver>) {
+fn allow_core_resources_to_set_version(session: &mut SessionExt) {
     exec_function(
         session,
         VERSION_MODULE_NAME,
@@ -595,14 +588,14 @@ fn allow_core_resources_to_set_version(session: &mut SessionExt<impl MoveResolve
 }
 
 /// Publish the framework release bundle.
-fn publish_framework(session: &mut SessionExt<impl MoveResolver>, framework: &ReleaseBundle) {
+fn publish_framework(session: &mut SessionExt, framework: &ReleaseBundle) {
     for pack in &framework.packages {
         publish_package(session, pack)
     }
 }
 
 /// Publish the given package.
-fn publish_package(session: &mut SessionExt<impl MoveResolver>, pack: &ReleasePackage) {
+fn publish_package(session: &mut SessionExt, pack: &ReleasePackage) {
     let modules = pack.sorted_code_and_modules();
     let addr = *modules.first().unwrap().1.self_id().address();
     let code = modules
@@ -630,7 +623,7 @@ fn publish_package(session: &mut SessionExt<impl MoveResolver>, pack: &ReleasePa
 }
 
 /// Trigger a reconfiguration. This emits an event that will be passed along to the storage layer.
-fn emit_new_block_and_epoch_event(session: &mut SessionExt<impl MoveResolver>) {
+fn emit_new_block_and_epoch_event(session: &mut SessionExt) {
     exec_function(
         session,
         "block",

--- a/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
+++ b/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
@@ -17,7 +17,7 @@ use aptos_types::{
 };
 use aptos_vm::{
     data_cache::StorageAdapter,
-    move_vm_ext::{MoveResolverExt, MoveVmExt, SessionExt, SessionId},
+    move_vm_ext::{MoveVmExt, SessionExt, SessionId},
 };
 use move_core_types::{
     identifier::Identifier,
@@ -28,9 +28,9 @@ use move_core_types::{
 use move_vm_runtime::session::SerializedReturnValues;
 use move_vm_types::gas::UnmeteredGasMeter;
 
-pub struct GenesisSession<'r, 'l, S>(SessionExt<'r, 'l, S>);
+pub struct GenesisSession<'r, 'l>(SessionExt<'r, 'l>);
 
-impl<'r, 'l, S: MoveResolverExt> GenesisSession<'r, 'l, S> {
+impl<'r, 'l> GenesisSession<'r, 'l> {
     pub fn exec_func(
         &mut self,
         module_name: &str,
@@ -109,7 +109,7 @@ impl<'r, 'l, S: MoveResolverExt> GenesisSession<'r, 'l, S> {
 
 pub fn build_changeset<S: StateView, F>(state_view: &S, procedure: F, chain_id: u8) -> ChangeSet
 where
-    F: FnOnce(&mut GenesisSession<StorageAdapter<S>>),
+    F: FnOnce(&mut GenesisSession),
 {
     let move_vm = MoveVmExt::new(
         NativeGasParameters::zeros(),

--- a/aptos-utils/Cargo.toml
+++ b/aptos-utils/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aptos-utils"
+version = "0.1.0"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]

--- a/aptos-utils/src/lib.rs
+++ b/aptos-utils/src/lib.rs
@@ -1,0 +1,24 @@
+// Copyright © Aptos Foundation
+
+/// An internal implementation to imitate the feature of `try` in unstable Rust.
+/// Useful to use '?' chaining on option/result without the need to wrap the expression in a
+/// function.
+/// Obsolete once rust-lang/rust#31436 is resolved and try is stable.
+#[macro_export]
+macro_rules! aptos_try {
+    ($e:expr) => {
+        (|| $e)()
+    };
+}
+
+/// When the expression is an error, return from the enclosing function.
+/// Use this in cases where the enclosing function returns `Result<(), Error>`.
+/// Writing 'f()?;' relies on a load-bearing '?' operator. If the operator is removed execution
+/// would continue on error. This macro is a more explicit way to return on error, ie.
+/// 'return_on_failure!(f());'
+#[macro_export]
+macro_rules! return_on_failure {
+    ($e:expr) => {
+        $e?;
+    };
+}

--- a/third_party/move/move-vm/runtime/src/loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader.rs
@@ -72,7 +72,8 @@ where
     }
 
     fn get(&self, key: &K) -> Option<&Arc<V>> {
-        self.id_map.get(key).and_then(|idx| self.binaries.get(*idx))
+        let index = self.id_map.get(key)?;
+        self.binaries.get(*index)
     }
 }
 
@@ -580,8 +581,11 @@ impl Loader {
         let cache = self.module_cache.read();
         cache
             .modules
-            .get(&module)
-            .and_then(|module| module.module.metadata.iter().find(|md| md.key == key))
+            .get(&module)?
+            .module
+            .metadata
+            .iter()
+            .find(|md| md.key == key)
             .cloned()
     }
 


### PR DESCRIPTION
Reverts aptos-labs/aptos-core#8040

The cause was me deleting a feature flag at

https://github.com/aptos-labs/aptos-core/blob/cfecfb386614b708ada45ad81034a49be6fc33cf/aptos-move/aptos-vm/src/aptos_vm_impl.rs#L603

Me reasoning was that get_module_metadata works independently of the feature flag because it just looks up the existence of the V1 key. But the feature flag causes some metadata to be dropped for txn where the feature isn't activated yet but where the metadata is already V1