### PR TITLE
[move-prover] on different theories for vector modeling

### DIFF
--- a/third_party/move/move-prover/tests/sources/regression/vector_theory_boogie_array.exp
+++ b/third_party/move/move-prover/tests/sources/regression/vector_theory_boogie_array.exp
@@ -1,0 +1,20 @@
+Move prover returns: exiting with verification errors
+error: post-condition does not hold
+   ┌─ tests/sources/regression/vector_theory_boogie_array.move:14:9
+   │
+14 │ ╭         ensures forall a: address where a != addr:
+15 │ │             old(contains(pool, a)) ==> contains(pool, a);
+   │ ╰─────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/regression/vector_theory_boogie_array.move:6: f1
+   =     at tests/sources/regression/vector_theory_boogie_array.move:11: f1 (spec)
+   =     at tests/sources/regression/vector_theory_boogie_array.move:6: f1
+   =         pool = <redacted>
+   =         addr = <redacted>
+   =     at tests/sources/regression/vector_theory_boogie_array.move:7: f1
+   =         idx = <redacted>
+   =     at tests/sources/regression/vector_theory_boogie_array.move:8: f1
+   =         pool = <redacted>
+   =     at tests/sources/regression/vector_theory_boogie_array.move:9: f1
+   =     at tests/sources/regression/vector_theory_boogie_array.move:11: f1 (spec)
+   =     at tests/sources/regression/vector_theory_boogie_array.move:14: f1 (spec)

--- a/third_party/move/move-prover/tests/sources/regression/vector_theory_boogie_array.move
+++ b/third_party/move/move-prover/tests/sources/regression/vector_theory_boogie_array.move
@@ -1,0 +1,37 @@
+// flag: --vector-theory=BoogieArray
+module 0x42::test {
+    use std::vector;
+    use extensions::table::{Self, Table};
+
+    fun f1(pool: &mut vector<address>, addr: address) {
+        let (_, idx) = vector::index_of(pool, &addr);
+        vector::remove(pool, idx);
+    }
+    spec f1 {
+        invariant forall i in 0..len(pool), j in 0..len(pool):
+            (pool[i] == pool[j]) ==> (i == j);
+
+        ensures forall a: address where a != addr:
+            old(contains(pool, a)) ==> contains(pool, a);
+    }
+
+    struct Pool {
+        shares: Table<address, u64>,
+        holders: vector<address>,
+    }
+
+    fun f2(pool: &mut Pool, addr: address) {
+        table::remove(&mut pool.shares, addr);
+        let (_, idx) = vector::index_of(&pool.holders, &addr);
+        vector::remove(&mut pool.holders, idx);
+    }
+    spec f2 {
+        invariant forall i in 0..len(pool.holders), j in 0..len(pool.holders):
+            pool.holders[i] == pool.holders[j] ==> i == j;
+
+        invariant forall addr: address:
+            (table::spec_contains(pool.shares, addr) <==> contains(pool.holders, addr));
+
+        pragma verify = false;  // timeout with the default array theory
+    }
+}

--- a/third_party/move/move-prover/tests/sources/regression/vector_theory_boogie_array_intern.move
+++ b/third_party/move/move-prover/tests/sources/regression/vector_theory_boogie_array_intern.move
@@ -1,0 +1,35 @@
+// flag: --vector-theory=BoogieArrayIntern
+module 0x42::test {
+    use std::vector;
+    use extensions::table::{Self, Table};
+
+    fun f1(pool: &mut vector<address>, addr: address) {
+        let (_, idx) = vector::index_of(pool, &addr);
+        vector::remove(pool, idx);
+    }
+    spec f1 {
+        invariant forall i in 0..len(pool), j in 0..len(pool):
+            (pool[i] == pool[j]) ==> (i == j);
+
+        ensures forall a: address where a != addr:
+            old(contains(pool, a)) ==> contains(pool, a);
+    }
+
+    struct Pool {
+        shares: Table<address, u64>,
+        holders: vector<address>,
+    }
+
+    fun f2(pool: &mut Pool, addr: address) {
+        table::remove(&mut pool.shares, addr);
+        let (_, idx) = vector::index_of(&pool.holders, &addr);
+        vector::remove(&mut pool.holders, idx);
+    }
+    spec f2 {
+        invariant forall i in 0..len(pool.holders), j in 0..len(pool.holders):
+            pool.holders[i] == pool.holders[j] ==> i == j;
+
+        invariant forall addr: address:
+            (table::spec_contains(pool.shares, addr) <==> contains(pool.holders, addr));
+    }
+}

--- a/third_party/move/move-prover/tests/sources/regression/vector_theory_smt_seq.move
+++ b/third_party/move/move-prover/tests/sources/regression/vector_theory_smt_seq.move
@@ -1,0 +1,35 @@
+// flag: --vector-theory=SmtSeq
+module 0x42::test {
+    use std::vector;
+    use extensions::table::{Self, Table};
+
+    fun f1(pool: &mut vector<address>, addr: address) {
+        let (_, idx) = vector::index_of(pool, &addr);
+        vector::remove(pool, idx);
+    }
+    spec f1 {
+        invariant forall i in 0..len(pool), j in 0..len(pool):
+            (pool[i] == pool[j]) ==> (i == j);
+
+        ensures forall a: address where a != addr:
+            old(contains(pool, a)) ==> contains(pool, a);
+    }
+
+    struct Pool {
+        shares: Table<address, u64>,
+        holders: vector<address>,
+    }
+
+    fun f2(pool: &mut Pool, addr: address) {
+        table::remove(&mut pool.shares, addr);
+        let (_, idx) = vector::index_of(&pool.holders, &addr);
+        vector::remove(&mut pool.holders, idx);
+    }
+    spec f2 {
+        invariant forall i in 0..len(pool.holders), j in 0..len(pool.holders):
+            pool.holders[i] == pool.holders[j] ==> i == j;
+
+        invariant forall addr: address:
+            (table::spec_contains(pool.shares, addr) <==> contains(pool.holders, addr));
+    }
+}


### PR DESCRIPTION
This PR contains two test cases to show how vector theories might have an impact on the prover's ability on proving complicated propositions w.r.t vector, especially with heavy involvement of quantifiers:

- On test case `f1`:
  - `BoogieArray` (the default vector theory) will given a verification error with an inconsistent counterexample while
  - `BoogieArrayIntern` and `SmtSeq` can prove the proposition

- On test case `f2`:
  - `BoogieArray` times out while
  - `BoogieArrayIntern` and `SmtSeq` can prove the proposition

Addressing issue #7422 

### Test Plan
CI
