### PR TITLE
[Storage] Remove get_latest_transaction_info_option API, and move all callers to use get_latest_version.

### DIFF
--- a/aptos-move/aptos-validator-interface/src/storage_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/storage_interface.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::AptosValidatorInterface;
-use anyhow::{anyhow, bail, ensure, Result};
+use anyhow::{bail, ensure, Result};
 use aptos_config::config::{
     RocksdbConfigs, BUFFERED_STATE_TARGET_ITEMS, DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
     NO_OP_STORAGE_PRUNER_CONFIG,
@@ -80,11 +80,7 @@ impl AptosValidatorInterface for DBDebuggerInterface {
     }
 
     async fn get_latest_version(&self) -> Result<Version> {
-        let (version, _) = self
-            .0
-            .get_latest_transaction_info_option()?
-            .ok_or_else(|| anyhow!("DB doesn't have any transaction."))?;
-        Ok(version)
+        self.0.get_latest_version()
     }
 
     async fn get_version_by_account_sequence(

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -48,12 +48,15 @@ fn test_genesis() {
         .reader
         .get_state_value_with_proof_by_version(&account_resource_path, 0)
         .unwrap();
-    let (txn_info_version, txn_info) = db
+    let latest_version = db.reader.get_latest_version().unwrap();
+    assert_eq!(latest_version, 0);
+    let txn_info = db
         .reader
-        .get_latest_transaction_info_option()
+        .get_transaction_info_iterator(0, 1)
+        .unwrap()
+        .next()
         .unwrap()
         .unwrap();
-    assert_eq!(txn_info_version, 0);
     state_proof
         .verify(
             txn_info.state_checkpoint_hash().unwrap(),

--- a/network/peer-monitoring-service/server/src/tests.rs
+++ b/network/peer-monitoring-service/server/src/tests.rs
@@ -53,8 +53,8 @@ use aptos_types::{
         state_value::{StateValue, StateValueChunkWithProof},
     },
     transaction::{
-        AccountTransactionsWithProof, TransactionInfo, TransactionListWithProof,
-        TransactionOutputListWithProof, TransactionWithProof, Version,
+        AccountTransactionsWithProof, TransactionListWithProof, TransactionOutputListWithProof,
+        TransactionWithProof, Version,
     },
     PeerId,
 };
@@ -746,8 +746,6 @@ mock! {
         fn get_latest_executed_trees(&self) -> anyhow::Result<ExecutedTrees>;
 
         fn get_epoch_ending_ledger_info(&self, known_version: u64) -> anyhow::Result<LedgerInfoWithSignatures>;
-
-        fn get_latest_transaction_info_option(&self) -> anyhow::Result<Option<(Version, TransactionInfo)>>;
 
         fn get_accumulator_root_hash(&self, _version: Version) -> anyhow::Result<HashValue>;
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/bootstrapper.rs
@@ -14,7 +14,7 @@ use crate::{
             create_data_stream_listener, create_empty_epoch_state, create_epoch_ending_ledger_info,
             create_full_node_driver_configuration, create_global_summary,
             create_output_list_with_proof, create_random_epoch_ending_ledger_info,
-            create_transaction_info, create_transaction_list_with_proof,
+            create_transaction_list_with_proof,
         },
     },
     utils::OutputFallbackHandler,
@@ -1178,8 +1178,8 @@ fn create_bootstrapper(
         .expect_get_latest_ledger_info()
         .returning(|| Ok(create_epoch_ending_ledger_info()));
     mock_database_reader
-        .expect_get_latest_transaction_info_option()
-        .returning(|| Ok(Some((0, create_transaction_info()))));
+        .expect_get_latest_version()
+        .returning(|| Ok(0));
 
     // Create the output fallback handler
     let time_service = time_service.unwrap_or_else(TimeService::mock);
@@ -1222,8 +1222,8 @@ fn create_bootstrapper_with_storage(
         .expect_get_latest_ledger_info()
         .returning(|| Ok(create_epoch_ending_ledger_info()));
     mock_database_reader
-        .expect_get_latest_transaction_info_option()
-        .returning(move || Ok(Some((latest_synced_version, create_transaction_info()))));
+        .expect_get_latest_version()
+        .returning(move || Ok(latest_synced_version));
 
     // Create the output fallback handler
     let output_fallback_handler =

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/continuous_syncer.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         utils::{
             create_data_stream_listener, create_epoch_ending_ledger_info, create_epoch_state,
-            create_full_node_driver_configuration, create_transaction_info,
+            create_full_node_driver_configuration,
         },
     },
     utils::OutputFallbackHandler,
@@ -502,8 +502,8 @@ fn create_continuous_syncer(
     // Create the mock db reader with the given synced version
     let mut mock_database_reader = create_mock_db_reader();
     mock_database_reader
-        .expect_get_latest_transaction_info_option()
-        .returning(move || Ok(Some((synced_version, create_transaction_info()))));
+        .expect_get_latest_version()
+        .returning(move || Ok(synced_version));
     mock_database_reader
         .expect_get_latest_epoch_state()
         .returning(move || Ok(create_epoch_state(current_epoch)));

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -5,9 +5,7 @@ use crate::{
     error::Error,
     metadata_storage::MetadataStorageInterface,
     storage_synchronizer::StorageSynchronizerInterface,
-    tests::utils::{
-        create_empty_epoch_state, create_epoch_ending_ledger_info, create_transaction_info,
-    },
+    tests::utils::{create_empty_epoch_state, create_epoch_ending_ledger_info},
 };
 use anyhow::Result;
 use aptos_crypto::HashValue;
@@ -38,8 +36,8 @@ use aptos_types::{
         state_value::{StateValue, StateValueChunkWithProof},
     },
     transaction::{
-        AccountTransactionsWithProof, TransactionInfo, TransactionListWithProof,
-        TransactionOutputListWithProof, TransactionToCommit, TransactionWithProof, Version,
+        AccountTransactionsWithProof, TransactionListWithProof, TransactionOutputListWithProof,
+        TransactionToCommit, TransactionWithProof, Version,
     },
 };
 use async_trait::async_trait;
@@ -71,9 +69,7 @@ pub fn create_mock_reader_writer(
     writer: Option<MockDatabaseWriter>,
 ) -> DbReaderWriter {
     let mut reader = reader.unwrap_or_else(create_mock_db_reader);
-    reader
-        .expect_get_latest_transaction_info_option()
-        .returning(|| Ok(Some((0, create_transaction_info()))));
+    reader.expect_get_latest_version().returning(|| Ok(0));
     reader
         .expect_get_latest_epoch_state()
         .returning(|| Ok(create_empty_epoch_state()));
@@ -248,8 +244,6 @@ mock! {
         fn get_latest_executed_trees(&self) -> Result<ExecutedTrees>;
 
         fn get_epoch_ending_ledger_info(&self, known_version: u64) -> Result<LedgerInfoWithSignatures>;
-
-        fn get_latest_transaction_info_option(&self) -> Result<Option<(Version, TransactionInfo)>>;
 
         fn get_accumulator_root_hash(&self, _version: Version) -> Result<HashValue>;
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/utils.rs
@@ -269,18 +269,9 @@ pub fn fetch_latest_synced_ledger_info(
 
 /// Fetches the latest synced version from the specified storage
 pub fn fetch_latest_synced_version(storage: Arc<dyn DbReader>) -> Result<Version, Error> {
-    let latest_transaction_info =
-        storage
-            .get_latest_transaction_info_option()
-            .map_err(|error| {
-                Error::StorageError(format!(
-                    "Failed to get the latest transaction info from storage: {:?}",
-                    error
-                ))
-            })?;
-    latest_transaction_info
-        .ok_or_else(|| Error::StorageError("Latest transaction info is missing!".into()))
-        .map(|(latest_synced_version, _)| latest_synced_version)
+    storage.get_latest_version().map_err(|e| {
+        Error::StorageError(format!("Failed to get latest version from storage: {e:?}"))
+    })
 }
 
 /// Initializes all relevant metric gauges (e.g., after a reboot

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -37,8 +37,8 @@ use aptos_types::{
         state_value::{StateValue, StateValueChunkWithProof},
     },
     transaction::{
-        AccountTransactionsWithProof, TransactionInfo, TransactionListWithProof,
-        TransactionOutputListWithProof, TransactionWithProof, Version,
+        AccountTransactionsWithProof, TransactionListWithProof, TransactionOutputListWithProof,
+        TransactionWithProof, Version,
     },
     PeerId,
 };
@@ -316,8 +316,6 @@ mock! {
         fn get_latest_executed_trees(&self) -> Result<ExecutedTrees>;
 
         fn get_epoch_ending_ledger_info(&self, known_version: u64) -> Result<LedgerInfoWithSignatures>;
-
-        fn get_latest_transaction_info_option(&self) -> Result<Option<(Version, TransactionInfo)>>;
 
         fn get_accumulator_root_hash(&self, _version: Version) -> Result<HashValue>;
 

--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -141,10 +141,7 @@ impl RestoreHandler {
     }
 
     pub fn get_next_expected_transaction_version(&self) -> Result<Version> {
-        Ok(self
-            .aptosdb
-            .get_latest_transaction_info_option()?
-            .map_or(0, |(ver, _txn_info)| ver + 1))
+        Ok(self.aptosdb.get_latest_version().map_or(0, |ver| ver + 1))
     }
 
     pub fn get_state_snapshot_before(

--- a/storage/aptosdb/src/db_debugger/truncate/mod.rs
+++ b/storage/aptosdb/src/db_debugger/truncate/mod.rs
@@ -234,7 +234,7 @@ mod test {
                 version += txns_to_commit.len() as u64;
             }
 
-            let db_version = db.get_latest_transaction_info_option().unwrap().unwrap().0;
+            let db_version = db.get_latest_version().unwrap();
             prop_assert_eq!(db_version, version - 1);
 
             drop(db);
@@ -253,7 +253,7 @@ mod test {
             cmd.run().unwrap();
 
             let db = AptosDB::new_for_test(&tmp_dir);
-            let db_version = db.get_latest_transaction_info_option().unwrap().unwrap().0;
+            let db_version = db.get_latest_version().unwrap();
             prop_assert_eq!(db_version, target_version);
 
             let txn_list_with_proof = db.get_transactions(0, db_version + 1, db_version, true).unwrap();

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -198,6 +198,7 @@ impl StateMerkleDb {
             &DbMetadataValue::Version(version),
         )?;
 
+        info!(version = version, "Committing StateMerkleDb.");
         self.state_merkle_metadata_db.write_schemas(batch)
     }
 

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -138,14 +138,7 @@ fn end_to_end() {
         assert_eq!(restore_ws, org_ws);
     }
 
-    assert_eq!(
-        tgt_db
-            .get_latest_transaction_info_option()
-            .unwrap()
-            .unwrap()
-            .0,
-        target_version,
-    );
+    assert_eq!(tgt_db.get_latest_version().unwrap(), target_version);
     let recovered_transactions = tgt_db
         .get_transactions(
             0,

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -305,9 +305,9 @@ pub trait DbReader: Send + Sync {
             .and_then(|opt| opt.ok_or_else(|| format_err!("Latest LedgerInfo not found.")))
     }
 
-    /// Returns the latest version, error on on non-bootstrapped DB.
+    /// Returns the latest committed version, error on on non-bootstrapped/empty DB.
     fn get_latest_version(&self) -> Result<Version> {
-        Ok(self.get_latest_ledger_info()?.ledger_info().version())
+        unimplemented!()
     }
 
     /// Returns the latest state checkpoint version if any.
@@ -444,13 +444,6 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
-    /// Gets the latest transaction info.
-    /// N.B. Unlike get_startup_info(), even if the db is not bootstrapped, this can return `Some`
-    /// -- those from a aptos db-tool restore run.
-    fn get_latest_transaction_info_option(&self) -> Result<Option<(Version, TransactionInfo)>> {
-        unimplemented!()
-    }
-
     /// Gets the transaction accumulator root hash at specified version.
     /// Caller must guarantee the version is not greater than the latest version.
     fn get_accumulator_root_hash(&self, _version: Version) -> Result<HashValue> {
@@ -569,16 +562,7 @@ impl MoveStorage for &dyn DbReader {
     }
 
     fn fetch_synced_version(&self) -> Result<u64> {
-        let (synced_version, _) = self
-            .get_latest_transaction_info_option()
-            .map_err(|e| {
-                format_err!(
-                    "[MoveStorage] Failed fetching latest transaction info: {}",
-                    e
-                )
-            })?
-            .ok_or_else(|| format_err!("[MoveStorage] Latest transaction info not found."))?;
-        Ok(synced_version)
+        self.get_latest_version()
     }
 
     fn fetch_latest_state_checkpoint_version(&self) -> Result<Version> {


### PR DESCRIPTION
### Description

After we split ledger commit to multiple batches, the latest transaction info version might not be equal to the latest "committed" version.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
