### PR TITLE
[Multisig v2] Implement atomic add/remove owners with signature update funcs

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/multisig_account.md
+++ b/aptos-move/framework/aptos-framework/doc/multisig_account.md
@@ -74,8 +74,10 @@ and implement the governance voting logic on top.
 -  [Function `create_with_owners_internal`](#0x1_multisig_account_create_with_owners_internal)
 -  [Function `add_owner`](#0x1_multisig_account_add_owner)
 -  [Function `add_owners`](#0x1_multisig_account_add_owners)
+-  [Function `add_owners_update_signatures_required`](#0x1_multisig_account_add_owners_update_signatures_required)
 -  [Function `remove_owner`](#0x1_multisig_account_remove_owner)
 -  [Function `remove_owners`](#0x1_multisig_account_remove_owners)
+-  [Function `remove_owners_update_signatures_required`](#0x1_multisig_account_remove_owners_update_signatures_required)
 -  [Function `update_signatures_required`](#0x1_multisig_account_update_signatures_required)
 -  [Function `update_metadata`](#0x1_multisig_account_update_metadata)
 -  [Function `update_metadata_internal`](#0x1_multisig_account_update_metadata_internal)
@@ -1531,6 +1533,36 @@ maliciously alter the owners list.
 
 </details>
 
+<a name="0x1_multisig_account_add_owners_update_signatures_required"></a>
+
+## Function `add_owners_update_signatures_required`
+
+Add owners then update number of signatures required, in a single operation.
+
+
+<pre><code>entry <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_add_owners_update_signatures_required">add_owners_update_signatures_required</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_owners: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, new_num_signatures_required: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>entry <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_add_owners_update_signatures_required">add_owners_update_signatures_required</a>(
+    <a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    new_owners: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;,
+    new_num_signatures_required: u64
+) <b>acquires</b> <a href="multisig_account.md#0x1_multisig_account_MultisigAccount">MultisigAccount</a> {
+    <a href="multisig_account.md#0x1_multisig_account_add_owners">add_owners</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>, new_owners);
+    <a href="multisig_account.md#0x1_multisig_account_update_signatures_required">update_signatures_required</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>, new_num_signatures_required);
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x1_multisig_account_remove_owner"></a>
 
 ## Function `remove_owner`
@@ -1611,6 +1643,36 @@ maliciously alter the owners list.
     );
 
     emit_event(&<b>mut</b> multisig_account_resource.remove_owners_events, <a href="multisig_account.md#0x1_multisig_account_RemoveOwnersEvent">RemoveOwnersEvent</a> { owners_removed });
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_multisig_account_remove_owners_update_signatures_required"></a>
+
+## Function `remove_owners_update_signatures_required`
+
+Update the number of signatures required then remove owners, in a single operation.
+
+
+<pre><code>entry <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_remove_owners_update_signatures_required">remove_owners_update_signatures_required</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, owners_to_remove: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, new_num_signatures_required: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>entry <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_remove_owners_update_signatures_required">remove_owners_update_signatures_required</a>(
+    <a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    owners_to_remove: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;,
+    new_num_signatures_required: u64
+) <b>acquires</b> <a href="multisig_account.md#0x1_multisig_account_MultisigAccount">MultisigAccount</a> {
+    <a href="multisig_account.md#0x1_multisig_account_update_signatures_required">update_signatures_required</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>, new_num_signatures_required);
+    <a href="multisig_account.md#0x1_multisig_account_remove_owners">remove_owners</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>, owners_to_remove);
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/multisig_account.md
+++ b/aptos-move/framework/aptos-framework/doc/multisig_account.md
@@ -74,10 +74,10 @@ and implement the governance voting logic on top.
 -  [Function `create_with_owners_internal`](#0x1_multisig_account_create_with_owners_internal)
 -  [Function `add_owner`](#0x1_multisig_account_add_owner)
 -  [Function `add_owners`](#0x1_multisig_account_add_owners)
--  [Function `add_owners_update_signatures_required`](#0x1_multisig_account_add_owners_update_signatures_required)
+-  [Function `add_owners_and_update_signatures_required`](#0x1_multisig_account_add_owners_and_update_signatures_required)
 -  [Function `remove_owner`](#0x1_multisig_account_remove_owner)
 -  [Function `remove_owners`](#0x1_multisig_account_remove_owners)
--  [Function `remove_owners_update_signatures_required`](#0x1_multisig_account_remove_owners_update_signatures_required)
+-  [Function `remove_owners_and_update_signatures_required`](#0x1_multisig_account_remove_owners_and_update_signatures_required)
 -  [Function `update_signatures_required`](#0x1_multisig_account_update_signatures_required)
 -  [Function `update_metadata`](#0x1_multisig_account_update_metadata)
 -  [Function `update_metadata_internal`](#0x1_multisig_account_update_metadata_internal)
@@ -1533,14 +1533,14 @@ maliciously alter the owners list.
 
 </details>
 
-<a name="0x1_multisig_account_add_owners_update_signatures_required"></a>
+<a name="0x1_multisig_account_add_owners_and_update_signatures_required"></a>
 
-## Function `add_owners_update_signatures_required`
+## Function `add_owners_and_update_signatures_required`
 
 Add owners then update number of signatures required, in a single operation.
 
 
-<pre><code>entry <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_add_owners_update_signatures_required">add_owners_update_signatures_required</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_owners: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, new_num_signatures_required: u64)
+<pre><code>entry <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_add_owners_and_update_signatures_required">add_owners_and_update_signatures_required</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_owners: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, new_num_signatures_required: u64)
 </code></pre>
 
 
@@ -1549,7 +1549,7 @@ Add owners then update number of signatures required, in a single operation.
 <summary>Implementation</summary>
 
 
-<pre><code>entry <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_add_owners_update_signatures_required">add_owners_update_signatures_required</a>(
+<pre><code>entry <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_add_owners_and_update_signatures_required">add_owners_and_update_signatures_required</a>(
     <a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     new_owners: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;,
     new_num_signatures_required: u64
@@ -1650,14 +1650,14 @@ maliciously alter the owners list.
 
 </details>
 
-<a name="0x1_multisig_account_remove_owners_update_signatures_required"></a>
+<a name="0x1_multisig_account_remove_owners_and_update_signatures_required"></a>
 
-## Function `remove_owners_update_signatures_required`
+## Function `remove_owners_and_update_signatures_required`
 
 Update the number of signatures required then remove owners, in a single operation.
 
 
-<pre><code>entry <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_remove_owners_update_signatures_required">remove_owners_update_signatures_required</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, owners_to_remove: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, new_num_signatures_required: u64)
+<pre><code>entry <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_remove_owners_and_update_signatures_required">remove_owners_and_update_signatures_required</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, owners_to_remove: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;, new_num_signatures_required: u64)
 </code></pre>
 
 
@@ -1666,7 +1666,7 @@ Update the number of signatures required then remove owners, in a single operati
 <summary>Implementation</summary>
 
 
-<pre><code>entry <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_remove_owners_update_signatures_required">remove_owners_update_signatures_required</a>(
+<pre><code>entry <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_remove_owners_and_update_signatures_required">remove_owners_and_update_signatures_required</a>(
     <a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     owners_to_remove: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;,
     new_num_signatures_required: u64

--- a/aptos-move/framework/aptos-framework/sources/multisig_account.move
+++ b/aptos-move/framework/aptos-framework/sources/multisig_account.move
@@ -521,7 +521,7 @@ module aptos_framework::multisig_account {
     }
 
     /// Add owners then update number of signatures required, in a single operation.
-    entry fun add_owners_update_signatures_required(
+    entry fun add_owners_and_update_signatures_required(
         multisig_account: &signer,
         new_owners: vector<address>,
         new_num_signatures_required: u64
@@ -578,7 +578,7 @@ module aptos_framework::multisig_account {
     }
 
     /// Update the number of signatures required then remove owners, in a single operation.
-    entry fun remove_owners_update_signatures_required(
+    entry fun remove_owners_and_update_signatures_required(
         multisig_account: &signer,
         owners_to_remove: vector<address>,
         new_num_signatures_required: u64

--- a/aptos-move/framework/aptos-framework/sources/multisig_account.move
+++ b/aptos-move/framework/aptos-framework/sources/multisig_account.move
@@ -520,6 +520,16 @@ module aptos_framework::multisig_account {
         });
     }
 
+    /// Add owners then update number of signatures required, in a single operation.
+    entry fun add_owners_update_signatures_required(
+        multisig_account: &signer,
+        new_owners: vector<address>,
+        new_num_signatures_required: u64
+    ) acquires MultisigAccount {
+        add_owners(multisig_account, new_owners);
+        update_signatures_required(multisig_account, new_num_signatures_required);
+    }
+
     /// Similar to remove_owners, but only allow removing one owner.
     entry fun remove_owner(
         multisig_account: &signer, owner_to_remove: address) acquires MultisigAccount {
@@ -565,6 +575,16 @@ module aptos_framework::multisig_account {
         );
 
         emit_event(&mut multisig_account_resource.remove_owners_events, RemoveOwnersEvent { owners_removed });
+    }
+
+    /// Update the number of signatures required then remove owners, in a single operation.
+    entry fun remove_owners_update_signatures_required(
+        multisig_account: &signer,
+        owners_to_remove: vector<address>,
+        new_num_signatures_required: u64
+    ) acquires MultisigAccount {
+        update_signatures_required(multisig_account, new_num_signatures_required);
+        remove_owners(multisig_account, owners_to_remove);
     }
 
     /// Update the number of signatures required to execute transaction in the specified multisig account.

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -338,7 +338,7 @@ pub enum EntryFunctionCall {
     },
 
     /// Add owners then update number of signatures required, in a single operation.
-    MultisigAccountAddOwnersUpdateSignaturesRequired {
+    MultisigAccountAddOwnersAndUpdateSignaturesRequired {
         new_owners: Vec<AccountAddress>,
         new_num_signatures_required: u64,
     },
@@ -434,7 +434,7 @@ pub enum EntryFunctionCall {
     },
 
     /// Update the number of signatures required then remove owners, in a single operation.
-    MultisigAccountRemoveOwnersUpdateSignaturesRequired {
+    MultisigAccountRemoveOwnersAndUpdateSignaturesRequired {
         owners_to_remove: Vec<AccountAddress>,
         new_num_signatures_required: u64,
     },
@@ -958,10 +958,10 @@ impl EntryFunctionCall {
             ManagedCoinRegister { coin_type } => managed_coin_register(coin_type),
             MultisigAccountAddOwner { new_owner } => multisig_account_add_owner(new_owner),
             MultisigAccountAddOwners { new_owners } => multisig_account_add_owners(new_owners),
-            MultisigAccountAddOwnersUpdateSignaturesRequired {
+            MultisigAccountAddOwnersAndUpdateSignaturesRequired {
                 new_owners,
                 new_num_signatures_required,
-            } => multisig_account_add_owners_update_signatures_required(
+            } => multisig_account_add_owners_and_update_signatures_required(
                 new_owners,
                 new_num_signatures_required,
             ),
@@ -1025,10 +1025,10 @@ impl EntryFunctionCall {
             MultisigAccountRemoveOwners { owners_to_remove } => {
                 multisig_account_remove_owners(owners_to_remove)
             },
-            MultisigAccountRemoveOwnersUpdateSignaturesRequired {
+            MultisigAccountRemoveOwnersAndUpdateSignaturesRequired {
                 owners_to_remove,
                 new_num_signatures_required,
-            } => multisig_account_remove_owners_update_signatures_required(
+            } => multisig_account_remove_owners_and_update_signatures_required(
                 owners_to_remove,
                 new_num_signatures_required,
             ),
@@ -2079,7 +2079,7 @@ pub fn multisig_account_add_owners(new_owners: Vec<AccountAddress>) -> Transacti
 }
 
 /// Add owners then update number of signatures required, in a single operation.
-pub fn multisig_account_add_owners_update_signatures_required(
+pub fn multisig_account_add_owners_and_update_signatures_required(
     new_owners: Vec<AccountAddress>,
     new_num_signatures_required: u64,
 ) -> TransactionPayload {
@@ -2091,7 +2091,7 @@ pub fn multisig_account_add_owners_update_signatures_required(
             ]),
             ident_str!("multisig_account").to_owned(),
         ),
-        ident_str!("add_owners_update_signatures_required").to_owned(),
+        ident_str!("add_owners_and_update_signatures_required").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&new_owners).unwrap(),
@@ -2347,7 +2347,7 @@ pub fn multisig_account_remove_owners(owners_to_remove: Vec<AccountAddress>) -> 
 }
 
 /// Update the number of signatures required then remove owners, in a single operation.
-pub fn multisig_account_remove_owners_update_signatures_required(
+pub fn multisig_account_remove_owners_and_update_signatures_required(
     owners_to_remove: Vec<AccountAddress>,
     new_num_signatures_required: u64,
 ) -> TransactionPayload {
@@ -2359,7 +2359,7 @@ pub fn multisig_account_remove_owners_update_signatures_required(
             ]),
             ident_str!("multisig_account").to_owned(),
         ),
-        ident_str!("remove_owners_update_signatures_required").to_owned(),
+        ident_str!("remove_owners_and_update_signatures_required").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&owners_to_remove).unwrap(),
@@ -3958,12 +3958,12 @@ mod decoder {
         }
     }
 
-    pub fn multisig_account_add_owners_update_signatures_required(
+    pub fn multisig_account_add_owners_and_update_signatures_required(
         payload: &TransactionPayload,
     ) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(
-                EntryFunctionCall::MultisigAccountAddOwnersUpdateSignaturesRequired {
+                EntryFunctionCall::MultisigAccountAddOwnersAndUpdateSignaturesRequired {
                     new_owners: bcs::from_bytes(script.args().get(0)?).ok()?,
                     new_num_signatures_required: bcs::from_bytes(script.args().get(1)?).ok()?,
                 },
@@ -4114,12 +4114,12 @@ mod decoder {
         }
     }
 
-    pub fn multisig_account_remove_owners_update_signatures_required(
+    pub fn multisig_account_remove_owners_and_update_signatures_required(
         payload: &TransactionPayload,
     ) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(
-                EntryFunctionCall::MultisigAccountRemoveOwnersUpdateSignaturesRequired {
+                EntryFunctionCall::MultisigAccountRemoveOwnersAndUpdateSignaturesRequired {
                     owners_to_remove: bcs::from_bytes(script.args().get(0)?).ok()?,
                     new_num_signatures_required: bcs::from_bytes(script.args().get(1)?).ok()?,
                 },
@@ -4956,8 +4956,8 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
             Box::new(decoder::multisig_account_add_owners),
         );
         map.insert(
-            "multisig_account_add_owners_update_signatures_required".to_string(),
-            Box::new(decoder::multisig_account_add_owners_update_signatures_required),
+            "multisig_account_add_owners_and_update_signatures_required".to_string(),
+            Box::new(decoder::multisig_account_add_owners_and_update_signatures_required),
         );
         map.insert(
             "multisig_account_approve_transaction".to_string(),
@@ -5000,8 +5000,8 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
             Box::new(decoder::multisig_account_remove_owners),
         );
         map.insert(
-            "multisig_account_remove_owners_update_signatures_required".to_string(),
-            Box::new(decoder::multisig_account_remove_owners_update_signatures_required),
+            "multisig_account_remove_owners_and_update_signatures_required".to_string(),
+            Box::new(decoder::multisig_account_remove_owners_and_update_signatures_required),
         );
         map.insert(
             "multisig_account_update_metadata".to_string(),

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -337,6 +337,12 @@ pub enum EntryFunctionCall {
         new_owners: Vec<AccountAddress>,
     },
 
+    /// Add owners then update number of signatures required, in a single operation.
+    MultisigAccountAddOwnersUpdateSignaturesRequired {
+        new_owners: Vec<AccountAddress>,
+        new_num_signatures_required: u64,
+    },
+
     /// Approve a multisig transaction.
     MultisigAccountApproveTransaction {
         multisig_account: AccountAddress,
@@ -425,6 +431,12 @@ pub enum EntryFunctionCall {
     /// maliciously alter the owners list.
     MultisigAccountRemoveOwners {
         owners_to_remove: Vec<AccountAddress>,
+    },
+
+    /// Update the number of signatures required then remove owners, in a single operation.
+    MultisigAccountRemoveOwnersUpdateSignaturesRequired {
+        owners_to_remove: Vec<AccountAddress>,
+        new_num_signatures_required: u64,
     },
 
     /// Allow the multisig account to update its own metadata. Note that this overrides the entire existing metadata.
@@ -946,6 +958,13 @@ impl EntryFunctionCall {
             ManagedCoinRegister { coin_type } => managed_coin_register(coin_type),
             MultisigAccountAddOwner { new_owner } => multisig_account_add_owner(new_owner),
             MultisigAccountAddOwners { new_owners } => multisig_account_add_owners(new_owners),
+            MultisigAccountAddOwnersUpdateSignaturesRequired {
+                new_owners,
+                new_num_signatures_required,
+            } => multisig_account_add_owners_update_signatures_required(
+                new_owners,
+                new_num_signatures_required,
+            ),
             MultisigAccountApproveTransaction {
                 multisig_account,
                 sequence_number,
@@ -1006,6 +1025,13 @@ impl EntryFunctionCall {
             MultisigAccountRemoveOwners { owners_to_remove } => {
                 multisig_account_remove_owners(owners_to_remove)
             },
+            MultisigAccountRemoveOwnersUpdateSignaturesRequired {
+                owners_to_remove,
+                new_num_signatures_required,
+            } => multisig_account_remove_owners_update_signatures_required(
+                owners_to_remove,
+                new_num_signatures_required,
+            ),
             MultisigAccountUpdateMetadata { keys, values } => {
                 multisig_account_update_metadata(keys, values)
             },
@@ -2052,6 +2078,28 @@ pub fn multisig_account_add_owners(new_owners: Vec<AccountAddress>) -> Transacti
     ))
 }
 
+/// Add owners then update number of signatures required, in a single operation.
+pub fn multisig_account_add_owners_update_signatures_required(
+    new_owners: Vec<AccountAddress>,
+    new_num_signatures_required: u64,
+) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("multisig_account").to_owned(),
+        ),
+        ident_str!("add_owners_update_signatures_required").to_owned(),
+        vec![],
+        vec![
+            bcs::to_bytes(&new_owners).unwrap(),
+            bcs::to_bytes(&new_num_signatures_required).unwrap(),
+        ],
+    ))
+}
+
 /// Approve a multisig transaction.
 pub fn multisig_account_approve_transaction(
     multisig_account: AccountAddress,
@@ -2295,6 +2343,28 @@ pub fn multisig_account_remove_owners(owners_to_remove: Vec<AccountAddress>) -> 
         ident_str!("remove_owners").to_owned(),
         vec![],
         vec![bcs::to_bytes(&owners_to_remove).unwrap()],
+    ))
+}
+
+/// Update the number of signatures required then remove owners, in a single operation.
+pub fn multisig_account_remove_owners_update_signatures_required(
+    owners_to_remove: Vec<AccountAddress>,
+    new_num_signatures_required: u64,
+) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("multisig_account").to_owned(),
+        ),
+        ident_str!("remove_owners_update_signatures_required").to_owned(),
+        vec![],
+        vec![
+            bcs::to_bytes(&owners_to_remove).unwrap(),
+            bcs::to_bytes(&new_num_signatures_required).unwrap(),
+        ],
     ))
 }
 
@@ -3888,6 +3958,21 @@ mod decoder {
         }
     }
 
+    pub fn multisig_account_add_owners_update_signatures_required(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(
+                EntryFunctionCall::MultisigAccountAddOwnersUpdateSignaturesRequired {
+                    new_owners: bcs::from_bytes(script.args().get(0)?).ok()?,
+                    new_num_signatures_required: bcs::from_bytes(script.args().get(1)?).ok()?,
+                },
+            )
+        } else {
+            None
+        }
+    }
+
     pub fn multisig_account_approve_transaction(
         payload: &TransactionPayload,
     ) -> Option<EntryFunctionCall> {
@@ -4024,6 +4109,21 @@ mod decoder {
             Some(EntryFunctionCall::MultisigAccountRemoveOwners {
                 owners_to_remove: bcs::from_bytes(script.args().get(0)?).ok()?,
             })
+        } else {
+            None
+        }
+    }
+
+    pub fn multisig_account_remove_owners_update_signatures_required(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(
+                EntryFunctionCall::MultisigAccountRemoveOwnersUpdateSignaturesRequired {
+                    owners_to_remove: bcs::from_bytes(script.args().get(0)?).ok()?,
+                    new_num_signatures_required: bcs::from_bytes(script.args().get(1)?).ok()?,
+                },
+            )
         } else {
             None
         }
@@ -4856,6 +4956,10 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
             Box::new(decoder::multisig_account_add_owners),
         );
         map.insert(
+            "multisig_account_add_owners_update_signatures_required".to_string(),
+            Box::new(decoder::multisig_account_add_owners_update_signatures_required),
+        );
+        map.insert(
             "multisig_account_approve_transaction".to_string(),
             Box::new(decoder::multisig_account_approve_transaction),
         );
@@ -4894,6 +4998,10 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
         map.insert(
             "multisig_account_remove_owners".to_string(),
             Box::new(decoder::multisig_account_remove_owners),
+        );
+        map.insert(
+            "multisig_account_remove_owners_update_signatures_required".to_string(),
+            Box::new(decoder::multisig_account_remove_owners_update_signatures_required),
         );
         map.insert(
             "multisig_account_update_metadata".to_string(),


### PR DESCRIPTION
@movekevin 

# Summary of changes

This PR adds two new functions to `multisig_account.move` for simultaneous updating owners and modifying the signature count. The remaining file changes are simply the result of auto-generated code from the Move modifications.

# Multisig account flow

Without this PR, the multisig account flow prohibits owners from being added/removed in the same transaction as a required signature count update. However this presents a UX problem because typically modifications to the security group comes with a signature count requirement update. For example:

## Removal

Consider a 4-of-7 multisig account that wishes to remove 3 signatories and go to 2-of-4. Before this PR, this modification would have to be broken down into two operations: if the signatory count is updated before removal, then the owners who are supposed to be removed could theoretically collude on a malicious transaction while the multisig is a 2-of-7. If the signatory count is updated after the removal, there could be a potential gridlock situation while the multisig is a 4-of-4 if one of the signatories has lost their key but hasn't noticed it since the last vote. This PR avoids potential conflicts that could arise during intermediate phases.

## Addition

Consider a 3-of-4 that wishes to go to 5-of-9 to dilute the votes of suspect actors: the signatory count can not be updated prior to addition (5 > 4), but if it is updated after addition then the multisig would reach a temporary state of 3-of-9 minority control. This PR avoids such a potential conflict.