### PR TITLE
[release] Add workflow to build release binaries

### DIFF
--- a/.github/workflows/build-node-binaries.yaml
+++ b/.github/workflows/build-node-binaries.yaml
@@ -1,0 +1,45 @@
+# This defines a workflow to make a release build of the aptos node.
+# In order to trigger it go to the Actions Tab of the Repo, click "Build Aptos Node Binaries" and then "Run Workflow".
+
+name: "Build Aptos Node Binaries"
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        type: string
+        required: true
+        description: "The ref to build from i.e. aptos-node-vX.X.X"
+
+jobs:
+  build-node-binary:
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
+    name: "Build Aptos Node Binary on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          # ref: ${{ github.event.inputs.git_ref }}
+          ref: aptos-node-v1.4.3
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+      - name: Build Aptos Node Binary ${{ matrix.os }}
+        run: |
+          set -eux
+
+          OS="${{ matrix.os }}"
+          SANITIZED_OS="${OS//./-}"
+          TARNAME="aptos-node-$SANITIZED_OS.tgz"
+
+          cargo build -p aptos-node --release
+          cd target/release
+          tar czvf "$TARNAME" aptos-node
+          mv "$TARNAME" ../../
+
+      - name: Upload Binary
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        with:
+          name: aptos-node-${{ matrix.os }}
+          path: aptos-node-*.tgz


### PR DESCRIPTION
This makes our builds available mirroring what we do for hotfix release

Test Plan:

Added a clause to run on PR, remove that before landing

https://github.com/aptos-labs/aptos-core/actions/runs/5159644124