### PR TITLE
[TF] Use a ManagedCertificate for testnet-addons ingress

### DIFF
--- a/terraform/aptos-node-testnet/gcp/addons.tf
+++ b/terraform/aptos-node-testnet/gcp/addons.tf
@@ -130,25 +130,6 @@ resource "google_compute_global_address" "testnet-addons-ingress" {
   name    = "aptos-${local.workspace_name}-testnet-addons-ingress"
 }
 
-# This kind of certificate is a GCE resource, and has to be
-# added to the ingress using ingress.gcp.kubernetes.io/pre-shared-cert.
-# K8s ManagedCertificate resources use
-# networking.gke.io/managed-certificates instead.
-resource "google_compute_managed_ssl_certificate" "testnet-addons" {
-  count   = var.zone_name != "" ? 1 : 0
-  project = var.project
-  name    = "aptos-${local.workspace_name}-testnet-addons"
-  lifecycle {
-    create_before_destroy = true
-  }
-  managed {
-    domains = [
-      "${local.domain}.",
-      "api.${local.domain}.",
-    ]
-  }
-}
-
 resource "helm_release" "testnet-addons" {
   count       = var.enable_forge ? 0 : 1
   name        = "testnet-addons"
@@ -171,8 +152,8 @@ resource "helm_release" "testnet-addons" {
         domain = local.domain
       }
       ingress = {
-        gcp_static_ip   = "aptos-${local.workspace_name}-testnet-addons-ingress"
-        gcp_certificate = "aptos-${local.workspace_name}-testnet-addons"
+        gce_static_ip           = "aptos-${local.workspace_name}-testnet-addons-ingress"
+        gce_managed_certificate = "aptos-${local.workspace_name}-testnet-addons"
       }
       load_test = {
         fullnodeGroups = try(var.aptos_node_helm_values.fullnode.groups, [])

--- a/terraform/helm/testnet-addons/README.md
+++ b/terraform/helm/testnet-addons/README.md
@@ -14,6 +14,7 @@ Additional components for aptos-nodes testnet
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| cloud | string | `"EKS"` |  |
 | genesis.chain_id | string | `nil` | Aptos Chain ID |
 | genesis.numValidators | string | `nil` | Number of validators deployed in this testnet |
 | genesis.username_prefix | string | `"aptos-node"` | Validator username prefix, used to get genesis secrets. This should be the fullname for the aptos-node helm release |
@@ -21,6 +22,8 @@ Additional components for aptos-nodes testnet
 | ingress.acm_certificate | string | `nil` | The ACM certificate to install on the ingress |
 | ingress.cookieDurationSeconds | int | `86400` | If stickiness is enabled, how long the session cookie should last |
 | ingress.enableStickyness | bool | `true` | Whether to enable session stickiness on the underlying load balancer |
+| ingress.gce_managed_certificate | string | `nil` | The GCE certificate to install on the ingress |
+| ingress.gce_static_ip | string | `nil` | The GCE static IP to install on the ingress |
 | ingress.loadBalancerSourceRanges | string | `nil` | List of CIDRs to accept traffic from |
 | ingress.wafAclArn | string | `nil` | The ARN of the WAF ACL to install on the ingress |
 | load_test.affinity | object | `{}` |  |

--- a/terraform/helm/testnet-addons/templates/ingress.yaml
+++ b/terraform/helm/testnet-addons/templates/ingress.yaml
@@ -35,9 +35,9 @@ metadata:
     kubernetes.io/ingress.class: "gce"
     # Allow HTTP but always return 301 because we have redirectToHttps enabled
     kubernetes.io/ingress.allow-http: "true"
-    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.gcp_static_ip }}
-    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.gcp_certificate }}
-    networking.gke.io/v1beta1.FrontendConfig: {{ include "testnet-addons.fullname" . }}-api
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.gce_static_ip }}
+    networking.gke.io/managed-certificates: {{ .Values.ingress.gce_managed_certificate }}
+    networking.gke.io/v1beta1.FrontendConfig: {{ include "testnet-addons.fullname" . }}
     {{- end }} # "GKE"
 spec:
   rules:
@@ -53,7 +53,8 @@ spec:
             port:
               number: 80
   {{- end }}
-  - http:
+  - host: {{ .Values.service.domain }}
+    http:
       paths:
       - path: /waypoint.txt
         pathType: Exact
@@ -81,10 +82,18 @@ spec:
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
-  name: {{ include "testnet-addons.fullname" . }}-api
-  namespace: default
+  name: {{ include "testnet-addons.fullname" . }}
 spec:
   redirectToHttps:
     enabled: true
-{{- end }}
 ---
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: {{ .Values.ingress.gce_managed_certificate }}
+spec:
+  domains:
+    - {{ .Values.service.domain }}
+    - api.{{ .Values.service.domain }}
+---
+{{- end }}

--- a/terraform/helm/testnet-addons/values.yaml
+++ b/terraform/helm/testnet-addons/values.yaml
@@ -83,8 +83,10 @@ service:
 ingress:
   # -- The ACM certificate to install on the ingress
   acm_certificate:
-  # -- The GCP certificate to install on the ingress
-  gcp_certificate:
+  # -- The GCE static IP to install on the ingress
+  gce_static_ip:
+  # -- The GCE certificate to install on the ingress
+  gce_managed_certificate:
   # -- The ARN of the WAF ACL to install on the ingress
   wafAclArn:
   # -- List of CIDRs to accept traffic from


### PR DESCRIPTION
Also, rename the Helm values to be similar to the ones in pfn-addons.
