### PR TITLE
Include static methods from `AptosClient` and `IndexerClient` classes in the `Provider` class

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 ## Unreleased
 
 - Fix get number of delegators Indexer query
+- Include static methods from `AptosClient` and `IndexerClient` classes in the `Provider` class
 
 ## 1.8.5 (2023-04-29)
 

--- a/ecosystem/typescript/sdk/src/providers/provider.ts
+++ b/ecosystem/typescript/sdk/src/providers/provider.ts
@@ -70,6 +70,7 @@ Here, we combine AptosClient and IndexerClient classes into one Provider class t
 methods and properties from both classes.
 */
 function applyMixin(targetClass: any, baseClass: any, baseClassProp: string) {
+  // Mixin instance methods
   Object.getOwnPropertyNames(baseClass.prototype).forEach((propertyName) => {
     const propertyDescriptor = Object.getOwnPropertyDescriptor(baseClass.prototype, propertyName);
     if (!propertyDescriptor) return;
@@ -78,6 +79,20 @@ function applyMixin(targetClass: any, baseClass: any, baseClassProp: string) {
       return (this as any)[baseClassProp][propertyName](...args);
     };
     Object.defineProperty(targetClass.prototype, propertyName, propertyDescriptor);
+  });
+  // Mixin static methods
+  Object.getOwnPropertyNames(baseClass).forEach((propertyName) => {
+    const propertyDescriptor = Object.getOwnPropertyDescriptor(baseClass, propertyName);
+    if (!propertyDescriptor) return;
+    // eslint-disable-next-line func-names
+    propertyDescriptor.value = function (...args: any) {
+      return (this as any)[baseClassProp][propertyName](...args);
+    };
+    if (targetClass.hasOwnProperty(propertyName)) {
+      // The mixin has already been applied, so skip applying it again
+      return;
+    }
+    Object.defineProperty(targetClass, propertyName, propertyDescriptor);
   });
 }
 

--- a/ecosystem/typescript/sdk/src/providers/provider.ts
+++ b/ecosystem/typescript/sdk/src/providers/provider.ts
@@ -88,7 +88,7 @@ function applyMixin(targetClass: any, baseClass: any, baseClassProp: string) {
     propertyDescriptor.value = function (...args: any) {
       return (this as any)[baseClassProp][propertyName](...args);
     };
-    if (targetClass.hasOwnProperty(propertyName)) {
+    if (targetClass.hasOwnProperty.call(targetClass, propertyName)) {
       // The mixin has already been applied, so skip applying it again
       return;
     }

--- a/ecosystem/typescript/sdk/src/tests/e2e/provider.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/provider.test.ts
@@ -27,6 +27,11 @@ describe("Provider", () => {
     expect(provider.indexerClient.endpoint).toBe("indexer-url");
   });
 
+  it("includes static methods", async () => {
+    expect(Provider).toHaveProperty("generateBCSTransaction");
+    expect(Provider).toHaveProperty("generateBCSSimulation");
+  });
+
   it("throws error when endpoint not provided", async () => {
     expect(() => {
       new Provider({ fullnodeUrl: "", indexerUrl: "" });


### PR DESCRIPTION
### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a101dca</samp>

This pull request adds a new feature to the `Provider` class in the `ecosystem/typescript/sdk` package, which enables it to inherit static methods from other client classes. This feature simplifies the usage of common transaction methods for users. The pull request also updates the changelog and adds a test case for the feature.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
