### PR TITLE
[python-sdk] fix a few issues with transaction batching

### DIFF
--- a/ecosystem/python/sdk/aptos_sdk/transaction_worker.py
+++ b/ecosystem/python/sdk/aptos_sdk/transaction_worker.py
@@ -49,6 +49,9 @@ class TransactionWorker:
         self._account_sequence_number = AccountSequenceNumber(
             rest_client, account.address()
         )
+        self._account_sequence_number.maximum_wait_time = (
+            rest_client.client_config.transaction_wait_in_seconds
+        )
         self._rest_client = rest_client
         self._transaction_generator = transaction_generator
 

--- a/ecosystem/python/sdk/examples/transaction-batching.py
+++ b/ecosystem/python/sdk/examples/transaction-batching.py
@@ -27,6 +27,14 @@ from aptos_sdk.transactions import (
 from .common import FAUCET_URL, NODE_URL
 
 
+def generate_rest_client(node_url: str) -> RestClient:
+    client_config = ClientConfig()
+    client_config.http2 = True
+    client_config.max_gas_amount = 100
+    client_config.transaction_wait_in_seconds = 60
+    return RestClient(NODE_URL, client_config)
+
+
 class TransactionGenerator:
     """
     Demonstrate how one might make a harness for submitting transactions. This class just keeps
@@ -123,7 +131,7 @@ class Worker:
         recipient: AccountAddress,
     ):
         self._conn = conn
-        self._rest_client = RestClient(node_url)
+        self._rest_client = generate_rest_client(node_url)
         self._account = account
         self._recipient = recipient
         self._txn_generator = TransactionGenerator(self._rest_client, self._recipient)
@@ -337,9 +345,7 @@ async def distribute(
 
 
 async def main():
-    client_config = ClientConfig()
-    client_config.http2 = True
-    rest_client = RestClient(NODE_URL, client_config)
+    rest_client = generate_rest_client(NODE_URL)
 
     num_accounts = 64
     transactions = 100000


### PR DESCRIPTION
* We were actually using http1 when we intended to use http2 for workers
* Reduce max gas amount for the client, since it doesn't need that much
* Pass the same timeout from a tranaction worker to the account sequence number

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
