### PR TITLE
[Faucet] Adjust faucet txn expiration / seqnum related values

### DIFF
--- a/crates/aptos-faucet/cli/src/main.rs
+++ b/crates/aptos-faucet/cli/src/main.rs
@@ -74,8 +74,8 @@ impl FaucetCliArgs {
             Duration::from_secs(30),
             None,
             self.max_gas_amount,
-            15,
-            20,
+            25, // transaction_expiration_secs
+            30, // wait_for_outstanding_txns_secs
             true,
         );
 

--- a/crates/aptos-faucet/core/src/funder/common.rs
+++ b/crates/aptos-faucet/core/src/funder/common.rs
@@ -179,11 +179,11 @@ impl TransactionSubmissionConfig {
     }
 
     fn default_transaction_expiration_secs() -> u64 {
-        15
+        25
     }
 
     fn default_wait_for_outstanding_txns_secs() -> u64 {
-        20
+        30
     }
 
     pub fn get_gas_unit_price_ttl_secs(&self) -> Duration {

--- a/crates/aptos-faucet/core/src/server/run.rs
+++ b/crates/aptos-faucet/core/src/server/run.rs
@@ -270,8 +270,8 @@ impl RunConfig {
                     30,      // gas_unit_price_ttl_secs
                     None,    // gas_unit_price_override
                     500_000, // max_gas_amount
-                    15,      // transaction_expiration_secs
-                    20,      // wait_for_outstanding_txns_secs
+                    30,      // transaction_expiration_secs
+                    35,      // wait_for_outstanding_txns_secs
                     false,   // wait_for_transactions
                 ),
                 mint_account_address: Some(aptos_test_root_address()),


### PR DESCRIPTION
### Description
Based on https://github.com/aptos-labs/aptos-core/actions/runs/5149399311/jobs/9272587458?pr=7533 it seems like, especially for use in CI, I lowered the txn expiration too low. This PR adjusts them. For the standard case I don't change the values completely back to what they were but when the faucet is used from the CLI (for a local testnet) they're back to what they were.

### Test Plan
Let's see how it goes in CI.
