### PR TITLE
[CLI][E2E] Improve reliability of framework, checkout correct code in CI

### DIFF
--- a/.github/workflows/cli-e2e-tests.yaml
+++ b/.github/workflows/cli-e2e-tests.yaml
@@ -24,6 +24,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ env.GIT_SHA }}
 
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -187,14 +187,14 @@ jobs:
   cli-e2e-tests:
     needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'CICD:skip-sdk-integration-test') && (
+      (
         github.event_name == 'push' ||
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
         github.event.pull_request.auto_merge != null) ||
         contains(github.event.pull_request.body, '#e2e'
       )
-    uses: ./.github/workflows/cli-e2e-tests.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/cli-e2e-tests.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}

--- a/crates/aptos/e2e/main.py
+++ b/crates/aptos/e2e/main.py
@@ -124,30 +124,36 @@ def main():
     else:
         logging.getLogger().setLevel(logging.INFO)
 
-    # Run a node + faucet and wait for them to start up.
-    container_name = run_node(args.base_network, args.image_repo_with_project)
-    wait_for_startup(container_name, args.base_startup_timeout)
-
     # Create the dir the test CLI will run from.
     shutil.rmtree(args.working_directory, ignore_errors=True)
     pathlib.Path(args.working_directory).mkdir(parents=True, exist_ok=True)
 
-    # Build the RunHelper object.
-    run_helper = RunHelper(
-        host_working_directory=args.working_directory,
-        image_repo_with_project=args.image_repo_with_project,
-        image_tag=args.test_cli_tag,
-        cli_path=args.test_cli_path,
-    )
+    # Run a node + faucet and wait for them to start up.
+    container_name = run_node(args.base_network, args.image_repo_with_project)
 
-    # Prepare the run helper. This ensures in advance that everything needed is there.
-    run_helper.prepare()
+    # We run these in a try finally so that if something goes wrong, such as the
+    # local testnet not starting up correctly or some unexpected error in the
+    # test framework, we still stop the node + faucet.
+    try:
+        wait_for_startup(container_name, args.base_startup_timeout)
 
-    # Run tests.
-    run_tests(run_helper)
+        # Build the RunHelper object.
+        run_helper = RunHelper(
+            host_working_directory=args.working_directory,
+            image_repo_with_project=args.image_repo_with_project,
+            image_tag=args.test_cli_tag,
+            cli_path=args.test_cli_path,
+            base_network=args.base_network,
+        )
 
-    # Stop the node + faucet.
-    stop_node(container_name)
+        # Prepare the run helper. This ensures in advance that everything needed is there.
+        run_helper.prepare()
+
+        # Run tests.
+        run_tests(run_helper)
+    finally:
+        # Stop the node + faucet.
+        stop_node(container_name)
 
     # Print out the results.
     if test_results.passed:

--- a/crates/aptos/e2e/test_helpers.py
+++ b/crates/aptos/e2e/test_helpers.py
@@ -9,7 +9,7 @@ import traceback
 from dataclasses import dataclass
 
 from aptos_sdk.client import RestClient
-from common import METRICS_PORT, NODE_PORT, AccountInfo, build_image_name
+from common import METRICS_PORT, NODE_PORT, AccountInfo, Network, build_image_name
 
 LOG = logging.getLogger(__name__)
 
@@ -23,13 +23,20 @@ class RunHelper:
     image_repo_with_project: str
     image_tag: str
     cli_path: str
+    base_network: Network
+
     test_count: int
 
     # This can be used by the tests to query the local testnet node.
     api_client: RestClient
 
     def __init__(
-        self, host_working_directory, image_repo_with_project, image_tag, cli_path
+        self,
+        host_working_directory,
+        image_repo_with_project,
+        image_tag,
+        cli_path,
+        base_network,
     ):
         if image_tag and cli_path:
             raise RuntimeError("Cannot specify both image_tag and cli_path")
@@ -39,6 +46,7 @@ class RunHelper:
         self.image_repo_with_project = image_repo_with_project
         self.image_tag = image_tag
         self.cli_path = os.path.abspath(cli_path) if cli_path else cli_path
+        self.base_network = base_network
         self.test_count = 0
         self.api_client = RestClient(f"http://127.0.0.1:{NODE_PORT}/v1")
 


### PR DESCRIPTION
### Description
This PR adds all the framework / CI changes that were originally in https://github.com/aptos-labs/aptos-core/pull/8550 and https://github.com/aptos-labs/aptos-core/pull/8517. This way this PR is just framework / CI stuff and the others are just test cases.

### Test Plan
CI.

I tested with `uses: ./.github/workflows/cli-e2e-tests.yaml` with `pull_request` at first to make sure it works.
