### PR TITLE
[Rust SDK] Add HardwareWalletAccount for ledger integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2798,6 +2798,7 @@ dependencies = [
  "aptos-cached-packages",
  "aptos-crypto",
  "aptos-global-constants",
+ "aptos-ledger",
  "aptos-rest-client",
  "aptos-types",
  "bcs 0.1.4",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -18,6 +18,7 @@ aptos-api-types = { workspace = true }
 aptos-cached-packages = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-global-constants = { workspace = true }
+aptos-ledger = { workspace = true }
 aptos-rest-client = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -180,7 +180,9 @@ pub trait TransactionSigner {
     fn sign_with_transaction_builder(&mut self, builder: TransactionBuilder) -> SignedTransaction;
 }
 
-/// Similar
+/// Similar to LocalAccount, but for hardware wallets.
+/// HardwareWallet does not have private key exported.
+/// Anything that requires private key should be go through HardwareWallet.
 #[derive(Debug)]
 pub struct HardwareWalletAccount {
     address: AccountAddress,

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -5,6 +5,7 @@
 use crate::{
     crypto::{
         ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+        signing_message,
         traits::Uniform,
     },
     transaction_builder::TransactionBuilder,
@@ -14,6 +15,8 @@ use crate::{
     },
 };
 use anyhow::Result;
+use aptos_crypto::ed25519::Ed25519Signature;
+use aptos_ledger::AptosLedgerError;
 use aptos_types::event::EventKey;
 pub use aptos_types::*;
 use bip39::{Language, Mnemonic, Seed};
@@ -162,6 +165,127 @@ impl LocalAccount {
 
     pub fn sent_event_key(&self) -> EventKey {
         EventKey::new(3, self.address)
+    }
+}
+
+/// Types of hardware wallet the SDK currently supports
+#[derive(Debug)]
+pub enum HardwareWalletType {
+    Ledger,
+}
+
+pub trait TransactionSigner {
+    fn sign_transaction(&self, txn: RawTransaction) -> SignedTransaction;
+
+    fn sign_with_transaction_builder(&mut self, builder: TransactionBuilder) -> SignedTransaction;
+}
+
+/// Similar
+#[derive(Debug)]
+pub struct HardwareWalletAccount {
+    address: AccountAddress,
+    public_key: Ed25519PublicKey,
+    authentication_key: AuthenticationKey,
+    derivation_path: String,
+    hardware_wallet_type: HardwareWalletType,
+    /// Same as LocalAccount's sequence_number.
+    sequence_number: u64,
+}
+
+impl TransactionSigner for HardwareWalletAccount {
+    fn sign_transaction(&self, txn: RawTransaction) -> SignedTransaction {
+        let signature = self
+            .sign_arbitrary_message(
+                signing_message(&txn)
+                    .expect("Unable to convert txn to signing message.")
+                    .as_ref(),
+            )
+            .expect("Unable to sign transaction from hardware wallet.");
+        SignedTransaction::new(txn, self.public_key().clone(), signature)
+    }
+
+    fn sign_with_transaction_builder(&mut self, builder: TransactionBuilder) -> SignedTransaction {
+        let raw_txn = builder
+            .sender(self.address())
+            .sequence_number(self.sequence_number())
+            .build();
+        *self.sequence_number_mut() += 1;
+        self.sign_transaction(raw_txn)
+    }
+}
+
+impl HardwareWalletAccount {
+    pub fn new(
+        address: AccountAddress,
+        public_key: Ed25519PublicKey,
+        authentication_key: AuthenticationKey,
+        derivation_path: String,
+        hardware_wallet_type: HardwareWalletType,
+        sequence_number: u64,
+    ) -> Self {
+        Self {
+            address,
+            public_key,
+            authentication_key,
+            derivation_path,
+            hardware_wallet_type,
+            sequence_number,
+        }
+    }
+
+    /// Create a new account from a Ledger device.
+    /// This requires the Ledger device to be connected, unlocked and the Aptos app to be opened
+    pub fn from_ledger(
+        derivation_path: String,
+        sequence_number: u64,
+    ) -> Result<Self, AptosLedgerError> {
+        let public_key = aptos_ledger::get_public_key(&derivation_path, false)?;
+        let authentication_key = AuthenticationKey::ed25519(&public_key);
+        let address = authentication_key.derived_address();
+
+        Ok(Self::new(
+            address,
+            public_key,
+            authentication_key,
+            derivation_path,
+            HardwareWalletType::Ledger,
+            sequence_number,
+        ))
+    }
+
+    pub fn address(&self) -> AccountAddress {
+        self.address
+    }
+
+    pub fn public_key(&self) -> &Ed25519PublicKey {
+        &self.public_key
+    }
+
+    pub fn authentication_key(&self) -> &AuthenticationKey {
+        &self.authentication_key
+    }
+
+    pub fn derivation_path(&self) -> &str {
+        &self.derivation_path
+    }
+
+    pub fn hardware_wallet_type(&self) -> &HardwareWalletType {
+        &self.hardware_wallet_type
+    }
+
+    pub fn sequence_number(&self) -> u64 {
+        self.sequence_number
+    }
+
+    pub fn sequence_number_mut(&mut self) -> &mut u64 {
+        &mut self.sequence_number
+    }
+
+    pub fn sign_arbitrary_message(
+        &self,
+        message: &[u8],
+    ) -> Result<Ed25519Signature, AptosLedgerError> {
+        aptos_ledger::sign_message(&self.derivation_path, message)
     }
 }
 


### PR DESCRIPTION
### Description

Add HardwareWalletAccount for ledger integration
1. mimic LocalAccount, but replace AccountKey with Derivative path
2. Added new trait for doing txn signing - We should have LocalAccount to implement this trait as well (Follow up item)
3. Add SDK to Ledger integration.

Next Step:
Will take HardwareWalletAccount into CLI, whenever we creating a LocalAccount, we need to check whether its a LocalAccount with private key, or Ledger HardwareWalletAccount

NOTE:
This will be merging into feature branch `[feature_branch/cli_ledger_integration](https://github.com/aptos-labs/aptos-core/tree/feature_branch/cli_ledger_integration)`, which will contains all ledger integration breaking changes

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
