### PR TITLE
[storage] update the cron job time to avoid conflict

### DIFF
--- a/terraform/helm/fullnode/values.yaml
+++ b/terraform/helm/fullnode/values.yaml
@@ -149,7 +149,7 @@ backup_verify:
 
 backup_compaction:
   # -- The schedule for backup compaction
-  schedule: "@daily"
+  schedule: "0 6 * * *"
   resources:
     limits:
       cpu: 1


### PR DESCRIPTION
### Description

Currently compaction and backup-verify runs at the same time. It can lead to retry of the backup-verify job due to moving of metadata files. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
