### PR TITLE
[Aptos Framework] Add check on empty vector during removed multisig v2 owners event emission

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/multisig_account.md
+++ b/aptos-move/framework/aptos-framework/doc/multisig_account.md
@@ -1641,8 +1641,9 @@ maliciously alter the owners list.
         <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(owners) &gt;= multisig_account_resource.num_signatures_required,
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="multisig_account.md#0x1_multisig_account_ENOT_ENOUGH_OWNERS">ENOT_ENOUGH_OWNERS</a>),
     );
-
-    emit_event(&<b>mut</b> multisig_account_resource.remove_owners_events, <a href="multisig_account.md#0x1_multisig_account_RemoveOwnersEvent">RemoveOwnersEvent</a> { owners_removed });
+    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&owners_removed) &gt; 0) {
+        emit_event(&<b>mut</b> multisig_account_resource.remove_owners_events, <a href="multisig_account.md#0x1_multisig_account_RemoveOwnersEvent">RemoveOwnersEvent</a> { owners_removed });
+    }
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/sources/multisig_account.move
+++ b/aptos-move/framework/aptos-framework/sources/multisig_account.move
@@ -573,8 +573,9 @@ module aptos_framework::multisig_account {
             vector::length(owners) >= multisig_account_resource.num_signatures_required,
             error::invalid_state(ENOT_ENOUGH_OWNERS),
         );
-
-        emit_event(&mut multisig_account_resource.remove_owners_events, RemoveOwnersEvent { owners_removed });
+        if (vector::length(&owners_removed) > 0) {
+            emit_event(&mut multisig_account_resource.remove_owners_events, RemoveOwnersEvent { owners_removed });
+        }
     }
 
     /// Update the number of signatures required then remove owners, in a single operation.


### PR DESCRIPTION
@davidiw @movekevin @wrwg 

Presently `remove_owners` accepts an `owners_to_remove` vector that does not necessarily have any overlap with existing signatories. Hence it is possible to successfully invoke the removal operation without actually removing any owners, resulting in an empty event emission. To avoid the confusion of empty events, this PR adds a check against a correspondingly empty vector.

Pending the resolution of #5369 there is no way to test this logic (in a unit test context), which may explain why it went unnoticed until now.