### PR TITLE
[Gas Estimation] enable

### DIFF
--- a/config/src/config/gas_estimation_config.rs
+++ b/config/src/config/gas_estimation_config.rs
@@ -37,7 +37,7 @@ pub struct GasEstimationConfig {
 impl Default for GasEstimationConfig {
     fn default() -> GasEstimationConfig {
         GasEstimationConfig {
-            enabled: false,
+            enabled: true,
             static_override: None,
             full_block_txns: 250,
             low_block_history: 10,


### PR DESCRIPTION
### Description

Enable gas estimation as default, so the updated estimation is deployed in prod on the next release.
