### PR TITLE
[TS SDK] Get token owners and current owner data queries

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 
 ## Unreleased
 
-- Use amount greater than 0 in `getTokenOwnersData` query
+- Add token standard v2 support to `getTokenOwnersData` query
+  - `propertyVersion` parameter is optional to support fetching token v2 data
+- Introduce `getTokenCurrentOwnerData` to fetch the current owner of a token
 
 ## 1.11.0 (2023-06-22)
 

--- a/ecosystem/typescript/sdk/src/indexer/generated/operations.ts
+++ b/ecosystem/typescript/sdk/src/indexer/generated/operations.ts
@@ -110,6 +110,13 @@ export type GetTokenActivitiesCountQueryVariables = Types.Exact<{
 
 export type GetTokenActivitiesCountQuery = { __typename?: 'query_root', token_activities_aggregate: { __typename?: 'token_activities_aggregate', aggregate?: { __typename?: 'token_activities_aggregate_fields', count: number } | null } };
 
+export type GetTokenCurrentOwnerDataQueryVariables = Types.Exact<{
+  where_condition: Types.Current_Token_Ownerships_V2_Bool_Exp;
+}>;
+
+
+export type GetTokenCurrentOwnerDataQuery = { __typename?: 'query_root', current_token_ownerships_v2: Array<{ __typename?: 'current_token_ownerships_v2', owner_address: string }> };
+
 export type GetTokenDataQueryVariables = Types.Exact<{
   where_condition?: Types.InputMaybe<Types.Current_Token_Datas_V2_Bool_Exp>;
 }>;
@@ -127,12 +134,11 @@ export type GetTokenOwnedFromCollectionQueryVariables = Types.Exact<{
 export type GetTokenOwnedFromCollectionQuery = { __typename?: 'query_root', current_token_ownerships_v2: Array<{ __typename?: 'current_token_ownerships_v2', token_standard: string, is_fungible_v2?: boolean | null, is_soulbound_v2?: boolean | null, property_version_v1: any, table_type_v1?: string | null, token_properties_mutated_v1?: any | null, amount: any, last_transaction_timestamp: any, last_transaction_version: any, storage_id: string, owner_address: string, current_token_data?: { __typename?: 'current_token_datas_v2', token_name: string, token_data_id: string, token_uri: string, token_properties: any, supply: any, maximum?: any | null, last_transaction_version: any, last_transaction_timestamp: any, largest_property_version_v1?: any | null, current_collection?: { __typename?: 'current_collections_v2', collection_name: string, creator_address: string, description: string, uri: string, collection_id: string, last_transaction_version: any, current_supply: any, mutable_description?: boolean | null, total_minted_v2?: any | null, table_handle_v1?: string | null, mutable_uri?: boolean | null } | null } | null }> };
 
 export type GetTokenOwnersDataQueryVariables = Types.Exact<{
-  token_id?: Types.InputMaybe<Types.Scalars['String']>;
-  property_version?: Types.InputMaybe<Types.Scalars['numeric']>;
+  where_condition: Types.Current_Token_Ownerships_V2_Bool_Exp;
 }>;
 
 
-export type GetTokenOwnersDataQuery = { __typename?: 'query_root', current_token_ownerships: Array<{ __typename?: 'current_token_ownerships', owner_address: string }> };
+export type GetTokenOwnersDataQuery = { __typename?: 'query_root', current_token_ownerships_v2: Array<{ __typename?: 'current_token_ownerships_v2', owner_address: string }> };
 
 export type GetTopUserTransactionsQueryVariables = Types.Exact<{
   limit?: Types.InputMaybe<Types.Scalars['Int']>;

--- a/ecosystem/typescript/sdk/src/indexer/generated/queries.ts
+++ b/ecosystem/typescript/sdk/src/indexer/generated/queries.ts
@@ -249,6 +249,13 @@ export const GetTokenActivitiesCount = `
   }
 }
     `;
+export const GetTokenCurrentOwnerData = `
+    query getTokenCurrentOwnerData($where_condition: current_token_ownerships_v2_bool_exp!) {
+  current_token_ownerships_v2(where: $where_condition) {
+    owner_address
+  }
+}
+    `;
 export const GetTokenData = `
     query getTokenData($where_condition: current_token_datas_v2_bool_exp) {
   current_token_datas_v2(where: $where_condition) {
@@ -285,10 +292,8 @@ export const GetTokenOwnedFromCollection = `
 }
     ${CurrentTokenOwnershipFieldsFragmentDoc}`;
 export const GetTokenOwnersData = `
-    query getTokenOwnersData($token_id: String, $property_version: numeric) {
-  current_token_ownerships(
-    where: {token_data_id_hash: {_eq: $token_id}, property_version: {_eq: $property_version}, amount: {_gt: "0"}}
-  ) {
+    query getTokenOwnersData($where_condition: current_token_ownerships_v2_bool_exp!) {
+  current_token_ownerships_v2(where: $where_condition) {
     owner_address
   }
 }
@@ -359,13 +364,16 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     getTokenActivitiesCount(variables?: Types.GetTokenActivitiesCountQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Types.GetTokenActivitiesCountQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<Types.GetTokenActivitiesCountQuery>(GetTokenActivitiesCount, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getTokenActivitiesCount', 'query');
     },
+    getTokenCurrentOwnerData(variables: Types.GetTokenCurrentOwnerDataQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Types.GetTokenCurrentOwnerDataQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<Types.GetTokenCurrentOwnerDataQuery>(GetTokenCurrentOwnerData, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getTokenCurrentOwnerData', 'query');
+    },
     getTokenData(variables?: Types.GetTokenDataQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Types.GetTokenDataQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<Types.GetTokenDataQuery>(GetTokenData, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getTokenData', 'query');
     },
     getTokenOwnedFromCollection(variables: Types.GetTokenOwnedFromCollectionQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Types.GetTokenOwnedFromCollectionQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<Types.GetTokenOwnedFromCollectionQuery>(GetTokenOwnedFromCollection, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getTokenOwnedFromCollection', 'query');
     },
-    getTokenOwnersData(variables?: Types.GetTokenOwnersDataQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Types.GetTokenOwnersDataQuery> {
+    getTokenOwnersData(variables: Types.GetTokenOwnersDataQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Types.GetTokenOwnersDataQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<Types.GetTokenOwnersDataQuery>(GetTokenOwnersData, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getTokenOwnersData', 'query');
     },
     getTopUserTransactions(variables?: Types.GetTopUserTransactionsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<Types.GetTopUserTransactionsQuery> {

--- a/ecosystem/typescript/sdk/src/indexer/queries/getTokenCurrentOwnerData.graphql
+++ b/ecosystem/typescript/sdk/src/indexer/queries/getTokenCurrentOwnerData.graphql
@@ -1,0 +1,5 @@
+query getTokenCurrentOwnerData($where_condition: current_token_ownerships_v2_bool_exp!) {
+  current_token_ownerships_v2(where: $where_condition) {
+    owner_address
+  }
+}

--- a/ecosystem/typescript/sdk/src/indexer/queries/getTokenOwnersData.graphql
+++ b/ecosystem/typescript/sdk/src/indexer/queries/getTokenOwnersData.graphql
@@ -1,11 +1,5 @@
-query getTokenOwnersData($token_id: String, $property_version: numeric) {
-  current_token_ownerships(
-    where: {
-      token_data_id_hash: { _eq: $token_id }
-      property_version: { _eq: $property_version }
-      amount: { _gt: "0" }
-    }
-  ) {
+query getTokenOwnersData($where_condition: current_token_ownerships_v2_bool_exp!) {
+  current_token_ownerships_v2(where: $where_condition) {
     owner_address
   }
 }

--- a/ecosystem/typescript/sdk/src/tests/e2e/indexer.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/indexer.test.ts
@@ -192,7 +192,20 @@ describe("Indexer", () => {
           accountNFTs.current_token_ownerships[0].current_token_data!.token_data_id_hash,
           0,
         );
-        expect(tokenOwnersData.current_token_ownerships[0].owner_address).toEqual(alice.address().hex());
+        expect(tokenOwnersData.current_token_ownerships_v2[0].owner_address).toEqual(alice.address().hex());
+      },
+      longTestTimeout,
+    );
+
+    it(
+      "gets token current owner data",
+      async () => {
+        const accountNFTs = await indexerClient.getAccountNFTs(alice.address().hex());
+        const tokenOwnersData = await indexerClient.getTokenCurrentOwnerData(
+          accountNFTs.current_token_ownerships[0].current_token_data!.token_data_id_hash,
+          0,
+        );
+        expect(tokenOwnersData.current_token_ownerships_v2[0].owner_address).toEqual(alice.address().hex());
       },
       longTestTimeout,
     );


### PR DESCRIPTION
### Description
This is a better solution for what we had in https://github.com/aptos-labs/aptos-core/pull/8861 .

- `getTokenOwnersData` - This query returns historical owners data. Add token v2 standard support.
- `getTokenCurrentOwnerData` - This query returns the current token owner data and supports token v2 standard.

### Test Plan
tests are passing
