### PR TITLE
Update generics.md

### DIFF
--- a/developer-docs-site/docs/move/book/generics.md
+++ b/developer-docs-site/docs/move/book/generics.md
@@ -435,7 +435,7 @@ module m {
     // error!
     // foo<T> -> foo<A<T>> -> foo<A<A<T>>> -> ...
     fun foo<T>() {
-        foo<Foo<T>>();
+        foo<A<T>>();
     }
 }
 }


### PR DESCRIPTION
Fix a typo in recursive type example.

### Description
Fix a trivial typo in one of the recursive type generics examples.

### Test Plan
Looked at Markdown preview.
