### PR TITLE
Add support for setting installation path to CLI install script

### DIFF
--- a/developer-docs-site/static/scripts/install_cli.py
+++ b/developer-docs-site/static/scripts/install_cli.py
@@ -215,13 +215,13 @@ class Installer:
         version: Optional[str] = None,
         force: bool = False,
         accept_all: bool = False,
-        path: Optional[str] = None,
+        bin_dir: Optional[str] = None,
     ) -> None:
         self._version = version
         self._force = force
         self._accept_all = accept_all
+        self._bin_dir = Path(bin_dir).expanduser() if bin_dir else None
 
-        self._bin_dir = None
         self._release_info = None
         self._latest_release_info = None
 
@@ -514,12 +514,17 @@ def main():
         action="store_true",
         default=False,
     )
+    parser.add_argument(
+        "--bin-dir",
+        help="If given, the CLI binary will be downloaded here instead",
+    )
 
     args = parser.parse_args()
 
     installer = Installer(
         force=args.force,
         accept_all=args.accept_all or not is_interactive(),
+        bin_dir=args.bin_dir,
     )
 
     try:


### PR DESCRIPTION
### Description
This support was already mostly there, we just had to use it. This will be helpful for CI.

### Test Plan
```
$ python3 developer-docs-site/static/scripts/install_cli.py --bin-dir /tmp
Latest CLI release: 1.0.14
Currently installed CLI: None
Determined target to be: MacOSX-x86_64

Welcome to the Aptos CLI installer!

This will download and install the latest version of the Aptos CLI at this location:

/tmp

Installing Aptos CLI (1.0.14): Downloading...
Installing Aptos CLI (1.0.14): Done!

The Aptos CLI (1.0.14) is installed now. Great!

To get started you need the Aptos CLI's bin directory (/tmp) in your `PATH`
environment variable.

Add the following to your shell configuration file (e.g. .bashrc):

export PATH="/tmp:$PATH"

After this, restart your terminal.

Alternatively, you can call the Aptos CLI explicitly with `/tmp/aptos`.

You can test that everything is set up by executing:

aptos info

$ python3 developer-docs-site/static/scripts/install_cli.py --bin-dir /tmp
Latest CLI release: 1.0.14
Currently installed CLI: 1.0.14

The latest version (1.0.14) is already installed.
$ mkdir ehhh
$ python3 developer-docs-site/static/scripts/install_cli.py --bin-dir ~/ehhh
Latest CLI release: 1.0.14
Currently installed CLI: None
Determined target to be: MacOSX-x86_64

Welcome to the Aptos CLI installer!

This will download and install the latest version of the Aptos CLI at this location:

/Users/dport/ehhh

Installing Aptos CLI (1.0.14): Downloading...
Installing Aptos CLI (1.0.14): Done!

The Aptos CLI (1.0.14) is installed now. Great!

To get started you need the Aptos CLI's bin directory (/Users/dport/ehhh) in your `PATH`
environment variable.

Add the following to your shell configuration file (e.g. .bashrc):

export PATH="/Users/dport/ehhh:$PATH"

After this, restart your terminal.

Alternatively, you can call the Aptos CLI explicitly with `/Users/dport/ehhh/aptos`.

You can test that everything is set up by executing:

aptos info

$ python3 developer-docs-site/static/scripts/install_cli.py --bin-dir ~/ehhh
Latest CLI release: 1.0.14
Currently installed CLI: 1.0.14

The latest version (1.0.14) is already installed.

$ python3 developer-docs-site/static/scripts/install_cli.py
Latest CLI release: 1.0.14
Currently installed CLI: 1.0.14

The latest version (1.0.14) is already installed.
```
