### PR TITLE
[gha][forge] fix ambiguous redirect to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/workflow-run-forge.yaml
+++ b/.github/workflows/workflow-run-forge.yaml
@@ -119,7 +119,7 @@ jobs:
         id: calculate-auth-duration
         run: |
           auth_duration=$(( $FORGE_RUNNER_DURATION_SECS > 5400 ? $FORGE_RUNNER_DURATION_SECS + 30 * 60 : 5400 ))
-          echo "auth_duration=${auth_duration}" >> $GITHUB_OUTPUTS
+          echo "auth_duration=${auth_duration}" >> $GITHUB_OUTPUT
 
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         id: docker-setup


### PR DESCRIPTION
### Description

Fix a typo. Outputs are written to `GITHUB_OUTPUT`

### Test Plan

Workflow dispatch 

<!-- Please provide us with clear details for verifying that your changes work. -->
