### PR TITLE
Add is_std_option function to StructTag

### DIFF
--- a/third_party/move/move-core/types/src/language_storage.rs
+++ b/third_party/move/move-core/types/src/language_storage.rs
@@ -135,6 +135,14 @@ impl StructTag {
             && self.name.as_str().eq("String")
     }
 
+    /// Returns true if this is a `StructTag` for a `std::option::Option` struct defined in the
+    /// standard library at address `move_std_addr`.
+    pub fn is_std_option(&self, move_std_addr: &AccountAddress) -> bool {
+        self.address == *move_std_addr
+            && self.module.as_str().eq("option")
+            && self.name.as_str().eq("Option")
+    }
+
     pub fn module_id(&self) -> ModuleId {
         ModuleId::new(self.address, self.module.to_owned())
     }


### PR DESCRIPTION
### Description
This function helps with some of the ABI codegen work I'm doing. Part of the Move stdlib so it should be uncontentious.

### Test Plan
I've used this successfully in code I'm adding later. Compile check. CI.
