### PR TITLE
[Faucet] Make outstanding txn wait duration configurable, update defaults

### DIFF
--- a/crates/aptos-faucet/cli/src/main.rs
+++ b/crates/aptos-faucet/cli/src/main.rs
@@ -74,8 +74,8 @@ impl FaucetCliArgs {
             Duration::from_secs(30),
             None,
             self.max_gas_amount,
-            10,
             15,
+            20,
             true,
         );
 

--- a/crates/aptos-faucet/cli/src/main.rs
+++ b/crates/aptos-faucet/cli/src/main.rs
@@ -74,7 +74,8 @@ impl FaucetCliArgs {
             Duration::from_secs(30),
             None,
             self.max_gas_amount,
-            30,
+            10,
+            15,
             true,
         );
 

--- a/crates/aptos-faucet/core/src/funder/common.rs
+++ b/crates/aptos-faucet/core/src/funder/common.rs
@@ -140,6 +140,10 @@ pub struct TransactionSubmissionConfig {
     #[serde(default = "TransactionSubmissionConfig::default_transaction_expiration_secs")]
     pub transaction_expiration_secs: u64,
 
+    /// Amount of time we'll wait for the seqnum to catch up before resetting it.
+    #[serde(default = "TransactionSubmissionConfig::default_wait_for_outstanding_txns_secs")]
+    pub wait_for_outstanding_txns_secs: u64,
+
     /// Whether to wait for the transaction before returning.
     #[serde(default)]
     pub wait_for_transactions: bool,
@@ -152,6 +156,7 @@ impl TransactionSubmissionConfig {
         gas_unit_price_override: Option<u64>,
         max_gas_amount: u64,
         transaction_expiration_secs: u64,
+        wait_for_outstanding_txns_secs: u64,
         wait_for_transactions: bool,
     ) -> Self {
         Self {
@@ -160,6 +165,7 @@ impl TransactionSubmissionConfig {
             gas_unit_price_override,
             max_gas_amount,
             transaction_expiration_secs,
+            wait_for_outstanding_txns_secs,
             wait_for_transactions,
         }
     }
@@ -173,7 +179,11 @@ impl TransactionSubmissionConfig {
     }
 
     fn default_transaction_expiration_secs() -> u64 {
-        30
+        10
+    }
+
+    fn default_wait_for_outstanding_txns_secs() -> u64 {
+        15
     }
 
     pub fn get_gas_unit_price_ttl_secs(&self) -> Duration {
@@ -198,6 +208,7 @@ pub async fn update_sequence_numbers(
     outstanding_requests: &RwLock<Vec<(AccountAddress, u64)>>,
     receiver_address: AccountAddress,
     amount: u64,
+    wait_for_outstanding_txns_secs: u64,
 ) -> Result<(u64, Option<u64>), AptosTapError> {
     let (mut funder_seq, mut receiver_seq) =
         get_sequence_numbers(client, funder_account, receiver_address).await?;
@@ -216,7 +227,7 @@ pub async fn update_sequence_numbers(
 
     let mut set_outstanding = false;
     // We shouldn't have too many outstanding txns
-    for _ in 0..60 {
+    for _ in 0..(wait_for_outstanding_txns_secs * 2) {
         if our_funder_seq < funder_seq + MAX_NUM_OUTSTANDING_TRANSACTIONS {
             // Enforce a stronger ordering of priorities based upon the MintParams that arrived
             // first. Then put the other folks to sleep to try again until the queue fills up.
@@ -353,7 +364,7 @@ pub async fn submit_transaction(
         Ok(_) => {
             info!(
                 hash = signed_transaction.clone().committed_hash().to_hex_literal(),
-                receiver_address = receiver_address,
+                address = receiver_address,
                 event = event_on_success,
             );
             Ok(signed_transaction)

--- a/crates/aptos-faucet/core/src/funder/common.rs
+++ b/crates/aptos-faucet/core/src/funder/common.rs
@@ -179,11 +179,11 @@ impl TransactionSubmissionConfig {
     }
 
     fn default_transaction_expiration_secs() -> u64 {
-        10
+        15
     }
 
     fn default_wait_for_outstanding_txns_secs() -> u64 {
-        15
+        20
     }
 
     pub fn get_gas_unit_price_ttl_secs(&self) -> Duration {

--- a/crates/aptos-faucet/core/src/funder/mint.rs
+++ b/crates/aptos-faucet/core/src/funder/mint.rs
@@ -76,6 +76,8 @@ impl MintFunderConfig {
             self.transaction_submission_config.max_gas_amount,
             self.transaction_submission_config
                 .transaction_expiration_secs,
+            self.transaction_submission_config
+                .wait_for_outstanding_txns_secs,
             self.transaction_submission_config.wait_for_transactions,
         );
 
@@ -112,6 +114,9 @@ pub struct MintFunder {
     /// requests in the order they came in.
     outstanding_requests: RwLock<Vec<(AccountAddress, u64)>>,
 
+    /// Amount of time we'll wait for the seqnum to catch up before resetting it.
+    wait_for_outstanding_txns_secs: u64,
+
     /// If set, we won't return responses until the transaction is processed.
     wait_for_transactions: bool,
 }
@@ -126,6 +131,7 @@ impl MintFunder {
         gas_unit_price_override: Option<u64>,
         max_gas_amount: u64,
         transaction_expiration_secs: u64,
+        wait_for_outstanding_txns_secs: u64,
         wait_for_transactions: bool,
     ) -> Self {
         let gas_unit_price_manager =
@@ -140,6 +146,7 @@ impl MintFunder {
             gas_unit_price_manager,
             gas_unit_price_override,
             outstanding_requests: RwLock::new(vec![]),
+            wait_for_outstanding_txns_secs,
             wait_for_transactions,
         }
     }
@@ -253,6 +260,7 @@ impl MintFunder {
             &self.outstanding_requests,
             receiver_address,
             amount,
+            self.wait_for_outstanding_txns_secs,
         )
         .await?;
 

--- a/crates/aptos-faucet/core/src/funder/transfer.rs
+++ b/crates/aptos-faucet/core/src/funder/transfer.rs
@@ -71,6 +71,8 @@ impl TransferFunderConfig {
             self.transaction_submission_config.max_gas_amount,
             self.transaction_submission_config
                 .transaction_expiration_secs,
+            self.transaction_submission_config
+                .wait_for_outstanding_txns_secs,
             self.transaction_submission_config.wait_for_transactions,
         );
 
@@ -103,6 +105,9 @@ pub struct TransferFunder {
     /// requests in the order they came in.
     outstanding_requests: RwLock<Vec<(AccountAddress, u64)>>,
 
+    /// Amount of time we'll wait for the seqnum to catch up before resetting it.
+    wait_for_outstanding_txns_secs: u64,
+
     /// If set, we won't return responses until the transaction is processed.
     wait_for_transactions: bool,
 }
@@ -118,6 +123,7 @@ impl TransferFunder {
         gas_unit_price_override: Option<u64>,
         max_gas_amount: u64,
         transaction_expiration_secs: u64,
+        wait_for_outstanding_txns_secs: u64,
         wait_for_transactions: bool,
     ) -> Self {
         let gas_unit_price_manager =
@@ -134,6 +140,7 @@ impl TransferFunder {
             gas_unit_price_manager,
             gas_unit_price_override,
             outstanding_requests: RwLock::new(vec![]),
+            wait_for_outstanding_txns_secs,
             wait_for_transactions,
         }
     }
@@ -246,6 +253,7 @@ impl FunderTrait for TransferFunder {
             &self.outstanding_requests,
             receiver_address,
             amount,
+            self.wait_for_outstanding_txns_secs,
         )
         .await?;
 

--- a/crates/aptos-faucet/core/src/server/run.rs
+++ b/crates/aptos-faucet/core/src/server/run.rs
@@ -270,7 +270,8 @@ impl RunConfig {
                     30,      // gas_unit_price_ttl_secs
                     None,    // gas_unit_price_override
                     500_000, // max_gas_amount
-                    30,      // transaction_expiration_secs
+                    10,      // transaction_expiration_secs
+                    15,      // wait_for_outstanding_txns_secs
                     false,   // wait_for_transactions
                 ),
                 mint_account_address: Some(aptos_test_root_address()),

--- a/crates/aptos-faucet/core/src/server/run.rs
+++ b/crates/aptos-faucet/core/src/server/run.rs
@@ -270,8 +270,8 @@ impl RunConfig {
                     30,      // gas_unit_price_ttl_secs
                     None,    // gas_unit_price_override
                     500_000, // max_gas_amount
-                    10,      // transaction_expiration_secs
-                    15,      // wait_for_outstanding_txns_secs
+                    15,      // transaction_expiration_secs
+                    20,      // wait_for_outstanding_txns_secs
                     false,   // wait_for_transactions
                 ),
                 mint_account_address: Some(aptos_test_root_address()),

--- a/crates/aptos-faucet/integration-tests/README.md
+++ b/crates/aptos-faucet/integration-tests/README.md
@@ -27,11 +27,24 @@ poetry run python main.py -h
 
 For example:
 ```
-poetry run python main.py --base-network mainnet
+poetry run python main.py --base-network testnet
 ```
+
+## Debugging
+If you are get an error message similar to this:
+```
+docker: no matching manifest for linux/arm64/v8 in the manifest list entries.
+```
+
+Try running the poetry command with this env var:
+```
+DOCKER_DEFAULT_PLATFORM=linux/amd64 poetry run python main.py --base-network testnet
+```
+This makes the docker commands use the x86_64 images since we don't publish images for ARM.
 
 ## Formatting:
 ```
 poetry run isort .
 poetry run black .
 ```
+

--- a/crates/aptos-faucet/integration-tests/local_testnet.py
+++ b/crates/aptos-faucet/integration-tests/local_testnet.py
@@ -16,7 +16,7 @@ LOG = logging.getLogger(__name__)
 # stop running it later using the container name. For an explanation of these
 # arguments, see the argument parser in main.py.
 def run_node(network: Network, image_repo_with_project: str, external_test_dir: str):
-    image_name = build_image_name(image_repo_with_project, network)
+    image_name = build_image_name(image_repo_with_project, str(network))
     container_name = f"local-testnet-{network}"
     internal_mount_path = "/mymount"
     LOG.info(f"Trying to run local testnet from image: {image_name}")
@@ -45,6 +45,8 @@ def run_node(network: Network, image_repo_with_project: str, external_test_dir: 
         [
             "docker",
             "run",
+            "--pull",
+            "always",
             "--name",
             container_name,
             "--detach",


### PR DESCRIPTION
### Description
> We should change the LB timeout back to 30 seconds and decrease the sleep duration from 30 seconds to 15 seconds. This way the seqnums will reset prior to the LB giving up and it’ll happen sooner than it does now.

> We should also decrease the expiration secs on the txn from 30 seconds to 10 seconds, the E2E latency on the txns should never be above 10 seconds. This is the value we generally use everywhere else (e.g. in the Rust and TS SDKs).

More information here: https://aptos-org.slack.com/archives/C05ATSJJCSV/p1685609837398169?thread_ts=1685606365.531029&cid=C05ATSJJCSV.

### Test Plan
E2E tests in CI.