### PR TITLE
[transaction-generator] Rename TransactionExecutor to ReliableTransactionSubmitter

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -16,7 +16,7 @@ use aptos_sdk::{
         AccountKey, LocalAccount,
     },
 };
-use aptos_transaction_generator_lib::{CounterState, TransactionExecutor, SEND_AMOUNT};
+use aptos_transaction_generator_lib::{CounterState, ReliableTransactionSubmitter, SEND_AMOUNT};
 use core::{
     cmp::min,
     result::Result::{Err, Ok},
@@ -57,7 +57,7 @@ impl<'t> AccountMinter<'t> {
     /// will create 10 seed accounts, each seed account create 10 new accounts
     pub async fn create_accounts(
         &mut self,
-        txn_executor: &dyn TransactionExecutor,
+        txn_executor: &dyn ReliableTransactionSubmitter,
         req: &EmitJobRequest,
         mode_params: &EmitModeParams,
         total_requested_accounts: usize,
@@ -258,7 +258,7 @@ impl<'t> AccountMinter<'t> {
 
     pub async fn mint_to_root(
         &mut self,
-        txn_executor: &dyn TransactionExecutor,
+        txn_executor: &dyn ReliableTransactionSubmitter,
         amount: u64,
     ) -> Result<()> {
         info!("Minting new coins to root");
@@ -275,7 +275,7 @@ impl<'t> AccountMinter<'t> {
     pub async fn create_and_fund_seed_accounts(
         &mut self,
         mut new_source_account: Option<LocalAccount>,
-        txn_executor: &dyn TransactionExecutor,
+        txn_executor: &dyn ReliableTransactionSubmitter,
         seed_account_num: usize,
         coins_per_seed_account: u64,
         max_submit_batch_size: usize,
@@ -317,7 +317,7 @@ impl<'t> AccountMinter<'t> {
 
     pub async fn load_vasp_account(
         &self,
-        txn_executor: &dyn TransactionExecutor,
+        txn_executor: &dyn ReliableTransactionSubmitter,
         index: usize,
     ) -> Result<LocalAccount> {
         let file = "vasp".to_owned() + index.to_string().as_str() + ".key";
@@ -341,7 +341,7 @@ impl<'t> AccountMinter<'t> {
 
     pub async fn create_new_source_account(
         &mut self,
-        txn_executor: &dyn TransactionExecutor,
+        txn_executor: &dyn ReliableTransactionSubmitter,
         coins_for_source: u64,
     ) -> Result<LocalAccount> {
         for i in 0..3 {
@@ -401,7 +401,7 @@ async fn create_and_fund_new_accounts<R>(
     num_new_accounts: usize,
     coins_per_new_account: u64,
     max_num_accounts_per_batch: usize,
-    txn_executor: &dyn TransactionExecutor,
+    txn_executor: &dyn ReliableTransactionSubmitter,
     txn_factory: &TransactionFactory,
     reuse_account: bool,
     mut rng: R,
@@ -448,7 +448,7 @@ where
 }
 
 async fn gen_reusable_accounts<R>(
-    txn_executor: &dyn TransactionExecutor,
+    txn_executor: &dyn ReliableTransactionSubmitter,
     num_accounts: usize,
     rng: &mut R,
 ) -> Result<Vec<LocalAccount>>
@@ -465,7 +465,7 @@ where
 }
 
 async fn gen_reusable_account<R>(
-    txn_executor: &dyn TransactionExecutor,
+    txn_executor: &dyn ReliableTransactionSubmitter,
     rng: &mut R,
 ) -> Result<LocalAccount>
 where

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -10,7 +10,7 @@ use crate::emitter::{
     account_minter::AccountMinter,
     stats::{DynamicStatsTracking, TxnStats},
     submission_worker::SubmissionWorker,
-    transaction_executor::RestApiTransactionExecutor,
+    transaction_executor::RestApiReliableTransactionSubmitter,
 };
 use again::RetryPolicy;
 use anyhow::{ensure, format_err, Result};
@@ -558,7 +558,7 @@ impl TxnEmitter {
             init_retries,
             req.init_retry_interval.as_secs_f32()
         );
-        let txn_executor = RestApiTransactionExecutor {
+        let txn_executor = RestApiReliableTransactionSubmitter {
             rest_clients: req.rest_clients.clone(),
             max_retries: init_retries,
             retry_after: req.init_retry_interval,

--- a/crates/transaction-emitter-lib/src/emitter/transaction_executor.rs
+++ b/crates/transaction-emitter-lib/src/emitter/transaction_executor.rs
@@ -8,7 +8,7 @@ use aptos_rest_client::{aptos_api_types::TransactionInfo, error::RestError, Clie
 use aptos_sdk::{
     move_types::account_address::AccountAddress, types::transaction::SignedTransaction,
 };
-use aptos_transaction_generator_lib::{CounterState, TransactionExecutor};
+use aptos_transaction_generator_lib::{CounterState, ReliableTransactionSubmitter};
 use async_trait::async_trait;
 use futures::future::join_all;
 use rand::{rngs::StdRng, seq::SliceRandom, thread_rng, Rng, SeedableRng};
@@ -18,13 +18,13 @@ use std::{
 };
 
 // Reliable/retrying transaction executor, used for initializing
-pub struct RestApiTransactionExecutor {
+pub struct RestApiReliableTransactionSubmitter {
     pub rest_clients: Vec<RestClient>,
     pub max_retries: usize,
     pub retry_after: Duration,
 }
 
-impl RestApiTransactionExecutor {
+impl RestApiReliableTransactionSubmitter {
     fn random_rest_client(&self) -> &RestClient {
         let mut rng = thread_rng();
         self.rest_clients.choose(&mut rng).unwrap()
@@ -239,7 +239,7 @@ async fn submit_and_check(
 }
 
 #[async_trait]
-impl TransactionExecutor for RestApiTransactionExecutor {
+impl ReliableTransactionSubmitter for RestApiReliableTransactionSubmitter {
     async fn get_account_balance(&self, account_address: AccountAddress) -> Result<u64> {
         Ok(RETRY_POLICY
             .retry(move || {

--- a/crates/transaction-generator-lib/src/call_custom_modules.rs
+++ b/crates/transaction-generator-lib/src/call_custom_modules.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{publishing::publish_util::Package, TransactionExecutor};
+use super::{publishing::publish_util::Package, ReliableTransactionSubmitter};
 use crate::{
     create_account_transaction, publishing::publish_util::PackageHandler, TransactionGenerator,
     TransactionGeneratorCreator,
@@ -51,7 +51,7 @@ pub trait UserModuleTransactionGenerator: Sync + Send {
         &self,
         init_accounts: &mut [LocalAccount],
         txn_factory: &TransactionFactory,
-        txn_executor: &dyn TransactionExecutor,
+        txn_executor: &dyn ReliableTransactionSubmitter,
         rng: &mut StdRng,
     ) -> Arc<TransactionGeneratorWorker>;
 }
@@ -113,7 +113,7 @@ impl CustomModulesDelegationGeneratorCreator {
         txn_factory: TransactionFactory,
         init_txn_factory: TransactionFactory,
         accounts: &mut [LocalAccount],
-        txn_executor: &dyn TransactionExecutor,
+        txn_executor: &dyn ReliableTransactionSubmitter,
         num_modules: usize,
         package_name: &str,
         workload: &mut dyn UserModuleTransactionGenerator,

--- a/crates/transaction-generator-lib/src/entry_points.rs
+++ b/crates/transaction-generator-lib/src/entry_points.rs
@@ -3,7 +3,7 @@
 
 use super::{
     publishing::{module_simple::EntryPoints, publish_util::Package},
-    TransactionExecutor,
+    ReliableTransactionSubmitter,
 };
 use crate::{
     call_custom_modules::{TransactionGeneratorWorker, UserModuleTransactionGenerator},
@@ -47,7 +47,7 @@ impl UserModuleTransactionGenerator for EntryPointTransactionGenerator {
         &self,
         init_accounts: &mut [LocalAccount],
         txn_factory: &TransactionFactory,
-        txn_executor: &dyn TransactionExecutor,
+        txn_executor: &dyn ReliableTransactionSubmitter,
         rng: &mut StdRng,
     ) -> Arc<TransactionGeneratorWorker> {
         let entry_point = self.entry_point;

--- a/crates/transaction-generator-lib/src/lib.rs
+++ b/crates/transaction-generator-lib/src/lib.rs
@@ -100,7 +100,7 @@ pub struct CounterState {
 }
 
 #[async_trait]
-pub trait TransactionExecutor: Sync + Send {
+pub trait ReliableTransactionSubmitter: Sync + Send {
     async fn get_account_balance(&self, account_address: AccountAddress) -> Result<u64>;
 
     async fn query_sequence_number(&self, account_address: AccountAddress) -> Result<u64>;
@@ -171,7 +171,7 @@ pub async fn create_txn_generator_creator(
     transaction_mix_per_phase: &[Vec<(TransactionType, usize)>],
     source_accounts: &mut [LocalAccount],
     initial_burner_accounts: Vec<LocalAccount>,
-    txn_executor: &dyn TransactionExecutor,
+    txn_executor: &dyn ReliableTransactionSubmitter,
     txn_factory: &TransactionFactory,
     init_txn_factory: &TransactionFactory,
     cur_phase: Arc<AtomicUsize>,

--- a/execution/executor-benchmark/src/db_reliable_submitter.rs
+++ b/execution/executor-benchmark/src/db_reliable_submitter.rs
@@ -10,9 +10,7 @@ use anyhow::{Context, Result};
 use aptos_crypto::HashValue;
 use aptos_state_view::account_with_state_view::AsAccountWithStateView;
 use aptos_storage_interface::{state_view::LatestDbStateCheckpointView, DbReaderWriter};
-use aptos_transaction_generator_lib::{
-    CounterState, TransactionExecutor as GenInitTransactionExecutor,
-};
+use aptos_transaction_generator_lib::{CounterState, ReliableTransactionSubmitter};
 use aptos_types::{
     account_address::AccountAddress,
     account_view::AccountView,
@@ -26,13 +24,13 @@ use std::{
     time::Duration,
 };
 
-pub struct DbGenInitTransactionExecutor {
+pub struct DbReliableTransactionSubmitter {
     pub db: DbReaderWriter,
     pub block_sender: mpsc::SyncSender<Vec<BenchmarkTransaction>>,
 }
 
 #[async_trait]
-impl GenInitTransactionExecutor for DbGenInitTransactionExecutor {
+impl ReliableTransactionSubmitter for DbReliableTransactionSubmitter {
     async fn get_account_balance(&self, account_address: AccountAddress) -> Result<u64> {
         let db_state_view = self.db.reader.latest_state_checkpoint_view().unwrap();
         let sender_coin_store_key = DbAccessUtil::new_state_key_aptos_coin(account_address);

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -6,7 +6,7 @@ mod account_generator;
 pub mod benchmark_transaction;
 pub mod db_access;
 pub mod db_generator;
-mod gen_executor;
+mod db_reliable_submitter;
 mod metrics;
 pub mod native_executor;
 pub mod pipeline;
@@ -37,7 +37,7 @@ use aptos_transaction_generator_lib::{
     create_txn_generator_creator, TransactionGeneratorCreator, TransactionType,
 };
 use aptos_vm::counters::TXN_GAS_USAGE;
-use gen_executor::DbGenInitTransactionExecutor;
+use db_reliable_submitter::DbReliableTransactionSubmitter;
 use pipeline::PipelineConfig;
 use std::{
     collections::HashMap,
@@ -291,7 +291,7 @@ where
     let (txn_generator_creator, _address_pool, _account_pool) = runtime.block_on(async {
         let phase = Arc::new(AtomicUsize::new(0));
 
-        let db_gen_init_transaction_executor = DbGenInitTransactionExecutor {
+        let db_gen_init_transaction_executor = DbReliableTransactionSubmitter {
             db: db.clone(),
             block_sender,
         };


### PR DESCRIPTION
cleanup follow-up from this comment - https://github.com/aptos-labs/aptos-core/pull/7651#discussion_r1164756699

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
