### PR TITLE
[helm][pfn-addons] default http/2 for backend protocol

### DIFF
--- a/terraform/helm/pfn-addons/templates/ingress.yaml
+++ b/terraform/helm/pfn-addons/templates/ingress.yaml
@@ -21,6 +21,7 @@ metadata:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     # ensure ALB ingress controller is version > 1.4.4
     alb.ingress.kubernetes.io/ssl-redirect: '443'
+    alb.ingress.kubernetes.io/backend-protocol-version: HTTP2
     {{- end }}
     {{- if .Values.ingress.wafAclArn }}
     alb.ingress.kubernetes.io/wafv2-acl-arn: {{ .Values.ingress.wafAclArn }}


### PR DESCRIPTION
### Description

Support HTTP/2 fwding to the backend. Docs here: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/#backend-protocol-version

### Test Plan

Deploy on a test cluster and check the ALB ingress controller creates what we want by checking the target groups created

<!-- Please provide us with clear details for verifying that your changes work. -->
