### PR TITLE
Deduplicate changelog headings

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Aptos CLI Changelog
 
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
 ## [1.0.14] - 2023/05/26
 ### Added
-- Add nested vector arg support
 - Updated DB bootstrap command with new DB restore features
-
-## [1.0.14] - 2023/05/25
-
-### Added
 - Recursive nested vector parsing
 - Multisig v2 governance support
 - JSON support for both input files and CLI argument input


### PR DESCRIPTION
@0xjinn @areshand  @banool  @msmouse 

In #8346 I bumped the changelog per [the request of](https://github.com/aptos-labs/aptos-core/pull/8346#pullrequestreview-1444662066) @banool and updated the CLI `Cargo.toml` accordingly.

It looks like #8398 duplicated some of this activity in a manner that did not introduce merge conflicts, but nevertheless instigated duplicate changelog headings.

This PR deduplicates the changelog headings.