### PR TITLE
[dag] reliable broadcast storage

### DIFF
--- a/consensus/src/consensusdb/schema/dag/mod.rs
+++ b/consensus/src/consensusdb/schema/dag/mod.rs
@@ -9,7 +9,7 @@
 //! |   digest   |   node/certified node    |
 //! ```
 
-use crate::dag::{CertifiedNode, Node};
+use crate::dag::{CertifiedNode, Node, NodeDigestSignature, NodeId};
 use anyhow::Result;
 use aptos_crypto::HashValue;
 use aptos_schemadb::{
@@ -33,6 +33,35 @@ impl KeyCodec<NodeSchema> for HashValue {
 }
 
 impl ValueCodec<NodeSchema> for Node {
+    fn encode_value(&self) -> Result<Vec<u8>> {
+        Ok(bcs::to_bytes(&self)?)
+    }
+
+    fn decode_value(data: &[u8]) -> Result<Self> {
+        Ok(bcs::from_bytes(data)?)
+    }
+}
+
+pub const NODE_DIGEST_SIGNATURE_CF_NAME: ColumnFamilyName = "node_digest_signature";
+
+define_schema!(
+    NodeDigestSignatureSchema,
+    NodeId,
+    NodeDigestSignature,
+    NODE_DIGEST_SIGNATURE_CF_NAME
+);
+
+impl KeyCodec<NodeDigestSignatureSchema> for NodeId {
+    fn encode_key(&self) -> Result<Vec<u8>> {
+        Ok(bcs::to_bytes(&self)?)
+    }
+
+    fn decode_key(data: &[u8]) -> Result<Self> {
+        Ok(bcs::from_bytes(data)?)
+    }
+}
+
+impl ValueCodec<NodeDigestSignatureSchema> for NodeDigestSignature {
     fn encode_value(&self) -> Result<Vec<u8>> {
         Ok(bcs::to_bytes(&self)?)
     }

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -43,6 +43,7 @@ impl DagDriver {
         time_service: Arc<dyn TimeService>,
         storage: Arc<dyn DAGStorage>,
     ) -> Self {
+        // TODO: rebroadcast nodes after recovery
         Self {
             author,
             epoch_state,

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use super::storage::DAGStorage;
 use crate::{
     dag::{
         dag_store::Dag,
@@ -28,6 +29,7 @@ pub(crate) struct DagDriver {
     current_round: Round,
     time_service: Arc<dyn TimeService>,
     rb_abort_handle: Option<AbortHandle>,
+    storage: Arc<dyn DAGStorage>,
 }
 
 impl DagDriver {
@@ -39,6 +41,7 @@ impl DagDriver {
         reliable_broadcast: Arc<ReliableBroadcast>,
         current_round: Round,
         time_service: Arc<dyn TimeService>,
+        storage: Arc<dyn DAGStorage>,
     ) -> Self {
         Self {
             author,
@@ -49,6 +52,7 @@ impl DagDriver {
             current_round,
             time_service,
             rb_abort_handle: None,
+            storage,
         }
     }
 
@@ -84,6 +88,9 @@ impl DagDriver {
             payload,
             strong_links,
         );
+        self.storage
+            .save_node(&new_node)
+            .expect("node must be saved");
         self.broadcast_node(new_node);
     }
 

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -1,6 +1,6 @@
 // Copyright © Aptos Foundation
 
-use super::{reliable_broadcast::CertifiedNodeHandler, types::TDAGMessage};
+use super::{reliable_broadcast::CertifiedNodeHandler, storage::DAGStorage, types::TDAGMessage};
 use crate::{
     dag::{
         dag_network::RpcHandler, dag_store::Dag, reliable_broadcast::NodeBroadcastHandler,
@@ -32,6 +32,7 @@ impl NetworkHandler {
         dag_rpc_rx: aptos_channel::Receiver<Author, IncomingDAGRequest>,
         signer: ValidatorSigner,
         epoch_state: Arc<EpochState>,
+        storage: Arc<dyn DAGStorage>,
     ) -> Self {
         Self {
             dag_rpc_rx,
@@ -39,6 +40,7 @@ impl NetworkHandler {
                 dag.clone(),
                 signer,
                 epoch_state.verifier.clone(),
+                storage,
             ),
             certified_node_receiver: CertifiedNodeHandler::new(dag),
             epoch_state,
@@ -46,6 +48,7 @@ impl NetworkHandler {
     }
 
     async fn start(mut self) {
+        // TODO(ibalajiarun): clean up Reliable Broadcast storage periodically.
         while let Some(msg) = self.dag_rpc_rx.next().await {
             if let Err(e) = self.process_rpc(msg).await {
                 warn!(error = ?e, "error processing rpc");

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -39,7 +39,7 @@ impl NetworkHandler {
             node_receiver: NodeBroadcastHandler::new(
                 dag.clone(),
                 signer,
-                epoch_state.verifier.clone(),
+                epoch_state.clone(),
                 storage,
             ),
             certified_node_receiver: CertifiedNodeHandler::new(dag),

--- a/consensus/src/dag/mod.rs
+++ b/consensus/src/dag/mod.rs
@@ -14,4 +14,4 @@ mod tests;
 mod types;
 
 pub use dag_network::RpcHandler;
-pub use types::{CertifiedNode, DAGNetworkMessage, Node};
+pub use types::{CertifiedNode, DAGNetworkMessage, Node, NodeDigestSignature, NodeId};

--- a/consensus/src/dag/storage.rs
+++ b/consensus/src/dag/storage.rs
@@ -1,15 +1,29 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use super::{types::NodeDigestSignature, NodeId};
 use crate::{
     consensusdb::ConsensusDB,
     dag::{CertifiedNode, Node},
 };
+use anyhow::Ok;
 use aptos_crypto::HashValue;
 use std::collections::HashMap;
 
 pub trait DAGStorage {
     fn save_node(&self, node: &Node) -> anyhow::Result<()>;
+
+    fn delete_node(&self, digest: HashValue) -> anyhow::Result<()>;
+
+    fn save_node_signature(
+        &self,
+        node_id: &NodeId,
+        node_digest_signature: &NodeDigestSignature,
+    ) -> anyhow::Result<()>;
+
+    fn get_node_signatures(&self) -> anyhow::Result<HashMap<NodeId, NodeDigestSignature>>;
+
+    fn delete_node_signatures(&self, node_ids: Vec<NodeId>) -> anyhow::Result<()>;
 
     fn save_certified_node(&self, node: &CertifiedNode) -> anyhow::Result<()>;
 
@@ -21,6 +35,26 @@ pub trait DAGStorage {
 impl DAGStorage for ConsensusDB {
     fn save_node(&self, node: &Node) -> anyhow::Result<()> {
         Ok(self.save_node(node)?)
+    }
+
+    fn delete_node(&self, digest: HashValue) -> anyhow::Result<()> {
+        Ok(self.delete_node(digest)?)
+    }
+
+    fn save_node_signature(
+        &self,
+        node_id: &NodeId,
+        node_digest_signature: &NodeDigestSignature,
+    ) -> anyhow::Result<()> {
+        Ok(self.save_node_signature(node_id, node_digest_signature)?)
+    }
+
+    fn get_node_signatures(&self) -> anyhow::Result<HashMap<NodeId, NodeDigestSignature>> {
+        Ok(self.get_node_signatures()?)
+    }
+
+    fn delete_node_signatures(&self, node_ids: Vec<NodeId>) -> anyhow::Result<()> {
+        Ok(self.delete_node_signatures(node_ids)?)
     }
 
     fn save_certified_node(&self, node: &CertifiedNode) -> anyhow::Result<()> {

--- a/consensus/src/dag/tests/dag_test.rs
+++ b/consensus/src/dag/tests/dag_test.rs
@@ -6,7 +6,9 @@ use crate::dag::{
     storage::DAGStorage,
     tests::helpers::new_certified_node,
     types::{CertifiedNode, Node},
+    NodeDigestSignature, NodeId,
 };
+use anyhow::Ok;
 use aptos_crypto::HashValue;
 use aptos_infallible::Mutex;
 use aptos_types::{epoch_state::EpochState, validator_verifier::random_validator_verifier};
@@ -14,6 +16,7 @@ use std::{collections::HashMap, sync::Arc};
 
 pub struct MockStorage {
     node_data: Mutex<HashMap<HashValue, Node>>,
+    node_signature_data: Mutex<HashMap<NodeId, NodeDigestSignature>>,
     certified_node_data: Mutex<HashMap<HashValue, CertifiedNode>>,
 }
 
@@ -21,6 +24,7 @@ impl MockStorage {
     pub fn new() -> Self {
         Self {
             node_data: Mutex::new(HashMap::new()),
+            node_signature_data: Mutex::new(HashMap::new()),
             certified_node_data: Mutex::new(HashMap::new()),
         }
     }
@@ -29,6 +33,33 @@ impl MockStorage {
 impl DAGStorage for MockStorage {
     fn save_node(&self, node: &Node) -> anyhow::Result<()> {
         self.node_data.lock().insert(node.digest(), node.clone());
+        Ok(())
+    }
+
+    fn delete_node(&self, digest: HashValue) -> anyhow::Result<()> {
+        self.node_data.lock().remove(&digest);
+        Ok(())
+    }
+
+    fn save_node_signature(
+        &self,
+        node_id: &NodeId,
+        node_digest_signature: &NodeDigestSignature,
+    ) -> anyhow::Result<()> {
+        self.node_signature_data
+            .lock()
+            .insert(node_id.clone(), node_digest_signature.clone());
+        Ok(())
+    }
+
+    fn get_node_signatures(&self) -> anyhow::Result<HashMap<NodeId, NodeDigestSignature>> {
+        Ok(self.node_signature_data.lock().clone())
+    }
+
+    fn delete_node_signatures(&self, node_ids: Vec<crate::dag::NodeId>) -> anyhow::Result<()> {
+        for node_id in node_ids {
+            self.node_signature_data.lock().remove(&node_id);
+        }
         Ok(())
     }
 

--- a/consensus/src/dag/tests/reliable_broadcast_tests.rs
+++ b/consensus/src/dag/tests/reliable_broadcast_tests.rs
@@ -9,14 +9,13 @@ use crate::{
             BroadcastStatus, CertifiedNodeHandleError, CertifiedNodeHandler,
             NodeBroadcastHandleError, NodeBroadcastHandler, ReliableBroadcast,
         },
+        storage::DAGStorage,
         tests::{
             dag_test::MockStorage,
             helpers::{new_certified_node, new_node},
         },
-        types::{
-            CertifiedAck, DAGMessage, NodeCertificate, NodeDigestSignature, TestAck, TestMessage,
-        },
-        RpcHandler,
+        types::{CertifiedAck, DAGMessage, NodeCertificate, TestAck, TestMessage},
+        NodeDigestSignature, NodeId, RpcHandler,
     },
     network::TConsensusMsg,
     network_interface::ConsensusMsg,
@@ -195,14 +194,15 @@ async fn test_node_broadcast_receiver_succeed() {
         verifier: validator_verifier.clone(),
     });
     let storage = Arc::new(MockStorage::new());
-    let dag = Arc::new(RwLock::new(Dag::new(epoch_state, storage)));
+    let dag = Arc::new(RwLock::new(Dag::new(epoch_state, storage.clone())));
 
     let wellformed_node = new_node(0, 10, signers[0].author(), vec![]);
     let equivocating_node = new_node(0, 20, signers[0].author(), vec![]);
 
     assert_ne!(wellformed_node.digest(), equivocating_node.digest());
 
-    let mut rb_receiver = NodeBroadcastHandler::new(dag, signers[3].clone(), validator_verifier);
+    let mut rb_receiver =
+        NodeBroadcastHandler::new(dag, signers[3].clone(), validator_verifier, storage);
 
     let expected_result = NodeDigestSignature::new(
         0,
@@ -227,9 +227,9 @@ async fn test_node_broadcast_receiver_failure() {
         .iter()
         .map(|signer| {
             let storage = Arc::new(MockStorage::new());
-            let dag = Arc::new(RwLock::new(Dag::new(epoch_state.clone(), storage)));
+            let dag = Arc::new(RwLock::new(Dag::new(epoch_state.clone(), storage.clone())));
 
-            NodeBroadcastHandler::new(dag, signer.clone(), validator_verifier.clone())
+            NodeBroadcastHandler::new(dag, signer.clone(), validator_verifier.clone(), storage)
         })
         .collect();
 
@@ -282,6 +282,37 @@ async fn test_node_broadcast_receiver_failure() {
         rb_receivers[0].process(node).unwrap_err().to_string(),
         NodeBroadcastHandleError::MissingParents.to_string()
     );
+}
+
+#[test]
+fn test_node_broadcast_receiver_storage() {
+    let (signers, validator_verifier) = random_validator_verifier(4, None, false);
+    let epoch_state = Arc::new(EpochState {
+        epoch: 1,
+        verifier: validator_verifier.clone(),
+    });
+    let storage = Arc::new(MockStorage::new());
+    let dag = Arc::new(RwLock::new(Dag::new(epoch_state, storage.clone())));
+
+    let node = new_node(0, 10, signers[0].author(), vec![]);
+
+    let mut rb_receiver = NodeBroadcastHandler::new(
+        dag.clone(),
+        signers[3].clone(),
+        validator_verifier.clone(),
+        storage.clone(),
+    );
+    let sig = rb_receiver.process(node).expect("must succeed");
+
+    assert_ok_eq!(
+        storage.get_node_signatures(),
+        HashMap::from([(NodeId::new(0, signers[0].author()), sig)])
+    );
+
+    let mut rb_receiver =
+        NodeBroadcastHandler::new(dag, signers[3].clone(), validator_verifier, storage.clone());
+    assert_ok!(rb_receiver.gc_before_round(2));
+    assert_eq!(storage.get_node_signatures().unwrap().len(), 0);
 }
 
 #[test]

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -275,6 +275,35 @@ impl TDAGMessage for Node {
     }
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Hash, Clone)]
+pub struct NodeId {
+    round: Round,
+    author: Author,
+}
+
+impl NodeId {
+    pub fn new(round: Round, author: Author) -> Self {
+        Self { round, author }
+    }
+
+    pub fn round(&self) -> Round {
+        self.round
+    }
+
+    pub fn author(&self) -> Author {
+        self.author
+    }
+}
+
+impl From<&Node> for NodeId {
+    fn from(node: &Node) -> Self {
+        Self {
+            round: node.metadata.round,
+            author: node.metadata.author,
+        }
+    }
+}
+
 /// Quorum signatures over the node digest
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct NodeCertificate {

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -77,9 +77,7 @@ impl<'a> From<&'a Node> for NodeWithoutDigest<'a> {
 /// Represents the metadata about the node, without payload and parents from Node
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct NodeMetadata {
-    epoch: u64,
-    round: Round,
-    author: Author,
+    node_id: NodeId,
     timestamp: u64,
     digest: HashValue,
 }
@@ -94,9 +92,11 @@ impl NodeMetadata {
         digest: HashValue,
     ) -> Self {
         Self {
-            epoch,
-            round,
-            author,
+            node_id: NodeId {
+                epoch,
+                round,
+                author,
+            },
             timestamp,
             digest,
         }
@@ -116,6 +116,14 @@ impl NodeMetadata {
 
     pub fn epoch(&self) -> u64 {
         self.epoch
+    }
+}
+
+impl Deref for NodeMetadata {
+    type Target = NodeId;
+
+    fn deref(&self) -> &Self::Target {
+        &self.node_id
     }
 }
 
@@ -160,9 +168,11 @@ impl Node {
 
         Self {
             metadata: NodeMetadata {
-                epoch,
-                round,
-                author,
+                node_id: NodeId {
+                    epoch,
+                    round,
+                    author,
+                },
                 timestamp,
                 digest,
             },
@@ -277,13 +287,22 @@ impl TDAGMessage for Node {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Hash, Clone)]
 pub struct NodeId {
+    epoch: u64,
     round: Round,
     author: Author,
 }
 
 impl NodeId {
-    pub fn new(round: Round, author: Author) -> Self {
-        Self { round, author }
+    pub fn new(epoch: u64, round: Round, author: Author) -> Self {
+        Self {
+            epoch,
+            round,
+            author,
+        }
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.epoch
     }
 
     pub fn round(&self) -> Round {
@@ -298,6 +317,7 @@ impl NodeId {
 impl From<&Node> for NodeId {
     fn from(node: &Node) -> Self {
         Self {
+            epoch: node.metadata.epoch,
             round: node.metadata.round,
             author: node.metadata.author,
         }


### PR DESCRIPTION
### Description

This PR adds storage support for reliable broadcast. The sender persists the node before broadcasting the node, and the receiver persists the signature before returning it. The GC logic is separated out: the idea is there will a periodic task that will call RB handler `gc_before_round` based on information from `dag` store.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

New tests.
