### PR TITLE
[txn-generator] Keep the original compiled module order

### DIFF
--- a/crates/transaction-generator-lib/src/publishing/module_simple.rs
+++ b/crates/transaction-generator-lib/src/publishing/module_simple.rs
@@ -17,7 +17,6 @@ use move_binary_format::{
 };
 use rand::{distributions::Alphanumeric, prelude::StdRng, seq::SliceRandom, Rng};
 use rand_core::RngCore;
-use std::collections::HashMap;
 
 //
 // Contains all the code to work on the Simple package


### PR DESCRIPTION
as if there are dependencies between the modules, that is required.

Also remove adding suffixes for same module published under different address. if we want to publish multiple modules under same address, we will need to use suffixes still

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e84abb</samp>

This pull request simplifies the data structure and naming scheme for packages of modules that are published to the blockchain. It replaces `HashMap` with `Vec` for storing modules in a `Package` enum, and adds a unique suffix to each module name based on the account address index. This avoids name collisions and improves performance.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
