### PR TITLE
[doc] Fix the folder layout of the example in the section Using Bytecode for Dependencies

### DIFF
--- a/developer-docs-site/docs/move/book/packages.md
+++ b/developer-docs-site/docs/move/book/packages.md
@@ -335,7 +335,7 @@ version = "0.0.0"
 C = "0x3"
 ```
 
-Place the bytecode file and the corresponding `Move.toml` file in the same directory with the bytecode in a `build` subdirectory. Note that an empty `sources` directory is required. For instance, the layout of the folder `B` (for the package `Bar`) and `C` (for the package `Foo`) would resemble:
+Place the bytecode file and the corresponding `Move.toml` file in the same directory with the bytecode in a `build` subdirectory. Note an empty `sources` directory is **required**. For instance, the layout of the folder `B` (for the package `Bar`) and `C` (for the package `Foo`) would resemble:
 
 ```rust
 ./B

--- a/developer-docs-site/docs/move/book/packages.md
+++ b/developer-docs-site/docs/move/book/packages.md
@@ -335,11 +335,12 @@ version = "0.0.0"
 C = "0x3"
 ```
 
-Place the bytecode file and the corresponding `Move.toml` file in the same directory with the bytecode in a `build` subdirectory. For instance, the layout of the folder `B` (for the package `Bar`) and `C` (for the package `Foo`) would resemble:
+Place the bytecode file and the corresponding `Move.toml` file in the same directory with the bytecode in a `build` subdirectory. Note that an empty `sources` directory is required. For instance, the layout of the folder `B` (for the package `Bar`) and `C` (for the package `Foo`) would resemble:
 
 ```rust
 ./B
 ├── Move.toml
+├── sources
 ├── build
  ├ Bar.mv
 ```


### PR DESCRIPTION
### Description

This commit fixes a doc error in the bytecode dependency example and adds a clarification for requiring an empty `sources` folder in the Move package folder.