### PR TITLE
[Storage Service] Add request moderator to better handle invalid requests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2814,6 +2814,7 @@ dependencies = [
  "aptos-infallible",
  "aptos-logger",
  "aptos-metrics-core",
+ "aptos-netcore",
  "aptos-network",
  "aptos-storage-interface",
  "aptos-storage-service-types",

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -143,6 +143,8 @@ pub struct StorageServiceConfig {
     pub max_concurrent_requests: u64,
     /// Maximum number of epoch ending ledger infos per chunk
     pub max_epoch_chunk_size: u64,
+    /// Maximum number of invalid requests per peer
+    pub max_invalid_requests_per_peer: u64,
     /// Maximum number of items in the lru cache before eviction
     pub max_lru_cache_size: u64,
     /// Maximum number of pending network messages
@@ -157,6 +159,10 @@ pub struct StorageServiceConfig {
     pub max_transaction_chunk_size: u64,
     /// Maximum number of transaction outputs per chunk
     pub max_transaction_output_chunk_size: u64,
+    /// Minimum time (secs) to ignore peers after too many invalid requests
+    pub min_time_to_ignore_peers_secs: u64,
+    /// The interval (ms) to refresh the request moderator state
+    pub request_moderator_refresh_interval_ms: u64,
     /// The interval (ms) to refresh the storage summary
     pub storage_summary_refresh_interval_ms: u64,
 }
@@ -166,13 +172,16 @@ impl Default for StorageServiceConfig {
         Self {
             max_concurrent_requests: 4000,
             max_epoch_chunk_size: MAX_EPOCH_CHUNK_SIZE,
+            max_invalid_requests_per_peer: 500,
             max_lru_cache_size: 500, // At ~0.6MiB per chunk, this should take no more than 0.5GiB
             max_network_channel_size: 4000,
             max_network_chunk_bytes: MAX_MESSAGE_SIZE as u64,
             max_state_chunk_size: MAX_STATE_CHUNK_SIZE,
-            max_subscription_period_ms: 5000,
+            max_subscription_period_ms: 5000, // 5 seconds
             max_transaction_chunk_size: MAX_TRANSACTION_CHUNK_SIZE,
             max_transaction_output_chunk_size: MAX_TRANSACTION_OUTPUT_CHUNK_SIZE,
+            min_time_to_ignore_peers_secs: 300, // 5 minutes
+            request_moderator_refresh_interval_ms: 1000, // 1 second
             storage_summary_refresh_interval_ms: 50,
         }
     }

--- a/state-sync/storage-service/server/Cargo.toml
+++ b/state-sync/storage-service/server/Cargo.toml
@@ -38,6 +38,7 @@ anyhow = { workspace = true }
 aptos-bitvec = { workspace = true }
 aptos-config = { workspace = true, features = ["fuzzing"] }
 aptos-crypto = { workspace = true }
+aptos-netcore = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-time-service = { workspace = true, features = ["async", "testing"] }
 aptos-types = { workspace = true }

--- a/state-sync/storage-service/server/src/error.rs
+++ b/state-sync/storage-service/server/src/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
     InvalidRequest(String),
     #[error("Storage error encountered: {0}")]
     StorageErrorEncountered(String),
+    #[error("Too many invalid requests: {0}")]
+    TooManyInvalidRequests(String),
     #[error("Unexpected error encountered: {0}")]
     UnexpectedErrorEncountered(String),
 }
@@ -20,6 +22,7 @@ impl Error {
         match self {
             Error::InvalidRequest(_) => "invalid_request",
             Error::StorageErrorEncountered(_) => "storage_error",
+            Error::TooManyInvalidRequests(_) => "too_many_invalid_requests",
             Error::UnexpectedErrorEncountered(_) => "unexpected_error",
         }
     }

--- a/state-sync/storage-service/server/src/lib.rs
+++ b/state-sync/storage-service/server/src/lib.rs
@@ -260,6 +260,12 @@ impl<T: StorageReaderInterface> StorageServiceServer<T> {
                 .await;
         }
     }
+
+    #[cfg(test)]
+    /// Returns a copy of the request moderator for test purposes
+    pub(crate) fn get_request_moderator(&self) -> Arc<RequestModerator> {
+        self.request_moderator.clone()
+    }
 }
 
 /// Refreshes the cached storage server summary

--- a/state-sync/storage-service/server/src/logging.rs
+++ b/state-sync/storage-service/server/src/logging.rs
@@ -37,6 +37,8 @@ impl<'a> LogSchema<'a> {
 #[serde(rename_all = "snake_case")]
 pub enum LogEntry {
     ReceivedStorageRequest,
+    RequestModeratorIgnoredPeer,
+    RequestModeratorRefresh,
     SentStorageResponse,
     StorageServiceError,
     StorageSummaryRefresh,

--- a/state-sync/storage-service/server/src/moderator.rs
+++ b/state-sync/storage-service/server/src/moderator.rs
@@ -1,0 +1,222 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{error::Error, logging::LogEntry, metrics, LogSchema};
+use aptos_config::{
+    config::StorageServiceConfig,
+    network_id::{NetworkId, PeerNetworkId},
+};
+use aptos_infallible::RwLock;
+use aptos_logger::warn;
+use aptos_network::application::storage::PeersAndMetadata;
+use aptos_storage_service_types::{
+    requests::StorageServiceRequest, responses::StorageServerSummary,
+};
+use aptos_time_service::{TimeService, TimeServiceTrait};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+/// A simple struct that tracks the state of an unhealthy peer
+pub struct UnhealthyPeerState {
+    ignore_start_time: Option<Instant>, // The time when we first started ignoring the peer
+    invalid_request_count: u64,         // The total number of invalid requests from the peer
+    max_invalid_requests: u64, // The max number of invalid requests before ignoring the peer
+    min_time_to_ignore_secs: u64, // The min time (secs) to ignore the peer (doubles each round)
+    time_service: TimeService, // The time service
+}
+
+impl UnhealthyPeerState {
+    pub fn new(
+        max_invalid_requests: u64,
+        min_time_to_ignore_secs: u64,
+        time_service: TimeService,
+    ) -> Self {
+        Self {
+            ignore_start_time: None,
+            invalid_request_count: 0,
+            max_invalid_requests,
+            min_time_to_ignore_secs,
+            time_service,
+        }
+    }
+
+    /// Increments the invalid request count for the peer and marks
+    /// the peer to be ignored if it has sent too many invalid requests.
+    /// Note: we only ignore peers on the public network.
+    pub fn increment_invalid_request_count(&mut self, peer_network_id: &PeerNetworkId) {
+        // Increment the invalid request count
+        self.invalid_request_count += 1;
+
+        // If the peer is a PFN and has sent too many invalid requests, start ignoring it
+        if self.ignore_start_time.is_none()
+            && peer_network_id.network_id().is_public_network()
+            && self.invalid_request_count >= self.max_invalid_requests
+        {
+            // TODO: at some point we'll want to terminate the connection entirely
+
+            // Start ignoring the peer
+            self.ignore_start_time = Some(self.time_service.now());
+
+            // Log the fact that we're now ignoring the peer
+            warn!(LogSchema::new(LogEntry::RequestModeratorIgnoredPeer)
+                .peer_network_id(peer_network_id)
+                .message("Ignoring peer due to too many invalid requests!"));
+        }
+    }
+
+    /// Returns true iff the peer should be ignored
+    pub fn is_ignored(&self) -> bool {
+        self.ignore_start_time.is_some()
+    }
+
+    /// Refreshes the peer's state (if it has been ignored for long enough).
+    /// Note: each time we unblock a peer, we double the min time to ignore the peer.
+    /// This provides an exponential backoff for peers that are sending too many invalid requests.
+    pub fn refresh_peer_state(&mut self, peer_network_id: &PeerNetworkId) {
+        if let Some(ignore_start_time) = self.ignore_start_time {
+            let ignored_duration = self.time_service.now().duration_since(ignore_start_time);
+            if ignored_duration >= Duration::from_secs(self.min_time_to_ignore_secs) {
+                // Reset the invalid request count
+                self.invalid_request_count = 0;
+
+                // Reset the ignore start time
+                self.ignore_start_time = None;
+
+                // Double the min time to ignore the peer
+                self.min_time_to_ignore_secs *= 2;
+
+                // Log the fact that we're no longer ignoring the peer
+                warn!(LogSchema::new(LogEntry::RequestModeratorIgnoredPeer)
+                    .peer_network_id(peer_network_id)
+                    .message("No longer ignoring peer! Enough time has elapsed."));
+            }
+        }
+    }
+}
+
+/// The request moderator is responsible for validating inbound storage
+/// requests and ensuring that only valid (and satisfiable) requests are processed.
+/// If a peer sends too many invalid requests, the moderator will mark the peer as
+/// "unhealthy" and will ignore requests from that peer for some time.
+pub struct RequestModerator {
+    cached_storage_server_summary: Arc<RwLock<StorageServerSummary>>,
+    peers_and_metadata: Arc<PeersAndMetadata>,
+    storage_service_config: StorageServiceConfig,
+    time_service: TimeService,
+    unhealthy_peer_states: Arc<RwLock<HashMap<PeerNetworkId, UnhealthyPeerState>>>,
+}
+
+impl RequestModerator {
+    pub fn new(
+        cached_storage_server_summary: Arc<RwLock<StorageServerSummary>>,
+        peers_and_metadata: Arc<PeersAndMetadata>,
+        storage_service_config: StorageServiceConfig,
+        time_service: TimeService,
+    ) -> Self {
+        Self {
+            cached_storage_server_summary,
+            unhealthy_peer_states: Arc::new(RwLock::new(HashMap::new())),
+            peers_and_metadata,
+            storage_service_config,
+            time_service,
+        }
+    }
+
+    /// Validates the given request and verifies that the peer is behaving
+    /// correctly. If the request fails validation, an error is returned.
+    pub fn validate_request(
+        &self,
+        peer_network_id: &PeerNetworkId,
+        request: &StorageServiceRequest,
+    ) -> Result<(), Error> {
+        // If the peer is being ignored, return an error
+        if let Some(peer_state) = self.unhealthy_peer_states.read().get(peer_network_id) {
+            if peer_state.is_ignored() {
+                return Err(Error::TooManyInvalidRequests(format!(
+                    "Peer is temporarily ignored. Unable to handle request: {:?}",
+                    request
+                )));
+            }
+        }
+
+        // Get the latest storage server summary
+        let storage_server_summary = self.cached_storage_server_summary.read().clone();
+
+        // Verify the request is serviceable using the current storage server summary
+        if !storage_server_summary.can_service(request) {
+            // Increment the invalid request count for the peer
+            let mut unhealthy_peer_states = self.unhealthy_peer_states.write();
+            let unhealthy_peer_state = unhealthy_peer_states
+                .entry(*peer_network_id)
+                .or_insert_with(|| {
+                    // Create a new unhealthy peer state (this is the first invalid request)
+                    let max_invalid_requests =
+                        self.storage_service_config.max_invalid_requests_per_peer;
+                    let min_time_to_ignore_peers_secs =
+                        self.storage_service_config.min_time_to_ignore_peers_secs;
+                    let time_service = self.time_service.clone();
+
+                    UnhealthyPeerState::new(
+                        max_invalid_requests,
+                        min_time_to_ignore_peers_secs,
+                        time_service,
+                    )
+                });
+            unhealthy_peer_state.increment_invalid_request_count(peer_network_id);
+
+            // Return the validation error
+            return Err(Error::InvalidRequest(format!(
+                "The given request cannot be satisfied. Request: {:?}, storage summary: {:?}",
+                request, storage_server_summary
+            )));
+        }
+
+        Ok(()) // The request is valid
+    }
+
+    /// Refresh the unhealthy peer states and garbage collect disconnected peers
+    pub fn refresh_unhealthy_peer_states(&self) -> Result<(), Error> {
+        // Get the currently connected peers
+        let connected_peers_and_metadata = self
+            .peers_and_metadata
+            .get_connected_peers_and_metadata()
+            .map_err(|error| {
+                Error::UnexpectedErrorEncountered(format!(
+                    "Unable to get connected peers and metadata: {}",
+                    error
+                ))
+            })?;
+
+        // Remove disconnected peers and refresh ignored peer states
+        let mut num_ignored_peers = 0;
+        self.unhealthy_peer_states
+            .write()
+            .retain(|peer_network_id, unhealthy_peer_state| {
+                if connected_peers_and_metadata.contains_key(peer_network_id) {
+                    // Refresh the ignored peer state
+                    unhealthy_peer_state.refresh_peer_state(peer_network_id);
+
+                    // If the peer is ignored, increment the ignored peer count
+                    if unhealthy_peer_state.is_ignored() {
+                        num_ignored_peers += 1;
+                    }
+
+                    true // The peer is still connected, so we should keep it
+                } else {
+                    false // The peer is no longer connected, so we should remove it
+                }
+            });
+
+        // Update the number of ignored peers
+        metrics::set_gauge(
+            &metrics::IGNORED_PEER_COUNT,
+            NetworkId::Public.as_str(),
+            num_ignored_peers,
+        );
+
+        Ok(())
+    }
+}

--- a/state-sync/storage-service/types/src/lib.rs
+++ b/state-sync/storage-service/types/src/lib.rs
@@ -33,6 +33,8 @@ pub enum StorageServiceError {
     InternalError(String),
     #[error("Invalid storage request: {0}")]
     InvalidRequest(String),
+    #[error("Too many invalid requests! Back off required: {0}")]
+    TooManyInvalidRequests(String),
 }
 
 /// A single storage service message sent or received over AptosNet.


### PR DESCRIPTION
Note: most of this PR is just unit tests.

### Description
This PR adds a new request moderator to the storage service. The moderator is responsible for validating inbound storage
requests and ensuring that only valid requests are processed. If a peer sends too many invalid requests, the moderator will mark the peer as "unhealthy" and will ignore requests from that peer for some time.

At a high-level, the moderator: (i) counts the number of invalid requests from a peer; (ii) once that number goes over a threshold (e.g., 500), the moderator marks the peer as unhealthy; (iii) the peer is then "ignored" for a period (e.g., 5 minutes), during which any requests will be sent a "too many invalid requests" error; and (iv) once the "ignore duration" has elapsed, the peer will be marked as healthy again and we will repeat the cycle. Each time a peer is ignored, we double the ignore duration (to better handle peers that might misbehave for long periods of time).

The PR offers the following commits:
1. Add the new request moderator to the storage service.
2. Add a set of new unit tests for the moderator.

### Test Plan
New and existing test infrastructure.