### PR TITLE
vertical pod autoscaling for pfn

### DIFF
--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -89,6 +89,7 @@ jobs:
   # to be land blocking for any PR on the aptos repo. This is why we run those tests
   # separate from test-sdk-confirm-client-generated-publish.
   run-indexer-tests:
+    needs: [permission-check]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3

--- a/terraform/fullnode/gcp/cluster.tf
+++ b/terraform/fullnode/gcp/cluster.tf
@@ -61,6 +61,10 @@ resource "google_container_cluster" "aptos" {
     provider = "CALICO"
   }
 
+  vertical_pod_autoscaling {
+    enabled = var.enable_vertical_pod_autoscaling
+  }
+
   cluster_autoscaling {
     enabled = var.gke_enable_node_autoprovisioning
 

--- a/terraform/fullnode/gcp/kubernetes.tf
+++ b/terraform/fullnode/gcp/kubernetes.tf
@@ -79,7 +79,8 @@ resource "helm_release" "fullnode" {
 
   values = [
     jsonencode({
-      imageTag     = var.image_tag
+      imageTag = var.image_tag
+      deploy = 1
       manageImages = var.manage_via_tf # if we're managing the entire deployment via terraform, override the images as well
       chain = {
         era  = var.era
@@ -124,6 +125,7 @@ resource "helm_release" "fullnode" {
           "iam.gke.io/gcp-service-account" = google_service_account.backup.email
         }
       }
+      verticalPodAutoscalingEnabled = var.enable_vertical_pod_autoscaling
     }),
     jsonencode(var.fullnode_helm_values),
     jsonencode(var.fullnode_helm_values_list == {} ? {} : var.fullnode_helm_values_list[count.index]),

--- a/terraform/fullnode/gcp/kubernetes.tf
+++ b/terraform/fullnode/gcp/kubernetes.tf
@@ -80,7 +80,6 @@ resource "helm_release" "fullnode" {
   values = [
     jsonencode({
       imageTag = var.image_tag
-      deploy = 1
       manageImages = var.manage_via_tf # if we're managing the entire deployment via terraform, override the images as well
       chain = {
         era  = var.era
@@ -126,6 +125,10 @@ resource "helm_release" "fullnode" {
         }
       }
       verticalPodAutoscalingEnabled = var.enable_vertical_pod_autoscaling
+      minAllowedForVpa = {
+        cpu = var.min_allowed_cpu_for_vertical_pod_autoscaling
+        memory = var.min_allowed_memory_for_vertical_pod_autoscaling
+      }
     }),
     jsonencode(var.fullnode_helm_values),
     jsonencode(var.fullnode_helm_values_list == {} ? {} : var.fullnode_helm_values_list[count.index]),

--- a/terraform/fullnode/gcp/kubernetes.tf
+++ b/terraform/fullnode/gcp/kubernetes.tf
@@ -129,6 +129,10 @@ resource "helm_release" "fullnode" {
         cpu = var.min_allowed_cpu_for_vertical_pod_autoscaling
         memory = var.min_allowed_memory_for_vertical_pod_autoscaling
       }
+      maxAllowedForVpa = {
+        cpu = var.max_allowed_cpu_for_vertical_pod_autoscaling
+        memory = var.max_allowed_memory_for_vertical_pod_autoscaling
+      }
     }),
     jsonencode(var.fullnode_helm_values),
     jsonencode(var.fullnode_helm_values_list == {} ? {} : var.fullnode_helm_values_list[count.index]),

--- a/terraform/fullnode/gcp/security.tf
+++ b/terraform/fullnode/gcp/security.tf
@@ -1,6 +1,8 @@
 # Security-related resources
 
-data "kubernetes_all_namespaces" "all" {}
+data "kubernetes_all_namespaces" "all" {
+  depends_on = [ google_container_cluster.aptos ]
+}
 
 locals {
   kubernetes_master_version = substr(google_container_cluster.aptos.master_version, 0, 4)

--- a/terraform/fullnode/gcp/variables.tf
+++ b/terraform/fullnode/gcp/variables.tf
@@ -201,6 +201,18 @@ variable "manage_via_tf" {
 }
 
 variable "enable_vertical_pod_autoscaling" {
-  description = "vertical pod autoscaling"
+  description = "Vertical pod autoscaling to automatically adjust resource requests"
   default = false
 }
+
+variable "min_allowed_cpu_for_vertical_pod_autoscaling" {
+  description = "MinAllowed CPU for vertical pod autoscaling"
+  default = 1
+}
+
+variable "min_allowed_memory_for_vertical_pod_autoscaling" {
+  description = "MinAllowed memory for vertical pod autoscaling"
+  default = "16Gi"
+}
+
+

--- a/terraform/fullnode/gcp/variables.tf
+++ b/terraform/fullnode/gcp/variables.tf
@@ -215,4 +215,15 @@ variable "min_allowed_memory_for_vertical_pod_autoscaling" {
   default = "16Gi"
 }
 
+variable "max_allowed_cpu_for_vertical_pod_autoscaling" {
+  description = "MaxAllowed CPU for vertical pod autoscaling"
+  default = 31
+}
+
+variable "max_allowed_memory_for_vertical_pod_autoscaling" {
+  description = "MaxAllowed memory for vertical pod autoscaling"
+  default = "116Gi"
+}
+
+
 

--- a/terraform/fullnode/gcp/variables.tf
+++ b/terraform/fullnode/gcp/variables.tf
@@ -199,3 +199,8 @@ variable "manage_via_tf" {
   description = "Whether to manage the aptos-node k8s workload via Terraform. If set to false, the helm_release resource will still be created and updated when values change, but it may not be updated on every apply"
   default     = true
 }
+
+variable "enable_vertical_pod_autoscaling" {
+  description = "vertical pod autoscaling"
+  default = false
+}

--- a/terraform/helm/aptos-node/templates/poddisruptionbudget.yaml
+++ b/terraform/helm/aptos-node/templates/poddisruptionbudget.yaml
@@ -1,0 +1,29 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "aptos-validator.fullname" . }}-validator
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: validator
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "aptos-validator.fullname" . }}-fullnode
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fullnode
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "aptos-validator.fullname" . }}-haproxy
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: haproxy

--- a/terraform/helm/fullnode/templates/fullnode.yaml
+++ b/terraform/helm/fullnode/templates/fullnode.yaml
@@ -23,7 +23,7 @@ spec:
         seccomp.security.alpha.kubernetes.io/pod: runtime/default
         prometheus.io/scrape: "true"
         prometheus.io/port: "9101"
-        autoscaling.k8s.io/vertical-pod-autoscaler-enabled: "true"
+        autoscaling.k8s.io/vertical-pod-autoscaler-enabled: {{ .Values.verticalPodAutoscalingEnabled | quote }}
     spec:
       terminationGracePeriodSeconds: 0
       containers:
@@ -46,8 +46,6 @@ spec:
           {{- end }}
           # Start the node
           /usr/local/bin/aptos-node -f /opt/aptos/etc/fullnode.yaml
-        resources:
-          {{- toYaml .Values.resources | nindent 10 }}
         env:
         - name: RUST_LOG
           value: {{ .Values.rust_log }}

--- a/terraform/helm/fullnode/templates/fullnode.yaml
+++ b/terraform/helm/fullnode/templates/fullnode.yaml
@@ -23,6 +23,7 @@ spec:
         seccomp.security.alpha.kubernetes.io/pod: runtime/default
         prometheus.io/scrape: "true"
         prometheus.io/port: "9101"
+        autoscaling.k8s.io/vertical-pod-autoscaler-enabled: "true"
     spec:
       terminationGracePeriodSeconds: 0
       containers:

--- a/terraform/helm/fullnode/templates/poddisruptionbudget.yaml
+++ b/terraform/helm/fullnode/templates/poddisruptionbudget.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "aptos-fullnode.fullname" . }}-fullnode
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fullnode

--- a/terraform/helm/fullnode/templates/verticalpodautoscaler.yaml
+++ b/terraform/helm/fullnode/templates/verticalpodautoscaler.yaml
@@ -12,4 +12,10 @@ spec:
   updatePolicy:
     updateMode: "Auto"
     minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        minAllowed:
+          cpu: {{ .Values.minAllowedForVpa.cpu }}
+          memory: {{ .Values.minAllowedForVpa.memory }}
 {{- end -}}

--- a/terraform/helm/fullnode/templates/verticalpodautoscaler.yaml
+++ b/terraform/helm/fullnode/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.verticalPodAutoscalingEnabled -}}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "aptos-fullnode.fullname" . }}
+  labels:
+    {{- include "aptos-fullnode.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    kind: StatefulSet
+    name: {{ include "aptos-fullnode.fullname" . }}
+  updatePolicy:
+    updateMode: "Auto"
+    minReplicas: 1
+{{- end -}}

--- a/terraform/helm/fullnode/templates/verticalpodautoscaler.yaml
+++ b/terraform/helm/fullnode/templates/verticalpodautoscaler.yaml
@@ -18,4 +18,7 @@ spec:
         minAllowed:
           cpu: {{ .Values.minAllowedForVpa.cpu }}
           memory: {{ .Values.minAllowedForVpa.memory }}
+        maxAllowed:
+          cpu: {{ .Values.maxAllowedForVpa.cpu }}
+          memory: {{ .Values.maxAllowedForVpa.memory }}
 {{- end -}}

--- a/terraform/helm/fullnode/values.yaml
+++ b/terraform/helm/fullnode/values.yaml
@@ -54,6 +54,10 @@ minAllowedForVpa:
   cpu:
   memory:
 
+maxAllowedForVpa:
+  cpu:
+  memory:
+
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/terraform/helm/fullnode/values.yaml
+++ b/terraform/helm/fullnode/values.yaml
@@ -47,16 +47,12 @@ image:
   tag:
   # -- Image pull policy to use for fullnode images
   pullPolicy: IfNotPresent
-
-resources:
-  limits:
-    cpu: 14
-    memory: 26Gi
-  requests:
-    cpu: 14
-    memory: 26Gi
   
-verticalPodAutoscalingEnabled: true
+verticalPodAutoscalingEnabled:
+
+minAllowedForVpa:
+  cpu:
+  memory:
 
 nodeSelector: {}
 tolerations: []

--- a/terraform/helm/fullnode/values.yaml
+++ b/terraform/helm/fullnode/values.yaml
@@ -55,6 +55,8 @@ resources:
   requests:
     cpu: 14
     memory: 26Gi
+  
+verticalPodAutoscalingEnabled: true
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
### Description
add vertical pod autoscaling for public fullnode, reference:
[reference1](https://cloud.google.com/kubernetes-engine/docs/concepts/verticalpodautoscaler)
[reference2](https://cloud.google.com/kubernetes-engine/docs/how-to/vertical-pod-autoscaling#gcloud_1)
### Test Plan
on local workplace, 
1. manually set the resource request to be extremely low:
```
resources:
  requests:
    cpu: 0.01
    memory: 0.01Gi
  
```
2. set the pod number to be 3, in local workplace, run following commands:
```
terraform apply
k describe pod pfn1-aptos-fullnode-0
```

it shows requests as follows, the same as what we set initially
```
Requests:
  cpu: 10m
  memory: 10737418240m
```

3. check the actual usage of this pod by running `k top pod pfn1-aptos-fullnode-0`, shows:

```
NAME                    CPU(cores)   MEMORY(bytes)   
pfn1-aptos-fullnode-0   234m         2582Mi  

```
it exceeds the resource we initially request, meaning that vpa is taking effect

the vpa detail:
```
NAME                  MODE   CPU    MEM          PROVIDED   AGE
pfn1-aptos-fullnode   Auto   775m   3260022784   True       38m
```

4. from the events of pod:
```
Warning  MultiplePodDisruptionBudgets  30m (x2 over 30m)  controllermanager        Pod "aptos"/"pfn1-aptos-fullnode-0" matches multiple PodDisruptionBudgets.  Chose "pfn2-aptos-fullnode-fullnode" arbitrarily.
```
so we know that MultiplePodDisruptionBudgets is also taking effect
