### PR TITLE
[TS SDK] Bump version to 1.12.0

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 
 ## Unreleased
 
+## 1.12.0 (2023-06-30)
+
 - Add token standard v2 support to `getTokenOwnersData` query
   - `propertyVersion` parameter is optional to support fetching token v2 data
 - Introduce `getTokenCurrentOwnerData` to fetch the current owner of a token
+- Add `mintAptosSubdomain` and `setSubdomainAddress` functions to `AnsClient`
 
 ## 1.11.0 (2023-06-22)
 

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -85,5 +85,5 @@
     "typedoc": "^0.23.20",
     "typescript": "4.8.2"
   },
-  "version": "1.11.0"
+  "version": "1.12.0"
 }

--- a/ecosystem/typescript/sdk/src/version.ts
+++ b/ecosystem/typescript/sdk/src/version.ts
@@ -1,2 +1,2 @@
 // hardcoded for now, we would want to have it injected dynamically
-export const VERSION = "1.11.0";
+export const VERSION = "1.12.0";


### PR DESCRIPTION
### Description
- Add token standard v2 support to `getTokenOwnersData` query
  - `propertyVersion` parameter is optional to support fetching token v2 data
- Introduce `getTokenCurrentOwnerData` to fetch the current owner of a token
- Add `mintAptosSubdomain` and `setSubdomainAddress` functions to `AnsClient`
### Test Plan
