### PR TITLE
[Execution/Storage][Sharding] Shard state updates in StateDelta.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2846,6 +2846,7 @@ dependencies = [
  "bcs 0.1.4",
  "crossbeam-channel",
  "dashmap",
+ "itertools",
  "move-core-types",
  "once_cell",
  "parking_lot 0.12.1",

--- a/execution/executor/src/components/in_memory_state_calculator_v2.rs
+++ b/execution/executor/src/components/in_memory_state_calculator_v2.rs
@@ -81,10 +81,13 @@ impl InMemoryStateCalculatorV2 {
             base.base_version,
             base.current_version,
         );
-        ensure!(
-            base.updates_since_base.is_empty(),
-            "Updates is not empty, cannot calculate state."
-        );
+        base.updates_since_base.iter().try_for_each(|shard| {
+            ensure!(
+                shard.is_empty(),
+                "Updates is not empty, cannot calculate state."
+            );
+            Ok(())
+        })?;
 
         let num_txns = to_keep.len();
         for (i, (txn, txn_output)) in to_keep.iter().enumerate() {
@@ -142,7 +145,7 @@ impl InMemoryStateCalculatorV2 {
             new_checkpoint_version,
             new_checkpoint,
             new_checkpoint_version,
-            HashMap::new(),
+            create_empty_sharded_state_updates(),
         );
 
         Ok((

--- a/storage/aptosdb/src/fake_aptosdb.rs
+++ b/storage/aptosdb/src/fake_aptosdb.rs
@@ -107,9 +107,6 @@ impl FakeBufferedState {
         if let Some(updates_until_next_checkpoint_since_current) =
             updates_until_next_checkpoint_since_current_option
         {
-            self.state_after_checkpoint
-                .updates_since_base
-                .extend(updates_until_next_checkpoint_since_current);
             self.state_after_checkpoint.current = new_state_after_checkpoint.base.clone();
             self.state_after_checkpoint.current_version = new_state_after_checkpoint.base_version;
             swap(

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -38,7 +38,7 @@ fn put_value_set(
         .iter()
         .map(|(key, value)| {
             sharded_value_set[key.get_shard_id() as usize].insert(key.clone(), Some(value.clone()));
-            (key.clone(), Some(value.clone()))
+            (key, Some(value))
         })
         .collect();
     let jmt_updates = jmt_updates(&value_set);

--- a/storage/aptosdb/src/state_store/state_snapshot_committer.rs
+++ b/storage/aptosdb/src/state_store/state_snapshot_committer.rs
@@ -78,8 +78,16 @@ impl StateSnapshotCommitter {
                     let (top_levels_batch, sharded_batch, root_hash) = self
                         .state_db
                         .state_merkle_db
+                        // TODO(grao): Provide a sharded version of this function.
                         .merklize_value_set(
-                            jmt_update_refs(&jmt_updates(&delta_to_commit.updates_since_base)),
+                            jmt_update_refs(&jmt_updates(
+                                &delta_to_commit
+                                    .updates_since_base
+                                    .iter()
+                                    .flatten()
+                                    .map(|(k, v)| (k, v.as_ref()))
+                                    .collect(),
+                            )),
                             Some(&node_hashes),
                             version,
                             base_version,

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -31,7 +31,7 @@ fn put_value_set(
         .iter()
         .map(|(key, value)| {
             sharded_value_set[key.get_shard_id() as usize].insert(key.clone(), Some(value.clone()));
-            (key.clone(), Some(value.clone()))
+            (key, Some(value))
         })
         .collect();
     let jmt_updates = jmt_updates(&value_set);

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -26,6 +26,7 @@ arr_macro = { workspace = true }
 bcs = { workspace = true }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true }
+itertools = { workspace = true }
 move-core-types = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -737,11 +737,11 @@ impl SaveTransactionsRequest {
 }
 
 pub fn jmt_updates(
-    state_updates: &HashMap<StateKey, Option<StateValue>>,
+    state_updates: &HashMap<&StateKey, Option<&StateValue>>,
 ) -> Vec<(HashValue, Option<(HashValue, StateKey)>)> {
     state_updates
         .iter()
-        .map(|(k, v_opt)| (k.hash(), v_opt.as_ref().map(|v| (v.hash(), k.clone()))))
+        .map(|(k, v_opt)| (k.hash(), v_opt.as_ref().map(|v| (v.hash(), (*k).clone()))))
         .collect()
 }
 


### PR DESCRIPTION
### Description
Avoid the flatten in the save_transaction_block, and move it to the async state commit stage in the background (will also be removed later when the JMT calculation part is sharded). By removing it from foreground thread, it gives us 5%+ performance gain for commit (measured by account creation benchmark from 0 to 20M accounts).

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
