### PR TITLE
clean AptosVmImpl::new() up a bit

### DIFF
--- a/aptos-move/aptos-gas/src/lib.rs
+++ b/aptos-move/aptos-gas/src/lib.rs
@@ -45,4 +45,6 @@ pub use move_core_types::gas_algebra::{
     Arg, Byte, GasQuantity, InternalGas, InternalGasPerArg, InternalGasPerByte, InternalGasUnit,
     NumArgs, NumBytes, UnitDiv,
 };
-pub use transaction::{ChangeSetConfigs, StorageGasParameters, TransactionGasParameters};
+pub use transaction::{
+    ChangeSetConfigs, StorageGasParameters, StoragePricing, TransactionGasParameters,
+};

--- a/aptos-move/aptos-gas/src/transaction/mod.rs
+++ b/aptos-move/aptos-gas/src/transaction/mod.rs
@@ -18,7 +18,7 @@ use move_core_types::gas_algebra::{
 
 mod storage;
 
-pub use storage::{ChangeSetConfigs, StorageGasParameters};
+pub use storage::{ChangeSetConfigs, StorageGasParameters, StoragePricing};
 
 const GAS_SCALING_FACTOR: u64 = 1_000_000;
 

--- a/aptos-move/aptos-gas/src/transaction/storage.rs
+++ b/aptos-move/aptos-gas/src/transaction/storage.rs
@@ -308,14 +308,9 @@ pub struct StorageGasParameters {
 impl StorageGasParameters {
     pub fn new(
         feature_version: u64,
-        gas_params: Option<&AptosGasParameters>,
+        gas_params: &AptosGasParameters,
         storage_gas_schedule: Option<&StorageGasSchedule>,
-    ) -> Option<Self> {
-        if feature_version == 0 || gas_params.is_none() {
-            return None;
-        }
-        let gas_params = gas_params.unwrap();
-
+    ) -> Self {
         let pricing = match storage_gas_schedule {
             Some(schedule) => {
                 StoragePricing::V2(StoragePricingV2::new(feature_version, schedule, gas_params))
@@ -325,10 +320,10 @@ impl StorageGasParameters {
 
         let change_set_configs = ChangeSetConfigs::new(feature_version, gas_params);
 
-        Some(Self {
+        Self {
             pricing,
             change_set_configs,
-        })
+        }
     }
 
     pub fn free_and_unlimited() -> Self {


### PR DESCRIPTION
### Description

Mainly to make it clear:
1. do not load `storage_gas_params` if there's no global `gas_params`
2. only override certain table gas parameters with io gas parameters when pricing v2 is active (for now it's equivalent to that there is the storage gas schedule stored on chain; gonna change after we deprecate the curves)

and make the above logic all exposed in `new()` (instead of partially under `StorageGasParams::new()`

### Test Plan
started full replay run here
https://github.com/aptos-labs/aptos-core/actions/runs/5212425745

