### PR TITLE
[Forge] Avoid hardcoding GCP cluster location

### DIFF
--- a/.github/workflows/forge-unstable.yaml
+++ b/.github/workflows/forge-unstable.yaml
@@ -96,7 +96,7 @@ jobs:
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       # GCP cluster
-      FORGE_CLUSTER_NAME: aptos-forge-0
+      FORGE_CLUSTER_NAME: aptos-forge-1
       COMMENT_HEADER: forge-continuous
       # This test suite is configured using the forge.py config test command
       FORGE_TEST_SUITE: continuous
@@ -137,7 +137,7 @@ jobs:
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       # GCP cluster
-      FORGE_CLUSTER_NAME: aptos-forge-0
+      FORGE_CLUSTER_NAME: aptos-forge-1
       FORGE_NAMESPACE: forge-state-sync-slow-processing-catching-up-test-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: state_sync_slow_processing_catching_up
@@ -152,7 +152,7 @@ jobs:
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       # GCP cluster
-      FORGE_CLUSTER_NAME: aptos-forge-0
+      FORGE_CLUSTER_NAME: aptos-forge-1
       FORGE_NAMESPACE: forge-twin-validator-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: twin_validator_test
@@ -166,7 +166,7 @@ jobs:
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       # GCP cluster
-      FORGE_CLUSTER_NAME: aptos-forge-0
+      FORGE_CLUSTER_NAME: aptos-forge-1
       FORGE_NAMESPACE: forge-three-region-with-different-node-speed-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 3600
       FORGE_TEST_SUITE: three_region_simulation_with_different_node_speed
@@ -182,7 +182,7 @@ jobs:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-state-sync-failures-catching-up-test-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       # GCP cluster
-      FORGE_CLUSTER_NAME: aptos-forge-0
+      FORGE_CLUSTER_NAME: aptos-forge-1
       FORGE_RUNNER_DURATION_SECS: 900
       FORGE_TEST_SUITE: state_sync_failures_catching_up
       FORGE_ENABLE_FAILPOINTS: true
@@ -195,6 +195,8 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      # GCP cluster
+      FORGE_CLUSTER_NAME: aptos-forge-1
       FORGE_NAMESPACE: forge-validator-reboot-stress-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       # Run for 40 minutes
       FORGE_RUNNER_DURATION_SECS: 2400

--- a/.github/workflows/workflow-run-forge.yaml
+++ b/.github/workflows/workflow-run-forge.yaml
@@ -142,9 +142,7 @@ jobs:
 
       - name: "Setup GCloud project"
         shell: bash
-        run: |
-          gcloud container clusters get-credentials aptos-forge-0 --zone us-central1-c --project aptos-forge-gcp-0
-          gcloud config set project aptos-forge-gcp-0
+        run: gcloud config set project aptos-forge-gcp-0
 
       - name: Run pre-Forge checks
         shell: bash

--- a/testsuite/fixtures/testMain.fixture
+++ b/testsuite/fixtures/testMain.fixture
@@ -1,4 +1,5 @@
-Using cluster: forge-big-1 in cloud: AWS
+Looking for cluster aptos-forge-big-1 in cloud AWS
+Found cluster: Cloud.AWS/us-west-2/aptos-forge-big-1
 Using the following image tags:
 	forge:  banana
 	swarm:  banana

--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -37,7 +37,7 @@ from forge_wrapper_core.process import Processes, SystemProcesses
 
 from forge_wrapper_core.shell import LocalShell, Shell
 from forge_wrapper_core.time import SystemTime, Time
-from forge_wrapper_core.cluster import Cloud, ForgeCluster, ForgeJob
+from forge_wrapper_core.cluster import Cloud, ForgeCluster, ForgeJob, find_forge_cluster
 
 # map of build variant (e.g. cargo profile and feature flags)
 BUILD_VARIANT_TAG_PREFIX_MAP = {
@@ -1331,9 +1331,11 @@ def test(
     else:
         cloud_enum = Cloud.GCP
 
-    log.info(f"Using cluster: {forge_cluster_name} in cloud: {cloud_enum.value}")
-    temp = context.filesystem.mkstemp()
-    forge_cluster = ForgeCluster(forge_cluster_name, temp, cloud=cloud_enum)
+    log.info(f"Looking for cluster {forge_cluster_name} in cloud {cloud_enum.value}")
+    forge_cluster = find_forge_cluster(
+        context.shell, cloud_enum, forge_cluster_name, context.filesystem.mkstemp()
+    )
+    log.info(f"Found cluster: {forge_cluster}")
     asyncio.run(forge_cluster.write(context.shell))
 
     # These features and profile flags are set as strings

--- a/testsuite/forge_wrapper_core/cluster.py
+++ b/testsuite/forge_wrapper_core/cluster.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from enum import Enum
 import json
 import os
-from typing import List, Optional, TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from .shell import Shell
 
@@ -44,48 +44,26 @@ class GetPodsResult(TypedDict):
     items: List[GetPodsItem]
 
 
-def list_eks_clusters(shell: Shell) -> List[str]:
-    cluster_json = shell.run(["aws", "eks", "list-clusters"]).unwrap()
-    # This type annotation is not enforced, just helpful
-    try:
-        cluster_result: AwsListClusterResult = json.loads(cluster_json.decode())
-        clusters = []
-        for cluster_name in cluster_result["clusters"]:
-            if cluster_name.startswith("aptos-forge-"):
-                clusters.append(cluster_name)
-        return clusters
-    except Exception as e:
-        raise AwsError("Failed to list eks clusters") from e
-
-
-def list_gke_clusters(shell: Shell) -> List[str]:
-    cluster_json = shell.run(
-        ["gcloud", "container", "clusters", "list", "--format=json"]
-    ).unwrap()
-    try:
-        cluster_result = json.loads(cluster_json.decode())
-        clusters = []
-        for cluster_config in cluster_result:
-            cluster_name = cluster_config["name"]
-            if cluster_name.startswith("aptos-forge-"):
-                clusters.append(cluster_name)
-        return clusters
-    except Exception as e:
-        raise GcpError("Failed to list eks clusters") from e
-
-
 @dataclass
 class ForgeCluster:
     name: str
-    kubeconf: str
     cloud: Cloud = Cloud.AWS
     region: Optional[str] = "us-west-2"
-    zone: Optional[str] = None
+    kubeconf: Optional[str] = None
+
+    def __repr__(self) -> str:
+        return f"{self.cloud}/{self.region}/{self.name}"
+
+    def set_kubeconf(self, kubeconf: str) -> ForgeCluster:
+        self.kubeconf = kubeconf
+        return self
 
     async def write(self, shell: Shell) -> None:
+        assert self.kubeconf is not None, "kubeconf must be set"
         await self.write_cluster_config(shell, self.name, self.kubeconf)
 
     async def get_jobs(self, shell: Shell) -> List[ForgeJob]:
+        assert self.kubeconf is not None, "kubeconf must be set"
         pod_result = (
             (
                 await shell.gen_run(
@@ -181,6 +159,7 @@ class ForgeCluster:
         elif self.cloud == Cloud.GCP:
             # set the KUBE_CONFIG to temp so the resulting kubeconfig is written to it
             os.environ["KUBECONFIG"] = temp
+            # The project must already be set via: gcloud config set project <project>
             cmd = [
                 "gcloud",
                 "container",
@@ -188,13 +167,61 @@ class ForgeCluster:
                 "get-credentials",
                 cluster_name,
                 "--zone",
-                # The default zone for now.
-                # The project must already be set via: gcloud config set project <project>
-                "us-central1-c",
+                self.region,
             ]
         else:
             raise Exception("Unsupported cloud type")
         (await shell.gen_run(cmd)).unwrap()
+
+
+def list_eks_clusters(shell: Shell) -> Dict[str, ForgeCluster]:
+    cluster_json = shell.run(["aws", "eks", "list-clusters"]).unwrap()
+    # This type annotation is not enforced, just helpful
+    try:
+        cluster_result: AwsListClusterResult = json.loads(cluster_json.decode())
+        clusters: Dict[str, ForgeCluster] = {}
+        for cluster_name in cluster_result["clusters"]:
+            if cluster_name.startswith("aptos-forge-"):
+                clusters[cluster_name] = ForgeCluster(
+                    cloud=Cloud.AWS,
+                    name=cluster_name,
+                )
+        return clusters
+    except Exception as e:
+        raise AwsError("Failed to list EKS clusters") from e
+
+
+def list_gke_clusters(shell: Shell) -> Dict[str, ForgeCluster]:
+    cluster_json = shell.run(
+        ["gcloud", "container", "clusters", "list", "--format=json"]
+    ).unwrap()
+    try:
+        cluster_result = json.loads(cluster_json.decode())
+        clusters: Dict[str, ForgeCluster] = {}
+        for cluster_config in cluster_result:
+            cluster_name = cluster_config["name"]
+            if cluster_name.startswith("aptos-forge-"):
+                clusters[cluster_name] = ForgeCluster(
+                    cloud=Cloud.GCP,
+                    name=cluster_name,
+                    region=cluster_config["location"],
+                )
+        return clusters
+    except Exception as e:
+        raise GcpError("Failed to list GKE clusters") from e
+
+
+def find_forge_cluster(
+    shell: Shell, cloud: Cloud, name: str, kubeconf: str
+) -> ForgeCluster:
+    clusters: Dict[str, ForgeCluster] = {}
+    if cloud == Cloud.AWS:
+        clusters = list_eks_clusters(shell)
+    else:
+        clusters = list_gke_clusters(shell)
+    if name not in clusters:
+        raise Exception(f"Cluster {name} not found")
+    return clusters[name].set_kubeconf(kubeconf)
 
 
 @dataclass


### PR DESCRIPTION
### Description

Instead of hard-coding "us-central1-c" as GCP region, which prevents Forge from scheduling workloads on clusters in other regions, get a cluster's region by listing the clusters in the project.

This is a minimally invasive change to unblock the migration to GCP. A more long-term change should read the cluster list from gs://mushu/clusters.yaml and propagate other cluster properties from there (like region, chain name, etc...).

Remove the fetching of cluster credentials in workflow-run-forge.yaml because it's redundant: Forge will overwrite them anyway. This is backwards-compatible.

### Test Plan

Tested manually by invoking the forge-unstable workflow on the PR branch: https://github.com/aptos-labs/aptos-core/actions/runs/4886592313.