### PR TITLE
[CLI][Ledger][2/n] Add StatusCode to Aptos Ledger crate

### DIFF
--- a/crates/aptos-ledger/src/lib.rs
+++ b/crates/aptos-ledger/src/lib.rs
@@ -67,11 +67,12 @@ impl From<LedgerHIDError> for AptosLedgerError {
 }
 
 #[derive(Debug)]
-/// Status code or retcode when communicating with ledger
-/// Most Aptos ones definted here https://github.com/aptos-labs/ledger-app-aptos/blob/main/doc/COMMANDS.md#status-words
+/// Status code returned when communicating with ledger
+/// Most Aptos ones defined here https://github.com/aptos-labs/ledger-app-aptos/blob/main/doc/COMMANDS.md#status-words
 /// Some of the ledger status code defined here - https://www.eftlab.com/knowledge-base/complete-list-of-apdu-responses
 pub enum AptosLedgerStatusCode {
-    // Aptos ledger app related status code
+    /// Aptos ledger app related status code
+
     /// Rejected by user
     Deny = 0x6985,
 
@@ -117,8 +118,9 @@ pub enum AptosLedgerStatusCode {
     /// Success
     Success = 0x9000,
 
-    // Ledger device related general status code
-    // There are more status code, but we only list the most common ones
+    /// Ledger device related general status code
+
+    /// There are more status code, but we only list the most common ones
     /// Ledger device is locked
     LedgerLocked = 0x5515,
 


### PR DESCRIPTION
### Description

This PR is built on top of this init refactor branch #8893 

1. Added new enum `AptosLedgerStatusCode` - I found these code from Aptos Ledger app and personal finding when I was testing the error. There are many error or status code out there. In this case we cover the most common ones, and the rest will go into `Unknown` error
3. Update all error return message from the ledger crate

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

➜  aptos-core git:(jin/ledger_status_code) aptos-debug init --ledger
Aptos already initialized for profile default, do you want to overwrite the existing config? [yes/no] >
yes
Configuring for profile default
Choose network from [devnet, testnet, mainnet, local, custom | defaults to devnet]

No network given, using devnet...
{
  "Error": "Unexpected error: Error - Ledger device is locked"
}
