### PR TITLE
[move] rename file extension from .yaml to .move

### DIFF
--- a/crates/aptos/src/move_tool/disassembler.rs
+++ b/crates/aptos/src/move_tool/disassembler.rs
@@ -23,7 +23,7 @@ use move_disassembler::disassembler::{Disassembler, DisassemblerOptions};
 use move_ir_types::location::Spanned;
 use std::{fs, path::PathBuf};
 
-const DISASSEMBLED_CODE_FILE: &str = "disassembled-code.yaml";
+const DISASSEMBLED_CODE_FILE: &str = "disassembled-code.move";
 
 /// Disassemble the Move bytecode pointed to
 ///


### PR DESCRIPTION
### Description
We should use the `.move` extension for disassembled code instead of `.yaml`
