### PR TITLE
[docs] fix command to fund local testnet account from faucet

### DIFF
--- a/developer-docs-site/docs/nodes/local-testnet/using-cli-to-run-a-local-testnet.md
+++ b/developer-docs-site/docs/nodes/local-testnet/using-cli-to-run-a-local-testnet.md
@@ -93,7 +93,7 @@ aptos init --profile $PROFILE --rest-url http://localhost:8080 --faucet-url http
 To fund accounts:
 
 ```bash
-aptos account fund --profile $PROFILE --account $PROFILE
+aptos account fund-with-faucet --profile $PROFILE --account $PROFILE
 ```
 
 To create resource accounts:


### PR DESCRIPTION
### Description
Fixing the command to fund an account on local testnet with the faucet in the docs for  `aptos-cli-v1.0.13`.  `aptos account fund-with-faucet` is now the correct command. 
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d013fa</samp>

Updated the documentation for running a local testnet with aptos-cli to use the new `fund-with-faucet` subcommand. This ensures the docs are consistent with the latest version of the tool and avoids using a deprecated feature.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
