### PR TITLE
[TS SDK] Set `WITH_CREDENTIALS`  to false on Indexer requests

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 ## Unreleased
 
 - Support `contentType` in request so custom headers would not override required headers
+- Set `WITH_CREDENTIALS` to false on Indexer requests
 
 ## 1.13.0 (2023-07-05)
 

--- a/ecosystem/typescript/sdk/src/providers/indexer.ts
+++ b/ecosystem/typescript/sdk/src/providers/indexer.ts
@@ -102,7 +102,7 @@ export class IndexerClient {
     const response = await post<GraphqlQuery, any>({
       url: this.endpoint,
       body: graphqlQuery,
-      overrides: { ...this.config },
+      overrides: { WITH_CREDENTIALS: false, ...this.config },
     });
     if (response.data.errors) {
       throw new ApiError(


### PR DESCRIPTION
### Description
Indexer queries fail on browser when `WITH_CREDENTIALS` is set to true
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
