### PR TITLE
[framework]Allow Customized rewards_rate_period_in_secs when Initialization

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/staking_config.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_config.md
@@ -256,7 +256,7 @@ Specified rewards rate decrease rate is invalid, which must be not greater than 
 
 <a name="0x1_staking_config_EINVALID_REWARDS_RATE_PERIOD"></a>
 
-Specified rewards rate period is invalid, which must be 1 year at the moment.
+Specified rewards rate period is invalid. It must be larger than 0 and cannot be changed if configured.
 
 
 <pre><code><b>const</b> <a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE_PERIOD">EINVALID_REWARDS_RATE_PERIOD</a>: u64 = 9;
@@ -835,6 +835,12 @@ Can only be called as part of the Aptos governance proposal process established 
     );
 
     <b>let</b> staking_rewards_config = <b>borrow_global_mut</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(@aptos_framework);
+    // Currently rewards_rate_period_in_secs is not allowed <b>to</b> be changed because this could bring complicated
+    // logics. At the moment the argument is just a placeholder for future <b>use</b>.
+    <b>assert</b>!(
+        rewards_rate_period_in_secs == staking_rewards_config.rewards_rate_period_in_secs,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE_PERIOD">EINVALID_REWARDS_RATE_PERIOD</a>),
+    );
     staking_rewards_config.rewards_rate = rewards_rate;
     staking_rewards_config.min_rewards_rate = min_rewards_rate;
     staking_rewards_config.rewards_rate_period_in_secs = rewards_rate_period_in_secs;
@@ -941,11 +947,10 @@ Can only be called as part of the Aptos governance proposal process established 
         <a href="../../aptos-stdlib/doc/fixed_point64.md#0x1_fixed_point64_ceil">fixed_point64::ceil</a>(rewards_rate_decrease_rate) &lt;= 1,
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE_DECREASE_RATE">EINVALID_REWARDS_RATE_DECREASE_RATE</a>)
     );
-    // This field, rewards_rate_period_in_secs is added <b>as</b> a placeholder. In case we want <b>to</b> change
-    // the reward period, we don't have <b>to</b> add a new <b>struct</b>.
-    // To avoid complex logic, now rewards rate decrease interval must be 1 year.
+    // This field, rewards_rate_period_in_secs must be greater than 0.
+    // TODO: rewards_rate_period_in_secs should be longer than the epoch duration but reading epoch duration causes a circular dependency.
     <b>assert</b>!(
-        rewards_rate_period_in_secs == <a href="staking_config.md#0x1_staking_config_ONE_YEAR_IN_SECS">ONE_YEAR_IN_SECS</a>,
+        rewards_rate_period_in_secs &gt; 0,
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_config.md#0x1_staking_config_EINVALID_REWARDS_RATE_PERIOD">EINVALID_REWARDS_RATE_PERIOD</a>),
     );
 }
@@ -1081,7 +1086,7 @@ Can only be called as part of the Aptos governance proposal process established 
     rewards_rate,
     <a href="../../aptos-stdlib/doc/fixed_point64.md#0x1_fixed_point64_spec_create_from_u128">fixed_point64::spec_create_from_u128</a>((1u128)));
 <b>invariant</b> <a href="../../aptos-stdlib/doc/fixed_point64.md#0x1_fixed_point64_spec_less_or_equal">fixed_point64::spec_less_or_equal</a>(min_rewards_rate, rewards_rate);
-<b>invariant</b> rewards_rate_period_in_secs == <a href="staking_config.md#0x1_staking_config_ONE_YEAR_IN_SECS">ONE_YEAR_IN_SECS</a>;
+<b>invariant</b> rewards_rate_period_in_secs &gt; 0;
 <b>invariant</b> <a href="../../aptos-stdlib/doc/fixed_point64.md#0x1_fixed_point64_spec_ceil">fixed_point64::spec_ceil</a>(rewards_rate_decrease_rate) &lt;= 1;
 </code></pre>
 
@@ -1297,7 +1302,9 @@ StakingRewardsConfig is under the @aptos_framework.
 
 <pre><code><b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">StakingRewardsConfigRequirement</a>;
 <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
+<b>let</b> staking_reward_config = <b>borrow_global</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(@aptos_framework);
 <b>aborts_if</b> addr != @aptos_framework;
+<b>aborts_if</b> staking_reward_config.rewards_rate_period_in_secs != rewards_rate_period_in_secs;
 <b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigValidationAbortsIf">StakingRewardsConfigValidationAbortsIf</a>;
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(addr);
 </code></pre>

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
@@ -28,7 +28,7 @@ module aptos_framework::staking_config {
     const EINVALID_LAST_REWARDS_RATE_PERIOD_START: u64 = 7;
     /// Specified rewards rate decrease rate is invalid, which must be not greater than BPS_DENOMINATOR.
     const EINVALID_REWARDS_RATE_DECREASE_RATE: u64 = 8;
-    /// Specified rewards rate period is invalid, which must be 1 year at the moment.
+    /// Specified rewards rate period is invalid. It must be larger than 0 and cannot be changed if configured.
     const EINVALID_REWARDS_RATE_PERIOD: u64 = 9;
     /// The function has been deprecated.
     const EDEPRECATED_FUNCTION: u64 = 10;
@@ -325,6 +325,12 @@ module aptos_framework::staking_config {
         );
 
         let staking_rewards_config = borrow_global_mut<StakingRewardsConfig>(@aptos_framework);
+        // Currently rewards_rate_period_in_secs is not allowed to be changed because this could bring complicated
+        // logics. At the moment the argument is just a placeholder for future use.
+        assert!(
+            rewards_rate_period_in_secs == staking_rewards_config.rewards_rate_period_in_secs,
+            error::invalid_argument(EINVALID_REWARDS_RATE_PERIOD),
+        );
         staking_rewards_config.rewards_rate = rewards_rate;
         staking_rewards_config.min_rewards_rate = min_rewards_rate;
         staking_rewards_config.rewards_rate_period_in_secs = rewards_rate_period_in_secs;
@@ -371,11 +377,10 @@ module aptos_framework::staking_config {
             fixed_point64::ceil(rewards_rate_decrease_rate) <= 1,
             error::invalid_argument(EINVALID_REWARDS_RATE_DECREASE_RATE)
         );
-        // This field, rewards_rate_period_in_secs is added as a placeholder. In case we want to change
-        // the reward period, we don't have to add a new struct.
-        // To avoid complex logic, now rewards rate decrease interval must be 1 year.
+        // This field, rewards_rate_period_in_secs must be greater than 0.
+        // TODO: rewards_rate_period_in_secs should be longer than the epoch duration but reading epoch duration causes a circular dependency.
         assert!(
-            rewards_rate_period_in_secs == ONE_YEAR_IN_SECS,
+            rewards_rate_period_in_secs > 0,
             error::invalid_argument(EINVALID_REWARDS_RATE_PERIOD),
         );
     }
@@ -579,6 +584,27 @@ module aptos_framework::staking_config {
             create_from_rational(1, 100),
             ONE_YEAR_IN_SECS,
             create_from_rational(101, 100),
+        );
+    }
+
+    #[test(aptos_framework = @aptos_framework)]
+    #[expected_failure(abort_code = 0x10009, location = Self)]
+    public entry fun test_update_rewards_config_cannot_change_rewards_rate_period(aptos_framework: signer) acquires StakingRewardsConfig {
+        let start_time_in_secs: u64 = 100001000000;
+        initialize_rewards_for_test(
+            &aptos_framework,
+            create_from_rational(15981, 1000000000),
+            create_from_rational(7991, 1000000000),
+            ONE_YEAR_IN_SECS,
+            start_time_in_secs,
+            create_from_rational(15, 1000),
+        );
+        update_rewards_config(
+            &aptos_framework,
+            create_from_rational(15981, 1000000000),
+            create_from_rational(7991, 1000000000),
+            ONE_YEAR_IN_SECS - 1,
+            create_from_rational(15, 1000),
         );
     }
 

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
@@ -20,7 +20,7 @@ spec aptos_framework::staking_config {
             rewards_rate,
             fixed_point64::spec_create_from_u128((1u128)));
         invariant fixed_point64::spec_less_or_equal(min_rewards_rate, rewards_rate);
-        invariant rewards_rate_period_in_secs == ONE_YEAR_IN_SECS;
+        invariant rewards_rate_period_in_secs > 0;
         invariant fixed_point64::spec_ceil(rewards_rate_decrease_rate) <= 1;
     }
 
@@ -155,7 +155,10 @@ spec aptos_framework::staking_config {
         use std::signer;
         include StakingRewardsConfigRequirement;
         let addr = signer::address_of(aptos_framework);
+        let staking_reward_config = borrow_global<StakingRewardsConfig>(@aptos_framework);
+
         aborts_if addr != @aptos_framework;
+        aborts_if staking_reward_config.rewards_rate_period_in_secs != rewards_rate_period_in_secs;
         include StakingRewardsConfigValidationAbortsIf;
         aborts_if !exists<StakingRewardsConfig>(addr);
     }
@@ -191,7 +194,7 @@ spec aptos_framework::staking_config {
 
     /// rewards_rate must be within [0, 1].
     /// min_rewards_rate must be not greater than rewards_rate.
-    /// rewards_rate_period_in_secs must equal to 1 year.
+    /// rewards_rate_period_in_secs must be greater than 0.
     /// rewards_rate_decrease_rate must be within [0,1].
     spec schema StakingRewardsConfigValidationAbortsIf {
         rewards_rate: FixedPoint64;
@@ -203,7 +206,7 @@ spec aptos_framework::staking_config {
             rewards_rate,
             fixed_point64::spec_create_from_u128((1u128)));
         aborts_if fixed_point64::spec_greater(min_rewards_rate, rewards_rate);
-        aborts_if rewards_rate_period_in_secs != ONE_YEAR_IN_SECS;
+        aborts_if rewards_rate_period_in_secs <= 0;
         aborts_if fixed_point64::spec_ceil(rewards_rate_decrease_rate) > 1;
     }
 
@@ -225,7 +228,7 @@ spec aptos_framework::staking_config {
             rewards_rate,
             fixed_point64::spec_create_from_u128((1u128)));
         requires fixed_point64::spec_less_or_equal(min_rewards_rate, rewards_rate);
-        requires rewards_rate_period_in_secs == ONE_YEAR_IN_SECS;
+        requires rewards_rate_period_in_secs > 0;
         requires last_rewards_rate_period_start_in_secs <= timestamp::spec_now_seconds();
         requires fixed_point64::spec_ceil(rewards_rate_decrease_rate) <= 1;
     }


### PR DESCRIPTION
### Description
- `rewards_rate_period_in_secs` can be customized when initialization. This can enable e2e testing on Devnet and Testnet.
- `rewards_rate_period_in_secs` still cannot be changed after initialization to avoid complicated logic. 
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Unit testing
Devnet/Testnet testing