### PR TITLE
[helm][fullnode] add lookup for all workloads

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -32,4 +32,5 @@ jobs:
 
       - name: Run Helm Lint
         if: steps.should-run-tests.outputs.SHOULD_RUN == 'true'
-        run: ./testsuite/testrun lint.py helm terraform/helm/*
+        run: ./testrun lint.py helm ../terraform/helm/*
+        working-directory: testsuite

--- a/terraform/helm/fullnode/templates/backup-verify.yaml
+++ b/terraform/helm/fullnode/templates/backup-verify.yaml
@@ -1,3 +1,4 @@
+{{ $backup_verify_cronjob := lookup "batch/v1" "CronJob" $.Release.Namespace (print (include "backup.fullname" .) "-backup-verify")}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -23,8 +24,11 @@ spec:
           terminationGracePeriodSeconds: 0
           containers:
           - name: backup-verify
-            # use the same image with the backup sts
+            {{- if and $backup_verify_cronjob (not $.Values.manageImages) }} # if the statefulset already exists and we do not want helm to simply overwrite the image, use the existing image
+            image: {{ (first $backup_verify_cronjob.spec.jobTemplate.spec.template.spec.containers).image }}
+            {{- else }}
             image: {{ .Values.backup.image.repo }}:{{ .Values.backup.image.tag | default .Values.imageTag }}
+            {{- end }}
             imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
             command:
             - /usr/local/bin/aptos-db-tool

--- a/terraform/helm/fullnode/templates/backup.yaml
+++ b/terraform/helm/fullnode/templates/backup.yaml
@@ -8,7 +8,7 @@ data:
 {{ (.Files.Glob "files/backup/*.yaml").AsConfig | indent 2 }}
 
 ---
-
+{{ $backup_statefulset := lookup "apps/v1" "StatefulSet" $.Release.Namespace (print (include "backup.fullname" .) "-backup")}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -35,7 +35,11 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: backup
+        {{- if and $backup_statefulset (not $.Values.manageImages) }} # if the statefulset already exists and we do not want helm to simply overwrite the image, use the existing image
+        image: {{ (first $backup_statefulset.spec.template.spec.containers).image }}
+        {{- else }}
         image: {{ .Values.backup.image.repo }}:{{ .Values.backup.image.tag | default .Values.imageTag }}
+        {{- end }}
         imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
         resources:
           {{- toYaml .Values.backup.resources | nindent 10 }}

--- a/terraform/helm/fullnode/templates/restore.yaml
+++ b/terraform/helm/fullnode/templates/restore.yaml
@@ -1,7 +1,9 @@
+{{ $restore_job_suffix := randAlpha 4 | lower }}
+{{ $backup_restore_job := lookup "batch/v1" "Job" $.Release.Namespace (print (include "backup.fullname" .) "-restore-" $restore_job_suffix) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "backup.fullname" . }}-restore-{{ randAlpha 4 | lower }}
+  name: {{ include "backup.fullname" . }}-restore-{{ $restore_job_suffix }}
   labels:
     {{- include "backup.labels" . | nindent 4 }}
     app.kubernetes.io/name: restore
@@ -20,7 +22,11 @@ spec:
       {{- with .Values.restore }}
       containers:
       - name: restore
+        {{- if and $backup_restore_job (not $.Values.manageImages) }} # if the statefulset already exists and we do not want helm to simply overwrite the image, use the existing image
+        image: {{ (first $backup_restore_job.spec.template.spec.containers).image }}
+        {{- else }}
         image: {{ .image.repo }}:{{ .image.tag | default $.Values.imageTag }}
+        {{- end }}
         imagePullPolicy: {{ .image.pullPolicy }}
         resources:
           {{- toYaml .resources | nindent 10 }}


### PR DESCRIPTION
### Description

So terraform apply doesn't blow away updates to these workloads through external means:
* restore job
* backup-verify cron
* backup stateful set

This has been done for validators, VFNs, and PFNs, but the `fullnode` chart also includes the above workfloads.

This unblocks some of the work @areshand need to do with updating the fullnode helm chart with compaction https://github.com/aptos-labs/aptos-core/pull/7375, as that will require a `helm upgrade`. We want to make sure that all workloads are unaffected by that.

### Test Plan

Verify locally using kind.
1. create a helm values file `kind_local_fullnode.yaml` specifying image tag A for all workloads (fullnode, backup, backup_verify, restore)
2. verify that all workloads come up with the right tag
3. change the tags in the values file, and also change `manageImages: false`. The result of this should be that subsequent `helm upgrade` should reuse the images already running, and not use the ones in the values file. ✅ 
4. flip `manageImages: true`, and subsequent `helm upgrade` uses the images specified in the values file ✅ 

<!-- Please provide us with clear details for verifying that your changes work. -->
