### PR TITLE
Add `entry_at_idx` function to SimpleMap

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/simple_map.md
+++ b/aptos-move/framework/aptos-stdlib/doc/simple_map.md
@@ -25,6 +25,7 @@ This module provides a solution for sorted maps, that is it has the properties t
 -  [Function `to_vec_pair`](#0x1_simple_map_to_vec_pair)
 -  [Function `destroy`](#0x1_simple_map_destroy)
 -  [Function `remove`](#0x1_simple_map_remove)
+-  [Function `entry_at_idx`](#0x1_simple_map_entry_at_idx)
 -  [Function `find`](#0x1_simple_map_find)
 -  [Specification](#@Specification_1)
     -  [Struct `SimpleMap`](#@Specification_1_SimpleMap)
@@ -457,6 +458,35 @@ using lambdas to destroy the individual keys and values.
     <b>let</b> placement = <a href="../../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> maybe_idx);
     <b>let</b> <a href="simple_map.md#0x1_simple_map_Element">Element</a> { key, value } = <a href="../../move-stdlib/doc/vector.md#0x1_vector_swap_remove">vector::swap_remove</a>(&<b>mut</b> map.data, placement);
     (key, value)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_simple_map_entry_at_idx"></a>
+
+## Function `entry_at_idx`
+
+Get the key and value at a given index in the underlying vector.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_entry_at_idx">entry_at_idx</a>&lt;Key: store, Value: store&gt;(map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">simple_map::SimpleMap</a>&lt;Key, Value&gt;, idx: u64): (&Key, &Value)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="simple_map.md#0x1_simple_map_entry_at_idx">entry_at_idx</a>&lt;Key: store, Value: store&gt;(
+    map: &<a href="simple_map.md#0x1_simple_map_SimpleMap">SimpleMap</a>&lt;Key, Value&gt;,
+    idx: u64
+): (&Key, &Value) {
+    <b>let</b> element = <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&map.data, idx);
+    (&element.key, &element.value)
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-stdlib/sources/simple_map.move
+++ b/aptos-move/framework/aptos-stdlib/sources/simple_map.move
@@ -134,6 +134,14 @@ module aptos_std::simple_map {
         (key, value)
     }
 
+    /// Get the key at a given index in the underlying vector.
+    public fun key_at_idx<Key: store, Value: store>(
+        map: &SimpleMap<Key, Value>,
+        idx: u64
+    ): &Key {
+        &vector::borrow(&map.data, idx).key
+    }
+
     fun find<Key: store, Value: store>(
         map: &SimpleMap<Key, Value>,
         key: &Key,

--- a/aptos-move/framework/aptos-stdlib/sources/simple_map.move
+++ b/aptos-move/framework/aptos-stdlib/sources/simple_map.move
@@ -134,12 +134,13 @@ module aptos_std::simple_map {
         (key, value)
     }
 
-    /// Get the key at a given index in the underlying vector.
-    public fun key_at_idx<Key: store, Value: store>(
+    /// Get the key and value at a given index in the underlying vector.
+    public fun entry_at_idx<Key: store, Value: store>(
         map: &SimpleMap<Key, Value>,
         idx: u64
-    ): &Key {
-        &vector::borrow(&map.data, idx).key
+    ): (&Key, &Value) {
+        let element = vector::borrow(&map.data, idx);
+        (&element.key, &element.value)
     }
 
     fun find<Key: store, Value: store>(


### PR DESCRIPTION
### Description
This function makes it possible to iterate through all items in a SimpleMap:
```
let len = simple_map::length(&my_map);
let i = 0;
while (i < len) {
    let key = *simple_map::key_at_idx(&my_map, i);
    // Do something.
    i = i + 1;
};
```

The inability to do this today results in a pattern where you have to have a SimpleMap with a vector alongside containing all the keys, which is unnecessary additional complexity / storage waste.

Internal discussion: https://aptos-org.slack.com/archives/C036X27DZNG/p1684789482036019.

### Test Plan
```
cd aptos-move/framework/aptos-stdlib
aptos move test
```
