### PR TITLE
[gha] check aptos-node version against branch

### DIFF
--- a/.github/actions/check-aptos-node-version/action.yml
+++ b/.github/actions/check-aptos-node-version/action.yml
@@ -1,0 +1,21 @@
+name: "Check aptos-node cargo version"
+description: |
+  Checks the aptos-node cargo version against the aptos-core branch name.
+inputs:
+  APTOS_CORE_BRANCH:
+    description: "The aptos-core git ref to check for version number"
+    required: true
+  APTOS_NODE_CARGO_TOML:
+    description: "The path to the aptos-node Cargo.toml file"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Check aptos-node-version
+      shell: bash
+      run: |
+        python3 ${{ github.action_path }}/check_aptos_node_version.py
+      env:
+        APTOS_CORE_BRANCH: ${{ inputs.APTOS_CORE_BRANCH }}
+        APTOS_NODE_CARGO_TOML: ${{ inputs.APTOS_NODE_CARGO_TOML }}

--- a/.github/actions/check-aptos-node-version/check_aptos_node_version.py
+++ b/.github/actions/check-aptos-node-version/check_aptos_node_version.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+import tomllib
+import os
+import sys
+import unittest
+import tempfile
+
+
+def main():
+    required_envs = ["APTOS_CORE_BRANCH", "APTOS_NODE_CARGO_TOML"]
+    for env in required_envs:
+        if not os.environ.get(env):
+            print(f"Required environment variable {env} not set")
+            sys.exit(1)
+
+    BRANCH = os.environ.get("APTOS_CORE_BRANCH")
+    APTOS_NODE_TOML = os.environ.get("APTOS_NODE_CARGO_TOML")
+
+    with open(APTOS_NODE_TOML, "rb") as f:
+        toml = tomllib.load(f)
+        package = toml.get("package")
+        if not package:
+            print("No package section in Cargo.toml")
+            sys.exit(1)
+        version = package.get("version")
+        if not version:
+            print("No version in Cargo.toml")
+            sys.exit(1)
+
+        minor_version = ".".join(version.split(".")[:2])
+        if minor_version not in BRANCH:
+            print(
+                f"aptos-node version {minor_version} does not match release branch {BRANCH}"
+            )
+            sys.exit(1)
+
+        print(
+            f"SUCCESS: aptos-node version {minor_version} matches release branch {BRANCH}!"
+        )
+
+
+if __name__ == "__main__":
+    main()
+
+
+class CheckAptosNodeVersionTests(unittest.TestCase):
+    def test_envs_not_specified(self):
+        with self.assertRaises(SystemExit):
+            os.environ["APTOS_CORE_BRANCH"] = ""
+            os.environ["APTOS_NODE_CARGO_TOML"] = ""
+            main()
+
+    def test_version_match(self):
+        tmp = tempfile.NamedTemporaryFile()
+        with open(tmp.name, "w") as f:
+            f.write(
+                """
+                [package]
+                version = "1.0.0"
+                """
+            )
+        os.environ["APTOS_CORE_BRANCH"] = "release-1.0"
+        os.environ["APTOS_NODE_CARGO_TOML"] = tmp.name
+        main()  # this should work
+
+    def test_version_mismatch(self):
+        tmp = tempfile.NamedTemporaryFile()
+        with open(tmp.name, "w") as f:
+            f.write(
+                """
+                [package]
+                version = "1.0.0"
+                """
+            )
+        os.environ["APTOS_CORE_BRANCH"] = "release-1.1"
+        os.environ["APTOS_NODE_CARGO_TOML"] = tmp.name
+        with self.assertRaises(SystemExit):
+            main()  # this should not work

--- a/.github/workflows/check-aptos-node-version.yaml
+++ b/.github/workflows/check-aptos-node-version.yaml
@@ -1,0 +1,24 @@
+name: Check aptos-node cargo version against release branch
+on:
+  push:
+    branches:
+      - aptos-release-v*
+      - rustielin/check-aptos-node-version # canary
+    tags:
+      - aptos-node-v*
+
+jobs:
+  check-aptos-node-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+
+      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4
+        with:
+          python-version: "3.11" # 3.11 comes with tomllib
+
+      - name: Check aptos-node-version
+        uses: ./.github/actions/check-aptos-node-version
+        with:
+          APTOS_CORE_BRANCH: ${{ github.ref_name }}
+          APTOS_NODE_CARGO_TOML: aptos-node/Cargo.toml


### PR DESCRIPTION
### Description

Quick GHA so we can check the aptos-node version against the current release branch/tag. This way, `aptos-node --version` does not fall out of sync

### Test Plan

Unit tests. Also check canary on this PR


<!-- Please provide us with clear details for verifying that your changes work. -->
