### PR TITLE
feat: add is_coin_store_frozen to the coin module

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/coin.md
+++ b/aptos-move/framework/aptos-framework/doc/coin.md
@@ -27,6 +27,7 @@ This module provides the foundation for typesafe Coins.
 -  [Function `coin_address`](#0x1_coin_coin_address)
 -  [Function `balance`](#0x1_coin_balance)
 -  [Function `is_coin_initialized`](#0x1_coin_is_coin_initialized)
+-  [Function `is_coin_store_frozen`](#0x1_coin_is_coin_store_frozen)
 -  [Function `is_account_registered`](#0x1_coin_is_account_registered)
 -  [Function `name`](#0x1_coin_name)
 -  [Function `symbol`](#0x1_coin_symbol)
@@ -880,6 +881,32 @@ Returns <code><b>true</b></code> if the type <code>CoinType</code> is an initial
 
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x1_coin_is_coin_initialized">is_coin_initialized</a>&lt;CoinType&gt;(): bool {
     <b>exists</b>&lt;<a href="coin.md#0x1_coin_CoinInfo">CoinInfo</a>&lt;CoinType&gt;&gt;(<a href="coin.md#0x1_coin_coin_address">coin_address</a>&lt;CoinType&gt;())
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_coin_is_coin_store_frozen"></a>
+
+## Function `is_coin_store_frozen`
+
+Returns <code><b>true</b></code> is account_addr has frozen the CoinStore
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x1_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType&gt;(account_addr: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x1_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType&gt;(account_addr: <b>address</b>): bool <b>acquires</b> <a href="coin.md#0x1_coin_CoinStore">CoinStore</a> {
+    <b>let</b> coin_store = <b>borrow_global</b>&lt;<a href="coin.md#0x1_coin_CoinStore">CoinStore</a>&lt;CoinType&gt;&gt;(account_addr);
+    coin_store.frozen
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/coin.md
+++ b/aptos-move/framework/aptos-framework/doc/coin.md
@@ -905,6 +905,10 @@ Returns <code><b>true</b></code> is account_addr has frozen the CoinStore
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x1_coin_is_coin_store_frozen">is_coin_store_frozen</a>&lt;CoinType&gt;(account_addr: <b>address</b>): bool <b>acquires</b> <a href="coin.md#0x1_coin_CoinStore">CoinStore</a> {
+    <b>if</b>(!<a href="coin.md#0x1_coin_is_account_registered">is_account_registered</a>&lt;CoinType&gt;(account_addr)) {
+      <b>return</b> <b>false</b>
+    };
+
     <b>let</b> coin_store = <b>borrow_global</b>&lt;<a href="coin.md#0x1_coin_CoinStore">CoinStore</a>&lt;CoinType&gt;&gt;(account_addr);
     coin_store.frozen
 }

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -242,6 +242,10 @@ module aptos_framework::coin {
     #[view]
     /// Returns `true` is account_addr has frozen the CoinStore
     public fun is_coin_store_frozen<CoinType>(account_addr: address): bool acquires CoinStore {
+        if(!is_account_registered<CoinType>(account_addr)) {
+          return false
+        };
+
         let coin_store = borrow_global<CoinStore<CoinType>>(account_addr);
         coin_store.frozen
     }
@@ -852,6 +856,9 @@ module aptos_framework::coin {
     #[test(account = @0x1)]
     public fun test_is_coin_store_frozen(account: signer) acquires CoinStore {
         let account_addr = signer::address_of(&account);
+        // An non registered account is has a frozen coin store
+        assert!(!is_coin_store_frozen<FakeMoney>(account_addr), 1);
+
         account::create_account_for_test(account_addr);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&account, 18, true);
 

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -240,6 +240,13 @@ module aptos_framework::coin {
     }
 
     #[view]
+    /// Returns `true` is account_addr has frozen the CoinStore
+    public fun is_coin_store_frozen<CoinType>(account_addr: address): bool acquires CoinStore {
+        let coin_store = borrow_global<CoinStore<CoinType>>(account_addr);
+        coin_store.frozen
+    }
+
+    #[view]
     /// Returns `true` if `account_addr` is registered to receive `CoinType`.
     public fun is_account_registered<CoinType>(account_addr: address): bool {
         exists<CoinStore<CoinType>>(account_addr)
@@ -836,6 +843,29 @@ module aptos_framework::coin {
         assert!(is_coin_initialized<FakeMoney>(), 1);
 
         move_to(&source, FakeMoneyCapabilities {
+            burn_cap,
+            freeze_cap,
+            mint_cap,
+        });
+    }
+
+    #[test(account = @0x1)]
+    public fun test_is_coin_store_frozen(account: signer) acquires CoinStore {
+        let account_addr = signer::address_of(&account);
+        account::create_account_for_test(account_addr);
+        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&account, 18, true);
+
+        assert!(!is_coin_store_frozen<FakeMoney>(account_addr), 1);
+
+        // freeze account
+        freeze_coin_store(account_addr, &freeze_cap);
+        assert!(is_coin_store_frozen<FakeMoney>(account_addr), 1);
+
+        // unfreeze account
+        unfreeze_coin_store(account_addr, &freeze_cap);
+        assert!(!is_coin_store_frozen<FakeMoney>(account_addr), 1);
+
+        move_to(&account, FakeMoneyCapabilities {
             burn_cap,
             freeze_cap,
             mint_cap,

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -240,10 +240,10 @@ module aptos_framework::coin {
     }
 
     #[view]
-    /// Returns `true` is account_addr has frozen the CoinStore
+    /// Returns `true` is account_addr has frozen the CoinStore or if it's not registered at all
     public fun is_coin_store_frozen<CoinType>(account_addr: address): bool acquires CoinStore {
         if(!is_account_registered<CoinType>(account_addr)) {
-          return false
+          return true
         };
 
         let coin_store = borrow_global<CoinStore<CoinType>>(account_addr);
@@ -856,8 +856,8 @@ module aptos_framework::coin {
     #[test(account = @0x1)]
     public fun test_is_coin_store_frozen(account: signer) acquires CoinStore {
         let account_addr = signer::address_of(&account);
-        // An non registered account is has a frozen coin store
-        assert!(!is_coin_store_frozen<FakeMoney>(account_addr), 1);
+        // An non registered account is has a frozen coin store by default
+        assert!(is_coin_store_frozen<FakeMoney>(account_addr), 1);
 
         account::create_account_for_test(account_addr);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&account, 18, true);


### PR DESCRIPTION
### Description

There is currently not an easy way to tell if a user has frozen his CoinStore. This is can be a useful information in some scenarios. For example, in an auction based module one might decide to implement a `bid` function that returns coins back to the highest bidder when he is outbided. However, this poses a Denial of Service (DOS) vulnerability as described in the following example:

1. Chunk calls bid sending a small amount
2. Chunk immediately freezes his coin store resource
3. Alice call `bid` with a higher amount, but the call reverts because the bid function cannot return the coins back to Chunk.
4. Chunk unfreezes the CoinStore at the end of the auction and claims the resource 

We can maybe abstract this into a more general `can_deposit` function which will also take into account if the coinstore is initialized in the first place, as well.

### Test Plan
Unit test
