### PR TITLE
Determine speculation mode from LogSchema (+allow disabling for sharding experiments)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,6 +22,7 @@
 /aptos-move/framework/src/natives/cryptography/ @alinush
 /aptos-move/framework/src/natives/aggregator_natives/ @georgemitenkov @gelash @zekun000
 /aptos-move/block-executor/ @gelash @zekun000 @sasha8 @danielxiangzl
+/aptos-move/sharded_block-executor/ @sitalkedia
 /aptos-move/mvhashmap/ @gelash @runtian-zhou @sasha8 @danielxiangzl
 /aptos-move/vm-genesis/ @davidiw @movekevin
 

--- a/aptos-move/aptos-vm-logging/src/lib.rs
+++ b/aptos-move/aptos-vm-logging/src/lib.rs
@@ -6,8 +6,8 @@ pub mod log_schema;
 
 pub mod prelude {
     pub use crate::{
-        alert, counters::CRITICAL_ERRORS, speculative_debug, speculative_error, speculative_info,
-        speculative_log, speculative_trace, speculative_warn,
+        alert, counters::CRITICAL_ERRORS, disable_speculative_logging, speculative_debug,
+        speculative_error, speculative_info, speculative_log, speculative_trace, speculative_warn,
     };
 }
 
@@ -16,7 +16,10 @@ use aptos_logger::{prelude::*, Level};
 use aptos_speculative_state_helper::{SpeculativeEvent, SpeculativeEvents};
 use arc_swap::ArcSwapOption;
 use once_cell::sync::Lazy;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 struct VMLogEntry {
     level: Level,
@@ -55,6 +58,24 @@ impl SpeculativeEvent for VMLogEntry {
 static BUFFERED_LOG_EVENTS: Lazy<ArcSwapOption<SpeculativeEvents<VMLogEntry>>> =
     Lazy::new(|| ArcSwapOption::from(None));
 
+static DISABLE_SPECULATION: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
+
+/// Disables speculation, clears the BUFFERED_LOG_EVENTS and overrides the corresponding
+/// errors on accesses. Dispatches log events directly.
+/// This is useful to experiment with sharded block-stm, for example, as different shards
+/// interfere with each others' speculative logging. This seems like the least intrusive
+/// temporary workaround.
+///
+/// Note: THIS SHOULD NOT BE USED (other than one case in sharded block-stm prototype).
+/// TODO: more proper solution.
+pub fn disable_speculative_logging() {
+    DISABLE_SPECULATION.store(true, Ordering::Relaxed);
+}
+
+fn speculation_disabled() -> bool {
+    DISABLE_SPECULATION.load(Ordering::Relaxed)
+}
+
 /// Initializes the storage of speculative logs for num_txns many transactions.
 pub fn init_speculative_logs(num_txns: usize) {
     BUFFERED_LOG_EVENTS.swap(Some(Arc::new(SpeculativeEvents::new(num_txns))));
@@ -65,27 +86,50 @@ pub fn init_speculative_logs(num_txns: usize) {
 /// events storage is not initialized or appropriately sized.
 pub fn speculative_log(level: Level, context: &AdapterLogSchema, message: String) {
     let txn_idx = context.get_txn_idx();
-    match &*BUFFERED_LOG_EVENTS.load() {
-        Some(log_events) => {
-            let log_event = VMLogEntry::new(level, context.clone(), message);
-            if let Err(e) = log_events.record(txn_idx, log_event) {
-                alert!("{:?}", e);
-            };
-        },
-        None => {},
-    };
-}
 
-/// Flushes the first num_to_flush logs in the currently stored logs, and swaps the speculative log / event storage with None.
-/// Must be called after block execution is complete (removes the storage from Arc).
-pub fn flush_speculative_logs(num_to_flush: usize) {
-    if let Some(log_events_ptr) = BUFFERED_LOG_EVENTS.swap(None) {
-        match Arc::try_unwrap(log_events_ptr) {
-            Ok(log_events) => log_events.flush(num_to_flush),
-            Err(_) => {
-                alert!("Speculative log storage must be uniquely owned to flush");
+    if !context.speculation_supported() && speculation_disabled() {
+        // Speculation isn't supported in the current mode, or disabled globally.
+        // log the entry directly.
+        let log_event = VMLogEntry::new(level, context.clone(), message);
+        log_event.dispatch();
+    } else {
+        // Store in speculative log events.
+        match &*BUFFERED_LOG_EVENTS.load() {
+            Some(log_events) => {
+                let log_event = VMLogEntry::new(level, context.clone(), message);
+                if let Err(e) = log_events.record(txn_idx, log_event) {
+                    alert!("{:?}", e);
+                };
+            },
+            None => {
+                alert!(
+                    "Speculative state not initialized to log message = {}",
+                    message
+                );
             },
         };
+    }
+}
+
+/// Flushes the first num_to_flush logs in the currently stored logs, and swaps the speculative
+/// log / event storage with None. Must be called after block execution is complete as it
+/// removes the storage from Arc.
+pub fn flush_speculative_logs(num_to_flush: usize) {
+    match BUFFERED_LOG_EVENTS.swap(None) {
+        Some(log_events_ptr) => {
+            match Arc::try_unwrap(log_events_ptr) {
+                Ok(log_events) => log_events.flush(num_to_flush),
+                Err(_) => {
+                    alert!("Speculative log storage must be uniquely owned to flush");
+                },
+            };
+        },
+        None => {
+            if !speculation_disabled() {
+                // Alert only if speculation is not disabled.
+                alert!("Clear all logs called on uninitialized speculative log storage");
+            }
+        },
     }
 }
 
@@ -98,7 +142,12 @@ pub fn clear_speculative_txn_logs(txn_idx: usize) {
                 alert!("{:?}", e);
             };
         },
-        None => {},
+        None => {
+            if !speculation_disabled() {
+                // Alert only if speculation is not disabled.
+                alert!("Clear all logs called on uninitialized speculative log storage");
+            }
+        },
     }
 }
 

--- a/aptos-move/aptos-vm-logging/src/log_schema.rs
+++ b/aptos-move/aptos-vm-logging/src/log_schema.rs
@@ -63,6 +63,12 @@ impl AdapterLogSchema {
         }
     }
 
+    // Is the adapter log schema used in a context that supports speculative
+    // logging (block execution and state-sync). It is from the name.
+    pub(crate) fn speculation_supported(&self) -> bool {
+        matches!(self.name, LogEntry::Execution)
+    }
+
     pub(crate) fn get_txn_idx(&self) -> usize {
         self.txn_idx
     }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -46,9 +46,7 @@ use aptos_types::{
     write_set::WriteSet,
 };
 use aptos_utils::{aptos_try, return_on_failure};
-use aptos_vm_logging::{
-    init_speculative_logs, log_schema::AdapterLogSchema, speculative_error, speculative_log,
-};
+use aptos_vm_logging::{log_schema::AdapterLogSchema, speculative_error, speculative_log};
 use fail::fail_point;
 use move_binary_format::{
     access::ModuleAccess,
@@ -1170,8 +1168,6 @@ impl AptosVM {
         F: FnOnce(u64, AptosGasParameters, StorageGasParameters, Gas) -> Result<G, VMStatus>,
     {
         // TODO(Gas): revisit this.
-        init_speculative_logs(1);
-
         let resolver = StorageAdapter::new(state_view);
         let vm = AptosVM::new(&resolver);
 

--- a/aptos-move/aptos-vm/src/sharded_block_executor/executor_shard.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/executor_shard.rs
@@ -1,10 +1,12 @@
 // Copyright © Aptos Foundation
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 use crate::{block_executor::BlockAptosVM, sharded_block_executor::ExecutorShardCommand};
 use aptos_logger::trace;
 use aptos_state_view::StateView;
 use aptos_types::transaction::TransactionOutput;
+use aptos_vm_logging::disable_speculative_logging;
 use move_core_types::vm_status::VMStatus;
 use std::sync::{
     mpsc::{Receiver, Sender},
@@ -35,6 +37,8 @@ impl<S: StateView + Sync + Send + 'static> ExecutorShard<S> {
                 .build()
                 .unwrap(),
         );
+        disable_speculative_logging();
+
         Self {
             shard_id,
             executor_thread_pool,


### PR DESCRIPTION
Should make sure that when we are in simulation, speculative logging doesn't introduce errors (no speculative storage), or swallow errors (if speculative execution is running concurrently).

Need a way to confirm this works as expected.