### PR TITLE
[dag] reliable broadcast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9154,9 +9154,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "oorandom"
@@ -10338,10 +10338,11 @@ dependencies = [
 
 [[package]]
 name = "random_word"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b2bb830d03b36582fd6723a57d2451b9db74574d21c34db9d7122c96b24fa0"
+checksum = "1d0f7171155590e912ab907550240a5764c665388ab0a1e46d783a493e816ff3"
 dependencies = [
+ "once_cell",
  "rand 0.8.5",
 ]
 

--- a/consensus/src/dag/mod.rs
+++ b/consensus/src/dag/mod.rs
@@ -1,0 +1,8 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[allow(dead_code)]
+mod reliable_broadcast;
+#[cfg(test)]
+mod tests;

--- a/consensus/src/dag/reliable_broadcast.rs
+++ b/consensus/src/dag/reliable_broadcast.rs
@@ -1,0 +1,98 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::network_interface::ConsensusMsg;
+use aptos_consensus_types::common::Author;
+use async_trait::async_trait;
+use futures::{stream::FuturesUnordered, StreamExt};
+use std::{future::Future, sync::Arc, time::Duration};
+use tokio::sync::oneshot;
+
+pub trait DAGMessage: Sized + Clone {
+    fn from_network_message(msg: ConsensusMsg) -> anyhow::Result<Self>;
+
+    fn into_network_message(self) -> ConsensusMsg;
+}
+
+pub trait BroadcastStatus {
+    type Message: DAGMessage;
+    type Ack: DAGMessage;
+    type Aggregated;
+
+    fn empty(validators: Vec<Author>) -> Self;
+
+    fn add(&mut self, peer: Author, ack: Self::Ack) -> anyhow::Result<Option<Self::Aggregated>>;
+}
+
+#[async_trait]
+pub trait DAGNetworkSender: Send + Sync {
+    async fn send_rpc(
+        &self,
+        receiver: Author,
+        message: ConsensusMsg,
+        timeout: Duration,
+    ) -> anyhow::Result<ConsensusMsg>;
+}
+
+pub struct ReliableBroadcast {
+    validators: Vec<Author>,
+    network_sender: Arc<dyn DAGNetworkSender>,
+}
+
+impl ReliableBroadcast {
+    pub fn new(validators: Vec<Author>, network_sender: Arc<dyn DAGNetworkSender>) -> Self {
+        Self {
+            validators,
+            network_sender,
+        }
+    }
+
+    pub fn broadcast<S: BroadcastStatus>(
+        &self,
+        message: S::Message,
+        return_tx: oneshot::Sender<S::Aggregated>,
+        mut cancel_rx: oneshot::Receiver<()>,
+    ) -> impl Future<Output = ()> {
+        let receivers: Vec<_> = self.validators.clone();
+        let network_message = message.into_network_message();
+        let network_sender = self.network_sender.clone();
+        async move {
+            let mut aggregating = S::empty(receivers.clone());
+            let mut fut = FuturesUnordered::new();
+            let send_message = |receiver, message| {
+                let network_sender = network_sender.clone();
+                async move {
+                    (
+                        receiver,
+                        network_sender
+                            .send_rpc(receiver, message, Duration::from_millis(500))
+                            .await,
+                    )
+                }
+            };
+            for receiver in receivers {
+                fut.push(send_message(receiver, network_message.clone()));
+            }
+            loop {
+                tokio::select! {
+                    Some((receiver, result)) = fut.next() => {
+                        match result {
+                            Ok(msg) =>  {
+                                if let Ok(ack) = S::Ack::from_network_message(msg) {
+                                    if let Ok(Some(aggregated)) = aggregating.add(receiver, ack) {
+                                        let _ = return_tx.send(aggregated);
+                                        return;
+                                    }
+                                }
+                            },
+                            Err(_) => fut.push(send_message(receiver, network_message.clone())),
+                        }
+                    }
+                    _ = &mut cancel_rx => {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/consensus/src/dag/tests/mod.rs
+++ b/consensus/src/dag/tests/mod.rs
@@ -1,0 +1,4 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+mod reliable_broadcast_tests;

--- a/consensus/src/dag/tests/reliable_broadcast_tests.rs
+++ b/consensus/src/dag/tests/reliable_broadcast_tests.rs
@@ -1,0 +1,153 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    dag::reliable_broadcast::{BroadcastStatus, DAGMessage, DAGNetworkSender, ReliableBroadcast},
+    network_interface::ConsensusMsg,
+};
+use anyhow::bail;
+use aptos_consensus_types::common::Author;
+use aptos_infallible::Mutex;
+use aptos_types::validator_verifier::random_validator_verifier;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{hash_map::Entry, HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
+use tokio::sync::oneshot;
+
+#[derive(Serialize, Deserialize, Clone)]
+struct TestMessage(Vec<u8>);
+
+impl DAGMessage for TestMessage {
+    fn from_network_message(msg: ConsensusMsg) -> anyhow::Result<Self> {
+        match msg {
+            ConsensusMsg::DAGTestMessage(payload) => Ok(Self(payload)),
+            _ => bail!("wrong message"),
+        }
+    }
+
+    fn into_network_message(self) -> ConsensusMsg {
+        ConsensusMsg::DAGTestMessage(self.0)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct TestAck;
+
+impl DAGMessage for TestAck {
+    fn from_network_message(_: ConsensusMsg) -> anyhow::Result<Self> {
+        Ok(TestAck)
+    }
+
+    fn into_network_message(self) -> ConsensusMsg {
+        ConsensusMsg::DAGTestMessage(vec![])
+    }
+}
+
+struct TestBroadcastStatus {
+    threshold: usize,
+    received: HashSet<Author>,
+}
+
+impl BroadcastStatus for TestBroadcastStatus {
+    type Ack = TestAck;
+    type Aggregated = HashSet<Author>;
+    type Message = TestMessage;
+
+    fn empty(receivers: Vec<Author>) -> Self {
+        Self {
+            threshold: receivers.len(),
+            received: HashSet::new(),
+        }
+    }
+
+    fn add(&mut self, peer: Author, _ack: Self::Ack) -> anyhow::Result<Option<Self::Aggregated>> {
+        self.received.insert(peer);
+        if self.received.len() == self.threshold {
+            Ok(Some(self.received.clone()))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+struct TestDAGSender {
+    failures: Mutex<HashMap<Author, u8>>,
+    received: Mutex<HashMap<Author, TestMessage>>,
+}
+
+impl TestDAGSender {
+    fn new(failures: HashMap<Author, u8>) -> Self {
+        Self {
+            failures: Mutex::new(failures),
+            received: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl DAGNetworkSender for TestDAGSender {
+    async fn send_rpc(
+        &self,
+        receiver: Author,
+        message: ConsensusMsg,
+        _timeout: Duration,
+    ) -> anyhow::Result<ConsensusMsg> {
+        match self.failures.lock().entry(receiver) {
+            Entry::Occupied(mut entry) => {
+                let count = entry.get_mut();
+                *count -= 1;
+                if *count == 0 {
+                    entry.remove();
+                }
+                bail!("simulated failure");
+            },
+            Entry::Vacant(_) => (),
+        };
+        self.received
+            .lock()
+            .insert(receiver, TestMessage::from_network_message(message)?);
+        Ok(ConsensusMsg::DAGTestMessage(vec![]))
+    }
+}
+
+#[tokio::test]
+async fn test_reliable_broadcast() {
+    let (_, validator_verifier) = random_validator_verifier(5, None, false);
+    let validators = validator_verifier.get_ordered_account_addresses();
+    let failures = HashMap::from([(validators[0], 1), (validators[2], 3)]);
+    let sender = Arc::new(TestDAGSender::new(failures));
+    let rb = ReliableBroadcast::new(validators.clone(), sender);
+    let message = TestMessage(vec![1, 2, 3]);
+    let (tx, rx) = oneshot::channel();
+    let (_cancel_tx, cancel_rx) = oneshot::channel();
+    tokio::spawn(rb.broadcast::<TestBroadcastStatus>(message, tx, cancel_rx));
+    assert_eq!(rx.await.unwrap(), validators.into_iter().collect());
+}
+
+#[tokio::test]
+async fn test_reliable_broadcast_cancel() {
+    let (_, validator_verifier) = random_validator_verifier(5, None, false);
+    let validators = validator_verifier.get_ordered_account_addresses();
+    let failures = HashMap::from([(validators[0], 1), (validators[2], 3)]);
+    let sender = Arc::new(TestDAGSender::new(failures));
+    let rb = ReliableBroadcast::new(validators.clone(), sender);
+    let message = TestMessage(vec![1, 2, 3]);
+
+    // explicit send cancel
+    let (tx, rx) = oneshot::channel();
+    let (cancel_tx, cancel_rx) = oneshot::channel();
+    cancel_tx.send(()).unwrap();
+    tokio::spawn(rb.broadcast::<TestBroadcastStatus>(message.clone(), tx, cancel_rx));
+    assert!(rx.await.is_err());
+
+    // implicit drop cancel
+    let (tx, rx) = oneshot::channel();
+    let (cancel_tx, cancel_rx) = oneshot::channel();
+    drop(cancel_tx);
+    tokio::spawn(rb.broadcast::<TestBroadcastStatus>(message, tx, cancel_rx));
+    assert!(rx.await.is_err());
+}

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -17,6 +17,7 @@ extern crate core;
 
 mod block_storage;
 mod consensusdb;
+mod dag;
 mod epoch_manager;
 mod error;
 mod experimental;

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -61,6 +61,8 @@ pub enum ConsensusMsg {
     SignedBatchInfo(Box<SignedBatchInfoMsg>),
     /// Quorum Store: Broadcast a certified proof of store (a digest that received 2f+1 votes).
     ProofOfStoreMsg(Box<ProofOfStoreMsg>),
+    #[cfg(test)]
+    DAGTestMessage(Vec<u8>),
 }
 
 /// Network type for consensus
@@ -83,6 +85,8 @@ impl ConsensusMsg {
             ConsensusMsg::BatchResponse(_) => "BatchResponse",
             ConsensusMsg::SignedBatchInfo(_) => "SignedBatchInfo",
             ConsensusMsg::ProofOfStoreMsg(_) => "ProofOfStoreMsg",
+            #[cfg(test)]
+            ConsensusMsg::DAGTestMessage(_) => "DAGTestMessage",
         }
     }
 }


### PR DESCRIPTION
This commit introduces an abstracted reliable broadcast concept, it's responsible to keep trying sending message until either it aggregates enough ack or it's cancelled.