### PR TITLE
[TS SDK] Add examples folder to .npmignore file

### DIFF
--- a/ecosystem/typescript/sdk/.npmignore
+++ b/ecosystem/typescript/sdk/.npmignore
@@ -2,3 +2,4 @@ coverage
 node_modules
 .aptos
 .env
+examples/


### PR DESCRIPTION
### Description
We don't need to publish the `examples` folder as part of the npm package. It increases the package size and there is no real need for it to be part of the package that users download but can simply be part of the repo.

Decrease package size by more than 60% from 3.9 MB to 1.3 MB and unpacked size by 29% from 9.1 MB to 6.4 MB

### Test Plan
test are passing
