### PR TITLE
[GHA] Increase the polling interval of merge_gatekeeper to 1 minute

### DIFF
--- a/.github/workflows/merge-gatekeeper.yaml
+++ b/.github/workflows/merge-gatekeeper.yaml
@@ -31,4 +31,5 @@ jobs:
         uses: upsidr/merge-gatekeeper@09af7a82c1666d0e64d2bd8c01797a0bcfd3bb5d # pin v1.2.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          interval: 60 # 1 minute
           timeout: 5400 # 1.5 hour


### PR DESCRIPTION
The current interval of 5 seconds triggers GH rate limiting.