### PR TITLE
Make Developer Platform CI use pull_request_target

### DIFF
--- a/.github/workflows/faucet-tests.yaml
+++ b/.github/workflows/faucet-tests.yaml
@@ -1,16 +1,38 @@
 name: "Faucet Integration Tests"
 on:
-  pull_request:
+  pull_request_target:
+    types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
   push:
     branches:
       - main
 
+permissions:
+  contents: read
+  id-token: write  # Required for GCP Workload Identity federation which we use to login into Google Artifact Registry
+
 jobs:
+  # Note on the job-level `if` conditions:
+  # This workflow is designed such that we run subsequent jobs only when a 'push'
+  # triggered the workflow or on 'pull_request's which have set auto_merge=true
+  # or have the label "CICD:run-e2e-tests".
+  permission-check:
+    if: |
+      github.event_name == 'push' ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'CICD:build-') ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'CICD:run-') ||
+      github.event.pull_request.auto_merge != null ||
+      contains(github.event.pull_request.body, '#e2e')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check repository permission for user which triggered workflow
+        uses: sushichop/action-repository-permission@13d208f5ae7a6a3fc0e5a7c2502c214983f0241c
+        with:
+          required-permission: write
+          comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
+
   run-tests-devnet:
+    needs: [permission-check]
     runs-on: high-perf-docker
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
@@ -25,7 +47,9 @@ jobs:
         with:
           NETWORK: devnet
           GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
+
   run-tests-testnet:
+    needs: [permission-check]
     runs-on: high-perf-docker
     permissions:
       contents: read

--- a/.github/workflows/indexer-grpc-integration-tests.yaml
+++ b/.github/workflows/indexer-grpc-integration-tests.yaml
@@ -1,6 +1,14 @@
 name: "Indexer gRPC Integration Tests"
 on:
-  pull_request:
+  pull_request_target:
+    types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write  # Required for GCP Workload Identity federation which we use to login into Google Artifact Registry
 
 # cancel redundant builds
 concurrency:
@@ -9,11 +17,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Note on the job-level `if` conditions:
+  # This workflow is designed such that we run subsequent jobs only when a 'push'
+  # triggered the workflow or on 'pull_request's which have set auto_merge=true
+  # or have the label "CICD:run-e2e-tests".
+  permission-check:
+    if: |
+      github.event_name == 'push' ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'CICD:build-') ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'CICD:run-') ||
+      github.event.pull_request.auto_merge != null ||
+      contains(github.event.pull_request.body, '#e2e')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check repository permission for user which triggered workflow
+        uses: sushichop/action-repository-permission@13d208f5ae7a6a3fc0e5a7c2502c214983f0241c
+        with:
+          required-permission: write
+          comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
+
   run-tests-local-testnet:
+    needs: [permission-check]
     runs-on: high-perf-docker
-    permissions:
-      contents: read
-      id-token: write
     env:
       # spin up the local testnet using the latest devnet image
       VALIDATOR_IMAGE_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/validator

--- a/.github/workflows/rust-client-tests.yaml
+++ b/.github/workflows/rust-client-tests.yaml
@@ -4,17 +4,39 @@
 
 name: "Rust SDK Client Tests"
 on:
-  pull_request:
+  pull_request_target:
+    types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
   push:
     branches:
       - main
 
+permissions:
+  contents: read
+  id-token: write  # Required for GCP Workload Identity federation which we use to login into Google Artifact Registry
+
 jobs:
+  # Note on the job-level `if` conditions:
+  # This workflow is designed such that we run subsequent jobs only when a 'push'
+  # triggered the workflow or on 'pull_request's which have set auto_merge=true
+  # or have the label "CICD:run-e2e-tests".
+  permission-check:
+    if: |
+      github.event_name == 'push' ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'CICD:build-') ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'CICD:run-') ||
+      github.event.pull_request.auto_merge != null ||
+      contains(github.event.pull_request.body, '#e2e')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check repository permission for user which triggered workflow
+        uses: sushichop/action-repository-permission@13d208f5ae7a6a3fc0e5a7c2502c214983f0241c
+        with:
+          required-permission: write
+          comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
+
   run-tests-devnet:
+    needs: [permission-check]
     runs-on: high-perf-docker
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
@@ -31,10 +53,8 @@ jobs:
           GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
 
   run-tests-testnet:
+    needs: [permission-check]
     runs-on: high-perf-docker
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
@@ -51,10 +71,8 @@ jobs:
           GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
 
   run-tests-mainnet:
+    needs: [permission-check]
     runs-on: high-perf-docker
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main

--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -5,17 +5,39 @@
 
 name: "TS SDK E2E Tests"
 on:
-  pull_request:
+  pull_request_target:
+    types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
   push:
     branches:
       - main
 
+permissions:
+  contents: read
+  id-token: write  # Required for GCP Workload Identity federation which we use to login into Google Artifact Registry
+
 jobs:
+  # Note on the job-level `if` conditions:
+  # This workflow is designed such that we run subsequent jobs only when a 'push'
+  # triggered the workflow or on 'pull_request's which have set auto_merge=true
+  # or have the label "CICD:run-e2e-tests".
+  permission-check:
+    if: |
+      github.event_name == 'push' ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'CICD:build-') ||
+      contains(join(github.event.pull_request.labels.*.name, ','), 'CICD:run-') ||
+      github.event.pull_request.auto_merge != null ||
+      contains(github.event.pull_request.body, '#e2e')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check repository permission for user which triggered workflow
+        uses: sushichop/action-repository-permission@13d208f5ae7a6a3fc0e5a7c2502c214983f0241c
+        with:
+          required-permission: write
+          comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
+
   run-tests-devnet:
+    needs: [permission-check]
     runs-on: high-perf-docker
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
@@ -32,10 +54,8 @@ jobs:
           GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
 
   run-tests-testnet:
+    needs: [permission-check]
     runs-on: high-perf-docker
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
@@ -52,10 +72,8 @@ jobs:
           GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
 
   run-tests-mainnet:
+    needs: [permission-check]
     runs-on: high-perf-docker
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main


### PR DESCRIPTION
### Description
Using `pull_request` works fine for contributors who are contributing via branches, but external contributors must contribute via a fork based approach. In those cases `pull_request` is unable to pull in the necessary secrets to run the test.

This PR migrates all of this CI to instead use the same approach we use in docker-build-test.yaml, where we use pull_request_target and a permissions check.

### Test Plan
Land to main.
