### PR TITLE
[CLI][Easy] fix derivation path serialization

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -231,6 +231,7 @@ pub struct ProfileConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub faucet_url: Option<String>,
     /// Derivation path index of the account on ledger
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub derivation_path: Option<String>,
 }
 


### PR DESCRIPTION
### Description
Need to skip serialization if derivation path is None

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Previously
```
  default:
    public_key: "0xa49209b1817b62bf7909f6cba036667d555fb23212b3846030377f25c3c66577"
    account: 6efb99725b135411c7ba442e01cd7ac53a62f341339e74420455f2908b77255a
    rest_url: "https://fullnode.devnet.aptoslabs.com"
    faucet_url: "https://faucet.devnet.aptoslabs.com"
    derivation_path: ~
```

now
```
default:
    private_key: "0x489c5505a09640e5816fafff434ba6f19c6025352f8a4a07c195f2e9decd697e"
    public_key: "0x85b6e6dcdaa6551383d014bb94faac084e8412625f1c134f14ca23075761ec64"
    account: e6fc96a9464ef0a85fd7146fdbae0a48c5930e44d5552ebca90ad0d0a2c7636c
    rest_url: "https://fullnode.devnet.aptoslabs.com"
    faucet_url: "https://faucet.devnet.aptoslabs.com"
```
