### PR TITLE
[docker] release faucet image

### DIFF
--- a/docker/release-images.mjs
+++ b/docker/release-images.mjs
@@ -51,6 +51,11 @@ const IMAGES_TO_RELEASE = {
       Features.Indexer,
     ],
   },
+  faucet: {
+    release: [
+      Features.Default,
+    ],
+  },
   forge: {
     release: [
       Features.Default,


### PR DESCRIPTION
### Description

Add `faucet` to list of images to mirror to DockerHub nightly and on releases.

### Test Plan

CI

<!-- Please provide us with clear details for verifying that your changes work. -->
