### PR TITLE
[Docker] Pin also libtinfo6 Debian package

### DIFF
--- a/docker/experimental/tools.Dockerfile
+++ b/docker/experimental/tools.Dockerfile
@@ -11,6 +11,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     wget \
     curl \
     perl-base=5.32.1-4+deb11u1 \
+    libtinfo6=6.2+20201114-2+deb11u1 \
     git \
     libssl1.1 \
     ca-certificates \

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -134,6 +134,7 @@ RUN apt-get update && apt-get --no-install-recommends --allow-downgrades -y \
     wget \
     curl \
     perl-base=5.32.1-4+deb11u1 \
+    libtinfo6=6.2+20201114-2+deb11u1 \
     git \
     libssl1.1 \
     ca-certificates \


### PR DESCRIPTION
The lack of a pin is causing failures([example](https://github.com/aptos-labs/aptos-core/actions/runs/4942740670/jobs/8836548806
)) because apt likes to update all packages and fails to backtrack to older versions if some dependencies are pinned.

The long-term solution is to figure out a way to avoid pinning packages altogether, especially foundation packages like perl-base and libtinfo, because the pins are fragile and will break often.