### PR TITLE
[Indexer] Token v2 improvement

### DIFF
--- a/crates/indexer/migrations/2023-05-24-052435_token_properties_v2/down.sql
+++ b/crates/indexer/migrations/2023-05-24-052435_token_properties_v2/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+DROP VIEW IF EXISTS current_collection_ownership_v2_view;
+DROP TABLE IF EXISTS current_token_v2_metadata;

--- a/crates/indexer/migrations/2023-05-24-052435_token_properties_v2/down.sql
+++ b/crates/indexer/migrations/2023-05-24-052435_token_properties_v2/down.sql
@@ -1,3 +1,5 @@
 -- This file should undo anything in `up.sql`
 DROP VIEW IF EXISTS current_collection_ownership_v2_view;
 DROP TABLE IF EXISTS current_token_v2_metadata;
+ALTER TABLE token_datas_v2 DROP COLUMN IF EXISTS decimals;
+ALTER TABLE current_token_datas_v2 DROP COLUMN IF EXISTS decimals;

--- a/crates/indexer/migrations/2023-05-24-052435_token_properties_v2/down.sql
+++ b/crates/indexer/migrations/2023-05-24-052435_token_properties_v2/down.sql
@@ -3,3 +3,5 @@ DROP VIEW IF EXISTS current_collection_ownership_v2_view;
 DROP TABLE IF EXISTS current_token_v2_metadata;
 ALTER TABLE token_datas_v2 DROP COLUMN IF EXISTS decimals;
 ALTER TABLE current_token_datas_v2 DROP COLUMN IF EXISTS decimals;
+ALTER TABLE token_ownerships_v2 DROP COLUMN IF EXISTS non_transferrable_by_owner;
+ALTER TABLE current_token_ownerships_v2 DROP COLUMN IF EXISTS non_transferrable_by_owner;

--- a/crates/indexer/migrations/2023-05-24-052435_token_properties_v2/up.sql
+++ b/crates/indexer/migrations/2023-05-24-052435_token_properties_v2/up.sql
@@ -1,0 +1,23 @@
+-- Your SQL goes here
+-- need this for getting NFTs grouped by collections
+create or replace view current_collection_ownership_v2_view as
+select owner_address,
+  b.collection_id,
+  MAX(a.last_transaction_version) as last_transaction_version,
+  COUNT(distinct a.token_data_id) as distinct_tokens
+from current_token_ownerships_v2 a
+  join current_token_datas_v2 b on a.token_data_id = b.token_data_id
+where a.amount > 0
+group by 1,
+  2;
+-- create table for all structs in token object core
+CREATE TABLE IF NOT EXISTS current_token_v2_metadata (
+  object_address VARCHAR(66) NOT NULL,
+  resource_type VARCHAR(128) NOT NULL,
+  data jsonb NOT NULL,
+  state_key_hash VARCHAR(66) NOT NULL,
+  last_transaction_version BIGINT NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  -- constraints
+  PRIMARY KEY (object_address, resource_type)
+);

--- a/crates/indexer/migrations/2023-05-24-052435_token_properties_v2/up.sql
+++ b/crates/indexer/migrations/2023-05-24-052435_token_properties_v2/up.sql
@@ -21,3 +21,8 @@ CREATE TABLE IF NOT EXISTS current_token_v2_metadata (
   -- constraints
   PRIMARY KEY (object_address, resource_type)
 );
+-- create table for all structs in token object core
+ALTER TABLE token_datas_v2
+ADD COLUMN IF NOT EXISTS decimals BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE current_token_datas_v2
+ADD COLUMN IF NOT EXISTS decimals BIGINT NOT NULL DEFAULT 0;

--- a/crates/indexer/migrations/2023-05-24-052435_token_properties_v2/up.sql
+++ b/crates/indexer/migrations/2023-05-24-052435_token_properties_v2/up.sql
@@ -26,3 +26,7 @@ ALTER TABLE token_datas_v2
 ADD COLUMN IF NOT EXISTS decimals BIGINT NOT NULL DEFAULT 0;
 ALTER TABLE current_token_datas_v2
 ADD COLUMN IF NOT EXISTS decimals BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE token_ownerships_v2
+ADD COLUMN IF NOT EXISTS non_transferrable_by_owner BOOLEAN;
+ALTER TABLE current_token_ownerships_v2
+ADD COLUMN IF NOT EXISTS non_transferrable_by_owner BOOLEAN;

--- a/crates/indexer/src/models/coin_models/mod.rs
+++ b/crates/indexer/src/models/coin_models/mod.rs
@@ -6,3 +6,4 @@ pub mod coin_balances;
 pub mod coin_infos;
 pub mod coin_supply;
 pub mod coin_utils;
+pub mod v2_fungible_asset_utils;

--- a/crates/indexer/src/models/coin_models/v2_fungible_asset_utils.rs
+++ b/crates/indexer/src/models/coin_models/v2_fungible_asset_utils.rs
@@ -1,0 +1,220 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+
+use crate::{
+    models::{
+        move_resources::MoveResource,
+        token_models::{token_utils::URI_LENGTH, v2_token_utils::ResourceReference},
+    },
+    util::truncate_str,
+};
+use anyhow::{Context, Result};
+use aptos_api_types::{deserialize_from_string, WriteResource};
+use bigdecimal::BigDecimal;
+use serde::{Deserialize, Serialize};
+
+const FUNGIBLE_ASSET_LENGTH: usize = 32;
+const FUNGIBLE_ASSET_SYMBOL: usize = 10;
+
+/* Section on fungible assets resources */
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct FungibleAssetMetadata {
+    name: String,
+    symbol: String,
+    pub decimals: i32,
+    icon_uri: String,
+    project_uri: String,
+}
+
+impl FungibleAssetMetadata {
+    pub fn from_write_resource(
+        write_resource: &WriteResource,
+        txn_version: i64,
+    ) -> anyhow::Result<Option<Self>> {
+        let type_str = format!(
+            "{}::{}::{}",
+            write_resource.data.typ.address,
+            write_resource.data.typ.module,
+            write_resource.data.typ.name
+        );
+        if !V2FungibleAssetResource::is_resource_supported(type_str.as_str()) {
+            return Ok(None);
+        }
+        let resource = MoveResource::from_write_resource(
+            write_resource,
+            0, // Placeholder, this isn't used anyway
+            txn_version,
+            0, // Placeholder, this isn't used anyway
+        );
+
+        if let V2FungibleAssetResource::FungibleAssetMetadata(inner) =
+            V2FungibleAssetResource::from_resource(
+                &type_str,
+                resource.data.as_ref().unwrap(),
+                txn_version,
+            )?
+        {
+            Ok(Some(inner))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn get_name(&self) -> String {
+        truncate_str(&self.name, FUNGIBLE_ASSET_LENGTH)
+    }
+
+    pub fn get_symbol(&self) -> String {
+        truncate_str(&self.name, FUNGIBLE_ASSET_SYMBOL)
+    }
+
+    pub fn get_icon_uri(&self) -> String {
+        truncate_str(&self.icon_uri, URI_LENGTH)
+    }
+
+    pub fn get_project_uri(&self) -> String {
+        truncate_str(&self.project_uri, URI_LENGTH)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct FungibleAssetStore {
+    pub metadata: ResourceReference,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub balance: BigDecimal,
+    pub frozen: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct FungibleAssetSupply {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub current: BigDecimal,
+    pub maximum: OptionalBigDecimal,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct OptionalBigDecimal {
+    vec: Vec<BigDecimalWrapper>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct BigDecimalWrapper(#[serde(deserialize_with = "deserialize_from_string")] pub BigDecimal);
+
+impl FungibleAssetSupply {
+    pub fn from_write_resource(
+        write_resource: &WriteResource,
+        txn_version: i64,
+    ) -> anyhow::Result<Option<Self>> {
+        let type_str = format!(
+            "{}::{}::{}",
+            write_resource.data.typ.address,
+            write_resource.data.typ.module,
+            write_resource.data.typ.name
+        );
+        if !V2FungibleAssetResource::is_resource_supported(type_str.as_str()) {
+            return Ok(None);
+        }
+        let resource = MoveResource::from_write_resource(
+            write_resource,
+            0, // Placeholder, this isn't used anyway
+            txn_version,
+            0, // Placeholder, this isn't used anyway
+        );
+
+        if let V2FungibleAssetResource::FungibleAssetSupply(inner) =
+            V2FungibleAssetResource::from_resource(
+                &type_str,
+                resource.data.as_ref().unwrap(),
+                txn_version,
+            )?
+        {
+            Ok(Some(inner))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn get_maximum(&self) -> Option<BigDecimal> {
+        self.maximum.vec.first().map(|x| x.0.clone())
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum V2FungibleAssetResource {
+    FungibleAssetMetadata(FungibleAssetMetadata),
+    FungibleAssetStore(FungibleAssetStore),
+    FungibleAssetSupply(FungibleAssetSupply),
+}
+
+impl V2FungibleAssetResource {
+    pub fn is_resource_supported(data_type: &str) -> bool {
+        matches!(
+            data_type,
+            "0x1::fungible_asset::Supply"
+                | "0x1::fungible_asset::Metadata"
+                | "0x1::fungible_asset::FungibleStore"
+        )
+    }
+
+    pub fn from_resource(
+        data_type: &str,
+        data: &serde_json::Value,
+        txn_version: i64,
+    ) -> Result<Self> {
+        match data_type {
+            "0x1::fungible_asset::Supply" => serde_json::from_value(data.clone())
+                .map(|inner| Some(Self::FungibleAssetSupply(inner))),
+            "0x1::fungible_asset::Metadata" => serde_json::from_value(data.clone())
+                .map(|inner| Some(Self::FungibleAssetMetadata(inner))),
+            "0x1::fungible_asset::FungibleStore" => serde_json::from_value(data.clone())
+                .map(|inner| Some(Self::FungibleAssetStore(inner))),
+            _ => Ok(None),
+        }
+        .context(format!(
+            "version {} failed! failed to parse type {}, data {:?}",
+            txn_version, data_type, data
+        ))?
+        .context(format!(
+            "Resource unsupported! Call is_resource_supported first. version {} type {}",
+            txn_version, data_type
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fungible_asset_supply_null() {
+        let test = r#"{"current": "0", "maximum": {"vec": []}}"#;
+        let test: serde_json::Value = serde_json::from_str(test).unwrap();
+        let supply = serde_json::from_value(test)
+            .map(V2FungibleAssetResource::FungibleAssetSupply)
+            .unwrap();
+        if let V2FungibleAssetResource::FungibleAssetSupply(supply) = supply {
+            assert_eq!(supply.current, BigDecimal::from(0));
+            assert_eq!(supply.get_maximum(), None);
+        } else {
+            panic!("Wrong type")
+        }
+    }
+
+    #[test]
+    fn test_fungible_asset_supply_nonnull() {
+        let test = r#"{"current": "100", "maximum": {"vec": ["5000"]}}"#;
+        let test: serde_json::Value = serde_json::from_str(test).unwrap();
+        let supply = serde_json::from_value(test)
+            .map(V2FungibleAssetResource::FungibleAssetSupply)
+            .unwrap();
+        if let V2FungibleAssetResource::FungibleAssetSupply(supply) = supply {
+            assert_eq!(supply.current, BigDecimal::from(100));
+            assert_eq!(supply.get_maximum(), Some(BigDecimal::from(5000)));
+        } else {
+            panic!("Wrong type")
+        }
+    }
+}

--- a/crates/indexer/src/models/token_models/mod.rs
+++ b/crates/indexer/src/models/token_models/mod.rs
@@ -13,5 +13,6 @@ pub mod tokens;
 pub mod v2_collections;
 pub mod v2_token_activities;
 pub mod v2_token_datas;
+pub mod v2_token_metadata;
 pub mod v2_token_ownerships;
 pub mod v2_token_utils;

--- a/crates/indexer/src/models/token_models/v2_token_activities.rs
+++ b/crates/indexer/src/models/token_models/v2_token_activities.rs
@@ -78,7 +78,7 @@ impl TokenActivityV2 {
             };
 
             if let Some(metadata) = token_v2_metadata.get(&token_data_id) {
-                let object_core = &metadata.object;
+                let object_core = &metadata.object.object_core;
                 let token_activity_helper = match token_event {
                     V2TokenEvent::MintEvent(_) => TokenActivityHelperV2 {
                         from_address: Some(object_core.get_owner_address()),

--- a/crates/indexer/src/models/token_models/v2_token_datas.rs
+++ b/crates/indexer/src/models/token_models/v2_token_datas.rs
@@ -39,6 +39,7 @@ pub struct TokenDataV2 {
     pub token_standard: String,
     pub is_fungible_v2: Option<bool>,
     pub transaction_timestamp: chrono::NaiveDateTime,
+    pub decimals: i64,
 }
 
 #[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
@@ -58,6 +59,7 @@ pub struct CurrentTokenDataV2 {
     pub is_fungible_v2: Option<bool>,
     pub last_transaction_version: i64,
     pub last_transaction_timestamp: chrono::NaiveDateTime,
+    pub decimals: i64,
 }
 
 impl TokenDataV2 {
@@ -71,10 +73,21 @@ impl TokenDataV2 {
         if let Some(inner) = &TokenV2::from_write_resource(write_resource, txn_version)? {
             let token_data_id = standardize_address(&write_resource.address.to_string());
             // Get maximum, supply, and is fungible from fungible asset if this is a fungible token
-            let (maximum, supply, is_fungible_v2) = (None, BigDecimal::zero(), Some(false));
+            let (mut maximum, mut supply, mut decimals, mut is_fungible_v2) =
+                (None, BigDecimal::zero(), 0, Some(false));
             // Get token properties from 0x4::property_map::PropertyMap
             let mut token_properties = serde_json::Value::Null;
             if let Some(metadata) = token_v2_metadata.get(&token_data_id) {
+                let fungible_asset_metadata = metadata.fungible_asset_metadata.as_ref();
+                let fungible_asset_supply = metadata.fungible_asset_supply.as_ref();
+                if let Some(metadata) = fungible_asset_metadata {
+                    if let Some(fa_supply) = fungible_asset_supply {
+                        maximum = fa_supply.get_maximum();
+                        supply = fa_supply.current.clone();
+                        decimals = metadata.decimals as i64;
+                        is_fungible_v2 = Some(true);
+                    }
+                }
                 token_properties = metadata
                     .property_map
                     .as_ref()
@@ -105,6 +118,7 @@ impl TokenDataV2 {
                     token_standard: TokenStandard::V2.to_string(),
                     is_fungible_v2,
                     transaction_timestamp: txn_timestamp,
+                    decimals,
                 },
                 CurrentTokenDataV2 {
                     token_data_id,
@@ -120,6 +134,7 @@ impl TokenDataV2 {
                     is_fungible_v2,
                     last_transaction_version: txn_version,
                     last_transaction_timestamp: txn_timestamp,
+                    decimals,
                 },
             )))
         } else {
@@ -177,6 +192,7 @@ impl TokenDataV2 {
                         token_standard: TokenStandard::V1.to_string(),
                         is_fungible_v2: None,
                         transaction_timestamp: txn_timestamp,
+                        decimals: 0,
                     },
                     CurrentTokenDataV2 {
                         token_data_id,
@@ -192,6 +208,7 @@ impl TokenDataV2 {
                         is_fungible_v2: None,
                         last_transaction_version: txn_version,
                         last_transaction_timestamp: txn_timestamp,
+                        decimals: 0,
                     },
                 )));
             } else {

--- a/crates/indexer/src/models/token_models/v2_token_metadata.rs
+++ b/crates/indexer/src/models/token_models/v2_token_metadata.rs
@@ -1,0 +1,65 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use super::{token_utils::NAME_LENGTH, v2_token_utils::TokenV2AggregatedDataMapping};
+use crate::{
+    models::move_resources::MoveResource,
+    schema::current_token_v2_metadata,
+    util::{standardize_address, truncate_str},
+};
+use anyhow::Context;
+use aptos_api_types::WriteResource;
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// PK of current_objects, i.e. object_address, resource_type
+pub type CurrentTokenV2MetadataPK = (String, String);
+
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(object_address, resource_type))]
+#[diesel(table_name = current_token_v2_metadata)]
+pub struct CurrentTokenV2Metadata {
+    pub object_address: String,
+    pub resource_type: String,
+    pub data: Value,
+    pub state_key_hash: String,
+    pub last_transaction_version: i64,
+}
+
+impl CurrentTokenV2Metadata {
+    /// Parsing unknown resources with 0x4::token::Token
+    pub fn from_write_resource(
+        write_resource: &WriteResource,
+        txn_version: i64,
+        token_v2_metadata: &TokenV2AggregatedDataMapping,
+    ) -> anyhow::Result<Option<Self>> {
+        let object_address = standardize_address(&write_resource.address.to_string());
+        if let Some(metadata) = token_v2_metadata.get(&object_address) {
+            // checking if token_v2
+            if metadata.token.is_some() {
+                let resource_type_addr = write_resource.data.typ.address.to_string();
+                if matches!(resource_type_addr.as_str(), "0x1" | "0x3" | "0x4") {
+                    return Ok(None);
+                }
+
+                let resource = MoveResource::from_write_resource(write_resource, 0, txn_version, 0);
+                let resource_type = truncate_str(&resource.type_, NAME_LENGTH);
+                return Ok(Some(CurrentTokenV2Metadata {
+                    object_address,
+                    resource_type,
+                    data: resource
+                        .data
+                        .context("data must be present in write resource")?,
+                    state_key_hash: resource.state_key_hash,
+                    last_transaction_version: txn_version,
+                }));
+            }
+        }
+        Ok(None)
+    }
+}

--- a/crates/indexer/src/models/token_models/v2_token_metadata.rs
+++ b/crates/indexer/src/models/token_models/v2_token_metadata.rs
@@ -48,6 +48,12 @@ impl CurrentTokenV2Metadata {
                 }
 
                 let resource = MoveResource::from_write_resource(write_resource, 0, txn_version, 0);
+
+                let state_key_hash = metadata.object.get_state_key_hash();
+                if state_key_hash != resource.state_key_hash {
+                    return Ok(None);
+                }
+    
                 let resource_type = truncate_str(&resource.type_, NAME_LENGTH);
                 return Ok(Some(CurrentTokenV2Metadata {
                     object_address,

--- a/crates/indexer/src/models/token_models/v2_token_metadata.rs
+++ b/crates/indexer/src/models/token_models/v2_token_metadata.rs
@@ -53,7 +53,7 @@ impl CurrentTokenV2Metadata {
                 if state_key_hash != resource.state_key_hash {
                     return Ok(None);
                 }
-    
+
                 let resource_type = truncate_str(&resource.type_, NAME_LENGTH);
                 return Ok(Some(CurrentTokenV2Metadata {
                     object_address,

--- a/crates/indexer/src/models/token_models/v2_token_utils.rs
+++ b/crates/indexer/src/models/token_models/v2_token_utils.rs
@@ -6,7 +6,11 @@
 
 use super::token_utils::{NAME_LENGTH, URI_LENGTH};
 use crate::{
-    models::{move_resources::MoveResource, v2_objects::CurrentObjectPK},
+    models::{
+        coin_models::v2_fungible_asset_utils::{FungibleAssetMetadata, FungibleAssetSupply},
+        move_resources::MoveResource,
+        v2_objects::CurrentObjectPK,
+    },
     util::{
         deserialize_token_object_property_map_from_bcs_hexstring, standardize_address, truncate_str,
     },
@@ -31,11 +35,13 @@ pub type EventIndex = i64;
 pub struct TokenV2AggregatedData {
     pub aptos_collection: Option<AptosCollection>,
     pub fixed_supply: Option<FixedSupply>,
+    pub fungible_asset_metadata: Option<FungibleAssetMetadata>,
+    pub fungible_asset_supply: Option<FungibleAssetSupply>,
     pub object: ObjectCore,
-    pub unlimited_supply: Option<UnlimitedSupply>,
     pub property_map: Option<PropertyMap>,
-    pub transfer_event: Option<(EventIndex, TransferEvent)>,
     pub token: Option<TokenV2>,
+    pub transfer_event: Option<(EventIndex, TransferEvent)>,
+    pub unlimited_supply: Option<UnlimitedSupply>,
 }
 
 /// Tracks which token standard a token / collection is built upon
@@ -93,6 +99,7 @@ impl ObjectCore {
     }
 }
 
+/* Section on Collection / Token */
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Collection {
     creator: String,
@@ -164,7 +171,7 @@ pub struct TokenV2 {
 
 impl TokenV2 {
     pub fn get_collection_address(&self) -> String {
-        standardize_address(&self.collection.inner)
+        self.collection.get_reference_address()
     }
 
     pub fn get_uri_trunc(&self) -> String {
@@ -210,6 +217,13 @@ pub struct ResourceReference {
     inner: String,
 }
 
+impl ResourceReference {
+    pub fn get_reference_address(&self) -> String {
+        standardize_address(&self.inner)
+    }
+}
+
+/* Section on Supply */
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FixedSupply {
     #[serde(deserialize_with = "deserialize_from_string")]
@@ -290,6 +304,7 @@ impl UnlimitedSupply {
     }
 }
 
+/* Section on Events */
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MintEvent {
     #[serde(deserialize_with = "deserialize_from_string")]
@@ -366,6 +381,7 @@ impl TransferEvent {
     }
 }
 
+/* Section on Property Maps */
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PropertyMap {
     #[serde(deserialize_with = "deserialize_token_object_property_map_from_bcs_hexstring")]
@@ -481,7 +497,7 @@ impl V2TokenEvent {
         data_type: &str,
         data: &serde_json::Value,
         txn_version: i64,
-    ) -> Result<Option<V2TokenEvent>> {
+    ) -> Result<Option<Self>> {
         match data_type {
             "0x4::collection::MintEvent" => {
                 serde_json::from_value(data.clone()).map(|inner| Some(Self::MintEvent(inner)))

--- a/crates/indexer/src/models/token_models/v2_token_utils.rs
+++ b/crates/indexer/src/models/token_models/v2_token_utils.rs
@@ -37,7 +37,7 @@ pub struct TokenV2AggregatedData {
     pub fixed_supply: Option<FixedSupply>,
     pub fungible_asset_metadata: Option<FungibleAssetMetadata>,
     pub fungible_asset_supply: Option<FungibleAssetSupply>,
-    pub object: ObjectCore,
+    pub object: ObjectWithMetadata,
     pub property_map: Option<PropertyMap>,
     pub token: Option<TokenV2>,
     pub transfer_event: Option<(EventIndex, TransferEvent)>,
@@ -70,6 +70,18 @@ pub struct ObjectCore {
 }
 
 impl ObjectCore {
+    pub fn get_owner_address(&self) -> String {
+        standardize_address(&self.owner)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ObjectWithMetadata {
+    pub object_core: ObjectCore,
+    state_key_hash: String,
+}
+
+impl ObjectWithMetadata {
     pub fn from_write_resource(
         write_resource: &WriteResource,
         txn_version: i64,
@@ -88,14 +100,17 @@ impl ObjectCore {
             &serde_json::to_value(&write_resource.data.data).unwrap(),
             txn_version,
         )? {
-            Ok(Some(inner))
+            Ok(Some(Self {
+                object_core: inner,
+                state_key_hash: standardize_address(write_resource.state_key_hash.as_str()),
+            }))
         } else {
             Ok(None)
         }
     }
 
-    pub fn get_owner_address(&self) -> String {
-        standardize_address(&self.owner)
+    pub fn get_state_key_hash(&self) -> String {
+        standardize_address(&self.state_key_hash)
     }
 }
 

--- a/crates/indexer/src/models/v2_objects.rs
+++ b/crates/indexer/src/models/v2_objects.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::unused_unit)]
 
-use super::token_models::v2_token_utils::ObjectCore;
+use super::token_models::v2_token_utils::ObjectWithMetadata;
 use crate::{
     models::move_resources::MoveResource,
     schema::{current_objects, objects},
@@ -83,30 +83,31 @@ impl Object {
         txn_version: i64,
         write_set_change_index: i64,
     ) -> anyhow::Result<Option<(Self, CurrentObject)>> {
-        if let Some(inner) = ObjectCore::from_write_resource(write_resource, txn_version)? {
+        if let Some(inner) = ObjectWithMetadata::from_write_resource(write_resource, txn_version)? {
             let resource = MoveResource::from_write_resource(
                 write_resource,
                 0, // Placeholder, this isn't used anyway
                 txn_version,
                 0, // Placeholder, this isn't used anyway
             );
+            let object_core = &inner.object_core;
             Ok(Some((
                 Self {
                     transaction_version: txn_version,
                     write_set_change_index,
                     object_address: resource.address.clone(),
-                    owner_address: Some(inner.get_owner_address()),
+                    owner_address: Some(object_core.get_owner_address()),
                     state_key_hash: resource.state_key_hash.clone(),
-                    guid_creation_num: Some(inner.guid_creation_num.clone()),
-                    allow_ungated_transfer: Some(inner.allow_ungated_transfer),
+                    guid_creation_num: Some(object_core.guid_creation_num.clone()),
+                    allow_ungated_transfer: Some(object_core.allow_ungated_transfer),
                     is_deleted: false,
                 },
                 CurrentObject {
                     object_address: resource.address,
-                    owner_address: Some(inner.get_owner_address()),
+                    owner_address: Some(object_core.get_owner_address()),
                     state_key_hash: resource.state_key_hash,
-                    allow_ungated_transfer: Some(inner.allow_ungated_transfer),
-                    last_guid_creation_num: Some(inner.guid_creation_num),
+                    allow_ungated_transfer: Some(object_core.allow_ungated_transfer),
+                    last_guid_creation_num: Some(object_core.guid_creation_num.clone()),
                     last_transaction_version: txn_version,
                     is_deleted: false,
                 },

--- a/crates/indexer/src/processors/token_processor.rs
+++ b/crates/indexer/src/processors/token_processor.rs
@@ -26,6 +26,7 @@ use crate::{
             v2_collections::{CollectionV2, CurrentCollectionV2, CurrentCollectionV2PK},
             v2_token_activities::TokenActivityV2,
             v2_token_datas::{CurrentTokenDataV2, CurrentTokenDataV2PK, TokenDataV2},
+            v2_token_metadata::{CurrentTokenV2Metadata, CurrentTokenV2MetadataPK},
             v2_token_ownerships::{
                 CurrentTokenOwnershipV2, CurrentTokenOwnershipV2PK, NFTOwnershipV2,
                 TokenOwnershipV2,
@@ -105,6 +106,7 @@ fn insert_to_db_impl(
         current_token_datas_v2,
         current_token_ownerships_v2,
         token_activities_v2,
+        current_token_v2_metadata,
     ): (
         &[CollectionV2],
         &[TokenDataV2],
@@ -113,6 +115,7 @@ fn insert_to_db_impl(
         &[CurrentTokenDataV2],
         &[CurrentTokenOwnershipV2],
         &[TokenActivityV2],
+        &[CurrentTokenV2Metadata],
     ),
 ) -> Result<(), diesel::result::Error> {
     let (tokens, token_ownerships, token_datas, collection_datas) = basic_token_transaction_lists;
@@ -136,6 +139,7 @@ fn insert_to_db_impl(
     insert_current_token_datas_v2(conn, current_token_datas_v2)?;
     insert_current_token_ownerships_v2(conn, current_token_ownerships_v2)?;
     insert_token_activities_v2(conn, token_activities_v2)?;
+    insert_current_token_v2_metadatas(conn, current_token_v2_metadata)?;
     Ok(())
 }
 
@@ -167,6 +171,7 @@ fn insert_to_db(
         current_token_datas_v2,
         current_token_ownerships_v2,
         token_activities_v2,
+        current_token_v2_metadata,
     ): (
         Vec<CollectionV2>,
         Vec<TokenDataV2>,
@@ -175,6 +180,7 @@ fn insert_to_db(
         Vec<CurrentTokenDataV2>,
         Vec<CurrentTokenOwnershipV2>,
         Vec<TokenActivityV2>,
+        Vec<CurrentTokenV2Metadata>,
     ),
 ) -> Result<(), diesel::result::Error> {
     aptos_logger::trace!(
@@ -210,6 +216,7 @@ fn insert_to_db(
                     &current_token_datas_v2,
                     &current_token_ownerships_v2,
                     &token_activities_v2,
+                    &current_token_v2_metadata,
                 ),
             )
         }) {
@@ -237,6 +244,7 @@ fn insert_to_db(
                 let current_token_ownerships_v2 =
                     clean_data_for_db(current_token_ownerships_v2, true);
                 let token_activities_v2 = clean_data_for_db(token_activities_v2, true);
+                let current_token_v2_metadata = clean_data_for_db(current_token_v2_metadata, true);
 
                 insert_to_db_impl(
                     pg_conn,
@@ -258,6 +266,7 @@ fn insert_to_db(
                         &current_token_datas_v2,
                         &current_token_ownerships_v2,
                         &token_activities_v2,
+                        &current_token_v2_metadata,
                     ),
                 )
             }),
@@ -786,6 +795,33 @@ fn insert_token_activities_v2(
     Ok(())
 }
 
+fn insert_current_token_v2_metadatas(
+    conn: &mut PgConnection,
+    items_to_insert: &[CurrentTokenV2Metadata],
+) -> Result<(), diesel::result::Error> {
+    use schema::current_token_v2_metadata::dsl::*;
+
+    let chunks = get_chunks(items_to_insert.len(), CurrentTokenV2Metadata::field_count());
+
+    for (start_ind, end_ind) in chunks {
+        execute_with_better_error(
+            conn,
+            diesel::insert_into(schema::current_token_v2_metadata::table)
+                .values(&items_to_insert[start_ind..end_ind])
+                .on_conflict((object_address, resource_type))
+                .do_update()
+                .set((
+                    data.eq(excluded(data)),
+                    state_key_hash.eq(excluded(state_key_hash)),
+                    last_transaction_version.eq(excluded(last_transaction_version)),
+                    inserted_at.eq(excluded(inserted_at)),
+                )),
+            Some(" WHERE current_token_v2_metadata.last_transaction_version <= excluded.last_transaction_version "),
+        )?;
+    }
+    Ok(())
+}
+
 #[async_trait]
 impl TransactionProcessor for TokenTransactionProcessor {
     fn name(&self) -> &'static str {
@@ -925,6 +961,7 @@ impl TransactionProcessor for TokenTransactionProcessor {
             current_token_ownerships_v2,
             current_token_datas_v2,
             token_activities_v2,
+            current_token_v2_metadata,
         ) = parse_v2_token(&transactions, &table_handle_to_owner, &mut conn);
 
         let tx_result = insert_to_db(
@@ -956,6 +993,7 @@ impl TransactionProcessor for TokenTransactionProcessor {
                 current_token_ownerships_v2,
                 current_token_datas_v2,
                 token_activities_v2,
+                current_token_v2_metadata,
             ),
         );
         match tx_result {
@@ -990,6 +1028,7 @@ fn parse_v2_token(
     Vec<CurrentTokenDataV2>,
     Vec<CurrentTokenOwnershipV2>,
     Vec<TokenActivityV2>,
+    Vec<CurrentTokenV2Metadata>,
 ) {
     // Token V2 and V1 combined
     let mut collections_v2 = vec![];
@@ -1009,7 +1048,10 @@ fn parse_v2_token(
     // Get Metadata for token v2 by object
     // We want to persist this through the entire batch so that even if a token is burned,
     // we can still get the object core metadata for it
-    let mut token_v2_metadata: TokenV2AggregatedDataMapping = HashMap::new();
+    let mut token_v2_metadata_helper: TokenV2AggregatedDataMapping = HashMap::new();
+    // Basically token properties
+    let mut current_token_v2_metadata: HashMap<CurrentTokenV2MetadataPK, CurrentTokenV2Metadata> =
+        HashMap::new();
 
     // Code above is inefficient (multiple passthroughs) so I'm approaching TokenV2 with a cleaner code structure
     for txn in transactions {
@@ -1032,7 +1074,7 @@ fn parse_v2_token(
                     if let Some(object_core) =
                         ObjectCore::from_write_resource(wr, txn_version).unwrap()
                     {
-                        token_v2_metadata.insert(
+                        token_v2_metadata_helper.insert(
                             standardize_address(&wr.address.to_string()),
                             TokenV2AggregatedData {
                                 aptos_collection: None,
@@ -1052,7 +1094,7 @@ fn parse_v2_token(
             for (_, wsc) in user_txn.info.changes.iter().enumerate() {
                 if let WriteSetChange::WriteResource(wr) = wsc {
                     let address = standardize_address(&wr.address.to_string());
-                    if let Some(aggregated_data) = token_v2_metadata.get_mut(&address) {
+                    if let Some(aggregated_data) = token_v2_metadata_helper.get_mut(&address) {
                         if let Some(fixed_supply) =
                             FixedSupply::from_write_resource(wr, txn_version).unwrap()
                         {
@@ -1091,7 +1133,7 @@ fn parse_v2_token(
                 if let Some(transfer_event) = TransferEvent::from_event(event, txn_version).unwrap()
                 {
                     if let Some(aggregated_data) =
-                        token_v2_metadata.get_mut(&transfer_event.get_object_address())
+                        token_v2_metadata_helper.get_mut(&transfer_event.get_object_address())
                     {
                         // we don't want index to be 0 otherwise we might have collision with write set change index
                         let index = if index == 0 {
@@ -1121,7 +1163,7 @@ fn parse_v2_token(
                     txn_timestamp,
                     index as i64,
                     &entry_function_id_str,
-                    &token_v2_metadata,
+                    &token_v2_metadata_helper,
                 )
                 .unwrap()
                 {
@@ -1237,7 +1279,7 @@ fn parse_v2_token(
                                 txn_version,
                                 wsc_index,
                                 txn_timestamp,
-                                &token_v2_metadata,
+                                &token_v2_metadata_helper,
                             )
                             .unwrap()
                         {
@@ -1253,7 +1295,7 @@ fn parse_v2_token(
                                 txn_version,
                                 wsc_index,
                                 txn_timestamp,
-                                &token_v2_metadata,
+                                &token_v2_metadata_helper,
                             )
                             .unwrap()
                         {
@@ -1265,7 +1307,7 @@ fn parse_v2_token(
                                 from_current_nft_ownership,
                             ) = TokenOwnershipV2::get_nft_v2_from_token_data(
                                 &token_data,
-                                &token_v2_metadata,
+                                &token_v2_metadata_helper,
                             )
                             .unwrap();
                             token_datas_v2.push(token_data);
@@ -1339,6 +1381,22 @@ fn parse_v2_token(
                                 );
                             }
                         }
+                        // Track token properties
+                        if let Some(token_metadata) = CurrentTokenV2Metadata::from_write_resource(
+                            resource,
+                            txn_version,
+                            &token_v2_metadata_helper,
+                        )
+                        .unwrap()
+                        {
+                            current_token_v2_metadata.insert(
+                                (
+                                    token_metadata.object_address.clone(),
+                                    token_metadata.resource_type.clone(),
+                                ),
+                                token_metadata,
+                            );
+                        }
                     },
                     WriteSetChange::DeleteResource(resource) => {
                         // Add burned NFT handling
@@ -1390,6 +1448,9 @@ fn parse_v2_token(
     let mut current_token_ownerships_v2 = current_token_ownerships_v2
         .into_values()
         .collect::<Vec<CurrentTokenOwnershipV2>>();
+    let mut current_token_v2_metadata = current_token_v2_metadata
+        .into_values()
+        .collect::<Vec<CurrentTokenV2Metadata>>();
 
     // Sort by PK
     current_collections_v2.sort_by(|a, b| a.collection_id.cmp(&b.collection_id));
@@ -1408,6 +1469,9 @@ fn parse_v2_token(
                 &b.storage_id,
             ))
     });
+    current_token_v2_metadata.sort_by(|a, b| {
+        (&a.object_address, &a.resource_type).cmp(&(&b.object_address, &b.resource_type))
+    });
 
     (
         collections_v2,
@@ -1417,5 +1481,6 @@ fn parse_v2_token(
         current_token_datas_v2,
         current_token_ownerships_v2,
         token_activities_v2,
+        current_token_v2_metadata,
     )
 }

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -1,3 +1,5 @@
+// Copyright © Aptos Foundation
+
 // @generated automatically by Diesel CLI.
 
 diesel::table! {

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -285,6 +285,7 @@ diesel::table! {
         last_transaction_version -> Int8,
         last_transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
+        decimals -> Int8,
     }
 }
 
@@ -639,6 +640,7 @@ diesel::table! {
         is_fungible_v2 -> Nullable<Bool>,
         transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
+        decimals -> Int8,
     }
 }
 

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -345,6 +345,17 @@ diesel::table! {
 }
 
 diesel::table! {
+    current_token_v2_metadata (object_address, resource_type) {
+        object_address -> Varchar,
+        resource_type -> Varchar,
+        data -> Jsonb,
+        state_key_hash -> Varchar,
+        last_transaction_version -> Int8,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     delegated_staking_activities (transaction_version, event_index) {
         transaction_version -> Int8,
         event_index -> Int8,
@@ -757,6 +768,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     current_token_ownerships,
     current_token_ownerships_v2,
     current_token_pending_claims,
+    current_token_v2_metadata,
     delegated_staking_activities,
     delegated_staking_pool_balances,
     delegated_staking_pools,

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -1,5 +1,3 @@
-// Copyright © Aptos Foundation
-
 // @generated automatically by Diesel CLI.
 
 diesel::table! {

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -322,6 +322,7 @@ diesel::table! {
         last_transaction_version -> Int8,
         last_transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
+        non_transferrable_by_owner -> Nullable<Bool>,
     }
 }
 
@@ -678,6 +679,7 @@ diesel::table! {
         is_fungible_v2 -> Nullable<Bool>,
         transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
+        non_transferrable_by_owner -> Nullable<Bool>,
     }
 }
 


### PR DESCRIPTION
### Description
* Index all metadata in the resource group under `current_token_v2_metadata` table
  * Actually currently we consider metadata as a part of a resource group if they have the same object address. However this should be changed to using `state_key_hash` to ensure that they are actually the same resource group
* Index fungible tokens in token ownership tables

NOTE, this PR does not include token activities yet. Coming next. 

### Test Plan
Shipped to devnet. Works
<!-- Please provide us with clear details for verifying that your changes work. -->
