### PR TITLE
[TF] Add variable "bootstrap_cluster" to GCP base module

### DIFF
--- a/terraform/aptos-node-testnet/gcp/main.tf
+++ b/terraform/aptos-node-testnet/gcp/main.tf
@@ -17,7 +17,8 @@ provider "helm" {
 module "validator" {
   source = "../../aptos-node/gcp"
 
-  manage_via_tf = var.manage_via_tf
+  cluster_bootstrap = var.cluster_bootstrap
+  manage_via_tf     = var.manage_via_tf
 
   # Project config
   project = var.project

--- a/terraform/aptos-node-testnet/gcp/variables.tf
+++ b/terraform/aptos-node-testnet/gcp/variables.tf
@@ -1,5 +1,11 @@
 ### Project config
 
+variable "cluster_bootstrap" {
+  description = "Set when bootstrapping a new cluster"
+  type        = bool
+  default     = false
+}
+
 variable "project" {
   description = "GCP project"
   type        = string

--- a/terraform/aptos-node/gcp/security.tf
+++ b/terraform/aptos-node/gcp/security.tf
@@ -1,6 +1,8 @@
 # Security-related resources
 
-data "kubernetes_all_namespaces" "all" {}
+data "kubernetes_all_namespaces" "all" {
+  count = var.cluster_bootstrap ? 0 : 1
+}
 
 locals {
   kubernetes_master_version = substr(google_container_cluster.aptos.master_version, 0, 4)
@@ -11,9 +13,9 @@ locals {
   }
 }
 
-# FIXME: Remove when migrating to K8s 1.25
+# FIXME: Remove after migration to K8s 1.25
 resource "kubernetes_role_binding" "disable-psp" {
-  for_each = toset(local.kubernetes_master_version <= "1.24" ? data.kubernetes_all_namespaces.all.namespaces : [])
+  for_each = toset(var.cluster_bootstrap ? [] : local.kubernetes_master_version <= "1.24" ? data.kubernetes_all_namespaces.all[0].namespaces : [])
   metadata {
     name      = "privileged-psp"
     namespace = each.value

--- a/terraform/aptos-node/gcp/variables.tf
+++ b/terraform/aptos-node/gcp/variables.tf
@@ -1,3 +1,11 @@
+### Project config
+
+variable "cluster_bootstrap" {
+  description = "Set when bootstrapping a new cluster"
+  type        = bool
+  default     = false
+}
+
 variable "project" {
   description = "GCP project"
   type        = string


### PR DESCRIPTION
# Description

The module uses data.kubernetes_all_namespaces to dynamically get the list of all namespaces, but that can only be done after a cluster has been turned up.
On cluster creation, TF attempts to connect to the K8s control place to fetch the list of namespaces, and fails.

The solution is to split cluster bootstrap in two phases. This is only necessary while we're in the middle of the migration from PSP to PSS.
Once all clusters have been upgraded to PSS and K8s version >=1.25, the bootstrapping dance can be removed.

# Test plan

Tested by turning up a GCP devnet.