### PR TITLE
Add boilerplate for node API v2

### DIFF
--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -89,6 +89,7 @@ jobs:
   # to be land blocking for any PR on the aptos repo. This is why we run those tests
   # separate from test-sdk-confirm-client-generated-publish.
   run-indexer-tests:
+    needs: [permission-check]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ members = [
     "crates/aptos-node-api/v1/core",
     "crates/aptos-node-api/v1/openapi-spec-generator",
     "crates/aptos-node-api/v1/types",
+    "crates/aptos-node-api/v2/service",
     "crates/aptos-node-identity",
     "crates/aptos-openapi",
     "crates/aptos-proptest-helpers",
@@ -257,6 +258,7 @@ aptos-node-api-v1-core = { path = "crates/aptos-node-api/v1/core" }
 aptos-node-api-v1-types = { path = "crates/aptos-node-api/v1/types" }
 aptos-node-api-v1-spec-generator = { path = "crates/aptos-node-api/v1/types" }
 aptos-node-api-test-context = { path = "crates/aptos-node-api/test-context" }
+aptos-node-api-v2-service = { path = "crates/aptos-node-api/v2/service" }
 aptos-backup-cli = { path = "storage/backup/backup-cli" }
 aptos-backup-service = { path = "storage/backup/backup-service" }
 aptos-bounded-executor = { path = "crates/bounded-executor" }
@@ -405,6 +407,8 @@ ark-serialize = "0.4.0"
 ark-std = { version = "0.4.0", features = ["getrandom"] }
 assert_approx_eq = "1.1.0"
 assert_unordered = "0.1.1"
+async-graphql = "5.0.10"
+async-graphql-poem = "5.0.10"
 async-stream = "0.3"
 async-trait = "0.1.53"
 axum = "0.5.16"

--- a/crates/aptos-node-api/entrypoint/Cargo.toml
+++ b/crates/aptos-node-api/entrypoint/Cargo.toml
@@ -19,6 +19,7 @@ aptos-logger = { workspace = true }
 aptos-mempool = { workspace = true }
 aptos-node-api-context = { workspace = true }
 aptos-node-api-v1-core = { workspace = true }
+aptos-node-api-v2-service = { workspace = true }
 aptos-runtimes = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-types = { workspace = true }

--- a/crates/aptos-node-api/test-context/Cargo.toml
+++ b/crates/aptos-node-api/test-context/Cargo.toml
@@ -27,6 +27,7 @@ aptos-node-api-context = { workspace = true }
 aptos-node-api-entrypoint = { workspace = true }
 aptos-node-api-v1-core = { workspace = true }
 aptos-node-api-v1-types = { workspace = true }
+aptos-node-api-v2-service = { workspace = true }
 aptos-sdk = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-temppath = { workspace = true }

--- a/crates/aptos-node-api/test-context/src/test_context.rs
+++ b/crates/aptos-node-api/test-context/src/test_context.rs
@@ -24,6 +24,7 @@ use aptos_node_api_v1_types::{
     mime_types, response::BasicError, HexEncodedBytes, TransactionOnChainData, X_APTOS_CHAIN_ID,
     X_APTOS_LEDGER_TIMESTAMP, X_APTOS_LEDGER_VERSION,
 };
+use aptos_node_api_v2_service::ApiV2Config;
 use aptos_sdk::{
     bcs,
     transaction_builder::TransactionFactory,
@@ -145,8 +146,11 @@ pub fn new_test_context(
 
     // Configure the testing depending on which API version we're testing.
     let runtime_handle = tokio::runtime::Handle::current();
-    let routes =
-        build_routes(ApiV1Config::new(context.clone())).expect("Failed to build API routes");
+    let routes = build_routes(
+        ApiV1Config::new(context.clone()),
+        ApiV2Config::new(context.clone()),
+    )
+    .expect("Failed to build API routes");
     let poem_address = attach_to_runtime(&runtime_handle, &node_config, routes, true)
         .expect("Failed to attach API to runtime");
     let api_specific_config = ApiSpecificConfig::V1(poem_address);

--- a/crates/aptos-node-api/v2/service/Cargo.toml
+++ b/crates/aptos-node-api/v2/service/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "aptos-node-api-v2-service"
+description = "Aptos node API v2 service"
+version = "2.0.1"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+aptos-node-api-context = { workspace = true }
+async-graphql = { workspace = true }
+async-graphql-poem = { workspace = true }
+poem = { workspace = true }
+

--- a/crates/aptos-node-api/v2/service/src/config.rs
+++ b/crates/aptos-node-api/v2/service/src/config.rs
@@ -1,0 +1,15 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_node_api_context::Context as ApiContext;
+use std::sync::Arc;
+
+pub struct ApiV2Config {
+    pub context: Arc<ApiContext>,
+}
+
+impl ApiV2Config {
+    pub fn new(context: Arc<ApiContext>) -> Self {
+        Self { context }
+    }
+}

--- a/crates/aptos-node-api/v2/service/src/lib.rs
+++ b/crates/aptos-node-api/v2/service/src/lib.rs
@@ -1,0 +1,10 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+mod config;
+mod module;
+mod routes;
+mod schema;
+
+pub use config::ApiV2Config;
+pub use routes::build_api_v2_routes;

--- a/crates/aptos-node-api/v2/service/src/module.rs
+++ b/crates/aptos-node-api/v2/service/src/module.rs
@@ -1,0 +1,17 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::schema::QueryRoot;
+use async_graphql::{Context, Object, SimpleObject};
+
+#[derive(Clone, Debug, SimpleObject)]
+pub struct Module {
+    module_id: String,
+}
+
+#[Object]
+impl QueryRoot {
+    async fn module(&self, _ctx: &Context<'_>, module_id: String) -> Module {
+        Module { module_id }
+    }
+}

--- a/crates/aptos-node-api/v2/service/src/routes.rs
+++ b/crates/aptos-node-api/v2/service/src/routes.rs
@@ -1,0 +1,22 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{schema::QueryRoot, ApiV2Config};
+use anyhow::Result;
+use async_graphql::{http::GraphiQLSource, EmptyMutation, EmptySubscription, Schema};
+use async_graphql_poem::GraphQL;
+use poem::{get, handler, web::Html, IntoEndpoint, IntoResponse, Route};
+
+#[handler]
+async fn graphiql() -> impl IntoResponse {
+    Html(GraphiQLSource::build().endpoint("/v2/read").finish())
+}
+
+pub fn build_api_v2_routes(_config: ApiV2Config) -> Result<impl IntoEndpoint> {
+    let schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription).finish();
+
+    // Build routes for the read API
+    let routes = Route::new().at("/read", get(graphiql).post(GraphQL::new(schema)));
+
+    Ok(routes)
+}

--- a/crates/aptos-node-api/v2/service/src/schema.rs
+++ b/crates/aptos-node-api/v2/service/src/schema.rs
@@ -1,0 +1,9 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{EmptyMutation, EmptySubscription, Schema};
+
+pub struct QueryRoot;
+
+#[allow(dead_code)]
+pub type ApiV2Schema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;


### PR DESCRIPTION
### Description
This PR adds boilerplate for the v2 read API.

### Test Plan
```
cargo run -p aptos -- node run-local-testnet --force-restart --with-faucet --assume-yes
```

Visit http://127.0.0.1:8080/v2/read and try a query like this:
```
{
  module(moduleId: "heyyy") {
    moduleId
  }
}
```