### PR TITLE
Remove all reference to aptoslabs.com/testnet-faucet, improve faucet docs

### DIFF
--- a/developer-docs-site/docs/guides/nfts/mint-nft-cli.md
+++ b/developer-docs-site/docs/guides/nfts/mint-nft-cli.md
@@ -71,10 +71,11 @@ In this section, we create a collection and token. This work maps to the demonst
 5. Receive output indicating success and resembling:
   ```shell
   No key given, generating key...
-  Account a233bf7be2b93f1e532f8ea88c49e0c70a873d082890b6d9685f89b5e40d50c2 does not exist, you will need to create and fund the account through a community faucet e.g. https://aptoslabs.com/testnet-faucet, or by transferring funds from another account
-  
+  Account abf6c939bfd8352b9769f9343dbc55a777349588a2ddc4668c8ddcd213169827 doesn't exist, creating it and funding it with 100000000 Octas
+  Account abf6c939bfd8352b9769f9343dbc55a777349588a2ddc4668c8ddcd213169827 funded successfully
+
   ---
-  Aptos CLI is now set up for account a233bf7be2b93f1e532f8ea88c49e0c70a873d082890b6d9685f89b5e40d50c2 as profile default!  Run `aptos --help` for more information about commands
+  Aptos CLI is now set up for account abf6c939bfd8352b9769f9343dbc55a777349588a2ddc4668c8ddcd213169827 as profile default!  Run `aptos --help` for more information about commands
   {
     "Result": "Success"
   }
@@ -122,7 +123,7 @@ aptos move publish --named-addresses mint_nft=a911e7374107ad434bbc5369289cf5855c
       "Result": {
         "transaction_hash": "0x576a2e9481e71b629335b98ea75c87d124e1b435e843e7a2ef8938ae21bebfa3",
         "gas_used": 11679,
-        "gas_unit_price": 100,  
+        "gas_unit_price": 100,
         "sender": "a911e7374107ad434bbc5369289cf5855c3b1a2938a6bfce0776c1d296271cde",
         "sequence_number": 0,
         "success": true,
@@ -348,7 +349,7 @@ cd aptos-move/move-examples/mint_nft/4-Getting-Production-Ready
 
 2. Edit `Move.toml` in that directory to replace `admin_addr = "0xbeef"` with the admin address we created in [3. Add admin account and functions](#3-add-admin-account-and-functions).
 
-2. Run the following CLI command to publish the module under a resource account, replacing `<seed>` and `<default-account-address>` with your own: 
+2. Run the following CLI command to publish the module under a resource account, replacing `<seed>` and `<default-account-address>` with your own:
 
 ```shell
 aptos move create-resource-account-and-publish-package --seed <seed> --address-name mint_nft --profile default --named-addresses source_addr=<default-account-address>

--- a/developer-docs-site/docs/nodes/deployments.md
+++ b/developer-docs-site/docs/nodes/deployments.md
@@ -9,10 +9,10 @@ hide_table_of_contents: true
 |Description                                 |Mainnet | Testnet | Devnet |
 |--------------------------------------------|---|---|---|
 |**REST API**             | https://fullnode.mainnet.aptoslabs.com/v1 | https://fullnode.testnet.aptoslabs.com/v1 | https://fullnode.devnet.aptoslabs.com/v1 |
-|**REST API Spec**        | <a href="https://fullnode.mainnet.aptoslabs.com/v1/spec#/">Link</a> | <a href="https://fullnode.testnet.aptoslabs.com/v1/spec#/">Link</a> | <a href="https://fullnode.devnet.aptoslabs.com/v1/spec#/">Link</a> | 
+|**REST API Spec**        | <a href="https://fullnode.mainnet.aptoslabs.com/v1/spec#/">Link</a> | <a href="https://fullnode.testnet.aptoslabs.com/v1/spec#/">Link</a> | <a href="https://fullnode.devnet.aptoslabs.com/v1/spec#/">Link</a> |
 |**Indexer API**          | https://indexer.mainnet.aptoslabs.com/v1/graphql | https://indexer-testnet.staging.gcp.aptosdev.com/v1/graphql | https://indexer-devnet.staging.gcp.aptosdev.com/v1/graphql |
-|**Indexer API Spec**     | <a href="https://cloud.hasura.io/public/graphiql?endpoint=https://indexer.mainnet.aptoslabs.com/v1/graphql">Link</a> | <a href="https://cloud.hasura.io/public/graphiql?endpoint=https://indexer-testnet.staging.gcp.aptosdev.com/v1/graphql">Link</a> | <a href="https://cloud.hasura.io/public/graphiql?endpoint=https://indexer-devnet.staging.gcp.aptosdev.com/v1/graphql">Link</a> | 
-|**Faucet**               | No Faucet | (API): https://faucet.testnet.aptoslabs.com <br/> (dApp): https://aptoslabs.com/testnet-faucet | https://faucet.devnet.aptoslabs.com/ |
+|**Indexer API Spec**     | <a href="https://cloud.hasura.io/public/graphiql?endpoint=https://indexer.mainnet.aptoslabs.com/v1/graphql">Link</a> | <a href="https://cloud.hasura.io/public/graphiql?endpoint=https://indexer-testnet.staging.gcp.aptosdev.com/v1/graphql">Link</a> | <a href="https://cloud.hasura.io/public/graphiql?endpoint=https://indexer-devnet.staging.gcp.aptosdev.com/v1/graphql">Link</a> |
+|**Faucet**               | No Faucet | https://faucet.testnet.aptoslabs.com/ | https://faucet.devnet.aptoslabs.com/ |
 |**Genesis and Waypoint** | https://github.com/aptos-labs/aptos-networks/tree/main/mainnet | https://github.com/aptos-labs/aptos-networks/tree/main/testnet| https://github.com/aptos-labs/aptos-networks/tree/main/devnet |
 |**Chain ID**             | 1 | 2 | [On Aptos Explorer **select Devnet from top right**](https://explorer.aptoslabs.com/?network=Devnet).|
 |**Epoch duration**       | 7200 seconds |7200 seconds | 7200 seconds |

--- a/developer-docs-site/docs/reference/glossary.md
+++ b/developer-docs-site/docs/reference/glossary.md
@@ -179,9 +179,12 @@ then there is a guarantee that T_N will never be included in the blockchain.
 
 ### Faucet
 
-- **Faucet** is the way to create Aptos currency with no real-world value, only on our devnet.
-- The Faucet is a service running along with the devnet. This service only exists to facilitate minting coins for the devnet.
-- You can use the Faucet by sending a request to create coins and transfer them into a given account on your behalf.
+- **Faucet** is a service that mints APT on devnet and testnet. APT on these networks has no real world value, it is only for development purposes.
+- You can use the faucet in a few different ways:
+  - With the [Aptos CLI](../tools/aptos-cli-tool/use-aptos-cli.md#fund-an-account-with-the-faucet).
+  - Through a wallet, such as Petra, Martian, or Pontem. You can find a full list [here](https://github.com/aptos-foundation/ecosystem-projects#wallets).
+  - Using an SDK, for example by using the `FaucetClient` in the TypeScript SDK.
+  - With a direct HTTP request. Learn how to do this [here](guides/system-integrators-guide.md#calling-the-faucet-other-languages).
 
 ### Fullnodes
 


### PR DESCRIPTION
### Description
We are migrating away from the testnet-faucet page now that the testnet faucet without the captcha in front has been stable for quite a while. More context here: https://aptos-org.slack.com/archives/C03CHLDTT4M/p1687263356587499.

See also https://github.com/aptos-labs/community-platform/pull/82.

### Test Plan
```
cd developer-docs-site
pnpm start
```
