### PR TITLE
Revert "[forge] Support for real multi-region experiments on GCP (#8019)

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -92,13 +92,13 @@ jobs:
   # Because the docker build happens in a reusable workflow, have a separate job that collects the right metadata
   # for the subsequent docker builds. Reusable workflows do not currently have the "env" context: https://github.com/orgs/community/discussions/26671
   determine-docker-build-metadata:
+    needs: [permission-check]
     runs-on: ubuntu-latest
     steps:
       - name: collect metadata
         run: |
-          echo "GIT_SHA: ${{ env.GIT_SHA }}"
-          echo "TARGET_CACHE_ID: ${{ env.TARGET_CACHE_ID }}"
-          echo "CONCURRENCY: ${{ github.workflow }}-${{ github.event_name }}-${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.sha || github.head_ref || github.ref }}"
+          echo "GIT_SHA: ${GIT_SHA}"
+          echo "TARGET_CACHE_ID: ${TARGET_CACHE_ID}"
     outputs:
       gitSha: ${{ env.GIT_SHA }}
       targetCacheId: ${{ env.TARGET_CACHE_ID }}

--- a/terraform/helm/aptos-node/README.md
+++ b/terraform/helm/aptos-node/README.md
@@ -19,7 +19,7 @@ Aptos blockchain node deployment
 | chain.name | string | `"testnet"` | Internal: name of the testnet to connect to |
 | enablePrivilegedMode | bool | `false` | TEST ONLY: Enable running as root for profiling |
 | fullnode.affinity | object | `{}` |  |
-| fullnode.config | object | `{"full_node_networks":[{"network_id":"public","seeds":{}}]}` | Fullnode configuration. See NodeConfig https://github.com/aptos-labs/aptos-core/blob/main/config/src/config/mod.rs |
+| fullnode.config | object | `{"full_node_networks":[{"max_inbound_connections":100,"network_id":"public","seeds":{}}],"mempool":{"default_failovers":0,"max_broadcasts_per_peer":4,"shared_mempool_batch_size":200,"shared_mempool_max_concurrent_inbound_syncs":16,"shared_mempool_tick_interval_ms":10}}` | Fullnode configuration. See NodeConfig https://github.com/aptos-labs/aptos-core/blob/main/config/src/config/mod.rs |
 | fullnode.force_enable_telemetry | bool | `false` | Flag to force enable telemetry service (useful for forge tests) |
 | fullnode.groups | list | `[{"name":"fullnode","replicas":1}]` | Specify fullnode groups by `name` and number of `replicas` |
 | fullnode.nodeSelector | object | `{}` |  |
@@ -53,7 +53,6 @@ Aptos blockchain node deployment
 | labels | string | `nil` |  |
 | loadTestGenesis | bool | `false` | Load test-data for starting a test network |
 | manageImages | bool | `true` | If true, helm will always override the deployed image with what is configured in the helm values. If not, helm will take the latest image from the currently running workloads, which is useful if you have a separate procedure to update images (e.g. rollout) |
-| multicluster | object | `{"enabled":false,"targetClusters":["cluster1","cluster2","cluster3"]}` | Options for multicluster mode. This is *experimental only*. |
 | numFullnodeGroups | int | `1` | Total number of fullnode groups to deploy |
 | numValidators | int | `1` | Number of validators to deploy |
 | overrideNodeConfig | bool | `false` | Specify validator and fullnode NodeConfigs via named ConfigMaps, rather than the generated ones from this chart. |
@@ -62,14 +61,12 @@ Aptos blockchain node deployment
 | service.fullnode.enableRestApi | bool | `true` | Enable the REST API on fullnodes |
 | service.fullnode.external.type | string | `"LoadBalancer"` | The Kubernetes ServiceType to use for fullnodes' HAProxy |
 | service.fullnode.externalTrafficPolicy | string | `"Local"` | The externalTrafficPolicy for the fullnode service |
-| service.fullnode.internal.headless | bool | `false` |  |
 | service.fullnode.internal.type | string | `"ClusterIP"` | The Kubernetes ServiceType to use for fullnodes |
 | service.fullnode.loadBalancerSourceRanges | string | `nil` | If set and if the ServiceType is LoadBalancer, allow traffic to fullnodes from these CIDRs |
 | service.validator.enableMetricsPort | bool | `true` | Enable the metrics port on the validator |
 | service.validator.enableRestApi | bool | `true` | Enable the REST API on the validator |
 | service.validator.external.type | string | `"LoadBalancer"` | The Kubernetes ServiceType to use for validator's HAProxy |
 | service.validator.externalTrafficPolicy | string | `"Local"` | The externalTrafficPolicy for the validator service |
-| service.validator.internal.headless | bool | `false` |  |
 | service.validator.internal.type | string | `"ClusterIP"` | The Kubernetes ServiceType to use for validator |
 | service.validator.loadBalancerSourceRanges | string | `nil` | If set and if the ServiceType is LoadBalancer, allow traffic to validators from these CIDRs |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
@@ -126,10 +123,6 @@ ServiceAccounts:
 * [optional] `<RELEASE_NAME>` - The default service account
 * `<RELEASE_NAME>-validator` - The validator service account
 * `<RELEASE_NAME>-fullnode` - The fullnode service account
-
-[optional] PodSecurityPolicy:
-* `<RELEASE_NAME>` - The default PodSecurityPolicy for validators and fullnodes
-* `<RELEASE_NAME>-haproxy` - The PodSecurityPolicy for HAProxy
 
 ## Common Operations
 

--- a/terraform/helm/aptos-node/templates/_helpers.tpl
+++ b/terraform/helm/aptos-node/templates/_helpers.tpl
@@ -47,22 +47,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
-Multicluster labels. `multiclusterLabels` takes in a tuple of context and index as arguments.
-It should be invoked as `aptos-validator.multiclusterLabels (tuple $ $i)` where $i is the index
-of the statefulset.
-*/}}
-{{- define "aptos-validator.multiclusterLabels" -}}
-{{- $ctx := index $ 0 -}}
-{{- if $ctx.Values.multicluster.enabled }}
-{{- $index := index $ 1 -}}
-{{- $numClusters := len $ctx.Values.multicluster.targetClusters }}
-{{- $clusterIndex := mod $index $numClusters }}
-{{- $cluster := index $ctx.Values.multicluster.targetClusters $clusterIndex }}
-multicluster/targetcluster: {{ $cluster }}
-{{- end }}
-{{- end -}}
-
-{{/*
 Selector labels
 */}}
 {{- define "aptos-validator.selectorLabels" -}}

--- a/terraform/helm/aptos-node/templates/fullnode.yaml
+++ b/terraform/helm/aptos-node/templates/fullnode.yaml
@@ -8,7 +8,6 @@ metadata:
   name: {{ include "aptos-validator.fullname" $ }}-{{$i}}-{{ .name }}
   labels:
     {{- include "aptos-validator.labels" $ | nindent 4 }}
-    {{- include "aptos-validator.multiclusterLabels" (tuple $ $i) | nindent 4 }}  
 spec:
   selector:
     {{- include "aptos-validator.selectorLabels" $ | nindent 4 }}
@@ -16,9 +15,6 @@ spec:
     app.kubernetes.io/instance: fullnode-{{$i}}
     group: {{ .name }}
   type: {{ $.Values.service.fullnode.internal.type }}
-  {{- if $.Values.service.fullnode.internal.headless }}
-  clusterIP: None
-  {{- end }}
   ports:
   - name: aptosnet
     port: 6182
@@ -38,7 +34,6 @@ metadata:
     app.kubernetes.io/name: fullnode
     app.kubernetes.io/instance: fullnode-{{$i}}
     group: {{ .name }}
-    {{- include "aptos-validator.multiclusterLabels" (tuple $ $i) | nindent 4 }}  
 spec:
   serviceName: {{ include "aptos-validator.fullname" $ }}-{{$i}}-{{ .name }}
   replicas: {{ .replicas }}

--- a/terraform/helm/aptos-node/templates/validator.yaml
+++ b/terraform/helm/aptos-node/templates/validator.yaml
@@ -6,16 +6,12 @@ metadata:
   name: {{ include "aptos-validator.fullname" $ }}-{{$i}}-validator
   labels:
     {{- include "aptos-validator.labels" $ | nindent 4 }}
-    {{- include "aptos-validator.multiclusterLabels" (tuple $ $i) | nindent 4 }} 
 spec:
   selector:
     {{- include "aptos-validator.selectorLabels" $ | nindent 4 }}
     app.kubernetes.io/name: validator
     app.kubernetes.io/instance: validator-{{$i}}
   type: {{ $.Values.service.validator.internal.type }}
-  {{- if $.Values.service.validator.internal.headless }}
-  clusterIP: None
-  {{- end }}
   ports:
   - name: validator
     port: 6180
@@ -59,7 +55,6 @@ metadata:
     {{- include "aptos-validator.labels" $ | nindent 4 }}
     app.kubernetes.io/name: validator
     app.kubernetes.io/instance: validator-{{$i}}
-    {{- include "aptos-validator.multiclusterLabels" (tuple $ $i) | nindent 4 }}  
 spec:
   serviceName: {{ include "aptos-validator.fullname" $ }}-{{$i}}-validator
   replicas: 1

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -14,11 +14,6 @@ numValidators: 1
 # -- Total number of fullnode groups to deploy
 numFullnodeGroups: 1
 
-# -- Options for multicluster mode. This is *experimental only*.
-multicluster:
-  enabled: false 
-  targetClusters: ["cluster1", "cluster2", "cluster3"]
-
 # -- Specify validator and fullnode NodeConfigs via named ConfigMaps, rather than the generated ones from this chart.
 overrideNodeConfig: false
 
@@ -143,7 +138,6 @@ service:
     internal:
       # -- The Kubernetes ServiceType to use for validator
       type: ClusterIP
-      headless: false
     # -- The externalTrafficPolicy for the validator service
     externalTrafficPolicy: Local
     # -- If set and if the ServiceType is LoadBalancer, allow traffic to validators from these CIDRs
@@ -159,7 +153,6 @@ service:
     internal:
       # -- The Kubernetes ServiceType to use for fullnodes
       type: ClusterIP
-      headless: false
     # -- The externalTrafficPolicy for the fullnode service
     externalTrafficPolicy: Local
     # -- If set and if the ServiceType is LoadBalancer, allow traffic to fullnodes from these CIDRs

--- a/terraform/helm/genesis/README.md
+++ b/terraform/helm/genesis/README.md
@@ -14,22 +14,20 @@ Aptos blockchain automated genesis ceremony for testnets
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| chain.allow_new_validators | bool | `false` | Allow new validators to join after genesis |
+| chain.allow_new_validators | bool | `false` | Allow new validators |
 | chain.chain_id | int | `4` | Aptos Chain ID |
 | chain.epoch_duration_secs | int | `7200` | Length of each epoch in seconds. Defaults to 2 hours |
 | chain.era | int | `1` | Internal: Bump this number to wipe the underlying storage |
-| chain.is_test | bool | `true` | If true, genesis will create a resources account that can mint coins. |
-| chain.max_stake | int | `100000000000000000` | Maximum stake. Defaults to 1B APTOS coins with 8 decimals |
+| chain.max_stake | int | `100000000000000000` | Maximum stake. Defaults to 1M APTOS coins with 8 decimals |
 | chain.min_price_per_gas_unit | int | `1` | Minimum price per gas unit |
 | chain.min_stake | int | `100000000000000` | Minimum stake. Defaults to 1M APTOS coins with 8 decimals |
 | chain.min_voting_threshold | int | `100000000000000` | Mininum voting threshold. Defaults to 1M APTOS coins with 8 decimals |
 | chain.name | string | `"testnet"` | Internal: name of the testnet to connect to |
 | chain.recurring_lockup_duration_secs | int | `86400` | Recurring lockup duration in seconds. Defaults to 1 day |
-| chain.required_proposer_stake | int | `100000000000000` | Required stake to be a proposer. 1M APTOS coins with 8 decimals |
+| chain.required_proposer_stake | int | `100000000000` | Required stake to be a proposer. 1M APTOS coins with 8 decimals |
 | chain.rewards_apy_percentage | int | `10` | Rewards APY percentage |
-| chain.root_key | string | `"0x5243ca72b0766d9e9cbf2debf6153443b01a1e0e6d086c7ea206eaf6f8043956"` | If specified, the key for the minting capability in testnet |
+| chain.root_key | string | `"0x5243ca72b0766d9e9cbf2debf6153443b01a1e0e6d086c7ea206eaf6f8043956"` | If specified, the root key for the testnet |
 | chain.voting_duration_secs | int | `43200` | Voting duration in seconds. Defaults to 12 hours |
-| chain.voting_power_increase_limit | int | `20` | Limit on how much voting power can join every epoch. Defaults to 20%. |
 | genesis.domain | string | `nil` | If set, the base domain name of the fullnode and validator endpoints |
 | genesis.fullnode.enable_onchain_discovery | bool | `true` | Use External DNS as created by aptos-node helm chart for fullnode host in genesis |
 | genesis.fullnode.internal_host_suffix | string | `"fullnode-lb"` | If `enable_onchain_discovery` is false, use this host suffix for internal kubernetes service name |
@@ -37,17 +35,17 @@ Aptos blockchain automated genesis ceremony for testnets
 | genesis.image.repo | string | `"aptoslabs/tools"` | Image repo to use for tools image for running genesis |
 | genesis.image.tag | string | `nil` | Image tag to use for tools image. If set, overrides `imageTag` |
 | genesis.moveModulesDir | string | `"/aptos-framework/move/modules"` | The local path for move modules in the docker image. Defaults to the aptos-framework in the aptoslabs/tools docker image |
-| genesis.multicluster | object | `{"domain_suffixes":"","enabled":false}` | Options for multicluster mode. This is *experimental only* |
 | genesis.numValidators | int | `1` | Number of validators to include in genesis |
 | genesis.username_prefix | string | `"aptos-node"` | If `enable_onchain_discovery` is false, use this kubernetes service name prefix. It should be the fullname for the aptos-node helm release |
 | genesis.validator.enable_onchain_discovery | bool | `false` | Use External DNS as created by aptos-node helm chart for validator host in genesis |
 | genesis.validator.internal_host_suffix | string | `"validator-lb"` | If `enable_onchain_discovery` is false, use this host suffix for internal kubernetes service name |
-| genesis.validator.key_seed | string | `nil` | Random seed to generate validator keys in order to make the key generation deterministic |
-| genesis.validator.larger_stake_amount | string | `"1000000000000000"` | Stake amount for nodes we are giving larger state to. Defaults to 10M APTOS coins with 8 decimals |
-| genesis.validator.num_validators_with_larger_stake | int | `0` | Number of validators to give larger stake in genesis to. |
 | genesis.validator.stake_amount | string | `"100000000000000"` | Stake amount for each validator in this testnet. Defaults to 1M APTOS coins with 8 decimals |
+| genesis.validator.num_validators_with_larger_stake | string | `"0"` | Stake amount for each validator in this testnet. Defaults to 1M APTOS coins with 8 decimals |
+| genesis.validator.larger_stake_amount | string | `"1000000000000000"` | Stake amount for each validator in this testnet. Defaults to 1M APTOS coins with 8 decimals |
 | imageTag | string | `"testnet"` | Default image tag to use for all tools images |
 | labels | string | `nil` |  |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `nil` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/terraform/helm/genesis/files/genesis.sh
+++ b/terraform/helm/genesis/files/genesis.sh
@@ -24,25 +24,6 @@ LARGER_STAKE_AMOUNT=${LARGER_STAKE_AMOUNT:-1}
 RANDOM_SEED=${RANDOM_SEED:-$RANDOM}
 export APTOS_DISABLE_TELEMETRY=true
 
-ENABLE_MULTICLUSTER_DOMAIN_SUFFIX=${ENABLE_MULTICLUSTER_DOMAIN_SUFFIX:-false}
-MULTICLUSTER_DOMAIN_SUFFIXES_DEFAULT="forge-multiregion-1,forge-multiregion-2,forge-multiregion-3"
-MULTICLUSTER_DOMAIN_SUFFIXES_STRING=${MULTICLUSTER_DOMAIN_SUFFIXES_STRING:-${MULTICLUSTER_DOMAIN_SUFFIXES_DEFAULT}}
-echo $MULTICLUSTER_DOMAIN_SUFFIXES_STRING
-# convert comma separated string to array
-IFS=',' read -r -a MULTICLUSTER_DOMAIN_SUFFIXES <<< "${MULTICLUSTER_DOMAIN_SUFFIXES_STRING}"
-
-if ! [[ $(declare -p MULTICLUSTER_DOMAIN_SUFFIXES) =~ "declare -a" ]]; then
-    echo "MULTICLUSTER_DOMAIN_SUFFIXES must be an array"
-    exit 1
-fi
-
-if [[ "${ENABLE_MULTICLUSTER_DOMAIN_SUFFIX}" == "true" ]]; then
-    if [ -z ${NAMESPACE} ]; then
-        echo "NAMESPACE must be set"
-        exit 1
-    fi
-fi
-
 if [ -z ${ERA} ] || [ -z ${NUM_VALIDATORS} ]; then
     echo "ERA (${ERA:-null}) and NUM_VALIDATORS (${NUM_VALIDATORS:-null}) must be set"
     exit 1
@@ -74,22 +55,14 @@ for i in $(seq 0 $(($NUM_VALIDATORS-1))); do
 
     mkdir $user_dir
 
-    if [[ "${FULLNODE_ENABLE_ONCHAIN_DISCOVERY}" = "true" ]]; then
+    if [ "${FULLNODE_ENABLE_ONCHAIN_DISCOVERY}" = "true" ]; then
         fullnode_host="fullnode${i}.${DOMAIN}:6182"
-    elif [[ "${ENABLE_MULTICLUSTER_DOMAIN_SUFFIX}" = "true" ]]; then
-        index=$(($i % ${#MULTICLUSTER_DOMAIN_SUFFIXES[@]}))
-        cluster=${MULTICLUSTER_DOMAIN_SUFFIXES[${index}]}
-        fullnode_host="${username}-${FULLNODE_INTERNAL_HOST_SUFFIX}.${NAMESPACE}.svc.${cluster}:6182"
-    else 
+    else
         fullnode_host="${username}-${FULLNODE_INTERNAL_HOST_SUFFIX}:6182"
     fi
 
-    if [[ "${VALIDATOR_ENABLE_ONCHAIN_DISCOVERY}" = "true" ]]; then
+    if [ "${VALIDATOR_ENABLE_ONCHAIN_DISCOVERY}" = "true" ]; then
         validator_host="val${i}.${DOMAIN}:6180"
-    elif [[ "${ENABLE_MULTICLUSTER_DOMAIN_SUFFIX}" = "true" ]]; then
-        index=$(($i % ${#MULTICLUSTER_DOMAIN_SUFFIXES[@]}))
-        cluster=${MULTICLUSTER_DOMAIN_SUFFIXES[${index}]}
-        validator_host="${username}-${VALIDATOR_INTERNAL_HOST_SUFFIX}.${NAMESPACE}.svc.${cluster}:6180"
     else
         validator_host="${username}-${VALIDATOR_INTERNAL_HOST_SUFFIX}:6180"
     fi

--- a/terraform/helm/genesis/templates/genesis.yaml
+++ b/terraform/helm/genesis/templates/genesis.yaml
@@ -130,12 +130,6 @@ spec:
           value: {{ .Values.genesis.validator.num_validators_with_larger_stake | quote }}
         - name: LARGER_STAKE_AMOUNT
           value: {{ .Values.genesis.validator.larger_stake_amount | quote }}
-        - name: NAMESPACE
-          value: {{ .Release.Namespace | quote }}
-        - name: ENABLE_MULTICLUSTER_DOMAIN_SUFFIX
-          value: {{ .Values.genesis.multicluster.enabled | quote }}
-        - name: MULTICLUSTER_DOMAIN_SUFFIXES_STRING
-          value: {{ .Values.genesis.multicluster.domain_suffixes | quote }}
         volumeMounts:
         - name: layout
           mountPath: /tmp/layout.yaml

--- a/terraform/helm/genesis/values.yaml
+++ b/terraform/helm/genesis/values.yaml
@@ -69,11 +69,6 @@ genesis:
     internal_host_suffix: fullnode-lb
   # -- The local path for move modules in the docker image. Defaults to the aptos-framework in the aptoslabs/tools docker image
   moveModulesDir: /aptos-framework/move/modules
-  # -- Options for multicluster mode. This is *experimental only*
-  multicluster:
-    enabled: false
-    # comma separated list of cluster names
-    domain_suffixes: ""
 
 serviceAccount:
   # -- Specifies whether a service account should be created

--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -1319,23 +1319,11 @@ def test(
     else:
         cloud_enum = Cloud.GCP
 
-    if forge_cluster_name == "multiregion":
-        log.info("Using multiregion cluster")
-        forge_cluster = ForgeCluster(
-            name=forge_cluster_name,
-            cloud=Cloud.GCP,
-            region="multiregion",
-            kubeconf=context.filesystem.mkstemp(),
-        )
-    else:
-        log.info(
-            f"Looking for cluster {forge_cluster_name} in cloud {cloud_enum.value}"
-        )
-        forge_cluster = find_forge_cluster(
-            context.shell, cloud_enum, forge_cluster_name, context.filesystem.mkstemp()
-        )
-        log.info(f"Found cluster: {forge_cluster}")
-
+    log.info(f"Looking for cluster {forge_cluster_name} in cloud {cloud_enum.value}")
+    forge_cluster = find_forge_cluster(
+        context.shell, cloud_enum, forge_cluster_name, context.filesystem.mkstemp()
+    )
+    log.info(f"Found cluster: {forge_cluster}")
     asyncio.run(forge_cluster.write(context.shell))
 
     # These features and profile flags are set as strings

--- a/testsuite/forge_wrapper_core/cluster.py
+++ b/testsuite/forge_wrapper_core/cluster.py
@@ -146,21 +146,7 @@ class ForgeCluster:
     async def write_cluster_config(
         self, shell: Shell, cluster_name: str, temp: str
     ) -> None:
-        if cluster_name == "multiregion":
-            cmd = [
-                "gcloud",
-                "secrets",
-                "versions",
-                "access",
-                "latest",
-                "--secret",
-                "karmada-kubeconfig",
-                "--project",
-                "forge-gcp-multiregion-test",
-                "--out-file",
-                temp,
-            ]
-        elif self.cloud == Cloud.AWS:
+        if self.cloud == Cloud.AWS:
             cmd = [
                 "aws",
                 "eks",


### PR DESCRIPTION
This reverts commit db80b182aa4fbdacfce3896b9c9d08e511d7a1f9.

### Description

Genesis in the GCP Devnet is failing with this error:
```
$ k logs pod/genesis-aptos-genesis-e0-nj9f8
forge-multiregion-1,forge-multiregion-2,forge-multiregion-3
If FULLNODE_ENABLE_ONCHAIN_DISCOVERY or VALIDATOR_ENABLE_ONCHAIN_DISCOVERY is set, DOMAIN must be set
```