### PR TITLE
[Gas Estimation] Include gas used as a threshold for marking blocks full

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -92,13 +92,13 @@ jobs:
   # Because the docker build happens in a reusable workflow, have a separate job that collects the right metadata
   # for the subsequent docker builds. Reusable workflows do not currently have the "env" context: https://github.com/orgs/community/discussions/26671
   determine-docker-build-metadata:
+    needs: [permission-check]
     runs-on: ubuntu-latest
     steps:
       - name: collect metadata
         run: |
-          echo "GIT_SHA: ${{ env.GIT_SHA }}"
-          echo "TARGET_CACHE_ID: ${{ env.TARGET_CACHE_ID }}"
-          echo "CONCURRENCY: ${{ github.workflow }}-${{ github.event_name }}-${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.sha || github.head_ref || github.ref }}"
+          echo "GIT_SHA: ${GIT_SHA}"
+          echo "TARGET_CACHE_ID: ${TARGET_CACHE_ID}"
     outputs:
       gitSha: ${{ env.GIT_SHA }}
       targetCacheId: ${{ env.TARGET_CACHE_ID }}

--- a/config/src/config/gas_estimation_config.rs
+++ b/config/src/config/gas_estimation_config.rs
@@ -15,6 +15,9 @@ pub struct GasEstimationConfig {
     pub enabled: bool,
     /// Number of transactions for blocks to be classified as full for gas estimation
     pub full_block_txns: usize,
+    // TODO: Move this to use the onchain config introduced in AIP-33
+    /// The amount of gas used for blocks to be classified as full for gas estimation
+    pub full_block_gas_used: u64,
     /// Maximum number of blocks read for low gas estimation
     pub low_block_history: usize,
     /// Maximum number of blocks read for market gas estimation
@@ -30,6 +33,7 @@ impl Default for GasEstimationConfig {
         GasEstimationConfig {
             enabled: false,
             full_block_txns: 250,
+            full_block_gas_used: 1000000,
             low_block_history: 10,
             market_block_history: 30,
             aggressive_block_history: 120,

--- a/config/src/config/gas_estimation_config.rs
+++ b/config/src/config/gas_estimation_config.rs
@@ -15,9 +15,6 @@ pub struct GasEstimationConfig {
     pub enabled: bool,
     /// Number of transactions for blocks to be classified as full for gas estimation
     pub full_block_txns: usize,
-    // TODO: Move this to use the onchain config introduced in AIP-33
-    /// The amount of gas used for blocks to be classified as full for gas estimation
-    pub full_block_gas_used: u64,
     /// Maximum number of blocks read for low gas estimation
     pub low_block_history: usize,
     /// Maximum number of blocks read for market gas estimation
@@ -33,7 +30,6 @@ impl Default for GasEstimationConfig {
         GasEstimationConfig {
             enabled: false,
             full_block_txns: 250,
-            full_block_gas_used: 1000000,
             low_block_history: 10,
             market_block_history: 30,
             aggressive_block_history: 120,

--- a/storage/aptosdb/src/fake_aptosdb.rs
+++ b/storage/aptosdb/src/fake_aptosdb.rs
@@ -489,14 +489,14 @@ impl DbReader for FakeAptosDB {
         })
     }
 
-    fn get_gas_prices(
+    fn get_gas_prices_and_used(
         &self,
         start_version: Version,
         limit: u64,
         ledger_version: Version,
-    ) -> Result<Vec<u64>> {
+    ) -> Result<Vec<(u64, u64)>> {
         self.inner
-            .get_gas_prices(start_version, limit, ledger_version)
+            .get_gas_prices_and_used(start_version, limit, ledger_version)
     }
 
     fn get_transaction_by_hash(

--- a/storage/aptosdb/src/fake_aptosdb.rs
+++ b/storage/aptosdb/src/fake_aptosdb.rs
@@ -489,16 +489,6 @@ impl DbReader for FakeAptosDB {
         })
     }
 
-    fn get_gas_prices_and_used(
-        &self,
-        start_version: Version,
-        limit: u64,
-        ledger_version: Version,
-    ) -> Result<Vec<(u64, u64)>> {
-        self.inner
-            .get_gas_prices_and_used(start_version, limit, ledger_version)
-    }
-
     fn get_transaction_by_hash(
         &self,
         hash: HashValue,

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -129,12 +129,12 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
-    fn get_gas_prices(
+    fn get_gas_prices_and_used(
         &self,
         start_version: Version,
         limit: u64,
         ledger_version: Version,
-    ) -> Result<Vec<u64>> {
+    ) -> Result<Vec<(u64, u64)>> {
         unimplemented!()
     }
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -129,15 +129,6 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
-    fn get_gas_prices_and_used(
-        &self,
-        start_version: Version,
-        limit: u64,
-        ledger_version: Version,
-    ) -> Result<Vec<(u64, u64)>> {
-        unimplemented!()
-    }
-
     /// See [AptosDB::get_transaction_by_hash].
     ///
     /// [AptosDB::get_transaction_by_hash]: ../aptosdb/struct.AptosDB.html#method.get_transaction_by_hash

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -39,7 +39,9 @@ pub use self::{
         ConsensusConfigV1, LeaderReputationType, OnChainConsensusConfig, ProposerAndVoterConfig,
         ProposerElectionType,
     },
-    execution_config::{ExecutionConfigV1, OnChainExecutionConfig, TransactionShufflerType},
+    execution_config::{
+        ExecutionConfigV1, ExecutionConfigV2, OnChainExecutionConfig, TransactionShufflerType,
+    },
     gas_schedule::{GasSchedule, GasScheduleV2, StorageGasSchedule},
     timed_features::{TimedFeatureFlag, TimedFeatureOverride, TimedFeatures},
     timestamp::CurrentTimeMicroseconds,


### PR DESCRIPTION
### Description

When doing gas estimation, add criteria for considering a block full if it has reached the gas limit. (Previously, only the txn count was considered.) The gas limit is read from the onchain execution config.

### Test Plan

Added smoke test that relies on the gas limit block full value.