### PR TITLE
[indexer-grpc] remove server_name from all configs

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/lib.rs
@@ -13,7 +13,6 @@ use worker::Worker;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IndexerGrpcCacheWorkerConfig {
-    pub server_name: String,
     pub fullnode_grpc_address: String,
     pub file_store_config: IndexerGrpcFileStoreConfig,
     pub redis_main_instance_address: String,
@@ -33,6 +32,6 @@ impl RunnableConfig for IndexerGrpcCacheWorkerConfig {
     }
 
     fn get_server_name(&self) -> String {
-        self.server_name.clone()
+        "idxcache".to_string()
     }
 }

--- a/ecosystem/indexer-grpc/indexer-grpc-file-store/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-file-store/src/lib.rs
@@ -13,7 +13,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct IndexerGrpcFileStoreWorkerConfig {
-    pub server_name: String,
     pub file_store_config: IndexerGrpcFileStoreConfig,
     pub redis_main_instance_address: String,
 }
@@ -30,6 +29,6 @@ impl RunnableConfig for IndexerGrpcFileStoreWorkerConfig {
     }
 
     fn get_server_name(&self) -> String {
-        self.server_name.clone()
+        "idxfile".to_string()
     }
 }

--- a/ecosystem/indexer-grpc/indexer-grpc-integration-tests/src/tests/fullnode_tests.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-integration-tests/src/tests/fullnode_tests.rs
@@ -222,7 +222,6 @@ async fn test_cold_start_cache_worker_progress() {
 
     let tmp_dir = TempDir::new().expect("Could not create temp dir"); // start with a new file store each time
     let cache_worker_config = IndexerGrpcCacheWorkerConfig {
-        server_name: "tcw-1".to_string(),
         fullnode_grpc_address: TESTNET_FULLNODE_GRPC_URL.to_string(),
         file_store_config: IndexerGrpcFileStoreConfig::LocalFileStore(LocalFileStore {
             local_file_store_path: tmp_dir.path().to_path_buf(),
@@ -289,7 +288,6 @@ async fn test_cold_start_file_store_worker_progress() {
     let tmp_dir = TempDir::new().expect("Could not create temp dir"); // start with a new file store each time
 
     let cache_worker_config = IndexerGrpcCacheWorkerConfig {
-        server_name: "tcw-1".to_string(),
         fullnode_grpc_address: TESTNET_FULLNODE_GRPC_URL.to_string(),
         file_store_config: IndexerGrpcFileStoreConfig::LocalFileStore(LocalFileStore {
             local_file_store_path: tmp_dir.path().to_path_buf(),
@@ -298,7 +296,6 @@ async fn test_cold_start_file_store_worker_progress() {
     };
 
     let file_store_worker_config = IndexerGrpcFileStoreWorkerConfig {
-        server_name: "tfs-1".to_string(),
         redis_main_instance_address: REDIS_PRIMARY_URL.to_string(),
         file_store_config: IndexerGrpcFileStoreConfig::LocalFileStore(LocalFileStore {
             local_file_store_path: tmp_dir.path().to_path_buf(),


### PR DESCRIPTION
### Description

This was accidentally re-introduced after https://github.com/aptos-labs/aptos-core/pull/8250 landed

### Test Plan

CI, after which point we should make the `Build+Test Docker Images / indexer-grpc-e2e-tests (pull_request_target)` test land-blocking


<!-- Please provide us with clear details for verifying that your changes work. -->
