### PR TITLE
[aptos-vm] Skip converting storage error

### DIFF
--- a/aptos-move/aptos-vm/src/errors.rs
+++ b/aptos-move/aptos-vm/src/errors.rs
@@ -132,6 +132,10 @@ pub fn convert_prologue_error(
             };
             VMStatus::Error(new_major_status, None)
         },
+        // Storage error can be a result of speculation failure so throw the error back for caller to handle.
+        VMStatus::Error(StatusCode::STORAGE_ERROR, msg) => {
+            VMStatus::Error(StatusCode::STORAGE_ERROR, msg)
+        },
         status @ VMStatus::ExecutionFailure { .. } | status @ VMStatus::Error(..) => {
             speculative_error!(
                 log_context,
@@ -176,7 +180,10 @@ pub fn convert_epilogue_error(
                 VMStatus::Error(StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION, None)
             },
         },
-
+        // Storage error can be a result of speculation failure so throw the error back for caller to handle.
+        VMStatus::Error(StatusCode::STORAGE_ERROR, msg) => {
+            VMStatus::Error(StatusCode::STORAGE_ERROR, msg)
+        },
         status => {
             speculative_error!(
                 log_context,
@@ -198,7 +205,10 @@ pub fn expect_only_successful_execution(
     let status = error.into_vm_status();
     Err(match status {
         VMStatus::Executed => VMStatus::Executed,
-
+        // Storage error can be a result of speculation failure so throw the error back for caller to handle.
+        VMStatus::Error(StatusCode::STORAGE_ERROR, msg) => {
+            VMStatus::Error(StatusCode::STORAGE_ERROR, msg)
+        },
         status => {
             // Only trigger a warning here as some errors could be a result of the speculative parallel execution.
             // We will report the errors after we obtained the final transaction output in update_counters_for_processed_chunk


### PR DESCRIPTION
### Description

Storage error can be a result of speculation error and should thus not be treated as `UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION`.

### Test Plan

TBD
