### PR TITLE
[Move-prover][Spec] Add support of generic types for exists in the prover

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/object.md
+++ b/aptos-move/framework/aptos-framework/doc/object.md
@@ -77,7 +77,11 @@ make it so that a reference to a global object can be returned from a function.
 -  [Function `is_owner`](#0x1_object_is_owner)
 -  [Function `owns`](#0x1_object_owns)
 -  [Specification](#@Specification_1)
+    -  [Function `address_to_object`](#@Specification_1_address_to_object)
     -  [Function `exists_at`](#@Specification_1_exists_at)
+    -  [Function `convert`](#@Specification_1_convert)
+    -  [Function `object_from_constructor_ref`](#@Specification_1_object_from_constructor_ref)
+    -  [Function `object_from_delete_ref`](#@Specification_1_object_from_delete_ref)
 
 
 <pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
@@ -1871,6 +1875,23 @@ Return true if the provided address has indirect or direct ownership of the prov
 ## Specification
 
 
+<a name="@Specification_1_address_to_object"></a>
+
+### Function `address_to_object`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_address_to_object">address_to_object</a>&lt;T: key&gt;(<a href="object.md#0x1_object">object</a>: <b>address</b>): <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(<a href="object.md#0x1_object">object</a>);
+<b>aborts_if</b> !<b>exists</b>&lt;T&gt;(<a href="object.md#0x1_object">object</a>);
+</code></pre>
+
+
+
 <a name="@Specification_1_exists_at"></a>
 
 ### Function `exists_at`
@@ -1883,6 +1904,57 @@ Return true if the provided address has indirect or direct ownership of the prov
 
 
 <pre><code><b>pragma</b> intrinsic;
+</code></pre>
+
+
+
+<a name="@Specification_1_convert"></a>
+
+### Function `convert`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_convert">convert</a>&lt;X: key, Y: key&gt;(<a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object_Object">object::Object</a>&lt;X&gt;): <a href="object.md#0x1_object_Object">object::Object</a>&lt;Y&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(<a href="object.md#0x1_object">object</a>.inner);
+<b>aborts_if</b> !<b>exists</b>&lt;Y&gt;(<a href="object.md#0x1_object">object</a>.inner);
+</code></pre>
+
+
+
+<a name="@Specification_1_object_from_constructor_ref"></a>
+
+### Function `object_from_constructor_ref`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_object_from_constructor_ref">object_from_constructor_ref</a>&lt;T: key&gt;(ref: &<a href="object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>): <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(ref.self);
+<b>aborts_if</b> !<b>exists</b>&lt;T&gt;(ref.self);
+</code></pre>
+
+
+
+<a name="@Specification_1_object_from_delete_ref"></a>
+
+### Function `object_from_delete_ref`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_object_from_delete_ref">object_from_delete_ref</a>&lt;T: key&gt;(ref: &<a href="object.md#0x1_object_DeleteRef">object::DeleteRef</a>): <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !<b>exists</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(ref.self);
+<b>aborts_if</b> !<b>exists</b>&lt;T&gt;(ref.self);
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
+++ b/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
@@ -37,6 +37,7 @@ fungible asset to it. This emits an deposit event.
 -  [Function `deposit_with_ref`](#0x1_primary_fungible_store_deposit_with_ref)
 -  [Function `transfer_with_ref`](#0x1_primary_fungible_store_transfer_with_ref)
 -  [Specification](#@Specification_0)
+    -  [Function `create_primary_store`](#@Specification_0_create_primary_store)
 
 
 <pre><code><b>use</b> <a href="fungible_asset.md#0x1_fungible_asset">0x1::fungible_asset</a>;
@@ -592,6 +593,26 @@ Transfer <code>amount</code> of FA from the primary store of <code>from</code> t
 
 
 <pre><code><b>pragma</b> verify = <b>false</b>;
+</code></pre>
+
+
+
+<a name="@Specification_0_create_primary_store"></a>
+
+### Function `create_primary_store`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_create_primary_store">create_primary_store</a>&lt;T: key&gt;(owner_addr: <b>address</b>, metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">fungible_asset::FungibleStore</a>&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> verify = <b>true</b>;
+<b>pragma</b> aborts_if_is_partial;
+<b>let</b> metadata_addr = metadata.inner;
+<b>aborts_if</b> !<b>exists</b>&lt;<a href="object.md#0x1_object_ObjectCore">object::ObjectCore</a>&gt;(metadata_addr);
+<b>aborts_if</b> !<b>exists</b>&lt;Metadata&gt;(metadata_addr);
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/object.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/object.spec.move
@@ -1,5 +1,27 @@
 spec aptos_framework::object {
+
     spec exists_at<T: key>(object: address): bool {
         pragma intrinsic;
     }
+
+    spec address_to_object<T: key>(object: address): Object<T> {
+        aborts_if !exists<ObjectCore>(object);
+        aborts_if !exists<T>(object);
+    }
+
+    spec convert<X: key, Y: key>(object: Object<X>): Object<Y> {
+        aborts_if !exists<ObjectCore>(object.inner);
+        aborts_if !exists<Y>(object.inner);
+    }
+
+    spec object_from_constructor_ref<T: key>(ref: &ConstructorRef): Object<T> {
+        aborts_if !exists<ObjectCore>(ref.self);
+        aborts_if !exists<T>(ref.self);
+    }
+
+    spec object_from_delete_ref<T: key>(ref: &DeleteRef): Object<T> {
+        aborts_if !exists<ObjectCore>(ref.self);
+        aborts_if !exists<T>(ref.self);
+    }
+
 }

--- a/aptos-move/framework/aptos-framework/sources/primary_fungible_store.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/primary_fungible_store.spec.move
@@ -3,4 +3,16 @@ spec aptos_framework::primary_fungible_store {
         // TODO: verification disabled until this module is specified.
         pragma verify = false;
     }
+
+    spec create_primary_store<T: key>(
+        owner_addr: address,
+        metadata: Object<T>,
+    ): Object<FungibleStore> {
+        use aptos_framework::object;
+        pragma verify = true;
+        pragma aborts_if_is_partial;
+        let metadata_addr = metadata.inner;
+        aborts_if !exists<object::ObjectCore>(metadata_addr);
+        aborts_if !exists<Metadata>(metadata_addr);
+    }
 }

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -600,8 +600,10 @@ impl ExpData {
             match e {
                 Call(id, Exists(label), _) | Call(id, Global(label), _) => {
                     let inst = &env.get_node_instantiation(*id);
-                    let (mid, sid, sinst) = inst[0].require_struct();
-                    result.insert((mid.qualified_inst(sid, sinst.to_owned()), label.to_owned()));
+                    if let Some((mid, sid, sinst)) = inst[0].require_struct_opt() {
+                        result
+                            .insert((mid.qualified_inst(sid, sinst.to_owned()), label.to_owned()));
+                    }
                 },
                 Call(id, SpecFunction(mid, fid, labels), _) => {
                     let inst = &env.get_node_instantiation(*id);

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -2318,7 +2318,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                 // calls to built-in functions might have additional requirements on the types
                 let oper = cand.get_operation();
                 match oper {
-                    | Operation::BorrowGlobal(_)
+                    Operation::BorrowGlobal(_)
                     | Operation::MoveFrom
                     | Operation::MoveTo
                     | Operation::Global(_) => {

--- a/third_party/move/move-model/src/exp_generator.rs
+++ b/third_party/move/move-model/src/exp_generator.rs
@@ -394,9 +394,17 @@ pub trait ExpGenerator<'env> {
     /// Get's the memory associated with a Call(Global,..) or Call(Exists, ..) node. Crashes
     /// if the the node is not typed as expected.
     fn get_memory_of_node(&self, node_id: NodeId) -> QualifiedInstId<StructId> {
+        self.get_memory_of_node_opt(node_id)
+            .expect("expected `Type::Struct`")
+    }
+
+    fn get_memory_of_node_opt(&self, node_id: NodeId) -> Option<QualifiedInstId<StructId>> {
         // We do have a call `f<R<..>>` so extract the type from the function instantiation.
         let rty = &self.global_env().get_node_instantiation(node_id)[0];
-        let (mid, sid, inst) = rty.require_struct();
-        mid.qualified_inst(sid, inst.to_owned())
+        if let Some((mid, sid, inst)) = rty.require_struct_opt() {
+            Some(mid.qualified_inst(sid, inst.to_owned()))
+        } else {
+            None
+        }
     }
 }

--- a/third_party/move/move-model/src/spec_translator.rs
+++ b/third_party/move/move-model/src/spec_translator.rs
@@ -704,14 +704,13 @@ impl<'a, 'b, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, 'b
                 )
                 .into_exp(),
             ),
-            Exists(None) if self.in_old => Some(
-                Call(
-                    id,
-                    Exists(Some(self.save_memory(self.builder.get_memory_of_node(id)))),
-                    args.to_owned(),
-                )
-                .into_exp(),
-            ),
+            Exists(None) if self.in_old => {
+                if let Some(mem) = self.builder.get_memory_of_node_opt(id) {
+                    Some(Call(id, Exists(Some(self.save_memory(mem))), args.to_owned()).into_exp())
+                } else {
+                    Some(Call(id, Exists(None), args.to_owned()).into_exp())
+                }
+            },
             SpecFunction(mid, fid, None) if self.in_old => {
                 let used_memory = {
                     let module_env = self.builder.global_env().get_module(*mid);

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -391,10 +391,18 @@ impl Type {
 
     /// Require this to be a struct, if so extracts its content.
     pub fn require_struct(&self) -> (ModuleId, StructId, &[Type]) {
-        if let Type::Struct(mid, sid, targs) = self {
-            (*mid, *sid, targs.as_slice())
+        if let Some(v) = self.require_struct_opt() {
+            v
         } else {
             panic!("expected `Type::Struct`, found: `{:?}`", self)
+        }
+    }
+
+    pub fn require_struct_opt(&self) -> Option<(ModuleId, StructId, &[Type])> {
+        if let Type::Struct(mid, sid, targs) = self {
+            Some((*mid, *sid, targs.as_slice()))
+        } else {
+            None
         }
     }
 

--- a/third_party/move/move-model/tests/sources/invariants_err.exp
+++ b/third_party/move/move-model/tests/sources/invariants_err.exp
@@ -19,19 +19,19 @@ error: invalid reference to post state
    │     │         expression referring to post state
    │     not allowed to refer to post state
 
-error: The type argument to `exists` and `global` must be a struct type but `u64` is not
+error: The type argument to `exists` must be a struct or TypeParameter type but `u64` is not either of them.
    ┌─ tests/sources/invariants_err.move:36:15
    │
 36 │     invariant exists<u64>(@0x0);
    │               ^^^^^^^^^^^^^^^^^
 
-error: The type argument to `exists` and `global` must be a struct type but `T` is not
+error: The type argument to `global` must be a struct type but `T` is not
    ┌─ tests/sources/invariants_err.move:37:18
    │
 37 │     invariant<T> global<T>(@0x1) == global<T>(@0x2);
    │                  ^^^^^^^^^^^^^^^
 
-error: The type argument to `exists` and `global` must be a struct type but `T` is not
+error: The type argument to `global` must be a struct type but `T` is not
    ┌─ tests/sources/invariants_err.move:37:37
    │
 37 │     invariant<T> global<T>(@0x1) == global<T>(@0x2);

--- a/third_party/move/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/third_party/move/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -7,7 +7,7 @@
 // TODO(tengzhang): helpers specifically for bv types need to be refactored
 
 use crate::{options::BoogieOptions, COMPILED_MODULE_AVAILABLE};
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use move_binary_format::file_format::TypeParameterIndex;
 use move_core_types::account_address::AccountAddress;
 use move_model::{
@@ -175,6 +175,31 @@ pub fn boogie_choice_fun_name(id: usize) -> String {
 pub fn boogie_modifies_memory_name(env: &GlobalEnv, memory: &QualifiedInstId<StructId>) -> String {
     let struct_env = &env.get_struct_qid(memory.to_qualified_id());
     format!("{}_$modifies", boogie_struct_name(struct_env, &memory.inst))
+}
+
+pub fn boogie_resource_ty_name(
+    env: &GlobalEnv,
+    memory: &Either<QualifiedInstId<StructId>, u16>,
+) -> String {
+    if let Either::Left(mem) = memory {
+        let struct_env = env.get_struct_qid(mem.to_qualified_id());
+        boogie_struct_name(&struct_env, &mem.inst)
+    } else {
+        format!("#{}", memory.clone().right().unwrap())
+    }
+}
+
+/// Creates the name of the resource memory.
+pub fn boogie_resource_memory_name_ty(
+    env: &GlobalEnv,
+    memory: &Either<QualifiedInstId<StructId>, u16>,
+    memory_label: &Option<MemoryLabel>,
+) -> String {
+    format!(
+        "{}_$memory{}",
+        boogie_resource_ty_name(env, memory),
+        boogie_memory_label(memory_label)
+    )
 }
 
 /// Creates the name of the resource memory for the given struct.

--- a/third_party/move/move-prover/bytecode/src/function_target_pipeline.rs
+++ b/third_party/move/move-prover/bytecode/src/function_target_pipeline.rs
@@ -225,6 +225,9 @@ impl FunctionTargetsHolder {
         &'env self,
         func_env: &'env FunctionEnv<'env>,
     ) -> Vec<(FunctionVariant, FunctionTarget<'env>)> {
+        if func_env.is_inline() {
+            return vec![];
+        }
         assert!(
             !func_env.is_inline(),
             "attempt to get bytecode function target for inline function"

--- a/third_party/move/move-prover/bytecode/src/mono_analysis.rs
+++ b/third_party/move/move-prover/bytecode/src/mono_analysis.rs
@@ -422,9 +422,13 @@ impl<'a> Analyzer<'a> {
             },
             Prop(_, _, exp) => self.analyze_exp(exp),
             SaveMem(_, _, mem) => {
-                let mem = self.instantiate_mem(mem.to_owned());
-                let struct_env = self.env.get_struct_qid(mem.to_qualified_id());
-                self.add_struct(struct_env, &mem.inst);
+                if mem.is_left() {
+                    let mem = self.instantiate_mem(mem.clone().left().unwrap());
+                    let struct_env = self.env.get_struct_qid(mem.to_qualified_id());
+                    self.add_struct(struct_env, &mem.inst)
+                } else {
+                    self.add_type(&Type::TypeParameter(mem.clone().right().unwrap()))
+                }
             },
             _ => {},
         }


### PR DESCRIPTION
### Description

This PR
- adds support of generic types for exists in the prover so that one can use `exists` at the spec level for the function `exists_at` in the `object` module.
- adds specs for `exists_at`.

Close #6658

