### PR TITLE
[TF] Add default for GKE maintenance window

### DIFF
--- a/terraform/aptos-node/gcp/variables.tf
+++ b/terraform/aptos-node/gcp/variables.tf
@@ -250,5 +250,11 @@ variable "gke_maintenance_policy" {
       recurrence = string
     })
   })
-  default = null
+  default = {
+    recurring_window = {
+      start_time = "2023-06-01T14:00:00Z"
+      end_time   = "2023-06-01T18:00:00Z"
+      recurrence = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"
+    }
+  }
 }


### PR DESCRIPTION
Terraform will complain that the default is null.
The default maintenance window is Monday-Friday, between 7am and 11am Pacific time.
