### PR TITLE
[Fix] Handle reconfig suffix blocks.

### DIFF
--- a/execution/executor-types/src/executed_block.rs
+++ b/execution/executor-types/src/executed_block.rs
@@ -41,7 +41,6 @@ impl ExecutedBlock {
         Self {
             result_view: self.result_view.clone(),
             next_epoch_state: self.next_epoch_state.clone(),
-            block_state_updates: self.block_state_updates.clone(),
             ..Default::default()
         }
     }

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1981,12 +1981,13 @@ impl DbWriter for AptosDB {
                     ledger_info_with_sigs,
                 )?;
 
-                let is_reconfig = txns_to_commit.last().map_or(false, |txn| txn.is_reconfig());
-                buffered_state.update(
-                    Some(block_state_updates),
-                    latest_in_memory_state,
-                    sync_commit || is_reconfig,
-                )?;
+                if !txns_to_commit.is_empty() {
+                    buffered_state.update(
+                        Some(block_state_updates),
+                        latest_in_memory_state,
+                        sync_commit || txns_to_commit.last().unwrap().is_reconfig(),
+                    )?;
+                }
             }
 
             self.post_commit(txns_to_commit, first_version, ledger_info_with_sigs)


### PR DESCRIPTION
### Description
Should pass empty state updates for reconfig suffix blocks.
Also skip the state commit if the block is empty.

### Test Plan
New UT.
