### PR TITLE
[Storage Service] Small tweaks to metrics.

### DIFF
--- a/state-sync/storage-service/server/src/lib.rs
+++ b/state-sync/storage-service/server/src/lib.rs
@@ -252,7 +252,6 @@ impl<T: StorageReaderInterface> StorageServiceServer<T> {
                     )
                     .process_request_and_respond(
                         peer_network_id,
-                        protocol_id,
                         storage_service_request,
                         network_request.response_sender,
                     );

--- a/state-sync/storage-service/server/src/metrics.rs
+++ b/state-sync/storage-service/server/src/metrics.rs
@@ -2,11 +2,11 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_config::network_id::NetworkId;
 use aptos_metrics_core::{
     register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, HistogramTimer,
     HistogramVec, IntCounterVec, IntGaugeVec,
 };
-use aptos_network::ProtocolId;
 use once_cell::sync::Lazy;
 
 /// Useful metric constants for the storage service
@@ -30,7 +30,7 @@ pub static LRU_CACHE_EVENT: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_storage_service_server_lru_cache",
         "Counters for lru cache events in the storage server",
-        &["protocol", "event"]
+        &["network_id", "event"]
     )
     .unwrap()
 });
@@ -42,6 +42,26 @@ pub static NETWORK_FRAME_OVERFLOW: Lazy<IntCounterVec> = Lazy::new(|| {
         "aptos_storage_service_server_network_frame_overflow",
         "Counters for network frame overflows in the storage server",
         &["response_type"]
+    )
+    .unwrap()
+});
+
+/// Counter for optimistic fetch request events
+pub static OPTIMISTIC_FETCH_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_storage_service_server_optimistic_fetch_event",
+        "Counters related to optimistic fetch events",
+        &["network_id", "event"]
+    )
+    .unwrap()
+});
+
+/// Time it takes to process a storage request
+pub static OPTIMISTIC_FETCH_LATENCIES: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "aptos_storage_service_server_optimistic_fetch_latency",
+        "Time it takes to process an optimistic fetch request",
+        &["network_id", "request_type"]
     )
     .unwrap()
 });
@@ -61,7 +81,7 @@ pub static STORAGE_ERRORS_ENCOUNTERED: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_storage_service_server_errors",
         "Counters related to the storage server errors encountered",
-        &["protocol", "error_type"]
+        &["network_id", "error_type"]
     )
     .unwrap()
 });
@@ -71,7 +91,7 @@ pub static STORAGE_REQUESTS_RECEIVED: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_storage_service_server_requests_received",
         "Counters related to the storage server requests received",
-        &["protocol", "request_type"]
+        &["network_id", "request_type"]
     )
     .unwrap()
 });
@@ -81,7 +101,7 @@ pub static STORAGE_RESPONSES_SENT: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_storage_service_server_responses_sent",
         "Counters related to the storage server responses sent",
-        &["protocol", "response_type"]
+        &["network_id", "response_type"]
     )
     .unwrap()
 });
@@ -91,17 +111,7 @@ pub static STORAGE_REQUEST_PROCESSING_LATENCY: Lazy<HistogramVec> = Lazy::new(||
     register_histogram_vec!(
         "aptos_storage_service_server_request_latency",
         "Time it takes to process a storage service request",
-        &["protocol", "request_type"]
-    )
-    .unwrap()
-});
-
-/// Counter for optimistic fetch request events
-pub static OPTIMISTIC_FETCH_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "aptos_storage_service_server_optimistic_fetch_event",
-        "Counters related to optimistic fetch events",
-        &["protocol", "event"]
+        &["network_id", "request_type"]
     )
     .unwrap()
 });
@@ -114,10 +124,22 @@ pub fn increment_network_frame_overflow(response_type: &str) {
 }
 
 /// Increments the given counter with the provided label values.
-pub fn increment_counter(counter: &Lazy<IntCounterVec>, protocol: ProtocolId, label: String) {
+pub fn increment_counter(counter: &Lazy<IntCounterVec>, network_id: NetworkId, label: String) {
     counter
-        .with_label_values(&[protocol.as_str(), &label])
+        .with_label_values(&[network_id.as_str(), &label])
         .inc();
+}
+
+/// Observes the value for the provided histogram and label
+pub fn observe_value_with_label(
+    histogram: &Lazy<HistogramVec>,
+    network_id: NetworkId,
+    label: &str,
+    value: f64,
+) {
+    histogram
+        .with_label_values(&[network_id.as_str(), label])
+        .observe(value)
 }
 
 /// Sets the gauge with the specific label and value
@@ -128,10 +150,10 @@ pub fn set_gauge(counter: &Lazy<IntGaugeVec>, label: &str, value: u64) {
 /// Starts the timer for the provided histogram and label values.
 pub fn start_timer(
     histogram: &Lazy<HistogramVec>,
-    protocol: ProtocolId,
+    network_id: NetworkId,
     label: String,
 ) -> HistogramTimer {
     histogram
-        .with_label_values(&[protocol.as_str(), &label])
+        .with_label_values(&[network_id.as_str(), &label])
         .start_timer()
 }

--- a/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use aptos_config::{config::StorageServiceConfig, network_id::PeerNetworkId};
 use aptos_infallible::{Mutex, RwLock};
-use aptos_network::protocols::wire::handshake::v1::ProtocolId;
 use aptos_storage_service_types::{
     requests::{
         DataRequest, NewTransactionOutputsWithProofRequest,
@@ -281,10 +280,5 @@ fn create_optimistic_fetch_request(
     let response_sender = ResponseSender::new(callback);
 
     // Create and return the optimistic fetch request
-    OptimisticFetchRequest::new(
-        ProtocolId::StorageServiceRpc,
-        storage_service_request,
-        response_sender,
-        time_service,
-    )
+    OptimisticFetchRequest::new(storage_service_request, response_sender, time_service)
 }


### PR DESCRIPTION
Note: this PR is based on: https://github.com/aptos-labs/aptos-core/pull/8402

### Description
This PR makes two small tweaks to the storage service metrics:
1. Replace "protocol" with "network_id" for various metrics. Protocol is not really useful anymore 😄
2. Add a new metric to track optimistic fetch latencies.

### Test Plan
Existing test infrastructure.