### PR TITLE
[cli] Add dev address mode for compiler

### DIFF
--- a/aptos-move/framework/src/aptos.rs
+++ b/aptos-move/framework/src/aptos.rs
@@ -99,6 +99,7 @@ impl ReleaseTarget {
             .collect::<Vec<_>>();
         ReleaseOptions {
             build_options: BuildOptions {
+                dev: false,
                 with_srcs,
                 with_abis: true,
                 with_source_maps: false,

--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -39,6 +39,9 @@ pub const UPGRADE_POLICY_CUSTOM_FIELD: &str = "upgrade_policy";
 /// Represents a set of options for building artifacts from Move.
 #[derive(Debug, Clone, Parser, Serialize, Deserialize)]
 pub struct BuildOptions {
+    /// Dev mode to use [dev-addresses]
+    #[clap(long)]
+    pub dev: bool,
     #[clap(long)]
     pub with_srcs: bool,
     #[clap(long)]
@@ -67,6 +70,7 @@ pub struct BuildOptions {
 impl Default for BuildOptions {
     fn default() -> Self {
         Self {
+            dev: false,
             with_srcs: false,
             with_abis: false,
             with_source_maps: false,
@@ -92,13 +96,14 @@ pub struct BuiltPackage {
 }
 
 pub fn build_model(
+    dev_mode: bool,
     package_path: &Path,
     additional_named_addresses: BTreeMap<String, AccountAddress>,
     target_filter: Option<String>,
     bytecode_version: Option<u32>,
 ) -> anyhow::Result<GlobalEnv> {
     let build_config = BuildConfig {
-        dev_mode: false,
+        dev_mode,
         additional_named_addresses,
         architecture: None,
         generate_abis: false,
@@ -124,7 +129,7 @@ impl BuiltPackage {
     pub fn build(package_path: PathBuf, options: BuildOptions) -> anyhow::Result<Self> {
         let bytecode_version = options.bytecode_version;
         let build_config = BuildConfig {
-            dev_mode: false,
+            dev_mode: options.dev,
             additional_named_addresses: options.named_addresses.clone(),
             architecture: None,
             generate_abis: options.with_abis,
@@ -142,6 +147,7 @@ impl BuiltPackage {
         // Build the Move model for extra processing and run extended checks as well derive
         // runtime metadata
         let model = &build_model(
+            options.dev,
             package_path.as_path(),
             options.named_addresses.clone(),
             None,

--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -39,7 +39,12 @@ pub const UPGRADE_POLICY_CUSTOM_FIELD: &str = "upgrade_policy";
 /// Represents a set of options for building artifacts from Move.
 #[derive(Debug, Clone, Parser, Serialize, Deserialize)]
 pub struct BuildOptions {
-    /// Dev mode to use [dev-addresses]
+    /// Enables dev mode, which uses all dev-addresses and dev-dependencies
+    ///
+    /// Dev mode allows for changing dependencies and addresses to the preset [dev-addresses] and
+    /// [dev-dependencies] fields.  This works both inside and out of tests for using preset values.
+    ///
+    /// Currently, it also additionally pulls in all test compilation artifacts
     #[clap(long)]
     pub dev: bool,
     #[clap(long)]

--- a/aptos-move/framework/src/prover.rs
+++ b/aptos-move/framework/src/prover.rs
@@ -98,6 +98,7 @@ impl ProverOptions {
     /// Runs the move prover on the package.
     pub fn prove(
         self,
+        dev_mode: bool,
         package_path: &Path,
         named_addresses: BTreeMap<String, AccountAddress>,
         bytecode_version: Option<u32>,
@@ -105,6 +106,7 @@ impl ProverOptions {
         let now = Instant::now();
         let for_test = self.for_test;
         let model = build_model(
+            dev_mode,
             package_path,
             named_addresses,
             self.filter.clone(),

--- a/aptos-move/framework/tests/move_prover_tests.rs
+++ b/aptos-move/framework/tests/move_prover_tests.rs
@@ -36,7 +36,7 @@ pub fn run_prover_for_pkg(path_to_pkg: impl Into<String>) {
         );
     } else {
         options
-            .prove(pkg_path.as_path(), BTreeMap::default(), None)
+            .prove(false, pkg_path.as_path(), BTreeMap::default(), None)
             .unwrap()
     }
 }

--- a/aptos-move/move-examples/cli-e2e-tests/devnet/Move.toml
+++ b/aptos-move/move-examples/cli-e2e-tests/devnet/Move.toml
@@ -5,6 +5,9 @@ version = "0.0.1"
 [addresses]
 addr = "_"
 
+[dev-addresses]
+addr = "0x12345"
+
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"
 rev = "devnet"

--- a/aptos-move/move-examples/cli-e2e-tests/mainnet/Move.toml
+++ b/aptos-move/move-examples/cli-e2e-tests/mainnet/Move.toml
@@ -5,6 +5,9 @@ version = "0.0.1"
 [addresses]
 addr = "_"
 
+[dev-addresses]
+addr = "0x12345"
+
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"
 rev = "mainnet"

--- a/aptos-move/move-examples/cli-e2e-tests/testnet/Move.toml
+++ b/aptos-move/move-examples/cli-e2e-tests/testnet/Move.toml
@@ -5,6 +5,9 @@ version = "0.0.1"
 [addresses]
 addr = "_"
 
+[dev-addresses]
+addr = "0x12345"
+
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"
 rev = "testnet"

--- a/crates/aptos/e2e/cases/move.py
+++ b/crates/aptos/e2e/cases/move.py
@@ -83,6 +83,26 @@ def test_move_compile(run_helper: RunHelper, test_name=None):
     if f"{account_info.account_address}::cli_e2e_tests" not in response.stdout:
         raise TestError("Module did not compile successfully")
 
+@test_case
+def test_move_compile_dev_mode(run_helper: RunHelper, test_name=None):
+    package_dir = f"move/cli-e2e-tests/{run_helper.base_network}"
+    account_info = run_helper.get_account_info()
+
+    # Compile the module.  Should not need an address passed in
+    response = run_helper.run_command(
+        test_name,
+        [
+            "aptos",
+            "move",
+            "compile",
+            "--dev",
+            "--package-dir",
+            package_dir,
+        ],
+    )
+
+    if f"{account_info.account_address}::cli_e2e_tests" not in response.stdout:
+        raise TestError("Module did not compile successfully")
 
 @test_case
 def test_move_compile_script(run_helper: RunHelper, test_name=None):

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -952,7 +952,12 @@ impl RestOptions {
 /// Options for compiling a move package dir
 #[derive(Debug, Clone, Parser)]
 pub struct MovePackageDir {
-    /// Dev mode, uses [dev-addresses] rather than [addresses] for compilation
+    /// Enables dev mode, which uses all dev-addresses and dev-dependencies
+    ///
+    /// Dev mode allows for changing dependencies and addresses to the preset [dev-addresses] and
+    /// [dev-dependencies] fields.  This works both inside and out of tests for using preset values.
+    ///
+    /// Currently, it also additionally pulls in all test compilation artifacts
     #[clap(long)]
     pub dev: bool,
     /// Path to a move package (the folder with a Move.toml file)

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -952,6 +952,9 @@ impl RestOptions {
 /// Options for compiling a move package dir
 #[derive(Debug, Clone, Parser)]
 pub struct MovePackageDir {
+    /// Dev mode, uses [dev-addresses] rather than [addresses] for compilation
+    #[clap(long)]
+    pub dev: bool,
     /// Path to a move package (the folder with a Move.toml file)
     #[clap(long, value_parser)]
     pub package_dir: Option<PathBuf>,
@@ -984,6 +987,7 @@ pub struct MovePackageDir {
 impl MovePackageDir {
     pub fn new(package_dir: PathBuf) -> Self {
         Self {
+            dev: false,
             package_dir: Some(package_dir),
             output_dir: None,
             named_addresses: Default::default(),

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -837,6 +837,7 @@ impl CliCommand<()> for GenerateUpgradeProposal {
         } = self;
         let package_path = move_options.get_package_path()?;
         let options = included_artifacts.build_options(
+            move_options.dev,
             move_options.skip_fetch_latest_git_deps,
             move_options.named_addresses(),
             move_options.bytecode_version,

--- a/crates/aptos/src/move_tool/coverage.rs
+++ b/crates/aptos/src/move_tool/coverage.rs
@@ -145,6 +145,7 @@ fn compile_coverage(
     move_options: MovePackageDir,
 ) -> CliTypedResult<(CoverageMap, CompiledPackage)> {
     let config = BuildConfig {
+        dev_mode: move_options.dev,
         additional_named_addresses: move_options.named_addresses(),
         test_mode: false,
         install_dir: move_options.output_dir.clone(),

--- a/crates/aptos/src/move_tool/manifest.rs
+++ b/crates/aptos/src/move_tool/manifest.rs
@@ -13,12 +13,13 @@ use std::collections::BTreeMap;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MovePackageManifest {
     pub package: PackageInfo,
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub addresses: BTreeMap<String, ManifestNamedAddress>,
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(rename = "dev-addresses")]
+    pub dev_addresses: BTreeMap<String, ManifestNamedAddress>,
     pub dependencies: BTreeMap<String, Dependency>,
+    #[serde(rename = "dev-dependencies")]
+    pub dev_dependencies: BTreeMap<String, Dependency>,
 }
-
 /// Representation of an option address so we can print it as "_"
 #[derive(Debug, Clone)]
 pub struct ManifestNamedAddress {
@@ -85,6 +86,7 @@ pub struct Dependency {
 pub struct PackageInfo {
     pub name: String,
     pub version: String,
+    pub authors: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub author: Option<String>,
+    pub license: Option<String>,
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -165,13 +165,23 @@ impl FrameworkPackageArgs {
         const APTOS_FRAMEWORK: &str = "AptosFramework";
         const APTOS_GIT_PATH: &str = "https://github.com/aptos-labs/aptos-core.git";
         const SUBDIR_PATH: &str = "aptos-move/framework/aptos-framework";
-        const DEFAULT_BRANCH: &str = "main";
+        const DEFAULT_BRANCH: &str = "mainnet";
 
         let move_toml = package_dir.join(SourcePackageLayout::Manifest.path());
         check_if_file_exists(move_toml.as_path(), prompt_options)?;
         create_dir_if_not_exist(
             package_dir
                 .join(SourcePackageLayout::Sources.path())
+                .as_path(),
+        )?;
+        create_dir_if_not_exist(
+            package_dir
+                .join(SourcePackageLayout::Tests.path())
+                .as_path(),
+        )?;
+        create_dir_if_not_exist(
+            package_dir
+                .join(SourcePackageLayout::Scripts.path())
                 .as_path(),
         )?;
 
@@ -202,10 +212,13 @@ impl FrameworkPackageArgs {
             package: PackageInfo {
                 name: name.to_string(),
                 version: "1.0.0".to_string(),
-                author: None,
+                license: None,
+                authors: vec![],
             },
             addresses,
             dependencies,
+            dev_addresses: Default::default(),
+            dev_dependencies: Default::default(),
         };
 
         write_to_file(
@@ -316,6 +329,7 @@ impl CliCommand<Vec<String>> for CompilePackage {
             .modules()
             .map(|m| m.self_id().to_string())
             .collect::<Vec<_>>();
+        // TODO: Also say how many scripts are compiled
         Ok(ids)
     }
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -301,6 +301,7 @@ impl CliCommand<Vec<String>> for CompilePackage {
                 .included_artifacts_args
                 .included_artifacts
                 .build_options(
+                    self.move_options.dev,
                     self.move_options.skip_fetch_latest_git_deps,
                     self.move_options.named_addresses(),
                     self.move_options.bytecode_version,
@@ -358,6 +359,7 @@ impl CompileScript {
         let build_options = BuildOptions {
             install_dir: self.move_options.output_dir.clone(),
             ..IncludedArtifacts::None.build_options(
+                self.move_options.dev,
                 self.move_options.skip_fetch_latest_git_deps,
                 self.move_options.named_addresses(),
                 self.move_options.bytecode_version,
@@ -434,6 +436,7 @@ impl CliCommand<&'static str> for TestPackage {
 
     async fn execute(self) -> CliTypedResult<&'static str> {
         let mut config = BuildConfig {
+            dev_mode: self.move_options.dev,
             additional_named_addresses: self.move_options.named_addresses(),
             test_mode: true,
             install_dir: self.move_options.output_dir.clone(),
@@ -443,6 +446,7 @@ impl CliCommand<&'static str> for TestPackage {
 
         // Build the Move model for extended checks
         let model = &build_model(
+            self.move_options.dev,
             self.move_options.get_package_path()?.as_path(),
             self.move_options.named_addresses(),
             None,
@@ -548,6 +552,7 @@ impl CliCommand<&'static str> for ProvePackage {
 
         let result = task::spawn_blocking(move || {
             prover_options.prove(
+                move_options.dev,
                 move_options.get_package_path()?.as_path(),
                 move_options.named_addresses(),
                 move_options.bytecode_version,
@@ -586,6 +591,7 @@ impl CliCommand<&'static str> for DocumentPackage {
             docgen_options,
         } = self;
         let build_options = BuildOptions {
+            dev: move_options.dev,
             with_srcs: false,
             with_abis: false,
             with_source_maps: false,
@@ -657,6 +663,7 @@ impl TryInto<PackagePublicationData> for &PublishPackage {
             .included_artifacts_args
             .included_artifacts
             .build_options(
+                self.move_options.dev,
                 self.move_options.skip_fetch_latest_git_deps,
                 self.move_options.named_addresses(),
                 self.move_options.bytecode_version,
@@ -723,6 +730,7 @@ impl FromStr for IncludedArtifacts {
 impl IncludedArtifacts {
     pub(crate) fn build_options(
         self,
+        dev: bool,
         skip_fetch_latest_git_deps: bool,
         named_addresses: BTreeMap<String, AccountAddress>,
         bytecode_version: Option<u32>,
@@ -730,6 +738,7 @@ impl IncludedArtifacts {
         use IncludedArtifacts::*;
         match self {
             None => BuildOptions {
+                dev,
                 with_srcs: false,
                 with_abis: false,
                 with_source_maps: false,
@@ -741,6 +750,7 @@ impl IncludedArtifacts {
                 ..BuildOptions::default()
             },
             Sparse => BuildOptions {
+                dev,
                 with_srcs: true,
                 with_abis: false,
                 with_source_maps: false,
@@ -751,6 +761,7 @@ impl IncludedArtifacts {
                 ..BuildOptions::default()
             },
             All => BuildOptions {
+                dev,
                 with_srcs: true,
                 with_abis: true,
                 with_source_maps: true,
@@ -895,6 +906,7 @@ impl CliCommand<TransactionSummary> for CreateResourceAccountAndPublishPackage {
 
         let package_path = move_options.get_package_path()?;
         let options = included_artifacts_args.included_artifacts.build_options(
+            move_options.dev,
             move_options.skip_fetch_latest_git_deps,
             move_options.named_addresses(),
             move_options.bytecode_version,
@@ -1025,6 +1037,7 @@ impl CliCommand<&'static str> for VerifyPackage {
             install_dir: self.move_options.output_dir.clone(),
             bytecode_version: self.move_options.bytecode_version,
             ..self.included_artifacts.build_options(
+                self.move_options.dev,
                 self.move_options.skip_fetch_latest_git_deps,
                 self.move_options.named_addresses(),
                 self.move_options.bytecode_version,

--- a/crates/aptos/src/move_tool/show.rs
+++ b/crates/aptos/src/move_tool/show.rs
@@ -60,6 +60,7 @@ impl CliCommand<Vec<EntryABI>> for ShowAbi {
                 .included_artifacts_args
                 .included_artifacts
                 .build_options(
+                    self.move_options.dev,
                     self.move_options.skip_fetch_latest_git_deps,
                     self.move_options.named_addresses(),
                     self.move_options.bytecode_version,

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -1036,6 +1036,7 @@ impl CliTestFramework {
 
     pub fn move_options(&self, account_strs: BTreeMap<&str, &str>) -> MovePackageDir {
         MovePackageDir {
+            dev: true,
             package_dir: Some(self.move_dir()),
             output_dir: None,
             named_addresses: Self::named_addresses(account_strs),

--- a/third_party/move/tools/move-cli/tests/build_tests/unbound_address/args.evm.exp
+++ b/third_party/move/tools/move-cli/tests/build_tests/unbound_address/args.evm.exp
@@ -5,4 +5,4 @@ Named address 'A' in package 'A'
 To fix this, add an entry for each unresolved address to the [addresses] section of ./Move.toml: e.g.,
 [addresses]
 Std = "0x1"
-Alternatively, you can also define [dev-addresses] and call with the -d flag
+Alternatively, you can also define [dev-addresses] and call with the --dev flag

--- a/third_party/move/tools/move-cli/tests/build_tests/unbound_address/args.exp
+++ b/third_party/move/tools/move-cli/tests/build_tests/unbound_address/args.exp
@@ -5,4 +5,4 @@ Named address 'A' in package 'A'
 To fix this, add an entry for each unresolved address to the [addresses] section of ./Move.toml: e.g.,
 [addresses]
 Std = "0x1"
-Alternatively, you can also define [dev-addresses] and call with the -d flag
+Alternatively, you can also define [dev-addresses] and call with the --dev flag

--- a/third_party/move/tools/move-package/src/resolution/resolution_graph.rs
+++ b/third_party/move/tools/move-package/src/resolution/resolution_graph.rs
@@ -180,7 +180,7 @@ impl ResolvingGraph {
                 "Unresolved addresses found: [\n{}\n]\n\
                 To fix this, add an entry for each unresolved address to the [addresses] section of {}/Move.toml: \
                 e.g.,\n[addresses]\nStd = \"0x1\"\n\
-                Alternatively, you can also define [dev-addresses] and call with the -d flag",
+                Alternatively, you can also define [dev-addresses] and call with the --dev flag",
                 unresolved_addresses.join("\n"),
                 root_package_path.to_string_lossy()
             )

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned/Move.exp
@@ -4,4 +4,4 @@ Named address 'A' in package 'test'
 To fix this, add an entry for each unresolved address to the [addresses] section of tests/test_sources/resolution/basic_no_deps_address_not_assigned/Move.toml: e.g.,
 [addresses]
 Std = "0x1"
-Alternatively, you can also define [dev-addresses] and call with the -d flag
+Alternatively, you can also define [dev-addresses] and call with the --dev flag


### PR DESCRIPTION
### Description
This allows --dev to be added to use the [dev-addresses] as well as updates that really confusing error message to match

### Test Plan
CI, and will test manually in a bit

https://github.com/aptos-labs/aptos-core/issues/8707