### PR TITLE
[Forge] Remove obsolete branches from watch list of forge-stable.yaml

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -28,7 +28,6 @@ on:
   push:
     branches:
       - aptos-release-v* # the aptos release branches
-      - aptos-node-v*
 
 env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}


### PR DESCRIPTION
The aptos-node-v* branches are no longer in use.
