### PR TITLE
[TF] More fixes for GCP DNS

### DIFF
--- a/terraform/aptos-node-testnet/aws/variables.tf
+++ b/terraform/aptos-node-testnet/aws/variables.tf
@@ -71,7 +71,6 @@ variable "chain_id" {
   default     = 4
 }
 
-
 variable "era" {
   description = "Chain era, used to start a clean chain"
   default     = 15

--- a/terraform/aptos-node-testnet/gcp/addons.tf
+++ b/terraform/aptos-node-testnet/gcp/addons.tf
@@ -1,5 +1,6 @@
 locals {
-  chaos_mesh_helm_chart_path = "${path.module}/../../helm/chaos"
+  chaos_mesh_helm_chart_path     = "${path.module}/../../helm/chaos"
+  testnet_addons_helm_chart_path = "${path.module}/../../helm/testnet-addons"
 }
 
 resource "kubernetes_namespace" "chaos-mesh" {
@@ -54,5 +55,115 @@ resource "helm_release" "chaos-mesh" {
   set {
     name  = "chart_sha1"
     value = sha1(join("", [for f in fileset(local.chaos_mesh_helm_chart_path, "**") : filesha1("${local.chaos_mesh_helm_chart_path}/${f}")]))
+  }
+}
+
+resource "google_service_account" "k8s-gcp-integrations" {
+  project    = var.project
+  account_id = "${local.workspace_name}-testnet-gcp"
+}
+
+resource "google_project_iam_member" "k8s-gcp-integrations-dns" {
+  project = local.zone_project
+  role    = "roles/dns.admin"
+  member  = "serviceAccount:${google_service_account.k8s-gcp-integrations.email}"
+}
+
+resource "google_service_account_iam_binding" "k8s-gcp-integrations" {
+  service_account_id = google_service_account.k8s-gcp-integrations.name
+  role               = "roles/iam.workloadIdentityUser"
+  members            = ["serviceAccount:${module.validator.gke_cluster_workload_identity_config[0].workload_pool}[kube-system/k8s-gcp-integrations]"]
+}
+
+resource "kubernetes_service_account" "k8s-gcp-integrations" {
+  metadata {
+    name      = "k8s-gcp-integrations"
+    namespace = "kube-system"
+    annotations = {
+      "iam.gke.io/gcp-service-account" = google_service_account.k8s-gcp-integrations.email
+    }
+  }
+}
+
+data "google_dns_managed_zone" "testnet" {
+  count   = var.zone_name != "" ? 1 : 0
+  name    = var.zone_name
+  project = local.zone_project
+}
+
+locals {
+  zone_project = var.zone_project != "" ? var.zone_project : var.project
+  dns_prefix   = var.workspace_dns ? "${local.workspace_name}.${var.dns_prefix_name}." : "${var.dns_prefix_name}."
+  domain       = var.zone_name != "" ? trimsuffix("${local.dns_prefix}${data.google_dns_managed_zone.testnet[0].dns_name}", ".") : null
+}
+
+resource "helm_release" "external-dns" {
+  count       = var.zone_name != "" ? 1 : 0
+  name        = "external-dns"
+  repository  = "https://kubernetes-sigs.github.io/external-dns"
+  chart       = "external-dns"
+  version     = "1.11.0"
+  namespace   = "kube-system"
+  max_history = 5
+  wait        = false
+
+  values = [
+    jsonencode({
+      serviceAccount = {
+        create = false
+        name   = kubernetes_service_account.k8s-gcp-integrations.metadata[0].name
+      }
+      provider      = "google"
+      domainFilters = var.zone_name != "" ? [data.google_dns_managed_zone.testnet[0].dns_name] : []
+      extraArgs = [
+        "--google-project=${local.zone_project}",
+        "--txt-owner-id=${local.workspace_name}",
+        "--txt-prefix=aptos",
+      ]
+    })
+  ]
+}
+
+resource "helm_release" "testnet-addons" {
+  count       = var.enable_forge ? 0 : 1
+  name        = "testnet-addons"
+  chart       = local.testnet_addons_helm_chart_path
+  max_history = 5
+  wait        = false
+
+  values = [
+    jsonencode({
+      cloud    = "GKE"
+      imageTag = var.image_tag
+      # The addons need to be able to refer to the Genesis parameters
+      genesis = {
+        era             = var.era
+        username_prefix = local.aptos_node_helm_prefix
+        chain_id        = var.chain_id
+        numValidators   = var.num_validators
+      }
+      service = {
+        domain = local.domain
+        # aws_tags = local.aws_tags
+      }
+      ingress = {
+        # acm_certificate          = length(aws_acm_certificate.ingress) > 0 ? aws_acm_certificate.ingress[0].arn : null
+        # loadBalancerSourceRanges = # var.client_sources_ipv4
+      }
+      load_test = {
+        fullnodeGroups = try(var.aptos_node_helm_values.fullnode.groups, [])
+        config = {
+          numFullnodeGroups = var.num_fullnode_groups
+        }
+      }
+    }),
+  ]
+  dynamic "set" {
+    for_each = var.manage_via_tf ? toset([""]) : toset([])
+    content {
+      # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
+      name  = "chart_sha1"
+      value = sha1(join("", [for f in fileset(local.testnet_addons_helm_chart_path, "**") : filesha1("${local.testnet_addons_helm_chart_path}/${f}")]))
+    }
   }
 }

--- a/terraform/aptos-node-testnet/gcp/main.tf
+++ b/terraform/aptos-node-testnet/gcp/main.tf
@@ -31,7 +31,8 @@ module "validator" {
   record_name  = var.record_name
   # do not create the main fullnode and validator DNS records
   # instead, rely on external-dns from the testnet-addons
-  create_dns_records = false
+  create_dns_records = var.create_dns_records
+  dns_ttl            = var.dns_ttl
 
   # General chain config
   era            = var.era
@@ -99,6 +100,7 @@ resource "helm_release" "genesis" {
       genesis = {
         numValidators   = var.num_validators
         username_prefix = local.aptos_node_helm_prefix
+        domain          = local.domain
         validator = {
           enable_onchain_discovery = false
         }

--- a/terraform/aptos-node-testnet/gcp/variables.tf
+++ b/terraform/aptos-node-testnet/gcp/variables.tf
@@ -50,6 +50,16 @@ variable "image_tag" {
 
 ### DNS config
 
+variable "workspace_dns" {
+  description = "Include Terraform workspace name in DNS records"
+  default     = true
+}
+
+variable "dns_prefix_name" {
+  description = "DNS prefix for fullnode url"
+  default     = "fullnode"
+}
+
 variable "zone_name" {
   description = "Zone name of GCP Cloud DNS zone to create records in"
   default     = ""
@@ -63,6 +73,16 @@ variable "zone_project" {
 variable "record_name" {
   description = "DNS record name to use (<workspace> is replaced with the TF workspace name)"
   default     = "<workspace>.aptos"
+}
+
+variable "create_dns_records" {
+  description = "Creates DNS records in var.zone_name that point to k8s service, as opposed to using external-dns or other means"
+  default     = true
+}
+
+variable "dns_ttl" {
+  description = "Time-to-Live for the Validator and Fullnode DNS records"
+  default     = 300
 }
 
 ### Testnet config

--- a/terraform/aptos-node/gcp/cluster.tf
+++ b/terraform/aptos-node/gcp/cluster.tf
@@ -13,6 +13,10 @@ resource "google_container_cluster" "aptos" {
     channel = "REGULAR"
   }
 
+  pod_security_policy_config {
+    enabled = false
+  }
+
   master_auth {
     client_certificate_config {
       issue_client_certificate = false

--- a/terraform/aptos-node/gcp/kubernetes.tf
+++ b/terraform/aptos-node/gcp/kubernetes.tf
@@ -77,6 +77,14 @@ resource "helm_release" "validator" {
           effect = "NoExecute"
         }]
       }
+      haproxy = {
+        nodeSelector = var.gke_enable_node_autoprovisioning ? {} : {
+          "cloud.google.com/gke-nodepool" = google_container_node_pool.utilities.name
+        }
+      }
+      service = {
+        domain = local.domain
+      }
     }),
     var.helm_values_file != "" ? file(var.helm_values_file) : "{}",
     jsonencode(var.helm_values),

--- a/terraform/aptos-node/gcp/outputs.tf
+++ b/terraform/aptos-node/gcp/outputs.tf
@@ -9,3 +9,7 @@ output "gke_cluster_endpoint" {
 output "gke_cluster_ca_certificate" {
   value = google_container_cluster.aptos.master_auth[0].cluster_ca_certificate
 }
+
+output "gke_cluster_workload_identity_config" {
+  value = google_container_cluster.aptos.workload_identity_config
+}

--- a/terraform/aptos-node/gcp/security.tf
+++ b/terraform/aptos-node/gcp/security.tf
@@ -1,36 +1,12 @@
 # Security-related resources
 
-data "kubernetes_all_namespaces" "all" {
-  count = var.cluster_bootstrap ? 0 : 1
-}
-
 locals {
-  kubernetes_master_version = substr(google_container_cluster.aptos.master_version, 0, 4)
-  baseline_pss_labels = {
+  # Enforce "privileged" PSS (i.e. allow everything), but warn about
+  # infractions of "baseline" profile
+  privileged_pss_labels = {
     "pod-security.kubernetes.io/audit"   = "baseline"
     "pod-security.kubernetes.io/warn"    = "baseline"
     "pod-security.kubernetes.io/enforce" = "privileged"
-  }
-}
-
-# FIXME: Remove after migration to K8s 1.25
-resource "kubernetes_role_binding" "disable-psp" {
-  for_each = toset(var.cluster_bootstrap ? [] : local.kubernetes_master_version <= "1.24" ? data.kubernetes_all_namespaces.all[0].namespaces : [])
-  metadata {
-    name      = "privileged-psp"
-    namespace = each.value
-  }
-
-  role_ref {
-    api_group = "rbac.authorization.k8s.io"
-    kind      = "ClusterRole"
-    name      = "gce:podsecuritypolicy:privileged"
-  }
-
-  subject {
-    api_group = "rbac.authorization.k8s.io"
-    kind      = "Group"
-    name      = "system:serviceaccounts:${each.value}"
   }
 }
 
@@ -40,5 +16,5 @@ resource "kubernetes_labels" "pss-default" {
   metadata {
     name = "default"
   }
-  labels = local.baseline_pss_labels
+  labels = local.privileged_pss_labels
 }

--- a/terraform/aptos-node/gcp/variables.tf
+++ b/terraform/aptos-node/gcp/variables.tf
@@ -46,26 +46,6 @@ variable "image_tag" {
   default     = "devnet"
 }
 
-variable "zone_name" {
-  description = "Zone name of GCP Cloud DNS zone to create records in"
-  default     = ""
-}
-
-variable "zone_project" {
-  description = "GCP project which the DNS zone is in (if different)"
-  default     = ""
-}
-
-variable "record_name" {
-  description = "DNS record name to use (<workspace> is replaced with the TF workspace name)"
-  default     = "<workspace>.aptos"
-}
-
-variable "create_dns_records" {
-  description = "Creates DNS records in var.zone_name that point to k8s service, as opposed to using external-dns or other means"
-  default     = true
-}
-
 variable "helm_chart" {
   description = "Path to aptos-validator Helm chart file"
   default     = ""
@@ -171,8 +151,39 @@ variable "manage_via_tf" {
   default     = true
 }
 
-### Autoscaling
+### DNS
 
+variable "zone_name" {
+  description = "Zone name of GCP Cloud DNS zone to create records in"
+  default     = ""
+}
+
+variable "zone_project" {
+  description = "GCP project which the DNS zone is in (if different)"
+  default     = ""
+}
+
+variable "workspace_dns" {
+  description = "Include Terraform workspace name in DNS records"
+  default     = true
+}
+
+variable "record_name" {
+  description = "DNS record name to use (<workspace> is replaced with the TF workspace name)"
+  default     = "<workspace>.aptos"
+}
+
+variable "create_dns_records" {
+  description = "Creates DNS records in var.zone_name that point to k8s service, as opposed to using external-dns or other means"
+  default     = true
+}
+
+variable "dns_ttl" {
+  description = "Time-to-Live for the Validator and Fullnode DNS records"
+  default     = 300
+}
+
+### Autoscaling
 
 variable "gke_enable_node_autoprovisioning" {
   description = "Enable node autoprovisioning for GKE cluster. See https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning"

--- a/terraform/aptos-node/gcp/versions.tf
+++ b/terraform/aptos-node/gcp/versions.tf
@@ -2,10 +2,12 @@ terraform {
   required_version = "~> 1.3.6"
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
+      version = "~> 4.54.0"
     }
     google-beta = {
-      source = "hashicorp/google-beta"
+      source  = "hashicorp/google-beta"
+      version = "~> 4.54.0"
     }
     helm = {
       source = "hashicorp/helm"

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -16,7 +16,7 @@ numFullnodeGroups: 1
 
 # -- Options for multicluster mode. This is *experimental only*.
 multicluster:
-  enabled: false 
+  enabled: false
   targetClusters: ["cluster1", "cluster2", "cluster3"]
 
 # -- Specify validator and fullnode NodeConfigs via named ConfigMaps, rather than the generated ones from this chart.
@@ -151,7 +151,7 @@ service:
     # -- Enable the REST API on the validator
     enableRestApi: true
     # -- Enable the metrics port on the validator
-    enableMetricsPort: true
+    enableMetricsPort: false
   fullnode:
     external:
       # -- The Kubernetes ServiceType to use for fullnodes' HAProxy
@@ -167,7 +167,7 @@ service:
     # -- Enable the REST API on fullnodes
     enableRestApi: true
     # -- Enable the metrics port on fullnodes
-    enableMetricsPort: true
+    enableMetricsPort: false
 
 serviceAccount:
   # -- Specifies whether a service account should be created

--- a/terraform/helm/testnet-addons/templates/ingress.yaml
+++ b/terraform/helm/testnet-addons/templates/ingress.yaml
@@ -5,14 +5,16 @@ metadata:
   labels:
     {{- include "testnet-addons.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.service.domain }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.service.domain }}
+    {{- end }}
+    # EKS annotations
+    {{- if eq .Values.cloud "EKS" }}
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/tags: {{ .Values.service.aws_tags | quote }}
     {{- if .Values.ingress.loadBalancerSourceRanges }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ join "," .Values.ingress.loadBalancerSourceRanges }}
-    {{- end }}
-    {{- if .Values.service.domain }}
-    external-dns.alpha.kubernetes.io/hostname: {{ .Values.service.domain }}
     {{- end }}
     {{- if .Values.ingress.acm_certificate }}
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate }}
@@ -27,6 +29,13 @@ metadata:
     alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds={{ .Values.ingress.cookieDurationSeconds }}
     alb.ingress.kubernetes.io/target-type: ip
     {{- end }}
+    {{- end }} # "EKS"
+    # GKE annotations
+    {{- if eq .Values.cloud "GKE" }}
+    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/ingress.allow-http: "true"
+    kubernetes.io/ingress.global-static-ip-name: "testnet-addons-ingress-ip"
+    {{- end }} # "GKE"
 spec:
   rules:
   {{- if .Values.service.domain }}

--- a/terraform/helm/testnet-addons/templates/ingress.yaml
+++ b/terraform/helm/testnet-addons/templates/ingress.yaml
@@ -33,8 +33,11 @@ metadata:
     # GKE annotations
     {{- if eq .Values.cloud "GKE" }}
     kubernetes.io/ingress.class: "gce"
+    # Allow HTTP but always return 301 because we have redirectToHttps enabled
     kubernetes.io/ingress.allow-http: "true"
-    kubernetes.io/ingress.global-static-ip-name: "testnet-addons-ingress-ip"
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.gcp_static_ip }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.gcp_certificate }}
+    networking.gke.io/v1beta1.FrontendConfig: {{ include "testnet-addons.fullname" . }}-api
     {{- end }} # "GKE"
 spec:
   rules:
@@ -73,3 +76,15 @@ spec:
             name: {{ include "testnet-addons.fullname" . }}-api
             port:
               number: 80
+---
+{{- if eq .Values.cloud "GKE" }}
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: {{ include "testnet-addons.fullname" . }}-api
+  namespace: default
+spec:
+  redirectToHttps:
+    enabled: true
+{{- end }}
+---

--- a/terraform/helm/testnet-addons/templates/service.yaml
+++ b/terraform/helm/testnet-addons/templates/service.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- if eq .Values.cloud "EKS" }}
     alb.ingress.kubernetes.io/healthcheck-path: /v1/-/healthy
     {{- end }}
+    {{- if eq .Values.cloud "GKE" }}
+    cloud.google.com/backend-config: '{"default":"{{ include "testnet-addons.fullname" . }}-api"}'
+    cloud.google.com/neg: '{"ingress": true}'
+    {{- end }}
 spec:
   selector:
     app.kubernetes.io/part-of: aptos-node
@@ -18,3 +22,22 @@ spec:
     targetPort: 8080
   type: NodePort
   externalTrafficPolicy: Local
+---
+{{- if eq .Values.cloud "GKE" }}
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: {{ include "testnet-addons.fullname" . }}-api
+  namespace: default
+spec:
+  healthCheck:
+    checkIntervalSec: 30
+    timeoutSec: 5
+    healthyThreshold: 1
+    unhealthyThreshold: 2
+    type: HTTP
+    requestPath: /v1/-/healthy
+    # container targetPort
+    port: 8080
+{{- end }}
+---

--- a/terraform/helm/testnet-addons/templates/service.yaml
+++ b/terraform/helm/testnet-addons/templates/service.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "testnet-addons.labels" . | nindent 4 }}
   annotations:
+    {{- if eq .Values.cloud "EKS" }}
     alb.ingress.kubernetes.io/healthcheck-path: /v1/-/healthy
+    {{- end }}
 spec:
   selector:
     app.kubernetes.io/part-of: aptos-node

--- a/terraform/helm/testnet-addons/values.yaml
+++ b/terraform/helm/testnet-addons/values.yaml
@@ -1,3 +1,6 @@
+# Cloud provider
+cloud: EKS
+
 # -- Default image tag to use for all aptos images
 imageTag: devnet
 
@@ -50,7 +53,7 @@ load_test:
   # -- The fullnode groups to target
   fullnode:
     groups:
-    - name: fullnode
+      - name: fullnode
   config:
     # -- The number of fullnode groups to run traffic against
     numFullnodeGroups:

--- a/terraform/helm/testnet-addons/values.yaml
+++ b/terraform/helm/testnet-addons/values.yaml
@@ -83,6 +83,8 @@ service:
 ingress:
   # -- The ACM certificate to install on the ingress
   acm_certificate:
+  # -- The GCP certificate to install on the ingress
+  gcp_certificate:
   # -- The ARN of the WAF ACL to install on the ingress
   wafAclArn:
   # -- List of CIDRs to accept traffic from


### PR DESCRIPTION
### Description

* add variable to control the record TTL and lower the default from 1h to 5min, as the rest of the records on GCP
* add variable *create_dns_records* to the testnet module as well, to be useable from the devnet module

### Test Plan

Tested on the new GCP Devnet.