### PR TITLE
[CLI][E2E] Ensure CLI is using workspace configuration when using `--test-cli-tag`

### DIFF
--- a/crates/aptos/e2e/README.md
+++ b/crates/aptos/e2e/README.md
@@ -30,8 +30,9 @@ poetry run python main.py -d --base-network mainnet --test-cli-path ~/aptos-core
 ```
 
 ## Debugging
-
 If you are get an error message similar to this:
+
+### CPU architecture
 ```
 docker: no matching manifest for linux/arm64/v8 in the manifest list entries.
 ```
@@ -42,7 +43,22 @@ DOCKER_DEFAULT_PLATFORM=linux/amd64 poetry run python main.py --base-network tes
 ```
 This makes the docker commands use the x86_64 images since we don't publish images for ARM.
 
-When running the e2e test using poetry locally, make sure you set your aptos config type to `workspace`, otherwise it won't be able to find the test account after `aptos init`. You can change it back to `global` afterward:
+### CLI config type
+If you see an error like this:
+```
+Traceback (most recent call last):
+  File "/Users/dport/a/core/crates/aptos/e2e/main.py", line 194, in <module>
+    if main():
+  File "/Users/dport/a/core/crates/aptos/e2e/main.py", line 156, in main
+    run_helper.prepare()
+  File "/Users/dport/a/core/crates/aptos/e2e/test_helpers.py", line 155, in prepare
+    self.prepare_cli()
+  File "/Users/dport/a/core/crates/aptos/e2e/test_helpers.py", line 189, in prepare_cli
+    raise RuntimeError(
+RuntimeError: When using --test-cli-path you must use workspace configuration, try running `aptos config set-global-config --config-type workspace`
+```
+
+It is because you are using the `--test-cli-path` flag but have configured the CLI to use the `global` config type. This is not currently compatible, you must switch the config type to workspace prior to running the E2E tests:
 ```
 aptos config set-global-config --config-type workspace
 ```

--- a/crates/aptos/e2e/local_testnet.py
+++ b/crates/aptos/e2e/local_testnet.py
@@ -38,8 +38,13 @@ def run_node(network: Network, image_repo_with_project: str):
         stderr=subprocess.DEVNULL,
     )
 
+    # If debug logging is enabled show the output of the command to run the container.
+    kwargs = {"check": True}
+    if LOG.getEffectiveLevel() > 10:
+        kwargs = {**kwargs, **{"stdout": subprocess.PIPE, "stderr": subprocess.PIPE}}
+
     # Run the container.
-    subprocess.check_output(
+    subprocess.run(
         [
             "docker",
             "run",
@@ -60,7 +65,9 @@ def run_node(network: Network, image_repo_with_project: str):
             "run-local-testnet",
             "--with-faucet",
         ],
+        **kwargs,
     )
+
     LOG.info(f"Running aptos CLI local testnet from image: {image_name}")
     return container_name
 

--- a/crates/aptos/e2e/test_helpers.py
+++ b/crates/aptos/e2e/test_helpers.py
@@ -1,6 +1,7 @@
 # Copyright © Aptos Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import logging
 import os
 import pathlib
@@ -175,6 +176,19 @@ class RunHelper:
         else:
             if not os.path.isfile(self.cli_path):
                 raise RuntimeError(f"CLI not found at path: {self.cli_path}")
+
+            # If we're testing a CLI in the host system, i.e. from the --test-cli-path flag,
+            # make sure we're using "workspace" configuration and not "global" configuration.
+            response = self.run_command(
+                "check_workspace_config",
+                ["aptos", "config", "show-global-config"],
+            )
+            response = json.loads(response.stdout)
+            if response["Result"]["config_type"].lower() != "workspace":
+                raise RuntimeError(
+                    "When using --test-cli-path you must use workspace configuration, "
+                    "try running `aptos config set-global-config --config-type workspace`"
+                )
 
     # Get the account info of the account created by test_init.
     def get_account_info(self):


### PR DESCRIPTION
### Description
Addresses https://github.com/aptos-labs/aptos-core/issues/8732.

### Test Plan
Demonstrating that you get an explicit error if the config type is global.
```
aptos config set-global-config --config-type global
```
```
DOCKER_DEFAULT_PLATFORM=linux/amd64 poetry run python main.py -d --base-network mainnet --test-cli-path ~/a/core/target/debug/aptos
```
```
Traceback (most recent call last):
  File "/Users/dport/a/core/crates/aptos/e2e/main.py", line 194, in <module>
    if main():
  File "/Users/dport/a/core/crates/aptos/e2e/main.py", line 156, in main
    run_helper.prepare()
  File "/Users/dport/a/core/crates/aptos/e2e/test_helpers.py", line 155, in prepare
    self.prepare_cli()
  File "/Users/dport/a/core/crates/aptos/e2e/test_helpers.py", line 189, in prepare_cli
    raise RuntimeError(
RuntimeError: When using --test-cli-path you must use workspace configuration, try running `aptos config set-global-config --config-type workspace`
```

Demonstrating that if the config type is workspace everything works fine.
```
aptos config set-global-config --config-type workspace
```
```
DOCKER_DEFAULT_PLATFORM=linux/amd64 poetry run python main.py -d --base-network mainnet --test-cli-path ~/a/core/target/debug/aptos
```
```
All tests passed!
```


Demonstrating that specifying what CLI to use with an image tag still works.
```
DOCKER_DEFAULT_PLATFORM=linux/amd64 poetry run python main.py -d --base-network mainnet --test-cli-tag devnet
```
```
All tests passed!
```
