### PR TITLE
[vm][gas] refactor: separate out the memory usage tracker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,7 @@ dependencies = [
  "aptos-gas",
  "aptos-gas-profiling",
  "aptos-logger",
+ "aptos-memory-usage-tracker",
  "aptos-resource-viewer",
  "aptos-rest-client",
  "aptos-state-view",
@@ -2009,6 +2010,7 @@ dependencies = [
  "aptos-gas",
  "aptos-gas-profiling",
  "aptos-keygen",
+ "aptos-memory-usage-tracker",
  "aptos-proptest-helpers",
  "aptos-state-view",
  "aptos-types",
@@ -2078,6 +2080,17 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "aptos-memory-usage-tracker"
+version = "0.1.0"
+dependencies = [
+ "aptos-gas",
+ "aptos-types",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-types",
 ]
 
 [[package]]
@@ -3470,6 +3483,7 @@ dependencies = [
  "aptos-infallible",
  "aptos-language-e2e-tests",
  "aptos-logger",
+ "aptos-memory-usage-tracker",
  "aptos-metrics-core",
  "aptos-move-stdlib",
  "aptos-mvhashmap",
@@ -7481,6 +7495,7 @@ dependencies = [
  "aptos-keygen",
  "aptos-language-e2e-tests",
  "aptos-logger",
+ "aptos-memory-usage-tracker",
  "aptos-state-view",
  "aptos-types",
  "aptos-vm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "aptos-move/aptos-debugger",
     "aptos-move/aptos-gas",
     "aptos-move/aptos-gas-profiling",
+    "aptos-move/aptos-memory-usage-tracker",
     "aptos-move/aptos-release-builder",
     "aptos-move/aptos-resource-viewer",
     "aptos-move/aptos-sdk-builder",
@@ -315,6 +316,7 @@ aptos-language-e2e-tests = { path = "aptos-move/e2e-tests" }
 aptos-ledger = { path = "crates/aptos-ledger" }
 aptos-log-derive = { path = "crates/aptos-log-derive" }
 aptos-logger = { path = "crates/aptos-logger" }
+aptos-memory-usage-tracker = { path = "aptos-move/aptos-memory-usage-tracker" }
 aptos-mempool = { path = "mempool" }
 aptos-mempool-notifications = { path = "state-sync/inter-component/mempool-notifications" }
 aptos-memsocket = { path = "network/memsocket" }

--- a/aptos-move/aptos-debugger/Cargo.toml
+++ b/aptos-move/aptos-debugger/Cargo.toml
@@ -15,6 +15,7 @@ aptos-crypto = { workspace = true }
 aptos-gas = { workspace = true }
 aptos-gas-profiling = { workspace = true }
 aptos-logger = { workspace = true }
+aptos-memory-usage-tracker = { workspace = true }
 aptos-resource-viewer = { workspace = true }
 aptos-rest-client = { workspace = true }
 aptos-state-view = { workspace = true }

--- a/aptos-move/aptos-debugger/src/lib.rs
+++ b/aptos-move/aptos-debugger/src/lib.rs
@@ -7,6 +7,7 @@ use aptos_gas::{
     LATEST_GAS_FEATURE_VERSION,
 };
 use aptos_gas_profiling::{GasProfiler, TransactionGasLog};
+use aptos_memory_usage_tracker::MemoryTrackedGasMeter;
 use aptos_resource_viewer::{AnnotatedAccountStateBlob, AptosValueAnnotator};
 use aptos_rest_client::Client;
 use aptos_state_view::TStateView;
@@ -79,12 +80,12 @@ impl AptosDebugger {
                 &txn,
                 &log_context,
                 |gas_feature_version, gas_params, storage_gas_params, balance| {
-                    let gas_meter = StandardGasMeter::new(
+                    let gas_meter = MemoryTrackedGasMeter::new(StandardGasMeter::new(
                         gas_feature_version,
                         gas_params,
                         storage_gas_params,
                         balance,
-                    );
+                    ));
                     let gas_profiler = match txn.payload() {
                         TransactionPayload::Script(_) => GasProfiler::new_script(gas_meter),
                         TransactionPayload::EntryFunction(entry_func) => GasProfiler::new_function(

--- a/aptos-move/aptos-gas-profiling/src/profiler.rs
+++ b/aptos-move/aptos-gas-profiling/src/profiler.rs
@@ -5,7 +5,7 @@ use crate::log::{
     CallFrame, EventStorage, ExecutionAndIOCosts, ExecutionGasEvent, FrameName, StorageFees,
     TransactionGasLog, WriteOpType, WriteStorage, WriteTransient,
 };
-use aptos_gas::{AptosGasMeter, Fee, Gas, GasScalingFactor};
+use aptos_gas::{AptosGasMeter, AptosGasParameters, Fee, Gas, GasScalingFactor};
 use aptos_types::{
     contract_event::ContractEvent, state_store::state_key::StateKey, write_set::WriteOp,
 };
@@ -476,6 +476,8 @@ where
 {
     delegate! {
         fn feature_version(&self) -> u64;
+
+        fn gas_params(&self) -> &AptosGasParameters;
 
         fn balance(&self) -> Gas;
 

--- a/aptos-move/aptos-gas/src/gas_meter.rs
+++ b/aptos-move/aptos-gas/src/gas_meter.rs
@@ -5,7 +5,7 @@
 //! parameters and traits to help manipulate them.
 
 use crate::{
-    algebra::{AbstractValueSize, Fee, Gas},
+    algebra::{Fee, Gas},
     instr::InstructionGasParameters,
     misc::MiscGasParameters,
     transaction::TransactionGasParameters,
@@ -13,8 +13,7 @@ use crate::{
 };
 use aptos_logger::error;
 use aptos_types::{
-    account_config::CORE_CODE_ADDRESS, contract_event::ContractEvent,
-    state_store::state_key::StateKey, write_set::WriteOp,
+    contract_event::ContractEvent, state_store::state_key::StateKey, write_set::WriteOp,
 };
 use move_binary_format::{
     errors::{Location, PartialVMError, PartialVMResult, VMResult},
@@ -228,6 +227,9 @@ pub trait AptosGasMeter: MoveGasMeter {
     /// Returns the gas feature version.
     fn feature_version(&self) -> u64;
 
+    /// Returns the struct that contains all (non-storage) gas parameters.
+    fn gas_params(&self) -> &AptosGasParameters;
+
     /// Returns the remaining balance, measured in (external) gas units.
     ///
     /// The number should be rounded down when converting from internal to external gas units.
@@ -357,7 +359,6 @@ pub struct StandardGasMeter {
     gas_params: AptosGasParameters,
     storage_gas_params: StorageGasParameters,
     balance: InternalGas,
-    memory_quota: AbstractValueSize,
 
     execution_gas_used: InternalGas,
     io_gas_used: InternalGas,
@@ -365,8 +366,6 @@ pub struct StandardGasMeter {
     storage_fee_in_internal_units: InternalGas,
     // The storage fee consumed by the storage operations.
     storage_fee_used: Fee,
-
-    should_leak_memory_for_native: bool,
 }
 
 impl StandardGasMeter {
@@ -376,7 +375,6 @@ impl StandardGasMeter {
         storage_gas_params: StorageGasParameters,
         balance: impl Into<Gas>,
     ) -> Self {
-        let memory_quota = gas_params.txn.memory_quota;
         let balance = balance.into().to_unit_with_params(&gas_params.txn);
 
         Self {
@@ -388,8 +386,6 @@ impl StandardGasMeter {
             io_gas_used: 0.into(),
             storage_fee_in_internal_units: 0.into(),
             storage_fee_used: 0.into(),
-            memory_quota,
-            should_leak_memory_for_native: false,
         }
     }
 
@@ -404,31 +400,6 @@ impl StandardGasMeter {
                 self.balance = 0.into();
                 Err(PartialVMError::new(StatusCode::OUT_OF_GAS))
             },
-        }
-    }
-
-    #[inline]
-    fn use_heap_memory(&mut self, amount: AbstractValueSize) -> PartialVMResult<()> {
-        if self.feature_version >= 3 {
-            match self.memory_quota.checked_sub(amount) {
-                Some(remaining_quota) => {
-                    self.memory_quota = remaining_quota;
-                    Ok(())
-                },
-                None => {
-                    self.memory_quota = 0.into();
-                    Err(PartialVMError::new(StatusCode::MEMORY_LIMIT_EXCEEDED))
-                },
-            }
-        } else {
-            Ok(())
-        }
-    }
-
-    #[inline]
-    fn release_heap_memory(&mut self, amount: AbstractValueSize) {
-        if self.feature_version >= 3 {
-            self.memory_quota += amount;
         }
     }
 
@@ -468,21 +439,8 @@ impl MoveGasMeter for StandardGasMeter {
     fn charge_native_function_before_execution(
         &mut self,
         _ty_args: impl ExactSizeIterator<Item = impl TypeView>,
-        args: impl ExactSizeIterator<Item = impl ValueView>,
+        _args: impl ExactSizeIterator<Item = impl ValueView>,
     ) -> PartialVMResult<()> {
-        // TODO(Gas): https://github.com/aptos-labs/aptos-core/issues/5485
-        if self.should_leak_memory_for_native {
-            return Ok(());
-        }
-
-        self.release_heap_memory(args.fold(AbstractValueSize::zero(), |acc, val| {
-            acc + self
-                .gas_params
-                .misc
-                .abs_val
-                .abstract_heap_size(val, self.feature_version)
-        }));
-
         Ok(())
     }
 
@@ -490,18 +448,8 @@ impl MoveGasMeter for StandardGasMeter {
     fn charge_native_function(
         &mut self,
         amount: InternalGas,
-        ret_vals: Option<impl ExactSizeIterator<Item = impl ValueView>>,
+        _ret_vals: Option<impl ExactSizeIterator<Item = impl ValueView>>,
     ) -> PartialVMResult<()> {
-        if let Some(ret_vals) = ret_vals {
-            self.use_heap_memory(ret_vals.fold(AbstractValueSize::zero(), |acc, val| {
-                acc + self
-                    .gas_params
-                    .misc
-                    .abs_val
-                    .abstract_heap_size(val, self.feature_version)
-            }))?;
-        }
-
         self.charge_execution(amount)
     }
 
@@ -513,17 +461,6 @@ impl MoveGasMeter for StandardGasMeter {
         val: Option<impl ValueView>,
         bytes_loaded: NumBytes,
     ) -> PartialVMResult<()> {
-        if self.feature_version != 0 {
-            // TODO(Gas): Rewrite this in a better way.
-            if let Some(val) = &val {
-                self.use_heap_memory(
-                    self.gas_params
-                        .misc
-                        .abs_val
-                        .abstract_heap_size(val, self.feature_version),
-                )?;
-            }
-        }
         if self.feature_version <= 8 && val.is_none() && bytes_loaded != 0.into() {
             return Err(PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message("in legacy versions, number of bytes loaded must be zero when the resource does not exist ".to_string()));
         }
@@ -535,14 +472,7 @@ impl MoveGasMeter for StandardGasMeter {
     }
 
     #[inline]
-    fn charge_pop(&mut self, popped_val: impl ValueView) -> PartialVMResult<()> {
-        self.release_heap_memory(
-            self.gas_params
-                .misc
-                .abs_val
-                .abstract_heap_size(popped_val, self.feature_version),
-        );
-
+    fn charge_pop(&mut self, _popped_val: impl ValueView) -> PartialVMResult<()> {
         self.charge_execution(self.gas_params.instr.pop)
     }
 
@@ -567,19 +497,12 @@ impl MoveGasMeter for StandardGasMeter {
     #[inline]
     fn charge_call_generic(
         &mut self,
-        module_id: &ModuleId,
+        _module_id: &ModuleId,
         _func_name: &str,
         ty_args: impl ExactSizeIterator<Item = impl TypeView>,
         args: impl ExactSizeIterator<Item = impl ValueView>,
         num_locals: NumArgs,
     ) -> PartialVMResult<()> {
-        // Save the info for charge_native_function_before_execution.
-        self.should_leak_memory_for_native = (*module_id.address() == CORE_CODE_ADDRESS
-            && module_id.name().as_str() == "table")
-            || (self.feature_version >= 4
-                && *module_id.address() == CORE_CODE_ADDRESS
-                && module_id.name().as_str() == "event");
-
         let params = &self.gas_params.instr;
 
         let mut cost = params.call_generic_base
@@ -601,14 +524,8 @@ impl MoveGasMeter for StandardGasMeter {
     #[inline]
     fn charge_ld_const_after_deserialization(
         &mut self,
-        val: impl ValueView,
+        _val: impl ValueView,
     ) -> PartialVMResult<()> {
-        self.use_heap_memory(
-            self.gas_params
-                .misc
-                .abs_val
-                .abstract_heap_size(val, self.feature_version),
-        )?;
         Ok(())
     }
 
@@ -619,8 +536,6 @@ impl MoveGasMeter for StandardGasMeter {
             .misc
             .abs_val
             .abstract_value_size_stack_and_heap(val, self.feature_version);
-
-        self.use_heap_memory(heap_size)?;
 
         // Note(Gas): this makes a deep copy so we need to charge for the full value size
         let instr_params = &self.gas_params.instr;
@@ -648,14 +563,6 @@ impl MoveGasMeter for StandardGasMeter {
     ) -> PartialVMResult<()> {
         let num_args = NumArgs::new(args.len() as u64);
 
-        self.use_heap_memory(args.fold(AbstractValueSize::zero(), |acc, val| {
-            acc + self
-                .gas_params
-                .misc
-                .abs_val
-                .abstract_stack_size(val, self.feature_version)
-        }))?;
-
         let params = &self.gas_params.instr;
         let cost = match is_generic {
             false => params.pack_base + params.pack_per_field * num_args,
@@ -671,14 +578,6 @@ impl MoveGasMeter for StandardGasMeter {
         args: impl ExactSizeIterator<Item = impl ValueView>,
     ) -> PartialVMResult<()> {
         let num_args = NumArgs::new(args.len() as u64);
-
-        self.release_heap_memory(args.fold(AbstractValueSize::zero(), |acc, val| {
-            acc + self
-                .gas_params
-                .misc
-                .abs_val
-                .abstract_stack_size(val, self.feature_version)
-        }));
 
         let params = &self.gas_params.instr;
         let cost = match is_generic {
@@ -696,8 +595,6 @@ impl MoveGasMeter for StandardGasMeter {
             .abs_val
             .abstract_value_size_stack_and_heap(val, self.feature_version);
 
-        self.use_heap_memory(heap_size)?;
-
         // Note(Gas): this makes a deep copy so we need to charge for the full value size
         let instr_params = &self.gas_params.instr;
         let cost = instr_params.read_ref_base
@@ -709,33 +606,13 @@ impl MoveGasMeter for StandardGasMeter {
     fn charge_write_ref(
         &mut self,
         _new_val: impl ValueView,
-        old_val: impl ValueView,
+        _old_val: impl ValueView,
     ) -> PartialVMResult<()> {
-        self.release_heap_memory(
-            self.gas_params
-                .misc
-                .abs_val
-                .abstract_heap_size(old_val, self.feature_version),
-        );
-
         self.charge_execution(self.gas_params.instr.write_ref_base)
     }
 
     #[inline]
     fn charge_eq(&mut self, lhs: impl ValueView, rhs: impl ValueView) -> PartialVMResult<()> {
-        self.release_heap_memory(
-            self.gas_params
-                .misc
-                .abs_val
-                .abstract_heap_size(&lhs, self.feature_version),
-        );
-        self.release_heap_memory(
-            self.gas_params
-                .misc
-                .abs_val
-                .abstract_heap_size(&rhs, self.feature_version),
-        );
-
         let instr_params = &self.gas_params.instr;
         let abs_val_params = &self.gas_params.misc.abs_val;
         let per_unit = instr_params.eq_per_abs_val_unit;
@@ -750,19 +627,6 @@ impl MoveGasMeter for StandardGasMeter {
 
     #[inline]
     fn charge_neq(&mut self, lhs: impl ValueView, rhs: impl ValueView) -> PartialVMResult<()> {
-        self.release_heap_memory(
-            self.gas_params
-                .misc
-                .abs_val
-                .abstract_heap_size(&lhs, self.feature_version),
-        );
-        self.release_heap_memory(
-            self.gas_params
-                .misc
-                .abs_val
-                .abstract_heap_size(&rhs, self.feature_version),
-        );
-
         let instr_params = &self.gas_params.instr;
         let abs_val_params = &self.gas_params.misc.abs_val;
         let per_unit = instr_params.neq_per_abs_val_unit;
@@ -847,10 +711,6 @@ impl MoveGasMeter for StandardGasMeter {
     ) -> PartialVMResult<()> {
         let num_args = NumArgs::new(args.len() as u64);
 
-        self.use_heap_memory(args.fold(AbstractValueSize::zero(), |acc, val| {
-            acc + self.gas_params.misc.abs_val.abstract_packed_size(val)
-        }))?;
-
         let params = &self.gas_params.instr;
         let cost = params.vec_pack_base + params.vec_pack_per_elem * num_args;
         self.charge_execution(cost)
@@ -861,12 +721,8 @@ impl MoveGasMeter for StandardGasMeter {
         &mut self,
         _ty: impl TypeView,
         expect_num_elements: NumArgs,
-        elems: impl ExactSizeIterator<Item = impl ValueView>,
+        _elems: impl ExactSizeIterator<Item = impl ValueView>,
     ) -> PartialVMResult<()> {
-        self.release_heap_memory(elems.fold(AbstractValueSize::zero(), |acc, val| {
-            acc + self.gas_params.misc.abs_val.abstract_packed_size(val)
-        }));
-
         let params = &self.gas_params.instr;
         let cost =
             params.vec_unpack_base + params.vec_unpack_per_expected_elem * expect_num_elements;
@@ -897,10 +753,8 @@ impl MoveGasMeter for StandardGasMeter {
     fn charge_vec_push_back(
         &mut self,
         _ty: impl TypeView,
-        val: impl ValueView,
+        _val: impl ValueView,
     ) -> PartialVMResult<()> {
-        self.use_heap_memory(self.gas_params.misc.abs_val.abstract_packed_size(val))?;
-
         self.charge_execution(self.gas_params.instr.vec_push_back_base)
     }
 
@@ -908,12 +762,8 @@ impl MoveGasMeter for StandardGasMeter {
     fn charge_vec_pop_back(
         &mut self,
         _ty: impl TypeView,
-        val: Option<impl ValueView>,
+        _val: Option<impl ValueView>,
     ) -> PartialVMResult<()> {
-        if let Some(val) = val {
-            self.release_heap_memory(self.gas_params.misc.abs_val.abstract_packed_size(val));
-        }
-
         self.charge_execution(self.gas_params.instr.vec_pop_back_base)
     }
 
@@ -925,16 +775,8 @@ impl MoveGasMeter for StandardGasMeter {
     #[inline]
     fn charge_drop_frame(
         &mut self,
-        locals: impl Iterator<Item = impl ValueView>,
+        _locals: impl Iterator<Item = impl ValueView>,
     ) -> PartialVMResult<()> {
-        self.release_heap_memory(locals.fold(AbstractValueSize::zero(), |acc, val| {
-            acc + self
-                .gas_params
-                .misc
-                .abs_val
-                .abstract_heap_size(val, self.feature_version)
-        }));
-
         Ok(())
     }
 }
@@ -942,6 +784,10 @@ impl MoveGasMeter for StandardGasMeter {
 impl AptosGasMeter for StandardGasMeter {
     fn feature_version(&self) -> u64 {
         self.feature_version
+    }
+
+    fn gas_params(&self) -> &AptosGasParameters {
+        &self.gas_params
     }
 
     fn balance(&self) -> Gas {

--- a/aptos-move/aptos-gas/src/params.rs
+++ b/aptos-move/aptos-gas/src/params.rs
@@ -20,7 +20,7 @@ macro_rules! define_gas_parameters {
         $params_name: ident,
         $prefix: literal,
         [$(
-            [$name: ident: $ty: ty, $key_bindings: tt, $initial: expr $(,)?]
+            [$name: ident: $ty: ty, $key_bindings: tt, $initial: expr $(, $tn: ident)? $(,)?]
         ),* $(,)?]
     ) => {
         #[derive(Debug, Clone)]
@@ -75,6 +75,15 @@ macro_rules! define_gas_parameters {
             }
         }
 
+        pub mod gas_params {
+            $(
+                $(
+                    /// Marker type representing the corresponding gas parameter.
+                    #[allow(non_camel_case_types)]
+                    pub enum $tn {}
+                )?
+            )*
+        }
 
         #[test]
         fn keys_should_be_unique_for_all_versions() {

--- a/aptos-move/aptos-memory-usage-tracker/Cargo.toml
+++ b/aptos-move/aptos-memory-usage-tracker/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "aptos-memory-usage-tracker"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+aptos-gas = { workspace = true }
+aptos-types = { workspace = true }
+move-binary-format = { workspace = true }
+move-core-types = { workspace = true }
+move-vm-types = { workspace = true }

--- a/aptos-move/aptos-memory-usage-tracker/src/lib.rs
+++ b/aptos-move/aptos-memory-usage-tracker/src/lib.rs
@@ -1,0 +1,506 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_gas::{
+    AbstractValueSize, AptosGasMeter, AptosGasParameters, Fee, FeePerGasUnit, Gas,
+    GasScalingFactor, InternalGas, NumArgs, NumBytes,
+};
+use aptos_types::{
+    account_config::CORE_CODE_ADDRESS, contract_event::ContractEvent,
+    state_store::state_key::StateKey, write_set::WriteOp,
+};
+use move_binary_format::{
+    errors::{PartialVMError, PartialVMResult, VMResult},
+    file_format::CodeOffset,
+};
+use move_core_types::{language_storage::ModuleId, vm_status::StatusCode};
+use move_vm_types::{
+    gas::{GasMeter as MoveGasMeter, SimpleInstruction},
+    views::{TypeView, ValueView},
+};
+
+/// Special gas meter implementation that tracks the VM's memory usage based on the operations
+/// executed.
+///
+/// Must be composed with a base gas meter.
+pub struct MemoryTrackedGasMeter<G> {
+    base: G,
+
+    memory_quota: AbstractValueSize,
+    should_leak_memory_for_native: bool,
+}
+
+impl<G> MemoryTrackedGasMeter<G>
+where
+    G: AptosGasMeter,
+{
+    pub fn new(base: G) -> Self {
+        let memory_quota = base.gas_params().txn.memory_quota;
+
+        Self {
+            base,
+            memory_quota,
+            should_leak_memory_for_native: false,
+        }
+    }
+
+    #[inline]
+    fn use_heap_memory(&mut self, amount: AbstractValueSize) -> PartialVMResult<()> {
+        if self.feature_version() >= 3 {
+            match self.memory_quota.checked_sub(amount) {
+                Some(remaining_quota) => {
+                    self.memory_quota = remaining_quota;
+                    Ok(())
+                },
+                None => {
+                    self.memory_quota = 0.into();
+                    Err(PartialVMError::new(StatusCode::MEMORY_LIMIT_EXCEEDED))
+                },
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    #[inline]
+    fn release_heap_memory(&mut self, amount: AbstractValueSize) {
+        if self.feature_version() >= 3 {
+            self.memory_quota += amount;
+        }
+    }
+}
+
+// TODO: consider switching to a library like https://docs.rs/delegate/latest/delegate/.
+macro_rules! delegate {
+    ($(
+        fn $fn: ident $(<$($lt: lifetime),*>)? (&self $(, $arg: ident : $ty: ty)* $(,)?) -> $ret_ty: ty;
+    )*) => {
+        $(fn $fn $(<$($lt)*>)? (&self, $($arg: $ty),*) -> $ret_ty {
+            self.base.$fn($($arg),*)
+        })*
+    };
+}
+
+macro_rules! delegate_mut {
+    ($(
+        fn $fn: ident $(<$($lt: lifetime),*>)? (&mut self $(, $arg: ident : $ty: ty)* $(,)?) -> $ret_ty: ty;
+    )*) => {
+        $(fn $fn $(<$($lt)*>)? (&mut self, $($arg: $ty),*) -> $ret_ty {
+            self.base.$fn($($arg),*)
+        })*
+    };
+}
+
+impl<G> MoveGasMeter for MemoryTrackedGasMeter<G>
+where
+    G: AptosGasMeter,
+{
+    delegate_mut! {
+        fn charge_simple_instr(&mut self, instr: SimpleInstruction) -> PartialVMResult<()>;
+
+        fn charge_br_true(&mut self, target_offset: Option<CodeOffset>) -> PartialVMResult<()>;
+
+        fn charge_br_false(&mut self, target_offset: Option<CodeOffset>) -> PartialVMResult<()>;
+
+        fn charge_branch(&mut self, target_offset: CodeOffset) -> PartialVMResult<()>;
+
+        fn charge_call(
+            &mut self,
+            module_id: &ModuleId,
+            func_name: &str,
+            args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+            num_locals: NumArgs,
+        ) -> PartialVMResult<()>;
+
+        fn charge_ld_const(&mut self, size: NumBytes) -> PartialVMResult<()>;
+
+        fn charge_move_loc(&mut self, val: impl ValueView) -> PartialVMResult<()>;
+
+        fn charge_store_loc(&mut self, val: impl ValueView) -> PartialVMResult<()>;
+
+        fn charge_borrow_global(
+            &mut self,
+            is_mut: bool,
+            is_generic: bool,
+            ty: impl TypeView,
+            is_success: bool,
+        ) -> PartialVMResult<()>;
+
+        fn charge_exists(
+            &mut self,
+            is_generic: bool,
+            ty: impl TypeView,
+            // TODO(Gas): see if we can get rid of this param
+            exists: bool,
+        ) -> PartialVMResult<()>;
+
+        fn charge_move_from(
+            &mut self,
+            is_generic: bool,
+            ty: impl TypeView,
+            val: Option<impl ValueView>,
+        ) -> PartialVMResult<()>;
+
+        fn charge_move_to(
+            &mut self,
+            is_generic: bool,
+            ty: impl TypeView,
+            val: impl ValueView,
+            is_success: bool,
+        ) -> PartialVMResult<()>;
+
+        fn charge_vec_len(&mut self, ty: impl TypeView) -> PartialVMResult<()>;
+
+        fn charge_vec_borrow(
+            &mut self,
+            is_mut: bool,
+            ty: impl TypeView,
+            is_success: bool,
+        ) -> PartialVMResult<()>;
+
+        fn charge_vec_swap(&mut self, ty: impl TypeView) -> PartialVMResult<()>;
+    }
+
+    #[inline]
+    fn balance_internal(&self) -> InternalGas {
+        self.base.balance_internal()
+    }
+
+    #[inline]
+    fn charge_call_generic(
+        &mut self,
+        module_id: &ModuleId,
+        func_name: &str,
+        ty_args: impl ExactSizeIterator<Item = impl TypeView> + Clone,
+        args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+        num_locals: NumArgs,
+    ) -> PartialVMResult<()> {
+        // Save the info for charge_native_function_before_execution.
+        self.should_leak_memory_for_native = (*module_id.address() == CORE_CODE_ADDRESS
+            && module_id.name().as_str() == "table")
+            || (self.feature_version() >= 4
+                && *module_id.address() == CORE_CODE_ADDRESS
+                && module_id.name().as_str() == "event");
+
+        self.base
+            .charge_call_generic(module_id, func_name, ty_args, args, num_locals)
+    }
+
+    #[inline]
+    fn charge_native_function_before_execution(
+        &mut self,
+        ty_args: impl ExactSizeIterator<Item = impl TypeView> + Clone,
+        args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+    ) -> PartialVMResult<()> {
+        // TODO(Gas): https://github.com/aptos-labs/aptos-core/issues/5485
+        if !self.should_leak_memory_for_native {
+            self.release_heap_memory(args.clone().fold(AbstractValueSize::zero(), |acc, val| {
+                acc + self
+                    .gas_params()
+                    .misc
+                    .abs_val
+                    .abstract_heap_size(val, self.feature_version())
+            }));
+        }
+
+        self.base
+            .charge_native_function_before_execution(ty_args, args)
+    }
+
+    #[inline]
+    fn charge_native_function(
+        &mut self,
+        amount: InternalGas,
+        ret_vals: Option<impl ExactSizeIterator<Item = impl ValueView> + Clone>,
+    ) -> PartialVMResult<()> {
+        if let Some(ret_vals) = ret_vals.clone() {
+            self.use_heap_memory(ret_vals.fold(AbstractValueSize::zero(), |acc, val| {
+                acc + self
+                    .gas_params()
+                    .misc
+                    .abs_val
+                    .abstract_heap_size(val, self.feature_version())
+            }))?;
+        }
+
+        self.base.charge_native_function(amount, ret_vals)
+    }
+
+    #[inline]
+    fn charge_load_resource(
+        &mut self,
+        addr: move_core_types::account_address::AccountAddress,
+        ty: impl TypeView,
+        val: Option<impl ValueView>,
+        bytes_loaded: aptos_gas::NumBytes,
+    ) -> PartialVMResult<()> {
+        if self.feature_version() != 0 {
+            // TODO(Gas): Rewrite this in a better way.
+            if let Some(val) = &val {
+                self.use_heap_memory(
+                    self.gas_params()
+                        .misc
+                        .abs_val
+                        .abstract_heap_size(val, self.feature_version()),
+                )?;
+            }
+        }
+
+        self.base.charge_load_resource(addr, ty, val, bytes_loaded)
+    }
+
+    #[inline]
+    fn charge_pop(&mut self, popped_val: impl ValueView) -> PartialVMResult<()> {
+        self.release_heap_memory(
+            self.gas_params()
+                .misc
+                .abs_val
+                .abstract_heap_size(&popped_val, self.feature_version()),
+        );
+
+        self.base.charge_pop(popped_val)
+    }
+
+    #[inline]
+    fn charge_ld_const_after_deserialization(
+        &mut self,
+        val: impl ValueView,
+    ) -> PartialVMResult<()> {
+        self.use_heap_memory(
+            self.gas_params()
+                .misc
+                .abs_val
+                .abstract_heap_size(&val, self.feature_version()),
+        )?;
+
+        self.base.charge_ld_const_after_deserialization(val)
+    }
+
+    #[inline]
+    fn charge_copy_loc(&mut self, val: impl ValueView) -> PartialVMResult<()> {
+        let heap_size = self
+            .gas_params()
+            .misc
+            .abs_val
+            .abstract_heap_size(&val, self.feature_version());
+
+        self.use_heap_memory(heap_size)?;
+
+        self.base.charge_copy_loc(val)
+    }
+
+    #[inline]
+    fn charge_pack(
+        &mut self,
+        is_generic: bool,
+        args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+    ) -> PartialVMResult<()> {
+        self.use_heap_memory(args.clone().fold(AbstractValueSize::zero(), |acc, val| {
+            acc + self
+                .gas_params()
+                .misc
+                .abs_val
+                .abstract_stack_size(val, self.feature_version())
+        }))?;
+
+        self.base.charge_pack(is_generic, args)
+    }
+
+    #[inline]
+    fn charge_unpack(
+        &mut self,
+        is_generic: bool,
+        args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+    ) -> PartialVMResult<()> {
+        self.release_heap_memory(args.clone().fold(AbstractValueSize::zero(), |acc, val| {
+            acc + self
+                .gas_params()
+                .misc
+                .abs_val
+                .abstract_stack_size(val, self.feature_version())
+        }));
+
+        self.base.charge_unpack(is_generic, args)
+    }
+
+    #[inline]
+    fn charge_read_ref(&mut self, val: impl ValueView) -> PartialVMResult<()> {
+        let heap_size = self
+            .gas_params()
+            .misc
+            .abs_val
+            .abstract_heap_size(&val, self.feature_version());
+
+        self.use_heap_memory(heap_size)?;
+
+        self.base.charge_read_ref(val)
+    }
+
+    #[inline]
+    fn charge_write_ref(
+        &mut self,
+        new_val: impl ValueView,
+        old_val: impl ValueView,
+    ) -> PartialVMResult<()> {
+        self.release_heap_memory(
+            self.gas_params()
+                .misc
+                .abs_val
+                .abstract_heap_size(&old_val, self.feature_version()),
+        );
+
+        self.base.charge_write_ref(new_val, old_val)
+    }
+
+    #[inline]
+    fn charge_eq(&mut self, lhs: impl ValueView, rhs: impl ValueView) -> PartialVMResult<()> {
+        self.release_heap_memory(
+            self.gas_params()
+                .misc
+                .abs_val
+                .abstract_heap_size(&lhs, self.feature_version()),
+        );
+        self.release_heap_memory(
+            self.gas_params()
+                .misc
+                .abs_val
+                .abstract_heap_size(&rhs, self.feature_version()),
+        );
+
+        self.base.charge_eq(lhs, rhs)
+    }
+
+    #[inline]
+    fn charge_neq(&mut self, lhs: impl ValueView, rhs: impl ValueView) -> PartialVMResult<()> {
+        self.release_heap_memory(
+            self.gas_params()
+                .misc
+                .abs_val
+                .abstract_heap_size(&lhs, self.feature_version()),
+        );
+        self.release_heap_memory(
+            self.gas_params()
+                .misc
+                .abs_val
+                .abstract_heap_size(&rhs, self.feature_version()),
+        );
+
+        self.base.charge_neq(lhs, rhs)
+    }
+
+    #[inline]
+    fn charge_vec_pack<'a>(
+        &mut self,
+        ty: impl TypeView + 'a,
+        args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+    ) -> PartialVMResult<()> {
+        self.use_heap_memory(args.clone().fold(AbstractValueSize::zero(), |acc, val| {
+            acc + self.gas_params().misc.abs_val.abstract_packed_size(val)
+        }))?;
+
+        self.base.charge_vec_pack(ty, args)
+    }
+
+    #[inline]
+    fn charge_vec_unpack(
+        &mut self,
+        ty: impl TypeView,
+        expect_num_elements: aptos_gas::NumArgs,
+        elems: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+    ) -> PartialVMResult<()> {
+        self.release_heap_memory(elems.clone().fold(AbstractValueSize::zero(), |acc, val| {
+            acc + self.gas_params().misc.abs_val.abstract_packed_size(val)
+        }));
+
+        self.base.charge_vec_unpack(ty, expect_num_elements, elems)
+    }
+
+    #[inline]
+    fn charge_vec_push_back(
+        &mut self,
+        ty: impl TypeView,
+        val: impl ValueView,
+    ) -> PartialVMResult<()> {
+        self.use_heap_memory(self.gas_params().misc.abs_val.abstract_packed_size(&val))?;
+
+        self.base.charge_vec_push_back(ty, val)
+    }
+
+    #[inline]
+    fn charge_vec_pop_back(
+        &mut self,
+        ty: impl TypeView,
+        val: Option<impl ValueView>,
+    ) -> PartialVMResult<()> {
+        if let Some(val) = &val {
+            self.release_heap_memory(self.gas_params().misc.abs_val.abstract_packed_size(val));
+        }
+
+        self.base.charge_vec_pop_back(ty, val)
+    }
+
+    #[inline]
+    fn charge_drop_frame(
+        &mut self,
+        locals: impl Iterator<Item = impl ValueView> + Clone,
+    ) -> PartialVMResult<()> {
+        self.release_heap_memory(locals.clone().fold(AbstractValueSize::zero(), |acc, val| {
+            acc + self
+                .gas_params()
+                .misc
+                .abs_val
+                .abstract_heap_size(val, self.feature_version())
+        }));
+
+        self.base.charge_drop_frame(locals)
+    }
+}
+
+impl<G> AptosGasMeter for MemoryTrackedGasMeter<G>
+where
+    G: AptosGasMeter,
+{
+    delegate! {
+        fn feature_version(&self) -> u64;
+
+        fn gas_params(&self) -> &AptosGasParameters;
+
+        fn balance(&self) -> Gas;
+
+        fn gas_unit_scaling_factor(&self) -> GasScalingFactor;
+
+        fn io_gas_per_write(&self, key: &StateKey, op: &WriteOp) -> InternalGas;
+
+        fn storage_fee_per_write(&self, key: &StateKey, op: &WriteOp) -> Fee;
+
+        fn storage_fee_per_event(&self, event: &ContractEvent) -> Fee;
+
+        fn storage_discount_for_events(&self, total_cost: Fee) -> Fee;
+
+        fn storage_fee_for_transaction_storage(&self, txn_size: NumBytes) -> Fee;
+
+        fn execution_gas_used(&self) -> Gas;
+
+        fn io_gas_used(&self) -> Gas;
+
+        fn storage_fee_used_in_gas_units(&self) -> Gas;
+
+        fn storage_fee_used(&self) -> Fee;
+    }
+
+    delegate_mut! {
+        fn charge_execution(&mut self, amount: InternalGas) -> PartialVMResult<()>;
+
+        fn charge_io(&mut self, amount: InternalGas) -> PartialVMResult<()>;
+
+        fn charge_storage_fee(
+            &mut self,
+            amount: Fee,
+            gas_unit_price: FeePerGasUnit,
+        ) -> PartialVMResult<()>;
+
+        fn charge_intrinsic_gas_for_transaction(&mut self, txn_size: NumBytes) -> VMResult<()>;
+
+
+    }
+}

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -23,6 +23,7 @@ aptos-framework =  { workspace = true }
 aptos-gas = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-logger = { workspace = true }
+aptos-memory-usage-tracker = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-move-stdlib = { workspace = true }
 aptos-mvhashmap = { workspace = true }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -26,6 +26,7 @@ use aptos_gas::{
     StorageGasParameters,
 };
 use aptos_logger::{enabled, prelude::*, Level};
+use aptos_memory_usage_tracker::MemoryTrackedGasMeter;
 use aptos_state_view::StateView;
 use aptos_types::{
     account_config,
@@ -1018,13 +1019,13 @@ impl AptosVM {
         &self,
         balance: Gas,
         log_context: &AdapterLogSchema,
-    ) -> Result<StandardGasMeter, VMStatus> {
-        Ok(StandardGasMeter::new(
+    ) -> Result<MemoryTrackedGasMeter<StandardGasMeter>, VMStatus> {
+        Ok(MemoryTrackedGasMeter::new(StandardGasMeter::new(
             self.0.get_gas_feature_version(),
             self.0.get_gas_parameters(log_context)?.clone(),
             self.0.get_storage_gas_parameters(log_context)?.clone(),
             balance,
-        ))
+        )))
     }
 
     fn execute_user_transaction_impl(
@@ -1409,12 +1410,12 @@ impl AptosVM {
     ) -> Result<Vec<Vec<u8>>> {
         let vm = AptosVM::new(state_view);
         let log_context = AdapterLogSchema::new(state_view.id(), 0);
-        let mut gas_meter = StandardGasMeter::new(
+        let mut gas_meter = MemoryTrackedGasMeter::new(StandardGasMeter::new(
             vm.0.get_gas_feature_version(),
             vm.0.get_gas_parameters(&log_context)?.clone(),
             vm.0.get_storage_gas_parameters(&log_context)?.clone(),
             gas_budget,
-        );
+        ));
         let resolver = vm.as_move_resolver(state_view);
         let mut session = vm.new_session(&resolver, SessionId::Void, true);
 
@@ -1845,12 +1846,12 @@ impl AptosSimulationVM {
             Ok(s) => s,
         };
 
-        let mut gas_meter = StandardGasMeter::new(
+        let mut gas_meter = MemoryTrackedGasMeter::new(StandardGasMeter::new(
             self.0 .0.get_gas_feature_version(),
             gas_params.clone(),
             storage_gas_params.clone(),
             txn_data.max_gas_amount(),
-        );
+        ));
 
         let mut new_published_modules_loaded = false;
         let result = match txn.payload() {

--- a/aptos-move/e2e-tests/Cargo.toml
+++ b/aptos-move/e2e-tests/Cargo.toml
@@ -21,6 +21,7 @@ aptos-framework = { workspace = true }
 aptos-gas = { workspace = true }
 aptos-gas-profiling = { workspace = true }
 aptos-keygen = { workspace = true }
+aptos-memory-usage-tracker = { workspace = true }
 aptos-proptest-helpers = { workspace = true }
 aptos-state-view = { workspace = true }
 aptos-types = { workspace = true }

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -22,6 +22,7 @@ use aptos_gas::{
 };
 use aptos_gas_profiling::{GasProfiler, TransactionGasLog};
 use aptos_keygen::KeyGen;
+use aptos_memory_usage_tracker::MemoryTrackedGasMeter;
 use aptos_state_view::TStateView;
 use aptos_types::{
     access_path::AccessPath,
@@ -504,12 +505,12 @@ impl FakeExecutor {
                 &txn,
                 &log_context,
                 |gas_feature_version, gas_params, storage_gas_params, balance| {
-                    let gas_meter = StandardGasMeter::new(
+                    let gas_meter = MemoryTrackedGasMeter::new(StandardGasMeter::new(
                         gas_feature_version,
                         gas_params,
                         storage_gas_params,
                         balance,
-                    );
+                    ));
                     let gas_profiler = match txn.payload() {
                         TransactionPayload::Script(_) => GasProfiler::new_script(gas_meter),
                         TransactionPayload::EntryFunction(entry_func) => GasProfiler::new_function(

--- a/aptos-move/e2e-testsuite/Cargo.toml
+++ b/aptos-move/e2e-testsuite/Cargo.toml
@@ -21,6 +21,7 @@ aptos-gas = { workspace = true, features = ["testing"] }
 aptos-keygen = { workspace = true }
 aptos-language-e2e-tests = { workspace = true }
 aptos-logger = { workspace = true }
+aptos-memory-usage-tracker = { workspace = true }
 aptos-state-view = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true, features = ['failpoints'] }

--- a/aptos-move/e2e-testsuite/src/tests/failed_transaction_tests.rs
+++ b/aptos-move/e2e-testsuite/src/tests/failed_transaction_tests.rs
@@ -6,6 +6,7 @@ use aptos_gas::{
     AptosGasParameters, StandardGasMeter, StorageGasParameters, LATEST_GAS_FEATURE_VERSION,
 };
 use aptos_language_e2e_tests::{common_transactions::peer_to_peer_txn, executor::FakeExecutor};
+use aptos_memory_usage_tracker::MemoryTrackedGasMeter;
 use aptos_state_view::TStateView;
 use aptos_types::{
     transaction::ExecutionStatus,
@@ -39,12 +40,12 @@ fn failed_transaction_cleanup_test() {
 
     let change_set_configs = storage_gas_params.change_set_configs.clone();
 
-    let mut gas_meter = StandardGasMeter::new(
+    let mut gas_meter = MemoryTrackedGasMeter::new(StandardGasMeter::new(
         LATEST_GAS_FEATURE_VERSION,
         gas_params,
         storage_gas_params,
         10_000,
-    );
+    ));
 
     // TYPE_MISMATCH should be kept and charged.
     let out1 = aptos_vm.failed_transaction_cleanup(


### PR DESCRIPTION
Back in time, the memory usage tracker was directly embedded into the gas meter because trait for composability did not exist. Now I'm moving it out as a separate layer, so that we have clearer separation of the logic. This does not change the behavior of the VM in any way.