### PR TITLE
[Faucet][CLI] Add message to indicate faucet is starting

### DIFF
--- a/crates/aptos-faucet/core/src/server/run.rs
+++ b/crates/aptos-faucet/core/src/server/run.rs
@@ -69,7 +69,7 @@ pub struct RunConfig {
 impl RunConfig {
     pub async fn run(self) -> Result<()> {
         info!("Running with config: {:#?}", self);
-        info!("Starting server...");
+        println!("Faucet is starting, please wait...");
 
         // Set whether we should use useful errors.
         // If it's already set, then we'll carry on


### PR DESCRIPTION
### Description
Small quality of life improvement. This way users can tell that the faucet hasn't actually started yet.

### Test Plan
```
$ cargo run -p aptos -- node run-local-testnet --force-restart --with-faucet --assume-yes
Completed generating configuration:
        Log file: "/Users/dport/.aptos/testnet/validator.log"
        Test dir: "/Users/dport/.aptos/testnet"
        Aptos root key path: "/Users/dport/.aptos/testnet/mint.key"
        Waypoint: 0:645b3a18445fbb7ae17031b2e5f14929bfbf8d5612acdd668be2a6824c31ea0d
        ChainId: testing
        REST API endpoint: http://0.0.0.0:8080
        Metrics endpoint: http://0.0.0.0:9101/metrics
        Aptosnet fullnode network endpoint: /ip4/0.0.0.0/tcp/6181

Aptos is running, press ctrl-c to exit

Faucet is starting, please wait...
Faucet is running. Faucet endpoint: http://0.0.0.0:8081
```
