### PR TITLE
[Execution] Add TransactionDeduper trait and implementation using (hash, signature)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,6 +570,7 @@ dependencies = [
  "anyhow",
  "aptos-bitvec",
  "aptos-bounded-executor",
+ "aptos-cached-packages",
  "aptos-channels",
  "aptos-config",
  "aptos-consensus-notifications",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "rand 0.7.3",
+ "rayon",
  "serde 1.0.149",
  "serde_bytes",
  "serde_json",

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -147,6 +147,7 @@ impl BlockAptosVM {
         // Verify the signatures of all the transactions in parallel.
         // This is time consuming so don't wait and do the checking
         // sequentially while executing the transactions.
+        // TODO: state sync runs this code but doesn't need to verify signatures
         let signature_verification_timer =
             BLOCK_EXECUTOR_SIGNATURE_VERIFICATION_SECONDS.start_timer();
         let signature_verified_block: Vec<PreprocessedTransaction> =

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -69,6 +69,7 @@ tokio = { workspace = true }
 tokio-metrics = { workspace = true }
 
 [dev-dependencies]
+aptos-cached-packages = { workspace = true }
 aptos-config = { workspace = true, features = ["fuzzing"] }
 aptos-consensus-types = { workspace = true, features = ["fuzzing"] }
 aptos-executor-test-helpers = { workspace = true }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -60,6 +60,7 @@ num-derive = { workspace = true }
 num-traits = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }
+rayon = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -122,10 +122,30 @@ pub static TXN_SHUFFLE_SECONDS: Lazy<Histogram> = Lazy::new(|| {
         // metric name
         "aptos_execution_transaction_shuffle_seconds",
         // metric description
-        "The time spent in seconds in initializing the VM in the block executor",
+        "The time spent in seconds in shuffle of transactions",
         exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 30).unwrap(),
     )
     .unwrap()
+});
+
+/// Transaction dedup call latency
+pub static TXN_DEDUP_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        // metric name
+        "aptos_execution_transaction_dedup_seconds",
+        // metric description
+        "The time spent in seconds in dedup of transaction",
+        exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 30).unwrap(),
+    )
+    .unwrap()
+});
+
+/// Transaction dedup number of filtered
+pub static TXN_DEDUP_FILTERED: Lazy<Histogram> = Lazy::new(|| {
+    register_avg_counter(
+        "aptos_execution_transaction_dedup_filtered",
+        "The number of duplicates filtered per block",
+    )
 });
 
 /// Number of rounds we were collecting votes for proposer

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -46,6 +46,7 @@ use crate::{
     recovery_manager::RecoveryManager,
     round_manager::{RoundManager, UnverifiedEvent, VerifiedEvent},
     state_replication::StateComputer,
+    transaction_deduper::create_transaction_deduper,
     transaction_shuffler::create_transaction_shuffler,
     util::time_service::TimeService,
 };
@@ -681,6 +682,8 @@ impl EpochManager {
         let transaction_shuffler =
             create_transaction_shuffler(onchain_execution_config.transaction_shuffler_type());
         let block_gas_limit = onchain_execution_config.block_gas_limit();
+        let transaction_deduper =
+            create_transaction_deduper(onchain_execution_config.transaction_deduper_type());
         self.quorum_store_msg_tx = quorum_store_msg_tx;
 
         let payload_client = QuorumStoreClient::new(
@@ -694,6 +697,7 @@ impl EpochManager {
             payload_manager.clone(),
             transaction_shuffler,
             block_gas_limit,
+            transaction_deduper,
         );
         let state_computer = if onchain_consensus_config.decoupled_execution() {
             Arc::new(self.spawn_decoupled_execution(

--- a/consensus/src/experimental/ordering_state_computer.rs
+++ b/consensus/src/experimental/ordering_state_computer.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     payload_manager::PayloadManager,
     state_replication::{StateComputer, StateComputerCommitCallBackType},
+    transaction_deduper::TransactionDeduper,
     transaction_shuffler::TransactionShuffler,
 };
 use anyhow::Result;
@@ -126,6 +127,7 @@ impl StateComputer for OrderingStateComputer {
         _payload_manager: Arc<PayloadManager>,
         _: Arc<dyn TransactionShuffler>,
         _: Option<u64>,
+        _: Arc<dyn TransactionDeduper>,
     ) {
     }
 

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -49,7 +49,9 @@ pub mod counters;
 pub mod network_interface;
 mod payload_manager;
 mod sender_aware_shuffler;
+mod transaction_deduper;
 mod transaction_shuffler;
+mod txn_and_authenticator_deduper;
 
 use aptos_metrics_core::IntGauge;
 pub use consensusdb::create_checkpoint;

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -51,7 +51,7 @@ mod payload_manager;
 mod sender_aware_shuffler;
 mod transaction_deduper;
 mod transaction_shuffler;
-mod txn_and_authenticator_deduper;
+mod txn_hash_and_authenticator_deduper;
 
 use aptos_metrics_core::IntGauge;
 pub use consensusdb::create_checkpoint;

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -9,6 +9,7 @@ use crate::{
     monitor,
     payload_manager::PayloadManager,
     state_replication::{StateComputer, StateComputerCommitCallBackType},
+    transaction_deduper::TransactionDeduper,
     transaction_shuffler::TransactionShuffler,
     txn_notifier::TxnNotifier,
 };
@@ -57,6 +58,7 @@ pub struct ExecutionProxy {
     write_mutex: AsyncMutex<LogicalTime>,
     payload_manager: Mutex<Option<Arc<PayloadManager>>>,
     transaction_shuffler: Mutex<Option<Arc<dyn TransactionShuffler>>>,
+    transaction_deduper: Mutex<Option<Arc<dyn TransactionDeduper>>>,
 }
 
 impl ExecutionProxy {
@@ -90,6 +92,7 @@ impl ExecutionProxy {
             write_mutex: AsyncMutex::new(LogicalTime::new(0, 0)),
             payload_manager: Mutex::new(None),
             transaction_shuffler: Mutex::new(None),
+            transaction_deduper: Mutex::new(None),
         }
     }
 }
@@ -117,10 +120,12 @@ impl StateComputer for ExecutionProxy {
         );
 
         let payload_manager = self.payload_manager.lock().as_ref().unwrap().clone();
+        let txn_deduper = self.transaction_deduper.lock().as_ref().unwrap().clone();
         let txn_shuffler = self.transaction_shuffler.lock().as_ref().unwrap().clone();
         let txns = payload_manager.get_transactions(block).await?;
 
-        let shuffled_txns = txn_shuffler.shuffle(txns);
+        let deduped_txns = txn_deduper.dedup(txns);
+        let shuffled_txns = txn_shuffler.shuffle(deduped_txns);
 
         let block_gas_limit = self.executor.get_block_gas_limit();
 
@@ -177,6 +182,7 @@ impl StateComputer for ExecutionProxy {
         let block_timestamp = finality_proof.commit_info().timestamp_usecs();
 
         let payload_manager = self.payload_manager.lock().as_ref().unwrap().clone();
+        let txn_deduper = self.transaction_deduper.lock().as_ref().unwrap().clone();
         let txn_shuffler = self.transaction_shuffler.lock().as_ref().unwrap().clone();
 
         let block_gas_limit = self.executor.get_block_gas_limit();
@@ -189,7 +195,8 @@ impl StateComputer for ExecutionProxy {
             }
 
             let signed_txns = payload_manager.get_transactions(block.block()).await?;
-            let shuffled_txns = txn_shuffler.shuffle(signed_txns);
+            let deduped_txns = txn_deduper.dedup(signed_txns);
+            let shuffled_txns = txn_shuffler.shuffle(deduped_txns);
 
             txns.extend(block.transactions_to_commit(
                 &self.validators.lock(),
@@ -289,6 +296,7 @@ impl StateComputer for ExecutionProxy {
         payload_manager: Arc<PayloadManager>,
         transaction_shuffler: Arc<dyn TransactionShuffler>,
         _block_gas_limit: Option<u64>,
+        transaction_deduper: Arc<dyn TransactionDeduper>,
     ) {
         *self.validators.lock() = epoch_state
             .verifier
@@ -301,6 +309,7 @@ impl StateComputer for ExecutionProxy {
         // TODO: Temporarily disable initializing block gas limit and leave it as default None,
         // until there is a better way to handle the possible panic when executor is initialized.
         // self.executor.update_block_gas_limit(block_gas_limit);
+        self.transaction_deduper.lock().replace(transaction_deduper);
     }
 
     // Clears the epoch-specific state. Only a sync_to call is expected before calling new_epoch
@@ -313,11 +322,17 @@ impl StateComputer for ExecutionProxy {
 
 #[tokio::test]
 async fn test_commit_sync_race() {
-    use crate::{error::MempoolError, transaction_shuffler::create_transaction_shuffler};
+    use crate::{
+        error::MempoolError, transaction_deduper::create_transaction_deduper,
+        transaction_shuffler::create_transaction_shuffler,
+    };
     use aptos_consensus_notifications::Error;
     use aptos_types::{
-        aggregate_signature::AggregateSignature, block_info::BlockInfo, ledger_info::LedgerInfo,
-        on_chain_config::TransactionShufflerType, transaction::SignedTransaction,
+        aggregate_signature::AggregateSignature,
+        block_info::BlockInfo,
+        ledger_info::LedgerInfo,
+        on_chain_config::{TransactionDeduperType, TransactionShufflerType},
+        transaction::SignedTransaction,
     };
 
     struct RecordedCommit {
@@ -424,6 +439,7 @@ async fn test_commit_sync_race() {
         Arc::new(PayloadManager::DirectMempool),
         create_transaction_shuffler(TransactionShufflerType::NoShuffling),
         None,
+        create_transaction_deduper(TransactionDeduperType::NoDedup),
     );
     executor
         .commit(&[], generate_li(1, 1), callback.clone())

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -5,6 +5,7 @@
 use crate::{
     error::{QuorumStoreError, StateSyncError},
     payload_manager::PayloadManager,
+    transaction_deduper::TransactionDeduper,
     transaction_shuffler::TransactionShuffler,
 };
 use anyhow::Result;
@@ -78,6 +79,7 @@ pub trait StateComputer: Send + Sync {
         payload_manager: Arc<PayloadManager>,
         transaction_shuffler: Arc<dyn TransactionShuffler>,
         block_gas_limit: Option<u64>,
+        transaction_deduper: Arc<dyn TransactionDeduper>,
     );
 
     // Reconfigure to clear epoch state at end of epoch.

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -8,6 +8,7 @@ use crate::{
     payload_manager::PayloadManager,
     state_replication::{StateComputer, StateComputerCommitCallBackType},
     test_utils::mock_storage::MockStorage,
+    transaction_deduper::TransactionDeduper,
     transaction_shuffler::TransactionShuffler,
 };
 use anyhow::{format_err, Result};
@@ -139,6 +140,7 @@ impl StateComputer for MockStateComputer {
         _: Arc<PayloadManager>,
         _: Arc<dyn TransactionShuffler>,
         _: Option<u64>,
+        _: Arc<dyn TransactionDeduper>,
     ) {
     }
 
@@ -176,6 +178,7 @@ impl StateComputer for EmptyStateComputer {
         _: Arc<PayloadManager>,
         _: Arc<dyn TransactionShuffler>,
         _: Option<u64>,
+        _: Arc<dyn TransactionDeduper>,
     ) {
     }
 
@@ -237,6 +240,7 @@ impl StateComputer for RandomComputeResultStateComputer {
         _: Arc<PayloadManager>,
         _: Arc<dyn TransactionShuffler>,
         _: Option<u64>,
+        _: Arc<dyn TransactionDeduper>,
     ) {
     }
 

--- a/consensus/src/transaction_deduper.rs
+++ b/consensus/src/transaction_deduper.rs
@@ -6,13 +6,13 @@ use aptos_logger::info;
 use aptos_types::{on_chain_config::TransactionDeduperType, transaction::SignedTransaction};
 use std::sync::Arc;
 
-/// Interface to dedup transactions
+/// Interface to dedup transactions. The dedup filters duplicate transactions within a block.
 pub trait TransactionDeduper: Send + Sync {
     fn dedup(&self, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction>;
 }
 
 /// No Op Deduper to maintain backward compatibility
-pub struct NoOpDeduper {}
+struct NoOpDeduper {}
 
 impl TransactionDeduper for NoOpDeduper {
     fn dedup(&self, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {

--- a/consensus/src/transaction_deduper.rs
+++ b/consensus/src/transaction_deduper.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::txn_and_authenticator_deduper::TxnHashAndAuthenticatorDeduper;
+use crate::txn_hash_and_authenticator_deduper::TxnHashAndAuthenticatorDeduper;
 use aptos_logger::info;
 use aptos_types::{on_chain_config::TransactionDeduperType, transaction::SignedTransaction};
 use std::sync::Arc;

--- a/consensus/src/transaction_deduper.rs
+++ b/consensus/src/transaction_deduper.rs
@@ -1,0 +1,33 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::txn_and_authenticator_deduper::TxnAndAuthenticatorDeduper;
+use aptos_logger::info;
+use aptos_types::{on_chain_config::TransactionDeduperType, transaction::SignedTransaction};
+use std::sync::Arc;
+
+/// Interface to dedup transactions
+pub trait TransactionDeduper: Send + Sync {
+    fn dedup(&self, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction>;
+}
+
+/// No Op Deduper to maintain backward compatibility
+pub struct NoOpDeduper {}
+
+impl TransactionDeduper for NoOpDeduper {
+    fn dedup(&self, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
+        txns
+    }
+}
+
+pub fn create_transaction_deduper(
+    deduper_type: TransactionDeduperType,
+) -> Arc<dyn TransactionDeduper> {
+    match deduper_type {
+        TransactionDeduperType::NoDedup => Arc::new(NoOpDeduper {}),
+        TransactionDeduperType::TxnAndAuthenticatorV1 => {
+            info!("Using simple hash set transaction deduper");
+            Arc::new(TxnAndAuthenticatorDeduper::new())
+        },
+    }
+}

--- a/consensus/src/transaction_deduper.rs
+++ b/consensus/src/transaction_deduper.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::txn_and_authenticator_deduper::TxnAndAuthenticatorDeduper;
+use crate::txn_and_authenticator_deduper::TxnHashAndAuthenticatorDeduper;
 use aptos_logger::info;
 use aptos_types::{on_chain_config::TransactionDeduperType, transaction::SignedTransaction};
 use std::sync::Arc;
@@ -25,9 +25,9 @@ pub fn create_transaction_deduper(
 ) -> Arc<dyn TransactionDeduper> {
     match deduper_type {
         TransactionDeduperType::NoDedup => Arc::new(NoOpDeduper {}),
-        TransactionDeduperType::TxnAndAuthenticatorV1 => {
+        TransactionDeduperType::TxnHashAndAuthenticatorV1 => {
             info!("Using simple hash set transaction deduper");
-            Arc::new(TxnAndAuthenticatorDeduper::new())
+            Arc::new(TxnHashAndAuthenticatorDeduper::new())
         },
     }
 }

--- a/consensus/src/txn_and_authenticator_deduper.rs
+++ b/consensus/src/txn_and_authenticator_deduper.rs
@@ -1,0 +1,38 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    counters::{TXN_DEDUP_FILTERED, TXN_DEDUP_SECONDS},
+    transaction_deduper::TransactionDeduper,
+};
+use aptos_types::transaction::SignedTransaction;
+use std::collections::HashSet;
+
+pub struct TxnAndAuthenticatorDeduper {}
+
+impl TransactionDeduper for TxnAndAuthenticatorDeduper {
+    fn dedup(&self, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
+        let _timer = TXN_DEDUP_SECONDS.start_timer();
+        let txns_len = txns.len();
+        let mut seen = HashSet::new();
+        let deduped_txns: Vec<_> = txns
+            .iter()
+            .filter(|txn| seen.insert((txn.raw_transaction_ref(), txn.authenticator_ref())))
+            .cloned()
+            .collect();
+        TXN_DEDUP_FILTERED.observe((txns_len - deduped_txns.len()) as f64);
+        deduped_txns
+    }
+}
+
+impl TxnAndAuthenticatorDeduper {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_dummy() {}
+}

--- a/consensus/src/txn_and_authenticator_deduper.rs
+++ b/consensus/src/txn_and_authenticator_deduper.rs
@@ -6,22 +6,68 @@ use crate::{
     transaction_deduper::TransactionDeduper,
 };
 use aptos_types::transaction::SignedTransaction;
-use std::collections::HashSet;
+use rayon::prelude::*;
+use std::collections::{HashMap, HashSet};
 
 pub struct TxnAndAuthenticatorDeduper {}
 
 impl TransactionDeduper for TxnAndAuthenticatorDeduper {
-    fn dedup(&self, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
+    fn dedup(&self, transactions: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
         let _timer = TXN_DEDUP_SECONDS.start_timer();
-        let txns_len = txns.len();
-        let mut seen = HashSet::new();
-        let deduped_txns: Vec<_> = txns
-            .iter()
-            .filter(|txn| seen.insert((txn.raw_transaction_ref(), txn.authenticator_ref())))
-            .cloned()
+        let mut seen = HashMap::new();
+        let mut is_possible_duplicate = false;
+        let mut possible_duplicates = vec![false; transactions.len()];
+        for (i, txn) in transactions.iter().enumerate() {
+            match seen.get(&(txn.sender(), txn.sequence_number())) {
+                None => {
+                    seen.insert((txn.sender(), txn.sequence_number()), i);
+                },
+                Some(first_index) => {
+                    is_possible_duplicate = true;
+                    possible_duplicates[*first_index] = true;
+                    possible_duplicates[i] = true;
+                },
+            }
+        }
+        if !is_possible_duplicate {
+            return transactions;
+        }
+
+        let hash_and_authenticators: Vec<_> = possible_duplicates
+            .into_par_iter()
+            .zip(&transactions)
+            .with_min_len(25)
+            .map(|(need_hash, txn)| match need_hash {
+                true => Some((txn.clone().committed_hash(), txn.authenticator())),
+                false => None,
+            })
             .collect();
-        TXN_DEDUP_FILTERED.observe((txns_len - deduped_txns.len()) as f64);
-        deduped_txns
+        let mut seen_hashes = HashSet::new();
+        let mut num_duplicates: usize = 0;
+        let duplicates: Vec<_> = hash_and_authenticators
+            .into_iter()
+            .map(|maybe_hash| match maybe_hash {
+                None => false,
+                Some(hash_and_authenticator) => {
+                    if seen_hashes.insert(hash_and_authenticator) {
+                        false
+                    } else {
+                        num_duplicates += 1;
+                        true
+                    }
+                },
+            })
+            .collect();
+        TXN_DEDUP_FILTERED.observe(num_duplicates as f64);
+        if num_duplicates == 0 {
+            return transactions;
+        }
+
+        transactions
+            .into_iter()
+            .zip(duplicates)
+            .filter_map(|(txn, is_duplicate)| if is_duplicate { None } else { Some(txn) })
+            .collect()
     }
 }
 

--- a/consensus/src/txn_hash_and_authenticator_deduper.rs
+++ b/consensus/src/txn_hash_and_authenticator_deduper.rs
@@ -30,6 +30,8 @@ use std::collections::{HashMap, HashSet};
 ///    grouped independently and run in parallel in Step 3.
 /// b. Txn hashes are calculated at many places within a validator. A per-txn hash cache could speed
 ///    up dedup or later operations.
+/// c. If signature verification is moved to before dedup, then only the signature has to be matched
+///    for duplicates and not the hash.
 pub(crate) struct TxnHashAndAuthenticatorDeduper {}
 
 impl TransactionDeduper for TxnHashAndAuthenticatorDeduper {

--- a/consensus/src/txn_hash_and_authenticator_deduper.rs
+++ b/consensus/src/txn_hash_and_authenticator_deduper.rs
@@ -83,7 +83,7 @@ impl TxnHashAndAuthenticatorDeduper {
 mod tests {
     use crate::{
         transaction_deduper::TransactionDeduper,
-        txn_and_authenticator_deduper::TxnHashAndAuthenticatorDeduper,
+        txn_hash_and_authenticator_deduper::TxnHashAndAuthenticatorDeduper,
     };
     use aptos_cached_packages::aptos_stdlib;
     use aptos_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};

--- a/consensus/src/txn_hash_and_authenticator_deduper.rs
+++ b/consensus/src/txn_hash_and_authenticator_deduper.rs
@@ -72,13 +72,13 @@ impl TransactionDeduper for TxnHashAndAuthenticatorDeduper {
             .into_iter()
             .zip(transactions)
             .filter_map(|(maybe_hash, txn)| match maybe_hash {
-                None => None,
+                None => Some(txn),
                 Some(hash_and_authenticator) => {
                     if seen_hashes.insert(hash_and_authenticator) {
-                        None
+                        Some(txn)
                     } else {
                         num_duplicates += 1;
-                        Some(txn)
+                        None
                     }
                 },
             })

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -46,7 +46,7 @@ impl OnChainExecutionConfig {
 /// This is used when on-chain config is not initialized.
 impl Default for OnChainExecutionConfig {
     fn default() -> Self {
-        OnChainExecutionConfig::V1(ExecutionConfigV1::default())
+        OnChainExecutionConfig::V3(ExecutionConfigV3::default())
     }
 }
 
@@ -108,7 +108,7 @@ impl Default for ExecutionConfigV3 {
         Self {
             transaction_shuffler_type: TransactionShufflerType::NoShuffling,
             block_gas_limit: None,
-            transaction_deduper_type: TransactionDeduperType::NoDedup,
+            transaction_deduper_type: TransactionDeduperType::TxnHashAndAuthenticatorV1,
         }
     }
 }

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -110,7 +110,7 @@ impl Default for ExecutionConfigV3 {
             transaction_shuffler_type: TransactionShufflerType::NoShuffling,
             block_gas_limit: None,
             // TODO: revert after testing
-            transaction_deduper_type: TransactionDeduperType::TxnAndAuthenticatorV1,
+            transaction_deduper_type: TransactionDeduperType::TxnHashAndAuthenticatorV1,
         }
     }
 }
@@ -126,7 +126,7 @@ pub enum TransactionShufflerType {
 #[serde(rename_all = "snake_case")] // cannot use tag = "type" as nested enums cannot work, and bcs doesn't support it
 pub enum TransactionDeduperType {
     NoDedup,
-    TxnAndAuthenticatorV1,
+    TxnHashAndAuthenticatorV1,
 }
 
 #[cfg(test)]

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -46,7 +46,7 @@ impl OnChainExecutionConfig {
 /// This is used when on-chain config is not initialized.
 impl Default for OnChainExecutionConfig {
     fn default() -> Self {
-        OnChainExecutionConfig::V3(ExecutionConfigV3::default())
+        OnChainExecutionConfig::V1(ExecutionConfigV1::default())
     }
 }
 
@@ -108,7 +108,7 @@ impl Default for ExecutionConfigV3 {
         Self {
             transaction_shuffler_type: TransactionShufflerType::NoShuffling,
             block_gas_limit: None,
-            transaction_deduper_type: TransactionDeduperType::TxnHashAndAuthenticatorV1,
+            transaction_deduper_type: TransactionDeduperType::NoDedup,
         }
     }
 }

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -45,8 +45,9 @@ impl OnChainExecutionConfig {
 
 /// This is used when on-chain config is not initialized.
 impl Default for OnChainExecutionConfig {
+    // TODO: revert after testing
     fn default() -> Self {
-        OnChainExecutionConfig::V1(ExecutionConfigV1::default())
+        OnChainExecutionConfig::V3(ExecutionConfigV3::default())
     }
 }
 

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -45,9 +45,8 @@ impl OnChainExecutionConfig {
 
 /// This is used when on-chain config is not initialized.
 impl Default for OnChainExecutionConfig {
-    // TODO: revert after testing
     fn default() -> Self {
-        OnChainExecutionConfig::V3(ExecutionConfigV3::default())
+        OnChainExecutionConfig::V1(ExecutionConfigV1::default())
     }
 }
 
@@ -109,8 +108,7 @@ impl Default for ExecutionConfigV3 {
         Self {
             transaction_shuffler_type: TransactionShufflerType::NoShuffling,
             block_gas_limit: None,
-            // TODO: revert after testing
-            transaction_deduper_type: TransactionDeduperType::TxnHashAndAuthenticatorV1,
+            transaction_deduper_type: TransactionDeduperType::NoDedup,
         }
     }
 }

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 pub enum OnChainExecutionConfig {
     V1(ExecutionConfigV1),
     V2(ExecutionConfigV2),
+    V3(ExecutionConfigV3),
 }
 
 /// The public interface that exposes all values with safe fallback.
@@ -19,6 +20,7 @@ impl OnChainExecutionConfig {
         match &self {
             OnChainExecutionConfig::V1(config) => config.transaction_shuffler_type.clone(),
             OnChainExecutionConfig::V2(config) => config.transaction_shuffler_type.clone(),
+            OnChainExecutionConfig::V3(config) => config.transaction_shuffler_type.clone(),
         }
     }
 
@@ -27,6 +29,16 @@ impl OnChainExecutionConfig {
         match &self {
             OnChainExecutionConfig::V1(_config) => None,
             OnChainExecutionConfig::V2(config) => config.block_gas_limit,
+            OnChainExecutionConfig::V3(config) => config.block_gas_limit,
+        }
+    }
+
+    /// The type of the transaction deduper being used.
+    pub fn transaction_deduper_type(&self) -> TransactionDeduperType {
+        match &self {
+            OnChainExecutionConfig::V1(_config) => TransactionDeduperType::NoDedup,
+            OnChainExecutionConfig::V2(_config) => TransactionDeduperType::NoDedup,
+            OnChainExecutionConfig::V3(config) => config.transaction_deduper_type.clone(),
         }
     }
 }
@@ -84,11 +96,36 @@ impl Default for ExecutionConfigV2 {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct ExecutionConfigV3 {
+    pub transaction_shuffler_type: TransactionShufflerType,
+    pub block_gas_limit: Option<u64>,
+    pub transaction_deduper_type: TransactionDeduperType,
+}
+
+impl Default for ExecutionConfigV3 {
+    fn default() -> Self {
+        Self {
+            transaction_shuffler_type: TransactionShufflerType::NoShuffling,
+            block_gas_limit: None,
+            // TODO: revert after testing
+            transaction_deduper_type: TransactionDeduperType::TxnAndAuthenticatorV1,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")] // cannot use tag = "type" as nested enums cannot work, and bcs doesn't support it
 pub enum TransactionShufflerType {
     NoShuffling,
     SenderAwareV1(u32),
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")] // cannot use tag = "type" as nested enums cannot work, and bcs doesn't support it
+pub enum TransactionDeduperType {
+    NoDedup,
+    TxnAndAuthenticatorV1,
 }
 
 #[cfg(test)]

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -40,7 +40,8 @@ pub use self::{
         ProposerElectionType,
     },
     execution_config::{
-        ExecutionConfigV1, ExecutionConfigV2, OnChainExecutionConfig, TransactionShufflerType,
+        ExecutionConfigV1, ExecutionConfigV2, OnChainExecutionConfig, TransactionDeduperType,
+        TransactionShufflerType,
     },
     gas_schedule::{GasSchedule, GasScheduleV2, StorageGasSchedule},
     timed_features::{TimedFeatureFlag, TimedFeatureOverride, TimedFeatures},

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -555,12 +555,20 @@ impl SignedTransaction {
         self.authenticator.clone()
     }
 
+    pub fn authenticator_ref(&self) -> &TransactionAuthenticator {
+        &self.authenticator
+    }
+
     pub fn sender(&self) -> AccountAddress {
         self.raw_txn.sender
     }
 
     pub fn into_raw_transaction(self) -> RawTransaction {
         self.raw_txn
+    }
+
+    pub fn raw_transaction_ref(&self) -> &RawTransaction {
+        &self.raw_txn
     }
 
     pub fn sequence_number(&self) -> u64 {


### PR DESCRIPTION
### Description

Adding TransactionDeduper trait and an implementation. The dedup is done within a block, just before transaction shuffle. It's guarded by an onchain config.

The purpose is to not send duplicate transactions to execution. While execution correctness is not affected by duplicates (and other work removed false error logs that fired due to them), it's possible that duplicate transactions could hurt throughput of parallel execution. By deduping ahead of time, we don't have to worry about that.

The implementation finds duplicates by matching (raw txn bcs hash, signature). Because calculating hash can be relatively expensive, it is only done when a shallow match is found of (account, seq_no), and it's done in parallel.

Overhead (as seen on forge):
* When there are no duplicates, the dedup is negligible -- it takes ~2ms per second.
* When there are ~100 duplicates per block, the dedup takes ~10ms per second.

### Test Plan

Added unit tests.
