### PR TITLE
[Sharding][Partitioning] Fix to ensure relative ordering for sender

### DIFF
--- a/execution/block-partitioner/src/sharded_block_partitioner/conflict_detector.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/conflict_detector.rs
@@ -12,7 +12,7 @@ use aptos_types::{
     },
 };
 use std::{
-    collections::hash_map::DefaultHasher,
+    collections::{hash_map::DefaultHasher, HashSet},
     hash::{Hash, Hasher},
     sync::Arc,
 };
@@ -45,9 +45,24 @@ impl CrossShardConflictDetector {
         let mut accepted_txns = Vec::new();
         let mut accepted_txn_dependencies = Vec::new();
         let mut rejected_txns = Vec::new();
+        let mut discarded_senders = HashSet::new();
         for (_, txn) in txns.into_iter().enumerate() {
             if self.check_for_cross_shard_conflict(self.shard_id, &txn, cross_shard_rw_set) {
+                if let Some(sender) = txn.sender() {
+                    discarded_senders.insert(sender);
+                }
                 rejected_txns.push(txn);
+            } else if let Some(sender) = txn.sender() {
+                if discarded_senders.contains(&sender) {
+                    rejected_txns.push(txn);
+                } else {
+                    accepted_txn_dependencies.push(self.get_deps_for_frozen_txn(
+                        &txn,
+                        Arc::new(vec![]),
+                        prev_rounds_rw_set_with_index.clone(),
+                    ));
+                    accepted_txns.push(txn);
+                }
             } else {
                 accepted_txn_dependencies.push(self.get_deps_for_frozen_txn(
                     &txn,

--- a/execution/block-partitioner/src/sharded_block_partitioner/cross_shard_messages.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/cross_shard_messages.rs
@@ -134,19 +134,14 @@ impl CrossShardClientInterface for CrossShardClient {
         let num_shards = self.message_txs.len();
 
         for (shard_id, dependent_edges) in dependent_edges.into_iter().enumerate() {
-            if shard_id != self.shard_id {
-                self.message_txs[shard_id]
-                    .send(CrossShardDependentEdgesMsg(dependent_edges))
-                    .unwrap();
-            }
+            self.message_txs[shard_id]
+                .send(CrossShardDependentEdgesMsg(dependent_edges))
+                .unwrap();
         }
 
         let mut cross_shard_dependent_edges = vec![vec![]; num_shards];
 
         for (i, msg_rx) in self.message_rxs.iter().enumerate() {
-            if i == self.shard_id {
-                continue;
-            }
             let msg = msg_rx.recv().unwrap();
             match msg {
                 CrossShardDependentEdgesMsg(dependent_edges) => {

--- a/execution/block-partitioner/src/sharded_block_partitioner/mod.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/mod.rs
@@ -407,12 +407,12 @@ mod tests {
     };
     use aptos_crypto::hash::CryptoHash;
     use aptos_types::{
-        block_executor::partitioner::{SubBlock, TxnIdxWithShardId},
+        block_executor::partitioner::{SubBlock, SubBlocksForShard, TxnIdxWithShardId},
         transaction::{analyzed_transaction::AnalyzedTransaction, Transaction},
     };
     use move_core_types::account_address::AccountAddress;
     use rand::{rngs::OsRng, Rng};
-    use std::collections::HashMap;
+    use std::{collections::HashMap, sync::Mutex};
 
     fn verify_no_cross_shard_dependency(sub_blocks_for_shards: Vec<SubBlock<Transaction>>) {
         for sub_blocks in sub_blocks_for_shards {
@@ -535,6 +535,53 @@ mod tests {
                 .cloned()
                 .collect(),
         );
+    }
+
+    fn get_account_seq_number(txn: &Transaction) -> (AccountAddress, u64) {
+        match txn {
+            Transaction::UserTransaction(txn) => (txn.sender(), txn.sequence_number()),
+            _ => unreachable!("Only user transaction can be executed in executor"),
+        }
+    }
+
+    #[test]
+    // Ensures that transactions from the same sender are not reordered.
+    fn test_relative_ordering_for_sender() {
+        let mut rng = OsRng;
+        let num_shards = 8;
+        let num_accounts = 50;
+        let num_txns = 500;
+        let mut accounts = Vec::new();
+        for _ in 0..num_accounts {
+            accounts.push(Mutex::new(generate_test_account()));
+        }
+        let mut transactions = Vec::new();
+
+        for _ in 0..num_txns {
+            let indices = rand::seq::index::sample(&mut rng, num_accounts, 2);
+            let sender = &mut accounts[indices.index(0)].lock().unwrap();
+            let receiver = &accounts[indices.index(1)].lock().unwrap();
+            let txn = create_signed_p2p_transaction(sender, vec![receiver]).remove(0);
+            transactions.push(txn.clone());
+            transactions.push(create_signed_p2p_transaction(sender, vec![receiver]).remove(0));
+        }
+
+        let partitioner = ShardedBlockPartitioner::new(num_shards);
+        let sub_blocks = partitioner.partition(transactions.clone(), 1);
+
+        let mut account_to_expected_seq_number: HashMap<AccountAddress, u64> = HashMap::new();
+        SubBlocksForShard::flatten(sub_blocks)
+            .iter()
+            .for_each(|txn| {
+                let (sender, seq_number) = get_account_seq_number(txn);
+                if account_to_expected_seq_number.contains_key(&sender) {
+                    assert_eq!(
+                        account_to_expected_seq_number.get(&sender).unwrap(),
+                        &seq_number
+                    );
+                }
+                account_to_expected_seq_number.insert(sender, seq_number + 1);
+            });
     }
 
     #[test]


### PR DESCRIPTION
### Description

Fix partitioning logic to maintain relative ordering of transaction across senders. This is done by moving all remaining txns from the sender to the end of the block, once we detect cross shard conflict for that sender.

### Test Plan

Added UTs.
