### PR TITLE
[GHA] Use spot VM for executor-performance

### DIFF
--- a/.github/workflows/execution-performance.yaml
+++ b/.github/workflows/execution-performance.yaml
@@ -8,3 +8,11 @@ jobs:
     secrets: inherit
     with:
       GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      RUNNER_NAME: executor-benchmark-runner
+
+  spot-runner-execution-performance:
+    uses: ./.github/workflows/workflow-run-execution-performance.yaml
+    secrets: inherit
+    with:
+      GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      RUNNER_NAME: spot-runner

--- a/.github/workflows/execution-performance.yaml
+++ b/.github/workflows/execution-performance.yaml
@@ -4,14 +4,14 @@ on:
 
 jobs:
   execution-performance:
-    uses: ./.github/workflows/workflow-run-execution-performance.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-execution-performance.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       RUNNER_NAME: executor-benchmark-runner
 
   spot-runner-execution-performance:
-    uses: ./.github/workflows/workflow-run-execution-performance.yaml
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-execution-performance.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/execution-performance.yaml
+++ b/.github/workflows/execution-performance.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   execution-performance:
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-execution-performance.yaml@main
+    uses: ./.github/workflows/workflow-run-execution-performance.yaml
     secrets: inherit
     with:
       GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/workflow-run-execution-performance.yaml
+++ b/.github/workflows/workflow-run-execution-performance.yaml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
         description: The git SHA1 to test.
+      RUNNER_NAME:
+        required: false
+        default: executor-benchmark-runner 
+        type: string
   # This allows the workflow to be triggered manually from the Github UI or CLI
   # NOTE: because the "number" type is not supported, we default to 720 minute timeout
   workflow_dispatch:
@@ -16,11 +20,19 @@ on:
         required: true
         type: string
         description: The git SHA1 to test.
+      RUNNER_NAME:
+        required: false
+        default: executor-benchmark-runner 
+        type: choice
+        options:
+        - spot-runner
+        - executor-benchmark-runner
+        description: The name of the runner to use for the test.
 
 jobs:
   sequential-execution-performance:
     timeout-minutes: 30
-    runs-on: spot-runner 
+    runs-on: ${{ inputs.RUNNER_NAME }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
@@ -36,7 +48,7 @@ jobs:
 
   parallel-execution-performance:
     timeout-minutes: 60
-    runs-on: spot-runner
+    runs-on: ${{ inputs.RUNNER_NAME }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
@@ -52,7 +64,7 @@ jobs:
 
   single-node-performance:
     timeout-minutes: 60
-    runs-on: spot-runner
+    runs-on: ${{ inputs.RUNNER_NAME }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:

--- a/.github/workflows/workflow-run-execution-performance.yaml
+++ b/.github/workflows/workflow-run-execution-performance.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   sequential-execution-performance:
     timeout-minutes: 30
-    runs-on: executor-benchmark-runner
+    runs-on: spot-runner 
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
@@ -36,7 +36,7 @@ jobs:
 
   parallel-execution-performance:
     timeout-minutes: 60
-    runs-on: executor-benchmark-runner
+    runs-on: spot-runner
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
@@ -52,7 +52,7 @@ jobs:
 
   single-node-performance:
     timeout-minutes: 60
-    runs-on: executor-benchmark-runner
+    runs-on: spot-runner
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:


### PR DESCRIPTION
### Description

This PR duplicates the executor-performance workflow to run on `spot-runner` GHA runners which are backed by spot VM pool. We will use this to assess the availability and performance of the spot VM pool and evaluate if we can expand its use.

 The duplicated workflow is not required check, so won't block merge on failure.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Tested it in this run: https://github.com/aptos-labs/aptos-core/actions/runs/5273676507
