### PR TITLE
Remove misleading javadoc for non-existent parameters

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/multisig_account.md
+++ b/aptos-move/framework/aptos-framework/doc/multisig_account.md
@@ -1771,9 +1771,6 @@ maliciously alter the number of signatures required.
 
 Create a multisig transaction, which will have one approval initially (from the creator).
 
-@param target_function The target function to call such as 0x123::module_to_call::function_to_call.
-@param args Vector of BCS-encoded argument values to invoke the target function with.
-
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_create_transaction">create_transaction</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: <b>address</b>, payload: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
 </code></pre>
@@ -1818,10 +1815,6 @@ Create a multisig transaction, which will have one approval initially (from the 
 Create a multisig transaction with a transaction hash instead of the full payload.
 This means the payload will be stored off chain for gas saving. Later, during execution, the executor will need
 to provide the full payload, which will be validated against the hash stored on-chain.
-
-@param function_hash The sha-256 hash of the function to invoke, e.g. 0x123::module_to_call::function_to_call.
-@param args_hash The sha-256 hash of the function arguments - a concatenated vector of the bcs-encoded
-function arguments.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_create_transaction_with_hash">create_transaction_with_hash</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: <b>address</b>, payload_hash: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)

--- a/aptos-move/framework/aptos-framework/sources/multisig_account.move
+++ b/aptos-move/framework/aptos-framework/sources/multisig_account.move
@@ -657,9 +657,6 @@ module aptos_framework::multisig_account {
     ////////////////////////// Multisig transaction flow ///////////////////////////////
 
     /// Create a multisig transaction, which will have one approval initially (from the creator).
-    ///
-    /// @param target_function The target function to call such as 0x123::module_to_call::function_to_call.
-    /// @param args Vector of BCS-encoded argument values to invoke the target function with.
     public entry fun create_transaction(
         owner: &signer,
         multisig_account: address,
@@ -685,10 +682,6 @@ module aptos_framework::multisig_account {
     /// Create a multisig transaction with a transaction hash instead of the full payload.
     /// This means the payload will be stored off chain for gas saving. Later, during execution, the executor will need
     /// to provide the full payload, which will be validated against the hash stored on-chain.
-    ///
-    /// @param function_hash The sha-256 hash of the function to invoke, e.g. 0x123::module_to_call::function_to_call.
-    /// @param args_hash The sha-256 hash of the function arguments - a concatenated vector of the bcs-encoded
-    /// function arguments.
     public entry fun create_transaction_with_hash(
         owner: &signer,
         multisig_account: address,

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -351,9 +351,6 @@ pub enum EntryFunctionCall {
     },
 
     /// Create a multisig transaction, which will have one approval initially (from the creator).
-    ///
-    /// @param target_function The target function to call such as 0x123::module_to_call::function_to_call.
-    /// @param args Vector of BCS-encoded argument values to invoke the target function with.
     MultisigAccountCreateTransaction {
         multisig_account: AccountAddress,
         payload: Vec<u8>,
@@ -362,10 +359,6 @@ pub enum EntryFunctionCall {
     /// Create a multisig transaction with a transaction hash instead of the full payload.
     /// This means the payload will be stored off chain for gas saving. Later, during execution, the executor will need
     /// to provide the full payload, which will be validated against the hash stored on-chain.
-    ///
-    /// @param function_hash The sha-256 hash of the function to invoke, e.g. 0x123::module_to_call::function_to_call.
-    /// @param args_hash The sha-256 hash of the function arguments - a concatenated vector of the bcs-encoded
-    /// function arguments.
     MultisigAccountCreateTransactionWithHash {
         multisig_account: AccountAddress,
         payload_hash: Vec<u8>,
@@ -2099,9 +2092,6 @@ pub fn multisig_account_create(
 }
 
 /// Create a multisig transaction, which will have one approval initially (from the creator).
-///
-/// @param target_function The target function to call such as 0x123::module_to_call::function_to_call.
-/// @param args Vector of BCS-encoded argument values to invoke the target function with.
 pub fn multisig_account_create_transaction(
     multisig_account: AccountAddress,
     payload: Vec<u8>,
@@ -2126,10 +2116,6 @@ pub fn multisig_account_create_transaction(
 /// Create a multisig transaction with a transaction hash instead of the full payload.
 /// This means the payload will be stored off chain for gas saving. Later, during execution, the executor will need
 /// to provide the full payload, which will be validated against the hash stored on-chain.
-///
-/// @param function_hash The sha-256 hash of the function to invoke, e.g. 0x123::module_to_call::function_to_call.
-/// @param args_hash The sha-256 hash of the function arguments - a concatenated vector of the bcs-encoded
-/// function arguments.
 pub fn multisig_account_create_transaction_with_hash(
     multisig_account: AccountAddress,
     payload_hash: Vec<u8>,


### PR DESCRIPTION
@davidiw @movekevin 

The removed doc comments refer to parameters that are not present in the relevant function signatures.

The javadoc descriptions are particularly misleading given that they refer to data structures fundamentally different from what should be validly passed. Source: https://github.com/aptos-labs/aptos-core/blob/754cdf83ce4ef2db160397aca4b4c82058999278/ecosystem/typescript/sdk/examples/typescript/multisig_account.ts#L72-L92