### PR TITLE
[mempool] metrics: add latency to block proposal

### DIFF
--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -601,7 +601,7 @@ impl TransactionStore {
                             last_timeline_id[i] = timeline_id;
                         }
                         let bucket = self.timeline_index.get_bucket(txn.ranking_score);
-                        Mempool::log_txn_commit_latency(
+                        Mempool::log_txn_latency(
                             txn.insertion_info,
                             bucket,
                             BROADCAST_BATCHED_LABEL,

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -94,9 +94,11 @@ pub const SUBMITTED_BY_CLIENT_LABEL: &str = "client";
 pub const SUBMITTED_BY_DOWNSTREAM_LABEL: &str = "downstream";
 pub const SUBMITTED_BY_PEER_VALIDATOR_LABEL: &str = "peer_validator";
 
-// Histogram buckets that make more sense at larger timescales than DEFAULT_BUCKETS
-const LARGER_LATENCY_BUCKETS: &[f64; 11] = &[
-    0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0, 40.0, 80.0, 160.0, 320.0,
+// Histogram buckets that expand DEFAULT_BUCKETS with larger timescales
+// and some more granularity between 100-250 ms
+const MEMPOOL_LATENCY_BUCKETS: &[f64] = &[
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.125, 0.15, 0.2, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0,
+    100.0, 250.0, 500.0,
 ];
 
 // Histogram buckets for tracking ranking score (see below test for the formula)
@@ -192,12 +194,13 @@ pub fn core_mempool_txn_commit_latency(
 /// Counter tracking latency of txns reaching various stages in committing
 /// (e.g. time from txn entering core mempool to being pulled in consensus block)
 static CORE_MEMPOOL_TXN_COMMIT_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
-    let histogram_opts = histogram_opts!(
+    register_histogram_vec!(
         "aptos_core_mempool_txn_commit_latency",
         "Latency of txn reaching various stages in core mempool after insertion",
-        LARGER_LATENCY_BUCKETS.to_vec()
-    );
-    register_histogram_vec!(histogram_opts, &["stage", "submitted_by", "bucket"]).unwrap()
+        &["stage", "submitted_by", "bucket"],
+        MEMPOOL_LATENCY_BUCKETS.to_vec()
+    )
+    .unwrap()
 });
 
 pub fn core_mempool_txn_ranking_score(

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -23,6 +23,7 @@ pub const SIZE_BYTES_LABEL: &str = "size_bytes";
 
 // Core mempool stages labels
 pub const COMMIT_ACCEPTED_LABEL: &str = "commit_accepted";
+pub const COMMIT_ACCEPTED_BLOCK_LABEL: &str = "commit_accepted_block";
 pub const COMMIT_REJECTED_LABEL: &str = "commit_rejected";
 pub const COMMIT_REJECTED_DUPLICATE_LABEL: &str = "commit_rejected_duplicate";
 pub const COMMIT_IGNORED_LABEL: &str = "commit_ignored";

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -545,13 +545,19 @@ pub(crate) fn process_committed_transactions(
     block_timestamp_usecs: u64,
 ) {
     let mut pool = mempool.lock();
+    let block_timestamp = Duration::from_micros(block_timestamp_usecs);
 
     for transaction in transactions {
+        pool.log_commit_transaction(
+            &transaction.sender,
+            transaction.sequence_number,
+            block_timestamp,
+        );
         pool.commit_transaction(&transaction.sender, transaction.sequence_number);
     }
 
     if block_timestamp_usecs > 0 {
-        pool.gc_by_expiration_time(Duration::from_micros(block_timestamp_usecs));
+        pool.gc_by_expiration_time(block_timestamp);
     }
 }
 


### PR DESCRIPTION
### Description

Add insertion-to-block-timestamp latency. This helps understand the time it takes to get a txn into Consensus.

Also added more buckets to mempool latency. This helps make the percentile charts more accurate and meaningful.

### Test Plan

Added to Mempool dashboard and ran forge.