### PR TITLE
add voting::is_proposal_id_assigned

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/voting.md
+++ b/aptos-move/framework/aptos-framework/doc/voting.md
@@ -42,6 +42,7 @@ the resolution process.
 -  [Function `resolve`](#0x1_voting_resolve)
 -  [Function `resolve_proposal_v2`](#0x1_voting_resolve_proposal_v2)
 -  [Function `next_proposal_id`](#0x1_voting_next_proposal_id)
+-  [Function `is_proposal_id_assigned`](#0x1_voting_is_proposal_id_assigned)
 -  [Function `is_voting_closed`](#0x1_voting_is_voting_closed)
 -  [Function `can_be_resolved_early`](#0x1_voting_can_be_resolved_early)
 -  [Function `get_proposal_state`](#0x1_voting_get_proposal_state)
@@ -63,6 +64,7 @@ the resolution process.
     -  [Function `resolve`](#@Specification_1_resolve)
     -  [Function `resolve_proposal_v2`](#@Specification_1_resolve_proposal_v2)
     -  [Function `next_proposal_id`](#@Specification_1_next_proposal_id)
+    -  [Function `is_proposal_id_assigned`](#@Specification_1_is_proposal_id_assigned)
     -  [Function `is_voting_closed`](#@Specification_1_is_voting_closed)
     -  [Function `can_be_resolved_early`](#@Specification_1_can_be_resolved_early)
     -  [Function `get_proposal_state`](#@Specification_1_get_proposal_state)
@@ -1116,9 +1118,36 @@ Return the next unassigned proposal id
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_next_proposal_id">next_proposal_id</a>&lt;ProposalType: store&gt;(voting_forum_address: <b>address</b>,): u64 <b>acquires</b> <a href="voting.md#0x1_voting_VotingForum">VotingForum</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_next_proposal_id">next_proposal_id</a>&lt;ProposalType: store&gt;(voting_forum_address: <b>address</b>): u64 <b>acquires</b> <a href="voting.md#0x1_voting_VotingForum">VotingForum</a> {
     <b>let</b> voting_forum = <b>borrow_global</b>&lt;<a href="voting.md#0x1_voting_VotingForum">VotingForum</a>&lt;ProposalType&gt;&gt;(voting_forum_address);
     voting_forum.next_proposal_id
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_voting_is_proposal_id_assigned"></a>
+
+## Function `is_proposal_id_assigned`
+
+Return true if the proposal id has been assigned
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_is_proposal_id_assigned">is_proposal_id_assigned</a>&lt;ProposalType: store&gt;(voting_forum_address: <b>address</b>, proposal_id: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_is_proposal_id_assigned">is_proposal_id_assigned</a>&lt;ProposalType: store&gt;(voting_forum_address: <b>address</b>, proposal_id: u64): bool <b>acquires</b> <a href="voting.md#0x1_voting_VotingForum">VotingForum</a> {
+    // Since the proposal id is simply an increasing nonce, we can just do cheap equality check. If this
+    // ever changes, the <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a> of proposals on the <a href="voting.md#0x1_voting">voting</a> forum should be directly checked
+    proposal_id &lt; <a href="voting.md#0x1_voting_next_proposal_id">next_proposal_id</a>&lt;ProposalType&gt;(voting_forum_address)
 }
 </code></pre>
 
@@ -1717,6 +1746,23 @@ Return true if the voting period of the given proposal has already ended.
 
 
 <pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="voting.md#0x1_voting_VotingForum">VotingForum</a>&lt;ProposalType&gt;&gt;(voting_forum_address);
+</code></pre>
+
+
+
+<a name="@Specification_1_is_proposal_id_assigned"></a>
+
+### Function `is_proposal_id_assigned`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_is_proposal_id_assigned">is_proposal_id_assigned</a>&lt;ProposalType: store&gt;(voting_forum_address: <b>address</b>, proposal_id: u64): bool
+</code></pre>
+
+
+
+
+<pre><code><b>requires</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>();
+<b>include</b> <a href="voting.md#0x1_voting_AbortsIfNotContainProposalID">AbortsIfNotContainProposalID</a>&lt;ProposalType&gt;;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/voting.md
+++ b/aptos-move/framework/aptos-framework/doc/voting.md
@@ -42,7 +42,7 @@ the resolution process.
 -  [Function `resolve`](#0x1_voting_resolve)
 -  [Function `resolve_proposal_v2`](#0x1_voting_resolve_proposal_v2)
 -  [Function `next_proposal_id`](#0x1_voting_next_proposal_id)
--  [Function `is_proposal_id_assigned`](#0x1_voting_is_proposal_id_assigned)
+-  [Function `proposal_exists`](#0x1_voting_proposal_exists)
 -  [Function `is_voting_closed`](#0x1_voting_is_voting_closed)
 -  [Function `can_be_resolved_early`](#0x1_voting_can_be_resolved_early)
 -  [Function `get_proposal_state`](#0x1_voting_get_proposal_state)
@@ -64,7 +64,7 @@ the resolution process.
     -  [Function `resolve`](#@Specification_1_resolve)
     -  [Function `resolve_proposal_v2`](#@Specification_1_resolve_proposal_v2)
     -  [Function `next_proposal_id`](#@Specification_1_next_proposal_id)
-    -  [Function `is_proposal_id_assigned`](#@Specification_1_is_proposal_id_assigned)
+    -  [Function `proposal_exists`](#@Specification_1_proposal_exists)
     -  [Function `is_voting_closed`](#@Specification_1_is_voting_closed)
     -  [Function `can_be_resolved_early`](#@Specification_1_can_be_resolved_early)
     -  [Function `get_proposal_state`](#@Specification_1_get_proposal_state)
@@ -1128,14 +1128,14 @@ Return the next unassigned proposal id
 
 </details>
 
-<a name="0x1_voting_is_proposal_id_assigned"></a>
+<a name="0x1_voting_proposal_exists"></a>
 
-## Function `is_proposal_id_assigned`
+## Function `proposal_exists`
 
-Return true if the proposal id has been assigned
+Return true if the proposal with the specified id exists
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_is_proposal_id_assigned">is_proposal_id_assigned</a>&lt;ProposalType: store&gt;(voting_forum_address: <b>address</b>, proposal_id: u64): bool
+<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_proposal_exists">proposal_exists</a>&lt;ProposalType: store&gt;(voting_forum_address: <b>address</b>, proposal_id: u64): bool
 </code></pre>
 
 
@@ -1144,7 +1144,7 @@ Return true if the proposal id has been assigned
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_is_proposal_id_assigned">is_proposal_id_assigned</a>&lt;ProposalType: store&gt;(voting_forum_address: <b>address</b>, proposal_id: u64): bool <b>acquires</b> <a href="voting.md#0x1_voting_VotingForum">VotingForum</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_proposal_exists">proposal_exists</a>&lt;ProposalType: store&gt;(voting_forum_address: <b>address</b>, proposal_id: u64): bool <b>acquires</b> <a href="voting.md#0x1_voting_VotingForum">VotingForum</a> {
     // Since the proposal id is simply an increasing nonce, we can just do cheap equality check. If this
     // ever changes, the <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a> of proposals on the <a href="voting.md#0x1_voting">voting</a> forum should be directly checked
     proposal_id &lt; <a href="voting.md#0x1_voting_next_proposal_id">next_proposal_id</a>&lt;ProposalType&gt;(voting_forum_address)
@@ -1750,12 +1750,12 @@ Return true if the voting period of the given proposal has already ended.
 
 
 
-<a name="@Specification_1_is_proposal_id_assigned"></a>
+<a name="@Specification_1_proposal_exists"></a>
 
-### Function `is_proposal_id_assigned`
+### Function `proposal_exists`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_is_proposal_id_assigned">is_proposal_id_assigned</a>&lt;ProposalType: store&gt;(voting_forum_address: <b>address</b>, proposal_id: u64): bool
+<pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_proposal_exists">proposal_exists</a>&lt;ProposalType: store&gt;(voting_forum_address: <b>address</b>, proposal_id: u64): bool
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/voting.move
+++ b/aptos-move/framework/aptos-framework/sources/voting.move
@@ -494,8 +494,8 @@ module aptos_framework::voting {
     }
 
     #[view]
-    /// Return true if the proposal id has been assigned
-    public fun is_proposal_id_assigned<ProposalType: store>(voting_forum_address: address, proposal_id: u64): bool acquires VotingForum {
+    /// Return true if the proposal with the specified id exists
+    public fun proposal_exists<ProposalType: store>(voting_forum_address: address, proposal_id: u64): bool acquires VotingForum {
         // Since the proposal id is simply an increasing nonce, we can just do cheap equality check. If this
         // ever changes, the table of proposals on the voting forum should be directly checked
         proposal_id < next_proposal_id<ProposalType>(voting_forum_address)

--- a/aptos-move/framework/aptos-framework/sources/voting.move
+++ b/aptos-move/framework/aptos-framework/sources/voting.move
@@ -488,9 +488,17 @@ module aptos_framework::voting {
 
     #[view]
     /// Return the next unassigned proposal id
-    public fun next_proposal_id<ProposalType: store>(voting_forum_address: address,): u64 acquires VotingForum {
+    public fun next_proposal_id<ProposalType: store>(voting_forum_address: address): u64 acquires VotingForum {
         let voting_forum = borrow_global<VotingForum<ProposalType>>(voting_forum_address);
         voting_forum.next_proposal_id
+    }
+
+    #[view]
+    /// Return true if the proposal id has been assigned
+    public fun is_proposal_id_assigned<ProposalType: store>(voting_forum_address: address, proposal_id: u64): bool acquires VotingForum {
+        // Since the proposal id is simply an increasing nonce, we can just do cheap equality check. If this
+        // ever changes, the table of proposals on the voting forum should be directly checked
+        proposal_id < next_proposal_id<ProposalType>(voting_forum_address)
     }
 
     #[view]

--- a/aptos-move/framework/aptos-framework/sources/voting.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/voting.spec.move
@@ -175,6 +175,12 @@ spec aptos_framework::voting {
         aborts_if !exists<VotingForum<ProposalType>>(voting_forum_address);
     }
 
+    spec is_proposal_id_assigned<ProposalType: store>(voting_forum_address: address, proposal_id: u64): bool {
+        use aptos_framework::chain_status;
+        requires chain_status::is_operating(); // Ensures existence of Timestamp
+        include AbortsIfNotContainProposalID<ProposalType>;
+    }
+
     spec is_voting_closed<ProposalType: store>(voting_forum_address: address, proposal_id: u64): bool {
         use aptos_framework::chain_status;
         // Ensures existence of Timestamp

--- a/aptos-move/framework/aptos-framework/sources/voting.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/voting.spec.move
@@ -175,7 +175,7 @@ spec aptos_framework::voting {
         aborts_if !exists<VotingForum<ProposalType>>(voting_forum_address);
     }
 
-    spec is_proposal_id_assigned<ProposalType: store>(voting_forum_address: address, proposal_id: u64): bool {
+    spec proposal_exists<ProposalType: store>(voting_forum_address: address, proposal_id: u64): bool {
         use aptos_framework::chain_status;
         requires chain_status::is_operating(); // Ensures existence of Timestamp
         include AbortsIfNotContainProposalID<ProposalType>;


### PR DESCRIPTION
### Description

voting.move aborts on invalid proposal ids. In order for our governance module to present a cleaner error, a view function on assigned proposal ids would be useful

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
n/a as this is simply a view function addition.
