### PR TITLE
[Executor Logging] enable speculative logging

### DIFF
--- a/aptos-move/aptos-vm/src/sharded_block_executor/executor_shard.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/executor_shard.rs
@@ -6,7 +6,6 @@ use crate::{block_executor::BlockAptosVM, sharded_block_executor::ExecutorShardC
 use aptos_logger::trace;
 use aptos_state_view::StateView;
 use aptos_types::transaction::TransactionOutput;
-use aptos_vm_logging::disable_speculative_logging;
 use move_core_types::vm_status::VMStatus;
 use std::sync::{
     mpsc::{Receiver, Sender},
@@ -37,7 +36,6 @@ impl<S: StateView + Sync + Send + 'static> ExecutorShard<S> {
                 .build()
                 .unwrap(),
         );
-        // disable_speculative_logging();
 
         Self {
             shard_id,

--- a/aptos-move/aptos-vm/src/sharded_block_executor/executor_shard.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/executor_shard.rs
@@ -37,7 +37,7 @@ impl<S: StateView + Sync + Send + 'static> ExecutorShard<S> {
                 .build()
                 .unwrap(),
         );
-        disable_speculative_logging();
+        // disable_speculative_logging();
 
         Self {
             shard_id,

--- a/aptos-move/aptos-vm/src/sharded_block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/mod.rs
@@ -56,6 +56,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedBlockExecutor<S> {
             command_txs.push(transactions_tx);
             result_rxs.push(result_rx);
             shard_join_handles.push(spawn_executor_shard(
+                num_executor_shards,
                 i,
                 executor_threads_per_shard,
                 transactions_rx,
@@ -129,6 +130,7 @@ impl<S: StateView + Sync + Send + 'static> Drop for ShardedBlockExecutor<S> {
 }
 
 fn spawn_executor_shard<S: StateView + Sync + Send + 'static>(
+    num_executor_shards: usize,
     shard_id: usize,
     concurrency_level: usize,
     command_rx: Receiver<ExecutorShardCommand<S>>,
@@ -140,6 +142,7 @@ fn spawn_executor_shard<S: StateView + Sync + Send + 'static>(
         .name(format!("executor-shard-{}", shard_id))
         .spawn(move || {
             let executor_shard = ExecutorShard::new(
+                num_executor_shards,
                 shard_id,
                 concurrency_level,
                 command_rx,


### PR DESCRIPTION
### Description
Only disable speculative logging for sharded BlockSTM, to remove the speculative error loggings when running non-sharded BlockSTM (such as single-node-benchmark). 
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
