### PR TITLE
[aptos-ledger][Easy] mark crypto and types public

### DIFF
--- a/crates/aptos-ledger/src/lib.rs
+++ b/crates/aptos-ledger/src/lib.rs
@@ -7,8 +7,10 @@
 
 #![deny(missing_docs)]
 
-use aptos_crypto::{ed25519::Ed25519PublicKey, ValidCryptoMaterialStringExt};
-use aptos_types::{account_address::AccountAddress, transaction::authenticator::AuthenticationKey};
+pub use aptos_crypto::{ed25519::Ed25519PublicKey, ValidCryptoMaterialStringExt};
+pub use aptos_types::{
+    account_address::AccountAddress, transaction::authenticator::AuthenticationKey,
+};
 use hex::encode;
 use ledger_apdu::APDUCommand;
 use ledger_transport_hid::{hidapi::HidApi, LedgerHIDError, TransportNativeHID};


### PR DESCRIPTION
### Description

Mark `aptos-crypto` and `aptos-types` pub, so public user can import it as well

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
