### PR TITLE
[Peer Monitoring Service] Update metrics and logs.

### DIFF
--- a/network/peer-monitoring-service/client/src/logging.rs
+++ b/network/peer-monitoring-service/client/src/logging.rs
@@ -55,6 +55,7 @@ pub enum LogEntry {
 #[serde(rename_all = "snake_case")]
 pub enum LogEvent {
     InvalidResponse,
+    LogAllPeerStates,
     PeerPingError,
     ResponseError,
     ResponseSuccess,

--- a/network/peer-monitoring-service/client/src/metrics.rs
+++ b/network/peer-monitoring-service/client/src/metrics.rs
@@ -3,13 +3,77 @@
 
 use aptos_config::network_id::PeerNetworkId;
 use aptos_metrics_core::{
-    register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, HistogramVec,
-    IntCounterVec, IntGaugeVec,
+    histogram_opts, register_histogram_vec, register_int_counter_vec, register_int_gauge_vec,
+    HistogramVec, IntCounterVec, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
 
 /// The special label TOTAL_COUNT stores the sum of all values in the counter
 pub const TOTAL_COUNT_LABEL: &str = "TOTAL_COUNT";
+
+// Histogram buckets for tracking average ping latencies (secs)
+const AVERAGE_PING_LATENCY_BUCKETS: &[f64] = &[
+    0.005, 0.01, 0.02, 0.03, 0.05, 0.1, 0.2, 0.3, 0.5, 1.0, 2.0, 3.0, 5.0, 10.0, 15.0, 20.0, 30.0,
+    40.0, 60.0, // Max is a minute
+];
+
+/// Counter for tracking the average ping latencies
+pub static AVERAGE_PING_LATENCIES: Lazy<HistogramVec> = Lazy::new(|| {
+    let histogram_opts = histogram_opts!(
+        "peer_monitoring_client_average_ping_latencies",
+        "Counters related to average ping latencies (secs)",
+        AVERAGE_PING_LATENCY_BUCKETS.to_vec()
+    );
+    register_histogram_vec!(histogram_opts, &["network_id"]).unwrap()
+});
+
+// Histogram buckets for tracking the distance from the validators
+const DISTANCE_FROM_VALIDATORS_BUCKETS: &[f64] = &[
+    0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0,
+    100.0, // Max distance should be 100
+];
+
+/// Counter for tracking the distance from validators
+pub static DISTANCE_FROM_VALIDATORS: Lazy<HistogramVec> = Lazy::new(|| {
+    let histogram_opts = histogram_opts!(
+        "peer_monitoring_client_distance_from_validators",
+        "Counters related to distance from validators (hops)",
+        DISTANCE_FROM_VALIDATORS_BUCKETS.to_vec()
+    );
+    register_histogram_vec!(histogram_opts, &["network_id"]).unwrap()
+});
+
+// Histogram buckets for tracking the node uptime (hours)
+const NODE_UPTIME_BUCKETS: &[f64] = &[
+    0.5, 1.0, 6.0, 12.0, 24.0, 48.0, 96.0, 192.0, 384.0, 768.0, 1536.0, 3072.0, 6144.0,
+    12288.0, // Max uptime is over a year
+];
+
+/// Counter for tracking the node uptime
+pub static NODE_UPTIME: Lazy<HistogramVec> = Lazy::new(|| {
+    let histogram_opts = histogram_opts!(
+        "peer_monitoring_client_node_uptime",
+        "Counters related to the node uptime (hours)",
+        NODE_UPTIME_BUCKETS.to_vec()
+    );
+    register_histogram_vec!(histogram_opts, &["network_id"]).unwrap()
+});
+
+// Histogram buckets for tracking the number of connected peers
+const NUM_CONNECTED_PEERS_BUCKETS: &[f64] = &[
+    0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 20.0, 30.0, 50.0, 100.0, 200.0, 400.0,
+    1000.0, // Max number of connected peers should never be more than 1000
+];
+
+/// Counter for tracking the number of connected peers
+pub static NUM_CONNECTED_PEERS: Lazy<HistogramVec> = Lazy::new(|| {
+    let histogram_opts = histogram_opts!(
+        "peer_monitoring_client_num_connected_peers",
+        "Counters related to the number of connected peers",
+        NUM_CONNECTED_PEERS_BUCKETS.to_vec()
+    );
+    register_histogram_vec!(histogram_opts, &["network_id"]).unwrap()
+});
 
 /// Counter for tracking sent requests
 pub static SENT_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
@@ -86,8 +150,16 @@ pub fn set_gauge(counter: &Lazy<IntGaugeVec>, label: &str, value: u64) {
     counter.with_label_values(&[label]).set(value as i64);
 }
 
-/// Observes the value for the provided histogram and label values
-pub fn observe_value(
+/// Observes the value for the provided histogram
+pub fn observe_value(histogram: &Lazy<HistogramVec>, peer_network_id: &PeerNetworkId, value: f64) {
+    let network_id = peer_network_id.network_id();
+    histogram
+        .with_label_values(&[network_id.as_str()])
+        .observe(value)
+}
+
+/// Observes the value for the provided histogram and label
+pub fn observe_value_with_label(
     histogram: &Lazy<HistogramVec>,
     request_label: &str,
     peer_network_id: &PeerNetworkId,

--- a/network/peer-monitoring-service/client/src/metrics.rs
+++ b/network/peer-monitoring-service/client/src/metrics.rs
@@ -16,7 +16,7 @@ pub static SENT_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "peer_monitoring_client_sent_requests",
         "Counters related to sent requests",
-        &["request_types", "network"]
+        &["request_types", "network_id"]
     )
     .unwrap()
 });
@@ -26,7 +26,7 @@ pub static SUCCESS_RESPONSES: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "peer_monitoring_client_success_responses",
         "Counters related to success responses",
-        &["response_type", "network"]
+        &["response_type", "network_id"]
     )
     .unwrap()
 });
@@ -36,7 +36,7 @@ pub static ERROR_RESPONSES: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "peer_monitoring_client_error_responses",
         "Counters related to error responses",
-        &["response_type", "network"]
+        &["response_type", "network_id"]
     )
     .unwrap()
 });
@@ -46,7 +46,7 @@ pub static REQUEST_LATENCIES: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "peer_monitoring_client_request_latencies",
         "Counters related to request latencies",
-        &["request_type", "network"]
+        &["request_type", "network_id"]
     )
     .unwrap()
 });
@@ -72,10 +72,12 @@ pub fn increment_request_counter(
     label: &str,
     peer_network_id: &PeerNetworkId,
 ) {
-    let network = peer_network_id.network_id();
-    counter.with_label_values(&[label, network.as_str()]).inc();
+    let network_id = peer_network_id.network_id();
     counter
-        .with_label_values(&[TOTAL_COUNT_LABEL, network.as_str()])
+        .with_label_values(&[label, network_id.as_str()])
+        .inc();
+    counter
+        .with_label_values(&[TOTAL_COUNT_LABEL, network_id.as_str()])
         .inc();
 }
 
@@ -91,8 +93,8 @@ pub fn observe_value(
     peer_network_id: &PeerNetworkId,
     value: f64,
 ) {
-    let network = peer_network_id.network_id();
+    let network_id = peer_network_id.network_id();
     histogram
-        .with_label_values(&[request_label, network.as_str()])
+        .with_label_values(&[request_label, network_id.as_str()])
         .observe(value)
 }

--- a/network/peer-monitoring-service/client/src/peer_states/key_value.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/key_value.rs
@@ -115,6 +115,9 @@ pub trait StateValueInterface {
         peer_network_id: &PeerNetworkId,
         error: Error,
     );
+
+    /// Updates the peer state metrics for the given peer
+    fn update_peer_state_metrics(&self, peer_network_id: &PeerNetworkId);
 }
 
 /// A simple enum representing the different types of

--- a/network/peer-monitoring-service/client/src/peer_states/latency_info.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/latency_info.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    metrics,
     peer_states::{key_value::StateValueInterface, request_tracker::RequestTracker},
     Error, LogEntry, LogEvent, LogSchema,
 };
@@ -199,6 +200,17 @@ impl StateValueInterface for LatencyInfoState {
             .message("Error encountered when pinging peer!")
             .peer(peer_network_id)
             .error(&error));
+    }
+
+    fn update_peer_state_metrics(&self, peer_network_id: &PeerNetworkId) {
+        if let Some(average_latency_ping_secs) = self.get_average_latency_ping_secs() {
+            // Update the average ping latency metric
+            metrics::observe_value(
+                &metrics::AVERAGE_PING_LATENCIES,
+                peer_network_id,
+                average_latency_ping_secs,
+            );
+        }
     }
 }
 

--- a/network/peer-monitoring-service/client/src/peer_states/mod.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/mod.rs
@@ -1,13 +1,17 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{metrics, Error, PeerMonitorState, PeerMonitoringServiceClient, PeerState};
+use crate::{
+    metrics, Error, LogEntry, LogEvent, LogSchema, PeerMonitorState, PeerMonitoringServiceClient,
+    PeerState,
+};
 use aptos_config::{config::PeerMonitoringServiceConfig, network_id::PeerNetworkId};
+use aptos_logger::{info, sample, sample::SampleRate};
 use aptos_network::application::{interface::NetworkClient, metadata::PeerMetadata};
 use aptos_peer_monitoring_service_types::PeerMonitoringServiceMessage;
 use aptos_time_service::TimeService;
 use key_value::PeerStateKey;
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 use tokio::runtime::Handle;
 
 pub mod key_value;
@@ -16,6 +20,9 @@ pub mod network_info;
 pub mod node_info;
 pub mod peer_state;
 mod request_tracker;
+
+/// The frequency at which we update the logs and metrics for the peer monitoring states
+const LOGS_AND_METRICS_FREQUENCY_SECS: u64 = 60; // 1 minute
 
 #[cfg(feature = "network-perf-test")] // Disabled by default
 mod performance_monitoring;
@@ -67,6 +74,12 @@ pub fn refresh_peer_states(
         update_in_flight_metrics(peer_state_key, num_in_flight_requests);
     }
 
+    // Periodically update the logs and metrics for the peer monitoring states
+    sample!(
+        SampleRate::Duration(Duration::from_secs(LOGS_AND_METRICS_FREQUENCY_SECS)),
+        update_peer_state_logs_and_metrics(&peer_monitor_state, &connected_peers_and_metadata)?;
+    );
+
     Ok(())
 }
 
@@ -92,4 +105,37 @@ fn get_peer_state(
 fn update_in_flight_metrics(peer_state_key: PeerStateKey, num_in_flight_requests: u64) {
     let request_label = peer_state_key.get_metrics_request_label();
     metrics::update_in_flight_requests(request_label, num_in_flight_requests);
+}
+
+/// Updates the logs and metrics for the peer monitoring states
+fn update_peer_state_logs_and_metrics(
+    peer_monitor_state: &PeerMonitorState,
+    connected_peers_and_metadata: &HashMap<PeerNetworkId, PeerMetadata>,
+) -> Result<(), Error> {
+    // Get the list of connected peers
+    let connected_peers: Vec<PeerNetworkId> =
+        connected_peers_and_metadata.keys().cloned().collect();
+
+    // Update the peer state metrics
+    for peer_state_key in PeerStateKey::get_all_keys() {
+        for peer_network_id in &connected_peers {
+            // Get the peer state and update the metrics
+            let peer_state = get_peer_state(peer_monitor_state, peer_network_id)?;
+            peer_state.update_peer_state_metrics(peer_network_id, &peer_state_key)?;
+        }
+    }
+
+    // Collect the peer states for logging
+    let mut all_peer_states = HashMap::new();
+    for peer_network_id in &connected_peers {
+        let peer_state = get_peer_state(peer_monitor_state, peer_network_id)?;
+        all_peer_states.insert(peer_network_id, format!("{}", peer_state));
+    }
+
+    // Log the peer states
+    info!(LogSchema::new(LogEntry::PeerMonitorLoop)
+        .event(LogEvent::LogAllPeerStates)
+        .message(&format!("All peer states: {:?}", all_peer_states)));
+
+    Ok(())
 }

--- a/network/peer-monitoring-service/client/src/peer_states/performance_monitoring.rs
+++ b/network/peer-monitoring-service/client/src/peer_states/performance_monitoring.rs
@@ -363,6 +363,11 @@ impl StateValueInterface for PerformanceMonitoringState {
             .peer(peer_network_id)
             .error(&error));
     }
+
+    fn update_peer_state_metrics(&self, _peer_network_id: &PeerNetworkId) {
+        // TODO: Update the peer state metrics for performance monitoring.
+        // This is currently a no-op.
+    }
 }
 
 impl Display for PerformanceMonitoringState {

--- a/network/peer-monitoring-service/server/src/metrics.rs
+++ b/network/peer-monitoring-service/server/src/metrics.rs
@@ -1,10 +1,10 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_config::network_id::NetworkId;
 use aptos_metrics_core::{
     register_histogram_vec, register_int_counter_vec, HistogramTimer, HistogramVec, IntCounterVec,
 };
-use aptos_network::ProtocolId;
 use once_cell::sync::Lazy;
 
 /// Counter for pending network events to the monitoring service (server-side)
@@ -22,7 +22,7 @@ pub static PEER_MONITORING_ERRORS_ENCOUNTERED: Lazy<IntCounterVec> = Lazy::new(|
     register_int_counter_vec!(
         "aptos_peer_monitoring_service_server_errors",
         "Counters related to the peer monitoring server errors encountered",
-        &["protocol", "error_type"]
+        &["network_id", "error_type"]
     )
     .unwrap()
 });
@@ -32,7 +32,7 @@ pub static PEER_MONITORING_REQUESTS_RECEIVED: Lazy<IntCounterVec> = Lazy::new(||
     register_int_counter_vec!(
         "aptos_peer_monitoring_service_server_requests_received",
         "Counters related to the peer monitoring server requests received",
-        &["protocol", "request_type"]
+        &["network_id", "request_type"]
     )
     .unwrap()
 });
@@ -42,7 +42,7 @@ pub static PEER_MONITORING_RESPONSES_SENT: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_peer_monitoring_service_server_responses_sent",
         "Counters related to the peer monitoring server responses sent",
-        &["protocol", "response_type"]
+        &["network_id", "response_type"]
     )
     .unwrap()
 });
@@ -52,23 +52,25 @@ pub static PEER_MONITORING_REQUEST_PROCESSING_LATENCY: Lazy<HistogramVec> = Lazy
     register_histogram_vec!(
         "aptos_peer_monitoring_service_server_request_latency",
         "Time it takes to process a peer monitoring service request",
-        &["protocol", "request_type"]
+        &["network_id", "request_type"]
     )
     .unwrap()
 });
 
 /// Increments the given counter with the provided label values.
-pub fn increment_counter(counter: &Lazy<IntCounterVec>, protocol: ProtocolId, label: &str) {
-    counter.with_label_values(&[protocol.as_str(), label]).inc();
+pub fn increment_counter(counter: &Lazy<IntCounterVec>, network_id: NetworkId, label: &str) {
+    counter
+        .with_label_values(&[network_id.as_str(), label])
+        .inc();
 }
 
 /// Starts the timer for the provided histogram and label values.
 pub fn start_timer(
     histogram: &Lazy<HistogramVec>,
-    protocol: ProtocolId,
+    network_id: NetworkId,
     label: &str,
 ) -> HistogramTimer {
     histogram
-        .with_label_values(&[protocol.as_str(), label])
+        .with_label_values(&[network_id.as_str(), label])
         .start_timer()
 }


### PR DESCRIPTION
Note: this PR is built on: https://github.com/aptos-labs/aptos-core/pull/8238.

### Description

This PR updates the metrics and logs for the peer monitoring service. Specifically, it offers two commits:
1. Cleans up the network ID label in the client and server metrics.
2. Adds new metrics to track the most obvious monitoring data, e.g., average ping latencies, distance from validators, number of connected peers and node uptime. We also periodically log this information.

### Test Plan
Manual verification and existing test infrastructure.