### PR TITLE
add a little leeway to replay-verify timeout

### DIFF
--- a/.github/workflows/replay-verify.yaml
+++ b/.github/workflows/replay-verify.yaml
@@ -63,7 +63,7 @@ jobs:
       BACKUP_CONFIG_TEMPLATE_PATH: terraform/helm/fullnode/files/backup/s3-public.yaml
       # workflow config
       RUNS_ON: "high-perf-docker-with-local-ssd"
-      TIMEOUT_MINUTES: 720
+      TIMEOUT_MINUTES: 840
 
   replay-mainnet:
     if: |
@@ -83,7 +83,7 @@ jobs:
       BACKUP_CONFIG_TEMPLATE_PATH: terraform/helm/fullnode/files/backup/s3-public.yaml
       # workflow config
       RUNS_ON: "high-perf-docker-with-local-ssd"
-      TIMEOUT_MINUTES: 720
+      TIMEOUT_MINUTES: 240
 
   test-replay:
     if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION

### Description

I think after more snapshots were put in the s3-public bucket, a run will finish under 12 hours but I don't want to accidentally waste another day, let's make it 14 hours for now.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
