### PR TITLE
Leaderboard link defaults to delegation nodes as opposed to all nodes

### DIFF
--- a/developer-docs-site/docs/nodes/leaderboard-metrics.md
+++ b/developer-docs-site/docs/nodes/leaderboard-metrics.md
@@ -5,7 +5,7 @@ slug: "leaderboard-metrics"
 
 # Leaderboard Metrics
 
-This document explains how the rewards for validator are evaluated and displayed on the [Aptos Validator Status](https://explorer.aptoslabs.com/validators) page. 
+This document explains how the rewards for validator are evaluated and displayed on the [Aptos Validator Status](https://explorer.aptoslabs.com/validators/all) page. 
 
 ## How rewards are calculated
 

--- a/developer-docs-site/docs/nodes/leaderboard-metrics.md
+++ b/developer-docs-site/docs/nodes/leaderboard-metrics.md
@@ -5,7 +5,7 @@ slug: "leaderboard-metrics"
 
 # Leaderboard Metrics
 
-This document explains how the rewards for validator are evaluated and displayed on the [Aptos Validator Status](https://explorer.aptoslabs.com/validators/all) page. 
+This document explains how the rewards for validator are evaluated and displayed on the [Aptos Validator Status](https://explorer.aptoslabs.com/validators/all?network=mainnet) page. 
 
 ## How rewards are calculated
 

--- a/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
@@ -96,7 +96,7 @@ aptos node join-validator-set \
 The validator set is updated at every epoch change. You will see your validator node joining the validator set only in the next epoch. Both validator and validator fullnode will start syncing once your validator is in the validator set.
 
 :::tip When is next epoch?
-You can see it on the [Aptos Explorer](https://explorer.aptoslabs.com/validators/all) or by running the command `aptos node get-stake-pool` as shown in [Checking your stake pool information](#checking-your-stake-pool-information).
+You can see it on the [Aptos Explorer](https://explorer.aptoslabs.com/validators/all?network=mainnet) or by running the command `aptos node get-stake-pool` as shown in [Checking your stake pool information](#checking-your-stake-pool-information).
 :::
 
 ### 6. Check the validator set

--- a/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
@@ -96,7 +96,7 @@ aptos node join-validator-set \
 The validator set is updated at every epoch change. You will see your validator node joining the validator set only in the next epoch. Both validator and validator fullnode will start syncing once your validator is in the validator set.
 
 :::tip When is next epoch?
-You can see it on the [Aptos Explorer](https://explorer.aptoslabs.com/validators) or by running the command `aptos node get-stake-pool` as shown in [Checking your stake pool information](#checking-your-stake-pool-information).
+You can see it on the [Aptos Explorer](https://explorer.aptoslabs.com/validators/all) or by running the command `aptos node get-stake-pool` as shown in [Checking your stake pool information](#checking-your-stake-pool-information).
 :::
 
 ### 6. Check the validator set


### PR DESCRIPTION
### Description
On the leaderboard metrics documentation the link to validator stats wasn't updated when delegation nodes were added and inadvertently shows a page where most nodes are down. This PR updates the link to active validators on mainnet

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

An alternative would be to update default behavior of the explorer to all nodes instead of delegation nodes

https://explorer.aptoslabs.com/validators

vs

https://explorer.aptoslabs.com/validators/all

