### PR TITLE
update buildx version

### DIFF
--- a/.github/actions/docker-setup/action.yaml
+++ b/.github/actions/docker-setup/action.yaml
@@ -53,7 +53,7 @@ runs:
       uses: aptos-labs/setup-buildx-action@7952e9cf0debaf1f3f3e5dc7d9c5ea6ececb127e # pin v2.4.0
       with:
         endpoint: builders
-        version: v0.10.1
+        version: v0.11.0
         custom-name: "core-builder"
         keep-state: true
         config-inline: |


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a5769e0</samp>

Updated the core-builder docker image version in `.github/actions/docker-setup/action.yaml` to improve the build and test process of aptos-core.
