### PR TITLE
clean up the metadata APIs

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -599,9 +599,11 @@ impl AptosVMImpl {
         module: &ModuleId,
     ) -> Option<RuntimeModuleMetadataV1> {
         if self.features.is_enabled(FeatureFlag::VM_BINARY_FORMAT_V6) {
-            aptos_framework::get_vm_metadata(&self.move_vm.get_ref(), module)
+            self.move_vm
+                .get_module_metadata(module, |md| aptos_framework::get_metadata(md?))
         } else {
-            aptos_framework::get_vm_metadata_v0(&self.move_vm.get_ref(), module)
+            self.move_vm
+                .get_module_metadata(module, |md| aptos_framework::get_metadata_v0(md?))
         }
     }
 

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -108,6 +108,7 @@ impl MoveVmExt {
         self.inner.flush_loader_cache_if_invalidated();
 
         SessionExt::new(
+            self,
             self.inner.new_session_with_extensions(remote, extensions),
             remote,
         )

--- a/aptos-move/framework/src/module_metadata.rs
+++ b/aptos-move/framework/src/module_metadata.rs
@@ -14,7 +14,6 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
     metadata::Metadata,
 };
-use move_vm_runtime::move_vm::MoveVMRef;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use thiserror::Error;
@@ -136,16 +135,6 @@ pub fn get_metadata_v0(md: &[Metadata]) -> Option<RuntimeModuleMetadataV1> {
     } else {
         None
     }
-}
-
-/// Extract metadata from the VM, upgrading V0 to V1 representation as needed
-pub fn get_vm_metadata(vm: &MoveVMRef, module_id: &ModuleId) -> Option<RuntimeModuleMetadataV1> {
-    vm.with_module_metadata(module_id, get_metadata)
-}
-
-/// Extract metadata from the VM, legacy V0 format upgraded to V1
-pub fn get_vm_metadata_v0(vm: &MoveVMRef, module_id: &ModuleId) -> Option<RuntimeModuleMetadataV1> {
-    vm.with_module_metadata(module_id, get_metadata_v0)
 }
 
 /// Check if the metadata has unknown key/data types

--- a/third_party/move/move-vm/runtime/src/move_vm.rs
+++ b/third_party/move/move-vm/runtime/src/move_vm.rs
@@ -20,10 +20,6 @@ pub struct MoveVM {
     runtime: VMRuntime,
 }
 
-pub struct MoveVMRef<'a> {
-    runtime: &'a VMRuntime,
-}
-
 impl MoveVM {
     pub fn new(
         natives: impl IntoIterator<Item = (AccountAddress, Identifier, Identifier, NativeFunction)>,
@@ -111,33 +107,14 @@ impl MoveVM {
         self.runtime.loader().get_and_clear_module_cache_hits()
     }
 
-    pub fn get_ref(&self) -> MoveVMRef {
-        MoveVMRef::new(&self.runtime)
-    }
-}
-
-impl<'l> MoveVMRef<'l> {
-    pub(crate) fn new(runtime: &'l VMRuntime) -> Self {
-        Self { runtime }
-    }
-
-    /// Attempts to discover metadata in a given module with given key. Availability
-    /// of this data may depend on multiple aspects. In general, no hard assumptions of
-    /// availability should be made, but typically, one can expect that
-    /// the modules which have been involved in the execution of the last session are available.
-    ///
-    /// This is called by an adapter to extract, for example, debug information out of
-    /// the metadata section of the code for post mortem analysis. Notice that because
-    /// of ownership of the underlying binary representation of modules hidden behind an rwlock,
-    /// this actually has to hand back a copy of the associated metadata, so metadata should
-    /// be organized keeping this in mind.
-    ///
-    /// TODO: in the new loader architecture, as the loader is visible to the adapter, one would
-    ///   call this directly via the loader instead of the VM.
-    pub fn with_module_metadata<T, F>(&self, module: &ModuleId, f: F) -> Option<T>
+    pub fn get_module_metadata<F, R>(&self, module_id: &ModuleId, f: F) -> R
     where
-        F: FnOnce(&[Metadata]) -> Option<T>,
+        F: FnOnce(Option<&[Metadata]>) -> R,
     {
-        f(&self.runtime.loader().get_module(module)?.module().metadata)
+        if let Some(m) = self.runtime.loader().get_module(module_id) {
+            f(Some(m.module().metadata.as_slice()))
+        } else {
+            f(None)
+        }
     }
 }

--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_cache::TransactionDataCache, loader::LoadedFunction, move_vm::MoveVMRef,
+    data_cache::TransactionDataCache, loader::LoadedFunction,
     native_extensions::NativeContextExtensions, runtime::VMRuntime,
 };
 use move_binary_format::{
@@ -17,6 +17,7 @@ use move_core_types::{
     gas_algebra::NumBytes,
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
+    metadata::Metadata,
     value::MoveTypeLayout,
 };
 use move_vm_types::{
@@ -388,8 +389,15 @@ impl<'r, 'l> Session<'r, 'l> {
         &mut self.native_extensions
     }
 
-    pub fn get_movevm(&self) -> MoveVMRef<'l> {
-        MoveVMRef::new(self.runtime)
+    pub fn get_module_metadata<'a, F, R>(&'a self, module_id: &ModuleId, f: F) -> R
+    where
+        F: FnOnce(Option<&[Metadata]>) -> R,
+    {
+        if let Some(m) = self.runtime.loader().get_module(module_id) {
+            f(Some(m.module().metadata.as_slice()))
+        } else {
+            f(None)
+        }
     }
 }
 


### PR DESCRIPTION
### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6528779</samp>

This pull request removes the `MoveVMRef` struct and refactors the code to use the `MoveVM` struct directly in various files. This simplifies the code and avoids unnecessary indirection when accessing the module metadata. It also adds a new method `get_module_metadata` to the `Session` and `MoveVMExt` structs.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
