### PR TITLE
[Forge] Add network emulation to PFN forge jobs.

### DIFF
--- a/.github/workflows/forge-specialized.yaml
+++ b/.github/workflows/forge-specialized.yaml
@@ -113,6 +113,32 @@ jobs:
 
   ### Public fullnode tests
 
+  # Measures PFN latencies with a constant TPS
+  run-forge-pfn-const-tps:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-pfn-const-tps-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
+      FORGE_TEST_SUITE: pfn_const_tps
+      POST_TO_SLACK: true
+
+  # Measures PFN latencies with a constant TPS (with network chaos)
+  run-forge-pfn-const-tps-network-chaos:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-pfn-const-tps-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
+      FORGE_TEST_SUITE: pfn_const_tps_with_network_chaos
+      POST_TO_SLACK: true
+
   # Measures max PFN throughput and latencies under load
   run-forge-pfn-performance:
     if: ${{ github.event_name != 'pull_request' }}
@@ -126,17 +152,17 @@ jobs:
       FORGE_TEST_SUITE: pfn_performance
       POST_TO_SLACK: true
 
-  # Measures PFN latencies with a constant TPS
-  run-forge-pfn-const-tps:
+  # Measures max PFN throughput and latencies under load (with network chaos)
+  run-forge-pfn-performance-network-chaos:
     if: ${{ github.event_name != 'pull_request' }}
     needs: determine-test-metadata
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-pfn-const-tps-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-pfn-performance-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
-      FORGE_TEST_SUITE: pfn_const_tps
+      FORGE_TEST_SUITE: pfn_performance_with_network_chaos
       POST_TO_SLACK: true
 
   ### State sync tests

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -550,9 +550,7 @@ fn single_test_suite(test_name: &str, duration: Duration) -> Result<ForgeConfig>
 
 fn wrap_with_realistic_env<T: NetworkTest + 'static>(test: T) -> CompositeNetworkTest {
     CompositeNetworkTest::new_with_two_wrappers(
-        MultiRegionNetworkEmulationTest {
-            override_config: None,
-        },
+        MultiRegionNetworkEmulationTest::default(),
         CpuChaosTest {
             override_config: None,
         },
@@ -1511,9 +1509,7 @@ fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
         // something to potentially improve upon.
         // So having VFNs for all validators
         .with_initial_fullnode_count(12)
-        .add_network_test(MultiRegionNetworkEmulationTest {
-            override_config: None,
-        })
+        .add_network_test(MultiRegionNetworkEmulationTest::default())
         .with_emit_job(EmitJobRequest::default().mode(EmitJobMode::MaxLoad {
             mempool_backlog: 150000,
         }))
@@ -1787,9 +1783,7 @@ fn mainnet_like_simulation_test() -> ForgeConfig {
                 .txn_expiration_time_secs(5 * 60),
         )
         .add_network_test(CompositeNetworkTest::new(
-            MultiRegionNetworkEmulationTest {
-                override_config: None,
-            },
+            MultiRegionNetworkEmulationTest::default(),
             CpuChaosTest {
                 override_config: None,
             },

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -541,8 +541,10 @@ fn single_test_suite(test_name: &str, duration: Duration) -> Result<ForgeConfig>
         "quorum_store_reconfig_enable_test" => quorum_store_reconfig_enable_test(),
         "mainnet_like_simulation_test" => mainnet_like_simulation_test(),
         "multiregion_benchmark_test" => multiregion_benchmark_test(),
-        "pfn_const_tps" => pfn_const_tps(duration),
-        "pfn_performance" => pfn_performance(duration),
+        "pfn_const_tps" => pfn_const_tps(duration, false),
+        "pfn_const_tps_with_network_chaos" => pfn_const_tps(duration, true),
+        "pfn_performance" => pfn_performance(duration, false),
+        "pfn_performance_with_network_chaos" => pfn_performance(duration, true),
         _ => return Err(format_err!("Invalid --suite given: {:?}", test_name)),
     };
     Ok(single_test_suite)
@@ -1848,13 +1850,14 @@ fn multiregion_benchmark_test() -> ForgeConfig {
 
 /// This test runs a constant-TPS benchmark where the network includes
 /// PFNs, and the transactions are submitted to the PFNs. This is useful
-/// for measuring latencies when the system is not saturated.
-fn pfn_const_tps(duration: Duration) -> ForgeConfig {
+/// for measuring latencies when the system is not saturated. If
+/// `add_network_emulation` is true, network chaos is enabled on the entire swarm.
+fn pfn_const_tps(duration: Duration, add_network_emulation: bool) -> ForgeConfig {
     ForgeConfig::default()
         .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
         .with_initial_fullnode_count(10)
-        .with_emit_job(EmitJobRequest::default().mode(EmitJobMode::ConstTps { tps: 500 }))
-        .add_network_test(PFNPerformance)
+        .with_emit_job(EmitJobRequest::default().mode(EmitJobMode::ConstTps { tps: 100 }))
+        .add_network_test(PFNPerformance::new(add_network_emulation))
         .with_genesis_helm_config_fn(Arc::new(|helm_values| {
             // Require frequent epoch changes
             helm_values["chain"]["epoch_duration_secs"] = 300.into();
@@ -1875,12 +1878,13 @@ fn pfn_const_tps(duration: Duration) -> ForgeConfig {
 
 /// This test runs a performance benchmark where the network includes
 /// PFNs, and the transactions are submitted to the PFNs. This is useful
-/// for measuring maximum throughput and latencies.
-fn pfn_performance(duration: Duration) -> ForgeConfig {
+/// for measuring maximum throughput and latencies. If `add_network_emulation`
+/// is true, network chaos is enabled on the entire swarm.
+fn pfn_performance(duration: Duration, add_network_emulation: bool) -> ForgeConfig {
     ForgeConfig::default()
         .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
         .with_initial_fullnode_count(10)
-        .add_network_test(PFNPerformance)
+        .add_network_test(PFNPerformance::new(add_network_emulation))
         .with_genesis_helm_config_fn(Arc::new(|helm_values| {
             // Require frequent epoch changes
             helm_values["chain"]["epoch_duration_secs"] = 300.into();

--- a/testsuite/testcases/src/modifiers.rs
+++ b/testsuite/testcases/src/modifiers.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{multi_region_network_test::chunk_validators, LoadDestination, NetworkLoadTest};
+use crate::{multi_region_network_test::chunk_peers, LoadDestination, NetworkLoadTest};
 use aptos_forge::{
     GroupCpuStress, NetworkContext, NetworkTest, Swarm, SwarmChaos, SwarmCpuStress, SwarmExt, Test,
 };
@@ -237,7 +237,7 @@ fn create_cpu_stress_template(
     all_validators: Vec<PeerId>,
     config: &CpuChaosConfig,
 ) -> SwarmCpuStress {
-    let validator_chunks = chunk_validators(all_validators, config.num_groups);
+    let validator_chunks = chunk_peers(all_validators, config.num_groups);
 
     let group_cpu_stresses = validator_chunks
         .into_iter()

--- a/testsuite/testcases/src/multi_region_network_test.rs
+++ b/testsuite/testcases/src/multi_region_network_test.rs
@@ -240,7 +240,9 @@ impl Test for MultiRegionNetworkEmulationTest {
     }
 }
 
-fn create_multi_region_swarm_network_chaos(
+/// Creates a SwarmNetEm to be injected via chaos. Network emulation
+/// is added to all the given peers using the specified config.
+pub fn create_multi_region_swarm_network_chaos(
     all_peers: Vec<PeerId>,
     network_emulation_config: Option<MultiRegionNetworkEmulationConfig>,
 ) -> SwarmNetEm {

--- a/testsuite/testcases/src/multi_region_network_test.rs
+++ b/testsuite/testcases/src/multi_region_network_test.rs
@@ -34,38 +34,40 @@ fn get_link_stats_table() -> BTreeMap<String, BTreeMap<String, (u64, f64)>> {
     stats_table
 }
 
-pub(crate) fn chunk_validators(validators: Vec<PeerId>, num_groups: usize) -> Vec<Vec<PeerId>> {
-    let approx_chunk_size = validators.len() / num_groups;
+/// Chunks the given set of peers into the number of specified groups
+pub(crate) fn chunk_peers(peers: Vec<PeerId>, num_groups: usize) -> Vec<Vec<PeerId>> {
+    // Chunk the peers into exact groups
+    let approx_chunk_size = peers.len() / num_groups;
+    let chunks = peers.chunks_exact(approx_chunk_size);
+    let mut peer_chunks: Vec<Vec<PeerId>> = chunks.clone().map(|chunk| chunk.to_vec()).collect();
 
-    let chunks = validators.chunks_exact(approx_chunk_size);
-
-    let mut validator_chunks: Vec<Vec<PeerId>> =
-        chunks.clone().map(|chunk| chunk.to_vec()).collect();
-
-    // Get any remaining validators and add them to the first group
-    let remaining_validators: Vec<PeerId> = chunks
+    // Get any remaining peers and add them to the first group
+    let remaining_peers: Vec<PeerId> = chunks
         .remainder()
         .iter()
-        // If `approx_validators_per_region` is 1, then it is possible we will have more regions than desired, so the
-        // remaining validators will be in the first group.
+        // If `approx_peers_per_region` is 1, then it is possible we will have more regions than
+        // desired, so the remaining peers will be in the first group.
         .chain(chunks.skip(num_groups).flatten())
         .cloned()
         .collect();
-    if !remaining_validators.is_empty() {
-        validator_chunks[0].append(remaining_validators.to_vec().as_mut());
+    if !remaining_peers.is_empty() {
+        peer_chunks[0].append(remaining_peers.to_vec().as_mut());
     }
 
-    validator_chunks
+    peer_chunks
 }
 
-/// Creates a table of validators grouped by region. The validators divided into N groups, where N is the number of regions
-/// provided in the link stats table. Any remaining validators are added to the first group.
+/// Creates a table of peers grouped by region. The peers are divided into N groups, where N is the
+/// number of regions provided in the link stats table. Any remaining peers are added to the first
+/// group.
 fn create_link_stats_table_with_peer_groups(
-    validators: Vec<PeerId>,
+    peers: Vec<PeerId>,
     link_stats_table: &LinkStatsTable,
 ) -> LinkStatsTableWithPeerGroups {
-    assert!(validators.len() >= link_stats_table.len());
+    // Verify that we have enough peers to simulate the link stats table
+    assert!(peers.len() >= link_stats_table.len());
 
+    // Verify that we have the correct number of regions to simulate the link stats table
     let number_of_regions = link_stats_table.len();
     assert!(
         number_of_regions >= 2,
@@ -76,20 +78,20 @@ fn create_link_stats_table_with_peer_groups(
         "ChaosMesh only supports simulating up to 4 regions."
     );
 
-    let validator_chunks = chunk_validators(validators, number_of_regions);
-
-    let validator_groups = validator_chunks
+    // Create the link stats table with peer groups
+    let peer_chunks = chunk_peers(peers, number_of_regions);
+    let peer_groups = peer_chunks
         .into_iter()
         .zip(link_stats_table.iter())
         .map(|(chunk, (from_region, stats))| (from_region.clone(), chunk, stats.clone()))
         .collect();
 
-    validator_groups
+    peer_groups
 }
 
 // A map of "source" regions to a map of "destination" region to (bandwidth, latency)
 type LinkStatsTable = BTreeMap<String, BTreeMap<String, (u64, f64)>>;
-// A map of "source" regions to a tuple of (list of validators, map of "destination" region to (bandwidth, latency))
+// A map of "source" regions to a tuple of (list of peers, map of "destination" region to (bandwidth, latency))
 type LinkStatsTableWithPeerGroups = Vec<(String, Vec<PeerId>, BTreeMap<String, (u64, f64)>)>;
 
 #[derive(Clone)]
@@ -113,8 +115,8 @@ impl Default for InterRegionNetEmConfig {
 
 impl InterRegionNetEmConfig {
     // Creates GroupNetEm for inter-region network chaos
-    fn build(&self, validator_groups: &LinkStatsTableWithPeerGroups) -> Vec<GroupNetEm> {
-        let group_netems: Vec<GroupNetEm> = validator_groups
+    fn build(&self, peer_groups: &LinkStatsTableWithPeerGroups) -> Vec<GroupNetEm> {
+        let group_netems: Vec<GroupNetEm> = peer_groups
             .iter()
             .combinations(2)
             .map(|comb| {
@@ -167,8 +169,8 @@ impl Default for IntraRegionNetEmConfig {
 }
 
 impl IntraRegionNetEmConfig {
-    fn build(&self, validator_groups: LinkStatsTableWithPeerGroups) -> Vec<GroupNetEm> {
-        let group_netems: Vec<GroupNetEm> = validator_groups
+    fn build(&self, peer_groups: LinkStatsTableWithPeerGroups) -> Vec<GroupNetEm> {
+        let group_netems: Vec<GroupNetEm> = peer_groups
             .iter()
             .map(|(region, chunk, _)| {
                 let netem = GroupNetEm {
@@ -210,17 +212,25 @@ impl Default for MultiRegionNetworkEmulationConfig {
 }
 
 /// A test to emulate network conditions for a multi-region setup.
+#[derive(Default)]
 pub struct MultiRegionNetworkEmulationTest {
-    pub override_config: Option<MultiRegionNetworkEmulationConfig>,
+    network_emulation_config: Option<MultiRegionNetworkEmulationConfig>,
 }
 
 impl MultiRegionNetworkEmulationTest {
+    pub fn new_with_config(network_emulation_config: MultiRegionNetworkEmulationConfig) -> Self {
+        Self {
+            network_emulation_config: Some(network_emulation_config),
+        }
+    }
+
+    /// Creates a new SwarmNetEm to be injected via chaos. Note: network
+    /// emulation is only done for the validators in the swarm (and not
+    /// the fullnodes).
     fn create_netem_chaos(&self, swarm: &mut dyn Swarm) -> SwarmNetEm {
         let all_validators = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
-
-        let config = self.override_config.clone().unwrap_or_default();
-
-        create_multi_region_swarm_network_chaos(all_validators, &config)
+        let network_emulation_config = self.network_emulation_config.clone();
+        create_multi_region_swarm_network_chaos(all_validators, network_emulation_config)
     }
 }
 
@@ -231,17 +241,26 @@ impl Test for MultiRegionNetworkEmulationTest {
 }
 
 fn create_multi_region_swarm_network_chaos(
-    all_validators: Vec<PeerId>,
-    config: &MultiRegionNetworkEmulationConfig,
+    all_peers: Vec<PeerId>,
+    network_emulation_config: Option<MultiRegionNetworkEmulationConfig>,
 ) -> SwarmNetEm {
-    let validator_groups =
-        create_link_stats_table_with_peer_groups(all_validators, &config.link_stats_table);
+    // Determine the network emulation config to use
+    let network_emulation_config = network_emulation_config.unwrap_or_default();
 
-    let inter_region_netem = config.inter_region_config.build(&validator_groups);
-    let intra_region_netem = config
+    // Create the link stats table for the peer groups
+    let peer_groups = create_link_stats_table_with_peer_groups(
+        all_peers,
+        &network_emulation_config.link_stats_table,
+    );
+
+    // Create the inter and intra network emulation configs
+    let inter_region_netem = network_emulation_config
+        .inter_region_config
+        .build(&peer_groups);
+    let intra_region_netem = network_emulation_config
         .intra_region_config
         .as_ref()
-        .map(|config| config.build(validator_groups))
+        .map(|config| config.build(peer_groups))
         .unwrap_or_default();
 
     SwarmNetEm {
@@ -278,34 +297,26 @@ mod tests {
     fn test_create_multi_region_swarm_network_chaos() {
         aptos_logger::Logger::new().init();
 
-        let config = MultiRegionNetworkEmulationConfig::default();
+        // Create a config with 8 peers and multiple regions
+        let all_peers = (0..8).map(|_| PeerId::random()).collect();
+        let netem = create_multi_region_swarm_network_chaos(all_peers, None);
 
-        let all_validators = (0..8).map(|_| PeerId::random()).collect();
-        let netem = create_multi_region_swarm_network_chaos(all_validators, &config);
-
+        // Verify the number of group netems
         assert_eq!(netem.group_netems.len(), 10);
 
-        let all_validators: Vec<PeerId> = (0..10).map(|_| PeerId::random()).collect();
-        let netem = create_multi_region_swarm_network_chaos(all_validators.clone(), &config);
+        // Create a config with 10 peers and multiple regions
+        let all_peers: Vec<PeerId> = (0..10).map(|_| PeerId::random()).collect();
+        let netem = create_multi_region_swarm_network_chaos(all_peers.clone(), None);
 
+        // Verify the resulting group netems
         assert_eq!(netem.group_netems.len(), 10);
         assert_eq!(netem.group_netems[0].source_nodes.len(), 4);
         assert_eq!(netem.group_netems[0].target_nodes.len(), 4);
         assert_eq!(netem.group_netems[0], GroupNetEm {
             name: "aws--ap-northeast-1-self-netem".to_owned(),
             rate_in_mbps: 10000,
-            source_nodes: vec![
-                all_validators[0],
-                all_validators[1],
-                all_validators[8],
-                all_validators[9],
-            ],
-            target_nodes: vec![
-                all_validators[0],
-                all_validators[1],
-                all_validators[8],
-                all_validators[9],
-            ],
+            source_nodes: vec![all_peers[0], all_peers[1], all_peers[8], all_peers[9],],
+            target_nodes: vec![all_peers[0], all_peers[1], all_peers[8], all_peers[9],],
             delay_latency_ms: 50,
             delay_jitter_ms: 5,
             delay_correlation_percentage: 50,


### PR DESCRIPTION
### Description
This PR offers the following modifications (each in their own commit):
1. Small clean ups to the `MultiRegionNetworkEmulationTest` and network emulation helpers (so that it can be reused and support network chaos for all node types).
2. Extend the existing PFN forge tests to support network chaos, and add two new PFN forge tests: (i) PFNs with max load and network chaos; and (ii) PFNs with constant TPS and network chaos.
3. Add the new PFN forge tests to the existing Github Actions workflow.

### Test Plan
Existing test infrastructure.