### PR TITLE
[forge] Fix long running job failure

### DIFF
--- a/.github/actions/docker-setup/action.yaml
+++ b/.github/actions/docker-setup/action.yaml
@@ -30,6 +30,12 @@ inputs:
   GIT_CREDENTIALS:
     description: "Optional credentials to pass to git. Useful if you need to pull private repos for dependencies"
     required: false
+  GCP_AUTH_DURATION:
+    description: "Duration of GCP auth token in seconds"
+    type: int
+    # setting this to 1.5h since sometimes docker builds (special performance
+    # builds etc.) take that long. Default is 1h.
+    default: 5400
 outputs:
   CLOUDSDK_AUTH_ACCESS_TOKEN:
     description: "GCP access token"
@@ -70,7 +76,7 @@ runs:
       with:
         create_credentials_file: false
         token_format: "access_token"
-        access_token_lifetime: 5400 # setting this to 1.5h since sometimes docker builds (special performance builds etc.) take that long. Default is 1h.
+        access_token_lifetime: ${{ inputs.GCP_AUTH_DURATION }}
         workload_identity_provider: ${{ inputs.GCP_WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ inputs.GCP_SERVICE_ACCOUNT_EMAIL }}
         export_environment_variables: ${{ inputs.EXPORT_GCP_PROJECT_VARIABLES }}

--- a/.github/workflows/workflow-run-forge.yaml
+++ b/.github/workflows/workflow-run-forge.yaml
@@ -128,6 +128,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+          GCP_AUTH_DURATION: ${{ inputs.FORGE_RUNNER_DURATION_SECS * 2 }}
 
       - name: "Install GCloud SDK"
         uses: "google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587" # pin@v1

--- a/testsuite/fixtures/testPossibleAuthFailureMessage.fixture
+++ b/testsuite/fixtures/testPossibleAuthFailureMessage.fixture
@@ -1,0 +1,4 @@
+
+Forge output: 
+Forge failed
+Forge took longer than 1 hour to run. This can cause the job to fail even when the test is successful because of gcp + github auth expiration. If you think this is the case please check the GCP_AUTH_DURATION in the github workflow.

--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -151,15 +151,19 @@ class ForgeResult:
         assert self._end_time is not None, "end_time is not set"
         return self._end_time
 
+    @property
+    def duration(self) -> float:
+        return (self.end_time - self.start_time).total_seconds()
+
     @classmethod
-    def from_args(cls, state: ForgeState, output: str) -> "ForgeResult":
+    def from_args(cls, state: ForgeState, output: str) -> ForgeResult:
         result = cls()
         result.state = state
         result.output = output
         return result
 
     @classmethod
-    def empty(cls) -> "ForgeResult":
+    def empty(cls) -> ForgeResult:
         return cls.from_args(ForgeState.EMPTY, "")
 
     @classmethod
@@ -207,7 +211,7 @@ class ForgeResult:
         self.debugging_output = output
 
     def format(self, context: ForgeContext) -> str:
-        output_lines = []
+        output_lines: List[str] = []
         if not self.succeeded():
             output_lines.append(self.debugging_output)
         output_lines.extend(
@@ -216,6 +220,13 @@ class ForgeResult:
                 f"Forge {self.state.value.lower()}ed",
             ]
         )
+        if self.state == ForgeState.FAIL and self.duration > 3600:
+            output_lines.append(
+                "Forge took longer than 1 hour to run. This can cause the job to"
+                " fail even when the test is successful because of gcp + github"
+                " auth expiration. If you think this is the case please check the"
+                " GCP_AUTH_DURATION in the github workflow."
+            )
         return "\n".join(output_lines)
 
     def succeeded(self) -> bool:

--- a/testsuite/forge_test.py
+++ b/testsuite/forge_test.py
@@ -3,7 +3,7 @@ import json
 import os
 import unittest
 import tempfile
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import (
     Any,
@@ -78,18 +78,28 @@ class AssertFixtureMixin:
     def assertFixture(
         self: HasAssertMultiLineEqual, test_str: str, fixture_name: str
     ) -> None:
+        fixture = None
         fixture_path = get_fixture_path(fixture_name)
         if os.getenv("FORGE_WRITE_FIXTURES") == "true":
             print(f"Writing fixture to {str(fixture_path)}")
             fixture_path.write_text(test_str)
             fixture = test_str
         else:
-            fixture = fixture_path.read_text()
+            try:
+                fixture = fixture_path.read_text()
+            except FileNotFoundError as e:
+                raise Exception(
+                    f"Fixture {fixture_path} is missing.\nRun with FORGE_WRITE_FIXTURES=true to update the fixtures"
+                ) from e
+            except Exception as e:
+                raise Exception(
+                    f"Failed while reading fixture:\n{e}\nRun with FORGE_WRITE_FIXTURES=true to update the fixtures"
+                ) from e
         temp = Path(tempfile.mkstemp()[1])
         temp.write_text(test_str)
         self.assertMultiLineEqual(
             test_str,
-            fixture,
+            fixture or "",
             f"Fixture {fixture_name} does not match"
             "\n"
             f"Wrote to {str(temp)} for comparison"
@@ -521,6 +531,16 @@ class ForgeFormattingTests(unittest.TestCase, AssertFixtureMixin):
             namespace,
             "forge-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         )
+
+    def testPossibleAuthFailureMessage(self) -> None:
+        result = ForgeResult.empty()
+        context = fake_context()
+        now = context.time.now()
+        result._start_time = now - timedelta(seconds=4800)
+        result._end_time = now
+        result.state = ForgeState.FAIL
+        output = result.format(context)
+        self.assertFixture(output, "testPossibleAuthFailureMessage.fixture")
 
 
 class ForgeMainTests(unittest.TestCase, AssertFixtureMixin):


### PR DESCRIPTION
Since the migration to GCP long duration forge jobs have been failing.

I looked at this with Rustie and initially we were stumped.

The code that determines the success is based on fetching the phase of the pod that is running the job, if the phase == "succeeded" then pass skip etc or anything else fail.

When looking at the debugging output (which had auth failure) I realized that the status check could possibly have auth failure as well.

This lead me to the auth duration, which is default to 1.5hr previously in aws forge we had a longer expiration by default!

So this PR addresses this by setting the auth expiration to double the runner duration.

I also add a little error handling in case someone hits this again

Test Plan: unittest + run the test on this branch
