### PR TITLE
[gha] fix merge gatekeeper with checkout

### DIFF
--- a/.github/workflows/merge-gatekeeper.yaml
+++ b/.github/workflows/merge-gatekeeper.yaml
@@ -16,6 +16,7 @@ jobs:
       checks: read
       statuses: read
     steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
       - name: Beta allowlist for certain actors
         shell: bash
         run: |


### PR DESCRIPTION
### Description

fix errors like this: https://github.com/aptos-labs/aptos-core/actions/runs/5246875935/jobs/9476292130?pr=8613

since you can't run the `gh` CLI without being in a git repo

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
