### PR TITLE
[Forge] Small fix to sanitize_forge_resource_name.

### DIFF
--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -988,8 +988,14 @@ def image_exists(
 
 def sanitize_forge_resource_name(forge_resource: str, max_length: int = 63) -> str:
     """
-    Sanitize the intended forge resource name to be a valid k8s resource name
+    Sanitize the intended forge resource name to be a valid k8s resource name.
+    Resource names must be: (i) 63 characters or less; (ii) contain characters
+    that are alphanumeric, '-', or '.'; (iii) start and end with an alphanumeric
+    character; and (iv) start with "forge-".
     """
+    if not forge_resource.startswith("forge-"):
+        raise Exception("Forge resource name must start with 'forge-'")
+
     sanitized_namespace = ""
     for i, c in enumerate(forge_resource):
         if i >= max_length:
@@ -997,9 +1003,13 @@ def sanitize_forge_resource_name(forge_resource: str, max_length: int = 63) -> s
         if c.isalnum():
             sanitized_namespace += c
         else:
-            sanitized_namespace += "-"
-    if not forge_resource.startswith("forge-"):
-        raise Exception("Forge resource name must start with 'forge-'")
+            sanitized_namespace += "-"  # Replace the invalid character with a '-'
+
+    if sanitized_namespace.endswith("-"):
+        sanitized_namespace = (
+            sanitized_namespace[:-1] + "0"
+        )  # Set the last character to '0'
+
     return sanitized_namespace
 
 

--- a/testsuite/forge_test.py
+++ b/testsuite/forge_test.py
@@ -623,10 +623,21 @@ class ForgeFormattingTests(unittest.TestCase, AssertFixtureMixin):
             "testFormatReport.fixture",
         )
 
+    def testSanitizeForgeNamespaceLastCharacter(self) -> None:
+        namespace_with_invalid_last_char = "forge-$$$"
+        namespace = sanitize_forge_resource_name(namespace_with_invalid_last_char)
+        self.assertEqual(namespace, "forge---0")
+
     def testSanitizeForgeNamespaceSlashes(self) -> None:
         namespace_with_slash = "forge-banana/apple"
         namespace = sanitize_forge_resource_name(namespace_with_slash)
         self.assertEqual(namespace, "forge-banana-apple")
+
+    def testSanitizeForgeNamespaceStartsWith(self) -> None:
+        namespace_with_invalid_start = "frog-"
+        self.assertRaises(
+            Exception, sanitize_forge_resource_name, namespace_with_invalid_start
+        )
 
     def testSanitizeForgeNamespaceTooLong(self) -> None:
         namespace_too_long = "forge-" + "a" * 10000


### PR DESCRIPTION
### Description
Note: This is required to unblock a currently failing forge test.

This PR fixes a small issue in the `sanitize_forge_resource_name` function. Specifically, it's possible for the forge namespace to end in a `-` (after sanitization), which is not valid. This PR extends the function and adds some new tests.

### Test Plan
New unit tests.