### PR TITLE
[forge] Add operator create command

### DIFF
--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -89,6 +89,7 @@ jobs:
   # to be land blocking for any PR on the aptos repo. This is why we run those tests
   # separate from test-sdk-confirm-client-generated-publish.
   run-indexer-tests:
+    needs: [permission-check]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3

--- a/testsuite/forge-cli/src/commands/mod.rs
+++ b/testsuite/forge-cli/src/commands/mod.rs
@@ -1,0 +1,3 @@
+// Copyright © Aptos Foundation
+
+pub mod operator;

--- a/testsuite/forge-cli/src/commands/operator.rs
+++ b/testsuite/forge-cli/src/commands/operator.rs
@@ -1,0 +1,114 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use aptos_forge::{
+    cleanup_cluster_with_management, install_testnet_resources, set_stateful_set_image_tag,
+    uninstall_testnet_resources,
+};
+use clap::{Parser, Subcommand};
+
+#[derive(Subcommand, Debug)]
+pub enum OperatorCommand {
+    /// Set the image tag for a node in the cluster
+    SetNodeImageTag(SetNodeImageTag),
+    /// Clean up an existing cluster
+    CleanUp(CleanUp),
+    /// Resize an existing cluster
+    Resize(Resize),
+}
+
+impl OperatorCommand {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            OperatorCommand::SetNodeImageTag(set_stateful_set_image_tag_config) => {
+                set_stateful_set_image_tag(
+                    set_stateful_set_image_tag_config.stateful_set_name,
+                    set_stateful_set_image_tag_config.container_name,
+                    set_stateful_set_image_tag_config.image_tag,
+                    set_stateful_set_image_tag_config.namespace,
+                )
+                .await?;
+            },
+            OperatorCommand::CleanUp(cleanup) => {
+                if let Some(namespace) = cleanup.namespace {
+                    uninstall_testnet_resources(namespace).await?;
+                } else {
+                    cleanup_cluster_with_management().await?;
+                }
+            },
+            OperatorCommand::Resize(resize) => {
+                install_testnet_resources(
+                    resize.namespace,
+                    resize.num_validators,
+                    resize.num_fullnodes,
+                    resize.validator_image_tag,
+                    resize.testnet_image_tag,
+                    resize.move_modules_dir,
+                    !resize.connect_directly,
+                    resize.enable_haproxy,
+                    None,
+                    None,
+                )
+                .await?;
+            },
+        }
+        Ok(())
+    }
+}
+
+#[derive(Parser, Debug)]
+pub struct SetNodeImageTag {
+    #[clap(long, help = "The name of the node StatefulSet to update")]
+    stateful_set_name: String,
+    #[clap(long, help = "The name of the container to update")]
+    container_name: String,
+    #[clap(long, help = "The docker image tag to use for the node")]
+    image_tag: String,
+    #[clap(long, help = "The kubernetes namespace to clean up")]
+    namespace: String,
+}
+
+#[derive(Parser, Debug)]
+pub struct CleanUp {
+    #[clap(
+        long,
+        help = "The kubernetes namespace to clean up. If unset, attemps to cleanup all by using forge-management configmaps"
+    )]
+    namespace: Option<String>,
+}
+
+#[derive(Parser, Debug)]
+pub struct Resize {
+    #[clap(long, help = "The kubernetes namespace to resize")]
+    namespace: String,
+    #[clap(long, default_value_t = 30)]
+    num_validators: usize,
+    #[clap(long, default_value_t = 1)]
+    num_fullnodes: usize,
+    #[clap(
+        long,
+        help = "Override the image tag used for validators",
+        default_value = "devnet"
+    )]
+    validator_image_tag: String,
+    #[clap(
+        long,
+        help = "Override the image tag used for testnet-specific components",
+        default_value = "devnet"
+    )]
+    testnet_image_tag: String,
+    #[clap(
+        long,
+        help = "Path to flattened directory containing compiled Move modules"
+    )]
+    move_modules_dir: Option<String>,
+    #[clap(
+        long,
+        help = "If set, dont use kubectl port forward to access the cluster"
+    )]
+    connect_directly: bool,
+    #[clap(long, help = "If set, enables HAProxy for each of the validators")]
+    enable_haproxy: bool,
+}

--- a/testsuite/forge-cli/src/lib.rs
+++ b/testsuite/forge-cli/src/lib.rs
@@ -1,0 +1,3 @@
+// Copyright © Aptos Foundation
+
+pub mod commands;

--- a/testsuite/forge-cli/src/lib.rs
+++ b/testsuite/forge-cli/src/lib.rs
@@ -1,3 +1,4 @@
 // Copyright © Aptos Foundation
 
 pub mod commands;
+pub mod utils;

--- a/testsuite/forge-cli/src/utils.rs
+++ b/testsuite/forge-cli/src/utils.rs
@@ -1,0 +1,48 @@
+// Copyright © Aptos Foundation
+
+use anyhow::{format_err, Result};
+use rand::{seq::SliceRandom, Rng, rngs::ThreadRng};
+
+/// Split out the hard to test portion from the testable portion
+pub fn generate_random_namespace() -> Result<String> {
+    let mut rng: ThreadRng = rand::thread_rng();
+    // Lets pick some four letter words ;)
+    let words = random_word::all_len(4)
+        .ok_or_else(|| {
+            format_err!(
+                "Failed to get namespace, rerun with --namespace <namespace>"
+            )
+        })?
+        .to_vec()
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<String>>();
+    random_namespace(words, &mut rng)
+}
+
+/// Make an easy to remember random namespace for your testnet
+pub fn random_namespace<R: Rng>(dictionary: Vec<String>, rng: &mut R) -> Result<String> {
+    // Pick four random words
+    let random_words = dictionary
+        .choose_multiple(rng, 4)
+        .cloned()
+        .collect::<Vec<String>>();
+    Ok(format!("forge-{}", random_words.join("-")))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_random_namespace() {
+        let mut rng = rand::rngs::mock::StepRng::new(100, 1);
+        let words = ["apple", "banana", "carrot", "durian", "eggplant", "fig"]
+            .to_vec()
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>();
+        let namespace = random_namespace(words, &mut rng).unwrap();
+        assert_eq!(namespace, "forge-durian-eggplant-fig-apple");
+    }
+}


### PR DESCRIPTION
Adds a command to create a forge network without having to run a test first

Test Plan: running command locally to create testnet

```
RUST_BACKTRACE=1 cargo run -p aptos-forge-cli -- operator create
```