### PR TITLE
[TS] Added a missing dependency

### DIFF
--- a/ecosystem/typescript/sdk/examples/typescript/package.json
+++ b/ecosystem/typescript/sdk/examples/typescript/package.json
@@ -20,7 +20,7 @@
     "aptos": "latest",
     "dotenv": "16.0.1",
     "ffi-napi": "^4.0.3",
-    "ref-array-di": "^1.2.2"
+    "node-gyp": "9.3.1"
   },
   "devDependencies": {
     "@types/ffi-napi": "^4.0.7",


### PR DESCRIPTION
### Description

- Added "node-gyp": "9.3.1" because it is required in building when using node 20
- Removed "ref-array-di": "^1.2.2" because it's not used any longer.

### Test Plan
pnpm i