### PR TITLE
[TS SDK] use `0x1::aptos_account::transfer` in tests

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 
 ## Unreleased
 
+- export `bcsSerializeU256` from `bcs/helper.ts`
+- Add `examples` folder to `.npmignore`
+- use `0x1::aptos_account::transfer` in tests
+
 ## 1.10.0 (2023-06-07)
 
 - Add `x-aptos-client` header to `IndexerClient` requests

--- a/ecosystem/typescript/sdk/examples/javascript/index.js
+++ b/ecosystem/typescript/sdk/examples/javascript/index.js
@@ -44,7 +44,9 @@ const aptosCoin = "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>";
   const indexerLedgerInfo = await provider.getIndexerLedgerInfo();
   const fullNodeChainId = await provider.getChainId();
 
-  console.log(`\n fullnode chain id is: ${fullNodeChainId}, indexer chain id is: ${indexerLedgerInfo}`);
+  console.log(
+    `\n fullnode chain id is: ${fullNodeChainId}, indexer chain id is: ${indexerLedgerInfo.ledger_infos[0].chain_id}`,
+  );
   if (indexerLedgerInfo.ledger_infos[0].chain_id !== fullNodeChainId) {
     console.log(`\n fullnode chain id and indexer chain id are not synced, skipping rest of tests`);
     return;

--- a/ecosystem/typescript/sdk/examples/typescript-esm/index.ts
+++ b/ecosystem/typescript/sdk/examples/typescript-esm/index.ts
@@ -35,26 +35,17 @@ const {
   console.log(`account1 coins: ${balance}. Should be 100_000_000!`);
 
   const account2 = new AptosAccount();
-  // Creates the second account and fund the account with 0 AptosCoin
-  await faucetClient.fundAccount(account2.address(), 0);
-  resources = await client.getAccountResources(account2.address());
-  accountResource = resources.find((r: any) => r.type === aptosCoinStore);
-  balance = parseInt((accountResource?.data as any).coin.value);
-  assert(balance === 0);
-  console.log(`account2 coins: ${balance}. Should be 0!`);
-
-  const token = new TypeTagStruct(StructTag.fromString("0x1::aptos_coin::AptosCoin"));
 
   // TS SDK support 3 types of transaction payloads: `EntryFunction`, `Script` and `Module`.
   // See https://aptos-labs.github.io/ts-sdk-doc/ for the details.
   const entryFunctionPayload = new TransactionPayloadEntryFunction(
     EntryFunction.natural(
       // Fully qualified module name, `AccountAddress::ModuleName`
-      "0x1::coin",
+      "0x1::aptos_account",
       // Module function
       "transfer",
       // The coin type to transfer
-      [token],
+      [],
       // Arguments for function `transfer`: receiver account address and amount to transfer
       [BCS.bcsToBytes(AccountAddress.fromHex(account2.address())), BCS.bcsSerializeUint64(717)],
     ),
@@ -99,7 +90,9 @@ const {
   const indexerLedgerInfo = await provider.getIndexerLedgerInfo();
   const fullNodeChainId = await provider.getChainId();
 
-  console.log(`\n fullnode chain id is: ${fullNodeChainId}, indexer chain id is: ${indexerLedgerInfo}`);
+  console.log(
+    `\n fullnode chain id is: ${fullNodeChainId}, indexer chain id is: ${indexerLedgerInfo.ledger_infos[0].chain_id}`,
+  );
   if (indexerLedgerInfo.ledger_infos[0].chain_id !== fullNodeChainId) {
     console.log(`\n fullnode chain id and indexer chain id are not synced, skipping rest of tests`);
     return;

--- a/ecosystem/typescript/sdk/examples/typescript/multisig_transaction.ts
+++ b/ecosystem/typescript/sdk/examples/typescript/multisig_transaction.ts
@@ -51,26 +51,17 @@ const FAUCET_URL = process.env.APTOS_FAUCET_URL || "https://faucet.devnet.aptosl
   console.log(`multisig account coins: ${balance}. Should be 100000000!`);
 
   const account4 = new AptosAccount();
-  // Creates a receiver account and fund the account with 0 AptosCoin
-  await faucetClient.fundAccount(account4.address(), 0);
-  resources = await client.getAccountResources(account4.address());
-  accountResource = resources.find((r) => r.type === aptosCoinStore);
-  balance = parseInt((accountResource?.data as any).coin.value);
-  assert(balance === 0);
-  console.log(`account4 coins: ${balance}. Should be 0!`);
-
-  const token = new TxnBuilderTypes.TypeTagStruct(TxnBuilderTypes.StructTag.fromString("0x1::aptos_coin::AptosCoin"));
 
   // TS SDK support 3 types of transaction payloads: `EntryFunction`, `Script` and `Module`.
   // See https://aptos-labs.github.io/ts-sdk-doc/ for the details.
   const entryFunctionPayload = new TxnBuilderTypes.TransactionPayloadEntryFunction(
     TxnBuilderTypes.EntryFunction.natural(
       // Fully qualified module name, `AccountAddress::ModuleName`
-      "0x1::coin",
+      "0x1::aptos_account",
       // Module function
       "transfer",
       // The coin type to transfer
-      [token],
+      [],
       // Arguments for function `transfer`: receiver account address and amount to transfer
       [BCS.bcsToBytes(TxnBuilderTypes.AccountAddress.fromHex(account4.address())), BCS.bcsSerializeUint64(123)],
     ),

--- a/ecosystem/typescript/sdk/src/aptos_types/transaction.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/transaction.ts
@@ -295,7 +295,7 @@ export class ModuleId {
   /**
    * Converts a string literal to a ModuleId
    * @param moduleId String literal in format "AccountAddress::module_name",
-   *   e.g. "0x1::coin"
+   *   e.g. "0x1::aptos_coin"
    * @returns
    */
   static fromStr(moduleId: string): ModuleId {

--- a/ecosystem/typescript/sdk/src/aptos_types/transaction.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/transaction.ts
@@ -294,8 +294,7 @@ export class ModuleId {
 
   /**
    * Converts a string literal to a ModuleId
-   * @param moduleId String literal in format "AccountAddress::module_name",
-   *   e.g. "0x1::aptos_coin"
+   * @param moduleId String literal in format "AccountAddress::module_name", e.g. "0x1::coin"
    * @returns
    */
   static fromStr(moduleId: string): ModuleId {

--- a/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
@@ -22,7 +22,7 @@ const account = "0x1::account::Account";
 
 const aptosCoin = "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>";
 
-const coinTransferFunction = "0x1::coin::transfer";
+const coinTransferFunction = "0x1::aptos_account::transfer";
 
 test("call should include x-aptos-client header", async () => {
   const client = new AptosClient(NODE_URL, { HEADERS: { my: "header" } });
@@ -97,18 +97,12 @@ test(
     expect((accountResource!.data as any).coin.value).toBe("100000000");
 
     const account2 = new AptosAccount();
-    await faucetClient.fundAccount(account2.address(), 0);
-    resources = await client.getAccountResources(account2.address());
-    accountResource = resources.find((r) => r.type === aptosCoin);
-    expect((accountResource!.data as any).coin.value).toBe("0");
-
-    const token = new TxnBuilderTypes.TypeTagStruct(TxnBuilderTypes.StructTag.fromString("0x1::aptos_coin::AptosCoin"));
 
     const entryFunctionPayload = new TxnBuilderTypes.TransactionPayloadEntryFunction(
       TxnBuilderTypes.EntryFunction.natural(
-        "0x1::coin",
+        "0x1::aptos_account",
         "transfer",
-        [token],
+        [],
         [bcsToBytes(TxnBuilderTypes.AccountAddress.fromHex(account2.address())), bcsSerializeUint64(717)],
       ),
     );
@@ -190,31 +184,23 @@ test(
     const client = new AptosClient(NODE_URL);
     const faucetClient = getFaucetClient();
 
-    const account1 = new AptosAccount();
-    await faucetClient.fundAccount(account1.address(), 100_000_000);
-    let resources = await client.getAccountResources(account1.address());
+    const sender = new AptosAccount();
+    await faucetClient.fundAccount(sender.address(), 100_000_000);
+    let resources = await client.getAccountResources(sender.address());
     let accountResource = resources.find((r) => r.type === aptosCoin);
     expect((accountResource!.data as any).coin.value).toBe("100000000");
 
-    const account2 = new AptosAccount();
-    await faucetClient.fundAccount(account2.address(), 0);
-    resources = await client.getAccountResources(account2.address());
-    accountResource = resources.find((r) => r.type === aptosCoin);
-    expect((accountResource!.data as any).coin.value).toBe("0");
+    const receiver = new AptosAccount();
 
-    const builder = new TransactionBuilderRemoteABI(client, { sender: account1.address() });
-    const rawTxn = await builder.build(
-      "0x1::coin::transfer",
-      ["0x1::aptos_coin::AptosCoin"],
-      [account2.address(), 400],
-    );
+    const builder = new TransactionBuilderRemoteABI(client, { sender: sender.address() });
+    const rawTxn = await builder.build("0x1::aptos_account::transfer", [], [receiver.address(), 400]);
 
-    const bcsTxn = AptosClient.generateBCSTransaction(account1, rawTxn);
+    const bcsTxn = AptosClient.generateBCSTransaction(sender, rawTxn);
     const transactionRes = await client.submitSignedBCSTransaction(bcsTxn);
 
     await client.waitForTransaction(transactionRes.hash);
 
-    resources = await client.getAccountResources(account2.address());
+    resources = await client.getAccountResources(receiver.address());
     accountResource = resources.find((r) => r.type === aptosCoin);
     expect((accountResource!.data as any).coin.value).toBe("400");
   },
@@ -249,18 +235,12 @@ test(
     expect((accountResource!.data as any).coin.value).toBe("50000000");
 
     const account4 = new AptosAccount();
-    await faucetClient.fundAccount(account4.address(), 0);
-    resources = await client.getAccountResources(account4.address());
-    accountResource = resources.find((r) => r.type === aptosCoin);
-    expect((accountResource!.data as any).coin.value).toBe("0");
-
-    const token = new TxnBuilderTypes.TypeTagStruct(TxnBuilderTypes.StructTag.fromString("0x1::aptos_coin::AptosCoin"));
 
     const entryFunctionPayload = new TxnBuilderTypes.TransactionPayloadEntryFunction(
       TxnBuilderTypes.EntryFunction.natural(
-        "0x1::coin",
+        "0x1::aptos_account",
         "transfer",
-        [token],
+        [],
         [bcsToBytes(TxnBuilderTypes.AccountAddress.fromHex(account4.address())), bcsSerializeUint64(123)],
       ),
     );
@@ -314,25 +294,19 @@ test(
     const account1 = new AptosAccount();
     const account2 = new AptosAccount();
     const txns1 = await faucetClient.fundAccount(account1.address(), 1000000);
-    const txns2 = await faucetClient.fundAccount(account2.address(), 1000000);
     const tx1 = await client.getTransactionByHash(txns1[0]);
-    const tx2 = await client.getTransactionByHash(txns2[0]);
     expect(tx1.type).toBe("user_transaction");
-    expect(tx2.type).toBe("user_transaction");
     const checkAptosCoin = async () => {
       const resources1 = await client.getAccountResources(account1.address());
-      const resources2 = await client.getAccountResources(account2.address());
       const account1Resource = resources1.find((r) => r.type === aptosCoin);
-      const account2Resource = resources2.find((r) => r.type === aptosCoin);
       expect((account1Resource!.data as { coin: { value: string } }).coin.value).toBe("1000000");
-      expect((account2Resource!.data as { coin: { value: string } }).coin.value).toBe("1000000");
     };
     await checkAptosCoin();
 
     const payload: Gen.TransactionPayload = {
       type: "entry_function_payload",
-      function: coinTransferFunction,
-      type_arguments: ["0x1::aptos_coin::AptosCoin"],
+      function: "0x1::aptos_account::transfer",
+      type_arguments: [],
       arguments: [account2.address().hex(), 100000],
     };
     const txnRequest = await client.generateTransaction(account1.address(), payload);
@@ -355,7 +329,7 @@ test(
         return (
           write.address === account2.address().hex() &&
           write.data.type === aptosCoin &&
-          (write.data.data as { coin: { value: string } }).coin.value === "1100000"
+          (write.data.data as { coin: { value: string } }).coin.value === "100000"
         );
       });
       expect(account2AptosCoin).toHaveLength(1);
@@ -371,53 +345,46 @@ test(
     const client = new AptosClient(NODE_URL);
     const faucetClient = getFaucetClient();
 
-    const account1 = new AptosAccount();
-    const account2 = new AptosAccount();
-    const txns1 = await faucetClient.fundAccount(account1.address(), 100_000_000);
-    const txns2 = await faucetClient.fundAccount(account2.address(), 100_000_000);
+    const sender = new AptosAccount();
+    const receiver = new AptosAccount();
+    const txns1 = await faucetClient.fundAccount(sender.address(), 100_000_000);
     const tx1 = await client.getTransactionByHash(txns1[0]);
-    const tx2 = await client.getTransactionByHash(txns2[0]);
     expect(tx1.type).toBe("user_transaction");
-    expect(tx2.type).toBe("user_transaction");
     const checkAptosCoin = async () => {
-      const resources1 = await client.getAccountResources(account1.address());
-      const resources2 = await client.getAccountResources(account2.address());
-      const account1Resource = resources1.find((r) => r.type === aptosCoin);
-      const account2Resource = resources2.find((r) => r.type === aptosCoin);
-      expect((account1Resource!.data as { coin: { value: string } }).coin.value).toBe("100000000");
-      expect((account2Resource!.data as { coin: { value: string } }).coin.value).toBe("100000000");
+      const resources1 = await client.getAccountResources(sender.address());
+      const senderResource = resources1.find((r) => r.type === aptosCoin);
+      expect((senderResource!.data as { coin: { value: string } }).coin.value).toBe("100000000");
     };
     await checkAptosCoin();
 
-    const token = new TxnBuilderTypes.TypeTagStruct(TxnBuilderTypes.StructTag.fromString("0x1::aptos_coin::AptosCoin"));
     const entryFunctionPayload = new TxnBuilderTypes.TransactionPayloadEntryFunction(
       TxnBuilderTypes.EntryFunction.natural(
-        "0x1::coin",
+        "0x1::aptos_account",
         "transfer",
-        [token],
-        [bcsToBytes(TxnBuilderTypes.AccountAddress.fromHex(account2.address())), bcsSerializeUint64(1000)],
+        [],
+        [bcsToBytes(TxnBuilderTypes.AccountAddress.fromHex(receiver.address())), bcsSerializeUint64(1000)],
       ),
     );
 
-    const rawTxn = await client.generateRawTransaction(account1.address(), entryFunctionPayload);
+    const rawTxn = await client.generateRawTransaction(sender.address(), entryFunctionPayload);
 
-    const bcsTxn = AptosClient.generateBCSSimulation(account1, rawTxn);
+    const bcsTxn = AptosClient.generateBCSSimulation(sender, rawTxn);
     const transactionRes = (await client.submitBCSSimulation(bcsTxn))[0];
     expect(parseInt(transactionRes.gas_used, 10) > 0);
     expect(transactionRes.success);
-    const account2AptosCoin = transactionRes.changes.filter((change) => {
+    const receiverAptosCoin = transactionRes.changes.filter((change) => {
       if (change.type !== "write_resource") {
         return false;
       }
       const write = change as Gen.WriteResource;
 
       return (
-        write.address === account2.address().toShortString() &&
+        write.address === receiver.address().toShortString() &&
         write.data.type === aptosCoin &&
-        (write.data.data as { coin: { value: string } }).coin.value === "100001000"
+        (write.data.data as { coin: { value: string } }).coin.value === "1000"
       );
     });
-    expect(account2AptosCoin).toHaveLength(1);
+    expect(receiverAptosCoin).toHaveLength(1);
     await checkAptosCoin();
   },
   longTestTimeout,

--- a/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
@@ -22,8 +22,6 @@ const account = "0x1::account::Account";
 
 const aptosCoin = "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>";
 
-const coinTransferFunction = "0x1::aptos_account::transfer";
-
 test("call should include x-aptos-client header", async () => {
   const client = new AptosClient(NODE_URL, { HEADERS: { my: "header" } });
   const heders = client.client.request.config.HEADERS;

--- a/ecosystem/typescript/sdk/src/tests/e2e/faucet_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/faucet_client.test.ts
@@ -33,15 +33,11 @@ test(
     expect((accountResource!.data as { coin: { value: string } }).coin.value).toBe("10000000");
 
     const account2 = new AptosAccount();
-    await faucetClient.fundAccount(account2.address(), 0);
-    resources = await client.getAccountResources(account2.address());
-    accountResource = resources.find((r) => r.type === aptosCoin);
-    expect((accountResource!.data as { coin: { value: string } }).coin.value).toBe("0");
 
     const payload: Gen.TransactionPayload_EntryFunctionPayload = {
       type: "entry_function_payload",
-      function: "0x1::coin::transfer",
-      type_arguments: ["0x1::aptos_coin::AptosCoin"],
+      function: "0x1::aptos_account::transfer",
+      type_arguments: [],
       arguments: [account2.address().hex(), 717],
     };
 

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -367,7 +367,8 @@ export class TransactionBuilderRemoteABI {
   /**
    * Builds a raw transaction. Only support script function a.k.a entry function payloads
    *
-   * @param func fully qualified function name in format <address>::<module>::<function>, e.g. 0x1::aptos_account::transfer
+   * @param func fully qualified function name in format <address>::<module>::<function>,
+   * e.g. 0x1::aptos_account::transfer
    * @param ty_tags
    * @param args
    * @returns RawTransaction

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -367,8 +367,7 @@ export class TransactionBuilderRemoteABI {
   /**
    * Builds a raw transaction. Only support script function a.k.a entry function payloads
    *
-   * @param func fully qualified function name in format <address>::<module>::<function>,
-   * e.g. 0x1::aptos_account::transfer
+   * @param func fully qualified function name in format <address>::<module>::<function>, e.g. 0x1::coin::transfer
    * @param ty_tags
    * @param args
    * @returns RawTransaction
@@ -381,7 +380,7 @@ export class TransactionBuilderRemoteABI {
     if (funcNameParts.length !== 3) {
       throw new Error(
         // eslint-disable-next-line max-len
-        "'func' needs to be a fully qualified function name in format <address>::<module>::<function>, e.g. 0x1::aptos_account::transfer",
+        "'func' needs to be a fully qualified function name in format <address>::<module>::<function>, e.g. 0x1::coin::transfer",
       );
     }
 

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -232,7 +232,7 @@ export class TransactionBuilderABI {
    * Builds a TransactionPayload. For dApps, chain ID and account sequence numbers are only known to the wallet.
    * Instead of building a RawTransaction (requires chainID and sequenceNumber), dApps can build a TransactionPayload
    * and pass the payload to the wallet for signing and sending.
-   * @param func Fully qualified func names, e.g. 0x1::Coin::transfer
+   * @param func Fully qualified func names, e.g. 0x1::aptos_account::transfer
    * @param ty_tags TypeTag strings
    * @param args Function arguments
    * @returns TransactionPayload
@@ -269,7 +269,7 @@ export class TransactionBuilderABI {
 
   /**
    * Builds a RawTransaction
-   * @param func Fully qualified func names, e.g. 0x1::Coin::transfer
+   * @param func Fully qualified func names, e.g. 0x1::aptos_account::transfer
    * @param ty_tags TypeTag strings.
    * @example Below are valid value examples
    * ```
@@ -367,7 +367,7 @@ export class TransactionBuilderRemoteABI {
   /**
    * Builds a raw transaction. Only support script function a.k.a entry function payloads
    *
-   * @param func fully qualified function name in format <address>::<module>::<function>, e.g. 0x1::coins::transfer
+   * @param func fully qualified function name in format <address>::<module>::<function>, e.g. 0x1::aptos_account::transfer
    * @param ty_tags
    * @param args
    * @returns RawTransaction
@@ -380,7 +380,7 @@ export class TransactionBuilderRemoteABI {
     if (funcNameParts.length !== 3) {
       throw new Error(
         // eslint-disable-next-line max-len
-        "'func' needs to be a fully qualified function name in format <address>::<module>::<function>, e.g. 0x1::coins::transfer",
+        "'func' needs to be a fully qualified function name in format <address>::<module>::<function>, e.g. 0x1::aptos_account::transfer",
       );
     }
 


### PR DESCRIPTION
### Description
use `0x1::aptos_account::transfer` instead of `0x1::coin::transfer` and update tests.
### Test Plan
tests are passing
