### PR TITLE
Storage service notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2431,6 +2431,7 @@ dependencies = [
  "aptos-state-view",
  "aptos-storage-interface",
  "aptos-storage-service-client",
+ "aptos-storage-service-notifications",
  "aptos-storage-service-server",
  "aptos-storage-service-types",
  "aptos-telemetry",
@@ -3021,6 +3022,7 @@ dependencies = [
  "aptos-scratchpad",
  "aptos-storage-interface",
  "aptos-storage-service-client",
+ "aptos-storage-service-notifications",
  "aptos-storage-service-types",
  "aptos-temppath",
  "aptos-time-service",
@@ -3096,6 +3098,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-storage-service-notifications"
+version = "0.1.0"
+dependencies = [
+ "aptos-channels",
+ "aptos-crypto",
+ "async-trait",
+ "claims",
+ "futures",
+ "serde 1.0.149",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "aptos-storage-service-server"
 version = "0.1.0"
 dependencies = [
@@ -3111,6 +3127,7 @@ dependencies = [
  "aptos-netcore",
  "aptos-network",
  "aptos-storage-interface",
+ "aptos-storage-service-notifications",
  "aptos-storage-service-types",
  "aptos-time-service",
  "aptos-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ members = [
     "state-sync/inter-component/consensus-notifications",
     "state-sync/inter-component/event-notifications",
     "state-sync/inter-component/mempool-notifications",
+    "state-sync/inter-component/storage-service-notifications",
     "state-sync/state-sync-v2/data-streaming-service",
     "state-sync/state-sync-v2/state-sync-driver",
     "state-sync/storage-service/client",
@@ -366,6 +367,7 @@ aptos-state-sync-driver = { path = "state-sync/state-sync-v2/state-sync-driver" 
 aptos-state-view = { path = "storage/state-view" }
 aptos-storage-interface = { path = "storage/storage-interface" }
 aptos-storage-service-client = { path = "state-sync/storage-service/client" }
+aptos-storage-service-notifications = { path = "state-sync/inter-component/storage-service-notifications" }
 aptos-storage-service-types = { path = "state-sync/storage-service/types" }
 aptos-storage-service-server = { path = "state-sync/storage-service/server" }
 aptos-telemetry = { path = "crates/aptos-telemetry" }

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -51,6 +51,7 @@ aptos-state-sync-driver = { workspace = true }
 aptos-state-view = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-storage-service-client = { workspace = true }
+aptos-storage-service-notifications = { workspace = true }
 aptos-storage-service-server = { workspace = true }
 aptos-storage-service-types = { workspace = true }
 aptos-telemetry = { workspace = true }

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,7 +2,7 @@
 cognitive-complexity-threshold = 100
 # types are used for safety encoding
 type-complexity-threshold = 10000
-# manipulating complex states machines in consensus
-too-many-arguments-threshold = 13
+# The state sync driver requires a lot of wiring and channel handles
+too-many-arguments-threshold = 14
 # Reasonably large enum variants are okay
 enum-variant-size-threshold = 1000

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -185,7 +185,7 @@ impl Default for StorageServiceConfig {
             max_transaction_output_chunk_size: MAX_TRANSACTION_OUTPUT_CHUNK_SIZE,
             min_time_to_ignore_peers_secs: 300, // 5 minutes
             request_moderator_refresh_interval_ms: 1000, // 1 second
-            storage_summary_refresh_interval_ms: 50,
+            storage_summary_refresh_interval_ms: 500,
         }
     }
 }

--- a/state-sync/inter-component/storage-service-notifications/Cargo.toml
+++ b/state-sync/inter-component/storage-service-notifications/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "aptos-storage-service-notifications"
+description = "The notification interface between state sync and the storage service"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+aptos-channels = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+aptos-crypto = { workspace = true }
+claims = { workspace = true }
+tokio = { workspace = true }

--- a/state-sync/inter-component/storage-service-notifications/src/lib.rs
+++ b/state-sync/inter-component/storage-service-notifications/src/lib.rs
@@ -1,0 +1,181 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use aptos_channels::{self, aptos_channel, message_queues::QueueStyle};
+use async_trait::async_trait;
+use futures::{stream::FusedStream, Stream};
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use thiserror::Error;
+
+// Note: we limit the queue depth to 1 because it doesn't make sense for the storage service
+// to execute for every notification (because it reads the latest version in the DB). Thus,
+// if there are X pending notifications, the first one will refresh using the latest DB and
+// the next X-1 will execute with an unchanged DB (thus, becoming a no-op and wasting the CPU).
+const STORAGE_SERVICE_NOTIFICATION_CHANNEL_SIZE: usize = 1;
+
+#[derive(Clone, Debug, Deserialize, Error, PartialEq, Eq, Serialize)]
+pub enum Error {
+    #[error("Commit notification failed: {0}")]
+    CommitNotificationError(String),
+}
+
+/// The interface between the state sync driver and the storage service, allowing the driver
+/// to notify the storage service of events (e.g., newly committed transactions).
+#[async_trait]
+pub trait StorageServiceNotificationSender: Send + Clone + Sync + 'static {
+    /// Notify the storage service of newly committed transactions
+    /// at the specified version.
+    async fn notify_new_commit(&self, highest_synced_version: u64) -> Result<(), Error>;
+}
+
+/// This method returns a (StorageServiceNotifier, StorageServiceNotificationListener) pair
+/// that can be used to allow state sync and the storage service to communicate.
+///
+/// Note: the driver should take the notifier and the storage service should take the listener.
+pub fn new_storage_service_notifier_listener_pair(
+) -> (StorageServiceNotifier, StorageServiceNotificationListener) {
+    // Create a dedicated channel for notifications
+    let (notification_sender, notification_receiver) = aptos_channel::new(
+        QueueStyle::LIFO,
+        STORAGE_SERVICE_NOTIFICATION_CHANNEL_SIZE,
+        None,
+    );
+
+    // Create a notification sender and listener
+    let storage_service_notifier = StorageServiceNotifier::new(notification_sender);
+    let storage_service_listener = StorageServiceNotificationListener::new(notification_receiver);
+
+    (storage_service_notifier, storage_service_listener)
+}
+
+/// The state sync driver component responsible for notifying the storage service
+#[derive(Clone, Debug)]
+pub struct StorageServiceNotifier {
+    notification_sender: aptos_channel::Sender<(), StorageServiceCommitNotification>,
+}
+
+impl StorageServiceNotifier {
+    fn new(
+        notification_sender: aptos_channel::Sender<(), StorageServiceCommitNotification>,
+    ) -> Self {
+        Self {
+            notification_sender,
+        }
+    }
+}
+
+#[async_trait]
+impl StorageServiceNotificationSender for StorageServiceNotifier {
+    async fn notify_new_commit(&self, highest_synced_version: u64) -> Result<(), Error> {
+        // Create a new commit notification
+        let commit_notification = StorageServiceCommitNotification {
+            highest_synced_version,
+        };
+
+        // Send the notification to the storage service
+        if let Err(error) = self
+            .notification_sender
+            .clone()
+            .push((), commit_notification)
+        {
+            return Err(Error::CommitNotificationError(format!(
+                "Failed to notify the storage service of committed transactions! Error: {:?}",
+                error
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+/// The storage service component responsible for handling state sync notifications
+#[derive(Debug)]
+pub struct StorageServiceNotificationListener {
+    notification_receiver: aptos_channel::Receiver<(), StorageServiceCommitNotification>,
+}
+
+impl StorageServiceNotificationListener {
+    fn new(
+        notification_receiver: aptos_channel::Receiver<(), StorageServiceCommitNotification>,
+    ) -> Self {
+        StorageServiceNotificationListener {
+            notification_receiver,
+        }
+    }
+}
+
+impl Stream for StorageServiceNotificationListener {
+    type Item = StorageServiceCommitNotification;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.get_mut().notification_receiver).poll_next(cx)
+    }
+}
+
+impl FusedStream for StorageServiceNotificationListener {
+    fn is_terminated(&self) -> bool {
+        self.notification_receiver.is_terminated()
+    }
+}
+
+/// A notification for newly committed transactions sent
+/// by the state sync driver to the storage service.
+#[derive(Debug)]
+pub struct StorageServiceCommitNotification {
+    pub highest_synced_version: u64, // The new highest synced version
+}
+
+impl fmt::Display for StorageServiceCommitNotification {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "StorageServiceCommitNotification [highest_synced_version: {}]",
+            self.highest_synced_version,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        new_storage_service_notifier_listener_pair, Error, StorageServiceNotificationSender,
+    };
+    use claims::assert_matches;
+    use futures::StreamExt;
+
+    #[tokio::test]
+    async fn test_storage_service_notification() {
+        // Create a storage service notifier and listener pair
+        let (storage_service_notifier, mut storage_service_listener) =
+            new_storage_service_notifier_listener_pair();
+
+        // Notify the storage service of a new commit
+        let highest_synced_version = 500;
+        storage_service_notifier
+            .notify_new_commit(highest_synced_version)
+            .await
+            .unwrap();
+
+        // Verify the storage service received the notification
+        let commit_notification = storage_service_listener.next().await.unwrap();
+        assert_eq!(
+            commit_notification.highest_synced_version,
+            highest_synced_version
+        );
+
+        // Drop the receiver, send a notification and verify an error is returned
+        drop(storage_service_listener);
+        let error = storage_service_notifier
+            .notify_new_commit(highest_synced_version)
+            .await
+            .unwrap_err();
+        assert_matches!(error, Error::CommitNotificationError(_));
+    }
+}

--- a/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
+++ b/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
@@ -29,6 +29,7 @@ aptos-runtimes = { workspace = true }
 aptos-schemadb = { workspace = true }
 aptos-scratchpad = { workspace = true }
 aptos-storage-interface = { workspace = true }
+aptos-storage-service-notifications = { workspace = true }
 aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
 async-trait = { workspace = true }

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
@@ -14,7 +14,7 @@ use crate::{
     notification_handlers::{
         CommitNotification, CommitNotificationListener, CommittedTransactions,
         ConsensusNotificationHandler, ErrorNotification, ErrorNotificationListener,
-        MempoolNotificationHandler,
+        MempoolNotificationHandler, StorageServiceNotificationHandler,
     },
     storage_synchronizer::StorageSynchronizerInterface,
     utils,
@@ -33,6 +33,7 @@ use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_mempool_notifications::MempoolNotificationSender;
 use aptos_storage_interface::DbReader;
+use aptos_storage_service_notifications::StorageServiceNotificationSender;
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::waypoint::Waypoint;
 use futures::StreamExt;
@@ -74,6 +75,7 @@ pub struct StateSyncDriver<
     DataClient,
     MempoolNotifier,
     MetadataStorage,
+    StorageServiceNotifier,
     StorageSyncer,
     StreamingClient,
 > {
@@ -113,6 +115,9 @@ pub struct StateSyncDriver<
     // The interface to read from storage
     storage: Arc<dyn DbReader>,
 
+    // The handler for notifications to the storage service
+    storage_service_notification_handler: StorageServiceNotificationHandler<StorageServiceNotifier>,
+
     // The storage synchronizer used to update local storage
     storage_synchronizer: StorageSyncer,
 
@@ -124,10 +129,18 @@ impl<
         DataClient: AptosDataClientInterface + Send + Clone + 'static,
         MempoolNotifier: MempoolNotificationSender,
         MetadataStorage: MetadataStorageInterface + Clone,
+        StorageServiceNotifier: StorageServiceNotificationSender,
         StorageSyncer: StorageSynchronizerInterface + Clone,
         StreamingClient: DataStreamingClient + Clone,
     >
-    StateSyncDriver<DataClient, MempoolNotifier, MetadataStorage, StorageSyncer, StreamingClient>
+    StateSyncDriver<
+        DataClient,
+        MempoolNotifier,
+        MetadataStorage,
+        StorageServiceNotifier,
+        StorageSyncer,
+        StreamingClient,
+    >
 {
     pub fn new(
         client_notification_listener: ClientNotificationListener,
@@ -138,6 +151,9 @@ impl<
         event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
         mempool_notification_handler: MempoolNotificationHandler<MempoolNotifier>,
         metadata_storage: MetadataStorage,
+        storage_service_notification_handler: StorageServiceNotificationHandler<
+            StorageServiceNotifier,
+        >,
         storage_synchronizer: StorageSyncer,
         aptos_data_client: DataClient,
         streaming_client: StreamingClient,
@@ -175,6 +191,7 @@ impl<
             mempool_notification_handler,
             start_time: None,
             storage,
+            storage_service_notification_handler,
             storage_synchronizer,
             time_service,
         }
@@ -297,6 +314,7 @@ impl<
             self.storage.clone(),
             self.mempool_notification_handler.clone(),
             self.event_subscription_service.clone(),
+            self.storage_service_notification_handler.clone(),
         )
         .await;
 
@@ -412,6 +430,7 @@ impl<
             self.storage.clone(),
             self.mempool_notification_handler.clone(),
             self.event_subscription_service.clone(),
+            self.storage_service_notification_handler.clone(),
         )
         .await;
     }

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
@@ -213,6 +213,8 @@ impl<
                     self.handle_client_notification(notification).await;
                 },
                 notification = self.commit_notification_listener.select_next_some() => {
+                    // TODO(joshlind): we should probably just remove this path
+                    // now that we aren't reusing it.
                     self.handle_commit_notification(notification).await;
                 }
                 notification = self.consensus_notification_handler.select_next_some() => {

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
@@ -7,8 +7,8 @@ use crate::{
     driver_client::{ClientNotificationListener, DriverClient, DriverNotification},
     metadata_storage::MetadataStorageInterface,
     notification_handlers::{
-        CommitNotificationListener, ConsensusNotificationHandler, ErrorNotificationListener,
-        MempoolNotificationHandler, StorageServiceNotificationHandler,
+        CommitNotification, CommitNotificationListener, ConsensusNotificationHandler,
+        ErrorNotificationListener, MempoolNotificationHandler, StorageServiceNotificationHandler,
     },
     storage_synchronizer::StorageSynchronizer,
 };
@@ -24,7 +24,10 @@ use aptos_storage_interface::DbReaderWriter;
 use aptos_storage_service_notifications::StorageServiceNotificationSender;
 use aptos_time_service::TimeService;
 use aptos_types::{move_resource::MoveStorage, waypoint::Waypoint};
-use futures::{channel::mpsc, executor::block_on};
+use futures::{
+    channel::{mpsc, mpsc::UnboundedSender},
+    executor::block_on,
+};
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 
@@ -35,8 +38,49 @@ pub struct DriverFactory {
 }
 
 impl DriverFactory {
-    /// Creates and spawns a new state sync driver
+    /// Creates and spawns a new state sync driver and returns the factory
     pub fn create_and_spawn_driver<
+        ChunkExecutor: ChunkExecutorTrait + 'static,
+        MempoolNotifier: MempoolNotificationSender + 'static,
+        MetadataStorage: MetadataStorageInterface + Clone + Send + Sync + 'static,
+        StorageServiceNotifier: StorageServiceNotificationSender + 'static,
+    >(
+        create_runtime: bool,
+        node_config: &NodeConfig,
+        waypoint: Waypoint,
+        storage: DbReaderWriter,
+        chunk_executor: Arc<ChunkExecutor>,
+        mempool_notification_sender: MempoolNotifier,
+        storage_service_notification_sender: StorageServiceNotifier,
+        metadata_storage: MetadataStorage,
+        consensus_listener: ConsensusNotificationListener,
+        event_subscription_service: EventSubscriptionService,
+        aptos_data_client: AptosDataClient,
+        streaming_service_client: StreamingServiceClient,
+        time_service: TimeService,
+    ) -> Self {
+        let (driver_factory, _) = Self::create_and_spawn_driver_internal(
+            create_runtime,
+            node_config,
+            waypoint,
+            storage,
+            chunk_executor,
+            mempool_notification_sender,
+            storage_service_notification_sender,
+            metadata_storage,
+            consensus_listener,
+            event_subscription_service,
+            aptos_data_client,
+            streaming_service_client,
+            time_service,
+        );
+        driver_factory
+    }
+
+    /// A simple utility function that creates a new state sync driver
+    /// and returns both the factory as well as the commit notification
+    /// sender for the driver. This is useful for testing.
+    pub(crate) fn create_and_spawn_driver_internal<
         ChunkExecutor: ChunkExecutorTrait + 'static,
         MempoolNotifier: MempoolNotificationSender + 'static,
         MetadataStorage: MetadataStorageInterface + Clone + Send + Sync + 'static,
@@ -55,7 +99,7 @@ impl DriverFactory {
         aptos_data_client: AptosDataClient,
         streaming_service_client: StreamingServiceClient,
         time_service: TimeService,
-    ) -> Self {
+    ) -> (Self, UnboundedSender<CommitNotification>) {
         // Notify subscribers of the initial on-chain config values
         match (&*storage.reader).fetch_latest_state_checkpoint_version() {
             Ok(synced_version) => {
@@ -103,7 +147,7 @@ impl DriverFactory {
         let (storage_synchronizer, _, _) = StorageSynchronizer::new(
             node_config.state_sync.state_sync_driver,
             chunk_executor,
-            commit_notification_sender,
+            commit_notification_sender.clone(),
             error_notification_sender,
             event_subscription_service.clone(),
             mempool_notification_handler.clone(),
@@ -145,10 +189,13 @@ impl DriverFactory {
             tokio::spawn(state_sync_driver.start_driver());
         }
 
-        Self {
+        // Create the driver factory
+        let driver_factory = Self {
             client_notification_sender,
             _driver_runtime: driver_runtime,
-        }
+        };
+
+        (driver_factory, commit_notification_sender)
     }
 
     /// Returns a new client that can be used to communicate with the driver

--- a/state-sync/state-sync-v2/state-sync-driver/src/error.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/error.rs
@@ -31,6 +31,8 @@ pub enum Error {
     InvalidPayload(String),
     #[error("Failed to notify mempool of the new commit: {0}")]
     NotifyMempoolError(String),
+    #[error("Failed to notify the storage service of the new commit: {0}")]
+    NotifyStorageServiceError(String),
     #[error("Received an old sync request for version {0}, but our committed version is: {1}")]
     OldSyncRequest(Version, Version),
     #[error("Received oneshot::canceled. The sender of a channel was dropped: {0}")]
@@ -60,6 +62,7 @@ impl Error {
             Error::IntegerOverflow(_) => "integer_overflow",
             Error::InvalidPayload(_) => "invalid_payload",
             Error::NotifyMempoolError(_) => "notify_mempool_error",
+            Error::NotifyStorageServiceError(_) => "notify_storage_service_error",
             Error::OldSyncRequest(_, _) => "old_sync_request",
             Error::SenderDroppedError(_) => "sender_dropped_error",
             Error::StorageError(_) => "storage_error",

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
@@ -5,9 +5,9 @@
 use crate::{
     driver_factory::DriverFactory,
     metadata_storage::PersistentMetadataStorage,
+    notification_handlers::CommitNotification,
     tests::utils::{
-        create_event, create_ledger_info_at_version, create_transaction,
-        verify_mempool_and_event_notification,
+        create_event, create_ledger_info_at_version, create_transaction, verify_commit_notification,
     },
 };
 use aptos_config::config::{NodeConfig, RoleType, StateSyncDriverConfig};
@@ -25,6 +25,7 @@ use aptos_mempool_notifications::MempoolNotificationListener;
 use aptos_network::application::{interface::NetworkClient, storage::PeersAndMetadata};
 use aptos_storage_interface::DbReaderWriter;
 use aptos_storage_service_client::StorageServiceClient;
+use aptos_storage_service_notifications::StorageServiceNotificationListener;
 use aptos_time_service::TimeService;
 use aptos_types::{
     event::EventKey,
@@ -34,7 +35,7 @@ use aptos_types::{
 };
 use aptos_vm::AptosVM;
 use claims::{assert_err, assert_none};
-use futures::{FutureExt, StreamExt};
+use futures::{channel::mpsc::UnboundedSender, FutureExt, SinkExt, StreamExt};
 use ntest::timeout;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::time::sleep;
@@ -43,7 +44,7 @@ use tokio::time::sleep;
 #[timeout(120_000)]
 async fn test_auto_bootstrapping() {
     // Create a driver for a validator with a waypoint at version 0
-    let (validator_driver, consensus_notifier, _, _, _, time_service) =
+    let (validator_driver, _, consensus_notifier, _, _, _, _, time_service) =
         create_validator_driver(None).await;
 
     // Verify auto-bootstrapping hasn't happened yet
@@ -60,7 +61,8 @@ async fn test_auto_bootstrapping() {
 #[timeout(120_000)]
 async fn test_consensus_commit_notification() {
     // Create a driver for a full node
-    let (_full_node_driver, consensus_notifier, _, _, _, _) = create_full_node_driver(None).await;
+    let (_full_node_driver, _, consensus_notifier, _, _, _, _, _) =
+        create_full_node_driver(None).await;
 
     // Verify that full nodes can't process commit notifications
     let result = consensus_notifier
@@ -69,7 +71,8 @@ async fn test_consensus_commit_notification() {
     assert_err!(result);
 
     // Create a driver for a validator with a waypoint at version 0
-    let (_validator_driver, consensus_notifier, _, _, _, _) = create_validator_driver(None).await;
+    let (_validator_driver, _, consensus_notifier, _, _, _, _, _) =
+        create_validator_driver(None).await;
 
     // Send a new commit notification and verify the node isn't bootstrapped
     let result = consensus_notifier
@@ -80,15 +83,67 @@ async fn test_consensus_commit_notification() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[timeout(120_000)]
-async fn test_mempool_commit_notifications() {
+async fn test_snapshot_commit_notifications() {
     // Create a driver for a validator with a waypoint at version 0
     let subscription_event_key = EventKey::random();
     let (
         validator_driver,
+        mut commit_notification_sender,
+        _,
+        mut mempool_listener,
+        _,
+        mut event_listener,
+        mut storage_service_listener,
+        time_service,
+    ) = create_validator_driver(Some(vec![subscription_event_key])).await;
+
+    // Wait for validator auto bootstrapping
+    wait_for_auto_bootstrapping(validator_driver, time_service).await;
+
+    // Create commit data for testing
+    let transactions = vec![create_transaction(), create_transaction()];
+    let events = vec![
+        create_event(Some(subscription_event_key)),
+        create_event(Some(subscription_event_key)),
+    ];
+
+    // Send a new commit notification to the driver (from the snapshot receiver)
+    let commit_notification = CommitNotification::new_committed_state_snapshot(
+        events.clone(),
+        transactions.clone(),
+        10_000,
+        0,
+    );
+    commit_notification_sender
+        .send(commit_notification)
+        .await
+        .unwrap();
+
+    // Verify that all components are notified
+    verify_commit_notification(
+        Some(&mut event_listener),
+        &mut mempool_listener,
+        &mut storage_service_listener,
+        transactions,
+        events,
+        0,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[timeout(120_000)]
+async fn test_consensus_commit_notifications() {
+    // Create a driver for a validator with a waypoint at version 0
+    let subscription_event_key = EventKey::random();
+    let (
+        validator_driver,
+        _,
         consensus_notifier,
         mut mempool_listener,
         _,
         mut event_listener,
+        mut storage_service_listener,
         time_service,
     ) = create_validator_driver(Some(vec![subscription_event_key])).await;
 
@@ -112,12 +167,14 @@ async fn test_mempool_commit_notifications() {
             .unwrap();
     });
 
-    // Verify mempool is notified and that the event listener is notified
-    verify_mempool_and_event_notification(
+    // Verify that all components are notified
+    verify_commit_notification(
         Some(&mut event_listener),
         &mut mempool_listener,
+        &mut storage_service_listener,
         transactions,
         events,
+        0,
     )
     .await;
 
@@ -131,10 +188,12 @@ async fn test_reconfiguration_notifications() {
     // Create a driver for a validator with a waypoint at version 0
     let (
         validator_driver,
+        _,
         consensus_notifier,
         mut mempool_listener,
         mut reconfig_listener,
         _,
+        mut storage_service_listener,
         time_service,
     ) = create_validator_driver(None).await;
 
@@ -164,9 +223,16 @@ async fn test_reconfiguration_notifications() {
                 .unwrap();
         });
 
-        // Verify mempool is notified
-        verify_mempool_and_event_notification(None, &mut mempool_listener, transactions, events)
-            .await;
+        // Verify that mempool and the storage service are notified
+        verify_commit_notification(
+            None,
+            &mut mempool_listener,
+            &mut storage_service_listener,
+            transactions,
+            events,
+            0,
+        )
+        .await;
 
         // Verify the reconfiguration listener is notified if a reconfiguration occurred
         if event_key == reconfiguration_event {
@@ -185,7 +251,8 @@ async fn test_reconfiguration_notifications() {
 #[timeout(120_000)]
 async fn test_consensus_sync_request() {
     // Create a driver for a full node
-    let (_full_node_driver, consensus_notifier, _, _, _, _) = create_full_node_driver(None).await;
+    let (_full_node_driver, _, consensus_notifier, _, _, _, _, _) =
+        create_full_node_driver(None).await;
 
     // Verify that full nodes can't process sync requests
     let result = consensus_notifier
@@ -194,7 +261,8 @@ async fn test_consensus_sync_request() {
     assert_err!(result);
 
     // Create a driver for a validator with a waypoint at version 0
-    let (_validator_driver, consensus_notifier, _, _, _, _) = create_validator_driver(None).await;
+    let (_validator_driver, _, consensus_notifier, _, _, _, _, _) =
+        create_validator_driver(None).await;
 
     // Send a new sync request and verify the node isn't bootstrapped
     let result = consensus_notifier
@@ -208,10 +276,12 @@ async fn create_validator_driver(
     event_key_subscriptions: Option<Vec<EventKey>>,
 ) -> (
     DriverFactory,
+    UnboundedSender<CommitNotification>,
     ConsensusNotifier,
     MempoolNotificationListener,
     ReconfigNotificationListener,
     EventNotificationListener,
+    StorageServiceNotificationListener,
     TimeService,
 ) {
     let mut node_config = NodeConfig::default();
@@ -229,10 +299,12 @@ async fn create_full_node_driver(
     event_key_subscriptions: Option<Vec<EventKey>>,
 ) -> (
     DriverFactory,
+    UnboundedSender<CommitNotification>,
     ConsensusNotifier,
     MempoolNotificationListener,
     ReconfigNotificationListener,
     EventNotificationListener,
+    StorageServiceNotificationListener,
     TimeService,
 ) {
     let mut node_config = NodeConfig::default();
@@ -248,10 +320,12 @@ async fn create_driver_for_tests(
     event_key_subscriptions: Option<Vec<EventKey>>,
 ) -> (
     DriverFactory,
+    UnboundedSender<CommitNotification>,
     ConsensusNotifier,
     MempoolNotificationListener,
     ReconfigNotificationListener,
     EventNotificationListener,
+    StorageServiceNotificationListener,
     TimeService,
 ) {
     // Initialize the logger for tests
@@ -288,7 +362,7 @@ async fn create_driver_for_tests(
         aptos_mempool_notifications::new_mempool_notifier_listener_pair();
 
     // Create the storage service notifier and listener
-    let (storage_service_notifier, _storage_service_listener) =
+    let (storage_service_notifier, storage_service_listener) =
         aptos_storage_service_notifications::new_storage_service_notifier_listener_pair();
 
     // Create the chunk executor
@@ -318,21 +392,22 @@ async fn create_driver_for_tests(
     let metadata_storage = PersistentMetadataStorage::new(db_path.path());
 
     // Create and spawn the driver
-    let driver_factory = DriverFactory::create_and_spawn_driver(
-        false,
-        &node_config,
-        waypoint,
-        db_rw,
-        chunk_executor,
-        mempool_notifier,
-        storage_service_notifier,
-        metadata_storage,
-        consensus_listener,
-        event_subscription_service,
-        aptos_data_client,
-        streaming_service_client,
-        time_service.clone(),
-    );
+    let (driver_factory, commit_notification_sender) =
+        DriverFactory::create_and_spawn_driver_internal(
+            false,
+            &node_config,
+            waypoint,
+            db_rw,
+            chunk_executor,
+            mempool_notifier,
+            storage_service_notifier,
+            metadata_storage,
+            consensus_listener,
+            event_subscription_service,
+            aptos_data_client,
+            streaming_service_client,
+            time_service.clone(),
+        );
 
     // The driver will notify reconfiguration subscribers of the initial configs.
     // Verify we've received this notification.
@@ -340,10 +415,12 @@ async fn create_driver_for_tests(
 
     (
         driver_factory,
+        commit_notification_sender,
         consensus_notifier,
         mempool_listener,
         reconfiguration_subscriber,
         event_subscriber,
+        storage_service_listener,
         time_service,
     )
 }

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
@@ -287,6 +287,10 @@ async fn create_driver_for_tests(
     let (mempool_notifier, mempool_listener) =
         aptos_mempool_notifications::new_mempool_notifier_listener_pair();
 
+    // Create the storage service notifier and listener
+    let (storage_service_notifier, _storage_service_listener) =
+        aptos_storage_service_notifications::new_storage_service_notifier_listener_pair();
+
     // Create the chunk executor
     let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()));
 
@@ -321,6 +325,7 @@ async fn create_driver_for_tests(
         db_rw,
         chunk_executor,
         mempool_notifier,
+        storage_service_notifier,
         metadata_storage,
         consensus_listener,
         event_subscription_service,

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver_factory.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver_factory.rs
@@ -62,6 +62,10 @@ fn test_new_initialized_configs() {
         .subscribe_to_reconfigurations()
         .unwrap();
 
+    // Create the storage service notifier and listener
+    let (storage_service_notifier, _storage_service_listener) =
+        aptos_storage_service_notifications::new_storage_service_notifier_listener_pair();
+
     // Create a test streaming service client
     let (streaming_service_client, _) = new_streaming_service_client_listener_pair();
 
@@ -91,6 +95,7 @@ fn test_new_initialized_configs() {
         db_rw,
         chunk_executor,
         mempool_notifier,
+        storage_service_notifier,
         metadata_storage,
         consensus_listener,
         event_subscription_service,

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -68,8 +68,20 @@ pub fn create_mock_reader_writer(
     reader: Option<MockDatabaseReader>,
     writer: Option<MockDatabaseWriter>,
 ) -> DbReaderWriter {
+    create_mock_reader_writer_with_version(reader, writer, 0)
+}
+
+/// Creates a mock database reader writer with the given
+/// highest synced transaction version.
+pub fn create_mock_reader_writer_with_version(
+    reader: Option<MockDatabaseReader>,
+    writer: Option<MockDatabaseWriter>,
+    highest_synced_version: u64,
+) -> DbReaderWriter {
     let mut reader = reader.unwrap_or_else(create_mock_db_reader);
-    reader.expect_get_latest_version().returning(|| Ok(0));
+    reader
+        .expect_get_latest_version()
+        .returning(move || Ok(highest_synced_version));
     reader
         .expect_get_latest_epoch_state()
         .returning(|| Ok(create_empty_epoch_state()));

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/storage_synchronizer.rs
@@ -6,7 +6,7 @@ use crate::{
     metadata_storage::PersistentMetadataStorage,
     notification_handlers::{
         CommitNotification, CommitNotificationListener, CommittedTransactions,
-        ErrorNotificationListener, MempoolNotificationHandler,
+        ErrorNotificationListener, MempoolNotificationHandler, StorageServiceNotificationHandler,
     },
     storage_synchronizer::{StorageSynchronizer, StorageSynchronizerInterface},
     tests::{
@@ -515,6 +515,12 @@ fn create_storage_synchronizer(
         StateSyncDriverConfig::default().mempool_commit_ack_timeout_ms,
     );
 
+    // Create the storage service handler
+    let (storage_service_notifier, _storage_service_listener) =
+        aptos_storage_service_notifications::new_storage_service_notifier_listener_pair();
+    let storage_service_notification_handler =
+        StorageServiceNotificationHandler::new(storage_service_notifier);
+
     // Create the metadata storage
     let db_path = aptos_temppath::TempPath::new();
     let metadata_storage = PersistentMetadataStorage::new(db_path.path());
@@ -527,6 +533,7 @@ fn create_storage_synchronizer(
         error_notification_sender,
         event_subscription_service.clone(),
         mempool_notification_handler,
+        storage_service_notification_handler,
         metadata_storage,
         mock_reader_writer,
         None,

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/storage_synchronizer.rs
@@ -12,12 +12,12 @@ use crate::{
     tests::{
         mocks::{
             create_mock_db_writer, create_mock_executor, create_mock_reader_writer,
-            create_mock_receiver, MockChunkExecutor,
+            create_mock_reader_writer_with_version, create_mock_receiver, MockChunkExecutor,
         },
         utils::{
             create_epoch_ending_ledger_info, create_event, create_output_list_with_proof,
             create_state_value_chunk_with_proof, create_transaction,
-            create_transaction_list_with_proof, verify_mempool_and_event_notification,
+            create_transaction_list_with_proof, verify_commit_notification,
         },
     },
 };
@@ -29,6 +29,7 @@ use aptos_executor_types::ChunkCommitNotification;
 use aptos_infallible::{Mutex, RwLock};
 use aptos_mempool_notifications::MempoolNotificationListener;
 use aptos_storage_interface::DbReaderWriter;
+use aptos_storage_service_notifications::StorageServiceNotificationListener;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     on_chain_config::ON_CHAIN_CONFIG_REGISTRY,
@@ -61,9 +62,22 @@ async fn test_apply_transaction_outputs() {
         .expect_commit_chunk()
         .return_once(move || expected_commit_return);
 
+    // Create the mock DB reader/writer
+    let highest_synced_version = 1090;
+    let mock_reader_writer =
+        create_mock_reader_writer_with_version(None, None, highest_synced_version);
+
     // Create the storage synchronizer
-    let (_, _, event_subscription_service, mut mempool_listener, mut storage_synchronizer, _, _) =
-        create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
+    let (
+        _,
+        _,
+        event_subscription_service,
+        mut mempool_listener,
+        mut storage_service_listener,
+        mut storage_synchronizer,
+        _,
+        _,
+    ) = create_storage_synchronizer(chunk_executor, mock_reader_writer);
 
     // Subscribe to the expected event
     let mut event_listener = event_subscription_service
@@ -82,14 +96,18 @@ async fn test_apply_transaction_outputs() {
         .await
         .unwrap();
 
-    // Verify we get a mempool and event notification. Also verify that there's no pending data.
-    verify_mempool_and_event_notification(
+    // Verify that all components are notified
+    verify_commit_notification(
         Some(&mut event_listener),
         &mut mempool_listener,
+        &mut storage_service_listener,
         vec![transaction_to_commit],
         vec![event_to_commit],
+        highest_synced_version,
     )
     .await;
+
+    // Verify there's no pending data
     verify_no_pending_data(&storage_synchronizer);
 }
 
@@ -103,7 +121,7 @@ async fn test_apply_transaction_outputs_error() {
         .returning(|_, _, _| Err(format_err!("Failed to apply chunk!")));
 
     // Create the storage synchronizer
-    let (_, mut error_listener, _, _, mut storage_synchronizer, _, _) =
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _, _) =
         create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
 
     // Attempt to apply a chunk of outputs
@@ -136,7 +154,7 @@ async fn test_commit_chunk_error() {
         .return_once(|| Err(format_err!("Failed to commit chunk!")));
 
     // Create the storage synchronizer
-    let (_, mut error_listener, _, _, mut storage_synchronizer, _, _) =
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _, _) =
         create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
 
     // Attempt to execute a chunk of transactions
@@ -177,9 +195,22 @@ async fn test_execute_transactions() {
         .expect_commit_chunk()
         .return_once(move || expected_commit_return);
 
+    // Create the mock DB reader/writer
+    let highest_synced_version = 10101;
+    let mock_reader_writer =
+        create_mock_reader_writer_with_version(None, None, highest_synced_version);
+
     // Create the storage synchronizer
-    let (_, _, event_subscription_service, mut mempool_listener, mut storage_synchronizer, _, _) =
-        create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
+    let (
+        _,
+        _,
+        event_subscription_service,
+        mut mempool_listener,
+        mut storage_service_listener,
+        mut storage_synchronizer,
+        _,
+        _,
+    ) = create_storage_synchronizer(chunk_executor, mock_reader_writer);
 
     // Subscribe to the expected event
     let mut event_listener = event_subscription_service
@@ -198,14 +229,18 @@ async fn test_execute_transactions() {
         .await
         .unwrap();
 
-    // Verify we get a mempool and event notification. Also verify that there's no pending data.
-    verify_mempool_and_event_notification(
+    // Verify that all components are notified
+    verify_commit_notification(
         Some(&mut event_listener),
         &mut mempool_listener,
+        &mut storage_service_listener,
         vec![transaction_to_commit],
         vec![event_to_commit],
+        highest_synced_version,
     )
     .await;
+
+    // Verify there's no pending data
     verify_no_pending_data(&storage_synchronizer);
 }
 
@@ -219,7 +254,7 @@ async fn test_execute_transactions_error() {
         .returning(|_, _, _| Err(format_err!("Failed to execute chunk!")));
 
     // Create the storage synchronizer
-    let (_, mut error_listener, _, _, mut storage_synchronizer, _, _) =
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _, _) =
         create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
 
     // Attempt to execute a chunk of transactions
@@ -247,7 +282,7 @@ async fn test_initialize_state_synchronizer_missing_info() {
     output_list_with_proof.proof.transaction_infos = vec![]; // This is invalid!
 
     // Create the storage synchronizer
-    let (_, _, _, _, mut storage_synchronizer, _, _) = create_storage_synchronizer(
+    let (_, _, _, _, _, mut storage_synchronizer, _, _) = create_storage_synchronizer(
         create_mock_executor(),
         create_mock_reader_writer(None, None),
     );
@@ -275,7 +310,7 @@ async fn test_initialize_state_synchronizer_receiver_error() {
         .returning(|_, _| Err(format_err!("Failed to get snapshot receiver!")));
 
     // Create the storage synchronizer
-    let (_, _, _, _, mut storage_synchronizer, _, _) = create_storage_synchronizer(
+    let (_, _, _, _, _, mut storage_synchronizer, _, _) = create_storage_synchronizer(
         create_mock_executor(),
         create_mock_reader_writer(None, Some(db_writer)),
     );
@@ -339,7 +374,7 @@ async fn test_save_states_completion() {
         .returning(|_, _, _| Ok(()));
 
     // Create the storage synchronizer
-    let (mut commit_listener, _, _, _, mut storage_synchronizer, _, _) =
+    let (mut commit_listener, _, _, _, _, mut storage_synchronizer, _, _) =
         create_storage_synchronizer(
             chunk_executor,
             create_mock_reader_writer(None, Some(db_writer)),
@@ -374,7 +409,6 @@ async fn test_save_states_completion() {
         events: vec![expected_event.clone()],
         transactions: vec![expected_transaction.clone()],
     };
-
     verify_snapshot_commit_notification(
         &mut commit_listener,
         expected_committed_transactions.clone(),
@@ -404,7 +438,7 @@ async fn test_save_states_dropped_error_listener() {
         .return_once(move |_, _| Ok(Box::new(snapshot_receiver)));
 
     // Create the storage synchronizer (drop all listeners)
-    let (_, _, _, _, mut storage_synchronizer, _, _) = create_storage_synchronizer(
+    let (_, _, _, _, _, mut storage_synchronizer, _, _) = create_storage_synchronizer(
         create_mock_executor(),
         create_mock_reader_writer(None, Some(db_writer)),
     );
@@ -445,10 +479,11 @@ async fn test_save_states_invalid_chunk() {
         .return_once(move |_, _| Ok(Box::new(snapshot_receiver)));
 
     // Create the storage synchronizer
-    let (_, mut error_listener, _, _, mut storage_synchronizer, _, _) = create_storage_synchronizer(
-        create_mock_executor(),
-        create_mock_reader_writer(None, Some(db_writer)),
-    );
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _, _) =
+        create_storage_synchronizer(
+            create_mock_executor(),
+            create_mock_reader_writer(None, Some(db_writer)),
+        );
 
     // Initialize the state synchronizer
     let _join_handle = storage_synchronizer
@@ -471,7 +506,7 @@ async fn test_save_states_invalid_chunk() {
 #[should_panic]
 fn test_save_states_without_initialize() {
     // Create the storage synchronizer
-    let (_, _, _, _, mut storage_synchronizer, _, _) = create_storage_synchronizer(
+    let (_, _, _, _, _, mut storage_synchronizer, _, _) = create_storage_synchronizer(
         create_mock_executor(),
         create_mock_reader_writer(None, None),
     );
@@ -490,6 +525,7 @@ fn create_storage_synchronizer(
     ErrorNotificationListener,
     Arc<Mutex<EventSubscriptionService>>,
     MempoolNotificationListener,
+    StorageServiceNotificationListener,
     StorageSynchronizer<MockChunkExecutor, PersistentMetadataStorage>,
     JoinHandle<()>,
     JoinHandle<()>,
@@ -516,7 +552,7 @@ fn create_storage_synchronizer(
     );
 
     // Create the storage service handler
-    let (storage_service_notifier, _storage_service_listener) =
+    let (storage_service_notifier, storage_service_listener) =
         aptos_storage_service_notifications::new_storage_service_notifier_listener_pair();
     let storage_service_notification_handler =
         StorageServiceNotificationHandler::new(storage_service_notifier);
@@ -544,6 +580,7 @@ fn create_storage_synchronizer(
         error_notification_listener,
         event_subscription_service,
         mempool_notification_listener,
+        storage_service_listener,
         storage_synchronizer,
         executor_handle,
         committer_handle,

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
@@ -14,6 +14,7 @@ use aptos_data_streaming_service::{
 };
 use aptos_event_notifications::EventNotificationListener;
 use aptos_mempool_notifications::{CommittedTransaction, MempoolNotificationListener};
+use aptos_storage_service_notifications::StorageServiceNotificationListener;
 use aptos_storage_service_types::responses::CompleteDataRange;
 use aptos_types::{
     account_address::AccountAddress,
@@ -219,14 +220,16 @@ pub fn create_transaction_output() -> TransactionOutput {
     )
 }
 
-/// Verifies that mempool is notified about the committed transactions and
-/// verifies that the event listener is notified about the committed
-/// events (if it exists).
-pub async fn verify_mempool_and_event_notification(
+/// Verifies that: (i) mempool is notified about the committed transactions;
+/// (ii) the event listener is notified about the committed events (if it exists);
+/// and (iii) the storage service is notified about the committed transactions.
+pub async fn verify_commit_notification(
     event_listener: Option<&mut EventNotificationListener>,
     mempool_notification_listener: &mut MempoolNotificationListener,
+    storage_service_notification_listener: &mut StorageServiceNotificationListener,
     expected_transactions: Vec<Transaction>,
     expected_events: Vec<ContractEvent>,
+    expected_highest_synced_version: u64,
 ) {
     // Verify mempool is notified and ack the notification
     let mempool_notification = mempool_notification_listener.select_next_some().await;
@@ -245,4 +248,13 @@ pub async fn verify_mempool_and_event_notification(
         let event_notification = event_listener.select_next_some().await;
         assert_eq!(event_notification.subscribed_events, expected_events);
     }
+
+    // Verify that the storage service is notified
+    let storage_service_notification = storage_service_notification_listener
+        .select_next_some()
+        .await;
+    assert_eq!(
+        storage_service_notification.highest_synced_version,
+        expected_highest_synced_version
+    );
 }

--- a/state-sync/state-sync-v2/state-sync-driver/src/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/utils.rs
@@ -9,6 +9,7 @@ use crate::{
     metrics,
     notification_handlers::{
         CommitNotification, CommittedTransactions, MempoolNotificationHandler,
+        StorageServiceNotificationHandler,
     },
     storage_synchronizer::StorageSynchronizerInterface,
 };
@@ -22,6 +23,7 @@ use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_mempool_notifications::MempoolNotificationSender;
 use aptos_storage_interface::DbReader;
+use aptos_storage_service_notifications::StorageServiceNotificationSender;
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::{
     epoch_change::Verifier,
@@ -304,12 +306,17 @@ pub fn initialize_sync_gauges(storage: Arc<dyn DbReader>) -> Result<(), Error> {
 }
 
 /// Handles a notification for committed transactions by
-/// notifying mempool and the event subscription service.
-pub async fn handle_committed_transactions<M: MempoolNotificationSender>(
+/// notifying mempool, the event subscription service and
+/// the storage service.
+pub async fn handle_committed_transactions<
+    M: MempoolNotificationSender,
+    S: StorageServiceNotificationSender,
+>(
     committed_transactions: CommittedTransactions,
     storage: Arc<dyn DbReader>,
     mempool_notification_handler: MempoolNotificationHandler<M>,
     event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
+    storage_service_notification_handler: StorageServiceNotificationHandler<S>,
 ) {
     // Fetch the latest synced version and ledger info from storage
     let (latest_synced_version, latest_synced_ledger_info) =
@@ -339,6 +346,7 @@ pub async fn handle_committed_transactions<M: MempoolNotificationSender>(
         latest_synced_ledger_info,
         mempool_notification_handler,
         event_subscription_service,
+        storage_service_notification_handler,
     )
     .await
     {

--- a/state-sync/storage-service/server/Cargo.toml
+++ b/state-sync/storage-service/server/Cargo.toml
@@ -21,6 +21,7 @@ aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-network = { workspace = true }
 aptos-storage-interface = { workspace = true }
+aptos-storage-service-notifications = { workspace = true }
 aptos-storage-service-types = { workspace = true }
 aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }

--- a/state-sync/storage-service/server/src/lib.rs
+++ b/state-sync/storage-service/server/src/lib.rs
@@ -9,10 +9,12 @@ use crate::{
     network::StorageServiceNetworkEvents,
 };
 use aptos_bounded_executor::BoundedExecutor;
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::{config::StorageServiceConfig, network_id::PeerNetworkId};
 use aptos_infallible::{Mutex, RwLock};
 use aptos_logger::prelude::*;
 use aptos_network::application::storage::PeersAndMetadata;
+use aptos_storage_service_notifications::StorageServiceNotificationListener;
 use aptos_storage_service_types::{
     requests::StorageServiceRequest,
     responses::{ProtocolMetadata, StorageServerSummary, StorageServiceResponse},
@@ -41,6 +43,12 @@ pub mod storage;
 #[cfg(test)]
 mod tests;
 
+// Note: we limit the queue depth to 1 because it doesn't make sense for the optimistic handler
+// to execute for every notification (because it reads the latest version in the cache). Thus,
+// if there are X pending notifications, the first one will refresh using the latest version and
+// the next X-1 will execute with an unchanged version (thus, becoming a no-op and wasting the CPU).
+const CACHED_SUMMARY_UPDATE_CHANNEL_SIZE: usize = 1;
+
 /// The server-side actor for the storage service. Handles inbound storage
 /// service requests from clients.
 pub struct StorageServiceServer<T> {
@@ -64,6 +72,9 @@ pub struct StorageServiceServer<T> {
 
     // A moderator for incoming peer requests
     request_moderator: Arc<RequestModerator>,
+
+    // The listener for notifications from state sync
+    storage_service_listener: Option<StorageServiceNotificationListener>,
 }
 
 impl<T: StorageReaderInterface> StorageServiceServer<T> {
@@ -74,6 +85,7 @@ impl<T: StorageReaderInterface> StorageServiceServer<T> {
         time_service: TimeService,
         peers_and_metadata: Arc<PeersAndMetadata>,
         network_requests: StorageServiceNetworkEvents,
+        storage_service_listener: StorageServiceNotificationListener,
     ) -> Self {
         let bounded_executor =
             BoundedExecutor::new(config.max_concurrent_requests as usize, executor);
@@ -88,6 +100,7 @@ impl<T: StorageReaderInterface> StorageServiceServer<T> {
             config,
             time_service.clone(),
         ));
+        let storage_service_listener = Some(storage_service_listener);
 
         Self {
             config,
@@ -99,37 +112,84 @@ impl<T: StorageReaderInterface> StorageServiceServer<T> {
             lru_response_cache,
             optimistic_fetches,
             request_moderator,
+            storage_service_listener,
         }
     }
 
+    /// Spawns all continuously running utility tasks
+    async fn spawn_continuous_storage_summary_tasks(&mut self) {
+        // Create a channel to notify the optimistic fetch
+        // handler about updates to the cached storage summary.
+        let (cached_summary_update_notifier, cached_summary_update_listener) =
+            aptos_channel::new(QueueStyle::LIFO, CACHED_SUMMARY_UPDATE_CHANNEL_SIZE, None);
+
+        // Spawn the refresher for the storage summary cache
+        self.spawn_storage_summary_refresher(cached_summary_update_notifier)
+            .await;
+
+        // Spawn the optimistic fetch handler
+        self.spawn_optimistic_fetch_handler(cached_summary_update_listener)
+            .await;
+
+        // Spawn the refresher for the request moderator
+        self.spawn_moderator_peer_refresher().await;
+    }
+
     /// Spawns a non-terminating task that refreshes the cached storage server summary
-    async fn spawn_storage_summary_refresher(&mut self) {
+    async fn spawn_storage_summary_refresher(
+        &mut self,
+        cached_summary_update_notifier: aptos_channel::Sender<(), CachedSummaryUpdateNotification>,
+    ) {
+        // Clone all required components for the task
         let cached_storage_server_summary = self.cached_storage_server_summary.clone();
         let config = self.config;
         let storage = self.storage.clone();
         let time_service = self.time_service.clone();
 
+        // Take the storage service listener
+        let mut storage_service_listener = self
+            .storage_service_listener
+            .take()
+            .expect("The storage service listener must be present!");
+
         // Spawn the task
         self.bounded_executor
             .spawn(async move {
+                // TODO: consider removing the interval once we've tested the notifications
+
                 // Create a ticker for the refresh interval
                 let duration = Duration::from_millis(config.storage_summary_refresh_interval_ms);
                 let ticker = time_service.interval(duration);
                 futures::pin_mut!(ticker);
 
-                // Periodically refresh the cache
+                // Continuously refresh the cache
                 loop {
-                    ticker.next().await;
+                    futures::select! {
+                        _ = ticker.select_next_some() => {
+                            // Refresh the cache periodically
+                            refresh_cached_storage_summary(
+                                cached_storage_server_summary.clone(),
+                                storage.clone(),
+                                config,
+                                cached_summary_update_notifier.clone(),
+                            )
+                        },
+                        notification = storage_service_listener.select_next_some() => {
+                            trace!(LogSchema::new(LogEntry::ReceivedCommitNotification)
+                                .message(&format!(
+                                    "Received commit notification for highest synced version: {:?}.",
+                                    notification.highest_synced_version
+                                ))
+                            );
 
-                    // Refresh the cache
-                    if let Err(error) = refresh_cached_storage_summary(
-                        cached_storage_server_summary.clone(),
-                        storage.clone(),
-                        config,
-                    ) {
-                        error!(LogSchema::new(LogEntry::StorageSummaryRefresh)
-                            .error(&error)
-                            .message("Failed to refresh the cached storage summary!"));
+                            // Refresh the cache because of a commit notification
+                            refresh_cached_storage_summary(
+                                cached_storage_server_summary.clone(),
+                                storage.clone(),
+                                config,
+                                cached_summary_update_notifier.clone(),
+                            )
+                        },
                     }
                 }
             })
@@ -137,7 +197,14 @@ impl<T: StorageReaderInterface> StorageServiceServer<T> {
     }
 
     /// Spawns a non-terminating task that handles optimistic fetches
-    async fn spawn_optimistic_fetch_handler(&mut self) {
+    async fn spawn_optimistic_fetch_handler(
+        &mut self,
+        mut cached_summary_update_listener: aptos_channel::Receiver<
+            (),
+            CachedSummaryUpdateNotification,
+        >,
+    ) {
+        // Clone all required components for the task
         let cached_storage_server_summary = self.cached_storage_server_summary.clone();
         let config = self.config;
         let optimistic_fetches = self.optimistic_fetches.clone();
@@ -149,28 +216,44 @@ impl<T: StorageReaderInterface> StorageServiceServer<T> {
         // Spawn the task
         self.bounded_executor
             .spawn(async move {
+                // TODO: consider removing the interval once we've tested the notifications
+
                 // Create a ticker for the refresh interval
                 let duration = Duration::from_millis(config.storage_summary_refresh_interval_ms);
                 let ticker = time_service.interval(duration);
                 futures::pin_mut!(ticker);
 
-                // Periodically check the optimistic fetches
+                // Continuously handle the optimistic fetches
                 loop {
-                    ticker.next().await;
+                    futures::select! {
+                        _ = ticker.select_next_some() => {
+                            // Handle the optimistic fetches periodically
+                            handle_active_optimistic_fetches(
+                                cached_storage_server_summary.clone(),
+                                config,
+                                optimistic_fetches.clone(),
+                                lru_response_cache.clone(),
+                                request_moderator.clone(),
+                                storage.clone(),
+                                time_service.clone(),
+                            )
+                        },
+                        notification = cached_summary_update_listener.select_next_some() => {
+                            trace!(LogSchema::new(LogEntry::ReceivedCacheUpdateNotification)
+                                .message(&format!("Received cache update notification! Highest synced version: {:?}", notification.highest_synced_version))
+                            );
 
-                    // Check and handle the active optimistic fetches
-                    if let Err(error) = optimistic_fetch::handle_active_optimistic_fetches(
-                        cached_storage_server_summary.clone(),
-                        config,
-                        optimistic_fetches.clone(),
-                        lru_response_cache.clone(),
-                        request_moderator.clone(),
-                        storage.clone(),
-                        time_service.clone(),
-                    ) {
-                        error!(LogSchema::new(LogEntry::OptimisticFetchRefresh)
-                            .error(&error)
-                            .message("Failed to handle active optimistic fetches!"));
+                            // Handle the optimistic fetches because of a cache update
+                            handle_active_optimistic_fetches(
+                                cached_storage_server_summary.clone(),
+                                config,
+                                optimistic_fetches.clone(),
+                                lru_response_cache.clone(),
+                                request_moderator.clone(),
+                                storage.clone(),
+                                time_service.clone(),
+                            )
+                        },
                     }
                 }
             })
@@ -180,6 +263,7 @@ impl<T: StorageReaderInterface> StorageServiceServer<T> {
     /// Spawns a non-terminating task that refreshes the unhealthy
     /// peer states in the request moderator.
     async fn spawn_moderator_peer_refresher(&mut self) {
+        // Clone all required components for the task
         let config = self.config;
         let request_moderator = self.request_moderator.clone();
         let time_service = self.time_service.clone();
@@ -209,16 +293,10 @@ impl<T: StorageReaderInterface> StorageServiceServer<T> {
 
     /// Starts the storage service server thread
     pub async fn start(mut self) {
-        // Spawn the refresher for the storage summary cache
-        self.spawn_storage_summary_refresher().await;
+        // Spawn the continuously running tasks
+        self.spawn_continuous_storage_summary_tasks().await;
 
-        // Spawn the optimistic fetch handler
-        self.spawn_optimistic_fetch_handler().await;
-
-        // Spawn the refresher for the request moderator
-        self.spawn_moderator_peer_refresher().await;
-
-        // Handle the storage requests
+        // Handle the storage requests as they arrive
         while let Some(network_request) = self.network_requests.next().await {
             // Log the request
             let peer_network_id = network_request.peer_network_id;
@@ -275,31 +353,100 @@ impl<T: StorageReaderInterface> StorageServiceServer<T> {
     }
 }
 
-/// Refreshes the cached storage server summary
+/// Handles the active optimistic fetches and logs any
+/// errors that were encountered.
+fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
+    cached_storage_server_summary: Arc<RwLock<StorageServerSummary>>,
+    config: StorageServiceConfig,
+    optimistic_fetches: Arc<Mutex<HashMap<PeerNetworkId, OptimisticFetchRequest>>>,
+    lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
+    request_moderator: Arc<RequestModerator>,
+    storage: T,
+    time_service: TimeService,
+) {
+    if let Err(error) = optimistic_fetch::handle_active_optimistic_fetches(
+        cached_storage_server_summary,
+        config,
+        optimistic_fetches,
+        lru_response_cache,
+        request_moderator,
+        storage,
+        time_service,
+    ) {
+        error!(LogSchema::new(LogEntry::OptimisticFetchRefresh)
+            .error(&error)
+            .message("Failed to handle active optimistic fetches!"));
+    }
+}
+
+/// Refreshes the cached storage server summary and sends
+/// a notification via the given channel. If an error
+/// occurs, it is logged.
 fn refresh_cached_storage_summary<T: StorageReaderInterface>(
     cached_storage_server_summary: Arc<RwLock<StorageServerSummary>>,
     storage: T,
     storage_config: StorageServiceConfig,
-) -> Result<(), Error> {
-    // Fetch the data summary from storage
-    let data_summary = storage
-        .get_data_summary()
-        .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
+    cached_summary_update_notifier: aptos_channel::Sender<(), CachedSummaryUpdateNotification>,
+) {
+    // Read the currently cached storage server summary
+    let existing_storage_server_summary = cached_storage_server_summary.read().clone();
+
+    // Fetch the new data summary from storage
+    let new_data_summary = match storage.get_data_summary() {
+        Ok(data_summary) => data_summary,
+        Err(error) => {
+            error!(LogSchema::new(LogEntry::StorageSummaryRefresh)
+                .error(&Error::StorageErrorEncountered(error.to_string()))
+                .message("Failed to refresh the cached storage summary!"));
+            return;
+        },
+    };
 
     // Initialize the protocol metadata
-    let protocol_metadata = ProtocolMetadata {
+    let new_protocol_metadata = ProtocolMetadata {
         max_epoch_chunk_size: storage_config.max_epoch_chunk_size,
         max_transaction_chunk_size: storage_config.max_transaction_chunk_size,
         max_state_chunk_size: storage_config.max_state_chunk_size,
         max_transaction_output_chunk_size: storage_config.max_transaction_output_chunk_size,
     };
 
-    // Save the storage server summary
-    let storage_server_summary = StorageServerSummary {
-        protocol_metadata,
-        data_summary,
+    // Create the new storage server summary
+    let new_storage_server_summary = StorageServerSummary {
+        protocol_metadata: new_protocol_metadata,
+        data_summary: new_data_summary,
     };
-    *cached_storage_server_summary.write() = storage_server_summary;
 
-    Ok(())
+    // If the new storage server summary is different to the existing one,
+    // update the cache and send a notification via the notifier channel.
+    if existing_storage_server_summary != new_storage_server_summary {
+        // Update the storage server summary cache
+        *cached_storage_server_summary.write() = new_storage_server_summary.clone();
+
+        // Create an update notification
+        let highest_synced_version = new_storage_server_summary
+            .data_summary
+            .get_synced_ledger_info_version();
+        let update_notification = CachedSummaryUpdateNotification::new(highest_synced_version);
+
+        // Send the notification via the notifier
+        if let Err(error) = cached_summary_update_notifier.push((), update_notification) {
+            error!(LogSchema::new(LogEntry::StorageSummaryRefresh)
+                .error(&Error::StorageErrorEncountered(error.to_string()))
+                .message("Failed to send an update notification for the new cached summary!"));
+        }
+    }
+}
+
+/// A simple notification sent to the optimistic fetch handler that the
+/// cached storage summary has been updated with the specified version.
+pub struct CachedSummaryUpdateNotification {
+    highest_synced_version: Option<u64>,
+}
+
+impl CachedSummaryUpdateNotification {
+    pub fn new(highest_synced_version: Option<u64>) -> Self {
+        Self {
+            highest_synced_version,
+        }
+    }
 }

--- a/state-sync/storage-service/server/src/lib.rs
+++ b/state-sync/storage-service/server/src/lib.rs
@@ -382,7 +382,7 @@ fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
 /// Refreshes the cached storage server summary and sends
 /// a notification via the given channel. If an error
 /// occurs, it is logged.
-fn refresh_cached_storage_summary<T: StorageReaderInterface>(
+pub(crate) fn refresh_cached_storage_summary<T: StorageReaderInterface>(
     cached_storage_server_summary: Arc<RwLock<StorageServerSummary>>,
     storage: T,
     storage_config: StorageServiceConfig,

--- a/state-sync/storage-service/server/src/logging.rs
+++ b/state-sync/storage-service/server/src/logging.rs
@@ -39,6 +39,8 @@ pub enum LogEntry {
     OptimisticFetchRefresh,
     OptimisticFetchRequest,
     OptimisticFetchResponse,
+    ReceivedCacheUpdateNotification,
+    ReceivedCommitNotification,
     ReceivedStorageRequest,
     RequestModeratorIgnoredPeer,
     RequestModeratorRefresh,

--- a/state-sync/storage-service/server/src/tests/cache.rs
+++ b/state-sync/storage-service/server/src/tests/cache.rs
@@ -51,7 +51,7 @@ async fn test_cachable_requests_compression() {
     }
 
     // Create the storage client and server
-    let (mut mock_client, mut service, _, _) = MockClient::new(Some(db_reader), None);
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
     utils::update_storage_server_summary(&mut service, end_version, 10);
     tokio::spawn(service.start());
 
@@ -118,7 +118,7 @@ async fn test_cachable_requests_data_versions() {
     }
 
     // Create the storage client and server
-    let (mut mock_client, mut service, _, _) = MockClient::new(Some(db_reader), None);
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
     utils::update_storage_server_summary(&mut service, end_version, 10);
     tokio::spawn(service.start());
 
@@ -195,7 +195,7 @@ async fn test_cachable_requests_eviction() {
     }
 
     // Create the storage client and server
-    let (mut mock_client, mut service, _, _) = MockClient::new(Some(db_reader), None);
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
     utils::update_storage_server_summary(&mut service, version + 10, 10);
     tokio::spawn(service.start());
 

--- a/state-sync/storage-service/server/src/tests/epoch_ending.rs
+++ b/state-sync/storage-service/server/src/tests/epoch_ending.rs
@@ -46,7 +46,7 @@ async fn test_get_epoch_ending_ledger_infos() {
         );
 
         // Create the storage client and server
-        let (mut mock_client, mut service, _, _) = MockClient::new(Some(db_reader), None);
+        let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
         utils::update_storage_server_summary(&mut service, 1000, expected_end_epoch);
         tokio::spawn(service.start());
 
@@ -100,7 +100,7 @@ async fn test_get_epoch_ending_ledger_infos_chunk_limit() {
     let storage_request = StorageServiceRequest::new(data_request, true);
 
     // Create the storage client and server
-    let (mut mock_client, mut service, _, _) = MockClient::new(Some(db_reader), None);
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
     utils::update_storage_server_summary(&mut service, 1000, expected_end_epoch);
     tokio::spawn(service.start());
 
@@ -119,7 +119,7 @@ async fn test_get_epoch_ending_ledger_infos_chunk_limit() {
 #[tokio::test]
 async fn test_get_epoch_ending_ledger_infos_invalid() {
     // Create the storage client and server
-    let (mut mock_client, service, _, _) = MockClient::new(None, None);
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, None);
     tokio::spawn(service.start());
 
     // Test invalid ranges
@@ -158,7 +158,7 @@ async fn test_get_epoch_ending_ledger_infos_not_serviceable() {
         let expected_end_epoch = start_epoch + chunk_size - 1;
 
         // Create the storage client and server (that cannot service the request)
-        let (mut mock_client, mut service, _, _) = MockClient::new(None, None);
+        let (mut mock_client, mut service, _, _, _) = MockClient::new(None, None);
         utils::update_storage_server_summary(&mut service, 1000, expected_end_epoch - 1);
         tokio::spawn(service.start());
 
@@ -256,7 +256,7 @@ async fn get_epoch_ending_ledger_infos_network_limit(network_limit_bytes: u64) {
         };
 
         // Create the storage client and server
-        let (mut mock_client, mut service, _, _) =
+        let (mut mock_client, mut service, _, _, _) =
             MockClient::new(Some(db_reader), Some(storage_config));
         utils::update_storage_server_summary(&mut service, 1000, expected_end_epoch);
         tokio::spawn(service.start());

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -100,6 +100,10 @@ impl MockClient {
         let storage_service_network_events =
             StorageServiceNetworkEvents::new(NetworkServiceEvents::new(network_and_events));
 
+        // Create the storage service notifier and listener
+        let (_storage_service_notifier, storage_service_listener) =
+            aptos_storage_service_notifications::new_storage_service_notifier_listener_pair();
+
         // Create the storage service
         let peers_and_metadata = create_peers_and_metadata(network_ids);
         let executor = tokio::runtime::Handle::current();
@@ -111,6 +115,7 @@ impl MockClient {
             mock_time_service.clone(),
             peers_and_metadata.clone(),
             storage_service_network_events,
+            storage_service_listener,
         );
 
         // Return the client and service

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -19,6 +19,7 @@ use aptos_network::{
     },
 };
 use aptos_storage_interface::{DbReader, ExecutedTrees, Order};
+use aptos_storage_service_notifications::StorageServiceNotifier;
 use aptos_storage_service_types::{
     requests::StorageServiceRequest, responses::StorageServiceResponse, StorageServiceError,
     StorageServiceMessage,
@@ -65,6 +66,7 @@ impl MockClient {
     ) -> (
         Self,
         StorageServiceServer<StorageReader>,
+        StorageServiceNotifier,
         MockTimeService,
         Arc<PeersAndMetadata>,
     ) {
@@ -101,7 +103,7 @@ impl MockClient {
             StorageServiceNetworkEvents::new(NetworkServiceEvents::new(network_and_events));
 
         // Create the storage service notifier and listener
-        let (_storage_service_notifier, storage_service_listener) =
+        let (storage_service_notifier, storage_service_listener) =
             aptos_storage_service_notifications::new_storage_service_notifier_listener_pair();
 
         // Create the storage service
@@ -125,6 +127,7 @@ impl MockClient {
         (
             mock_client,
             storage_server,
+            storage_service_notifier,
             mock_time_service.into_mock(),
             peers_and_metadata,
         )

--- a/state-sync/storage-service/server/src/tests/new_transaction_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/new_transaction_outputs.rs
@@ -47,7 +47,8 @@ async fn test_get_new_transaction_outputs() {
         );
 
         // Create the storage client and server
-        let (mut mock_client, service, mock_time, _) = MockClient::new(Some(db_reader), None);
+        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+            MockClient::new(Some(db_reader), None);
         let active_optimistic_fetches = service.get_optimistic_fetches();
         tokio::spawn(service.start());
 
@@ -61,8 +62,13 @@ async fn test_get_new_transaction_outputs() {
         // Verify no optimistic fetch response has been received yet
         assert_none!(response_receiver.try_recv().unwrap());
 
-        // Elapse enough time to force the optimistic fetch thread to work
-        utils::wait_for_optimistic_fetch_service_to_refresh(&mut mock_client, &mock_time).await;
+        // Force the optimistic fetch handler to work
+        utils::force_optimistic_fetch_handler_to_run(
+            &mut mock_client,
+            &mock_time,
+            &storage_service_notifier,
+        )
+        .await;
 
         // Verify a response is received and that it contains the correct data
         verify_new_transaction_outputs_with_proof(
@@ -118,7 +124,8 @@ async fn test_get_new_transaction_outputs_different_networks() {
         );
 
         // Create the storage client and server
-        let (mut mock_client, service, mock_time, _) = MockClient::new(Some(db_reader), None);
+        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+            MockClient::new(Some(db_reader), None);
         let active_optimistic_fetches = service.get_optimistic_fetches();
         tokio::spawn(service.start());
 
@@ -150,8 +157,13 @@ async fn test_get_new_transaction_outputs_different_networks() {
         assert_none!(response_receiver_1.try_recv().unwrap());
         assert_none!(response_receiver_2.try_recv().unwrap());
 
-        // Elapse enough time to force the optimistic fetch thread to work
-        utils::wait_for_optimistic_fetch_service_to_refresh(&mut mock_client, &mock_time).await;
+        // Force the optimistic fetch handler to work
+        utils::force_optimistic_fetch_handler_to_run(
+            &mut mock_client,
+            &mock_time,
+            &storage_service_notifier,
+        )
+        .await;
 
         // Verify a response is received and that it contains the correct data
         verify_new_transaction_outputs_with_proof(
@@ -213,7 +225,8 @@ async fn test_get_new_transaction_outputs_epoch_change() {
     );
 
     // Create the storage client and server
-    let (mut mock_client, service, mock_time, _) = MockClient::new(Some(db_reader), None);
+    let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+        MockClient::new(Some(db_reader), None);
     let active_optimistic_fetches = service.get_optimistic_fetches();
     tokio::spawn(service.start());
 
@@ -224,8 +237,13 @@ async fn test_get_new_transaction_outputs_epoch_change() {
     // Wait until the optimistic fetch is active
     utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
 
-    // Elapse enough time to force the optimistic fetch thread to work
-    utils::wait_for_optimistic_fetch_service_to_refresh(&mut mock_client, &mock_time).await;
+    // Force the optimistic fetch handler to work
+    utils::force_optimistic_fetch_handler_to_run(
+        &mut mock_client,
+        &mock_time,
+        &storage_service_notifier,
+    )
+    .await;
 
     // Verify a response is received and that it contains the correct data
     verify_new_transaction_outputs_with_proof(
@@ -266,7 +284,8 @@ async fn test_get_new_transaction_outputs_max_chunk() {
     );
 
     // Create the storage client and server
-    let (mut mock_client, service, mock_time, _) = MockClient::new(Some(db_reader), None);
+    let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+        MockClient::new(Some(db_reader), None);
     let active_optimistic_fetches = service.get_optimistic_fetches();
     tokio::spawn(service.start());
 
@@ -277,8 +296,13 @@ async fn test_get_new_transaction_outputs_max_chunk() {
     // Wait until the optimistic fetch is active
     utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
 
-    // Elapse enough time to force the optimistic fetch thread to work
-    utils::wait_for_optimistic_fetch_service_to_refresh(&mut mock_client, &mock_time).await;
+    // Force the optimistic fetch handler to work
+    utils::force_optimistic_fetch_handler_to_run(
+        &mut mock_client,
+        &mock_time,
+        &storage_service_notifier,
+    )
+    .await;
 
     // Verify a response is received and that it contains the correct data
     verify_new_transaction_outputs_with_proof(

--- a/state-sync/storage-service/server/src/tests/new_transactions.rs
+++ b/state-sync/storage-service/server/src/tests/new_transactions.rs
@@ -53,7 +53,8 @@ async fn test_get_new_transactions() {
             );
 
             // Create the storage client and server
-            let (mut mock_client, service, mock_time, _) = MockClient::new(Some(db_reader), None);
+            let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                MockClient::new(Some(db_reader), None);
             let active_optimistic_fetches = service.get_optimistic_fetches();
             tokio::spawn(service.start());
 
@@ -72,8 +73,13 @@ async fn test_get_new_transactions() {
             // Verify no optimistic fetch response has been received yet
             assert_none!(response_receiver.try_recv().unwrap());
 
-            // Elapse enough time to force the optimistic fetch thread to work
-            utils::wait_for_optimistic_fetch_service_to_refresh(&mut mock_client, &mock_time).await;
+            // Force the optimistic fetch handler to work
+            utils::force_optimistic_fetch_handler_to_run(
+                &mut mock_client,
+                &mock_time,
+                &storage_service_notifier,
+            )
+            .await;
 
             // Verify a response is received and that it contains the correct data
             verify_new_transactions_with_proof(
@@ -138,7 +144,8 @@ async fn test_get_new_transactions_different_networks() {
             );
 
             // Create the storage client and server
-            let (mut mock_client, service, mock_time, _) = MockClient::new(Some(db_reader), None);
+            let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                MockClient::new(Some(db_reader), None);
             let active_optimistic_fetches = service.get_optimistic_fetches();
             tokio::spawn(service.start());
 
@@ -172,8 +179,13 @@ async fn test_get_new_transactions_different_networks() {
             assert_none!(response_receiver_1.try_recv().unwrap());
             assert_none!(response_receiver_2.try_recv().unwrap());
 
-            // Elapse enough time to force the optimistic fetch thread to work
-            utils::wait_for_optimistic_fetch_service_to_refresh(&mut mock_client, &mock_time).await;
+            // Force the optimistic fetch handler to work
+            utils::force_optimistic_fetch_handler_to_run(
+                &mut mock_client,
+                &mock_time,
+                &storage_service_notifier,
+            )
+            .await;
 
             // Verify a response is received and that it contains the correct data for both peers
             verify_new_transactions_with_proof(
@@ -240,7 +252,8 @@ async fn test_get_new_transactions_epoch_change() {
         );
 
         // Create the storage client and server
-        let (mut mock_client, service, mock_time, _) = MockClient::new(Some(db_reader), None);
+        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+            MockClient::new(Some(db_reader), None);
         let active_optimistic_fetches = service.get_optimistic_fetches();
         tokio::spawn(service.start());
 
@@ -256,8 +269,13 @@ async fn test_get_new_transactions_epoch_change() {
         // Wait until the optimistic fetch is active
         utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
 
-        // Elapse enough time to force the optimistic fetch thread to work
-        utils::wait_for_optimistic_fetch_service_to_refresh(&mut mock_client, &mock_time).await;
+        // Force the optimistic fetch handler to work
+        utils::force_optimistic_fetch_handler_to_run(
+            &mut mock_client,
+            &mock_time,
+            &storage_service_notifier,
+        )
+        .await;
 
         // Verify a response is received and that it contains the correct data
         verify_new_transactions_with_proof(
@@ -303,7 +321,8 @@ async fn test_get_new_transactions_max_chunk() {
         );
 
         // Create the storage client and server
-        let (mut mock_client, service, mock_time, _) = MockClient::new(Some(db_reader), None);
+        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+            MockClient::new(Some(db_reader), None);
         let active_optimistic_fetches = service.get_optimistic_fetches();
         tokio::spawn(service.start());
 
@@ -319,8 +338,13 @@ async fn test_get_new_transactions_max_chunk() {
         // Wait until the optimistic fetch is active
         utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
 
-        // Elapse enough time to force the optimistic fetch thread to work
-        utils::wait_for_optimistic_fetch_service_to_refresh(&mut mock_client, &mock_time).await;
+        // Force the optimistic fetch handler to work
+        utils::force_optimistic_fetch_handler_to_run(
+            &mut mock_client,
+            &mock_time,
+            &storage_service_notifier,
+        )
+        .await;
 
         // Verify a response is received and that it contains the correct data
         verify_new_transactions_with_proof(
@@ -381,13 +405,8 @@ async fn verify_new_transactions_with_proof(
     expected_transactions_with_proof: TransactionListWithProof,
     expected_ledger_info: LedgerInfoWithSignatures,
 ) {
-    match mock_client
-        .wait_for_response(receiver)
-        .await
-        .unwrap()
-        .get_data_response()
-        .unwrap()
-    {
+    let storage_service_response = mock_client.wait_for_response(receiver).await.unwrap();
+    match storage_service_response.get_data_response().unwrap() {
         DataResponse::NewTransactionsWithProof((transactions_with_proof, ledger_info)) => {
             assert_eq!(transactions_with_proof, expected_transactions_with_proof);
             assert_eq!(ledger_info, expected_ledger_info);

--- a/state-sync/storage-service/server/src/tests/new_transactions_or_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/new_transactions_or_outputs.rs
@@ -74,7 +74,7 @@ async fn test_get_new_transactions_or_outputs() {
                 &output_list_with_proof,
                 &transaction_list_with_proof,
             );
-            let (mut mock_client, service, mock_time, _) =
+            let (mut mock_client, service, storage_service_notifier, mock_time, _) =
                 MockClient::new(Some(db_reader), Some(storage_config));
             let active_optimistic_fetches = service.get_optimistic_fetches();
             tokio::spawn(service.start());
@@ -95,8 +95,13 @@ async fn test_get_new_transactions_or_outputs() {
             // Verify no optimistic fetch response has been received yet
             assert_none!(response_receiver.try_recv().unwrap());
 
-            // Elapse enough time to force the optimistic fetch thread to work
-            utils::wait_for_optimistic_fetch_service_to_refresh(&mut mock_client, &mock_time).await;
+            // Force the optimistic fetch handler to work
+            utils::force_optimistic_fetch_handler_to_run(
+                &mut mock_client,
+                &mock_time,
+                &storage_service_notifier,
+            )
+            .await;
 
             // Verify a response is received and that it contains the correct data
             if fallback_to_transactions {
@@ -198,7 +203,7 @@ async fn test_get_new_transactions_or_outputs_different_network() {
                 &output_list_with_proof_1,
                 &transaction_list_with_proof,
             );
-            let (mut mock_client, service, mock_time, _) =
+            let (mut mock_client, service, storage_service_notifier, mock_time, _) =
                 MockClient::new(Some(db_reader), Some(storage_config));
             let active_optimistic_fetches = service.get_optimistic_fetches();
             tokio::spawn(service.start());
@@ -235,8 +240,13 @@ async fn test_get_new_transactions_or_outputs_different_network() {
             assert_none!(response_receiver_1.try_recv().unwrap());
             assert_none!(response_receiver_2.try_recv().unwrap());
 
-            // Elapse enough time to force the optimistic fetch thread to work
-            utils::wait_for_optimistic_fetch_service_to_refresh(&mut mock_client, &mock_time).await;
+            // Force the optimistic fetch handler to work
+            utils::force_optimistic_fetch_handler_to_run(
+                &mut mock_client,
+                &mock_time,
+                &storage_service_notifier,
+            )
+            .await;
 
             // Verify a response is received and that it contains the correct data
             if fallback_to_transactions {
@@ -343,7 +353,7 @@ async fn test_get_new_transactions_or_outputs_epoch_change() {
             &output_list_with_proof,
             &transaction_list_with_proof,
         );
-        let (mut mock_client, service, mock_time, _) =
+        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
             MockClient::new(Some(db_reader), Some(storage_config));
         let active_optimistic_fetches = service.get_optimistic_fetches();
         tokio::spawn(service.start());
@@ -361,8 +371,13 @@ async fn test_get_new_transactions_or_outputs_epoch_change() {
         // Wait until the optimistic fetch is active
         utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
 
-        // Elapse enough time to force the optimistic fetch thread to work
-        utils::wait_for_optimistic_fetch_service_to_refresh(&mut mock_client, &mock_time).await;
+        // Force the optimistic fetch handler to work
+        utils::force_optimistic_fetch_handler_to_run(
+            &mut mock_client,
+            &mock_time,
+            &storage_service_notifier,
+        )
+        .await;
 
         // Verify a response is received and that it contains the correct data
         if fallback_to_transactions {
@@ -442,7 +457,7 @@ async fn test_get_new_transactions_or_outputs_max_chunk() {
             &output_list_with_proof,
             &transaction_list_with_proof,
         );
-        let (mut mock_client, service, mock_time, _) =
+        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
             MockClient::new(Some(db_reader), Some(storage_config));
         let active_optimistic_fetches = service.get_optimistic_fetches();
         tokio::spawn(service.start());
@@ -460,8 +475,13 @@ async fn test_get_new_transactions_or_outputs_max_chunk() {
         // Wait until the optimistic fetch is active
         utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
 
-        // Elapse enough time to force the optimistic fetch thread to work
-        utils::wait_for_optimistic_fetch_service_to_refresh(&mut mock_client, &mock_time).await;
+        // Force the optimistic fetch handler to work
+        utils::force_optimistic_fetch_handler_to_run(
+            &mut mock_client,
+            &mock_time,
+            &storage_service_notifier,
+        )
+        .await;
 
         // Verify a response is received and that it contains the correct data
         if fallback_to_transactions {

--- a/state-sync/storage-service/server/src/tests/number_of_states.rs
+++ b/state-sync/storage-service/server/src/tests/number_of_states.rs
@@ -25,7 +25,7 @@ async fn test_get_number_of_states_at_version() {
         .returning(move |_| Ok(number_of_states as usize));
 
     // Create the storage client and server
-    let (mut mock_client, mut service, _, _) = MockClient::new(Some(db_reader), None);
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
     utils::update_storage_server_summary(&mut service, version, 10);
     tokio::spawn(service.start());
 
@@ -48,7 +48,7 @@ async fn test_get_number_of_states_at_version_not_serviceable() {
     let version = 101;
 
     // Create the storage client and server (that cannot service the request)
-    let (mut mock_client, mut service, _, _) = MockClient::new(None, None);
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(None, None);
     utils::update_storage_server_summary(&mut service, version - 1, 10);
     tokio::spawn(service.start());
 
@@ -75,7 +75,7 @@ async fn test_get_number_of_states_at_version_invalid() {
         .returning(move |_| Err(format_err!("Version does not exist!")));
 
     // Create the storage client and server
-    let (mut mock_client, mut service, _, _) = MockClient::new(Some(db_reader), None);
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
     utils::update_storage_server_summary(&mut service, version, 10);
     tokio::spawn(service.start());
 

--- a/state-sync/storage-service/server/src/tests/protocol_version.rs
+++ b/state-sync/storage-service/server/src/tests/protocol_version.rs
@@ -14,7 +14,7 @@ const PROTOCOL_VERSION: u64 = 1;
 #[tokio::test]
 async fn test_get_server_protocol_version() {
     // Create the storage client and server
-    let (mut mock_client, service, _, _) = MockClient::new(None, None);
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, None);
     tokio::spawn(service.start());
 
     // Process a request to fetch the protocol version

--- a/state-sync/storage-service/server/src/tests/request_moderator.rs
+++ b/state-sync/storage-service/server/src/tests/request_moderator.rs
@@ -44,7 +44,8 @@ async fn test_request_moderator_ignore_pfn() {
     };
 
     // Create the storage client and server
-    let (mut mock_client, mut service, _, _) = MockClient::new(None, Some(storage_service_config));
+    let (mut mock_client, mut service, _, _, _) =
+        MockClient::new(None, Some(storage_service_config));
     utils::update_storage_server_summary(
         &mut service,
         highest_synced_version,
@@ -143,7 +144,7 @@ async fn test_request_moderator_increase_time() {
     };
 
     // Create the storage client and server
-    let (mut mock_client, mut service, time_service, peers_and_metadata) =
+    let (mut mock_client, mut service, _, time_service, peers_and_metadata) =
         MockClient::new(None, Some(storage_service_config));
     utils::update_storage_server_summary(
         &mut service,
@@ -233,7 +234,7 @@ async fn test_request_moderator_peer_garbage_collect() {
     };
 
     // Create the storage client and server
-    let (mut mock_client, mut service, time_service, peers_and_metadata) =
+    let (mut mock_client, mut service, _, time_service, peers_and_metadata) =
         MockClient::new(None, Some(storage_service_config));
     utils::update_storage_server_summary(
         &mut service,

--- a/state-sync/storage-service/server/src/tests/state_values.rs
+++ b/state-sync/storage-service/server/src/tests/state_values.rs
@@ -54,7 +54,7 @@ async fn test_get_states_with_proof() {
         );
 
         // Create the storage client and server
-        let (mut mock_client, mut service, _, _) = MockClient::new(Some(db_reader), None);
+        let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
         utils::update_storage_server_summary(&mut service, version, 10);
         tokio::spawn(service.start());
 
@@ -101,7 +101,7 @@ async fn test_get_states_with_proof_chunk_limit() {
     );
 
     // Create the storage client and server
-    let (mut mock_client, mut service, _, _) = MockClient::new(Some(db_reader), None);
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
     utils::update_storage_server_summary(&mut service, version, 10);
     tokio::spawn(service.start());
 
@@ -127,7 +127,7 @@ async fn test_get_states_with_proof_chunk_limit() {
 #[tokio::test]
 async fn test_get_states_with_proof_invalid() {
     // Create the storage client and server
-    let (mut mock_client, service, _, _) = MockClient::new(None, None);
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, None);
     tokio::spawn(service.start());
 
     // Test invalid ranges
@@ -160,7 +160,7 @@ async fn test_get_states_with_proof_not_serviceable() {
         let end_index = start_index + chunk_size - 1;
 
         // Create the storage client and server (that cannot service the request)
-        let (mut mock_client, mut service, _, _) = MockClient::new(None, None);
+        let (mut mock_client, mut service, _, _, _) = MockClient::new(None, None);
         utils::update_storage_server_summary(&mut service, version - 1, 10);
         tokio::spawn(service.start());
 
@@ -274,7 +274,7 @@ async fn get_states_with_proof_network_limit(network_limit_bytes: u64) {
         };
 
         // Create the storage client and server
-        let (mut mock_client, mut service, _, _) =
+        let (mut mock_client, mut service, _, _, _) =
             MockClient::new(Some(db_reader), Some(storage_config));
         utils::update_storage_server_summary(&mut service, version, 10);
         tokio::spawn(service.start());

--- a/state-sync/storage-service/server/src/tests/storage_summary.rs
+++ b/state-sync/storage-service/server/src/tests/storage_summary.rs
@@ -1,8 +1,19 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::tests::{mock, mock::MockClient, utils};
+use crate::{
+    refresh_cached_storage_summary,
+    storage::StorageReader,
+    tests::{
+        mock,
+        mock::{MockClient, MockDatabaseReader},
+        utils,
+    },
+};
+use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::config::StorageServiceConfig;
+use aptos_infallible::RwLock;
+use aptos_storage_service_notifications::StorageServiceNotificationSender;
 use aptos_storage_service_types::{
     requests::DataRequest,
     responses::{
@@ -11,9 +22,129 @@ use aptos_storage_service_types::{
     },
     StorageServiceError,
 };
+use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
+use futures::StreamExt;
+use std::{sync::Arc, time::Duration};
+use tokio::time::timeout;
+
+// The maximum number of seconds to wait for a cache update notification
+const MAX_CACHE_UPDATE_NOTIFICATION_WAIT_SECS: u64 = 10;
 
 #[tokio::test]
-async fn test_get_storage_server_summary() {
+async fn test_refresh_cached_storage_summary() {
+    // Create test data
+    let highest_version = 1000;
+    let highest_epoch = 430;
+    let lowest_version = 11;
+    let state_prune_window = 200;
+    let highest_ledger_info =
+        utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+
+    // Create the mock storage reader
+    let storage_service_config = StorageServiceConfig::default();
+    let db_reader = create_db_reader_with_expectations(
+        lowest_version,
+        state_prune_window,
+        highest_ledger_info.clone(),
+    );
+    let storage_reader = StorageReader::new(storage_service_config, Arc::new(db_reader));
+
+    // Create the storage summary cache
+    let cached_storage_server_summary = Arc::new(RwLock::new(StorageServerSummary::default()));
+
+    // Create the cached summary update notifier
+    let (cached_summary_update_notifier, mut cached_summary_update_listener) =
+        aptos_channel::new(QueueStyle::FIFO, 1, None);
+
+    // Refresh the storage summary cache
+    refresh_cached_storage_summary(
+        cached_storage_server_summary.clone(),
+        storage_reader.clone(),
+        storage_service_config,
+        cached_summary_update_notifier.clone(),
+    );
+
+    // Verify that the cached summary update listener is notified
+    let update_notification = timeout(
+        Duration::from_secs(MAX_CACHE_UPDATE_NOTIFICATION_WAIT_SECS),
+        cached_summary_update_listener.select_next_some(),
+    )
+    .await
+    .expect("Timed-out while waiting to receive a cache update notification!");
+    assert_eq!(
+        update_notification.highest_synced_version,
+        Some(highest_version)
+    );
+
+    // Refresh the storage summary cache again and verify no notification is
+    // received (because the highest synced version has not changed).
+    if timeout(
+        Duration::from_secs(MAX_CACHE_UPDATE_NOTIFICATION_WAIT_SECS),
+        cached_summary_update_listener.select_next_some(),
+    )
+    .await
+    .is_ok()
+    {
+        panic!("Received a cache update notification when none was expected!");
+    }
+
+    // Manually modify the protocol metadata to ensure that
+    // the next refresh will trigger a notification.
+    cached_storage_server_summary
+        .write()
+        .protocol_metadata
+        .max_transaction_output_chunk_size = 123;
+
+    // Refresh the storage summary cache
+    refresh_cached_storage_summary(
+        cached_storage_server_summary.clone(),
+        storage_reader.clone(),
+        storage_service_config,
+        cached_summary_update_notifier.clone(),
+    );
+
+    // Verify that the cached summary update listener is notified
+    let update_notification = timeout(
+        Duration::from_secs(MAX_CACHE_UPDATE_NOTIFICATION_WAIT_SECS),
+        cached_summary_update_listener.select_next_some(),
+    )
+    .await
+    .expect("Timed-out while waiting to receive a cache update notification!");
+    assert_eq!(
+        update_notification.highest_synced_version,
+        Some(highest_version)
+    );
+
+    // Manually modify the data summary to ensure that
+    // the next refresh will trigger a notification.
+    cached_storage_server_summary
+        .write()
+        .data_summary
+        .transactions = Some(CompleteDataRange::new(10, 11).unwrap());
+
+    // Refresh the storage summary cache
+    refresh_cached_storage_summary(
+        cached_storage_server_summary.clone(),
+        storage_reader.clone(),
+        storage_service_config,
+        cached_summary_update_notifier.clone(),
+    );
+
+    // Verify that the cached summary update listener is notified
+    let update_notification = timeout(
+        Duration::from_secs(MAX_CACHE_UPDATE_NOTIFICATION_WAIT_SECS),
+        cached_summary_update_listener.select_next_some(),
+    )
+    .await
+    .expect("Timed-out while waiting to receive a cache update notification!");
+    assert_eq!(
+        update_notification.highest_synced_version,
+        Some(highest_version)
+    );
+}
+
+#[tokio::test]
+async fn test_get_storage_server_summary_advance_time() {
     // Create test data
     let highest_version = 506;
     let highest_epoch = 30;
@@ -23,52 +154,160 @@ async fn test_get_storage_server_summary() {
         utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
 
     // Create the mock db reader
+    let db_reader = create_db_reader_with_expectations(
+        lowest_version,
+        state_prune_window,
+        highest_ledger_info.clone(),
+    );
+
+    // Create the storage client and server
+    let (mut mock_client, service, _, mock_time, _) = MockClient::new(Some(db_reader), None);
+    let storage_summary_cache = service.cached_storage_server_summary.clone();
+    tokio::spawn(service.start());
+
+    // Test multiple updates to the storage summary cache
+    for _ in 0..100 {
+        // Fetch the storage summary and verify we get a default summary response
+        let response = get_storage_server_summary(&mut mock_client, true)
+            .await
+            .unwrap();
+        let default_response = StorageServiceResponse::new(
+            DataResponse::StorageServerSummary(StorageServerSummary::default()),
+            true,
+        )
+        .unwrap();
+        assert_eq!(response, default_response);
+
+        // Elapse enough time to force a cache update
+        utils::advance_storage_refresh_time(&mock_time).await;
+
+        // Process another request to fetch the storage summary
+        let response = get_storage_server_summary(&mut mock_client, true)
+            .await
+            .unwrap();
+
+        // Verify the response is correct (after the cache update)
+        verify_server_summary_response(
+            highest_version,
+            highest_epoch,
+            lowest_version,
+            state_prune_window,
+            highest_ledger_info.clone(),
+            response,
+        );
+
+        // Manually overwrite the storage summary cache
+        *storage_summary_cache.write() = StorageServerSummary::default();
+    }
+}
+
+#[tokio::test]
+async fn test_get_storage_server_summary_notification() {
+    // Create test data
+    let highest_version = 1000;
+    let highest_epoch = 430;
+    let lowest_version = 11;
+    let state_prune_window = 200;
+    let highest_ledger_info =
+        utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+
+    // Create the mock db reader
+    let db_reader = create_db_reader_with_expectations(
+        lowest_version,
+        state_prune_window,
+        highest_ledger_info.clone(),
+    );
+
+    // Create the storage client and server
+    let (mut mock_client, service, storage_service_notifier, _, _) =
+        MockClient::new(Some(db_reader), None);
+    let storage_summary_cache = service.cached_storage_server_summary.clone();
+    tokio::spawn(service.start());
+
+    // Test multiple updates to the storage summary cache
+    for _ in 0..100 {
+        // Fetch the storage summary and verify we get a default summary response
+        let response = get_storage_server_summary(&mut mock_client, true)
+            .await
+            .unwrap();
+        let default_response = StorageServiceResponse::new(
+            DataResponse::StorageServerSummary(StorageServerSummary::default()),
+            true,
+        )
+        .unwrap();
+        assert_eq!(response, default_response);
+
+        // Send a notification to the storage service. This will cause the cache to be updated.
+        storage_service_notifier.notify_new_commit(1).await.unwrap();
+
+        // Process another request to fetch the storage summary
+        let response = get_storage_server_summary(&mut mock_client, true)
+            .await
+            .unwrap();
+
+        // Verify the response is correct (after the cache update)
+        verify_server_summary_response(
+            highest_version,
+            highest_epoch,
+            lowest_version,
+            state_prune_window,
+            highest_ledger_info.clone(),
+            response,
+        );
+
+        // Manually overwrite the storage summary cache
+        *storage_summary_cache.write() = StorageServerSummary::default();
+    }
+}
+
+/// Creates a mock database reader with the necessary
+/// expectations to satisfy the storage server summary request.
+fn create_db_reader_with_expectations(
+    lowest_version: Version,
+    state_prune_window: usize,
+    highest_ledger_info: LedgerInfoWithSignatures,
+) -> MockDatabaseReader {
+    // Create the mock reader
     let mut db_reader = mock::create_mock_db_reader();
-    let highest_ledger_info_clone = highest_ledger_info.clone();
+
+    // Set the read call expectations
     db_reader
         .expect_get_latest_ledger_info()
-        .times(1)
-        .returning(move || Ok(highest_ledger_info_clone.clone()));
+        .returning(move || Ok(highest_ledger_info.clone()));
     db_reader
         .expect_get_first_txn_version()
-        .times(1)
         .returning(move || Ok(Some(lowest_version)));
     db_reader
         .expect_get_first_write_set_version()
-        .times(1)
         .returning(move || Ok(Some(lowest_version)));
     db_reader
         .expect_get_epoch_snapshot_prune_window()
-        .times(1)
         .returning(move || Ok(state_prune_window));
     db_reader
         .expect_is_state_merkle_pruner_enabled()
         .returning(move || Ok(true));
+    db_reader
+}
 
-    // Create the storage client and server
-    let (mut mock_client, service, mock_time, _) = MockClient::new(Some(db_reader), None);
-    tokio::spawn(service.start());
+/// Sends a storage summary request and processes the response
+async fn get_storage_server_summary(
+    mock_client: &mut MockClient,
+    use_compression: bool,
+) -> Result<StorageServiceResponse, StorageServiceError> {
+    let data_request = DataRequest::GetStorageServerSummary;
+    utils::send_storage_request(mock_client, use_compression, data_request).await
+}
 
-    // Fetch the storage summary and verify we get a default summary response
-    let response = get_storage_server_summary(&mut mock_client, true)
-        .await
-        .unwrap();
-    let default_response = StorageServiceResponse::new(
-        DataResponse::StorageServerSummary(StorageServerSummary::default()),
-        true,
-    )
-    .unwrap();
-    assert_eq!(response, default_response);
-
-    // Elapse enough time to force a cache update
-    utils::advance_storage_refresh_time(&mock_time).await;
-
-    // Process another request to fetch the storage summary
-    let response = get_storage_server_summary(&mut mock_client, true)
-        .await
-        .unwrap();
-
-    // Verify the response is correct (after the cache update)
+/// Verifies that the given storage server summary response is valid
+fn verify_server_summary_response(
+    highest_version: u64,
+    highest_epoch: u64,
+    lowest_version: Version,
+    state_prune_window: usize,
+    highest_ledger_info: LedgerInfoWithSignatures,
+    response: StorageServiceResponse,
+) {
+    // Create the expected response
     let default_storage_config = StorageServiceConfig::default();
     let expected_server_summary = StorageServerSummary {
         protocol_metadata: ProtocolMetadata {
@@ -94,21 +333,14 @@ async fn test_get_storage_server_summary() {
             ),
         },
     };
+
+    // Verify the response matches the expected response
     assert_eq!(
         response,
         StorageServiceResponse::new(
             DataResponse::StorageServerSummary(expected_server_summary),
-            true
+            true,
         )
         .unwrap()
     );
-}
-
-/// Sends a storage summary request and processes the response
-async fn get_storage_server_summary(
-    mock_client: &mut MockClient,
-    use_compression: bool,
-) -> Result<StorageServiceResponse, StorageServiceError> {
-    let data_request = DataRequest::GetStorageServerSummary;
-    utils::send_storage_request(mock_client, use_compression, data_request).await
 }

--- a/state-sync/storage-service/server/src/tests/transaction_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/transaction_outputs.rs
@@ -34,7 +34,7 @@ async fn test_get_transaction_outputs_with_proof() {
         );
 
         // Create the storage client and server
-        let (mut mock_client, mut service, _, _) = MockClient::new(Some(db_reader), None);
+        let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
         utils::update_storage_server_summary(&mut service, proof_version + 100, 10);
         tokio::spawn(service.start());
 
@@ -84,7 +84,7 @@ async fn test_get_transaction_outputs_with_proof_chunk_limit() {
     );
 
     // Create the storage client and server
-    let (mut mock_client, mut service, _, _) = MockClient::new(Some(db_reader), None);
+    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
     utils::update_storage_server_summary(&mut service, proof_version + chunk_size, 10);
     tokio::spawn(service.start());
 
@@ -114,7 +114,7 @@ async fn test_get_transaction_outputs_with_proof_chunk_limit() {
 #[tokio::test]
 async fn test_get_transaction_outputs_with_proof_invalid() {
     // Create the storage client and server
-    let (mut mock_client, service, _, _) = MockClient::new(None, None);
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, None);
     tokio::spawn(service.start());
 
     // Test invalid ranges
@@ -152,7 +152,7 @@ async fn test_get_transaction_outputs_with_proof_not_serviceable() {
         let proof_version = end_version;
 
         // Create the storage client and server (that cannot service the request)
-        let (mut mock_client, mut service, _, _) = MockClient::new(None, None);
+        let (mut mock_client, mut service, _, _, _) = MockClient::new(None, None);
         utils::update_storage_server_summary(&mut service, proof_version - 1, 10);
         tokio::spawn(service.start());
 
@@ -226,7 +226,7 @@ async fn get_outputs_with_proof_network_limit(network_limit_bytes: u64) {
         };
 
         // Create the storage client and server
-        let (mut mock_client, mut service, _, _) =
+        let (mut mock_client, mut service, _, _, _) =
             MockClient::new(Some(db_reader), Some(storage_config));
         utils::update_storage_server_summary(&mut service, proof_version, 10);
         tokio::spawn(service.start());

--- a/state-sync/storage-service/server/src/tests/transactions.rs
+++ b/state-sync/storage-service/server/src/tests/transactions.rs
@@ -37,7 +37,7 @@ async fn test_get_transactions_with_proof() {
             );
 
             // Create the storage client and server
-            let (mut mock_client, mut service, _, _) = MockClient::new(Some(db_reader), None);
+            let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
             utils::update_storage_server_summary(&mut service, proof_version, 10);
             tokio::spawn(service.start());
 
@@ -93,7 +93,7 @@ async fn test_get_transactions_with_chunk_limit() {
         );
 
         // Create the storage client and server
-        let (mut mock_client, mut service, _, _) = MockClient::new(Some(db_reader), None);
+        let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
         utils::update_storage_server_summary(&mut service, proof_version + chunk_size, 10);
         tokio::spawn(service.start());
 
@@ -122,7 +122,7 @@ async fn test_get_transactions_with_chunk_limit() {
 #[tokio::test]
 async fn test_get_transactions_with_proof_invalid() {
     // Create the storage client and server
-    let (mut mock_client, service, _, _) = MockClient::new(None, None);
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, None);
     tokio::spawn(service.start());
 
     // Test invalid ranges
@@ -163,7 +163,7 @@ async fn test_get_transactions_with_proof_not_serviceable() {
             let proof_version = end_version;
 
             // Create the storage client and server (that cannot service the request)
-            let (mut mock_client, mut service, _, _) = MockClient::new(None, None);
+            let (mut mock_client, mut service, _, _, _) = MockClient::new(None, None);
             utils::update_storage_server_summary(&mut service, proof_version - 1, 10);
             tokio::spawn(service.start());
 
@@ -229,7 +229,7 @@ async fn get_transactions_with_proof_network_limit(network_limit_bytes: u64) {
             };
 
             // Create the storage client and server
-            let (mut mock_client, mut service, _, _) =
+            let (mut mock_client, mut service, _, _, _) =
                 MockClient::new(Some(db_reader), Some(storage_config));
             utils::update_storage_server_summary(&mut service, proof_version + 1, 10);
             tokio::spawn(service.start());

--- a/state-sync/storage-service/server/src/tests/transactions_or_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/transactions_or_outputs.rs
@@ -61,7 +61,7 @@ async fn test_get_transactions_or_outputs_with_proof() {
                 &output_list_with_proof,
                 &transaction_list_with_proof,
             );
-            let (mut mock_client, mut service, _, _) =
+            let (mut mock_client, mut service, _, _, _) =
                 MockClient::new(Some(db_reader), Some(storage_config));
             utils::update_storage_server_summary(&mut service, proof_version + 100, 10);
             tokio::spawn(service.start());
@@ -137,7 +137,7 @@ async fn test_get_transactions_or_outputs_with_proof_chunk_limit() {
             &output_list_with_proof,
             &transaction_list_with_proof,
         );
-        let (mut mock_client, mut service, _, _) =
+        let (mut mock_client, mut service, _, _, _) =
             MockClient::new(Some(db_reader), Some(storage_config));
         utils::update_storage_server_summary(&mut service, proof_version + chunk_size, 10);
         tokio::spawn(service.start());
@@ -168,7 +168,7 @@ async fn test_get_transactions_or_outputs_with_proof_chunk_limit() {
 #[tokio::test]
 async fn test_get_transactions_or_outputs_with_proof_invalid() {
     // Create the storage client and server
-    let (mut mock_client, service, _, _) = MockClient::new(None, None);
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, None);
     tokio::spawn(service.start());
 
     // Test invalid ranges
@@ -208,7 +208,7 @@ async fn test_get_transactions_or_outputs_with_proof_not_serviceable() {
         let proof_version = end_version;
 
         // Create the storage client and server (that cannot service the request)
-        let (mut mock_client, mut service, _, _) = MockClient::new(None, None);
+        let (mut mock_client, mut service, _, _, _) = MockClient::new(None, None);
         utils::update_storage_server_summary(&mut service, proof_version - 1, 10);
         tokio::spawn(service.start());
 
@@ -311,7 +311,7 @@ async fn get_transactions_or_outputs_with_proof_network_limit(network_limit_byte
                 max_network_chunk_bytes: network_limit_bytes,
                 ..Default::default()
             };
-            let (mut mock_client, mut service, _, _) =
+            let (mut mock_client, mut service, _, _, _) =
                 MockClient::new(Some(db_reader), Some(storage_config));
             utils::update_storage_server_summary(&mut service, proof_version + 100, 10);
             tokio::spawn(service.start());

--- a/state-sync/storage-service/types/src/responses.rs
+++ b/state-sync/storage-service/types/src/responses.rs
@@ -537,6 +537,13 @@ impl DataSummary {
             .map(|li| (li.ledger_info().version() + OPTIMISTIC_FETCH_VERSION_DELTA) > known_version)
             .unwrap_or(false)
     }
+
+    /// Returns the version of the synced ledger info (if one exists)
+    pub fn get_synced_ledger_info_version(&self) -> Option<u64> {
+        self.synced_ledger_info
+            .as_ref()
+            .map(|ledger_info| ledger_info.ledger_info().version())
+    }
 }
 
 /// A struct representing a contiguous, non-empty data range (lowest to highest,


### PR DESCRIPTION
Note: 70% of this PR is just unit tests.

### Description
This PR updates state sync to notify the storage service on successful commits. This allows the storage service to immediately serve (and advertise) new data to peers (in contrast to the current approach where the storage service must first poll the DB to look for updates). From a few (informal) experiments, this cuts end-to-end latency by about ~75ms per hop.

The PR offers two commits:
1. Add commit notifications from state sync to the storage service. This is mostly boilerplate as we already have commit notification components that exist today (i.e., for mempool and the event subscription service). Thus, we simply add another notification component and the necessary wiring between state sync and the storage service.
2. Extend the unit (and integration) tests to verify the new functionality.

Notes:
1. We keep the existing polling functionality in the storage server but drastically reduce the frequency (from every `50 ms` to `500 ms`). This is mainly to provide a fallback in case there is a bug and/or unknown race condition in the code. We can eventually remove this (if we wish), but it feels more robust to keep it in place for now.
2. We limit the queue depths (from state sync to the storage service, and from the storage service to the optimistic fetch handler) to `1`. This is because it doesn't make sense for the storage service to execute for every notification message (because it reads the latest version in the DB). Thus, if there are `X` pending notifications, the first one will refresh using the latest DB state and the next `X-1` will execute with an unchanged DB (thus, becoming a no-op and wasting the CPU).

### Test Plan
New and existing test infrastructure.