### PR TITLE
[CLI] Add init from ledger account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,7 @@ dependencies = [
  "aptos-github-client",
  "aptos-global-constants",
  "aptos-keygen",
+ "aptos-ledger 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "aptos-logger",
  "aptos-network-checker",
  "aptos-node",
@@ -1970,6 +1971,19 @@ version = "0.2.0"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
+ "hex",
+ "ledger-apdu",
+ "ledger-transport-hid",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
+name = "aptos-ledger"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0ed01cb40b4828546eb717af0a3471d2b8c4cfdfe8bd6d3cb68ef99be6353a9"
+dependencies = [
  "hex",
  "ledger-apdu",
  "ledger-transport-hid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
  "aptos-github-client",
  "aptos-global-constants",
  "aptos-keygen",
- "aptos-ledger 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aptos-ledger",
  "aptos-logger",
  "aptos-network-checker",
  "aptos-node",
@@ -1971,19 +1971,6 @@ version = "0.2.0"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
- "hex",
- "ledger-apdu",
- "ledger-transport-hid",
- "once_cell",
- "thiserror",
-]
-
-[[package]]
-name = "aptos-ledger"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ed01cb40b4828546eb717af0a3471d2b8c4cfdfe8bd6d3cb68ef99be6353a9"
-dependencies = [
  "hex",
  "ledger-apdu",
  "ledger-transport-hid",

--- a/crates/aptos-ledger/src/lib.rs
+++ b/crates/aptos-ledger/src/lib.rs
@@ -24,9 +24,10 @@ use std::{
 };
 use thiserror::Error;
 
-// A piece of data which tells a wallet how to derive a specific key within a tree of keys
-// 637 is the key for Aptos
-const DERIVATIVE_PATH: &str = "m/44'/637'/{index}'/0'/0'";
+/// Derivative path template
+/// A piece of data which tells a wallet how to derive a specific key within a tree of keys
+/// 637 is the key for Aptos
+pub const DERIVATIVE_PATH: &str = "m/44'/637'/{index}'/0'/0'";
 
 const CLA_APTOS: u8 = 0x5B; // Aptos CLA Instruction class
 const INS_GET_VERSION: u8 = 0x03; // Get version instruction code
@@ -72,6 +73,33 @@ impl Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
     }
+}
+
+/// Validate the input derivative path to check if it's valid
+pub fn validate_derivative_path(input: &str) -> bool {
+    let prefix = "m/44'/637'/";
+    let suffix = "'";
+
+    if input.starts_with(prefix) && input.ends_with(suffix) {
+        let inner_input = &input[prefix.len()..input.len()];
+
+        // Sample: 0'/0'/0'
+        let sections: Vec<&str> = inner_input.split('/').collect();
+        if sections.len() != 3 {
+            return false;
+        }
+
+        for section in sections {
+            let section_value = &section.trim_end_matches('\'');
+            if section_value.parse::<u32>().is_ok() {
+                continue;
+            }
+            return false;
+        }
+
+        return true;
+    }
+    false
 }
 
 /// Returns the current version of the Aptos app on Ledger

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -31,6 +31,7 @@ aptos-genesis = { workspace = true }
 aptos-github-client = { workspace = true }
 aptos-global-constants = { workspace = true }
 aptos-keygen = { workspace = true }
+aptos-ledger = "0.1.0"
 aptos-logger = { workspace = true }
 aptos-network-checker = { workspace = true }
 aptos-node = { workspace = true }

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -31,7 +31,7 @@ aptos-genesis = { workspace = true }
 aptos-github-client = { workspace = true }
 aptos-global-constants = { workspace = true }
 aptos-keygen = { workspace = true }
-aptos-ledger = "0.1.0"
+aptos-ledger = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-network-checker = { workspace = true }
 aptos-node = { workspace = true }

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -53,6 +53,10 @@ pub struct InitTool {
     #[clap(long)]
     pub skip_faucet: bool,
 
+    /// Whether you want to create a profile from your ledger account
+    ///
+    /// Make sure that you have Ledger device connected, unlocked, and have Aptos app installed
+    /// and opened. Otherwise CLI would not be able to open the connection to your account
     #[clap(long)]
     pub from_ledger: bool,
 

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -150,7 +150,7 @@ impl CliCommand<()> for InitTool {
             // Private key stays in ledger
             None
         } else {
-            let inner_pkey = if let Some(key) = self
+            let ed25519_private_key = if let Some(key) = self
                 .private_key_options
                 .extract_private_key_cli(self.encoding_options.encoding)?
             {
@@ -177,7 +177,7 @@ impl CliCommand<()> for InitTool {
                 }
             };
 
-            Some(inner_pkey)
+            Some(ed25519_private_key)
         };
 
         // Public key

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -189,6 +189,12 @@ impl From<bcs::Error> for CliError {
     }
 }
 
+impl From<aptos_ledger::AptosLedgerError> for CliError {
+    fn from(e: aptos_ledger::AptosLedgerError) -> Self {
+        CliError::UnexpectedError(e.to_string())
+    }
+}
+
 /// Config saved to `.aptos/config.yaml`
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CliConfig {
@@ -222,7 +228,7 @@ pub struct ProfileConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub faucet_url: Option<String>,
     /// Derivative path index of the account on ledger
-    pub bip44_index: Option<String>,
+    pub derivative_path: Option<String>,
 }
 
 /// ProfileConfig but without the private parts

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -221,6 +221,8 @@ pub struct ProfileConfig {
     /// URL for the Faucet endpoint (if applicable)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub faucet_url: Option<String>,
+    /// Derivative path index of the account on ledger
+    pub bip44_index: Option<String>,
 }
 
 /// ProfileConfig but without the private parts

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -547,7 +547,7 @@ impl CliTestFramework {
             prompt_options: PromptOptions::yes(),
             encoding_options: EncodingOptions::default(),
             skip_faucet: false,
-            from_ledger: false,
+            ledger: false,
         }
         .execute()
         .await

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -547,6 +547,7 @@ impl CliTestFramework {
             prompt_options: PromptOptions::yes(),
             encoding_options: EncodingOptions::default(),
             skip_faucet: false,
+            from_ledger: false,
         }
         .execute()
         .await


### PR DESCRIPTION
### Description

First PR to allow user to init and create profile from their ledger account

NOTE: This is PR only assume you have your ledger account at the index 0 derivative path.

### Test Plan

Success init
```
➜  aptos-core git:(jin/ledger_cli_integration) ✗ aptos-debug init --ledger
Aptos already initialized for profile default, do you want to overwrite the existing config? [yes/no] >
yes
Configuring for profile default
Choose network from [devnet, testnet, mainnet, local, custom | defaults to devnet]

No network given, using devnet...
Please choose a derivative path from the following 5 ledger accounts, or choose an arbitrary path that you want to use:
Path: m/44'/637'/1'/0'/0' Address 21563230cf6d69ee72a51d21920430d844ee48235e708edbafbc69708075a86e
Path: m/44'/637'/2'/0'/0' Address 667446181b3b980ef29f5145a7a2cc34d433fc3ee8c97fc044fd978435f2cb8d
Path: m/44'/637'/0'/0'/0' Address 59836ba1dd0c845713bdab34346688d6f1dba290dbf677929f2fc20593ba0cfb
Path: m/44'/637'/3'/0'/0' Address 2dcf037a9f31d93e202c074229a1b69ea8ee4d2f2d63323476001c65b0ec4f31
Path: m/44'/637'/4'/0'/0' Address 23c579a9bdde1a59f1c9d36d8d379aeefe7a5997b5b58bd5a5b0c12a4f170431
m/44'/637'/1'/0'/0'
Account 21563230cf6d69ee72a51d21920430d844ee48235e708edbafbc69708075a86e doesn't exist, creating it and funding it with 100000000 Octas
Account 21563230cf6d69ee72a51d21920430d844ee48235e708edbafbc69708075a86e funded successfully

---
Aptos CLI is now set up for account 21563230cf6d69ee72a51d21920430d844ee48235e708edbafbc69708075a86e as profile default!  Run `aptos --help` for more information about commands
{
  "Result": "Success"
}

```

profile created
```
  default:
    public_key: "0xf15355adc165b2d9136985e79e49d2ba509db90af9c3fdcbbf1eb2fa6a29a9dd"
    account: 21563230cf6d69ee72a51d21920430d844ee48235e708edbafbc69708075a86e
    rest_url: "https://fullnode.devnet.aptoslabs.com"
    faucet_url: "https://faucet.devnet.aptoslabs.com"
    derivative_path: "m/44'/637'/1'/0'/0'"
```
