### PR TITLE
remove using the deprecated redis set cmd.

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/cache_operator.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/cache_operator.rs
@@ -118,12 +118,12 @@ impl<T: redis::aio::ConnectionLike + Send> CacheOperator<T> {
 
     // Set up the cache if needed.
     pub async fn cache_setup_if_needed(&mut self) -> bool {
-        let version_inserted: bool = self
-            .conn
-            .set_nx::<&str, &str, bool>(
-                CACHE_KEY_LATEST_VERSION,
-                CACHE_DEFAULT_LATEST_VERSION_NUMBER,
-            )
+        let version_inserted: bool =
+            redis::cmd("SET")
+            .arg(CACHE_KEY_LATEST_VERSION)
+            .arg(CACHE_DEFAULT_LATEST_VERSION_NUMBER)
+            .arg("NX")
+            .query_async(&mut self.conn)
             .await
             .expect("Redis latest_version check failed.");
         if version_inserted {
@@ -282,9 +282,10 @@ mod tests {
     async fn cache_is_setup_if_empty() {
         // Key doesn't exists and SET_NX returns 1.
         let cmds = vec![MockCmd::new(
-            redis::cmd("SETNX")
+            redis::cmd("SET")
                 .arg(CACHE_KEY_LATEST_VERSION)
-                .arg(CACHE_DEFAULT_LATEST_VERSION_NUMBER),
+                .arg(CACHE_DEFAULT_LATEST_VERSION_NUMBER)
+                .arg("NX"),
             Ok("1"),
         )];
         let mock_connection = MockRedisConnection::new(cmds);
@@ -297,9 +298,10 @@ mod tests {
     #[tokio::test]
     async fn cache_is_setup_if_not_empty() {
         let cmds = vec![MockCmd::new(
-            redis::cmd("SETNX")
+            redis::cmd("SET")
                 .arg(CACHE_KEY_LATEST_VERSION)
-                .arg(CACHE_DEFAULT_LATEST_VERSION_NUMBER),
+                .arg(CACHE_DEFAULT_LATEST_VERSION_NUMBER)
+                .arg("NX"),
             Ok("0"),
         )];
         let mock_connection = MockRedisConnection::new(cmds);


### PR DESCRIPTION
### Description
* Instead of using `SETNX`, use `SET key val NX`
* 
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
