### PR TITLE
[release] Add credentials to cut release branch workflow

### DIFF
--- a/.github/workflows/cut-release-branch.yaml
+++ b/.github/workflows/cut-release-branch.yaml
@@ -32,11 +32,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          token: ${{ secrets.CUT_RELEASE_BRANCH_CREDENTIALS }}
+          fetch-depth: 0
       - name: Cut Release Branch
         run: |
           set -ex
 
           BRANCH_NAME="${{ inputs.BRANCH_PREFIX }}${{ inputs.NEW_VERSION }}${{ inputs.BRANCH_SUFFIX }}"
+          git branch
 
           git checkout ${{ inputs.GIT_HASH }}
           git checkout -b "$BRANCH_NAME"


### PR DESCRIPTION
Add credentials to allow pushing to aptos core

Test Plan: run workflow from branch

```
git add . && git commit --amend --no-edit && git push -f && gh workflow run --ref perry-fix-cut-branch -F NEW_VERSION=a.b cut-release-branch.yaml -F GIT_HASH=main
```

https://github.com/aptos-labs/aptos-core/actions/runs/5480751652/jobs/9984278547
