### PR TITLE
[aptos-vm] Charge invariant violation txn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7264,6 +7264,7 @@ dependencies = [
  "aptos-vm-logging",
  "aptos-writeset-generator",
  "bcs 0.1.4",
+ "fail 0.5.0",
  "itertools",
  "move-binary-format",
  "move-bytecode-verifier",

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -47,3 +47,14 @@ proposals:
                 weight_by_voting_power: true
                 use_history_from_previous_epoch_max_count: 5
           max_failed_authors_to_store: 10
+  - name: enable_charge_invariant_violation
+    metadata:
+      title: "Enable charge_invariant_violation"
+      description: "AIP-20: Support of generic cryptography algebra operations in Aptos standard library."
+      source_code_url: "https://github.com/aptos-labs/aptos-core/pull/8213"
+      discussion_url: "https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-35.md"
+    execution_mode: MultiStep
+    update_sequence:
+    - FeatureFlag:
+        enabled:
+          - charge_invariant_violation

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -38,6 +38,7 @@ pub enum FeatureFlag {
     PartialGovernanceVoting,
     SignatureCheckerV2,
     StorageSlotMetadata,
+    ChargeInvariantViolation,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -152,6 +153,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::PartialGovernanceVoting => AptosFeatureFlag::PARTIAL_GOVERNANCE_VOTING,
             FeatureFlag::SignatureCheckerV2 => AptosFeatureFlag::SIGNATURE_CHECKER_V2,
             FeatureFlag::StorageSlotMetadata => AptosFeatureFlag::STORAGE_SLOT_METADATA,
+            FeatureFlag::ChargeInvariantViolation => AptosFeatureFlag::CHARGE_INVARIANT_VIOLATION,
         }
     }
 }
@@ -191,6 +193,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::PARTIAL_GOVERNANCE_VOTING => FeatureFlag::PartialGovernanceVoting,
             AptosFeatureFlag::SIGNATURE_CHECKER_V2 => FeatureFlag::SignatureCheckerV2,
             AptosFeatureFlag::STORAGE_SLOT_METADATA => FeatureFlag::StorageSlotMetadata,
+            AptosFeatureFlag::CHARGE_INVARIANT_VIOLATION => FeatureFlag::ChargeInvariantViolation,
         }
     }
 }

--- a/aptos-move/aptos-vm/src/adapter_common.rs
+++ b/aptos-move/aptos-vm/src/adapter_common.rs
@@ -112,14 +112,7 @@ pub(crate) fn preprocess_transaction<A: VMAdapter>(txn: Transaction) -> Preproce
 
 pub(crate) fn discard_error_vm_status(err: VMStatus) -> (VMStatus, TransactionOutputExt) {
     let vm_status = err.clone();
-    let error_code = match err.keep_or_discard() {
-        Ok(_) => {
-            debug_assert!(false, "discarding non-discardable error: {:?}", vm_status);
-            vm_status.status_code()
-        },
-        Err(code) => code,
-    };
-    (vm_status, discard_error_output(error_code))
+    (vm_status, discard_error_output(err.status_code()))
 }
 
 pub(crate) fn discard_error_output(err: StatusCode) -> TransactionOutputExt {

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -259,7 +259,12 @@ impl AptosVM {
             .0
             .new_session(resolver, SessionId::txn_meta(txn_data), true);
 
-        match TransactionStatus::from(error_code.clone()) {
+        match TransactionStatus::from_vm_status(
+            error_code.clone(),
+            self.0
+                .get_features()
+                .is_enabled(FeatureFlag::CHARGE_INVARIANT_VIOLATION),
+        ) {
             TransactionStatus::Keep(status) => {
                 // Inject abort info if available.
                 let status = match status {
@@ -1098,7 +1103,12 @@ impl AptosVM {
                     );
                 }
 
-                let txn_status = TransactionStatus::from(err.clone());
+                let txn_status = TransactionStatus::from_vm_status(
+                    err.clone(),
+                    self.0
+                        .get_features()
+                        .is_enabled(FeatureFlag::CHARGE_INVARIANT_VIOLATION),
+                );
                 if txn_status.is_discarded() {
                     discard_error_vm_status(err)
                 } else {
@@ -1857,7 +1867,13 @@ impl AptosSimulationVM {
                 if new_published_modules_loaded {
                     self.0 .0.mark_loader_cache_as_invalid();
                 };
-                let txn_status = TransactionStatus::from(err.clone());
+                let txn_status = TransactionStatus::from_vm_status(
+                    err.clone(),
+                    self.0
+                         .0
+                        .get_features()
+                        .is_enabled(FeatureFlag::CHARGE_INVARIANT_VIOLATION),
+                );
                 if txn_status.is_discarded() {
                     discard_error_vm_status(err)
                 } else {

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -41,7 +41,7 @@ use aptos_types::{
         TransactionOutput, TransactionPayload, TransactionStatus, VMValidatorResult,
         WriteSetPayload,
     },
-    vm_status::{AbortLocation, DiscardedVMStatus, StatusCode, VMStatus},
+    vm_status::{AbortLocation, StatusCode, VMStatus},
     write_set::WriteSet,
 };
 use aptos_utils::{aptos_try, return_on_failure};
@@ -1671,9 +1671,7 @@ impl VMAdapter for AptosVM {
                 let _timer = TXN_TOTAL_SECONDS.start_timer();
                 let (vm_status, output) = self.execute_user_transaction(resolver, txn, log_context);
 
-                if let Err(DiscardedVMStatus::UNKNOWN_INVARIANT_VIOLATION_ERROR) =
-                    vm_status.clone().keep_or_discard()
-                {
+                if let StatusType::InvariantViolation = vm_status.status_type() {
                     error!(
                         *log_context,
                         "[aptos_vm] Transaction breaking invariant violation. txn: {:?}, status: {:?}",

--- a/aptos-move/e2e-move-tests/src/tests/access_path_test.rs
+++ b/aptos-move/e2e-move-tests/src/tests/access_path_test.rs
@@ -4,7 +4,7 @@
 use crate::{assert_success, MoveHarness};
 use aptos_types::{
     account_address::AccountAddress,
-    transaction::{ModuleBundle, TransactionPayload},
+    transaction::{ExecutionStatus, ModuleBundle, TransactionPayload},
 };
 use move_binary_format::{
     file_format::{
@@ -113,5 +113,8 @@ fn access_path_panic() {
         Vec::<Vec<u8>>::new(),
     );
 
-    assert_eq!(res.status().unwrap_err(), StatusCode::STORAGE_ERROR);
+    assert_eq!(
+        res.status().unwrap(),
+        ExecutionStatus::MiscellaneousError(Some(StatusCode::STORAGE_ERROR))
+    );
 }

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_module_dependency_fails_verification.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_module_dependency_fails_verification.exp
@@ -4,14 +4,73 @@ Ok(
             write_set: V0(
                 WriteSetV0(
                     WriteSetMut {
-                        write_set: {},
+                        write_set: {
+                            StateKey {
+                                inner: AccessPath(
+                                    AccessPath { address: f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1, path: 01000000000000000000000000000000000000000000000000000000000000000104636f696e09436f696e53746f7265010700000000000000000000000000000000000000000000000000000000000000010a6170746f735f636f696e094170746f73436f696e00 },
+                                ),
+                                hash: OnceCell(Uninit),
+                            }: Modification(3e420f00000000000000000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe100000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1),
+                            StateKey {
+                                inner: AccessPath(
+                                    AccessPath { address: f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1, path: 010000000000000000000000000000000000000000000000000000000000000001076163636f756e74074163636f756e7400 },
+                                ),
+                                hash: OnceCell(Uninit),
+                            }: Modification(20f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe10b00000000000000000000000000000000000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe100000000000000000100000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe10000),
+                            StateKey {
+                                inner: TableItem {
+                                    handle: TableHandle(
+                                        1b854694ae746cdbd8d44186ca4929b2b337df21d1c74633be19b2710552fdca,
+                                    ),
+                                    key: [
+                                        6,
+                                        25,
+                                        220,
+                                        41,
+                                        160,
+                                        170,
+                                        200,
+                                        250,
+                                        20,
+                                        103,
+                                        20,
+                                        5,
+                                        142,
+                                        141,
+                                        214,
+                                        210,
+                                        208,
+                                        243,
+                                        189,
+                                        245,
+                                        246,
+                                        51,
+                                        25,
+                                        7,
+                                        191,
+                                        145,
+                                        243,
+                                        172,
+                                        216,
+                                        30,
+                                        105,
+                                        53,
+                                    ],
+                                },
+                                hash: OnceCell(Uninit),
+                            }: Modification(fde0f505000000000100000000000000),
+                        },
                     },
                 ),
             ),
             events: [],
-            gas_used: 0,
-            status: Discard(
-                UNEXPECTED_VERIFIER_ERROR,
+            gas_used: 2,
+            status: Keep(
+                MiscellaneousError(
+                    Some(
+                        UNEXPECTED_VERIFIER_ERROR,
+                    ),
+                ),
             ),
         },
     ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_module_transitive_dependency_fails_verification.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_module_transitive_dependency_fails_verification.exp
@@ -4,14 +4,73 @@ Ok(
             write_set: V0(
                 WriteSetV0(
                     WriteSetMut {
-                        write_set: {},
+                        write_set: {
+                            StateKey {
+                                inner: AccessPath(
+                                    AccessPath { address: f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1, path: 01000000000000000000000000000000000000000000000000000000000000000104636f696e09436f696e53746f7265010700000000000000000000000000000000000000000000000000000000000000010a6170746f735f636f696e094170746f73436f696e00 },
+                                ),
+                                hash: OnceCell(Uninit),
+                            }: Modification(3e420f00000000000000000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe100000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1),
+                            StateKey {
+                                inner: AccessPath(
+                                    AccessPath { address: f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1, path: 010000000000000000000000000000000000000000000000000000000000000001076163636f756e74074163636f756e7400 },
+                                ),
+                                hash: OnceCell(Uninit),
+                            }: Modification(20f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe10b00000000000000000000000000000000000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe100000000000000000100000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe10000),
+                            StateKey {
+                                inner: TableItem {
+                                    handle: TableHandle(
+                                        1b854694ae746cdbd8d44186ca4929b2b337df21d1c74633be19b2710552fdca,
+                                    ),
+                                    key: [
+                                        6,
+                                        25,
+                                        220,
+                                        41,
+                                        160,
+                                        170,
+                                        200,
+                                        250,
+                                        20,
+                                        103,
+                                        20,
+                                        5,
+                                        142,
+                                        141,
+                                        214,
+                                        210,
+                                        208,
+                                        243,
+                                        189,
+                                        245,
+                                        246,
+                                        51,
+                                        25,
+                                        7,
+                                        191,
+                                        145,
+                                        243,
+                                        172,
+                                        216,
+                                        30,
+                                        105,
+                                        53,
+                                    ],
+                                },
+                                hash: OnceCell(Uninit),
+                            }: Modification(fde0f505000000000100000000000000),
+                        },
                     },
                 ),
             ),
             events: [],
-            gas_used: 0,
-            status: Discard(
-                UNEXPECTED_VERIFIER_ERROR,
+            gas_used: 2,
+            status: Keep(
+                MiscellaneousError(
+                    Some(
+                        UNEXPECTED_VERIFIER_ERROR,
+                    ),
+                ),
             ),
         },
     ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_script_dependency_fails_verification.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_script_dependency_fails_verification.exp
@@ -4,14 +4,73 @@ Ok(
             write_set: V0(
                 WriteSetV0(
                     WriteSetMut {
-                        write_set: {},
+                        write_set: {
+                            StateKey {
+                                inner: AccessPath(
+                                    AccessPath { address: f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1, path: 01000000000000000000000000000000000000000000000000000000000000000104636f696e09436f696e53746f7265010700000000000000000000000000000000000000000000000000000000000000010a6170746f735f636f696e094170746f73436f696e00 },
+                                ),
+                                hash: OnceCell(Uninit),
+                            }: Modification(3e420f00000000000000000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe100000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1),
+                            StateKey {
+                                inner: AccessPath(
+                                    AccessPath { address: f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1, path: 010000000000000000000000000000000000000000000000000000000000000001076163636f756e74074163636f756e7400 },
+                                ),
+                                hash: OnceCell(Uninit),
+                            }: Modification(20f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe10b00000000000000000000000000000000000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe100000000000000000100000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe10000),
+                            StateKey {
+                                inner: TableItem {
+                                    handle: TableHandle(
+                                        1b854694ae746cdbd8d44186ca4929b2b337df21d1c74633be19b2710552fdca,
+                                    ),
+                                    key: [
+                                        6,
+                                        25,
+                                        220,
+                                        41,
+                                        160,
+                                        170,
+                                        200,
+                                        250,
+                                        20,
+                                        103,
+                                        20,
+                                        5,
+                                        142,
+                                        141,
+                                        214,
+                                        210,
+                                        208,
+                                        243,
+                                        189,
+                                        245,
+                                        246,
+                                        51,
+                                        25,
+                                        7,
+                                        191,
+                                        145,
+                                        243,
+                                        172,
+                                        216,
+                                        30,
+                                        105,
+                                        53,
+                                    ],
+                                },
+                                hash: OnceCell(Uninit),
+                            }: Modification(fde0f505000000000100000000000000),
+                        },
                     },
                 ),
             ),
             events: [],
-            gas_used: 0,
-            status: Discard(
-                UNEXPECTED_VERIFIER_ERROR,
+            gas_used: 2,
+            status: Keep(
+                MiscellaneousError(
+                    Some(
+                        UNEXPECTED_VERIFIER_ERROR,
+                    ),
+                ),
             ),
         },
     ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_script_transitive_dependency_fails_verification.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_script_transitive_dependency_fails_verification.exp
@@ -4,14 +4,73 @@ Ok(
             write_set: V0(
                 WriteSetV0(
                     WriteSetMut {
-                        write_set: {},
+                        write_set: {
+                            StateKey {
+                                inner: AccessPath(
+                                    AccessPath { address: f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1, path: 01000000000000000000000000000000000000000000000000000000000000000104636f696e09436f696e53746f7265010700000000000000000000000000000000000000000000000000000000000000010a6170746f735f636f696e094170746f73436f696e00 },
+                                ),
+                                hash: OnceCell(Uninit),
+                            }: Modification(3e420f00000000000000000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe100000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1),
+                            StateKey {
+                                inner: AccessPath(
+                                    AccessPath { address: f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1, path: 010000000000000000000000000000000000000000000000000000000000000001076163636f756e74074163636f756e7400 },
+                                ),
+                                hash: OnceCell(Uninit),
+                            }: Modification(20f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe10b00000000000000000000000000000000000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe100000000000000000100000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe10000),
+                            StateKey {
+                                inner: TableItem {
+                                    handle: TableHandle(
+                                        1b854694ae746cdbd8d44186ca4929b2b337df21d1c74633be19b2710552fdca,
+                                    ),
+                                    key: [
+                                        6,
+                                        25,
+                                        220,
+                                        41,
+                                        160,
+                                        170,
+                                        200,
+                                        250,
+                                        20,
+                                        103,
+                                        20,
+                                        5,
+                                        142,
+                                        141,
+                                        214,
+                                        210,
+                                        208,
+                                        243,
+                                        189,
+                                        245,
+                                        246,
+                                        51,
+                                        25,
+                                        7,
+                                        191,
+                                        145,
+                                        243,
+                                        172,
+                                        216,
+                                        30,
+                                        105,
+                                        53,
+                                    ],
+                                },
+                                hash: OnceCell(Uninit),
+                            }: Modification(fde0f505000000000100000000000000),
+                        },
                     },
                 ),
             ),
             events: [],
-            gas_used: 0,
-            status: Discard(
-                UNEXPECTED_VERIFIER_ERROR,
+            gas_used: 2,
+            status: Keep(
+                MiscellaneousError(
+                    Some(
+                        UNEXPECTED_VERIFIER_ERROR,
+                    ),
+                ),
             ),
         },
     ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_type_tag_dependency_fails_verification.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_type_tag_dependency_fails_verification.exp
@@ -4,14 +4,73 @@ Ok(
             write_set: V0(
                 WriteSetV0(
                     WriteSetMut {
-                        write_set: {},
+                        write_set: {
+                            StateKey {
+                                inner: AccessPath(
+                                    AccessPath { address: f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1, path: 01000000000000000000000000000000000000000000000000000000000000000104636f696e09436f696e53746f7265010700000000000000000000000000000000000000000000000000000000000000010a6170746f735f636f696e094170746f73436f696e00 },
+                                ),
+                                hash: OnceCell(Uninit),
+                            }: Modification(3e420f00000000000000000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe100000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1),
+                            StateKey {
+                                inner: AccessPath(
+                                    AccessPath { address: f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1, path: 010000000000000000000000000000000000000000000000000000000000000001076163636f756e74074163636f756e7400 },
+                                ),
+                                hash: OnceCell(Uninit),
+                            }: Modification(20f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe10b00000000000000000000000000000000000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe100000000000000000100000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe10000),
+                            StateKey {
+                                inner: TableItem {
+                                    handle: TableHandle(
+                                        1b854694ae746cdbd8d44186ca4929b2b337df21d1c74633be19b2710552fdca,
+                                    ),
+                                    key: [
+                                        6,
+                                        25,
+                                        220,
+                                        41,
+                                        160,
+                                        170,
+                                        200,
+                                        250,
+                                        20,
+                                        103,
+                                        20,
+                                        5,
+                                        142,
+                                        141,
+                                        214,
+                                        210,
+                                        208,
+                                        243,
+                                        189,
+                                        245,
+                                        246,
+                                        51,
+                                        25,
+                                        7,
+                                        191,
+                                        145,
+                                        243,
+                                        172,
+                                        216,
+                                        30,
+                                        105,
+                                        53,
+                                    ],
+                                },
+                                hash: OnceCell(Uninit),
+                            }: Modification(fde0f505000000000100000000000000),
+                        },
                     },
                 ),
             ),
             events: [],
-            gas_used: 0,
-            status: Discard(
-                UNEXPECTED_VERIFIER_ERROR,
+            gas_used: 2,
+            status: Keep(
+                MiscellaneousError(
+                    Some(
+                        UNEXPECTED_VERIFIER_ERROR,
+                    ),
+                ),
             ),
         },
     ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_type_tag_transitive_dependency_fails_verification.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_type_tag_transitive_dependency_fails_verification.exp
@@ -4,14 +4,73 @@ Ok(
             write_set: V0(
                 WriteSetV0(
                     WriteSetMut {
-                        write_set: {},
+                        write_set: {
+                            StateKey {
+                                inner: AccessPath(
+                                    AccessPath { address: f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1, path: 01000000000000000000000000000000000000000000000000000000000000000104636f696e09436f696e53746f7265010700000000000000000000000000000000000000000000000000000000000000010a6170746f735f636f696e094170746f73436f696e00 },
+                                ),
+                                hash: OnceCell(Uninit),
+                            }: Modification(3e420f00000000000000000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe100000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1),
+                            StateKey {
+                                inner: AccessPath(
+                                    AccessPath { address: f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe1, path: 010000000000000000000000000000000000000000000000000000000000000001076163636f756e74074163636f756e7400 },
+                                ),
+                                hash: OnceCell(Uninit),
+                            }: Modification(20f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe10b00000000000000000000000000000000000000000000000000000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe100000000000000000100000000000000f5b9d6f01a99e74c790e2f330c092fa05455a8193f1dfc1b113ecc54d067afe10000),
+                            StateKey {
+                                inner: TableItem {
+                                    handle: TableHandle(
+                                        1b854694ae746cdbd8d44186ca4929b2b337df21d1c74633be19b2710552fdca,
+                                    ),
+                                    key: [
+                                        6,
+                                        25,
+                                        220,
+                                        41,
+                                        160,
+                                        170,
+                                        200,
+                                        250,
+                                        20,
+                                        103,
+                                        20,
+                                        5,
+                                        142,
+                                        141,
+                                        214,
+                                        210,
+                                        208,
+                                        243,
+                                        189,
+                                        245,
+                                        246,
+                                        51,
+                                        25,
+                                        7,
+                                        191,
+                                        145,
+                                        243,
+                                        172,
+                                        216,
+                                        30,
+                                        105,
+                                        53,
+                                    ],
+                                },
+                                hash: OnceCell(Uninit),
+                            }: Modification(fde0f505000000000100000000000000),
+                        },
                     },
                 ),
             ),
             events: [],
-            gas_used: 0,
-            status: Discard(
-                UNEXPECTED_VERIFIER_ERROR,
+            gas_used: 2,
+            status: Keep(
+                MiscellaneousError(
+                    Some(
+                        UNEXPECTED_VERIFIER_ERROR,
+                    ),
+                ),
             ),
         },
     ],

--- a/aptos-move/e2e-testsuite/Cargo.toml
+++ b/aptos-move/e2e-testsuite/Cargo.toml
@@ -23,11 +23,12 @@ aptos-language-e2e-tests = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-state-view = { workspace = true }
 aptos-types = { workspace = true }
-aptos-vm = { workspace = true }
+aptos-vm = { workspace = true, features = ['failpoints'] }
 aptos-vm-genesis = { workspace = true }
 aptos-vm-logging = { workspace = true }
 aptos-writeset-generator = { workspace = true }
 bcs = { workspace = true }
+fail = { workspace = true, features = ['failpoints'] }
 itertools = { workspace = true }
 move-binary-format = { workspace = true }
 move-bytecode-verifier = { workspace = true }

--- a/aptos-move/e2e-testsuite/src/tests/failed_transaction_tests.rs
+++ b/aptos-move/e2e-testsuite/src/tests/failed_transaction_tests.rs
@@ -64,7 +64,7 @@ fn failed_transaction_cleanup_test() {
         Ok(ExecutionStatus::MiscellaneousError(Some(TYPE_MISMATCH)))
     );
 
-    // Invariant violations should be discarded and not charged.
+    // Invariant violations should be charged.
     let out2 = aptos_vm.failed_transaction_cleanup(
         VMStatus::Error(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR, None),
         &mut gas_meter,
@@ -73,12 +73,13 @@ fn failed_transaction_cleanup_test() {
         &log_context,
         &change_set_configs,
     );
-    assert!(out2.txn_output().write_set().is_empty());
-    assert!(out2.txn_output().gas_used() == 0);
-    assert!(out2.txn_output().status().is_discarded());
+    assert!(out2.txn_output().gas_used() != 0);
+    assert!(!out2.txn_output().status().is_discarded());
     assert_eq!(
         out2.txn_output().status().status(),
-        Err(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+        Ok(ExecutionStatus::MiscellaneousError(Some(
+            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR
+        )))
     );
 }
 

--- a/aptos-move/e2e-testsuite/src/tests/invariant_violation.rs
+++ b/aptos-move/e2e-testsuite/src/tests/invariant_violation.rs
@@ -1,0 +1,66 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_language_e2e_tests::{common_transactions::peer_to_peer_txn, executor::FakeExecutor};
+use aptos_types::{
+    account_address::AccountAddress,
+    on_chain_config::FeatureFlag,
+    transaction::{ExecutionStatus, TransactionStatus},
+    vm_status::DiscardedVMStatus,
+};
+use move_core_types::{value::MoveValue, vm_status::StatusCode};
+
+#[test]
+fn invariant_violation_error() {
+    let _scenario = fail::FailScenario::setup();
+    fail::cfg(
+        "move_adapter::execute_script_or_entry_function",
+        "100%return",
+    )
+    .unwrap();
+
+    ::aptos_logger::Logger::init_for_testing();
+
+    let mut executor = FakeExecutor::from_head_genesis();
+
+    // create and publish a sender with 1_000_000 coins and a receiver with 100_000 coins
+    let sender = executor.create_raw_account_data(1_000_000, 10);
+    let receiver = executor.create_raw_account_data(100_000, 10);
+    executor.add_account_data(&sender);
+    executor.add_account_data(&receiver);
+
+    let transfer_amount = 1_000;
+    let txn = peer_to_peer_txn(sender.account(), receiver.account(), 10, transfer_amount, 0);
+
+    // execute transaction
+    let output = executor.execute_transaction(txn.clone());
+
+    // CHARGE_INVARIANT_VIOLATION enabled at genesis so this txn is kept.
+    assert_eq!(
+        output.status(),
+        &TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(Some(
+            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR
+        ))),
+    );
+
+    // Disable the CHARGE_INVARIANT_VIOLATION flag.
+    executor.exec("features", "change_feature_flags", vec![], vec![
+        MoveValue::Signer(AccountAddress::ONE)
+            .simple_serialize()
+            .unwrap(),
+        MoveValue::Vector(vec![]).simple_serialize().unwrap(),
+        MoveValue::Vector(vec![MoveValue::U64(
+            FeatureFlag::CHARGE_INVARIANT_VIOLATION as u64,
+        )])
+        .simple_serialize()
+        .unwrap(),
+    ]);
+
+    let output = executor.execute_transaction(txn);
+
+    // With CHARGE_INVARIANT_VIOLATION disabled this transaction will be discarded.
+    assert_eq!(
+        output.status(),
+        &TransactionStatus::Discard(DiscardedVMStatus::UNKNOWN_INVARIANT_VIOLATION_ERROR),
+    );
+}

--- a/aptos-move/e2e-testsuite/src/tests/mod.rs
+++ b/aptos-move/e2e-testsuite/src/tests/mod.rs
@@ -19,6 +19,7 @@ mod execution_strategies;
 mod failed_transaction_tests;
 mod genesis;
 mod genesis_initializations;
+mod invariant_violation;
 mod mint;
 mod module_publishing;
 mod on_chain_configs;

--- a/aptos-move/e2e-testsuite/src/tests/verify_txn.rs
+++ b/aptos-move/e2e-testsuite/src/tests/verify_txn.rs
@@ -726,8 +726,8 @@ fn test_script_dependency_fails_verification() {
     // invariant violation as we try to load `Test`
     assert_eq!(executor.verify_transaction(txn.clone()).status(), None);
     match executor.execute_transaction(txn).status() {
-        TransactionStatus::Discard(status) => {
-            assert_eq!(status, &StatusCode::UNEXPECTED_VERIFIER_ERROR);
+        TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(status)) => {
+            assert_eq!(status, &Some(StatusCode::UNEXPECTED_VERIFIER_ERROR));
         },
         _ => panic!("Kept transaction with an invariant violation!"),
     }
@@ -762,8 +762,8 @@ fn test_module_dependency_fails_verification() {
     // invariant violation as we try to load `Test`
     assert_eq!(executor.verify_transaction(txn.clone()).status(), None);
     match executor.execute_transaction(txn).status() {
-        TransactionStatus::Discard(status) => {
-            assert_eq!(status, &StatusCode::UNEXPECTED_VERIFIER_ERROR);
+        TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(status)) => {
+            assert_eq!(status, &Some(StatusCode::UNEXPECTED_VERIFIER_ERROR));
         },
         _ => panic!("Kept transaction with an invariant violation!"),
     }
@@ -814,8 +814,8 @@ fn test_type_tag_dependency_fails_verification() {
     // invariant violation as we try to load `Test`
     assert_eq!(executor.verify_transaction(txn.clone()).status(), None);
     match executor.execute_transaction(txn).status() {
-        TransactionStatus::Discard(status) => {
-            assert_eq!(status, &StatusCode::UNEXPECTED_VERIFIER_ERROR);
+        TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(status)) => {
+            assert_eq!(status, &Some(StatusCode::UNEXPECTED_VERIFIER_ERROR));
         },
         _ => panic!("Kept transaction with an invariant violation!"),
     }
@@ -865,8 +865,8 @@ fn test_script_transitive_dependency_fails_verification() {
     // invariant violation as we try to load `Test`
     assert_eq!(executor.verify_transaction(txn.clone()).status(), None);
     match executor.execute_transaction(txn).status() {
-        TransactionStatus::Discard(status) => {
-            assert_eq!(status, &StatusCode::UNEXPECTED_VERIFIER_ERROR);
+        TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(status)) => {
+            assert_eq!(status, &Some(StatusCode::UNEXPECTED_VERIFIER_ERROR));
         },
         _ => panic!("Kept transaction with an invariant violation!"),
     }
@@ -926,8 +926,8 @@ fn test_module_transitive_dependency_fails_verification() {
     // invariant violation as we try to load `Test`
     assert_eq!(executor.verify_transaction(txn.clone()).status(), None);
     match executor.execute_transaction(txn).status() {
-        TransactionStatus::Discard(status) => {
-            assert_eq!(status, &StatusCode::UNEXPECTED_VERIFIER_ERROR);
+        TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(status)) => {
+            assert_eq!(status, &Some(StatusCode::UNEXPECTED_VERIFIER_ERROR));
         },
         _ => panic!("Kept transaction with an invariant violation!"),
     }
@@ -983,8 +983,8 @@ fn test_type_tag_transitive_dependency_fails_verification() {
     // invariant violation as we try to load `Test`
     assert_eq!(executor.verify_transaction(txn.clone()).status(), None);
     match executor.execute_transaction(txn).status() {
-        TransactionStatus::Discard(status) => {
-            assert_eq!(status, &StatusCode::UNEXPECTED_VERIFIER_ERROR);
+        TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(status)) => {
+            assert_eq!(status, &Some(StatusCode::UNEXPECTED_VERIFIER_ERROR));
         },
         _ => panic!("Kept transaction with an invariant violation!"),
     }

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -148,6 +148,17 @@ Lifetime: transient
 
 
 
+<a name="0x1_features_CHARGE_INVARIANT_VIOLATION"></a>
+
+Charge invariant violation error.
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_CHARGE_INVARIANT_VIOLATION">CHARGE_INVARIANT_VIOLATION</a>: u64 = 20;
+</code></pre>
+
+
+
 <a name="0x1_features_CODE_DEPENDENCY_CHECK"></a>
 
 Whether validation of package dependencies is enabled, and the related native function is

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -182,6 +182,10 @@ module std::features {
         is_enabled(PARTIAL_GOVERNANCE_VOTING)
     }
 
+    /// Charge invariant violation error.
+    /// Lifetime: transient
+    const CHARGE_INVARIANT_VIOLATION: u64 = 20;
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -434,6 +434,7 @@ pub fn default_features() -> Vec<FeatureFlag> {
         FeatureFlag::CRYPTOGRAPHY_ALGEBRA_NATIVES,
         FeatureFlag::BLS12_381_STRUCTURES,
         FeatureFlag::STORAGE_SLOT_METADATA,
+        FeatureFlag::CHARGE_INVARIANT_VIOLATION,
     ]
 }
 

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -27,6 +27,7 @@ pub enum FeatureFlag {
     PARTIAL_GOVERNANCE_VOTING = 17,
     SIGNATURE_CHECKER_V2 = 18,
     STORAGE_SLOT_METADATA = 19,
+    CHARGE_INVARIANT_VIOLATION = 20,
 }
 
 /// Representation of features on chain as a bitset.

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -835,6 +835,7 @@ impl TransactionStatus {
 
     pub fn from_vm_status(vm_status: VMStatus, charge_invariant_violation: bool) -> Self {
         let status_code = vm_status.status_code();
+        // TODO: keep_or_discard logic should be deprecated from Move repo and refactored into here.
         match vm_status.keep_or_discard() {
             Ok(recorded) => match recorded {
                 KeptVMStatus::MiscellaneousError => {

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -832,10 +832,8 @@ impl TransactionStatus {
             _ => Err(format_err!("Not Keep.")),
         }
     }
-}
 
-impl From<VMStatus> for TransactionStatus {
-    fn from(vm_status: VMStatus) -> Self {
+    pub fn from_vm_status(vm_status: VMStatus, charge_invariant_violation: bool) -> Self {
         let status_code = vm_status.status_code();
         match vm_status.keep_or_discard() {
             Ok(recorded) => match recorded {
@@ -844,8 +842,22 @@ impl From<VMStatus> for TransactionStatus {
                 },
                 _ => TransactionStatus::Keep(recorded.into()),
             },
-            Err(code) => TransactionStatus::Discard(code),
+            Err(code) => {
+                if code.status_type() == StatusType::InvariantViolation
+                    && charge_invariant_violation
+                {
+                    TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(Some(code)))
+                } else {
+                    TransactionStatus::Discard(code)
+                }
+            },
         }
+    }
+}
+
+impl From<VMStatus> for TransactionStatus {
+    fn from(vm_status: VMStatus) -> Self {
+        TransactionStatus::from_vm_status(vm_status, true)
     }
 }
 


### PR DESCRIPTION
### Description

Charges gas for TXNs that lead to an invariant violation error, when the feature flag is set.

Will need to decide if we need to enable this flag in the upcoming release.

### Test Plan

Uses failpoint injection to make sure that:
1. With the flag enabled, an invariant violation error TXN will be kept and charged gas.
2. With the flag disabled, the TXN will be marked as discarded.