### PR TITLE
[dag] certified node receiver handler

### DIFF
--- a/consensus/src/dag/tests/dag_test.rs
+++ b/consensus/src/dag/tests/dag_test.rs
@@ -4,15 +4,12 @@
 use crate::dag::{
     dag_store::Dag,
     storage::DAGStorage,
-    types::{CertifiedNode, Node, NodeCertificate},
+    tests::helpers::new_certified_node,
+    types::{CertifiedNode, Node},
 };
-use aptos_consensus_types::common::{Author, Payload, Round};
 use aptos_crypto::HashValue;
 use aptos_infallible::Mutex;
-use aptos_types::{
-    aggregate_signature::AggregateSignature, epoch_state::EpochState,
-    validator_verifier::random_validator_verifier,
-};
+use aptos_types::{epoch_state::EpochState, validator_verifier::random_validator_verifier};
 use std::{collections::HashMap, sync::Arc};
 
 pub struct MockStorage {
@@ -169,13 +166,4 @@ fn test_dag_recover_from_storage() {
 
     let _new_epoch_dag = Dag::new(new_epoch_state, storage.clone());
     assert!(storage.certified_node_data.lock().is_empty());
-}
-
-fn new_certified_node(
-    round: Round,
-    author: Author,
-    parents: Vec<NodeCertificate>,
-) -> CertifiedNode {
-    let node = Node::new(1, round, author, 0, Payload::empty(false), parents);
-    CertifiedNode::new(node, AggregateSignature::empty())
 }

--- a/consensus/src/dag/tests/helpers.rs
+++ b/consensus/src/dag/tests/helpers.rs
@@ -1,0 +1,23 @@
+// Copyright © Aptos Foundation
+
+use crate::dag::types::{CertifiedNode, Node, NodeCertificate};
+use aptos_consensus_types::common::{Author, Payload, Round};
+use aptos_types::aggregate_signature::AggregateSignature;
+
+pub(crate) fn new_certified_node(
+    round: Round,
+    author: Author,
+    parents: Vec<NodeCertificate>,
+) -> CertifiedNode {
+    let node = Node::new(1, round, author, 0, Payload::empty(false), parents);
+    CertifiedNode::new(node, AggregateSignature::empty())
+}
+
+pub(crate) fn new_node(
+    round: Round,
+    timestamp: u64,
+    author: Author,
+    parents: Vec<NodeCertificate>,
+) -> Node {
+    Node::new(0, round, author, timestamp, Payload::empty(false), parents)
+}

--- a/consensus/src/dag/tests/mod.rs
+++ b/consensus/src/dag/tests/mod.rs
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod dag_test;
+mod helpers;
 mod reliable_broadcast_tests;


### PR DESCRIPTION
### Description

This PR adds the receiver side of the Certified Node handler. A validator receives a certified node via RPC and adds it to the DAG after verifying it. It is only added if its parents exist and if they don't, there is a `TODO` to try to fetch it.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

New unit tests.
