### PR TITLE
[gha] set up merge gatekeeper

### DIFF
--- a/.github/workflows/merge-gatekeeper.yaml
+++ b/.github/workflows/merge-gatekeeper.yaml
@@ -1,0 +1,34 @@
+name: "*Merge Gatekeeper"
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
+
+env:
+  MERGE_GATEKEEPER_ALLOWLIST: "rustielin,perryjrandall,geekflyer,sherry-x,sionescu,ibalajiarun,igor-aptos,sitalkedia"
+
+jobs:
+  merge-gatekeeper:
+    runs-on: ubuntu-latest
+    # Restrict permissions of the GITHUB_TOKEN.
+    # Docs: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      checks: read
+      statuses: read
+    steps:
+      - name: Beta allowlist for certain actors
+        shell: bash
+        run: |
+          if grep -v "$GITHUB_ACTOR" <<< "$MERGE_GATEKEEPER_ALLOWLIST"; then
+            echo "Your username is not in the beta testing list for merge gatekeeper."
+            echo "Please add yourself if you are interested, in the env MERGE_GATEKEEPER_ALLOWLIST."
+            gh run cancel ${{ github.run_id }}
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Run Merge Gatekeeper
+        uses: upsidr/merge-gatekeeper@09af7a82c1666d0e64d2bd8c01797a0bcfd3bb5d # pin v1.2.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          timeout: 5400 # 1.5 hour


### PR DESCRIPTION
### Description

Try out merge gatekeeper (https://github.com/upsidr/merge-gatekeeper)

This will allow us to get close to target determination in our monorepo, if we use it in conjunction with modified GHA triggers that only run certain checks when certain file paths are changed.

### Test Plan

Just check out the workflow output for now. We can run the merge gatekeeper in parallel with the rest of our CI without side effects, so long as we don't change the branch protection to require it.

<!-- Please provide us with clear details for verifying that your changes work. -->
