### PR TITLE
[aptos-debugger] Fix resource group fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3145,6 +3145,7 @@ dependencies = [
  "aptos-storage-interface",
  "aptos-types",
  "async-trait",
+ "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "itertools",
  "lru 0.7.8",
  "move-binary-format",

--- a/aptos-move/aptos-validator-interface/Cargo.toml
+++ b/aptos-move/aptos-validator-interface/Cargo.toml
@@ -22,6 +22,7 @@ aptos-state-view = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-types = { workspace = true }
 async-trait = { workspace = true }
+bcs = { workspace = true }
 itertools = { workspace = true }
 lru = { workspace = true }
 move-binary-format = { workspace = true }

--- a/aptos-move/aptos-validator-interface/src/rest_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/rest_interface.rs
@@ -64,7 +64,7 @@ impl AptosValidatorInterface for RestDebuggerInterface {
                         .into_inner()
                         .to_vec(),
                 ))),
-                Path::Resource(tag) | Path::ResourceGroup(tag) => Ok(self
+                Path::Resource(tag) => Ok(self
                     .0
                     .get_account_resource_at_version_bytes(
                         path.address,
@@ -74,6 +74,17 @@ impl AptosValidatorInterface for RestDebuggerInterface {
                     .await
                     .ok()
                     .map(|inner| StateValue::new_legacy(inner.into_inner()))),
+
+                Path::ResourceGroup(_) => Ok(self
+                    .0
+                    .get_account_resources_at_version_bcs(path.address, version)
+                    .await
+                    .ok()
+                    .and_then(|inner| {
+                        Some(StateValue::new_legacy(
+                            bcs::to_bytes(&inner.into_inner()).ok()?,
+                        ))
+                    })),
             },
             StateKeyInner::TableItem { handle, key } => Ok(Some(StateValue::new_legacy(
                 self.0


### PR DESCRIPTION
### Description

The logic for getting values in resource group was broken in the validator-interface repo: there will be nothing under the struct tag if we are querying by resource group. To work around this temporarily,  I simulated the resource group behavior by fetching all the resources and return the superset blob back to caller. This is fairly ugly workaround which may require us add a better api for resource group in the future

### Test Plan

Manually tested the debugger with a txn that read resource group and make sure it can be executed successfully.
