### PR TITLE
[Forge] Add basic PFN performance test.

### DIFF
--- a/.github/workflows/forge-specialized.yaml
+++ b/.github/workflows/forge-specialized.yaml
@@ -1,0 +1,140 @@
+# Continuously run specialized forge tests against the latest main branch.
+# These tests run less frequently than regular forge tests (i.e., stable
+# and unstable).
+name: Continuous Forge Tests - Specialized
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+  id-token: write
+  actions: write # Required for workflow cancellation via check-aptos-core
+
+on:
+  # Allow triggering manually
+  workflow_dispatch:
+    inputs:
+      IMAGE_TAG:
+        required: false
+        type: string
+        description: The docker image tag to test. This may be a git SHA1, or a tag like "<branch>_<git SHA1>". If not specified, Forge will find the latest build based on the git history (starting from GIT_SHA input)
+      GIT_SHA:
+        required: false
+        type: string
+        description: The git SHA1 to checkout. This affects the Forge test runner that is used. If not specified, the latest main will be used
+  schedule:
+    - cron: "0 6 */2 * *" # The main branch cadence. This runs every other day at 6am UTC.
+  pull_request:
+    paths:
+      - ".github/workflows/forge-specialized.yaml"
+      - "testsuite/find_latest_image.py"
+  push:
+    branches:
+      - aptos-release-v* # The aptos release branches
+
+env:
+  AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  IMAGE_TAG: ${{ inputs.IMAGE_TAG }} # This is only used for workflow_dispatch, otherwise defaults to empty
+  AWS_REGION: us-west-2
+
+jobs:
+  # This job determines the image tag and branch to test, and passes them to the other jobs.
+  # NOTE: this may be better as a separate workflow as the logic is quite complex but generalizable.
+  determine-test-metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      IMAGE_TAG: ${{ steps.determine-test-image-tag.outputs.IMAGE_TAG }}
+      BRANCH: ${{ steps.determine-test-branch.outputs.BRANCH }}
+    steps:
+      - name: Determine branch based on cadence
+        id: determine-test-branch
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            if [[ "${{ github.event.schedule }}" == "0 9 * * *" ]]; then
+              echo "Branch: main"
+              echo "BRANCH=main" >> $GITHUB_OUTPUT
+            else
+              echo "Unknown schedule: ${{ github.event.schedule }}"
+              exit 1
+            fi
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+              echo "Branch: ${{ github.ref_name }}"
+              echo "BRANCH=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "Using GIT_SHA"
+            # on workflow_dispatch, this will simply use the inputs.GIT_SHA given (or the default)
+            # on pull_request, this will default to null and the following "checkout" step will use the PR's base branch
+            echo "BRANCH=${{ inputs.GIT_SHA }}" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          ref: ${{ steps.determine-test-branch.outputs.BRANCH }}
+          fetch-depth: 0
+
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
+        with:
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
+
+      # find_latest_images.py requires docker utilities and having authenticated to internal docker image registries
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+        id: docker-setup
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          EXPORT_GCP_PROJECT_VARIABLES: "false"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+
+      - uses: ./.github/actions/python-setup
+        with:
+          pyproject_directory: testsuite
+
+      - name: Determine image tag
+        id: determine-test-image-tag
+        # Forge relies on the default and failpoints variants
+        run: ./testrun find_latest_image.py --variant failpoints --variant performance
+        shell: bash
+        working-directory: testsuite
+
+      - name: Write summary
+        run: |
+          IMAGE_TAG=${{ steps.determine-test-image-tag.outputs.IMAGE_TAG }}
+          BRANCH=${{ steps.determine-test-branch.outputs.BRANCH }}
+          if [ -n "${BRANCH}" ]; then
+            echo "BRANCH: [${BRANCH}](https://github.com/${{ github.repository }}/tree/${BRANCH})" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "IMAGE_TAG: [${IMAGE_TAG}](https://github.com/${{ github.repository }}/commit/${IMAGE_TAG})" >> $GITHUB_STEP_SUMMARY
+
+
+  ### Public fullnode tests
+
+  # Measures max PFN throughput and latencies under load
+  run-forge-pfn-performance:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-pfn-performance-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
+      FORGE_TEST_SUITE: pfn_performance
+      POST_TO_SLACK: true
+
+  # Measures PFN latencies with a constant TPS
+  run-forge-pfn-const-tps:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-pfn-const-tps-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
+      FORGE_TEST_SUITE: pfn_const_tps
+      POST_TO_SLACK: true

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -15,6 +15,7 @@ pub mod network_loss_test;
 pub mod network_partition_test;
 pub mod partial_nodes_down_test;
 pub mod performance_test;
+pub mod public_fullnode_performance;
 pub mod quorum_store_onchain_enable_test;
 pub mod reconfiguration_test;
 pub mod state_sync_performance;
@@ -138,6 +139,7 @@ pub trait NetworkLoadTest: Test {
     fn setup(&self, _ctx: &mut NetworkContext) -> Result<LoadDestination> {
         Ok(LoadDestination::FullnodesOtherwiseValidators)
     }
+
     // Load is started before this function is called, and stops after this function returns.
     // Expected duration is passed into this function, expecting this function to take that much
     // time to finish. How long this function takes will dictate how long the actual test lasts.

--- a/testsuite/testcases/src/public_fullnode_performance.rs
+++ b/testsuite/testcases/src/public_fullnode_performance.rs
@@ -1,0 +1,77 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{LoadDestination, NetworkLoadTest};
+use anyhow::Error;
+use aptos_forge::{NetworkContext, NetworkTest, Result, Test};
+use aptos_logger::info;
+use aptos_sdk::move_types::account_address::AccountAddress;
+use aptos_types::PeerId;
+use tokio::runtime::Runtime;
+
+/// A simple test that adds multiple public fullnodes (PFNs)
+/// to the swarm and submits transactions through them.
+pub struct PFNPerformance;
+
+impl Test for PFNPerformance {
+    fn name(&self) -> &'static str {
+        "PFNPerformance"
+    }
+}
+
+impl NetworkTest for PFNPerformance {
+    fn run(&self, ctx: &mut NetworkContext<'_>) -> Result<()> {
+        <dyn NetworkLoadTest>::run(self, ctx)
+    }
+}
+
+impl NetworkLoadTest for PFNPerformance {
+    /// We must override the setup function to: (i) create PFNs in
+    /// the swarm; and (ii) use those PFNs as the load destination.
+    fn setup(&self, ctx: &mut NetworkContext) -> Result<LoadDestination> {
+        // Add the PFNs to the swarm
+        let num_pfns = 10;
+        let pfn_peer_ids = create_and_add_pfns(ctx, num_pfns)?;
+
+        // Use the PFNs as the load destination
+        Ok(LoadDestination::Peers(pfn_peer_ids))
+    }
+}
+
+/// Adds a number of PFNs to the network and returns the peer IDs
+fn create_and_add_pfns(ctx: &mut NetworkContext, num_pfns: u64) -> Result<Vec<PeerId>, Error> {
+    info!("Creating {} public fullnodes!", num_pfns);
+
+    // Identify the version for the PFNs
+    let swarm = ctx.swarm();
+    let pfn_version = swarm.versions().max().unwrap();
+
+    // Create the PFN swarm
+    let runtime = Runtime::new().unwrap();
+    let pfn_peer_ids: Vec<AccountAddress> = (0..num_pfns)
+        .map(|_| {
+            // Create a config for the PFN. Note: this needs to be done here
+            // because the config will generate a unique peer ID for the PFN.
+            let pfn_config = swarm.get_default_pfn_node_config();
+
+            // Add the PFN to the swarm
+            let peer_id = runtime
+                .block_on(swarm.add_full_node(&pfn_version, pfn_config))
+                .unwrap();
+
+            // Verify the PFN was added
+            if swarm.full_node(peer_id).is_none() {
+                panic!(
+                    "Failed to locate the PFN in the swarm! Peer ID: {:?}",
+                    peer_id
+                );
+            }
+
+            // Return the peer ID
+            info!("Created new PFN with peer ID: {:?}", peer_id);
+            peer_id
+        })
+        .collect();
+
+    Ok(pfn_peer_ids)
+}


### PR DESCRIPTION
### Description

This PR adds support for two basic PFN enabled forge tests: (i) a max load test (to measure throughput and latency under load); and (ii) a const TPS test (to measure latency when the system is not saturated).

The PR also adds a new workflow for specialized forge tests (i.e., tests that don't need to run daily, like the stable and unstable forge tests). This is currently set to run every other day, but I might reduce it to bi-weekly in the future.

Note: I also plan to migrate a number of other forge tests to the new workflow to help reduce job frequencies 😄 

### Test Plan
Manual verification using the `exp` script.