### PR TITLE
Increase readability of nodes landing page

### DIFF
--- a/developer-docs-site/docs/nodes/nodes-landing.md
+++ b/developer-docs-site/docs/nodes/nodes-landing.md
@@ -42,7 +42,7 @@ Also learn how to run a public fullnode on a local network and connect to either
           </div>
           <a href="../concepts/staking" class="list-group-item">
             <div class="d-flex w-100 justify-content-between">
-              <h4 class="mb-1">Staking on Aptos (concept)</h4>
+              <h4 class="mb-1">Staking on Aptos</h4>
             </div>
             <small>A comprehensive guide to how staking works on Aptos.</small>
           </a>
@@ -120,7 +120,7 @@ Also learn how to run a public fullnode on a local network and connect to either
         <div class="card-body">
           <h2 class="card-title">Fullnode</h2>
           <p class="card-text">
-            A section with detailed, step-by-step instructions on everything fullnode. 
+            A section with detailed, step-by-step instructions on everything related to Aptos fullnode. 
           </p>
         </div>
         <div class="list-group list-group-flush">

--- a/developer-docs-site/src/css/custom.css
+++ b/developer-docs-site/src/css/custom.css
@@ -361,6 +361,11 @@ b.navbar__title{
   margin-bottom: 0;
   border-radius: 0.25rem;
 }
+
+.list-group-item small {
+  color: black;
+}
+
 .list-group-item-action {
   width: 100%;
   /* color: #495057; */

--- a/developer-docs-site/src/css/custom.css
+++ b/developer-docs-site/src/css/custom.css
@@ -366,6 +366,10 @@ b.navbar__title{
   color: black;
 }
 
+html[data-theme='dark'] .list-group-item small {
+  color: white;
+}
+
 .list-group-item-action {
   width: 100%;
   /* color: #495057; */


### PR DESCRIPTION
### Description

Update custom.css to set the color of small text within list-group-item to black/white (depending on the selected theme). The page currently looks like a wall of turquoise-colored text. 

Before:
![image](https://github.com/aptos-labs/aptos-core/assets/125399153/0af5acaf-1f69-4ab7-bb69-62f051498a75)

After:
![image](https://github.com/aptos-labs/aptos-core/assets/125399153/45efd51d-2ba6-4dfe-9454-013a5fff4713)
