### PR TITLE
[CLI] Improve error message when running move tests fails

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -496,7 +496,7 @@ impl CliCommand<&'static str> for TestPackage {
             self.compute_coverage,
             &mut std::io::stdout(),
         )
-        .map_err(|err| CliError::UnexpectedError(err.to_string()))?;
+        .map_err(|err| CliError::UnexpectedError(format!("Failed to run tests: {:#}", err)))?;
 
         // Print coverage summary if --coverage is set
         if self.compute_coverage {


### PR DESCRIPTION
### Description
Improves error messages for `aptos move test` by showing full error context. This addresses the case where running the tests fails, not tests running successfully but not passing.

### Test Plan
Command:
```
aptos move test --named-addresses addr=0x1
```

Before:
```
{
  "Error": "Unexpected error: Unable to resolve packages for package 'cli_e2e_tests'"
}
```

After:
```
{
  "Error": "Unexpected error: Failed to run tests: Unable to resolve packages for package 'cli_e2e_tests': Unable to resolve named address 'addr' inpackage 'cli_e2e_tests' when resolving dependencies in dev mode: Attempted to assign a different value '0x12345' to an a already-assigned named address '0x1'"
}
```
