### PR TITLE
[Aptos Node] Bump cargo version of aptos-node to 1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-node"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "aptos-api",

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos-node"
 description = "Aptos node"
-version = "1.4.0"
+version = "1.5.0"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
### Description
This PR bumps the cargo version of aptos-node to 1.5, so that `./aptos-node --version` will return the correct version.

### Test Plan
Manual verification.