### PR TITLE
[lto] Use thin LTO instead of default fat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -627,14 +627,14 @@ inherits = "release"
 opt-level = 3
 debug = true
 overflow-checks = true
-lto = true
+lto = "thin"
 codegen-units = 1
 
 [profile.cli]
 inherits = "release"
 debug = false
 opt-level = "z"
-lto = true
+lto = "thin"
 strip = true
 codegen-units = 1
 


### PR DESCRIPTION
Fat lto takes forever to compile, thin LTO acheives most of the benefit
with little additional compile time

https://doc.rust-lang.org/cargo/reference/profiles.html#lto

Test Plan: need help validating the performance?
