### PR TITLE
local swarm and run_forever health check

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1725,7 +1725,7 @@ impl NetworkTest for RunForever {
         while keep_running.load(Ordering::Acquire) {
             if let Err(x) = ctx.runtime.block_on(ctx.swarm.health_check()) {
                 error!("swarm failed health check: {}", x);
-                return Err(x)
+                return Err(x);
             }
             thread::sleep(Duration::from_millis(500));
         }

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -465,6 +465,16 @@ impl Drop for LocalSwarm {
 #[async_trait::async_trait]
 impl Swarm for LocalSwarm {
     async fn health_check(&mut self) -> Result<()> {
+        for node in self.validators.values_mut() {
+            if let Err(e) = node.health_check().await {
+                return Err(anyhow!(e))
+            }
+        }
+        for node in self.fullnodes.values_mut() {
+            if let Err(e) = node.health_check().await {
+                return Err(anyhow!(e))
+            }
+        }
         Ok(())
     }
 

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -467,12 +467,12 @@ impl Swarm for LocalSwarm {
     async fn health_check(&mut self) -> Result<()> {
         for node in self.validators.values_mut() {
             if let Err(e) = node.health_check().await {
-                return Err(anyhow!(e))
+                return Err(anyhow!(e));
             }
         }
         for node in self.fullnodes.values_mut() {
             if let Err(e) = node.health_check().await {
-                return Err(anyhow!(e))
+                return Err(anyhow!(e));
             }
         }
         Ok(())


### PR DESCRIPTION
### Description

local swarm gains `health_check()`
`run_forever` uses `health_check()` and exits if an underlying node fails.

### Test Plan

Ran locally, killed one `aptos-node` and forge and the other node exited.