### PR TITLE
[CLI][Ledger][easy] update ledger msg signing func

### DIFF
--- a/crates/aptos-ledger/src/lib.rs
+++ b/crates/aptos-ledger/src/lib.rs
@@ -316,11 +316,9 @@ pub fn get_public_key(path: &str, display: bool) -> Result<Ed25519PublicKey, Apt
 ///
 /// # Arguments
 ///
-/// * `raw_message` - the serialized raw transaction that need to be signed
-pub fn sign_message(
-    path: &str,
-    raw_message: Vec<u8>,
-) -> Result<Ed25519Signature, AptosLedgerError> {
+/// * `path` - derivative path of the ledger account
+/// * `raw_message` - the raw message that need to be signed
+pub fn sign_message(path: &str, raw_message: &[u8]) -> Result<Ed25519Signature, AptosLedgerError> {
     // open connection to ledger
     let transport = open_ledger_transport()?;
 

--- a/crates/aptos-ledger/src/lib.rs
+++ b/crates/aptos-ledger/src/lib.rs
@@ -7,6 +7,7 @@
 
 #![deny(missing_docs)]
 
+use aptos_crypto::ed25519::Ed25519Signature;
 pub use aptos_crypto::{ed25519::Ed25519PublicKey, ValidCryptoMaterialStringExt};
 pub use aptos_types::{
     account_address::AccountAddress, transaction::authenticator::AuthenticationKey,
@@ -315,8 +316,11 @@ pub fn get_public_key(path: &str, display: bool) -> Result<Ed25519PublicKey, Apt
 ///
 /// # Arguments
 ///
-/// * `raw_txn` - the serialized raw transaction that need to be signed
-pub fn sign_txn(path: &str, raw_txn: Vec<u8>) -> Result<Vec<u8>, AptosLedgerError> {
+/// * `raw_message` - the serialized raw transaction that need to be signed
+pub fn sign_message(
+    path: &str,
+    raw_message: Vec<u8>,
+) -> Result<Ed25519Signature, AptosLedgerError> {
     // open connection to ledger
     let transport = open_ledger_transport()?;
 
@@ -336,7 +340,7 @@ pub fn sign_txn(path: &str, raw_txn: Vec<u8>) -> Result<Vec<u8>, AptosLedgerErro
         return Err(AptosLedgerError::UnexpectedError(err.to_string(), None));
     }
 
-    let chunks = raw_txn.chunks(MAX_APDU_LEN);
+    let chunks = raw_message.chunks(MAX_APDU_LEN);
     let chunks_count = chunks.len();
 
     for (i, chunk) in chunks.enumerate() {
@@ -356,7 +360,9 @@ pub fn sign_txn(path: &str, raw_txn: Vec<u8>) -> Result<Vec<u8>, AptosLedgerErro
 
                         let signature_len: usize = response_buffer[0] as usize;
                         let signature_buffer = &response_buffer[1..1 + signature_len];
-                        return Ok(signature_buffer.to_vec());
+                        return Ed25519Signature::try_from(signature_buffer).map_err(|err| {
+                            AptosLedgerError::UnexpectedError(err.to_string(), None)
+                        });
                     }
                 } else {
                     let error_string = response


### PR DESCRIPTION
### Description

Update the signing func from ledger crate to output `Ed25519Signature`. So it can be easily consume by RustSDK or CLI

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Manually wrote a unit test to test this

```
#[test]
fn test_sign_txn() {
    let txn_string = b"b5e97db07fa0bd0e5598aa3643a9bc6f6693bddc1a9fec9e674a461eaa00b193783135e8b00430253a22ba041d860c373d7a1501ccf7ac2d1ad37a8ed2775aee000000000000000002000000000000000000000000000000000000000000000000000000000000000104636f696e087472616e73666572010700000000000000000000000000000000000000000000000000000000000000010a6170746f735f636f696e094170746f73436f696e000220094c6fc0d3b382a599c37e1aaa7618eff2c96a3586876082c4594c50c50d7dde082a00000000000000204e0000000000006400000000000000565c51630000000022";
    let signed_msg = sign_message("m/44'/637'/0'/0'/0'", txn_string.to_vec());
    println!("Signed message: {:?}", signed_msg);
}
```

output:
`Signed message: Ok(Ed25519Signature(6b999302af0edf3d795226fab8b335e2d615eeec35b5552f9b7ff0f7f85a2414bd82af87f03780b13011b29331dbece69ac30f006670c2738fa1224b79001206))`
