### PR TITLE
[Storage Service] Add simple wait to optimistic fetch tests.

### DIFF
--- a/state-sync/storage-service/server/src/lib.rs
+++ b/state-sync/storage-service/server/src/lib.rs
@@ -265,6 +265,14 @@ impl<T: StorageReaderInterface> StorageServiceServer<T> {
     pub(crate) fn get_request_moderator(&self) -> Arc<RequestModerator> {
         self.request_moderator.clone()
     }
+
+    #[cfg(test)]
+    /// Returns a copy of the active optimistic fetches for test purposes
+    pub(crate) fn get_optimistic_fetches(
+        &self,
+    ) -> Arc<Mutex<HashMap<PeerNetworkId, OptimisticFetchRequest>>> {
+        self.optimistic_fetches.clone()
+    }
 }
 
 /// Refreshes the cached storage server summary

--- a/state-sync/storage-service/server/src/tests/new_transactions.rs
+++ b/state-sync/storage-service/server/src/tests/new_transactions.rs
@@ -54,6 +54,7 @@ async fn test_get_new_transactions() {
 
             // Create the storage client and server
             let (mut mock_client, service, mock_time, _) = MockClient::new(Some(db_reader), None);
+            let active_optimistic_fetches = service.get_optimistic_fetches();
             tokio::spawn(service.start());
 
             // Send a request to optimistically fetch new transactions
@@ -64,6 +65,9 @@ async fn test_get_new_transactions() {
                 include_events,
             )
             .await;
+
+            // Wait until the optimistic fetch is active
+            utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
 
             // Verify no optimistic fetch response has been received yet
             assert_none!(response_receiver.try_recv().unwrap());
@@ -135,6 +139,7 @@ async fn test_get_new_transactions_different_networks() {
 
             // Create the storage client and server
             let (mut mock_client, service, mock_time, _) = MockClient::new(Some(db_reader), None);
+            let active_optimistic_fetches = service.get_optimistic_fetches();
             tokio::spawn(service.start());
 
             // Send a request to optimistically fetch new transactions for peer 1
@@ -159,6 +164,9 @@ async fn test_get_new_transactions_different_networks() {
                 Some(peer_network_2),
             )
             .await;
+
+            // Wait until the optimistic fetches are active
+            utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 2).await;
 
             // Verify no optimistic fetch response has been received yet
             assert_none!(response_receiver_1.try_recv().unwrap());
@@ -233,6 +241,7 @@ async fn test_get_new_transactions_epoch_change() {
 
         // Create the storage client and server
         let (mut mock_client, service, mock_time, _) = MockClient::new(Some(db_reader), None);
+        let active_optimistic_fetches = service.get_optimistic_fetches();
         tokio::spawn(service.start());
 
         // Send a request to optimistically fetch new transactions
@@ -243,6 +252,9 @@ async fn test_get_new_transactions_epoch_change() {
             include_events,
         )
         .await;
+
+        // Wait until the optimistic fetch is active
+        utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
 
         // Elapse enough time to force the optimistic fetch thread to work
         utils::wait_for_optimistic_fetch_service_to_refresh(&mut mock_client, &mock_time).await;
@@ -292,6 +304,7 @@ async fn test_get_new_transactions_max_chunk() {
 
         // Create the storage client and server
         let (mut mock_client, service, mock_time, _) = MockClient::new(Some(db_reader), None);
+        let active_optimistic_fetches = service.get_optimistic_fetches();
         tokio::spawn(service.start());
 
         // Send a request to optimistically fetch new transactions
@@ -302,6 +315,9 @@ async fn test_get_new_transactions_max_chunk() {
             include_events,
         )
         .await;
+
+        // Wait until the optimistic fetch is active
+        utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
 
         // Elapse enough time to force the optimistic fetch thread to work
         utils::wait_for_optimistic_fetch_service_to_refresh(&mut mock_client, &mock_time).await;

--- a/state-sync/storage-service/server/src/tests/new_transactions_or_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/new_transactions_or_outputs.rs
@@ -76,6 +76,7 @@ async fn test_get_new_transactions_or_outputs() {
             );
             let (mut mock_client, service, mock_time, _) =
                 MockClient::new(Some(db_reader), Some(storage_config));
+            let active_optimistic_fetches = service.get_optimistic_fetches();
             tokio::spawn(service.start());
 
             // Send a request to optimistically fetch new transactions or outputs
@@ -87,6 +88,9 @@ async fn test_get_new_transactions_or_outputs() {
                 0, // Outputs cannot be reduced and will fallback to transactions
             )
             .await;
+
+            // Wait until the optimistic fetch is active
+            utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
 
             // Verify no optimistic fetch response has been received yet
             assert_none!(response_receiver.try_recv().unwrap());
@@ -196,6 +200,7 @@ async fn test_get_new_transactions_or_outputs_different_network() {
             );
             let (mut mock_client, service, mock_time, _) =
                 MockClient::new(Some(db_reader), Some(storage_config));
+            let active_optimistic_fetches = service.get_optimistic_fetches();
             tokio::spawn(service.start());
 
             // Send a request to optimistically fetch new transactions or outputs for peer 1
@@ -222,6 +227,9 @@ async fn test_get_new_transactions_or_outputs_different_network() {
                 Some(peer_network_2),
             )
             .await;
+
+            // Wait until the optimistic fetches are active
+            utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 2).await;
 
             // Verify no optimistic fetch response has been received yet
             assert_none!(response_receiver_1.try_recv().unwrap());
@@ -337,6 +345,7 @@ async fn test_get_new_transactions_or_outputs_epoch_change() {
         );
         let (mut mock_client, service, mock_time, _) =
             MockClient::new(Some(db_reader), Some(storage_config));
+        let active_optimistic_fetches = service.get_optimistic_fetches();
         tokio::spawn(service.start());
 
         // Send a request to optimistically fetch new transaction outputs
@@ -348,6 +357,9 @@ async fn test_get_new_transactions_or_outputs_epoch_change() {
             5,
         )
         .await;
+
+        // Wait until the optimistic fetch is active
+        utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
 
         // Elapse enough time to force the optimistic fetch thread to work
         utils::wait_for_optimistic_fetch_service_to_refresh(&mut mock_client, &mock_time).await;
@@ -432,6 +444,7 @@ async fn test_get_new_transactions_or_outputs_max_chunk() {
         );
         let (mut mock_client, service, mock_time, _) =
             MockClient::new(Some(db_reader), Some(storage_config));
+        let active_optimistic_fetches = service.get_optimistic_fetches();
         tokio::spawn(service.start());
 
         // Send a request to optimistically fetch new transaction outputs
@@ -443,6 +456,9 @@ async fn test_get_new_transactions_or_outputs_max_chunk() {
             max_num_output_reductions,
         )
         .await;
+
+        // Wait until the optimistic fetch is active
+        utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
 
         // Elapse enough time to force the optimistic fetch thread to work
         utils::wait_for_optimistic_fetch_service_to_refresh(&mut mock_client, &mock_time).await;


### PR DESCRIPTION
### Description
This PR adds a simple wait to the optimistic fetch test cases. This should hopefully help to reduce some test flakes (where the test runner thread runs faster than the optimistic fetch handler).

### Test Plan
Existing test infrastructure.