### PR TITLE
[Sharding][Execution] Support sharded APIs for parallel execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3330,6 +3330,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.7.3",
+ "rayon",
  "regex",
  "serde 1.0.149",
  "serde_bytes",

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -30,6 +30,7 @@ use aptos_state_view::StateView;
 use aptos_types::{
     account_config,
     account_config::new_block_event_key,
+    block_executor::partitioner::ExecutableTransactions,
     block_metadata::BlockMetadata,
     on_chain_config::{new_epoch_event_key, FeatureFlag, TimedFeatureOverride},
     transaction::{
@@ -1505,7 +1506,7 @@ impl VMExecutor for AptosVM {
         let count = transactions.len();
         let ret = BlockAptosVM::execute_block(
             Arc::clone(&RAYON_EXEC_POOL),
-            transactions,
+            ExecutableTransactions::Unsharded(transactions),
             state_view,
             Self::get_concurrency_level(),
             maybe_block_gas_limit,

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -25,6 +25,7 @@ use aptos_block_executor::{
 use aptos_infallible::Mutex;
 use aptos_state_view::{StateView, StateViewId};
 use aptos_types::{
+    block_executor::partitioner::{ExecutableTransactions, SubBlock, TransactionWithDependencies},
     executable::ExecutableTestType,
     state_store::state_key::StateKey,
     transaction::{Transaction, TransactionOutput, TransactionStatus},
@@ -132,9 +133,50 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
 pub struct BlockAptosVM();
 
 impl BlockAptosVM {
+    fn verify_transactions(
+        transactions: ExecutableTransactions<Transaction>,
+    ) -> ExecutableTransactions<PreprocessedTransaction> {
+        match transactions {
+            ExecutableTransactions::Unsharded(transactions) => {
+                let signature_verified_txns = transactions
+                    .into_par_iter()
+                    .with_min_len(25)
+                    .map(preprocess_transaction::<AptosVM>)
+                    .collect();
+                ExecutableTransactions::Unsharded(signature_verified_txns)
+            },
+            ExecutableTransactions::Sharded(sub_blocks) => {
+                let signature_verified_block = sub_blocks
+                    .into_par_iter()
+                    .map(|sub_block| {
+                        let start_index = sub_block.start_index;
+                        let verified_txns = sub_block
+                            .into_transactions_with_deps()
+                            .into_par_iter()
+                            .with_min_len(25)
+                            .map(|txn_with_deps| {
+                                let TransactionWithDependencies {
+                                    txn,
+                                    cross_shard_dependencies,
+                                } = txn_with_deps;
+                                let preprocessed_txn = preprocess_transaction::<AptosVM>(txn);
+                                TransactionWithDependencies::new(
+                                    preprocessed_txn,
+                                    cross_shard_dependencies,
+                                )
+                            })
+                            .collect();
+                        SubBlock::new(start_index, verified_txns)
+                    })
+                    .collect();
+                ExecutableTransactions::Sharded(signature_verified_block)
+            },
+        }
+    }
+
     pub fn execute_block<S: StateView + Sync>(
         executor_thread_pool: Arc<ThreadPool>,
-        transactions: Vec<Transaction>,
+        transactions: ExecutableTransactions<Transaction>,
         state_view: &S,
         concurrency_level: usize,
         maybe_block_gas_limit: Option<u64>,
@@ -146,17 +188,11 @@ impl BlockAptosVM {
         // TODO: state sync runs this code but doesn't need to verify signatures
         let signature_verification_timer =
             BLOCK_EXECUTOR_SIGNATURE_VERIFICATION_SECONDS.start_timer();
-        let signature_verified_block: Vec<PreprocessedTransaction> =
-            executor_thread_pool.install(|| {
-                transactions
-                    .into_par_iter()
-                    .with_min_len(25)
-                    .map(preprocess_transaction::<AptosVM>)
-                    .collect()
-            });
+        let signature_verified_block =
+            executor_thread_pool.install(|| Self::verify_transactions(transactions));
         drop(signature_verification_timer);
 
-        let num_txns = signature_verified_block.len();
+        let num_txns = signature_verified_block.num_transactions();
         if state_view.id() != StateViewId::Miscellaneous {
             // Speculation is disabled in Miscellaneous context, which is used by testing and
             // can even lead to concurrent execute_block invocations, leading to errors on flush.

--- a/aptos-move/aptos-vm/src/sharded_block_executor/block_executor_client.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/block_executor_client.rs
@@ -2,7 +2,10 @@
 
 use crate::block_executor::BlockAptosVM;
 use aptos_state_view::StateView;
-use aptos_types::transaction::{Transaction, TransactionOutput};
+use aptos_types::{
+    block_executor::partitioner::ExecutableTransactions,
+    transaction::{Transaction, TransactionOutput},
+};
 use move_core_types::vm_status::VMStatus;
 use std::sync::Arc;
 
@@ -26,7 +29,8 @@ impl BlockExecutorClient for LocalExecutorClient {
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         BlockAptosVM::execute_block(
             self.executor_thread_pool.clone(),
-            transactions,
+            // TODO: (skedia) Change this to sharded transactions
+            ExecutableTransactions::Unsharded(transactions),
             state_view,
             concurrency_level,
             maybe_block_gas_limit,

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -22,7 +22,9 @@ use aptos_mvhashmap::{
     MVHashMap,
 };
 use aptos_state_view::TStateView;
-use aptos_types::{executable::Executable, write_set::WriteOp};
+use aptos_types::{
+    block_executor::partitioner::ExecutableTransactions, executable::Executable, write_set::WriteOp,
+};
 use aptos_vm_logging::{clear_speculative_txn_logs, init_speculative_logs};
 use num_cpus;
 use rayon::ThreadPool;
@@ -428,7 +430,7 @@ where
     pub(crate) fn execute_transactions_parallel(
         &self,
         executor_initial_arguments: E::Argument,
-        signature_verified_block: &Vec<T>,
+        signature_verified_block: &ExecutableTransactions<T>,
         base_view: &S,
     ) -> Result<Vec<E::Output>, E::Error> {
         let _timer = PARALLEL_EXECUTION_SECONDS.start_timer();
@@ -437,6 +439,13 @@ where
         // Need to special case no roles (commit hook by thread itself) to run
         // w. concurrency_level = 1 for some reason.
         assert!(self.concurrency_level > 1, "Must use sequential execution");
+
+        let signature_verified_block = match signature_verified_block {
+            ExecutableTransactions::Unsharded(txns) => txns,
+            ExecutableTransactions::Sharded(_) => {
+                unimplemented!("Sharded execution is not supported yet")
+            },
+        };
 
         let versioned_cache = MVHashMap::new();
 
@@ -526,9 +535,16 @@ where
     pub(crate) fn execute_transactions_sequential(
         &self,
         executor_arguments: E::Argument,
-        signature_verified_block: &[T],
+        signature_verified_block: &ExecutableTransactions<T>,
         base_view: &S,
     ) -> Result<Vec<E::Output>, E::Error> {
+        let signature_verified_block = match signature_verified_block {
+            ExecutableTransactions::Unsharded(txns) => txns,
+            ExecutableTransactions::Sharded(_) => {
+                unimplemented!("Sharded execution is not supported yet")
+            },
+        };
+
         let num_txns = signature_verified_block.len();
         let executor = E::init(executor_arguments);
         let data_map = UnsyncMap::new();
@@ -600,7 +616,7 @@ where
     pub fn execute_block(
         &self,
         executor_arguments: E::Argument,
-        signature_verified_block: Vec<T>,
+        signature_verified_block: ExecutableTransactions<T>,
         base_view: &S,
     ) -> Result<Vec<E::Output>, E::Error> {
         let mut ret = if self.concurrency_level > 1 {
@@ -622,7 +638,7 @@ where
 
             // All logs from the parallel execution should be cleared and not reported.
             // Clear by re-initializing the speculative logs.
-            init_speculative_logs(signature_verified_block.len());
+            init_speculative_logs(signature_verified_block.num_transactions());
 
             ret = self.execute_transactions_sequential(
                 executor_arguments,

--- a/aptos-move/block-executor/src/proptest_types/bencher.rs
+++ b/aptos-move/block-executor/src/proptest_types/bencher.rs
@@ -9,7 +9,9 @@ use crate::{
         TransactionGenParams, ValueType,
     },
 };
-use aptos_types::executable::ExecutableTestType;
+use aptos_types::{
+    block_executor::partitioner::ExecutableTransactions, executable::ExecutableTestType,
+};
 use criterion::{BatchSize, Bencher as CBencher};
 use num_cpus;
 use proptest::{
@@ -34,7 +36,7 @@ pub(crate) struct BencherState<
 > where
     Vec<u8>: From<V>,
 {
-    transactions: Vec<Transaction<KeyType<K>, ValueType<V>>>,
+    transactions: ExecutableTransactions<Transaction<KeyType<K>, ValueType<V>>>,
     expected_output: ExpectedOutput<ValueType<V>>,
 }
 
@@ -104,7 +106,7 @@ where
         let expected_output = ExpectedOutput::generate_baseline(&transactions, None, None);
 
         Self {
-            transactions,
+            transactions: ExecutableTransactions::Unsharded(transactions),
             expected_output,
         }
     }

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -10,7 +10,9 @@ use crate::{
         TransactionGenParams, ValueType,
     },
 };
-use aptos_types::executable::ExecutableTestType;
+use aptos_types::{
+    block_executor::partitioner::ExecutableTransactions, executable::ExecutableTestType,
+};
 use claims::assert_ok;
 use num_cpus;
 use proptest::{
@@ -60,6 +62,8 @@ fn run_transactions<K, V>(
             .unwrap(),
     );
 
+    let executable_txns = ExecutableTransactions::Unsharded(transactions);
+
     for _ in 0..num_repeat {
         let output = BlockExecutor::<
             Transaction<KeyType<K>, ValueType<V>>,
@@ -71,15 +75,18 @@ fn run_transactions<K, V>(
             executor_thread_pool.clone(),
             maybe_block_gas_limit,
         )
-        .execute_transactions_parallel((), &transactions, &data_view);
+        .execute_transactions_parallel((), &executable_txns, &data_view);
 
         if module_access.0 && module_access.1 {
             assert_eq!(output.unwrap_err(), Error::ModulePathReadWrite);
             continue;
         }
 
-        let baseline =
-            ExpectedOutput::generate_baseline(&transactions, None, maybe_block_gas_limit);
+        let baseline = ExpectedOutput::generate_baseline(
+            executable_txns.get_unsharded_transactions().unwrap(),
+            None,
+            maybe_block_gas_limit,
+        );
         baseline.assert_output(&output);
     }
 }
@@ -184,6 +191,8 @@ fn deltas_writes_mixed_with_block_gas_limit(num_txns: usize, maybe_block_gas_lim
         .map(|txn_gen| txn_gen.materialize_with_deltas(&universe, 15, false))
         .collect();
 
+    let executable_txns = ExecutableTransactions::Unsharded(transactions);
+
     let data_view = DeltaDataView::<KeyType<[u8; 32]>, ValueType<[u8; 32]>> {
         phantom: PhantomData,
     };
@@ -206,10 +215,13 @@ fn deltas_writes_mixed_with_block_gas_limit(num_txns: usize, maybe_block_gas_lim
             executor_thread_pool.clone(),
             maybe_block_gas_limit,
         )
-        .execute_transactions_parallel((), &transactions, &data_view);
+        .execute_transactions_parallel((), &executable_txns, &data_view);
 
-        let baseline =
-            ExpectedOutput::generate_baseline(&transactions, None, maybe_block_gas_limit);
+        let baseline = ExpectedOutput::generate_baseline(
+            executable_txns.get_unsharded_transactions().unwrap(),
+            None,
+            maybe_block_gas_limit,
+        );
         baseline.assert_output(&output);
     }
 }
@@ -239,6 +251,8 @@ fn deltas_resolver_with_block_gas_limit(num_txns: usize, maybe_block_gas_limit: 
         .map(|txn_gen| txn_gen.materialize_with_deltas(&universe, 15, false))
         .collect();
 
+    let executable_txns = ExecutableTransactions::Unsharded(transactions);
+
     let executor_thread_pool = Arc::new(
         rayon::ThreadPoolBuilder::new()
             .num_threads(num_cpus::get())
@@ -257,7 +271,7 @@ fn deltas_resolver_with_block_gas_limit(num_txns: usize, maybe_block_gas_limit: 
             executor_thread_pool.clone(),
             maybe_block_gas_limit,
         )
-        .execute_transactions_parallel((), &transactions, &data_view);
+        .execute_transactions_parallel((), &executable_txns, &data_view);
 
         let delta_writes = output
             .as_ref()
@@ -267,7 +281,7 @@ fn deltas_resolver_with_block_gas_limit(num_txns: usize, maybe_block_gas_limit: 
             .collect();
 
         let baseline = ExpectedOutput::generate_baseline(
-            &transactions,
+            executable_txns.get_unsharded_transactions().unwrap(),
             Some(delta_writes),
             maybe_block_gas_limit,
         );
@@ -413,6 +427,8 @@ fn publishing_fixed_params_with_block_gas_limit(
         phantom: PhantomData,
     };
 
+    let executable_txns = ExecutableTransactions::Unsharded(transactions.clone());
+
     let executor_thread_pool = Arc::new(
         rayon::ThreadPoolBuilder::new()
             .num_threads(num_cpus::get())
@@ -427,7 +443,7 @@ fn publishing_fixed_params_with_block_gas_limit(
         DeltaDataView<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
         ExecutableTestType,
     >::new(num_cpus::get(), executor_thread_pool, maybe_block_gas_limit)
-    .execute_transactions_parallel((), &transactions, &data_view);
+    .execute_transactions_parallel((), &executable_txns, &data_view);
     assert_ok!(output);
 
     // Adjust the reads of txn indices[2] to contain module read to key 42.
@@ -464,6 +480,8 @@ fn publishing_fixed_params_with_block_gas_limit(
             .unwrap(),
     );
 
+    let executable_txns = ExecutableTransactions::Unsharded(transactions);
+
     for _ in 0..200 {
         let output = BlockExecutor::<
             Transaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
@@ -475,7 +493,7 @@ fn publishing_fixed_params_with_block_gas_limit(
             executor_thread_pool.clone(),
             Some(max(w_index, r_index) as u64 + 1),
         ) // Ensure enough gas limit to commit the module txns
-        .execute_transactions_parallel((), &transactions, &data_view);
+        .execute_transactions_parallel((), &executable_txns, &data_view);
 
         assert_eq!(output.unwrap_err(), Error::ModulePathReadWrite);
     }

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -24,7 +24,7 @@ pub enum ExecutionStatus<T, E> {
     SkipRest(T),
 }
 
-/// Trait that defines a transaction that could be parallel executed by the scheduler. Each
+/// Trait that defines a transaction type that can be executed by the block executor. A transaction
 /// transaction will write to a key value storage as their side effect.
 pub trait Transaction: Sync + Send + 'static {
     type Key: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug;

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -28,6 +28,7 @@ use aptos_types::{
         new_block_event_key, AccountResource, CoinInfoResource, CoinStoreResource, NewBlockEvent,
         CORE_CODE_ADDRESS,
     },
+    block_executor::partitioner::ExecutableTransactions,
     block_metadata::BlockMetadata,
     chain_id::ChainId,
     on_chain_config::{
@@ -416,7 +417,7 @@ impl FakeExecutor {
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         BlockAptosVM::execute_block(
             self.executor_thread_pool.clone(),
-            txn_block,
+            ExecutableTransactions::Unsharded(txn_block),
             &self.data_store,
             usize::min(4, num_cpus::get()),
             None,

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -331,9 +331,9 @@ async fn test_commit_sync_race() {
         transaction_shuffler::create_transaction_shuffler,
     };
     use aptos_consensus_notifications::Error;
-    use aptos_executor_types::ExecutableBlock;
     use aptos_types::{
         aggregate_signature::AggregateSignature,
+        block_executor::partitioner::ExecutableBlock,
         block_info::BlockInfo,
         ledger_info::LedgerInfo,
         on_chain_config::{TransactionDeduperType, TransactionShufflerType},
@@ -355,7 +355,7 @@ async fn test_commit_sync_race() {
 
         fn execute_block(
             &self,
-            _block: ExecutableBlock,
+            _block: ExecutableBlock<Transaction>,
             _parent_block_id: HashValue,
             _maybe_block_gas_limit: Option<u64>,
         ) -> Result<StateComputeResult, ExecutionError> {

--- a/execution/block-partitioner/src/lib.rs
+++ b/execution/block-partitioner/src/lib.rs
@@ -4,7 +4,6 @@
 
 pub mod sharded_block_partitioner;
 pub mod test_utils;
-pub mod types;
 
 use aptos_types::transaction::Transaction;
 

--- a/execution/block-partitioner/src/sharded_block_partitioner/conflict_detector.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/conflict_detector.rs
@@ -1,13 +1,13 @@
 // Copyright © Aptos Foundation
 
-use crate::{
-    sharded_block_partitioner::dependency_analysis::{RWSet, WriteSetWithTxnIndex},
-    types::{
+use crate::sharded_block_partitioner::dependency_analysis::{RWSet, WriteSetWithTxnIndex};
+use aptos_types::{
+    block_executor::partitioner::{
         CrossShardDependencies, ShardId, SubBlock, TransactionWithDependencies, TxnIdxWithShardId,
         TxnIndex,
     },
+    transaction::analyzed_transaction::{AnalyzedTransaction, StorageLocation},
 };
-use aptos_types::transaction::analyzed_transaction::{AnalyzedTransaction, StorageLocation};
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
@@ -114,7 +114,7 @@ impl CrossShardConflictDetector {
         current_round_rw_set_with_index: Arc<Vec<WriteSetWithTxnIndex>>,
         prev_round_rw_set_with_index: Arc<Vec<WriteSetWithTxnIndex>>,
         index_offset: TxnIndex,
-    ) -> (SubBlock, Vec<CrossShardDependencies>) {
+    ) -> (SubBlock<AnalyzedTransaction>, Vec<CrossShardDependencies>) {
         let mut frozen_txns = Vec::new();
         let mut cross_shard_dependencies = Vec::new();
         for txn in txns.into_iter() {

--- a/execution/block-partitioner/src/sharded_block_partitioner/cross_shard_messages.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/cross_shard_messages.rs
@@ -1,13 +1,11 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    sharded_block_partitioner::{
-        cross_shard_messages::CrossShardMsg::CrossShardDependentEdgesMsg,
-        dependency_analysis::{RWSet, WriteSetWithTxnIndex},
-    },
-    types::{CrossShardEdges, ShardId, TxnIndex},
+use crate::sharded_block_partitioner::{
+    cross_shard_messages::CrossShardMsg::CrossShardDependentEdgesMsg,
+    dependency_analysis::{RWSet, WriteSetWithTxnIndex},
 };
+use aptos_types::block_executor::partitioner::{CrossShardEdges, ShardId, TxnIndex};
 use std::sync::mpsc::{Receiver, Sender};
 
 #[derive(Clone, Debug)]

--- a/execution/block-partitioner/src/sharded_block_partitioner/dependency_analysis.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/dependency_analysis.rs
@@ -1,7 +1,9 @@
 // Copyright © Aptos Foundation
 
-use crate::types::TxnIndex;
-use aptos_types::transaction::analyzed_transaction::{AnalyzedTransaction, StorageLocation};
+use aptos_types::{
+    block_executor::partitioner::TxnIndex,
+    transaction::analyzed_transaction::{AnalyzedTransaction, StorageLocation},
+};
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,

--- a/execution/block-partitioner/src/sharded_block_partitioner/dependent_edges.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/dependent_edges.rs
@@ -1,14 +1,15 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    sharded_block_partitioner::cross_shard_messages::{
-        CrossShardClientInterface, CrossShardDependentEdges,
-    },
-    types::{
+use crate::sharded_block_partitioner::cross_shard_messages::{
+    CrossShardClientInterface, CrossShardDependentEdges,
+};
+use aptos_types::{
+    block_executor::partitioner::{
         CrossShardDependencies, CrossShardEdges, ShardId, SubBlocksForShard, TxnIdxWithShardId,
         TxnIndex,
     },
+    transaction::analyzed_transaction::AnalyzedTransaction,
 };
 use itertools::Itertools;
 use std::{collections::HashMap, sync::Arc};
@@ -16,7 +17,7 @@ use std::{collections::HashMap, sync::Arc};
 pub struct DependentEdgeCreator {
     shard_id: ShardId,
     cross_shard_client: Arc<dyn CrossShardClientInterface>,
-    froze_sub_blocks: SubBlocksForShard,
+    froze_sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
     num_shards: usize,
 }
 
@@ -32,7 +33,7 @@ impl DependentEdgeCreator {
     pub fn new(
         shard_id: ShardId,
         cross_shard_client: Arc<dyn CrossShardClientInterface>,
-        froze_sub_blocks: SubBlocksForShard,
+        froze_sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
         num_shards: usize,
     ) -> Self {
         Self {
@@ -155,7 +156,7 @@ impl DependentEdgeCreator {
         }
     }
 
-    pub fn into_frozen_sub_blocks(self) -> SubBlocksForShard {
+    pub fn into_frozen_sub_blocks(self) -> SubBlocksForShard<AnalyzedTransaction> {
         self.froze_sub_blocks
     }
 }
@@ -168,12 +169,14 @@ mod tests {
             dependent_edges::DependentEdgeCreator,
         },
         test_utils::create_non_conflicting_p2p_transaction,
-        types::{
+    };
+    use aptos_types::{
+        block_executor::partitioner::{
             CrossShardDependencies, CrossShardEdges, SubBlock, SubBlocksForShard,
             TransactionWithDependencies, TxnIdxWithShardId,
         },
+        transaction::analyzed_transaction::StorageLocation,
     };
-    use aptos_types::transaction::analyzed_transaction::StorageLocation;
     use std::sync::Arc;
 
     #[test]

--- a/execution/block-partitioner/src/sharded_block_partitioner/messages.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/messages.rs
@@ -1,10 +1,10 @@
 // Copyright © Aptos Foundation
 
-use crate::{
-    sharded_block_partitioner::dependency_analysis::WriteSetWithTxnIndex,
-    types::{SubBlocksForShard, TxnIndex},
+use crate::sharded_block_partitioner::dependency_analysis::WriteSetWithTxnIndex;
+use aptos_types::{
+    block_executor::partitioner::{SubBlocksForShard, TxnIndex},
+    transaction::analyzed_transaction::AnalyzedTransaction,
 };
-use aptos_types::transaction::analyzed_transaction::AnalyzedTransaction;
 use std::sync::Arc;
 
 pub struct DiscardCrossShardDep {
@@ -14,7 +14,7 @@ pub struct DiscardCrossShardDep {
     pub current_round_start_index: TxnIndex,
     // This is the frozen sub block for the current shard and is passed because we want to modify
     // it to add dependency back edges.
-    pub frozen_sub_blocks: SubBlocksForShard,
+    pub frozen_sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
 }
 
 impl DiscardCrossShardDep {
@@ -22,7 +22,7 @@ impl DiscardCrossShardDep {
         transactions: Vec<AnalyzedTransaction>,
         prev_rounds_write_set_with_index: Arc<Vec<WriteSetWithTxnIndex>>,
         current_round_start_index: TxnIndex,
-        frozen_sub_blocks: SubBlocksForShard,
+        frozen_sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
     ) -> Self {
         Self {
             transactions,
@@ -38,7 +38,7 @@ pub struct AddWithCrossShardDep {
     pub index_offset: TxnIndex,
     // The frozen dependencies in previous chunks.
     pub prev_rounds_write_set_with_index: Arc<Vec<WriteSetWithTxnIndex>>,
-    pub frozen_sub_blocks: SubBlocksForShard,
+    pub frozen_sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
 }
 
 impl AddWithCrossShardDep {
@@ -46,7 +46,7 @@ impl AddWithCrossShardDep {
         transactions: Vec<AnalyzedTransaction>,
         index_offset: TxnIndex,
         prev_rounds_write_set_with_index: Arc<Vec<WriteSetWithTxnIndex>>,
-        frozen_sub_blocks: SubBlocksForShard,
+        frozen_sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
     ) -> Self {
         Self {
             transactions,
@@ -58,14 +58,14 @@ impl AddWithCrossShardDep {
 }
 
 pub struct PartitioningResp {
-    pub frozen_sub_blocks: SubBlocksForShard,
+    pub frozen_sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
     pub write_set_with_index: WriteSetWithTxnIndex,
     pub discarded_txns: Vec<AnalyzedTransaction>,
 }
 
 impl PartitioningResp {
     pub fn new(
-        frozen_sub_blocks: SubBlocksForShard,
+        frozen_sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
         write_set_with_index: WriteSetWithTxnIndex,
         discarded_txns: Vec<AnalyzedTransaction>,
     ) -> Self {

--- a/execution/block-partitioner/src/sharded_block_partitioner/partitioning_shard.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/partitioning_shard.rs
@@ -1,16 +1,17 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
-use crate::{
-    sharded_block_partitioner::{
-        conflict_detector::CrossShardConflictDetector,
-        cross_shard_messages::{CrossShardClient, CrossShardClientInterface, CrossShardMsg},
-        dependency_analysis::{RWSet, WriteSetWithTxnIndex},
-        dependent_edges::DependentEdgeCreator,
-        messages::{AddWithCrossShardDep, ControlMsg, DiscardCrossShardDep, PartitioningResp},
-    },
-    types::{ShardId, SubBlock, TransactionWithDependencies},
+use crate::sharded_block_partitioner::{
+    conflict_detector::CrossShardConflictDetector,
+    cross_shard_messages::{CrossShardClient, CrossShardClientInterface, CrossShardMsg},
+    dependency_analysis::{RWSet, WriteSetWithTxnIndex},
+    dependent_edges::DependentEdgeCreator,
+    messages::{AddWithCrossShardDep, ControlMsg, DiscardCrossShardDep, PartitioningResp},
 };
 use aptos_logger::trace;
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+use aptos_types::block_executor::partitioner::{ShardId, SubBlock, TransactionWithDependencies};
+use aptos_types::transaction::analyzed_transaction::AnalyzedTransaction;
 use std::sync::{
     mpsc::{Receiver, Sender},
     Arc,
@@ -93,7 +94,7 @@ impl PartitioningShard {
             .into_iter()
             .zip(accepted_cross_shard_dependencies.into_iter())
             .map(|(txn, dependencies)| TransactionWithDependencies::new(txn, dependencies))
-            .collect::<Vec<TransactionWithDependencies>>();
+            .collect::<Vec<TransactionWithDependencies<AnalyzedTransaction>>>();
 
         let mut frozen_sub_blocks = dependent_edge_creator.into_frozen_sub_blocks();
         let current_frozen_sub_block = SubBlock::new(index_offset, accepted_txns_with_dependencies);

--- a/execution/executor-benchmark/src/native_executor.rs
+++ b/execution/executor-benchmark/src/native_executor.rs
@@ -9,11 +9,11 @@ use anyhow::Result;
 use aptos_executor::{
     block_executor::TransactionBlockExecutor, components::chunk_output::ChunkOutput,
 };
-use aptos_executor_types::ExecutableTransactions;
 use aptos_storage_interface::cached_state_view::CachedStateView;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{deposit::DepositEvent, withdraw::WithdrawEvent},
+    block_executor::partitioner::ExecutableTransactions,
     contract_event::ContractEvent,
     event::EventKey,
     state_store::state_key::StateKey,
@@ -337,7 +337,7 @@ impl NativeExecutor {
 
 impl TransactionBlockExecutor for NativeExecutor {
     fn execute_transaction_block(
-        transactions: ExecutableTransactions,
+        transactions: ExecutableTransactions<Transaction>,
         state_view: CachedStateView,
         _maybe_block_gas_limit: Option<u64>,
     ) -> Result<ChunkOutput> {

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -4,13 +4,13 @@
 #![forbid(unsafe_code)]
 
 use anyhow::Result;
-use aptos_block_partitioner::types::SubBlock;
 use aptos_crypto::{
     hash::{EventAccumulatorHasher, TransactionAccumulatorHasher, ACCUMULATOR_PLACEHOLDER_HASH},
     HashValue,
 };
 use aptos_scratchpad::{ProofRead, SparseMerkleTree};
 use aptos_types::{
+    block_executor::partitioner::ExecutableBlock,
     contract_event::ContractEvent,
     epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
@@ -90,7 +90,7 @@ pub trait BlockExecutorTrait: Send + Sync {
     /// Executes a block.
     fn execute_block(
         &self,
-        block: ExecutableBlock,
+        block: ExecutableBlock<Transaction>,
         parent_block_id: HashValue,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<StateComputeResult, Error>;
@@ -125,49 +125,6 @@ pub trait BlockExecutorTrait: Send + Sync {
 
     /// Finishes the block executor by releasing memory held by inner data structures(SMT).
     fn finish(&self);
-}
-
-pub struct ExecutableBlock {
-    pub block_id: HashValue,
-    pub transactions: ExecutableTransactions,
-}
-
-impl ExecutableBlock {
-    pub fn new(block_id: HashValue, transactions: ExecutableTransactions) -> Self {
-        Self {
-            block_id,
-            transactions,
-        }
-    }
-}
-
-impl From<(HashValue, Vec<Transaction>)> for ExecutableBlock {
-    fn from((block_id, transactions): (HashValue, Vec<Transaction>)) -> Self {
-        Self::new(block_id, ExecutableTransactions::Unsharded(transactions))
-    }
-}
-
-pub enum ExecutableTransactions {
-    Unsharded(Vec<Transaction>),
-    Sharded(Vec<SubBlock>),
-}
-
-impl ExecutableTransactions {
-    pub fn num_transactions(&self) -> usize {
-        match self {
-            ExecutableTransactions::Unsharded(transactions) => transactions.len(),
-            ExecutableTransactions::Sharded(sub_blocks) => sub_blocks
-                .iter()
-                .map(|sub_block| sub_block.num_txns())
-                .sum(),
-        }
-    }
-}
-
-impl From<Vec<Transaction>> for ExecutableTransactions {
-    fn from(txns: Vec<Transaction>) -> Self {
-        Self::Unsharded(txns)
-    }
 }
 
 #[derive(Clone)]

--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -15,9 +15,7 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_crypto::HashValue;
-use aptos_executor_types::{
-    BlockExecutorTrait, Error, ExecutableBlock, ExecutableTransactions, StateComputeResult,
-};
+use aptos_executor_types::{BlockExecutorTrait, Error, StateComputeResult};
 use aptos_infallible::RwLock;
 use aptos_logger::prelude::*;
 use aptos_scratchpad::SparseMerkleTree;
@@ -25,14 +23,19 @@ use aptos_state_view::StateViewId;
 use aptos_storage_interface::{
     async_proof_fetcher::AsyncProofFetcher, cached_state_view::CachedStateView, DbReaderWriter,
 };
-use aptos_types::{ledger_info::LedgerInfoWithSignatures, state_store::state_value::StateValue};
+use aptos_types::{
+    block_executor::partitioner::{ExecutableBlock, ExecutableTransactions},
+    ledger_info::LedgerInfoWithSignatures,
+    state_store::state_value::StateValue,
+    transaction::Transaction,
+};
 use aptos_vm::AptosVM;
 use fail::fail_point;
 use std::{marker::PhantomData, sync::Arc};
 
 pub trait TransactionBlockExecutor: Send + Sync {
     fn execute_transaction_block(
-        transactions: ExecutableTransactions,
+        transactions: ExecutableTransactions<Transaction>,
         state_view: CachedStateView,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<ChunkOutput>;
@@ -40,7 +43,7 @@ pub trait TransactionBlockExecutor: Send + Sync {
 
 impl TransactionBlockExecutor for AptosVM {
     fn execute_transaction_block(
-        transactions: ExecutableTransactions,
+        transactions: ExecutableTransactions<Transaction>,
         state_view: CachedStateView,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<ChunkOutput> {
@@ -104,7 +107,7 @@ where
 
     fn execute_block(
         &self,
-        block: ExecutableBlock,
+        block: ExecutableBlock<Transaction>,
         parent_block_id: HashValue,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<StateComputeResult, Error> {
@@ -174,7 +177,7 @@ where
 
     fn execute_block(
         &self,
-        block: ExecutableBlock,
+        block: ExecutableBlock<Transaction>,
         parent_block_id: HashValue,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<StateComputeResult, Error> {

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -7,7 +7,7 @@
 use crate::{components::apply_chunk_output::ApplyChunkOutput, metrics};
 use anyhow::Result;
 use aptos_crypto::HashValue;
-use aptos_executor_types::{ExecutableTransactions, ExecutedBlock, ExecutedChunk};
+use aptos_executor_types::{ExecutedBlock, ExecutedChunk};
 use aptos_infallible::Mutex;
 use aptos_logger::{sample, sample::SampleRate, trace, warn};
 use aptos_storage_interface::{
@@ -16,6 +16,7 @@ use aptos_storage_interface::{
 };
 use aptos_types::{
     account_config::CORE_CODE_ADDRESS,
+    block_executor::partitioner::ExecutableTransactions,
     transaction::{ExecutionStatus, Transaction, TransactionOutput, TransactionStatus},
 };
 use aptos_vm::{
@@ -47,7 +48,7 @@ pub struct ChunkOutput {
 
 impl ChunkOutput {
     pub fn by_transaction_execution<V: VMExecutor>(
-        transactions: ExecutableTransactions,
+        transactions: ExecutableTransactions<Transaction>,
         state_view: CachedStateView,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<Self> {

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -8,12 +8,13 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
-use aptos_executor_types::{BlockExecutorTrait, ExecutableTransactions};
+use aptos_executor_types::BlockExecutorTrait;
 use aptos_state_view::StateView;
 use aptos_storage_interface::{
     cached_state_view::CachedStateView, state_delta::StateDelta, DbReader, DbReaderWriter, DbWriter,
 };
 use aptos_types::{
+    block_executor::partitioner::ExecutableTransactions,
     ledger_info::LedgerInfoWithSignatures,
     test_helpers::transaction_test_helpers::BLOCK_GAS_LIMIT,
     transaction::{Transaction, TransactionOutput, TransactionToCommit, Version},
@@ -52,7 +53,7 @@ pub struct FakeVM;
 
 impl TransactionBlockExecutor for FakeVM {
     fn execute_transaction_block(
-        transactions: ExecutableTransactions,
+        transactions: ExecutableTransactions<Transaction>,
         state_view: CachedStateView,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<ChunkOutput> {

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -8,13 +8,13 @@ mod mock_vm_test;
 use crate::{block_executor::TransactionBlockExecutor, components::chunk_output::ChunkOutput};
 use anyhow::Result;
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
-use aptos_executor_types::ExecutableTransactions;
 use aptos_state_view::StateView;
 use aptos_storage_interface::cached_state_view::CachedStateView;
 use aptos_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
     account_config::CORE_CODE_ADDRESS,
+    block_executor::partitioner::ExecutableTransactions,
     chain_id::ChainId,
     contract_event::ContractEvent,
     event::EventKey,
@@ -60,7 +60,7 @@ pub struct MockVM;
 
 impl TransactionBlockExecutor for MockVM {
     fn execute_transaction_block(
-        transactions: ExecutableTransactions,
+        transactions: ExecutableTransactions<Transaction>,
         state_view: CachedStateView,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<ChunkOutput> {

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -31,6 +31,7 @@ once_cell = { workspace = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 rand = { workspace = true }
+rayon = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }

--- a/types/src/block_executor/mod.rs
+++ b/types/src/block_executor/mod.rs
@@ -1,0 +1,5 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod partitioner;

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -51,6 +51,7 @@ pub use utility_coin::*;
 
 pub mod account_view;
 pub mod aggregate_signature;
+pub mod block_executor;
 pub mod state_store;
 #[cfg(test)]
 mod unit_tests;


### PR DESCRIPTION
### Description

- Plumb the ExecutableTransactions all the way through the block executor to the parallel execution entry point. This is a pre-requisite for sharding
- No functionality change has been introduced - support for sharding will be introduced in subsequent PRs.

### Test Plan

Existing UTs
