### PR TITLE
Add `to_standard_string` function to Address structs that is compliant with AIP 40

### DIFF
--- a/api/types/src/address.rs
+++ b/api/types/src/address.rs
@@ -17,6 +17,25 @@ impl Address {
     pub fn inner(&self) -> &AccountAddress {
         &self.0
     }
+
+    /// Represent an account address in a way that is compliant with the v1 address
+    /// standard. The standard is defined as part of AIP-40, read more here:
+    /// https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md
+    ///
+    /// In short, all special addresses MUST be represented in SHORT form, e.g.
+    ///
+    /// 0x1
+    ///
+    /// All other addresses MUST be represented in LONG form, e.g.
+    ///
+    /// 0x002098630cfad4734812fa37dc18d9b8d59242feabe49259e26318d468a99584
+    ///
+    /// For an explanation of what defines a special address, see `is_special`.
+    ///
+    /// All string representations of addresses MUST be prefixed with 0x.
+    pub fn to_standard_string(&self) -> String {
+        self.0.to_standard_string()
+    }
 }
 
 impl fmt::Display for Address {


### PR DESCRIPTION
### Stack
- Previous in stack: N/A
- Next in stack: https://github.com/aptos-labs/aptos-core/pull/9186

### Description

This PR adds a `to_standard_string()` function to the various Address structs. This function outputs the account address in a way that is compliant with the proposed standard: https://github.com/aptos-foundation/AIPs/pull/175. 

Currently the purpose of this PR is to complement the AIP. Once the AIP is accepted, I will publish this PR, making any changes if necessary based on the discussion in the AIP. 

Note that the AIP just standardizes the way we format addresses currently (v1), this is not a full identifier overhaul (v2).

In a later set of PRs I will do the following:
- In every instance where the existing Display impl is used (e.g. in `format` or with `to_string()` I will make it explicitly use the underlying function (so nothing should change).
- After that I will make the Display impl for all of these structs call `to_standard_string` internally. This way the default string formatting for addresses will be standard compliant.
- In all future uses we will use the new standards compliant Display impl.

**Update**: Instead, I will change the Display + Serialize impl and update places that shouldn't use the new formatting to use the old function that we used to use in Display.

This PR affects both `third_party` and non `third_party` code. I can split this PR into two if that's how we prefer to do it.

### Test Plan
```
cd third_party/move/move-core/types
cargo test
```

```
cd api/types
cargo test
```

I'm not totally confident with the binary / hex stuff in this PR, please take a close look at the tests to make sure they're legit.