### PR TITLE
[Storage][Sharding] Write a separate index to support "read everything by key prefix" operation.

### DIFF
--- a/storage/aptosdb/src/backup/restore_utils.rs
+++ b/storage/aptosdb/src/backup/restore_utils.rs
@@ -111,12 +111,14 @@ pub(crate) fn save_transactions(
     txn_infos: &[TransactionInfo],
     events: &[Vec<ContractEvent>],
     write_sets: Vec<WriteSet>,
-    existing_batch: Option<(&mut SchemaBatch, &mut ShardedStateKvSchemaBatch)>,
+    existing_batch: Option<(
+        &mut SchemaBatch,
+        &mut ShardedStateKvSchemaBatch,
+        &SchemaBatch,
+    )>,
     kv_replay: bool,
 ) -> Result<()> {
-    if let Some(existing_batch) = existing_batch {
-        let batch = existing_batch.0;
-        let state_kv_batches = existing_batch.1;
+    if let Some((batch, state_kv_batches, state_kv_metadata_batch)) = existing_batch {
         save_transactions_impl(
             Arc::clone(&ledger_store),
             transaction_store,
@@ -129,11 +131,13 @@ pub(crate) fn save_transactions(
             write_sets.as_ref(),
             batch,
             state_kv_batches,
+            state_kv_metadata_batch,
             kv_replay,
         )?;
     } else {
         let mut batch = SchemaBatch::new();
         let mut sharded_kv_schema_batch = new_sharded_kv_schema_batch();
+        let state_kv_metadata_batch = SchemaBatch::new();
         save_transactions_impl(
             Arc::clone(&ledger_store),
             transaction_store,
@@ -146,15 +150,17 @@ pub(crate) fn save_transactions(
             write_sets.as_ref(),
             &mut batch,
             &mut sharded_kv_schema_batch,
+            &state_kv_metadata_batch,
             kv_replay,
         )?;
         // get the last version and commit to the state kv db
         // commit the state kv before ledger in case of failure happens
         let last_version = first_version + txns.len() as u64 - 1;
-        state_store
-            .state_db
-            .state_kv_db
-            .commit(last_version, sharded_kv_schema_batch)?;
+        state_store.state_db.state_kv_db.commit(
+            last_version,
+            state_kv_metadata_batch,
+            sharded_kv_schema_batch,
+        )?;
 
         // TODO(grao): Support splitted ledger DBs here.
         ledger_store.ledger_db.metadata_db().write_schemas(batch)?;
@@ -220,6 +226,7 @@ pub(crate) fn save_transactions_impl(
     write_sets: &[WriteSet],
     batch: &mut SchemaBatch,
     state_kv_batches: &mut ShardedStateKvSchemaBatch,
+    state_kv_metadata_batch: &SchemaBatch,
     kv_replay: bool,
 ) -> Result<()> {
     // TODO(grao): Support splited ledger db here.
@@ -234,7 +241,14 @@ pub(crate) fn save_transactions_impl(
     }
 
     if kv_replay && first_version > 0 && state_store.get_usage(Some(first_version - 1)).is_ok() {
-        state_store.put_write_sets(write_sets.to_vec(), first_version, batch, state_kv_batches)?;
+        state_store.put_write_sets(
+            write_sets.to_vec(),
+            first_version,
+            batch,
+            state_kv_batches,
+            state_kv_metadata_batch,
+            state_store.state_kv_db.enabled_sharding(),
+        )?;
     }
 
     Ok(())

--- a/storage/aptosdb/src/db_options.rs
+++ b/storage/aptosdb/src/db_options.rs
@@ -104,6 +104,7 @@ pub(super) fn state_kv_db_column_families() -> Vec<ColumnFamilyName> {
         DB_METADATA_CF_NAME,
         STALE_STATE_VALUE_INDEX_CF_NAME,
         STATE_VALUE_CF_NAME,
+        STATE_VALUE_INDEX_CF_NAME,
     ]
 }
 

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -922,6 +922,7 @@ impl AptosDB {
 
         let ledger_metadata_batch = SchemaBatch::new();
         let sharded_state_kv_batches = new_sharded_kv_schema_batch();
+        let state_kv_metadata_batch = SchemaBatch::new();
 
         // TODO(grao): Make state_store take sharded state updates.
         self.state_store.put_value_sets(
@@ -931,6 +932,8 @@ impl AptosDB {
             sharded_state_cache,
             &ledger_metadata_batch,
             &sharded_state_kv_batches,
+            &state_kv_metadata_batch,
+            self.state_store.state_kv_db.enabled_sharding(),
         )?;
 
         let last_version = first_version + txns_to_commit.len() as u64 - 1;
@@ -953,7 +956,11 @@ impl AptosDB {
             });
             s.spawn(|| {
                 self.state_kv_db
-                    .commit(last_version, sharded_state_kv_batches)
+                    .commit(
+                        last_version,
+                        state_kv_metadata_batch,
+                        sharded_state_kv_batches,
+                    )
                     .unwrap();
             });
         });
@@ -2159,6 +2166,7 @@ impl DbWriter for AptosDB {
             // Create a single change set for all further write operations
             let mut batch = SchemaBatch::new();
             let mut sharded_kv_batch = new_sharded_kv_schema_batch();
+            let state_kv_metadata_batch = SchemaBatch::new();
             // Save the target transactions, outputs, infos and events
             let (transactions, outputs): (Vec<Transaction>, Vec<TransactionOutput>) =
                 output_with_proof
@@ -2186,7 +2194,7 @@ impl DbWriter for AptosDB {
                 &transaction_infos,
                 &events,
                 wsets,
-                Option::Some((&mut batch, &mut sharded_kv_batch)),
+                Option::Some((&mut batch, &mut sharded_kv_batch, &state_kv_metadata_batch)),
                 false,
             )?;
 

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -53,6 +53,7 @@ fn put_value_set(
 
     let ledger_batch = SchemaBatch::new();
     let sharded_state_kv_batches = new_sharded_kv_schema_batch();
+    let state_kv_metadata_batch = SchemaBatch::new();
     state_store
         .put_value_sets(
             vec![&sharded_value_set],
@@ -61,6 +62,8 @@ fn put_value_set(
             None,
             &ledger_batch,
             &sharded_state_kv_batches,
+            &state_kv_metadata_batch,
+            /*put_state_value_indices=*/ false,
         )
         .unwrap();
     state_store
@@ -70,7 +73,7 @@ fn put_value_set(
         .unwrap();
     state_store
         .state_kv_db
-        .commit(version, sharded_state_kv_batches)
+        .commit(version, state_kv_metadata_batch, sharded_state_kv_batches)
         .unwrap();
 
     root

--- a/storage/aptosdb/src/schema/mod.rs
+++ b/storage/aptosdb/src/schema/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod stale_node_index;
 pub(crate) mod stale_node_index_cross_epoch;
 pub(crate) mod stale_state_value_index;
 pub(crate) mod state_value;
+pub(crate) mod state_value_index;
 pub(crate) mod transaction;
 pub(crate) mod transaction_accumulator;
 pub(crate) mod transaction_by_account;
@@ -41,6 +42,7 @@ pub const STALE_NODE_INDEX_CF_NAME: ColumnFamilyName = "stale_node_index";
 pub const STALE_NODE_INDEX_CROSS_EPOCH_CF_NAME: ColumnFamilyName = "stale_node_index_cross_epoch";
 pub const STALE_STATE_VALUE_INDEX_CF_NAME: ColumnFamilyName = "stale_state_value_index";
 pub const STATE_VALUE_CF_NAME: ColumnFamilyName = "state_value";
+pub const STATE_VALUE_INDEX_CF_NAME: ColumnFamilyName = "state_value_index";
 pub const TRANSACTION_CF_NAME: ColumnFamilyName = "transaction";
 pub const TRANSACTION_ACCUMULATOR_CF_NAME: ColumnFamilyName = "transaction_accumulator";
 pub const TRANSACTION_BY_ACCOUNT_CF_NAME: ColumnFamilyName = "transaction_by_account";
@@ -94,6 +96,7 @@ pub mod fuzzing {
                 data,
             );
             assert_no_panic_decoding::<super::state_value::StateValueSchema>(data);
+            assert_no_panic_decoding::<super::state_value_index::StateValueIndexSchema>(data);
             assert_no_panic_decoding::<super::transaction::TransactionSchema>(data);
             assert_no_panic_decoding::<super::transaction_accumulator::TransactionAccumulatorSchema>(
                 data,

--- a/storage/aptosdb/src/schema/state_value_index/mod.rs
+++ b/storage/aptosdb/src/schema/state_value_index/mod.rs
@@ -1,0 +1,67 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Historically we support an API that returns everything by key prefix (e.g. return all states
+// under an account) operation. This was implemented by seeking the StateKv db by prefix directly.
+// However in the new sharding world, account (or whatever prefix) is not a first class concept in
+// the storage layer, and we will store data for an account in different shards, based on the hash
+// of StateKey. Therefore the API cannot be supported by doing a single db seek.
+//
+// Our long term vision, is to move such support into indexer, before they are ready, we add this
+// index for now to temporarily unblock the sharded db migration.
+
+use crate::schema::{ensure_slice_len_eq, ensure_slice_len_gt, STATE_VALUE_INDEX_CF_NAME};
+use anyhow::Result;
+use aptos_schemadb::{
+    define_schema,
+    schema::{KeyCodec, SeekKeyCodec, ValueCodec},
+};
+use aptos_types::{
+    state_store::{state_key::StateKey, state_key_prefix::StateKeyPrefix},
+    transaction::Version,
+};
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use std::{io::Write, mem::size_of};
+
+type Key = (StateKey, Version);
+
+define_schema!(StateValueIndexSchema, Key, (), STATE_VALUE_INDEX_CF_NAME);
+
+impl KeyCodec<StateValueIndexSchema> for Key {
+    fn encode_key(&self) -> Result<Vec<u8>> {
+        let mut encoded = vec![];
+        encoded.write_all(&self.0.encode()?)?;
+        encoded.write_u64::<BigEndian>(!self.1)?;
+        Ok(encoded)
+    }
+
+    fn decode_key(data: &[u8]) -> Result<Self> {
+        const VERSION_SIZE: usize = size_of::<Version>();
+
+        ensure_slice_len_gt(data, VERSION_SIZE)?;
+        let state_key_len = data.len() - VERSION_SIZE;
+        let state_key: StateKey = StateKey::decode(&data[..state_key_len])?;
+        let version = !(&data[state_key_len..]).read_u64::<BigEndian>()?;
+        Ok((state_key, version))
+    }
+}
+
+impl ValueCodec<StateValueIndexSchema> for () {
+    fn encode_value(&self) -> Result<Vec<u8>> {
+        Ok(Vec::new())
+    }
+
+    fn decode_value(data: &[u8]) -> Result<Self> {
+        ensure_slice_len_eq(data, 0)?;
+        Ok(())
+    }
+}
+
+impl SeekKeyCodec<StateValueIndexSchema> for &StateKeyPrefix {
+    fn encode_seek_key(&self) -> Result<Vec<u8>> {
+        self.encode()
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/storage/aptosdb/src/schema/state_value_index/test.rs
+++ b/storage/aptosdb/src/schema/state_value_index/test.rs
@@ -1,0 +1,18 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use aptos_schemadb::{schema::fuzzing::assert_encode_decode, test_no_panic_decoding};
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn test_encode_decode(
+        state_key in any::<StateKey>(),
+        version in any::<Version>(),
+    ) {
+        assert_encode_decode::<StateValueIndexSchema>(&(state_key, version), &());
+    }
+}
+
+test_no_panic_decoding!(StateValueIndexSchema);

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -27,6 +27,7 @@ pub const STATE_KV_METADATA_DB_NAME: &str = "state_kv_metadata_db";
 pub struct StateKvDb {
     state_kv_metadata_db: Arc<DB>,
     state_kv_db_shards: [Arc<DB>; NUM_STATE_SHARDS],
+    enabled_sharding: bool,
 }
 
 impl StateKvDb {
@@ -43,6 +44,7 @@ impl StateKvDb {
             return Ok(Self {
                 state_kv_metadata_db: Arc::clone(&ledger_db),
                 state_kv_db_shards: arr![Arc::clone(&ledger_db); 16],
+                enabled_sharding: false,
             });
         }
 
@@ -68,24 +70,19 @@ impl StateKvDb {
             "Opened state kv metadata db!"
         );
 
-        // TODO(grao): Support sharding here.
-        let sharding = false;
         let state_kv_db_shards = {
-            if sharding {
-                let mut shard_id: usize = 0;
-                arr![{
-                    let db = Self::open_shard(db_root_path.as_ref(), shard_id as u8, &state_kv_db_config, readonly)?;
-                    shard_id += 1;
-                    Arc::new(db)
-                }; 16]
-            } else {
-                arr![Arc::clone(&state_kv_metadata_db); 16]
-            }
+            let mut shard_id: usize = 0;
+            arr![{
+                let db = Self::open_shard(db_root_path.as_ref(), shard_id as u8, &state_kv_db_config, readonly)?;
+                shard_id += 1;
+                Arc::new(db)
+            }; 16]
         };
 
         let state_kv_db = Self {
             state_kv_metadata_db,
             state_kv_db_shards,
+            enabled_sharding: true,
         };
 
         if let Some(overall_kv_commit_progress) = get_state_kv_commit_progress(&state_kv_db)? {
@@ -98,6 +95,7 @@ impl StateKvDb {
     pub(crate) fn commit(
         &self,
         version: Version,
+        state_kv_metadata_batch: SchemaBatch,
         sharded_state_kv_batches: [SchemaBatch; NUM_STATE_SHARDS],
     ) -> Result<()> {
         COMMIT_POOL.scope(|s| {
@@ -111,6 +109,9 @@ impl StateKvDb {
                 });
             }
         });
+
+        self.state_kv_metadata_db
+            .write_schemas(state_kv_metadata_batch)?;
 
         self.write_progress(version)
     }
@@ -150,16 +151,10 @@ impl StateKvDb {
             .metadata_db()
             .create_checkpoint(Self::metadata_db_path(cp_root_path.as_ref()))?;
 
-        let sharding = false;
-        if sharding {
-            for shard_id in 0..NUM_STATE_SHARDS {
-                state_kv_db
-                    .db_shard(shard_id as u8)
-                    .create_checkpoint(Self::db_shard_path(
-                        cp_root_path.as_ref(),
-                        shard_id as u8,
-                    ))?;
-            }
+        for shard_id in 0..NUM_STATE_SHARDS {
+            state_kv_db
+                .db_shard(shard_id as u8)
+                .create_checkpoint(Self::db_shard_path(cp_root_path.as_ref(), shard_id as u8))?;
         }
 
         Ok(())
@@ -171,6 +166,10 @@ impl StateKvDb {
 
     pub(crate) fn db_shard(&self, shard_id: u8) -> &DB {
         &self.state_kv_db_shards[shard_id as usize]
+    }
+
+    pub(crate) fn enabled_sharding(&self) -> bool {
+        self.enabled_sharding
     }
 
     pub(crate) fn commit_single_shard(

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     epoch_by_version::EpochByVersionSchema,
     ledger_db::LedgerDb,
     metrics::{STATE_ITEMS, TOTAL_STATE_BYTES},
-    schema::state_value::StateValueSchema,
+    schema::{state_value::StateValueSchema, state_value_index::StateValueIndexSchema},
     stale_state_value_index::StaleStateValueIndexSchema,
     state_kv_db::StateKvDb,
     state_merkle_db::StateMerkleDb,
@@ -590,12 +590,12 @@ impl StateStore {
         first_key_opt: Option<&StateKey>,
         desired_version: Version,
     ) -> Result<PrefixedStateValueIterator> {
-        // TODO(grao): Support sharding here.
         PrefixedStateValueIterator::new(
-            self.state_kv_db.metadata_db(),
+            &self.state_kv_db,
             key_prefix.clone(),
             first_key_opt.cloned(),
             desired_version,
+            self.state_kv_db.enabled_sharding(),
         )
     }
 
@@ -615,6 +615,8 @@ impl StateStore {
         first_version: Version,
         batch: &SchemaBatch,
         sharded_state_kv_batches: &ShardedStateKvSchemaBatch,
+        state_kv_metadata_batch: &SchemaBatch,
+        put_state_value_indices: bool,
     ) -> Result<()> {
         let _timer = OTHER_TIMERS_SECONDS
             .with_label_values(&["put_writesets"])
@@ -648,6 +650,8 @@ impl StateStore {
             value_state_sets.to_vec(),
             first_version,
             sharded_state_kv_batches,
+            state_kv_metadata_batch,
+            put_state_value_indices,
         )?;
 
         Ok(())
@@ -662,6 +666,8 @@ impl StateStore {
         sharded_state_cache: Option<&ShardedStateCache>,
         ledger_batch: &SchemaBatch,
         sharded_state_kv_batches: &ShardedStateKvSchemaBatch,
+        state_kv_metadata_batch: &SchemaBatch,
+        put_state_value_indices: bool,
     ) -> Result<()> {
         let _timer = OTHER_TIMERS_SECONDS
             .with_label_values(&["put_value_sets"])
@@ -680,7 +686,13 @@ impl StateStore {
             .with_label_values(&["add_state_kv_batch"])
             .start_timer();
 
-        self.put_state_values(value_state_sets, first_version, sharded_state_kv_batches)
+        self.put_state_values(
+            value_state_sets,
+            first_version,
+            sharded_state_kv_batches,
+            state_kv_metadata_batch,
+            put_state_value_indices,
+        )
     }
 
     pub fn put_state_values(
@@ -688,6 +700,8 @@ impl StateStore {
         value_state_sets: Vec<&ShardedStateUpdates>,
         first_version: Version,
         sharded_state_kv_batches: &ShardedStateKvSchemaBatch,
+        state_kv_metadata_batch: &SchemaBatch,
+        put_state_value_indices: bool,
     ) -> Result<()> {
         sharded_state_kv_batches
             .par_iter()
@@ -705,6 +719,22 @@ impl StateStore {
                     })
                     .collect::<Result<_>>()
             })?;
+
+        // Eventually this index will move to indexer side. For now we temporarily write this into
+        // metadata db to unblock the sharded DB migration.
+        // TODO(grao): Remove when we are ready.
+        if put_state_value_indices {
+            value_state_sets
+                .par_iter()
+                .enumerate()
+                .try_for_each(|(i, updates)| {
+                    let version = first_version + i as Version;
+                    updates.iter().flatten().try_for_each(|(k, _)| {
+                        state_kv_metadata_batch
+                            .put::<StateValueIndexSchema>(&(k.clone(), version), &())
+                    })
+                })?;
+        }
 
         Ok(())
     }

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -46,6 +46,7 @@ fn put_value_set(
         .unwrap();
     let ledger_batch = SchemaBatch::new();
     let sharded_state_kv_batches = new_sharded_kv_schema_batch();
+    let state_kv_metadata_batch = SchemaBatch::new();
     state_store
         .put_value_sets(
             vec![&sharded_value_set],
@@ -54,6 +55,8 @@ fn put_value_set(
             None,
             &ledger_batch,
             &sharded_state_kv_batches,
+            &state_kv_metadata_batch,
+            /*put_state_value_indices=*/ false,
         )
         .unwrap();
     state_store
@@ -63,7 +66,7 @@ fn put_value_set(
         .unwrap();
     state_store
         .state_kv_db
-        .commit(version, sharded_state_kv_batches)
+        .commit(version, state_kv_metadata_batch, sharded_state_kv_batches)
         .unwrap();
     root
 }

--- a/storage/aptosdb/src/test_helper.rs
+++ b/storage/aptosdb/src/test_helper.rs
@@ -67,6 +67,7 @@ pub(crate) fn update_store(
             .unwrap();
         let ledger_batch = SchemaBatch::new();
         let sharded_state_kv_batches = new_sharded_kv_schema_batch();
+        let state_kv_metadata_batch = SchemaBatch::new();
         store
             .put_value_sets(
                 vec![&sharded_value_state_set],
@@ -75,6 +76,8 @@ pub(crate) fn update_store(
                 None,
                 &ledger_batch,
                 &sharded_state_kv_batches,
+                &state_kv_metadata_batch,
+                /*put_state_value_indices=*/ false,
             )
             .unwrap();
         store
@@ -84,7 +87,7 @@ pub(crate) fn update_store(
             .unwrap();
         store
             .state_kv_db
-            .commit(version, sharded_state_kv_batches)
+            .commit(version, state_kv_metadata_batch, sharded_state_kv_batches)
             .unwrap();
     }
     root_hash

--- a/storage/aptosdb/src/utils/iterators.rs
+++ b/storage/aptosdb/src/utils/iterators.rs
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    event::EventSchema, ledger_info::LedgerInfoSchema, state_value::StateValueSchema,
-    transaction_by_account::TransactionByAccountSchema,
+    schema::{
+        event::EventSchema, ledger_info::LedgerInfoSchema, state_value::StateValueSchema,
+        state_value_index::StateValueIndexSchema,
+        transaction_by_account::TransactionByAccountSchema,
+    },
+    state_kv_db::StateKvDb,
 };
 use anyhow::{anyhow, ensure, Result};
-use aptos_schemadb::{iterator::SchemaIterator, ReadOptions, DB};
+use aptos_schemadb::{iterator::SchemaIterator, ReadOptions};
 use aptos_types::{
     account_address::AccountAddress,
     contract_event::ContractEvent,
@@ -91,19 +95,23 @@ where
 }
 
 pub struct PrefixedStateValueIterator<'a> {
-    inner: SchemaIterator<'a, StateValueSchema>,
+    db: &'a StateKvDb,
+    kv_iter: Option<SchemaIterator<'a, StateValueSchema>>,
+    index_iter: Option<SchemaIterator<'a, StateValueIndexSchema>>,
     key_prefix: StateKeyPrefix,
     prev_key: Option<StateKey>,
     desired_version: Version,
     is_finished: bool,
+    use_index: bool,
 }
 
 impl<'a> PrefixedStateValueIterator<'a> {
     pub fn new(
-        db: &'a DB,
+        db: &'a StateKvDb,
         key_prefix: StateKeyPrefix,
         first_key: Option<StateKey>,
         desired_version: Version,
+        use_index: bool,
     ) -> Result<Self> {
         let mut read_opts = ReadOptions::default();
         // Without this, iterators are not guaranteed a total order of all keys, but only keys for the same prefix.
@@ -116,26 +124,39 @@ impl<'a> PrefixedStateValueIterator<'a> {
         // here will stick with prefix `aptos/abc` and return `None` or any arbitrary result after visited all the
         // keys starting with `aptos/abc`.
         read_opts.set_total_order_seek(true);
-        let mut iter = db.iter::<StateValueSchema>(read_opts)?;
-        if let Some(first_key) = &first_key {
-            iter.seek(&(first_key.clone(), u64::MAX))?;
+        let (kv_iter, index_iter) = if use_index {
+            let mut index_iter = db.metadata_db().iter::<StateValueIndexSchema>(read_opts)?;
+            if let Some(first_key) = &first_key {
+                index_iter.seek(&(first_key.clone(), u64::MAX))?;
+            } else {
+                index_iter.seek(&&key_prefix)?;
+            };
+            (None, Some(index_iter))
         } else {
-            iter.seek(&&key_prefix)?;
+            let mut kv_iter = db.metadata_db().iter::<StateValueSchema>(read_opts)?;
+            if let Some(first_key) = &first_key {
+                kv_iter.seek(&(first_key.clone(), u64::MAX))?;
+            } else {
+                kv_iter.seek(&&key_prefix)?;
+            };
+            (Some(kv_iter), None)
         };
         Ok(Self {
-            inner: iter,
+            db,
+            kv_iter,
+            index_iter,
             key_prefix,
             prev_key: None,
             desired_version,
             is_finished: false,
+            use_index,
         })
     }
 
-    fn next_impl(&mut self) -> Result<Option<(StateKey, StateValue)>> {
+    fn next_by_kv(&mut self) -> Result<Option<(StateKey, StateValue)>> {
+        let iter = self.kv_iter.as_mut().unwrap();
         if !self.is_finished {
-            while let Some(((state_key, version), state_value_opt)) =
-                self.inner.next().transpose()?
-            {
+            while let Some(((state_key, version), state_value_opt)) = iter.next().transpose()? {
                 // In case the previous seek() ends on the same key with version 0.
                 if Some(&state_key) == self.prev_key.as_ref() {
                     continue;
@@ -149,16 +170,55 @@ impl<'a> PrefixedStateValueIterator<'a> {
                 }
 
                 if version > self.desired_version {
-                    self.inner
-                        .seek(&(state_key.clone(), self.desired_version))?;
+                    iter.seek(&(state_key.clone(), self.desired_version))?;
                     continue;
                 }
 
                 self.prev_key = Some(state_key.clone());
                 // Seek to the next key - this can be done by seeking to the current key with version 0
-                self.inner.seek(&(state_key.clone(), 0))?;
+                iter.seek(&(state_key.clone(), 0))?;
 
                 if let Some(state_value) = state_value_opt {
+                    return Ok(Some((state_key, state_value)));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    fn next_by_index(&mut self) -> Result<Option<(StateKey, StateValue)>> {
+        let iter = self.index_iter.as_mut().unwrap();
+        if !self.is_finished {
+            while let Some(((state_key, version), _)) = iter.next().transpose()? {
+                // In case the previous seek() ends on the same key with version 0.
+                if Some(&state_key) == self.prev_key.as_ref() {
+                    continue;
+                }
+                // Cursor is currently at the first available version of the state key.
+                // Check if the key_prefix is a valid prefix of the state_key we got from DB.
+                if !self.key_prefix.is_prefix(&state_key)? {
+                    // No more keys matching the key_prefix, we can return the result.
+                    self.is_finished = true;
+                    break;
+                }
+
+                if version > self.desired_version {
+                    iter.seek(&(state_key.clone(), self.desired_version))?;
+                    continue;
+                }
+
+                self.prev_key = Some(state_key.clone());
+                // Seek to the next key - this can be done by seeking to the current key with version 0
+                iter.seek(&(state_key.clone(), 0))?;
+
+                if let Some(state_value) = self
+                    .db
+                    .db_shard(state_key.get_shard_id())
+                    .get::<StateValueSchema>(&(state_key.clone(), version))?
+                    .ok_or_else(|| {
+                        anyhow!("Key {state_key:?} is not found at version {version}.")
+                    })?
+                {
                     return Ok(Some((state_key, state_value)));
                 }
             }
@@ -171,7 +231,11 @@ impl<'a> Iterator for PrefixedStateValueIterator<'a> {
     type Item = Result<(StateKey, StateValue)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.next_impl().transpose()
+        if self.use_index {
+            self.next_by_index().transpose()
+        } else {
+            self.next_by_kv().transpose()
+        }
     }
 }
 

--- a/storage/db-tool/src/tests.rs
+++ b/storage/db-tool/src/tests.rs
@@ -436,7 +436,7 @@ mod compaction_tests {
         .unwrap();
 
         // verify the new DB has the same data as the original DB
-        let (ledger_db, tree_db, _) =
+        let (_ledger_db, tree_db, state_kv_db) =
             AptosDB::open_dbs(new_db_dir, RocksdbConfigs::default(), true, 0).unwrap();
 
         // assert the kv are the same in db and new_db
@@ -445,10 +445,11 @@ mod compaction_tests {
         // TODO(grao): Support state kv db sharding here.
         for ver in start..=end {
             let new_iter = PrefixedStateValueIterator::new(
-                ledger_db.metadata_db(),
+                &state_kv_db,
                 StateKeyPrefix::new(AccessPath, b"".to_vec()),
                 None,
                 ver,
+                false,
             )
             .unwrap();
             let old_iter = db


### PR DESCRIPTION
### Description
Historically we support an API that returns everything by key prefix (e.g. return all states under an account) operation. This was implemented by seeking the StateKv db by prefix directly. However in the new sharding world, account (or whatever prefix) is not a first class concept in the storage layer, and we will store data for an account in different shards, based on the hash of StateKey. Therefore the API cannot be supported by doing a single db seek.

Our long term vision, is to move such support into indexer, before they are ready, we add this index for now to temporarily unblock the sharded db migration.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
