### PR TITLE
[helm][fullnode/aptos-node] add basic PodDisruptionBudget

### DIFF
--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -89,6 +89,7 @@ jobs:
   # to be land blocking for any PR on the aptos repo. This is why we run those tests
   # separate from test-sdk-confirm-client-generated-publish.
   run-indexer-tests:
+    needs: [permission-check]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3

--- a/terraform/helm/aptos-node/templates/poddisruptionbudget.yaml
+++ b/terraform/helm/aptos-node/templates/poddisruptionbudget.yaml
@@ -1,0 +1,29 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "aptos-validator.fullname" . }}-validator
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: validator
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "aptos-validator.fullname" . }}-fullnode
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fullnode
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "aptos-validator.fullname" . }}-haproxy
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: haproxy

--- a/terraform/helm/fullnode/templates/poddisruptionbudget.yaml
+++ b/terraform/helm/fullnode/templates/poddisruptionbudget.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "aptos-fullnode.fullname" . }}-fullnode
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fullnode


### PR DESCRIPTION
### Description

Add a pod disruption budget to validators, vfns, and PFNs, such that we try to contain the number of services that can go down at any given point when the disruptions are voluntary

PDB is stable since 1.21 so we can roll it out everywhere without gating it by a helm value for instance

### Test Plan

Apply it

<!-- Please provide us with clear details for verifying that your changes work. -->
