### PR TITLE
[tf/gcp][fullnode] make NAP use PFN service account

### DIFF
--- a/terraform/fullnode/gcp/cluster.tf
+++ b/terraform/fullnode/gcp/cluster.tf
@@ -74,6 +74,10 @@ resource "google_container_cluster" "aptos" {
         maximum       = resource_limits.value
       }
     }
+    auto_provisioning_defaults {
+      oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+      service_account = google_service_account.gke.email
+    }
   }
 }
 

--- a/terraform/helm/fullnode/templates/backup-verify.yaml
+++ b/terraform/helm/fullnode/templates/backup-verify.yaml
@@ -78,15 +78,15 @@ spec:
             fsGroup: 6180
           {{- with .nodeSelector }}
           nodeSelector:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .affinity }}
           affinity:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .tolerations }}
           tolerations:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
           volumes:


### PR DESCRIPTION
### Description

When Node Auto-provisioning (NAP) is installed on the GKE cluster, use the serviceaccount created in the module, rather than leaving it unspecified, which defaults to the default GCE service account.

Also, fix an indentation issue with the fullnode backup/backup_verify/restore workloads, when specifying an affinity, such as for NAP (specifying a machine family)

### Test Plan

Apply

<!-- Please provide us with clear details for verifying that your changes work. -->
