### PR TITLE
[vm-logging] mitigate concurrent speculative logging issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,7 @@ dependencies = [
  "aptos-temppath",
  "aptos-types",
  "aptos-vm",
+ "aptos-vm-logging",
  "aptos-vm-validator",
  "bcs 0.1.4",
  "bytes",

--- a/api/test-context/Cargo.toml
+++ b/api/test-context/Cargo.toml
@@ -31,6 +31,7 @@ aptos-storage-interface = { workspace = true }
 aptos-temppath = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
+aptos-vm-logging = { workspace = true }
 aptos-vm-validator = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }

--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -93,6 +93,9 @@ pub fn new_test_context(
     node_config: NodeConfig,
     use_db_with_indexer: bool,
 ) -> TestContext {
+    // Speculative logging uses a global variable and when many instances use it together, they
+    // panic, so we disable this to run tests.
+    aptos_vm_logging::disable_speculative_logging();
     let tmp_dir = TempPath::new();
     tmp_dir.create_as_dir().unwrap();
 

--- a/aptos-move/aptos-vm-logging/src/lib.rs
+++ b/aptos-move/aptos-vm-logging/src/lib.rs
@@ -81,7 +81,9 @@ fn speculation_disabled() -> bool {
 
 /// Initializes the storage of speculative logs for num_txns many transactions.
 pub fn init_speculative_logs(num_txns: usize) {
-    BUFFERED_LOG_EVENTS.swap(Some(Arc::new(SpeculativeEvents::new(num_txns))));
+    if !speculation_disabled() {
+        BUFFERED_LOG_EVENTS.swap(Some(Arc::new(SpeculativeEvents::new(num_txns))));
+    }
 }
 
 /// Adds a message at a specified logging level and given context (that includes txn index)


### PR DESCRIPTION
* If speculative logging is disabled, don't init
* Disable speculative logging for api tests so they don't crash due to shared state

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
