### PR TITLE
[gha] ability to call run-fullnode-sync from workflow_dispatch

### DIFF
--- a/.github/actions/fullnode-sync/action.yaml
+++ b/.github/actions/fullnode-sync/action.yaml
@@ -2,11 +2,8 @@ name: "Fullnode Sync"
 description: |
   Runs a fullnode from aptos-core, assuming it is already checked out in the current working directory.
 inputs:
-  TIMEOUT_MINUTES:
-    description: "The number of minutes to wait for fullnode sync to finish."
-    required: true
-  BRANCH:
-    description: "The aptos-core branch to switch to before running the fullnode."
+  GIT_REF:
+    description: "The aptos-core git ref (branch or commit hash) to switch to before running the fullnode."
     required: true
   NETWORK:
     description: "The network to connect the fullnode to: devnet, testnet, or mainnet."
@@ -37,9 +34,9 @@ runs:
       run: |
         source "$HOME/.cargo/env" # Required for allowing python access to cargo
         pip install -r ${{ github.action_path }}/requirements.txt
-        timeout "${{ inputs.TIMEOUT_MINUTES }}m" python3 ${{ github.action_path }}/fullnode_sync.py
+        python3 ${{ github.action_path }}/fullnode_sync.py
       env:
-        BRANCH: ${{ inputs.BRANCH }}
+        GIT_REF: ${{ inputs.GIT_REF }}
         NETWORK: ${{ inputs.NETWORK }}
         BOOTSTRAPPING_MODE: ${{ inputs.BOOTSTRAPPING_MODE }}
         CONTINUOUS_SYNCING_MODE: ${{ inputs.CONTINUOUS_SYNCING_MODE }}

--- a/.github/actions/fullnode-sync/fullnode_sync.py
+++ b/.github/actions/fullnode-sync/fullnode_sync.py
@@ -183,12 +183,12 @@ def get_public_and_target_version(network):
   return (public_version, target_version)
 
 
-def spawn_fullnode(branch, network, bootstrapping_mode, continuous_syncing_mode, node_log_file_path):
+def spawn_fullnode(git_ref, network, bootstrapping_mode, continuous_syncing_mode, node_log_file_path):
   """Spawns the fullnode"""
   # Display the fullnode setup
-  print("Starting the fullnode using branch: {branch}, for network: {network}, " \
+  print("Starting the fullnode using git ref: {git_ref}, for network: {network}, " \
         "with bootstrapping mode: {bootstrapping_mode} and continuous syncing " \
-        "mode: {continuous_syncing_mode}!".format(branch=branch, network=network,
+        "mode: {continuous_syncing_mode}!".format(git_ref=git_ref, network=network,
                                                   bootstrapping_mode=bootstrapping_mode,
                                                   continuous_syncing_mode=continuous_syncing_mode))
 
@@ -239,17 +239,17 @@ def get_genesis_and_waypoint(network):
   subprocess.run(["curl", "-s", "-O", waypoint_file_path])
 
 
-def checkout_git_branch(branch):
-  """Checkout the specified git branch. This assumes the working directory is aptos-core"""
+def checkout_git_ref(git_ref):
+  """Checkout the specified git ref. This assumes the working directory is aptos-core"""
   subprocess.run(["git", "fetch"])
-  subprocess.run(["git", "checkout", branch])
+  subprocess.run(["git", "checkout", git_ref])
   subprocess.run(["git", "log", "-1"]) # Display the git commit we're running on
 
 
 def main():
   # Ensure we have all required environment variables
   REQUIRED_ENVS = [
-    "BRANCH",
+    "GIT_REF",
     "NETWORK",
     "BOOTSTRAPPING_MODE",
     "CONTINUOUS_SYNCING_MODE",
@@ -260,15 +260,15 @@ def main():
     raise Exception("Missing required ENV variables!")
 
   # Fetch each of the environment variables
-  BRANCH = os.environ["BRANCH"]
+  GIT_REF = os.environ["GIT_REF"]
   NETWORK = os.environ["NETWORK"]
   BOOTSTRAPPING_MODE = os.environ["BOOTSTRAPPING_MODE"]
   CONTINUOUS_SYNCING_MODE = os.environ["CONTINUOUS_SYNCING_MODE"]
   DATA_DIR_FILE_PATH = os.environ["DATA_DIR_FILE_PATH"]
   NODE_LOG_FILE_PATH = os.environ["NODE_LOG_FILE_PATH"]
 
-  # Check out the correct git branch
-  checkout_git_branch(BRANCH)
+  # Check out the correct git ref (branch or commit hash)
+  checkout_git_ref(GIT_REF)
 
   # Get the genesis blob and waypoint
   get_genesis_and_waypoint(NETWORK)
@@ -280,7 +280,7 @@ def main():
   (public_version, target_version) = get_public_and_target_version(NETWORK)
 
   # Spawn the fullnode
-  fullnode_process_handle = spawn_fullnode(BRANCH, NETWORK, BOOTSTRAPPING_MODE, CONTINUOUS_SYNCING_MODE, NODE_LOG_FILE_PATH)
+  fullnode_process_handle = spawn_fullnode(GIT_REF, NETWORK, BOOTSTRAPPING_MODE, CONTINUOUS_SYNCING_MODE, NODE_LOG_FILE_PATH)
 
   # Wait for the fullnode to come up
   wait_for_fullnode_to_start(fullnode_process_handle)

--- a/.github/workflows/fullnode-execute-devnet-main.yaml
+++ b/.github/workflows/fullnode-execute-devnet-main.yaml
@@ -28,7 +28,7 @@ jobs:
     secrets: inherit
     with:
       TEST_NAME: fullnode-execute-devnet-main
-      BRANCH: main
+      GIT_REF: main
       NETWORK: devnet
       BOOTSTRAPPING_MODE: ExecuteTransactionsFromGenesis
       CONTINUOUS_SYNCING_MODE: ExecuteTransactions

--- a/.github/workflows/fullnode-execute-devnet-stable.yaml
+++ b/.github/workflows/fullnode-execute-devnet-stable.yaml
@@ -28,7 +28,7 @@ jobs:
     secrets: inherit
     with:
       TEST_NAME: fullnode-execute-devnet-stable
-      BRANCH: devnet
+      GIT_REF: devnet
       NETWORK: devnet
       BOOTSTRAPPING_MODE: ExecuteTransactionsFromGenesis
       CONTINUOUS_SYNCING_MODE: ExecuteTransactions

--- a/.github/workflows/fullnode-fast-mainnet-main.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-main.yaml
@@ -28,7 +28,7 @@ jobs:
     secrets: inherit
     with:
       TEST_NAME: fullnode-fast-mainnet-main
-      BRANCH: main
+      GIT_REF: main
       NETWORK: mainnet
       BOOTSTRAPPING_MODE: DownloadLatestStates
       CONTINUOUS_SYNCING_MODE: ExecuteTransactions

--- a/.github/workflows/fullnode-fast-mainnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-stable.yaml
@@ -28,7 +28,7 @@ jobs:
     secrets: inherit
     with:
       TEST_NAME: fullnode-fast-mainnet-stable
-      BRANCH: mainnet
+      GIT_REF: mainnet
       NETWORK: mainnet
       BOOTSTRAPPING_MODE: DownloadLatestStates
       CONTINUOUS_SYNCING_MODE: ExecuteTransactions

--- a/.github/workflows/fullnode-fast-testnet-main.yaml
+++ b/.github/workflows/fullnode-fast-testnet-main.yaml
@@ -28,7 +28,7 @@ jobs:
     secrets: inherit
     with:
       TEST_NAME: fullnode-fast-testnet-main
-      BRANCH: main
+      GIT_REF: main
       NETWORK: testnet
       BOOTSTRAPPING_MODE: DownloadLatestStates
       CONTINUOUS_SYNCING_MODE: ExecuteTransactions

--- a/.github/workflows/fullnode-fast-testnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-testnet-stable.yaml
@@ -28,7 +28,7 @@ jobs:
     secrets: inherit
     with:
       TEST_NAME: fullnode-fast-testnet-stable
-      BRANCH: testnet
+      GIT_REF: testnet
       NETWORK: testnet
       BOOTSTRAPPING_MODE: DownloadLatestStates
       CONTINUOUS_SYNCING_MODE: ExecuteTransactions

--- a/.github/workflows/fullnode-intelligent-devnet-main.yaml
+++ b/.github/workflows/fullnode-intelligent-devnet-main.yaml
@@ -29,7 +29,7 @@ jobs:
     secrets: inherit
     with:
       TEST_NAME: fullnode-intelligent-devnet-main
-      BRANCH: main
+      GIT_REF: main
       NETWORK: devnet
       BOOTSTRAPPING_MODE: ExecuteOrApplyFromGenesis
       CONTINUOUS_SYNCING_MODE: ExecuteTransactionsOrApplyOutputs

--- a/.github/workflows/fullnode-output-mainnet-main.yaml
+++ b/.github/workflows/fullnode-output-mainnet-main.yaml
@@ -27,7 +27,7 @@ jobs:
     secrets: inherit
     with:
       TEST_NAME: fullnode-output-mainnet-main
-      BRANCH: main
+      GIT_REF: main
       NETWORK: mainnet
       BOOTSTRAPPING_MODE: ApplyTransactionOutputsFromGenesis
       CONTINUOUS_SYNCING_MODE: ApplyTransactionOutputs

--- a/.github/workflows/run-fullnode-sync.yaml
+++ b/.github/workflows/run-fullnode-sync.yaml
@@ -11,8 +11,8 @@ on:
         description: "The unique name of the fullnode test."
         type: string
         required: true
-      BRANCH:
-        description: "The aptos-core branch (or ref) to switch to before running the fullnode."
+      GIT_REF:
+        description: "The aptos-core git ref (GIT_REF or commit hash) to switch to before running the fullnode."
         type: string
         required: true
       NETWORK:
@@ -38,8 +38,8 @@ on:
         description: "The unique name of the fullnode test."
         type: string
         required: true
-      BRANCH:
-        description: "The aptos-core branch (or ref) to switch to before running the fullnode."
+      GIT_REF:
+        description: "The aptos-core GIT_REF (or ref) to switch to before running the fullnode."
         type: string
         required: true
       NETWORK:
@@ -58,14 +58,13 @@ on:
 jobs:
   fullnode-sync:
     runs-on: medium-perf-docker-with-local-ssd
-    timeout-minutes: ${{ inputs.TIMEOUT_MINUTES || 300 }}
+    timeout-minutes: ${{ inputs.TIMEOUT_MINUTES || 300 }} # the default run is 300 minutes (5 hours). Specified here because workflow_dispatch uses string rather than number
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
 
       - uses: ./.github/actions/fullnode-sync
         with:
-          TIMEOUT_MINUTES: ${{ inputs.TIMEOUT_MINUTES || 300 }}
-          BRANCH: ${{ inputs.BRANCH }}
+          GIT_REF: ${{ inputs.GIT_REF }}
           NETWORK: ${{ inputs.NETWORK }}
           BOOTSTRAPPING_MODE: ${{ inputs.BOOTSTRAPPING_MODE }}
           CONTINUOUS_SYNCING_MODE: ${{ inputs.CONTINUOUS_SYNCING_MODE }}
@@ -94,7 +93,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}
 
       # Because we have to checkout the actions and then check out a different
-      # branch, it's possible the actions directory will be modified. So, we
+      # git ref, it's possible the actions directory will be modified. So, we
       # need to check it out again for the Post Run actions/checkout to succeed.
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:

--- a/.github/workflows/run-fullnode-sync.yaml
+++ b/.github/workflows/run-fullnode-sync.yaml
@@ -12,7 +12,7 @@ on:
         type: string
         required: true
       BRANCH:
-        description: "The aptos-core branch to switch to before running the fullnode."
+        description: "The aptos-core branch (or ref) to switch to before running the fullnode."
         type: string
         required: true
       NETWORK:
@@ -32,17 +32,39 @@ on:
         type: number
         required: false
         default: 300 # Run for at most 5 hours
+  workflow_dispatch:
+    inputs:
+      TEST_NAME:
+        description: "The unique name of the fullnode test."
+        type: string
+        required: true
+      BRANCH:
+        description: "The aptos-core branch (or ref) to switch to before running the fullnode."
+        type: string
+        required: true
+      NETWORK:
+        description: "The network to connect the fullnode to: devnet, testnet, or mainnet."
+        type: string
+        required: true
+      BOOTSTRAPPING_MODE:
+        description: "The state sync bootstrapping mode for the fullnode."
+        type: string
+        required: true
+      CONTINUOUS_SYNCING_MODE:
+        description: "The state sync continuous syncing mode for the fullnode."
+        type: string
+        required: true
 
 jobs:
   fullnode-sync:
     runs-on: medium-perf-docker-with-local-ssd
-    timeout-minutes: ${{ inputs.TIMEOUT_MINUTES }}
+    timeout-minutes: ${{ inputs.TIMEOUT_MINUTES || 300 }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
 
       - uses: ./.github/actions/fullnode-sync
         with:
-          TIMEOUT_MINUTES: ${{ inputs.TIMEOUT_MINUTES }}
+          TIMEOUT_MINUTES: ${{ inputs.TIMEOUT_MINUTES || 300 }}
           BRANCH: ${{ inputs.BRANCH }}
           NETWORK: ${{ inputs.NETWORK }}
           BOOTSTRAPPING_MODE: ${{ inputs.BOOTSTRAPPING_MODE }}


### PR DESCRIPTION
### Description

Adds the `workflow_dispatch` trigger to the reusable workflow `Run Fullnode Sync` (`run-fullnode-sync.yaml`). This lets someone go to the UI to trigger it, with all the options like branch (or git ref), branch, bootstrapping/continuous-syncing mode, etc. like how each of the `fullnode-execute-{network}-{branch}.yaml` jobs call.

### Test Plan

`gh` cli. It can also equivalently be run from the GHA UI

```
# because it's not landed in main branch yet, have to specify --ref <this_branch>
gh workflow run run-fullnode-sync.yaml --ref rustielin/fullnode-sync-gh -F=TEST_NAME=rustie-test -F=BRANCH=5d067dbbd9468397a7618b040a4306ee3a36c6d1 -F=NETWORK=devnet -F=BOOTSTRAPPING_MODE=ExecuteTransactionsFromGenesis -F=CONTINUOUS_SYNCING_MODE=ExecuteTransactions
```

it makes a run like this: https://github.com/aptos-labs/aptos-core/actions/runs/5008782115/jobs/8977013420

<!-- Please provide us with clear details for verifying that your changes work. -->
