### PR TITLE
[CLI] Add JSON input file support, docs (#7709)

### DIFF
--- a/aptos-move/move-examples/cli_args/Move.toml
+++ b/aptos-move/move-examples/cli_args/Move.toml
@@ -1,12 +1,11 @@
+# :!:>manifest
 [package]
 name = "CliArgs"
 version = "0.1.0"
 upgrade_policy = "compatible"
 
 [addresses]
-deploy_address = "_"
-std = "0x1"
-aptos_framework = "0x1"
+test_account = "_"
 
-[dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+[dependencies.AptosFramework]
+local = "../../framework/aptos-framework" # <:!:manifest

--- a/aptos-move/move-examples/cli_args/entry_function_arguments.json
+++ b/aptos-move/move-examples/cli_args/entry_function_arguments.json
@@ -1,0 +1,30 @@
+{
+    "function_id": "<test_account>::cli_args::set_vals",
+    "type_args": [
+        "0x1::account::Account",
+        "0x1::chain_id::ChainId"
+    ],
+    "args": [
+        {
+            "arg_type": "u8",
+            "arg_value": 123
+        },
+        {
+            "arg_type": "bool",
+            "arg_value": [false, true, false, false]
+        },
+        {
+            "arg_type": "address",
+            "arg_value": [
+                [
+                    "0xace",
+                    "0xbee"
+                ],
+                [
+                    "0xcad"
+                ],
+                []
+            ]
+        }
+    ]
+}

--- a/aptos-move/move-examples/cli_args/script_function_arguments.json
+++ b/aptos-move/move-examples/cli_args/script_function_arguments.json
@@ -1,0 +1,20 @@
+{
+    "type_args": [
+        "0x1::account::Account",
+        "0x1::chain_id::ChainId"
+    ],
+    "args": [
+        {
+            "arg_type": "u8",
+            "arg_value": 123
+        },
+        {
+            "arg_type": "u8",
+            "arg_value": [122, 123, 124, 125]
+        },
+        {
+            "arg_type": "address",
+            "arg_value": "0xace"
+        }
+    ]
+}

--- a/aptos-move/move-examples/cli_args/scripts/set_vals.move
+++ b/aptos-move/move-examples/cli_args/scripts/set_vals.move
@@ -1,0 +1,28 @@
+// :!:>script
+script {
+    use test_account::cli_args;
+    use std::vector;
+
+    /// Get a `bool` vector where each element indicates `true` if the
+    /// corresponding element in `u8_vec` is greater than `u8_solo`.
+    /// Then pack `address_solo` in a `vector<vector<<address>>` and
+    /// pass resulting argument set to public entry function.
+    fun set_vals<T1, T2>(
+        account: signer,
+        u8_solo: u8,
+        u8_vec: vector<u8>,
+        address_solo: address,
+    ) {
+        let bool_vec = vector[];
+        let i = 0;
+        while (i < vector::length(&u8_vec)) {
+            vector::push_back(
+                &mut bool_vec,
+                *vector::borrow(&u8_vec, i) > u8_solo
+            );
+            i = i + 1;
+        };
+        let addr_vec_vec = vector[vector[address_solo]];
+        cli_args::set_vals<T1, T2>(account, u8_solo, bool_vec, addr_vec_vec);
+    }
+} // <:!:script

--- a/aptos-move/move-examples/cli_args/sources/cli_args.move
+++ b/aptos-move/move-examples/cli_args/sources/cli_args.move
@@ -1,37 +1,57 @@
-module deploy_address::cli_args {
+// :!:>resource
+module test_account::cli_args {
     use std::signer;
+    use aptos_std::type_info::{Self, TypeInfo};
 
-    struct Holder has key {
+
+    struct Holder has key, drop {
         u8_solo: u8,
         bool_vec: vector<bool>,
         address_vec_vec: vector<vector<address>>,
-    }
+        type_info_1: TypeInfo,
+        type_info_2: TypeInfo,
+    } //<:!:resource
 
 
-    #[view]
-    public fun reveal(host: address): (u8, vector<bool>, vector<vector<address>>) acquires Holder {
-        let holder_ref = borrow_global<Holder>(host);
-        (holder_ref.u8_solo, holder_ref.bool_vec, holder_ref.address_vec_vec)
-    }
-
-    public entry fun set_vals(
+    // :!:>setter
+    /// Set values in a `Holder` under `account`.
+    public entry fun set_vals<T1, T2>(
         account: signer,
         u8_solo: u8,
         bool_vec: vector<bool>,
         address_vec_vec: vector<vector<address>>,
     ) acquires Holder {
         let account_addr = signer::address_of(&account);
-        if (!exists<Holder>(account_addr)) {
-            move_to(&account, Holder {
-                u8_solo,
-                bool_vec,
-                address_vec_vec,
-            })
-        } else {
-            let old_holder = borrow_global_mut<Holder>(account_addr);
-            old_holder.u8_solo = u8_solo;
-            old_holder.bool_vec = bool_vec;
-            old_holder.address_vec_vec = address_vec_vec;
-        }
+        if (exists<Holder>(account_addr)) {
+            move_from<Holder>(account_addr);
+        };
+        move_to(&account, Holder {
+            u8_solo,
+            bool_vec,
+            address_vec_vec,
+            type_info_1: type_info::type_of<T1>(),
+            type_info_2: type_info::type_of<T2>(),
+        });
+    } //<:!:setter
+
+    // :!:>view
+    #[view]
+    /// Reveal first three fields in host's `Holder`, as well as two
+    /// `bool` flags denoting if `T1` and `T2` respectively match
+    /// `Holder.type_info_1` and `Holder.type_info_2`.
+    public fun reveal<T1, T2>(host: address): (
+        u8,
+        vector<bool>,
+        vector<vector<address>>,
+        bool,
+        bool
+    ) acquires Holder {
+        let holder_ref = borrow_global<Holder>(host);
+        (holder_ref.u8_solo,
+         holder_ref.bool_vec,
+         holder_ref.address_vec_vec,
+         type_info::type_of<T1>() == holder_ref.type_info_1,
+         type_info::type_of<T2>() == holder_ref.type_info_2)
     }
-}
+
+} //<:!:view

--- a/aptos-move/move-examples/cli_args/view_function_arguments.json
+++ b/aptos-move/move-examples/cli_args/view_function_arguments.json
@@ -1,0 +1,13 @@
+{
+    "function_id": "<test_account>::cli_args::reveal",
+    "type_args": [
+        "0x1::account::Account",
+        "0x1::account::Account"
+    ],
+    "args": [
+        {
+            "arg_type": "address",
+            "arg_value": "<test_account>"
+        }
+    ]
+}

--- a/crates/aptos/src/account/multisig_account.rs
+++ b/crates/aptos/src/account/multisig_account.rs
@@ -116,9 +116,8 @@ impl CliCommand<TransactionSummary> for CreateTransaction {
     }
 
     async fn execute(self) -> CliTypedResult<TransactionSummary> {
-        let payload = MultisigTransactionPayload::EntryFunction(
-            self.entry_function_args.create_entry_function_payload()?,
-        );
+        let payload =
+            MultisigTransactionPayload::EntryFunction(self.entry_function_args.try_into()?);
         self.txn_options
             .submit_transaction(aptos_stdlib::multisig_account_create_transaction(
                 self.multisig_account.multisig_address,

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -23,7 +23,7 @@ use aptos_types::{
 use itertools::Itertools;
 use move_core_types::account_address::AccountAddress;
 use reqwest::Url;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 use std::{
@@ -472,4 +472,11 @@ pub async fn profile_or_submit(
             .await
             .map(TransactionSummary::from)
     }
+}
+
+/// Try parsing JSON in file at path into a specified type.
+pub fn parse_json_file<T: for<'a> Deserialize<'a>>(path_ref: &Path) -> CliTypedResult<T> {
+    serde_json::from_slice::<T>(&read_from_file(path_ref)?).map_err(|err| {
+        CliError::UnableToReadFile(format!("{}", path_ref.display()), err.to_string())
+    })
 }

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -16,7 +16,8 @@ use crate::{
             CliTypedResult, EncodingOptions, EntryFunctionArguments, FaucetOptions, GasOptions,
             KeyType, MoveManifestAccountWrapper, MovePackageDir, OptionalPoolAddressArgs,
             PoolAddressArgs, PrivateKeyInputOptions, PromptOptions, PublicKeyInputOptions,
-            RestOptions, RngArgs, SaveFile, TransactionOptions, TransactionSummary,
+            RestOptions, RngArgs, SaveFile, ScriptFunctionArguments, TransactionOptions,
+            TransactionSummary, TypeArgVec,
         },
         utils::write_to_file,
     },
@@ -310,22 +311,25 @@ impl CliTestFramework {
     ) -> CliTypedResult<TransactionSummary> {
         RunFunction {
             entry_function_args: EntryFunctionArguments {
-                function_id: MemberId {
+                function_id: Some(MemberId {
                     module_id: ModuleId::new(AccountAddress::ONE, ident_str!("coin").into()),
                     member_id: ident_str!("transfer").into(),
-                },
+                }),
                 arg_vec: ArgWithTypeVec {
                     args: vec![
                         ArgWithType::from_str("address:0xdeadbeefcafebabe").unwrap(),
                         ArgWithType::from_str(&format!("u64:{}", amount)).unwrap(),
                     ],
                 },
-                type_args: vec![MoveType::Struct(MoveStructTag::new(
-                    AccountAddress::ONE.into(),
-                    ident_str!("aptos_coin").into(),
-                    ident_str!("AptosCoin").into(),
-                    vec![],
-                ))],
+                type_arg_vec: TypeArgVec {
+                    type_args: vec![MoveType::Struct(MoveStructTag::new(
+                        AccountAddress::ONE.into(),
+                        ident_str!("aptos_coin").into(),
+                        ident_str!("AptosCoin").into(),
+                        vec![],
+                    ))],
+                },
+                json_file: None,
             },
             txn_options: self.transaction_options(sender_index, gas_options),
         }
@@ -587,8 +591,9 @@ impl CliTestFramework {
     ) -> CliTypedResult<TransactionSummary> {
         RunFunction {
             entry_function_args: EntryFunctionArguments {
-                function_id: MemberId::from_str("0x1::staking_contract::create_staking_contract")
-                    .unwrap(),
+                function_id: Some(
+                    MemberId::from_str("0x1::staking_contract::create_staking_contract").unwrap(),
+                ),
                 arg_vec: ArgWithTypeVec {
                     args: vec![
                         ArgWithType::address(self.account_id(operator_index)),
@@ -598,7 +603,8 @@ impl CliTestFramework {
                         ArgWithType::bytes(vec![]),
                     ],
                 },
-                type_args: vec![],
+                type_arg_vec: TypeArgVec { type_args: vec![] },
+                json_file: None,
             },
             txn_options: self.transaction_options(owner_index, None),
         }
@@ -909,12 +915,15 @@ impl CliTestFramework {
         }
 
         RunFunction {
-            txn_options: self.transaction_options(index, gas_options),
             entry_function_args: EntryFunctionArguments {
-                function_id,
+                function_id: Some(function_id),
                 arg_vec: ArgWithTypeVec { args: parsed_args },
-                type_args: parsed_type_args,
+                type_arg_vec: TypeArgVec {
+                    type_args: parsed_type_args,
+                },
+                json_file: None,
             },
+            txn_options: self.transaction_options(index, gas_options),
         }
         .execute()
         .await
@@ -976,8 +985,11 @@ impl CliTestFramework {
                 framework_package_args,
                 bytecode_version: None,
             },
-            arg_vec: ArgWithTypeVec { args: Vec::new() },
-            type_args: Vec::new(),
+            script_function_args: ScriptFunctionArguments {
+                type_arg_vec: TypeArgVec { type_args: vec![] },
+                arg_vec: ArgWithTypeVec { args: vec![] },
+                json_file: None,
+            },
         }
         .execute()
         .await
@@ -1002,8 +1014,11 @@ impl CliTestFramework {
                 },
                 bytecode_version: None,
             },
-            arg_vec: ArgWithTypeVec { args },
-            type_args,
+            script_function_args: ScriptFunctionArguments {
+                type_arg_vec: TypeArgVec { type_args },
+                arg_vec: ArgWithTypeVec { args },
+                json_file: None,
+            },
         }
         .execute()
         .await

--- a/developer-docs-site/docs/move/move-on-aptos/cli.md
+++ b/developer-docs-site/docs/move/move-on-aptos/cli.md
@@ -483,38 +483,10 @@ To pass vectors (including nested vectors) as arguments from the command line, u
 
 The function ID, type arguments, and arguments can alternatively be specified in a JSON file:
 
-```json title="entry_function_arguments.json"
-{
-    "function_id": "<test_account>::cli_args::set_vals",
-    "type_args": [
-        "0x1::account::Account",
-        "0x1::chain_id::ChainId"
-    ],
-    "args": [
-        {
-            "arg_type": "u8",
-            "arg_value": 123
-        },
-        {
-            "arg_type": "bool",
-            "arg_value": [false, true, false, false]
-        },
-        {
-            "arg_type": "address",
-            "arg_value": [
-                [
-                    "0xace",
-                    "0xbee"
-                ],
-                [
-                    "0xcad"
-                ],
-                []
-            ]
-        }
-    ]
-}
-```
+import CodeBlock from '@theme/CodeBlock';
+import entry_json_file from '!!raw-loader!../../../../aptos-move/move-examples/cli_args/entry_function_arguments.json';
+
+<CodeBlock language="json" title="entry_function_arguments.json">{entry_json_file}</CodeBlock>
 
 Here, the call to `aptos move run` looks like:
 
@@ -523,6 +495,10 @@ aptos move run \
     --private-key-file <test_account.key> \
     --json-file entry_function_arguments.json
 ```
+
+:::tip
+If you are trying to run the example yourself don't forget to substitute `<test_account>` with an appropriate address in the JSON file from the [`CliArgs` example package](https://github.com/aptos-labs/aptos-core/tree/main/aptos-move/move-examples/cli_args)!
+:::
 
 ### View functions
 
@@ -547,21 +523,9 @@ aptos move view \
 aptos move view --json-file view_function_arguments.json
 ```
 
-```json title="view_function_arguments.json"
-{
-    "function_id": "<test_account>::cli_args::reveal",
-    "type_args": [
-        "0x1::account::Account",
-        "0x1::account::Account"
-    ],
-    "args": [
-        {
-            "arg_type": "address",
-            "arg_value": "<test_account>"
-        }
-    ]
-}
-```
+import view_json_file from '!!raw-loader!../../../../aptos-move/move-examples/cli_args/view_function_arguments.json';
+
+<CodeBlock language="json" title="view_function_arguments.json">{view_json_file}</CodeBlock>
 
 ```zsh title="Output"
 {
@@ -627,28 +591,9 @@ aptos move run-script \
     --json-file script_function_arguments.json
 ```
 
-```json title="script_function_arguments.json"
-{
-    "type_args": [
-        "0x1::account::Account",
-        "0x1::chain_id::ChainId"
-    ],
-    "args": [
-        {
-            "arg_type": "u8",
-            "arg_value": 123
-        },
-        {
-            "arg_type": "u8",
-            "arg_value": [122, 123, 124, 125]
-        },
-        {
-            "arg_type": "address",
-            "arg_value": "0xace"
-        }
-    ]
-}
-```
+import script_json_file from '!!raw-loader!../../../../aptos-move/move-examples/cli_args/script_function_arguments.json';
+
+<CodeBlock language="json" title="script_function_arguments.json">{script_json_file}</CodeBlock>
 
 Both such script function invocations result in the following `reveal()` view function output:
 

--- a/developer-docs-site/docs/tools/aptos-cli-tool/use-aptos-cli.md
+++ b/developer-docs-site/docs/tools/aptos-cli-tool/use-aptos-cli.md
@@ -750,54 +750,6 @@ The `peer_config.yaml` file will be created in your current working directory, w
 
 Move examples can be found in the [Move section](../../move/move-on-aptos/cli).
 
-You can also pass multi-nested vector arguments, like in the `cli_args` example from [move-examples](https://github.com/aptos-labs/aptos-core/tree/main/aptos-move/move-examples):
-
-:::tip
-To pass vectors (including nested vectors) as arguments, use JSON syntax escaped with quotes!
-:::
-
-```zsh
-aptos move run \
-    --function-id <deployer_address>::cli_args::set_vals \
-    --private-key-file <your-key-file> \
-    --args \
-        u8:123 \
-        "bool:[false, true, false, false]" \
-        'address:[["0xace", "0xbee"], ["0xcad"], ["0xdee"], []]'
-```
-
-Then you can call the view function to see your arguments persisted on-chain!
-
-```zsh
-aptos move view \
-    --function-id <deployer_address>::cli_args::reveal \
-    --args address:<deployer_address>
-{
-  "Result": [
-    123,
-    [
-      false,
-      true,
-      false,
-      false
-    ],
-    [
-      [
-        "0xace",
-        "0xbee"
-      ],
-      [
-        "0xcad"
-      ],
-      [
-        "0xdee"
-      ],
-      []
-    ]
-  ]
-}
-```
-
 ## Node command examples
 
 This section summarizes how to run a local testnet with Aptos CLI. See [Run a Local Testnet with Aptos CLI](../../nodes/local-testnet/using-cli-to-run-a-local-testnet.md) for more details.

--- a/developer-docs-site/package.json
+++ b/developer-docs-site/package.json
@@ -41,6 +41,7 @@
     "prism-react-renderer": "1.2.1",
     "process": "^0.11.10",
     "prop-types": "^15.8.1",
+    "raw-loader": "^4.0.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-markdown": "^8.0.7",

--- a/developer-docs-site/pnpm-lock.yaml
+++ b/developer-docs-site/pnpm-lock.yaml
@@ -33,7 +33,7 @@ dependencies:
     version: 1.6.22(react@17.0.2)
   '@stoplight/elements':
     specifier: ^7.7.16
-    version: 7.7.16(@babel/core@7.21.4)(react-dom@17.0.2)(react@17.0.2)
+    version: 7.7.16(react-dom@17.0.2)(react@17.0.2)
   '@types/prop-types':
     specifier: ^15.7.5
     version: 15.7.5
@@ -64,6 +64,9 @@ dependencies:
   prop-types:
     specifier: ^15.8.1
     version: 15.8.1
+  raw-loader:
+    specifier: ^4.0.2
+    version: 4.0.2(webpack@5.80.0)
   react:
     specifier: 17.0.2
     version: 17.0.2
@@ -2901,7 +2904,7 @@ packages:
       webpack-sources: 3.2.3
     dev: false
 
-  /@stoplight/elements-core@7.7.16(@babel/core@7.21.4)(react-dom@17.0.2)(react@17.0.2):
+  /@stoplight/elements-core@7.7.16(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-P1DF+jyx9nQna+S30eAyr8J6gPIzAYTwKJEBnSCjdCkashPXu3X3nqi0Go9ykKnNDgrvlJyW9eFzEbY0bI5pHQ==}
     engines: {node: '>=14.13'}
     peerDependencies:
@@ -2912,7 +2915,7 @@ packages:
       '@stoplight/json': 3.20.2
       '@stoplight/json-schema-ref-parser': 9.2.2
       '@stoplight/json-schema-sampler': 0.2.3
-      '@stoplight/json-schema-viewer': 4.9.0(@babel/core@7.21.4)(@stoplight/markdown-viewer@5.6.0)(@stoplight/mosaic-code-viewer@1.40.0)(@stoplight/mosaic@1.40.0)(react-dom@17.0.2)(react@17.0.2)
+      '@stoplight/json-schema-viewer': 4.9.0(@stoplight/markdown-viewer@5.6.0)(@stoplight/mosaic-code-viewer@1.40.0)(@stoplight/mosaic@1.40.0)(react-dom@17.0.2)(react@17.0.2)
       '@stoplight/markdown-viewer': 5.6.0(@stoplight/mosaic-code-viewer@1.40.0)(@stoplight/mosaic@1.40.0)(react-dom@17.0.2)(react@17.0.2)
       '@stoplight/mosaic': 1.40.0(react-dom@17.0.2)(react@17.0.2)
       '@stoplight/mosaic-code-editor': 1.40.0(react-dom@17.0.2)(react@17.0.2)
@@ -2923,7 +2926,7 @@ packages:
       '@stoplight/yaml': 4.2.3
       classnames: 2.3.2
       httpsnippet-lite: 3.0.5
-      jotai: 1.3.9(@babel/core@7.21.4)(react-query@3.39.3)(react@17.0.2)
+      jotai: 1.3.9(react-query@3.39.3)(react@17.0.2)
       json-schema: 0.4.0
       lodash: 4.17.21
       nanoid: 3.3.6
@@ -2960,14 +2963,14 @@ packages:
       - xstate
     dev: false
 
-  /@stoplight/elements@7.7.16(@babel/core@7.21.4)(react-dom@17.0.2)(react@17.0.2):
+  /@stoplight/elements@7.7.16(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-hIyzZkzC0Y/ehalfilW6b12NUtKmCAx86im/p/PVZ0xNgcDC2hPaYk6aVlzqxjWMHmzLQ6sxKtuynm5+0mafOw==}
     engines: {node: '>=14.13'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@stoplight/elements-core': 7.7.16(@babel/core@7.21.4)(react-dom@17.0.2)(react@17.0.2)
+      '@stoplight/elements-core': 7.7.16(react-dom@17.0.2)(react@17.0.2)
       '@stoplight/http-spec': 5.7.2
       '@stoplight/json': 3.20.2
       '@stoplight/mosaic': 1.40.0(react-dom@17.0.2)(react@17.0.2)
@@ -3078,7 +3081,7 @@ packages:
       magic-error: 0.0.1
     dev: false
 
-  /@stoplight/json-schema-viewer@4.9.0(@babel/core@7.21.4)(@stoplight/markdown-viewer@5.6.0)(@stoplight/mosaic-code-viewer@1.40.0)(@stoplight/mosaic@1.40.0)(react-dom@17.0.2)(react@17.0.2):
+  /@stoplight/json-schema-viewer@4.9.0(@stoplight/markdown-viewer@5.6.0)(@stoplight/mosaic-code-viewer@1.40.0)(@stoplight/mosaic@1.40.0)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-xuOt1FFeFxiy/bJrD0++9rjKY0NlaxH7y6jDZGCMGmH0y2vykpC2ZbHji+ol7/rB5TvVp7oE0NwlpK8TVizinw==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -3097,7 +3100,7 @@ packages:
       '@types/json-schema': 7.0.11
       classnames: 2.3.2
       fnv-plus: 1.3.1
-      jotai: 1.13.1(@babel/core@7.21.4)(react@17.0.2)
+      jotai: 1.13.1(react@17.0.2)
       lodash: 4.17.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -3942,10 +3945,8 @@ packages:
       indent-string: 4.0.0
     dev: false
 
-  /ajv-formats@2.1.1(ajv@8.12.0):
+  /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -6776,7 +6777,7 @@ packages:
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
 
-  /jotai@1.13.1(@babel/core@7.21.4)(react@17.0.2):
+  /jotai@1.13.1(react@17.0.2):
     resolution: {integrity: sha512-RUmH1S4vLsG3V6fbGlKzGJnLrDcC/HNb5gH2AeA9DzuJknoVxSGvvg8OBB7lke+gDc4oXmdVsaKn/xDUhWZ0vw==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
@@ -6816,11 +6817,10 @@ packages:
       jotai-zustand:
         optional: true
     dependencies:
-      '@babel/core': 7.21.4
       react: 17.0.2
     dev: false
 
-  /jotai@1.3.9(@babel/core@7.21.4)(react-query@3.39.3)(react@17.0.2):
+  /jotai@1.3.9(react-query@3.39.3)(react@17.0.2):
     resolution: {integrity: sha512-b6DvH9gf+7TfjaboCO54g+C0yhaakIaUBtjLf0dk1p15FWCzNw/93sezdXy9cCaZ8qcEdMLJcjBwQlORmIq29g==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
@@ -6854,7 +6854,6 @@ packages:
       xstate:
         optional: true
     dependencies:
-      '@babel/core': 7.21.4
       react: 17.0.2
       react-query: 3.39.3(react-dom@17.0.2)(react@17.0.2)
     dev: false
@@ -8949,6 +8948,17 @@ packages:
       unpipe: 1.0.0
     dev: false
 
+  /raw-loader@4.0.2(webpack@5.80.0):
+    resolution: {integrity: sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    dependencies:
+      loader-utils: 2.0.4
+      schema-utils: 3.1.2
+      webpack: 5.80.0
+    dev: false
+
   /rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
@@ -9688,7 +9698,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.12.0
-      ajv-formats: 2.1.1(ajv@8.12.0)
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0(ajv@8.12.0)
     dev: false
 

--- a/developer-docs-site/scripts/additional_dict.txt
+++ b/developer-docs-site/scripts/additional_dict.txt
@@ -41,6 +41,7 @@ CPU
 CPUs
 ChainID
 Clippy
+CodeBlock
 CoinStore
 CoinType
 CollectionData


### PR DESCRIPTION
@0xjinn @gregnazario @davidiw 

# Summary of changes

* Add JSON file input support for Move public entry, script, and view functions
* Abstract out assorted `TryInto` and `TryFrom` implementations in accordance with [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) design principles
* Add docs site tutorial with representative Move example package

# JSON syntax

As described in the [docs site tutorial preview for this PR](https://deploy-preview-8054--aptos-developer-docs.netlify.app/move/move-on-aptos/cli#arguments-in-json), a public entry function can now be invoked with arguments passed from either the CLI or from a JSON file:

## Arguments passed via CLI

```zsh title="Running function with nested vector arguments from CLI"
aptos move run \
    --function-id <test_account>::cli_args::set_vals \
    --private-key-file <test_account.key> \
    --type-args \
        0x1::account::Account \
        0x1::chain_id::ChainId \
    --args \
        u8:123 \
        "bool:[false, true, false, false]" \
        'address:[["0xace", "0xbee"], ["0xcad"], []]'
```

## Arguments passed via JSON file

Command:

```zsh
aptos move run \
    --private-key-file <test_account.key> \
    --json-file entry_function_arguments.json
```

JSON file:

```json title="entry_function_arguments.json"
{
    "function_id": "<test_account>::cli_args::set_vals",
    "type_args": [
        "0x1::account::Account",
        "0x1::chain_id::ChainId"
    ],
    "args": [
        {
            "arg_type": "u8",
            "arg_value": 123
        },
        {
            "arg_type": "bool",
            "arg_value": [false, true, false, false]
        },
        {
            "arg_type": "address",
            "arg_value": [
                [
                    "0xace",
                    "0xbee"
                ],
                [
                    "0xcad"
                ],
                []
            ]
        }
    ]
}

```

The docs site tutorial also includes examples for view functions and script functions.