### PR TITLE
Refactor block execute/commit pipeline.

### DIFF
--- a/execution/executor-types/src/executed_chunk.rs
+++ b/execution/executor-types/src/executed_chunk.rs
@@ -13,9 +13,10 @@ use aptos_types::{
     epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
     proof::accumulator::InMemoryAccumulator,
+    state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{Transaction, TransactionInfo, TransactionStatus, TransactionToCommit},
 };
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 #[derive(Default)]
 pub struct ExecutedChunk {
@@ -25,6 +26,8 @@ pub struct ExecutedChunk {
     /// If set, this is the new epoch info that should be changed to if this is committed.
     pub next_epoch_state: Option<EpochState>,
     pub ledger_info: Option<LedgerInfoWithSignatures>,
+    // Only used when it is a block.
+    pub block_state_updates: Option<HashMap<StateKey, Option<StateValue>>>,
 }
 
 impl ExecutedChunk {
@@ -40,6 +43,7 @@ impl ExecutedChunk {
         Self {
             result_view: self.result_view.clone(),
             next_epoch_state: self.next_epoch_state.clone(),
+            block_state_updates: self.block_state_updates.clone(),
             ..Default::default()
         }
     }

--- a/execution/executor/proptest-regressions/tests/mod.txt
+++ b/execution/executor/proptest-regressions/tests/mod.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 8d8247fbd6da3ebef1e20384b2f0c098c1a6f0edd28041ffdc99afc406654c67 # shrinks to (num_user_txns, reconfig_txn_index) = (10, 0)
+cc 06cc3868004fdece03d52e325e1086deaa8eed5686d2490640b52d6b42e8ece8 # shrinks to a_size = 0, b_size = 0, c_size = 0, amount = 1

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -80,10 +80,22 @@ impl ChunkOutput {
         self,
         base_view: &ExecutedTrees,
     ) -> Result<(ExecutedChunk, Vec<Transaction>, Vec<Transaction>)> {
-        fail_point!("executor::vm_execute_chunk", |_| {
+        fail_point!("executor::apply_to_ledger", |_| {
             Err(anyhow::anyhow!("Injected error in apply_to_ledger."))
         });
-        ApplyChunkOutput::apply(self, base_view)
+        ApplyChunkOutput::apply_chunk(self, base_view)
+    }
+
+    pub fn apply_to_ledger_for_block(
+        self,
+        base_view: &ExecutedTrees,
+    ) -> Result<(ExecutedChunk, Vec<Transaction>, Vec<Transaction>)> {
+        fail_point!("executor::apply_to_ledger_for_block", |_| {
+            Err(anyhow::anyhow!(
+                "Injected error in apply_to_ledger_for_block."
+            ))
+        });
+        ApplyChunkOutput::apply_block(self, base_view)
     }
 
     pub fn trace_log_transaction_status(&self) {

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -547,10 +547,6 @@ impl TestBlock {
         };
         TestBlock { txns, id }
     }
-
-    fn len(&self) -> u64 {
-        self.txns.len() as u64
-    }
 }
 
 // Executes a list of transactions by executing and immediately committing one at a time. Returns
@@ -590,58 +586,6 @@ fn run_transactions_naive(transactions: Vec<Transaction>) -> HashValue {
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
-
-    #[test]
-    #[cfg_attr(feature = "consensus-only-perf-test", ignore)]
-    fn test_executor_two_branches(
-        a_size in 0..30u64,
-        b_size in 0..30u64,
-        c_size in 0..30u64,
-        amount in any::<u32>(),
-    ) {
-        // Genesis -> A -> B
-        //            |
-        //            └--> C
-        let block_a = TestBlock::new(a_size, amount, gen_block_id(1));
-        let block_b = TestBlock::new(b_size, amount, gen_block_id(2));
-        let block_c = TestBlock::new(c_size, amount, gen_block_id(3));
-        // Execute block A, B and C. Hold all results in memory.
-        let executor = TestExecutor::new();
-        let parent_block_id = executor.committed_block_id();
-
-        let output_a = executor.execute_block(
-            (block_a.id, block_a.txns.clone()), parent_block_id
-        ).unwrap();
-        let root_hash_a = output_a.root_hash();
-        prop_assert_eq!(output_a.version(), block_a.len());
-        let output_b = executor.execute_block((block_b.id, block_b.txns.clone()), block_a.id).unwrap();
-        prop_assert_eq!(output_b.version(), block_a.len() + block_b.len());
-        let output_c = executor.execute_block((block_c.id, block_c.txns.clone()), block_a.id).unwrap();
-        prop_assert_eq!(output_c.version(), block_a.len() + block_c.len());
-
-        let root_hash_b = output_b.root_hash();
-        let root_hash_c = output_c.root_hash();
-
-        // Execute block A and B. Execute and commit one transaction at a time.
-        let expected_root_hash_a = run_transactions_naive(block_a.txns.clone());
-        prop_assert_eq!(root_hash_a, expected_root_hash_a);
-
-        let expected_root_hash_b = run_transactions_naive({
-            let mut txns = vec![];
-            txns.extend(block_a.txns.iter().cloned());
-            txns.extend(block_b.txns.iter().cloned());
-            txns
-        });
-        prop_assert_eq!(root_hash_b, expected_root_hash_b);
-
-        let expected_root_hash_c = run_transactions_naive({
-            let mut txns = vec![];
-            txns.extend(block_a.txns.iter().cloned());
-            txns.extend(block_c.txns.iter().cloned());
-            txns
-        });
-        prop_assert_eq!(root_hash_c, expected_root_hash_c);
-    }
 
     #[test]
     #[cfg_attr(feature = "consensus-only-perf-test", ignore)]

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1922,6 +1922,69 @@ impl DbWriter for AptosDB {
         })
     }
 
+    /// Same as save_transactions, but only for a whole block.
+    fn save_transaction_block(
+        &self,
+        txns_to_commit: &[TransactionToCommit],
+        first_version: Version,
+        base_state_version: Option<Version>,
+        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        sync_commit: bool,
+        // TODO(grao): Consider remove this.
+        latest_in_memory_state: StateDelta,
+        block_state_updates: HashMap<StateKey, Option<StateValue>>,
+    ) -> Result<()> {
+        gauged_api("save_transaction_block", || {
+            // Executing and committing from more than one threads not allowed -- consensus and
+            // state sync must hand over to each other after all pending execution and committing
+            // complete.
+            let _lock = self
+                .ledger_commit_lock
+                .try_lock()
+                .expect("Concurrent committing detected.");
+
+            // For reconfig suffix.
+            if ledger_info_with_sigs.is_none() && txns_to_commit.is_empty() {
+                return Ok(());
+            }
+
+            self.save_transactions_validation(
+                txns_to_commit,
+                first_version,
+                base_state_version,
+                ledger_info_with_sigs,
+                &latest_in_memory_state,
+            )?;
+
+            let (ledger_batch, sharded_state_kv_batches, new_root_hash) = self
+                .save_transactions_impl(
+                    txns_to_commit,
+                    first_version,
+                    latest_in_memory_state.current.usage(),
+                )?;
+
+            {
+                let mut buffered_state = self.state_store.buffered_state().lock();
+                let last_version = first_version + txns_to_commit.len() as u64 - 1;
+                self.commit_ledger_and_state_kv_db(
+                    last_version,
+                    ledger_batch,
+                    sharded_state_kv_batches,
+                    new_root_hash,
+                    ledger_info_with_sigs,
+                )?;
+
+                buffered_state.update(
+                    Some(block_state_updates),
+                    latest_in_memory_state,
+                    sync_commit || txns_to_commit.last().unwrap().is_reconfig(),
+                )?;
+            }
+
+            self.post_commit(txns_to_commit, first_version, ledger_info_with_sigs)
+        })
+    }
+
     fn get_state_snapshot_receiver(
         &self,
         version: Version,

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -628,6 +628,24 @@ pub trait DbWriter: Send + Sync {
     ) -> Result<()> {
         unimplemented!()
     }
+
+    /// Persist transactions for block.
+    /// See [`AptosDB::save_transaction_block`].
+    ///
+    /// [`AptosDB::save_transaction_block`]:
+    /// ../aptosdb/struct.AptosDB.html#method.save_transaction_block
+    fn save_transaction_block(
+        &self,
+        txns_to_commit: &[TransactionToCommit],
+        first_version: Version,
+        base_state_version: Option<Version>,
+        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        sync_commit: bool,
+        latest_in_memory_state: StateDelta,
+        block_state_updates: HashMap<StateKey, Option<StateValue>>,
+    ) -> Result<()> {
+        unimplemented!()
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
### Description

- Add save_transaction_block.
- Change block executor to commit blocks one by one and use the new API.
- Change block executor to use InMemoryStateCalculatorV2.

Empty block, except reconfig suffix, will be rejected now.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
