### PR TITLE
[Peer Monitor] Improve distance logic and enable client.

### DIFF
--- a/config/src/config/peer_monitoring_config.rs
+++ b/config/src/config/peer_monitoring_config.rs
@@ -218,8 +218,18 @@ impl ConfigOptimizer for PeerMonitoringServiceConfig {
         let peer_monitoring_config = &mut node_config.peer_monitoring_service;
         let local_monitoring_config_yaml = &local_config_yaml["peer_monitoring_service"];
 
-        // Increase the max number of message bytes if the network-perf-test feature is enabled
+        // Enable the peer monitoring service client for all networks
+        // that aren't testnet or mainnet (for testing).
         let mut modified_config = false;
+        if !chain_id.is_testnet()
+            && !chain_id.is_mainnet()
+            && local_monitoring_config_yaml["enable_peer_monitoring_client"].is_null()
+        {
+            peer_monitoring_config.enable_peer_monitoring_client = true;
+            modified_config = true;
+        }
+
+        // Increase the max number of message bytes if the network-perf-test feature is enabled
         if local_monitoring_config_yaml["max_num_response_bytes"].is_null()
             && is_network_perf_test_enabled()
         {
@@ -296,5 +306,97 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+
+    #[test]
+    fn test_optimize_enable_monitoring_client() {
+        // Create a node config with the peer monitoring client disabled
+        let mut node_config = create_config_with_disabled_client();
+
+        // Optimize the config and verify modifications are made
+        let modified_config = PeerMonitoringServiceConfig::optimize(
+            &mut node_config,
+            &serde_yaml::from_str("{}").unwrap(), // An empty local config,
+            NodeType::ValidatorFullnode,
+            ChainId::test(),
+        )
+        .unwrap();
+        assert!(modified_config);
+
+        // Verify that the peer monitoring client is enabled
+        assert!(
+            node_config
+                .peer_monitoring_service
+                .enable_peer_monitoring_client
+        );
+    }
+
+    #[test]
+    fn test_optimize_enable_monitoring_client_mainnet() {
+        // Create a node config with the peer monitoring client disabled
+        let node_config = create_config_with_disabled_client();
+
+        // Test that the peer monitoring client is not enabled for testnet and mainnet
+        for chain_id in &[ChainId::testnet(), ChainId::mainnet()] {
+            // Optimize the config and verify no modifications are made
+            let modified_config = PeerMonitoringServiceConfig::optimize(
+                &mut node_config.clone(),
+                &serde_yaml::from_str("{}").unwrap(), // An empty local config,
+                NodeType::Validator,
+                *chain_id,
+            )
+            .unwrap();
+            assert!(!modified_config);
+
+            // Verify that the peer monitoring client is disabled
+            assert!(
+                !node_config
+                    .peer_monitoring_service
+                    .enable_peer_monitoring_client
+            );
+        }
+    }
+
+    #[test]
+    fn test_optimize_enable_monitoring_client_no_override() {
+        // Create a node config with the peer monitoring client disabled
+        let node_config = create_config_with_disabled_client();
+
+        // Create a local config YAML with the peer monitoring client disabled
+        let local_config_yaml = serde_yaml::from_str(
+            r#"
+            peer_monitoring_service:
+                enable_peer_monitoring_client: false
+            "#,
+        )
+        .unwrap();
+
+        // Optimize the config and verify no modifications are made
+        let modified_config = PeerMonitoringServiceConfig::optimize(
+            &mut node_config.clone(),
+            &local_config_yaml,
+            NodeType::PublicFullnode,
+            ChainId::test(),
+        )
+        .unwrap();
+        assert!(!modified_config);
+
+        // Verify that the peer monitoring client is still disabled
+        assert!(
+            !node_config
+                .peer_monitoring_service
+                .enable_peer_monitoring_client
+        );
+    }
+
+    /// Creates a node config with the peer monitoring client disabled
+    fn create_config_with_disabled_client() -> NodeConfig {
+        NodeConfig {
+            peer_monitoring_service: PeerMonitoringServiceConfig {
+                enable_peer_monitoring_client: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
     }
 }

--- a/network/peer-monitoring-service/client/src/peer_states/network_info.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/network_info.rs
@@ -129,18 +129,13 @@ impl StateValueInterface for NetworkInfoState {
                 let peer_is_vfn = peer_metadata.get_connection_metadata().role.is_vfn();
                 let peer_has_correct_network = match self.base_config.role {
                     RoleType::Validator => network_id.is_vfn_network(), // We're a validator
-                    RoleType::FullNode => network_id.is_public_network(), // We're a PFN
+                    RoleType::FullNode => network_id.is_public_network(), // We're a VFN or PFN
                 };
                 peer_is_vfn && peer_has_correct_network
             },
             distance_from_validators => {
-                // The peer should not be a validator, or a VFN, and the
-                // depth must be less than or equal to the max.
-                let peer_is_validator = peer_metadata.get_connection_metadata().role.is_validator();
-                let peer_is_vfn = peer_metadata.get_connection_metadata().role.is_vfn();
-                !peer_is_validator
-                    && !peer_is_vfn
-                    && distance_from_validators <= MAX_DISTANCE_FROM_VALIDATORS
+                // The distance must be less than or equal to the max
+                distance_from_validators <= MAX_DISTANCE_FROM_VALIDATORS
             },
         };
 
@@ -222,51 +217,63 @@ mod test {
 
         // Attempt to store a network response with an invalid depth of
         // 0 (the peer is a VFN, not a validator).
-        handle_monitoring_service_response(
+        handle_response_and_verify_distance(
             &mut network_info_state,
             NetworkId::Vfn,
             PeerRole::ValidatorFullNode,
             0,
+            None,
         );
-
-        // Verify there is still no latest network info response
-        verify_empty_network_response(&network_info_state);
 
         // Attempt to store a network response with an invalid depth of
         // 1 (the peer is a validator, not a VFN).
-        handle_monitoring_service_response(
+        handle_response_and_verify_distance(
             &mut network_info_state,
             NetworkId::Validator,
             PeerRole::Validator,
             1,
+            None,
         );
 
-        // Verify there is still no latest network info response
-        verify_empty_network_response(&network_info_state);
+        // Attempt to store a network response with a valid depth of
+        // 3 (the peer is a validator that is disconnected from the set).
+        handle_response_and_verify_distance(
+            &mut network_info_state,
+            NetworkId::Validator,
+            PeerRole::Validator,
+            3,
+            Some(3),
+        );
 
-        // Attempt to store a network response with an invalid depth of
-        // 10 (the peer is a VFN).
-        handle_monitoring_service_response(
+        // Attempt to store a network response with a valid depth of
+        // 10 (the peer is a VFN that has poor connections).
+        handle_response_and_verify_distance(
             &mut network_info_state,
             NetworkId::Vfn,
             PeerRole::ValidatorFullNode,
             10,
+            Some(10),
         );
-
-        // Verify there is still no latest network info response
-        verify_empty_network_response(&network_info_state);
 
         // Attempt to store a network response with a valid depth of
         // 1 (the peer is a VFN).
-        handle_monitoring_service_response(
+        handle_response_and_verify_distance(
             &mut network_info_state,
             NetworkId::Vfn,
             PeerRole::ValidatorFullNode,
             1,
+            Some(1),
         );
 
-        // Verify the latest stored distance is correct
-        verify_network_response_distance(&network_info_state, 1);
+        // Attempt to store a network response with a valid depth of
+        // 0 (the peer is a validator).
+        handle_response_and_verify_distance(
+            &mut network_info_state,
+            NetworkId::Validator,
+            PeerRole::Validator,
+            0,
+            Some(0),
+        );
     }
 
     #[test]
@@ -279,51 +286,63 @@ mod test {
 
         // Attempt to store a network response with an invalid depth of
         // 1 (the peer is a validator).
-        handle_monitoring_service_response(
+        handle_response_and_verify_distance(
             &mut network_info_state,
             NetworkId::Validator,
             PeerRole::Validator,
             1,
+            None,
         );
-
-        // Verify there is still no latest network info response
-        verify_empty_network_response(&network_info_state);
 
         // Attempt to store a network response with an invalid depth of
         // 0 (the peer is a PFN, not a validator).
-        handle_monitoring_service_response(
+        handle_response_and_verify_distance(
             &mut network_info_state,
             NetworkId::Public,
             PeerRole::Unknown,
             0,
+            None,
         );
-
-        // Verify there is still no latest network info response
-        verify_empty_network_response(&network_info_state);
 
         // Attempt to store a network response with an invalid depth of
         // 1 (the peer is a VFN, but VFNs can't connect to other VFN networks).
-        handle_monitoring_service_response(
+        handle_response_and_verify_distance(
             &mut network_info_state,
             NetworkId::Vfn,
             PeerRole::ValidatorFullNode,
             1,
+            None,
         );
 
-        // Verify there is still no latest network info response
-        verify_empty_network_response(&network_info_state);
-
         // Attempt to store a network response with a valid depth of
-        // 2 (the peer is a public fullnode).
-        handle_monitoring_service_response(
+        // 3 (the peer is a PFN).
+        handle_response_and_verify_distance(
             &mut network_info_state,
             NetworkId::Public,
             PeerRole::Unknown,
-            2,
+            3,
+            Some(3),
         );
 
-        // Verify the latest stored distance is correct
-        verify_network_response_distance(&network_info_state, 2);
+        // Attempt to store a network response with a valid depth of
+        // 2 (the peer is a validator that is disconnected from the set).
+        handle_response_and_verify_distance(
+            &mut network_info_state,
+            NetworkId::Vfn,
+            PeerRole::Validator,
+            2,
+            Some(2),
+        );
+
+        // Attempt to store a network response with a valid depth of
+        // 0 (the peer is a validator).
+        handle_response_and_verify_distance(
+            &mut network_info_state,
+            NetworkId::Vfn,
+            PeerRole::Validator,
+            0,
+            Some(0),
+        );
     }
 
     #[test]
@@ -336,53 +355,53 @@ mod test {
 
         // Attempt to store a network response with an invalid depth of
         // 0 (the peer is a PFN, not a validator).
-        handle_monitoring_service_response(
+        handle_response_and_verify_distance(
             &mut network_info_state,
             NetworkId::Public,
             PeerRole::Unknown,
             0,
+            None,
         );
-
-        // Verify there is still no latest network info response
-        verify_empty_network_response(&network_info_state);
 
         // Attempt to store a network response with an invalid depth of
         // 1 (the peer is a PFN, not a VFN).
-        handle_monitoring_service_response(
+        handle_response_and_verify_distance(
             &mut network_info_state,
             NetworkId::Public,
             PeerRole::PreferredUpstream,
             1,
+            None,
         );
 
-        // Verify there is still no latest network info response
-        verify_empty_network_response(&network_info_state);
-
-        // Attempt to store a network response with an invalid depth of
-        // 2 (the peer is a VFN).
-        handle_monitoring_service_response(
+        // Attempt to store a network response with a valid depth of
+        // 2 (the peer is a VFN that has no validator connection).
+        handle_response_and_verify_distance(
             &mut network_info_state,
-            NetworkId::Vfn,
+            NetworkId::Public,
             PeerRole::ValidatorFullNode,
             2,
+            Some(2),
         );
 
-        // Verify there is still no latest network info response
-        verify_empty_network_response(&network_info_state);
+        // Attempt to store a network response with a valid depth of
+        // 1 (the peer is a VFN).
+        handle_response_and_verify_distance(
+            &mut network_info_state,
+            NetworkId::Public,
+            PeerRole::ValidatorFullNode,
+            1,
+            Some(1),
+        );
 
-        // Handle two correct responses
+        // Handle two valid responses from a PFN
         for distance_from_validators in [2, 3] {
-            // Attempt to store a network response with a valid depth
-            // (the peer is a PFN).
-            handle_monitoring_service_response(
+            handle_response_and_verify_distance(
                 &mut network_info_state,
                 NetworkId::Public,
                 PeerRole::Unknown,
                 distance_from_validators,
+                Some(distance_from_validators),
             );
-
-            // Verify the latest stored distance is correct
-            verify_network_response_distance(&network_info_state, distance_from_validators);
         }
     }
 
@@ -396,6 +415,34 @@ mod test {
             ..Default::default()
         };
         NetworkInfoState::new(node_config, TimeService::mock())
+    }
+
+    /// Handles a monitoring service response from a peer
+    /// and verifies the latest stored distance.
+    fn handle_response_and_verify_distance(
+        network_info_state: &mut NetworkInfoState,
+        network_id: NetworkId,
+        peer_role: PeerRole,
+        distance_from_validators: u64,
+        latest_stored_distance: Option<u64>,
+    ) {
+        // Handle the monitoring service response
+        handle_monitoring_service_response(
+            network_info_state,
+            network_id,
+            peer_role,
+            distance_from_validators,
+        );
+
+        // Verify that the latest stored distance is correct
+        match latest_stored_distance {
+            Some(latest_stored_distance) => {
+                verify_network_response_distance(network_info_state, latest_stored_distance);
+            },
+            None => {
+                verify_empty_network_response(network_info_state);
+            },
+        }
     }
 
     /// Handles a monitoring service response from a peer

--- a/network/peer-monitoring-service/server/src/tests.rs
+++ b/network/peer-monitoring-service/server/src/tests.rs
@@ -113,7 +113,7 @@ async fn test_get_network_information_fullnode() {
     // Connect a new peer to the fullnode
     let peer_id_1 = PeerId::random();
     let peer_network_id_1 = PeerNetworkId::new(NetworkId::Public, peer_id_1);
-    let mut connection_metadata_1 = create_connection_metadata(peer_id_1);
+    let mut connection_metadata_1 = create_connection_metadata(peer_id_1, PeerRole::Unknown);
     peers_and_metadata
         .insert_connection_metadata(peer_network_id_1, connection_metadata_1.clone())
         .unwrap();
@@ -175,7 +175,7 @@ async fn test_get_network_information_fullnode() {
     let peer_id_2 = PeerId::random();
     let peer_network_id_2 = PeerNetworkId::new(NetworkId::Validator, peer_id_2);
     let peer_distance_2 = 0; // The peer is a validator
-    let connection_metadata_2 = create_connection_metadata(peer_id_2);
+    let connection_metadata_2 = create_connection_metadata(peer_id_2, PeerRole::Validator);
     let expected_peers = btreemap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2.clone()};
     let latest_network_info_response = NetworkInformationResponse {
         connected_peers: transform_connection_metadata(expected_peers),
@@ -223,13 +223,19 @@ async fn test_get_network_information_validator() {
         MockClient::new(Some(base_config), None, None);
     tokio::spawn(service.start());
 
-    // Process a client request to fetch the network information and verify distance is 0
-    verify_network_information(&mut mock_client, BTreeMap::new(), 0).await;
+    // Process a client request to fetch the network information and verify
+    // the distance is the max (the server has no peers!).
+    verify_network_information(
+        &mut mock_client,
+        BTreeMap::new(),
+        MAX_DISTANCE_FROM_VALIDATORS,
+    )
+    .await;
 
     // Connect a new peer to the validator (another validator)
     let peer_id_1 = PeerId::random();
     let peer_network_id_1 = PeerNetworkId::new(NetworkId::Validator, peer_id_1);
-    let connection_metadata_1 = create_connection_metadata(peer_id_1);
+    let connection_metadata_1 = create_connection_metadata(peer_id_1, PeerRole::Validator);
     peers_and_metadata
         .insert_connection_metadata(peer_network_id_1, connection_metadata_1.clone())
         .unwrap();
@@ -239,7 +245,7 @@ async fn test_get_network_information_validator() {
     verify_network_information(&mut mock_client, expected_peers.clone(), 0).await;
 
     // Update the peer monitoring metadata for peer 1
-    let peer_distance_1 = 0; // Peer 1 now has other connections
+    let peer_distance_1 = 1; // Peer 1 now has other connections
     let latest_network_info_response = NetworkInformationResponse {
         connected_peers: transform_connection_metadata(expected_peers.clone()),
         distance_from_validators: peer_distance_1,
@@ -253,11 +259,11 @@ async fn test_get_network_information_validator() {
     // Process a client request to fetch the network information and verify the response
     verify_network_information(&mut mock_client, expected_peers, 0).await;
 
-    // Connect another peer to the validator
+    // Connect another peer to the validator (a VFN)
     let peer_id_2 = PeerId::random();
     let peer_network_id_2 = PeerNetworkId::new(NetworkId::Vfn, peer_id_2);
-    let peer_distance_2 = 1; // The peer is a VFN
-    let connection_metadata_2 = create_connection_metadata(peer_id_2);
+    let peer_distance_2 = 2; // The peer is a VFN
+    let connection_metadata_2 = create_connection_metadata(peer_id_2, PeerRole::ValidatorFullNode);
     let expected_peers = btreemap! {peer_network_id_1 => connection_metadata_1.clone(), peer_network_id_2 => connection_metadata_2.clone()};
     let latest_network_info_response = NetworkInformationResponse {
         connected_peers: transform_connection_metadata(expected_peers.clone()),
@@ -275,16 +281,16 @@ async fn test_get_network_information_validator() {
     // Process a client request to fetch the network information and verify the response
     verify_network_information(&mut mock_client, expected_peers, 0).await;
 
-    // Disconnect peer 2
+    // Disconnect peer 1
     peers_and_metadata
-        .update_connection_state(peer_network_id_2, ConnectionState::Disconnected)
+        .update_connection_state(peer_network_id_1, ConnectionState::Disconnected)
         .unwrap();
 
     // Process a request to fetch the network information and verify the response
     verify_network_information(
         &mut mock_client,
-        btreemap! {peer_network_id_1 => connection_metadata_1},
-        0,
+        btreemap! {peer_network_id_2 => connection_metadata_2},
+        peer_distance_2 + 1,
     )
     .await;
 }
@@ -413,7 +419,7 @@ cfg_block! {
 }
 
 /// A simple utility function to create a new connection metadata for tests
-fn create_connection_metadata(peer_id: AccountAddress) -> ConnectionMetadata {
+fn create_connection_metadata(peer_id: AccountAddress, peer_role: PeerRole) -> ConnectionMetadata {
     ConnectionMetadata::new(
         peer_id,
         ConnectionId::default(),
@@ -421,7 +427,7 @@ fn create_connection_metadata(peer_id: AccountAddress) -> ConnectionMetadata {
         ConnectionOrigin::Inbound,
         MessagingProtocolVersion::V1,
         ProtocolIdSet::empty(),
-        PeerRole::Unknown,
+        peer_role,
     )
 }
 


### PR DESCRIPTION
Note: most of this PR is just tests.

### Description

This PR offers several commits:
- Improve the logic around distance calculations for peers in the peer monitoring service. Specifically, extend the logic to support disconnected (or badly connected) validators and VFNs.
- Enable the monitoring client for test networks and devnet (but not testnet or mainnet).

### Test Plan
Existing and new unit tests.