### PR TITLE
[Rust Toolchain] Set rust-version to 1.70.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,7 +240,7 @@ homepage = "https://aptoslabs.com"
 license = "Apache-2.0"
 publish = false
 repository = "https://github.com/aptos-labs/aptos-core"
-rust-version = "1.70.0"
+rust-version = "1.70"
 
 [workspace.dependencies]
 # Internal crate dependencies.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,7 +240,7 @@ homepage = "https://aptoslabs.com"
 license = "Apache-2.0"
 publish = false
 repository = "https://github.com/aptos-labs/aptos-core"
-rust-version = "1.64"
+rust-version = "1.70.0"
 
 [workspace.dependencies]
 # Internal crate dependencies.

--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -77,7 +77,7 @@ target "builder-base" {
   target     = "builder-base"
   context    = "."
   contexts = {
-    rust = "docker-image://rust:1.66.1-bullseye@sha256:f72949bcf1daf8954c0e0ed8b7e10ac4c641608f6aa5f0ef7c172c49f35bd9b5"
+    rust = "docker-image://rust:1.70.0-bullseye@sha256:56418f03475cf7b107f87d7fabe99ce9a4a9f9904daafa99be7c50d9e7b8f84d"
   }
   args = {
     PROFILE            = "${PROFILE}"


### PR DESCRIPTION
### Description

As a follow-up to #8693. To explicitly fail the compilation instead of having potentially confusing compiler mismatch.

https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
> If the currently selected version of the Rust compiler is older than the stated version, cargo will exit with an error, telling the user what version is required.

The check found the docker image was old and had to be bumped as well.

### Test Plan

CICD
