### PR TITLE
Revert "[Gas Estimation] enable v2 by default (#8325)"

### DIFF
--- a/config/src/config/gas_estimation_config.rs
+++ b/config/src/config/gas_estimation_config.rs
@@ -28,7 +28,7 @@ pub struct GasEstimationConfig {
 impl Default for GasEstimationConfig {
     fn default() -> GasEstimationConfig {
         GasEstimationConfig {
-            enabled: true,
+            enabled: false,
             full_block_txns: 250,
             low_block_history: 10,
             market_block_history: 30,


### PR DESCRIPTION
This reverts commit 0d24ca3f2236b8d2e07ac693f9a068d1bcf6e191.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
