### PR TITLE
[docker] add docker-compose for indexer-grpc

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -234,6 +234,19 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
 
+  indexer-grpc-e2e-tests:
+    needs: [rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
+    if: |
+      (github.event_name == 'push' && github.ref_name != 'main') ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+      github.event.pull_request.auto_merge != null ||
+      contains(github.event.pull_request.body, '#e2e')
+    uses: ./.github/workflows/docker-indexer-grpc-test.yaml
+    secrets: inherit
+    with:
+      GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+
   forge-e2e-test:
     needs: [rust-images-all, determine-docker-build-metadata]
     if: | # always() ensures that the job will run even if some of the previous docker variant build jobs were skipped https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions

--- a/.github/workflows/docker-indexer-grpc-test.yaml
+++ b/.github/workflows/docker-indexer-grpc-test.yaml
@@ -1,0 +1,65 @@
+name: "Docker Indexer gRPC test"
+on:
+  pull_request:
+    paths:
+      - "docker/compose/indexer-grpc/*.yaml"
+  workflow_call:
+    inputs:
+      GIT_SHA:
+        required: true
+        type: string
+        description: Use this to override the git SHA1, branch name (e.g. devnet) or tag to pull docker images with
+
+jobs:
+  test-indexer-grpc-docker-compose:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      VALIDATOR_IMAGE_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/validator
+      FAUCET_IMAGE_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/faucet
+      INDEXER_GRPC_IMAGE_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/indexer-grpc
+      IMAGE_TAG: ${{ inputs.GIT_SHA || 'f4100b21da4e9ba10fadd184e92e3d1c22bc282e' }} # hardcode to a known good build when not running on workflow_call
+
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          ref: ${{ inputs.GIT_SHA || github.event.pull_request.head.sha || github.sha }}
+
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+
+      - name: Run validator-testnet docker compose
+        run: docker-compose up -d
+        shell: bash
+        working-directory: docker/compose/validator-testnet
+
+      - name: Wait for the validator to make some progress
+        run: sleep 30
+        shell: bash
+
+      - name: Run indexer-grpc docker compose
+        run: docker-compose up -d
+        shell: bash
+        working-directory: docker/compose/indexer-grpc
+
+      - name: Test with grpcurl
+        run: ./docker/compose/indexer-grpc/test_indexer_grpc_docker_compose.sh
+        shell: bash
+
+      - name: Print docker-compose validator-testnet logs on failure
+        if: ${{ failure() }}
+        working-directory: docker/compose/validator-testnet
+        run: docker-compose logs
+
+      - name: Print docker-compose indexer-grpc logs on failure
+        if: ${{ failure() }}
+        working-directory: docker/compose/indexer-grpc
+        run: docker-compose logs

--- a/docker/compose/indexer-grpc/README.md
+++ b/docker/compose/indexer-grpc/README.md
@@ -1,0 +1,23 @@
+# Indexer GRPC Docker Compose
+
+This docker-compose is meant to be run in tandem with the `validator-testnet`:
+* In `docker/compose/validator-testnet`, start the node: `docker-compose up -d`
+  * After it's spun up, you should be able to access its REST API and gRPC endpoints. See the logs and node config file for more details
+* In `docker/compose/indexer-grpc`, start the indexer GRPC setup: `docker-compose up -d`
+
+After this point, you will have the following:
+* Single validator testnet
+* Redis
+* Indexer GRPC Cache Worker
+* Indexer GRPC File Store (writing to docker volume)
+* Indexer GRPC Data Service
+
+Relevant ports are exposed on the docker host for testing purposes
+
+## Reset
+
+A simple script is provided to kill and remove all relevant docker containers and volumes, to reset the whole local testnet and indexer setup:
+
+```
+./reset_indexer_grpc_testnet.sh
+```

--- a/docker/compose/indexer-grpc/cache-worker-config.yaml
+++ b/docker/compose/indexer-grpc/cache-worker-config.yaml
@@ -1,0 +1,9 @@
+health_check_port: 8082
+
+server_config:
+  server_name: "cache-worker"
+  fullnode_grpc_address: 172.16.1.10:50051
+  file_store_config:
+    file_store_type: LocalFileStore
+    local_file_store_path: /opt/aptos/file-store
+  redis_main_instance_address: 172.16.1.12:6379

--- a/docker/compose/indexer-grpc/data-service-config.yaml
+++ b/docker/compose/indexer-grpc/data-service-config.yaml
@@ -1,0 +1,10 @@
+health_check_port: 8084
+
+server_config:
+  server_name: "data-service"
+  data_service_grpc_listen_address: 0.0.0.0:50052
+  whitelisted_auth_tokens: ["dummy_token"]
+  file_store_config:
+    file_store_type: LocalFileStore
+    local_file_store_path: /opt/aptos/file-store
+  redis_read_replica_address: 172.16.1.12:6379

--- a/docker/compose/indexer-grpc/docker-compose.yaml
+++ b/docker/compose/indexer-grpc/docker-compose.yaml
@@ -1,0 +1,97 @@
+# This compose file defines the services needed to run the indexer-grpc
+# It requires a redis instance to be running, and will start the following
+# services:
+# - indexer-grpc-cache-worker
+# - indexer-grpc-file-store (with the local file store on a docker volume)
+# - indexer-grpc-data-service
+# 
+# The indexer-grpc also requires a fullnode to be running with the indexer-grpc
+# feature enabled. This can be done using the `validator-testing` compose file
+# which starts with a local single-node network. The shared docker network
+# then connects the two compose files together.
+#
+# To start the services, run `docker-compose up -d`
+version: "3.8"
+services:
+  redis:
+    image: redis:6.2
+    networks:
+      shared:
+        ipv4_address:  172.16.1.12
+    restart: unless-stopped
+    expose:
+      - 6379
+    ports:
+      - 6379:6379
+
+  indexer-grpc-cache-worker:
+    image: "${INDEXER_GRPC_IMAGE_REPO:-aptoslabs/indexer-grpc}:${IMAGE_TAG:-devnet}"
+    networks:
+      shared:
+        ipv4_address:  172.16.1.13
+    restart: unless-stopped
+    volumes:
+      - type: volume # XXX: needed now before refactor https://github.com/aptos-labs/aptos-core/pull/8139
+        source: indexer-grpc-file-store
+        target: /opt/aptos/file-store
+      - type: bind
+        source: ./cache-worker-config.yaml
+        target: /opt/aptos/cache-worker-config.yaml
+    command:
+      - '/usr/local/bin/aptos-indexer-grpc-cache-worker'
+      - '--config-path'
+      - '/opt/aptos/cache-worker-config.yaml'
+    depends_on:
+      - redis
+
+  indexer-grpc-file-store:
+    image: "${INDEXER_GRPC_IMAGE_REPO:-aptoslabs/indexer-grpc}:${IMAGE_TAG:-devnet}"
+    networks:
+      shared:
+        ipv4_address:  172.16.1.14
+    restart: unless-stopped
+    volumes:
+      - type: volume
+        source: indexer-grpc-file-store
+        target: /opt/aptos/file-store
+      - type: bind
+        source: ./file-store-config.yaml
+        target: /opt/aptos/file-store-config.yaml
+    command:
+      - '/usr/local/bin/aptos-indexer-grpc-file-store'
+      - '--config-path'
+      - '/opt/aptos/file-store-config.yaml'
+    depends_on:
+      - indexer-grpc-cache-worker
+
+  indexer-grpc-data-service:
+    image: "${INDEXER_GRPC_IMAGE_REPO:-aptoslabs/indexer-grpc}:${IMAGE_TAG:-devnet}"
+    networks:
+      shared:
+        ipv4_address:  172.16.1.15
+    restart: unless-stopped
+    volumes:
+      - type: volume # XXX: needed now before refactor https://github.com/aptos-labs/aptos-core/pull/8139
+        source: indexer-grpc-file-store
+        target: /opt/aptos/file-store
+      - type: bind
+        source: ./data-service-config.yaml
+        target: /opt/aptos/data-service-config.yaml
+    command:
+      - '/usr/local/bin/aptos-indexer-grpc-data-service'
+      - '--config-path'
+      - '/opt/aptos/data-service-config.yaml'
+    ports:
+      - "50052:50052" # GRPC
+    depends_on:
+      - indexer-grpc-cache-worker
+
+# This joins the indexer-grpc compose with the validator-testnet compose using a shared docker network
+networks:
+  shared:
+    external: true
+    name: "aptos-docker-compose-shared"
+
+volumes:
+  indexer-grpc-file-store:
+    name: indexer-grpc-file-store

--- a/docker/compose/indexer-grpc/file-store-config.yaml
+++ b/docker/compose/indexer-grpc/file-store-config.yaml
@@ -1,0 +1,8 @@
+health_check_port: 8083
+
+server_config:
+  server_name: "file-store"
+  redis_main_instance_address: 172.16.1.12:6379
+  file_store_config:
+    file_store_type: LocalFileStore
+    local_file_store_path: /opt/aptos/file-store

--- a/docker/compose/indexer-grpc/reset_indexer_grpc_testnet.sh
+++ b/docker/compose/indexer-grpc/reset_indexer_grpc_testnet.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# kill everything
+docker ps -a | grep -E "validator|faucet|indexer|redis" | awk '{ print $1 }' | xargs -I{} docker kill {}
+docker ps -a | grep -E "validator|faucet|indexer|redis" | awk '{ print $1 }' | xargs -I{} docker rm {}
+
+# delete volume
+docker volume rm aptos-shared indexer-grpc-file-store

--- a/docker/compose/indexer-grpc/test_indexer_grpc_docker_compose.sh
+++ b/docker/compose/indexer-grpc/test_indexer_grpc_docker_compose.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# A quick script that checks the e2e setup for the indexer-grpc service on docker-compose
+
+if ! command -v grpcurl &>/dev/null; then
+    wget https://github.com/fullstorydev/grpcurl/releases/download/v1.8.7/grpcurl_1.8.7_linux_x86_64.tar.gz
+    sha=$(shasum -a 256 grpcurl_1.8.7_linux_x86_64.tar.gz | awk '{ print $1 }')
+    [ "$sha" != "b50a9c9cdbabab03c0460a7218eab4a954913d696b4d69ffb720f42d869dbdd5" ] && echo "shasum mismatch" && exit 1
+    tar -xvf grpcurl_1.8.7_linux_x86_64.tar.gz
+    chmod +x grpcurl
+    mv grpcurl /usr/local/bin/grpcurl
+    grpcurl -version
+fi
+
+# Try hitting the indexer-grpc setup in a number of ways
+# 
+
+# try getting the internal grpc on the fullnode itself
+stream_time_seconds=30
+start_time=$(date +%s)
+timeout "${stream_time_seconds}s" grpcurl  -max-msg-sz 10000000 -d '{ "starting_version": 0 }' -import-path crates/aptos-protos/proto -proto aptos/internal/fullnode/v1/fullnode_data.proto  -plaintext 127.0.0.1:50051 aptos.internal.fullnode.v1.FullnodeData/GetTransactionsFromNode
+end_time=$(date +%s)
+total_time=$((end_time - start_time))
+echo "grpcurl took ${total_time} seconds to run"
+
+if [ $total_time -lt "${stream_time_seconds}" ]; then
+    echo "grpcurl exited early, which indicates failure"
+    echo "RawData/GetTransactions on the aptos-node should be an endless stream"
+    exit 1
+fi
+
+# try hitting the data service
+stream_time_seconds=30
+start_time=$(date +%s)
+timeout "${stream_time_seconds}s" grpcurl  -max-msg-sz 10000000 -d '{ "starting_version": 0 }' -H "x-aptos-data-authorization:dummy_token"  -import-path crates/aptos-protos/proto -proto aptos/indexer/v1/raw_data.proto  -plaintext 127.0.0.1:50052 aptos.indexer.v1.RawData/GetTransactions
+end_time=$(date +%s)
+total_time=$((end_time - start_time))
+echo "grpcurl took ${total_time} seconds to run"
+
+if [ $total_time -lt "${stream_time_seconds}" ]; then
+    echo "grpcurl exited early, which indicates failure"
+    echo "RawData/GetTransactions on the data service should be an endless stream"
+    exit 1
+fi
+
+echo "All tests passed!"

--- a/docker/compose/validator-testnet/docker-compose.yaml
+++ b/docker/compose/validator-testnet/docker-compose.yaml
@@ -34,9 +34,13 @@ services:
       - type: volume
         source: aptos-shared
         target: /opt/aptos/var
-    command: ["/usr/local/bin/aptos-node", "--test", "--test-dir", "/opt/aptos/var/"]
+      - type: bind
+        source: ./validator_node_template.yaml
+        target: /opt/aptos/config.yaml
+    command: ["/usr/local/bin/aptos-node", "--test", "--test-dir", "/opt/aptos/var/", "--test-config-override", "/opt/aptos/config.yaml"]
     ports:
-      - "8080:8080"
+      - "8080:8080" # REST API
+      - "50051:50051" # Indexer GRPC, if enabled
     expose:
       - 9101
 
@@ -59,17 +63,18 @@ services:
             sleep 1
           else
             sleep 1
-            /usr/local/bin/aptos-faucet \\
+            /usr/local/bin/aptos-faucet-service \\
+              run-simple \\
+              --key-file-path /opt/aptos/var/mint.key \\
               --chain-id TESTING \\
-              --mint-key-file-path /opt/aptos/var/mint.key \\
-              --server-url http://172.16.1.10:8080
+              --node-url http://172.16.1.10:8080
             echo 'Faucet failed to run likely due to the Validator still starting. Will try again.'
           fi
         done
         exit 1
       "
     ports:
-      - "8000:8000"
+      - "8081:8081"
 
 networks:
   shared:

--- a/docker/compose/validator-testnet/validator_node_template.yaml
+++ b/docker/compose/validator-testnet/validator_node_template.yaml
@@ -1,32 +1,12 @@
-consensus:
-  # The following slow consensus down when there are no active transactions to process
-  round_initial_timeout_ms: 20000
-  mempool_poll_count: 333
+storage:
+  enable_indexer: true
 
-# The rest of this config is copy paste of config/src/config/test_data/validator.yaml
-validator_network:
-  listen_address: "/ip4/0.0.0.0/tcp/6180"
-  identity:
-    type: "from_storage"
-    key_name: "validator_network"
-    peer_id_name: "owner_account"
-    backend:
-      type: "vault"
-      server: "https://127.0.0.1:8200"
-      ca_certificate: "/full/path/to/certificate"
-      token:
-        from_disk: "/full/path/to/token"
+indexer_grpc:
+  enabled: true
+  address: 0.0.0.0:50051
+  processor_task_count: 10
+  processor_batch_size: 100
+  output_batch_size: 100
 
-full_node_networks:
-  - listen_address: "/ip4/0.0.0.0/tcp/7180"
-    identity:
-      type: "from_storage"
-      key_name: "fullnode_network"
-        peer_id_name: "owner_account"
-        backend:
-          type: "vault"
-          server: "https://127.0.0.1:8200"
-          token:
-                from_disk: "/full/path/to/token"
-    network_id:
-      private: "vfn"
+api:
+  address: 0.0.0.0:8080


### PR DESCRIPTION
### Description

Edits the existing `validator-testnet` docker-compose:
* Enable indexer grpc in the default config. (Since this whole setup is for testing, it makes sense to just enable all features. If folks feel strongly, we can remove this and just add in a README to edit the config to enable indexer GRPC instead)

New `indexer-grpc` docker-compose, including:
* cache worker
* file store (with local filestore)
* data service
* redis

Mounts into existing docker compose networks, using static IPs. (We can re-evaluate getting rid of these static IPs, as they were only necessary when we faced docker networking issues in CircleCI)

A simple check is implemented in GHA that checks if we can connect to the indexer-grpc via `grpcurl`. For now (since the workflow is not landed in main yet), we test on `pull_request`, and use a hard-coded recent docker image build to spin up the whole docker-compose setup.

Bonus:
* Get the validator-testnet docker-compose to work with tap, after finally updating the image (this devnet release via https://github.com/aptos-labs/aptos-core/pull/8136). With this week's devnet release, we should publish an announcement calling this out.

### Test Plan

New e2e test https://github.com/aptos-labs/aptos-core/actions/runs/4986678324/jobs/8927692834?pr=8207
Also verify locally (which is what the test does): https://github.com/aptos-labs/aptos-core/blob/08c67319c6dc15f6585a3db2ae94b1ae4d087b7e/.github/workflows/docker-indexer-grpc.yaml
* export some vars to select docker image to use: `FAUCET_IMAGE_REPO`, `VALIDATOR_IMAGE_REPO`, `INDEXER_GRPC_IMAGE_REPO`, `IMAGE_TAG`
* in docker/compose/validator-testnet: `docker-compose up -d`
* in docker/compose/indexer-grpc: `docker-compose up -d`
* hit some endpoints using `grpcurl`

<!-- Please provide us with clear details for verifying that your changes work. -->
