### PR TITLE
[docs] Fix Scroll Margin for Move Reference anchors

### DIFF
--- a/developer-docs-site/src/css/custom.css
+++ b/developer-docs-site/src/css/custom.css
@@ -1243,6 +1243,10 @@ html[data-theme='dark'] .sidebar-divider {
   width: 80%;
 }
 
+.move-content a[name] {
+  scroll-margin-top: calc(var(--ifm-navbar-height) + 0.5rem);
+}
+
 .move-sidebar {
   float: left;
   height: 100%; /* 100% Full-height */


### PR DESCRIPTION
### Description
Fixes anchor scroll position accounting for `position:sticky` header using [scroll-margin-top](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top) css property. 

https://github.com/aptos-labs/aptos-core/assets/98909677/8154cdd0-9bfa-4685-99d3-4c64ea20acc1


Eventually we should clean this up further - instead of placing empty `<a name="0x1_account_Account"></a>` above each section we should use `id` attached to every heading tag within our `.md` files like this:

`## [Some Aptos Heading](#some-aptos-heading)`

which would render:

`<h2 id="some-aptos-heading">Some Aptos Heading</h2>`

The reason for `id` instead of `name`: The `name` attribute for the `<a>` element is not supported in HTML5. While it still works in most browsers for backward compatibility, it's considered outdated.

Would also suggest we stick to dashes `-` as opposed to underscores `_` within the ids. 


### Test Plan
Verify all hash links are scrolling to correct position within `/reference/move` with headings not being hidden behind the header.
