### PR TITLE
Revert "update PR template to enable AI summary by default (#7948)"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,4 @@
 ### Description
 
-copilot:summary
-
 ### Test Plan
 <!-- Please provide us with clear details for verifying that your changes work. -->


### PR DESCRIPTION
As per internal discussion removing the github copilot pr annotations from the PR template due to noisyness and lack of usefulness on some PRs.
PR creators can still use the copilot annotations by adding manually `copilot: summary` etc. but it's not part of the template anymore