### PR TITLE
[types] remove unnecessary transaction validation usage

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -9,6 +9,7 @@ use crate::{
     move_vm_ext::{MoveResolverExt, MoveVmExt, SessionExt, SessionId},
     system_module_names::{MULTISIG_ACCOUNT_MODULE, VALIDATE_MULTISIG_TRANSACTION},
     transaction_metadata::TransactionMetadata,
+    transaction_validation::APTOS_TRANSACTION_VALIDATION,
 };
 use aptos_framework::RuntimeModuleMetadataV1;
 use aptos_gas::{
@@ -18,7 +19,7 @@ use aptos_gas::{
 use aptos_logger::{enabled, prelude::*, Level};
 use aptos_state_view::StateView;
 use aptos_types::{
-    account_config::{TransactionValidation, APTOS_TRANSACTION_VALIDATION, CORE_CODE_ADDRESS},
+    account_config::CORE_CODE_ADDRESS,
     chain_id::ChainId,
     fee_statement::FeeStatement,
     on_chain_config::{
@@ -38,7 +39,6 @@ use move_binary_format::{
 use move_core_types::{
     gas_algebra::NumArgs,
     language_storage::ModuleId,
-    move_resource::MoveStructType,
     value::{serialize_values, MoveValue},
 };
 use move_vm_runtime::logging::expect_no_verification_errors;
@@ -55,7 +55,6 @@ pub struct AptosVMImpl {
     gas_params: Result<AptosGasParameters, String>,
     storage_gas_params: Result<StorageGasParameters, String>,
     version: Option<Version>,
-    transaction_validation: Option<TransactionValidation>,
     features: Features,
 }
 
@@ -153,7 +152,6 @@ impl AptosVMImpl {
         .expect("should be able to create Move VM; check if there are duplicated natives");
 
         let version = Version::fetch_config(&storage);
-        let transaction_validation = Self::get_transaction_validation(&storage);
 
         Self {
             move_vm,
@@ -161,7 +159,6 @@ impl AptosVMImpl {
             gas_params,
             storage_gas_params,
             version,
-            transaction_validation,
             features,
         }
     }
@@ -173,25 +170,6 @@ impl AptosVMImpl {
     /// Provides access to some internal APIs of the VM.
     pub fn internals(&self) -> AptosVMInternals {
         AptosVMInternals(self)
-    }
-
-    pub(crate) fn transaction_validation(&self) -> &TransactionValidation {
-        self.transaction_validation
-            .as_ref()
-            .unwrap_or(&APTOS_TRANSACTION_VALIDATION)
-    }
-
-    // TODO: Move this to an on-chain config once those are a part of the core framework
-    fn get_transaction_validation(
-        resolver: &impl MoveResolverExt,
-    ) -> Option<TransactionValidation> {
-        match resolver
-            .get_resource(&CORE_CODE_ADDRESS, &TransactionValidation::struct_tag())
-            .ok()?
-        {
-            Some(blob) => bcs::from_bytes::<TransactionValidation>(&blob).ok(),
-            _ => None,
-        }
     }
 
     pub fn get_gas_parameters(
@@ -369,7 +347,6 @@ impl AptosVMImpl {
         txn_data: &TransactionMetadata,
         log_context: &AdapterLogSchema,
     ) -> Result<(), VMStatus> {
-        let transaction_validation = self.transaction_validation();
         let txn_sequence_number = txn_data.sequence_number();
         let txn_authentication_key = txn_data.authentication_key().to_vec();
         let txn_gas_price = txn_data.gas_unit_price();
@@ -407,13 +384,13 @@ impl AptosVMImpl {
             ]
         };
         let prologue_function_name = if txn_data.is_multi_agent() {
-            &transaction_validation.multi_agent_prologue_name
+            &APTOS_TRANSACTION_VALIDATION.multi_agent_prologue_name
         } else {
-            &transaction_validation.script_prologue_name
+            &APTOS_TRANSACTION_VALIDATION.script_prologue_name
         };
         session
             .execute_function_bypass_visibility(
-                &transaction_validation.module_id(),
+                &APTOS_TRANSACTION_VALIDATION.module_id(),
                 prologue_function_name,
                 // TODO: Deprecate this once we remove gas currency on the Move side.
                 vec![],
@@ -422,7 +399,7 @@ impl AptosVMImpl {
             )
             .map(|_return_vals| ())
             .map_err(expect_no_verification_errors)
-            .or_else(|err| convert_prologue_error(transaction_validation, err, log_context))
+            .or_else(|err| convert_prologue_error(err, log_context))
     }
 
     /// Run the prologue of a transaction by calling into `MODULE_PROLOGUE_NAME` function stored
@@ -433,8 +410,6 @@ impl AptosVMImpl {
         txn_data: &TransactionMetadata,
         log_context: &AdapterLogSchema,
     ) -> Result<(), VMStatus> {
-        let transaction_validation = self.transaction_validation();
-
         let txn_sequence_number = txn_data.sequence_number();
         let txn_authentication_key = txn_data.authentication_key();
         let txn_gas_price = txn_data.gas_unit_price();
@@ -444,8 +419,8 @@ impl AptosVMImpl {
         let mut gas_meter = UnmeteredGasMeter;
         session
             .execute_function_bypass_visibility(
-                &transaction_validation.module_id(),
-                &transaction_validation.module_prologue_name,
+                &APTOS_TRANSACTION_VALIDATION.module_id(),
+                &APTOS_TRANSACTION_VALIDATION.module_prologue_name,
                 // TODO: Deprecate this once we remove gas currency on the Move side.
                 vec![],
                 serialize_values(&vec![
@@ -461,7 +436,7 @@ impl AptosVMImpl {
             )
             .map(|_return_vals| ())
             .map_err(expect_no_verification_errors)
-            .or_else(|err| convert_prologue_error(transaction_validation, err, log_context))
+            .or_else(|err| convert_prologue_error(err, log_context))
     }
 
     /// Run the prologue for a multisig transaction. This needs to verify that:
@@ -476,7 +451,6 @@ impl AptosVMImpl {
         payload: &Multisig,
         log_context: &AdapterLogSchema,
     ) -> Result<(), VMStatus> {
-        let transaction_validation = self.transaction_validation();
         let unreachable_error = VMStatus::error(StatusCode::UNREACHABLE, None);
         let provided_payload = if let Some(payload) = &payload.transaction_payload {
             bcs::to_bytes(&payload).map_err(|_| unreachable_error.clone())?
@@ -499,7 +473,7 @@ impl AptosVMImpl {
             )
             .map(|_return_vals| ())
             .map_err(expect_no_verification_errors)
-            .or_else(|err| convert_prologue_error(transaction_validation, err, log_context))
+            .or_else(|err| convert_prologue_error(err, log_context))
     }
 
     fn run_epiloque(
@@ -507,7 +481,6 @@ impl AptosVMImpl {
         session: &mut SessionExt,
         gas_remaining: Gas,
         txn_data: &TransactionMetadata,
-        transaction_validation: &TransactionValidation,
     ) -> VMResult<()> {
         let txn_sequence_number = txn_data.sequence_number();
         let txn_gas_price = txn_data.gas_unit_price();
@@ -517,8 +490,8 @@ impl AptosVMImpl {
         if txn_sequence_number & GAS_PAYER_FLAG_BIT == 0 {
             // Regular tx, run the normal epilogue
             session.execute_function_bypass_visibility(
-                &transaction_validation.module_id(),
-                &transaction_validation.user_epilogue_name,
+                &APTOS_TRANSACTION_VALIDATION.module_id(),
+                &APTOS_TRANSACTION_VALIDATION.user_epilogue_name,
                 // TODO: Deprecate this once we remove gas currency on the Move side.
                 vec![],
                 serialize_values(&vec![
@@ -537,8 +510,8 @@ impl AptosVMImpl {
                     .finish(Location::Undefined)
             })?;
             session.execute_function_bypass_visibility(
-                &transaction_validation.module_id(),
-                &transaction_validation.user_epilogue_gas_payer_name,
+                &APTOS_TRANSACTION_VALIDATION.module_id(),
+                &APTOS_TRANSACTION_VALIDATION.user_epilogue_gas_payer_name,
                 // TODO: Deprecate this once we remove gas currency on the Move side.
                 vec![],
                 serialize_values(&vec![
@@ -572,9 +545,8 @@ impl AptosVMImpl {
             ))
         });
 
-        let transaction_validation = self.transaction_validation();
-        self.run_epiloque(session, gas_remaining, txn_data, transaction_validation)
-            .or_else(|err| convert_epilogue_error(transaction_validation, err, log_context))
+        self.run_epiloque(session, gas_remaining, txn_data)
+            .or_else(|err| convert_epilogue_error(err, log_context))
     }
 
     /// Run the failure epilogue of a transaction by calling into `USER_EPILOGUE_NAME` function
@@ -586,12 +558,11 @@ impl AptosVMImpl {
         txn_data: &TransactionMetadata,
         log_context: &AdapterLogSchema,
     ) -> Result<(), VMStatus> {
-        let transaction_validation = self.transaction_validation();
-        self.run_epiloque(session, gas_remaining, txn_data, transaction_validation)
+        self.run_epiloque(session, gas_remaining, txn_data)
             .or_else(|e| {
                 expect_only_successful_execution(
                     e,
-                    transaction_validation.user_epilogue_name.as_str(),
+                    APTOS_TRANSACTION_VALIDATION.user_epilogue_name.as_str(),
                     log_context,
                 )
             })

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -119,6 +119,7 @@ pub mod natives;
 pub mod sharded_block_executor;
 pub mod system_module_names;
 pub mod transaction_metadata;
+mod transaction_validation;
 mod verifier;
 
 pub use crate::aptos_vm::AptosVM;

--- a/aptos-move/aptos-vm/src/transaction_validation.rs
+++ b/aptos-move/aptos-vm/src/transaction_validation.rs
@@ -1,18 +1,12 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::account_config::constants::CORE_CODE_ADDRESS;
+use aptos_types::account_config::constants::CORE_CODE_ADDRESS;
 use move_core_types::{
-    account_address::AccountAddress,
-    ident_str,
-    identifier::{IdentStr, Identifier},
-    language_storage::ModuleId,
-    move_resource::{MoveResource, MoveStructType},
+    account_address::AccountAddress, ident_str, identifier::Identifier, language_storage::ModuleId,
     vm_status::AbortLocation,
 };
 use once_cell::sync::Lazy;
-#[cfg(any(test, feature = "fuzzing"))]
-use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 pub static APTOS_TRANSACTION_VALIDATION: Lazy<TransactionValidation> =
@@ -26,9 +20,8 @@ pub static APTOS_TRANSACTION_VALIDATION: Lazy<TransactionValidation> =
         user_epilogue_gas_payer_name: Identifier::new("epilogue_gas_payer").unwrap(),
     });
 
-/// A Rust representation of chain-specific account information
+/// On-chain functions used to validate transactions
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct TransactionValidation {
     pub module_addr: AccountAddress,
     pub module_name: Identifier,
@@ -53,10 +46,3 @@ impl TransactionValidation {
                 ))
     }
 }
-
-impl MoveStructType for TransactionValidation {
-    const MODULE_NAME: &'static IdentStr = ident_str!("transaction_validation");
-    const STRUCT_NAME: &'static IdentStr = ident_str!("TransactionValidation");
-}
-
-impl MoveResource for TransactionValidation {}

--- a/types/src/account_config/resources/mod.rs
+++ b/types/src/account_config/resources/mod.rs
@@ -7,11 +7,9 @@ pub mod coin_info;
 pub mod coin_store;
 pub mod core_account;
 pub mod object;
-pub mod transaction_validation;
 
 pub use chain_id::*;
 pub use coin_info::*;
 pub use coin_store::*;
 pub use core_account::*;
 pub use object::*;
-pub use transaction_validation::*;


### PR DESCRIPTION
When we began we just copied this from the legacy code base, it appears to be unnecessary overhead.

Considering that any non-public function is upgradeable, we can seamlessly update the code / configuration without needing to separate them into code and configuration. Furthermore, the configuration is complicated by that new fields cannot be added without another resource and all the complexity that goes with that. Instead, let's assume in the VM that these functions are fixed constants rather than read them each time from storage.

Note, this is a further emphasis of the work that was begun by the fee payer that left this in limbo, so this also cleans up some potentially confusion.