### PR TITLE
[CLI][Ledger] Add hardware wallet options

### DIFF
--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -1,14 +1,13 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::types::HardwareWalletOptions;
 use crate::{
     account::key_rotation::lookup_address,
     common::{
         types::{
             account_address_from_public_key, CliCommand, CliConfig, CliError, CliTypedResult,
-            ConfigSearchMode, EncodingOptions, PrivateKeyInputOptions, ProfileConfig,
-            ProfileOptions, PromptOptions, RngArgs, DEFAULT_PROFILE,
+            ConfigSearchMode, EncodingOptions, HardwareWalletOptions, PrivateKeyInputOptions,
+            ProfileConfig, ProfileOptions, PromptOptions, RngArgs, DEFAULT_PROFILE,
         },
         utils::{fund_account, prompt_yes_with_override, read_line, wait_for_transactions},
     },
@@ -182,7 +181,7 @@ impl CliCommand<()> for InitTool {
         profile_config.derivation_path = derivation_path.clone();
 
         // Private key
-        let private_key = if self.ledger || self.hardware_wallet_options.is_hardware_wallet() {
+        let private_key = if self.is_hardware_wallet() {
             // Private key stays in ledger
             None
         } else {
@@ -217,7 +216,7 @@ impl CliCommand<()> for InitTool {
         };
 
         // Public key
-        let public_key = if self.ledger || self.hardware_wallet_options.is_hardware_wallet() {
+        let public_key = if self.is_hardware_wallet() {
             let pub_key = match aptos_ledger::get_public_key(
                 derivation_path
                     .ok_or(CliError::UnexpectedError(
@@ -408,6 +407,10 @@ impl InitTool {
         };
         profile_config.faucet_url = faucet_url;
         Ok(())
+    }
+
+    fn is_hardware_wallet(&self) -> bool {
+        self.hardware_wallet_options.is_hardware_wallet() || self.ledger
     }
 }
 

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -739,6 +739,40 @@ pub trait ParsePrivateKey {
 }
 
 #[derive(Debug, Default, Parser)]
+pub struct HardwareWalletOptions {
+    /// Derivation Path of your account in hardware wallet
+    ///
+    /// e.g format - [m/44'/637'/0'/0'/0]
+    /// Make sure your wallet is unblocked and have Aptos opened
+    #[clap(long)]
+    pub derivation_path: Option<String>,
+
+    /// Index of your account in hardware wallet
+    ///
+    /// This is the simpler version of derivation path e.g format - [0]
+    /// we will translate this index into [m/44'/637'/0'/0'/0]
+    #[clap(long)]
+    pub derivation_index: Option<String>,
+}
+
+impl HardwareWalletOptions {
+    pub fn extract_derivation_path(&self) -> CliTypedResult<Option<String>> {
+        if let Some(derivation_path) = &self.derivation_path {
+            Ok(Some(derivation_path.clone()))
+        } else if let Some(derivation_index) = &self.derivation_index {
+            let derivation_path = format!("m/44'/637'/{}'/0'/0'", derivation_index);
+            Ok(Some(derivation_path))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn is_hardware_wallet(&self) -> bool {
+        self.derivation_path.is_some() || self.derivation_index.is_some()
+    }
+}
+
+#[derive(Debug, Default, Parser)]
 pub struct PrivateKeyInputOptions {
     /// Signing Ed25519 private key file path
     ///

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -548,6 +548,7 @@ impl CliTestFramework {
             encoding_options: EncodingOptions::default(),
             skip_faucet: false,
             ledger: false,
+            hardware_wallet_options: Default::default(),
         }
         .execute()
         .await


### PR DESCRIPTION
### Description

NOTE: This will be merging into ledger feature branch instead of main

This is similar to the private key option we had. Basically create a struct to better manage the `derivation path` or `derivation index` option. There might be case that user do not have profile initialized, but wanted to go-ahead and use their ledger for submitting the transaction

Next Step:
Add this option for txn signing

### Test Plan
```
<!-- Please provide us with clear details for verifying that your changes work. -->
➜  aptos-core git:(feature_branch/cli_ledger_integration) ✗ aptos-debug init --derivation-index 15 --profile deri15
Configuring for profile deri15
Choose network from [devnet, testnet, mainnet, local, custom | defaults to devnet]

No network given, using devnet...
Account 4b19d281ce22da0f39ac3d75d8e1aeef27c430d8830dc659d106990eb70cbd6f doesn't exist, creating it and funding it with 100000000 Octas
Account 4b19d281ce22da0f39ac3d75d8e1aeef27c430d8830dc659d106990eb70cbd6f funded successfully

---
Aptos CLI is now set up for account 4b19d281ce22da0f39ac3d75d8e1aeef27c430d8830dc659d106990eb70cbd6f as profile deri15!  Run `aptos --help` for more information about commands
{
  "Result": "Success"
}
```

Result on the config
```
  deri15:
    public_key: "0x7e0e012edd9d932b2079973457abd44bdc485d93af1843f75bef89c2c28f4dc5"
    account: 4b19d281ce22da0f39ac3d75d8e1aeef27c430d8830dc659d106990eb70cbd6f
    rest_url: "https://fullnode.devnet.aptoslabs.com"
    faucet_url: "https://faucet.devnet.aptoslabs.com"
    derivation_path: "m/44'/637'/15'/0'/0'"
```