### PR TITLE
[Storage Service] Several performance and scalability improvements.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3145,6 +3145,7 @@ dependencies = [
  "aptos-storage-service-types",
  "aptos-time-service",
  "aptos-types",
+ "arc-swap",
  "bcs 0.1.4",
  "bytes",
  "claims",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3149,6 +3149,7 @@ dependencies = [
  "bcs 0.1.4",
  "bytes",
  "claims",
+ "dashmap",
  "futures",
  "lru 0.7.8",
  "maplit",

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -127,7 +127,7 @@ impl Default for StateSyncDriverConfig {
             continuous_syncing_mode: ContinuousSyncingMode::ExecuteTransactionsOrApplyOutputs,
             enable_auto_bootstrapping: false,
             fallback_to_output_syncing_secs: 180, // 3 minutes
-            progress_check_interval_ms: 100,
+            progress_check_interval_ms: 50,
             max_connection_deadline_secs: 10,
             max_consecutive_stream_notifications: 10,
             max_num_stream_timeouts: 12,
@@ -228,7 +228,7 @@ impl Default for DataStreamingServiceConfig {
             max_data_stream_channel_sizes: 300,
             max_request_retry: 5,
             max_notification_id_mappings: 300,
-            progress_check_interval_ms: 100,
+            progress_check_interval_ms: 50,
         }
     }
 }

--- a/state-sync/storage-service/server/Cargo.toml
+++ b/state-sync/storage-service/server/Cargo.toml
@@ -28,6 +28,7 @@ aptos-types = { workspace = true }
 arc-swap = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
+dashmap = { workspace = true }
 futures = { workspace = true }
 lru = { workspace = true }
 once_cell = { workspace = true }

--- a/state-sync/storage-service/server/Cargo.toml
+++ b/state-sync/storage-service/server/Cargo.toml
@@ -25,6 +25,7 @@ aptos-storage-service-notifications = { workspace = true }
 aptos-storage-service-types = { workspace = true }
 aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
+arc-swap = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }

--- a/state-sync/storage-service/server/src/handler.rs
+++ b/state-sync/storage-service/server/src/handler.rs
@@ -14,7 +14,7 @@ use crate::{
     storage::StorageReaderInterface,
 };
 use aptos_config::network_id::PeerNetworkId;
-use aptos_infallible::{Mutex, RwLock};
+use aptos_infallible::Mutex;
 use aptos_logger::{debug, error, sample, sample::SampleRate, trace, warn};
 use aptos_storage_service_types::{
     requests::{
@@ -29,6 +29,7 @@ use aptos_storage_service_types::{
 };
 use aptos_time_service::TimeService;
 use aptos_types::transaction::Version;
+use arc_swap::ArcSwap;
 use lru::LruCache;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
@@ -42,7 +43,7 @@ const SUMMARY_LOG_FREQUENCY_SECS: u64 = 5; // The frequency to log the storage s
 /// request. We usually clone/create a new handler for every request.
 #[derive(Clone)]
 pub struct Handler<T> {
-    cached_storage_server_summary: Arc<RwLock<StorageServerSummary>>,
+    cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     optimistic_fetches: Arc<Mutex<HashMap<PeerNetworkId, OptimisticFetchRequest>>>,
     lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
     request_moderator: Arc<RequestModerator>,
@@ -52,7 +53,7 @@ pub struct Handler<T> {
 
 impl<T: StorageReaderInterface> Handler<T> {
     pub fn new(
-        cached_storage_server_summary: Arc<RwLock<StorageServerSummary>>,
+        cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
         optimistic_fetches: Arc<Mutex<HashMap<PeerNetworkId, OptimisticFetchRequest>>>,
         lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
         request_moderator: Arc<RequestModerator>,
@@ -333,8 +334,8 @@ impl<T: StorageReaderInterface> Handler<T> {
     }
 
     fn get_storage_server_summary(&self) -> DataResponse {
-        let storage_server_summary = self.cached_storage_server_summary.read().clone();
-        DataResponse::StorageServerSummary(storage_server_summary)
+        let storage_server_summary = self.cached_storage_server_summary.load().clone();
+        DataResponse::StorageServerSummary(storage_server_summary.as_ref().clone())
     }
 
     fn get_transaction_outputs_with_proof(

--- a/state-sync/storage-service/server/src/lib.rs
+++ b/state-sync/storage-service/server/src/lib.rs
@@ -21,13 +21,14 @@ use aptos_storage_service_types::{
 };
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use arc_swap::ArcSwap;
+use dashmap::DashMap;
 use error::Error;
 use futures::stream::StreamExt;
 use handler::Handler;
 use lru::LruCache;
 use moderator::RequestModerator;
 use optimistic_fetch::OptimisticFetchRequest;
-use std::{collections::HashMap, ops::Deref, sync::Arc, time::Duration};
+use std::{ops::Deref, sync::Arc, time::Duration};
 use storage::StorageReaderInterface;
 use thiserror::Error;
 use tokio::runtime::Handle;
@@ -69,7 +70,7 @@ pub struct StorageServiceServer<T> {
     lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
 
     // A set of active optimistic fetches for peers waiting for new data
-    optimistic_fetches: Arc<Mutex<HashMap<PeerNetworkId, OptimisticFetchRequest>>>,
+    optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
 
     // A moderator for incoming peer requests
     request_moderator: Arc<RequestModerator>,
@@ -92,7 +93,7 @@ impl<T: StorageReaderInterface> StorageServiceServer<T> {
             BoundedExecutor::new(config.max_concurrent_requests as usize, executor);
         let cached_storage_server_summary =
             Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
-        let optimistic_fetches = Arc::new(Mutex::new(HashMap::new()));
+        let optimistic_fetches = Arc::new(DashMap::new());
         let lru_response_cache = Arc::new(Mutex::new(LruCache::new(
             config.max_lru_cache_size as usize,
         )));
@@ -350,7 +351,7 @@ impl<T: StorageReaderInterface> StorageServiceServer<T> {
     /// Returns a copy of the active optimistic fetches for test purposes
     pub(crate) fn get_optimistic_fetches(
         &self,
-    ) -> Arc<Mutex<HashMap<PeerNetworkId, OptimisticFetchRequest>>> {
+    ) -> Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>> {
         self.optimistic_fetches.clone()
     }
 }
@@ -360,7 +361,7 @@ impl<T: StorageReaderInterface> StorageServiceServer<T> {
 fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
     cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     config: StorageServiceConfig,
-    optimistic_fetches: Arc<Mutex<HashMap<PeerNetworkId, OptimisticFetchRequest>>>,
+    optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
     lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
     request_moderator: Arc<RequestModerator>,
     storage: T,

--- a/state-sync/storage-service/server/src/metrics.rs
+++ b/state-sync/storage-service/server/src/metrics.rs
@@ -46,6 +46,16 @@ pub static NETWORK_FRAME_OVERFLOW: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Gauge for tracking the number of active optimistic fetches
+pub static OPTIMISTIC_FETCH_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_storage_service_server_optimistic_fetch_count",
+        "Gauge for tracking the number of active optimistic fetches",
+        &["network_id"]
+    )
+    .unwrap()
+});
+
 /// Counter for optimistic fetch request events
 pub static OPTIMISTIC_FETCH_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(

--- a/state-sync/storage-service/server/src/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/optimistic_fetch.rs
@@ -174,11 +174,9 @@ pub(crate) fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
     storage: T,
     time_service: TimeService,
 ) -> Result<(), Error> {
-    // Remove all expired optimistic fetches
-    remove_expired_optimistic_fetches(config, optimistic_fetches.clone());
-
     // Identify the peers with ready optimistic fetches
     let peers_with_ready_optimistic_fetches = get_peers_with_ready_optimistic_fetches(
+        config,
         cached_storage_server_summary.clone(),
         optimistic_fetches.clone(),
         lru_response_cache.clone(),
@@ -230,6 +228,7 @@ pub(crate) fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
 /// Returns the list of peers that made those optimistic fetches
 /// alongside the ledger info at the target version for the peer.
 pub(crate) fn get_peers_with_ready_optimistic_fetches<T: StorageReaderInterface>(
+    config: StorageServiceConfig,
     cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
     lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
@@ -246,13 +245,20 @@ pub(crate) fn get_peers_with_ready_optimistic_fetches<T: StorageReaderInterface>
     let highest_synced_version = highest_synced_ledger_info.ledger_info().version();
     let highest_synced_epoch = highest_synced_ledger_info.ledger_info().epoch();
 
-    // Identify the peers with ready optimistic fetches
-    let mut ready_optimistic_fetches = vec![];
-    let mut invalid_peer_optimistic_fetches = vec![];
+    // Identify the peers with expired, invalid and ready optimistic fetches
+    let mut peers_with_expired_optimistic_fetches = vec![];
+    let mut peers_with_invalid_optimistic_fetches = vec![];
+    let mut peers_with_ready_optimistic_fetches = vec![];
     for optimistic_fetch in optimistic_fetches.iter() {
         // Get the peer and the optimistic fetch request
         let peer = optimistic_fetch.key();
         let optimistic_fetch = optimistic_fetch.value();
+
+        // Ensure the optimistic fetch hasn't expired
+        if optimistic_fetch.is_expired(config.max_optimistic_fetch_period) {
+            peers_with_expired_optimistic_fetches.push(*peer);
+            continue;
+        }
 
         // Check if we have synced beyond the highest known version
         let highest_known_version = optimistic_fetch.highest_known_version();
@@ -274,19 +280,31 @@ pub(crate) fn get_peers_with_ready_optimistic_fetches<T: StorageReaderInterface>
                 // Check that we haven't been sent an invalid optimistic fetch request
                 // (i.e., a request that does not respect an epoch boundary).
                 if epoch_ending_ledger_info.ledger_info().version() <= highest_known_version {
-                    invalid_peer_optimistic_fetches.push(*peer);
+                    peers_with_invalid_optimistic_fetches.push(*peer);
                 } else {
-                    ready_optimistic_fetches.push((*peer, epoch_ending_ledger_info));
+                    peers_with_ready_optimistic_fetches.push((*peer, epoch_ending_ledger_info));
                 }
             } else {
-                ready_optimistic_fetches.push((*peer, highest_synced_ledger_info.clone()));
+                peers_with_ready_optimistic_fetches
+                    .push((*peer, highest_synced_ledger_info.clone()));
             };
         }
     }
 
+    // Remove the expired optimistic fetches
+    for peer_network_id in peers_with_expired_optimistic_fetches {
+        if optimistic_fetches.remove(&peer_network_id).is_some() {
+            increment_counter(
+                &metrics::OPTIMISTIC_FETCH_EVENTS,
+                peer_network_id.network_id(),
+                OPTIMISTIC_FETCH_EXPIRE.into(),
+            );
+        }
+    }
+
     // Remove the invalid optimistic fetches
-    for peer in invalid_peer_optimistic_fetches {
-        if let Some((_, optimistic_fetch)) = optimistic_fetches.remove(&peer) {
+    for peer_network_id in peers_with_invalid_optimistic_fetches {
+        if let Some((_, optimistic_fetch)) = optimistic_fetches.remove(&peer_network_id) {
             warn!(LogSchema::new(LogEntry::OptimisticFetchRefresh)
                 .error(&Error::InvalidRequest(
                     "Mismatch between known version and epoch!".into()
@@ -297,7 +315,7 @@ pub(crate) fn get_peers_with_ready_optimistic_fetches<T: StorageReaderInterface>
     }
 
     // Return the ready optimistic fetches
-    Ok(ready_optimistic_fetches)
+    Ok(peers_with_ready_optimistic_fetches)
 }
 
 /// Gets the epoch ending ledger info at the given epoch
@@ -458,24 +476,4 @@ fn notify_peer_of_new_data<T: StorageReaderInterface>(
         },
         Err(error) => Err(error),
     }
-}
-
-/// Removes all expired optimistic fetches
-pub(crate) fn remove_expired_optimistic_fetches(
-    config: StorageServiceConfig,
-    optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
-) {
-    optimistic_fetches.retain(|peer_network_id, optimistic_fetch| {
-        // Update the expired optimistic fetch metrics
-        if optimistic_fetch.is_expired(config.max_optimistic_fetch_period) {
-            increment_counter(
-                &metrics::OPTIMISTIC_FETCH_EVENTS,
-                peer_network_id.network_id(),
-                OPTIMISTIC_FETCH_EXPIRE.into(),
-            );
-        }
-
-        // Only retain non-expired optimistic fetches
-        !optimistic_fetch.is_expired(config.max_optimistic_fetch_period)
-    });
 }

--- a/state-sync/storage-service/server/src/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/optimistic_fetch.rs
@@ -12,7 +12,7 @@ use crate::{
     LogEntry, LogSchema,
 };
 use aptos_config::{config::StorageServiceConfig, network_id::PeerNetworkId};
-use aptos_infallible::{Mutex, RwLock};
+use aptos_infallible::Mutex;
 use aptos_logger::warn;
 use aptos_storage_service_types::{
     requests::{
@@ -24,6 +24,7 @@ use aptos_storage_service_types::{
 };
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::ledger_info::LedgerInfoWithSignatures;
+use arc_swap::ArcSwap;
 use lru::LruCache;
 use std::{cmp::min, collections::HashMap, sync::Arc, time::Instant};
 
@@ -164,7 +165,7 @@ impl OptimisticFetchRequest {
 
 /// Handles ready (and expired) optimistic fetches
 pub(crate) fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
-    cached_storage_server_summary: Arc<RwLock<StorageServerSummary>>,
+    cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     config: StorageServiceConfig,
     optimistic_fetches: Arc<Mutex<HashMap<PeerNetworkId, OptimisticFetchRequest>>>,
     lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
@@ -228,7 +229,7 @@ pub(crate) fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
 /// Returns the list of peers that made those optimistic fetches
 /// alongside the ledger info at the target version for the peer.
 pub(crate) fn get_peers_with_ready_optimistic_fetches<T: StorageReaderInterface>(
-    cached_storage_server_summary: Arc<RwLock<StorageServerSummary>>,
+    cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     optimistic_fetches: Arc<Mutex<HashMap<PeerNetworkId, OptimisticFetchRequest>>>,
     lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
     request_moderator: Arc<RequestModerator>,
@@ -236,9 +237,9 @@ pub(crate) fn get_peers_with_ready_optimistic_fetches<T: StorageReaderInterface>
     time_service: TimeService,
 ) -> aptos_storage_service_types::Result<Vec<(PeerNetworkId, LedgerInfoWithSignatures)>, Error> {
     // Fetch the latest storage summary and highest synced version
-    let latest_storage_summary = cached_storage_server_summary.read().clone();
-    let highest_synced_ledger_info = match latest_storage_summary.data_summary.synced_ledger_info {
-        Some(ledger_info) => ledger_info,
+    let latest_storage_summary = cached_storage_server_summary.load().clone();
+    let highest_synced_ledger_info = match &latest_storage_summary.data_summary.synced_ledger_info {
+        Some(ledger_info) => ledger_info.clone(),
         None => return Ok(vec![]),
     };
     let highest_synced_version = highest_synced_ledger_info.ledger_info().version();
@@ -295,7 +296,7 @@ pub(crate) fn get_peers_with_ready_optimistic_fetches<T: StorageReaderInterface>
 
 /// Gets the epoch ending ledger info at the given epoch
 fn get_epoch_ending_ledger_info<T: StorageReaderInterface>(
-    cached_storage_server_summary: Arc<RwLock<StorageServerSummary>>,
+    cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     optimistic_fetches: Arc<Mutex<HashMap<PeerNetworkId, OptimisticFetchRequest>>>,
     epoch: u64,
     lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
@@ -355,7 +356,7 @@ fn get_epoch_ending_ledger_info<T: StorageReaderInterface>(
 /// because: (i) each sub-part should already be checked; and (ii)
 /// optimistic fetch responses are best effort.
 fn notify_peer_of_new_data<T: StorageReaderInterface>(
-    cached_storage_server_summary: Arc<RwLock<StorageServerSummary>>,
+    cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     config: StorageServiceConfig,
     optimistic_fetches: Arc<Mutex<HashMap<PeerNetworkId, OptimisticFetchRequest>>>,
     lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,

--- a/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
@@ -20,7 +20,7 @@ use aptos_storage_service_types::{
     responses::{CompleteDataRange, StorageServerSummary},
 };
 use aptos_time_service::TimeService;
-use aptos_types::epoch_change::EpochChangeProof;
+use aptos_types::{epoch_change::EpochChangeProof, ledger_info::LedgerInfoWithSignatures};
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use futures::channel::oneshot;
@@ -58,7 +58,8 @@ async fn test_peers_with_ready_optimistic_fetches() {
     utils::expect_get_epoch_ending_ledger_infos(&mut db_reader, 1, 2, epoch_change_proof);
 
     // Create the storage reader
-    let storage_reader = StorageReader::new(StorageServiceConfig::default(), Arc::new(db_reader));
+    let storage_service_config = StorageServiceConfig::default();
+    let storage_reader = StorageReader::new(storage_service_config, Arc::new(db_reader));
 
     // Create test data with an empty storage server summary
     let cached_storage_server_summary =
@@ -67,13 +68,14 @@ async fn test_peers_with_ready_optimistic_fetches() {
     let request_moderator = Arc::new(RequestModerator::new(
         cached_storage_server_summary.clone(),
         mock::create_peers_and_metadata(vec![]),
-        StorageServiceConfig::default(),
+        storage_service_config,
         time_service.clone(),
     ));
 
     // Verify that there are no peers with ready optimistic fetches
     let peers_with_ready_optimistic_fetches =
         optimistic_fetch::get_peers_with_ready_optimistic_fetches(
+            storage_service_config,
             cached_storage_server_summary.clone(),
             optimistic_fetches.clone(),
             lru_response_cache.clone(),
@@ -85,17 +87,13 @@ async fn test_peers_with_ready_optimistic_fetches() {
     assert!(peers_with_ready_optimistic_fetches.is_empty());
 
     // Update the storage server summary so that there is new data for optimistic fetch 1
-    let mut storage_server_summary = StorageServerSummary::default();
-    storage_server_summary
-        .data_summary
-        .epoch_ending_ledger_infos = Some(CompleteDataRange::new(0, 1).unwrap());
-    let synced_ledger_info = utils::create_test_ledger_info_with_sigs(1, 2);
-    storage_server_summary.data_summary.synced_ledger_info = Some(synced_ledger_info.clone());
-    cached_storage_server_summary.store(Arc::new(storage_server_summary));
+    let synced_ledger_info =
+        update_storage_server_summary(cached_storage_server_summary.clone(), 2, 1);
 
     // Verify that optimistic fetch 1 is ready
     let peers_with_ready_optimistic_fetches =
         optimistic_fetch::get_peers_with_ready_optimistic_fetches(
+            storage_service_config,
             cached_storage_server_summary.clone(),
             optimistic_fetches.clone(),
             lru_response_cache.clone(),
@@ -114,17 +112,12 @@ async fn test_peers_with_ready_optimistic_fetches() {
 
     // Update the storage server summary so that there is new data for optimistic fetch 2,
     // but the optimistic fetch is invalid because it doesn't respect an epoch boundary.
-    let mut storage_server_summary = StorageServerSummary::default();
-    storage_server_summary
-        .data_summary
-        .epoch_ending_ledger_infos = Some(CompleteDataRange::new(0, 2).unwrap());
-    let synced_ledger_info = utils::create_test_ledger_info_with_sigs(2, 100);
-    storage_server_summary.data_summary.synced_ledger_info = Some(synced_ledger_info);
-    cached_storage_server_summary.store(Arc::new(storage_server_summary));
+    let _ = update_storage_server_summary(cached_storage_server_summary.clone(), 100, 2);
 
     // Verify that optimistic fetch 2 is not returned because it was invalid
     let peers_with_ready_optimistic_fetches =
         optimistic_fetch::get_peers_with_ready_optimistic_fetches(
+            storage_service_config,
             cached_storage_server_summary,
             optimistic_fetches,
             lru_response_cache,
@@ -148,14 +141,28 @@ async fn test_remove_expired_optimistic_fetches() {
         ..Default::default()
     };
 
-    // Create a mock time service
+    // Create the mock storage reader and time service
+    let db_reader = mock::create_mock_db_reader();
+    let storage = StorageReader::new(storage_service_config, Arc::new(db_reader));
     let time_service = TimeService::mock();
+
+    // Create the test components
+    let cached_storage_server_summary =
+        Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
+    let lru_response_cache = Arc::new(Mutex::new(LruCache::new(0)));
+    let request_moderator = Arc::new(RequestModerator::new(
+        cached_storage_server_summary.clone(),
+        mock::create_peers_and_metadata(vec![]),
+        storage_service_config,
+        time_service.clone(),
+    ));
 
     // Create the first batch of test optimistic fetches
     let num_optimistic_fetches_in_batch = 10;
     let optimistic_fetches = Arc::new(DashMap::new());
     for _ in 0..num_optimistic_fetches_in_batch {
-        let optimistic_fetch = create_optimistic_fetch_request(time_service.clone(), None, None);
+        let optimistic_fetch =
+            create_optimistic_fetch_request(time_service.clone(), Some(9), Some(9));
         optimistic_fetches.insert(PeerNetworkId::random(), optimistic_fetch);
     }
 
@@ -169,16 +176,28 @@ async fn test_remove_expired_optimistic_fetches() {
         .advance_async(Duration::from_millis(max_optimistic_fetch_period / 2))
         .await;
 
+    // Update the storage server summary so that there is new data
+    let _ = update_storage_server_summary(cached_storage_server_summary.clone(), 1, 1);
+
     // Remove the expired optimistic fetches and verify none were removed
-    optimistic_fetch::remove_expired_optimistic_fetches(
-        storage_service_config,
-        optimistic_fetches.clone(),
-    );
+    let peers_with_ready_optimistic_fetches =
+        optimistic_fetch::get_peers_with_ready_optimistic_fetches(
+            storage_service_config,
+            cached_storage_server_summary.clone(),
+            optimistic_fetches.clone(),
+            lru_response_cache.clone(),
+            request_moderator.clone(),
+            storage.clone(),
+            time_service.clone(),
+        )
+        .unwrap();
+    assert!(peers_with_ready_optimistic_fetches.is_empty());
     assert_eq!(optimistic_fetches.len(), num_optimistic_fetches_in_batch);
 
     // Create another batch of optimistic fetches
     for _ in 0..num_optimistic_fetches_in_batch {
-        let optimistic_fetch = create_optimistic_fetch_request(time_service.clone(), None, None);
+        let optimistic_fetch =
+            create_optimistic_fetch_request(time_service.clone(), Some(9), Some(9));
         optimistic_fetches.insert(PeerNetworkId::random(), optimistic_fetch);
     }
 
@@ -196,23 +215,40 @@ async fn test_remove_expired_optimistic_fetches() {
         .await;
 
     // Remove the expired optimistic fetches and verify the first batch was removed
-    optimistic_fetch::remove_expired_optimistic_fetches(
-        storage_service_config,
-        optimistic_fetches.clone(),
-    );
+    let peers_with_ready_optimistic_fetches =
+        optimistic_fetch::get_peers_with_ready_optimistic_fetches(
+            storage_service_config,
+            cached_storage_server_summary.clone(),
+            optimistic_fetches.clone(),
+            lru_response_cache.clone(),
+            request_moderator.clone(),
+            storage.clone(),
+            time_service.clone(),
+        )
+        .unwrap();
+    assert!(peers_with_ready_optimistic_fetches.is_empty());
     assert_eq!(optimistic_fetches.len(), num_optimistic_fetches_in_batch);
 
     // Elapse enough time to expire the second batch of optimistic fetches
     time_service
+        .clone()
         .into_mock()
-        .advance_async(Duration::from_millis(max_optimistic_fetch_period))
+        .advance_async(Duration::from_millis(max_optimistic_fetch_period + 1))
         .await;
 
     // Remove the expired optimistic fetches and verify the second batch was removed
-    optimistic_fetch::remove_expired_optimistic_fetches(
-        storage_service_config,
-        optimistic_fetches.clone(),
-    );
+    let peers_with_ready_optimistic_fetches =
+        optimistic_fetch::get_peers_with_ready_optimistic_fetches(
+            storage_service_config,
+            cached_storage_server_summary.clone(),
+            optimistic_fetches.clone(),
+            lru_response_cache,
+            request_moderator,
+            storage.clone(),
+            time_service.clone(),
+        )
+        .unwrap();
+    assert!(peers_with_ready_optimistic_fetches.is_empty());
     assert!(optimistic_fetches.is_empty());
 }
 
@@ -267,4 +303,28 @@ fn create_optimistic_fetch_request(
 
     // Create and return the optimistic fetch request
     OptimisticFetchRequest::new(storage_service_request, response_sender, time_service)
+}
+
+/// Updates the storage server summary with new data and returns the synced ledger info
+fn update_storage_server_summary(
+    cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
+    highest_synced_version: u64,
+    highest_synced_epoch: u64,
+) -> LedgerInfoWithSignatures {
+    // Create the storage server summary and synced ledger info
+    let mut storage_server_summary = StorageServerSummary::default();
+    let highest_synced_ledger_info =
+        utils::create_test_ledger_info_with_sigs(highest_synced_epoch, highest_synced_version);
+
+    // Update the epoch ending ledger infos and synced ledger info
+    storage_server_summary
+        .data_summary
+        .epoch_ending_ledger_infos = Some(CompleteDataRange::new(0, highest_synced_epoch).unwrap());
+    storage_server_summary.data_summary.synced_ledger_info =
+        Some(highest_synced_ledger_info.clone());
+
+    // Update the cached storage server summary
+    cached_storage_server_summary.store(Arc::new(storage_server_summary));
+
+    highest_synced_ledger_info
 }

--- a/state-sync/storage-service/server/src/tests/utils.rs
+++ b/state-sync/storage-service/server/src/tests/utils.rs
@@ -401,7 +401,9 @@ pub fn update_storage_server_summary(
     data_summary.transaction_outputs = Some(data_range);
 
     // Update the storage server summary
-    *storage_server.cached_storage_server_summary.write() = storage_server_summary;
+    storage_server
+        .cached_storage_server_summary
+        .store(Arc::new(storage_server_summary));
 }
 
 /// Advances the storage refresh time and

--- a/state-sync/storage-service/server/src/tests/utils.rs
+++ b/state-sync/storage-service/server/src/tests/utils.rs
@@ -12,7 +12,6 @@ use aptos_config::{
     network_id::{NetworkId, PeerNetworkId},
 };
 use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, SigningKey, Uniform};
-use aptos_infallible::Mutex;
 use aptos_storage_service_notifications::{
     StorageServiceNotificationSender, StorageServiceNotifier,
 };
@@ -42,9 +41,10 @@ use aptos_types::{
     validator_verifier::ValidatorVerifier,
     write_set::WriteSet,
 };
+use dashmap::DashMap;
 use mockall::predicate::eq;
 use rand::{rngs::OsRng, Rng};
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 /// Advances the given timer by the amount of time it takes to refresh storage
 pub async fn advance_storage_refresh_time(mock_time: &MockTimeService) {
@@ -501,11 +501,11 @@ pub async fn force_optimistic_fetch_handler_to_run(
 
 /// Waits for the specified number of optimistic fetches to be active
 pub async fn wait_for_active_optimistic_fetches(
-    active_optimistic_fetches: Arc<Mutex<HashMap<PeerNetworkId, OptimisticFetchRequest>>>,
+    active_optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
     expected_num_active_fetches: usize,
 ) {
     loop {
-        let num_active_fetches = active_optimistic_fetches.lock().len();
+        let num_active_fetches = active_optimistic_fetches.len();
         if num_active_fetches == expected_num_active_fetches {
             return; // We found the expected number of active fetches
         }


### PR DESCRIPTION
### Description
This PR offers a number of performance, scalability and observability improvements to the optimistic fetch handling logic in the storage service.

Each improvement is offered in its own commit:
1. Migrate the cached storage server summary from `Arc<RwLock<T>>` to `Arc<ArcSwap<T>>`. [ArcSwap](https://docs.rs/arc-swap/latest/arc_swap/) is more efficient for read-mostly scenarios, which matches that of the cached storage server summary (i.e., lots of concurrent reads, infrequent writes).
2. Migrate the active optimistic fetch map from `Arc<Mutex<HashMap<K,V>>>` to `Arc<DashMap<K, V>>,`. This reduces lock contention when handling concurrent optimistic fetch inserts and deletions. See [DashMap](https://docs.rs/dashmap/latest/dashmap/struct.DashMap.html).
3. Modify `get_peers_with_ready_optimistic_fetches` to identify ready, expired and invalid optimistic fetches in a single set pass (as opposed to multiple passes).
4. Parallelize `handle_ready_optimistic_fetches` to notify each peer of new data in a separate thread. This helps to reduce latencies when there are a lot of ready requests, as each request requires first reading from storage before sending the data to the peer. Now, we do this in parallel (as opposed to sequentially).
5. Parallelize `identify_ready_and_invalid_optimistic_fetches` to identify the ready and invalid optimistic fetches in separate threads. Similar to above, this helps to reduce latencies when there are a lot of pending requests, as each request requires reading from storage.
6. Add a new metric counter to track the number of active optimistic fetches. This is useful for monitoring optimistic fetch load across network IDs.
7. Reduce the task polling intervals in the state sync driver and data streaming service from `100ms` to `50ms`. This helps to reduce the time a received data response is pending in memory, without adding much additional overhead.

### Test Plan
New and existing test infrastructure (i.e., all modifications required updating the existing set of unit tests to ensure that the new functionality is correct).