### PR TITLE
[Devnet genesis] turn on txn dedup and quorum store at genesis

### DIFF
--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -61,7 +61,7 @@ impl OnChainConsensusConfig {
 /// This is used when on-chain config is not initialized.
 impl Default for OnChainConsensusConfig {
     fn default() -> Self {
-        OnChainConsensusConfig::V1(ConsensusConfigV1::default())
+        OnChainConsensusConfig::V2(ConsensusConfigV1::default())
     }
 }
 

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -46,7 +46,7 @@ impl OnChainExecutionConfig {
 /// This is used when on-chain config is not initialized.
 impl Default for OnChainExecutionConfig {
     fn default() -> Self {
-        OnChainExecutionConfig::V1(ExecutionConfigV1::default())
+        OnChainExecutionConfig::V3(ExecutionConfigV3::default())
     }
 }
 
@@ -108,7 +108,7 @@ impl Default for ExecutionConfigV3 {
         Self {
             transaction_shuffler_type: TransactionShufflerType::NoShuffling,
             block_gas_limit: None,
-            transaction_deduper_type: TransactionDeduperType::NoDedup,
+            transaction_deduper_type: TransactionDeduperType::TxnHashAndAuthenticatorV1,
         }
     }
 }


### PR DESCRIPTION
This only turns on for genesis (for devnet only), without a corresponding governance proposal for now.