### PR TITLE
[scripts] make dev_setup.sh more resilient

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -14,7 +14,7 @@
 # 3 ${HOME}/bin/, or ${INSTALL_DIR} is expected to be on the path - hashicorp tools/etc.  will be installed there on linux systems.
 
 # fast fail.
-set -eo pipefail
+set -eox pipefail
 
 SHELLCHECK_VERSION=0.7.1
 GRCOV_VERSION=0.8.2
@@ -470,8 +470,11 @@ function install_dotnet {
     fi
     # Below we need to (a) set TERM variable because the .net installer expects it and it is not set
     # in some environments (b) use bash not sh because the installer uses bash features.
-    curl -sSL https://dot.net/v1/dotnet-install.sh \
-        | TERM=linux /bin/bash -s -- --channel $DOTNET_VERSION --install-dir "${DOTNET_INSTALL_DIR}" --version latest
+    # NOTE: use wget to better follow the redirect
+    wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
+    chmod +x dotnet-install.sh
+    ./dotnet-install.sh --channel $DOTNET_VERSION --install-dir "${DOTNET_INSTALL_DIR}" --version latest
+    rm dotnet-install.sh
   else
     echo Dotnet already installed.
   fi


### PR DESCRIPTION
### Description

Try to repro some network issues 

There's some nasty redirects in our .NET installation it turns out. Using `wget` instead of `curl` seems to fix it for the most part.

Sometimes it redirects back to https://dot.net/v1/dotnet-install.sh (which then errors out), and sometimes to https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh (the correct one)

Also set `-x` in `dev_setup.sh` when running in CI only. Don't set it when running on laptops since it will become too verbose.

### Test Plan

Try `wget` and `curl` the URL a bunch of times. I'm able to repro the main issue like so:

```
for i in `seq 0 100`; do curl -Ls -o /dev/null -w %{url_effective} https://dot.net/v1/dotnet-install.sh && echo ; done
```

all the CI that relies on dev_setup.sh working on this PR, despite a spike in errors across other PRs

<!-- Please provide us with clear details for verifying that your changes work. -->
