### PR TITLE
[Smoke tests] add an env variable to save node logs locally

### DIFF
--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -456,7 +456,7 @@ impl LocalSwarm {
 impl Drop for LocalSwarm {
     fn drop(&mut self) {
         // If panicking, persist logs
-        if std::thread::panicking() {
+        if std::env::var("LOCAL_SWARM_SAVE_LOGS").is_ok() || std::thread::panicking() {
             eprintln!("Logs located at {}", self.logs_location());
         }
     }


### PR DESCRIPTION
### Description

This makes it easier to inspect node logs after running a successful smoke test.

Example usage:
```
LOCAL_SWARM_SAVE_LOGS=1 cargo test --package smoke-test test_full_node_basic_flow -- --nocapture
```

The last logged line will have the location, e.g.,
```
Logs located at /var/folders/7h/r8yg843j0tl24vsc33ddl9s40000gn/T/.tmpHbbwHX
```