### PR TITLE
interactive blockstm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-block-partitioner"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-crypto",
+ "aptos-logger",
+ "aptos-metrics-core",
+ "aptos-types",
+ "bcs 0.1.4",
+ "clap 3.2.23",
+ "dashmap",
+ "itertools",
+ "move-core-types",
+ "rand 0.7.3",
+ "rayon",
+]
+
+[[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
 dependencies = [
@@ -3286,6 +3304,7 @@ dependencies = [
  "anyhow",
  "aptos-aggregator",
  "aptos-block-executor",
+ "aptos-block-partitioner",
  "aptos-crypto",
  "aptos-crypto-derive",
  "aptos-framework",
@@ -3316,6 +3335,7 @@ dependencies = [
  "once_cell",
  "ouroboros 0.15.6",
  "proptest",
+ "rand 0.7.3",
  "rayon",
  "serde 1.0.149",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,6 +3320,7 @@ dependencies = [
  "aptos-utils",
  "aptos-vm-logging",
  "bcs 0.1.4",
+ "crossbeam",
  "dashmap",
  "fail 0.5.0",
  "move-binary-format",
@@ -3337,6 +3338,7 @@ dependencies = [
  "proptest",
  "rand 0.7.3",
  "rayon",
+ "select",
  "serde 1.0.149",
  "serde_json",
  "smallvec",
@@ -4479,7 +4481,7 @@ checksum = "29c39203181991a7dd4343b8005bd804e7a9a37afb8ac070e43771e8c820bbde"
 dependencies = [
  "chrono",
  "chrono-tz-build",
- "phf",
+ "phf 0.11.1",
 ]
 
 [[package]]
@@ -4489,8 +4491,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f509c3a87b33437b05e2458750a0700e5bdd6956176773e6c7d6dd15a283a0c"
 dependencies = [
  "parse-zoneinfo",
- "phf",
- "phf_codegen",
+ "phf 0.11.1",
+ "phf_codegen 0.11.1",
 ]
 
 [[package]]
@@ -6009,6 +6011,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6566,6 +6578,20 @@ name = "hound"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d13cdbd5dbb29f9c88095bbdc2590c9cba0d0a1269b983fef6b2cdd7e9f4db1"
+
+[[package]]
+name = "html5ever"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "proc-macro2 1.0.59",
+ "quote 1.0.28",
+ "syn 1.0.105",
+]
 
 [[package]]
 name = "http"
@@ -7666,6 +7692,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7679,6 +7711,32 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "markup5ever"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
+dependencies = [
+ "log",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9521dd6750f8e80ee6c53d65e2e4656d7de37064f3a7a5d2d11d05df93839c2"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "tendril",
+ "xml5ever",
+]
 
 [[package]]
 name = "match_cfg"
@@ -9464,6 +9522,15 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
@@ -9473,12 +9540,32 @@ dependencies = [
 
 [[package]]
 name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf_codegen"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a56ac890c5e3ca598bbdeaa99964edb5b0258a583a9eb6ef4e89fc85d9224770"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.1",
  "phf_shared 0.11.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -10859,6 +10946,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "select"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f9da09dc3f4dfdb6374cbffff7a2cffcec316874d4429899eefdc97b3b94dcd"
+dependencies = [
+ "bit-set",
+ "html5ever",
+ "markup5ever_rcdom",
+]
+
+[[package]]
 name = "self_update"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11499,6 +11597,19 @@ dependencies = [
  "parking_lot 0.12.1",
  "phf_shared 0.10.0",
  "precomputed-hash",
+ "serde 1.0.149",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+ "proc-macro2 1.0.59",
+ "quote 1.0.28",
 ]
 
 [[package]]
@@ -11655,6 +11766,17 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -12427,7 +12549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a87d58ddb21cda9e2236e99f1f27e7094334aae4cd580dd8f5ffa137580de61a"
 dependencies = [
  "iana-time-zone",
- "phf",
+ "phf 0.11.1",
  "phf_shared 0.11.1",
  "tz-rs",
  "utcnow",
@@ -13135,6 +13257,17 @@ dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
  "zeroize",
+]
+
+[[package]]
+name = "xml5ever"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4034e1d05af98b51ad7214527730626f019682d797ba38b51689212118d8e650"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ members = [
     "ecosystem/indexer-grpc/indexer-grpc-utils",
     "ecosystem/node-checker",
     "ecosystem/node-checker/fn-check-client",
+    "execution/block-partitioner",
     "execution/db-bootstrapper",
     "execution/executor",
     "execution/executor-benchmark",
@@ -270,6 +271,7 @@ aptos-debugger = { path = "aptos-move/aptos-debugger" }
 aptos-event-notifications = { path = "state-sync/inter-component/event-notifications" }
 aptos-executable-store = { path = "storage/executable-store" }
 aptos-executor = { path = "execution/executor" }
+aptos-block-partitioner = { path = "execution/block-partitioner" }
 aptos-executor-test-helpers = { path = "execution/executor-test-helpers" }
 aptos-executor-types = { path = "execution/executor-types" }
 aptos-faucet-cli = { path = "crates/aptos-faucet/cli" }

--- a/aptos-move/aptos-transaction-benchmarks/src/transactions.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/transactions.rs
@@ -13,7 +13,7 @@ use aptos_language_e2e_tests::{
 use aptos_types::{
     block_metadata::BlockMetadata,
     on_chain_config::{OnChainConfig, ValidatorSet},
-    transaction::Transaction,
+    transaction::{analyzed_transaction::AnalyzedTransaction, Transaction},
 };
 use aptos_vm::{data_cache::AsMoveResolver, sharded_block_executor::ShardedBlockExecutor};
 use criterion::{measurement::Measurement, BatchSize, Bencher};
@@ -247,7 +247,7 @@ where
         }
     }
 
-    pub fn gen_transaction(&mut self, no_conflict_txns: bool) -> Vec<Transaction> {
+    pub fn gen_transaction(&mut self, no_conflict_txns: bool) -> Vec<AnalyzedTransaction> {
         if no_conflict_txns {
             // resetting the picker here so that we can re-use the same accounts from last block
             // but still generate non conflicting transactions for this block.
@@ -258,10 +258,10 @@ where
             .new_tree(&mut runner)
             .expect("creating a new value should succeed")
             .current();
-        let mut transactions: Vec<Transaction> = transaction_gens
+        let mut transactions: Vec<AnalyzedTransaction> = transaction_gens
             .into_iter()
             .map(|txn_gen| {
-                Transaction::UserTransaction(txn_gen.apply(&mut self.account_universe).0)
+                Transaction::UserTransaction(txn_gen.apply(&mut self.account_universe).0).into()
             })
             .collect();
 
@@ -281,7 +281,7 @@ where
             1,
         );
 
-        transactions.insert(0, Transaction::BlockMetadata(new_block));
+        transactions.insert(0, Transaction::BlockMetadata(new_block).into());
         transactions
     }
 
@@ -309,7 +309,7 @@ where
 
     fn execute_benchmark(
         &self,
-        transactions: Vec<Transaction>,
+        transactions: Vec<AnalyzedTransaction>,
         block_executor: Arc<ShardedBlockExecutor<FakeDataStore>>,
         concurrency_level_per_shard: usize,
     ) -> usize {

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 aptos-aggregator = { workspace = true }
 aptos-block-executor = { workspace = true }
+aptos-block-partitioner = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-crypto-derive = { workspace = true }
 aptos-framework =  { workspace = true }
@@ -44,6 +45,7 @@ move-vm-types = { workspace = true }
 num_cpus = { workspace = true }
 once_cell = { workspace = true }
 ouroboros = { workspace = true }
+rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -31,6 +31,7 @@ aptos-types = { workspace = true }
 aptos-utils = { workspace = true }
 aptos-vm-logging = { workspace = true }
 bcs = { workspace = true }
+crossbeam = { workspace = true }
 dashmap = { workspace = true }
 fail = { workspace = true }
 move-binary-format = { workspace = true }
@@ -47,6 +48,7 @@ once_cell = { workspace = true }
 ouroboros = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
+select = "0.6.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 smallvec = { workspace = true }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -36,10 +36,10 @@ use aptos_types::{
     block_metadata::BlockMetadata,
     on_chain_config::{new_epoch_event_key, FeatureFlag, TimedFeatureOverride},
     transaction::{
-        ChangeSet, EntryFunction, ExecutionError, ExecutionStatus, ModuleBundle, Multisig,
-        MultisigTransactionPayload, SignatureCheckedTransaction, SignedTransaction, Transaction,
-        TransactionOutput, TransactionPayload, TransactionStatus, VMValidatorResult,
-        WriteSetPayload,
+        analyzed_transaction::AnalyzedTransaction, ChangeSet, EntryFunction, ExecutionError,
+        ExecutionStatus, ModuleBundle, Multisig, MultisigTransactionPayload,
+        SignatureCheckedTransaction, SignedTransaction, Transaction, TransactionOutput,
+        TransactionPayload, TransactionStatus, VMValidatorResult, WriteSetPayload,
     },
     vm_status::{AbortLocation, StatusCode, VMStatus},
     write_set::WriteSet,
@@ -1513,7 +1513,7 @@ impl VMExecutor for AptosVM {
 
     fn execute_block_sharded<S: StateView + Sync + Send + 'static>(
         sharded_block_executor: &ShardedBlockExecutor<S>,
-        transactions: Vec<Transaction>,
+        transactions: Vec<AnalyzedTransaction>,
         state_view: Arc<S>,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         let log_context = AdapterLogSchema::new(state_view.id(), 0);

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -125,7 +125,10 @@ pub use crate::aptos_vm::AptosVM;
 use crate::sharded_block_executor::ShardedBlockExecutor;
 use aptos_state_view::StateView;
 use aptos_types::{
-    transaction::{SignedTransaction, Transaction, TransactionOutput, VMValidatorResult},
+    transaction::{
+        analyzed_transaction::AnalyzedTransaction, SignedTransaction, Transaction,
+        TransactionOutput, VMValidatorResult,
+    },
     vm_status::VMStatus,
 };
 use std::{marker::Sync, sync::Arc};
@@ -165,7 +168,7 @@ pub trait VMExecutor: Send + Sync {
     /// Executes a block of transactions using a sharded block executor and returns the results.
     fn execute_block_sharded<S: StateView + Sync + Send + 'static>(
         sharded_block_executor: &ShardedBlockExecutor<S>,
-        transactions: Vec<Transaction>,
+        transactions: Vec<AnalyzedTransaction>,
         state_view: Arc<S>,
     ) -> Result<Vec<TransactionOutput>, VMStatus>;
 }

--- a/aptos-move/aptos-vm/src/sharded_block_executor/executor_shard.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/executor_shard.rs
@@ -8,20 +8,22 @@ use aptos_state_view::StateView;
 use aptos_types::transaction::TransactionOutput;
 use aptos_vm_logging::disable_speculative_logging;
 use move_core_types::vm_status::VMStatus;
-use std::sync::{
-    mpsc::{Receiver, Sender},
-    Arc,
-};
+use std::sync::{mpsc::{Receiver, Sender}, Arc, Mutex};
+use std::thread;
+use std::thread::JoinHandle;
 
 /// A remote block executor that receives transactions from a channel and executes them in parallel.
 /// Currently it runs in the local machine and it will be further extended to run in a remote machine.
 pub struct ExecutorShard<S: StateView + Sync + Send + 'static> {
     shard_id: usize,
     executor_thread_pool: Arc<rayon::ThreadPool>,
+    tx: Sender<ExecutorShardCommand<S>>,
     rx: Receiver<ExecutorShardCommand<S>>,
     master_tx: Sender<Result<Vec<TransactionOutput>, VMStatus>>,
     peer_txs: Vec<Sender<ExecutorShardCommand<S>>>,
     maybe_gas_limit: Option<u64>,
+    maybe_state_view: Option<Arc<S>>,
+    maybe_work_thread: Option<JoinHandle<()>>,
 }
 
 impl<S: StateView + Sync + Send + 'static> ExecutorShard<S> {
@@ -29,6 +31,7 @@ impl<S: StateView + Sync + Send + 'static> ExecutorShard<S> {
         num_executor_shards: usize,
         shard_id: usize,
         num_executor_threads: usize,
+        command_tx: Sender<ExecutorShardCommand<S>>,
         command_rx: Receiver<ExecutorShardCommand<S>>,
         master_tx: Sender<Result<Vec<TransactionOutput>, VMStatus>>,
         peer_txs: Vec<Sender<ExecutorShardCommand<S>>>,
@@ -49,14 +52,17 @@ impl<S: StateView + Sync + Send + 'static> ExecutorShard<S> {
         Self {
             shard_id,
             executor_thread_pool,
+            tx: command_tx,
             rx: command_rx,
             master_tx,
             peer_txs,
             maybe_gas_limit,
+            maybe_state_view: None,
+            maybe_work_thread: None,
         }
     }
 
-    pub fn start(&self) {
+    pub fn start(&mut self) {
         loop {
             let command = self.rx.recv().unwrap();
             match command {
@@ -65,20 +71,33 @@ impl<S: StateView + Sync + Send + 'static> ExecutorShard<S> {
                     transactions,
                     concurrency_level_per_shard,
                 ) => {
+                    let shard_id = self.shard_id;
                     trace!(
                         "Shard {} received ExecuteBlock command of block size {} ",
-                        self.shard_id,
+                        shard_id,
                         transactions.len()
                     );
-                    let ret = BlockAptosVM::execute_block(
-                        self.executor_thread_pool.clone(),
-                        transactions,
-                        state_view.as_ref(),
-                        concurrency_level_per_shard,
-                        self.maybe_gas_limit,
-                    );
-                    drop(state_view);
-                    self.master_tx.send(ret).unwrap();
+                    self.maybe_state_view = Some(state_view.clone());
+                    let tx_clone = self.tx.clone();
+                    let pool = self.executor_thread_pool.clone();
+                    let maybe_gas_limit = self.maybe_gas_limit;
+
+                    let join_handle = thread::Builder::new().name(format!("executor-shard-{}-blockstm", shard_id)).spawn(move||{
+                        let ret = BlockAptosVM::execute_block(
+                            pool,
+                            transactions,
+                            state_view.as_ref(),
+                            concurrency_level_per_shard,
+                            maybe_gas_limit,
+                        );
+                        tx_clone.send(ExecutorShardCommand::ExeDone(ret)).unwrap();
+                    }).unwrap();
+                    self.maybe_work_thread = Some(join_handle);
+                },
+                ExecutorShardCommand::ExeDone(txo_or_vmst) => {
+                    drop(self.maybe_state_view.take().unwrap());
+                    self.master_tx.send(txo_or_vmst).unwrap();
+                    self.maybe_work_thread.take().unwrap().join().unwrap();
                 },
                 ExecutorShardCommand::Stop => {
                     break;

--- a/aptos-move/block-executor/src/blockstm.rs
+++ b/aptos-move/block-executor/src/blockstm.rs
@@ -1,0 +1,520 @@
+// Copyright © Aptos Foundation
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::marker::PhantomData;
+use std::sync::{Arc, mpsc, Mutex};
+use std::sync::mpsc::{Receiver, Sender};
+use rayon::ThreadPool;
+use aptos_logger::info;
+use aptos_mvhashmap::MVHashMap;
+use aptos_mvhashmap::types::MVDataError::{Dependency, Unresolved};
+use aptos_mvhashmap::types::MVDataOutput::{Resolved, Versioned};
+use aptos_mvhashmap::types::{TxnIndex, Version};
+use aptos_state_view::TStateView;
+use aptos_types::executable::ExecutableTestType;
+use aptos_types::write_set::WriteOp;
+use aptos_vm_logging::{clear_speculative_txn_logs};
+use crate::{
+    counters,
+    counters::{TASK_EXECUTE_SECONDS, TASK_VALIDATE_SECONDS, VM_INIT_SECONDS, WORK_WITH_TASK_SECONDS}
+};
+use crate::errors::Error;
+use crate::scheduler::{DependencyStatus, Scheduler, SchedulerTask, Wave};
+use crate::task::{ExecutionStatus, ExecutorTask, Transaction, TransactionOutput};
+use crate::txn_last_input_output::TxnLastInputOutput;
+use crate::view::{LatestView, MVHashMapView};
+use aptos_aggregator::delta_change_set::{deserialize, serialize};
+
+#[derive(Debug)]
+enum CommitRole {
+    Coordinator(Vec<Sender<TxnIndex>>),
+    Worker(Receiver<TxnIndex>),
+}
+
+pub struct InteractiveBlockSTM<T: Transaction, E: ExecutorTask, S> {
+    executor_initial_arguments: Arc<E::Argument>,
+    concurrency_level: usize,
+    executor_thread_pool: Arc<ThreadPool>,
+    base_view: Arc<S>,
+    txn_indices: BTreeSet<TxnIndex>,
+    versioned_cache: Arc<MVHashMap<T::Key, T::Value, ExecutableTestType>>,
+    scheduler: Arc<Scheduler>,
+    last_input_output: Arc<TxnLastInputOutput<T::Key, E::Output, E::Error>>,
+    txns: Arc<BTreeMap<TxnIndex, T>>,
+    worker_finished_rxs: Vec<Receiver<()>>,
+    maybe_gas_limit: Option<u64>,
+    phantom: PhantomData<(T, E, S)>,
+}
+
+impl<T, E, S> InteractiveBlockSTM<T, E, S>
+    where
+        T: Transaction,
+        E: ExecutorTask<Txn = T>,
+        S: TStateView<Key = T::Key> + Send + Sync + 'static,
+        <E as ExecutorTask>::Argument: 'static,
+{
+    pub fn new(
+        executor_initial_arguments: Arc<E::Argument>,
+        concurrency_level: usize,
+        executor_thread_pool: Arc<ThreadPool>,
+        base_view: Arc<S>,
+        maybe_gas_limit: Option<u64>
+    ) -> Self {
+        Self {
+            executor_initial_arguments,
+            concurrency_level,
+            executor_thread_pool,
+            base_view,
+            txn_indices: BTreeSet::new(),
+            versioned_cache: Arc::new(MVHashMap::new(None)),
+            scheduler: Arc::new(Scheduler::new()),
+            last_input_output: Arc::new(TxnLastInputOutput::new()),
+            txns: Arc::new(BTreeMap::new()),
+            worker_finished_rxs: vec![],
+            maybe_gas_limit,
+            phantom: Default::default(),
+        }
+    }
+
+    pub fn start(&mut self) {
+        let mut roles: Vec<CommitRole> = vec![];
+        let mut senders: Vec<Sender<u32>> = Vec::with_capacity(self.concurrency_level - 1);
+        for _ in 0..(self.concurrency_level - 1) {
+            let (tx, rx) = mpsc::channel();
+            roles.push(CommitRole::Worker(rx));
+            senders.push(tx);
+        }
+        // Add the coordinator role. Coordinator is responsible for committing
+        // indices and assigning post-commit work per index to other workers.
+        // Note: It is important that the Coordinator is the first thread that
+        // picks up a role will be a coordinator. Hence, if multiple parallel
+        // executors are running concurrently, they will all have active coordinator.
+        roles.push(CommitRole::Coordinator(senders));
+
+        for i in 0..self.concurrency_level {
+            let role = roles.pop().expect("Role must be set for all threads");
+            let (worker_finished_tx, worker_finished_rx) = mpsc::channel();
+            let maybe_gas_limit = self.maybe_gas_limit;
+            self.worker_finished_rxs.push(worker_finished_rx);
+            let last_input_output = self.last_input_output.clone();
+            let executor_initial_arguments = self.executor_initial_arguments.clone();
+            let txns = self.txns.clone();
+            let versioned_cache = self.versioned_cache.clone();
+            let scheduler= self.scheduler.clone();
+            let base_view = self.base_view.clone();
+            self.executor_thread_pool.spawn(move|| {
+                Self::work_task_with_scope(
+                    maybe_gas_limit,
+                    executor_initial_arguments,
+                    txns,
+                    last_input_output,
+                    versioned_cache,
+                    scheduler,
+                    base_view,
+                    role,
+                );
+                worker_finished_tx.send(()).unwrap();
+            });
+        }
+    }
+
+    pub fn new_txn(&mut self, txn: &T) {
+        todo!()
+    }
+
+    pub fn new_external_txn_output(&mut self, execution_status: ExecutionStatus<<E as ExecutorTask>::Output, <E as ExecutorTask>::Error>) {
+        todo!()
+    }
+
+    pub fn end_of_txn_stream(&mut self) {
+        todo!()
+    }
+
+    pub fn wait(&mut self) -> Result<BTreeMap<TxnIndex, E::Output>, E::Error> {
+        for rx in self.worker_finished_rxs.iter() {
+            rx.recv().unwrap();
+        }
+
+        // TODO: for large block sizes and many cores, extract outputs in parallel.
+        let mut final_results = BTreeMap::new();
+
+        let maybe_err = if self.last_input_output.module_publishing_may_race() {
+            unimplemented!()
+        } else {
+            let mut ret = None;
+            for &idx in self.txn_indices.iter() {
+                match self.last_input_output.take_output(idx) {
+                    ExecutionStatus::Success(t) => final_results.insert(idx, t),
+                    ExecutionStatus::SkipRest(t) => {
+                        final_results.insert(idx, t);
+                        break;
+                    },
+                    ExecutionStatus::Abort(err) => {
+                        ret = Some(err);
+                        break;
+                    },
+                };
+            }
+            ret
+        };
+
+        //TODO: explicit async probably has to be back.
+
+        match maybe_err {
+            Some(err) => todo!(),
+            None => {
+                let p = match final_results.last_key_value() {
+                    Some((&k, _)) => k + 1,
+                    None => 0,
+                };
+                for &i in self.txn_indices.range(p..){
+                    final_results.insert(i, E::Output::skip_output());
+                }
+                Ok(final_results)
+            },
+        }
+    }
+
+    fn work_task_with_scope(
+        maybe_gas_limit: Option<u64>,
+        executor_arguments: Arc<E::Argument>,
+        block: Arc<BTreeMap<TxnIndex, T>>,
+        last_input_output: Arc<TxnLastInputOutput<T::Key, E::Output, E::Error>>,
+        versioned_cache: Arc<MVHashMap<T::Key, T::Value, ExecutableTestType>>,
+        scheduler: Arc<Scheduler>,
+        base_view: Arc<S>,
+        role: CommitRole,
+    ) {
+        // Make executor for each task. TODO: fast concurrent executor.
+        let init_timer = VM_INIT_SECONDS.start_timer();
+        let executor = E::init(*executor_arguments);
+        drop(init_timer);
+
+        let committing = matches!(role, CommitRole::Coordinator(_));
+
+        let _timer = WORK_WITH_TASK_SECONDS.start_timer();
+        let mut scheduler_task = SchedulerTask::NoTask;
+        let mut accumulated_gas = 0;
+        let mut worker_idx = 0;
+        loop {
+            // Only one thread does try_commit to avoid contention.
+            match &role {
+                CommitRole::Coordinator(post_commit_txs) => {
+                    Self::coordinator_commit_hook(
+                        maybe_gas_limit,
+                        scheduler.clone(),
+                        post_commit_txs,
+                        &mut worker_idx,
+                        &mut accumulated_gas,
+                        &mut scheduler_task,
+                        last_input_output.clone(),
+                    );
+                },
+                CommitRole::Worker(rx) => {
+                    while let Ok(txn_idx) = rx.try_recv() {
+                        Self::worker_commit_hook(
+                            txn_idx,
+                            versioned_cache.clone(),
+                            last_input_output.clone(),
+                            base_view.clone(),
+                        );
+                    }
+                },
+            }
+
+            scheduler_task = match scheduler_task {
+                SchedulerTask::ValidationTask(version_to_validate, wave) => Self::validate(
+                    version_to_validate,
+                    wave,
+                    last_input_output.clone(),
+                    versioned_cache.clone(),
+                    scheduler.clone(),
+                ),
+                SchedulerTask::ExecutionTask(version_to_execute, None) => Self::execute(
+                    version_to_execute,
+                    block.clone(),
+                    last_input_output.clone(),
+                    versioned_cache.clone(),
+                    scheduler.clone(),
+                    &executor,
+                    base_view.clone(),
+                ),
+                SchedulerTask::ExecutionTask(_, Some(condvar)) => {
+                    let (lock, cvar) = &*condvar;
+                    // Mark dependency resolved.
+                    *lock.lock() = DependencyStatus::Resolved;
+                    // Wake up the process waiting for dependency.
+                    cvar.notify_one();
+
+                    SchedulerTask::NoTask
+                },
+                SchedulerTask::NoTask => scheduler.next_task(committing),
+                SchedulerTask::Done => {
+                    // Make sure to drain any remaining commit tasks assigned by the coordinator.
+                    if let CommitRole::Worker(rx) = &role {
+                        // Until the sender drops the tx, an index for commit_hook might be sent.
+                        while let Ok(txn_idx) = rx.recv() {
+                            Self::worker_commit_hook(
+                                txn_idx,
+                                versioned_cache.clone(),
+                                last_input_output.clone(),
+                                base_view.clone(),
+                            );
+                        }
+                    }
+                    break;
+                },
+            }
+        }
+
+    }
+
+    pub fn validate(
+        version_to_validate: Version,
+        validation_wave: Wave,
+        last_input_output: Arc<TxnLastInputOutput<T::Key, E::Output, E::Error>>,
+        versioned_cache: Arc<MVHashMap<T::Key, T::Value, ExecutableTestType>>,
+        scheduler: Arc<Scheduler>,
+    ) -> SchedulerTask {
+        let _timer = TASK_VALIDATE_SECONDS.start_timer();
+        let (idx_to_validate, incarnation) = version_to_validate;
+        let read_set = last_input_output
+            .read_set(idx_to_validate)
+            .expect("[BlockSTM]: Prior read-set must be recorded");
+
+        let valid = read_set.iter().all(|r| {
+            match versioned_cache.fetch_data(r.path(), idx_to_validate) {
+                Ok(Versioned(version, _)) => r.validate_version(version),
+                Ok(Resolved(value)) => r.validate_resolved(value),
+                // Dependency implies a validation failure, and if the original read were to
+                // observe an unresolved delta, it would set the aggregator base value in the
+                // multi-versioned data-structure, resolve, and record the resolved value.
+                Err(Dependency(_)) | Err(Unresolved(_)) => false,
+                Err(NotFound) => r.validate_storage(),
+                // We successfully validate when read (again) results in a delta application
+                // failure. If the failure is speculative, a later validation will fail due to
+                // a read without this error. However, if the failure is real, passing
+                // validation here allows to avoid infinitely looping and instead panic when
+                // materializing deltas as writes in the final output preparation state. Panic
+                // is also preferable as it allows testing for this scenario.
+                Err(DeltaApplicationFailure) => r.validate_delta_application_failure(),
+            }
+        });
+
+        let aborted = !valid && scheduler.try_abort(idx_to_validate, incarnation);
+
+        if aborted {
+            counters::SPECULATIVE_ABORT_COUNT.inc();
+
+            // Any logs from the aborted execution should be cleared and not reported.
+            clear_speculative_txn_logs(idx_to_validate as usize);
+
+            // Not valid and successfully aborted, mark the latest write/delta sets as estimates.
+            for k in last_input_output.modified_keys(idx_to_validate) {
+                versioned_cache.mark_estimate(&k, idx_to_validate);
+            }
+
+            scheduler.finish_abort(idx_to_validate, incarnation)
+        } else {
+            scheduler.finish_validation(idx_to_validate, validation_wave);
+            SchedulerTask::NoTask
+        }
+    }
+
+    fn execute(
+        version: Version,
+        signature_verified_block: Arc<BTreeMap<TxnIndex, T>>,
+        last_input_output: Arc<TxnLastInputOutput<T::Key, E::Output, E::Error>>,
+        versioned_cache: Arc<MVHashMap<T::Key, T::Value, ExecutableTestType>>,
+        scheduler: Arc<Scheduler>,
+        executor: &E,
+        base_view: Arc<S>,
+    ) -> SchedulerTask {
+        let _timer = TASK_EXECUTE_SECONDS.start_timer();
+        let (idx_to_execute, incarnation) = version;
+        let txn = signature_verified_block.get(&idx_to_execute).unwrap();
+
+        let speculative_view = MVHashMapView::new(versioned_cache.as_ref(), scheduler.as_ref());
+
+        // VM execution.
+        let latest_view = LatestView::<T, S>::new_mv_view(base_view.as_ref(), &speculative_view, idx_to_execute);
+        let execute_result: ExecutionStatus<<E as ExecutorTask>::Output, <E as ExecutorTask>::Error> = executor.execute_transaction(
+            &latest_view,
+            txn,
+            idx_to_execute,
+            false,
+        );
+        let mut prev_modified_keys = last_input_output.modified_keys(idx_to_execute);
+
+        // For tracking whether the recent execution wrote outside of the previous write/delta set.
+        let mut updates_outside = false;
+        let mut apply_updates = |output: &E::Output| {
+            // First, apply writes.
+            let write_version = (idx_to_execute, incarnation);
+            for (k, v) in output.get_writes().into_iter() {
+                if !prev_modified_keys.remove(&k) {
+                    updates_outside = true;
+                }
+                versioned_cache.write(&k, write_version, v);
+            }
+
+            // Then, apply deltas.
+            for (k, d) in output.get_deltas().into_iter() {
+                if !prev_modified_keys.remove(&k) {
+                    updates_outside = true;
+                }
+                versioned_cache.add_delta(&k, idx_to_execute, d);
+            }
+        };
+
+        let result = match execute_result {
+            // These statuses are the results of speculative execution, so even for
+            // SkipRest (skip the rest of transactions) and Abort (abort execution with
+            // user defined error), no immediate action is taken. Instead the statuses
+            // are recorded and (final statuses) are analyzed when the block is executed.
+            ExecutionStatus::Success(output) => {
+                // Apply the writes/deltas to the versioned_data_cache.
+                apply_updates(&output);
+                ExecutionStatus::Success(output)
+            },
+            ExecutionStatus::SkipRest(output) => {
+                // Apply the writes/deltas and record status indicating skip.
+                apply_updates(&output);
+                ExecutionStatus::SkipRest(output)
+            },
+            ExecutionStatus::Abort(err) => {
+                // Record the status indicating abort.
+                ExecutionStatus::Abort(Error::UserError(err))
+            },
+        };
+
+        // Remove entries from previous write/delta set that were not overwritten.
+        for k in prev_modified_keys {
+            versioned_cache.delete(&k, idx_to_execute);
+        }
+
+        if last_input_output
+            .record(idx_to_execute, speculative_view.take_reads(), result)
+            .is_err()
+        {
+            // When there is module publishing r/w intersection, can early halt BlockSTM to
+            // fallback to sequential execution.
+            scheduler.halt();
+            return SchedulerTask::NoTask;
+        }
+        scheduler.finish_execution(idx_to_execute, incarnation, updates_outside)
+    }
+
+    fn coordinator_commit_hook(
+        maybe_gas_limit: Option<u64>,
+        scheduler: Arc<Scheduler>,
+        post_commit_txs: &Vec<Sender<u32>>,
+        worker_idx: &mut usize,
+        accumulated_gas: &mut u64,
+        scheduler_task: &mut SchedulerTask,
+        last_input_output: Arc<TxnLastInputOutput<T::Key, E::Output, E::Error>>,
+    ) {
+        while let Some(txn_idx) = scheduler.try_commit() {
+            post_commit_txs[*worker_idx]
+                .send(txn_idx)
+                .expect("Worker must be available");
+            // Iterate round robin over workers to do commit_hook.
+            *worker_idx = (*worker_idx + 1) % post_commit_txs.len();
+
+            // Committed the last transaction, BlockSTM finishes execution.
+            if scheduler.txn_index_right_after(txn_idx).is_none() && scheduler.no_more_txns {
+                *scheduler_task = SchedulerTask::Done;
+
+                counters::PARALLEL_PER_BLOCK_GAS.observe(*accumulated_gas as f64);
+                counters::PARALLEL_PER_BLOCK_COMMITTED_TXNS.observe((txn_idx + 1) as f64);
+                info!(
+                    "[BlockSTM]: Parallel execution completed, all {} txns committed.",
+                    scheduler.get_txn_local_position(txn_idx) + 1
+                );
+                break;
+            }
+
+            // For committed txns with Success status, calculate the accumulated gas.
+            // For committed txns with Abort or SkipRest status, early halt BlockSTM.
+            match last_input_output.gas_used(txn_idx) {
+                Some(gas) => {
+                    *accumulated_gas += gas;
+                    counters::PARALLEL_PER_TXN_GAS.observe(gas as f64);
+                },
+                None => {
+                    scheduler.halt();
+
+                    counters::PARALLEL_PER_BLOCK_GAS.observe(*accumulated_gas as f64);
+                    counters::PARALLEL_PER_BLOCK_COMMITTED_TXNS.observe((txn_idx + 1) as f64);
+                    info!("[BlockSTM]: Parallel execution early halted due to Abort or SkipRest txn, {} txns committed.", scheduler.get_txn_local_position(txn_idx) + 1);
+                    break;
+                },
+            };
+
+            if let Some(per_block_gas_limit) = maybe_gas_limit {
+                // When the accumulated gas of the committed txns exceeds PER_BLOCK_GAS_LIMIT, early halt BlockSTM.
+                if *accumulated_gas >= per_block_gas_limit {
+                    // Set the execution output status to be SkipRest, to skip the rest of the txns.
+                    last_input_output.update_to_skip_rest(txn_idx);
+                    scheduler.halt();
+
+                    counters::PARALLEL_PER_BLOCK_GAS.observe(*accumulated_gas as f64);
+                    counters::PARALLEL_PER_BLOCK_COMMITTED_TXNS.observe((txn_idx + 1) as f64);
+                    counters::PARALLEL_EXCEED_PER_BLOCK_GAS_LIMIT_COUNT.inc();
+                    info!("[BlockSTM]: Parallel execution early halted due to accumulated_gas {} >= PER_BLOCK_GAS_LIMIT {}, {} txns committed", *accumulated_gas, per_block_gas_limit, txn_idx);
+                    break;
+                }
+            }
+
+            // Remark: When early halting the BlockSTM, we have to make sure the current / new tasks
+            // will be properly handled by the threads. For instance, it is possible that the committing
+            // thread holds an execution task from the last iteration, and then early halts the BlockSTM
+            // due to a txn execution abort. In this case, we cannot reset the scheduler_task of the
+            // committing thread (to be Done), otherwise some other pending thread waiting for the execution
+            // will be pending on read forever (since the halt logic let the execution task to wake up such
+            // pending task).
+        }
+    }
+
+    fn worker_commit_hook(
+        txn_idx: TxnIndex,
+        versioned_cache: Arc<MVHashMap<T::Key, T::Value, ExecutableTestType>>,
+        last_input_output: Arc<TxnLastInputOutput<T::Key, E::Output, E::Error>>,
+        base_view: Arc<S>,
+    ) {
+        let (num_deltas, delta_keys) = last_input_output.delta_keys(txn_idx);
+        let mut delta_writes = Vec::with_capacity(num_deltas);
+        for k in delta_keys {
+            // Note that delta materialization happens concurrently, but under concurrent
+            // commit_hooks (which may be dispatched by the coordinator), threads may end up
+            // contending on delta materialization of the same aggregator. However, the
+            // materialization is based on previously materialized values and should not
+            // introduce long critical sections. Moreover, with more aggregators, and given
+            // that the commit_hook will be performed at dispersed times based on the
+            // completion of the respective previous tasks of threads, this should not be
+            // an immediate bottleneck - confirmed by an experiment with 32 core and a
+            // single materialized aggregator. If needed, the contention may be further
+            // mitigated by batching consecutive commit_hooks.
+            let committed_delta = versioned_cache
+                .materialize_delta(&k, txn_idx)
+                .unwrap_or_else(|op| {
+                    let storage_value = base_view
+                        .get_state_value_bytes(&k)
+                        .expect("No base value for committed delta in storage")
+                        .map(|bytes| deserialize(&bytes))
+                        .expect("Cannot deserialize base value for committed delta");
+
+                    versioned_cache.set_aggregator_base_value(&k, storage_value);
+                    op.apply_to(storage_value)
+                        .expect("Materializing delta w. base value set must succeed")
+                });
+
+            // Must contain committed value as we set the base value above.
+            delta_writes.push((
+                k.clone(),
+                WriteOp::Modification(serialize(&committed_delta)),
+            ));
+        }
+        last_input_output.record_delta_writes(txn_idx, delta_writes);
+    }
+}

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -17,8 +17,8 @@ use crate::{
 use aptos_aggregator::delta_change_set::{deserialize, serialize};
 use aptos_logger::{debug, info};
 use aptos_mvhashmap::{
-    types::{MVDataError, MVDataOutput, TxnIndex, Version},
     MVHashMap,
+    types::{MVDataError, MVDataOutput, TxnIndex, Version},
 };
 use aptos_state_view::TStateView;
 use aptos_types::{
@@ -32,9 +32,9 @@ use std::{
     collections::btree_map::BTreeMap,
     marker::PhantomData,
     sync::{
+        Arc,
         mpsc,
         mpsc::{Receiver, Sender},
-        Arc,
     },
 };
 use std::collections::BTreeSet;
@@ -449,10 +449,11 @@ where
         }
 
         let num_txns = signature_verified_block.len() as u32;
-        let last_input_output = TxnLastInputOutput::new(num_txns);
+        let mut last_input_output: TxnLastInputOutput<<T as Transaction>::Key, <E as ExecutorTask>::Output, <E as ExecutorTask>::Error> = TxnLastInputOutput::new();
         let mut scheduler = Scheduler::new();
         let txn_indices: BTreeSet<TxnIndex> = (0..num_txns).collect();
-        scheduler.add_txns(txn_indices);
+        last_input_output.add_txns(&txn_indices);
+        scheduler.add_txns(&txn_indices);
         scheduler.end_of_txn_stream();
         let mut roles: Vec<CommitRole> = vec![];
         let mut senders: Vec<Sender<u32>> = Vec::with_capacity(self.concurrency_level - 1);

--- a/aptos-move/block-executor/src/lib.rs
+++ b/aptos-move/block-executor/src/lib.rs
@@ -147,3 +147,4 @@ mod txn_last_input_output;
 #[cfg(test)]
 mod unit_tests;
 pub mod view;
+pub mod blockstm;

--- a/aptos-move/block-executor/src/scheduler.rs
+++ b/aptos-move/block-executor/src/scheduler.rs
@@ -253,7 +253,7 @@ impl Scheduler {
         }
     }
 
-    pub fn add_txns(&mut self, new_indices: BTreeSet<TxnIndex>) {
+    pub fn add_txns(&mut self, new_indices: &BTreeSet<TxnIndex>) {
         if let Some(&old_biggest) = self.txn_indices.last() {
             if let Some(&new_smallest) = new_indices.first() {
                 if old_biggest > new_smallest {

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -51,7 +51,7 @@ pub trait ExecutorTask: Sync {
 
     /// Type to initialize the single thread transaction executor. Copy and Sync are required because
     /// we will create an instance of executor on each individual thread.
-    type Argument: Sync + Copy;
+    type Argument: Send + Sync + Copy;
 
     /// Create an instance of the transaction executor.
     fn init(args: Self::Argument) -> Self;

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -259,7 +259,9 @@ fn early_skips() {
 
 #[test]
 fn scheduler_tasks() {
-    let s = Scheduler::new(5);
+    let mut s = Scheduler::new();
+    s.add_txns(5);
+    s.end_of_txn_stream();
 
     for i in 0..5 {
         // No validation tasks.
@@ -350,7 +352,9 @@ fn scheduler_tasks() {
 
 #[test]
 fn scheduler_first_wave() {
-    let s = Scheduler::new(6);
+    let mut s = Scheduler::new();
+    s.add_txns(6);
+    s.end_of_txn_stream();
 
     for i in 0..5 {
         // Nothing to validate.
@@ -405,7 +409,9 @@ fn scheduler_first_wave() {
 
 #[test]
 fn scheduler_dependency() {
-    let s = Scheduler::new(10);
+    let mut s = Scheduler::new();
+    s.add_txns(10);
+    s.end_of_txn_stream();
 
     for i in 0..5 {
         // Nothing to validate.
@@ -452,7 +458,9 @@ fn scheduler_dependency() {
 // Will return a scheduler in a state where all transactions are scheduled for
 // for execution, validation index = num_txns, and wave = 0.
 fn incarnation_one_scheduler(num_txns: TxnIndex) -> Scheduler {
-    let s = Scheduler::new(num_txns);
+    let mut s = Scheduler::new();
+    s.add_txns(num_txns);
+    s.end_of_txn_stream();
 
     for i in 0..num_txns {
         // Get the first executions out of the way.
@@ -566,7 +574,9 @@ fn scheduler_incarnation() {
 
 #[test]
 fn scheduler_basic() {
-    let s = Scheduler::new(3);
+    let mut s = Scheduler::new();
+    s.add_txns(3);
+    s.end_of_txn_stream();
 
     for i in 0..3 {
         // Nothing to validate.
@@ -616,7 +626,9 @@ fn scheduler_basic() {
 
 #[test]
 fn scheduler_drain_idx() {
-    let s = Scheduler::new(3);
+    let mut s = Scheduler::new();
+    s.add_txns(3);
+    s.end_of_txn_stream();
 
     for i in 0..3 {
         // Nothing to validate.
@@ -759,7 +771,9 @@ fn no_conflict_task_count() {
 
     let num_txns: TxnIndex = 1000;
     for num_concurrent_tasks in [1, 5, 10, 20] {
-        let s = Scheduler::new(num_txns);
+        let mut s = Scheduler::new();
+        s.add_txns(num_txns);
+        s.end_of_txn_stream();
 
         let mut tasks = BTreeMap::new();
 

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -260,7 +260,7 @@ fn early_skips() {
 #[test]
 fn scheduler_tasks() {
     let mut s = Scheduler::new();
-    s.add_txns((0..5).collect());
+    s.add_txns(&(0..5).collect());
     s.end_of_txn_stream();
 
     for i in 0..5 {
@@ -353,7 +353,7 @@ fn scheduler_tasks() {
 #[test]
 fn scheduler_first_wave() {
     let mut s = Scheduler::new();
-    s.add_txns((0..6).collect());
+    s.add_txns(&(0..6).collect());
     s.end_of_txn_stream();
 
     for i in 0..5 {
@@ -410,7 +410,7 @@ fn scheduler_first_wave() {
 #[test]
 fn scheduler_dependency() {
     let mut s = Scheduler::new();
-    s.add_txns((0..10).collect());
+    s.add_txns(&(0..10).collect());
     s.end_of_txn_stream();
 
     for i in 0..5 {
@@ -459,7 +459,7 @@ fn scheduler_dependency() {
 // for execution, validation index = num_txns, and wave = 0.
 fn incarnation_one_scheduler(num_txns: TxnIndex) -> Scheduler {
     let mut s = Scheduler::new();
-    s.add_txns((0..num_txns).collect());
+    s.add_txns(&(0..num_txns).collect());
     s.end_of_txn_stream();
 
     for i in 0..num_txns {
@@ -575,7 +575,7 @@ fn scheduler_incarnation() {
 #[test]
 fn scheduler_basic() {
     let mut s = Scheduler::new();
-    s.add_txns((0..3).collect());
+    s.add_txns(&(0..3).collect());
     s.end_of_txn_stream();
 
     for i in 0..3 {
@@ -627,7 +627,7 @@ fn scheduler_basic() {
 #[test]
 fn scheduler_drain_idx() {
     let mut s = Scheduler::new();
-    s.add_txns((0..3).collect());
+    s.add_txns(&(0..3).collect());
     s.end_of_txn_stream();
 
     for i in 0..3 {
@@ -772,7 +772,7 @@ fn no_conflict_task_count() {
     let num_txns: TxnIndex = 1000;
     for num_concurrent_tasks in [1, 5, 10, 20] {
         let mut s = Scheduler::new();
-        s.add_txns((0..num_txns).collect());
+        s.add_txns(&(0..num_txns).collect());
         s.end_of_txn_stream();
 
         let mut tasks = BTreeMap::new();

--- a/aptos-move/mvhashmap/src/types.rs
+++ b/aptos-move/mvhashmap/src/types.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 pub type TxnIndex = u32;
 pub type Incarnation = u32;
 pub type Version = (TxnIndex, Incarnation);
+pub const TXN_IDX_NONE: TxnIndex = 0xffffffff;
 
 #[derive(Clone, Copy, PartialEq)]
 pub(crate) enum Flag {

--- a/execution/block-partitioner/Cargo.toml
+++ b/execution/block-partitioner/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "aptos-block-partitioner"
+description = "A tool to partition a block store into smaller chunks based on graph partitioning."
+
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+aptos-crypto = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-metrics-core = { workspace = true }
+aptos-types = { workspace = true }
+bcs = { workspace = true }
+clap = { workspace = true }
+dashmap = { workspace = true }
+itertools = { workspace = true }
+move-core-types = { workspace = true }
+rand = { workspace = true }
+rayon = { workspace = true }
+
+[features]
+default = []

--- a/execution/block-partitioner/src/lib.rs
+++ b/execution/block-partitioner/src/lib.rs
@@ -1,11 +1,19 @@
 // Copyright © Aptos Foundation
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use aptos_types::transaction::Transaction;
+
+pub mod sharded_block_partitioner;
+pub mod test_utils;
+pub mod types;
+
+use aptos_types::transaction::analyzed_transaction::AnalyzedTransaction;
 
 pub trait BlockPartitioner: Send + Sync {
-    fn partition(&self, transactions: Vec<Transaction>, num_shards: usize)
-        -> Vec<Vec<Transaction>>;
+    fn partition(
+        &self,
+        transactions: Vec<AnalyzedTransaction>,
+        num_shards: usize,
+    ) -> Vec<Vec<AnalyzedTransaction>>;
 }
 
 /// An implementation of partitioner that splits the transactions into equal-sized chunks.
@@ -14,9 +22,9 @@ pub struct UniformPartitioner {}
 impl BlockPartitioner for UniformPartitioner {
     fn partition(
         &self,
-        transactions: Vec<Transaction>,
+        transactions: Vec<AnalyzedTransaction>,
         num_shards: usize,
-    ) -> Vec<Vec<Transaction>> {
+    ) -> Vec<Vec<AnalyzedTransaction>> {
         let total_txns = transactions.len();
         if total_txns == 0 {
             return vec![];

--- a/execution/block-partitioner/src/main.rs
+++ b/execution/block-partitioner/src/main.rs
@@ -1,0 +1,61 @@
+// Copyright © Aptos Foundation
+
+use aptos_block_partitioner::{
+    sharded_block_partitioner::ShardedBlockPartitioner,
+    test_utils::{create_signed_p2p_transaction, generate_test_account, TestAccount},
+};
+use aptos_types::transaction::analyzed_transaction::AnalyzedTransaction;
+use clap::Parser;
+use rand::{rngs::OsRng, Rng};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use std::{sync::Mutex, time::Instant};
+
+#[derive(Debug, Parser)]
+struct Args {
+    #[clap(long, default_value = "2000000")]
+    pub num_accounts: usize,
+
+    #[clap(long, default_value = "100000")]
+    pub block_size: usize,
+
+    #[clap(long, default_value = "10")]
+    pub num_blocks: usize,
+
+    #[clap(long, default_value = "12")]
+    pub num_shards: usize,
+}
+
+fn main() {
+    println!("Starting the block partitioning benchmark");
+    let args = Args::parse();
+    let num_accounts = args.num_accounts;
+    println!("Creating {} accounts", num_accounts);
+    let accounts: Vec<Mutex<TestAccount>> = (0..num_accounts)
+        .into_par_iter()
+        .map(|_i| Mutex::new(generate_test_account()))
+        .collect();
+    println!("Created {} accounts", num_accounts);
+    println!("Creating {} transactions", args.block_size);
+    let transactions: Vec<AnalyzedTransaction> = (0..args.block_size)
+        .into_iter()
+        .map(|_| {
+            // randomly select a sender and receiver from accounts
+            let mut rng = OsRng;
+            let sender_index = rng.gen_range(0, num_accounts);
+            let receiver_index = rng.gen_range(0, num_accounts);
+            let receiver = accounts[receiver_index].lock().unwrap();
+            let mut sender = accounts[sender_index].lock().unwrap();
+            create_signed_p2p_transaction(&mut sender, vec![&receiver]).remove(0)
+        })
+        .collect();
+
+    let partitioner = ShardedBlockPartitioner::new(args.num_shards);
+    for _ in 0..args.num_blocks {
+        let transactions = transactions.clone();
+        println!("Starting to partition");
+        let now = Instant::now();
+        partitioner.partition(transactions, 1);
+        let elapsed = now.elapsed();
+        println!("Time taken to partition: {:?}", elapsed);
+    }
+}

--- a/execution/block-partitioner/src/sharded_block_partitioner/conflict_detector.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/conflict_detector.rs
@@ -2,9 +2,7 @@
 
 use crate::{
     sharded_block_partitioner::dependency_analysis::{RWSet, RWSetWithTxnIndex},
-    types::{
-        CrossShardDependencies, ShardId, TransactionWithDependencies, TransactionsChunk, TxnIndex,
-    },
+    types::{CrossShardDependencies, ShardId, SubBlock, TransactionWithDependencies, TxnIndex},
 };
 use aptos_crypto::hash::CryptoHash;
 use aptos_types::transaction::analyzed_transaction::AnalyzedTransaction;
@@ -118,7 +116,7 @@ impl CrossShardConflictDetector {
         current_round_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
         prev_round_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
         index_offset: TxnIndex,
-    ) -> TransactionsChunk {
+    ) -> SubBlock {
         let mut frozen_txns = Vec::new();
         for txn in txns.into_iter() {
             let dependency = self.get_dependencies_for_frozen_txn(
@@ -128,7 +126,7 @@ impl CrossShardConflictDetector {
             );
             frozen_txns.push(TransactionWithDependencies::new(txn, dependency));
         }
-        TransactionsChunk::new(index_offset, frozen_txns)
+        SubBlock::new(index_offset, frozen_txns)
     }
 
     fn check_for_cross_shard_conflict(

--- a/execution/block-partitioner/src/sharded_block_partitioner/conflict_detector.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/conflict_detector.rs
@@ -1,0 +1,198 @@
+// Copyright © Aptos Foundation
+
+use crate::{
+    sharded_block_partitioner::dependency_analysis::{RWSet, RWSetWithTxnIndex},
+    types::{
+        CrossShardDependencies, ShardId, TransactionWithDependencies, TransactionsChunk, TxnIndex,
+    },
+};
+use aptos_crypto::hash::CryptoHash;
+use aptos_types::transaction::analyzed_transaction::AnalyzedTransaction;
+use std::sync::Arc;
+
+pub struct CrossShardConflictDetector {
+    shard_id: ShardId,
+    num_shards: usize,
+}
+
+impl CrossShardConflictDetector {
+    pub fn new(shard_id: ShardId, num_shards: usize) -> Self {
+        Self {
+            shard_id,
+            num_shards,
+        }
+    }
+
+    pub fn discard_txns_with_cross_shard_deps(
+        &mut self,
+        txns: Vec<AnalyzedTransaction>,
+        cross_shard_rw_set: &[RWSet],
+        prev_rounds_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
+    ) -> (
+        Vec<AnalyzedTransaction>,
+        Vec<CrossShardDependencies>,
+        Vec<AnalyzedTransaction>,
+    ) {
+        // Iterate through all the transactions and if any shard has taken read/write lock on the storage location
+        // and has a higher priority than this shard id, then this transaction needs to be moved to the end of the block.
+        let mut accepted_txns = Vec::new();
+        let mut accepted_txn_dependencies = Vec::new();
+        let mut rejected_txns = Vec::new();
+        for (_, txn) in txns.into_iter().enumerate() {
+            if self.check_for_cross_shard_conflict(self.shard_id, &txn, cross_shard_rw_set) {
+                rejected_txns.push(txn);
+            } else {
+                accepted_txn_dependencies.push(self.get_dependencies_for_frozen_txn(
+                    &txn,
+                    Arc::new(vec![]),
+                    prev_rounds_rw_set_with_index.clone(),
+                ));
+                accepted_txns.push(txn);
+            }
+        }
+        (accepted_txns, accepted_txn_dependencies, rejected_txns)
+    }
+
+    /// Adds a cross shard dependency for a transaction. This can be done by finding the maximum transaction index
+    /// that has taken a read/write lock on the storage location the current transaction is trying to read/write.
+    /// We traverse the current round read/write set in reverse order starting from shard id -1 and look for the first
+    /// txn index that has taken a read/write lock on the storage location. If we can't find any such txn index, we
+    /// traverse the previous rounds read/write set in reverse order and look for the first txn index that has taken
+    /// a read/write lock on the storage location.
+    fn get_dependencies_for_frozen_txn(
+        &self,
+        frozen_txn: &AnalyzedTransaction,
+        current_round_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
+        prev_rounds_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
+    ) -> CrossShardDependencies {
+        if current_round_rw_set_with_index.is_empty() && prev_rounds_rw_set_with_index.is_empty() {
+            return CrossShardDependencies::default();
+        }
+        // Iterate through the frozen dependencies and add the max transaction index for each storage location
+        let mut cross_shard_dependencies = CrossShardDependencies::default();
+        for read_location in frozen_txn.read_set().iter() {
+            // For current round, iterate through all shards less than current shards in the reverse order and for previous rounds iterate through all shards in the reverse order
+            // and find the first shard id that has taken a write lock on the storage location. This ensures that we find the highest txn index that is conflicting
+            // with the current transaction.
+            for rw_set_with_index in current_round_rw_set_with_index
+                .iter()
+                .take(self.shard_id)
+                .chain(prev_rounds_rw_set_with_index.iter())
+            {
+                if rw_set_with_index.has_write_lock(read_location) {
+                    cross_shard_dependencies.add_depends_on_txn(
+                        rw_set_with_index.get_write_lock_txn_index(read_location),
+                    );
+                    break;
+                }
+            }
+        }
+
+        for write_location in frozen_txn.write_set().iter() {
+            for rw_set_with_index in current_round_rw_set_with_index
+                .iter()
+                .take(self.shard_id)
+                .chain(prev_rounds_rw_set_with_index.iter())
+            {
+                if rw_set_with_index.has_read_lock(write_location) {
+                    cross_shard_dependencies.add_depends_on_txn(
+                        rw_set_with_index.get_read_lock_txn_index(write_location),
+                    );
+                    break;
+                }
+                if rw_set_with_index.has_write_lock(write_location) {
+                    cross_shard_dependencies.add_depends_on_txn(
+                        rw_set_with_index.get_write_lock_txn_index(write_location),
+                    );
+                    break;
+                }
+            }
+        }
+
+        cross_shard_dependencies
+    }
+
+    pub fn get_frozen_chunk(
+        &self,
+        txns: Vec<AnalyzedTransaction>,
+        current_round_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
+        prev_round_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
+        index_offset: TxnIndex,
+    ) -> TransactionsChunk {
+        let mut frozen_txns = Vec::new();
+        for txn in txns.into_iter() {
+            let dependency = self.get_dependencies_for_frozen_txn(
+                &txn,
+                current_round_rw_set_with_index.clone(),
+                prev_round_rw_set_with_index.clone(),
+            );
+            frozen_txns.push(TransactionWithDependencies::new(txn, dependency));
+        }
+        TransactionsChunk::new(index_offset, frozen_txns)
+    }
+
+    fn check_for_cross_shard_conflict(
+        &self,
+        current_shard_id: ShardId,
+        txn: &AnalyzedTransaction,
+        cross_shard_rw_set: &[RWSet],
+    ) -> bool {
+        if self.check_for_read_conflict(current_shard_id, txn, cross_shard_rw_set) {
+            return true;
+        }
+        if self.check_for_write_conflict(current_shard_id, txn, cross_shard_rw_set) {
+            return true;
+        }
+        false
+    }
+
+    fn check_for_read_conflict(
+        &self,
+        current_shard_id: ShardId,
+        txn: &AnalyzedTransaction,
+        cross_shard_rw_set: &[RWSet],
+    ) -> bool {
+        for read_location in txn.read_set().iter() {
+            // Each storage location is allocated an anchor shard id, which is used to conflict resolution deterministically across shards.
+            // During conflict resolution, shards starts scanning from the anchor shard id and
+            // first shard id that has taken a read/write lock on this storage location is the owner of this storage location.
+            // Please note another alternative is scan from first shard id, but this will result in non-uniform load across shards in case of conflicts.
+            let anchor_shard_id = read_location.hash().byte(0) as usize % self.num_shards;
+            for offset in 0..self.num_shards {
+                let shard_id = (anchor_shard_id + offset) % self.num_shards;
+                // Ignore if this is from the same shard
+                if shard_id == current_shard_id {
+                    // We only need to check if any shard id < current shard id has taken a write lock on the storage location
+                    break;
+                }
+                if cross_shard_rw_set[shard_id].has_write_lock(read_location) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn check_for_write_conflict(
+        &self,
+        current_shard_id: usize,
+        txn: &AnalyzedTransaction,
+        cross_shard_rw_set: &[RWSet],
+    ) -> bool {
+        for write_location in txn.write_set().iter() {
+            let anchor_shard_id = write_location.hash().byte(0) as usize % self.num_shards;
+            for offset in 0..self.num_shards {
+                let shard_id = (anchor_shard_id + offset) % self.num_shards;
+                // Ignore if this is from the same shard
+                if shard_id == current_shard_id {
+                    // We only need to check if any shard id < current shard id has taken a write lock on the storage location
+                    break;
+                }
+                if cross_shard_rw_set[shard_id].has_read_or_write_lock(write_location) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}

--- a/execution/block-partitioner/src/sharded_block_partitioner/conflict_detector.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/conflict_detector.rs
@@ -73,9 +73,9 @@ impl CrossShardConflictDetector {
             // and find the first shard id that has taken a write lock on the storage location. This ensures that we find the highest txn index that is conflicting
             // with the current transaction.
             for rw_set_with_index in current_round_rw_set_with_index
-                .iter()
+                .iter().rev()
                 .take(self.shard_id)
-                .chain(prev_rounds_rw_set_with_index.iter())
+                .chain(prev_rounds_rw_set_with_index.iter().rev())
             {
                 if rw_set_with_index.has_write_lock(read_location) {
                     cross_shard_dependencies.add_depends_on_txn(
@@ -88,9 +88,9 @@ impl CrossShardConflictDetector {
 
         for write_location in frozen_txn.write_set().iter() {
             for rw_set_with_index in current_round_rw_set_with_index
-                .iter()
+                .iter().rev()
                 .take(self.shard_id)
-                .chain(prev_rounds_rw_set_with_index.iter())
+                .chain(prev_rounds_rw_set_with_index.iter().rev())
             {
                 if rw_set_with_index.has_read_lock(write_location) {
                     cross_shard_dependencies.add_depends_on_txn(

--- a/execution/block-partitioner/src/sharded_block_partitioner/dependency_analysis.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/dependency_analysis.rs
@@ -1,0 +1,103 @@
+// Copyright © Aptos Foundation
+
+use crate::types::TxnIndex;
+use aptos_types::transaction::analyzed_transaction::{AnalyzedTransaction, StorageLocation};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+#[derive(Default, Clone, Debug)]
+pub struct RWSet {
+    // Represents a set of storage locations that are read by the transactions in this shard.
+    read_set: Arc<HashSet<StorageLocation>>,
+    // Represents a set of storage locations that are written by the transactions in this shard.
+    write_set: Arc<HashSet<StorageLocation>>,
+}
+
+impl RWSet {
+    pub fn new(txns: &[AnalyzedTransaction]) -> Self {
+        let mut read_set = HashSet::new();
+        let mut write_set = HashSet::new();
+        for analyzed_txn in txns {
+            for write_location in analyzed_txn.write_set().iter() {
+                write_set.insert(write_location.clone());
+            }
+            for read_location in analyzed_txn.read_set().iter() {
+                read_set.insert(read_location.clone());
+            }
+        }
+
+        Self {
+            read_set: Arc::new(read_set),
+            write_set: Arc::new(write_set),
+        }
+    }
+
+    pub fn has_write_lock(&self, location: &StorageLocation) -> bool {
+        self.write_set.contains(location)
+    }
+
+    pub fn has_read_lock(&self, location: &StorageLocation) -> bool {
+        self.read_set.contains(location)
+    }
+
+    pub fn has_read_or_write_lock(&self, location: &StorageLocation) -> bool {
+        self.has_read_lock(location) || self.has_write_lock(location)
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+/// Contains a list of storage location along with the maximum transaction index in this shard
+/// that has taken a read/write lock on this storage location.  For example, if the chunk contains 3
+/// transactions with read/write set as follows:
+/// Txn 0: Read set: [A, B, C]
+/// Txn 1: Read set: [A, B]
+/// Txn 2: Read set: [A]
+/// Then the RWSetWithTxnIndex will be:
+/// Read set: {A: 2, B: 1, C: 0}
+/// Similar applies for the write set.
+/// Please note that the index is the global index which includes the offset of the shard.
+pub struct RWSetWithTxnIndex {
+    read_set: Arc<HashMap<StorageLocation, TxnIndex>>,
+    write_set: Arc<HashMap<StorageLocation, TxnIndex>>,
+}
+
+impl RWSetWithTxnIndex {
+    // Creates a new dependency analysis object from a list of transactions. In this case, since the
+    // transactions are frozen, we can set the maximum transaction index to the index of the last
+    // transaction in the list.
+    pub fn new(txns: &[AnalyzedTransaction], txn_index_offset: TxnIndex) -> Self {
+        let mut read_set = HashMap::new();
+        let mut write_set = HashMap::new();
+        for (index, txn) in txns.iter().enumerate() {
+            for write_location in txn.write_set().iter() {
+                write_set.insert(write_location.clone(), txn_index_offset + index);
+            }
+            for read_location in txn.read_set().iter() {
+                read_set.insert(read_location.clone(), txn_index_offset + index);
+            }
+        }
+
+        Self {
+            read_set: Arc::new(read_set),
+            write_set: Arc::new(write_set),
+        }
+    }
+
+    pub fn has_write_lock(&self, location: &StorageLocation) -> bool {
+        self.write_set.contains_key(location)
+    }
+
+    pub fn has_read_lock(&self, location: &StorageLocation) -> bool {
+        self.read_set.contains_key(location)
+    }
+
+    pub fn get_write_lock_txn_index(&self, location: &StorageLocation) -> TxnIndex {
+        *self.write_set.get(location).unwrap()
+    }
+
+    pub fn get_read_lock_txn_index(&self, location: &StorageLocation) -> TxnIndex {
+        *self.read_set.get(location).unwrap()
+    }
+}

--- a/execution/block-partitioner/src/sharded_block_partitioner/messages.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/messages.rs
@@ -1,0 +1,87 @@
+// Copyright © Aptos Foundation
+
+use crate::{
+    sharded_block_partitioner::dependency_analysis::{RWSet, RWSetWithTxnIndex},
+    types::{TransactionsChunk, TxnIndex},
+};
+use aptos_types::transaction::analyzed_transaction::AnalyzedTransaction;
+use std::sync::Arc;
+
+pub enum ControlMsg {
+    DiscardCrossShardDepReq(DiscardTxnsWithCrossShardDep),
+    AddCrossShardDepReq(AddTxnsWithCrossShardDep),
+    Stop,
+}
+
+#[derive(Clone, Debug)]
+pub enum CrossShardMsg {
+    RWSetWithTxnIndexMsg(RWSetWithTxnIndex),
+    RWSetMsg(RWSet),
+    // Number of accepted transactions in the shard for the current round.
+    AcceptedTxnsMsg(usize),
+}
+
+pub struct DiscardTxnsWithCrossShardDep {
+    pub transactions: Vec<AnalyzedTransaction>,
+    // The frozen dependencies in previous chunks.
+    pub prev_rounds_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
+    pub prev_rounds_frozen_chunks: Arc<Vec<TransactionsChunk>>,
+}
+
+impl DiscardTxnsWithCrossShardDep {
+    pub fn new(
+        transactions: Vec<AnalyzedTransaction>,
+        prev_rounds_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
+        prev_rounds_frozen_chunks: Arc<Vec<TransactionsChunk>>,
+    ) -> Self {
+        Self {
+            transactions,
+            prev_rounds_rw_set_with_index,
+            prev_rounds_frozen_chunks,
+        }
+    }
+}
+
+pub struct AddTxnsWithCrossShardDep {
+    pub transactions: Vec<AnalyzedTransaction>,
+    pub index_offset: TxnIndex,
+    pub prev_rounds_frozen_chunks: Arc<Vec<TransactionsChunk>>,
+    // The frozen dependencies in previous chunks.
+    pub prev_rounds_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
+}
+
+impl AddTxnsWithCrossShardDep {
+    pub fn new(
+        transactions: Vec<AnalyzedTransaction>,
+        index_offset: TxnIndex,
+        prev_rounds_frozen_chunks: Arc<Vec<TransactionsChunk>>,
+        prev_rounds_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
+    ) -> Self {
+        Self {
+            transactions,
+            index_offset,
+            prev_rounds_rw_set_with_index,
+            prev_rounds_frozen_chunks,
+        }
+    }
+}
+
+pub struct PartitioningBlockResponse {
+    pub frozen_chunk: TransactionsChunk,
+    pub rw_set_with_index: RWSetWithTxnIndex,
+    pub rejected_txns: Vec<AnalyzedTransaction>,
+}
+
+impl PartitioningBlockResponse {
+    pub fn new(
+        frozen_chunk: TransactionsChunk,
+        frozen_dependencies: RWSetWithTxnIndex,
+        rejected_txns: Vec<AnalyzedTransaction>,
+    ) -> Self {
+        Self {
+            frozen_chunk,
+            rw_set_with_index: frozen_dependencies,
+            rejected_txns,
+        }
+    }
+}

--- a/execution/block-partitioner/src/sharded_block_partitioner/messages.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/messages.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     sharded_block_partitioner::dependency_analysis::{RWSet, RWSetWithTxnIndex},
-    types::{TransactionsChunk, TxnIndex},
+    types::{SubBlock, TxnIndex},
 };
 use aptos_types::transaction::analyzed_transaction::AnalyzedTransaction;
 use std::sync::Arc;
@@ -25,14 +25,14 @@ pub struct DiscardTxnsWithCrossShardDep {
     pub transactions: Vec<AnalyzedTransaction>,
     // The frozen dependencies in previous chunks.
     pub prev_rounds_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
-    pub prev_rounds_frozen_chunks: Arc<Vec<TransactionsChunk>>,
+    pub prev_rounds_frozen_chunks: Arc<Vec<SubBlock>>,
 }
 
 impl DiscardTxnsWithCrossShardDep {
     pub fn new(
         transactions: Vec<AnalyzedTransaction>,
         prev_rounds_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
-        prev_rounds_frozen_chunks: Arc<Vec<TransactionsChunk>>,
+        prev_rounds_frozen_chunks: Arc<Vec<SubBlock>>,
     ) -> Self {
         Self {
             transactions,
@@ -45,7 +45,7 @@ impl DiscardTxnsWithCrossShardDep {
 pub struct AddTxnsWithCrossShardDep {
     pub transactions: Vec<AnalyzedTransaction>,
     pub index_offset: TxnIndex,
-    pub prev_rounds_frozen_chunks: Arc<Vec<TransactionsChunk>>,
+    pub prev_rounds_frozen_chunks: Arc<Vec<SubBlock>>,
     // The frozen dependencies in previous chunks.
     pub prev_rounds_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
 }
@@ -54,7 +54,7 @@ impl AddTxnsWithCrossShardDep {
     pub fn new(
         transactions: Vec<AnalyzedTransaction>,
         index_offset: TxnIndex,
-        prev_rounds_frozen_chunks: Arc<Vec<TransactionsChunk>>,
+        prev_rounds_frozen_chunks: Arc<Vec<SubBlock>>,
         prev_rounds_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
     ) -> Self {
         Self {
@@ -67,14 +67,14 @@ impl AddTxnsWithCrossShardDep {
 }
 
 pub struct PartitioningBlockResponse {
-    pub frozen_chunk: TransactionsChunk,
+    pub frozen_chunk: SubBlock,
     pub rw_set_with_index: RWSetWithTxnIndex,
     pub rejected_txns: Vec<AnalyzedTransaction>,
 }
 
 impl PartitioningBlockResponse {
     pub fn new(
-        frozen_chunk: TransactionsChunk,
+        frozen_chunk: SubBlock,
         frozen_dependencies: RWSetWithTxnIndex,
         rejected_txns: Vec<AnalyzedTransaction>,
     ) -> Self {

--- a/execution/block-partitioner/src/sharded_block_partitioner/mod.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/mod.rs
@@ -296,7 +296,7 @@ impl ShardedBlockPartitioner {
         let mut frozen_rw_set_with_index = Arc::new(Vec::new());
         let mut frozen_chunks = Arc::new(Vec::new());
 
-        for _ in 0..num_partitioning_round {
+        for i in 0..num_partitioning_round {
             let (
                 current_frozen_chunks_vec,
                 current_frozen_rw_set_with_index_vec,
@@ -306,6 +306,13 @@ impl ShardedBlockPartitioner {
                 frozen_chunks.clone(),
                 frozen_rw_set_with_index.clone(),
             );
+            println!("round {i} finished.");
+            for (j, x) in current_frozen_chunks_vec.iter().enumerate() {
+                println!("current_frozen_chunks[{j}]={x:?}");
+            }
+            for (j, x) in current_frozen_rw_set_with_index_vec.iter().enumerate() {
+                println!("current_frozen_rw_set[{j}]={x:?}");
+            }
             let mut prev_frozen_chunk = Arc::try_unwrap(frozen_chunks).unwrap();
             let mut prev_frozen_rw_set_with_index =
                 Arc::try_unwrap(frozen_rw_set_with_index).unwrap();

--- a/execution/block-partitioner/src/sharded_block_partitioner/mod.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/mod.rs
@@ -1,0 +1,685 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    sharded_block_partitioner::{
+        dependency_analysis::RWSetWithTxnIndex,
+        messages::{
+            AddTxnsWithCrossShardDep, ControlMsg,
+            ControlMsg::{AddCrossShardDepReq, DiscardCrossShardDepReq},
+            CrossShardMsg, DiscardTxnsWithCrossShardDep, PartitioningBlockResponse,
+        },
+        partitioning_shard::PartitioningShard,
+    },
+    types::{ShardId, TransactionsChunk},
+};
+use aptos_logger::{error, info};
+use aptos_types::transaction::analyzed_transaction::AnalyzedTransaction;
+use std::{
+    collections::HashMap,
+    sync::{
+        mpsc::{Receiver, Sender},
+        Arc,
+    },
+    thread,
+};
+
+mod conflict_detector;
+mod dependency_analysis;
+mod messages;
+mod partitioning_shard;
+
+/// A sharded block partitioner that partitions a block into multiple transaction chunks.
+/// On a high level, the partitioning process is as follows:
+/// ```plaintext
+/// 1. A block is partitioned into equally sized transaction chunks and sent to each shard.
+///
+///    Block:
+///
+///    T1 {write set: A, B}
+///    T2 {write set: B, C}
+///    T3 {write set: C, D}
+///    T4 {write set: D, E}
+///    T5 {write set: E, F}
+///    T6 {write set: F, G}
+///    T7 {write set: G, H}
+///    T8 {write set: H, I}
+///    T9 {write set: I, J}
+///
+/// 2. Discard a bunch of transactions from the chunks and create new chunks so that
+///    there is no cross-shard dependency between transactions in a chunk.
+///   2.1 Following information is passed to each shard:
+///      - candidate transaction chunks to be partitioned
+///      - previously frozen transaction chunks (if any)
+///      - read-write set index mapping from previous iteration (if any) - this contains the maximum absolute index
+///        of the transaction that read/wrote to a storage location indexed by the storage location.
+///   2.1 Each shard creates a read-write set for all transactions in the chunk and broadcasts it to all other shards.
+///      Shard 0                          Shard 1                           Shard 2
+///    +----------------------------+  +-------------------------------+  +-------------------------------+
+///    |        Read-Write Set      |  |         Read-Write Set         |  |         Read-Write Set         |
+///    |                            |  |                               |  |                               |
+///    |   T1 {A, B}                |  |   T4 {D, E}                   |  |   T7 {G, H}                   |
+///    |   T2 {B, C}                |  |   T5 {E, F}                   |  |   T8 {H, I}                   |
+///    |   T3 {C, D}                |  |   T6 {F, G}                   |  |   T9 {I, J}                   |
+///    +----------------------------+  +-------------------------------+  +-------------------------------+
+///   2.2 Each shard collects read-write sets from all other shards and discards transactions that have cross-shard dependencies.
+///              Shard 0                          Shard 1                           Shard 2
+///    +----------------------------+  +-------------------------------+  +-------------------------------+
+///    |        Discarded Txns      |  |         Discarded Txns         |  |         Discarded Txns         |
+///    |                            |  |                               |  |                               |
+///    |   - T3 (cross-shard dependency with T4) |  |   - T6 (cross-shard dependency with T7) |  | No discard |
+///    +----------------------------+  +-------------------------------+  +-------------------------------+
+///   2.3 Each shard broadcasts the number of transactions that it plans to put in the current chunk.
+///      Shard 0                          Shard 1                           Shard 2
+///    +----------------------------+  +-------------------------------+  +-------------------------------+
+///    |          Chunk Count       |  |          Chunk Count          |  |          Chunk Count          |
+///    |                            |  |                               |  |                               |
+///    |   2                        |  |   2                           |  |      3                        |
+///    +----------------------------+  +-------------------------------+  +-------------------------------+
+///   2.4 Each shard collects the number of transactions that all other shards plan to put in the current chunk and based
+///      on that, it finalizes the absolute index offset of the current chunk. It uses this information to create a read-write set
+///      index, which is a mapping of all the storage location to the maximum absolute index of the transaction that read/wrote to that location.
+///      Shard 0                          Shard 1                           Shard 2
+///    +----------------------------+  +-------------------------------+  +-------------------------------+
+///    |          Index Offset      |  |          Index Offset         |  |          Index Offset         |
+///    |                            |  |                               |  |                               |
+///    |   0                        |  |   2                           |  |   4                           |
+///    +----------------------------+  +-------------------------------+  +-------------------------------+
+///   2.5 It also uses the read-write set index mapping passed in previous iteration to add cross-shard dependencies to the transactions. This is
+///     done by looking up the read-write set index for each storage location that a transaction reads/writes to and adding a cross-shard dependency
+///   2.6 Returns two lists of transactions: one list of transactions that are discarded and another list of transactions that are kept.
+/// 3. Use the discarded transactions to create new chunks and repeat the step 2 until N iterations.
+/// 4. For remaining transaction chunks, add cross-shard dependencies to the transactions. This is done as follows:
+///   4.1 Create a read-write set with index mapping for all the transactions in the remaining chunks.
+///   4.2 Broadcast and collect read-write set with index mapping from all shards.
+///   4.3 Add cross-shard dependencies to the transactions in the remaining chunks by looking up the read-write set index
+///       for each storage location that a transaction reads/writes to. The idea is to find the maximum transaction index
+///       that reads/writes to the same location and add that as a dependency. This can be done as follows: First look up the read-write set index
+///       mapping received from other shards in current iteration in descending order of shard id. If the read-write set index is not found,
+///       look up the read-write set index mapping received from other shards in previous iteration(s) in descending order of shard id.
+/// ```
+///
+pub struct ShardedBlockPartitioner {
+    num_shards: usize,
+    control_txs: Vec<Sender<ControlMsg>>,
+    result_rxs: Vec<Receiver<PartitioningBlockResponse>>,
+    shard_threads: Vec<thread::JoinHandle<()>>,
+}
+
+impl ShardedBlockPartitioner {
+    pub fn new(num_shards: usize) -> Self {
+        info!(
+            "Creating a new sharded block partitioner with {} shards",
+            num_shards
+        );
+        assert!(num_shards > 0, "num_partitioning_shards must be > 0");
+        // create channels for cross shard messages across all shards. This is a full mesh connection.
+        // Each shard has a vector of channels for sending messages to other shards and
+        // a vector of channels for receiving messages from other shards.
+        let mut messages_txs = vec![];
+        let mut messages_rxs = vec![];
+        for _ in 0..num_shards {
+            messages_txs.push(vec![]);
+            messages_rxs.push(vec![]);
+            for _ in 0..num_shards {
+                let (messages_tx, messages_rx) = std::sync::mpsc::channel();
+                messages_txs.last_mut().unwrap().push(messages_tx);
+                messages_rxs.last_mut().unwrap().push(messages_rx);
+            }
+        }
+        let mut control_txs = vec![];
+        let mut result_rxs = vec![];
+        let mut shard_join_handles = vec![];
+        for (i, message_rxs) in messages_rxs.into_iter().enumerate() {
+            let (control_tx, control_rx) = std::sync::mpsc::channel();
+            let (result_tx, result_rx) = std::sync::mpsc::channel();
+            control_txs.push(control_tx);
+            result_rxs.push(result_rx);
+            shard_join_handles.push(spawn_partitioning_shard(
+                i,
+                control_rx,
+                result_tx,
+                message_rxs,
+                messages_txs.iter().map(|txs| txs[i].clone()).collect(),
+            ));
+        }
+        Self {
+            num_shards,
+            control_txs,
+            result_rxs,
+            shard_threads: shard_join_handles,
+        }
+    }
+
+    // reorders the transactions so that transactions from the same sender always go to the same shard.
+    // This places transactions from the same sender next to each other, which is not optimal for parallelism.
+    // TODO(skedia): Improve this logic to shuffle senders
+    fn reorder_txns_by_senders(
+        &self,
+        txns: Vec<AnalyzedTransaction>,
+    ) -> Vec<Vec<AnalyzedTransaction>> {
+        let approx_txns_per_shard = (txns.len() as f64 / self.num_shards as f64).ceil() as usize;
+        let mut sender_to_txns = HashMap::new();
+        let mut sender_order = Vec::new(); // Track sender ordering
+
+        for txn in txns {
+            let sender = txn.sender().unwrap();
+            if !sender_to_txns.contains_key(&sender) {
+                sender_order.push(sender); // Add sender to the order vector
+            }
+            sender_to_txns
+                .entry(sender)
+                .or_insert_with(Vec::new)
+                .push(txn);
+        }
+
+        let mut result = Vec::new();
+        result.push(Vec::new());
+
+        for sender in sender_order {
+            let txns = sender_to_txns.remove(&sender).unwrap();
+            let txns_in_shard = result.last().unwrap().len();
+
+            if txns_in_shard < approx_txns_per_shard {
+                result.last_mut().unwrap().extend(txns);
+            } else {
+                result.push(txns);
+            }
+        }
+
+        // pad the rest of the shard with empty txns
+        for _ in result.len()..self.num_shards {
+            result.push(Vec::new());
+        }
+
+        result
+    }
+
+    fn send_partition_msgs(&self, partition_msg: Vec<ControlMsg>) {
+        for (i, msg) in partition_msg.into_iter().enumerate() {
+            self.control_txs[i].send(msg).unwrap();
+        }
+    }
+
+    fn collect_partition_block_response(
+        &self,
+    ) -> (
+        Vec<TransactionsChunk>,
+        Vec<RWSetWithTxnIndex>,
+        Vec<Vec<AnalyzedTransaction>>,
+    ) {
+        let mut frozen_chunks = Vec::new();
+        let mut frozen_rw_set_with_index = Vec::new();
+        let mut rejected_txns_vec = Vec::new();
+        for rx in &self.result_rxs {
+            let PartitioningBlockResponse {
+                frozen_chunk,
+                rw_set_with_index,
+                rejected_txns,
+            } = rx.recv().unwrap();
+            frozen_chunks.push(frozen_chunk);
+            frozen_rw_set_with_index.push(rw_set_with_index);
+            rejected_txns_vec.push(rejected_txns);
+        }
+        (frozen_chunks, frozen_rw_set_with_index, rejected_txns_vec)
+    }
+
+    fn discard_txns_with_cross_shard_dependencies(
+        &self,
+        txns_to_partition: Vec<Vec<AnalyzedTransaction>>,
+        frozen_chunks: Arc<Vec<TransactionsChunk>>,
+        frozen_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
+    ) -> (
+        Vec<TransactionsChunk>,
+        Vec<RWSetWithTxnIndex>,
+        Vec<Vec<AnalyzedTransaction>>,
+    ) {
+        let partition_block_msgs = txns_to_partition
+            .into_iter()
+            .map(|txns| {
+                DiscardCrossShardDepReq(DiscardTxnsWithCrossShardDep::new(
+                    txns,
+                    frozen_rw_set_with_index.clone(),
+                    frozen_chunks.clone(),
+                ))
+            })
+            .collect();
+        self.send_partition_msgs(partition_block_msgs);
+        self.collect_partition_block_response()
+    }
+
+    fn add_cross_shard_dependencies(
+        &self,
+        index_offset: usize,
+        remaining_txns_vec: Vec<Vec<AnalyzedTransaction>>,
+        frozen_chunks: Arc<Vec<TransactionsChunk>>,
+        frozen_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
+    ) -> (
+        Vec<TransactionsChunk>,
+        Vec<RWSetWithTxnIndex>,
+        Vec<Vec<AnalyzedTransaction>>,
+    ) {
+        let mut index_offset = index_offset;
+        let partition_block_msgs = remaining_txns_vec
+            .into_iter()
+            .map(|remaining_txns| {
+                let remaining_txns_len = remaining_txns.len();
+                let partitioning_msg = AddCrossShardDepReq(AddTxnsWithCrossShardDep::new(
+                    remaining_txns,
+                    index_offset,
+                    frozen_chunks.clone(),
+                    frozen_rw_set_with_index.clone(),
+                ));
+                index_offset += remaining_txns_len;
+                partitioning_msg
+            })
+            .collect::<Vec<ControlMsg>>();
+        self.send_partition_msgs(partition_block_msgs);
+        self.collect_partition_block_response()
+    }
+
+    /// We repeatedly partition chunks, discarding a bunch of transactions with cross-shard dependencies. The set of discarded
+    /// transactions are used as candidate chunks in the next round. This process is repeated until num_partitioning_rounds.
+    /// The remaining transactions are then added to the chunks with cross-shard dependencies.
+    pub fn partition(
+        &self,
+        transactions: Vec<AnalyzedTransaction>,
+        num_partitioning_round: usize,
+    ) -> Vec<TransactionsChunk> {
+        let total_txns = transactions.len();
+        if total_txns == 0 {
+            return vec![];
+        }
+
+        // First round, we filter all transactions with cross-shard dependencies
+        let mut txns_to_partition = self.reorder_txns_by_senders(transactions);
+        let mut frozen_rw_set_with_index = Arc::new(Vec::new());
+        let mut frozen_chunks = Arc::new(Vec::new());
+
+        for _ in 0..num_partitioning_round {
+            let (
+                current_frozen_chunks_vec,
+                current_frozen_rw_set_with_index_vec,
+                latest_txns_to_partition,
+            ) = self.discard_txns_with_cross_shard_dependencies(
+                txns_to_partition,
+                frozen_chunks.clone(),
+                frozen_rw_set_with_index.clone(),
+            );
+            let mut prev_frozen_chunk = Arc::try_unwrap(frozen_chunks).unwrap();
+            let mut prev_frozen_rw_set_with_index =
+                Arc::try_unwrap(frozen_rw_set_with_index).unwrap();
+            prev_frozen_chunk.extend(current_frozen_chunks_vec);
+            prev_frozen_rw_set_with_index.extend(current_frozen_rw_set_with_index_vec);
+            frozen_chunks = Arc::new(prev_frozen_chunk);
+            frozen_rw_set_with_index = Arc::new(prev_frozen_rw_set_with_index);
+            txns_to_partition = latest_txns_to_partition;
+            if txns_to_partition
+                .iter()
+                .map(|txns| txns.len())
+                .sum::<usize>()
+                == 0
+            {
+                return Arc::try_unwrap(frozen_chunks).unwrap();
+            }
+        }
+
+        // We just add cross shard dependencies for remaining transactions.
+        let index_offset = frozen_chunks.iter().map(|chunk| chunk.len()).sum::<usize>();
+        let (remaining_frozen_chunks, _, _) = self.add_cross_shard_dependencies(
+            index_offset,
+            txns_to_partition,
+            frozen_chunks.clone(),
+            frozen_rw_set_with_index,
+        );
+
+        Arc::try_unwrap(frozen_chunks)
+            .unwrap()
+            .into_iter()
+            .chain(remaining_frozen_chunks.into_iter())
+            .collect::<Vec<TransactionsChunk>>()
+    }
+}
+
+impl Drop for ShardedBlockPartitioner {
+    /// Best effort stops all the executor shards and waits for the thread to finish.
+    fn drop(&mut self) {
+        // send stop command to all executor shards
+        for control_tx in self.control_txs.iter() {
+            if let Err(e) = control_tx.send(ControlMsg::Stop) {
+                error!("Failed to send stop command to executor shard: {:?}", e);
+            }
+        }
+
+        // wait for all executor shards to stop
+        for shard_thread in self.shard_threads.drain(..) {
+            shard_thread.join().unwrap_or_else(|e| {
+                error!("Failed to join executor shard thread: {:?}", e);
+            });
+        }
+    }
+}
+
+fn spawn_partitioning_shard(
+    shard_id: ShardId,
+    control_rx: Receiver<ControlMsg>,
+    result_tx: Sender<PartitioningBlockResponse>,
+    message_rxs: Vec<Receiver<CrossShardMsg>>,
+    messages_txs: Vec<Sender<CrossShardMsg>>,
+) -> thread::JoinHandle<()> {
+    // create and start a new executor shard in a separate thread
+    thread::Builder::new()
+        .name(format!("partitioning-shard-{}", shard_id))
+        .spawn(move || {
+            let partitioning_shard =
+                PartitioningShard::new(shard_id, control_rx, result_tx, message_rxs, messages_txs);
+            partitioning_shard.start();
+        })
+        .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        sharded_block_partitioner::ShardedBlockPartitioner,
+        test_utils::{
+            create_non_conflicting_p2p_transaction, create_signed_p2p_transaction,
+            generate_test_account, generate_test_account_for_address, TestAccount,
+        },
+        types::TransactionsChunk,
+    };
+    use aptos_types::transaction::analyzed_transaction::AnalyzedTransaction;
+    use move_core_types::account_address::AccountAddress;
+    use rand::{rngs::OsRng, Rng};
+    use std::collections::HashMap;
+
+    fn verify_no_cross_shard_dependency(partitioned_txns: Vec<TransactionsChunk>) {
+        for chunk in partitioned_txns {
+            for txn in chunk.transactions {
+                assert_eq!(txn.cross_shard_dependencies().len(), 0);
+            }
+        }
+    }
+
+    #[test]
+    // Test that the partitioner works correctly for a single sender and multiple receivers.
+    // In this case the expectation is that only the first shard will contain transactions and all
+    // other shards will be empty.
+    fn test_single_sender_txns() {
+        let mut sender = generate_test_account();
+        let mut receivers = Vec::new();
+        let num_txns = 10;
+        for _ in 0..num_txns {
+            receivers.push(generate_test_account());
+        }
+        let transactions = create_signed_p2p_transaction(
+            &mut sender,
+            receivers.iter().collect::<Vec<&TestAccount>>(),
+        );
+        let partitioner = ShardedBlockPartitioner::new(4);
+        let partitioned_txns = partitioner.partition(transactions.clone(), 1);
+        assert_eq!(partitioned_txns.len(), 4);
+        // The first shard should contain all the transactions
+        assert_eq!(partitioned_txns[0].len(), num_txns);
+        // The rest of the shards should be empty
+        for txns in partitioned_txns.iter().take(4).skip(1) {
+            assert_eq!(txns.len(), 0);
+        }
+        // Verify that the transactions are in the same order as the original transactions and cross shard
+        // dependencies are empty.
+        for (i, txn) in partitioned_txns[0].transactions.iter().enumerate() {
+            assert_eq!(txn.txn(), &transactions[i]);
+            assert_eq!(txn.cross_shard_dependencies().len(), 0);
+        }
+    }
+
+    #[test]
+    // Test that the partitioner works correctly for no conflict transactions. In this case, the
+    // expectation is that no transaction is reordered.
+    fn test_non_conflicting_txns() {
+        let num_txns = 4;
+        let num_shards = 2;
+        let mut transactions = Vec::new();
+        for _ in 0..num_txns {
+            transactions.push(create_non_conflicting_p2p_transaction())
+        }
+        let partitioner = ShardedBlockPartitioner::new(num_shards);
+        let partitioned_txns = partitioner.partition(transactions.clone(), 1);
+        assert_eq!(partitioned_txns.len(), num_shards);
+        // Verify that the transactions are in the same order as the original transactions and cross shard
+        // dependencies are empty.
+        let mut current_index = 0;
+        for analyzed_txns in partitioned_txns.into_iter() {
+            assert_eq!(analyzed_txns.len(), num_txns / num_shards);
+            for txn in analyzed_txns.transactions.iter() {
+                assert_eq!(txn.txn(), &transactions[current_index]);
+                assert_eq!(txn.cross_shard_dependencies().len(), 0);
+                current_index += 1;
+            }
+        }
+    }
+
+    #[test]
+    fn test_same_sender_in_one_shard() {
+        let num_shards = 3;
+        let mut sender = generate_test_account();
+        let mut txns_from_sender = Vec::new();
+        for _ in 0..5 {
+            txns_from_sender.push(
+                create_signed_p2p_transaction(&mut sender, vec![&generate_test_account()])
+                    .remove(0),
+            );
+        }
+        let mut non_conflicting_transactions = Vec::new();
+        for _ in 0..5 {
+            non_conflicting_transactions.push(create_non_conflicting_p2p_transaction());
+        }
+
+        let mut transactions = Vec::new();
+        let mut txn_from_sender_index = 0;
+        let mut non_conflicting_txn_index = 0;
+        transactions.push(non_conflicting_transactions[non_conflicting_txn_index].clone());
+        non_conflicting_txn_index += 1;
+        transactions.push(txns_from_sender[txn_from_sender_index].clone());
+        txn_from_sender_index += 1;
+        transactions.push(txns_from_sender[txn_from_sender_index].clone());
+        txn_from_sender_index += 1;
+        transactions.push(non_conflicting_transactions[non_conflicting_txn_index].clone());
+        non_conflicting_txn_index += 1;
+        transactions.push(txns_from_sender[txn_from_sender_index].clone());
+        txn_from_sender_index += 1;
+        transactions.push(txns_from_sender[txn_from_sender_index].clone());
+        txn_from_sender_index += 1;
+        transactions.push(non_conflicting_transactions[non_conflicting_txn_index].clone());
+        transactions.push(txns_from_sender[txn_from_sender_index].clone());
+
+        let partitioner = ShardedBlockPartitioner::new(num_shards);
+        let partitioned_txns = partitioner.partition(transactions.clone(), 1);
+        assert_eq!(partitioned_txns.len(), num_shards);
+        assert_eq!(partitioned_txns[0].len(), 6);
+        assert_eq!(partitioned_txns[1].len(), 2);
+        assert_eq!(partitioned_txns[2].len(), 0);
+
+        // verify that all transactions from the sender end up in shard 0
+        for (index, txn) in txns_from_sender.iter().enumerate() {
+            assert_eq!(partitioned_txns[0].transactions[index + 1].txn(), txn);
+        }
+        verify_no_cross_shard_dependency(partitioned_txns);
+    }
+
+    #[test]
+    fn test_cross_shard_dependencies() {
+        let num_shards = 3;
+        let mut account1 = generate_test_account_for_address(AccountAddress::new([0; 32]));
+        let mut account2 = generate_test_account_for_address(AccountAddress::new([1; 32]));
+        let mut account3 = generate_test_account_for_address(AccountAddress::new([2; 32]));
+        let mut account4 = generate_test_account_for_address(AccountAddress::new([4; 32]));
+        let mut account5 = generate_test_account_for_address(AccountAddress::new([5; 32]));
+        let account6 = generate_test_account_for_address(AccountAddress::new([6; 32]));
+
+        let txn0 = create_signed_p2p_transaction(&mut account1, vec![&account2]).remove(0); // txn 0
+        let txn1 = create_signed_p2p_transaction(&mut account1, vec![&account3]).remove(0); // txn 1
+        let txn2 = create_signed_p2p_transaction(&mut account2, vec![&account4]).remove(0); // txn 2
+                                                                                            // Should go in shard 1
+        let txn3 = create_signed_p2p_transaction(&mut account3, vec![&account4]).remove(0); // txn 3
+        let txn4 = create_signed_p2p_transaction(&mut account3, vec![&account1]).remove(0); // txn 4
+        let txn5 = create_signed_p2p_transaction(&mut account3, vec![&account2]).remove(0); // txn 5
+                                                                                            // Should go in shard 2
+        let txn6 = create_signed_p2p_transaction(&mut account4, vec![&account1]).remove(0); // txn 6
+        let txn7 = create_signed_p2p_transaction(&mut account4, vec![&account2]).remove(0); // txn 7
+        let txn8 = create_signed_p2p_transaction(&mut account5, vec![&account6]).remove(0); // txn 8
+
+        let transactions = vec![
+            txn0.clone(),
+            txn1.clone(),
+            txn2.clone(),
+            txn3.clone(),
+            txn4.clone(),
+            txn5.clone(),
+            txn6.clone(),
+            txn7.clone(),
+            txn8.clone(),
+        ];
+
+        let partitioner = ShardedBlockPartitioner::new(num_shards);
+        let partitioned_chunks = partitioner.partition(transactions, 1);
+        assert_eq!(partitioned_chunks.len(), 2 * num_shards);
+
+        // In first round of the partitioning, we should have txn0, txn1 and txn2 in shard 0 and
+        // 0 in shard 1 and txn8 in shard 2
+        assert_eq!(partitioned_chunks[0].len(), 3);
+        assert_eq!(partitioned_chunks[1].len(), 0);
+        assert_eq!(partitioned_chunks[2].len(), 1);
+
+        assert_eq!(
+            partitioned_chunks[0]
+                .transactions_with_deps()
+                .iter()
+                .map(|x| x.txn.clone())
+                .collect::<Vec<AnalyzedTransaction>>(),
+            vec![txn0, txn1, txn2]
+        );
+        assert_eq!(
+            partitioned_chunks[2]
+                .transactions_with_deps()
+                .iter()
+                .map(|x| x.txn.clone())
+                .collect::<Vec<AnalyzedTransaction>>(),
+            vec![txn8]
+        );
+
+        // Rest of the transactions will be added in round 2 along with their dependencies
+        assert_eq!(partitioned_chunks[3].len(), 0);
+        assert_eq!(partitioned_chunks[4].len(), 3);
+        assert_eq!(partitioned_chunks[5].len(), 2);
+
+        assert_eq!(
+            partitioned_chunks[4]
+                .transactions_with_deps()
+                .iter()
+                .map(|x| x.txn.clone())
+                .collect::<Vec<AnalyzedTransaction>>(),
+            vec![txn3, txn4, txn5]
+        );
+        assert_eq!(
+            partitioned_chunks[5]
+                .transactions_with_deps()
+                .iter()
+                .map(|x| x.txn.clone())
+                .collect::<Vec<AnalyzedTransaction>>(),
+            vec![txn6, txn7]
+        );
+
+        // Verify transaction dependencies
+        verify_no_cross_shard_dependency(vec![
+            partitioned_chunks[0].clone(),
+            partitioned_chunks[1].clone(),
+            partitioned_chunks[2].clone(),
+        ]);
+        // txn3 depends on txn1 (index 1) and txn2 (index 2)
+        assert!(partitioned_chunks[4].transactions_with_deps()[0]
+            .cross_shard_dependencies
+            .is_depends_on(1));
+        assert!(partitioned_chunks[4].transactions_with_deps()[0]
+            .cross_shard_dependencies
+            .is_depends_on(2));
+
+        // txn4 depends on txn1 (index 1)
+        assert!(partitioned_chunks[4].transactions_with_deps()[1]
+            .cross_shard_dependencies
+            .is_depends_on(1));
+        // txn5 depends on txn1 (index 1) and txn2 (index 2)
+        assert!(partitioned_chunks[4].transactions_with_deps()[2]
+            .cross_shard_dependencies
+            .is_depends_on(1));
+        assert!(partitioned_chunks[4].transactions_with_deps()[2]
+            .cross_shard_dependencies
+            .is_depends_on(2));
+        // txn6 depends on txn3 (index 4) and txn4 (index 5)
+        assert!(partitioned_chunks[5].transactions_with_deps()[0]
+            .cross_shard_dependencies
+            .is_depends_on(4));
+        assert!(partitioned_chunks[5].transactions_with_deps()[0]
+            .cross_shard_dependencies
+            .is_depends_on(5));
+        // txn7 depends on txn3 (index 4) and txn5 (index 5)
+        assert!(partitioned_chunks[5].transactions_with_deps()[1]
+            .cross_shard_dependencies
+            .is_depends_on(4));
+        assert!(partitioned_chunks[5].transactions_with_deps()[1]
+            .cross_shard_dependencies
+            .is_depends_on(6));
+    }
+
+    #[test]
+    // Generates a bunch of random transactions and ensures that after the partitioning, there is
+    // no conflict across shards.
+    fn test_no_conflict_across_shards_in_first_round() {
+        let mut rng = OsRng;
+        let max_accounts = 500;
+        let max_txns = 2000;
+        let max_num_shards = 64;
+        let num_accounts = rng.gen_range(1, max_accounts);
+        let mut accounts = Vec::new();
+        for _ in 0..num_accounts {
+            accounts.push(generate_test_account());
+        }
+        let num_txns = rng.gen_range(1, max_txns);
+        let mut transactions = Vec::new();
+        let num_shards = rng.gen_range(1, max_num_shards);
+
+        for _ in 0..num_txns {
+            // randomly select a sender and receiver from accounts
+            let sender_index = rng.gen_range(0, accounts.len());
+            let mut sender = accounts.swap_remove(sender_index);
+            let receiver_index = rng.gen_range(0, accounts.len());
+            let receiver = accounts.get(receiver_index).unwrap();
+            transactions.push(create_signed_p2p_transaction(&mut sender, vec![receiver]).remove(0));
+            accounts.push(sender)
+        }
+        let partitioner = ShardedBlockPartitioner::new(num_shards);
+        let partitioned_txns = partitioner.partition(transactions, 1);
+        // Build a map of storage location to corresponding shards in first round
+        // and ensure that no storage location is present in more than one shard.
+        let mut storage_location_to_shard_map = HashMap::new();
+        for (shard_id, txns) in partitioned_txns.iter().enumerate().take(num_shards) {
+            for txn in txns.transactions_with_deps().iter() {
+                let storage_locations = txn
+                    .txn()
+                    .read_set()
+                    .iter()
+                    .chain(txn.txn().write_set().iter());
+                for storage_location in storage_locations {
+                    if storage_location_to_shard_map.contains_key(storage_location) {
+                        assert_eq!(
+                            storage_location_to_shard_map.get(storage_location).unwrap(),
+                            &shard_id
+                        );
+                    } else {
+                        storage_location_to_shard_map.insert(storage_location, shard_id);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/execution/block-partitioner/src/sharded_block_partitioner/mod.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         },
         partitioning_shard::PartitioningShard,
     },
-    types::{ShardId, TransactionsChunk},
+    types::{ShardId, SubBlock},
 };
 use aptos_logger::{error, info};
 use aptos_types::transaction::analyzed_transaction::AnalyzedTransaction;
@@ -204,7 +204,7 @@ impl ShardedBlockPartitioner {
     fn collect_partition_block_response(
         &self,
     ) -> (
-        Vec<TransactionsChunk>,
+        Vec<SubBlock>,
         Vec<RWSetWithTxnIndex>,
         Vec<Vec<AnalyzedTransaction>>,
     ) {
@@ -227,10 +227,10 @@ impl ShardedBlockPartitioner {
     fn discard_txns_with_cross_shard_dependencies(
         &self,
         txns_to_partition: Vec<Vec<AnalyzedTransaction>>,
-        frozen_chunks: Arc<Vec<TransactionsChunk>>,
+        frozen_chunks: Arc<Vec<SubBlock>>,
         frozen_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
     ) -> (
-        Vec<TransactionsChunk>,
+        Vec<SubBlock>,
         Vec<RWSetWithTxnIndex>,
         Vec<Vec<AnalyzedTransaction>>,
     ) {
@@ -252,10 +252,10 @@ impl ShardedBlockPartitioner {
         &self,
         index_offset: usize,
         remaining_txns_vec: Vec<Vec<AnalyzedTransaction>>,
-        frozen_chunks: Arc<Vec<TransactionsChunk>>,
+        frozen_chunks: Arc<Vec<SubBlock>>,
         frozen_rw_set_with_index: Arc<Vec<RWSetWithTxnIndex>>,
     ) -> (
-        Vec<TransactionsChunk>,
+        Vec<SubBlock>,
         Vec<RWSetWithTxnIndex>,
         Vec<Vec<AnalyzedTransaction>>,
     ) {
@@ -285,7 +285,7 @@ impl ShardedBlockPartitioner {
         &self,
         transactions: Vec<AnalyzedTransaction>,
         num_partitioning_round: usize,
-    ) -> Vec<TransactionsChunk> {
+    ) -> Vec<SubBlock> {
         let total_txns = transactions.len();
         if total_txns == 0 {
             return vec![];
@@ -337,7 +337,7 @@ impl ShardedBlockPartitioner {
             .unwrap()
             .into_iter()
             .chain(remaining_frozen_chunks.into_iter())
-            .collect::<Vec<TransactionsChunk>>()
+            .collect::<Vec<SubBlock>>()
     }
 }
 
@@ -386,14 +386,14 @@ mod tests {
             create_non_conflicting_p2p_transaction, create_signed_p2p_transaction,
             generate_test_account, generate_test_account_for_address, TestAccount,
         },
-        types::TransactionsChunk,
+        types::SubBlock,
     };
     use aptos_types::transaction::analyzed_transaction::AnalyzedTransaction;
     use move_core_types::account_address::AccountAddress;
     use rand::{rngs::OsRng, Rng};
     use std::collections::HashMap;
 
-    fn verify_no_cross_shard_dependency(partitioned_txns: Vec<TransactionsChunk>) {
+    fn verify_no_cross_shard_dependency(partitioned_txns: Vec<SubBlock>) {
         for chunk in partitioned_txns {
             for txn in chunk.transactions {
                 assert_eq!(txn.cross_shard_dependencies().len(), 0);

--- a/execution/block-partitioner/src/sharded_block_partitioner/partitioning_shard.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/partitioning_shard.rs
@@ -1,0 +1,242 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    sharded_block_partitioner::{
+        conflict_detector::CrossShardConflictDetector,
+        dependency_analysis::{RWSet, RWSetWithTxnIndex},
+        messages::{
+            AddTxnsWithCrossShardDep, ControlMsg, CrossShardMsg, DiscardTxnsWithCrossShardDep,
+            PartitioningBlockResponse,
+        },
+    },
+    types::{ShardId, TransactionWithDependencies, TransactionsChunk},
+};
+use aptos_logger::trace;
+use std::sync::{
+    mpsc::{Receiver, Sender},
+    Arc,
+};
+
+pub struct PartitioningShard {
+    shard_id: ShardId,
+    control_rx: Receiver<ControlMsg>,
+    result_tx: Sender<PartitioningBlockResponse>,
+    message_rxs: Vec<Receiver<CrossShardMsg>>,
+    message_txs: Vec<Sender<CrossShardMsg>>,
+}
+
+impl PartitioningShard {
+    pub fn new(
+        shard_id: ShardId,
+        control_rx: Receiver<ControlMsg>,
+        result_tx: Sender<PartitioningBlockResponse>,
+        message_rxs: Vec<Receiver<CrossShardMsg>>,
+        messages_txs: Vec<Sender<CrossShardMsg>>,
+    ) -> Self {
+        Self {
+            shard_id,
+            control_rx,
+            result_tx,
+            message_rxs,
+            message_txs: messages_txs,
+        }
+    }
+
+    fn broadcast_rw_set(&self, rw_set: RWSet) {
+        let num_shards = self.message_txs.len();
+        for i in 0..num_shards {
+            if i != self.shard_id {
+                self.message_txs[i]
+                    .send(CrossShardMsg::RWSetMsg(rw_set.clone()))
+                    .unwrap();
+            }
+        }
+    }
+
+    fn collect_rw_set(&self) -> Vec<RWSet> {
+        let mut rw_set_vec = vec![RWSet::default(); self.message_txs.len()];
+        for (i, msg_rx) in self.message_rxs.iter().enumerate() {
+            if i == self.shard_id {
+                continue;
+            }
+
+            let msg = msg_rx.recv().unwrap();
+            match msg {
+                CrossShardMsg::RWSetMsg(rw_set) => {
+                    rw_set_vec[i] = rw_set;
+                },
+                _ => panic!("Unexpected message"),
+            }
+        }
+        rw_set_vec
+    }
+
+    fn broadcast_rw_set_with_index(&self, rw_set_with_index: RWSetWithTxnIndex) {
+        let num_shards = self.message_txs.len();
+        for i in 0..num_shards {
+            if i != self.shard_id {
+                self.message_txs[i]
+                    .send(CrossShardMsg::RWSetWithTxnIndexMsg(
+                        rw_set_with_index.clone(),
+                    ))
+                    .unwrap();
+            }
+        }
+    }
+
+    fn collect_rw_set_with_index(&self) -> Vec<RWSetWithTxnIndex> {
+        let mut rw_set_with_index_vec = vec![RWSetWithTxnIndex::default(); self.message_txs.len()];
+        for (i, msg_rx) in self.message_rxs.iter().enumerate() {
+            if i == self.shard_id {
+                continue;
+            }
+            let msg = msg_rx.recv().unwrap();
+            match msg {
+                CrossShardMsg::RWSetWithTxnIndexMsg(rw_set_with_index) => {
+                    rw_set_with_index_vec[i] = rw_set_with_index;
+                },
+                _ => panic!("Unexpected message"),
+            }
+        }
+        rw_set_with_index_vec
+    }
+
+    fn broadcast_num_accepted_txns(&self, num_accepted_txns: usize) {
+        let num_shards = self.message_txs.len();
+        for i in 0..num_shards {
+            if i != self.shard_id {
+                self.message_txs[i]
+                    .send(CrossShardMsg::AcceptedTxnsMsg(num_accepted_txns))
+                    .unwrap();
+            }
+        }
+    }
+
+    fn collect_num_accepted_txns(&self) -> Vec<usize> {
+        let mut accepted_txns_vec = vec![0; self.message_txs.len()];
+        for (i, msg_rx) in self.message_rxs.iter().enumerate() {
+            if i == self.shard_id {
+                continue;
+            }
+            let msg = msg_rx.recv().unwrap();
+            match msg {
+                CrossShardMsg::AcceptedTxnsMsg(num_accepted_txns) => {
+                    accepted_txns_vec[i] = num_accepted_txns;
+                },
+                _ => panic!("Unexpected message"),
+            }
+        }
+        accepted_txns_vec
+    }
+
+    fn discard_txns_with_cross_shard_deps(&self, partition_msg: DiscardTxnsWithCrossShardDep) {
+        let DiscardTxnsWithCrossShardDep {
+            transactions,
+            prev_rounds_rw_set_with_index,
+            prev_rounds_frozen_chunks,
+        } = partition_msg;
+        let num_shards = self.message_txs.len();
+        let mut conflict_detector = CrossShardConflictDetector::new(self.shard_id, num_shards);
+        // If transaction filtering is allowed, we need to prepare the dependency analysis and broadcast it to other shards
+        // Based on the dependency analysis received from other shards, we will reject transactions that are conflicting with
+        // transactions in other shards
+        let read_write_set = RWSet::new(&transactions);
+        self.broadcast_rw_set(read_write_set);
+        let cross_shard_rw_set = self.collect_rw_set();
+        let (accepted_txns, accepted_cross_shard_dependencies, rejected_txns) = conflict_detector
+            .discard_txns_with_cross_shard_deps(
+                transactions,
+                &cross_shard_rw_set,
+                prev_rounds_rw_set_with_index,
+            );
+        // Broadcast and collect the stats around number of accepted and rejected transactions from other shards
+        // this will be used to determine the absolute index of accepted transactions in this shard.
+        self.broadcast_num_accepted_txns(accepted_txns.len());
+        let accepted_txns_vec = self.collect_num_accepted_txns();
+        // Calculate the absolute index of accepted transactions in this shard, which is the sum of all accepted transactions
+        // from other shards whose shard id is smaller than the current shard id and the number of accepted transactions in the
+        // previous rounds
+        let mut index_offset = prev_rounds_frozen_chunks
+            .iter()
+            .map(|chunk| chunk.len())
+            .sum::<usize>();
+        for num_accepted_txns in accepted_txns_vec.iter().take(self.shard_id) {
+            index_offset += num_accepted_txns;
+        }
+
+        // Calculate the RWSetWithTxnIndex for the accepted transactions
+        let current_rw_set_with_index = RWSetWithTxnIndex::new(&accepted_txns, index_offset);
+
+        let accepted_txns_with_dependencies = accepted_txns
+            .into_iter()
+            .zip(accepted_cross_shard_dependencies.into_iter())
+            .map(|(txn, dependencies)| TransactionWithDependencies::new(txn, dependencies))
+            .collect::<Vec<TransactionWithDependencies>>();
+
+        let frozen_chunk = TransactionsChunk::new(index_offset, accepted_txns_with_dependencies);
+        drop(prev_rounds_frozen_chunks);
+        // send the result back to the controller
+        self.result_tx
+            .send(PartitioningBlockResponse::new(
+                frozen_chunk,
+                current_rw_set_with_index,
+                rejected_txns,
+            ))
+            .unwrap();
+    }
+
+    fn add_txns_with_cross_shard_deps(&self, partition_msg: AddTxnsWithCrossShardDep) {
+        let AddTxnsWithCrossShardDep {
+            transactions,
+            index_offset,
+            prev_rounds_frozen_chunks,
+            // The frozen dependencies in previous chunks.
+            prev_rounds_rw_set_with_index,
+        } = partition_msg;
+        let num_shards = self.message_txs.len();
+        let conflict_detector = CrossShardConflictDetector::new(self.shard_id, num_shards);
+
+        // Since txn filtering is not allowed, we can create the RW set with maximum txn
+        // index with the index offset passed.
+        let rw_set_with_index_for_shard = RWSetWithTxnIndex::new(&transactions, index_offset);
+
+        self.broadcast_rw_set_with_index(rw_set_with_index_for_shard.clone());
+        let current_round_rw_set_with_index = self.collect_rw_set_with_index();
+        let frozen_chunk = conflict_detector.get_frozen_chunk(
+            transactions,
+            Arc::new(current_round_rw_set_with_index),
+            prev_rounds_rw_set_with_index,
+            index_offset,
+        );
+
+        drop(prev_rounds_frozen_chunks);
+
+        self.result_tx
+            .send(PartitioningBlockResponse::new(
+                frozen_chunk,
+                rw_set_with_index_for_shard,
+                vec![],
+            ))
+            .unwrap();
+    }
+
+    pub fn start(&self) {
+        loop {
+            let command = self.control_rx.recv().unwrap();
+            match command {
+                ControlMsg::DiscardCrossShardDepReq(msg) => {
+                    self.discard_txns_with_cross_shard_deps(msg);
+                },
+                ControlMsg::AddCrossShardDepReq(msg) => {
+                    self.add_txns_with_cross_shard_deps(msg);
+                },
+                ControlMsg::Stop => {
+                    break;
+                },
+            }
+        }
+        trace!("Shard {} is shutting down", self.shard_id);
+    }
+}

--- a/execution/block-partitioner/src/sharded_block_partitioner/partitioning_shard.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/partitioning_shard.rs
@@ -11,7 +11,7 @@ use crate::{
             PartitioningBlockResponse,
         },
     },
-    types::{ShardId, TransactionWithDependencies, TransactionsChunk},
+    types::{ShardId, SubBlock, TransactionWithDependencies},
 };
 use aptos_logger::trace;
 use std::sync::{
@@ -175,7 +175,7 @@ impl PartitioningShard {
             .map(|(txn, dependencies)| TransactionWithDependencies::new(txn, dependencies))
             .collect::<Vec<TransactionWithDependencies>>();
 
-        let frozen_chunk = TransactionsChunk::new(index_offset, accepted_txns_with_dependencies);
+        let frozen_chunk = SubBlock::new(index_offset, accepted_txns_with_dependencies);
         drop(prev_rounds_frozen_chunks);
         // send the result back to the controller
         self.result_tx

--- a/execution/block-partitioner/src/test_utils.rs
+++ b/execution/block-partitioner/src/test_utils.rs
@@ -1,0 +1,109 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_crypto::{ed25519::ed25519_keys::Ed25519PrivateKey, PrivateKey, SigningKey, Uniform};
+use aptos_types::{
+    chain_id::ChainId,
+    transaction::{
+        analyzed_transaction::AnalyzedTransaction, EntryFunction, RawTransaction, Script,
+        SignedTransaction, Transaction, TransactionPayload,
+    },
+    utility_coin::APTOS_COIN_TYPE,
+};
+use move_core_types::{
+    account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
+};
+
+#[derive(Debug)]
+pub struct TestAccount {
+    pub account_address: AccountAddress,
+    pub private_key: Ed25519PrivateKey,
+    pub sequence_number: u64,
+}
+
+pub fn generate_test_account() -> TestAccount {
+    TestAccount {
+        account_address: AccountAddress::random(),
+        private_key: Ed25519PrivateKey::generate_for_testing(),
+        sequence_number: 0,
+    }
+}
+
+pub fn generate_test_account_for_address(account_address: AccountAddress) -> TestAccount {
+    TestAccount {
+        account_address,
+        private_key: Ed25519PrivateKey::generate_for_testing(),
+        sequence_number: 0,
+    }
+}
+
+pub fn create_no_dependency_transaction(num_transactions: usize) -> Vec<AnalyzedTransaction> {
+    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let public_key = private_key.public_key();
+    let sender = AccountAddress::random();
+
+    let mut transactions = Vec::new();
+
+    for i in 0..num_transactions {
+        let transaction_payload = TransactionPayload::Script(Script::new(vec![], vec![], vec![]));
+        let raw_transaction = RawTransaction::new(
+            sender,
+            i as u64,
+            transaction_payload,
+            0,
+            0,
+            0,
+            ChainId::new(10),
+        );
+        let txn = Transaction::UserTransaction(SignedTransaction::new(
+            raw_transaction.clone(),
+            public_key.clone(),
+            private_key.sign(&raw_transaction).unwrap(),
+        ));
+        transactions.push(txn.into())
+    }
+    transactions
+}
+
+pub fn create_non_conflicting_p2p_transaction() -> AnalyzedTransaction {
+    // create unique sender and receiver accounts so that there is no conflict
+    let mut sender = generate_test_account();
+    let receiver = generate_test_account();
+    create_signed_p2p_transaction(&mut sender, vec![&receiver]).remove(0)
+}
+
+pub fn create_signed_p2p_transaction(
+    sender: &mut TestAccount,
+    receivers: Vec<&TestAccount>,
+) -> Vec<AnalyzedTransaction> {
+    let mut transactions = Vec::new();
+    for (_, receiver) in receivers.iter().enumerate() {
+        let transaction_payload = TransactionPayload::EntryFunction(EntryFunction::new(
+            ModuleId::new(AccountAddress::ONE, Identifier::new("coin").unwrap()),
+            Identifier::new("transfer").unwrap(),
+            vec![APTOS_COIN_TYPE.clone()],
+            vec![
+                bcs::to_bytes(&receiver.account_address).unwrap(),
+                bcs::to_bytes(&1u64).unwrap(),
+            ],
+        ));
+
+        let raw_transaction = RawTransaction::new(
+            sender.account_address,
+            sender.sequence_number,
+            transaction_payload,
+            0,
+            0,
+            0,
+            ChainId::new(10),
+        );
+        sender.sequence_number += 1;
+        let txn = Transaction::UserTransaction(SignedTransaction::new(
+            raw_transaction.clone(),
+            sender.private_key.public_key().clone(),
+            sender.private_key.sign(&raw_transaction).unwrap(),
+        ));
+        transactions.push(txn.into())
+    }
+    transactions
+}

--- a/execution/block-partitioner/src/types.rs
+++ b/execution/block-partitioner/src/types.rs
@@ -1,0 +1,109 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_types::transaction::analyzed_transaction::AnalyzedTransaction;
+use std::collections::HashSet;
+
+pub type ShardId = usize;
+pub type TxnIndex = usize;
+
+#[derive(Default, Debug, Clone)]
+/// Represents the dependencies of a transaction on other transactions across shards. Two types
+/// of dependencies are supported:
+/// 1. `depends_on`: The transaction depends on the execution of the transactions in the set. In this
+/// case, the transaction can only be executed after the transactions in the set have been executed.
+/// 2. `dependents`: The transactions in the set depend on the execution of the transaction. In this
+/// case, the transactions in the set can only be executed after the transaction has been executed.
+pub struct CrossShardDependencies {
+    depends_on: HashSet<TxnIndex>,
+    // TODO (skedia) add support for this.
+    _dependents: HashSet<TxnIndex>,
+}
+
+impl CrossShardDependencies {
+    pub fn len(&self) -> usize {
+        self.depends_on.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.depends_on.is_empty()
+    }
+
+    pub fn is_depends_on(&self, txn_index: TxnIndex) -> bool {
+        self.depends_on.contains(&txn_index)
+    }
+
+    pub fn add_depends_on_txn(&mut self, txn_index: TxnIndex) {
+        self.depends_on.insert(txn_index);
+    }
+}
+
+#[derive(Debug, Clone)]
+/// A contiguous chunk of transactions (along with their dependencies) in a block.
+///
+/// Each `TransactionsChunk` represents a sequential section of transactions within a block.
+/// The chunk includes the index of the first transaction relative to the block and a vector
+/// of `TransactionWithDependencies` representing the transactions included in the chunk.
+///
+/// Illustration:
+/// ```plaintext
+///  Block (Split into 3 transactions chunks):
+///  +----------------+------------------+------------------+
+///  | Chunk 1        | Chunk 2          | Chunk 3          |
+///  +----------------+------------------+------------------+
+///  | Transaction 1  | Transaction 4    | Transaction 7    |
+///  | Transaction 2  | Transaction 5    | Transaction 8    |
+///  | Transaction 3  | Transaction 6    | Transaction 9    |
+///  +----------------+------------------+------------------+
+/// ```
+pub struct TransactionsChunk {
+    // This is the index of first transaction relative to the block.
+    pub start_index: TxnIndex,
+    pub transactions: Vec<TransactionWithDependencies>,
+}
+
+impl TransactionsChunk {
+    pub fn new(start_index: TxnIndex, transactions: Vec<TransactionWithDependencies>) -> Self {
+        Self {
+            start_index,
+            transactions,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.transactions.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.transactions.is_empty()
+    }
+
+    pub fn transactions_with_deps(&self) -> &Vec<TransactionWithDependencies> {
+        &self.transactions
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TransactionWithDependencies {
+    pub txn: AnalyzedTransaction,
+    pub cross_shard_dependencies: CrossShardDependencies,
+}
+
+impl TransactionWithDependencies {
+    pub fn new(txn: AnalyzedTransaction, cross_shard_dependencies: CrossShardDependencies) -> Self {
+        Self {
+            txn,
+            cross_shard_dependencies,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn txn(&self) -> &AnalyzedTransaction {
+        &self.txn
+    }
+
+    #[cfg(test)]
+    pub fn cross_shard_dependencies(&self) -> &CrossShardDependencies {
+        &self.cross_shard_dependencies
+    }
+}

--- a/execution/block-partitioner/src/types.rs
+++ b/execution/block-partitioner/src/types.rs
@@ -41,7 +41,7 @@ impl CrossShardDependencies {
 #[derive(Debug, Clone)]
 /// A contiguous chunk of transactions (along with their dependencies) in a block.
 ///
-/// Each `TransactionsChunk` represents a sequential section of transactions within a block.
+/// Each `SubBlock` represents a sequential section of transactions within a block.
 /// The chunk includes the index of the first transaction relative to the block and a vector
 /// of `TransactionWithDependencies` representing the transactions included in the chunk.
 ///
@@ -56,13 +56,13 @@ impl CrossShardDependencies {
 ///  | Transaction 3  | Transaction 6    | Transaction 9    |
 ///  +----------------+------------------+------------------+
 /// ```
-pub struct TransactionsChunk {
+pub struct SubBlock {
     // This is the index of first transaction relative to the block.
     pub start_index: TxnIndex,
     pub transactions: Vec<TransactionWithDependencies>,
 }
 
-impl TransactionsChunk {
+impl SubBlock {
     pub fn new(start_index: TxnIndex, transactions: Vec<TransactionWithDependencies>) -> Self {
         Self {
             start_index,

--- a/execution/block-partitioner/src/types.rs
+++ b/execution/block-partitioner/src/types.rs
@@ -3,11 +3,12 @@
 
 use aptos_types::transaction::analyzed_transaction::AnalyzedTransaction;
 use std::collections::HashSet;
+use std::fmt::{Debug, Formatter, Write};
 
 pub type ShardId = usize;
 pub type TxnIndex = usize;
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Clone)]
 /// Represents the dependencies of a transaction on other transactions across shards. Two types
 /// of dependencies are supported:
 /// 1. `depends_on`: The transaction depends on the execution of the transactions in the set. In this
@@ -20,6 +21,12 @@ pub struct CrossShardDependencies {
     _dependents: HashSet<TxnIndex>,
 }
 
+impl Debug for CrossShardDependencies {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let deps = &self.depends_on;
+        f.write_str(format!("{deps:?}").as_str())
+    }
+}
 impl CrossShardDependencies {
     pub fn len(&self) -> usize {
         self.depends_on.len()
@@ -83,10 +90,18 @@ impl SubBlock {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct TransactionWithDependencies {
     pub txn: AnalyzedTransaction,
     pub cross_shard_dependencies: CrossShardDependencies,
+}
+
+impl Debug for TransactionWithDependencies {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let txn  = &self.txn;
+        let deps = &self.cross_shard_dependencies;
+        f.write_str(format!("TXN({txn:?},deps={deps:?})").as_str())
+    }
 }
 
 impl TransactionWithDependencies {

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -15,7 +15,10 @@ use aptos_storage_interface::{
 };
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
-    transaction::{Transaction, TransactionOutput, TransactionToCommit, Version},
+    transaction::{
+        analyzed_transaction::AnalyzedTransaction, Transaction, TransactionOutput,
+        TransactionToCommit, Version,
+    },
     vm_status::VMStatus,
 };
 use aptos_vm::{sharded_block_executor::ShardedBlockExecutor, VMExecutor};
@@ -72,7 +75,7 @@ impl TransactionBlockExecutor for FakeVM {
 impl VMExecutor for FakeVM {
     fn execute_block_sharded<S: StateView + Send + Sync>(
         _sharded_block_executor: &ShardedBlockExecutor<S>,
-        _transactions: Vec<Transaction>,
+        _transactions: Vec<AnalyzedTransaction>,
         _state_view: Arc<S>,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         Ok(Vec::new())

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -23,9 +23,10 @@ use aptos_types::{
     },
     state_store::state_key::StateKey,
     transaction::{
-        ChangeSet, ExecutionStatus, NoOpChangeSetChecker, RawTransaction, Script,
-        SignedTransaction, Transaction, TransactionArgument, TransactionOutput, TransactionPayload,
-        TransactionStatus, WriteSetPayload,
+        analyzed_transaction::AnalyzedTransaction, ChangeSet, ExecutionStatus,
+        NoOpChangeSetChecker, RawTransaction, Script, SignedTransaction, Transaction,
+        TransactionArgument, TransactionOutput, TransactionPayload, TransactionStatus,
+        WriteSetPayload,
     },
     vm_status::{StatusCode, VMStatus},
     write_set::{WriteOp, WriteSet, WriteSetMut},
@@ -222,7 +223,7 @@ impl VMExecutor for MockVM {
 
     fn execute_block_sharded<S: StateView + Sync + Send + 'static>(
         _sharded_block_executor: &ShardedBlockExecutor<S>,
-        _transactions: Vec<Transaction>,
+        _transactions: Vec<AnalyzedTransaction>,
         _state_view: Arc<S>,
     ) -> std::result::Result<Vec<TransactionOutput>, VMStatus> {
         todo!()

--- a/third_party/move/move-core/types/src/account_address.rs
+++ b/third_party/move/move-core/types/src/account_address.rs
@@ -15,6 +15,12 @@ use std::{convert::TryFrom, fmt, str::FromStr};
 pub struct AccountAddress([u8; AccountAddress::LENGTH]);
 
 impl AccountAddress {
+    pub fn brief(&self) -> String {
+        hex::encode(self.0).split_off(60)
+    }
+}
+
+impl AccountAddress {
     /// The number of bytes in an address.
     /// Default to 16 bytes, can be set to 20 bytes with address20 feature.
     pub const LENGTH: usize = 32;

--- a/types/src/transaction/analyzed_transaction.rs
+++ b/types/src/transaction/analyzed_transaction.rs
@@ -1,0 +1,259 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    access_path::AccessPath,
+    account_config::{AccountResource, CoinStoreResource},
+    state_store::{state_key::StateKey, table::TableHandle},
+    transaction::{SignedTransaction, Transaction, TransactionPayload},
+};
+use aptos_crypto::{
+    hash::{CryptoHash, DummyHasher},
+    HashValue,
+};
+pub use move_core_types::abi::{
+    ArgumentABI, ScriptFunctionABI as EntryFunctionABI, TransactionScriptABI, TypeArgumentABI,
+};
+use move_core_types::{
+    account_address::AccountAddress, language_storage::StructTag, move_resource::MoveStructType,
+};
+use std::hash::{Hash, Hasher};
+
+#[derive(Clone, Debug)]
+pub struct AnalyzedTransaction {
+    transaction: Transaction,
+    /// Set of storage locations that are read by the transaction - this doesn't include location
+    /// that are written by the transactions to avoid duplication of locations across read and write sets
+    /// This can be accurate or strictly overestimated.
+    read_set: Vec<StorageLocation>,
+    /// Set of storage locations that are written by the transaction. This can be accurate or strictly
+    /// overestimated.
+    write_set: Vec<StorageLocation>,
+    /// A transaction is predictable if neither the read_hint or the write_hint have wildcards.
+    predictable_transaction: bool,
+    /// The hash of the transaction - this is cached for performance reasons.
+    hash: HashValue,
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum StorageLocation {
+    // A specific storage location denoted by an address and a struct tag.
+    Specific(StateKey),
+    // Storage location denoted by a struct tag and any arbitrary address.
+    // Example read<T>(*), write<T>(*) in Move
+    WildCardStruct(StructTag),
+    // Storage location denoted by a table handle and any arbitrary item in the table.
+    WildCardTable(TableHandle),
+}
+
+impl CryptoHash for StorageLocation {
+    type Hasher = DummyHasher;
+
+    fn hash(&self) -> HashValue {
+        match self {
+            StorageLocation::Specific(state_key) => CryptoHash::hash(state_key),
+            _ => todo!("hashing of wildcard storage location is not supported yet"),
+        }
+    }
+}
+
+impl AnalyzedTransaction {
+    pub fn new(
+        transaction: Transaction,
+        read_set: Vec<StorageLocation>,
+        write_set: Vec<StorageLocation>,
+    ) -> Self {
+        let hints_contain_wildcard = read_set
+            .iter()
+            .chain(write_set.iter())
+            .any(|hint| !matches!(hint, StorageLocation::Specific(_)));
+        let hash = transaction.hash();
+        AnalyzedTransaction {
+            transaction,
+            read_set,
+            write_set,
+            predictable_transaction: !hints_contain_wildcard,
+            hash,
+        }
+    }
+
+    pub fn into_inner(self) -> Transaction {
+        self.transaction
+    }
+
+    pub fn transaction(&self) -> &Transaction {
+        &self.transaction
+    }
+
+    pub fn read_set(&self) -> &[StorageLocation] {
+        &self.read_set
+    }
+
+    pub fn write_set(&self) -> &[StorageLocation] {
+        &self.write_set
+    }
+
+    pub fn predictable_transaction(&self) -> bool {
+        self.predictable_transaction
+    }
+
+    pub fn sender(&self) -> Option<AccountAddress> {
+        match &self.transaction {
+            Transaction::UserTransaction(signed_txn) => Some(signed_txn.sender()),
+            _ => None,
+        }
+    }
+
+    pub fn analyzed_transaction_for_coin_transfer(
+        signed_txn: SignedTransaction,
+        sender_address: AccountAddress,
+        receiver_address: AccountAddress,
+        receiver_exists: bool,
+    ) -> Self {
+        let sender_account_resource_key = StateKey::access_path(AccessPath::new(
+            sender_address,
+            AccountResource::struct_tag().access_vector(),
+        ));
+
+        let sender_coin_store_key = StateKey::access_path(AccessPath::new(
+            sender_address,
+            CoinStoreResource::struct_tag().access_vector(),
+        ));
+        let receiver_account_resource_key = StateKey::access_path(AccessPath::new(
+            receiver_address,
+            AccountResource::struct_tag().access_vector(),
+        ));
+        let receiver_coin_store_key = StateKey::access_path(AccessPath::new(
+            receiver_address,
+            CoinStoreResource::struct_tag().access_vector(),
+        ));
+        let mut write_set = vec![
+            StorageLocation::Specific(sender_coin_store_key),
+            StorageLocation::Specific(receiver_coin_store_key),
+            StorageLocation::Specific(sender_account_resource_key),
+        ];
+        if !receiver_exists {
+            // If the receiver doesn't exist, we create the receiver account, so we need to read the
+            // receiver account resource.
+            write_set.push(StorageLocation::Specific(receiver_account_resource_key));
+        }
+        AnalyzedTransaction::new(
+            Transaction::UserTransaction(signed_txn),
+            vec![],
+            // read and write locations are same for coin transfer
+            write_set,
+        )
+    }
+
+    pub fn analyzed_transaction_for_create_account(
+        signed_txn: SignedTransaction,
+        sender_address: AccountAddress,
+        receiver_address: AccountAddress,
+    ) -> Self {
+        let sender_account_resource_key = StateKey::access_path(AccessPath::new(
+            sender_address,
+            AccountResource::struct_tag().access_vector(),
+        ));
+        let sender_coin_store_key = StateKey::access_path(AccessPath::new(
+            sender_address,
+            CoinStoreResource::struct_tag().access_vector(),
+        ));
+        let receiver_account_resource_key = StateKey::access_path(AccessPath::new(
+            receiver_address,
+            AccountResource::struct_tag().access_vector(),
+        ));
+        let receiver_coin_store_key = StateKey::access_path(AccessPath::new(
+            receiver_address,
+            CoinStoreResource::struct_tag().access_vector(),
+        ));
+        let read_hints = vec![
+            StorageLocation::Specific(sender_coin_store_key),
+            StorageLocation::Specific(sender_account_resource_key),
+            StorageLocation::Specific(receiver_coin_store_key),
+            StorageLocation::Specific(receiver_account_resource_key),
+        ];
+        AnalyzedTransaction::new(
+            Transaction::UserTransaction(signed_txn),
+            vec![],
+            // read and write locations are same for create account
+            read_hints,
+        )
+    }
+}
+
+impl PartialEq<Self> for AnalyzedTransaction {
+    fn eq(&self, other: &Self) -> bool {
+        self.hash == other.hash
+    }
+}
+
+impl Eq for AnalyzedTransaction {}
+
+impl Hash for AnalyzedTransaction {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(self.hash.as_ref());
+    }
+}
+
+impl From<Transaction> for AnalyzedTransaction {
+    fn from(txn: Transaction) -> Self {
+        match txn {
+            Transaction::UserTransaction(signed_txn) => match signed_txn.payload() {
+                TransactionPayload::EntryFunction(func) => {
+                    match (
+                        *func.module().address(),
+                        func.module().name().as_str(),
+                        func.function().as_str(),
+                    ) {
+                        (AccountAddress::ONE, "coin", "transfer") => {
+                            let sender_address = signed_txn.sender();
+                            let receiver_address = bcs::from_bytes(&func.args()[0]).unwrap();
+                            AnalyzedTransaction::analyzed_transaction_for_coin_transfer(
+                                signed_txn,
+                                sender_address,
+                                receiver_address,
+                                true,
+                            )
+                        },
+                        (AccountAddress::ONE, "aptos_account", "transfer") => {
+                            let sender_address = signed_txn.sender();
+                            let receiver_address = bcs::from_bytes(&func.args()[0]).unwrap();
+                            AnalyzedTransaction::analyzed_transaction_for_coin_transfer(
+                                signed_txn,
+                                sender_address,
+                                receiver_address,
+                                false,
+                            )
+                        },
+                        (AccountAddress::ONE, "aptos_account", "create_account") => {
+                            let sender_address = signed_txn.sender();
+                            let receiver_address = bcs::from_bytes(&func.args()[0]).unwrap();
+                            AnalyzedTransaction::analyzed_transaction_for_create_account(
+                                signed_txn,
+                                sender_address,
+                                receiver_address,
+                            )
+                        },
+                        _ => AnalyzedTransaction::new(
+                            Transaction::UserTransaction(signed_txn),
+                            vec![],
+                            vec![],
+                        ),
+                    }
+                },
+                _ => AnalyzedTransaction::new(
+                    Transaction::UserTransaction(signed_txn),
+                    vec![],
+                    vec![],
+                ),
+            },
+            _ => AnalyzedTransaction::new(txn, vec![], vec![]),
+        }
+    }
+}
+
+impl From<AnalyzedTransaction> for Transaction {
+    fn from(val: AnalyzedTransaction) -> Self {
+        val.transaction
+    }
+}

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -35,6 +35,7 @@ use std::{
     fmt::{Debug, Display, Formatter},
 };
 
+pub mod analyzed_transaction;
 pub mod authenticator;
 mod change_set;
 mod module;
@@ -944,6 +945,10 @@ impl TransactionOutput {
             gas_used,
             status,
         }
+    }
+
+    pub fn retried() -> Self {
+        Self::new(WriteSet::default(), vec![], 0, TransactionStatus::Retry)
     }
 
     pub fn into(self) -> (WriteSet, Vec<ContractEvent>) {


### PR DESCRIPTION
### Background

It is assumed that the distributed partitioner, given a raw block, a `num_shards`, and a `num_rounds`, will output something as below. (`num_shards=3, num_rounds=3`)
<img width="1620" alt="image" src="https://github.com/aptos-labs/aptos-core/assets/4213569/7924f15c-c952-4612-8185-0159a1ba9df5">
where:
- A small nodes with `Tx` is a txn with its finalized inner-block index as `x`.
- An edge is a txn dependency relation defined and outputted by the partitioner.
  + Red: cross-shard; black: internal

More notes on the partitioner behavior.
- Partitioner may output sub-blocks round by round.
- Partitioner ensures: for a round that is not the last round, the sub-blocks inside it do not have cross-shard dependencies. (But may in-shard/cross-round dependencies are possible.)
- The txn distributions over sub-blocks may not be so even as illustrated in the chart. Some sub-blocks can be empty.

This change is about modifying BlockSTM to consume the output of the partitioner.

### Dev plan

BlockSTM should do the following.
- [x] change its state representation: structs `Scheduler`, `TxnLastInputOutput` should be modified to support the global `TxnIndex`, which will be non-contiguous from the perspective of a single blockstm instance.
    + This makes it easy to apply cross-shard write set to local multi-versioned cache.
- [ ] Pull the BlockSTM logic out of `execute_transactions_parallel()` into a class with:
  + method `start()` to get workers/coordinator running in the thread pool.
  + method `append_txn(txn)` to add new schedulable txns.
  + method `no_more_txns()` to signal the end of the txn stream.
  + method `apply_external_txn_output(txn_index, execution_status)` to apply the txn update from other shards.
  + method `wait()` to wait for all blockstm work to be done and get the result.
- [ ] expect a stream of txn/an "end-of-stream" signal from the local `ExecutorShard`, instead of the full txn list available at the beginning.
- [ ] no longer terminate when (1) all known txns are committed - terminate only when (1) and "end-of-txn" was received.
- [ ] accept external txn results and apply their write set locally.
- [ ] after committing a txn, notify the local `ExecutorShard` with the txn's results.

#### shard behavior changes
`ExecutorShard` should:
- [ ] expect a stream of sub-blocks/an "end-of-stream" signal from the sharding master, instead of the full sub-block list assigned to it at the beginning.
- [ ] buffer the received txns, forward a txn to blockstm when:
  + all its cross-shard deps are done
  + all txns before it were forwarded
- [ ] whenever forward a txn to blockstm, forward its cross-shard dep's writeset first.
- [ ] listen to txn results from other shards and keep track of the cross-shard dep requirements of all received txns.
- [ ] listen to txn results from local blockstm; forward them to the corresponding peer if someone waits for them (assuming `CrossShardDependencies._dependents` is correctly populated.
 
other necessary dev items
