### PR TITLE
Add all_modules function to BuiltPackage

### DIFF
--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -253,6 +253,17 @@ impl BuiltPackage {
             })
     }
 
+    /// Returns an iterator for all compiled proper (non-script) modules, including
+    /// modules that are dependencies of the root modules.
+    pub fn all_modules(&self) -> impl Iterator<Item = &CompiledModule> {
+        self.package
+            .all_modules()
+            .filter_map(|unit| match &unit.unit {
+                CompiledUnit::Module(NamedCompiledModule { module, .. }) => Some(module),
+                CompiledUnit::Script(_) => None,
+            })
+    }
+
     /// Returns the number of scripts in the package.
     pub fn script_count(&self) -> usize {
         self.package.scripts().count()


### PR DESCRIPTION
### Description
Getting all modules in a package, including dependencies, is helpful for downstream tools I am building. For example, to generate types based on a package, you need to do it for all modules, not just the root modules.

### Test Plan
CI.
