### PR TITLE
[aptos-node] add --config-override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,6 +2159,8 @@ dependencies = [
  "rayon",
  "serde 1.0.149",
  "serde_json",
+ "serde_merge",
+ "serde_yaml 0.8.26",
  "tokio",
  "tokio-stream",
  "url",
@@ -10815,6 +10817,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde 1.0.149",
+]
+
+[[package]]
+name = "serde_merge"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "606e91878516232ac3b16c12e063d4468d762f16d77e7aef14a1f2326c5f409b"
+dependencies = [
+ "serde 1.0.149",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -525,6 +525,7 @@ serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_bytes = "0.11.6"
 serde_json = { version = "1.0.81", features = ["preserve_order"] }
 serde_repr = "0.1"
+serde_merge = "0.1.3"
 serde-name = "0.1.1"
 serde-generate = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccba" }
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccba" }

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -68,6 +68,8 @@ rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_merge = { workspace = true }
+serde_yaml = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 url = { workspace = true }

--- a/aptos-node/src/tests.rs
+++ b/aptos-node/src/tests.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::network;
+use crate::{create_single_node_test_config, network};
 use aptos_config::config::{NodeConfig, WaypointConfig};
 use aptos_event_notifications::EventSubscriptionService;
 use aptos_infallible::RwLock;
@@ -10,7 +10,7 @@ use aptos_temppath::TempPath;
 use aptos_types::{
     chain_id::ChainId, on_chain_config::ON_CHAIN_CONFIG_REGISTRY, waypoint::Waypoint,
 };
-use std::sync::Arc;
+use std::{fs, sync::Arc};
 
 /// A mock database implementing DbReader and DbWriter
 pub struct MockDatabase;
@@ -50,4 +50,57 @@ fn test_mutual_authentication_validators() {
 #[test]
 fn test_aptos_vm_does_not_have_test_natives() {
     aptos_vm::natives::assert_no_test_natives(crate::utils::ERROR_MSG_BAD_FEATURE_FLAGS)
+}
+
+#[test]
+fn test_create_single_node_test_config() {
+    // create a test config override and merge it with the default config
+    // this will get cleaned up by the tempdir when it goes out of scope
+    let test_dir = aptos_temppath::TempPath::new().as_ref().to_path_buf();
+    fs::DirBuilder::new()
+        .recursive(true)
+        .create(&test_dir)
+        .expect("Failed to create test_dir");
+    let config_override_path = test_dir.join("override.yaml");
+    let config_override: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+        storage:
+            enable_indexer: true
+        indexer_grpc:
+            enabled: true
+            address: 0.0.0.0:50053
+            processor_task_count: 10
+            processor_batch_size: 100
+            output_batch_size: 100
+        api:
+            address: 0.0.0.0:8081
+        "#,
+    )
+    .unwrap();
+    let f = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open(&config_override_path)
+        .expect("Couldn't open file");
+    serde_yaml::to_writer(f, &config_override).unwrap();
+
+    // merge it
+    let default_node_config = NodeConfig::get_default_validator_config();
+    let merged_config =
+        create_single_node_test_config(None, Some(config_override_path), false).unwrap();
+
+    // overriden configs
+    assert!(merged_config.storage.enable_indexer);
+    assert!(merged_config.indexer_grpc.enabled);
+    // default config is unchanged
+    assert_eq!(
+        merged_config
+            .state_sync
+            .state_sync_driver
+            .bootstrapping_mode,
+        default_node_config
+            .state_sync
+            .state_sync_driver
+            .bootstrapping_mode
+    );
 }

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -1055,6 +1055,13 @@ pub struct RunLocalTestnet {
     #[clap(long, parse(from_os_str))]
     test_dir: Option<PathBuf>,
 
+    /// Path to node configuration file override for local test mode.
+    ///
+    /// If provided, the default node config will be overridden by the config in the given file.
+    /// Cannot be used with --config-path
+    #[clap(long, parse(from_os_str), conflicts_with("config-path"))]
+    test_config_override: Option<PathBuf>,
+
     /// Random seed for key generation in test mode
     ///
     /// This allows you to have deterministic keys for testing
@@ -1127,6 +1134,7 @@ impl CliCommand<()> for RunLocalTestnet {
         let node_thread_handle = thread::spawn(move || {
             let result = aptos_node::setup_test_environment_and_start_node(
                 config_path,
+                self.test_config_override,
                 Some(test_dir_copy),
                 false,
                 false,


### PR DESCRIPTION
# Overview

Add `--config-override` flag to `aptos-node`, so we can override the default nodeconfig, which is especially useful when used with `--test`, since the single node testnet mode will auto-populate a lot of fields. This PR uses `serde_merge` to handle the merging and deserialization for us.

Run a local testnet and merge it with a config that enables indexer GRPC:

```
storage:
  enable_indexer: true

indexer_grpc:
  enabled: true
  address: 0.0.0.0:50051
  processor_task_count: 10
  processor_batch_size: 100
  output_batch_size: 100

```

Then start the node:

```
cargo run -p aptos-node -- --test --config-override test_config.yaml
```


The output NodeConfig and also the logs show that the GRPC endpoint is now working!

```
WARNING: Entering test mode! This should never be used in production!
Completed generating configuration:
        **Merged default config with override from path: "test_config.yaml"
        Log file: "/private/var/folders/0r/0cqndyk91kb6s_xv23gdvsdw0000gn/T/bd8fd545c16b34856518744d3ab8aa08/validator.log"
        Test dir: "/private/var/folders/0r/0cqndyk91kb6s_xv23gdvsdw0000gn/T/bd8fd545c16b34856518744d3ab8aa08"
        Aptos root key path: "/private/var/folders/0r/0cqndyk91kb6s_xv23gdvsdw0000gn/T/bd8fd545c16b34856518744d3ab8aa08/mint.key"
        Waypoint: 0:4b7a0c3d90ee83433ddabdf033b35a6c742b010a9b0aa404a0e83397c60b756c
        ChainId: testing
        REST API endpoint: http://0.0.0.0:8080
        Metrics endpoint: http://0.0.0.0:9101/metrics
        Aptosnet fullnode network endpoint: /ip4/0.0.0.0/tcp/6181
        Indexer gRPC endpoint: 0.0.0.0:50053

Aptos is running, press ctrl-c to exit
```

# Test plan

New unit test, and existing CI
