### PR TITLE
[forge][fix] Track and remove chaos properly

### DIFF
--- a/testsuite/testcases/src/modifiers.rs
+++ b/testsuite/testcases/src/modifiers.rs
@@ -217,6 +217,16 @@ pub struct CpuChaosTest {
     pub override_config: Option<CpuChaosConfig>,
 }
 
+impl CpuChaosTest {
+    fn create_cpu_chaos(&self, swarm: &mut dyn Swarm) -> SwarmCpuStress {
+        let all_validators = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
+
+        let config = self.override_config.as_ref().cloned().unwrap_or_default();
+
+        create_cpu_stress_template(all_validators, &config)
+    }
+}
+
 impl Test for CpuChaosTest {
     fn name(&self) -> &'static str {
         "CpuChaosWrapper"
@@ -244,15 +254,8 @@ fn create_cpu_stress_template(
 
 impl NetworkLoadTest for CpuChaosTest {
     fn setup(&self, ctx: &mut NetworkContext) -> anyhow::Result<LoadDestination> {
-        let all_validators = ctx
-            .swarm()
-            .validators()
-            .map(|v| v.peer_id())
-            .collect::<Vec<_>>();
+        let swarm_cpu_stress = self.create_cpu_chaos(ctx.swarm());
 
-        let config = self.override_config.as_ref().cloned().unwrap_or_default();
-
-        let swarm_cpu_stress = create_cpu_stress_template(all_validators, &config);
         ctx.swarm()
             .inject_chaos(SwarmChaos::CpuStress(swarm_cpu_stress))?;
 
@@ -260,11 +263,8 @@ impl NetworkLoadTest for CpuChaosTest {
     }
 
     fn finish(&self, swarm: &mut dyn Swarm) -> anyhow::Result<()> {
-        let all_validators = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
+        let swarm_cpu_stress = self.create_cpu_chaos(swarm);
 
-        let config = self.override_config.as_ref().cloned().unwrap_or_default();
-
-        let swarm_cpu_stress = create_cpu_stress_template(all_validators, &config);
         swarm.remove_chaos(SwarmChaos::CpuStress(swarm_cpu_stress))
     }
 }


### PR DESCRIPTION
### Description

This PR fixes a bug where some tests remove all chaoses, but it only should remove those that the test adds.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Multi-region test now succeeds properly.

```
two traffics test: inner traffic : committed: 5967 txn/s, latency: 6540 ms, (p50: 6300 ms, p90: 7800 ms, p99: 12600 ms), latency samples: 2589920
two traffics test : committed: 100 txn/s, latency: 2559 ms, (p50: 2400 ms, p90: 3000 ms, p99: 4500 ms), latency samples: 1820
Max round gap was 1 [limit 4] at version 655404. Max no progress secs was 3.913393 [limit 10] at version 655404.
Test Ok
```
