### PR TITLE
Add non-storage gas into executor benchmark for block gas limit calibration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,6 +1112,7 @@ name = "aptos-executor-benchmark"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-block-executor",
  "aptos-block-partitioner",
  "aptos-config",
  "aptos-crypto",

--- a/aptos-move/block-executor/src/counters.rs
+++ b/aptos-move/block-executor/src/counters.rs
@@ -3,7 +3,7 @@
 
 use aptos_metrics_core::{
     exponential_buckets, register_histogram, register_histogram_vec, register_int_counter,
-    Histogram, HistogramVec, IntCounter,
+    register_int_counter_vec, Histogram, HistogramVec, IntCounter, IntCounterVec,
 };
 use once_cell::sync::Lazy;
 
@@ -13,36 +13,43 @@ impl GasType {
     pub const EXECUTION_GAS: &'static str = "execution_gas";
     pub const IO_GAS: &'static str = "io_gas";
     pub const NON_STORAGE_GAS: &'static str = "non_storage_gas";
-    pub const STORAGE_FEE: &'static str = "storage_fee";
-    pub const STORAGE_GAS: &'static str = "storage_gas";
+    pub const STORAGE_FEE: &'static str = "storage_in_octas";
+    pub const STORAGE_GAS: &'static str = "storage_in_gas";
     pub const TOTAL_GAS: &'static str = "total_gas";
+}
+
+pub struct Mode;
+
+impl Mode {
+    pub const PARALLEL: &'static str = "parallel";
+    pub const SEQUENTIAL: &'static str = "sequential";
 }
 
 /// Record the block gas during parallel execution.
 pub fn observe_parallel_execution_block_gas(cost: u64, gas_type: &'static str) {
-    PARALLEL_BLOCK_GAS
-        .with_label_values(&[gas_type])
+    BLOCK_GAS
+        .with_label_values(&[Mode::PARALLEL, gas_type])
         .observe(cost as f64);
 }
 
 /// Record the txn gas during parallel execution.
 pub fn observe_parallel_execution_txn_gas(cost: u64, gas_type: &'static str) {
-    PARALLEL_TXN_GAS
-        .with_label_values(&[gas_type])
+    TXN_GAS
+        .with_label_values(&[Mode::PARALLEL, gas_type])
         .observe(cost as f64);
 }
 
 /// Record the block gas during sequential execution.
 pub fn observe_sequential_execution_block_gas(cost: u64, gas_type: &'static str) {
-    SEQUENTIAL_BLOCK_GAS
-        .with_label_values(&[gas_type])
+    BLOCK_GAS
+        .with_label_values(&[Mode::SEQUENTIAL, gas_type])
         .observe(cost as f64);
 }
 
 /// Record the txn gas during sequential execution.
 pub fn observe_sequential_execution_txn_gas(cost: u64, gas_type: &'static str) {
-    SEQUENTIAL_TXN_GAS
-        .with_label_values(&[gas_type])
+    TXN_GAS
+        .with_label_values(&[Mode::SEQUENTIAL, gas_type])
         .observe(cost as f64);
 }
 
@@ -65,19 +72,11 @@ pub static SPECULATIVE_ABORT_COUNT: Lazy<IntCounter> = Lazy::new(|| {
 });
 
 /// Count of times the BlockSTM is early halted due to exceeding the per-block gas limit.
-pub static PARALLEL_EXCEED_PER_BLOCK_GAS_LIMIT_COUNT: Lazy<IntCounter> = Lazy::new(|| {
-    register_int_counter!(
-        "aptos_execution_par_gas_limit_count",
-        "Count of times the BlockSTM is early halted due to exceeding the per-block gas limit"
-    )
-    .unwrap()
-});
-
-/// Count of times the sequential execution is early halted due to exceeding the per-block gas limit.
-pub static SEQUENTIAL_EXCEED_PER_BLOCK_GAS_LIMIT_COUNT: Lazy<IntCounter> = Lazy::new(|| {
-    register_int_counter!(
-        "aptos_execution_seq_gas_limit_count",
-        "Count of times the sequential execution is early halted due to exceeding the per-block gas limit"
+pub static EXCEED_PER_BLOCK_GAS_LIMIT_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_execution_gas_limit_count",
+        "Count of times the BlockSTM is early halted due to exceeding the per-block gas limit",
+        &["mode"]
     )
     .unwrap()
 });
@@ -168,55 +167,29 @@ pub static DEPENDENCY_WAIT_SECONDS: Lazy<Histogram> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static PARALLEL_BLOCK_GAS: Lazy<HistogramVec> = Lazy::new(|| {
+pub static BLOCK_GAS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
-        "aptos_execution_parallel_block_gas",
-        "Histogram for different block gas costs (execution, io, storage, storage fee, non-storage) during parallel execution",
-        &["stage"]
+        "aptos_execution_block_gas",
+        "Histogram for different block gas costs (execution, io, storage, storage fee, non-storage)",
+        &["mode", "stage"]
     )
     .unwrap()
 });
 
-pub static PARALLEL_TXN_GAS: Lazy<HistogramVec> = Lazy::new(|| {
+pub static TXN_GAS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
-        "aptos_execution_parallel_txn_gas",
-        "Histogram for different average txn gas costs (execution, io, storage, storage fee, non-storage) during parallel execution",
-        &["stage"]
+        "aptos_execution_txn_gas",
+        "Histogram for different average txn gas costs (execution, io, storage, storage fee, non-storage)",
+        &["mode", "stage"]
     )
     .unwrap()
 });
 
-pub static SEQUENTIAL_BLOCK_GAS: Lazy<HistogramVec> = Lazy::new(|| {
+pub static BLOCK_COMMITTED_TXNS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
-        "aptos_execution_sequential_block_gas",
-        "Histogram for different block gas costs (execution, io, storage, storage fee, non-storage) during sequential execution",
-        &["stage"]
-    )
-    .unwrap()
-});
-
-pub static SEQUENTIAL_TXN_GAS: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        "aptos_execution_sequential_txn_gas",
-        "Histogram for different average txn gas costs (execution, io, storage, storage fee, non-storage) during sequential execution",
-        &["stage"]
-    )
-    .unwrap()
-});
-
-pub static PARALLEL_BLOCK_COMMITTED_TXNS: Lazy<Histogram> = Lazy::new(|| {
-    register_histogram!(
-        "aptos_execution_par_block_committed_txns",
-        "The per-block committed txns in parallel execution (Block STM)",
-        exponential_buckets(/*start=*/ 1.0, /*factor=*/ 2.0, /*count=*/ 30).unwrap(),
-    )
-    .unwrap()
-});
-
-pub static SEQUENTIAL_BLOCK_COMMITTED_TXNS: Lazy<Histogram> = Lazy::new(|| {
-    register_histogram!(
-        "aptos_execution_seq_block_committed_txns",
-        "The per-block committed txns in sequential execution",
+        "aptos_execution_block_committed_txns",
+        "The per-block committed txns (Block STM)",
+        &["mode"],
         exponential_buckets(/*start=*/ 1.0, /*factor=*/ 2.0, /*count=*/ 30).unwrap(),
     )
     .unwrap()

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -135,7 +135,9 @@ where
             accumulated_fee_statement.storage_fee_used(),
             GasType::STORAGE_FEE,
         );
-        counters::PARALLEL_BLOCK_COMMITTED_TXNS.observe(num_committed as f64);
+        counters::BLOCK_COMMITTED_TXNS
+            .with_label_values(&[counters::Mode::PARALLEL])
+            .observe(num_committed as f64);
     }
 
     fn update_parallel_txn_gas_counters(&self, fee_statement: &FeeStatement) {
@@ -189,7 +191,9 @@ where
             accumulated_fee_statement.storage_fee_used(),
             GasType::STORAGE_FEE,
         );
-        counters::PARALLEL_BLOCK_COMMITTED_TXNS.observe(num_committed as f64);
+        counters::BLOCK_COMMITTED_TXNS
+            .with_label_values(&[counters::Mode::PARALLEL])
+            .observe(num_committed as f64);
     }
 
     fn update_sequential_txn_gas_counters(&self, fee_statement: &FeeStatement) {
@@ -424,7 +428,9 @@ where
                         accumulated_fee_statement,
                         (txn_idx + 1) as usize,
                     );
-                    counters::PARALLEL_EXCEED_PER_BLOCK_GAS_LIMIT_COUNT.inc();
+                    counters::EXCEED_PER_BLOCK_GAS_LIMIT_COUNT
+                        .with_label_values(&[counters::Mode::PARALLEL])
+                        .inc();
                     info!("[BlockSTM]: Parallel execution early halted due to accumulated_non_storage_gas {} >= PER_BLOCK_GAS_LIMIT {}, {} txns committed", accumulated_non_storage_gas, per_block_gas_limit, txn_idx);
                     break;
                 }
@@ -735,7 +741,9 @@ where
                 let accumulated_non_storage_gas = accumulated_fee_statement.execution_gas_used()
                     + accumulated_fee_statement.io_gas_used();
                 if accumulated_non_storage_gas >= per_block_gas_limit {
-                    counters::SEQUENTIAL_EXCEED_PER_BLOCK_GAS_LIMIT_COUNT.inc();
+                    counters::EXCEED_PER_BLOCK_GAS_LIMIT_COUNT
+                        .with_label_values(&[counters::Mode::SEQUENTIAL])
+                        .inc();
                     info!("[Execution]: Sequential execution early halted due to accumulated_non_storage_gas {} >= PER_BLOCK_GAS_LIMIT {}, {} txns committed", accumulated_non_storage_gas, per_block_gas_limit, ret.len());
                     break;
                 }

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-block-executor = { workspace = true }
 aptos-block-partitioner = { workspace = true }
 aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -18,6 +18,7 @@ use crate::{
     pipeline::Pipeline, transaction_committer::TransactionCommitter,
     transaction_executor::TransactionExecutor, transaction_generator::TransactionGenerator,
 };
+use aptos_block_executor::counters as block_executor_counters;
 use aptos_config::config::{NodeConfig, PrunerConfig};
 use aptos_db::AptosDB;
 use aptos_executor::{
@@ -31,13 +32,13 @@ use aptos_jellyfish_merkle::metrics::{
     APTOS_JELLYFISH_INTERNAL_ENCODED_BYTES, APTOS_JELLYFISH_LEAF_ENCODED_BYTES,
 };
 use aptos_logger::{info, warn};
+use aptos_metrics_core::Histogram;
 use aptos_sdk::types::LocalAccount;
 use aptos_storage_interface::DbReaderWriter;
 use aptos_transaction_generator_lib::{
     create_txn_generator_creator, TransactionGeneratorCreator, TransactionType,
     TransactionType::NonConflictingCoinTransfer,
 };
-use aptos_vm::counters::TXN_GAS_USAGE;
 use db_reliable_submitter::DbReliableTransactionSubmitter;
 use pipeline::PipelineConfig;
 use std::{
@@ -198,7 +199,7 @@ pub fn run_benchmark<V>(
     );
 
     let mut start_time = Instant::now();
-    let start_gas = TXN_GAS_USAGE.get_sample_sum();
+    let start_gas_measurement = GasMesurement::start();
 
     let start_execution_total = APTOS_EXECUTOR_EXECUTE_BLOCK_SECONDS.get_sample_sum();
     let start_vm_only = APTOS_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS.get_sample_sum();
@@ -250,7 +251,8 @@ pub fn run_benchmark<V>(
 
     let elapsed = start_time.elapsed().as_secs_f64();
     let delta_v = (db.reader.get_latest_version().unwrap() - version) as f64;
-    let delta_gas = TXN_GAS_USAGE.get_sample_sum() - start_gas;
+    let (delta_gas, delta_gas_count) = start_gas_measurement.end();
+
     let delta_vm_time = APTOS_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS.get_sample_sum() - start_vm_time;
     info!(
         "VM execution TPS {} txn/s",
@@ -266,6 +268,10 @@ pub fn run_benchmark<V>(
     );
     info!("Overall TPS: {} txn/s", delta_v / elapsed);
     info!("Overall GPS: {} gas/s", delta_gas / elapsed);
+    info!(
+        "Overall GPT: {} gas/txn",
+        delta_gas / (delta_gas_count as f64).max(1.0)
+    );
 
     let time_in_execution =
         APTOS_EXECUTOR_EXECUTE_BLOCK_SECONDS.get_sample_sum() - start_execution_total;
@@ -562,5 +568,48 @@ mod tests {
     fn test_native_benchmark() {
         // correct execution not yet implemented, so cannot be checked for validity
         test_generic_benchmark::<NativeExecutor>(None, false);
+    }
+}
+
+struct GasMesurement {
+    start_gas: f64,
+    start_gas_count: u64,
+}
+
+impl GasMesurement {
+    pub fn sequential_gas_counter() -> Histogram {
+        block_executor_counters::TXN_GAS.with_label_values(&[
+            block_executor_counters::Mode::SEQUENTIAL,
+            block_executor_counters::GasType::NON_STORAGE_GAS,
+        ])
+    }
+
+    pub fn parallel_gas_counter() -> Histogram {
+        block_executor_counters::TXN_GAS.with_label_values(&[
+            block_executor_counters::Mode::PARALLEL,
+            block_executor_counters::GasType::NON_STORAGE_GAS,
+        ])
+    }
+
+    pub fn start() -> Self {
+        let start_gas = Self::sequential_gas_counter().get_sample_sum()
+            + Self::parallel_gas_counter().get_sample_sum();
+        let start_gas_count = Self::sequential_gas_counter().get_sample_count()
+            + Self::parallel_gas_counter().get_sample_count();
+
+        Self {
+            start_gas,
+            start_gas_count,
+        }
+    }
+
+    pub fn end(self) -> (f64, u64) {
+        let delta_gas = (Self::sequential_gas_counter().get_sample_sum()
+            + Self::parallel_gas_counter().get_sample_sum())
+            - self.start_gas;
+        let delta_gas_count = (Self::sequential_gas_counter().get_sample_count()
+            + Self::parallel_gas_counter().get_sample_count())
+            - self.start_gas_count;
+        (delta_gas, delta_gas_count)
     }
 }


### PR DESCRIPTION

and modify counters to have parallel/sequential be label instead of new counters, for simpler grafana queries

### Description

### Test Plan
use output of single_node_performance run to calibrate block gas limit
