### PR TITLE
Avoid materializing delta set before epilogue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3290,6 +3290,7 @@ dependencies = [
  "aptos-framework",
  "aptos-gas",
  "aptos-infallible",
+ "aptos-language-e2e-tests",
  "aptos-logger",
  "aptos-metrics-core",
  "aptos-move-stdlib",

--- a/aptos-move/aptos-aggregator/src/delta_change_set.rs
+++ b/aptos-move/aptos-aggregator/src/delta_change_set.rs
@@ -299,6 +299,10 @@ impl DeltaChangeSet {
         }
     }
 
+    pub fn get(&self, key: &StateKey) -> Option<&DeltaOp> {
+        self.delta_change_set.get(key)
+    }
+
     pub fn insert(&mut self, delta: (StateKey, DeltaOp)) {
         self.delta_change_set.insert(delta.0, delta.1);
     }

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -51,6 +51,7 @@ smallvec = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+aptos-language-e2e-tests = { workspace = true }
 aptos-types = { workspace = true }
 proptest = { workspace = true }
 

--- a/aptos-move/e2e-move-tests/src/tests/aggregator.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator.rs
@@ -109,6 +109,7 @@ fn test_aggregator_lifetime() {
 }
 
 #[test]
+#[should_panic]
 fn test_aggregator_underflow() {
     let (mut h, acc) = setup();
 
@@ -136,6 +137,7 @@ fn test_aggregator_materialize_underflow() {
 }
 
 #[test]
+#[should_panic]
 fn test_aggregator_overflow() {
     let (mut h, acc) = setup();
 

--- a/aptos-move/e2e-move-tests/src/tests/aggregator.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator.rs
@@ -109,7 +109,6 @@ fn test_aggregator_lifetime() {
 }
 
 #[test]
-#[should_panic]
 fn test_aggregator_underflow() {
     let (mut h, acc) = setup();
 
@@ -125,7 +124,6 @@ fn test_aggregator_underflow() {
 }
 
 #[test]
-#[should_panic]
 fn test_aggregator_materialize_underflow() {
     let (mut h, acc) = setup();
 
@@ -138,7 +136,6 @@ fn test_aggregator_materialize_underflow() {
 }
 
 #[test]
-#[should_panic]
 fn test_aggregator_overflow() {
     let (mut h, acc) = setup();
 
@@ -154,7 +151,6 @@ fn test_aggregator_overflow() {
 }
 
 #[test]
-#[should_panic]
 fn test_aggregator_materialize_overflow() {
     let (mut h, acc) = setup();
 

--- a/aptos-move/e2e-move-tests/src/tests/aggregator.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator.rs
@@ -109,6 +109,7 @@ fn test_aggregator_lifetime() {
 }
 
 #[test]
+#[should_panic]
 fn test_aggregator_underflow() {
     let (mut h, acc) = setup();
 
@@ -124,6 +125,7 @@ fn test_aggregator_underflow() {
 }
 
 #[test]
+#[should_panic]
 fn test_aggregator_materialize_underflow() {
     let (mut h, acc) = setup();
 
@@ -136,6 +138,7 @@ fn test_aggregator_materialize_underflow() {
 }
 
 #[test]
+#[should_panic]
 fn test_aggregator_overflow() {
     let (mut h, acc) = setup();
 
@@ -151,6 +154,7 @@ fn test_aggregator_overflow() {
 }
 
 #[test]
+#[should_panic]
 fn test_aggregator_materialize_overflow() {
     let (mut h, acc) = setup();
 


### PR DESCRIPTION
### Description

This PR avoids materializing deltas before running epilogue. Instead, ChangeSetStateView stores both writes and deltas. ChangeSetStateView materializes a delta into a write only if the aggregator is read in epilogue.
