### PR TITLE
Add a view function to return address of StakePool to be created

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/delegation_pool.md
+++ b/aptos-move/framework/aptos-framework/doc/delegation_pool.md
@@ -145,6 +145,7 @@ transferred to A
 -  [Function `calculate_and_update_voter_total_voting_power`](#0x1_delegation_pool_calculate_and_update_voter_total_voting_power)
 -  [Function `calculate_and_update_remaining_voting_power`](#0x1_delegation_pool_calculate_and_update_remaining_voting_power)
 -  [Function `calculate_and_update_delegator_voter`](#0x1_delegation_pool_calculate_and_update_delegator_voter)
+-  [Function `get_expected_stake_pool_address`](#0x1_delegation_pool_get_expected_stake_pool_address)
 -  [Function `initialize_delegation_pool`](#0x1_delegation_pool_initialize_delegation_pool)
 -  [Function `enable_partial_governance_voting`](#0x1_delegation_pool_enable_partial_governance_voting)
 -  [Function `vote`](#0x1_delegation_pool_vote)
@@ -161,6 +162,7 @@ transferred to A
 -  [Function `get_delegator_active_shares`](#0x1_delegation_pool_get_delegator_active_shares)
 -  [Function `get_delegator_pending_inactive_shares`](#0x1_delegation_pool_get_delegator_pending_inactive_shares)
 -  [Function `get_used_voting_power`](#0x1_delegation_pool_get_used_voting_power)
+-  [Function `create_resource_account_seed`](#0x1_delegation_pool_create_resource_account_seed)
 -  [Function `borrow_mut_used_voting_power`](#0x1_delegation_pool_borrow_mut_used_voting_power)
 -  [Function `update_and_borrow_mut_delegator_vote_delegation`](#0x1_delegation_pool_update_and_borrow_mut_delegator_vote_delegation)
 -  [Function `update_and_borrow_mut_delegated_votes`](#0x1_delegation_pool_update_and_borrow_mut_delegated_votes)
@@ -1661,6 +1663,34 @@ latest state.
 
 </details>
 
+<a name="0x1_delegation_pool_get_expected_stake_pool_address"></a>
+
+## Function `get_expected_stake_pool_address`
+
+Return the address of the stake pool to be created with the provided owner, and seed.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_get_expected_stake_pool_address">get_expected_stake_pool_address</a>(owner: <b>address</b>, delegation_pool_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_get_expected_stake_pool_address">get_expected_stake_pool_address</a>(owner: <b>address</b>, delegation_pool_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+): <b>address</b> {
+    <b>let</b> seed = <a href="delegation_pool.md#0x1_delegation_pool_create_resource_account_seed">create_resource_account_seed</a>(delegation_pool_creation_seed);
+    <a href="account.md#0x1_account_create_resource_address">account::create_resource_address</a>(&owner, seed)
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x1_delegation_pool_initialize_delegation_pool"></a>
 
 ## Function `initialize_delegation_pool`
@@ -1691,11 +1721,7 @@ Ownership over setting the operator/voter is granted to <code>owner</code> who h
     <b>assert</b>!(<a href="delegation_pool.md#0x1_delegation_pool_operator_commission_percentage">operator_commission_percentage</a> &lt;= <a href="delegation_pool.md#0x1_delegation_pool_MAX_FEE">MAX_FEE</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="delegation_pool.md#0x1_delegation_pool_EINVALID_COMMISSION_PERCENTAGE">EINVALID_COMMISSION_PERCENTAGE</a>));
 
     // generate a seed <b>to</b> be used <b>to</b> create the resource <a href="account.md#0x1_account">account</a> hosting the delegation pool
-    <b>let</b> seed = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
-    // <b>include</b> <b>module</b> salt (before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> subseeds) <b>to</b> avoid conflicts <b>with</b> other modules creating resource accounts
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, <a href="delegation_pool.md#0x1_delegation_pool_MODULE_SALT">MODULE_SALT</a>);
-    // <b>include</b> an additional salt in case the same resource <a href="account.md#0x1_account">account</a> <b>has</b> already been created
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, delegation_pool_creation_seed);
+    <b>let</b> seed = <a href="delegation_pool.md#0x1_delegation_pool_create_resource_account_seed">create_resource_account_seed</a>(delegation_pool_creation_seed);
 
     <b>let</b> (stake_pool_signer, stake_pool_signer_cap) = <a href="account.md#0x1_account_create_resource_account">account::create_resource_account</a>(owner, seed);
     <a href="coin.md#0x1_coin_register">coin::register</a>&lt;AptosCoin&gt;(&stake_pool_signer);
@@ -2239,6 +2265,38 @@ Get the used voting power of a voter on a proposal.
         proposal_id,
     };
     *<a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_borrow_with_default">smart_table::borrow_with_default</a>(votes, key, &0)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_delegation_pool_create_resource_account_seed"></a>
+
+## Function `create_resource_account_seed`
+
+Create the seed to derive the resource account address.
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_create_resource_account_seed">create_resource_account_seed</a>(delegation_pool_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_create_resource_account_seed">create_resource_account_seed</a>(
+    delegation_pool_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>let</b> seed = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
+    // <b>include</b> <b>module</b> salt (before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> subseeds) <b>to</b> avoid conflicts <b>with</b> other modules creating resource accounts
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, <a href="delegation_pool.md#0x1_delegation_pool_MODULE_SALT">MODULE_SALT</a>);
+    // <b>include</b> an additional salt in case the same resource <a href="account.md#0x1_account">account</a> <b>has</b> already been created
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, delegation_pool_creation_seed);
+    seed
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/staking_contract.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_contract.md
@@ -52,6 +52,7 @@ pool.
 -  [Function `staking_contract_amounts`](#0x1_staking_contract_staking_contract_amounts)
 -  [Function `pending_distribution_counts`](#0x1_staking_contract_pending_distribution_counts)
 -  [Function `staking_contract_exists`](#0x1_staking_contract_staking_contract_exists)
+-  [Function `get_expected_stake_pool_address`](#0x1_staking_contract_get_expected_stake_pool_address)
 -  [Function `create_staking_contract`](#0x1_staking_contract_create_staking_contract)
 -  [Function `create_staking_contract_with_coins`](#0x1_staking_contract_create_staking_contract_with_coins)
 -  [Function `add_stake`](#0x1_staking_contract_add_stake)
@@ -71,6 +72,7 @@ pool.
 -  [Function `get_staking_contract_amounts_internal`](#0x1_staking_contract_get_staking_contract_amounts_internal)
 -  [Function `create_stake_pool`](#0x1_staking_contract_create_stake_pool)
 -  [Function `update_distribution_pool`](#0x1_staking_contract_update_distribution_pool)
+-  [Function `compute_resource_account_seed`](#0x1_staking_contract_compute_resource_account_seed)
 -  [Function `new_staking_contracts_holder`](#0x1_staking_contract_new_staking_contracts_holder)
 -  [Specification](#@Specification_1)
     -  [Function `stake_pool_address`](#@Specification_1_stake_pool_address)
@@ -1029,6 +1031,37 @@ Return true if the staking contract between the provided staker and operator exi
 
 </details>
 
+<a name="0x1_staking_contract_get_expected_stake_pool_address"></a>
+
+## Function `get_expected_stake_pool_address`
+
+Return the address of the stake pool to be created with the provided staker, operator, and seed.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="staking_contract.md#0x1_staking_contract_get_expected_stake_pool_address">get_expected_stake_pool_address</a>(staker: <b>address</b>, operator: <b>address</b>, contract_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="staking_contract.md#0x1_staking_contract_get_expected_stake_pool_address">get_expected_stake_pool_address</a>(
+    staker: <b>address</b>,
+    operator: <b>address</b>,
+    contract_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+): <b>address</b> {
+    <b>let</b> seed = <a href="staking_contract.md#0x1_staking_contract_compute_resource_account_seed">compute_resource_account_seed</a>(staker, operator, contract_creation_seed);
+    <a href="account.md#0x1_account_create_resource_address">account::create_resource_address</a>(&staker, seed)
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x1_staking_contract_create_staking_contract"></a>
 
 ## Function `create_staking_contract`
@@ -1820,14 +1853,8 @@ Calculate accumulated rewards and commissions since last update.
     voter: <b>address</b>,
     contract_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
 ): (<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, SignerCapability, OwnerCapability) {
-    // Generate a seed that will be used <b>to</b> create the resource <a href="account.md#0x1_account">account</a> that hosts the staking contract.
-    <b>let</b> seed = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker));
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&operator));
-    // Include a salt <b>to</b> avoid conflicts <b>with</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> other modules out there that might also generate
-    // deterministic resource accounts for the same staker + operator addresses.
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, <a href="staking_contract.md#0x1_staking_contract_SALT">SALT</a>);
-    // Add an extra salt given by the staker in case an <a href="account.md#0x1_account">account</a> <b>with</b> the same <b>address</b> <b>has</b> already been created.
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, contract_creation_seed);
+    <b>let</b> seed = <a href="staking_contract.md#0x1_staking_contract_compute_resource_account_seed">compute_resource_account_seed</a>(
+        <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker), operator, contract_creation_seed);
 
     <b>let</b> (stake_pool_signer, stake_pool_signer_cap) = <a href="account.md#0x1_account_create_resource_account">account::create_resource_account</a>(staker, seed);
     <a href="stake.md#0x1_stake_initialize_stake_owner">stake::initialize_stake_owner</a>(&stake_pool_signer, 0, operator, voter);
@@ -1891,6 +1918,43 @@ Calculate accumulated rewards and commissions since last update.
     });
 
     <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_update_total_coins">pool_u64::update_total_coins</a>(distribution_pool, updated_total_coins);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_staking_contract_compute_resource_account_seed"></a>
+
+## Function `compute_resource_account_seed`
+
+Compute the seed to derive the resource account address.
+
+
+<pre><code><b>fun</b> <a href="staking_contract.md#0x1_staking_contract_compute_resource_account_seed">compute_resource_account_seed</a>(staker: <b>address</b>, operator: <b>address</b>, contract_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="staking_contract.md#0x1_staking_contract_compute_resource_account_seed">compute_resource_account_seed</a>(
+    staker: <b>address</b>,
+    operator: <b>address</b>,
+    contract_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    // Generate a seed that will be used <b>to</b> create the resource <a href="account.md#0x1_account">account</a> that hosts the staking contract.
+    <b>let</b> seed = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&staker);
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&operator));
+    // Include a salt <b>to</b> avoid conflicts <b>with</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> other modules out there that might also generate
+    // deterministic resource accounts for the same staker + operator addresses.
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, <a href="staking_contract.md#0x1_staking_contract_SALT">SALT</a>);
+    // Add an extra salt given by the staker in case an <a href="account.md#0x1_account">account</a> <b>with</b> the same <b>address</b> <b>has</b> already been created.
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, contract_creation_seed);
+    seed
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/staking_contract.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_contract.md
@@ -72,7 +72,7 @@ pool.
 -  [Function `get_staking_contract_amounts_internal`](#0x1_staking_contract_get_staking_contract_amounts_internal)
 -  [Function `create_stake_pool`](#0x1_staking_contract_create_stake_pool)
 -  [Function `update_distribution_pool`](#0x1_staking_contract_update_distribution_pool)
--  [Function `compute_resource_account_seed`](#0x1_staking_contract_compute_resource_account_seed)
+-  [Function `create_resource_account_seed`](#0x1_staking_contract_create_resource_account_seed)
 -  [Function `new_staking_contracts_holder`](#0x1_staking_contract_new_staking_contracts_holder)
 -  [Specification](#@Specification_1)
     -  [Function `stake_pool_address`](#@Specification_1_stake_pool_address)
@@ -1053,7 +1053,7 @@ Return the address of the stake pool to be created with the provided staker, ope
     operator: <b>address</b>,
     contract_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
 ): <b>address</b> {
-    <b>let</b> seed = <a href="staking_contract.md#0x1_staking_contract_compute_resource_account_seed">compute_resource_account_seed</a>(staker, operator, contract_creation_seed);
+    <b>let</b> seed = <a href="staking_contract.md#0x1_staking_contract_create_resource_account_seed">create_resource_account_seed</a>(staker, operator, contract_creation_seed);
     <a href="account.md#0x1_account_create_resource_address">account::create_resource_address</a>(&staker, seed)
 }
 </code></pre>
@@ -1853,7 +1853,7 @@ Calculate accumulated rewards and commissions since last update.
     voter: <b>address</b>,
     contract_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
 ): (<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, SignerCapability, OwnerCapability) {
-    <b>let</b> seed = <a href="staking_contract.md#0x1_staking_contract_compute_resource_account_seed">compute_resource_account_seed</a>(
+    <b>let</b> seed = <a href="staking_contract.md#0x1_staking_contract_create_resource_account_seed">create_resource_account_seed</a>(
         <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker), operator, contract_creation_seed);
 
     <b>let</b> (stake_pool_signer, stake_pool_signer_cap) = <a href="account.md#0x1_account_create_resource_account">account::create_resource_account</a>(staker, seed);
@@ -1925,14 +1925,14 @@ Calculate accumulated rewards and commissions since last update.
 
 </details>
 
-<a name="0x1_staking_contract_compute_resource_account_seed"></a>
+<a name="0x1_staking_contract_create_resource_account_seed"></a>
 
-## Function `compute_resource_account_seed`
+## Function `create_resource_account_seed`
 
-Compute the seed to derive the resource account address.
+Create the seed to derive the resource account address.
 
 
-<pre><code><b>fun</b> <a href="staking_contract.md#0x1_staking_contract_compute_resource_account_seed">compute_resource_account_seed</a>(staker: <b>address</b>, operator: <b>address</b>, contract_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>fun</b> <a href="staking_contract.md#0x1_staking_contract_create_resource_account_seed">create_resource_account_seed</a>(staker: <b>address</b>, operator: <b>address</b>, contract_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -1941,7 +1941,7 @@ Compute the seed to derive the resource account address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="staking_contract.md#0x1_staking_contract_compute_resource_account_seed">compute_resource_account_seed</a>(
+<pre><code><b>fun</b> <a href="staking_contract.md#0x1_staking_contract_create_resource_account_seed">create_resource_account_seed</a>(
     staker: <b>address</b>,
     operator: <b>address</b>,
     contract_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,

--- a/aptos-move/framework/aptos-framework/doc/staking_contract.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_contract.md
@@ -1035,7 +1035,7 @@ Return true if the staking contract between the provided staker and operator exi
 
 ## Function `get_expected_stake_pool_address`
 
-Return the address of the stake pool to be created with the provided staker, operator, and seed.
+Return the address of the stake pool to be created with the provided staker, operator and seed.
 
 
 <pre><code>#[view]
@@ -1853,6 +1853,7 @@ Calculate accumulated rewards and commissions since last update.
     voter: <b>address</b>,
     contract_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
 ): (<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, SignerCapability, OwnerCapability) {
+    // Generate a seed that will be used <b>to</b> create the resource <a href="account.md#0x1_account">account</a> that hosts the staking contract.
     <b>let</b> seed = <a href="staking_contract.md#0x1_staking_contract_create_resource_account_seed">create_resource_account_seed</a>(
         <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker), operator, contract_creation_seed);
 
@@ -1946,7 +1947,6 @@ Create the seed to derive the resource account address.
     operator: <b>address</b>,
     contract_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
 ): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    // Generate a seed that will be used <b>to</b> create the resource <a href="account.md#0x1_account">account</a> that hosts the staking contract.
     <b>let</b> seed = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&staker);
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&operator));
     // Include a salt <b>to</b> avoid conflicts <b>with</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> other modules out there that might also generate

--- a/aptos-move/framework/aptos-framework/sources/staking_contract.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.move
@@ -240,7 +240,7 @@ module aptos_framework::staking_contract {
         operator: address,
         contract_creation_seed: vector<u8>,
     ): address {
-        let seed = compute_resource_account_seed(staker, operator, contract_creation_seed);
+        let seed = create_resource_account_seed(staker, operator, contract_creation_seed);
         account::create_resource_address(&staker, seed)
     }
 
@@ -680,7 +680,7 @@ module aptos_framework::staking_contract {
         voter: address,
         contract_creation_seed: vector<u8>,
     ): (signer, SignerCapability, OwnerCapability) {
-        let seed = compute_resource_account_seed(
+        let seed = create_resource_account_seed(
             signer::address_of(staker), operator, contract_creation_seed);
 
         let (stake_pool_signer, stake_pool_signer_cap) = account::create_resource_account(staker, seed);
@@ -727,8 +727,8 @@ module aptos_framework::staking_contract {
         pool_u64::update_total_coins(distribution_pool, updated_total_coins);
     }
 
-    /// Compute the seed to derive the resource account address.
-    fun compute_resource_account_seed(
+    /// Create the seed to derive the resource account address.
+    fun create_resource_account_seed(
         staker: address,
         operator: address,
         contract_creation_seed: vector<u8>,

--- a/aptos-move/framework/aptos-framework/sources/staking_contract.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.move
@@ -233,6 +233,17 @@ module aptos_framework::staking_contract {
         simple_map::contains_key(&store.staking_contracts, &operator)
     }
 
+    #[view]
+    /// Return the address of the stake pool to be created with the provided staker, operator, and seed.
+    public fun get_expected_stake_pool_address(
+        staker: address,
+        operator: address,
+        contract_creation_seed: vector<u8>,
+    ): address {
+        let seed = compute_resource_account_seed(staker, operator, contract_creation_seed);
+        account::create_resource_address(&staker, seed)
+    }
+
     /// Staker can call this function to create a simple staking contract with a specified operator.
     public entry fun create_staking_contract(
         staker: &signer,
@@ -669,14 +680,8 @@ module aptos_framework::staking_contract {
         voter: address,
         contract_creation_seed: vector<u8>,
     ): (signer, SignerCapability, OwnerCapability) {
-        // Generate a seed that will be used to create the resource account that hosts the staking contract.
-        let seed = bcs::to_bytes(&signer::address_of(staker));
-        vector::append(&mut seed, bcs::to_bytes(&operator));
-        // Include a salt to avoid conflicts with any other modules out there that might also generate
-        // deterministic resource accounts for the same staker + operator addresses.
-        vector::append(&mut seed, SALT);
-        // Add an extra salt given by the staker in case an account with the same address has already been created.
-        vector::append(&mut seed, contract_creation_seed);
+        let seed = compute_resource_account_seed(
+            signer::address_of(staker), operator, contract_creation_seed);
 
         let (stake_pool_signer, stake_pool_signer_cap) = account::create_resource_account(staker, seed);
         stake::initialize_stake_owner(&stake_pool_signer, 0, operator, voter);
@@ -720,6 +725,23 @@ module aptos_framework::staking_contract {
         });
 
         pool_u64::update_total_coins(distribution_pool, updated_total_coins);
+    }
+
+    /// Compute the seed to derive the resource account address.
+    fun compute_resource_account_seed(
+        staker: address,
+        operator: address,
+        contract_creation_seed: vector<u8>,
+    ): vector<u8> {
+        // Generate a seed that will be used to create the resource account that hosts the staking contract.
+        let seed = bcs::to_bytes(&staker);
+        vector::append(&mut seed, bcs::to_bytes(&operator));
+        // Include a salt to avoid conflicts with any other modules out there that might also generate
+        // deterministic resource accounts for the same staker + operator addresses.
+        vector::append(&mut seed, SALT);
+        // Add an extra salt given by the staker in case an account with the same address has already been created.
+        vector::append(&mut seed, contract_creation_seed);
+        seed
     }
 
     /// Create a new staking_contracts resource.
@@ -1257,6 +1279,12 @@ module aptos_framework::staking_contract {
         stake::end_epoch();
         let balance_2epoch = with_rewards(balance_1epoch - unpaid_commission);
         stake::assert_stake_pool(pool_address, balance_2epoch, 0, 0, with_rewards(unpaid_commission));
+    }
+
+    #[test(staker = @0xe256f4f4e2986cada739e339895cf5585082ff247464cab8ec56eea726bd2263, operator= @0x9f0a211d218b082987408f1e393afe1ba0c202c6d280f081399788d3360c7f09)]
+    public entry fun test_get_expected_stake_pool_address(staker: address, operator: address) {
+        let pool_address = get_expected_stake_pool_address(staker, operator, vector[]);
+        assert!(pool_address == @0xeecd6e9fb71f3a67db6321e93deecf7a9d7c3f4fac6cd170deb3e8b183281943, 0);
     }
 
     #[test_only]

--- a/aptos-move/framework/aptos-framework/sources/staking_contract.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.move
@@ -234,7 +234,7 @@ module aptos_framework::staking_contract {
     }
 
     #[view]
-    /// Return the address of the stake pool to be created with the provided staker, operator, and seed.
+    /// Return the address of the stake pool to be created with the provided staker, operator and seed.
     public fun get_expected_stake_pool_address(
         staker: address,
         operator: address,
@@ -680,6 +680,7 @@ module aptos_framework::staking_contract {
         voter: address,
         contract_creation_seed: vector<u8>,
     ): (signer, SignerCapability, OwnerCapability) {
+        // Generate a seed that will be used to create the resource account that hosts the staking contract.
         let seed = create_resource_account_seed(
             signer::address_of(staker), operator, contract_creation_seed);
 
@@ -733,7 +734,6 @@ module aptos_framework::staking_contract {
         operator: address,
         contract_creation_seed: vector<u8>,
     ): vector<u8> {
-        // Generate a seed that will be used to create the resource account that hosts the staking contract.
         let seed = bcs::to_bytes(&staker);
         vector::append(&mut seed, bcs::to_bytes(&operator));
         // Include a salt to avoid conflicts with any other modules out there that might also generate
@@ -1283,8 +1283,8 @@ module aptos_framework::staking_contract {
 
     #[test(staker = @0xe256f4f4e2986cada739e339895cf5585082ff247464cab8ec56eea726bd2263, operator= @0x9f0a211d218b082987408f1e393afe1ba0c202c6d280f081399788d3360c7f09)]
     public entry fun test_get_expected_stake_pool_address(staker: address, operator: address) {
-        let pool_address = get_expected_stake_pool_address(staker, operator, vector[]);
-        assert!(pool_address == @0xeecd6e9fb71f3a67db6321e93deecf7a9d7c3f4fac6cd170deb3e8b183281943, 0);
+        let pool_address = get_expected_stake_pool_address(staker, operator, vector[0x42, 0x42]);
+        assert!(pool_address == @0x9d9648031ada367c26f7878eb0b0406ae6a969b1a43090269e5cdfabe1b48f0f, 0);
     }
 
     #[test_only]


### PR DESCRIPTION
### Description
It's hard to simulate creating a `StakingContract`/`DelegationPool` on testnet because of whitelist. Add a view function to return the expected address of stake pool to be created.
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Unit testing.