### PR TITLE
[TF] Add toggles for enabling GCFS and GVNIC on GCP

### DIFF
--- a/terraform/aptos-node-testnet/gcp/main.tf
+++ b/terraform/aptos-node-testnet/gcp/main.tf
@@ -44,6 +44,10 @@ module "validator" {
   k8s_api_sources         = var.k8s_api_sources
   cluster_ipv4_cidr_block = var.cluster_ipv4_cidr_block
 
+  # node config
+  gke_cluster_enable_gcfs  = var.gke_cluster_enable_gcfs
+  gke_cluster_enable_gvnic = var.gke_cluster_enable_gvnic
+
   # autoscaling
   gke_enable_node_autoprovisioning     = var.gke_enable_node_autoprovisioning
   gke_node_autoprovisioning_max_cpu    = var.gke_node_autoprovisioning_max_cpu

--- a/terraform/aptos-node-testnet/gcp/variables.tf
+++ b/terraform/aptos-node-testnet/gcp/variables.tf
@@ -148,6 +148,18 @@ variable "enable_prometheus_node_exporter" {
   default     = true
 }
 
+### Cluster node config
+
+variable "gke_cluster_enable_gcfs" {
+  description = "Enable GCFS at the cluster level"
+  default     = false
+}
+
+variable "gke_cluster_enable_gvnic" {
+  description = "Enable GVNIC (networking driver) at the cluster level"
+  default     = false
+}
+
 ### Autoscaling
 
 variable "gke_enable_node_autoprovisioning" {

--- a/terraform/aptos-node/gcp/cluster.tf
+++ b/terraform/aptos-node/gcp/cluster.tf
@@ -53,6 +53,15 @@ resource "google_container_cluster" "aptos" {
     provider = "CALICO"
   }
 
+  node_config {
+    gcfs_config {
+      enabled = var.gke_cluster_enable_gcfs
+    }
+    gvnic {
+      enabled = var.gke_cluster_enable_gvnic
+    }
+  }
+
   cluster_autoscaling {
     enabled = var.gke_enable_node_autoprovisioning
 

--- a/terraform/aptos-node/gcp/variables.tf
+++ b/terraform/aptos-node/gcp/variables.tf
@@ -171,8 +171,19 @@ variable "manage_via_tf" {
   default     = true
 }
 
-### Autoscaling
+### Cluster node config
 
+variable "gke_cluster_enable_gcfs" {
+  description = "Enable GCFS at the cluster level"
+  default     = false
+}
+
+variable "gke_cluster_enable_gvnic" {
+  description = "Enable GVNIC (networking driver) at the cluster level"
+  default     = false
+}
+
+### Autoscaling
 
 variable "gke_enable_node_autoprovisioning" {
   description = "Enable node autoprovisioning for GKE cluster. See https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning"


### PR DESCRIPTION
### Description

* Google Container File System is a virtual file-system that allows lazy-mounting an image so that containerd can start running a container without having fully downloaded the image. The file-system will fetch on-the-fly only the data that is actually read.
* Google Virtual NIC is a virtual network interface specifically optimized for GCP, as an alternative to virtIO.

### Test Plan

Will deploy first on the GCP devnet.