### PR TITLE
Update release builder to use the correct reconfigure function

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -91,7 +91,7 @@ pub fn generate_feature_upgrade_proposal(
         &writer,
         is_testnet,
         next_execution_hash.clone(),
-        &["std::features", "aptos_framework::reconfiguration"],
+        &["std::features"],
         |writer| {
             emit!(writer, "let enabled_blob: vector<u64> = ");
             generate_features_blob(writer, &enabled);
@@ -106,19 +106,13 @@ pub fn generate_feature_upgrade_proposal(
                     writer,
                     "features::change_feature_flags(framework_signer, enabled_blob, disabled_blob);"
                 );
-                emitln!(
-                    writer,
-                    "reconfiguration::reconfigure_with_signer(framework_signer);"
-                );
+                emitln!(writer, "aptos_governance::reconfigure(framework_signer);");
             } else {
                 emitln!(
                     writer,
                     "features::change_feature_flags(&framework_signer, enabled_blob, disabled_blob);"
                 );
-                emitln!(
-                    writer,
-                    "reconfiguration::reconfigure_with_signer(&framework_signer);"
-                );
+                emitln!(writer, "aptos_governance::reconfigure(&framework_signer);");
             }
         },
     );

--- a/aptos-move/framework/aptos-framework/doc/reconfiguration.md
+++ b/aptos-move/framework/aptos-framework/doc/reconfiguration.md
@@ -15,7 +15,6 @@ to synchronize configuration changes for the validators.
 -  [Function `disable_reconfiguration`](#0x1_reconfiguration_disable_reconfiguration)
 -  [Function `enable_reconfiguration`](#0x1_reconfiguration_enable_reconfiguration)
 -  [Function `reconfiguration_enabled`](#0x1_reconfiguration_reconfiguration_enabled)
--  [Function `reconfigure_with_signer`](#0x1_reconfiguration_reconfigure_with_signer)
 -  [Function `reconfigure`](#0x1_reconfiguration_reconfigure)
 -  [Function `last_reconfiguration_time`](#0x1_reconfiguration_last_reconfiguration_time)
 -  [Function `current_epoch`](#0x1_reconfiguration_current_epoch)
@@ -24,7 +23,6 @@ to synchronize configuration changes for the validators.
     -  [Function `initialize`](#@Specification_1_initialize)
     -  [Function `disable_reconfiguration`](#@Specification_1_disable_reconfiguration)
     -  [Function `enable_reconfiguration`](#@Specification_1_enable_reconfiguration)
-    -  [Function `reconfigure_with_signer`](#@Specification_1_reconfigure_with_signer)
     -  [Function `reconfigure`](#@Specification_1_reconfigure)
     -  [Function `last_reconfiguration_time`](#@Specification_1_last_reconfiguration_time)
     -  [Function `current_epoch`](#@Specification_1_current_epoch)
@@ -318,32 +316,6 @@ This function should only be used for offline WriteSet generation purpose and sh
 
 </details>
 
-<a name="0x1_reconfiguration_reconfigure_with_signer"></a>
-
-## Function `reconfigure_with_signer`
-
-Signal validators to start using new configuration. Must be called from aptos_framework signer.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="reconfiguration.md#0x1_reconfiguration_reconfigure_with_signer">reconfigure_with_signer</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="reconfiguration.md#0x1_reconfiguration_reconfigure_with_signer">reconfigure_with_signer</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="reconfiguration.md#0x1_reconfiguration_Configuration">Configuration</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    <a href="reconfiguration.md#0x1_reconfiguration_reconfigure">reconfigure</a>();
-}
-</code></pre>
-
-
-
-</details>
-
 <a name="0x1_reconfiguration_reconfigure"></a>
 
 ## Function `reconfigure`
@@ -589,28 +561,6 @@ Make sure the caller is admin and check the resource DisableReconfiguration.
 
 <pre><code><b>include</b> <a href="reconfiguration.md#0x1_reconfiguration_AbortsIfNotAptosFramework">AbortsIfNotAptosFramework</a>;
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="reconfiguration.md#0x1_reconfiguration_DisableReconfiguration">DisableReconfiguration</a>&gt;(@aptos_framework);
-</code></pre>
-
-
-
-<a name="@Specification_1_reconfigure_with_signer"></a>
-
-### Function `reconfigure_with_signer`
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="reconfiguration.md#0x1_reconfiguration_reconfigure_with_signer">reconfigure_with_signer</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
-</code></pre>
-
-
-
-
-<pre><code><b>pragma</b> verify_duration_estimate = 120;
-<b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">stake::ValidatorFees</a>&gt;(@aptos_framework);
-<b>requires</b> <b>exists</b>&lt;CoinInfo&lt;AptosCoin&gt;&gt;(@aptos_framework);
-<b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
-<b>include</b> <a href="reconfiguration.md#0x1_reconfiguration_AbortsIfNotAptosFramework">AbortsIfNotAptosFramework</a>;
-<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
-<b>aborts_if</b> <b>false</b>;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.move
@@ -92,12 +92,6 @@ module aptos_framework::reconfiguration {
         !exists<DisableReconfiguration>(@aptos_framework)
     }
 
-    /// Signal validators to start using new configuration. Must be called from aptos_framework signer.
-    public fun reconfigure_with_signer(aptos_framework: &signer) acquires Configuration {
-        system_addresses::assert_aptos_framework(aptos_framework);
-        reconfigure();
-    }
-
     /// Signal validators to start using new configuration. Must be called from friend config modules.
     public(friend) fun reconfigure() acquires Configuration {
         // Do not do anything if genesis has not finished.

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.spec.move
@@ -61,23 +61,6 @@ spec aptos_framework::reconfiguration {
         aborts_if !exists<Configuration>(@aptos_framework);
     }
 
-    spec reconfigure_with_signer {
-        use aptos_framework::coin::CoinInfo;
-        use aptos_framework::aptos_coin::AptosCoin;
-        use aptos_framework::transaction_fee;
-        use aptos_framework::staking_config;
-
-        pragma verify_duration_estimate = 120; // TODO: set because of timeout (property proved)
-
-        requires exists<stake::ValidatorFees>(@aptos_framework);
-        requires exists<CoinInfo<AptosCoin>>(@aptos_framework);
-
-        include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
-        include AbortsIfNotAptosFramework;
-        include staking_config::StakingRewardsConfigRequirement;
-        aborts_if false;
-    }
-
     spec reconfigure {
         use aptos_framework::coin::CoinInfo;
         use aptos_framework::aptos_coin::AptosCoin;


### PR DESCRIPTION
### Description
The current feature flags component of release builder is using the wrong (newly added) reconfigure function. We have an existing one in aptos_governance that was added before mainnet for precisely this purpose and should be used instead.
