### PR TITLE
[move-examples] Add events to marketplace example

### DIFF
--- a/aptos-move/move-examples/marketplace/sources/collection_offer.move
+++ b/aptos-move/move-examples/marketplace/sources/collection_offer.move
@@ -13,7 +13,6 @@ module collection_offer {
     use std::string::String;
 
     use aptos_framework::coin::{Self, Coin};
-    use aptos_framework::event::{Self, EventHandle};
     use aptos_framework::object::{Self, DeleteRef, Object};
     use aptos_framework::timestamp;
 
@@ -23,6 +22,7 @@ module collection_offer {
     use aptos_token_objects::royalty;
     use aptos_token_objects::token::{Self as tokenv2, Token as TokenV2};
 
+    use marketplace::events;
     use marketplace::fee_schedule::{Self, FeeSchedule};
     use marketplace::listing::{Self, TokenV1Container};
 
@@ -50,15 +50,6 @@ module collection_offer {
         remaining: u64,
         expiration_time: u64,
         delete_ref: DeleteRef,
-        events: EventHandle<CollectionOfferEvent>,
-    }
-
-    /// An event for when a collection offer has been met.
-    struct CollectionOfferEvent has drop, store {
-        seller: address,
-        price: u64,
-        royalties: u64,
-        commission: u64,
     }
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
@@ -83,7 +74,7 @@ module collection_offer {
     // Initializers
 
     /// Create a tokenv1 collection offer.
-    public entry fun init_for_tokenv1<CoinType>(
+    public entry fun init_for_tokenv1_entry<CoinType>(
         purchaser: &signer,
         creator_address: address,
         collection_name: String,
@@ -92,7 +83,7 @@ module collection_offer {
         amount: u64,
         expiration_time: u64,
     ) {
-        init_for_tokenv1_internal<CoinType>(
+        init_for_tokenv1<CoinType>(
             purchaser,
             creator_address,
             collection_name,
@@ -103,7 +94,7 @@ module collection_offer {
         );
     }
 
-    public fun init_for_tokenv1_internal<CoinType>(
+    public fun init_for_tokenv1<CoinType>(
         purchaser: &signer,
         creator_address: address,
         collection_name: String,
@@ -115,11 +106,22 @@ module collection_offer {
         let offer_signer = init_offer(purchaser, fee_schedule, item_price, amount, expiration_time);
         init_coin_holder<CoinType>(purchaser, &offer_signer, fee_schedule, item_price * amount);
         move_to(&offer_signer, CollectionOfferTokenV1 { creator_address, collection_name });
-        object::address_to_object(signer::address_of(&offer_signer))
+
+        let collection_offer_addr = signer::address_of(&offer_signer);
+        events::emit_collection_offer_placed(
+            fee_schedule,
+            collection_offer_addr,
+            signer::address_of(purchaser),
+            item_price,
+            amount,
+            events::collection_metadata_for_tokenv1(creator_address, collection_name),
+        );
+
+        object::address_to_object(collection_offer_addr)
     }
 
     /// Create a tokenv2 collection offer.
-    public entry fun init_for_tokenv2<CoinType>(
+    public entry fun init_for_tokenv2_entry<CoinType>(
         purchaser: &signer,
         collection: Object<Collection>,
         fee_schedule: Object<FeeSchedule>,
@@ -127,7 +129,7 @@ module collection_offer {
         amount: u64,
         expiration_time: u64,
     ) {
-        init_for_tokenv2_internal<CoinType>(
+        init_for_tokenv2<CoinType>(
             purchaser,
             collection,
             fee_schedule,
@@ -137,7 +139,7 @@ module collection_offer {
         );
     }
 
-    public fun init_for_tokenv2_internal<CoinType>(
+    public fun init_for_tokenv2<CoinType>(
         purchaser: &signer,
         collection: Object<Collection>,
         fee_schedule: Object<FeeSchedule>,
@@ -148,7 +150,18 @@ module collection_offer {
         let offer_signer = init_offer(purchaser, fee_schedule, item_price, amount, expiration_time);
         init_coin_holder<CoinType>(purchaser, &offer_signer, fee_schedule, item_price * amount);
         move_to(&offer_signer, CollectionOfferTokenV2 { collection });
-        object::address_to_object(signer::address_of(&offer_signer))
+
+        let collection_offer_addr = signer::address_of(&offer_signer);
+        events::emit_collection_offer_placed(
+            fee_schedule,
+            collection_offer_addr,
+            signer::address_of(purchaser),
+            item_price,
+            amount,
+            events::collection_metadata_for_tokenv2(collection),
+        );
+
+        object::address_to_object(collection_offer_addr)
     }
 
     inline fun init_offer(
@@ -170,7 +183,6 @@ module collection_offer {
             remaining: amount,
             expiration_time,
             delete_ref: object::generate_delete_ref(&constructor_ref),
-            events: object::new_event_handle(&offer_signer),
         };
         move_to(&offer_signer, offer);
 
@@ -207,34 +219,54 @@ module collection_offer {
             object::is_owner(collection_offer, signer::address_of(purchaser)),
             error::permission_denied(ENOT_OWNER),
         );
+        let collection_offer_obj = borrow_global_mut<CollectionOffer>(collection_offer_addr);
+        let collection_metadata = if (exists<CollectionOfferTokenV2>(collection_offer_addr)) {
+            events::collection_metadata_for_tokenv2(
+                borrow_global<CollectionOfferTokenV2>(collection_offer_addr).collection,
+            )
+        } else {
+            let offer_info = borrow_global<CollectionOfferTokenV1>(collection_offer_addr);
+            events::collection_metadata_for_tokenv1(
+                offer_info.creator_address,
+                offer_info.collection_name,
+            )
+        };
+
+        events::emit_collection_offer_canceled(
+            collection_offer_obj.fee_schedule,
+            collection_offer_addr,
+            signer::address_of(purchaser),
+            collection_offer_obj.item_price,
+            collection_offer_obj.remaining,
+            collection_metadata,
+        );
 
         cleanup<CoinType>(collection_offer);
     }
 
     /// Sell a tokenv1 to a collection offer.
-    public entry fun sell_tokenv1<CoinType>(
+    public entry fun sell_tokenv1_entry<CoinType>(
         seller: &signer,
         collection_offer: Object<CollectionOffer>,
         token_name: String,
         property_version: u64,
-    )
-    acquires CoinOffer, CollectionOffer, CollectionOfferTokenV1, CollectionOfferTokenV2
+    ) acquires CoinOffer, CollectionOffer, CollectionOfferTokenV1, CollectionOfferTokenV2
     {
-        sell_tokenv1_internal<CoinType>(seller, collection_offer, token_name, property_version);
+        sell_tokenv1<CoinType>(seller, collection_offer, token_name, property_version);
     }
 
     /// Sell a tokenv1 to a collection offer.
-    public fun sell_tokenv1_internal<CoinType>(
+    public fun sell_tokenv1<CoinType>(
         seller: &signer,
         collection_offer: Object<CollectionOffer>,
         token_name: String,
         property_version: u64,
     ): Option<Object<TokenV1Container>>
     acquires
-    CoinOffer,
-    CollectionOffer,
-    CollectionOfferTokenV1,
-    CollectionOfferTokenV2
+        CoinOffer,
+        CollectionOffer,
+        CollectionOfferTokenV1,
+        CollectionOfferTokenV2
     {
         let collection_offer_addr = object::object_address(&collection_offer);
         assert!(
@@ -269,11 +301,13 @@ module collection_offer {
 
         let royalty = tokenv1::get_royalty(token_id);
         settle_payments<CoinType>(
+            object::owner(collection_offer),
             signer::address_of(seller),
             collection_offer_addr,
             tokenv1::get_royalty_payee(&royalty),
             tokenv1::get_royalty_denominator(&royalty),
             tokenv1::get_royalty_numerator(&royalty),
+            events::token_metadata_for_tokenv1(token_id),
         );
 
         container
@@ -316,11 +350,13 @@ module collection_offer {
         };
 
         settle_payments<CoinType>(
+            object::owner(collection_offer),
             signer::address_of(seller),
             collection_offer_addr,
             royalty_payee,
             royalty_denominator,
             royalty_numerator,
+            events::token_metadata_for_tokenv2(token),
         );
     }
 
@@ -328,13 +364,15 @@ module collection_offer {
     /// the creator for royalties, and the marketplace for commission. If there are no more slots,
     /// cleanup the offer.
     inline fun settle_payments<CoinType>(
+        buyer: address,
         seller: address,
         collection_offer_addr: address,
         royalty_payee: address,
         royalty_denominator: u64,
         royalty_numerator: u64,
+        token_metadata: events::TokenMetadata,
     ) acquires CoinOffer, CollectionOffer, CollectionOfferTokenV1, CollectionOfferTokenV2 {
-        assert!(exists<CollectionOffer>(collection_offer_addr), 0);
+        assert!(exists<CollectionOffer>(collection_offer_addr), error::not_found(ENO_COLLECTION_OFFER));
         let collection_offer_obj = borrow_global_mut<CollectionOffer>(collection_offer_addr);
         assert!(
             timestamp::now_seconds() < collection_offer_obj.expiration_time,
@@ -360,13 +398,16 @@ module collection_offer {
 
         coin::deposit(seller, coins);
 
-        let event = CollectionOfferEvent {
+        events::emit_collection_offer_filled(
+            fee_schedule,
+            collection_offer_addr,
+            buyer,
             seller,
             price,
-            royalties: royalty_charge,
-            commission: commission_charge,
-        };
-        event::emit_event(&mut collection_offer_obj.events, event);
+            royalty_charge,
+            commission_charge,
+            token_metadata,
+        );
 
         collection_offer_obj.remaining = collection_offer_obj.remaining - 1;
         if (collection_offer_obj.remaining == 0) {
@@ -389,9 +430,7 @@ module collection_offer {
             remaining: _,
             expiration_time: _,
             delete_ref,
-            events,
         } = move_from(collection_offer_addr);
-        event::destroy_handle(events);
         object::delete(delete_ref);
 
         if (exists<CollectionOfferTokenV2>(collection_offer_addr)) {
@@ -503,7 +542,7 @@ module collection_offer_tests {
             test_utils::setup(aptos_framework, marketplace, seller, purchaser);
         let token = test_utils::mint_tokenv2(seller);
         assert!(object::is_owner(token, seller_addr), 0);
-        let collection_offer = collection_offer::init_for_tokenv2_internal<AptosCoin>(
+        let collection_offer = collection_offer::init_for_tokenv2<AptosCoin>(
             purchaser,
             tokenv2::collection_object(token),
             test_utils::fee_schedule(marketplace),
@@ -553,7 +592,7 @@ module collection_offer_tests {
         let (creator_addr, collection_name, token_name, property_version) =
             tokenv1::get_token_id_fields(&token_id);
 
-        let collection_offer = collection_offer::init_for_tokenv1_internal<AptosCoin>(
+        let collection_offer = collection_offer::init_for_tokenv1<AptosCoin>(
             purchaser,
             creator_addr,
             collection_name,
@@ -568,14 +607,14 @@ module collection_offer_tests {
         assert!(coin::balance<AptosCoin>(purchaser_addr) == 8999, 0);
         assert!(coin::balance<AptosCoin>(seller_addr) == 10000, 0);
 
-        collection_offer::sell_tokenv1_internal<AptosCoin>(seller, collection_offer, token_name, property_version);
+        collection_offer::sell_tokenv1<AptosCoin>(seller, collection_offer, token_name, property_version);
         assert!(coin::balance<AptosCoin>(marketplace_addr) == 6, 0);
         assert!(coin::balance<AptosCoin>(purchaser_addr) == 8999, 0);
         assert!(coin::balance<AptosCoin>(seller_addr) == 10495, 0);
         assert!(tokenv1::balance_of(purchaser_addr, token_id) == 1, 0);
         assert!(collection_offer::remaining(collection_offer) == 1, 0);
 
-        collection_offer::sell_tokenv1_internal<AptosCoin>(purchaser, collection_offer, token_name, property_version);
+        collection_offer::sell_tokenv1<AptosCoin>(purchaser, collection_offer, token_name, property_version);
         assert!(coin::balance<AptosCoin>(marketplace_addr) == 11, 0);
         assert!(coin::balance<AptosCoin>(purchaser_addr) == 9489, 0);
         assert!(coin::balance<AptosCoin>(seller_addr) == 10500, 0);
@@ -599,7 +638,7 @@ module collection_offer_tests {
         let (creator_addr, collection_name, token_name, property_version) =
             tokenv1::get_token_id_fields(&token_id);
 
-        let collection_offer = collection_offer::init_for_tokenv1_internal<AptosCoin>(
+        let collection_offer = collection_offer::init_for_tokenv1<AptosCoin>(
             purchaser,
             creator_addr,
             collection_name,
@@ -609,7 +648,7 @@ module collection_offer_tests {
             timestamp::now_seconds() + 200,
         );
 
-        let token_container = collection_offer::sell_tokenv1_internal<AptosCoin>(
+        let token_container = collection_offer::sell_tokenv1<AptosCoin>(
             seller,
             collection_offer,
             token_name,
@@ -630,7 +669,7 @@ module collection_offer_tests {
     ) {
         test_utils::setup(aptos_framework, marketplace, seller, purchaser);
         let token = test_utils::mint_tokenv2(seller);
-        let collection_offer = collection_offer::init_for_tokenv2_internal<AptosCoin>(
+        let collection_offer = collection_offer::init_for_tokenv2<AptosCoin>(
             purchaser,
             tokenv2::collection_object(token),
             test_utils::fee_schedule(marketplace),
@@ -654,7 +693,7 @@ module collection_offer_tests {
         let (creator_addr, collection_name, token_name, property_version) =
             tokenv1::get_token_id_fields(&token_id);
 
-        let collection_offer = collection_offer::init_for_tokenv1_internal<AptosCoin>(
+        let collection_offer = collection_offer::init_for_tokenv1<AptosCoin>(
             purchaser,
             creator_addr,
             collection_name,
@@ -664,7 +703,7 @@ module collection_offer_tests {
             timestamp::now_seconds() + 200,
         );
 
-        collection_offer::sell_tokenv1_internal<AptosCoin>(
+        collection_offer::sell_tokenv1<AptosCoin>(
             marketplace,
             collection_offer,
             token_name,
@@ -682,7 +721,7 @@ module collection_offer_tests {
     ) {
         test_utils::setup(aptos_framework, marketplace, seller, purchaser);
         let token = test_utils::mint_tokenv2(seller);
-        let collection_offer = collection_offer::init_for_tokenv2_internal<AptosCoin>(
+        let collection_offer = collection_offer::init_for_tokenv2<AptosCoin>(
             purchaser,
             tokenv2::collection_object(token),
             test_utils::fee_schedule(marketplace),
@@ -704,7 +743,7 @@ module collection_offer_tests {
     ) {
         test_utils::setup(aptos_framework, marketplace, seller, purchaser);
         let token = test_utils::mint_tokenv2(seller);
-        let collection_offer = collection_offer::init_for_tokenv2_internal<AptosCoin>(
+        let collection_offer = collection_offer::init_for_tokenv2<AptosCoin>(
             purchaser,
             tokenv2::collection_object(token),
             test_utils::fee_schedule(marketplace),
@@ -736,7 +775,7 @@ module collection_offer_tests {
             string::utf8(b"..."),
         );
 
-        let collection_offer = collection_offer::init_for_tokenv2_internal<AptosCoin>(
+        let collection_offer = collection_offer::init_for_tokenv2<AptosCoin>(
             purchaser,
             object::object_from_constructor_ref(&other_collection),
             test_utils::fee_schedule(marketplace),
@@ -767,7 +806,7 @@ module collection_offer_tests {
             vector[true, true, true],
         );
 
-        let collection_offer = collection_offer::init_for_tokenv1_internal<AptosCoin>(
+        let collection_offer = collection_offer::init_for_tokenv1<AptosCoin>(
             purchaser,
             purchaser_addr,
             string::utf8(b"..."),
@@ -780,7 +819,7 @@ module collection_offer_tests {
         let token_id = test_utils::mint_tokenv1(seller);
         let (_creator_addr, _collection_name, token_name, property_version) =
             tokenv1::get_token_id_fields(&token_id);
-        collection_offer::sell_tokenv1_internal<AptosCoin>(
+        collection_offer::sell_tokenv1<AptosCoin>(
             marketplace,
             collection_offer,
             token_name,

--- a/aptos-move/move-examples/marketplace/sources/events.move
+++ b/aptos-move/move-examples/marketplace/sources/events.move
@@ -1,0 +1,322 @@
+/// Defines all the events associated with a marketplace. Note: this is attached to a FeeSchedule.
+module marketplace::events {
+    use std::error;
+    use std::option::{Self, Option};
+    use std::string::String;
+
+    use aptos_framework::event::{Self, EventHandle};
+    use aptos_framework::object::{Self, Object};
+
+    use aptos_token::token as tokenv1;
+    use aptos_token_objects::collection as collectionv2;
+    use aptos_token_objects::token as tokenv2;
+
+    friend marketplace::coin_listing;
+    friend marketplace::collection_offer;
+    friend marketplace::fee_schedule;
+    friend marketplace::listing;
+
+    /// Marketplace does not have EventsV1
+    const ENO_EVENTS_V1: u64 = 1;
+
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    /// A holder for all events for a marketplace
+    struct EventsV1 has key {
+        auction_bid_events: EventHandle<AuctionBidEvent>,
+        listing_placed_events: EventHandle<ListingPlacedEvent>,
+        listing_canceled_events: EventHandle<ListingCanceledEvent>,
+        listing_filled_events: EventHandle<ListingFilledEvent>,
+
+        collection_offer_placed_events: EventHandle<CollectionOfferPlacedEvent>,
+        collection_offer_canceled_events: EventHandle<CollectionOfferCanceledEvent>,
+        collection_offer_filled_events: EventHandle<CollectionOfferFilledEvent>,
+    }
+
+    // Initializers
+
+    public(friend) fun init(fee_schedule_signer: &signer) {
+        let events = EventsV1 {
+            auction_bid_events: object::new_event_handle(fee_schedule_signer),
+            listing_placed_events: object::new_event_handle(fee_schedule_signer),
+            listing_canceled_events: object::new_event_handle(fee_schedule_signer),
+            listing_filled_events: object::new_event_handle(fee_schedule_signer),
+            collection_offer_placed_events: object::new_event_handle(fee_schedule_signer),
+            collection_offer_canceled_events: object::new_event_handle(fee_schedule_signer),
+            collection_offer_filled_events: object::new_event_handle(fee_schedule_signer),
+        };
+        move_to(fee_schedule_signer, events);
+    }
+
+    // TokenMetadata and helpers
+
+    struct TokenMetadata has drop, store {
+        creator_address: address,
+        collection_name: String,
+        collection: Option<Object<collectionv2::Collection>>,
+        token_name: String,
+        token: Option<Object<tokenv2::Token>>,
+        property_version: Option<u64>,
+    }
+
+    public fun token_metadata_for_tokenv1(token_id: tokenv1::TokenId): TokenMetadata {
+        let (creator_address, collection_name, token_name, property_version) =
+            tokenv1::get_token_id_fields(&token_id);
+
+        TokenMetadata {
+            creator_address,
+            collection_name,
+            collection: option::none(),
+            token_name,
+            token: option::none(),
+            property_version: option::some(property_version),
+        }
+    }
+
+    public fun token_metadata_for_tokenv2(token: Object<tokenv2::Token>): TokenMetadata {
+        TokenMetadata {
+            creator_address: tokenv2::creator(token),
+            collection_name: tokenv2::collection_name(token),
+            collection: option::some(tokenv2::collection_object(token)),
+            token_name: tokenv2::name(token),
+            token: option::some(token),
+            property_version: option::none(),
+        }
+    }
+
+    // CollectionMetadata and helpers
+
+    struct CollectionMetadata has drop, store {
+        creator_address: address,
+        collection_name: String,
+        collection: Option<Object<collectionv2::Collection>>,
+    }
+
+    public fun collection_metadata_for_tokenv1(
+        creator_address: address,
+        collection_name: String,
+    ): CollectionMetadata {
+        CollectionMetadata {
+            creator_address,
+            collection_name,
+            collection: option::none(),
+        }
+    }
+
+    public fun collection_metadata_for_tokenv2(
+        collection: Object<collectionv2::Collection>,
+    ): CollectionMetadata {
+        CollectionMetadata {
+            creator_address: collectionv2::creator(collection),
+            collection_name: collectionv2::name(collection),
+            collection: option::some(collection),
+        }
+    }
+
+    // Listing events
+
+    /// An event triggered upon each bid.
+    struct AuctionBidEvent has drop, store {
+        listing: address,
+        new_bidder: address,
+        new_bid: u64,
+        new_end_time: u64,
+        previous_bidder: Option<address>,
+        previous_bid: Option<u64>,
+        previous_end_time: u64,
+        token_metadata: TokenMetadata,
+    }
+
+    public(friend) fun emit_bid_event<T: key>(
+        marketplace: Object<T>,
+        listing: address,
+        new_bidder: address,
+        new_bid: u64,
+        new_end_time: u64,
+        previous_bidder: Option<address>,
+        previous_bid: Option<u64>,
+        previous_end_time: u64,
+        token_metadata: TokenMetadata,
+    ) acquires EventsV1 {
+        let marketplace_events = get_events_v1(marketplace);
+        event::emit_event(&mut marketplace_events.auction_bid_events, AuctionBidEvent {
+            listing,
+            new_bidder,
+            new_bid,
+            new_end_time,
+            previous_bidder,
+            previous_bid,
+            previous_end_time,
+            token_metadata,
+        });
+    }
+
+    struct ListingPlacedEvent has drop, store {
+        listing: address,
+        seller: address,
+        price: u64,
+        token_metadata: TokenMetadata
+    }
+
+    public(friend) fun emit_listing_placed<T: key>(
+        marketplace: Object<T>,
+        listing: address,
+        seller: address,
+        price: u64,
+        token_metadata: TokenMetadata,
+    ) acquires EventsV1 {
+        let marketplace_events = get_events_v1(marketplace);
+        event::emit_event(&mut marketplace_events.listing_placed_events, ListingPlacedEvent {
+            listing,
+            seller,
+            price,
+            token_metadata,
+        });
+    }
+
+    struct ListingCanceledEvent has drop, store {
+        listing: address,
+        seller: address,
+        price: u64,
+        token_metadata: TokenMetadata
+    }
+
+    public(friend) fun emit_listing_canceled<T: key>(
+        marketplace: Object<T>,
+        listing: address,
+        seller: address,
+        price: u64,
+        token_metadata: TokenMetadata,
+    ) acquires EventsV1 {
+        let marketplace_events = get_events_v1(marketplace);
+        event::emit_event(&mut marketplace_events.listing_canceled_events, ListingCanceledEvent {
+            listing,
+            seller,
+            price,
+            token_metadata,
+        });
+    }
+
+    struct ListingFilledEvent has drop, store {
+        listing: address,
+        seller: address,
+        purchaser: address,
+        price: u64,
+        commission: u64,
+        royalties: u64,
+        token_metadata: TokenMetadata
+    }
+
+    public(friend) fun emit_listing_filled<T: key>(
+        marketplace: Object<T>,
+        listing: address,
+        seller: address,
+        purchaser: address,
+        price: u64,
+        commission: u64,
+        royalties: u64,
+        token_metadata: TokenMetadata,
+    ) acquires EventsV1 {
+        let marketplace_events = get_events_v1(marketplace);
+        event::emit_event(&mut marketplace_events.listing_filled_events, ListingFilledEvent {
+            listing,
+            seller,
+            purchaser,
+            price,
+            commission,
+            royalties,
+            token_metadata,
+        });
+    }
+
+    // Collection offer events
+
+    struct CollectionOfferPlacedEvent has drop, store {
+        collection_offer: address,
+        purchaser: address,
+        price: u64,
+        token_amount: u64,
+        collection_metadata: CollectionMetadata,
+    }
+
+    public(friend) fun emit_collection_offer_placed<T: key>(
+        marketplace: Object<T>,
+        collection_offer: address,
+        purchaser: address,
+        price: u64,
+        token_amount: u64,
+        collection_metadata: CollectionMetadata,
+    ) acquires EventsV1 {
+        let marketplace_events = get_events_v1(marketplace);
+        event::emit_event(&mut marketplace_events.collection_offer_placed_events, CollectionOfferPlacedEvent {
+            collection_offer,
+            purchaser,
+            price,
+            token_amount,
+            collection_metadata,
+        });
+    }
+
+    struct CollectionOfferCanceledEvent has drop, store {
+        collection_offer: address,
+        purchaser: address,
+        price: u64,
+        remaining_token_amount: u64,
+        collection_metadata: CollectionMetadata,
+    }
+
+    public(friend) fun emit_collection_offer_canceled<T: key>(
+        marketplace: Object<T>,
+        collection_offer: address,
+        purchaser: address,
+        price: u64,
+        remaining_token_amount: u64,
+        collection_metadata: CollectionMetadata,
+    ) acquires EventsV1 {
+        let marketplace_events = get_events_v1(marketplace);
+        event::emit_event(&mut marketplace_events.collection_offer_canceled_events, CollectionOfferCanceledEvent {
+            collection_offer,
+            purchaser,
+            price,
+            remaining_token_amount,
+            collection_metadata,
+        });
+    }
+
+    struct CollectionOfferFilledEvent has drop, store {
+        collection_offer: address,
+        purchaser: address,
+        seller: address,
+        price: u64,
+        royalties: u64,
+        commission: u64,
+        token_metadata: TokenMetadata,
+    }
+
+    public(friend) fun emit_collection_offer_filled<T: key>(
+        marketplace: Object<T>,
+        collection_offer: address,
+        purchaser: address,
+        seller: address,
+        price: u64,
+        royalties: u64,
+        commission: u64,
+        token_metadata: TokenMetadata,
+    ) acquires EventsV1 {
+        let marketplace_events = get_events_v1(marketplace);
+        event::emit_event(&mut marketplace_events.collection_offer_filled_events, CollectionOfferFilledEvent {
+            collection_offer,
+            purchaser,
+            seller,
+            price,
+            royalties,
+            commission,
+            token_metadata,
+        });
+    }
+
+    inline fun get_events_v1<T: key>(marketplace: Object<T>): &mut EventsV1 acquires EventsV1 {
+        let addr = object::object_address(&marketplace);
+        assert!(exists<EventsV1>(addr), error::not_found(ENO_EVENTS_V1));
+        borrow_global_mut<EventsV1>(addr)
+    }
+}

--- a/aptos-move/move-examples/marketplace/sources/listing.move
+++ b/aptos-move/move-examples/marketplace/sources/listing.move
@@ -20,6 +20,7 @@ module marketplace::listing {
     use aptos_token_objects::token as tokenv2;
     use aptos_token_objects::royalty;
 
+    use marketplace::events;
     use marketplace::fee_schedule::FeeSchedule;
 
     friend marketplace::coin_listing;
@@ -261,6 +262,22 @@ module marketplace::listing {
             } else {
                 (@0x0, 0)
             }
+        }
+    }
+
+    #[view]
+    /// Produce a events::TokenMetadata for a listing
+    public fun token_metadata(
+        object: Object<Listing>,
+    ): events::TokenMetadata acquires Listing, TokenV1Container {
+        let listing = borrow_listing(object);
+        let obj_addr = object::object_address(&listing.object);
+        if (exists<TokenV1Container>(obj_addr)) {
+            let token_container = borrow_global<TokenV1Container>(obj_addr);
+            let token_id = tokenv1::get_token_id(&token_container.token);
+            events::token_metadata_for_tokenv1(token_id)
+        } else {
+            events::token_metadata_for_tokenv2(object::convert(listing.object))
         }
     }
 

--- a/aptos-move/move-examples/marketplace/sources/test_utils.move
+++ b/aptos-move/move-examples/marketplace/sources/test_utils.move
@@ -49,7 +49,7 @@ module marketplace::test_utils {
     }
 
     public fun fee_schedule(seller: &signer): Object<FeeSchedule> {
-        fee_schedule::init_internal(
+        fee_schedule::init(
             seller,
             signer::address_of(seller),
             2,


### PR DESCRIPTION
### Description
This adds marketplace token offers instead of just collection offers.  This allows users to bid on any token at any time, as well as cancel it at any time.

Built on top of https://github.com/aptos-labs/aptos-core/pull/8742

### Test Plan
TBD, CI tests are copied from Collection offer, but should test once manually
