### PR TITLE
[GHA] Pin main branch workflow for indexer workflow

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -207,7 +207,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
       github.event.pull_request.auto_merge != null ||
       contains(github.event.pull_request.body, '#e2e')
-    uses: ./.github/workflows/docker-indexer-grpc-test.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/docker-indexer-grpc-test.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}


### PR DESCRIPTION
### Description

I think the `docker-indexer-grpc-test.yaml` should be pinned to the main branch, like other workflows.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
