### PR TITLE
Release builder support custom aptos-core path

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/framework.rs
+++ b/aptos-move/aptos-release-builder/src/components/framework.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::components::get_execution_hash;
+use crate::{aptos_core_path, components::get_execution_hash};
 use anyhow::Result;
 use aptos_framework::{BuildOptions, BuiltPackage, ReleasePackage};
 use aptos_temppath::TempPath;
@@ -58,10 +58,6 @@ pub fn generate_upgrade_proposals(
         package_path_list.reverse();
     }
 
-    let mut root_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf();
-    root_path.pop();
-    root_path.pop();
-
     for (publish_addr, relative_package_path) in package_path_list.iter() {
         let account = AccountAddress::from_hex_literal(publish_addr)?;
         let temp_script_path = TempPath::new();
@@ -72,7 +68,7 @@ pub fn generate_upgrade_proposals(
         let mut package_path = if config.git_hash.is_some() {
             temp_root_path.path().to_path_buf()
         } else {
-            root_path.canonicalize()?
+            aptos_core_path()
         };
 
         package_path.push(relative_package_path);

--- a/aptos-move/aptos-release-builder/src/components/mod.rs
+++ b/aptos-move/aptos-release-builder/src/components/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use self::framework::FrameworkReleaseConfig;
-use crate::components::feature_flags::Features;
+use crate::{aptos_framework_path, components::feature_flags::Features, release_builder_path};
 use anyhow::{anyhow, bail, Result};
 use aptos::governance::GenerateExecutionHash;
 use aptos_rest_client::Client;
@@ -205,8 +205,7 @@ impl ReleaseEntry {
                 }
             },
             ReleaseEntry::RawScript(script_path) => {
-                let base_path =
-                    PathBuf::from(std::env!("CARGO_MANIFEST_DIR")).join(script_path.as_path());
+                let base_path = release_builder_path().join(script_path.as_path());
                 let file_name = base_path
                     .file_name()
                     .and_then(|name| name.to_str())
@@ -538,6 +537,7 @@ pub fn get_execution_hash(result: &Vec<(String, String)>) -> Vec<u8> {
 
         let (_, hash) = GenerateExecutionHash {
             script_path: Option::from(move_script_path),
+            framework_local_dir: Some(aptos_framework_path()),
         }
         .generate_hash()
         .unwrap();
@@ -562,6 +562,7 @@ fn append_script_hash(raw_script: String) -> String {
 
     let (_, hash) = GenerateExecutionHash {
         script_path: Option::from(move_script_path),
+        framework_local_dir: Some(aptos_framework_path()),
     }
     .generate_hash()
     .unwrap();

--- a/aptos-move/aptos-release-builder/src/lib.rs
+++ b/aptos-move/aptos-release-builder/src/lib.rs
@@ -4,8 +4,13 @@
 pub mod components;
 mod utils;
 pub mod validate;
+
 pub use components::{ExecutionMode, ReleaseConfig, ReleaseEntry};
-use once_cell::sync::Lazy;
+use once_cell::sync::{Lazy, OnceCell};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 // Update me after branch cut.
 const RELEASE_CONFIG: &str = include_str!("../data/release.yaml");
@@ -16,4 +21,42 @@ static CURRENT_RELEASE_CONFIG: Lazy<ReleaseConfig> =
 /// Returns the release bundle with which the last testnet was build or updated.
 pub fn current_release_config() -> &'static ReleaseConfig {
     &CURRENT_RELEASE_CONFIG
+}
+
+static APTOS_CORE_PATH: OnceCell<PathBuf> = OnceCell::new();
+
+fn aptos_core_path_at_compile_time() -> PathBuf {
+    let mut path = Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf();
+    path.pop();
+    path.pop();
+    path = path.canonicalize().unwrap();
+    path
+}
+
+pub fn initialize_aptos_core_path(overriden_path: Option<PathBuf>) {
+    if let Some(path) = overriden_path {
+        APTOS_CORE_PATH.set(path).unwrap();
+    } else {
+        APTOS_CORE_PATH
+            .set(aptos_core_path_at_compile_time())
+            .unwrap();
+    };
+}
+
+pub(crate) fn aptos_core_path() -> PathBuf {
+    APTOS_CORE_PATH
+        .get_or_init(aptos_core_path_at_compile_time)
+        .clone()
+}
+
+pub(crate) fn aptos_framework_path() -> PathBuf {
+    let mut path = aptos_core_path();
+    path.push("aptos-move/framework/aptos-framework");
+    path
+}
+
+pub(crate) fn release_builder_path() -> PathBuf {
+    let mut path = aptos_core_path();
+    path.push("aptos-move/aptos-release-builder");
+    path
 }

--- a/aptos-move/aptos-release-builder/src/main.rs
+++ b/aptos-move/aptos-release-builder/src/main.rs
@@ -3,7 +3,10 @@
 
 use anyhow::Result;
 use aptos_crypto::{ed25519::Ed25519PrivateKey, ValidCryptoMaterialStringExt};
-use aptos_release_builder::validate::{DEFAULT_RESOLUTION_TIME, FAST_RESOLUTION_TIME};
+use aptos_release_builder::{
+    initialize_aptos_core_path,
+    validate::{DEFAULT_RESOLUTION_TIME, FAST_RESOLUTION_TIME},
+};
 use aptos_types::{account_address::AccountAddress, chain_id::ChainId};
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
@@ -12,6 +15,8 @@ use std::path::PathBuf;
 pub struct Argument {
     #[clap(subcommand)]
     cmd: Commands,
+    #[clap(long)]
+    aptos_core_path: Option<PathBuf>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -68,6 +73,7 @@ pub enum InputOptions {
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Argument::parse();
+    initialize_aptos_core_path(args.aptos_core_path.clone());
 
     // TODO: Being able to parse the release config from a TOML file to generate the proposals.
     match args.cmd {

--- a/aptos-move/aptos-release-builder/src/validate.rs
+++ b/aptos-move/aptos-release-builder/src/validate.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{components::ProposalMetadata, ExecutionMode, ReleaseConfig};
+use crate::{aptos_framework_path, components::ProposalMetadata, ExecutionMode, ReleaseConfig};
 use anyhow::Result;
 use aptos::{
     common::types::CliCommand,
@@ -39,13 +39,6 @@ pub struct NetworkConfig {
 #[derive(Deserialize)]
 struct CreateProposalEvent {
     proposal_id: U64,
-}
-
-fn aptos_framework_path() -> PathBuf {
-    let mut path = Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf();
-    path.pop();
-    path.push("framework/aptos-framework");
-    path
 }
 
 impl NetworkConfig {
@@ -370,16 +363,15 @@ async fn execute_release(
     let scripts_path = TempPath::new();
     scripts_path.create_as_dir()?;
 
-    release_config.generate_release_proposal_scripts(
-        if let Some(dir) = &output_dir {
-            dir.as_path()
-        } else {
-            scripts_path.path()
-        },
-    )?;
+    let proposal_folder = if let Some(dir) = &output_dir {
+        dir.as_path()
+    } else {
+        scripts_path.path()
+    };
+    release_config.generate_release_proposal_scripts(proposal_folder)?;
 
     for proposal in release_config.proposals {
-        let mut proposal_path = scripts_path.path().to_path_buf();
+        let mut proposal_path = proposal_folder.to_path_buf();
         proposal_path.push("sources");
         proposal_path.push(&release_config.name);
         proposal_path.push(proposal.name.as_str());


### PR DESCRIPTION
### Description
- By providing arg `--aptos-core-path`, release builder can read `aptos-framework` and scripts to compile from a custom `aptos-core` path. If the arg is not provided, release builder will use the path itself was compiled at.
- Fix a bug. When `--test-dir` is specified, `validate-proposals` will fail because release builder is reading compiled proposals in a wrong path.
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Local test.
Rename `aptos-core` to `aptos-core-r` then run binary `validate-proposals`.
`./aptos-release-builder --aptos-core-path <path to aptos-core> validate-proposals --release-config <path to release.yaml> --output-dir /tmp/release_output --endpoint http://0.0.0.0:8080 --mint-to-validator from-directory --test-dir <path to .aptos/testnet>`