### PR TITLE
Forge continuous tests - tune params based on recent runs

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -119,7 +119,8 @@ jobs:
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-realistic-env-max-load-long-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_RUNNER_DURATION_SECS: 7200
+      # reduce temporarily, until longer tests can pass.
+      FORGE_RUNNER_DURATION_SECS: 2400
       FORGE_TEST_SUITE: realistic_env_max_load
       POST_TO_SLACK: true
 

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -783,18 +783,19 @@ fn realistic_env_load_sweep_test() -> ForgeConfig {
             test: Box::new(PerformanceBenchmark),
             workloads: Workloads::TPS(&[10, 100, 1000, 3000, 5000]),
             criteria: [
-                (9, 1.5, 3.),
-                (95, 1.5, 3.),
-                (950, 2., 3.),
-                (2750, 2.5, 4.),
-                (4600, 3., 5.),
+                (9, 1.5, 3., 4.),
+                (95, 1.5, 3., 4.),
+                (950, 2., 3., 4.),
+                (2750, 2.5, 3.5, 4.5),
+                (4600, 3., 4., 5.),
             ]
             .into_iter()
-            .map(|(min_tps, max_lat_p50, max_lat_p99)| {
+            .map(|(min_tps, max_lat_p50, max_lat_p90, max_lat_p99)| {
                 SuccessCriteria::new(min_tps)
                     .add_max_expired_tps(0)
                     .add_max_failed_submission_tps(0)
                     .add_latency_threshold(max_lat_p50, LatencyType::P50)
+                    .add_latency_threshold(max_lat_p90, LatencyType::P90)
                     .add_latency_threshold(max_lat_p99, LatencyType::P99)
             })
             .collect(),
@@ -1546,8 +1547,10 @@ fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
                 .add_no_restarts()
                 .add_wait_for_catchup_s(60)
                 .add_system_metrics_threshold(SystemMetricsThreshold::new(
-                    // Check that we don't use more than 12 CPU cores for 30% of the time.
-                    MetricsThreshold::new(12, 30),
+                    // Tuned for throughput uses more cores than regular tests,
+                    // as it achieves higher throughput
+                    // Check that we don't use more than 14 CPU cores for 30% of the time.
+                    MetricsThreshold::new(14, 30),
                     // Check that we don't use more than 10 GB of memory for 30% of the time.
                     MetricsThreshold::new(10 * 1024 * 1024 * 1024, 30),
                 ))


### PR DESCRIPTION
- increase cpu on high throughput
- increase p99 latency for sweep, for variance, but add p90 test with lower values
- reduce duration of long test, until long test can run successfully

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
