### PR TITLE
[Performance] Pass state cache to commit stage.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,6 +2777,7 @@ dependencies = [
  "aptos-state-view",
  "aptos-types",
  "aptos-vm",
+ "arr_macro",
  "assert_unordered",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "crossbeam-channel",

--- a/execution/executor-types/src/executed_block.rs
+++ b/execution/executor-types/src/executed_block.rs
@@ -6,7 +6,7 @@
 use crate::StateComputeResult;
 use anyhow::{ensure, Result};
 use aptos_crypto::{hash::TransactionAccumulatorHasher, HashValue};
-use aptos_storage_interface::ExecutedTrees;
+use aptos_storage_interface::{cached_state_view::ShardedStateCache, ExecutedTrees};
 use aptos_types::{
     contract_event::ContractEvent,
     epoch_state::EpochState,
@@ -26,6 +26,7 @@ pub struct ExecutedBlock {
     pub reconfig_events: Vec<ContractEvent>,
     pub transaction_info_hashes: Vec<HashValue>,
     pub block_state_updates: HashMap<StateKey, Option<StateValue>>,
+    pub sharded_state_cache: ShardedStateCache,
 }
 
 impl ExecutedBlock {

--- a/execution/executor-types/src/in_memory_state_calculator.rs
+++ b/execution/executor-types/src/in_memory_state_calculator.rs
@@ -65,7 +65,7 @@ impl InMemoryStateCalculator {
     pub fn new(base: &StateDelta, state_cache: StateCache) -> Self {
         let StateCache {
             frozen_base,
-            state_cache,
+            sharded_state_cache,
             proofs,
         } = state_cache;
         let StateDelta {
@@ -75,6 +75,14 @@ impl InMemoryStateCalculator {
             current_version,
             updates_since_base,
         } = base.clone();
+
+        // TODO(grao): Rethink the strategy for state sync, and optimize this.
+        let state_cache = sharded_state_cache
+            .iter()
+            .flatten()
+            .into_iter()
+            .map(|entry| (entry.key().clone(), entry.value().1.clone()))
+            .collect();
 
         Self {
             _frozen_base: frozen_base,

--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -331,6 +331,7 @@ where
                 result_in_memory_state,
                 // TODO(grao): Avoid this clone.
                 block.output.block_state_updates.clone(),
+                &block.output.sharded_state_cache,
             )?;
             first_version += txns_to_commit.len() as u64;
             committed_block = block.clone();

--- a/execution/executor/src/components/apply_chunk_output.rs
+++ b/execution/executor/src/components/apply_chunk_output.rs
@@ -59,6 +59,7 @@ impl ApplyChunkOutput {
             result_state,
             next_epoch_state,
             block_state_updates,
+            sharded_state_cache,
         ) = {
             let _timer = APTOS_EXECUTOR_OTHER_TIMERS_SECONDS
                 .with_label_values(&["calculate_for_transaction_block"])
@@ -95,6 +96,7 @@ impl ApplyChunkOutput {
                 reconfig_events,
                 transaction_info_hashes,
                 block_state_updates,
+                sharded_state_cache,
             },
             to_discard,
             to_retry,

--- a/storage/aptosdb/src/fake_aptosdb.rs
+++ b/storage/aptosdb/src/fake_aptosdb.rs
@@ -15,7 +15,8 @@ use aptos_crypto::{
 };
 use aptos_infallible::Mutex;
 use aptos_storage_interface::{
-    state_delta::StateDelta, DbReader, DbWriter, ExecutedTrees, MAX_REQUEST_LIMIT,
+    cached_state_view::ShardedStateCache, state_delta::StateDelta, DbReader, DbWriter,
+    ExecutedTrees, MAX_REQUEST_LIMIT,
 };
 use aptos_types::{
     access_path::AccessPath,
@@ -418,6 +419,7 @@ impl DbWriter for FakeAptosDB {
         sync_commit: bool,
         latest_in_memory_state: StateDelta,
         _block_state_updates: HashMap<StateKey, Option<StateValue>>,
+        _sharded_state_cache: &ShardedStateCache,
     ) -> Result<()> {
         self.save_transactions_impl(
             txns_to_commit,

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -54,6 +54,7 @@ fn put_value_set(
             vec![&value_set],
             version,
             StateStorageUsage::new_untracked(),
+            None,
             &ledger_batch,
             &sharded_state_kv_batches,
         )

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -41,6 +41,7 @@ fn put_value_set(
             vec![&value_set],
             version,
             StateStorageUsage::new_untracked(),
+            None,
             &ledger_batch,
             &sharded_state_kv_batches,
         )

--- a/storage/aptosdb/src/test_helper.rs
+++ b/storage/aptosdb/src/test_helper.rs
@@ -70,6 +70,7 @@ pub(crate) fn update_store(
                 vec![&value_state_set],
                 version,
                 StateStorageUsage::new_untracked(),
+                None,
                 &ledger_batch,
                 &sharded_state_kv_batches,
             )

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -22,6 +22,7 @@ aptos-secure-net = { workspace = true }
 aptos-state-view = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
+arr_macro = { workspace = true }
 bcs = { workspace = true }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true }

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -2,6 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::cached_state_view::ShardedStateCache;
 use anyhow::{anyhow, format_err, Result};
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_types::{
@@ -379,7 +380,7 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
-    /// Gets an account state by account address.
+    /// Gets the state value by state key at version.
     /// See [AptosDB::get_state_value_by_version].
     ///
     /// [AptosDB::get_state_value_by_version]:
@@ -389,6 +390,20 @@ pub trait DbReader: Send + Sync {
         state_key: &StateKey,
         version: Version,
     ) -> Result<Option<StateValue>> {
+        unimplemented!()
+    }
+
+    /// Get the latest state value and its corresponding version when it's of the given key up
+    /// to the given version.
+    /// See [AptosDB::get_state_value_with_version_by_version].
+    ///
+    /// [AptosDB::get_state_value_with_version_by_version]:
+    /// ../aptosdb/struct.AptosDB.html#method.get_state_value_with_version_by_version
+    fn get_state_value_with_version_by_version(
+        &self,
+        state_key: &StateKey,
+        version: Version,
+    ) -> Result<Option<(Version, StateValue)>> {
         unimplemented!()
     }
 
@@ -641,6 +656,7 @@ pub trait DbWriter: Send + Sync {
         sync_commit: bool,
         latest_in_memory_state: StateDelta,
         block_state_updates: HashMap<StateKey, Option<StateValue>>,
+        sharded_state_cache: &ShardedStateCache,
     ) -> Result<()> {
         unimplemented!()
     }

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -54,6 +54,16 @@ impl DbReader for MockDbReaderWriter {
             _ => Err(anyhow!("Not supported state key type {:?}", state_key)),
         }
     }
+
+    fn get_state_value_with_version_by_version(
+        &self,
+        state_key: &StateKey,
+        version: Version,
+    ) -> Result<Option<(Version, StateValue)>> {
+        Ok(self
+            .get_state_value_by_version(state_key, version)?
+            .map(|value| (version, value)))
+    }
 }
 
 fn get_mock_account_state() -> AccountState {


### PR DESCRIPTION
### Description

Produce state cache in a sharded way during block execution, and pass it to commit stage to save the read operations.

The improvements are various, depending on the traffic pattern.

In general, two improvements:
1. It eliminates the calculation to produce the sharded state cache, so in some benchmark (e.g. batch100-transfer with native vm, we see a 10+% speed up in execution phase).
2. It reduces the # of storage read at commit stage. (depending on the traffic pattern, the counter shows up to 70%+ of reduction)

Also see below for an account creation benchmark (0->20M), left side has this PR, right side is the baseline.
<img width="1019" alt="Screen Shot 2023-05-12 at 10 48 36 PM" src="https://github.com/aptos-labs/aptos-core/assets/3603304/70716d4b-25b2-4620-85bc-8302d19e5641">

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
