### PR TITLE
[CLI] Bump version to 2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.0.1] - 2023/06/05
+### Fixed
+- Updated txn expiration configuration for the faucet built into the CLI to make local testnet startup more reliable.
+
 ## [2.0.0] - 2023/06/01
 ### Added
 - Multisig v2 governance support

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "2.0.0"
+version = "2.0.1"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
### Description
Releasing a CLI with changes to the faucet txn expiration times.

### Test Plan
Just bumped release number.
