### PR TITLE
[tf/gcp] add dns support  for GCP testnet

### DIFF
--- a/terraform/aptos-node-testnet/gcp/main.tf
+++ b/terraform/aptos-node-testnet/gcp/main.tf
@@ -29,6 +29,9 @@ module "validator" {
   zone_name    = var.zone_name # keep empty if you don't want a DNS name
   zone_project = var.zone_project
   record_name  = var.record_name
+  # do not create the main fullnode and validator DNS records
+  # instead, rely on external-dns from the testnet-addons
+  create_dns_records = false
 
   # General chain config
   era            = var.era

--- a/terraform/aptos-node/aws/dns.tf
+++ b/terraform/aptos-node/aws/dns.tf
@@ -24,6 +24,7 @@ locals {
 data "kubernetes_service" "validator-lb" {
   count = var.zone_id == "" || !var.create_records ? 0 : 1
   metadata {
+    # This is the main validator LB service that is created by the aptos-node helm chart
     name = "${local.workspace_name}-aptos-node-0-validator-lb"
   }
   depends_on = [time_sleep.lb_creation]
@@ -32,6 +33,7 @@ data "kubernetes_service" "validator-lb" {
 data "kubernetes_service" "fullnode-lb" {
   count = var.zone_id == "" || !var.create_records ? 0 : 1
   metadata {
+    # This is the main fullnode LB service that is created by the aptos-node helm chart
     name = "${local.workspace_name}-aptos-node-0-fullnode-lb"
   }
   depends_on = [time_sleep.lb_creation]

--- a/terraform/aptos-node/gcp/variables.tf
+++ b/terraform/aptos-node/gcp/variables.tf
@@ -61,6 +61,11 @@ variable "record_name" {
   default     = "<workspace>.aptos"
 }
 
+variable "create_dns_records" {
+  description = "Creates DNS records in var.zone_name that point to k8s service, as opposed to using external-dns or other means"
+  default     = true
+}
+
 variable "helm_chart" {
   description = "Path to aptos-validator Helm chart file"
   default     = ""


### PR DESCRIPTION
### Description

Add variable `var.create_dns_records` to control whether or not to create validator and fullnode specific DNS records directly on the first validator. These are only really useful in the case of deploying just a single validator/VFN, since there's 2 records that need to be created (one for validator and one for fullnode). It's simpler to create the record directly in TF rather than using an external dependency like external-dns.

Since we're hosting a bunch of validators and fullnodes for testnets, we'd want each one to have a DNS name. That's a use case for external-dns. So in testnets, set `create_dns_records = false`, and let external-dns handle the rest



### Test Plan

Lint & apply, unblocking new devnet GCP deployment

<!-- Please provide us with clear details for verifying that your changes work. -->
