### PR TITLE
[Gas Estimation] some improvements based on AIP feedback

### DIFF
--- a/api/goldens/aptos_api__tests__transactions_test__test_gas_estimation_static_override.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_gas_estimation_static_override.json
@@ -1,5 +1,5 @@
 {
-  "deprioritized_gas_estimate": 500,
-  "gas_estimate": 500,
-  "prioritized_gas_estimate": 1000
+  "deprioritized_gas_estimate": 100,
+  "gas_estimate": 200,
+  "prioritized_gas_estimate": 300
 }

--- a/api/goldens/aptos_api__tests__transactions_test__test_gas_estimation_static_override.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_gas_estimation_static_override.json
@@ -1,0 +1,5 @@
+{
+  "deprioritized_gas_estimate": 500,
+  "gas_estimate": 500,
+  "prioritized_gas_estimate": 1000
+}

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -1053,7 +1053,7 @@ impl Context {
                 );
                 return Ok(self.default_gas_estimation(min_gas_unit_price));
             },
-            Some(price) => *price,
+            Some(price) => low_price.max(*price),
         };
 
         // (3) aggressive
@@ -1069,7 +1069,7 @@ impl Context {
                 );
                 return Ok(self.default_gas_estimation(min_gas_unit_price));
             },
-            Some(price) => *price,
+            Some(price) => market_price.max(*price),
         };
         // round up to next bucket
         let aggressive_price = self.next_bucket(p90_price);

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -51,7 +51,7 @@ use futures::{channel::oneshot, SinkExt};
 use move_core_types::language_storage::{ModuleId, StructTag};
 use std::{
     collections::{BTreeMap, HashMap},
-    ops::Bound::Included,
+    ops::{Bound::Included, Deref},
     sync::{Arc, RwLock, RwLockWriteGuard},
     time::Instant,
 };
@@ -832,8 +832,10 @@ impl Context {
         }
     }
 
-    fn cached_gas_estimation(&self, current_epoch: u64) -> Option<GasEstimation> {
-        let cache = self.gas_estimation_cache.read().unwrap();
+    fn cached_gas_estimation<T>(&self, cache: &T, current_epoch: u64) -> Option<GasEstimation>
+    where
+        T: Deref<Target = GasEstimationCache>,
+    {
         if let Some(epoch) = cache.last_updated_epoch {
             if let Some(time) = cache.last_updated_time {
                 if let Some(estimation) = cache.estimation {
@@ -900,17 +902,30 @@ impl Context {
         if !config.enabled {
             return Ok(self.default_gas_estimation(min_gas_unit_price));
         }
+        if let Some((low, market, aggressive)) = config.static_override {
+            return Ok(GasEstimation {
+                deprioritized_gas_estimate: Some(low),
+                gas_estimate: market,
+                prioritized_gas_estimate: Some(aggressive),
+            });
+        }
 
         let epoch = ledger_info.epoch.0;
 
         // 0. (0) Return cached result if it exists
-        if let Some(cached_gas_estimation) = self.cached_gas_estimation(epoch) {
+        let cache = self.gas_estimation_cache.read().unwrap();
+        if let Some(cached_gas_estimation) = self.cached_gas_estimation(&cache, epoch) {
             return Ok(cached_gas_estimation);
         }
+        drop(cache);
 
         // 0. (1) Write lock and prepare cache
         let mut cache = self.gas_estimation_cache.write().unwrap();
-        // TODO: retry cached result after acquiring write lock
+        // Retry cached result after acquiring write lock
+        if let Some(cached_gas_estimation) = self.cached_gas_estimation(&cache, epoch) {
+            return Ok(cached_gas_estimation);
+        }
+        // Clear the cache if the epoch has changed
         if let Some(cached_epoch) = cache.last_updated_epoch {
             if cached_epoch != epoch {
                 cache.min_inclusion_prices.clear();

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -902,11 +902,11 @@ impl Context {
         if !config.enabled {
             return Ok(self.default_gas_estimation(min_gas_unit_price));
         }
-        if let Some((low, market, aggressive)) = config.static_override {
+        if let Some(static_override) = &config.static_override {
             return Ok(GasEstimation {
-                deprioritized_gas_estimate: Some(low),
-                gas_estimate: market,
-                prioritized_gas_estimate: Some(aggressive),
+                deprioritized_gas_estimate: Some(static_override.low),
+                gas_estimate: static_override.market,
+                prioritized_gas_estimate: Some(static_override.aggressive),
             });
         }
 

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -5,7 +5,7 @@
 use super::new_test_context;
 use crate::tests::new_test_context_with_config;
 use aptos_api_test_context::{assert_json, current_function_name, pretty, TestContext};
-use aptos_config::config::NodeConfig;
+use aptos_config::config::{GasEstimationStaticOverride, NodeConfig};
 use aptos_crypto::{
     ed25519::Ed25519PrivateKey,
     multi_ed25519::{MultiEd25519PrivateKey, MultiEd25519PublicKey},
@@ -1196,7 +1196,11 @@ async fn test_gas_estimation_disabled() {
 async fn test_gas_estimation_static_override() {
     let mut node_config = NodeConfig::default();
     node_config.api.gas_estimation.enabled = true;
-    node_config.api.gas_estimation.static_override = Some((500, 500, 1000));
+    node_config.api.gas_estimation.static_override = Some(GasEstimationStaticOverride {
+        low: 100,
+        market: 200,
+        aggressive: 300,
+    });
     let mut context = new_test_context_with_config(current_function_name!(), node_config);
 
     let ctx = &mut context;

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -1192,6 +1192,35 @@ async fn test_gas_estimation_disabled() {
     context.check_golden_output(resp);
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_gas_estimation_static_override() {
+    let mut node_config = NodeConfig::default();
+    node_config.api.gas_estimation.enabled = true;
+    node_config.api.gas_estimation.static_override = Some((500, 500, 1000));
+    let mut context = new_test_context_with_config(current_function_name!(), node_config);
+
+    let ctx = &mut context;
+    let creator = &mut ctx.gen_account();
+    let mint_txn = ctx.mint_user_account(creator).await;
+
+    // Include the mint txn in the first block
+    let mut block = vec![mint_txn];
+    // First block is ignored in gas estimate, so make 11
+    for _i in 0..11 {
+        fill_block(&mut block, ctx, creator).await;
+        ctx.commit_block(&block).await;
+        block.clear();
+    }
+
+    // It's disabled, so we always expect the default, despite the blocks being filled above
+    let resp = context.get("/estimate_gas_price").await;
+    for _i in 0..2 {
+        let cached = context.get("/estimate_gas_price").await;
+        assert_eq!(resp, cached);
+    }
+    context.check_golden_output(resp);
+}
+
 fn gen_string(len: u64) -> String {
     let mut rng = thread_rng();
     std::iter::repeat(())

--- a/config/src/config/gas_estimation_config.rs
+++ b/config/src/config/gas_estimation_config.rs
@@ -9,13 +9,19 @@ use aptos_types::chain_id::ChainId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct GasEstimationStaticOverride {
+    pub low: u64,
+    pub market: u64,
+    pub aggressive: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct GasEstimationConfig {
     /// A gate for computing GasEstimation. If false, just returns the default.
     pub enabled: bool,
-    /// Provide static values to override, e.g., Some((100, 100, 150)). If set, just returns these
-    /// values instead of computing the actual GasEstimation.
-    pub static_override: Option<(u64, u64, u64)>,
+    /// Static values to override. If set, use these values instead of computing a GasEstimation.
+    pub static_override: Option<GasEstimationStaticOverride>,
     /// Number of transactions for blocks to be classified as full for gas estimation
     pub full_block_txns: usize,
     /// Maximum number of blocks read for low gas estimation

--- a/config/src/config/gas_estimation_config.rs
+++ b/config/src/config/gas_estimation_config.rs
@@ -13,6 +13,9 @@ use serde::{Deserialize, Serialize};
 pub struct GasEstimationConfig {
     /// A gate for computing GasEstimation. If false, just returns the default.
     pub enabled: bool,
+    /// Provide static values to override, e.g., Some((100, 100, 150)). If set, just returns these
+    /// values instead of computing the actual GasEstimation.
+    pub static_override: Option<(u64, u64, u64)>,
     /// Number of transactions for blocks to be classified as full for gas estimation
     pub full_block_txns: usize,
     /// Maximum number of blocks read for low gas estimation
@@ -29,6 +32,7 @@ impl Default for GasEstimationConfig {
     fn default() -> GasEstimationConfig {
         GasEstimationConfig {
             enabled: false,
+            static_override: None,
             full_block_txns: 250,
             low_block_history: 10,
             market_block_history: 30,

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -35,6 +35,7 @@ pub use base_config::*;
 pub use consensus_config::*;
 pub use error::*;
 pub use execution_config::*;
+pub use gas_estimation_config::*;
 pub use identity_config::*;
 pub use indexer_config::*;
 pub use indexer_grpc_config::*;


### PR DESCRIPTION
### Description

Follow-up of #8186 based on feedback.
1. Add an option to override the API results with fixed constants.
2. Re-read from the cache after acquiring write lock, as the entry could have been written between the initial read and acquiring the write lock.
3. Enforce invariant that aggressive >= market >= low.

### Test Plan

Added unit test.
