### PR TITLE
[vm] add error messages for failing to initialize gas parameters

### DIFF
--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -1143,12 +1143,13 @@ impl Context {
                     let feature_version = gas_schedule.feature_version;
                     let gas_schedule = gas_schedule.to_btree_map();
                     AptosGasParameters::from_on_chain_gas_schedule(&gas_schedule, feature_version)
+                        .ok()
                 }) {
                     Some(gas_schedule) => Ok(gas_schedule),
                     None => GasSchedule::fetch_config(&storage_adapter)
                         .and_then(|gas_schedule| {
                             let gas_schedule = gas_schedule.to_btree_map();
-                            AptosGasParameters::from_on_chain_gas_schedule(&gas_schedule, 0)
+                            AptosGasParameters::from_on_chain_gas_schedule(&gas_schedule, 0).ok()
                         })
                         .ok_or_else(|| {
                             E::internal_with_code(

--- a/aptos-move/aptos-gas/src/gas_meter.rs
+++ b/aptos-move/aptos-gas/src/gas_meter.rs
@@ -76,7 +76,7 @@ pub trait FromOnChainGasSchedule: Sized {
     fn from_on_chain_gas_schedule(
         gas_schedule: &BTreeMap<String, u64>,
         feature_version: u64,
-    ) -> Option<Self>;
+    ) -> Result<Self, String>;
 }
 
 /// A trait for converting to a list of entries of the on-chain gas schedule.
@@ -105,8 +105,8 @@ impl FromOnChainGasSchedule for NativeGasParameters {
     fn from_on_chain_gas_schedule(
         gas_schedule: &BTreeMap<String, u64>,
         feature_version: u64,
-    ) -> Option<Self> {
-        Some(Self {
+    ) -> Result<Self, String> {
+        Ok(Self {
             move_stdlib: FromOnChainGasSchedule::from_on_chain_gas_schedule(
                 gas_schedule,
                 feature_version,
@@ -169,8 +169,8 @@ impl FromOnChainGasSchedule for AptosGasParameters {
     fn from_on_chain_gas_schedule(
         gas_schedule: &BTreeMap<String, u64>,
         feature_version: u64,
-    ) -> Option<Self> {
-        Some(Self {
+    ) -> Result<Self, String> {
+        Ok(Self {
             misc: FromOnChainGasSchedule::from_on_chain_gas_schedule(
                 gas_schedule,
                 feature_version,

--- a/aptos-move/aptos-gas/src/misc.rs
+++ b/aptos-move/aptos-gas/src/misc.rs
@@ -580,8 +580,8 @@ impl FromOnChainGasSchedule for MiscGasParameters {
     fn from_on_chain_gas_schedule(
         gas_schedule: &BTreeMap<String, u64>,
         feature_version: u64,
-    ) -> Option<Self> {
-        Some(Self {
+    ) -> Result<Self, String> {
+        Ok(Self {
             abs_val: FromOnChainGasSchedule::from_on_chain_gas_schedule(
                 gas_schedule,
                 feature_version,

--- a/aptos-move/aptos-gas/src/params.rs
+++ b/aptos-move/aptos-gas/src/params.rs
@@ -30,16 +30,17 @@ macro_rules! define_gas_parameters {
 
         impl $crate::gas_meter::FromOnChainGasSchedule for $params_name {
             #[allow(unused_variables)]
-            fn from_on_chain_gas_schedule(gas_schedule: &std::collections::BTreeMap<String, u64>, feature_version: u64) -> Option<Self> {
+            fn from_on_chain_gas_schedule(gas_schedule: &std::collections::BTreeMap<String, u64>, feature_version: u64) -> Result<Self, String> {
                 let mut params = $params_name::zeros();
 
                 $(
                     if let Some(key) = $crate::params::define_gas_parameters_extract_key_at_version!($key_bindings, feature_version) {
-                        params.$name = gas_schedule.get(&format!("{}.{}", $prefix, key)).cloned()?.into();
+                        let name = format!("{}.{}", $prefix, key);
+                        params.$name = gas_schedule.get(&name).cloned().ok_or_else(|| format!("Gas parameter {} does not exist. Feature version: {}.", name, feature_version))?.into();
                     }
                 )*
 
-                Some(params)
+                Ok(params)
             }
         }
 

--- a/aptos-move/aptos-gas/src/transaction/storage.rs
+++ b/aptos-move/aptos-gas/src/transaction/storage.rs
@@ -234,7 +234,7 @@ impl StoragePricing {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ChangeSetConfigs {
     gas_feature_version: u64,
     max_bytes_per_write_op: u64,
@@ -337,7 +337,7 @@ impl CheckChangeSet for ChangeSetConfigs {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct StorageGasParameters {
     pub pricing: StoragePricing,
     pub change_set_configs: ChangeSetConfigs,

--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -536,6 +536,18 @@ impl MoveHarness {
             .sequence_number()
     }
 
+    pub fn modify_gas_schedule_raw(&mut self, modify: impl FnOnce(&mut GasScheduleV2)) {
+        let mut gas_schedule: GasScheduleV2 = self
+            .read_resource(&CORE_CODE_ADDRESS, GasScheduleV2::struct_tag())
+            .unwrap();
+        modify(&mut gas_schedule);
+        self.set_resource(
+            CORE_CODE_ADDRESS,
+            GasScheduleV2::struct_tag(),
+            &gas_schedule,
+        )
+    }
+
     pub fn modify_gas_schedule(&mut self, modify: impl FnOnce(&mut AptosGasParameters)) {
         let gas_schedule: GasScheduleV2 = self
             .read_resource(&CORE_CODE_ADDRESS, GasScheduleV2::struct_tag())

--- a/aptos-move/e2e-move-tests/src/tests/common.data/do_nothing/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/common.data/do_nothing/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "do_nothing"
+version = "0.0.0"
+
+[dependencies]
+MoveStdlib = { local = "../../../../../framework/move-stdlib" }

--- a/aptos-move/e2e-move-tests/src/tests/common.data/do_nothing/sources/test.move
+++ b/aptos-move/e2e-move-tests/src/tests/common.data/do_nothing/sources/test.move
@@ -1,0 +1,3 @@
+module 0xbeef::test {
+    public entry fun do_nothing() {}
+}

--- a/aptos-move/e2e-move-tests/src/tests/missing_gas_parameter.rs
+++ b/aptos-move/e2e-move-tests/src/tests/missing_gas_parameter.rs
@@ -1,0 +1,28 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{tests::common, MoveHarness};
+use aptos_types::{account_address::AccountAddress, transaction::TransactionStatus};
+use move_core_types::vm_status::StatusCode;
+
+#[test]
+fn missing_gas_parameter() {
+    let mut h = MoveHarness::new();
+
+    h.modify_gas_schedule_raw(|gas_schedule| {
+        let idx = gas_schedule
+            .entries
+            .iter()
+            .position(|(key, _val)| key == "instr.add")
+            .unwrap();
+        gas_schedule.entries.remove(idx);
+    });
+
+    // Load the code
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
+    let txn_status = h.publish_package(&acc, &common::test_dir_path("common.data/do_nothing"));
+    assert!(matches!(
+        txn_status,
+        TransactionStatus::Discard(StatusCode::VM_STARTUP_FAILURE)
+    ))
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -20,6 +20,7 @@ mod max_loop_depth;
 mod memory_quota;
 mod metadata;
 mod mint_nft;
+mod missing_gas_parameter;
 mod new_integer_types;
 mod nft_dao;
 mod offer_rotation_capability;

--- a/third_party/move/move-core/types/src/vm_status.rs
+++ b/third_party/move/move-core/types/src/vm_status.rs
@@ -282,6 +282,10 @@ impl fmt::Display for VMStatus {
             status = format!("{} with sub status {}", status, code);
         }
 
+        if let Some(msg) = self.message() {
+            status = format!("{} with message {}", status, msg);
+        }
+
         write!(f, "{}", status)
     }
 }


### PR DESCRIPTION
This adds additional error messages that would help us pinpoint the failing gas parameter when the gas schedule fails to load.

Resolves https://github.com/aptos-labs/aptos-core/issues/5989