### PR TITLE
[telemetry-svc][bug-fix] Add timeouts for requests

### DIFF
--- a/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
+++ b/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
@@ -10,7 +10,6 @@ use crate::{
     metrics::METRICS_INGEST_BACKEND_REQUEST_DURATION,
     types::{auth::Claims, common::NodeType},
 };
-use futures::{select, stream::FuturesUnordered, FutureExt, StreamExt};
 use reqwest::{header::CONTENT_ENCODING, StatusCode};
 use std::time::Duration;
 use tokio::time::Instant;
@@ -61,82 +60,55 @@ pub async fn handle_metrics_ingest(
 
     let start_timer = Instant::now();
 
-    let mut post_futures: FuturesUnordered<_> = client
-        .into_iter()
-        .map(|(name, client)| async {
-            let result = client
-                .post_prometheus_metrics(
-                    metrics_body.clone(),
-                    extra_labels.clone(),
-                    encoding.clone().unwrap_or_default(),
-                )
-                .await;
+    let post_futures = client.iter().map(|(name, client)| async {
+        let result = tokio::time::timeout(
+            Duration::from_secs(MAX_METRICS_POST_WAIT_DURATION_SECS),
+            client.post_prometheus_metrics(
+                metrics_body.clone(),
+                extra_labels.clone(),
+                encoding.clone().unwrap_or_default(),
+            ),
+        )
+        .await;
 
-            match result {
-                Ok(res) => {
-                    METRICS_INGEST_BACKEND_REQUEST_DURATION
-                        .with_label_values(&[
-                            &claims.peer_id.to_string(),
-                            name,
-                            res.status().as_str(),
-                        ])
-                        .observe(start_timer.elapsed().as_secs_f64());
-                    if res.status().is_success() {
-                        debug!("remote write to victoria metrics succeeded");
-                    } else {
-                        error!(
-                            "remote write failed to victoria_metrics for client {}: {}",
-                            name.clone(),
-                            res.error_for_status().err().unwrap()
-                        );
-                        return Err(());
-                    }
-                },
-                Err(err) => {
-                    METRICS_INGEST_BACKEND_REQUEST_DURATION
-                        .with_label_values(&[name, "Unknown"])
-                        .observe(start_timer.elapsed().as_secs_f64());
+        match result {
+            Ok(Ok(res)) => {
+                METRICS_INGEST_BACKEND_REQUEST_DURATION
+                    .with_label_values(&[&claims.peer_id.to_string(), name, res.status().as_str()])
+                    .observe(start_timer.elapsed().as_secs_f64());
+                if res.status().is_success() {
+                    debug!("remote write to victoria metrics succeeded");
+                } else {
                     error!(
-                        "error sending remote write request for client {}: {}",
+                        "remote write failed to victoria_metrics for client {}: {}",
                         name.clone(),
-                        err
+                        res.error_for_status().err().unwrap()
                     );
                     return Err(());
-                },
-            }
-            Ok(())
-        })
-        .collect();
-
-    // wait for all futures to complete or for the timeout to expire. If none of the futures complete successfully,
-    // we return an error.
-    let mut successful_posts = 0;
-    let mut failed_posts = 0;
-    loop {
-        select! {
-            _ = tokio::time::sleep(Duration::from_secs(MAX_METRICS_POST_WAIT_DURATION_SECS)).fuse() => {
-                break;
-            },
-            res = post_futures.select_next_some() => {
-                match res {
-                    Ok(_) => {
-                        successful_posts += 1;
-                    },
-                    Err(_) => {
-                        failed_posts += 1;
-                        if failed_posts == client.len() {
-                            break;
-                        }
-                    },
                 }
             },
-            complete => {
-                break;
-            }
+            Ok(Err(err)) => {
+                METRICS_INGEST_BACKEND_REQUEST_DURATION
+                    .with_label_values(&[name, "Unknown"])
+                    .observe(start_timer.elapsed().as_secs_f64());
+                error!(
+                    "error sending remote write request for client {}: {}",
+                    name.clone(),
+                    err
+                );
+                return Err(());
+            },
+            Err(_) => return Err(()),
         }
-    }
+        Ok(())
+    });
 
-    if successful_posts == 0 {
+    #[allow(clippy::unnecessary_fold)]
+    if futures::future::join_all(post_futures)
+        .await
+        .iter()
+        .all(|result| result.is_err())
+    {
         return Err(reject::custom(ServiceError::internal(
             MetricsIngestError::IngestionError.into(),
         )));

--- a/crates/aptos-telemetry/src/sender.rs
+++ b/crates/aptos-telemetry/src/sender.rs
@@ -21,10 +21,12 @@ use prometheus::{default_registry, Registry};
 use reqwest::{header::CONTENT_ENCODING, Response, StatusCode, Url};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, RequestBuilder};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
-use std::{io::Write, sync::Arc};
+use std::{io::Write, sync::Arc, time::Duration};
 use uuid::Uuid;
 
 pub const DEFAULT_VERSION_PATH_BASE: &str = "api/v1/";
+
+pub const PROMETHEUS_PUSH_METRICS_TIMEOUT_SECS: u64 = 10;
 
 struct AuthContext {
     noise_config: Option<NoiseConfig>,
@@ -135,7 +137,8 @@ impl TelemetrySender {
                 self.client
                     .post(self.build_path("ingest/metrics")?)
                     .header(CONTENT_ENCODING, "gzip")
-                    .body(compressed_bytes),
+                    .body(compressed_bytes)
+                    .timeout(Duration::from_secs(PROMETHEUS_PUSH_METRICS_TIMEOUT_SECS)),
             )
             .await;
 

--- a/crates/aptos-telemetry/src/sender.rs
+++ b/crates/aptos-telemetry/src/sender.rs
@@ -26,7 +26,8 @@ use uuid::Uuid;
 
 pub const DEFAULT_VERSION_PATH_BASE: &str = "api/v1/";
 
-pub const PROMETHEUS_PUSH_METRICS_TIMEOUT_SECS: u64 = 10;
+pub const PROMETHEUS_PUSH_METRICS_TIMEOUT_SECS: u64 = 8;
+pub const TELEMETRY_SERVICE_TOTAL_RETRY_DURATION_SECS: u64 = 10;
 
 struct AuthContext {
     noise_config: Option<NoiseConfig>,
@@ -58,7 +59,7 @@ pub(crate) struct TelemetrySender {
 
 impl TelemetrySender {
     pub fn new(base_url: Url, chain_id: ChainId, node_config: &NodeConfig) -> Self {
-        let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
+        let retry_policy = ExponentialBackoff::builder().build_with_total_retry_duration(Duration::from_secs(TELEMETRY_SERVICE_TOTAL_RETRY_DURATION_SECS));
 
         let reqwest_client = reqwest::Client::new();
         let client = ClientBuilder::new(reqwest_client)

--- a/crates/aptos-telemetry/src/sender.rs
+++ b/crates/aptos-telemetry/src/sender.rs
@@ -59,7 +59,9 @@ pub(crate) struct TelemetrySender {
 
 impl TelemetrySender {
     pub fn new(base_url: Url, chain_id: ChainId, node_config: &NodeConfig) -> Self {
-        let retry_policy = ExponentialBackoff::builder().build_with_total_retry_duration(Duration::from_secs(TELEMETRY_SERVICE_TOTAL_RETRY_DURATION_SECS));
+        let retry_policy = ExponentialBackoff::builder().build_with_total_retry_duration(
+            Duration::from_secs(TELEMETRY_SERVICE_TOTAL_RETRY_DURATION_SECS),
+        );
 
         let reqwest_client = reqwest::Client::new();
         let client = ClientBuilder::new(reqwest_client)


### PR DESCRIPTION
### Description

This PR should fix a bug with telemetry service that causes metrics push requests to take a long time to complete. The issue is:

First, there is no timeout on the client side. This can affect the 15-second cadence to send metrics periodically to telemetry service. A 5-second timeout has been added on the client-side.

Second, the server waits for all backend push metrics API calls to complete either successfully or fail. This is problematic because the API calls themselves have reties associated with failures, so waiting on all the backend calls means waiting on the slowest call. To fix this, we will wait for a timeout and decide as success if any of the backend calls have succeeded.

There is now a limit on maximum retry duration of 10 seconds on the node-side and the metrics are dropped otherwise and metrics are sent in the next interval.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Existing tests.
