### PR TITLE
Fixed signer to be formatted properly

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -45,6 +45,7 @@ pub enum FeatureFlag {
     GasPayerEnabled,
     AptosUniqueIdentifiers,
     BulletproofsNatives,
+    SignerNativeFormatFix,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -168,6 +169,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::GasPayerEnabled => AptosFeatureFlag::GAS_PAYER_ENABLED,
             FeatureFlag::AptosUniqueIdentifiers => AptosFeatureFlag::APTOS_UNIQUE_IDENTIFIERS,
             FeatureFlag::BulletproofsNatives => AptosFeatureFlag::BULLETPROOFS_NATIVES,
+            FeatureFlag::SignerNativeFormatFix => AptosFeatureFlag::SIGNER_NATIVE_FORMAT_FIX,
         }
     }
 }
@@ -214,6 +216,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::GAS_PAYER_ENABLED => FeatureFlag::GasPayerEnabled,
             AptosFeatureFlag::APTOS_UNIQUE_IDENTIFIERS => FeatureFlag::AptosUniqueIdentifiers,
             AptosFeatureFlag::BULLETPROOFS_NATIVES => FeatureFlag::BulletproofsNatives,
+            AptosFeatureFlag::SIGNER_NATIVE_FORMAT_FIX => FeatureFlag::SignerNativeFormatFix,
         }
     }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/debug.move
+++ b/aptos-move/framework/aptos-stdlib/sources/debug.move
@@ -66,7 +66,6 @@ module aptos_std::debug {
     public fun test()  {
         let x = 42;
         assert_equal(&x, b"42");
-        print(&x);
 
         let v = vector::empty();
         vector::push_back(&mut v, 100);
@@ -102,8 +101,9 @@ module aptos_std::debug {
         assert_equal(&str, b"\"Can you say \\\"Hel\\\\lo\\\"?\"");
     }
 
-    #[test]
-    fun test_print_primitive_types() {
+
+    #[test(s = @0x123)]
+    fun test_print_primitive_types(s: signer) {
         let u8 = 255u8;
         assert_equal(&u8, b"255");
 
@@ -131,10 +131,8 @@ module aptos_std::debug {
         let a = @0x1234c0ffee;
         assert_equal(&a, b"@0x1234c0ffee");
 
-        // print a signer
-        /*let senders = create_signers_for_testing(1);
-        let sender = vector::pop_back(&mut senders);
-        print(&sender);*/
+        let signer = s;
+        assert_equal(&signer, b"signer(@0x123)");
     }
 
     const MSG_1 : vector<u8> = b"abcdef";
@@ -159,8 +157,8 @@ module aptos_std::debug {
         assert_equal(&obj, b"0x1::debug::TestInner {\n  val: 10,\n  vec: [],\n  msgs: []\n}");
     }
 
-    #[test]
-    fun test_print_vectors() {
+    #[test(s1 = @0x123, s2 = @0x456)]
+    fun test_print_vectors(s1: signer, s2: signer) {
         let v_u8 = x"ffabcdef";
         assert_equal(&v_u8, b"0xffabcdef");
 
@@ -185,8 +183,8 @@ module aptos_std::debug {
         let v_addr = vector[@0x1234, @0x5678, @0xabcdef];
         assert_equal(&v_addr, b"[ @0x1234, @0x5678, @0xabcdef ]");
 
-        /*let v_signer = create_signers_for_testing(4);
-        print(&v_signer);*/
+        let v_signer = vector[s1, s2];
+        assert_equal(&v_signer, b"[ signer(@0x123), signer(@0x456) ]");
 
         let v = vector[
             TestInner {
@@ -203,8 +201,8 @@ module aptos_std::debug {
         assert_equal(&v, b"[\n  0x1::debug::TestInner {\n    val: 4,\n    vec: [ 127, 128 ],\n    msgs: [\n      0x00ff,\n      0xabcd\n    ]\n  },\n  0x1::debug::TestInner {\n    val: 8,\n    vec: [ 128, 129 ],\n    msgs: [\n      0x0000\n    ]\n  }\n]");
     }
 
-    #[test]
-    fun test_print_vector_of_vectors() {
+    #[test(s1 = @0x123, s2 = @0x456)]
+    fun test_print_vector_of_vectors(s1: signer, s2: signer) {
         let v_u8 = vector[x"ffab", x"cdef"];
         assert_equal(&v_u8, b"[\n  0xffab,\n  0xcdef\n]");
 
@@ -229,8 +227,8 @@ module aptos_std::debug {
         let v_addr = vector[vector[@0x1234, @0x5678], vector[@0xabcdef, @0x9999]];
         assert_equal(&v_addr, b"[\n  [ @0x1234, @0x5678 ],\n  [ @0xabcdef, @0x9999 ]\n]");
 
-        /*let v_signer = vector[create_signers_for_testing(2), create_signers_for_testing(2)];
-        print(&v_signer);*/
+        let v_signer = vector[vector[s1], vector[s2]];
+        assert_equal(&v_signer, b"[\n  [ signer(@0x123) ],\n  [ signer(@0x456) ]\n]");
 
         let v = vector[
             vector[

--- a/aptos-move/framework/aptos-stdlib/sources/debug.move
+++ b/aptos-move/framework/aptos-stdlib/sources/debug.move
@@ -102,6 +102,8 @@ module aptos_std::debug {
     }
 
 
+    #[test_only]
+    use std::features;
     #[test(s = @0x123)]
     fun test_print_primitive_types(s: signer) {
         let u8 = 255u8;
@@ -131,8 +133,10 @@ module aptos_std::debug {
         let a = @0x1234c0ffee;
         assert_equal(&a, b"@0x1234c0ffee");
 
-        let signer = s;
-        assert_equal(&signer, b"signer(@0x123)");
+        if (features::signer_native_format_fix_enabled()) {
+            let signer = s;
+            assert_equal(&signer, b"signer(@0x123)");
+        }
     }
 
     const MSG_1 : vector<u8> = b"abcdef";
@@ -183,8 +187,10 @@ module aptos_std::debug {
         let v_addr = vector[@0x1234, @0x5678, @0xabcdef];
         assert_equal(&v_addr, b"[ @0x1234, @0x5678, @0xabcdef ]");
 
-        let v_signer = vector[s1, s2];
-        assert_equal(&v_signer, b"[ signer(@0x123), signer(@0x456) ]");
+        if (features::signer_native_format_fix_enabled()) {
+            let v_signer = vector[s1, s2];
+            assert_equal(&v_signer, b"[ signer(@0x123), signer(@0x456) ]");
+        };
 
         let v = vector[
             TestInner {
@@ -227,8 +233,10 @@ module aptos_std::debug {
         let v_addr = vector[vector[@0x1234, @0x5678], vector[@0xabcdef, @0x9999]];
         assert_equal(&v_addr, b"[\n  [ @0x1234, @0x5678 ],\n  [ @0xabcdef, @0x9999 ]\n]");
 
-        let v_signer = vector[vector[s1], vector[s2]];
-        assert_equal(&v_signer, b"[\n  [ signer(@0x123) ],\n  [ signer(@0x456) ]\n]");
+        if (features::signer_native_format_fix_enabled()) {
+            let v_signer = vector[vector[s1], vector[s2]];
+            assert_equal(&v_signer, b"[\n  [ signer(@0x123) ],\n  [ signer(@0x456) ]\n]");
+        };
 
         let v = vector[
             vector[

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -66,6 +66,8 @@ return true.
 -  [Function `auids_enabled`](#0x1_features_auids_enabled)
 -  [Function `get_bulletproofs_feature`](#0x1_features_get_bulletproofs_feature)
 -  [Function `bulletproofs_enabled`](#0x1_features_bulletproofs_enabled)
+-  [Function `get_signer_native_format_fix_feature`](#0x1_features_get_signer_native_format_fix_feature)
+-  [Function `signer_native_format_fix_enabled`](#0x1_features_signer_native_format_fix_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `is_enabled`](#0x1_features_is_enabled)
 -  [Function `set`](#0x1_features_set)
@@ -341,6 +343,17 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_SHA_512_AND_RIPEMD_160_NATIVES">SHA_512_AND_RIPEMD_160_NATIVES</a>: u64 = 3;
+</code></pre>
+
+
+
+<a name="0x1_features_SIGNER_NATIVE_FORMAT_FIX"></a>
+
+Fix the native formatter for signer.
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_SIGNER_NATIVE_FORMAT_FIX">SIGNER_NATIVE_FORMAT_FIX</a>: u64 = 25;
 </code></pre>
 
 
@@ -1181,6 +1194,52 @@ Lifetime: transient
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_bulletproofs_enabled">bulletproofs_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_BULLETPROOFS_NATIVES">BULLETPROOFS_NATIVES</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_features_get_signer_native_format_fix_feature"></a>
+
+## Function `get_signer_native_format_fix_feature`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_signer_native_format_fix_feature">get_signer_native_format_fix_feature</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_signer_native_format_fix_feature">get_signer_native_format_fix_feature</a>(): u64 { <a href="features.md#0x1_features_SIGNER_NATIVE_FORMAT_FIX">SIGNER_NATIVE_FORMAT_FIX</a> }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_features_signer_native_format_fix_enabled"></a>
+
+## Function `signer_native_format_fix_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_signer_native_format_fix_enabled">signer_native_format_fix_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_signer_native_format_fix_enabled">signer_native_format_fix_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_SIGNER_NATIVE_FORMAT_FIX">SIGNER_NATIVE_FORMAT_FIX</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -50,9 +50,7 @@ module std::features {
     /// This is needed because of the introduction of new native functions.
     /// Lifetime: transient
     const SHA_512_AND_RIPEMD_160_NATIVES: u64 = 3;
-
     public fun get_sha_512_and_ripemd_160_feature(): u64 { SHA_512_AND_RIPEMD_160_NATIVES }
-
     public fun sha_512_and_ripemd_160_enabled(): bool acquires Features {
         is_enabled(SHA_512_AND_RIPEMD_160_NATIVES)
     }
@@ -61,9 +59,7 @@ module std::features {
     /// This is needed because of the introduction of a new native function.
     /// Lifetime: transient
     const APTOS_STD_CHAIN_ID_NATIVES: u64 = 4;
-
     public fun get_aptos_stdlib_chain_id_feature(): u64 { APTOS_STD_CHAIN_ID_NATIVES }
-
     public fun aptos_stdlib_chain_id_enabled(): bool acquires Features {
         is_enabled(APTOS_STD_CHAIN_ID_NATIVES)
     }
@@ -71,9 +67,7 @@ module std::features {
     /// Whether to allow the use of binary format version v6.
     /// Lifetime: transient
     const VM_BINARY_FORMAT_V6: u64 = 5;
-
     public fun get_vm_binary_format_v6(): u64 { VM_BINARY_FORMAT_V6 }
-
     public fun allow_vm_binary_format_v6(): bool acquires Features {
         is_enabled(VM_BINARY_FORMAT_V6)
     }
@@ -81,9 +75,7 @@ module std::features {
     /// Whether gas fees are collected and distributed to the block proposers.
     /// Lifetime: transient
     const COLLECT_AND_DISTRIBUTE_GAS_FEES: u64 = 6;
-
     public fun get_collect_and_distribute_gas_fees_feature(): u64 { COLLECT_AND_DISTRIBUTE_GAS_FEES }
-
     public fun collect_and_distribute_gas_fees(): bool acquires Features {
         is_enabled(COLLECT_AND_DISTRIBUTE_GAS_FEES)
     }
@@ -92,9 +84,7 @@ module std::features {
     /// This is needed because of the introduction of a new native function.
     /// Lifetime: transient
     const MULTI_ED25519_PK_VALIDATE_V2_NATIVES: u64 = 7;
-
     public fun multi_ed25519_pk_validate_v2_feature(): u64 { MULTI_ED25519_PK_VALIDATE_V2_NATIVES }
-
     public fun multi_ed25519_pk_validate_v2_enabled(): bool acquires Features {
         is_enabled(MULTI_ED25519_PK_VALIDATE_V2_NATIVES)
     }
@@ -103,9 +93,7 @@ module std::features {
     /// This is needed because of the introduction of new native function(s).
     /// Lifetime: transient
     const BLAKE2B_256_NATIVE: u64 = 8;
-
     public fun get_blake2b_256_feature(): u64 { BLAKE2B_256_NATIVE }
-
     public fun blake2b_256_enabled(): bool acquires Features {
         is_enabled(BLAKE2B_256_NATIVE)
     }
@@ -113,18 +101,14 @@ module std::features {
     /// Whether resource groups are enabled.
     /// This is needed because of new attributes for structs and a change in storage representation.
     const RESOURCE_GROUPS: u64 = 9;
-
     public fun get_resource_groups_feature(): u64 { RESOURCE_GROUPS }
-
     public fun resource_groups_enabled(): bool acquires Features {
         is_enabled(RESOURCE_GROUPS)
     }
 
     /// Whether multisig accounts (different from accounts with multi-ed25519 auth keys) are enabled.
     const MULTISIG_ACCOUNTS: u64 = 10;
-
     public fun get_multisig_accounts_feature(): u64 { MULTISIG_ACCOUNTS }
-
     public fun multisig_accounts_enabled(): bool acquires Features {
         is_enabled(MULTISIG_ACCOUNTS)
     }
@@ -132,9 +116,7 @@ module std::features {
     /// Whether delegation pools are enabled.
     /// Lifetime: transient
     const DELEGATION_POOLS: u64 = 11;
-
     public fun get_delegation_pools_feature(): u64 { DELEGATION_POOLS }
-
     public fun delegation_pools_enabled(): bool acquires Features {
         is_enabled(DELEGATION_POOLS)
     }
@@ -213,11 +195,17 @@ module std::features {
     /// available. This is needed because of the introduction of a new native function.
     /// Lifetime: transient
     const BULLETPROOFS_NATIVES: u64 = 24;
-
     public fun get_bulletproofs_feature(): u64 { BULLETPROOFS_NATIVES }
-
     public fun bulletproofs_enabled(): bool acquires Features {
         is_enabled(BULLETPROOFS_NATIVES)
+    }
+
+    /// Fix the native formatter for signer.
+    /// Lifetime: transient
+    const SIGNER_NATIVE_FORMAT_FIX: u64 = 25;
+    public fun get_signer_native_format_fix_feature(): u64 { SIGNER_NATIVE_FORMAT_FIX }
+    public fun signer_native_format_fix_enabled(): bool acquires Features {
+        is_enabled(SIGNER_NATIVE_FORMAT_FIX)
     }
 
     // ============================================================================================

--- a/aptos-move/framework/src/natives/string_utils.rs
+++ b/aptos-move/framework/src/natives/string_utils.rs
@@ -175,13 +175,18 @@ fn native_format_impl(
             write!(out, "@{}", str).unwrap();
         },
         MoveTypeLayout::Signer => {
-            let addr = val.value_as::<move_core_types::account_address::AccountAddress>()?;
+            let strct = val.value_as::<Struct>()?;
+            let addr = strct
+                .unpack()?
+                .next()
+                .unwrap()
+                .value_as::<move_core_types::account_address::AccountAddress>()?;
             let str = if context.canonicalize {
                 addr.to_canonical_string()
             } else {
                 addr.to_hex_literal()
             };
-            write!(out, "signer({})", str).unwrap();
+            write!(out, "signer(@{})", str).unwrap();
         },
         MoveTypeLayout::Vector(ty) => {
             if let MoveTypeLayout::U8 = ty.as_ref() {

--- a/aptos-move/framework/src/natives/string_utils.rs
+++ b/aptos-move/framework/src/natives/string_utils.rs
@@ -7,6 +7,7 @@ use aptos_native_interface::{
     safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeError,
     SafeNativeResult,
 };
+use aptos_types::on_chain_config::FeatureFlag;
 use ark_std::iterable::Iterable;
 use move_core_types::{
     account_address::AccountAddress,
@@ -175,18 +176,30 @@ fn native_format_impl(
             write!(out, "@{}", str).unwrap();
         },
         MoveTypeLayout::Signer => {
-            let strct = val.value_as::<Struct>()?;
-            let addr = strct
-                .unpack()?
-                .next()
-                .unwrap()
-                .value_as::<move_core_types::account_address::AccountAddress>()?;
+            let fix_enabled = context
+                .context
+                .get_feature_flags()
+                .is_enabled(FeatureFlag::SIGNER_NATIVE_FORMAT_FIX);
+            let addr = if fix_enabled {
+                val.value_as::<Struct>()?
+                    .unpack()?
+                    .next()
+                    .unwrap()
+                    .value_as::<move_core_types::account_address::AccountAddress>()?
+            } else {
+                val.value_as::<move_core_types::account_address::AccountAddress>()?
+            };
+
             let str = if context.canonicalize {
                 addr.to_canonical_string()
             } else {
                 addr.to_hex_literal()
             };
-            write!(out, "signer(@{})", str).unwrap();
+            if fix_enabled {
+                write!(out, "signer(@{})", str).unwrap();
+            } else {
+                write!(out, "signer({})", str).unwrap();
+            }
         },
         MoveTypeLayout::Vector(ty) => {
             if let MoveTypeLayout::U8 = ty.as_ref() {

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -32,6 +32,7 @@ pub enum FeatureFlag {
     GAS_PAYER_ENABLED = 22,
     APTOS_UNIQUE_IDENTIFIERS = 23,
     BULLETPROOFS_NATIVES = 24,
+    SIGNER_NATIVE_FORMAT_FIX = 25,
 }
 
 /// Representation of features on chain as a bitset.


### PR DESCRIPTION
### Description
- This PR fixes the issue (https://github.com/aptos-labs/aptos-core/issues/8865.) of `string_utils::native_format` in formatting signer values

Resolves https://github.com/aptos-labs/aptos-core/issues/8865.

### Test Plan
cargo test -p aptos-framework