### PR TITLE
[Executor] MVHashMap changes for ExecutableStore

### DIFF
--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -25,6 +25,7 @@ use aptos_block_executor::{
 use aptos_infallible::Mutex;
 use aptos_state_view::{StateView, StateViewId};
 use aptos_types::{
+    executable::ExecutableTestType,
     state_store::state_key::StateKey,
     transaction::{Transaction, TransactionOutput, TransactionStatus},
     write_set::WriteOp,
@@ -163,7 +164,12 @@ impl BlockAptosVM {
         }
 
         BLOCK_EXECUTOR_CONCURRENCY.set(concurrency_level as i64);
-        let executor = BlockExecutor::<PreprocessedTransaction, AptosExecutorTask<S>, S>::new(
+        let executor = BlockExecutor::<
+            PreprocessedTransaction,
+            AptosExecutorTask<S>,
+            S,
+            ExecutableTestType,
+        >::new(
             concurrency_level,
             executor_thread_pool,
             maybe_block_gas_limit,

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -18,18 +18,15 @@ use aptos_aggregator::delta_change_set::{deserialize, serialize};
 use aptos_logger::{debug, info};
 use aptos_mvhashmap::{
     types::{MVDataError, MVDataOutput, TxnIndex, Version},
+    unsync_map::UnsyncMap,
     MVHashMap,
 };
 use aptos_state_view::TStateView;
-use aptos_types::{
-    executable::ExecutableTestType, // TODO: fix up with the proper generics.
-    write_set::WriteOp,
-};
+use aptos_types::{executable::Executable, write_set::WriteOp};
 use aptos_vm_logging::{clear_speculative_txn_logs, init_speculative_logs};
 use num_cpus;
 use rayon::ThreadPool;
 use std::{
-    collections::btree_map::BTreeMap,
     marker::PhantomData,
     sync::{
         mpsc,
@@ -44,20 +41,21 @@ enum CommitRole {
     Worker(Receiver<TxnIndex>),
 }
 
-pub struct BlockExecutor<T, E, S> {
+pub struct BlockExecutor<T, E, S, X> {
     // number of active concurrent tasks, corresponding to the maximum number of rayon
     // threads that may be concurrently participating in parallel execution.
     concurrency_level: usize,
     executor_thread_pool: Arc<ThreadPool>,
     maybe_block_gas_limit: Option<u64>,
-    phantom: PhantomData<(T, E, S)>,
+    phantom: PhantomData<(T, E, S, X)>,
 }
 
-impl<T, E, S> BlockExecutor<T, E, S>
+impl<T, E, S, X> BlockExecutor<T, E, S, X>
 where
     T: Transaction,
     E: ExecutorTask<Txn = T>,
     S: TStateView<Key = T::Key> + Sync,
+    X: Executable + 'static,
 {
     /// The caller needs to ensure that concurrency_level > 1 (0 is illegal and 1 should
     /// be handled by sequential execution) and that concurrency_level <= num_cpus.
@@ -84,7 +82,7 @@ where
         version: Version,
         signature_verified_block: &[T],
         last_input_output: &TxnLastInputOutput<T::Key, E::Output, E::Error>,
-        versioned_cache: &MVHashMap<T::Key, T::Value, ExecutableTestType>,
+        versioned_cache: &MVHashMap<T::Key, T::Value, X>,
         scheduler: &Scheduler,
         executor: &E,
         base_view: &S,
@@ -97,7 +95,7 @@ where
 
         // VM execution.
         let execute_result = executor.execute_transaction(
-            &LatestView::<T, S>::new_mv_view(base_view, &speculative_view, idx_to_execute),
+            &LatestView::<T, S, X>::new_mv_view(base_view, &speculative_view, idx_to_execute),
             txn,
             idx_to_execute,
             false,
@@ -113,7 +111,7 @@ where
                 if !prev_modified_keys.remove(&k) {
                     updates_outside = true;
                 }
-                versioned_cache.write(&k, write_version, v);
+                versioned_cache.write(k, write_version, v);
             }
 
             // Then, apply deltas.
@@ -121,7 +119,7 @@ where
                 if !prev_modified_keys.remove(&k) {
                     updates_outside = true;
                 }
-                versioned_cache.add_delta(&k, idx_to_execute, d);
+                versioned_cache.add_delta(k, idx_to_execute, d);
             }
         };
 
@@ -168,7 +166,7 @@ where
         version_to_validate: Version,
         validation_wave: Wave,
         last_input_output: &TxnLastInputOutput<T::Key, E::Output, E::Error>,
-        versioned_cache: &MVHashMap<T::Key, T::Value, ExecutableTestType>,
+        versioned_cache: &MVHashMap<T::Key, T::Value, X>,
         scheduler: &Scheduler,
     ) -> SchedulerTask {
         use MVDataError::*;
@@ -294,7 +292,7 @@ where
     fn worker_commit_hook(
         &self,
         txn_idx: TxnIndex,
-        versioned_cache: &MVHashMap<T::Key, T::Value, ExecutableTestType>,
+        versioned_cache: &MVHashMap<T::Key, T::Value, X>,
         last_input_output: &TxnLastInputOutput<T::Key, E::Output, E::Error>,
         base_view: &S,
     ) {
@@ -339,7 +337,7 @@ where
         executor_arguments: &E::Argument,
         block: &[T],
         last_input_output: &TxnLastInputOutput<T::Key, E::Output, E::Error>,
-        versioned_cache: &MVHashMap<T::Key, T::Value, ExecutableTestType>,
+        versioned_cache: &MVHashMap<T::Key, T::Value, X>,
         scheduler: &Scheduler,
         base_view: &S,
         role: CommitRole,
@@ -440,7 +438,7 @@ where
         // w. concurrency_level = 1 for some reason.
         assert!(self.concurrency_level > 1, "Must use sequential execution");
 
-        let versioned_cache = MVHashMap::new(None);
+        let versioned_cache = MVHashMap::new();
 
         if signature_verified_block.is_empty() {
             return Ok(vec![]);
@@ -533,13 +531,13 @@ where
     ) -> Result<Vec<E::Output>, E::Error> {
         let num_txns = signature_verified_block.len();
         let executor = E::init(executor_arguments);
-        let mut data_map = BTreeMap::new();
+        let data_map = UnsyncMap::new();
 
         let mut ret = Vec::with_capacity(num_txns);
         let mut accumulated_gas = 0;
         for (idx, txn) in signature_verified_block.iter().enumerate() {
             let res = executor.execute_transaction(
-                &LatestView::<T, S>::new_btree_view(base_view, &data_map, idx as TxnIndex),
+                &LatestView::<T, S, X>::new_btree_view(base_view, &data_map, idx as TxnIndex),
                 txn,
                 idx as TxnIndex,
                 true,
@@ -555,7 +553,7 @@ where
                     );
                     // Apply the writes.
                     for (ap, write_op) in output.get_writes().into_iter() {
-                        data_map.insert(ap, write_op);
+                        data_map.write(ap, write_op);
                     }
                     // Calculating the accumulated gas of the committed txns.
                     let txn_gas = output.gas_used();

--- a/aptos-move/block-executor/src/proptest_types/bencher.rs
+++ b/aptos-move/block-executor/src/proptest_types/bencher.rs
@@ -9,6 +9,7 @@ use crate::{
         TransactionGenParams, ValueType,
     },
 };
+use aptos_types::executable::ExecutableTestType;
 use criterion::{BatchSize, Bencher as CBencher};
 use num_cpus;
 use proptest::{
@@ -124,6 +125,7 @@ where
             Transaction<KeyType<K>, ValueType<V>>,
             Task<KeyType<K>, ValueType<V>>,
             EmptyDataView<KeyType<K>, ValueType<V>>,
+            ExecutableTestType,
         >::new(num_cpus::get(), executor_thread_pool, None)
         .execute_transactions_parallel((), &self.transactions, &data_view);
 

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -10,6 +10,7 @@ use crate::{
         TransactionGenParams, ValueType,
     },
 };
+use aptos_types::executable::ExecutableTestType;
 use claims::assert_ok;
 use num_cpus;
 use proptest::{
@@ -64,6 +65,7 @@ fn run_transactions<K, V>(
             Transaction<KeyType<K>, ValueType<V>>,
             Task<KeyType<K>, ValueType<V>>,
             EmptyDataView<KeyType<K>, ValueType<V>>,
+            ExecutableTestType,
         >::new(
             num_cpus::get(),
             executor_thread_pool.clone(),
@@ -198,6 +200,7 @@ fn deltas_writes_mixed_with_block_gas_limit(num_txns: usize, maybe_block_gas_lim
             Transaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             Task<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             DeltaDataView<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
+            ExecutableTestType,
         >::new(
             num_cpus::get(),
             executor_thread_pool.clone(),
@@ -248,6 +251,7 @@ fn deltas_resolver_with_block_gas_limit(num_txns: usize, maybe_block_gas_limit: 
             Transaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             Task<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             DeltaDataView<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
+            ExecutableTestType,
         >::new(
             num_cpus::get(),
             executor_thread_pool.clone(),
@@ -421,6 +425,7 @@ fn publishing_fixed_params_with_block_gas_limit(
         Transaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
         Task<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
         DeltaDataView<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
+        ExecutableTestType,
     >::new(num_cpus::get(), executor_thread_pool, maybe_block_gas_limit)
     .execute_transactions_parallel((), &transactions, &data_view);
     assert_ok!(output);
@@ -464,6 +469,7 @@ fn publishing_fixed_params_with_block_gas_limit(
             Transaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             Task<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             DeltaDataView<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
+            ExecutableTestType,
         >::new(
             num_cpus::get(),
             executor_thread_pool.clone(),

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -9,7 +9,10 @@ use crate::{
 };
 use aptos_aggregator::delta_change_set::{delta_add, delta_sub, DeltaOp, DeltaUpdate};
 use aptos_mvhashmap::types::TxnIndex;
-use aptos_types::{executable::ModulePath, write_set::TransactionWrite};
+use aptos_types::{
+    executable::{ExecutableTestType, ModulePath},
+    write_set::TransactionWrite,
+};
 use claims::{assert_matches, assert_some_eq};
 use rand::{prelude::*, random};
 use std::{
@@ -37,11 +40,12 @@ where
             .unwrap(),
     );
 
-    let output = BlockExecutor::<Transaction<K, V>, Task<K, V>, DeltaDataView<K, V>>::new(
-        num_cpus::get(),
-        executor_thread_pool,
-        None,
-    )
+    let output = BlockExecutor::<
+        Transaction<K, V>,
+        Task<K, V>,
+        DeltaDataView<K, V>,
+        ExecutableTestType,
+    >::new(num_cpus::get(), executor_thread_pool, None)
     .execute_transactions_parallel((), &transactions, &data_view);
 
     let baseline = ExpectedOutput::generate_baseline(&transactions, None, None);

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -11,18 +11,19 @@ use anyhow::Result;
 use aptos_aggregator::delta_change_set::{deserialize, serialize};
 use aptos_logger::error;
 use aptos_mvhashmap::{
-    types::{MVCodeError, MVCodeOutput, MVDataError, MVDataOutput, TxnIndex},
+    types::{MVDataError, MVDataOutput, MVModulesError, MVModulesOutput, TxnIndex},
+    unsync_map::UnsyncMap,
     MVHashMap,
 };
 use aptos_state_view::{StateViewId, TStateView};
 use aptos_types::{
-    executable::{ExecutableTestType, ModulePath},
+    executable::{Executable, ModulePath},
     state_store::{state_storage_usage::StateStorageUsage, state_value::StateValue},
     vm_status::{StatusCode, VMStatus},
     write_set::TransactionWrite,
 };
 use aptos_vm_logging::{log_schema::AdapterLogSchema, prelude::*};
-use std::{cell::RefCell, collections::BTreeMap, fmt::Debug, hash::Hash, sync::Arc};
+use std::{cell::RefCell, fmt::Debug, hash::Hash, sync::Arc};
 
 /// A struct that is always used by a single thread performing an execution task. The struct is
 /// passed to the VM and acts as a proxy to resolve reads first in the shared multi-version
@@ -31,8 +32,8 @@ use std::{cell::RefCell, collections::BTreeMap, fmt::Debug, hash::Hash, sync::Ar
 /// TODO(issue 10177): MvHashMapView currently needs to be sync due to trait bounds, but should
 /// not be. In this case, the read_dependency member can have a RefCell<bool> type and the
 /// captured_reads member can have RefCell<Vec<ReadDescriptor<K>>> type.
-pub(crate) struct MVHashMapView<'a, K, V: TransactionWrite> {
-    versioned_map: &'a MVHashMap<K, V, ExecutableTestType>, // TODO: proper generic type
+pub(crate) struct MVHashMapView<'a, K, V: TransactionWrite, X: Executable> {
+    versioned_map: &'a MVHashMap<K, V, X>,
     scheduler: &'a Scheduler,
     captured_reads: RefCell<Vec<ReadDescriptor<K>>>,
 }
@@ -57,12 +58,10 @@ impl<
         'a,
         K: ModulePath + PartialOrd + Ord + Send + Clone + Debug + Hash + Eq,
         V: TransactionWrite + Send + Sync,
-    > MVHashMapView<'a, K, V>
+        X: Executable,
+    > MVHashMapView<'a, K, V, X>
 {
-    pub(crate) fn new(
-        versioned_map: &'a MVHashMap<K, V, ExecutableTestType>,
-        scheduler: &'a Scheduler,
-    ) -> Self {
+    pub(crate) fn new(versioned_map: &'a MVHashMap<K, V, X>, scheduler: &'a Scheduler) -> Self {
         Self {
             versioned_map,
             scheduler,
@@ -76,18 +75,18 @@ impl<
     }
 
     // TODO: Actually fill in the logic to record fetched executables, etc.
-    fn fetch_code(
+    fn fetch_module(
         &self,
         key: &K,
         txn_idx: TxnIndex,
-    ) -> anyhow::Result<MVCodeOutput<V, ExecutableTestType>, MVCodeError> {
+    ) -> anyhow::Result<MVModulesOutput<V, X>, MVModulesError> {
         // Add a fake read from storage to register in reads for now in order
         // for the read / write path intersection fallback for modules to still work.
         self.captured_reads
             .borrow_mut()
             .push(ReadDescriptor::from_storage(key.clone()));
 
-        self.versioned_map.fetch_code(key, txn_idx)
+        self.versioned_map.fetch_module(key, txn_idx)
     }
 
     fn set_aggregator_base_value(&self, key: &K, value: u128) {
@@ -170,23 +169,23 @@ impl<
     }
 }
 
-enum ViewMapKind<'a, T: Transaction> {
-    MultiVersion(&'a MVHashMapView<'a, T::Key, T::Value>),
-    BTree(&'a BTreeMap<T::Key, T::Value>),
+enum ViewMapKind<'a, T: Transaction, X: Executable> {
+    MultiVersion(&'a MVHashMapView<'a, T::Key, T::Value, X>),
+    Unsync(&'a UnsyncMap<T::Key, T::Value, X>),
 }
 
-pub(crate) struct LatestView<'a, T: Transaction, S: TStateView<Key = T::Key>> {
+pub(crate) struct LatestView<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> {
     base_view: &'a S,
-    latest_view: ViewMapKind<'a, T>,
+    latest_view: ViewMapKind<'a, T, X>,
     txn_idx: TxnIndex,
 }
 
-impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
+impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<'a, T, S, X> {
     pub(crate) fn new_mv_view(
         base_view: &'a S,
-        map: &'a MVHashMapView<'a, T::Key, T::Value>,
+        map: &'a MVHashMapView<'a, T::Key, T::Value, X>,
         txn_idx: TxnIndex,
-    ) -> LatestView<'a, T, S> {
+    ) -> LatestView<'a, T, S, X> {
         LatestView {
             base_view,
             latest_view: ViewMapKind::MultiVersion(map),
@@ -196,12 +195,12 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
 
     pub(crate) fn new_btree_view(
         base_view: &'a S,
-        map: &'a BTreeMap<T::Key, T::Value>,
+        map: &'a UnsyncMap<T::Key, T::Value, X>,
         txn_idx: TxnIndex,
-    ) -> LatestView<'a, T, S> {
+    ) -> LatestView<'a, T, S, X> {
         LatestView {
             base_view,
-            latest_view: ViewMapKind::BTree(map),
+            latest_view: ViewMapKind::Unsync(map),
             txn_idx,
         }
     }
@@ -223,17 +222,19 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
     }
 }
 
-impl<'a, T: Transaction, S: TStateView<Key = T::Key>> TStateView for LatestView<'a, T, S> {
+impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TStateView
+    for LatestView<'a, T, S, X>
+{
     type Key = T::Key;
 
     fn get_state_value(&self, state_key: &T::Key) -> anyhow::Result<Option<StateValue>> {
         match self.latest_view {
             ViewMapKind::MultiVersion(map) => match state_key.module_path() {
                 Some(_) => {
-                    use MVCodeError::*;
-                    use MVCodeOutput::*;
+                    use MVModulesError::*;
+                    use MVModulesOutput::*;
 
-                    match map.fetch_code(state_key, self.txn_idx) {
+                    match map.fetch_module(state_key, self.txn_idx) {
                         Ok(Executable(_)) => unreachable!("Versioned executable not implemented"),
                         Ok(Module((v, _))) => Ok(v.as_state_value()),
                         Err(Dependency(_)) => {
@@ -280,7 +281,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> TStateView for LatestView<
                     }
                 },
             },
-            ViewMapKind::BTree(map) => map.get(state_key).map_or_else(
+            ViewMapKind::Unsync(map) => map.fetch_data(state_key).map_or_else(
                 || self.get_base_value(state_key),
                 |v| Ok(v.as_state_value()),
             ),

--- a/aptos-move/mvhashmap/src/lib.rs
+++ b/aptos-move/mvhashmap/src/lib.rs
@@ -3,20 +3,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    types::{MVCodeError, MVCodeOutput, MVDataError, MVDataOutput, TxnIndex, Version},
-    versioned_code::VersionedCode,
+    types::{MVDataError, MVDataOutput, MVModulesError, MVModulesOutput, TxnIndex, Version},
     versioned_data::VersionedData,
+    versioned_modules::VersionedModules,
 };
 use aptos_aggregator::delta_change_set::DeltaOp;
+use aptos_crypto::hash::HashValue;
 use aptos_types::{
-    executable::{Executable, ExecutableDescriptor, ModulePath},
+    executable::{Executable, ModulePath},
     write_set::TransactionWrite,
 };
 use std::{fmt::Debug, hash::Hash};
 
 pub mod types;
-pub mod versioned_code;
+pub mod unsync_map;
+mod utils;
 pub mod versioned_data;
+pub mod versioned_modules;
 
 #[cfg(test)]
 mod unit_tests;
@@ -28,37 +31,35 @@ mod unit_tests;
 /// given key, it holds exclusive access and doesn't need to explicitly synchronize
 /// with other reader/writers.
 ///
-/// TODO: separate V into different generic types for data and modules / code (currently
-/// both WriteOp for executor, and use extract_raw_bytes. data for aggregators, and
-/// code for computing the module hash.
+/// TODO: separate V into different generic types for data and code modules with specialized
+/// traits (currently both WriteOp for executor).
 pub struct MVHashMap<K, V: TransactionWrite, X: Executable> {
     data: VersionedData<K, V>,
-    code: VersionedCode<K, V, X>,
+    modules: VersionedModules<K, V, X>,
 }
 
 impl<K: ModulePath + Hash + Clone + Eq + Debug, V: TransactionWrite, X: Executable>
     MVHashMap<K, V, X>
 {
     // -----------------------------------
-    // Functions shared for data and code.
+    // Functions shared for data and modules.
 
-    // Option<VersionedCode> is passed to allow re-using code cache between blocks.
-    pub fn new(code_cache: Option<VersionedCode<K, V, X>>) -> MVHashMap<K, V, X> {
+    pub fn new() -> MVHashMap<K, V, X> {
         MVHashMap {
             data: VersionedData::new(),
-            code: code_cache.unwrap_or_default(),
+            modules: VersionedModules::new(),
         }
     }
 
-    pub fn take(self) -> (VersionedData<K, V>, VersionedCode<K, V, X>) {
-        (self.data, self.code)
+    pub fn take(self) -> (VersionedData<K, V>, VersionedModules<K, V, X>) {
+        (self.data, self.modules)
     }
 
     /// Mark an entry from transaction 'txn_idx' at access path 'key' as an estimated write
     /// (for future incarnation). Will panic if the entry is not in the data-structure.
     pub fn mark_estimate(&self, key: &K, txn_idx: TxnIndex) {
         match key.module_path() {
-            Some(_) => self.code.mark_estimate(key, txn_idx),
+            Some(_) => self.modules.mark_estimate(key, txn_idx),
             None => self.data.mark_estimate(key, txn_idx),
         }
     }
@@ -68,15 +69,15 @@ impl<K: ModulePath + Hash + Clone + Eq + Debug, V: TransactionWrite, X: Executab
     pub fn delete(&self, key: &K, txn_idx: TxnIndex) {
         // This internally deserializes the path, TODO: fix.
         match key.module_path() {
-            Some(_) => self.code.delete(key, txn_idx),
+            Some(_) => self.modules.delete(key, txn_idx),
             None => self.data.delete(key, txn_idx),
         };
     }
 
-    /// Add a versioned write at a specified key, in code or data map according to the key.
-    pub fn write(&self, key: &K, version: Version, value: V) {
+    /// Add a versioned write at a specified key, in data or modules map according to the key.
+    pub fn write(&self, key: K, version: Version, value: V) {
         match key.module_path() {
-            Some(_) => self.code.write(key, version.0, value),
+            Some(_) => self.modules.write(key, version.0, value),
             None => self.data.write(key, version, value),
         }
     }
@@ -85,7 +86,7 @@ impl<K: ModulePath + Hash + Clone + Eq + Debug, V: TransactionWrite, X: Executab
     // Functions specific to the multi-versioned data.
 
     /// Add a delta at a specified key.
-    pub fn add_delta(&self, key: &K, txn_idx: TxnIndex, delta: DeltaOp) {
+    pub fn add_delta(&self, key: K, txn_idx: TxnIndex, delta: DeltaOp) {
         debug_assert!(
             key.module_path().is_none(),
             "Delta must be stored at a path corresponding to data"
@@ -122,21 +123,25 @@ impl<K: ModulePath + Hash + Clone + Eq + Debug, V: TransactionWrite, X: Executab
     }
 
     // ----------------------------------------------
-    // Functions specific to the multi-versioned code.
+    // Functions specific to the multi-versioned modules map.
 
     /// Adds a new executable to the multi-version data-structure. The executable is either
     /// storage-version (and fixed) or uniquely identified by the (cryptographic) hash of the
     /// module published during the block.
-    pub fn store_executable(&self, key: &K, descriptor: ExecutableDescriptor, executable: X) {
-        self.code.store_executable(key, descriptor, executable);
+    pub fn store_executable(&self, key: &K, descriptor_hash: HashValue, executable: X) {
+        self.modules
+            .store_executable(key, descriptor_hash, executable);
     }
 
-    pub fn fetch_code(
+    /// Fetches the latest module stored at the given key, either as in an executable form,
+    /// if already cached, or in a raw module format that the VM can convert to an executable.
+    /// The errors are returned if no module is found, or if a dependency is encountered.
+    pub fn fetch_module(
         &self,
         key: &K,
         txn_idx: TxnIndex,
-    ) -> anyhow::Result<MVCodeOutput<V, X>, MVCodeError> {
-        self.code.fetch_code(key, txn_idx)
+    ) -> anyhow::Result<MVModulesOutput<V, X>, MVModulesError> {
+        self.modules.fetch_module(key, txn_idx)
     }
 }
 
@@ -144,6 +149,6 @@ impl<K: ModulePath + Hash + Clone + Debug + Eq, V: TransactionWrite, X: Executab
     for MVHashMap<K, V, X>
 {
     fn default() -> Self {
-        Self::new(None)
+        Self::new()
     }
 }

--- a/aptos-move/mvhashmap/src/types.rs
+++ b/aptos-move/mvhashmap/src/types.rs
@@ -30,7 +30,7 @@ pub enum MVDataError {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum MVCodeError {
+pub enum MVModulesError {
     /// No prior entry is found.
     NotFound,
     /// A dependency on other transaction has been found during the read.
@@ -51,12 +51,12 @@ pub enum MVDataOutput<V> {
 
 /// Returned as Ok(..) when read successfully from the multi-version data-structure.
 #[derive(Debug, PartialEq, Eq)]
-pub enum MVCodeOutput<M, X> {
+pub enum MVModulesOutput<M, X> {
     /// Arc to the executable corresponding to the latest module, and a descriptor
     /// with either the module hash or indicator that the module is from storage.
     Executable((Arc<X>, ExecutableDescriptor)),
     /// Arc to the latest module, together with its (cryptographic) hash. Note that
-    /// this can't be a storage-level module, as it's from multi-versioned code map.
+    /// this can't be a storage-level module, as it's from multi-versioned modules map.
     /// The Option can be None if HashValue can't be computed, currently may happen
     /// if the latest entry corresponded to the module deletion.
     Module((Arc<M>, HashValue)),

--- a/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
@@ -190,7 +190,7 @@ where
 
     let baseline = Baseline::new(transactions.as_slice());
     // Only testing data, provide executable type ().
-    let map = MVHashMap::<KeyType<K>, Value<V>, ExecutableTestType>::new(None);
+    let map = MVHashMap::<KeyType<K>, Value<V>, ExecutableTestType>::new();
 
     // make ESTIMATE placeholders for all versions to be updated.
     // allows to test that correct values appear at the end of concurrent execution.
@@ -205,7 +205,7 @@ where
         })
         .collect::<Vec<_>>();
     for (key, idx) in versions_to_write {
-        map.write(&KeyType(key.clone()), (idx as TxnIndex, 0), Value(None));
+        map.write(KeyType(key.clone()), (idx as TxnIndex, 0), Value(None));
         map.mark_estimate(&KeyType(key), idx as TxnIndex);
     }
 
@@ -283,17 +283,17 @@ where
                         }
                     },
                     Operator::Remove => {
-                        map.write(&KeyType(key.clone()), (idx as TxnIndex, 1), Value(None));
+                        map.write(KeyType(key.clone()), (idx as TxnIndex, 1), Value(None));
                     },
                     Operator::Insert(v) => {
                         map.write(
-                            &KeyType(key.clone()),
+                            KeyType(key.clone()),
                             (idx as TxnIndex, 1),
                             Value(Some(v.clone())),
                         );
                     },
                     Operator::Update(delta) => {
-                        map.add_delta(&KeyType(key.clone()), idx as TxnIndex, *delta)
+                        map.add_delta(KeyType(key.clone()), idx as TxnIndex, *delta)
                     },
                 }
             })
@@ -301,6 +301,8 @@ where
     });
     Ok(())
 }
+
+// TODO: proptest MVHashMap delete and dependency handling!
 
 proptest! {
     #[test]

--- a/aptos-move/mvhashmap/src/unsync_map.rs
+++ b/aptos-move/mvhashmap/src/unsync_map.rs
@@ -1,0 +1,90 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{types::MVModulesOutput, utils::module_hash};
+use aptos_crypto::hash::HashValue;
+use aptos_types::{
+    executable::{Executable, ExecutableDescriptor, ModulePath},
+    write_set::TransactionWrite,
+};
+use std::{cell::RefCell, collections::HashMap, hash::Hash, sync::Arc};
+
+/// UnsyncMap is designed to mimic the functionality of MVHashMap for sequential execution.
+/// In this case only the latest recorded version is relevant, simplifying the implementation.
+/// The functionality also includes Executable caching based on the hash of ExecutableDescriptor
+/// (i.e. module hash for modules published during the latest block - not at storage version).
+pub struct UnsyncMap<K: ModulePath, V: TransactionWrite, X: Executable> {
+    // Only use Arc to provide unified interfaces with the MVHashMap / concurrent setting. This
+    // simplifies the trait-based integration for executable caching. TODO: better representation.
+    // Optional hash can store the hash of the module to avoid re-computations.
+    map: RefCell<HashMap<K, (Arc<V>, Option<HashValue>)>>,
+    executable_cache: RefCell<HashMap<HashValue, Arc<X>>>,
+    executable_bytes: RefCell<usize>,
+}
+
+impl<K: ModulePath + Hash + Clone + Eq, V: TransactionWrite, X: Executable> Default
+    for UnsyncMap<K, V, X>
+{
+    fn default() -> Self {
+        Self {
+            map: RefCell::new(HashMap::new()),
+            executable_cache: RefCell::new(HashMap::new()),
+            executable_bytes: RefCell::new(0),
+        }
+    }
+}
+
+impl<K: ModulePath + Hash + Clone + Eq, V: TransactionWrite, X: Executable> UnsyncMap<K, V, X> {
+    pub fn new() -> Self {
+        Self {
+            map: RefCell::new(HashMap::new()),
+            executable_cache: RefCell::new(HashMap::new()),
+            executable_bytes: RefCell::new(0),
+        }
+    }
+
+    pub fn fetch_data(&self, key: &K) -> Option<Arc<V>> {
+        self.map.borrow().get(key).map(|entry| entry.0.clone())
+    }
+
+    pub fn fetch_module(&self, key: &K) -> Option<MVModulesOutput<V, X>> {
+        use MVModulesOutput::*;
+        debug_assert!(key.module_path().is_some());
+
+        self.map.borrow_mut().get_mut(key).map(|entry| {
+            let hash = entry.1.get_or_insert(module_hash(entry.0.as_ref()));
+
+            self.executable_cache.borrow().get(hash).map_or_else(
+                || Module((entry.0.clone(), *hash)),
+                |x| Executable((x.clone(), ExecutableDescriptor::Published(*hash))),
+            )
+        })
+    }
+
+    pub fn write(&self, key: K, value: V) {
+        self.map.borrow_mut().insert(key, (Arc::new(value), None));
+    }
+
+    /// We return false if the executable was already stored, as this isn't supposed to happen
+    /// during sequential execution (and the caller may choose to e.g. log a message).
+    /// Versioned modules storage does not cache executables at storage version, hence directly
+    /// the descriptor hash in ExecutableDescriptor::Published is provided.
+    pub fn store_executable(&self, descriptor_hash: HashValue, executable: X) -> bool {
+        let size = executable.size_bytes();
+        if self
+            .executable_cache
+            .borrow_mut()
+            .insert(descriptor_hash, Arc::new(executable))
+            .is_some()
+        {
+            *self.executable_bytes.borrow_mut() += size;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn executable_size(&self) -> usize {
+        *self.executable_bytes.borrow()
+    }
+}

--- a/aptos-move/mvhashmap/src/utils.rs
+++ b/aptos-move/mvhashmap/src/utils.rs
@@ -1,0 +1,16 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_crypto::hash::{DefaultHasher, HashValue};
+use aptos_types::write_set::TransactionWrite;
+
+pub(crate) fn module_hash<V: TransactionWrite>(module: &V) -> HashValue {
+    module
+        .extract_raw_bytes()
+        .map(|bytes| {
+            let mut hasher = DefaultHasher::new(b"Module");
+            hasher.update(&bytes);
+            hasher.finish()
+        })
+        .expect("Module can't be deleted")
+}

--- a/aptos-move/mvhashmap/src/versioned_data.rs
+++ b/aptos-move/mvhashmap/src/versioned_data.rs
@@ -217,8 +217,8 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite> VersionedData<K, V> {
         assert_eq!(*v.aggregator_base_value.get_or_insert(value), value);
     }
 
-    pub(crate) fn add_delta(&self, key: &K, txn_idx: TxnIndex, delta: DeltaOp) {
-        let mut v = self.values.entry(key.clone()).or_default();
+    pub(crate) fn add_delta(&self, key: K, txn_idx: TxnIndex, delta: DeltaOp) {
+        let mut v = self.values.entry(key).or_default();
         v.versioned_map
             .insert(txn_idx, CachePadded::new(Entry::new_delta_from(delta)));
     }
@@ -251,10 +251,10 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite> VersionedData<K, V> {
             .unwrap_or(Err(MVDataError::NotFound))
     }
 
-    pub(crate) fn write(&self, key: &K, version: Version, data: V) {
+    pub(crate) fn write(&self, key: K, version: Version, data: V) {
         let (txn_idx, incarnation) = version;
 
-        let mut v = self.values.entry(key.clone()).or_default();
+        let mut v = self.values.entry(key).or_default();
         let prev_entry = v.versioned_map.insert(
             txn_idx,
             CachePadded::new(Entry::new_write_from(incarnation, data)),

--- a/testsuite/sequential_execution_performance.py
+++ b/testsuite/sequential_execution_performance.py
@@ -4,7 +4,7 @@ import subprocess, re
 
 # Set the tps threshold for block size 1k, 10k and 50k
 BLOCK_SIZES = ["1k", "10k", "50k"]
-THRESHOLDS = {"1k": 3000, "10k": 4000, "50k": 7000}
+THRESHOLDS = {"1k": 3200, "10k": 4300, "50k": 7400}
 THRESHOLD_NOISE = 0.1
 
 # Run the VM sequential execution with performance optimizations enabled

--- a/types/src/executable.rs
+++ b/types/src/executable.rs
@@ -37,7 +37,7 @@ impl ModulePath for StateKey {
 /// For the executor to manage memory consumption, executables should provide size.
 /// Note: explore finer-grained eviction mechanisms, e.g. LRU-based, or having
 /// different ownership for the arena / memory.
-pub trait Executable: Clone {
+pub trait Executable: Clone + Send + Sync {
     fn size_bytes(&self) -> usize;
 }
 
@@ -50,9 +50,12 @@ impl Executable for ExecutableTestType {
     }
 }
 
+// TODO: variant for a compiled module when available to avoid deserialization.
 pub enum FetchedModule<X: Executable> {
     Blob(Option<Vec<u8>>),
-    // TODO: compiled module when available to avoid deserialization.
+    // Note: We could use Weak / & for parallel and sequential modes, respectively
+    // but rely on Arc for a simple and unified treatment for the time being.
+    // TODO: change Arc<X> to custom reference when we have memory manager / arena.
     Executable(Arc<X>),
 }
 


### PR DESCRIPTION
Isolating more changes from the ExecutableStore support adventure in easier to review PRs (https://github.com/aptos-labs/aptos-core/pull/7873/files#diff-8a3b172f46266133eecd1c04ba084071b6d0cc9998813e3f45d4a2ba22676a24).

Mainly refactoring, and introducing unsync_map, MVHashMap equivalent for sequential execution replacing bare BTreeMap so that it can also cache (hash-based / in-block) executables. As per comments from the big PR, baseline ExecutableCache will be passed to the MVHashMap view so base level executable caching will be similar to going to storage for blobs when data is not in MVHashMap.