### PR TITLE
[CLI] remove rlib and dylib

### DIFF
--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -97,6 +97,3 @@ cli-framework-test-move = []
 
 [build-dependencies]
 shadow-rs = { workspace = true }
-
-[lib]
-crate-type = ["rlib", "dylib"]


### PR DESCRIPTION
### Description
Removing rlib and dylib from CLI toml for now, because it is breaking some of the executor benchmark.

### Follow up
Need to think of what or how generating the rlib and dylib is breaking the executor benchmark, or come up with alternative.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
