### PR TITLE
[Python SDK Reference Example] Update faucet amounts, fix method reference

### DIFF
--- a/ecosystem/python/sdk/examples/your-coin.py
+++ b/ecosystem/python/sdk/examples/your-coin.py
@@ -38,7 +38,7 @@ class CoinClient(RestClient):
             [TypeTag(StructTag.from_str(f"{coin_address}::moon_coin::MoonCoin"))],
             [],
         )
-        signed_transaction = self.create_single_signer_bcs_transaction(
+        signed_transaction = self.create_bcs_signed_transaction(
             sender, TransactionPayload(payload)
         )
         return self.submit_bcs_transaction(signed_transaction)
@@ -57,7 +57,7 @@ class CoinClient(RestClient):
                 TransactionArgument(amount, Serializer.u64),
             ],
         )
-        signed_transaction = self.create_single_signer_bcs_transaction(
+        signed_transaction = self.create_bcs_signed_transaction(
             minter, TransactionPayload(payload)
         )
         return self.submit_bcs_transaction(signed_transaction)
@@ -91,8 +91,8 @@ if __name__ == "__main__":
     rest_client = CoinClient(NODE_URL)
     faucet_client = FaucetClient(FAUCET_URL, rest_client)
 
-    faucet_client.fund_account(alice.address(), 20_000)
-    faucet_client.fund_account(bob.address(), 20_000)
+    faucet_client.fund_account(alice.address(), 20_000_000)
+    faucet_client.fund_account(bob.address(), 20_000_000)
 
     input("\nUpdate the module with Alice's address, compile, and press enter.")
 


### PR DESCRIPTION
### Description

The amounts given to the "participants" in this transaction example are not high enough to pay the fee for deploying the contract. This is the result if you run the example right now:

```
File "/Users/egd/projects/aptos-core/ecosystem/python/sdk/aptos_sdk/client.py", line 222, in submit_bcs_transaction
    raise ApiError(response.text, response.status_code)
aptos_sdk.client.ApiError: {"message":"Invalid transaction: Type: Validation Code: INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE","error_code":"vm_error","vm_error_code":5}
```

Raising the amount by multiples of ten indicated that 20 million is the appropriate number here.

Fixing that issue reveals another issue: https://github.com/aptos-labs/aptos-core/pull/5770 seems to have broken this code by renaming a method `create_single_signer_bcs_transaction` to `create_bcs_signed_transaction`. Trying to run the example gives you this error:

```
    signed_transaction = self.create_single_signer_bcs_transaction(
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'CoinClient' object has no attribute 'create_single_signer_bcs_transaction'. Did you mean: 'create_bcs_signed_transaction'?
```

The fix is straightforward: replace the broken method calls with the right method name.

### Test Plan

This is how the example runs after the fixes:

```
=== Addresses ===
Alice: 0x8973ab623f2d01d13e825db9c0bf7312c3a2fdfb2f4618bfa1b2ca2e656f0f9e
Bob: 0x39dd425f1943d93fa6154f6a20056f28892fc3dacdd8ad58d1ae43293db0be15

Update the module with Alice's address, compile, and press enter.

Publishing MoonCoin package.

Bob registers the newly created coin so he can receive it from Alice.
Bob's initial MoonCoin balance: 0.
Alice mints Bob some of the new coin.
Bob's updated MoonCoin balance: 100.
```
