### PR TITLE
[terraform][gcp][testnet] make default daily 24h

### DIFF
--- a/terraform/aptos-node-testnet/gcp/variables.tf
+++ b/terraform/aptos-node-testnet/gcp/variables.tf
@@ -213,9 +213,9 @@ variable "gke_maintenance_policy" {
   })
   default = {
     recurring_window = {
-      start_time = "2023-06-01T14:00:00Z"
-      end_time   = "2023-06-01T18:00:00Z"
-      recurrence = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"
+      start_time = "2023-06-15T00:00:00Z"
+      end_time   = "2023-06-15T23:59:00Z"
+      recurrence = "FREQ=DAILY"
     }
   }
 }

--- a/terraform/aptos-node/gcp/variables.tf
+++ b/terraform/aptos-node/gcp/variables.tf
@@ -252,9 +252,9 @@ variable "gke_maintenance_policy" {
   })
   default = {
     recurring_window = {
-      start_time = "2023-06-01T14:00:00Z"
-      end_time   = "2023-06-01T18:00:00Z"
-      recurrence = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"
+      start_time = "2023-06-15T00:00:00Z"
+      end_time   = "2023-06-15T23:59:00Z"
+      recurrence = "FREQ=DAILY"
     }
   }
 }


### PR DESCRIPTION
### Description

We want to keep the maintenance window defaults to match GKE defaults because this template could be used by anyone to deploy nodes. We will override them for our nodes internally.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->