### PR TITLE
[Network] Fix bug in VFN role and improve role propagation.

### DIFF
--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -449,11 +449,12 @@ where
                     // TODO: We should prevent `Unknown` from discovery sources
                     if !self.mutual_authentication
                         && metadata.origin == ConnectionOrigin::Inbound
-                        && metadata.role == PeerRole::Unknown
+                        && (metadata.role == PeerRole::ValidatorFullNode
+                            || metadata.role == PeerRole::Unknown)
                     {
                         None
                     } else {
-                        Some(*peer_id)
+                        Some(*peer_id) // The peer is stale
                     }
                 });
 
@@ -860,6 +861,12 @@ where
                 }
             },
         }
+    }
+
+    #[cfg(test)]
+    /// Returns the set of connected peers (for test purposes)
+    fn get_connected_peers(&self) -> HashMap<PeerId, ConnectionMetadata> {
+        self.connected.clone()
     }
 }
 

--- a/network/src/logging.rs
+++ b/network/src/logging.rs
@@ -37,6 +37,7 @@ pub struct NetworkSchema<'a> {
     connection_origin: Option<&'a ConnectionOrigin>,
     #[schema(display)]
     discovery_source: Option<&'a DiscoverySource>,
+    message: Option<String>,
     #[schema(display)]
     network_address: Option<&'a NetworkAddress>,
     network_context: &'a NetworkContext,
@@ -50,6 +51,7 @@ impl<'a> NetworkSchema<'a> {
             connection_id: None,
             connection_origin: None,
             discovery_source: None,
+            message: None,
             network_address: None,
             network_context,
             remote_peer: None,

--- a/network/src/noise/mod.rs
+++ b/network/src/noise/mod.rs
@@ -66,11 +66,11 @@
 //!
 //! // perform the handshake
 //! let (client_session, server_session) = executor::block_on(future::join(
-//!    client.upgrade_outbound(dialer_socket, server_public, AntiReplayTimestamps::now),
+//!    client.upgrade_outbound(dialer_socket, server_peer_id, server_public, AntiReplayTimestamps::now),
 //!    server.upgrade_inbound(listener_socket),
 //! ));
 //!
-//! let mut client_session = client_session
+//! let (mut client_session, _) = client_session
 //!     .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
 //! let (mut server_session, _client_peer_id, _trust_level) = server_session
 //!     .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;

--- a/network/src/noise/stream.rs
+++ b/network/src/noise/stream.rs
@@ -578,13 +578,19 @@ mod test {
         let (dialer_socket, listener_socket) = MemorySocket::new_pair();
 
         // perform the handshake
+        let server_peer_id = server.network_context.peer_id();
         let (client_session, server_session) = block_on(join(
-            client.upgrade_outbound(dialer_socket, server_public_key, AntiReplayTimestamps::now),
+            client.upgrade_outbound(
+                dialer_socket,
+                server_peer_id,
+                server_public_key,
+                AntiReplayTimestamps::now,
+            ),
             server.upgrade_inbound(listener_socket),
         ));
 
         //
-        let client_session = client_session.unwrap();
+        let (client_session, _) = client_session.unwrap();
         let (server_session, _, _) = server_session.unwrap();
         (client_session, server_session)
     }
@@ -684,13 +690,19 @@ mod test {
         let ((client, _client_public_key), (server, server_public_key)) = build_peers();
 
         // perform the handshake
+        let server_peer_id = server.network_context.peer_id();
         let (client, server) = block_on(join(
-            client.upgrade_outbound(dialer_socket, server_public_key, AntiReplayTimestamps::now),
+            client.upgrade_outbound(
+                dialer_socket,
+                server_peer_id,
+                server_public_key,
+                AntiReplayTimestamps::now,
+            ),
             server.upgrade_inbound(listener_socket),
         ));
 
         // get session
-        let mut client = client.unwrap();
+        let (mut client, _) = client.unwrap();
         let (mut server, _, _) = server.unwrap();
 
         // test send and receive

--- a/network/src/testutils/mod.rs
+++ b/network/src/testutils/mod.rs
@@ -18,6 +18,7 @@ pub mod test_node;
 pub fn create_client_server_network_context(
     client_public_key: Option<PublicKey>,
     server_public_key: Option<PublicKey>,
+    peers_and_metadata: Option<Arc<PeersAndMetadata>>,
 ) -> (NetworkContext, NetworkContext, Arc<PeersAndMetadata>) {
     // Create the client context
     let client_network_context = create_context_for_public_key(client_public_key);
@@ -30,7 +31,8 @@ pub fn create_client_server_network_context(
     );
 
     // Create the trusted peers and metadata
-    let peers_and_metadata = PeersAndMetadata::new(&[client_network_context.network_id()]);
+    let peers_and_metadata = peers_and_metadata
+        .unwrap_or_else(|| PeersAndMetadata::new(&[client_network_context.network_id()]));
 
     (
         client_network_context,

--- a/network/src/transport/mod.rs
+++ b/network/src/transport/mod.rs
@@ -344,9 +344,14 @@ pub async fn upgrade_outbound<T: TSocket>(
     let socket = fut_socket.await?;
 
     // noise handshake
-    let mut socket = ctxt
+    let (mut socket, peer_role) = ctxt
         .noise
-        .upgrade_outbound(socket, remote_pubkey, AntiReplayTimestamps::now)
+        .upgrade_outbound(
+            socket,
+            remote_peer_id,
+            remote_pubkey,
+            AntiReplayTimestamps::now,
+        )
         .await
         .map_err(|err| {
             if err.should_security_log() {
@@ -396,7 +401,7 @@ pub async fn upgrade_outbound<T: TSocket>(
             origin,
             messaging_protocol,
             application_protocols,
-            PeerRole::Unknown,
+            peer_role,
         ),
     })
 }

--- a/network/src/transport/test.rs
+++ b/network/src/transport/test.rs
@@ -79,7 +79,7 @@ where
         Auth::Mutual => {
             // Create the dialer and listener network contexts
             let (dialer_network_context, listener_network_context, peers_and_metadata) =
-                testutils::create_client_server_network_context(None, None);
+                testutils::create_client_server_network_context(None, None, None);
 
             // Add the trusted peers
             let network_id = listener_network_context.network_id();
@@ -111,6 +111,7 @@ where
                 testutils::create_client_server_network_context(
                     Some(dialer_key.public_key()),
                     Some(listener_key.public_key()),
+                    None,
                 );
 
             // Add the trusted peers
@@ -143,6 +144,7 @@ where
                 testutils::create_client_server_network_context(
                     Some(dialer_key.public_key()),
                     Some(listener_key.public_key()),
+                    None,
                 );
 
             // Get the trusted peers


### PR DESCRIPTION
Note: most of this PR is just new tests.

### Description
This PR fixes a bug in the network stack whereby VFNs connecting to validators are assigned the "Unknown" role, instead of the "ValidatorFullnode" role (as they should be). The PR also helps to improve role assignment logic, specifically that peer roles should always be assigned when a noise handshake completes (regardless of inbound or outbound origin). This is not currently the case.

To achieve this, the PR offers the following commits:
1. Update the peer role logic to assign VFNs the "ValidatorFullnode" role when connecting to validators.
2. Update the noise handshake code to assign peer roles during handshake time for outbound connections. This removes a workaround that assigns the role after the handshake is done.
3. Update the stale peer logic to not remove inbound connections with the "ValidatorFullnode" role.

The PR also adds a new set of unit tests to better verify this behaviour (in each commit).

### Test Plan
Existing and new unit tests.