### PR TITLE
[move-compiler] Fix Issue 8934: display an error instead of ICE on native inline fun

### DIFF
--- a/third_party/move/move-compiler/tests/move_check/inlining/native_inline.exp
+++ b/third_party/move/move-compiler/tests/move_check/inlining/native_inline.exp
@@ -1,0 +1,6 @@
+error[E14003]: feature not supported in inlined functions
+  ┌─ tests/move_check/inlining/native_inline.move:3:12
+  │
+3 │     public native inline fun foo();
+  │            ^^^^^^ inline function foo must not be native
+

--- a/third_party/move/move-compiler/tests/move_check/inlining/native_inline.move
+++ b/third_party/move/move-compiler/tests/move_check/inlining/native_inline.move
@@ -1,0 +1,8 @@
+module 0x42::Test {
+
+    public native inline fun foo();
+
+    public fun test() {
+        foo()
+    }
+}


### PR DESCRIPTION
### Description

[move-compiler] Inlining: raise an error instead of ICE on a native inline fun declaration. (#8934)

Considered doing it in the parser, but it's easier in the inliner code.

### Test Plan
Added a test case demonstrating bug.  Should have no effect outside of this situation.
