### PR TITLE
[single node benchmark] Breakdown of time spent across phases

### DIFF
--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -21,7 +21,13 @@ use crate::{
 };
 use aptos_config::config::{NodeConfig, PrunerConfig};
 use aptos_db::AptosDB;
-use aptos_executor::block_executor::{BlockExecutor, TransactionBlockExecutor};
+use aptos_executor::{
+    block_executor::{BlockExecutor, TransactionBlockExecutor},
+    metrics::{
+        APTOS_EXECUTOR_COMMIT_BLOCKS_SECONDS, APTOS_EXECUTOR_EXECUTE_BLOCK_SECONDS,
+        APTOS_EXECUTOR_OTHER_TIMERS_SECONDS, APTOS_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS,
+    },
+};
 use aptos_jellyfish_merkle::metrics::{
     APTOS_JELLYFISH_INTERNAL_ENCODED_BYTES, APTOS_JELLYFISH_LEAF_ENCODED_BYTES,
 };
@@ -34,6 +40,7 @@ use aptos_vm::counters::TXN_GAS_USAGE;
 use gen_executor::DbGenInitTransactionExecutor;
 use pipeline::PipelineConfig;
 use std::{
+    collections::HashMap,
     fs,
     path::Path,
     sync::{atomic::AtomicUsize, Arc},
@@ -146,6 +153,37 @@ pub fn run_benchmark<V>(
 
     let mut start_time = Instant::now();
     let start_gas = TXN_GAS_USAGE.get_sample_sum();
+
+    let start_execution_total = APTOS_EXECUTOR_EXECUTE_BLOCK_SECONDS.get_sample_sum();
+    let start_vm_only = APTOS_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS.get_sample_sum();
+    let other_labels = vec![
+        ("1.", true, "verified_state_view"),
+        ("2.", true, "apply_to_ledger"),
+        ("2.1.", false, "sort_transactions"),
+        ("2.2.", false, "calculate_for_transaction_block"),
+        ("2.2.1.", false, "get_sharded_state_updates"),
+        ("2.2.2.", false, "calculate_block_state_updates"),
+        ("2.2.3.", false, "calculate_usage"),
+        ("2.2.4.", false, "make_checkpoint"),
+        ("2.3.", false, "assemble_ledger_diff_for_block"),
+        ("2.3.1.", false, "calculate_events_and_writeset_hashes"),
+        ("3.", true, "as_state_compute_result"),
+        ("4.", true, "get_txns_to_commit"),
+    ];
+
+    let start_by_other = other_labels
+        .iter()
+        .map(|(_prefix, _top_level, other_label)| {
+            (
+                other_label.to_string(),
+                APTOS_EXECUTOR_OTHER_TIMERS_SECONDS
+                    .with_label_values(&[other_label])
+                    .get_sample_sum(),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    let start_commit_total = APTOS_EXECUTOR_COMMIT_BLOCKS_SECONDS.get_sample_sum();
+
     if let Some(transaction_generator_creator) = transaction_generator_creator {
         generator.run_workload(
             block_size,
@@ -163,8 +201,8 @@ pub fn run_benchmark<V>(
     generator.drop_sender();
     pipeline.join();
 
-    let elapsed = start_time.elapsed().as_secs_f32();
-    let delta_v = db.reader.get_latest_version().unwrap() - version;
+    let elapsed = start_time.elapsed().as_secs_f64();
+    let delta_v = (db.reader.get_latest_version().unwrap() - version) as f64;
     let delta_gas = TXN_GAS_USAGE.get_sample_sum() - start_gas;
     info!(
         "Executed workload {}",
@@ -174,8 +212,43 @@ pub fn run_benchmark<V>(
             "raw transfer".to_string()
         }
     );
-    info!("Overall TPS: {} txn/s", delta_v as f32 / elapsed);
-    info!("Overall GPS: {} gas/s", delta_gas as f32 / elapsed);
+    info!("Overall TPS: {} txn/s", delta_v / elapsed);
+    info!("Overall GPS: {} gas/s", delta_gas / elapsed);
+
+    let time_in_execution =
+        APTOS_EXECUTOR_EXECUTE_BLOCK_SECONDS.get_sample_sum() - start_execution_total;
+    info!(
+        "Overall fraction of total: {:.3} in execution (component TPS: {})",
+        time_in_execution / elapsed,
+        delta_v / time_in_execution
+    );
+    let time_in_vm = APTOS_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS.get_sample_sum() - start_vm_only;
+    info!(
+        "Overall fraction of execution {:.3} in VM (component TPS: {})",
+        time_in_vm / time_in_execution,
+        delta_v / time_in_vm
+    );
+    for (prefix, top_level, other_label) in other_labels {
+        let time_in_label = APTOS_EXECUTOR_OTHER_TIMERS_SECONDS
+            .with_label_values(&[other_label])
+            .get_sample_sum()
+            - start_by_other.get(other_label).unwrap();
+        if top_level || time_in_label / time_in_execution > 0.01 {
+            info!(
+                "Overall fraction of execution {:.3} in {} {} (component TPS: {})",
+                time_in_label / time_in_execution,
+                prefix,
+                other_label,
+                delta_v / time_in_label
+            );
+        }
+    }
+    let time_in_commit = APTOS_EXECUTOR_COMMIT_BLOCKS_SECONDS.get_sample_sum() - start_commit_total;
+    info!(
+        "Overall fraction of total: {:.3} in commit (component TPS: {})",
+        time_in_commit / elapsed,
+        delta_v / time_in_commit
+    );
 
     if verify_sequence_numbers {
         generator.verify_sequence_numbers(db.reader);

--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -3,12 +3,14 @@
 # Copyright © Aptos Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-import subprocess
 import re
 import os
 import tempfile
 import json
+from typing import Callable, Optional, Tuple, Mapping, Sequence
 from tabulate import tabulate
+from subprocess import Popen, PIPE, CalledProcessError
+from dataclasses import dataclass
 
 
 # numbers are based on the machine spec used by github action
@@ -66,8 +68,8 @@ if os.environ.get("DETAILED"):
 else:
     EXECUTION_ONLY_CONCURRENCY_LEVELS = []
 
-if os.environ.get("DEFAULT_BUILD"):
-    BUILD_FLAG = ""  # "--release"
+if os.environ.get("RELEASE_BUILD"):
+    BUILD_FLAG = "--release"
 else:
     BUILD_FLAG = "--profile performance"
 
@@ -76,16 +78,132 @@ target_directory = "execution/executor-benchmark/src"
 
 
 def execute_command(command):
-    try:
-        output = subprocess.check_output(
-            command, shell=True, text=True, cwd=target_directory
-        )
-    except subprocess.CalledProcessError as e:
-        print(e.output)
-        raise e
+    result = []
+    with Popen(
+        command,
+        shell=True,
+        text=True,
+        cwd=target_directory,
+        stdout=PIPE,
+        bufsize=1,
+        universal_newlines=True,
+    ) as p:
+        # stream to output while command is executing
+        for line in p.stdout:
+            print(line, end="")
+            result.append(line)
 
-    print(output)
-    return output
+    if p.returncode != 0:
+        raise CalledProcessError(p.returncode, p.args)
+
+    # return the full output in the end for postprocessing
+    return "\n".join(result)
+
+
+@dataclass
+class RunGroupKey:
+    transaction_type: str
+    module_working_set_size: int
+    executor_type: str
+
+
+@dataclass
+class RunResults:
+    tps: float
+    gps: float
+    fraction_in_execution: float
+    fraction_of_execution_in_vm: float
+    fraction_in_commit: float
+
+
+@dataclass
+class RunGroupInstance:
+    key: RunGroupKey
+    single_node_result: RunResults
+    concurrency_level_results: Mapping[int, RunResults]
+    block_size: int
+    expected_tps: float
+
+
+def extract_run_results(output: str, execution_only: bool) -> RunResults:
+    if execution_only:
+        tps = float(re.findall(r"Overall execution TPS: (\d+\.?\d*) txn/s", output)[-1])
+        gps = float(re.findall(r"Overall execution GPS: (\d+\.?\d*) gas/s", output)[-1])
+    else:
+        tps = float(re.findall(r"Overall TPS: (\d+\.?\d*) txn/s", output)[0])
+        gps = float(re.findall(r"Overall GPS: (\d+\.?\d*) gas/s", output)[-1])
+
+    fraction_in_execution = float(
+        re.findall(r"Overall fraction of total: (\d+\.?\d*) in execution", output)[-1]
+    )
+    fraction_of_execution_in_vm = float(
+        re.findall(r"Overall fraction of execution (\d+\.?\d*) in VM", output)[-1]
+    )
+    fraction_in_commit = float(
+        re.findall(r"Overall fraction of total: (\d+\.?\d*) in commit", output)[-1]
+    )
+
+    return RunResults(
+        tps, gps, fraction_in_execution, fraction_of_execution_in_vm, fraction_in_commit
+    )
+
+
+def print_table(
+    results: Sequence[RunGroupInstance],
+    by_levels: bool,
+    single_field: Optional[Tuple[str, Callable[[RunResults], any]]],
+    concurrency_levels=EXECUTION_ONLY_CONCURRENCY_LEVELS,
+):
+    headers = [
+        "transaction_type",
+        "module_working_set",
+        "executor",
+        "block_size",
+        "expected t/s",
+    ]
+    if by_levels:
+        headers.extend(
+            [
+                f"exe_only {concurrency_level}"
+                for concurrency_level in concurrency_levels
+            ]
+        )
+        assert single_field is not None
+
+    if single_field is not None:
+        field_name, _ = single_field
+        headers.append(field_name)
+    else:
+        headers.extend(["t/s", "exe/total", "vm/exe", "commit/total", "g/s"])
+
+    rows = []
+    for result in results:
+        row = [
+            result.key.transaction_type,
+            result.key.module_working_set_size,
+            result.key.executor_type,
+            result.block_size,
+            result.expected_tps,
+        ]
+        if by_levels:
+            _, field_getter = single_field
+            for concurrency_level in concurrency_levels:
+                row.append(
+                    field_getter(result.concurrency_level_results[concurrency_level])
+                )
+
+        if single_field is not None:
+            _, field_getter = single_field
+            row.append(field_getter(result.single_node_result))
+        else:
+            row.append(int(round(result.single_node_result.tps)))
+            row.append(round(result.single_node_result.fraction_in_execution, 3))
+            row.append(round(result.single_node_result.fraction_of_execution_in_vm, 3))
+            row.append(round(result.single_node_result.fraction_in_commit, 3))
+            row.append(int(round(result.single_node_result.gps)))
+        rows.append(row)
+
+    print(tabulate(rows, headers=headers))
 
 
 errors = []
@@ -95,11 +213,7 @@ with tempfile.TemporaryDirectory() as tmpdirname:
     create_db_command = f"cargo run {BUILD_FLAG} -- --block-size {BLOCK_SIZE} --concurrency-level {CONCURRENCY_LEVEL} --use-state-kv-db --use-sharded-state-merkle-db create-db --data-dir {tmpdirname}/db --num-accounts {NUM_ACCOUNTS}"
     output = execute_command(create_db_command)
 
-    achieved_tps = {}
-    achieved_gps = {}
-
-    rows = []
-    gas_rows = []
+    results = []
 
     for (transaction_type, use_native_executor, module_working_set_size), (
         expected_tps,
@@ -108,48 +222,38 @@ with tempfile.TemporaryDirectory() as tmpdirname:
         print(f"Testing {transaction_type}")
         cur_block_size = int(min([expected_tps, BLOCK_SIZE]))
 
-        achieved_tps[transaction_type] = {}
-        achieved_gps[transaction_type] = {}
-        use_native_executor_row_str = "native" if use_native_executor else "VM"
-        row = [
-            transaction_type,
-            module_working_set_size,
-            use_native_executor_row_str,
-            cur_block_size,
-            expected_tps,
-        ]
-        gas_row = [
-            transaction_type,
-            module_working_set_size,
-            use_native_executor_row_str,
-            cur_block_size,
-        ]
+        executor_type = "native" if use_native_executor else "VM"
 
         use_native_executor_str = "--use-native-executor" if use_native_executor else ""
         common_command_suffix = f"{use_native_executor_str} --generate-then-execute --transactions-per-sender 1 --block-size {cur_block_size} --use-state-kv-db --use-sharded-state-merkle-db run-executor --transaction-type {transaction_type} --module-working-set-size {module_working_set_size} --main-signer-accounts {MAIN_SIGNER_ACCOUNTS} --additional-dst-pool-accounts {ADDITIONAL_DST_POOL_ACCOUNTS} --data-dir {tmpdirname}/db  --checkpoint-dir {tmpdirname}/cp"
+
+        concurrency_level_results = {}
+
         for concurrency_level in EXECUTION_ONLY_CONCURRENCY_LEVELS:
             test_db_command = f"cargo run {BUILD_FLAG} -- --concurrency-level {concurrency_level}  --skip-commit {common_command_suffix} --blocks {NUM_BLOCKS_DETAILED}"
             output = execute_command(test_db_command)
 
-            tps = float(
-                re.findall(r"Overall execution TPS: (\d+\.?\d*) txn/s", output)[-1]
+            concurrency_level_results[concurrency_level] = extract_run_results(
+                output, execution_only=True
             )
-            gps = float(
-                re.findall(r"Overall execution GPS: (\d+\.?\d*) gas/s", output)[-1]
-            )
-
-            achieved_tps[transaction_type][concurrency_level] = tps
-            achieved_gps[transaction_type][concurrency_level] = gps
-            row.append(int(round(tps)))
-            gas_row.append(int(round(gps)))
 
         test_db_command = f"cargo run {BUILD_FLAG} -- --concurrency-level {CONCURRENCY_LEVEL} {common_command_suffix} --blocks {NUM_BLOCKS}"
         output = execute_command(test_db_command)
 
-        tps = float(re.findall(r"Overall TPS: (\d+\.?\d*) txn/s", output)[0])
-        gps = float(re.findall(r"Overall GPS: (\d+\.?\d*) gas/s", output)[-1])
-        achieved_tps[transaction_type][0] = tps
-        achieved_gps[transaction_type][0] = gps
+        current_run_key = RunGroupKey(
+            transaction_type, module_working_set_size, executor_type
+        )
+        single_node_result = extract_run_results(output, execution_only=False)
+
+        results.append(
+            RunGroupInstance(
+                key=current_run_key,
+                single_node_result=single_node_result,
+                concurrency_level_results=concurrency_level_results,
+                block_size=cur_block_size,
+                expected_tps=expected_tps,
+            )
+        )
 
         # line to be able to aggreate and visualize in Humio
         print(
@@ -158,69 +262,51 @@ with tempfile.TemporaryDirectory() as tmpdirname:
                     "grep": "grep_json_single_node_perf",
                     "transaction_type": transaction_type,
                     "module_working_set_size": module_working_set_size,
-                    "executor_type": use_native_executor_row_str,
+                    "executor_type": executor_type,
                     "block_size": cur_block_size,
                     "expected_tps": expected_tps,
-                    "tps": tps,
-                    "gps": gps,
+                    "tps": single_node_result.tps,
+                    "gps": single_node_result.gps,
                     "code_perf_version": CODE_PERF_VERSION,
                 }
             )
         )
 
-        row.append(int(round(tps)))
-        gas_row.append(int(round(gps)))
-
-        rows.append(row)
-        gas_rows.append(gas_row)
-
-        print(
-            tabulate(
-                rows,
-                headers=[
-                    "transaction_type",
-                    "module_working_set",
-                    "executor",
-                    "block_size",
-                    "expected t/s",
-                ]
-                + [
-                    f"exe_only {concurrency_level}"
-                    for concurrency_level in EXECUTION_ONLY_CONCURRENCY_LEVELS
-                ]
-                + ["t/s"],
-            )
+        print_table(
+            results, by_levels=True, single_field=("t/s", lambda r: int(round(r.tps)))
         )
-
-        print(
-            tabulate(
-                gas_rows,
-                headers=["transaction_type", "executor", "block_size"]
-                + [
-                    f"exe_only {concurrency_level}"
-                    for concurrency_level in EXECUTION_ONLY_CONCURRENCY_LEVELS
-                ]
-                + ["g/s"],
-            )
+        print_table(
+            results, by_levels=True, single_field=("g/s", lambda r: int(round(r.gps)))
         )
+        print_table(
+            results,
+            by_levels=True,
+            single_field=("exe/total", lambda r: round(r.fraction_in_execution, 3)),
+        )
+        print_table(
+            results,
+            by_levels=True,
+            single_field=("vm/exe", lambda r: round(r.fraction_of_execution_in_vm, 3)),
+        )
+        print_table(results, by_levels=False, single_field=None)
 
-        if tps < expected_tps * NOISE_LOWER_LIMIT:
-            text = f"regression detected {tps} < {expected_tps * NOISE_LOWER_LIMIT} = {expected_tps} * {NOISE_LOWER_LIMIT}, {transaction_type} with {use_native_executor_row_str} executor didn't meet TPS requirements"
+        if single_node_result.tps < expected_tps * NOISE_LOWER_LIMIT:
+            text = f"regression detected {single_node_result.tps} < {expected_tps * NOISE_LOWER_LIMIT} = {expected_tps} * {NOISE_LOWER_LIMIT}, {current_run_key} didn't meet TPS requirements"
             if check_active:
                 errors.append(text)
             else:
                 warnings.append(text)
-        elif tps < expected_tps * NOISE_LOWER_LIMIT_WARN:
-            text = f"potential (but within normal noise) regression detected {tps} < {expected_tps * NOISE_LOWER_LIMIT_WARN} = {expected_tps} * {NOISE_LOWER_LIMIT_WARN}, {transaction_type} with {use_native_executor_row_str} executor didn't meet TPS requirements"
+        elif single_node_result.tps < expected_tps * NOISE_LOWER_LIMIT_WARN:
+            text = f"potential (but within normal noise) regression detected {single_node_result.tps} < {expected_tps * NOISE_LOWER_LIMIT_WARN} = {expected_tps} * {NOISE_LOWER_LIMIT_WARN}, {current_run_key} didn't meet TPS requirements"
             warnings.append(text)
-        elif tps > expected_tps * NOISE_UPPER_LIMIT:
-            text = f"perf improvement detected {tps} > {expected_tps * NOISE_UPPER_LIMIT} = {expected_tps} * {NOISE_UPPER_LIMIT}, {transaction_type} with {use_native_executor_row_str} executor exceeded TPS requirements, increase TPS requirements to match new baseline"
+        elif single_node_result.tps > expected_tps * NOISE_UPPER_LIMIT:
+            text = f"perf improvement detected {single_node_result.tps} > {expected_tps * NOISE_UPPER_LIMIT} = {expected_tps} * {NOISE_UPPER_LIMIT}, {current_run_key} exceeded TPS requirements, increase TPS requirements to match new baseline"
             if check_active:
                 errors.append(text)
             else:
                 warnings.append(text)
-        elif tps > expected_tps * NOISE_UPPER_LIMIT_WARN:
-            text = f"potential (but within normal noise) perf improvement detected {tps} > {expected_tps * NOISE_UPPER_LIMIT_WARN} = {expected_tps} * {NOISE_UPPER_LIMIT_WARN}, {transaction_type} with {use_native_executor_row_str} executor exceeded TPS requirements, increase TPS requirements to match new baseline"
+        elif single_node_result.tps > expected_tps * NOISE_UPPER_LIMIT_WARN:
+            text = f"potential (but within normal noise) perf improvement detected {single_node_result.tps} > {expected_tps * NOISE_UPPER_LIMIT_WARN} = {expected_tps} * {NOISE_UPPER_LIMIT_WARN}, {current_run_key} exceeded TPS requirements, increase TPS requirements to match new baseline"
             warnings.append(text)
 
 if warnings:


### PR DESCRIPTION
### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 741d478</samp>

This pull request enhances the executor benchmark and its testing script. It adds metrics and logging to `lib.rs` to measure and report the executor performance. It also refactors and improves `single_node_performance.py` to run, parse, and print the benchmark output more efficiently and clearly. It also lowers the benchmark size for faster testing.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
