### PR TITLE
[gha] release aptos-node version with workflow_dispatch

### DIFF
--- a/.github/actions/release-aptos-node/action.yml
+++ b/.github/actions/release-aptos-node/action.yml
@@ -1,0 +1,21 @@
+name: "Bump aptos-node cargo version"
+description: |
+  Bumps the aptos-node cargo version against the aptos-core branch name.
+inputs:
+  release_tag:
+    description: "The release tag which includes the version to bump"
+    required: true
+  aptos_node_cargo_toml:
+    description: "The path to the aptos-node Cargo.toml file"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Bump aptos-node-version
+      shell: bash
+      run: |
+        python3 ${{ github.action_path }}/bump_aptos_node_version.py
+      env:
+        RELEASE_TAG: ${{ inputs.release_tag }}
+        APTOS_NODE_CARGO_TOML: ${{ inputs.aptos_node_cargo_toml }}

--- a/.github/actions/release-aptos-node/bump_aptos_node_version.py
+++ b/.github/actions/release-aptos-node/bump_aptos_node_version.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import unittest
+import tempfile
+import re
+
+
+VERSION_LINE_REGEX = re.compile(r"^version =")
+VERSION_IN_RELEASE_TAG_REGEX = r"v(\d+)\.(\d+)\.(\d+)$"
+
+
+def get_release_number_from_release_tag(release_tag: str) -> str:
+    """Get the release number from the release tag. The release tag looks like aptos-node-vX.Y.Z"""
+    result = re.search(VERSION_IN_RELEASE_TAG_REGEX, release_tag)
+    if not result:
+        print(f"Release tag {release_tag} does not match the expected format")
+        sys.exit(1)
+    return ".".join(result.groups())
+
+
+def main():
+    required_envs = ["RELEASE_TAG", "APTOS_NODE_CARGO_TOML"]
+    for env in required_envs:
+        if not os.environ.get(env):
+            print(f"Required environment variable {env} not set")
+            sys.exit(1)
+
+    RELEASE_TAG = os.environ.get("RELEASE_TAG")
+    APTOS_NODE_TOML = os.environ.get("APTOS_NODE_CARGO_TOML")
+
+    new_lines = []  # construct the file again
+    with open(APTOS_NODE_TOML, "r") as f:
+        lines = f.readlines()
+        for line in lines:
+            new_line = line
+            if VERSION_LINE_REGEX.match(line):
+                new_line = (
+                    f'version = "{get_release_number_from_release_tag(RELEASE_TAG)}"\n'
+                )
+            new_lines.append(new_line)
+
+    with open(APTOS_NODE_TOML, "w") as f:
+        f.writelines(new_lines)
+
+if __name__ == "__main__":
+    main()
+
+
+class CheckAptosNodeVersionTests(unittest.TestCase):
+    def test_envs_not_specified(self):
+        with self.assertRaises(SystemExit):
+            os.environ["RELEASE_TAG"] = ""
+            os.environ["APTOS_NODE_CARGO_TOML"] = ""
+            main()
+
+    def test_version_match(self):
+        tmp = tempfile.NamedTemporaryFile()
+        with open(tmp.name, "w") as f:
+            f.write(
+                """
+                [package]
+                version = "1.0.0"
+                """
+            )
+        os.environ["RELEASE_TAG"] = "release-1.0"
+        os.environ["APTOS_NODE_CARGO_TOML"] = tmp.name
+        main()  # this should work
+
+    def test_version_mismatch(self):
+        tmp = tempfile.NamedTemporaryFile()
+        with open(tmp.name, "w") as f:
+            f.write(
+                """
+                [package]
+                version = "1.0.0"
+                """
+            )
+        os.environ["RELEASE_TAG"] = "release-v1.1.0"
+        os.environ["APTOS_NODE_CARGO_TOML"] = tmp.name
+        main()
+        with open(tmp.name, "r") as f:
+            lines = f.readlines()
+            for line in lines:
+                if VERSION_LINE_REGEX.match(line):
+                    self.assertEqual(line, 'version = "1.1.0"\n')
+
+    def test_release_number_from_tag(self):
+        self.assertEqual(get_release_number_from_release_tag("release-v1.0.0"), "1.0.0")

--- a/.github/workflows/aptos-node-release.yaml
+++ b/.github/workflows/aptos-node-release.yaml
@@ -1,0 +1,42 @@
+name: "Release aptos-node"
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        type: string
+        required: true
+        description: "The release tag to create. E.g. `aptos-node-v0.2.3`:"
+      branch:
+        type: string
+        required: true
+        description: "The branch to cut the release from"
+      release_title:
+        type: string
+        required: false
+        description: 'Name of the release, e.g. "Aptos Node Release v1.2.3":'
+
+jobs:
+  release-aptos-node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          ref: ${{ inputs.branch }}
+
+      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4
+
+      - name: Bump aptos-node version
+        uses: aptos-labs/aptos-core/.github/actions/release-aptos-node@main
+        with:
+          release_tag: ${{ inputs.release_tag }}
+          aptos_node_cargo_toml: aptos-node/Cargo.toml
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@671dc9c9e0c2d73f07fa45a3eb0220e1622f0c5f # pin@v4
+        with:
+          add-paths: aptos-node
+          title: "[aptos-node] update release version"
+          body: Automated release bump for ${{ inputs.release_tag }}. Change the PR base accordingly
+          commit-message: "[aptos-node] update release version"
+          branch: auto-release-${{ inputs.release_tag }}
+          delete-branch: true


### PR DESCRIPTION
### Description

Create a workflow that bumps the version in the Cargo.toml and submits a PR to the relevant release branch. This makes sure that the output of `aptos-node --version` is consistent to the release it comes from.

NOTE: due to potential reordering etc of the TOML during formatting etc, just using regex to edit the version key in the file.

### Test Plan

Unit tests

Also run the following in a separate playground repo:

```
APTOS_NODE_CARGO_TOML="aptos-node/Cargo.toml" RELEASE_TAG=aptos-node-v0.6.9 ./.github/actions/release-aptos-node/bump_aptos_node_version.py
```

Context: https://aptos-org.slack.com/archives/C054M887T0D/p1685478620958779?thread_ts=1685462406.648099&cid=C054M887T0D


<!-- Please provide us with clear details for verifying that your changes work. -->
