### PR TITLE
rosetta delegator address balances

### DIFF
--- a/crates/aptos-rosetta/src/account.rs
+++ b/crates/aptos-rosetta/src/account.rs
@@ -107,7 +107,9 @@ async fn get_balances(
             owner_address,
             pool_address.unwrap(),
             version,
-        ).await {
+        )
+        .await
+        {
             Ok(Some(balance_result)) => {
                 if let Some(balance) = balance_result.balance {
                     total_requested_balance = Some(

--- a/crates/aptos-rosetta/src/account.rs
+++ b/crates/aptos-rosetta/src/account.rs
@@ -94,6 +94,44 @@ async fn get_balances(
     maybe_filter_currencies: Option<Vec<Currency>>,
 ) -> ApiResult<(u64, Option<Vec<AccountAddress>>, Vec<Amount>, u64)> {
     let owner_address = account.account_address()?;
+    let pool_address = account.pool_address()?;
+
+    let mut balances = vec![];
+    let mut lockup_expiration: u64 = 0;
+    let mut total_requested_balance: Option<u64> = None;
+
+    if pool_address.is_some() {
+        match get_delegation_stake_balances(
+            rest_client,
+            &account,
+            owner_address,
+            pool_address.unwrap(),
+            version,
+        ).await {
+            Ok(Some(balance_result)) => {
+                if let Some(balance) = balance_result.balance {
+                    total_requested_balance = Some(
+                        total_requested_balance.unwrap_or_default()
+                            + u64::from_str(&balance.value).unwrap_or_default(),
+                    );
+                }
+                lockup_expiration = balance_result.lockup_expiration;
+                if let Some(balance) = total_requested_balance {
+                    balances.push(Amount {
+                        value: balance.to_string(),
+                        currency: native_coin(),
+                    })
+                }
+            },
+            result => {
+                warn!(
+                    "Failed to retrieve requested balance for delegator_address: {}, pool_address: {}: {:?}",
+                    owner_address, pool_address.unwrap(), result
+                )
+            },
+        }
+    }
+
     // Retrieve all account resources
     if let Ok(response) = rest_client
         .get_account_resources_at_version_bcs(owner_address, version)
@@ -102,8 +140,6 @@ async fn get_balances(
         let resources = response.into_inner();
         let mut maybe_sequence_number = None;
         let mut maybe_operators = None;
-        let mut balances = vec![];
-        let mut lockup_expiration: u64 = 0;
 
         // Iterate through resources, converting balances
         for (struct_tag, bytes) in resources {
@@ -132,12 +168,11 @@ async fn get_balances(
                     }
                 },
                 (AccountAddress::ONE, STAKING_CONTRACT_MODULE, STORE_RESOURCE) => {
-                    if account.is_base_account() {
+                    if account.is_base_account() || pool_address.is_some() {
                         continue;
                     }
 
                     let store: Store = bcs::from_bytes(&bytes)?;
-                    let mut total_requested_balance: Option<u64> = None;
                     maybe_operators = Some(vec![]);
                     for (operator, contract) in store.staking_contracts {
                         // Keep track of operators

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -39,7 +39,7 @@ impl AccountIdentifier {
     pub fn pool_address(&self) -> ApiResult<Option<AccountAddress>> {
         if let Some(sub_account) = &self.sub_account {
             if let Some(metadata) = &sub_account.metadata {
-                return str_to_account_address(&metadata.pool_address.as_str()).map(Some);
+                return str_to_account_address(metadata.pool_address.as_str()).map(Some);
             }
         }
 

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -43,10 +43,7 @@ impl AccountIdentifier {
             }
         }
 
-        Err(ApiError::InvalidInput(Some(format!(
-            "Invalid pool address {:?}",
-            self
-        ))))
+        Ok(None)
     }
 
     pub fn base_account(address: AccountAddress) -> Self {

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -36,6 +36,19 @@ impl AccountIdentifier {
         str_to_account_address(self.address.as_str())
     }
 
+    pub fn pool_address(&self) -> ApiResult<Option<AccountAddress>> {
+        if let Some(sub_account) = &self.sub_account {
+            if let Some(metadata) = &sub_account.metadata {
+                return str_to_account_address(&metadata.pool_address.as_str()).map(Some);
+            }
+        }
+
+        Err(ApiError::InvalidInput(Some(format!(
+            "Invalid pool address {:?}",
+            self
+        ))))
+    }
+
     pub fn base_account(address: AccountAddress) -> Self {
         AccountIdentifier {
             address: to_hex_lower(&address),
@@ -132,6 +145,30 @@ impl AccountIdentifier {
         }
     }
 
+    pub fn is_delegator_active_stake(&self) -> bool {
+        if let Some(ref inner) = self.sub_account {
+            inner.is_delegator_active_stake()
+        } else {
+            false
+        }
+    }
+
+    pub fn is_delegator_inactive_stake(&self) -> bool {
+        if let Some(ref inner) = self.sub_account {
+            inner.is_delegator_inactive_stake()
+        } else {
+            false
+        }
+    }
+
+    pub fn is_delegator_pending_inactive_stake(&self) -> bool {
+        if let Some(ref inner) = self.sub_account {
+            inner.is_delegator_pending_inactive_stake()
+        } else {
+            false
+        }
+    }
+
     pub fn is_operator_stake(&self) -> bool {
         if let Some(ref inner) = self.sub_account {
             !(inner.is_total_stake()
@@ -167,6 +204,9 @@ fn str_to_account_address(address: &str) -> Result<AccountAddress, ApiError> {
 pub struct SubAccountIdentifier {
     /// Hex encoded AccountAddress beginning with 0x
     pub address: String,
+    /// Metadata only used for delegated staking
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<SubAccountIdentifierMetadata>,
 }
 
 const STAKE: &str = "stake";
@@ -180,36 +220,42 @@ impl SubAccountIdentifier {
     pub fn new_total_stake() -> SubAccountIdentifier {
         SubAccountIdentifier {
             address: STAKE.to_string(),
+            metadata: None,
         }
     }
 
     pub fn new_pending_active_stake() -> SubAccountIdentifier {
         SubAccountIdentifier {
             address: PENDING_ACTIVE_STAKE.to_string(),
+            metadata: None,
         }
     }
 
     pub fn new_active_stake() -> SubAccountIdentifier {
         SubAccountIdentifier {
             address: ACTIVE_STAKE.to_string(),
+            metadata: None,
         }
     }
 
     pub fn new_pending_inactive_stake() -> SubAccountIdentifier {
         SubAccountIdentifier {
             address: PENDING_INACTIVE_STAKE.to_string(),
+            metadata: None,
         }
     }
 
     pub fn new_inactive_stake() -> SubAccountIdentifier {
         SubAccountIdentifier {
             address: INACTIVE_STAKE.to_string(),
+            metadata: None,
         }
     }
 
     pub fn new_operator_stake(operator: AccountAddress) -> SubAccountIdentifier {
         SubAccountIdentifier {
             address: format!("{}-{}", STAKE, to_hex_lower(&operator)),
+            metadata: None,
         }
     }
 
@@ -222,15 +268,27 @@ impl SubAccountIdentifier {
     }
 
     pub fn is_active_stake(&self) -> bool {
-        self.address.as_str() == ACTIVE_STAKE
+        self.address.as_str() == ACTIVE_STAKE && self.metadata.is_none()
     }
 
     pub fn is_pending_inactive_stake(&self) -> bool {
-        self.address.as_str() == PENDING_INACTIVE_STAKE
+        self.address.as_str() == PENDING_INACTIVE_STAKE && self.metadata.is_none()
     }
 
     pub fn is_inactive_stake(&self) -> bool {
-        self.address.as_str() == INACTIVE_STAKE
+        self.address.as_str() == INACTIVE_STAKE && self.metadata.is_none()
+    }
+
+    pub fn is_delegator_active_stake(&self) -> bool {
+        self.address.as_str() == ACTIVE_STAKE && self.metadata.is_some()
+    }
+
+    pub fn is_delegator_inactive_stake(&self) -> bool {
+        self.address.as_str() == INACTIVE_STAKE && self.metadata.is_some()
+    }
+
+    pub fn is_delegator_pending_inactive_stake(&self) -> bool {
+        self.address.as_str() == PENDING_INACTIVE_STAKE && self.metadata.is_some()
     }
 
     pub fn operator_address(&self) -> ApiResult<AccountAddress> {
@@ -248,6 +306,20 @@ impl SubAccountIdentifier {
             "Sub account isn't an operator address {:?}",
             self
         ))))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct SubAccountIdentifierMetadata {
+    /// Hex encoded Pool beginning with 0x
+    pub pool_address: String,
+}
+
+impl SubAccountIdentifierMetadata {
+    pub fn new_pool_address(pool_address: AccountAddress) -> Self {
+        SubAccountIdentifierMetadata {
+            pool_address: to_hex_lower(&pool_address),
+        }
     }
 }
 

--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -342,12 +342,8 @@ pub async fn get_delegation_stake_balances(
             function: DELEGATION_POOL_GET_STAKE_FUNCTION.clone(),
             type_arguments: vec![],
             arguments: vec![
-                serde_json::Value::String(String::from(
-                    pool_address.to_string(),
-                )),
-                serde_json::Value::String(String::from(
-                    owner_address.to_string()
-                )),
+                serde_json::Value::String(pool_address.to_string()),
+                serde_json::Value::String(owner_address.to_string()),
             ],
         },
         Some(version),
@@ -368,9 +364,7 @@ pub async fn get_delegation_stake_balances(
             function: STAKE_GET_LOCKUP_SECS_FUNCTION.clone(),
             type_arguments: vec![],
             arguments: vec![
-                serde_json::Value::String(String::from(
-                    pool_address.to_string(),
-                )),
+                serde_json::Value::String(pool_address.to_string()),
             ]
         },
         Some(version),
@@ -388,8 +382,8 @@ pub async fn get_delegation_stake_balances(
             lockup_expiration,
         }))
     } else {
-        return Err(ApiError::InternalError(Some(
+        Err(ApiError::InternalError(Some(
             "Unable to construct BalanceResult instance".to_string(),
-        )));
+        )))
     }
 }


### PR DESCRIPTION
### Description
Implement the delegator address balances rosetta endpoint.

The rosetta client should manage its own delegator and pool address relationship when fetching relevant data.
The request payload should look like this (added the metadata field under sub_account_identifier):
```
"account_identifier": {
    "address": "0x899d44dca988af7895cdc9828ae0e7f6c5c42d74fa1610e693fb5f613cb8c09a", // owner/delegator address
    "sub_account": {
        "address": "active_stake", // string active
        # this is the new field added
        "metadata": {
            "pool_address": "0xbd50bb20e1972747db365c3a6e31255d78867c6b8df9877ea6054bb335dd6031" // pool_address
        }
    }
}
```

**About balance fetching**:
Using delegator address [0x65b1e4d62e803d7e3a5c715baa33391757ae530c9fef287bf2d7d15c1ea6e3e6](https://explorer.aptoslabs.com/account/0x65b1e4d62e803d7e3a5c715baa33391757ae530c9fef287bf2d7d15c1ea6e3e6?network=mainnet) and its validator address [0x2ded75e99c6efbe143a9648a3e88ebf9d0cf249b2af44d510bdd0287e8adcc79](https://explorer.aptoslabs.com/account/0x2ded75e99c6efbe143a9648a3e88ebf9d0cf249b2af44d510bdd0287e8adcc79?network=mainnet) as an example

The response should be similar to native staking:
Variables that should be fetched from the **delegator address:**
1. Sequence number from its `0x1::account::Account` resource
2. Balances from delegation_pool.move get_stake() function

Variables should be fetched from the **pool address:**
~~1. Operator from `0x1::stake::StakePool` resource~~
2. Lockup until secs from `0x1::stake::StakePool` resource

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Tested with remote online node from e2e
**delegated staking balance**
<img width="929" alt="Screenshot 2023-06-01 at 4 15 45 PM" src="https://github.com/aptos-labs/aptos-core/assets/25248616/f855b580-76ef-4431-b7ea-4fc0de1244fd">


**native staking balance**
<img width="928" alt="Screenshot 2023-06-01 at 4 16 37 PM" src="https://github.com/aptos-labs/aptos-core/assets/25248616/b7e3cc6f-ea69-4e9e-8da5-175721303ffd">


**direct balance**
<img width="932" alt="Screenshot 2023-06-01 at 4 17 25 PM" src="https://github.com/aptos-labs/aptos-core/assets/25248616/bb60440f-5161-4307-ba14-c4f7bf7de57a">
