### PR TITLE
[aptos-rosetta] Support add / unlock for delegation pool

### DIFF
--- a/crates/aptos-rosetta/src/client.rs
+++ b/crates/aptos-rosetta/src/client.rs
@@ -471,6 +471,85 @@ impl RosettaClient {
         .await
     }
 
+    pub async fn add_delegated_stake(
+        &self,
+        network_identifier: &NetworkIdentifier,
+        private_key: &Ed25519PrivateKey,
+        pool_address: AccountAddress,
+        amount: Option<u64>,
+        expiry_time_secs: u64,
+        sequence_number: Option<u64>,
+        max_gas: Option<u64>,
+        gas_unit_price: Option<u64>,
+    ) -> anyhow::Result<TransactionIdentifier> {
+        let delegator = self
+            .get_account_address(network_identifier.clone(), private_key)
+            .await?;
+
+        let mut keys = HashMap::new();
+        keys.insert(delegator, private_key);
+
+        let operations = vec![Operation::add_delegated_stake(
+            0,
+            None,
+            delegator,
+            AccountIdentifier::base_account(pool_address),
+            amount,
+        )];
+
+        self.submit_operations(
+            delegator,
+            network_identifier.clone(),
+            &keys,
+            operations,
+            expiry_time_secs,
+            sequence_number,
+            max_gas,
+            gas_unit_price,
+            true,
+        )
+        .await
+    }
+
+    pub async fn unlock_delegated_stake(
+        &self,
+        network_identifier: &NetworkIdentifier,
+        private_key: &Ed25519PrivateKey,
+        pool_address: AccountAddress,
+        amount: Option<u64>,
+        expiry_time_secs: u64,
+        sequence_number: Option<u64>,
+        max_gas: Option<u64>,
+        gas_unit_price: Option<u64>,
+    ) -> anyhow::Result<TransactionIdentifier> {
+        let delegator = self
+            .get_account_address(network_identifier.clone(), private_key)
+            .await?;
+        let mut keys = HashMap::new();
+        keys.insert(delegator, private_key);
+
+        let operations = vec![Operation::unlock_delegated_stake(
+            0,
+            None,
+            delegator,
+            AccountIdentifier::base_account(pool_address),
+            amount,
+        )];
+
+        self.submit_operations(
+            delegator,
+            network_identifier.clone(),
+            &keys,
+            operations,
+            expiry_time_secs,
+            sequence_number,
+            max_gas,
+            gas_unit_price,
+            true,
+        )
+        .await
+    }
+
     /// Retrieves the account address from the derivation path if there isn't an overriding account specified
     async fn get_account_address(
         &self,

--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -103,6 +103,8 @@ pub enum OperationType {
     ResetLockup,
     UnlockStake,
     DistributeStakingRewards,
+    AddDelegatedStake,
+    UnlockDelegatedStake,
     // Fee must always be last for ordering
     Fee,
 }
@@ -119,6 +121,8 @@ impl OperationType {
     const STAKING_REWARD: &'static str = "staking_reward";
     const UNLOCK_STAKE: &'static str = "unlock_stake";
     const WITHDRAW: &'static str = "withdraw";
+    const ADD_DELEGATED_STAKE: &'static str = "add_delegated_stake";
+    const UNLOCK_DELEGATED_STAKE: &'static str = "unlock_delegated_stake";
 
     pub fn all() -> Vec<OperationType> {
         use OperationType::*;
@@ -134,6 +138,8 @@ impl OperationType {
             ResetLockup,
             UnlockStake,
             DistributeStakingRewards,
+            AddDelegatedStake,
+            UnlockDelegatedStake,
         ]
     }
 }
@@ -154,6 +160,8 @@ impl FromStr for OperationType {
             Self::RESET_LOCKUP => Ok(OperationType::ResetLockup),
             Self::UNLOCK_STAKE => Ok(OperationType::UnlockStake),
             Self::DISTRIBUTE_STAKING_REWARDS => Ok(OperationType::DistributeStakingRewards),
+            Self::ADD_DELEGATED_STAKE => Ok(OperationType::AddDelegatedStake),
+            Self::UNLOCK_DELEGATED_STAKE => Ok(OperationType::UnlockDelegatedStake),
             _ => Err(ApiError::DeserializationFailed(Some(format!(
                 "Invalid OperationType: {}",
                 s
@@ -176,6 +184,8 @@ impl Display for OperationType {
             ResetLockup => Self::RESET_LOCKUP,
             UnlockStake => Self::UNLOCK_STAKE,
             DistributeStakingRewards => Self::DISTRIBUTE_STAKING_REWARDS,
+            AddDelegatedStake => Self::ADD_DELEGATED_STAKE,
+            UnlockDelegatedStake => Self::UNLOCK_DELEGATED_STAKE,
             Fee => Self::FEE,
         })
     }

--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -110,6 +110,7 @@ pub enum OperationType {
 }
 
 impl OperationType {
+    const ADD_DELEGATED_STAKE: &'static str = "add_delegated_stake";
     const CREATE_ACCOUNT: &'static str = "create_account";
     const DEPOSIT: &'static str = "deposit";
     const DISTRIBUTE_STAKING_REWARDS: &'static str = "distribute_staking_rewards";
@@ -119,10 +120,9 @@ impl OperationType {
     const SET_OPERATOR: &'static str = "set_operator";
     const SET_VOTER: &'static str = "set_voter";
     const STAKING_REWARD: &'static str = "staking_reward";
+    const UNLOCK_DELEGATED_STAKE: &'static str = "unlock_delegated_stake";
     const UNLOCK_STAKE: &'static str = "unlock_stake";
     const WITHDRAW: &'static str = "withdraw";
-    const ADD_DELEGATED_STAKE: &'static str = "add_delegated_stake";
-    const UNLOCK_DELEGATED_STAKE: &'static str = "unlock_delegated_stake";
 
     pub fn all() -> Vec<OperationType> {
         use OperationType::*;

--- a/crates/aptos-rosetta/src/types/move_types.rs
+++ b/crates/aptos-rosetta/src/types/move_types.rs
@@ -40,9 +40,9 @@ pub const UNLOCK_STAKE_FUNCTION: &str = "unlock_stake";
 pub const DISTRIBUTE_STAKING_REWARDS_FUNCTION: &str = "distribute";
 
 // Delegation Pool Contract
-pub const ADD_DELEGATED_STAKE_FUNCTION: &str = "add_delegated_stake";
-pub const UNLOCK_DELEGATED_STAKE_FUNCTION: &str = "unlock_delegated_stake";
-pub const WITHDRAW_UNDELEGATED_FUNDS_FUNCTION: &str = "withdraw_undelegated_funds";
+pub const DELEGATION_POOL_ADD_STAKE_FUNCTION: &str = "add_stake";
+pub const DELEGATION_POOL_UNLOCK_FUNCTTON: &str = "unlock";
+pub const DELEGATION_POOL_WITHDRAW_FUNCTION: &str = "withdraw";
 
 pub const DECIMALS_FIELD: &str = "decimal";
 pub const DEPOSIT_EVENTS_FIELD: &str = "deposit_events";
@@ -212,7 +212,6 @@ pub struct AddDelegationEvent {
     pub pool_address: AccountAddress,
     pub delegator_address: AccountAddress,
     pub amount_added: u64,
-    pub add_stake_fee: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -8,13 +8,9 @@
 use crate::{
     common::{is_native_coin, native_coin, native_coin_tag},
     construction::{
-        parse_create_stake_pool_operation,
-        parse_delegation_pool_add_stake_operation,
-        parse_distribute_staking_rewards_operation,
-        parse_reset_lockup_operation,
-        parse_set_operator_operation,
-        parse_set_voter_operation,
-        parse_delegation_pool_unlock_operation,
+        parse_create_stake_pool_operation, parse_delegation_pool_add_stake_operation,
+        parse_delegation_pool_unlock_operation, parse_distribute_staking_rewards_operation,
+        parse_reset_lockup_operation, parse_set_operator_operation, parse_set_voter_operation,
         parse_unlock_stake_operation,
     },
     error::ApiResult,

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -8,8 +8,13 @@
 use crate::{
     common::{is_native_coin, native_coin, native_coin_tag},
     construction::{
-        parse_create_stake_pool_operation, parse_distribute_staking_rewards_operation,
-        parse_reset_lockup_operation, parse_set_operator_operation, parse_set_voter_operation,
+        parse_create_stake_pool_operation,
+        parse_delegation_pool_add_stake_operation,
+        parse_distribute_staking_rewards_operation,
+        parse_reset_lockup_operation,
+        parse_set_operator_operation,
+        parse_set_voter_operation,
+        parse_delegation_pool_unlock_operation,
         parse_unlock_stake_operation,
     },
     error::ApiResult,
@@ -174,7 +179,6 @@ pub struct Operation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account: Option<AccountIdentifier>,
     /// Amount in the operation
-    ///
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<Amount>,
     /// Operation specific metadata for any operation that's missing information it needs
@@ -508,6 +512,43 @@ impl Operation {
             .as_ref()
             .and_then(|inner| inner.commission_percentage.map(|inner| inner.0))
     }
+
+    pub fn add_delegated_stake(
+        operation_index: u64,
+        status: Option<OperationStatusType>,
+        delegator: AccountAddress,
+        pool_address: AccountIdentifier,
+        amount: Option<u64>,
+    ) -> Operation {
+        Operation::new(
+            OperationType::AddDelegatedStake,
+            operation_index,
+            status,
+            AccountIdentifier::base_account(delegator),
+            None,
+            Some(OperationMetadata::add_delegated_stake(pool_address, amount)),
+        )
+    }
+
+    pub fn unlock_delegated_stake(
+        operation_index: u64,
+        status: Option<OperationStatusType>,
+        delegator: AccountAddress,
+        pool_address: AccountIdentifier,
+        amount: Option<u64>,
+    ) -> Operation {
+        Operation::new(
+            OperationType::UnlockDelegatedStake,
+            operation_index,
+            status,
+            AccountIdentifier::base_account(delegator),
+            None,
+            Some(OperationMetadata::unlock_delegated_stake(
+                pool_address,
+                amount,
+            )),
+        )
+    }
 }
 
 impl std::cmp::PartialOrd for Operation {
@@ -560,6 +601,8 @@ pub struct OperationMetadata {
     pub amount: Option<U64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub staker: Option<AccountIdentifier>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pool_address: Option<AccountIdentifier>,
 }
 
 impl OperationMetadata {
@@ -628,6 +671,22 @@ impl OperationMetadata {
         OperationMetadata {
             operator: Some(operator),
             staker: Some(staker),
+            ..Default::default()
+        }
+    }
+
+    pub fn add_delegated_stake(pool_address: AccountIdentifier, amount: Option<u64>) -> Self {
+        OperationMetadata {
+            pool_address: Some(pool_address),
+            amount: amount.map(U64::from),
+            ..Default::default()
+        }
+    }
+
+    pub fn unlock_delegated_stake(pool_address: AccountIdentifier, amount: Option<u64>) -> Self {
+        OperationMetadata {
+            pool_address: Some(pool_address),
+            amount: amount.map(U64::from),
             ..Default::default()
         }
     }
@@ -952,6 +1011,28 @@ fn parse_failed_operations_from_txn_payload(
                     }
                 } else {
                     warn!("Failed to parse distribute staking rewards {:?}", inner);
+                }
+            },
+            (AccountAddress::ONE, DELEGATION_POOL_MODULE, DELEGATION_POOL_ADD_STAKE_FUNCTION) => {
+                if let Ok(mut ops) =
+                    parse_delegation_pool_add_stake_operation(sender, inner.ty_args(), inner.args())
+                {
+                    if let Some(operation) = ops.get_mut(0) {
+                        operation.status = Some(OperationStatusType::Failure.to_string());
+                    }
+                } else {
+                    warn!("Failed to parse delegation_pool::add_stake {:?}", inner);
+                }
+            },
+            (AccountAddress::ONE, DELEGATION_POOL_MODULE, DELEGATION_POOL_UNLOCK_FUNCTTON) => {
+                if let Ok(mut ops) =
+                    parse_delegation_pool_unlock_operation(sender, inner.ty_args(), inner.args())
+                {
+                    if let Some(operation) = ops.get_mut(0) {
+                        operation.status = Some(OperationStatusType::Failure.to_string());
+                    }
+                } else {
+                    warn!("Failed to parse delegation_pool::unlock {:?}", inner);
                 }
             },
             _ => {
@@ -1595,6 +1676,8 @@ pub enum InternalOperation {
     ResetLockup(ResetLockup),
     UnlockStake(UnlockStake),
     DistributeStakingRewards(DistributeStakingRewards),
+    AddDelegatedStake(AddDelegatedStake),
+    UnlockDelegatedStake(UnlockDelegatedStake),
 }
 
 impl InternalOperation {
@@ -1758,6 +1841,40 @@ impl InternalOperation {
                                 ));
                             }
                         },
+                        Ok(OperationType::AddDelegatedStake) => {
+                            if let (
+                                Some(OperationMetadata {
+                                    pool_address: Some(pool_address),
+                                    amount,
+                                    ..
+                                }),
+                                Some(account),
+                            ) = (&operation.metadata, &operation.account)
+                            {
+                                return Ok(Self::AddDelegatedStake(AddDelegatedStake {
+                                    delegator: account.account_address()?,
+                                    pool_address: pool_address.account_address()?,
+                                    amount: amount.map(u64::from).unwrap_or_default(),
+                                }));
+                            }
+                        },
+                        Ok(OperationType::UnlockDelegatedStake) => {
+                            if let (
+                                Some(OperationMetadata {
+                                    pool_address: Some(pool_address),
+                                    amount,
+                                    ..
+                                }),
+                                Some(account),
+                            ) = (&operation.metadata, &operation.account)
+                            {
+                                return Ok(Self::UnlockDelegatedStake(UnlockDelegatedStake {
+                                    delegator: account.account_address()?,
+                                    pool_address: pool_address.account_address()?,
+                                    amount: amount.map(u64::from).unwrap_or_default(),
+                                }));
+                            }
+                        },
                         _ => {},
                     }
                 }
@@ -1787,6 +1904,8 @@ impl InternalOperation {
             Self::ResetLockup(inner) => inner.owner,
             Self::UnlockStake(inner) => inner.owner,
             Self::DistributeStakingRewards(inner) => inner.sender,
+            Self::AddDelegatedStake(inner) => inner.delegator,
+            Self::UnlockDelegatedStake(inner) => inner.delegator,
         }
     }
 
@@ -1860,6 +1979,20 @@ impl InternalOperation {
                     distribute_staking_rewards.operator,
                 ),
                 distribute_staking_rewards.sender,
+            ),
+            InternalOperation::AddDelegatedStake(add_delegated_stake) => (
+                aptos_stdlib::delegation_pool_add_stake(
+                    add_delegated_stake.pool_address,
+                    add_delegated_stake.amount,
+                ),
+                add_delegated_stake.delegator,
+            ),
+            InternalOperation::UnlockDelegatedStake(unlock_delegated_stake) => (
+                aptos_stdlib::delegation_pool_unlock(
+                    unlock_delegated_stake.pool_address,
+                    unlock_delegated_stake.amount,
+                ),
+                unlock_delegated_stake.delegator,
             ),
         })
     }
@@ -2032,4 +2165,18 @@ pub struct DistributeStakingRewards {
     pub sender: AccountAddress,
     pub operator: AccountAddress,
     pub staker: AccountAddress,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AddDelegatedStake {
+    pub delegator: AccountAddress,
+    pub pool_address: AccountAddress,
+    pub amount: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct UnlockDelegatedStake {
+    pub delegator: AccountAddress,
+    pub pool_address: AccountAddress,
+    pub amount: u64,
 }

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -38,6 +38,7 @@ use aptos_types::{
     account_address::AccountAddress, account_config::CORE_CODE_ADDRESS, chain_id::ChainId,
     on_chain_config::GasScheduleV2, transaction::SignedTransaction,
 };
+use serde_json::json;
 use std::{
     collections::{BTreeMap, HashSet},
     future::Future,
@@ -143,10 +144,13 @@ async fn test_block_transactions() {
     )
     .await
     .unwrap();
-    assert_eq!(response.block_identifier, BlockIdentifier {
-        index: 0,
-        hash: BlockHash::new(chain_id, 0).to_string(),
-    });
+    assert_eq!(
+        response.block_identifier,
+        BlockIdentifier {
+            index: 0,
+            hash: BlockHash::new(chain_id, 0).to_string(),
+        }
+    );
 
     // First fund account 1 with lots more gas
     cli.fund_account(0, Some(DEFAULT_FUNDED_COINS * 10))
@@ -263,10 +267,13 @@ async fn test_account_balance() {
     )
     .await
     .unwrap();
-    assert_eq!(response.block_identifier, BlockIdentifier {
-        index: 0,
-        hash: BlockHash::new(chain_id, 0).to_string(),
-    });
+    assert_eq!(
+        response.block_identifier,
+        BlockIdentifier {
+            index: 0,
+            hash: BlockHash::new(chain_id, 0).to_string(),
+        }
+    );
 
     // First fund account 1 with lots more gas
     cli.fund_account(0, Some(DEFAULT_FUNDED_COINS * 2))
@@ -500,6 +507,24 @@ async fn unlock_stake(
         .sequence_number(sequence_number);
 
     let txn = account.sign_with_transaction_builder(unlock_stake);
+    info.client().submit_and_wait(&txn).await.unwrap()
+}
+
+async fn create_delegation_pool(
+    info: &AptosPublicInfo<'_>,
+    account: &mut LocalAccount,
+    commission_percentage: u64,
+    sequence_number: u64,
+) -> Response<Transaction> {
+    let delegation_pool_creation = info
+        .transaction_factory()
+        .payload(aptos_stdlib::delegation_pool_initialize_delegation_pool(
+            commission_percentage,
+            vec![],
+        ))
+        .sequence_number(sequence_number);
+
+    let txn = account.sign_with_transaction_builder(delegation_pool_creation);
     info.client().submit_and_wait(&txn).await.unwrap()
 }
 
@@ -1512,6 +1537,121 @@ async fn parse_operations(
                     panic!("Not a user transaction");
                 }
             },
+            OperationType::AddDelegatedStake => {
+                if actual_successful {
+                    assert_eq!(
+                        OperationStatusType::Success,
+                        status,
+                        "Successful transaction should have successful add_delegated_stake operation"
+                    );
+                } else {
+                    assert_eq!(
+                        OperationStatusType::Failure,
+                        status,
+                        "Failed transaction should have failed add_delegated_stake operation"
+                    );
+                }
+
+                // Check that add stake was set the same
+                if let aptos_types::transaction::Transaction::UserTransaction(ref txn) =
+                    actual_txn.transaction
+                {
+                    if let aptos_types::transaction::TransactionPayload::EntryFunction(
+                        ref payload,
+                    ) = txn.payload()
+                    {
+                        let actual_pool_address: AccountAddress =
+                            bcs::from_bytes(payload.args().first().unwrap()).unwrap();
+
+                        let pool_address = operation
+                            .metadata
+                            .as_ref()
+                            .unwrap()
+                            .pool_address
+                            .as_ref()
+                            .unwrap()
+                            .account_address()
+                            .unwrap();
+
+                        assert_eq!(actual_pool_address, pool_address);
+
+                        let actual_amount: u64 =
+                            bcs::from_bytes(payload.args().get(1).unwrap()).unwrap();
+
+                        let amount = operation
+                            .metadata
+                            .as_ref()
+                            .unwrap()
+                            .amount
+                            .as_ref()
+                            .unwrap()
+                            .0;
+
+                        assert_eq!(actual_amount, amount);
+                    } else {
+                        panic!("Not an entry function");
+                    }
+                } else {
+                    panic!("Not a user transaction");
+                }
+            },
+            OperationType::UnlockDelegatedStake => {
+                if actual_successful {
+                    assert_eq!(
+                        OperationStatusType::Success,
+                        status,
+                        "Successful transaction should have successful unlock_delegated_stake operation"
+                    );
+                } else {
+                    assert_eq!(
+                        OperationStatusType::Failure,
+                        status,
+                        "Failed transaction should have failed unlock_delegated_stake operation"
+                    );
+                }
+
+                // Check that unlock stake was set the same
+                if let aptos_types::transaction::Transaction::UserTransaction(ref txn) =
+                    actual_txn.transaction
+                {
+                    if let aptos_types::transaction::TransactionPayload::EntryFunction(
+                        ref payload,
+                    ) = txn.payload()
+                    {
+                        let actual_pool_address: AccountAddress =
+                            bcs::from_bytes(payload.args().first().unwrap()).unwrap();
+                        let pool_address = operation
+                            .metadata
+                            .as_ref()
+                            .unwrap()
+                            .pool_address
+                            .as_ref()
+                            .unwrap()
+                            .account_address()
+                            .unwrap();
+
+                        assert_eq!(actual_pool_address, pool_address);
+
+                        let actual_amount: u64 =
+                            bcs::from_bytes(payload.args().get(1).unwrap()).unwrap();
+
+                        let amount = operation
+                            .metadata
+                            .as_ref()
+                            .unwrap()
+                            .amount
+                            .as_ref()
+                            .unwrap()
+                            .0;
+
+                        assert_eq!(actual_amount, amount);
+                    } else {
+                        panic!("Not an entry function");
+                    }
+                } else {
+                    panic!("Not a user transaction");
+                }
+            },
         }
     }
 
@@ -2099,6 +2239,266 @@ fn expiry_time(txn_expiry_duration: Duration) -> Duration {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .saturating_add(txn_expiry_duration)
+}
+
+async fn add_delegated_stake_and_wait(
+    rosetta_client: &RosettaClient,
+    rest_client: &aptos_rest_client::Client,
+    network_identifier: &NetworkIdentifier,
+    sender_key: &Ed25519PrivateKey,
+    pool_address: AccountAddress,
+    amount: Option<u64>,
+    txn_expiry_duration: Duration,
+    sequence_number: Option<u64>,
+    max_gas: Option<u64>,
+    gas_unit_price: Option<u64>,
+) -> Result<Box<UserTransaction>, ErrorWrapper> {
+    let expiry_time = expiry_time(txn_expiry_duration);
+    let txn_hash = rosetta_client
+        .add_delegated_stake(
+            network_identifier,
+            sender_key,
+            pool_address,
+            amount,
+            expiry_time.as_secs(),
+            sequence_number,
+            max_gas,
+            gas_unit_price,
+        )
+        .await
+        .map_err(ErrorWrapper::BeforeSubmission)?
+        .hash;
+
+    wait_for_transaction(rest_client, expiry_time, txn_hash)
+        .await
+        .map_err(ErrorWrapper::AfterSubmission)
+}
+
+async fn unlock_delegated_stake_and_wait(
+    rosetta_client: &RosettaClient,
+    rest_client: &aptos_rest_client::Client,
+    network_identifier: &NetworkIdentifier,
+    sender_key: &Ed25519PrivateKey,
+    pool_address: AccountAddress,
+    amount: Option<u64>,
+    txn_expiry_duration: Duration,
+    sequence_number: Option<u64>,
+    max_gas: Option<u64>,
+    gas_unit_price: Option<u64>,
+) -> Result<Box<UserTransaction>, ErrorWrapper> {
+    let expiry_time = expiry_time(txn_expiry_duration);
+    let txn_hash = rosetta_client
+        .unlock_delegated_stake(
+            network_identifier,
+            sender_key,
+            pool_address,
+            amount,
+            expiry_time.as_secs(),
+            sequence_number,
+            max_gas,
+            gas_unit_price,
+        )
+        .await
+        .map_err(ErrorWrapper::BeforeSubmission)?
+        .hash;
+    wait_for_transaction(rest_client, expiry_time, txn_hash)
+        .await
+        .map_err(ErrorWrapper::AfterSubmission)
+}
+
+#[tokio::test]
+async fn test_delegation_pool_operations() {
+    const NUM_TXNS_PER_PAGE: u16 = 2;
+
+    let (mut swarm, cli, _, rosetta_client) = setup_test(
+        2,
+        Arc::new(|_, config, _| config.api.max_transactions_page_size = NUM_TXNS_PER_PAGE),
+    )
+    .await;
+
+    // 20 APT
+    let delegate_initial_balance = 20 * u64::pow(10, 8);
+    cli.fund_account(0, Some(delegate_initial_balance))
+        .await
+        .unwrap();
+    let delegate_account_private_key = cli.private_key(0);
+
+    let chain_id = swarm.chain_id();
+    let validator = swarm.validators().next().unwrap();
+    let rest_client = validator.rest_client();
+    let _request = NetworkRequest {
+        network_identifier: NetworkIdentifier::from(chain_id),
+    };
+    let network_identifier = chain_id.into();
+
+    let root_address = swarm.aptos_public_info().root_account().address();
+    let root_sequence_number = swarm
+        .aptos_public_info()
+        .client()
+        .get_account_bcs(root_address)
+        .await
+        .unwrap()
+        .into_inner()
+        .sequence_number();
+
+    *swarm
+        .aptos_public_info()
+        .root_account()
+        .sequence_number_mut() = root_sequence_number;
+
+    let mut delegation_pool_creator_account = swarm
+        .aptos_public_info()
+        .create_and_fund_user_account(1_000_000_000_000_000)
+        .await
+        .unwrap();
+
+    let res = create_delegation_pool(
+        &swarm.aptos_public_info(),
+        &mut delegation_pool_creator_account,
+        10,
+        1,
+    )
+    .await;
+
+    let (tx, _) = res.into_parts();
+    let tx_serialized = json!(tx);
+    let mut pool_address_str = "";
+
+    if let Some(changes) = tx_serialized["changes"].as_array() {
+        for change in changes {
+            if change["data"]["type"] == "0x1::delegation_pool::DelegationPool" {
+                pool_address_str = change["address"].as_str().unwrap();
+                break;
+            }
+        }
+    }
+    let pool_address = AccountAddress::from_hex_literal(pool_address_str).unwrap();
+
+    // Must stake at least 11 APT
+    let staked_amount = 11 * u64::pow(10, 8);
+
+    add_delegated_stake_and_wait(
+        &rosetta_client,
+        &rest_client,
+        &network_identifier,
+        delegate_account_private_key,
+        pool_address,
+        Some(staked_amount),
+        Duration::from_secs(5),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("Should successfully add delegated stake");
+
+    let final_txn = unlock_delegated_stake_and_wait(
+        &rosetta_client,
+        &rest_client,
+        &network_identifier,
+        delegate_account_private_key,
+        pool_address,
+        Some(staked_amount),
+        Duration::from_secs(5),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("Should successfully unlock delegated stake");
+
+    let final_block_to_check = rest_client
+        .get_block_by_version(final_txn.info.version.0, false)
+        .await
+        .expect("Should be able to get block info for completed txns");
+
+    // Check a couple blocks past the final transaction to check more txns
+    let final_block_height = final_block_to_check.into_inner().block_height.0 + 2;
+
+    // TODO: Track total supply?
+    // TODO: Check account balance block hashes?
+    // TODO: Handle multiple coin types
+
+    // Wait until the Rosetta service is ready
+    let request = NetworkRequest {
+        network_identifier: NetworkIdentifier::from(chain_id),
+    };
+
+    loop {
+        let status = try_until_ok_default(|| rosetta_client.network_status(&request))
+            .await
+            .unwrap();
+        if status.current_block_identifier.index >= final_block_height {
+            break;
+        }
+    }
+
+    // Now we have to watch all the changes
+    let mut current_version = 0;
+    let mut balances = BTreeMap::<AccountAddress, BTreeMap<u64, i128>>::new();
+    let mut previous_block_index = 0;
+    let mut block_hashes = HashSet::new();
+    for block_height in 0..final_block_height {
+        let request = BlockRequest::by_index(chain_id, block_height);
+        let response: BlockResponse = rosetta_client
+            .block(&request)
+            .await
+            .expect("Should be able to get blocks that are already known");
+        let block = response.block;
+        let actual_block = rest_client
+            .get_block_by_height_bcs(block_height, true)
+            .await
+            .expect("Should be able to get block for a known block")
+            .into_inner();
+
+        assert_eq!(
+            block.block_identifier.index, block_height,
+            "The block should match the requested block"
+        );
+        assert_eq!(
+            block.block_identifier.hash,
+            BlockHash::new(chain_id, block_height).to_string(),
+            "Block hash should match chain_id-block_height"
+        );
+        assert_eq!(
+            block.parent_block_identifier.index, previous_block_index,
+            "Parent block index should be previous block"
+        );
+        assert_eq!(
+            block.parent_block_identifier.hash,
+            BlockHash::new(chain_id, previous_block_index).to_string(),
+            "Parent block hash should be previous block chain_id-block_height"
+        );
+        assert!(
+            block_hashes.insert(block.block_identifier.hash.clone()),
+            "Block hash was repeated {}",
+            block.block_identifier.hash
+        );
+
+        // It's only greater or equal because microseconds are cut off
+        let expected_timestamp = if block_height == 0 {
+            Y2K_MS
+        } else {
+            actual_block.block_timestamp.saturating_div(1000)
+        };
+        assert_eq!(
+            expected_timestamp, block.timestamp,
+            "Block timestamp should match actual timestamp but in ms"
+        );
+
+        // TODO: double check that all transactions do show with the flag, and that all expected txns
+        // are shown without the flag
+
+        let actual_txns = actual_block
+            .transactions
+            .as_ref()
+            .expect("Every actual block should have transactions");
+
+        parse_block_transactions(&block, &mut balances, actual_txns, &mut current_version).await;
+
+        // Keep track of the previous
+        previous_block_index = block_height;
+    }
 }
 
 #[derive(Debug)]

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -144,13 +144,10 @@ async fn test_block_transactions() {
     )
     .await
     .unwrap();
-    assert_eq!(
-        response.block_identifier,
-        BlockIdentifier {
-            index: 0,
-            hash: BlockHash::new(chain_id, 0).to_string(),
-        }
-    );
+    assert_eq!(response.block_identifier, BlockIdentifier {
+        index: 0,
+        hash: BlockHash::new(chain_id, 0).to_string(),
+    });
 
     // First fund account 1 with lots more gas
     cli.fund_account(0, Some(DEFAULT_FUNDED_COINS * 10))
@@ -267,13 +264,10 @@ async fn test_account_balance() {
     )
     .await
     .unwrap();
-    assert_eq!(
-        response.block_identifier,
-        BlockIdentifier {
-            index: 0,
-            hash: BlockHash::new(chain_id, 0).to_string(),
-        }
-    );
+    assert_eq!(response.block_identifier, BlockIdentifier {
+        index: 0,
+        hash: BlockHash::new(chain_id, 0).to_string(),
+    });
 
     // First fund account 1 with lots more gas
     cli.fund_account(0, Some(DEFAULT_FUNDED_COINS * 2))


### PR DESCRIPTION
Added the following functionality for delegation_pool::add_stake and delegation_pool::unlock in the Rosetta implementation:
- Parsing of operations
- Construction API / client support

### Description

Adding support to aptos-rosetta for `delegation_pool::add_stake` and `delegation_pool::unlock`.

### Test Plan

Smoke tests