### PR TITLE
Run TS SDK tests against local testnets built from prod branches, split API and Rust node API client checks into separate job

### DIFF
--- a/.github/actions/run-local-testnet/action.yaml
+++ b/.github/actions/run-local-testnet/action.yaml
@@ -1,0 +1,43 @@
+name: "Run Local Testnet"
+description: |
+  Runs a local testnet from a Docker image built from a particular image tag
+inputs:
+  IMAGE_TAG:
+    description: "The image tag to use for running the local testnet, e.g. devnet / testnet / mainnet or some SHA"
+    required: true
+  GCP_DOCKER_ARTIFACT_REPO:
+    description: "The GCP Docker artifact repository"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Create a directory that we'll bindmount into the container into which it can
+    # store all its configuration and files.
+    - name: Create directory for testnet files
+      run: mkdir -p ${{ runner.temp }}/testnet
+      shell: bash
+
+    # Run a local testnet. We mount in the testnet directory we just created.
+    - run: docker run -p 8080:8080 -p 8081:8081 -v ${{ runner.temp }}/testnet:/testnet --name=local-testnet-${{ inputs.IMAGE_TAG }} --detach ${{ inputs.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.IMAGE_TAG }} aptos node run-local-testnet --with-faucet --test-dir /testnet
+      shell: bash
+
+    # Install node + npm.
+    - uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # pin@v3
+      with:
+        node-version-file: .node-version
+        registry-url: "https://registry.npmjs.org"
+
+    # Wait for the node API and faucet of the local testnet to start up.
+    - run: npm install -g wait-on
+      shell: bash
+    - run: wait-on -t 60000 --httpTimeout 60000 http-get://127.0.0.1:8080/v1
+      shell: bash
+    - run: wait-on -t 60000 --httpTimeout 60000 http-get://127.0.0.1:8081
+      shell: bash
+
+    # Print the logs from the local testnet if the tests failed.
+    - name: Print local testnet logs if something failed
+      run: docker logs local-testnet-${{ inputs.IMAGE_TAG }}
+      shell: bash
+      if: ${{ failure() }}

--- a/.github/actions/run-rust-client-tests/action.yaml
+++ b/.github/actions/run-rust-client-tests/action.yaml
@@ -1,0 +1,24 @@
+name: "Run Rust Node Client Tests"
+description: |
+  Run the Rust Node Client (aptos-rest-client) tests against a local testnet built from a particular release branch
+inputs:
+  NETWORK:
+    description: "The network to use for running the local testnet, one of devnet / testnet / mainnet"
+    required: true
+  GCP_DOCKER_ARTIFACT_REPO:
+    description: "The GCP Docker artifact repository"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Run a local testnet.
+    - uses: ./.github/actions/run-local-testnet
+      with:
+        IMAGE_TAG: ${{ inputs.NETWORK }}
+        GCP_DOCKER_ARTIFACT_REPO: ${{ inputs.GCP_DOCKER_ARTIFACT_REPO }}
+
+    # Run the tests.
+    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+    - run: cargo run -p aptos-rest-client --example account -- --api-url 'http://127.0.0.1:8080/v1'
+      shell: bash

--- a/.github/actions/run-ts-sdk-e2e-tests/action.yaml
+++ b/.github/actions/run-ts-sdk-e2e-tests/action.yaml
@@ -1,0 +1,65 @@
+name: "Run SDK E2E tests"
+description: |
+  Run the SDK E2E tests against a local testnet built from a particular release branch
+inputs:
+  NETWORK:
+    description: "The network to use for running the local testnet, one of devnet / testnet / mainnet"
+    required: true
+  GCP_DOCKER_ARTIFACT_REPO:
+    description: "The GCP Docker artifact repository"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Install node and pnpm.
+    - uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # pin@v3
+      with:
+        node-version-file: .node-version
+        registry-url: "https://registry.npmjs.org"
+    - uses: pnpm/action-setup@537643d491d20c2712d11533497cb47b2d0eb9d5 # pin https://github.com/pnpm/action-setup/releases/tag/v2.2.3
+
+    # Set up the necessary env vars for the test suite.
+    - run: echo "APTOS_NODE_URL=http://127.0.0.1:8080/v1" >> .env
+      shell: bash
+      working-directory: ./ecosystem/typescript/sdk
+    - run: echo "APTOS_FAUCET_URL=http://127.0.0.1:8081" >> .env
+      shell: bash
+      working-directory: ./ecosystem/typescript/sdk
+    - run: echo "ANS_TEST_ACCOUNT_PRIVATE_KEY=0x37368b46ce665362562c6d1d4ec01a08c8644c488690df5a17e13ba163e20221" >> .env
+      shell: bash
+      working-directory: ./ecosystem/typescript/sdk
+    - run: echo "ANS_TEST_ACCOUNT_ADDRESS=585fc9f0f0c54183b039ffc770ca282ebd87307916c215a3e692f2f8e4305e82" >> .env
+      shell: bash
+      working-directory: ./ecosystem/typescript/sdk
+    - run: echo "DOCKER_IMAGE=${{ inputs.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.NETWORK }}" >>.env
+      shell: bash
+      working-directory: ./ecosystem/typescript/sdk
+    - run: echo "NETWORK=${{ inputs.NETWORK }}" >> .env
+      shell: bash
+      working-directory: ./ecosystem/typescript/sdk
+
+    # Run package install. If install fails, it probably means the updated lockfile was
+    # not included in the commit.
+    - run: pnpm install --frozen-lockfile
+      shell: bash
+      working-directory: ./ecosystem/typescript/sdk
+
+    # Run a local testnet.
+    - uses: ./.github/actions/run-local-testnet
+      with:
+        IMAGE_TAG: ${{ inputs.NETWORK }}
+        GCP_DOCKER_ARTIFACT_REPO: ${{ inputs.GCP_DOCKER_ARTIFACT_REPO }}
+
+    # Run the TS SDK tests.
+    - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
+      name: sdk-pnpm-test
+      env:
+        # This is important, it ensures that the tempdir we create for cloning the ANS
+        # repo and mounting it into the CLI container is created in a location that
+        # actually supports mounting. Learn more here: https://stackoverflow.com/a/76523941/3846032.
+        TMPDIR: ${{ runner.temp }}
+      with:
+        max_attempts: 3
+        timeout_minutes: 25
+        command: cd ./ecosystem/typescript/sdk && pnpm run test:ci

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -182,7 +182,7 @@ jobs:
       BUILD_ADDL_TESTING_IMAGES: true
       TARGET_REGISTRY: ${{ needs.determine-docker-build-metadata.outputs.targetRegistry }}
 
-  sdk-release:
+  node-api-compatibility-tests:
     needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
     if: |
       (github.event_name == 'push' && github.ref_name != 'main') ||
@@ -190,7 +190,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
       github.event.pull_request.auto_merge != null ||
       contains(github.event.pull_request.body, '#e2e')
-    uses: aptos-labs/aptos-core/.github/workflows/sdk-release.yaml@main
+    uses: ./.github/workflows/node-api-compatibility-tests.yaml
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -351,6 +351,6 @@ jobs:
       FORGE_TEST_SUITE: multiregion_benchmark_test
       IMAGE_TAG: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_RUNNER_DURATION_SECS: 300
-      COMMENT_HEADER: forge-multiregion-test 
+      COMMENT_HEADER: forge-multiregion-test
       FORGE_NAMESPACE: forge-multiregion-test-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
       FORGE_CLUSTER_NAME: forge-multiregion

--- a/.github/workflows/node-api-compatibility-tests.yaml
+++ b/.github/workflows/node-api-compatibility-tests.yaml
@@ -12,7 +12,9 @@
 ##   - Replace env.IMAGE_TAG for a known image tag
 ##   - env.GIT_SHA will resolve to that of your PR branch
 
-name: "API + TS SDK CI"
+# These tests ensure that the Node API, the OpenAPI spec that is generated from it,
+# and the TS SDK inner client that is generated from that, all match up.
+name: "Node API Compatibility Tests"
 on:
   # This is called from within the docker-build-test.yaml workflow since we depend
   # on the images having been built before this workflow runs.
@@ -22,9 +24,6 @@ on:
         required: true
         type: string
         description: Use this to override the git SHA1, branch name (e.g. devnet) or tag to release the SDK from
-  pull_request:
-    paths:
-      - .github/workflows/sdk-release.yaml
 
 env:
   # This is the docker image tag that will be used for the SDK release.
@@ -36,17 +35,11 @@ jobs:
   # Confirm that the generated client within the TS SDK has been re-generated
   # if there are any changes that would affect it within the PR / commit. If
   # everything is checked in, run tests, build the SDK, and upload it to npmjs.
-  test-sdk-confirm-client-generated-publish:
+  node-api-compatibility-tests:
     runs-on: high-perf-docker
     permissions:
       contents: read
       id-token: write
-    env:
-      APTOS_NODE_URL: http://127.0.0.1:8080/v1
-      APTOS_FAUCET_URL: http://127.0.0.1:8081
-      FAUCET_AUTH_TOKEN: ${{ secrets.DEVNET_TAP_AUTH_TOKEN }}
-      ANS_TEST_ACCOUNT_PRIVATE_KEY: "0x37368b46ce665362562c6d1d4ec01a08c8644c488690df5a17e13ba163e20221"
-      ANS_TEST_ACCOUNT_ADDRESS: "585fc9f0f0c54183b039ffc770ca282ebd87307916c215a3e692f2f8e4305e82"
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
@@ -84,6 +77,7 @@ jobs:
           max_attempts: 3
           timeout_minutes: 20
           command: docker run --rm --mount=type=bind,source=${{ runner.temp }}/specs,target=/specs ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/tools:${IMAGE_TAG} aptos-openapi-spec-generator -f yaml -o /specs/spec.yaml
+
       - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
         name: generate-json-spec
         with:
@@ -98,21 +92,6 @@ jobs:
       - run: git diff --no-index --ignore-space-at-eol --ignore-blank-lines ${{ runner.temp }}/specs/spec.yaml api/doc/spec.yaml
       - run: git diff --no-index --ignore-space-at-eol --ignore-blank-lines ${{ runner.temp }}/specs/spec.json api/doc/spec.json
 
-      # Set up dotenv file for tests (jest doesn't read env vars properly).
-      - run: echo "APTOS_NODE_URL=$APTOS_NODE_URL" >> ./ecosystem/typescript/sdk/.env
-      - run: echo "APTOS_FAUCET_URL=$APTOS_FAUCET_URL" >> ./ecosystem/typescript/sdk/.env
-      - run: echo "FAUCET_AUTH_TOKEN=$FAUCET_AUTH_TOKEN" >> ./ecosystem/typescript/sdk/.env
-      - run: echo "ANS_TEST_ACCOUNT_PRIVATE_KEY=$ANS_TEST_ACCOUNT_PRIVATE_KEY" >> ./ecosystem/typescript/sdk/.env
-      - run: echo "ANS_TEST_ACCOUNT_ADDRESS=$ANS_TEST_ACCOUNT_ADDRESS" >> ./ecosystem/typescript/sdk/.env
-
-      # These two have to be defined here and not in the env section because the runner
-      # context is only available here.
-      - run: echo "APTOS_INVOCATION='docker run -v ${{ runner.temp }}/ans:/tmp/ans --network host ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/tools:${IMAGE_TAG} aptos'" >> ./ecosystem/typescript/sdk/.env
-      - run: echo "ANS_REPO_LOCATION=${{ runner.temp }}/ans" >> ./ecosystem/typescript/sdk/.env
-
-      - run: cp ./ecosystem/typescript/sdk/.env ./ecosystem/typescript/sdk/examples/typescript/.env
-      - run: cp ./ecosystem/typescript/sdk/.env ./ecosystem/typescript/sdk/examples/javascript/.env
-
       # Run package install. If install fails, it probably means the lockfile
       # was not included in the commit.
       - run: cd ./ecosystem/typescript/sdk && pnpm install --frozen-lockfile
@@ -122,57 +101,3 @@ jobs:
       - run: echo "If this step fails, run the following command locally to fix it:"
       - run: echo "cd ecosystem/typescript/sdk && pnpm generate-client"
       - run: git diff --no-index --ignore-space-at-eol --ignore-blank-lines ./ecosystem/typescript/sdk/src/generated/ /tmp/generated_client/
-
-      # Run a local testnet built from the same commit.
-      - run: docker run -p 8080:8080 -p 8081:8081 --name=local-testnet --detach ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/tools:${IMAGE_TAG} aptos node run-local-testnet --with-faucet
-
-      # Wait for the API and faucet to startup.
-      - run: npm install -g wait-on
-      - run: wait-on -t 60000 --httpTimeout 60000 http-get://127.0.0.1:8080/v1
-      - run: wait-on -t 60000 --httpTimeout 60000 http-get://127.0.0.1:8081
-
-      # Run the TS SDK tests and confirm the build works.
-      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
-        name: sdk-pnpm-test
-        with:
-          max_attempts: 3
-          timeout_minutes: 20
-          command: cd ./ecosystem/typescript/sdk && pnpm run test:ci
-      - run: cd ./ecosystem/typescript/sdk && pnpm build
-
-      # Confirm the Rust API client examples pass.
-      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
-      - run: cargo run -p aptos-rest-client --example account -- --api-url http://127.0.01:8080
-
-      - name: Print docker-compose testnet logs on failure
-        if: ${{ failure() }}
-        working-directory: docker/compose/validator-testnet
-        run: docker logs local-testnet
-
-  # Run the TS SDK indexer tests. Note: indexer service can be flaky and we
-  # dont want those tests to be land blocking for any PR on the aptos repo.
-  # This is why we run those tests separate from
-  # test-sdk-confirm-client-generated-publish.
-  run-indexer-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-        with:
-          ref: ${{ env.GIT_SHA }}
-      - uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # pin@v3
-        with:
-          node-version-file: .node-version
-          registry-url: "https://registry.npmjs.org"
-      - uses: pnpm/action-setup@537643d491d20c2712d11533497cb47b2d0eb9d5 # pin https://github.com/pnpm/action-setup/releases/tag/v2.2.3
-
-      # Run package install. If install fails, it probably means the lockfile
-      # was not included in the commit.
-      - run: cd ./ecosystem/typescript/sdk && pnpm install --frozen-lockfile
-
-      # Run indexer tests.
-      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
-        name: ts-sdk-indexer-test
-        with:
-          max_attempts: 3
-          timeout_minutes: 20
-          command: cd ./ecosystem/typescript/sdk && pnpm run test:indexer

--- a/.github/workflows/rust-client-tests.yaml
+++ b/.github/workflows/rust-client-tests.yaml
@@ -1,0 +1,71 @@
+# Each of these jobs runs the Rust SDK client tests from this commit against a local
+# testnet built from one of the production release branches. In other words, we run the
+# tests against a local devnet, testnet, and mainnet.
+
+name: "Rust SDK Client Tests"
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  run-tests-devnet:
+    runs-on: high-perf-docker
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - uses: ./.github/actions/run-rust-client-tests
+        with:
+          NETWORK: devnet
+          GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
+
+  run-tests-testnet:
+    runs-on: high-perf-docker
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - uses: ./.github/actions/run-rust-client-tests
+        with:
+          NETWORK: testnet
+          GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
+
+  run-tests-mainnet:
+    runs-on: high-perf-docker
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - uses: ./.github/actions/run-rust-client-tests
+        with:
+          NETWORK: mainnet
+          GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}

--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -1,0 +1,102 @@
+# Each of these jobs runs the TS SDK E2E tests from this commit against a local testnet
+# built from one of the production release branches. In other words, we run the TS SDK
+# tests against a local devnet, testnet, and mainnet. We also run the TS SDK tests for
+# the indexer, though those run against the production indexer for now.
+
+name: "TS SDK E2E Tests"
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  run-tests-devnet:
+    runs-on: high-perf-docker
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - uses: ./.github/actions/run-ts-sdk-e2e-tests
+        with:
+          NETWORK: devnet
+          GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
+
+  run-tests-testnet:
+    runs-on: high-perf-docker
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - uses: ./.github/actions/run-ts-sdk-e2e-tests
+        with:
+          NETWORK: testnet
+          GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
+
+  run-tests-mainnet:
+    runs-on: high-perf-docker
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - uses: ./.github/actions/run-ts-sdk-e2e-tests
+        with:
+          NETWORK: mainnet
+          GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
+
+  # Run the TS SDK indexer tests. Note: Unlike the above tests where everything is self
+  # contained because we run a local testnet, these tests operate against the
+  # production indexer service. This service can be flaky so we don't want those tests
+  # to be land blocking for any PR on the aptos repo. This is why we run those tests
+  # separate from test-sdk-confirm-client-generated-publish.
+  run-indexer-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          ref: ${{ env.GIT_SHA }}
+      - uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # pin@v3
+        with:
+          node-version-file: .node-version
+          registry-url: "https://registry.npmjs.org"
+      - uses: pnpm/action-setup@537643d491d20c2712d11533497cb47b2d0eb9d5 # pin https://github.com/pnpm/action-setup/releases/tag/v2.2.3
+
+      # Run package install. If install fails, it probably means the lockfile
+      # was not included in the commit.
+      - run: cd ./ecosystem/typescript/sdk && pnpm install --frozen-lockfile
+
+      # Run indexer tests.
+      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
+        name: ts-sdk-indexer-test
+        with:
+          max_attempts: 3
+          timeout_minutes: 20
+          command: cd ./ecosystem/typescript/sdk && pnpm run test:indexer
+

--- a/ecosystem/typescript/sdk/scripts/publish_ans_contract.ts
+++ b/ecosystem/typescript/sdk/scripts/publish_ans_contract.ts
@@ -12,52 +12,67 @@ require("dotenv").config();
  * This script runs when testing locally and on CI (as part of sdk-release.yaml) using `pnpm test`.
  */
 
-// on local publishing we want to use `aptos` commnads and on CI we want to use `docker`
-const APTOS_INVOCATION = process.env.APTOS_INVOCATION || "aptos";
-// environment we use when testing
+// URLs at which the node and faucet are running.
 const APTOS_NODE_URL = process.env.APTOS_NODE_URL;
 const APTOS_FAUCET_URL = process.env.APTOS_FAUCET_URL;
-// ans account we use to publish the contract
-const ANS_REPO_LOCATION = process.env.ANS_REPO_LOCATION || "/tmp/ans";
+
+// Env vars that configure how we run the CLI.
+const DOCKER_IMAGE = process.env.DOCKER_IMAGE;
+
+// ANS account we use to publish the contract
 const ANS_TEST_ACCOUNT_PRIVATE_KEY =
   process.env.ANS_TEST_ACCOUNT_PRIVATE_KEY || "0x37368b46ce665362562c6d1d4ec01a08c8644c488690df5a17e13ba163e20221";
 const ANS_TEST_ACCOUNT_ADDRESS =
-  process.env.ANS_TEST_ACCOUNT_ADDRESS || "585fc9f0f0c54183b039ffc770ca282ebd87307916c215a3e692f2f8e4305e82";
+  process.env.ANS_TEST_ACCOUNT_ADDRESS || "0x585fc9f0f0c54183b039ffc770ca282ebd87307916c215a3e692f2f8e4305e82";
 
 try {
-  deleteAnsFolder();
-  // 1. Clone ANS repository into the current directory
-  console.log("---clone ANS repository---");
-  execSync(`git clone https://github.com/aptos-labs/aptos-names-contracts.git ${ANS_REPO_LOCATION}`, {
-    stdio: "inherit",
+  // 0. Create a temporary directory to clone the repo into. Note: For this to work in
+  // CI, it is essential that TMPDIR is set to a directory that can actually be mounted.
+  // Learn more here: https://stackoverflow.com/a/76523941/3846032.
+  console.log("---creating temporary directory for ANS code---");
+  let tempDir = execSync("mktemp -d").toString("utf8").trim();
+
+  // 1. Clone the ANS repo into the temporary directory.
+  console.log(`---cloning ANS repository to ${tempDir}---`);
+  execSync(`git clone https://github.com/aptos-labs/aptos-names-contracts.git ${tempDir}`, {
+    stdout: "inherit",
   });
 
-  // 2. fund ans account
+  // The command we use to run the CLI.
+  let cliInvocation;
+  // Where the CLI should look to find the ANS repo.
+  let repoDir;
+
+  if (DOCKER_IMAGE) {
+    // If we're using a docker image we mount the temp dir into the container.
+    console.log("---running CLI using docker image---");
+    cliInvocation = `docker run --network host --mount=type=bind,source=${tempDir},target=/code ${DOCKER_IMAGE} aptos`;
+    repoDir = "/code";
+  } else {
+    // If we're using a local CLI we just use the temp dir directly.
+    console.log("---running CLI using local binary---");
+    cliInvocation = "aptos";
+    repoDir = tempDir;
+  }
+
+  // 2. Fund ANS account.
   console.log("---funding account---");
   execSync(
-    `${APTOS_INVOCATION} account fund-with-faucet --account ${ANS_TEST_ACCOUNT_ADDRESS} --faucet-url ${APTOS_FAUCET_URL} --url ${APTOS_NODE_URL}`,
+    `${cliInvocation} account fund-with-faucet --account ${ANS_TEST_ACCOUNT_ADDRESS} --faucet-url ${APTOS_FAUCET_URL} --url ${APTOS_NODE_URL}`,
     { stdio: "inherit" },
   );
 
-  // 3. publish ans modules under the ans account
-  console.log("---publish ans modules---");
+  // 3. Publish the ANS modules under the ANS account.
+  console.log("---publishing ans modules---");
   execSync(
-    `${APTOS_INVOCATION} move publish --package-dir /tmp/ans/core --assume-yes --private-key=${ANS_TEST_ACCOUNT_PRIVATE_KEY} --named-addresses aptos_names=0x${ANS_TEST_ACCOUNT_ADDRESS},aptos_names_admin=0x${ANS_TEST_ACCOUNT_ADDRESS},aptos_names_funds=0x${ANS_TEST_ACCOUNT_ADDRESS} --url=${APTOS_NODE_URL}`,
+    `${cliInvocation} move publish --package-dir ${repoDir}/core --assume-yes --private-key=${ANS_TEST_ACCOUNT_PRIVATE_KEY} --named-addresses aptos_names=${ANS_TEST_ACCOUNT_ADDRESS},aptos_names_admin=${ANS_TEST_ACCOUNT_ADDRESS},aptos_names_funds=${ANS_TEST_ACCOUNT_ADDRESS} --url=${APTOS_NODE_URL}`,
     { stdio: "inherit" },
   );
-
-  // 4. Delete aptos-names-contracts folder created by the git clone command
-  console.log("---module published, deleting aptos-names-contracts folder---");
-  deleteAnsFolder();
+  console.log("---module published---");
 } catch (error: any) {
   console.error("An error occurred:");
   console.error("Status", error?.status);
   console.error("parsed stdout", error?.stdout?.toString("utf8"));
   console.error("parsed stderr", error?.stderr?.toString("utf8"));
-  deleteAnsFolder();
   process.exit(1);
-}
-
-function deleteAnsFolder() {
-  execSync("rm -rf /tmp/ans", { stdio: "inherit" });
 }


### PR DESCRIPTION
### Description
Currently we run the TS SDK tests against a local testnet built from the same commit. So if you make a PR, it will run a local testnet built from the code in that PR and then run the tests against it. This helps check for compatibility between the SDK and main but that's actually not really necessary. Instead, what matters is confirming that the SDK is compatible with each of the production networks. As such, in this PR I make it that the SDK runs against local testnets built from the production networks (devnet, testnet, mainnet).

To ensure compatibility we run these tests on main and on PRs to check for changes to the SDK that could break compatibility with the production networks.

One nice benefit of this change is the SDK tests no longer have to wait for the whole image build phase, it can just run immediately.

I also switch up `publish_ans_contract.ts` to make the retries actually work in CI. They didn't previously because we weren't deleting the ANS directory properly, so now we use temp directories. The way I do it has to workaround the following issues that GitHub the company probably won't fix any time soon:
- https://github.com/orgs/community/discussions/58633 (https://support.github.com/ticket/personal/0/2217441)
- https://stackoverflow.com/a/76523941/3846032

After removing the TS SDK tests, I spit the remaining stuff into two separate workflows too:
1. I put the API + spec + generated TS code compatibility tests into their own workflow.
2. I put the Rust SDK client tests into their own workflow. This workflow works the same as the TS SDK tests, in which we run the code against three different local testnets.

Note: With this new setup, it means that some of the tests as they are now don't work against testnet and mainnet because the fungible asset module is not deployed there yet. To fix this, I made the tests run conditionally depending on the `NETWORK` env var. I also improved the error messages by making the test suite check that the txns are successful.

This addresses https://github.com/aptos-labs/aptos-core/issues/8740.

### Test Plan
CI. I tested it with `pull_request` instead of `pull_request_target` and the relevant tests (the api compatibility tests) worked.

The Rust node API client tests are flaky because of this toolchain issue. It is not related to this PR, I have seen them pass.

I also ran the TS SDK tests locally and they worked.