### PR TITLE
[CLI] fix aptos ledger init

### DIFF
--- a/crates/aptos-ledger/src/lib.rs
+++ b/crates/aptos-ledger/src/lib.rs
@@ -16,7 +16,7 @@ use hex::encode;
 use ledger_apdu::APDUCommand;
 use ledger_transport_hid::{hidapi::HidApi, LedgerHIDError, TransportNativeHID};
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     fmt,
     fmt::{Debug, Display},
     ops::Range,
@@ -25,10 +25,10 @@ use std::{
 };
 use thiserror::Error;
 
-/// Derivative path template
+/// derivation path template
 /// A piece of data which tells a wallet how to derive a specific key within a tree of keys
 /// 637 is the key for Aptos
-pub const DERIVATIVE_PATH: &str = "m/44'/637'/{index}'/0'/0'";
+pub const DERIVATION_PATH: &str = "m/44'/637'/{index}'/0'/0'";
 
 const CLA_APTOS: u8 = 0x5B; // Aptos CLA Instruction class
 const INS_GET_VERSION: u8 = 0x03; // Get version instruction code
@@ -76,8 +76,8 @@ impl Display for Version {
     }
 }
 
-/// Validate the input derivative path to check if it's valid
-pub fn validate_derivative_path(input: &str) -> bool {
+/// Validate the input derivation path to check if it's valid
+pub fn validate_derivation_path(input: &str) -> bool {
     let prefix = "m/44'/637'/";
     let suffix = "'";
 
@@ -183,7 +183,7 @@ pub fn get_app_name() -> Result<String, AptosLedgerError> {
 /// * `index_range` - start(inclusive) - end(exclusive) acounts, that you want to fetch, if None default to 0-10
 pub fn fetch_batch_accounts(
     index_range: Option<Range<u32>>,
-) -> Result<HashMap<String, AccountAddress>, AptosLedgerError> {
+) -> Result<BTreeMap<String, AccountAddress>, AptosLedgerError> {
     let range = if let Some(range) = index_range {
         range
     } else {
@@ -201,9 +201,9 @@ pub fn fetch_batch_accounts(
     // Open connection to ledger
     let transport = open_ledger_transport()?;
 
-    let mut accounts = HashMap::new();
+    let mut accounts = BTreeMap::new();
     for i in range {
-        let path = DERIVATIVE_PATH.replace("{index}", &i.to_string());
+        let path = DERIVATION_PATH.replace("{index}", &i.to_string());
         let cdata = serialize_bip32(&path);
 
         match transport.exchange(&APDUCommand {
@@ -263,7 +263,7 @@ pub fn get_public_key(path: &str, display: bool) -> Result<Ed25519PublicKey, Apt
     // Open connection to ledger
     let transport = open_ledger_transport()?;
 
-    // Serialize the derivative path
+    // Serialize the derivation path
     let cdata = serialize_bip32(path);
 
     // APDU command's instruction parameter 1 or p1
@@ -316,22 +316,22 @@ pub fn get_public_key(path: &str, display: bool) -> Result<Ed25519PublicKey, Apt
 ///
 /// # Arguments
 ///
-/// * `path` - derivative path of the ledger account
+/// * `path` - derivation path of the ledger account
 /// * `raw_message` - the raw message that need to be signed
 pub fn sign_message(path: &str, raw_message: &[u8]) -> Result<Ed25519Signature, AptosLedgerError> {
     // open connection to ledger
     let transport = open_ledger_transport()?;
 
-    // Serialize the derivative path
-    let derivative_path_bytes = serialize_bip32(path);
+    // Serialize the derivation path
+    let derivation_path_bytes = serialize_bip32(path);
 
-    // Send the derivative path over as first message
+    // Send the derivation path over as first message
     let sign_start = transport.exchange(&APDUCommand {
         cla: CLA_APTOS,
         ins: INS_SIGN_TXN,
         p1: P1_START,
         p2: P2_MORE,
-        data: derivative_path_bytes,
+        data: derivation_path_bytes,
     });
 
     if let Err(err) = sign_start {

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -139,31 +139,37 @@ impl CliCommand<()> for InitTool {
         }
 
         // Fetch the top 5 (index 0-4) accounts from Ledger
-        let derivative_path = if self.ledger {
+        let derivation_path = if self.ledger {
             let account_map = aptos_ledger::fetch_batch_accounts(Some(0..5))?;
             eprintln!(
-                "Please choose a derivative path from the following {} ledger accounts, or choose an arbitrary path that you want to use:",
+                "Please choose an index from the following {} ledger accounts, or choose an arbitrary index that you want to use:",
                 account_map.len()
             );
-            for (index, account) in account_map.iter() {
-                eprintln!("Path: {} Address {}", index, account);
+
+            // Iterate through the accounts and print them out
+            for (index, (deri_path, account)) in account_map.iter().enumerate() {
+                eprintln!(
+                    "Index: {}, Derivatiion Path: {} Address: {}",
+                    index, deri_path, account
+                );
             }
-            let input = read_line("derivative_path")?;
-            let input = input.trim();
+            let input_index = read_line("derivation_index")?;
+            let input_index = input_index.trim();
+            let path = aptos_ledger::DERIVATION_PATH.replace("{index}", input_index);
 
             // Validate the path
-            if !aptos_ledger::validate_derivative_path(input) {
+            if !aptos_ledger::validate_derivation_path(&path) {
                 return Err(CliError::UnexpectedError(
-                    "Invalid derivative path".to_owned(),
+                    "Invalid derivation path".to_owned(),
                 ));
             }
-            Some(input.to_string())
+            Some(path)
         } else {
             None
         };
 
-        // Set the derivative_path to the one user chose
-        profile_config.derivative_path = derivative_path.clone();
+        // Set the derivation_path to the one user chose
+        profile_config.derivation_path = derivation_path.clone();
 
         // Private key
         let private_key = if self.ledger {
@@ -203,9 +209,9 @@ impl CliCommand<()> for InitTool {
         // Public key
         let public_key = if self.ledger {
             let pub_key = match aptos_ledger::get_public_key(
-                derivative_path
+                derivation_path
                     .ok_or(CliError::UnexpectedError(
-                        "Invalid derivative path".to_string(),
+                        "Invalid derivation path".to_string(),
                     ))?
                     .as_str(),
                 false,

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -227,8 +227,8 @@ pub struct ProfileConfig {
     /// URL for the Faucet endpoint (if applicable)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub faucet_url: Option<String>,
-    /// Derivative path index of the account on ledger
-    pub derivative_path: Option<String>,
+    /// derivation path index of the account on ledger
+    pub derivation_path: Option<String>,
 }
 
 /// ProfileConfig but without the private parts


### PR DESCRIPTION
### Description

1. fix naming `derivative_path` -> `derivatioin_path`
2. allow user to pick index instead of whole derivation path

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->


```
➜  aptos-core git:(jin/fix_aptos_ledger_init) ✗ aptos-debug init --ledger --profile=pledger
Aptos already initialized for profile pledger, do you want to overwrite the existing config? [yes/no] >
yes
Configuring for profile pledger
Choose network from [devnet, testnet, mainnet, local, custom | defaults to devnet]

No network given, using devnet...
Please choose an index from the following 5 ledger accounts, or choose an arbitrary index that you want to use:
Index: 0, Derivatiion Path: m/44'/637'/0'/0'/0' Address: 59836ba1dd0c845713bdab34346688d6f1dba290dbf677929f2fc20593ba0cfb
Index: 1, Derivatiion Path: m/44'/637'/1'/0'/0' Address: 21563230cf6d69ee72a51d21920430d844ee48235e708edbafbc69708075a86e
Index: 2, Derivatiion Path: m/44'/637'/2'/0'/0' Address: 667446181b3b980ef29f5145a7a2cc34d433fc3ee8c97fc044fd978435f2cb8d
Index: 3, Derivatiion Path: m/44'/637'/3'/0'/0' Address: 2dcf037a9f31d93e202c074229a1b69ea8ee4d2f2d63323476001c65b0ec4f31
Index: 4, Derivatiion Path: m/44'/637'/4'/0'/0' Address: 23c579a9bdde1a59f1c9d36d8d379aeefe7a5997b5b58bd5a5b0c12a4f170431
0
Account 59836ba1dd0c845713bdab34346688d6f1dba290dbf677929f2fc20593ba0cfb has been already found onchain

---
Aptos CLI is now set up for account 59836ba1dd0c845713bdab34346688d6f1dba290dbf677929f2fc20593ba0cfb as profile pledger!  Run `aptos --help` for more information about commands
{
  "Result": "Success"
}
```
