### PR TITLE
[API] Fix request client regex

### DIFF
--- a/api/src/log.rs
+++ b/api/src/log.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 const REQUEST_SOURCE_CLIENT_UNKNOWN: &str = "unknown";
 static REQUEST_SOURCE_CLIENT_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"aptos-[a-zA-Z]+/[0-9A-Za-z\.\-]+").unwrap());
+    Lazy::new(|| Regex::new(r"aptos-[a-zA-Z\-]+/[0-9A-Za-z\.\-]+").unwrap());
 
 /// Logs information about the request and response if the response status code
 /// is >= 500, to help us debug since this will be an error on our side.


### PR DESCRIPTION
### Description
The current regex does not match `aptos-ts-sdk/1.9.1` because it only expects a single `-` in the part before the `/`. This was an oversight because I tested it initially with just `aptos-cli`.

### Test Plan
```
cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes --with-faucet
```
```
curl -H 'x-aptos-client: aptos-ts-sdk/7.8.9' http://127.0.0.1:8080/v1
```
```
curl -s http://127.0.0.1:9101/metrics | grep -i request_source
```

Before:
```
aptos_api_request_source_client{operation_id="get_ledger_info",request_source_client="unknown",status="200"} 2
```

After:
```
aptos_api_request_source_client{operation_id="get_ledger_info",request_source_client="aptos-ts-sdk/7.8.9",status="200"} 1
```