### PR TITLE
[CLI][E2E] Expose metrics port of local testnet node

### DIFF
--- a/crates/aptos/e2e/README.md
+++ b/crates/aptos/e2e/README.md
@@ -10,6 +10,7 @@ curl -sSL https://install.python-poetry.org | python3 -
 
 Once you have Poetry, you can install the dependencies for the testing framework like this:
 ```
+poetry config virtualenvs.in-project true  # This helps with IDE integration
 poetry install
 ```
 

--- a/crates/aptos/e2e/cases/init.py
+++ b/crates/aptos/e2e/cases/init.py
@@ -3,6 +3,7 @@
 
 import os
 
+import requests
 from common import TestError
 from test_helpers import RunHelper
 from test_results import test_case
@@ -41,3 +42,12 @@ def test_init(run_helper: RunHelper, test_name=None):
         raise TestError(
             f"Failed to query local testnet for account {account_info.account_address}"
         ) from e
+
+
+@test_case
+def test_metrics_accessible(run_helper: RunHelper, test_name=None):
+    # Assert that the metrics endpoint is accessible and returns valid json if
+    # requested. If the endpoint is not accessible or does not return valid
+    # JSON this will throw an exception which will be caught as a test failure.
+    metrics_url = run_helper.get_metrics_url(json=True)
+    requests.get(metrics_url).json()

--- a/crates/aptos/e2e/common.py
+++ b/crates/aptos/e2e/common.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from enum import Enum
 
 NODE_PORT = 8080
+METRICS_PORT = 9101
 FAUCET_PORT = 8081
 
 

--- a/crates/aptos/e2e/local_testnet.py
+++ b/crates/aptos/e2e/local_testnet.py
@@ -8,7 +8,7 @@ import subprocess
 import time
 
 import requests
-from common import FAUCET_PORT, NODE_PORT, Network, build_image_name
+from common import FAUCET_PORT, METRICS_PORT, NODE_PORT, Network, build_image_name
 
 LOG = logging.getLogger(__name__)
 
@@ -50,6 +50,8 @@ def run_node(network: Network, image_repo_with_project: str):
             container_name,
             "-p",
             f"{NODE_PORT}:{NODE_PORT}",
+            "-p",
+            f"{METRICS_PORT}:{METRICS_PORT}",
             "-p",
             f"{FAUCET_PORT}:{FAUCET_PORT}",
             image_name,

--- a/crates/aptos/e2e/main.py
+++ b/crates/aptos/e2e/main.py
@@ -30,7 +30,7 @@ import shutil
 import sys
 
 from cases.account import test_account_create, test_account_fund_with_faucet
-from cases.init import test_init
+from cases.init import test_init, test_metrics_accessible
 from common import Network
 from local_testnet import run_node, stop_node, wait_for_startup
 from test_helpers import RunHelper
@@ -96,6 +96,9 @@ def parse_args():
 
 
 def run_tests(run_helper):
+    # Make sure the metrics port is accessible.
+    test_metrics_accessible(run_helper)
+
     # Run init tests. We run these first to set up the CLI.
     test_init(run_helper)
 

--- a/crates/aptos/e2e/pyproject.toml
+++ b/crates/aptos/e2e/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Aptos Labs <opensource@aptoslabs.com>"]
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.7 <4"
+python = ">=3.7 <3.10"
 aptos-sdk = "^0.5.1"
 requests = "^2.28.2"
 

--- a/crates/aptos/e2e/test_helpers.py
+++ b/crates/aptos/e2e/test_helpers.py
@@ -9,7 +9,7 @@ import traceback
 from dataclasses import dataclass
 
 from aptos_sdk.client import RestClient
-from common import AccountInfo, build_image_name
+from common import METRICS_PORT, NODE_PORT, AccountInfo, build_image_name
 
 LOG = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ class RunHelper:
     cli_path: str
     test_count: int
 
-    # This can be used by the tests to query the local testnet.
+    # This can be used by the tests to query the local testnet node.
     api_client: RestClient
 
     def __init__(
@@ -40,7 +40,7 @@ class RunHelper:
         self.image_tag = image_tag
         self.cli_path = os.path.abspath(cli_path) if cli_path else cli_path
         self.test_count = 0
-        self.api_client = RestClient(f"http://127.0.0.1:8080/v1")
+        self.api_client = RestClient(f"http://127.0.0.1:{NODE_PORT}/v1")
 
     def build_image_name(self):
         return build_image_name(self.image_repo_with_project, self.image_tag)
@@ -160,6 +160,10 @@ class RunHelper:
             public_key=public_key,
             account_address=account_address,
         )
+
+    def get_metrics_url(self, json=False):
+        path = "metrics" if not json else "json_metrics"
+        return f"http://127.0.0.1:{METRICS_PORT}/{path}"
 
 
 # This function helps with writing the stdout / stderr of a subprocess to files.

--- a/crates/aptos/e2e/test_results.py
+++ b/crates/aptos/e2e/test_results.py
@@ -17,7 +17,8 @@ class TestResults:
 
 
 # This is a decorator that you put above every test case. It handles capturing test
-# success / failure so it can be reported at the end of the test suite.
+# success / failure so it can be reported at the end of the test suite. It also handles
+# passing in test_name based on the name of the function so the caller doesn't have to.
 def build_test_case_decorator(test_results: TestResults):
     def test_case_inner(f):
         @wraps(f)


### PR DESCRIPTION
### Description
Currently the metrics of the node are inaccessible because the metrics port on the container is not published. This PR fixes that and tests for it.

### Test Plan
```
poetry run python main.py --base-network mainnet --test-cli-tag mainnet
```

See CI also.