### PR TITLE
[Storage] Add a flag to skip writing indices and usage which will eventually go away.

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -69,6 +69,8 @@ pub struct RocksdbConfigs {
     // Note: Not ready for production use yet.
     // TODO(grao): Add RocksdbConfig for individual DBs when necessary.
     pub split_ledger_db: bool,
+    // Note: Not ready for production use yet.
+    pub skip_index_and_usage: bool,
     pub state_kv_db_config: RocksdbConfig,
     pub index_db_config: RocksdbConfig,
 }
@@ -80,6 +82,7 @@ impl Default for RocksdbConfigs {
             state_merkle_db_config: RocksdbConfig::default(),
             use_sharded_state_merkle_db: false,
             split_ledger_db: false,
+            skip_index_and_usage: false,
             state_kv_db_config: RocksdbConfig::default(),
             index_db_config: RocksdbConfig {
                 max_open_files: 1000,

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -28,6 +28,7 @@ pub fn create_db_with_accounts<V>(
     verify_sequence_numbers: bool,
     split_ledger_db: bool,
     use_sharded_state_merkle_db: bool,
+    skip_index_and_usage: bool,
     pipeline_config: PipelineConfig,
 ) where
     V: TransactionBlockExecutor + 'static,
@@ -40,7 +41,12 @@ pub fn create_db_with_accounts<V>(
     // create if not exists
     fs::create_dir_all(db_dir.as_ref()).unwrap();
 
-    bootstrap_with_genesis(&db_dir, split_ledger_db, use_sharded_state_merkle_db);
+    bootstrap_with_genesis(
+        &db_dir,
+        split_ledger_db,
+        use_sharded_state_merkle_db,
+        skip_index_and_usage,
+    );
 
     println!(
         "Finished empty DB creation, DB dir: {}. Creating accounts now...",
@@ -57,6 +63,7 @@ pub fn create_db_with_accounts<V>(
         verify_sequence_numbers,
         split_ledger_db,
         use_sharded_state_merkle_db,
+        skip_index_and_usage,
         pipeline_config,
     );
 }
@@ -65,6 +72,7 @@ fn bootstrap_with_genesis(
     db_dir: impl AsRef<Path>,
     split_ledger_db: bool,
     use_sharded_state_merkle_db: bool,
+    skip_index_and_usage: bool,
 ) {
     let (config, _genesis_key) = aptos_genesis::test_utils::test_config();
 
@@ -72,6 +80,7 @@ fn bootstrap_with_genesis(
     rocksdb_configs.state_merkle_db_config.max_open_files = -1;
     rocksdb_configs.split_ledger_db = split_ledger_db;
     rocksdb_configs.use_sharded_state_merkle_db = use_sharded_state_merkle_db;
+    rocksdb_configs.skip_index_and_usage = skip_index_and_usage;
     let (_db, db_rw) = DbReaderWriter::wrap(
         AptosDB::open(
             &db_dir,

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -106,6 +106,7 @@ pub fn run_benchmark<V>(
     pruner_config: PrunerConfig,
     split_ledger_db: bool,
     use_sharded_state_merkle_db: bool,
+    skip_index_and_usage: bool,
     pipeline_config: PipelineConfig,
 ) where
     V: TransactionBlockExecutor + 'static,
@@ -122,6 +123,7 @@ pub fn run_benchmark<V>(
     config.storage.storage_pruner_config = pruner_config;
     config.storage.rocksdb_configs.split_ledger_db = split_ledger_db;
     config.storage.rocksdb_configs.use_sharded_state_merkle_db = use_sharded_state_merkle_db;
+    config.storage.rocksdb_configs.skip_index_and_usage = skip_index_and_usage;
 
     let (db, executor) = init_db_and_executor::<V>(&config);
     let transaction_generator_creator = transaction_type.map(|transaction_type| {
@@ -358,6 +360,7 @@ pub fn add_accounts<V>(
     verify_sequence_numbers: bool,
     split_ledger_db: bool,
     use_sharded_state_merkle_db: bool,
+    skip_index_and_usage: bool,
     pipeline_config: PipelineConfig,
 ) where
     V: TransactionBlockExecutor + 'static,
@@ -379,6 +382,7 @@ pub fn add_accounts<V>(
         verify_sequence_numbers,
         split_ledger_db,
         use_sharded_state_merkle_db,
+        skip_index_and_usage,
         pipeline_config,
     );
 }
@@ -393,6 +397,7 @@ fn add_accounts_impl<V>(
     verify_sequence_numbers: bool,
     split_ledger_db: bool,
     use_sharded_state_merkle_db: bool,
+    skip_index_and_usage: bool,
     pipeline_config: PipelineConfig,
 ) where
     V: TransactionBlockExecutor + 'static,
@@ -402,6 +407,7 @@ fn add_accounts_impl<V>(
     config.storage.storage_pruner_config = pruner_config;
     config.storage.rocksdb_configs.split_ledger_db = split_ledger_db;
     config.storage.rocksdb_configs.use_sharded_state_merkle_db = use_sharded_state_merkle_db;
+    config.storage.rocksdb_configs.skip_index_and_usage = skip_index_and_usage;
     let (db, executor) = init_db_and_executor::<V>(&config);
 
     let version = db.reader.get_latest_version().unwrap();
@@ -499,6 +505,7 @@ mod tests {
             verify_sequence_numbers,
             false,
             false,
+            false,
             PipelineConfig {
                 delay_execution_start: false,
                 split_stages: false,
@@ -521,6 +528,7 @@ mod tests {
             checkpoint_dir,
             verify_sequence_numbers,
             NO_OP_STORAGE_PRUNER_CONFIG,
+            false,
             false,
             false,
             PipelineConfig {

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -129,6 +129,9 @@ struct Opt {
     #[clap(long)]
     use_sharded_state_merkle_db: bool,
 
+    #[clap(long)]
+    skip_index_and_usage: bool,
+
     #[clap(flatten)]
     pipeline_opt: PipelineOpt,
 
@@ -231,6 +234,7 @@ where
                 opt.verify_sequence_numbers,
                 opt.split_ledger_db,
                 opt.use_sharded_state_merkle_db,
+                opt.skip_index_and_usage,
                 opt.pipeline_opt.pipeline_config(),
             );
         },
@@ -256,6 +260,7 @@ where
                 opt.pruner_opt.pruner_config(),
                 opt.split_ledger_db,
                 opt.use_sharded_state_merkle_db,
+                opt.skip_index_and_usage,
                 opt.pipeline_opt.pipeline_config(),
             );
         },
@@ -275,6 +280,7 @@ where
                 opt.verify_sequence_numbers,
                 opt.split_ledger_db,
                 opt.use_sharded_state_merkle_db,
+                opt.skip_index_and_usage,
                 opt.pipeline_opt.pipeline_config(),
             );
         },

--- a/execution/executor/src/components/in_memory_state_calculator_v2.rs
+++ b/execution/executor/src/components/in_memory_state_calculator_v2.rs
@@ -220,6 +220,9 @@ impl InMemoryStateCalculatorV2 {
         let _timer = APTOS_EXECUTOR_OTHER_TIMERS_SECONDS
             .with_label_values(&["calculate_usage"])
             .start_timer();
+        if old_usage.is_untracked() {
+            return StateStorageUsage::new_untracked();
+        }
         let (items_delta, bytes_delta) = updates
             .par_iter()
             .enumerate()

--- a/storage/aptosdb/src/backup/restore_utils.rs
+++ b/storage/aptosdb/src/backup/restore_utils.rs
@@ -238,7 +238,12 @@ pub(crate) fn save_transactions_impl(
 ) -> Result<()> {
     // TODO(grao): Support splited ledger db here.
     for (idx, txn) in txns.iter().enumerate() {
-        transaction_store.put_transaction(first_version + idx as Version, txn, batch)?;
+        transaction_store.put_transaction(
+            first_version + idx as Version,
+            txn,
+            /*skip_index=*/ false,
+            batch,
+        )?;
     }
     ledger_store.put_transaction_infos(first_version, txn_infos, batch, batch)?;
     event_store.put_events_multiple_versions(first_version, events, batch)?;

--- a/storage/aptosdb/src/pruner/event_store/test.rs
+++ b/storage/aptosdb/src/pruner/event_store/test.rs
@@ -62,7 +62,12 @@ fn verify_event_store_pruner(events: Vec<Vec<ContractEvent>>) {
     // Write events to DB
     for (version, events_for_version) in events.iter().enumerate() {
         event_store
-            .put_events(version as u64, events_for_version, &batch)
+            .put_events(
+                version as u64,
+                events_for_version,
+                /*skip_index=*/ false,
+                &batch,
+            )
             .unwrap();
     }
     aptos_db.ledger_db.event_db().write_schemas(batch).unwrap();
@@ -103,7 +108,12 @@ fn verify_event_store_pruner_disabled(events: Vec<Vec<ContractEvent>>) {
     // Write events to DB
     for (version, events_for_version) in events.iter().enumerate() {
         event_store
-            .put_events(version as u64, events_for_version, &batch)
+            .put_events(
+                version as u64,
+                events_for_version,
+                /*skip_index=*/ false,
+                &batch,
+            )
             .unwrap();
     }
     aptos_db.ledger_db.event_db().write_schemas(batch).unwrap();

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -64,6 +64,7 @@ fn put_value_set(
             &sharded_state_kv_batches,
             &state_kv_metadata_batch,
             /*put_state_value_indices=*/ false,
+            /*skip_usage=*/ false,
         )
         .unwrap();
     state_store

--- a/storage/aptosdb/src/pruner/transaction_store/test.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/test.rs
@@ -237,7 +237,12 @@ fn put_txn_in_store(
     let transaction_batch = SchemaBatch::new();
     for i in 0..txns.len() {
         transaction_store
-            .put_transaction(i as u64, txns.get(i).unwrap(), &transaction_batch)
+            .put_transaction(
+                i as u64,
+                txns.get(i).unwrap(),
+                /*skip_index=*/ false,
+                &transaction_batch,
+            )
             .unwrap();
     }
     aptos_db

--- a/storage/aptosdb/src/state_store/state_merkle_batch_committer.rs
+++ b/storage/aptosdb/src/state_store/state_merkle_batch_committer.rs
@@ -85,7 +85,9 @@ impl StateMerkleBatchCommitter {
                         .epoch_snapshot_pruner
                         .maybe_set_pruner_target_db_version(current_version);
 
-                    self.check_usage_consistency(&state_delta).unwrap();
+                    if !self.state_db.skip_usage {
+                        self.check_usage_consistency(&state_delta).unwrap();
+                    }
                 },
                 CommitMessage::Sync(finish_sender) => finish_sender.send(()).unwrap(),
                 CommitMessage::Exit => {

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -57,6 +57,7 @@ fn put_value_set(
             &sharded_state_kv_batches,
             &state_kv_metadata_batch,
             /*put_state_value_indices=*/ false,
+            /*skip_usage=*/ false,
         )
         .unwrap();
     state_store

--- a/storage/aptosdb/src/test_helper.rs
+++ b/storage/aptosdb/src/test_helper.rs
@@ -78,6 +78,7 @@ pub(crate) fn update_store(
                 &sharded_state_kv_batches,
                 &state_kv_metadata_batch,
                 /*put_state_value_indices=*/ false,
+                /*skip_usage=*/ false,
             )
             .unwrap();
         store

--- a/storage/aptosdb/src/transaction_store/mod.rs
+++ b/storage/aptosdb/src/transaction_store/mod.rs
@@ -146,13 +146,16 @@ impl TransactionStore {
         &self,
         version: Version,
         transaction: &Transaction,
+        skip_index: bool,
         batch: &SchemaBatch,
     ) -> Result<()> {
-        if let Some(txn) = transaction.try_as_signed_user_txn() {
-            batch.put::<TransactionByAccountSchema>(
-                &(txn.sender(), txn.sequence_number()),
-                &version,
-            )?;
+        if !skip_index {
+            if let Some(txn) = transaction.try_as_signed_user_txn() {
+                batch.put::<TransactionByAccountSchema>(
+                    &(txn.sender(), txn.sequence_number()),
+                    &version,
+                )?;
+            }
         }
         batch.put::<TransactionByHashSchema>(&transaction.hash(), &version)?;
         batch.put::<TransactionSchema>(&version, transaction)?;

--- a/storage/aptosdb/src/transaction_store/test.rs
+++ b/storage/aptosdb/src/transaction_store/test.rs
@@ -217,7 +217,9 @@ fn init_store(
 
     let batch = SchemaBatch::new();
     for (ver, txn) in txns.iter().enumerate() {
-        store.put_transaction(ver as Version, txn, &batch).unwrap();
+        store
+            .put_transaction(ver as Version, txn, /*skip_index=*/ false, &batch)
+            .unwrap();
     }
     store
         .ledger_db

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -99,6 +99,7 @@ impl From<RocksdbOpt> for RocksdbConfigs {
             },
             split_ledger_db: opt.split_ledger_db,
             use_sharded_state_merkle_db: opt.use_sharded_state_merkle_db,
+            skip_index_and_usage: false,
             state_kv_db_config: RocksdbConfig {
                 max_open_files: opt.state_kv_db_max_open_files,
                 max_total_wal_size: opt.state_kv_db_max_total_wal_size,

--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -19,17 +19,17 @@ EXPECTED_TPS = {
     ("no-op", False, 1): (18800.0, True),
     ("no-op", False, 1000): (2980.0, True),
     ("coin-transfer", False, 1): (12600.0, True),
-    ("coin-transfer", True, 1): (22100.0, True),
+    ("coin-transfer", True, 1): (30000.0, True),
     ("account-generation", False, 1): (11000.0, True),
-    ("account-generation", True, 1): (20000.0, True),
+    ("account-generation", True, 1): (26000.0, True),
     # changed to not use account_pool. either recalibrate or add here to use account pool.
     ("account-resource32-b", False, 1): (15000.0, False),
     ("modify-global-resource", False, 1): (3700.0, True),
     ("modify-global-resource", False, 10): (10800.0, True),
     # seems to have changed, disabling as land_blocking, until recalibrated
-    ("publish-package", False, 1): (159.0, False),
+    ("publish-package", False, 1): (120.0, False),
     ("batch100-transfer", False, 1): (350, True),
-    ("batch100-transfer", True, 1): (630, True),
+    ("batch100-transfer", True, 1): (880, True),
     ("token-v1ft-mint-and-transfer", False, 1): (1650.0, True),
     ("token-v1ft-mint-and-transfer", False, 20): (7100.0, True),
     ("token-v1nft-mint-and-transfer-sequential", False, 1): (1100.0, True),
@@ -222,7 +222,7 @@ errors = []
 warnings = []
 
 with tempfile.TemporaryDirectory() as tmpdirname:
-    create_db_command = f"cargo run {BUILD_FLAG} -- --block-size {BLOCK_SIZE} --concurrency-level {CONCURRENCY_LEVEL} --split-ledger-db --use-sharded-state-merkle-db create-db --data-dir {tmpdirname}/db --num-accounts {NUM_ACCOUNTS}"
+    create_db_command = f"cargo run {BUILD_FLAG} -- --block-size {BLOCK_SIZE} --concurrency-level {CONCURRENCY_LEVEL} --split-ledger-db --use-sharded-state-merkle-db --skip-index-and-usage create-db --data-dir {tmpdirname}/db --num-accounts {NUM_ACCOUNTS}"
     output = execute_command(create_db_command)
 
     results = []
@@ -237,7 +237,7 @@ with tempfile.TemporaryDirectory() as tmpdirname:
         executor_type = "native" if use_native_executor else "VM"
 
         use_native_executor_str = "--use-native-executor" if use_native_executor else ""
-        common_command_suffix = f"{use_native_executor_str} --generate-then-execute --transactions-per-sender 1 --block-size {cur_block_size} --split-ledger-db --use-sharded-state-merkle-db run-executor --transaction-type {transaction_type} --module-working-set-size {module_working_set_size} --main-signer-accounts {MAIN_SIGNER_ACCOUNTS} --additional-dst-pool-accounts {ADDITIONAL_DST_POOL_ACCOUNTS} --data-dir {tmpdirname}/db  --checkpoint-dir {tmpdirname}/cp"
+        common_command_suffix = f"{use_native_executor_str} --generate-then-execute --transactions-per-sender 1 --block-size {cur_block_size} --split-ledger-db --use-sharded-state-merkle-db --skip-index-and-usage run-executor --transaction-type {transaction_type} --module-working-set-size {module_working_set_size} --main-signer-accounts {MAIN_SIGNER_ACCOUNTS} --additional-dst-pool-accounts {ADDITIONAL_DST_POOL_ACCOUNTS} --data-dir {tmpdirname}/db  --checkpoint-dir {tmpdirname}/cp"
 
         concurrency_level_results = {}
 


### PR DESCRIPTION
### Description
Add a flag to skip indices and storage usage, which will eventually be removed from core AptosDB. This will help us get a better idea in benchmark on how much TPS we can reach later.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
