### PR TITLE
[Forge] Fix name collision and add CPU chaos to PFN jobs.

### DIFF
--- a/.github/workflows/forge-specialized.yaml
+++ b/.github/workflows/forge-specialized.yaml
@@ -134,7 +134,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-pfn-const-tps-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-pfn-const-tps-with-network-chaos-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
       FORGE_TEST_SUITE: pfn_const_tps_with_network_chaos
       POST_TO_SLACK: true
@@ -160,7 +160,7 @@ jobs:
     secrets: inherit
     with:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-pfn-performance-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-pfn-performance-with-network-chaos-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
       FORGE_TEST_SUITE: pfn_performance_with_network_chaos
       POST_TO_SLACK: true

--- a/.github/workflows/forge-specialized.yaml
+++ b/.github/workflows/forge-specialized.yaml
@@ -110,7 +110,6 @@ jobs:
           fi
           echo "IMAGE_TAG: [${IMAGE_TAG}](https://github.com/${{ github.repository }}/commit/${IMAGE_TAG})" >> $GITHUB_STEP_SUMMARY
 
-
   ### Public fullnode tests
 
   # Measures PFN latencies with a constant TPS
@@ -139,6 +138,19 @@ jobs:
       FORGE_TEST_SUITE: pfn_const_tps_with_network_chaos
       POST_TO_SLACK: true
 
+  # Measures PFN latencies with a constant TPS (with a realistic environment)
+  run-forge-pfn-const-tps-realistic-env:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-pfn-const-tps-with-realistic-env-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
+      FORGE_TEST_SUITE: pfn_const_tps_with_realistic_env
+      POST_TO_SLACK: true
+
   # Measures max PFN throughput and latencies under load
   run-forge-pfn-performance:
     if: ${{ github.event_name != 'pull_request' }}
@@ -163,6 +175,19 @@ jobs:
       FORGE_NAMESPACE: forge-pfn-performance-with-network-chaos-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
       FORGE_TEST_SUITE: pfn_performance_with_network_chaos
+      POST_TO_SLACK: true
+
+  # Measures max PFN throughput and latencies under load (with a realistic environment)
+  run-forge-pfn-performance-realistic-env:
+      if: ${{ github.event_name != 'pull_request' }}
+      needs: determine-test-metadata
+      uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+      secrets: inherit
+      with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-pfn-performance-with-realistic-env-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
+      FORGE_TEST_SUITE: pfn_performance_with_realistic_env
       POST_TO_SLACK: true
 
   ### State sync tests

--- a/testsuite/testcases/src/modifiers.rs
+++ b/testsuite/testcases/src/modifiers.rs
@@ -213,17 +213,23 @@ impl Default for CpuChaosConfig {
     }
 }
 
+#[derive(Default)]
 pub struct CpuChaosTest {
-    pub override_config: Option<CpuChaosConfig>,
+    cpu_chaos_config: CpuChaosConfig,
 }
 
 impl CpuChaosTest {
+    pub fn new_with_config(cpu_chaos_config: CpuChaosConfig) -> Self {
+        Self { cpu_chaos_config }
+    }
+
+    /// Creates a new SwarmCpuStress to be injected via chaos. Note:
+    /// CPU chaos is only done for the validators in the swarm (and
+    /// not the fullnodes).
     fn create_cpu_chaos(&self, swarm: &mut dyn Swarm) -> SwarmCpuStress {
         let all_validators = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
-
-        let config = self.override_config.as_ref().cloned().unwrap_or_default();
-
-        create_cpu_stress_template(all_validators, &config)
+        let cpu_chaos_config = self.cpu_chaos_config.clone();
+        create_swarm_cpu_stress(all_validators, Some(cpu_chaos_config))
     }
 }
 
@@ -233,22 +239,28 @@ impl Test for CpuChaosTest {
     }
 }
 
-fn create_cpu_stress_template(
-    all_validators: Vec<PeerId>,
-    config: &CpuChaosConfig,
+/// Creates a SwarmCpuStress to be injected via chaos. CPU chaos
+/// is added to all the given peers using the specified config.
+pub fn create_swarm_cpu_stress(
+    all_peers: Vec<PeerId>,
+    cpu_chaos_config: Option<CpuChaosConfig>,
 ) -> SwarmCpuStress {
-    let validator_chunks = chunk_peers(all_validators, config.num_groups);
+    // Determine the CPU chaos config to use
+    let cpu_chaos_config = cpu_chaos_config.unwrap_or_default();
 
-    let group_cpu_stresses = validator_chunks
+    // Chunk the peers into groups and create a GroupCpuStress for each group
+    let peer_chunks = chunk_peers(all_peers, cpu_chaos_config.num_groups);
+    let group_cpu_stresses = peer_chunks
         .into_iter()
         .enumerate()
         .map(|(idx, chunk)| GroupCpuStress {
             name: format!("group-{}-cpu-stress", idx),
             target_nodes: chunk,
-            num_workers: (config.num_groups - idx) as u64,
-            load_per_worker: config.load_per_worker,
+            num_workers: (cpu_chaos_config.num_groups - idx) as u64,
+            load_per_worker: cpu_chaos_config.load_per_worker,
         })
         .collect();
+
     SwarmCpuStress { group_cpu_stresses }
 }
 

--- a/testsuite/testcases/src/multi_region_network_test.rs
+++ b/testsuite/testcases/src/multi_region_network_test.rs
@@ -214,13 +214,13 @@ impl Default for MultiRegionNetworkEmulationConfig {
 /// A test to emulate network conditions for a multi-region setup.
 #[derive(Default)]
 pub struct MultiRegionNetworkEmulationTest {
-    network_emulation_config: Option<MultiRegionNetworkEmulationConfig>,
+    network_emulation_config: MultiRegionNetworkEmulationConfig,
 }
 
 impl MultiRegionNetworkEmulationTest {
     pub fn new_with_config(network_emulation_config: MultiRegionNetworkEmulationConfig) -> Self {
         Self {
-            network_emulation_config: Some(network_emulation_config),
+            network_emulation_config,
         }
     }
 
@@ -230,7 +230,7 @@ impl MultiRegionNetworkEmulationTest {
     fn create_netem_chaos(&self, swarm: &mut dyn Swarm) -> SwarmNetEm {
         let all_validators = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
         let network_emulation_config = self.network_emulation_config.clone();
-        create_multi_region_swarm_network_chaos(all_validators, network_emulation_config)
+        create_multi_region_swarm_network_chaos(all_validators, Some(network_emulation_config))
     }
 }
 

--- a/testsuite/testcases/src/public_fullnode_performance.rs
+++ b/testsuite/testcases/src/public_fullnode_performance.rs
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    modifiers::create_swarm_cpu_stress,
     multi_region_network_test::create_multi_region_swarm_network_chaos, LoadDestination,
     NetworkLoadTest,
 };
 use anyhow::Error;
-use aptos_forge::{NetworkContext, NetworkTest, Result, Swarm, SwarmChaos, SwarmNetEm, Test};
+use aptos_forge::{
+    NetworkContext, NetworkTest, Result, Swarm, SwarmChaos, SwarmCpuStress, SwarmNetEm, Test,
+};
 use aptos_logger::info;
 use aptos_sdk::move_types::account_address::AccountAddress;
 use aptos_types::PeerId;
@@ -22,29 +25,50 @@ use tokio::runtime::Runtime;
 /// be configured for all nodes in the swarm.
 #[derive(Default)]
 pub struct PFNPerformance {
+    add_cpu_chaos: bool,
     add_network_emulation: bool,
     shuffle_rng_seed: [u8; 32],
 }
 
 impl PFNPerformance {
-    pub fn new(add_network_emulation: bool) -> Self {
+    pub fn new(add_cpu_chaos: bool, add_network_emulation: bool) -> Self {
         // Create a random seed for the shuffle RNG
         let shuffle_rng_seed: [u8; 32] = OsRng.gen();
 
         Self {
+            add_cpu_chaos,
             add_network_emulation,
             shuffle_rng_seed,
         }
     }
 
+    /// Creates CPU chaos for the swarm. Note: CPU chaos is added
+    /// to all validators, VFNs and PFNs in the swarm.
+    fn create_cpu_chaos(&self, swarm: &mut dyn Swarm) -> SwarmCpuStress {
+        // Gather and shuffle all peers IDs (so that we get random CPU chaos)
+        let shuffled_peer_ids = self.gather_and_shuffle_peer_ids(swarm);
+
+        // Create CPU chaos for the swarm
+        create_swarm_cpu_stress(shuffled_peer_ids, None)
+    }
+
     /// Creates network emulation chaos for the swarm. Note: network chaos
     /// is added to all validators, VFNs and PFNs in the swarm.
     fn create_network_emulation_chaos(&self, swarm: &mut dyn Swarm) -> SwarmNetEm {
+        // Gather and shuffle all peers IDs (so that we get random network emulation)
+        let shuffled_peer_ids = self.gather_and_shuffle_peer_ids(swarm);
+
+        // Create network emulation chaos for the swarm
+        create_multi_region_swarm_network_chaos(shuffled_peer_ids, None)
+    }
+
+    /// Gathers and shuffles all peer IDs in the swarm
+    fn gather_and_shuffle_peer_ids(&self, swarm: &mut dyn Swarm) -> Vec<AccountAddress> {
         // Identify the validators and fullnodes in the swarm
         let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
         let fullnode_peer_ids = swarm.full_nodes().map(|v| v.peer_id()).collect::<Vec<_>>();
 
-        // Gather and shuffle all peers IDs (so that we get random network emulation)
+        // Gather and shuffle all peers IDs
         let mut all_peer_ids = validator_peer_ids
             .iter()
             .chain(fullnode_peer_ids.iter())
@@ -52,8 +76,7 @@ impl PFNPerformance {
             .collect::<Vec<_>>();
         all_peer_ids.shuffle(&mut StdRng::from_seed(self.shuffle_rng_seed));
 
-        // Create network emulation chaos for the swarm
-        create_multi_region_swarm_network_chaos(all_peer_ids, None)
+        all_peer_ids
     }
 }
 
@@ -77,6 +100,12 @@ impl NetworkLoadTest for PFNPerformance {
         let num_pfns = 10;
         let pfn_peer_ids = create_and_add_pfns(ctx, num_pfns)?;
 
+        // Add CPU chaos to the swarm
+        if self.add_cpu_chaos {
+            let cpu_chaos = self.create_cpu_chaos(ctx.swarm());
+            ctx.swarm().inject_chaos(SwarmChaos::CpuStress(cpu_chaos))?;
+        }
+
         // Add network emulation to the swarm
         if self.add_network_emulation {
             let network_chaos = self.create_network_emulation_chaos(ctx.swarm());
@@ -88,6 +117,12 @@ impl NetworkLoadTest for PFNPerformance {
     }
 
     fn finish(&self, swarm: &mut dyn Swarm) -> Result<()> {
+        // Remove CPU chaos from the swarm
+        if self.add_cpu_chaos {
+            let cpu_chaos = self.create_cpu_chaos(swarm);
+            swarm.remove_chaos(SwarmChaos::CpuStress(cpu_chaos))?;
+        }
+
         // Remove network emulation from the swarm
         if self.add_network_emulation {
             let network_chaos = self.create_network_emulation_chaos(swarm);


### PR DESCRIPTION
### Description
This PR follows on from https://github.com/aptos-labs/aptos-core/pull/8976 and offers two improvements (each in their own commits):
1. (Trivial) Fix a forge namespace collision between the new PFN tests.
2. Add CPU chaos to the PFN forge tests (alongside 2 new PFN tests that use this chaos).

### Test Plan
Existing test infrastructure and manual verification.