### PR TITLE
[single node benchmark] calibrate thresholds based on v2 runs

### DIFF
--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -14,37 +14,39 @@ from tabulate import tabulate
 # numbers are based on the machine spec used by github action
 # Local machine numbers will be higher.
 EXPECTED_TPS = {
-    ("no-op", False, 1): (18200.0, True),
-    ("no-op", False, 1000): (2550.0, True),
-    ("coin-transfer", False, 1): (11800.0, True),
-    ("coin-transfer", True, 1): (18900.0, True),
-    ("account-generation", False, 1): (9900.0, True),
-    ("account-generation", True, 1): (16300.0, True),
-    ("create-new-account-resource", False, 1): (11700.0, True),
-    ("modify-global-resource", False, 1): (4000.0, True),
-    ("modify-global-resource", False, 10): (10500.0, True),
-    ("publish-package", False, 1): (130.0, True),
-    ("batch100-transfer", False, 1): (300, True),
-    ("batch100-transfer", True, 1): (500, True),
+    ("no-op", False, 1): (18800.0, True),
+    ("no-op", False, 1000): (2980.0, True),
+    ("coin-transfer", False, 1): (12200.0, True),
+    ("coin-transfer", True, 1): (22000.0, True),
+    ("account-generation", False, 1): (11000.0, True),
+    ("account-generation", True, 1): (17600.0, True),
+    ("create-new-account-resource", False, 1): (12600.0, True),
+    ("modify-global-resource", False, 1): (3900.0, True),
+    ("modify-global-resource", False, 10): (10800.0, True),
+    ("publish-package", False, 1): (150.0, True),
+    ("batch100-transfer", False, 1): (330, True),
+    ("batch100-transfer", True, 1): (550, True),
     ("token-v1ft-mint-and-transfer", False, 1): (1700.0, True),
-    ("token-v1ft-mint-and-transfer", False, 20): (6400.0, False),
+    ("token-v1ft-mint-and-transfer", False, 20): (7000.0, True),
     ("token-v1nft-mint-and-transfer-sequential", False, 1): (1100.0, True),
-    ("token-v1nft-mint-and-transfer-sequential", False, 20): (4400.0, False),
-    ("token-v1nft-mint-and-transfer-parallel", False, 1): (1700.0, False),
-    ("token-v1nft-mint-and-transfer-parallel", False, 20): (5000.0, False),
+    ("token-v1nft-mint-and-transfer-sequential", False, 20): (5200.0, True),
+    ("token-v1nft-mint-and-transfer-parallel", False, 1): (1380.0, True),
+    ("token-v1nft-mint-and-transfer-parallel", False, 20): (5300.0, True),
     # ("token-v1ft-mint-and-store", False): 1000.0,
     # ("token-v1nft-mint-and-store-sequential", False): 1000.0,
     # ("token-v1nft-mint-and-store-parallel", False): 1000.0,
-    ("no-op2-signers", False, 1): (18200.0, False),
-    ("no-op5-signers", False, 1): (18200.0, False),
-    ("token-v2-ambassador-mint", False, 1): (2000.0, False),
-    ("token-v2-ambassador-mint", False, 20): (5000.0, False),
+    ("no-op2-signers", False, 1): (18600.0, True),
+    ("no-op5-signers", False, 1): (18600.0, True),
+    ("token-v2-ambassador-mint", False, 1): (1750.0, True),
+    ("token-v2-ambassador-mint", False, 20): (5380.0, True),
 }
 
 NOISE_LOWER_LIMIT = 0.8
-# temporarily increasing upper threshold for perf improvements in #8002,
-# TODO will reduce back after calibration
-NOISE_UPPER_LIMIT = 1.3
+NOISE_LOWER_LIMIT_WARN = 0.9
+# If you want to calibrate the upper limit for perf improvement, you can
+# increase this value temporarily (i.e. to 1.3) and readjust back after a day or two of runs
+NOISE_UPPER_LIMIT = 1.1
+NOISE_UPPER_LIMIT_WARN = 1.05
 
 # bump after a perf improvement, so you can easily distinguish runs
 # that are on top of this commit
@@ -208,17 +210,25 @@ with tempfile.TemporaryDirectory() as tmpdirname:
                 errors.append(text)
             else:
                 warnings.append(text)
+        elif tps < expected_tps * NOISE_LOWER_LIMIT_WARN:
+            text = f"potential (but within normal noise) regression detected {tps} < {expected_tps * NOISE_LOWER_LIMIT_WARN} = {expected_tps} * {NOISE_LOWER_LIMIT_WARN}, {transaction_type} with {use_native_executor_row_str} executor didn't meet TPS requirements"
+            warnings.append(text)
         elif tps > expected_tps * NOISE_UPPER_LIMIT:
             text = f"perf improvement detected {tps} > {expected_tps * NOISE_UPPER_LIMIT} = {expected_tps} * {NOISE_UPPER_LIMIT}, {transaction_type} with {use_native_executor_row_str} executor exceeded TPS requirements, increase TPS requirements to match new baseline"
             if check_active:
                 errors.append(text)
             else:
                 warnings.append(text)
+        elif tps > expected_tps * NOISE_UPPER_LIMIT_WARN:
+            text = f"potential (but within normal noise) perf improvement detected {tps} > {expected_tps * NOISE_UPPER_LIMIT_WARN} = {expected_tps} * {NOISE_UPPER_LIMIT_WARN}, {transaction_type} with {use_native_executor_row_str} executor exceeded TPS requirements, increase TPS requirements to match new baseline"
+            warnings.append(text)
 
 if warnings:
+    print("Warnings: ")
     print("\n".join(warnings))
 
 if errors:
+    print("Errors: ")
     print("\n".join(errors))
     exit(1)
 


### PR DESCRIPTION
- we have split out move code into multiple packages, so loading individual packages got faster
- otherwise callibrate based on larger sample set than we originally had
- enable some of the new tests that have enough examples

- test correctly caught regression on one of the PRs - https://github.com/aptos-labs/aptos-core/actions/runs/4908726176, and it got resolved before landing.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
