### PR TITLE
[Storage Service] Surface renames and refactors.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -155,7 +155,7 @@ pub struct StorageServiceConfig {
     /// Maximum number of bytes to send per network message
     pub max_network_chunk_bytes: u64,
     /// Maximum period (ms) of pending optimistic fetch requests
-    pub max_optimistic_fetch_period: u64,
+    pub max_optimistic_fetch_period_ms: u64,
     /// Maximum number of state keys and values per chunk
     pub max_state_chunk_size: u64,
     /// Maximum number of transactions per chunk
@@ -179,7 +179,7 @@ impl Default for StorageServiceConfig {
             max_lru_cache_size: 500, // At ~0.6MiB per chunk, this should take no more than 0.5GiB
             max_network_channel_size: 4000,
             max_network_chunk_bytes: MAX_MESSAGE_SIZE as u64,
-            max_optimistic_fetch_period: 5000, // 5 seconds
+            max_optimistic_fetch_period_ms: 5000, // 5 seconds
             max_state_chunk_size: MAX_STATE_CHUNK_SIZE,
             max_transaction_chunk_size: MAX_TRANSACTION_CHUNK_SIZE,
             max_transaction_output_chunk_size: MAX_TRANSACTION_OUTPUT_CHUNK_SIZE,

--- a/crates/aptos-time-service/src/lib.rs
+++ b/crates/aptos-time-service/src/lib.rs
@@ -93,6 +93,11 @@ impl TimeService {
     }
 
     #[cfg(any(test, feature = "testing"))]
+    pub fn from_mock(mock: MockTimeService) -> Self {
+        Self::MockTimeService(mock)
+    }
+
+    #[cfg(any(test, feature = "testing"))]
     pub fn into_mock(self) -> MockTimeService {
         match self {
             TimeService::MockTimeService(inner) => inner,

--- a/state-sync/aptos-data-client/src/tests/priority.rs
+++ b/state-sync/aptos-data-client/src/tests/priority.rs
@@ -14,7 +14,7 @@ use aptos_storage_service_types::{
         DataRequest, NewTransactionOutputsWithProofRequest, NewTransactionsWithProofRequest,
         StorageServiceRequest, TransactionOutputsWithProofRequest,
     },
-    responses::OPTIMISTIC_FETCH_VERSION_DELTA,
+    responses::OPTIMISTIC_FETCH_VERSION_LAG,
 };
 use claims::assert_matches;
 
@@ -209,7 +209,7 @@ async fn prioritized_peer_subscription_selection() {
         // Update the priority peer to be too far behind and verify it is not selected
         client.update_summary(
             priority_peer_1,
-            utils::create_storage_summary(known_version - OPTIMISTIC_FETCH_VERSION_DELTA),
+            utils::create_storage_summary(known_version - OPTIMISTIC_FETCH_VERSION_LAG),
         );
         assert_eq!(
             client.choose_peer_for_request(&storage_request),
@@ -219,7 +219,7 @@ async fn prioritized_peer_subscription_selection() {
         // Update the regular peer to be too far behind and verify neither is selected
         client.update_summary(
             regular_peer_1,
-            utils::create_storage_summary(known_version - (OPTIMISTIC_FETCH_VERSION_DELTA * 2)),
+            utils::create_storage_summary(known_version - (OPTIMISTIC_FETCH_VERSION_LAG * 2)),
         );
         assert_matches!(
             client.choose_peer_for_request(&storage_request),

--- a/state-sync/storage-service/server/src/lib.rs
+++ b/state-sync/storage-service/server/src/lib.rs
@@ -41,6 +41,7 @@ mod moderator;
 pub mod network;
 mod optimistic_fetch;
 pub mod storage;
+mod utils;
 
 #[cfg(test)]
 mod tests;

--- a/state-sync/storage-service/server/src/metrics.rs
+++ b/state-sync/storage-service/server/src/metrics.rs
@@ -66,7 +66,7 @@ pub static OPTIMISTIC_FETCH_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Time it takes to process a storage request
+/// Time it takes to process an optimistic fetch request
 pub static OPTIMISTIC_FETCH_LATENCIES: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "aptos_storage_service_server_optimistic_fetch_latency",

--- a/state-sync/storage-service/server/src/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/optimistic_fetch.rs
@@ -3,13 +3,12 @@
 
 use crate::{
     error::Error,
-    handler::Handler,
     metrics,
     metrics::{increment_counter, OPTIMISTIC_FETCH_EXPIRE},
     moderator::RequestModerator,
     network::ResponseSender,
     storage::StorageReaderInterface,
-    LogEntry, LogSchema,
+    utils, LogEntry, LogSchema,
 };
 use aptos_bounded_executor::BoundedExecutor;
 use aptos_config::{
@@ -20,11 +19,10 @@ use aptos_infallible::Mutex;
 use aptos_logger::{error, warn};
 use aptos_storage_service_types::{
     requests::{
-        DataRequest, EpochEndingLedgerInfoRequest, StorageServiceRequest,
-        TransactionOutputsWithProofRequest, TransactionsOrOutputsWithProofRequest,
-        TransactionsWithProofRequest,
+        DataRequest, StorageServiceRequest, TransactionOutputsWithProofRequest,
+        TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
     },
-    responses::{DataResponse, StorageServerSummary, StorageServiceResponse},
+    responses::{StorageServerSummary, StorageServiceResponse},
 };
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
@@ -56,9 +54,14 @@ impl OptimisticFetchRequest {
         }
     }
 
+    /// Returns the response sender and consumes the request
+    pub fn get_response_sender(self) -> ResponseSender {
+        self.response_sender
+    }
+
     /// Creates a new storage service request to satisfy the optimistic fetch
     /// using the new data at the specified `target_ledger_info`.
-    fn get_storage_request_for_missing_data(
+    pub fn get_storage_request_for_missing_data(
         &self,
         config: StorageServiceConfig,
         target_ledger_info: &LedgerInfoWithSignatures,
@@ -248,7 +251,7 @@ async fn handle_ready_optimistic_fetches<T: StorageReaderInterface>(
                     let optimistic_fetch_request = optimistic_fetch.request.clone();
 
                     // Notify the peer of the new data
-                    if let Err(error) = notify_peer_of_new_data(
+                    if let Err(error) = utils::notify_peer_of_new_data(
                         cached_storage_server_summary.clone(),
                         config,
                         optimistic_fetches.clone(),
@@ -450,7 +453,7 @@ async fn identify_ready_and_invalid_optimistic_fetches<T: StorageReaderInterface
                     if highest_known_epoch < highest_synced_epoch {
                         // Fetch the epoch ending ledger info from storage (the
                         // peer needs to sync to their epoch ending ledger info).
-                        let epoch_ending_ledger_info = match get_epoch_ending_ledger_info(
+                        let epoch_ending_ledger_info = match utils::get_epoch_ending_ledger_info(
                             cached_storage_server_summary.clone(),
                             optimistic_fetches.clone(),
                             highest_known_epoch,
@@ -510,166 +513,6 @@ async fn identify_ready_and_invalid_optimistic_fetches<T: StorageReaderInterface
         peers_with_ready_optimistic_fetches,
         peers_with_invalid_optimistic_fetches,
     )
-}
-
-/// Gets the epoch ending ledger info at the given epoch
-fn get_epoch_ending_ledger_info<T: StorageReaderInterface>(
-    cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
-    optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
-    epoch: u64,
-    lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
-    request_moderator: Arc<RequestModerator>,
-    peer_network_id: &PeerNetworkId,
-    storage: T,
-    time_service: TimeService,
-) -> aptos_storage_service_types::Result<LedgerInfoWithSignatures, Error> {
-    // Create a new storage request for the epoch ending ledger info
-    let data_request = DataRequest::GetEpochEndingLedgerInfos(EpochEndingLedgerInfoRequest {
-        start_epoch: epoch,
-        expected_end_epoch: epoch,
-    });
-    let storage_request = StorageServiceRequest::new(
-        data_request,
-        false, // Don't compress because this isn't going over the wire
-    );
-
-    // Process the request
-    let handler = Handler::new(
-        cached_storage_server_summary,
-        optimistic_fetches,
-        lru_response_cache,
-        request_moderator,
-        storage,
-        time_service,
-    );
-    let storage_response = handler.process_request(peer_network_id, storage_request, true);
-
-    // Verify the response
-    match storage_response {
-        Ok(storage_response) => match &storage_response.get_data_response() {
-            Ok(DataResponse::EpochEndingLedgerInfos(epoch_change_proof)) => {
-                if let Some(ledger_info) = epoch_change_proof.ledger_info_with_sigs.first() {
-                    Ok(ledger_info.clone())
-                } else {
-                    Err(Error::UnexpectedErrorEncountered(
-                        "Empty change proof found!".into(),
-                    ))
-                }
-            },
-            data_response => Err(Error::StorageErrorEncountered(format!(
-                "Failed to get epoch ending ledger info! Got: {:?}",
-                data_response
-            ))),
-        },
-        Err(error) => Err(Error::StorageErrorEncountered(format!(
-            "Failed to get epoch ending ledger info! Error: {:?}",
-            error
-        ))),
-    }
-}
-
-/// Notifies a peer of new data according to the target ledger info.
-///
-/// Note: we don't need to check the size of the optimistic fetch response
-/// because: (i) each sub-part should already be checked; and (ii)
-/// optimistic fetch responses are best effort.
-fn notify_peer_of_new_data<T: StorageReaderInterface>(
-    cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
-    config: StorageServiceConfig,
-    optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
-    lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
-    request_moderator: Arc<RequestModerator>,
-    storage: T,
-    time_service: TimeService,
-    peer_network_id: &PeerNetworkId,
-    optimistic_fetch: OptimisticFetchRequest,
-    target_ledger_info: LedgerInfoWithSignatures,
-) -> aptos_storage_service_types::Result<(), Error> {
-    match optimistic_fetch.get_storage_request_for_missing_data(config, &target_ledger_info) {
-        Ok(storage_request) => {
-            // Handle the storage service request to fetch the missing data
-            let use_compression = storage_request.use_compression;
-            let handler = Handler::new(
-                cached_storage_server_summary,
-                optimistic_fetches,
-                lru_response_cache,
-                request_moderator,
-                storage,
-                time_service,
-            );
-            let storage_response =
-                handler.process_request(peer_network_id, storage_request.clone(), true);
-
-            // Transform the missing data into an optimistic fetch response
-            let transformed_data_response = match storage_response {
-                Ok(storage_response) => match storage_response.get_data_response() {
-                    Ok(DataResponse::TransactionsWithProof(transactions_with_proof)) => {
-                        DataResponse::NewTransactionsWithProof((
-                            transactions_with_proof,
-                            target_ledger_info.clone(),
-                        ))
-                    },
-                    Ok(DataResponse::TransactionOutputsWithProof(outputs_with_proof)) => {
-                        DataResponse::NewTransactionOutputsWithProof((
-                            outputs_with_proof,
-                            target_ledger_info.clone(),
-                        ))
-                    },
-                    Ok(DataResponse::TransactionsOrOutputsWithProof((
-                        transactions_with_proof,
-                        outputs_with_proof,
-                    ))) => {
-                        if let Some(transactions_with_proof) = transactions_with_proof {
-                            DataResponse::NewTransactionsOrOutputsWithProof((
-                                (Some(transactions_with_proof), None),
-                                target_ledger_info.clone(),
-                            ))
-                        } else if let Some(outputs_with_proof) = outputs_with_proof {
-                            DataResponse::NewTransactionsOrOutputsWithProof((
-                                (None, Some(outputs_with_proof)),
-                                target_ledger_info.clone(),
-                            ))
-                        } else {
-                            return Err(Error::UnexpectedErrorEncountered(
-                                "Failed to get a transaction or output response for peer!".into(),
-                            ));
-                        }
-                    },
-                    data_response => {
-                        return Err(Error::UnexpectedErrorEncountered(format!(
-                            "Failed to get appropriate data response for peer! Got: {:?}",
-                            data_response
-                        )))
-                    },
-                },
-                response => {
-                    return Err(Error::UnexpectedErrorEncountered(format!(
-                        "Failed to fetch missing data for peer! {:?}",
-                        response
-                    )))
-                },
-            };
-            let storage_response =
-                match StorageServiceResponse::new(transformed_data_response, use_compression) {
-                    Ok(storage_response) => storage_response,
-                    Err(error) => {
-                        return Err(Error::UnexpectedErrorEncountered(format!(
-                            "Failed to create transformed response! Error: {:?}",
-                            error
-                        )));
-                    },
-                };
-
-            // Send the response to the peer
-            handler.send_response(
-                storage_request,
-                Ok(storage_response),
-                optimistic_fetch.response_sender,
-            );
-            Ok(())
-        },
-        Err(error) => Err(error),
-    }
 }
 
 /// Removes the expired optimistic fetches from the active map

--- a/state-sync/storage-service/server/src/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/optimistic_fetch.rs
@@ -363,7 +363,7 @@ async fn identify_expired_invalid_and_ready_fetches<T: StorageReaderInterface>(
         let optimistic_fetch = optimistic_fetch.value();
 
         // Gather the peer's highest synced version and epoch
-        if !optimistic_fetch.is_expired(config.max_optimistic_fetch_period) {
+        if !optimistic_fetch.is_expired(config.max_optimistic_fetch_period_ms) {
             let highest_known_version = optimistic_fetch.highest_known_version();
             let highest_known_epoch = optimistic_fetch.highest_known_epoch();
 

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    metrics, network::StorageServiceNetworkEvents, storage::StorageReader, StorageServiceServer,
+    metrics, network::StorageServiceNetworkEvents, storage::StorageReader, tests::utils,
+    StorageServiceServer,
 };
 use anyhow::Result;
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::{config::StorageServiceConfig, network_id::NetworkId};
 use aptos_crypto::HashValue;
-use aptos_logger::Level;
 use aptos_network::{
     application::{interface::NetworkServiceEvents, storage::PeersAndMetadata},
     peer_manager::PeerManagerNotification,
@@ -70,7 +70,7 @@ impl MockClient {
         MockTimeService,
         Arc<PeersAndMetadata>,
     ) {
-        initialize_logger();
+        utils::initialize_logger();
 
         // Create the storage reader
         let storage_config = storage_config.unwrap_or_default();
@@ -211,14 +211,6 @@ fn get_random_network_id() -> NetworkId {
         2 => NetworkId::Public,
         num => panic!("This shouldn't be possible! Got num: {:?}", num),
     }
-}
-
-/// Initializes the Aptos logger for tests
-fn initialize_logger() {
-    aptos_logger::Logger::builder()
-        .is_async(false)
-        .level(Level::Debug)
-        .build();
 }
 
 // This automatically creates a MockDatabaseReader.

--- a/state-sync/storage-service/server/src/tests/new_transaction_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/new_transaction_outputs.rs
@@ -6,14 +6,10 @@ use aptos_config::{
     config::StorageServiceConfig,
     network_id::{NetworkId, PeerNetworkId},
 };
-use aptos_storage_service_types::{
-    requests::{DataRequest, NewTransactionOutputsWithProofRequest, StorageServiceRequest},
-    responses::DataResponse,
+use aptos_storage_service_types::requests::{
+    DataRequest, NewTransactionOutputsWithProofRequest, StorageServiceRequest,
 };
-use aptos_types::{
-    epoch_change::EpochChangeProof, ledger_info::LedgerInfoWithSignatures,
-    transaction::TransactionOutputListWithProof, PeerId,
-};
+use aptos_types::{epoch_change::EpochChangeProof, PeerId};
 use claims::assert_none;
 use futures::channel::oneshot::Receiver;
 
@@ -71,7 +67,7 @@ async fn test_get_new_transaction_outputs() {
         .await;
 
         // Verify a response is received and that it contains the correct data
-        verify_new_transaction_outputs_with_proof(
+        utils::verify_new_transaction_outputs_with_proof(
             &mut mock_client,
             response_receiver,
             output_list_with_proof,
@@ -166,14 +162,14 @@ async fn test_get_new_transaction_outputs_different_networks() {
         .await;
 
         // Verify a response is received and that it contains the correct data
-        verify_new_transaction_outputs_with_proof(
+        utils::verify_new_transaction_outputs_with_proof(
             &mut mock_client,
             response_receiver_1,
             output_list_with_proof_1,
             highest_ledger_info.clone(),
         )
         .await;
-        verify_new_transaction_outputs_with_proof(
+        utils::verify_new_transaction_outputs_with_proof(
             &mut mock_client,
             response_receiver_2,
             output_list_with_proof_2,
@@ -246,7 +242,7 @@ async fn test_get_new_transaction_outputs_epoch_change() {
     .await;
 
     // Verify a response is received and that it contains the correct data
-    verify_new_transaction_outputs_with_proof(
+    utils::verify_new_transaction_outputs_with_proof(
         &mut mock_client,
         response_receiver,
         output_list_with_proof,
@@ -305,7 +301,7 @@ async fn test_get_new_transaction_outputs_max_chunk() {
     .await;
 
     // Verify a response is received and that it contains the correct data
-    verify_new_transaction_outputs_with_proof(
+    utils::verify_new_transaction_outputs_with_proof(
         &mut mock_client,
         response_receiver,
         output_list_with_proof,
@@ -343,30 +339,4 @@ async fn get_new_outputs_with_proof_for_peer(
     mock_client
         .send_request(storage_request, peer_id, network_id)
         .await
-}
-
-/// Verifies that a new transaction outputs with proof response is received
-/// and that the response contains the correct data.
-async fn verify_new_transaction_outputs_with_proof(
-    mock_client: &mut MockClient,
-    receiver: Receiver<Result<bytes::Bytes, aptos_network::protocols::network::RpcError>>,
-    output_list_with_proof: TransactionOutputListWithProof,
-    expected_ledger_info: LedgerInfoWithSignatures,
-) {
-    match mock_client
-        .wait_for_response(receiver)
-        .await
-        .unwrap()
-        .get_data_response()
-        .unwrap()
-    {
-        DataResponse::NewTransactionOutputsWithProof((outputs_with_proof, ledger_info)) => {
-            assert_eq!(outputs_with_proof, output_list_with_proof);
-            assert_eq!(ledger_info, expected_ledger_info);
-        },
-        response => panic!(
-            "Expected new transaction outputs with proof but got: {:?}",
-            response
-        ),
-    };
 }

--- a/state-sync/storage-service/server/src/tests/new_transactions.rs
+++ b/state-sync/storage-service/server/src/tests/new_transactions.rs
@@ -6,14 +6,10 @@ use aptos_config::{
     config::StorageServiceConfig,
     network_id::{NetworkId, PeerNetworkId},
 };
-use aptos_storage_service_types::{
-    requests::{DataRequest, NewTransactionsWithProofRequest, StorageServiceRequest},
-    responses::DataResponse,
+use aptos_storage_service_types::requests::{
+    DataRequest, NewTransactionsWithProofRequest, StorageServiceRequest,
 };
-use aptos_types::{
-    epoch_change::EpochChangeProof, ledger_info::LedgerInfoWithSignatures,
-    transaction::TransactionListWithProof, PeerId,
-};
+use aptos_types::{epoch_change::EpochChangeProof, PeerId};
 use claims::assert_none;
 use futures::channel::oneshot::Receiver;
 
@@ -82,7 +78,7 @@ async fn test_get_new_transactions() {
             .await;
 
             // Verify a response is received and that it contains the correct data
-            verify_new_transactions_with_proof(
+            utils::verify_new_transactions_with_proof(
                 &mut mock_client,
                 response_receiver,
                 transaction_list_with_proof,
@@ -188,14 +184,14 @@ async fn test_get_new_transactions_different_networks() {
             .await;
 
             // Verify a response is received and that it contains the correct data for both peers
-            verify_new_transactions_with_proof(
+            utils::verify_new_transactions_with_proof(
                 &mut mock_client,
                 response_receiver_1,
                 transaction_list_with_proof_1,
                 highest_ledger_info.clone(),
             )
             .await;
-            verify_new_transactions_with_proof(
+            utils::verify_new_transactions_with_proof(
                 &mut mock_client,
                 response_receiver_2,
                 transaction_list_with_proof_2,
@@ -278,7 +274,7 @@ async fn test_get_new_transactions_epoch_change() {
         .await;
 
         // Verify a response is received and that it contains the correct data
-        verify_new_transactions_with_proof(
+        utils::verify_new_transactions_with_proof(
             &mut mock_client,
             response_receiver,
             transaction_list_with_proof,
@@ -347,7 +343,7 @@ async fn test_get_new_transactions_max_chunk() {
         .await;
 
         // Verify a response is received and that it contains the correct data
-        verify_new_transactions_with_proof(
+        utils::verify_new_transactions_with_proof(
             &mut mock_client,
             response_receiver,
             transaction_list_with_proof,
@@ -395,25 +391,4 @@ async fn get_new_transactions_with_proof_for_peer(
     mock_client
         .send_request(storage_request, peer_id, network_id)
         .await
-}
-
-/// Verifies that a new transactions with proof response is received
-/// and that the response contains the correct data.
-async fn verify_new_transactions_with_proof(
-    mock_client: &mut MockClient,
-    receiver: Receiver<Result<bytes::Bytes, aptos_network::protocols::network::RpcError>>,
-    expected_transactions_with_proof: TransactionListWithProof,
-    expected_ledger_info: LedgerInfoWithSignatures,
-) {
-    let storage_service_response = mock_client.wait_for_response(receiver).await.unwrap();
-    match storage_service_response.get_data_response().unwrap() {
-        DataResponse::NewTransactionsWithProof((transactions_with_proof, ledger_info)) => {
-            assert_eq!(transactions_with_proof, expected_transactions_with_proof);
-            assert_eq!(ledger_info, expected_ledger_info);
-        },
-        response => panic!(
-            "Expected new transaction with proof but got: {:?}",
-            response
-        ),
-    };
 }

--- a/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
@@ -27,7 +27,7 @@ use dashmap::DashMap;
 use futures::channel::oneshot;
 use lru::LruCache;
 use rand::{rngs::OsRng, Rng};
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 use tokio::runtime::Handle;
 
 #[tokio::test]
@@ -180,11 +180,7 @@ async fn test_remove_expired_optimistic_fetches() {
     assert_eq!(optimistic_fetches.len(), num_optimistic_fetches_in_batch);
 
     // Elapse a small amount of time (not enough to expire the optimistic fetches)
-    time_service
-        .clone()
-        .into_mock()
-        .advance_async(Duration::from_millis(max_optimistic_fetch_period_ms / 2))
-        .await;
+    utils::elapse_time(max_optimistic_fetch_period_ms / 2, &time_service).await;
 
     // Update the storage server summary so that there is new data
     let _ = update_storage_server_summary(cached_storage_server_summary.clone(), 1, 1);
@@ -220,11 +216,7 @@ async fn test_remove_expired_optimistic_fetches() {
     );
 
     // Elapse enough time to expire the first batch of optimistic fetches
-    time_service
-        .clone()
-        .into_mock()
-        .advance_async(Duration::from_millis(max_optimistic_fetch_period_ms))
-        .await;
+    utils::elapse_time(max_optimistic_fetch_period_ms, &time_service).await;
 
     // Remove the expired optimistic fetches and verify the first batch was removed
     let peers_with_ready_optimistic_fetches =
@@ -244,11 +236,7 @@ async fn test_remove_expired_optimistic_fetches() {
     assert_eq!(optimistic_fetches.len(), num_optimistic_fetches_in_batch);
 
     // Elapse enough time to expire the second batch of optimistic fetches
-    time_service
-        .clone()
-        .into_mock()
-        .advance_async(Duration::from_millis(max_optimistic_fetch_period_ms + 1))
-        .await;
+    utils::elapse_time(max_optimistic_fetch_period_ms + 1, &time_service).await;
 
     // Remove the expired optimistic fetches and verify the second batch was removed
     let peers_with_ready_optimistic_fetches =

--- a/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
@@ -144,9 +144,9 @@ async fn test_peers_with_ready_optimistic_fetches() {
 #[tokio::test]
 async fn test_remove_expired_optimistic_fetches() {
     // Create a storage service config
-    let max_optimistic_fetch_period = 100;
+    let max_optimistic_fetch_period_ms = 100;
     let storage_service_config = StorageServiceConfig {
-        max_optimistic_fetch_period,
+        max_optimistic_fetch_period_ms,
         ..Default::default()
     };
 
@@ -183,7 +183,7 @@ async fn test_remove_expired_optimistic_fetches() {
     time_service
         .clone()
         .into_mock()
-        .advance_async(Duration::from_millis(max_optimistic_fetch_period / 2))
+        .advance_async(Duration::from_millis(max_optimistic_fetch_period_ms / 2))
         .await;
 
     // Update the storage server summary so that there is new data
@@ -223,7 +223,7 @@ async fn test_remove_expired_optimistic_fetches() {
     time_service
         .clone()
         .into_mock()
-        .advance_async(Duration::from_millis(max_optimistic_fetch_period))
+        .advance_async(Duration::from_millis(max_optimistic_fetch_period_ms))
         .await;
 
     // Remove the expired optimistic fetches and verify the first batch was removed
@@ -247,7 +247,7 @@ async fn test_remove_expired_optimistic_fetches() {
     time_service
         .clone()
         .into_mock()
-        .advance_async(Duration::from_millis(max_optimistic_fetch_period + 1))
+        .advance_async(Duration::from_millis(max_optimistic_fetch_period_ms + 1))
         .await;
 
     // Remove the expired optimistic fetches and verify the second batch was removed

--- a/state-sync/storage-service/server/src/utils.rs
+++ b/state-sync/storage-service/server/src/utils.rs
@@ -1,0 +1,179 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    error::Error, handler::Handler, moderator::RequestModerator,
+    optimistic_fetch::OptimisticFetchRequest, storage::StorageReaderInterface,
+};
+use aptos_config::{config::StorageServiceConfig, network_id::PeerNetworkId};
+use aptos_infallible::Mutex;
+use aptos_storage_service_types::{
+    requests::{DataRequest, EpochEndingLedgerInfoRequest, StorageServiceRequest},
+    responses::{DataResponse, StorageServerSummary, StorageServiceResponse},
+};
+use aptos_time_service::TimeService;
+use aptos_types::ledger_info::LedgerInfoWithSignatures;
+use arc_swap::ArcSwap;
+use dashmap::DashMap;
+use lru::LruCache;
+use std::sync::Arc;
+
+/// Gets the epoch ending ledger info at the given epoch
+pub fn get_epoch_ending_ledger_info<T: StorageReaderInterface>(
+    cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
+    optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
+    epoch: u64,
+    lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
+    request_moderator: Arc<RequestModerator>,
+    peer_network_id: &PeerNetworkId,
+    storage: T,
+    time_service: TimeService,
+) -> aptos_storage_service_types::Result<LedgerInfoWithSignatures, Error> {
+    // Create a new storage request for the epoch ending ledger info
+    let data_request = DataRequest::GetEpochEndingLedgerInfos(EpochEndingLedgerInfoRequest {
+        start_epoch: epoch,
+        expected_end_epoch: epoch,
+    });
+    let storage_request = StorageServiceRequest::new(
+        data_request,
+        false, // Don't compress because this isn't going over the wire
+    );
+
+    // Process the request
+    let handler = Handler::new(
+        cached_storage_server_summary,
+        optimistic_fetches,
+        lru_response_cache,
+        request_moderator,
+        storage,
+        time_service,
+    );
+    let storage_response = handler.process_request(peer_network_id, storage_request, true);
+
+    // Verify the response
+    match storage_response {
+        Ok(storage_response) => match &storage_response.get_data_response() {
+            Ok(DataResponse::EpochEndingLedgerInfos(epoch_change_proof)) => {
+                if let Some(ledger_info) = epoch_change_proof.ledger_info_with_sigs.first() {
+                    Ok(ledger_info.clone())
+                } else {
+                    Err(Error::UnexpectedErrorEncountered(
+                        "Empty change proof found!".into(),
+                    ))
+                }
+            },
+            data_response => Err(Error::StorageErrorEncountered(format!(
+                "Failed to get epoch ending ledger info! Got: {:?}",
+                data_response
+            ))),
+        },
+        Err(error) => Err(Error::StorageErrorEncountered(format!(
+            "Failed to get epoch ending ledger info! Error: {:?}",
+            error
+        ))),
+    }
+}
+
+/// Notifies a peer of new data according to the target ledger info.
+///
+/// Note: we don't need to check the size of the optimistic fetch response
+/// because: (i) each sub-part should already be checked; and (ii)
+/// optimistic fetch responses are best effort.
+pub fn notify_peer_of_new_data<T: StorageReaderInterface>(
+    cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
+    config: StorageServiceConfig,
+    optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
+    lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
+    request_moderator: Arc<RequestModerator>,
+    storage: T,
+    time_service: TimeService,
+    peer_network_id: &PeerNetworkId,
+    optimistic_fetch: OptimisticFetchRequest,
+    target_ledger_info: LedgerInfoWithSignatures,
+) -> aptos_storage_service_types::Result<(), Error> {
+    match optimistic_fetch.get_storage_request_for_missing_data(config, &target_ledger_info) {
+        Ok(storage_request) => {
+            // Handle the storage service request to fetch the missing data
+            let use_compression = storage_request.use_compression;
+            let handler = Handler::new(
+                cached_storage_server_summary,
+                optimistic_fetches,
+                lru_response_cache,
+                request_moderator,
+                storage,
+                time_service,
+            );
+            let storage_response =
+                handler.process_request(peer_network_id, storage_request.clone(), true);
+
+            // Transform the missing data into an optimistic fetch response
+            let transformed_data_response = match storage_response {
+                Ok(storage_response) => match storage_response.get_data_response() {
+                    Ok(DataResponse::TransactionsWithProof(transactions_with_proof)) => {
+                        DataResponse::NewTransactionsWithProof((
+                            transactions_with_proof,
+                            target_ledger_info.clone(),
+                        ))
+                    },
+                    Ok(DataResponse::TransactionOutputsWithProof(outputs_with_proof)) => {
+                        DataResponse::NewTransactionOutputsWithProof((
+                            outputs_with_proof,
+                            target_ledger_info.clone(),
+                        ))
+                    },
+                    Ok(DataResponse::TransactionsOrOutputsWithProof((
+                        transactions_with_proof,
+                        outputs_with_proof,
+                    ))) => {
+                        if let Some(transactions_with_proof) = transactions_with_proof {
+                            DataResponse::NewTransactionsOrOutputsWithProof((
+                                (Some(transactions_with_proof), None),
+                                target_ledger_info.clone(),
+                            ))
+                        } else if let Some(outputs_with_proof) = outputs_with_proof {
+                            DataResponse::NewTransactionsOrOutputsWithProof((
+                                (None, Some(outputs_with_proof)),
+                                target_ledger_info.clone(),
+                            ))
+                        } else {
+                            return Err(Error::UnexpectedErrorEncountered(
+                                "Failed to get a transaction or output response for peer!".into(),
+                            ));
+                        }
+                    },
+                    data_response => {
+                        return Err(Error::UnexpectedErrorEncountered(format!(
+                            "Failed to get appropriate data response for peer! Got: {:?}",
+                            data_response
+                        )))
+                    },
+                },
+                response => {
+                    return Err(Error::UnexpectedErrorEncountered(format!(
+                        "Failed to fetch missing data for peer! {:?}",
+                        response
+                    )))
+                },
+            };
+            let storage_response =
+                match StorageServiceResponse::new(transformed_data_response, use_compression) {
+                    Ok(storage_response) => storage_response,
+                    Err(error) => {
+                        return Err(Error::UnexpectedErrorEncountered(format!(
+                            "Failed to create transformed response! Error: {:?}",
+                            error
+                        )));
+                    },
+                };
+
+            // Send the response to the peer
+            handler.send_response(
+                storage_request,
+                Ok(storage_response),
+                optimistic_fetch.get_response_sender(),
+            );
+            Ok(())
+        },
+        Err(error) => Err(error),
+    }
+}

--- a/state-sync/storage-service/types/src/responses.rs
+++ b/state-sync/storage-service/types/src/responses.rs
@@ -30,10 +30,10 @@ use std::{
 };
 use thiserror::Error;
 
-/// The version delta we'll tolerate when considering if a peer is eligible
+/// The version lag we'll tolerate when considering if a peer is eligible
 /// to handle an optimistic fetch for new data. This value is set assuming
-/// 5k TPS for a 5 second delay, which should be more than enough.
-pub const OPTIMISTIC_FETCH_VERSION_DELTA: u64 = 25000;
+/// 5k TPS for a 10 second delay, which should be more than enough.
+pub const OPTIMISTIC_FETCH_VERSION_LAG: u64 = 50_000;
 
 #[derive(Clone, Debug, Deserialize, Error, PartialEq, Eq, Serialize)]
 pub enum Error {
@@ -534,7 +534,7 @@ impl DataSummary {
     fn can_service_optimistic_request(&self, known_version: u64) -> bool {
         self.synced_ledger_info
             .as_ref()
-            .map(|li| (li.ledger_info().version() + OPTIMISTIC_FETCH_VERSION_DELTA) > known_version)
+            .map(|li| (li.ledger_info().version() + OPTIMISTIC_FETCH_VERSION_LAG) > known_version)
             .unwrap_or(false)
     }
 


### PR DESCRIPTION
Note: (i) nothing should really change in this PR; and (ii) this PR is built on: https://github.com/aptos-labs/aptos-core/pull/9014.

### Description
This PR offers a small number of surface changes (i.e., variable renames and utility function refactors). Specifically, it offers the following (each in their own commit):
1. Rename `max_optimistic_fetch_period` to `max_optimistic_fetch_period_ms`.
2. Rename `OPTIMISTIC_FETCH_VERSION_DELTA` to `OPTIMISTIC_FETCH_VERSION_LAG` and increase the version lag (to tolerate higher TPS networks and timeouts).
3. Add a simple `from_mock` utility method to the `TimeService`.
4. Move several utility functions into the `utils.rs` files. This is so they can be re-used in the future.
5. Alphabetically order the test `utils.rs` file. This should help make it easier to navigate now that the file has grown.

### Test Plan
Existing test infrastructure.