### PR TITLE
[ts-sdk] Allow local endpoint provider

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos Node SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Add support for local testing without an indexer
 
 ## 1.13.2 (2023-07-12)
 - Add support for `Option<T>` and `vector<Object<T>>` in the SDK

--- a/ecosystem/typescript/sdk/src/providers/provider.ts
+++ b/ecosystem/typescript/sdk/src/providers/provider.ts
@@ -21,7 +21,7 @@ type NetworkWithCustom = Network | "CUSTOM";
  * const accountNFTs = await provider.getAccountNFTs("0x123");
  * ```
  *
- * @param network enum of type Network - MAINNET | TESTNET | DEVENET or custom endpoints of type CustomEndpoints
+ * @param network enum of type Network - MAINNET | TESTNET | DEVNET | LOCAL or custom endpoints of type CustomEndpoints
  * @param config AptosClient config arg - additional configuration options for the generated Axios client.
  */
 export class Provider {
@@ -45,8 +45,15 @@ export class Provider {
       this.network = network;
     }
 
-    if (!fullNodeUrl || !indexerUrl) {
-      throw new Error("network is not provided");
+    if (!fullNodeUrl) {
+      throw new Error("network is not provided, must provide a Network or a fullNodeUrl");
+    }
+
+    // For local dev purposes and indexer URL may not be given
+    if (!indexerUrl && (this.network === "CUSTOM" || this.network === Network.LOCAL)) {
+      indexerUrl = "No indexer URL given";
+    } else {
+      throw new Error("network does not have an indexer URL");
     }
 
     this.aptosClient = new AptosClient(fullNodeUrl, config, doNotFixNodeUrl);

--- a/ecosystem/typescript/sdk/src/utils/api-endpoints.ts
+++ b/ecosystem/typescript/sdk/src/utils/api-endpoints.ts
@@ -2,24 +2,28 @@ export const NetworkToIndexerAPI: Record<string, string> = {
   mainnet: "https://indexer.mainnet.aptoslabs.com/v1/graphql",
   testnet: "https://indexer-testnet.staging.gcp.aptosdev.com/v1/graphql",
   devnet: "https://indexer-devnet.staging.gcp.aptosdev.com/v1/graphql",
+  local: "",
 };
 
 export const NetworkToNodeAPI: Record<string, string> = {
   mainnet: "https://fullnode.mainnet.aptoslabs.com/v1",
   testnet: "https://fullnode.testnet.aptoslabs.com/v1",
   devnet: "https://fullnode.devnet.aptoslabs.com/v1",
+  local: "http://localhost:8080/v1",
 };
 
 export const NodeAPIToNetwork: Record<string, string> = {
   "https://fullnode.mainnet.aptoslabs.com/v1": "mainnet",
   "https://fullnode.testnet.aptoslabs.com/v1": "testnet",
   "https://fullnode.devnet.aptoslabs.com/v1": "devnet",
+  "http://localhost:8080/v1": "local",
 };
 
 export enum Network {
   MAINNET = "mainnet",
   TESTNET = "testnet",
   DEVNET = "devnet",
+  LOCAL = "local",
 }
 
 export interface CustomEndpoints {


### PR DESCRIPTION
### Description
This allows local development with the TS SDK.  It isn't ideal though, because an indexer client still exists, it just won't work correctly.

### Test Plan
I've tested locally