### PR TITLE
Revert "[TF] Add toggles for enabling GCFS and GVNIC on GCP"

### DIFF
--- a/terraform/aptos-node-testnet/gcp/main.tf
+++ b/terraform/aptos-node-testnet/gcp/main.tf
@@ -44,10 +44,6 @@ module "validator" {
   k8s_api_sources         = var.k8s_api_sources
   cluster_ipv4_cidr_block = var.cluster_ipv4_cidr_block
 
-  # node config
-  gke_cluster_enable_gcfs  = var.gke_cluster_enable_gcfs
-  gke_cluster_enable_gvnic = var.gke_cluster_enable_gvnic
-
   # autoscaling
   gke_enable_node_autoprovisioning     = var.gke_enable_node_autoprovisioning
   gke_node_autoprovisioning_max_cpu    = var.gke_node_autoprovisioning_max_cpu

--- a/terraform/aptos-node-testnet/gcp/variables.tf
+++ b/terraform/aptos-node-testnet/gcp/variables.tf
@@ -148,18 +148,6 @@ variable "enable_prometheus_node_exporter" {
   default     = true
 }
 
-### Cluster node config
-
-variable "gke_cluster_enable_gcfs" {
-  description = "Enable GCFS at the cluster level"
-  default     = false
-}
-
-variable "gke_cluster_enable_gvnic" {
-  description = "Enable GVNIC (networking driver) at the cluster level"
-  default     = false
-}
-
 ### Autoscaling
 
 variable "gke_enable_node_autoprovisioning" {

--- a/terraform/aptos-node/gcp/cluster.tf
+++ b/terraform/aptos-node/gcp/cluster.tf
@@ -53,15 +53,6 @@ resource "google_container_cluster" "aptos" {
     provider = "CALICO"
   }
 
-  node_config {
-    gcfs_config {
-      enabled = var.gke_cluster_enable_gcfs
-    }
-    gvnic {
-      enabled = var.gke_cluster_enable_gvnic
-    }
-  }
-
   cluster_autoscaling {
     enabled = var.gke_enable_node_autoprovisioning
 

--- a/terraform/aptos-node/gcp/variables.tf
+++ b/terraform/aptos-node/gcp/variables.tf
@@ -171,19 +171,8 @@ variable "manage_via_tf" {
   default     = true
 }
 
-### Cluster node config
-
-variable "gke_cluster_enable_gcfs" {
-  description = "Enable GCFS at the cluster level"
-  default     = false
-}
-
-variable "gke_cluster_enable_gvnic" {
-  description = "Enable GVNIC (networking driver) at the cluster level"
-  default     = false
-}
-
 ### Autoscaling
+
 
 variable "gke_enable_node_autoprovisioning" {
   description = "Enable node autoprovisioning for GKE cluster. See https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning"


### PR DESCRIPTION
Reverts aptos-labs/aptos-core#8249

Enabling GCFS and GVNIC seems broken on Terraform so revert this for the moment.

If any of those two features are enabled, `terraform apply` will try to destroy and recreate the cluster every time. It seems that those protobuf fields are empty when `terraform refresh` reads the cluster state, so `apply` will assume they're missing and try to recreate the cluster.