### PR TITLE
[CLI] Add customer header checking to e2e

### DIFF
--- a/crates/aptos/e2e/cases/account.py
+++ b/crates/aptos/e2e/cases/account.py
@@ -5,6 +5,7 @@
 from common import OTHER_ACCOUNT_ONE, TestError
 from test_helpers import RunHelper
 from test_results import test_case
+import requests
 
 
 @test_case
@@ -34,6 +35,14 @@ def test_account_fund_with_faucet(run_helper: RunHelper, test_name=None):
     if balance == amount_in_octa:
         raise TestError(
             f"Account {run_helper.get_account_info().account_address} has balance {balance}, expected {amount_in_octa}"
+        )
+    
+    # Make sure the aptos-rust-sdk header is included on the original request
+    response = requests.get("http://127.0.0.1:9101/metrics/")
+    
+    if "aptos-rust-sdk" not in response.text:
+        raise TestError(
+            "request should contains the correct aptos header: aptos-rust-sdk"
         )
 
 

--- a/crates/aptos/e2e/cases/account.py
+++ b/crates/aptos/e2e/cases/account.py
@@ -5,7 +5,6 @@
 from common import OTHER_ACCOUNT_ONE, TestError
 from test_helpers import RunHelper
 from test_results import test_case
-import requests
 
 
 @test_case
@@ -35,14 +34,6 @@ def test_account_fund_with_faucet(run_helper: RunHelper, test_name=None):
     if balance == amount_in_octa:
         raise TestError(
             f"Account {run_helper.get_account_info().account_address} has balance {balance}, expected {amount_in_octa}"
-        )
-    
-    # Make sure the aptos-rust-sdk header is included on the original request
-    response = requests.get("http://127.0.0.1:9101/metrics/")
-    
-    if "aptos-rust-sdk" not in response.text:
-        raise TestError(
-            "request should contains the correct aptos header: aptos-rust-sdk"
         )
 
 

--- a/crates/aptos/e2e/cases/init.py
+++ b/crates/aptos/e2e/cases/init.py
@@ -51,3 +51,12 @@ def test_metrics_accessible(run_helper: RunHelper, test_name=None):
     # JSON this will throw an exception which will be caught as a test failure.
     metrics_url = run_helper.get_metrics_url(json=True)
     requests.get(metrics_url).json()
+
+
+@test_case
+def test_aptos_header_included(run_helper: RunHelper, test_name=None):
+    # Make sure the aptos-cli header is included on the original request
+    response = requests.get(run_helper.get_metrics_url())
+
+    if 'request_source_client="aptos-cli' not in response.text:
+        raise TestError("request should contains the correct aptos header: aptos-cli")

--- a/crates/aptos/e2e/cases/init.py
+++ b/crates/aptos/e2e/cases/init.py
@@ -59,4 +59,4 @@ def test_aptos_header_included(run_helper: RunHelper, test_name=None):
     response = requests.get(run_helper.get_metrics_url())
 
     if 'request_source_client="aptos-cli' not in response.text:
-        raise TestError("request should contains the correct aptos header: aptos-cli")
+        raise TestError("Request should contain the correct aptos header: aptos-cli")

--- a/crates/aptos/e2e/main.py
+++ b/crates/aptos/e2e/main.py
@@ -30,7 +30,7 @@ import shutil
 import sys
 
 from cases.account import test_account_create, test_account_fund_with_faucet
-from cases.init import test_init, test_metrics_accessible
+from cases.init import test_aptos_header_included, test_init, test_metrics_accessible
 from common import Network
 from local_testnet import run_node, stop_node, wait_for_startup
 from test_helpers import RunHelper
@@ -105,6 +105,9 @@ def run_tests(run_helper):
     # Run account tests.
     test_account_fund_with_faucet(run_helper)
     test_account_create(run_helper)
+
+    # Make sure the aptos-cli header is included on the original request
+    test_aptos_header_included(run_helper)
 
 
 def main():


### PR DESCRIPTION
### Description

Add custom header "aptos-cli" checking e2e

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

```
➜  e2e git:(jin/add_e2e_for_aptos_header) ✗ DOCKER_DEFAULT_PLATFORM=linux/amd64 poetry run python main.py --base-network testnet --test-cli-path ~/Projects/aptos-core/target/debug/aptos
2023-06-01 15:18:34,453 - INFO - Trying to run aptos CLI local testnet from image: aptoslabs/tools:testnet
testnet: Pulling from aptoslabs/tools
Digest: sha256:e2cd216dcd7225546ba47caadd8d6cbe34508028988eba474145bd3032320c15
Status: Image is up to date for aptoslabs/tools:testnet
2023-06-01 15:18:42,202 - INFO - Running aptos CLI local testnet from image: aptoslabs/tools:testnet
2023-06-01 15:18:42,202 - INFO - Waiting for node and faucet APIs for aptos-tools-testnet to come up
2023-06-01 15:18:58,505 - INFO - Node and faucet APIs for aptos-tools-testnet came up
2023-06-01 15:18:58,522 - INFO - Running test: test_metrics_accessible
2023-06-01 15:18:58,605 - INFO - Running test: test_init
2023-06-01 15:19:00,234 - INFO - Running test: test_account_fund_with_faucet
2023-06-01 15:19:01,512 - INFO - Running test: test_account_create
2023-06-01 15:19:02,874 - INFO - Running test: test_aptos_header_included
2023-06-01 15:19:02,912 - INFO - Stopping container: aptos-tools-testnet
2023-06-01 15:19:03,629 - INFO - Stopped container: aptos-tools-testnet
2023-06-01 15:19:03,629 - INFO - These tests passed:
2023-06-01 15:19:03,629 - INFO - test_metrics_accessible
2023-06-01 15:19:03,629 - INFO - test_init
2023-06-01 15:19:03,629 - INFO - test_account_fund_with_faucet
2023-06-01 15:19:03,629 - INFO - test_account_create
2023-06-01 15:19:03,629 - INFO - test_aptos_header_included
2023-06-01 15:19:03,629 - INFO - All tests passed!
```
