### PR TITLE
[TS SDK] make indexerUrl as an optional param

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 
 - Add `x-aptos-client` header to `IndexerClient` requests
 - Add `standardizeAddress` static function to `AccountAddress` class to standardizes an address to the format "0x" followed by 64 lowercase hexadecimal digits.
+- Change `indexerUrl` param on `Provider` class to an optional parameter
 
 ## 1.9.1 (2023-05-24)
 

--- a/ecosystem/typescript/sdk/src/utils/api-endpoints.ts
+++ b/ecosystem/typescript/sdk/src/utils/api-endpoints.ts
@@ -18,5 +18,5 @@ export enum Network {
 
 export interface CustomEndpoints {
   fullnodeUrl: string;
-  indexerUrl: string;
+  indexerUrl?: string;
 }


### PR DESCRIPTION
### Description
local development for indexer is not widely used and it is a bit annoying to need to set it whenever we want to use local node
### Test Plan
tests are passing