### PR TITLE
[ts-sdk] fix: Incorrect serialization of TypeTags

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos Node SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Fixed serialization of arguments like `u16`, `u32` and `u256`
 
 ## 1.13.0 (2023-07-05)
 

--- a/ecosystem/typescript/sdk/src/aptos_types/type_tag.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/type_tag.ts
@@ -47,7 +47,7 @@ export class TypeTagBool extends TypeTag {
     serializer.serializeU32AsUleb128(0);
   }
 
-  static load(deserializer: Deserializer): TypeTagBool {
+  static load(_deserializer: Deserializer): TypeTagBool {
     return new TypeTagBool();
   }
 }
@@ -64,7 +64,7 @@ export class TypeTagU8 extends TypeTag {
 
 export class TypeTagU16 extends TypeTag {
   serialize(serializer: Serializer): void {
-    serializer.serializeU32AsUleb128(1);
+    serializer.serializeU32AsUleb128(8);
   }
 
   static load(_deserializer: Deserializer): TypeTagU16 {
@@ -74,7 +74,7 @@ export class TypeTagU16 extends TypeTag {
 
 export class TypeTagU32 extends TypeTag {
   serialize(serializer: Serializer): void {
-    serializer.serializeU32AsUleb128(1);
+    serializer.serializeU32AsUleb128(9);
   }
 
   static load(_deserializer: Deserializer): TypeTagU32 {
@@ -104,7 +104,7 @@ export class TypeTagU128 extends TypeTag {
 
 export class TypeTagU256 extends TypeTag {
   serialize(serializer: Serializer): void {
-    serializer.serializeU32AsUleb128(1);
+    serializer.serializeU32AsUleb128(10);
   }
 
   static load(_deserializer: Deserializer): TypeTagU256 {

--- a/ecosystem/typescript/sdk/src/tests/unit/type_tag.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/unit/type_tag.test.ts
@@ -1,11 +1,13 @@
 import {
   StructTag,
+  TypeTag,
   TypeTagAddress,
   TypeTagBool,
   TypeTagParser,
-  TypeTagParserError,
-  TypeTagStruct,
+  TypeTagParserError, TypeTagSigner,
+  TypeTagStruct, TypeTagU128, TypeTagU16, TypeTagU256, TypeTagU32, TypeTagU64, TypeTagU8, TypeTagVector,
 } from "../../aptos_types/type_tag";
+import {Deserializer, Serializer } from "../../bcs";
 
 const expectedTypeTag = {
   string: "0x0000000000000000000000000000000000000000000000000000000000000001::some_module::SomeResource",
@@ -137,3 +139,110 @@ describe("TypeTagParser", () => {
     });
   });
 });
+
+describe("Deserialize TypeTags", () => {
+  test('deserializes a TypeTagBool correctly', () => {
+    const serializer = new Serializer();
+    const tag = new TypeTagBool();
+
+    tag.serialize(serializer);
+
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagBool)
+  })
+
+  test('deserializes a TypeTagU8 correctly', () => {
+    const serializer = new Serializer();
+    const tag = new TypeTagU8();
+
+    tag.serialize(serializer);
+
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU8)
+  })
+
+  test('deserializes a TypeTagU16 correctly', () => {
+    const serializer = new Serializer();
+    const tag = new TypeTagU16();
+
+    tag.serialize(serializer);
+
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU16)
+  })
+
+  test('deserializes a TypeTagU32 correctly', () => {
+    const serializer = new Serializer();
+    const tag = new TypeTagU32();
+
+    tag.serialize(serializer);
+
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU32)
+  })
+
+  test('deserializes a TypeTagU64 correctly', () => {
+    const serializer = new Serializer();
+    const tag = new TypeTagU64();
+
+    tag.serialize(serializer);
+
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU64)
+  })
+
+  test('deserializes a TypeTagU128 correctly', () => {
+    const serializer = new Serializer();
+    const tag = new TypeTagU128();
+
+    tag.serialize(serializer);
+
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU128)
+  })
+
+  test('deserializes a TypeTagU256 correctly', () => {
+    const serializer = new Serializer();
+    const tag = new TypeTagU256();
+
+    tag.serialize(serializer);
+
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU256)
+  })
+
+  test('deserializes a TypeTagAddress correctly', () => {
+    const serializer = new Serializer();
+    const tag = new TypeTagAddress();
+
+    tag.serialize(serializer);
+
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagAddress)
+  })
+
+  test('deserializes a TypeTagSigner correctly', () => {
+    const serializer = new Serializer();
+    const tag = new TypeTagSigner();
+
+    tag.serialize(serializer);
+
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagSigner)
+  })
+
+  test('deserializes a TypeTagVector correctly', () => {
+    const serializer = new Serializer();
+    const tag = new TypeTagVector(new TypeTagU32());
+
+    tag.serialize(serializer);
+    const deserialized = TypeTag.deserialize(new Deserializer(serializer.getBytes())) as TypeTagVector;
+    expect(deserialized).toBeInstanceOf(TypeTagVector)
+    expect(deserialized.value).toBeInstanceOf(TypeTagU32)
+  })
+
+  test('deserializes a TypeTagStruct correctly', () => {
+    const serializer = new Serializer();
+    const tag = new TypeTagStruct(StructTag.fromString(expectedTypeTag.string));
+
+    tag.serialize(serializer);
+    const deserialized = TypeTag.deserialize(new Deserializer(serializer.getBytes())) as TypeTagStruct;
+    expect(deserialized).toBeInstanceOf(TypeTagStruct)
+    expect(deserialized.value).toBeInstanceOf(StructTag)
+    expect(deserialized.value.address.toHexString()).toEqual(expectedTypeTag.address);
+    expect(deserialized.value.module_name.value).toEqual("some_module");
+    expect(deserialized.value.name.value).toEqual("SomeResource");
+    expect(deserialized.value.type_args.length).toEqual(0);
+  })
+})

--- a/ecosystem/typescript/sdk/src/tests/unit/type_tag.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/unit/type_tag.test.ts
@@ -4,10 +4,18 @@ import {
   TypeTagAddress,
   TypeTagBool,
   TypeTagParser,
-  TypeTagParserError, TypeTagSigner,
-  TypeTagStruct, TypeTagU128, TypeTagU16, TypeTagU256, TypeTagU32, TypeTagU64, TypeTagU8, TypeTagVector,
+  TypeTagParserError,
+  TypeTagSigner,
+  TypeTagStruct,
+  TypeTagU128,
+  TypeTagU16,
+  TypeTagU256,
+  TypeTagU32,
+  TypeTagU64,
+  TypeTagU8,
+  TypeTagVector,
 } from "../../aptos_types/type_tag";
-import {Deserializer, Serializer } from "../../bcs";
+import { Deserializer, Serializer } from "../../bcs";
 
 const expectedTypeTag = {
   string: "0x0000000000000000000000000000000000000000000000000000000000000001::some_module::SomeResource",
@@ -141,108 +149,108 @@ describe("TypeTagParser", () => {
 });
 
 describe("Deserialize TypeTags", () => {
-  test('deserializes a TypeTagBool correctly', () => {
+  test("deserializes a TypeTagBool correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagBool();
 
     tag.serialize(serializer);
 
-    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagBool)
-  })
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagBool);
+  });
 
-  test('deserializes a TypeTagU8 correctly', () => {
+  test("deserializes a TypeTagU8 correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagU8();
 
     tag.serialize(serializer);
 
-    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU8)
-  })
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU8);
+  });
 
-  test('deserializes a TypeTagU16 correctly', () => {
+  test("deserializes a TypeTagU16 correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagU16();
 
     tag.serialize(serializer);
 
-    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU16)
-  })
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU16);
+  });
 
-  test('deserializes a TypeTagU32 correctly', () => {
+  test("deserializes a TypeTagU32 correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagU32();
 
     tag.serialize(serializer);
 
-    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU32)
-  })
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU32);
+  });
 
-  test('deserializes a TypeTagU64 correctly', () => {
+  test("deserializes a TypeTagU64 correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagU64();
 
     tag.serialize(serializer);
 
-    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU64)
-  })
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU64);
+  });
 
-  test('deserializes a TypeTagU128 correctly', () => {
+  test("deserializes a TypeTagU128 correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagU128();
 
     tag.serialize(serializer);
 
-    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU128)
-  })
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU128);
+  });
 
-  test('deserializes a TypeTagU256 correctly', () => {
+  test("deserializes a TypeTagU256 correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagU256();
 
     tag.serialize(serializer);
 
-    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU256)
-  })
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagU256);
+  });
 
-  test('deserializes a TypeTagAddress correctly', () => {
+  test("deserializes a TypeTagAddress correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagAddress();
 
     tag.serialize(serializer);
 
-    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagAddress)
-  })
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagAddress);
+  });
 
-  test('deserializes a TypeTagSigner correctly', () => {
+  test("deserializes a TypeTagSigner correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagSigner();
 
     tag.serialize(serializer);
 
-    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagSigner)
-  })
+    expect(TypeTag.deserialize(new Deserializer(serializer.getBytes()))).toBeInstanceOf(TypeTagSigner);
+  });
 
-  test('deserializes a TypeTagVector correctly', () => {
+  test("deserializes a TypeTagVector correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagVector(new TypeTagU32());
 
     tag.serialize(serializer);
     const deserialized = TypeTag.deserialize(new Deserializer(serializer.getBytes())) as TypeTagVector;
-    expect(deserialized).toBeInstanceOf(TypeTagVector)
-    expect(deserialized.value).toBeInstanceOf(TypeTagU32)
-  })
+    expect(deserialized).toBeInstanceOf(TypeTagVector);
+    expect(deserialized.value).toBeInstanceOf(TypeTagU32);
+  });
 
-  test('deserializes a TypeTagStruct correctly', () => {
+  test("deserializes a TypeTagStruct correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagStruct(StructTag.fromString(expectedTypeTag.string));
 
     tag.serialize(serializer);
     const deserialized = TypeTag.deserialize(new Deserializer(serializer.getBytes())) as TypeTagStruct;
-    expect(deserialized).toBeInstanceOf(TypeTagStruct)
-    expect(deserialized.value).toBeInstanceOf(StructTag)
+    expect(deserialized).toBeInstanceOf(TypeTagStruct);
+    expect(deserialized.value).toBeInstanceOf(StructTag);
     expect(deserialized.value.address.toHexString()).toEqual(expectedTypeTag.address);
     expect(deserialized.value.module_name.value).toEqual("some_module");
     expect(deserialized.value.name.value).toEqual("SomeResource");
     expect(deserialized.value.type_args.length).toEqual(0);
-  })
-})
+  });
+});


### PR DESCRIPTION
### Description
Fix for issue  #8899 

### Test Plan
Test cases for checking all TypeTag types have been written. In the future, it is better to add a different test for each new type.
