### PR TITLE
[Network] Perform message deserialization in parallel.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,7 @@ dependencies = [
  "cfg_block",
  "get_if_addrs",
  "mirai-annotations",
+ "num_cpus",
  "poem-openapi",
  "rand 0.7.3",
  "serde 1.0.149",

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -28,6 +28,7 @@ cfg-if = { workspace = true }
 cfg_block = { workspace = true }
 get_if_addrs = { workspace = true }
 mirai-annotations = { workspace = true }
+num_cpus = { workspace = true }
 poem-openapi = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -165,7 +165,7 @@ impl NetworkConfig {
         };
 
         // Configure the number of parallel deserialization tasks
-        config.configure_num_deseserialization_tasks();
+        config.configure_num_deserialization_tasks();
 
         // Prepare the identity based on the identity format
         config.prepare_identity();
@@ -176,7 +176,7 @@ impl NetworkConfig {
     /// Configures the number of parallel deserialization tasks
     /// based on the number of CPU cores of the machine. This is
     /// only done if the config does not specify a value.
-    fn configure_num_deseserialization_tasks(&mut self) {
+    fn configure_num_deserialization_tasks(&mut self) {
         if self.max_parallel_deserialization_tasks.is_none() {
             self.max_parallel_deserialization_tasks = Some(num_cpus::get());
         }
@@ -522,7 +522,7 @@ mod tests {
         };
 
         // Configure the number of deserialization tasks and verify that it is not overridden
-        network_config.configure_num_deseserialization_tasks();
+        network_config.configure_num_deserialization_tasks();
         assert_eq!(network_config.max_parallel_deserialization_tasks, Some(1));
     }
 }

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -119,6 +119,8 @@ pub struct NetworkConfig {
     pub outbound_rate_limit_config: Option<RateLimitConfig>,
     /// The maximum size of an inbound or outbound message (it may be divided into multiple frame)
     pub max_message_size: usize,
+    /// The maximum number of parallel message deserialization tasks that can run (per application)
+    pub max_parallel_deserialization_tasks: Option<usize>,
 }
 
 impl Default for NetworkConfig {
@@ -159,9 +161,25 @@ impl NetworkConfig {
             inbound_tx_buffer_size_bytes: Some(INBOUND_TCP_TX_BUFFER_SIZE),
             outbound_rx_buffer_size_bytes: Some(OUTBOUND_TCP_RX_BUFFER_SIZE),
             outbound_tx_buffer_size_bytes: Some(OUTBOUND_TCP_TX_BUFFER_SIZE),
+            max_parallel_deserialization_tasks: None,
         };
+
+        // Configure the number of parallel deserialization tasks
+        config.configure_num_deseserialization_tasks();
+
+        // Prepare the identity based on the identity format
         config.prepare_identity();
+
         config
+    }
+
+    /// Configures the number of parallel deserialization tasks
+    /// based on the number of CPU cores of the machine. This is
+    /// only done if the config does not specify a value.
+    fn configure_num_deseserialization_tasks(&mut self) {
+        if self.max_parallel_deserialization_tasks.is_none() {
+            self.max_parallel_deserialization_tasks = Some(num_cpus::get());
+        }
     }
 
     pub fn identity_key(&self) -> x25519::PrivateKey {
@@ -481,5 +499,30 @@ impl Peer {
             .filter_map(NetworkAddress::find_noise_proto)
             .collect();
         Peer::new(addresses, keys, role)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_num_parallel_deserialization_tasks() {
+        // Create a default network config and verify the number of deserialization tasks
+        let network_config = NetworkConfig::default();
+        assert_eq!(
+            network_config.max_parallel_deserialization_tasks,
+            Some(num_cpus::get())
+        );
+
+        // Create a network config with the number of deserialization tasks set to 1
+        let mut network_config = NetworkConfig {
+            max_parallel_deserialization_tasks: Some(1),
+            ..NetworkConfig::default()
+        };
+
+        // Configure the number of deserialization tasks and verify that it is not overridden
+        network_config.configure_num_deseserialization_tasks();
+        assert_eq!(network_config.max_parallel_deserialization_tasks, Some(1));
     }
 }

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -617,7 +617,7 @@ mod tests {
                 validator_verifier.clone(),
             );
 
-            let network_events = NetworkEvents::new(consensus_rx, conn_status_rx);
+            let network_events = NetworkEvents::new(consensus_rx, conn_status_rx, None);
             let network_service_events =
                 NetworkServiceEvents::new(hashmap! {NetworkId::Validator => network_events});
             let (task, receiver) = NetworkTask::new(network_service_events, self_receiver);
@@ -728,7 +728,7 @@ mod tests {
                 validator_verifier.clone(),
             );
 
-            let network_events = NetworkEvents::new(consensus_rx, conn_status_rx);
+            let network_events = NetworkEvents::new(consensus_rx, conn_status_rx, None);
             let network_service_events =
                 NetworkServiceEvents::new(hashmap! {NetworkId::Validator => network_events});
             let (task, receiver) = NetworkTask::new(network_service_events, self_receiver);
@@ -797,7 +797,7 @@ mod tests {
             aptos_channel::new(QueueStyle::FIFO, 8, None);
         let (connection_notifs_tx, connection_notifs_rx) =
             aptos_channel::new(QueueStyle::FIFO, 8, None);
-        let network_events = NetworkEvents::new(peer_mgr_notifs_rx, connection_notifs_rx);
+        let network_events = NetworkEvents::new(peer_mgr_notifs_rx, connection_notifs_rx, None);
         let network_service_events =
             NetworkServiceEvents::new(hashmap! {NetworkId::Validator => network_events});
         let (self_sender, self_receiver) = aptos_channels::new_test(8);

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -570,6 +570,8 @@ mod tests {
     #[test]
     fn test_network_api() {
         let runtime = consensus_runtime();
+        let _entered_runtime = runtime.enter();
+
         let num_nodes = 5;
         let mut receivers: Vec<NetworkReceivers> = Vec::new();
         let mut playground = NetworkPlayground::new(runtime.handle().clone());
@@ -680,6 +682,8 @@ mod tests {
     #[test]
     fn test_rpc() {
         let runtime = consensus_runtime();
+        let _entered_runtime = runtime.enter();
+
         let num_nodes = 2;
         let mut senders = Vec::new();
         let mut receivers: Vec<NetworkReceivers> = Vec::new();
@@ -793,6 +797,9 @@ mod tests {
 
     #[test]
     fn test_bad_message() {
+        let runtime = consensus_runtime();
+        let _entered_runtime = runtime.enter();
+
         let (peer_mgr_notifs_tx, peer_mgr_notifs_rx) =
             aptos_channel::new(QueueStyle::FIFO, 8, None);
         let (connection_notifs_tx, connection_notifs_rx) =

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -207,7 +207,7 @@ impl NodeSetup {
             playground.peer_protocols(),
         );
         let consensus_network_client = ConsensusNetworkClient::new(network_client);
-        let network_events = NetworkEvents::new(consensus_rx, conn_status_rx);
+        let network_events = NetworkEvents::new(consensus_rx, conn_status_rx, None);
         let author = signer.author();
 
         let twin_id = TwinId { id, author };

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -186,6 +186,7 @@ impl NodeSetup {
         safety_rules_manager: SafetyRulesManager,
         id: usize,
     ) -> Self {
+        let _entered_runtime = executor.enter();
         let epoch_state = EpochState {
             epoch: 1,
             verifier: storage.get_validator_set().into(),

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -73,6 +73,12 @@ impl SMRNode {
         storage: Arc<MockStorage>,
         twin_id: TwinId,
     ) -> Self {
+        // Create a runtime for the twin
+        let thread_name = format!("twin-{}", twin_id.id);
+        let runtime = aptos_runtimes::spawn_named_runtime(thread_name, None);
+        let _entered_runtime = runtime.enter();
+
+        // Setup the network and SMR node
         let (network_reqs_tx, network_reqs_rx) = aptos_channel::new(QueueStyle::FIFO, 8, None);
         let (connection_reqs_tx, _) = aptos_channel::new(QueueStyle::FIFO, 8, None);
         let (consensus_tx, consensus_rx) = aptos_channel::new(QueueStyle::FIFO, 8, None);
@@ -127,9 +133,6 @@ impl SMRNode {
                 on_chain_configs: payload,
             })
             .unwrap();
-
-        let thread_name = format!("twin-{}", twin_id.id,);
-        let runtime = aptos_runtimes::spawn_named_runtime(thread_name, None);
 
         let time_service = Arc::new(ClockTimeService::new(runtime.handle().clone()));
 

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -89,7 +89,7 @@ impl SMRNode {
             playground.peer_protocols(),
         );
         let consensus_network_client = ConsensusNetworkClient::new(network_client);
-        let network_events = NetworkEvents::new(consensus_rx, conn_notifs_channel);
+        let network_events = NetworkEvents::new(consensus_rx, conn_notifs_channel, None);
         let network_service_events =
             NetworkServiceEvents::new(hashmap! {NetworkId::Validator => network_events});
 

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -112,7 +112,7 @@ impl MockSharedMempool {
             PeerManagerRequestSender::new(network_reqs_tx),
             ConnectionRequestSender::new(connection_reqs_tx),
         );
-        let network_events = NetworkEvents::new(network_notifs_rx, conn_notifs_rx);
+        let network_events = NetworkEvents::new(network_notifs_rx, conn_notifs_rx, None);
         let (ac_client, client_events) = mpsc::channel(1_024);
         let (quorum_store_sender, quorum_store_receiver) = mpsc::channel(1_024);
         let (mempool_notifier, mempool_listener) =

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -56,6 +56,7 @@ impl MockSharedMempool {
     /// and the channel through which shared mempool receives client events.
     pub fn new() -> Self {
         let runtime = aptos_runtimes::spawn_named_runtime("shared-mem".into(), None);
+        let _entered_runtime = runtime.enter();
         let (ac_client, mempool, quorum_store_sender, mempool_notifier) = Self::start(
             runtime.handle(),
             &DbReaderWriter::new(MockDbReaderWriter),

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -572,7 +572,7 @@ fn setup_node_network_interface(
         PeerManagerRequestSender::new(network_reqs_tx),
         ConnectionRequestSender::new(connection_reqs_tx),
     );
-    let network_events = NetworkEvents::new(network_notifs_rx, conn_status_rx);
+    let network_events = NetworkEvents::new(network_notifs_rx, conn_status_rx, None);
 
     (
         NodeNetworkInterface {

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -561,6 +561,7 @@ fn setup_node_network_interfaces(
 fn setup_node_network_interface(
     peer_network_id: PeerNetworkId,
 ) -> (NodeNetworkInterface, MempoolNetworkHandle) {
+    // Create the network sender and events receiver
     static MAX_QUEUE_SIZE: usize = 8;
     let (network_reqs_tx, network_reqs_rx) =
         aptos_channel::new(QueueStyle::FIFO, MAX_QUEUE_SIZE, None);

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -544,7 +544,8 @@ fn setup_network(
         PeerManagerRequestSender::new(reqs_outbound_sender),
         ConnectionRequestSender::new(connection_outbound_sender),
     );
-    let network_events = NetworkEvents::new(reqs_inbound_receiver, connection_inbound_receiver);
+    let network_events =
+        NetworkEvents::new(reqs_inbound_receiver, connection_inbound_receiver, None);
 
     (
         network_sender,

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -207,6 +207,7 @@ impl NetworkBuilder {
             config.ping_interval_ms,
             config.ping_timeout_ms,
             config.ping_failures_tolerated,
+            config.max_parallel_deserialization_tasks,
         );
 
         // Always add a connectivity manager to keep track of known peers
@@ -415,10 +416,13 @@ impl NetworkBuilder {
         ping_interval_ms: u64,
         ping_timeout_ms: u64,
         ping_failures_tolerated: u64,
+        max_parallel_deserialization_tasks: Option<usize>,
     ) -> &mut Self {
         // Initialize and start HealthChecker.
-        let (hc_network_tx, hc_network_rx) =
-            self.add_client_and_service(&health_checker::health_checker_network_config());
+        let (hc_network_tx, hc_network_rx) = self.add_client_and_service(
+            &health_checker::health_checker_network_config(),
+            max_parallel_deserialization_tasks,
+        );
         self.health_checker_builder = Some(HealthCheckerBuilder::new(
             self.network_context(),
             self.time_service.clone(),
@@ -442,10 +446,14 @@ impl NetworkBuilder {
     pub fn add_client_and_service<SenderT: NewNetworkSender, EventsT: NewNetworkEvents>(
         &mut self,
         config: &NetworkApplicationConfig,
+        max_parallel_deserialization_tasks: Option<usize>,
     ) -> (SenderT, EventsT) {
         (
             self.add_client(&config.network_client_config),
-            self.add_service(&config.network_service_config),
+            self.add_service(
+                &config.network_service_config,
+                max_parallel_deserialization_tasks,
+            ),
         )
     }
 
@@ -459,10 +467,18 @@ impl NetworkBuilder {
     /// Register a new service application with the network. Return the service
     /// interface for handling network requests.
     // TODO(philiphayes): return new NetworkService (name TBD) interface?
-    fn add_service<EventsT: NewNetworkEvents>(&mut self, config: &NetworkServiceConfig) -> EventsT {
+    fn add_service<EventsT: NewNetworkEvents>(
+        &mut self,
+        config: &NetworkServiceConfig,
+        max_parallel_deserialization_tasks: Option<usize>,
+    ) -> EventsT {
         let (peer_mgr_reqs_rx, connection_notifs_rx) =
             self.peer_manager_builder.add_service(config);
-        EventsT::new(peer_mgr_reqs_rx, connection_notifs_rx)
+        EventsT::new(
+            peer_mgr_reqs_rx,
+            connection_notifs_rx,
+            max_parallel_deserialization_tasks,
+        )
     }
 }
 

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -106,8 +106,8 @@ pub fn setup_network() -> DummyNetwork {
         peers_and_metadata.clone(),
     );
 
-    let (listener_sender, mut listener_events) =
-        network_builder.add_client_and_service::<_, DummyNetworkEvents>(&dummy_network_config());
+    let (listener_sender, mut listener_events) = network_builder
+        .add_client_and_service::<_, DummyNetworkEvents>(&dummy_network_config(), None);
     network_builder.build(runtime.handle().clone()).start();
     let listener_network_client = NetworkClient::new(
         vec![TEST_DIRECT_SEND_PROTOCOL],
@@ -139,8 +139,8 @@ pub fn setup_network() -> DummyNetwork {
         peers_and_metadata.clone(),
     );
 
-    let (dialer_sender, mut dialer_events) =
-        network_builder.add_client_and_service::<_, DummyNetworkEvents>(&dummy_network_config());
+    let (dialer_sender, mut dialer_events) = network_builder
+        .add_client_and_service::<_, DummyNetworkEvents>(&dummy_network_config(), None);
     network_builder.build(runtime.handle().clone()).start();
     let dialer_network_client = NetworkClient::new(
         vec![TEST_DIRECT_SEND_PROTOCOL],

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -65,7 +65,11 @@ pub struct DummyNetwork {
 
 /// The following sets up a 2 peer network and verifies connectivity.
 pub fn setup_network() -> DummyNetwork {
+    // Create and enter a runtime
     let runtime = Runtime::new().unwrap();
+    let _entered_runtime = runtime.enter();
+
+    // Create a new set of peers
     let role = RoleType::Validator;
     let network_id = NetworkId::Validator;
     let chain_id = ChainId::default();

--- a/network/peer-monitoring-service/server/src/tests.rs
+++ b/network/peer-monitoring-service/server/src/tests.rs
@@ -543,6 +543,7 @@ impl MockClient {
             let network_events = NetworkEvents::new(
                 peer_manager_notification_receiver,
                 connection_notification_receiver,
+                None,
             );
             network_and_events.insert(network_id, network_events);
             peer_manager_notifiers.insert(network_id, peer_manager_notifier);

--- a/network/src/application/tests.rs
+++ b/network/src/application/tests.rs
@@ -774,7 +774,7 @@ fn create_network_sender_and_events(
             ConnectionRequestSender::new(connection_outbound_sender),
         );
         let network_events =
-            NetworkEvents::new(inbound_request_receiver, connection_inbound_receiver);
+            NetworkEvents::new(inbound_request_receiver, connection_inbound_receiver, None);
 
         // Save the sender, events and receivers
         network_senders.insert(*network_id, network_sender);

--- a/network/src/peer_manager/types.rs
+++ b/network/src/peer_manager/types.rs
@@ -34,6 +34,16 @@ pub enum PeerManagerNotification {
     RecvMessage(PeerId, Message),
 }
 
+impl PeerManagerNotification {
+    /// Returns the peer ID of the notification
+    pub fn get_peer_id(&self) -> PeerId {
+        match self {
+            PeerManagerNotification::RecvRpc(peer_id, _) => *peer_id,
+            PeerManagerNotification::RecvMessage(peer_id, _) => *peer_id,
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub enum ConnectionRequest {
     DialPeer(

--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_time_service::{MockTimeService, TimeService};
-use futures::{executor::block_on, future};
+use futures::future;
 use maplit::hashmap;
 use std::sync::Arc;
 
@@ -197,8 +197,8 @@ async fn expect_pong(res_rx: oneshot::Receiver<Result<Bytes, RpcError>>) {
     };
 }
 
-#[test]
-fn outbound() {
+#[tokio::test]
+async fn outbound() {
     let (mut harness, health_checker) = TestHarness::new_strict();
 
     let test = async move {
@@ -215,11 +215,11 @@ fn outbound() {
         // Health Checker should attempt to ping the new peer.
         harness.expect_ping_send_ok().await;
     };
-    block_on(future::join(health_checker.start(), test));
+    future::join(health_checker.start(), test).await;
 }
 
-#[test]
-fn inbound() {
+#[tokio::test]
+async fn inbound() {
     let (mut harness, health_checker) = TestHarness::new_strict();
 
     let test = async move {
@@ -233,11 +233,11 @@ fn inbound() {
         // HealthChecker should respond with a pong.
         expect_pong(res_rx).await;
     };
-    block_on(future::join(health_checker.start(), test));
+    future::join(health_checker.start(), test).await;
 }
 
-#[test]
-fn outbound_failure_permissive() {
+#[tokio::test]
+async fn outbound_failure_permissive() {
     let ping_failures_tolerated = 10;
     let (mut harness, health_checker) = TestHarness::new_permissive(ping_failures_tolerated);
 
@@ -260,11 +260,11 @@ fn outbound_failure_permissive() {
         // Health checker should disconnect from peer after tolerated number of failures
         harness.expect_disconnect(peer_id).await;
     };
-    block_on(future::join(health_checker.start(), test));
+    future::join(health_checker.start(), test).await;
 }
 
-#[test]
-fn ping_success_resets_fail_counter() {
+#[tokio::test]
+async fn ping_success_resets_fail_counter() {
     let failures_triggered = 10;
     let ping_failures_tolerated = 2 * 10;
     let (mut harness, health_checker) = TestHarness::new_permissive(ping_failures_tolerated);
@@ -307,11 +307,11 @@ fn ping_success_resets_fail_counter() {
         // Health checker should disconnect from peer after tolerated number of failures
         harness.expect_disconnect(peer_id).await;
     };
-    block_on(future::join(health_checker.start(), test));
+    future::join(health_checker.start(), test).await;
 }
 
-#[test]
-fn outbound_failure_strict() {
+#[tokio::test]
+async fn outbound_failure_strict() {
     let (mut harness, health_checker) = TestHarness::new_strict();
 
     let test = async move {
@@ -331,5 +331,5 @@ fn outbound_failure_strict() {
         // Health checker should disconnect from peer.
         harness.expect_disconnect(peer_id).await;
     };
-    block_on(future::join(health_checker.start(), test));
+    future::join(health_checker.start(), test).await;
 }

--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -54,7 +54,7 @@ impl TestHarness {
             ConnectionRequestSender::new(connection_reqs_tx),
         );
         let hc_network_rx =
-            HealthCheckerNetworkEvents::new(peer_mgr_notifs_rx, connection_notifs_rx);
+            HealthCheckerNetworkEvents::new(peer_mgr_notifs_rx, connection_notifs_rx, None);
 
         let network_context = NetworkContext::mock();
         let peers_and_metadata = PeersAndMetadata::new(&[network_context.network_id()]);

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -14,23 +14,27 @@ use crate::{
     transport::ConnectionMetadata,
     ProtocolId,
 };
-use aptos_channels::aptos_channel;
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_logger::prelude::*;
 use aptos_short_hex_str::AsShortHexStr;
 use aptos_types::{network_address::NetworkAddress, PeerId};
 use bytes::Bytes;
 use futures::{
     channel::oneshot,
-    future,
-    stream::{FilterMap, FusedStream, Map, Select, Stream, StreamExt},
+    stream::{FusedStream, Map, Select, Stream, StreamExt},
     task::{Context, Poll},
 };
+use futures_util::FutureExt;
 use pin_project::pin_project;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{cmp::min, fmt::Debug, marker::PhantomData, pin::Pin, time::Duration};
+use tokio::runtime::Handle;
 
 pub trait Message: DeserializeOwned + Serialize {}
 impl<T: DeserializeOwned + Serialize> Message for T {}
+
+// TODO: do we want to make this configurable?
+const MAX_DESERIALIZATION_QUEUE_SIZE_PER_PEER: usize = 30;
 
 /// Events received by network clients in a validator
 ///
@@ -154,11 +158,7 @@ impl NetworkApplicationConfig {
 pub struct NetworkEvents<TMessage> {
     #[pin]
     event_stream: Select<
-        FilterMap<
-            aptos_channel::Receiver<(PeerId, ProtocolId), PeerManagerNotification>,
-            future::Ready<Option<Event<TMessage>>>,
-            fn(PeerManagerNotification) -> future::Ready<Option<Event<TMessage>>>,
-        >,
+        aptos_channel::Receiver<PeerId, Event<TMessage>>,
         Map<
             aptos_channel::Receiver<PeerId, ConnectionNotification>,
             fn(ConnectionNotification) -> Event<TMessage>,
@@ -172,22 +172,67 @@ pub trait NewNetworkEvents {
     fn new(
         peer_mgr_notifs_rx: aptos_channel::Receiver<(PeerId, ProtocolId), PeerManagerNotification>,
         connection_notifs_rx: aptos_channel::Receiver<PeerId, ConnectionNotification>,
+        max_parallel_deserialization_tasks: Option<usize>,
     ) -> Self;
 }
 
-impl<TMessage: Message> NewNetworkEvents for NetworkEvents<TMessage> {
+impl<TMessage: Message + Send + 'static> NewNetworkEvents for NetworkEvents<TMessage> {
     fn new(
         peer_mgr_notifs_rx: aptos_channel::Receiver<(PeerId, ProtocolId), PeerManagerNotification>,
         connection_notifs_rx: aptos_channel::Receiver<PeerId, ConnectionNotification>,
+        max_parallel_deserialization_tasks: Option<usize>,
     ) -> Self {
-        let data_event_stream = peer_mgr_notifs_rx.filter_map(
-            peer_mgr_notif_to_event
-                as fn(PeerManagerNotification) -> future::Ready<Option<Event<TMessage>>>,
+        // Create a channel for deserialized messages
+        let (deserialized_message_sender, deserialized_message_receiver) = aptos_channel::new(
+            QueueStyle::FIFO,
+            MAX_DESERIALIZATION_QUEUE_SIZE_PER_PEER,
+            None,
         );
+
+        // Deserialize the peer manager notifications in parallel (for each
+        // network application) and send them to the receiver. Note: this
+        // may cause out of order message delivery, but applications
+        // should already be handling this.
+        Handle::current().spawn(async move {
+            peer_mgr_notifs_rx
+                .for_each_concurrent(
+                    max_parallel_deserialization_tasks,
+                    move |peer_manager_notification| {
+                        // Get the peer ID for the notification
+                        let deserialized_message_sender = deserialized_message_sender.clone();
+                        let peer_id_for_notification = peer_manager_notification.get_peer_id();
+
+                        // Spawn a new blocking task to deserialize the message
+                        Handle::current()
+                            .spawn_blocking(move || {
+                                if let Some(deserialized_message) =
+                                    peer_mgr_notif_to_event(peer_manager_notification)
+                                {
+                                    if let Err(error) = deserialized_message_sender
+                                        .push(peer_id_for_notification, deserialized_message)
+                                    {
+                                        warn!(
+                                            "Failed to send deserialized message to receiver: {:?}",
+                                            error
+                                        );
+                                    }
+                                }
+                            })
+                            .map(|_| ())
+                    },
+                )
+                .await
+        });
+
+        // Process the control messages
         let control_event_stream = connection_notifs_rx
             .map(control_msg_to_event as fn(ConnectionNotification) -> Event<TMessage>);
+
         Self {
-            event_stream: ::futures::stream::select(data_event_stream, control_event_stream),
+            event_stream: ::futures::stream::select(
+                deserialized_message_receiver,
+                control_event_stream,
+            ),
             _marker: PhantomData,
         }
     }
@@ -208,9 +253,9 @@ impl<TMessage> Stream for NetworkEvents<TMessage> {
 /// Deserialize inbound direct send and rpc messages into the application `TMessage`
 /// type, logging and dropping messages that fail to deserialize.
 fn peer_mgr_notif_to_event<TMessage: Message>(
-    notif: PeerManagerNotification,
-) -> future::Ready<Option<Event<TMessage>>> {
-    let maybe_event = match notif {
+    notification: PeerManagerNotification,
+) -> Option<Event<TMessage>> {
+    match notification {
         PeerManagerNotification::RecvRpc(peer_id, rpc_req) => {
             request_to_network_event(peer_id, &rpc_req)
                 .map(|msg| Event::RpcRequest(peer_id, msg, rpc_req.protocol_id, rpc_req.res_tx))
@@ -218,8 +263,7 @@ fn peer_mgr_notif_to_event<TMessage: Message>(
         PeerManagerNotification::RecvMessage(peer_id, request) => {
             request_to_network_event(peer_id, &request).map(|msg| Event::Message(peer_id, msg))
         },
-    };
-    future::ready(maybe_event)
+    }
 }
 
 /// Converts a `SerializedRequest` into a network `Event` for sending to other nodes

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -92,6 +92,7 @@ impl MockClient {
             let network_events = NetworkEvents::new(
                 peer_manager_notification_receiver,
                 connection_notification_receiver,
+                None,
             );
             network_and_events.insert(network_id, network_events);
             peer_manager_notifiers.insert(network_id, peer_manager_notifier);

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -182,7 +182,7 @@ async fn test_full_node_bootstrap_snapshot_transactions_or_outputs() {
     let mut swarm = SwarmBuilder::new_local(1)
         .with_aptos()
         .with_init_config(Arc::new(|_, config, _| {
-            config.state_sync.storage_service.max_network_chunk_bytes = 300 * 1024;
+            config.state_sync.storage_service.max_network_chunk_bytes = 500 * 1024;
         }))
         .build()
         .await;


### PR DESCRIPTION
### Description
This PR updates the networking code to perform message deserialization in parallel (as opposed to serially, where each application only has a single thread that processes one message at a time). Now, we use `for_each_concurrent` that spawns up to a fixed number of threads and does deserialization in parallel (per application).

This was originally reported as a bottleneck in the consensus tests, but it has since been reproduced by the network benchmarks.

### Test Plan
Existing test infrastructure.