### PR TITLE
Separate speculative logging errors out in alerting (lower priority)

### DIFF
--- a/aptos-move/aptos-vm-logging/src/counters.rs
+++ b/aptos-move/aptos-vm-logging/src/counters.rs
@@ -9,3 +9,13 @@ use once_cell::sync::Lazy;
 pub static CRITICAL_ERRORS: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!("aptos_vm_critical_errors", "Number of critical errors").unwrap()
 });
+
+/// Count the number of errors within the speculative logging logic / implementation.
+/// Intended to trigger lower priority / urgency alerts.
+pub static SPECULATIVE_LOGGING_ERRORS: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_vm_speculative_logging_errors",
+        "Number of errors in speculative logging implementation"
+    )
+    .unwrap()
+});


### PR DESCRIPTION
Previously the same alerting mechanism as for vm errors was re-used for handling errors within the speculative logging implementation itself. While those errors are also serious enough that we need to be notified, the urgency is much lower - i.e. it would make sense to configure with low urgency / priority, while the vm critical errors are highest urgency.

Separating the counters is the first step, once this code is landed, we can configure a new lower urgency alert based on this counter that can page either blockchain oncall, move oncall (and/or @gelash :D), but it at least will not be commingled with real VM-internal errors.
