### PR TITLE
Add get-latest-cli action

### DIFF
--- a/.github/actions/get-latest-cli/action.yaml
+++ b/.github/actions/get-latest-cli/action.yaml
@@ -1,0 +1,21 @@
+name: "Get latest Aptos CLI"
+description: |
+  Fetches the latest released Aptos CLI.
+inputs:
+  destination_directory:
+    description: "Directory to install the CLI in"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Setup python
+      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4
+    - name: Get installation script
+      shell: bash
+      run: |
+        curl -fsSL "https://aptos.dev/scripts/install_cli.py" > install_cli.py
+    - name: Run installation script
+      shell: bash
+      run: |
+        python3 install_cli.py --bin-dir ${{ inputs.destination_directory }}


### PR DESCRIPTION
### Description
This PR adds a GH action to install the CLI.

We could theoretically expand this to create a profile as well but I felt that made the action sort of complicated (just look at `aptos init`, it has a lot of flags we'd probably want to expose). We can chat about that though.

Depends on https://github.com/aptos-labs/aptos-core/pull/8446.

### Test Plan
@brianolson tested this in internal-ops, thanks Brian!!
