### PR TITLE
Add support for staking Coins directly

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -92,13 +92,13 @@ jobs:
   # Because the docker build happens in a reusable workflow, have a separate job that collects the right metadata
   # for the subsequent docker builds. Reusable workflows do not currently have the "env" context: https://github.com/orgs/community/discussions/26671
   determine-docker-build-metadata:
+    needs: [permission-check]
     runs-on: ubuntu-latest
     steps:
       - name: collect metadata
         run: |
-          echo "GIT_SHA: ${{ env.GIT_SHA }}"
-          echo "TARGET_CACHE_ID: ${{ env.TARGET_CACHE_ID }}"
-          echo "CONCURRENCY: ${{ github.workflow }}-${{ github.event_name }}-${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.sha || github.head_ref || github.ref }}"
+          echo "GIT_SHA: ${GIT_SHA}"
+          echo "TARGET_CACHE_ID: ${TARGET_CACHE_ID}"
     outputs:
       gitSha: ${{ env.GIT_SHA }}
       targetCacheId: ${{ env.TARGET_CACHE_ID }}


### PR DESCRIPTION
### Description
If you want to interact with a delegated stake pool currently you have the to deal with the following constraints:
1. You can't stake `Coin<AptosCoin>` directly / unstake and receive `Coin<AptosCoin>`.
2. Because of this, you can only interact with the stake pool from an account with an Account resource, which excludes interactions from objects.

More context here: https://aptos-org.slack.com/archives/C036X27DZNG/p1684629998327789. 

More discussion required on if we want to actually land this. If we do, we might need an AIP. Probably not, but we should discuss it.

### Test Plan
```
cd aptos-move/framework/aptos-framework
aptos move test
```
