### PR TITLE
[TF] Disable the monitoring Helm chart by default

### DIFF
--- a/terraform/aptos-node-testnet/aws/variables.tf
+++ b/terraform/aptos-node-testnet/aws/variables.tf
@@ -113,7 +113,7 @@ variable "logger_helm_values" {
 
 variable "enable_monitoring" {
   description = "Enable monitoring helm chart"
-  default     = true
+  default     = false
 }
 
 variable "monitoring_helm_values" {
@@ -124,12 +124,12 @@ variable "monitoring_helm_values" {
 
 variable "enable_prometheus_node_exporter" {
   description = "Enable prometheus-node-exporter within monitoring helm chart"
-  default     = true
+  default     = false
 }
 
 variable "enable_kube_state_metrics" {
   description = "Enable kube-state-metrics within monitoring helm chart"
-  default     = true
+  default     = false
 }
 
 variable "testnet_addons_helm_values" {

--- a/terraform/aptos-node-testnet/gcp/variables.tf
+++ b/terraform/aptos-node-testnet/gcp/variables.tf
@@ -154,7 +154,7 @@ variable "enable_forge" {
 
 variable "enable_monitoring" {
   description = "Enable monitoring helm chart"
-  default     = true
+  default     = false
 }
 
 variable "monitoring_helm_values" {
@@ -165,7 +165,7 @@ variable "monitoring_helm_values" {
 
 variable "enable_prometheus_node_exporter" {
   description = "Enable prometheus-node-exporter within monitoring helm chart"
-  default     = true
+  default     = false
 }
 
 ### Autoscaling


### PR DESCRIPTION
The monitoring chart is no longer used internally, but we keep it because it might be used by partners.