### PR TITLE
[Execution][Sharding] Changes to block execution API to be able to pass sharded sub-blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,6 +1011,7 @@ name = "aptos-executor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-block-partitioner",
  "aptos-cached-packages",
  "aptos-config",
  "aptos-consensus-types",
@@ -1114,6 +1115,7 @@ name = "aptos-executor-types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-block-partitioner",
  "aptos-crypto",
  "aptos-scratchpad",
  "aptos-secure-net",

--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -604,7 +604,7 @@ impl TestContext {
         let parent_id = self.executor.committed_block_id();
         let result = self
             .executor
-            .execute_block((metadata.id(), txns.clone()), parent_id, None)
+            .execute_block((metadata.id(), txns.clone()).into(), parent_id, None)
             .unwrap();
         let mut compute_status = result.compute_status().clone();
         assert_eq!(compute_status.len(), txns.len(), "{:?}", result);

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -144,7 +144,7 @@ impl StateComputer for ExecutionProxy {
             "execute_block",
             tokio::task::spawn_blocking(move || {
                 executor.execute_block(
-                    (block_id, transactions_to_execute),
+                    (block_id, transactions_to_execute).into(),
                     parent_block_id,
                     block_gas_limit,
                 )
@@ -331,6 +331,7 @@ async fn test_commit_sync_race() {
         transaction_shuffler::create_transaction_shuffler,
     };
     use aptos_consensus_notifications::Error;
+    use aptos_executor_types::ExecutableBlock;
     use aptos_types::{
         aggregate_signature::AggregateSignature,
         block_info::BlockInfo,
@@ -354,7 +355,7 @@ async fn test_commit_sync_race() {
 
         fn execute_block(
             &self,
-            _block: (HashValue, Vec<Transaction>),
+            _block: ExecutableBlock,
             _parent_block_id: HashValue,
             _maybe_block_gas_limit: Option<u64>,
         ) -> Result<StateComputeResult, ExecutionError> {

--- a/execution/executor-benchmark/src/native_executor.rs
+++ b/execution/executor-benchmark/src/native_executor.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use aptos_executor::{
     block_executor::TransactionBlockExecutor, components::chunk_output::ChunkOutput,
 };
+use aptos_executor_types::ExecutableTransactions;
 use aptos_storage_interface::cached_state_view::CachedStateView;
 use aptos_types::{
     account_address::AccountAddress,
@@ -336,10 +337,14 @@ impl NativeExecutor {
 
 impl TransactionBlockExecutor for NativeExecutor {
     fn execute_transaction_block(
-        transactions: Vec<Transaction>,
+        transactions: ExecutableTransactions,
         state_view: CachedStateView,
         _maybe_block_gas_limit: Option<u64>,
     ) -> Result<ChunkOutput> {
+        let transactions = match transactions {
+            ExecutableTransactions::Unsharded(txns) => txns,
+            _ => todo!("sharded execution not yet supported"),
+        };
         let transaction_outputs = NATIVE_EXECUTOR_POOL.install(|| {
             transactions
                 .par_iter()

--- a/execution/executor-benchmark/src/transaction_executor.rs
+++ b/execution/executor-benchmark/src/transaction_executor.rs
@@ -61,7 +61,7 @@ where
         let block_id = HashValue::random();
         let output = self
             .executor
-            .execute_block((block_id, transactions), self.parent_block_id, None)
+            .execute_block((block_id, transactions).into(), self.parent_block_id, None)
             .unwrap();
 
         assert_eq!(output.compute_status().len(), num_txns);

--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -164,7 +164,7 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
 
     let output1 = executor
         .execute_block(
-            (block1_id, block1.clone()),
+            (block1_id, block1.clone()).into(),
             parent_block_id,
             BLOCK_GAS_LIMIT,
         )
@@ -375,7 +375,11 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
 
     // Execute block 2, 3, 4
     let output2 = executor
-        .execute_block((block2_id, block2), epoch2_genesis_id, BLOCK_GAS_LIMIT)
+        .execute_block(
+            (block2_id, block2).into(),
+            epoch2_genesis_id,
+            BLOCK_GAS_LIMIT,
+        )
         .unwrap();
     let li2 = gen_ledger_info_with_sigs(2, &output2, block2_id, &[signer.clone()]);
     let epoch3_genesis_id = Block::make_genesis_block_from_ledger_info(li2.ledger_info()).id();
@@ -391,7 +395,7 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
 
     let output3 = executor
         .execute_block(
-            (block3_id, block3.clone()),
+            (block3_id, block3.clone()).into(),
             epoch3_genesis_id,
             BLOCK_GAS_LIMIT,
         )

--- a/execution/executor-types/Cargo.toml
+++ b/execution/executor-types/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-block-partitioner = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-scratchpad = { workspace = true }
 aptos-secure-net = { workspace = true }

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-block-partitioner = { workspace = true }
 aptos-consensus-types = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-executor-types = { workspace = true }

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -204,7 +204,7 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
         let chunk_output = {
             let _timer = APTOS_EXECUTOR_VM_EXECUTE_CHUNK_SECONDS.start_timer();
             // State sync executor shouldn't have block gas limit.
-            ChunkOutput::by_transaction_execution::<V>(transactions, state_view, None)?
+            ChunkOutput::by_transaction_execution::<V>(transactions.into(), state_view, None)?
         };
         let executed_chunk = Self::apply_chunk_output_for_state_sync(
             verified_target_li,
@@ -528,10 +528,11 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
             .iter()
             .take((end_version - begin_version) as usize)
             .cloned()
-            .collect();
+            .collect::<Vec<Transaction>>();
 
         // State sync executor shouldn't have block gas limit.
-        let chunk_output = ChunkOutput::by_transaction_execution::<V>(txns, state_view, None)?;
+        let chunk_output =
+            ChunkOutput::by_transaction_execution::<V>(txns.into(), state_view, None)?;
         // not `zip_eq`, deliberately
         for (version, txn_out, txn_info, write_set, events) in multizip((
             begin_version..end_version,

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -58,7 +58,8 @@ impl ChunkOutput {
                 )
             },
             ExecutableTransactions::Sharded(_) => {
-                // TODO(skedia) Change this into sharded once we move partitioner out of the
+                // TODO(skedia): Change this into sharded once we move partitioner out of the
+                // sharded block executor.
                 todo!("sharded execution integration is not yet done")
             },
         }

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -7,7 +7,7 @@
 use crate::{components::apply_chunk_output::ApplyChunkOutput, metrics};
 use anyhow::Result;
 use aptos_crypto::HashValue;
-use aptos_executor_types::{ExecutedBlock, ExecutedChunk};
+use aptos_executor_types::{ExecutableTransactions, ExecutedBlock, ExecutedChunk};
 use aptos_infallible::Mutex;
 use aptos_logger::{sample, sample::SampleRate, trace, warn};
 use aptos_storage_interface::{
@@ -45,6 +45,26 @@ pub struct ChunkOutput {
 
 impl ChunkOutput {
     pub fn by_transaction_execution<V: VMExecutor>(
+        transactions: ExecutableTransactions,
+        state_view: CachedStateView,
+        maybe_block_gas_limit: Option<u64>,
+    ) -> Result<Self> {
+        match transactions {
+            ExecutableTransactions::Unsharded(txns) => {
+                Self::by_transaction_execution_unsharded::<V>(
+                    txns,
+                    state_view,
+                    maybe_block_gas_limit,
+                )
+            },
+            ExecutableTransactions::Sharded(_) => {
+                // TODO(skedia) Change this into sharded once we move partitioner out of the
+                todo!("sharded execution integration is not yet done")
+            },
+        }
+    }
+
+    fn by_transaction_execution_unsharded<V: VMExecutor>(
         transactions: Vec<Transaction>,
         state_view: CachedStateView,
         maybe_block_gas_limit: Option<u64>,

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -137,7 +137,7 @@ pub fn calculate_genesis<V: VMExecutor>(
     };
 
     let (mut output, _, _) = ChunkOutput::by_transaction_execution::<V>(
-        vec![genesis_txn.clone()],
+        vec![genesis_txn.clone()].into(),
         base_state_view,
         None,
     )?

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
-use aptos_executor_types::BlockExecutorTrait;
+use aptos_executor_types::{BlockExecutorTrait, ExecutableTransactions};
 use aptos_state_view::StateView;
 use aptos_storage_interface::{
     cached_state_view::CachedStateView, state_delta::StateDelta, DbReader, DbReaderWriter, DbWriter,
@@ -39,7 +39,8 @@ pub fn fuzz_execute_and_commit_blocks(
     let mut block_ids = vec![];
     for block in blocks {
         let block_id = block.0;
-        let _execution_results = executor.execute_block(block, parent_block_id, BLOCK_GAS_LIMIT);
+        let _execution_results =
+            executor.execute_block(block.into(), parent_block_id, BLOCK_GAS_LIMIT);
         parent_block_id = block_id;
         block_ids.push(block_id);
     }
@@ -51,7 +52,7 @@ pub struct FakeVM;
 
 impl TransactionBlockExecutor for FakeVM {
     fn execute_transaction_block(
-        transactions: Vec<Transaction>,
+        transactions: ExecutableTransactions,
         state_view: CachedStateView,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<ChunkOutput> {

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -8,6 +8,7 @@ mod mock_vm_test;
 use crate::{block_executor::TransactionBlockExecutor, components::chunk_output::ChunkOutput};
 use anyhow::Result;
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
+use aptos_executor_types::ExecutableTransactions;
 use aptos_state_view::StateView;
 use aptos_storage_interface::cached_state_view::CachedStateView;
 use aptos_types::{
@@ -59,7 +60,7 @@ pub struct MockVM;
 
 impl TransactionBlockExecutor for MockVM {
     fn execute_transaction_block(
-        transactions: Vec<Transaction>,
+        transactions: ExecutableTransactions,
         state_view: CachedStateView,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<ChunkOutput> {

--- a/execution/executor/src/tests/chunk_executor_tests.rs
+++ b/execution/executor/src/tests/chunk_executor_tests.rs
@@ -274,7 +274,7 @@ fn test_executor_execute_and_commit_chunk_local_result_mismatch() {
             .collect::<Vec<_>>();
         let output = executor
             .execute_block(
-                (block_id, block(txns, BLOCK_GAS_LIMIT)),
+                (block_id, block(txns, BLOCK_GAS_LIMIT)).into(),
                 parent_block_id,
                 BLOCK_GAS_LIMIT,
             )
@@ -324,7 +324,7 @@ fn test_executor_execute_and_commit_chunk_without_verify() {
             .map(|_| encode_mint_transaction(tests::gen_address(rng.gen::<u64>()), 100))
             .collect::<Vec<_>>();
         let output = executor
-            .execute_block((block_id, block(txns)), parent_block_id)
+            .execute_block((block_id, block(txns)).into(), parent_block_id)
             .unwrap();
         let ledger_info = tests::gen_ledger_info(6, output.root_hash(), block_id, 1);
         executor.commit_blocks(vec![block_id], ledger_info).unwrap();

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -53,7 +53,7 @@ fn execute_and_commit_block(
 
     let output = executor
         .execute_block(
-            (id, block(vec![txn], BLOCK_GAS_LIMIT)),
+            (id, block(vec![txn], BLOCK_GAS_LIMIT)).into(),
             parent_block_id,
             BLOCK_GAS_LIMIT,
         )
@@ -152,7 +152,7 @@ fn test_executor_status() {
 
     let output = executor
         .execute_block(
-            (block_id, block(vec![txn0, txn1, txn2], BLOCK_GAS_LIMIT)),
+            (block_id, block(vec![txn0, txn1, txn2], BLOCK_GAS_LIMIT)).into(),
             parent_block_id,
             BLOCK_GAS_LIMIT,
         )
@@ -182,7 +182,7 @@ fn test_executor_status_consensus_only() {
 
     let output = executor
         .execute_block(
-            (block_id, block(vec![txn0, txn1, txn2], BLOCK_GAS_LIMIT)),
+            (block_id, block(vec![txn0, txn1, txn2], BLOCK_GAS_LIMIT)).into(),
             parent_block_id,
         )
         .unwrap();
@@ -211,7 +211,7 @@ fn test_executor_one_block() {
         .collect::<Vec<_>>();
     let output = executor
         .execute_block(
-            (block_id, block(txns, BLOCK_GAS_LIMIT)),
+            (block_id, block(txns, BLOCK_GAS_LIMIT)).into(),
             parent_block_id,
             BLOCK_GAS_LIMIT,
         )
@@ -257,14 +257,14 @@ fn test_executor_two_blocks_with_failed_txns() {
         .collect::<Vec<_>>();
     let _output1 = executor
         .execute_block(
-            (block1_id, block(block1_txns, BLOCK_GAS_LIMIT)),
+            (block1_id, block(block1_txns, BLOCK_GAS_LIMIT)).into(),
             parent_block_id,
             BLOCK_GAS_LIMIT,
         )
         .unwrap();
     let output2 = executor
         .execute_block(
-            (block2_id, block(block2_txns, BLOCK_GAS_LIMIT)),
+            (block2_id, block(block2_txns, BLOCK_GAS_LIMIT)).into(),
             block1_id,
             BLOCK_GAS_LIMIT,
         )
@@ -286,7 +286,7 @@ fn test_executor_commit_twice() {
     let block1_id = gen_block_id(1);
     let output1 = executor
         .execute_block(
-            (block1_id, block(block1_txns, BLOCK_GAS_LIMIT)),
+            (block1_id, block(block1_txns, BLOCK_GAS_LIMIT)).into(),
             parent_block_id,
             BLOCK_GAS_LIMIT,
         )
@@ -316,7 +316,7 @@ fn test_executor_execute_same_block_multiple_times() {
     for _i in 0..100 {
         let output = executor
             .execute_block(
-                (block_id, block(txns.clone(), BLOCK_GAS_LIMIT)),
+                (block_id, block(txns.clone(), BLOCK_GAS_LIMIT)).into(),
                 parent_block_id,
                 BLOCK_GAS_LIMIT,
             )
@@ -363,7 +363,7 @@ fn create_transaction_chunks(
 
     let output = executor
         .execute_block(
-            (id, txns.clone()),
+            (id, txns.clone()).into(),
             executor.committed_block_id(),
             BLOCK_GAS_LIMIT,
         )
@@ -403,7 +403,7 @@ fn test_noop_block_after_reconfiguration() {
     let first_block_id = gen_block_id(1);
     let output1 = executor
         .execute_block(
-            (first_block_id, vec![first_txn]),
+            (first_block_id, vec![first_txn]).into(),
             parent_block_id,
             BLOCK_GAS_LIMIT,
         )
@@ -412,7 +412,7 @@ fn test_noop_block_after_reconfiguration() {
     let second_block = TestBlock::new(10, 10, gen_block_id(2), BLOCK_GAS_LIMIT);
     let output2 = executor
         .execute_block(
-            (second_block.id, second_block.txns),
+            (second_block.id, second_block.txns).into(),
             parent_block_id,
             BLOCK_GAS_LIMIT,
         )
@@ -596,16 +596,32 @@ fn test_reconfig_suffix_empty_blocks() {
     block_b.txns.push(encode_reconfiguration_transaction());
     let parent_block_id = executor.committed_block_id();
     executor
-        .execute_block((block_a.id, block_a.txns), parent_block_id, BLOCK_GAS_LIMIT)
+        .execute_block(
+            (block_a.id, block_a.txns).into(),
+            parent_block_id,
+            BLOCK_GAS_LIMIT,
+        )
         .unwrap();
     let output = executor
-        .execute_block((block_b.id, block_b.txns), block_a.id, BLOCK_GAS_LIMIT)
+        .execute_block(
+            (block_b.id, block_b.txns).into(),
+            block_a.id,
+            BLOCK_GAS_LIMIT,
+        )
         .unwrap();
     executor
-        .execute_block((block_c.id, block_c.txns), block_b.id, BLOCK_GAS_LIMIT)
+        .execute_block(
+            (block_c.id, block_c.txns).into(),
+            block_b.id,
+            BLOCK_GAS_LIMIT,
+        )
         .unwrap();
     executor
-        .execute_block((block_d.id, block_d.txns), block_c.id, BLOCK_GAS_LIMIT)
+        .execute_block(
+            (block_d.id, block_d.txns).into(),
+            block_c.id,
+            BLOCK_GAS_LIMIT,
+        )
         .unwrap();
 
     let ledger_info = gen_ledger_info(20002, output.root_hash(), block_d.id, 1);
@@ -655,7 +671,7 @@ fn run_transactions_naive(
 
     for txn in transactions {
         let out = ChunkOutput::by_transaction_execution::<MockVM>(
-            vec![txn],
+            vec![txn].into(),
             ledger_view
                 .verified_state_view(
                     StateViewId::Miscellaneous,
@@ -703,7 +719,7 @@ proptest! {
 
             let parent_block_id = executor.committed_block_id();
             let output = executor.execute_block(
-                (block_id, block.txns.clone()), parent_block_id, BLOCK_GAS_LIMIT
+                (block_id, block.txns.clone()).into(), parent_block_id, BLOCK_GAS_LIMIT
             ).unwrap();
 
             // assert: txns after the reconfiguration are with status "Retry"
@@ -722,7 +738,7 @@ proptest! {
             // retry txns after reconfiguration
             let retry_block_id = gen_block_id(2);
             let retry_output = executor.execute_block(
-                (retry_block_id, block.txns.iter().skip(reconfig_txn_index as usize + 1).cloned().collect()), parent_block_id, BLOCK_GAS_LIMIT
+                (retry_block_id, block.txns.iter().skip(reconfig_txn_index as usize + 1).cloned().collect()).into(), parent_block_id, BLOCK_GAS_LIMIT
             ).unwrap();
             prop_assert!(retry_output.compute_status().iter().all(|s| matches!(*s, TransactionStatus::Keep(_))));
 
@@ -768,7 +784,7 @@ proptest! {
         {
             parent_block_id = executor.committed_block_id();
             let output_a = executor.execute_block(
-                (block_a.id, block_a.txns.clone()), parent_block_id, BLOCK_GAS_LIMIT
+                (block_a.id, block_a.txns.clone()).into(), parent_block_id, BLOCK_GAS_LIMIT
             ).unwrap();
             root_hash = output_a.root_hash();
             let ledger_info = gen_ledger_info(ledger_version_from_block_size(block_a.txns.len(), BLOCK_GAS_LIMIT) as u64, root_hash, block_a.id, 1);
@@ -779,7 +795,7 @@ proptest! {
         // Now we construct a new executor and run one more block.
         {
             let executor = BlockExecutor::<MockVM>::new(db);
-            let output_b = executor.execute_block((block_b.id, block_b.txns.clone()), parent_block_id, BLOCK_GAS_LIMIT).unwrap();
+            let output_b = executor.execute_block((block_b.id, block_b.txns.clone()).into(), parent_block_id, BLOCK_GAS_LIMIT).unwrap();
             root_hash = output_b.root_hash();
             let ledger_info = gen_ledger_info(
                 (ledger_version_from_block_size(block_a.txns.len(), BLOCK_GAS_LIMIT) + ledger_version_from_block_size(block_b.txns.len(), BLOCK_GAS_LIMIT)) as u64,
@@ -836,13 +852,13 @@ proptest! {
         let parent_block_id = executor.committed_block_id();
         let first_block_id = gen_block_id(1);
         let _output1 = executor.execute_block(
-            (first_block_id, first_block_txns),
+            (first_block_id, first_block_txns).into(),
             parent_block_id, BLOCK_GAS_LIMIT
         ).unwrap();
 
         let second_block_id = gen_block_id(2);
         let output2 = executor.execute_block(
-            (second_block_id, block(second_block_txns, BLOCK_GAS_LIMIT)),
+            (second_block_id, block(second_block_txns, BLOCK_GAS_LIMIT)).into(),
             first_block_id, BLOCK_GAS_LIMIT
         ).unwrap();
 

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -87,7 +87,7 @@ fn execute_and_commit(txns: Vec<Transaction>, db: &DbReaderWriter, signer: &Vali
     let executor = BlockExecutor::<AptosVM>::new(db.clone());
     let output = executor
         .execute_block(
-            (block_id, block(txns, BLOCK_GAS_LIMIT)),
+            (block_id, block(txns, BLOCK_GAS_LIMIT)).into(),
             executor.committed_block_id(),
             BLOCK_GAS_LIMIT,
         )

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -141,7 +141,7 @@ fn test_reconfiguration() {
     let block_id = gen_block_id(1);
     let vm_output = executor
         .execute_block(
-            (block_id, txn_block.clone()),
+            (block_id, txn_block.clone()).into(),
             parent_block_id,
             BLOCK_GAS_LIMIT,
         )


### PR DESCRIPTION
### Description

This PR introduces the `ExecutableBlock`, which contains a vector of transactions in case of unsharded execution and a vector of sub-blocks in case of sharded execution and updates the block execute APIs accordingly. There is no functionality change introduced - later PR will start using the sharded APIs. 

### Test Plan

Existing UTs.
