### PR TITLE
[dag] node fetch handler at receiver

### DIFF
--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -58,6 +58,7 @@ jobs:
   # to be land blocking for any PR on the aptos repo. This is why we run those tests
   # separate from test-sdk-confirm-client-generated-publish.
   run-indexer-tests:
+    needs: [permission-check]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -60,7 +60,7 @@ impl DagDriver {
     pub fn add_node(&mut self, node: CertifiedNode) -> anyhow::Result<()> {
         let mut dag_writer = self.dag.write();
         let round = node.metadata().round();
-        if dag_writer.all_exists(node.parents_metadata_iter()) {
+        if dag_writer.all_exists(node.parents_metadata()) {
             dag_writer.add_node(node)?;
             if self.current_round == round {
                 let maybe_strong_links = dag_writer

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -60,7 +60,7 @@ impl DagDriver {
     pub fn add_node(&mut self, node: CertifiedNode) -> anyhow::Result<()> {
         let mut dag_writer = self.dag.write();
         let round = node.metadata().round();
-        if dag_writer.all_exists(node.parents()) {
+        if dag_writer.all_exists(node.parents_metadata_iter()) {
             dag_writer.add_node(node)?;
             if self.current_round == round {
                 let maybe_strong_links = dag_writer

--- a/consensus/src/dag/dag_fetcher.rs
+++ b/consensus/src/dag/dag_fetcher.rs
@@ -174,6 +174,8 @@ impl RpcHandler for FetchRequestHandler {
             .map(|node_status| node_status.as_node().clone().deref().clone())
             .collect();
 
+        // TODO: decide if the response is too big and act accordingly.
+
         Ok(FetchResponse::new(
             message.epoch(),
             certified_nodes,

--- a/consensus/src/dag/dag_fetcher.rs
+++ b/consensus/src/dag/dag_fetcher.rs
@@ -89,7 +89,7 @@ impl DagFetcher {
                 let dag_reader = self.dag.read();
 
                 let missing_parents: Vec<NodeMetadata> =
-                    dag_reader.filter_missing(local_request.node().parents_metadata_iter());
+                    dag_reader.filter_missing(local_request.node().parents_metadata_iter()).cloned().collect();
 
                 if missing_parents.is_empty() {
                     local_request.notify();

--- a/consensus/src/dag/dag_fetcher.rs
+++ b/consensus/src/dag/dag_fetcher.rs
@@ -88,8 +88,10 @@ impl DagFetcher {
             let remote_request = {
                 let dag_reader = self.dag.read();
 
-                let missing_parents: Vec<NodeMetadata> =
-                    dag_reader.filter_missing(local_request.node().parents_metadata_iter()).cloned().collect();
+                let missing_parents: Vec<NodeMetadata> = dag_reader
+                    .filter_missing(local_request.node().parents_metadata())
+                    .cloned()
+                    .collect();
 
                 if missing_parents.is_empty() {
                     local_request.notify();
@@ -126,7 +128,7 @@ impl DagFetcher {
                 if self
                     .dag
                     .read()
-                    .all_exists(local_request.node().parents_metadata_iter())
+                    .all_exists(local_request.node().parents_metadata())
                 {
                     local_request.notify();
                 } else {

--- a/consensus/src/dag/dag_fetcher.rs
+++ b/consensus/src/dag/dag_fetcher.rs
@@ -99,7 +99,13 @@ impl DagFetcher {
                         .node()
                         .parents()
                         .iter()
-                        .map(|node| node.metadata().clone())
+                        .filter_map(|node| {
+                            if dag_reader.get_node(node.metadata()).is_some() {
+                                None
+                            } else {
+                                Some(node.metadata().clone())
+                            }
+                        })
                         .collect(),
                     dag_reader.bitmask(local_request.node().round()),
                 )
@@ -176,9 +182,6 @@ impl RpcHandler for FetchRequestHandler {
 
         // TODO: decide if the response is too big and act accordingly.
 
-        Ok(FetchResponse::new(
-            message.epoch(),
-            certified_nodes,
-        ))
+        Ok(FetchResponse::new(message.epoch(), certified_nodes))
     }
 }

--- a/consensus/src/dag/dag_fetcher.rs
+++ b/consensus/src/dag/dag_fetcher.rs
@@ -135,22 +135,22 @@ impl DagFetcher {
 }
 
 #[derive(Debug, ThisError)]
-pub enum FetchHandleError {
+pub enum FetchRequestHandleError {
     #[error("parents are missing")]
     ParentsMissing,
 }
 
-pub struct FetchHandler {
+pub struct FetchRequestHandler {
     dag: Arc<RwLock<Dag>>,
 }
 
-impl FetchHandler {
+impl FetchRequestHandler {
     pub fn new(dag: Arc<RwLock<Dag>>) -> Self {
         Self { dag }
     }
 }
 
-impl RpcHandler for FetchHandler {
+impl RpcHandler for FetchRequestHandler {
     type Request = RemoteFetchRequest;
     type Response = FetchResponse;
 
@@ -162,7 +162,7 @@ impl RpcHandler for FetchHandler {
                 .parents()
                 .iter()
                 .all(|metadata| dag_reader.get_node(metadata).is_some()),
-            FetchHandleError::ParentsMissing
+            FetchRequestHandleError::ParentsMissing
         );
 
         let certified_nodes: Vec<_> = dag_reader

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 
 use super::{
-    dag_fetcher::FetchHandler, reliable_broadcast::CertifiedNodeHandler, storage::DAGStorage,
+    dag_fetcher::FetchRequestHandler, reliable_broadcast::CertifiedNodeHandler, storage::DAGStorage,
     types::TDAGMessage,
 };
 use crate::{
@@ -26,7 +26,7 @@ struct NetworkHandler {
     dag_rpc_rx: aptos_channel::Receiver<Author, IncomingDAGRequest>,
     node_receiver: NodeBroadcastHandler,
     certified_node_receiver: CertifiedNodeHandler,
-    fetch_receiver: FetchHandler,
+    fetch_receiver: FetchRequestHandler,
     epoch_state: Arc<EpochState>,
 }
 
@@ -48,7 +48,7 @@ impl NetworkHandler {
             ),
             certified_node_receiver: CertifiedNodeHandler::new(dag.clone()),
             epoch_state,
-            fetch_receiver: FetchHandler::new(dag),
+            fetch_receiver: FetchRequestHandler::new(dag),
         }
     }
 

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -47,8 +47,8 @@ impl NetworkHandler {
                 storage,
             ),
             certified_node_receiver: CertifiedNodeHandler::new(dag.clone()),
-            epoch_state,
-            fetch_receiver: FetchRequestHandler::new(dag),
+            epoch_state: epoch_state.clone(),
+            fetch_receiver: FetchRequestHandler::new(dag, epoch_state),
         }
     }
 

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -1,8 +1,8 @@
 // Copyright © Aptos Foundation
 
 use super::{
-    dag_fetcher::FetchRequestHandler, reliable_broadcast::CertifiedNodeHandler, storage::DAGStorage,
-    types::TDAGMessage,
+    dag_fetcher::FetchRequestHandler, reliable_broadcast::CertifiedNodeHandler,
+    storage::DAGStorage, types::TDAGMessage,
 };
 use crate::{
     dag::{

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -1,6 +1,9 @@
 // Copyright © Aptos Foundation
 
-use super::{reliable_broadcast::CertifiedNodeHandler, storage::DAGStorage, types::TDAGMessage};
+use super::{
+    dag_fetcher::FetchHandler, reliable_broadcast::CertifiedNodeHandler, storage::DAGStorage,
+    types::TDAGMessage,
+};
 use crate::{
     dag::{
         dag_network::RpcHandler, dag_store::Dag, reliable_broadcast::NodeBroadcastHandler,
@@ -23,6 +26,7 @@ struct NetworkHandler {
     dag_rpc_rx: aptos_channel::Receiver<Author, IncomingDAGRequest>,
     node_receiver: NodeBroadcastHandler,
     certified_node_receiver: CertifiedNodeHandler,
+    fetch_receiver: FetchHandler,
     epoch_state: Arc<EpochState>,
 }
 
@@ -42,8 +46,9 @@ impl NetworkHandler {
                 epoch_state.clone(),
                 storage,
             ),
-            certified_node_receiver: CertifiedNodeHandler::new(dag),
+            certified_node_receiver: CertifiedNodeHandler::new(dag.clone()),
             epoch_state,
+            fetch_receiver: FetchHandler::new(dag),
         }
     }
 
@@ -66,8 +71,6 @@ impl NetworkHandler {
             bail!("message author and network author mismatch");
         }
 
-        // TODO: verify epoch number and author
-
         let response: anyhow::Result<DAGMessage> = match dag_message {
             DAGMessage::NodeMsg(node) => node
                 .verify(&self.epoch_state.verifier)
@@ -76,6 +79,10 @@ impl NetworkHandler {
             DAGMessage::CertifiedNodeMsg(node) => node
                 .verify(&self.epoch_state.verifier)
                 .and_then(|_| self.certified_node_receiver.process(node))
+                .map(|r| r.into()),
+            DAGMessage::FetchRequest(request) => request
+                .verify(&self.epoch_state.verifier)
+                .and_then(|_| self.fetch_receiver.process(request))
                 .map(|r| r.into()),
             _ => {
                 error!("unknown rpc message {:?}", dag_message);

--- a/consensus/src/dag/dag_store.rs
+++ b/consensus/src/dag/dag_store.rs
@@ -124,23 +124,21 @@ impl Dag {
         self.get_node_ref_by_metadata(metadata).is_some()
     }
 
-    pub fn all_exists<'a>(&self, mut nodes: impl Iterator<Item = &'a NodeMetadata>) -> bool {
-        nodes.all(|metadata| self.exists(metadata))
+    pub fn all_exists<'a>(&self, nodes: impl Iterator<Item = &'a NodeMetadata>) -> bool {
+        self.filter_missing(nodes).next().is_none()
     }
 
-    pub fn filter_missing<'a>(
-        &self,
-        nodes: impl Iterator<Item = &'a NodeMetadata>,
-    ) -> Vec<NodeMetadata> {
-        nodes
-            .filter_map(|node_metadata| {
-                if self.exists(node_metadata) {
-                    None
-                } else {
-                    Some(node_metadata.clone())
-                }
-            })
-            .collect()
+    pub fn filter_missing<'a, 'b>(
+        &'b self,
+        nodes: impl Iterator<Item = &'a NodeMetadata> + 'b,
+    ) -> impl Iterator<Item = &'a NodeMetadata> + 'b {
+        nodes.filter_map(|node_metadata| {
+            if self.exists(node_metadata) {
+                None
+            } else {
+                Some(node_metadata)
+            }
+        })
     }
 
     fn get_node_ref_by_metadata(&self, metadata: &NodeMetadata) -> Option<&NodeStatus> {

--- a/consensus/src/dag/dag_store.rs
+++ b/consensus/src/dag/dag_store.rs
@@ -132,13 +132,7 @@ impl Dag {
         &'b self,
         nodes: impl Iterator<Item = &'a NodeMetadata> + 'b,
     ) -> impl Iterator<Item = &'a NodeMetadata> + 'b {
-        nodes.filter_map(|node_metadata| {
-            if self.exists(node_metadata) {
-                None
-            } else {
-                Some(node_metadata)
-            }
-        })
+        nodes.filter(|node_metadata| !self.exists(node_metadata))
     }
 
     fn get_node_ref_by_metadata(&self, metadata: &NodeMetadata) -> Option<&NodeStatus> {
@@ -229,6 +223,7 @@ impl Dag {
         &self,
         targets: &[NodeMetadata],
         until: Option<Round>,
+        // TODO: replace filter with bool to filter unordered
         filter: impl Fn(&NodeStatus) -> bool,
     ) -> impl Iterator<Item = &NodeStatus> {
         let until = until.unwrap_or(self.lowest_round());

--- a/consensus/src/dag/dag_store.rs
+++ b/consensus/src/dag/dag_store.rs
@@ -291,10 +291,7 @@ impl Dag {
         let lowest_round = match self.lowest_incomplete_round() {
             Some(round) => round,
             None => {
-                return DagSnapshotBitmask::new(self.highest_round() + 1, vec![vec![
-                    false;
-                    self.author_to_index.len()
-                ]]);
+                return DagSnapshotBitmask::new(self.highest_round() + 1, vec![]);
             },
         };
 

--- a/consensus/src/dag/order_rule.rs
+++ b/consensus/src/dag/order_rule.rs
@@ -105,8 +105,8 @@ impl OrderRule {
                 && *metadata.author() == self.anchor_election.get_anchor(metadata.round())
         };
         while let Some(prev_anchor) = dag_reader
-            .reachable_from_target_node(
-                &current_anchor,
+            .reachable(
+                &[current_anchor.metadata().clone()],
                 Some(self.lowest_unordered_anchor_round),
                 |node_status| matches!(node_status, NodeStatus::Unordered(_)),
             )

--- a/consensus/src/dag/order_rule.rs
+++ b/consensus/src/dag/order_rule.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use super::dag_store::NodeStatus;
 use crate::{
     dag::{anchor_election::AnchorElection, dag_store::Dag, types::NodeMetadata, CertifiedNode},
     experimental::buffer_manager::OrderedBlocks,
@@ -104,7 +105,11 @@ impl OrderRule {
                 && *metadata.author() == self.anchor_election.get_anchor(metadata.round())
         };
         while let Some(prev_anchor) = dag_reader
-            .reachable(&current_anchor, Some(self.lowest_unordered_anchor_round))
+            .reachable(
+                &current_anchor,
+                Some(self.lowest_unordered_anchor_round),
+                |node_status| matches!(node_status, NodeStatus::Unordered(_)),
+            )
             .map(|node_status| node_status.as_node())
             .find(|node| is_anchor(node.metadata()))
         {

--- a/consensus/src/dag/order_rule.rs
+++ b/consensus/src/dag/order_rule.rs
@@ -105,7 +105,7 @@ impl OrderRule {
                 && *metadata.author() == self.anchor_election.get_anchor(metadata.round())
         };
         while let Some(prev_anchor) = dag_reader
-            .reachable(
+            .reachable_from_target_node(
                 &current_anchor,
                 Some(self.lowest_unordered_anchor_round),
                 |node_status| matches!(node_status, NodeStatus::Unordered(_)),

--- a/consensus/src/dag/reliable_broadcast.rs
+++ b/consensus/src/dag/reliable_broadcast.rs
@@ -260,7 +260,7 @@ impl RpcHandler for CertifiedNodeHandler {
                 return Ok(CertifiedAck::new(node.metadata().epoch()));
             }
 
-            if !dag_reader.all_exists(node.parents()) {
+            if !dag_reader.all_exists(node.parents_metadata_iter()) {
                 // TODO(ibalajiarun): implement fetching logic.
                 bail!(CertifiedNodeHandleError::MissingParents);
             }

--- a/consensus/src/dag/reliable_broadcast.rs
+++ b/consensus/src/dag/reliable_broadcast.rs
@@ -260,7 +260,7 @@ impl RpcHandler for CertifiedNodeHandler {
                 return Ok(CertifiedAck::new(node.metadata().epoch()));
             }
 
-            if !dag_reader.all_exists(node.parents_metadata_iter()) {
+            if !dag_reader.all_exists(node.parents_metadata()) {
                 // TODO(ibalajiarun): implement fetching logic.
                 bail!(CertifiedNodeHandleError::MissingParents);
             }

--- a/consensus/src/dag/tests/dag_test.rs
+++ b/consensus/src/dag/tests/dag_test.rs
@@ -83,7 +83,7 @@ fn setup() -> (Vec<ValidatorSigner>, Arc<EpochState>, Dag, Arc<MockStorage>) {
     let (signers, validator_verifier) = random_validator_verifier(4, None, false);
     let epoch_state = Arc::new(EpochState {
         epoch: 1,
-        verifier: validator_verifier.clone(),
+        verifier: validator_verifier,
     });
     let storage = Arc::new(MockStorage::new());
     let dag = Dag::new(epoch_state.clone(), storage.clone());
@@ -218,12 +218,6 @@ fn test_dag_bitmask() {
         metadatas.push(node.metadata().clone());
         assert!(dag.add_node(node).is_ok());
     }
-    assert_eq!(
-        dag.bitmask(15),
-        DagSnapshotBitmask::new(5, vec![])
-    );
-    assert_eq!(
-        dag.bitmask(6),
-        DagSnapshotBitmask::new(5, vec![])
-    );
+    assert_eq!(dag.bitmask(15), DagSnapshotBitmask::new(5, vec![]));
+    assert_eq!(dag.bitmask(6), DagSnapshotBitmask::new(5, vec![]));
 }

--- a/consensus/src/dag/tests/dag_test.rs
+++ b/consensus/src/dag/tests/dag_test.rs
@@ -220,10 +220,10 @@ fn test_dag_bitmask() {
     }
     assert_eq!(
         dag.bitmask(15),
-        DagSnapshotBitmask::new(5, vec![vec![false; signers.len()]])
+        DagSnapshotBitmask::new(5, vec![])
     );
     assert_eq!(
         dag.bitmask(6),
-        DagSnapshotBitmask::new(5, vec![vec![false; signers.len()]])
+        DagSnapshotBitmask::new(5, vec![])
     );
 }

--- a/consensus/src/dag/tests/dag_test.rs
+++ b/consensus/src/dag/tests/dag_test.rs
@@ -5,13 +5,16 @@ use crate::dag::{
     dag_store::Dag,
     storage::DAGStorage,
     tests::helpers::new_certified_node,
-    types::{CertifiedNode, Node},
+    types::{CertifiedNode, DagSnapshotBitmask, Node},
     NodeId, Vote,
 };
 use anyhow::Ok;
 use aptos_crypto::HashValue;
 use aptos_infallible::Mutex;
-use aptos_types::{epoch_state::EpochState, validator_verifier::random_validator_verifier};
+use aptos_types::{
+    epoch_state::EpochState, validator_signer::ValidatorSigner,
+    validator_verifier::random_validator_verifier,
+};
 use std::{collections::HashMap, sync::Arc};
 
 pub struct MockStorage {
@@ -76,15 +79,20 @@ impl DAGStorage for MockStorage {
     }
 }
 
-#[test]
-fn test_dag_insertion_succeed() {
+fn setup() -> (Vec<ValidatorSigner>, Arc<EpochState>, Dag, Arc<MockStorage>) {
     let (signers, validator_verifier) = random_validator_verifier(4, None, false);
     let epoch_state = Arc::new(EpochState {
         epoch: 1,
         verifier: validator_verifier.clone(),
     });
     let storage = Arc::new(MockStorage::new());
-    let mut dag = Dag::new(epoch_state, storage);
+    let dag = Dag::new(epoch_state.clone(), storage.clone());
+    (signers, epoch_state, dag, storage)
+}
+
+#[test]
+fn test_dag_insertion_succeed() {
+    let (signers, epoch_state, mut dag, _) = setup();
 
     // Round 1 - nodes 0, 1, 2 links to vec![]
     for signer in &signers[0..3] {
@@ -92,7 +100,7 @@ fn test_dag_insertion_succeed() {
         assert!(dag.add_node(node).is_ok());
     }
     let parents = dag
-        .get_strong_links_for_round(1, &validator_verifier)
+        .get_strong_links_for_round(1, &epoch_state.verifier)
         .unwrap();
 
     // Round 2 nodes 0, 1, 2 links to 0, 1, 2
@@ -103,7 +111,7 @@ fn test_dag_insertion_succeed() {
 
     // Round 3 nodes 1, 2 links to 0, 1, 2
     let parents = dag
-        .get_strong_links_for_round(2, &validator_verifier)
+        .get_strong_links_for_round(2, &epoch_state.verifier)
         .unwrap();
 
     for signer in &signers[1..3] {
@@ -113,19 +121,13 @@ fn test_dag_insertion_succeed() {
 
     // not enough strong links
     assert!(dag
-        .get_strong_links_for_round(3, &validator_verifier)
+        .get_strong_links_for_round(3, &epoch_state.verifier)
         .is_none());
 }
 
 #[test]
 fn test_dag_insertion_failure() {
-    let (signers, validator_verifier) = random_validator_verifier(4, None, false);
-    let epoch_state = Arc::new(EpochState {
-        epoch: 1,
-        verifier: validator_verifier.clone(),
-    });
-    let storage = Arc::new(MockStorage::new());
-    let mut dag = Dag::new(epoch_state, storage);
+    let (signers, epoch_state, mut dag, _) = setup();
 
     // Round 1 - nodes 0, 1, 2 links to vec![]
     for signer in &signers[0..3] {
@@ -137,7 +139,7 @@ fn test_dag_insertion_failure() {
 
     let missing_node = new_certified_node(1, signers[3].author(), vec![]);
     let mut parents = dag
-        .get_strong_links_for_round(1, &validator_verifier)
+        .get_strong_links_for_round(1, &epoch_state.verifier)
         .unwrap();
     parents.push(missing_node.certificate());
 
@@ -158,19 +160,13 @@ fn test_dag_insertion_failure() {
 
 #[test]
 fn test_dag_recover_from_storage() {
-    let (signers, validator_verifier) = random_validator_verifier(4, None, false);
-    let epoch_state = Arc::new(EpochState {
-        epoch: 1,
-        verifier: validator_verifier.clone(),
-    });
-    let storage = Arc::new(MockStorage::new());
-    let mut dag = Dag::new(epoch_state.clone(), storage.clone());
+    let (signers, epoch_state, mut dag, storage) = setup();
 
     let mut metadatas = vec![];
 
     for round in 1..10 {
         let parents = dag
-            .get_strong_links_for_round(round, &validator_verifier)
+            .get_strong_links_for_round(round, &epoch_state.verifier)
             .unwrap_or_default();
         for signer in &signers[0..3] {
             let node = new_certified_node(round, signer.author(), parents.clone());
@@ -178,7 +174,7 @@ fn test_dag_recover_from_storage() {
             assert!(dag.add_node(node).is_ok());
         }
     }
-    let new_dag = Dag::new(epoch_state, storage.clone());
+    let new_dag = Dag::new(epoch_state.clone(), storage.clone());
 
     for metadata in &metadatas {
         assert!(new_dag.exists(metadata));
@@ -186,9 +182,48 @@ fn test_dag_recover_from_storage() {
 
     let new_epoch_state = Arc::new(EpochState {
         epoch: 2,
-        verifier: validator_verifier,
+        verifier: epoch_state.verifier.clone(),
     });
 
     let _new_epoch_dag = Dag::new(new_epoch_state, storage.clone());
     assert!(storage.certified_node_data.lock().is_empty());
+}
+
+#[test]
+fn test_dag_bitmask() {
+    let (signers, epoch_state, mut dag, _) = setup();
+
+    let mut metadatas = vec![];
+
+    for round in 1..5 {
+        let parents = dag
+            .get_strong_links_for_round(round, &epoch_state.verifier)
+            .unwrap_or_default();
+        for signer in &signers[0..3] {
+            let node = new_certified_node(round, signer.author(), parents.clone());
+            metadatas.push(node.metadata().clone());
+            assert!(dag.add_node(node).is_ok());
+        }
+    }
+    assert_eq!(
+        dag.bitmask(15),
+        DagSnapshotBitmask::new(1, vec![vec![true, true, true, false]; 4])
+    );
+
+    for round in 1..5 {
+        let parents = dag
+            .get_strong_links_for_round(round, &epoch_state.verifier)
+            .unwrap_or_default();
+        let node = new_certified_node(round, signers[3].author(), parents.clone());
+        metadatas.push(node.metadata().clone());
+        assert!(dag.add_node(node).is_ok());
+    }
+    assert_eq!(
+        dag.bitmask(15),
+        DagSnapshotBitmask::new(5, vec![vec![false; signers.len()]])
+    );
+    assert_eq!(
+        dag.bitmask(6),
+        DagSnapshotBitmask::new(5, vec![vec![false; signers.len()]])
+    );
 }

--- a/consensus/src/dag/tests/fetcher_test.rs
+++ b/consensus/src/dag/tests/fetcher_test.rs
@@ -2,7 +2,7 @@
 
 use super::dag_test::MockStorage;
 use crate::dag::{
-    dag_fetcher::FetchHandler,
+    dag_fetcher::FetchRequestHandler,
     dag_store::Dag,
     tests::helpers::new_certified_node,
     types::{DagSnapshotBitmask, FetchResponse, RemoteFetchRequest},
@@ -23,7 +23,7 @@ fn test_dag_fetcher_receiver() {
     let storage = Arc::new(MockStorage::new());
     let dag = Arc::new(RwLock::new(Dag::new(epoch_state, storage)));
 
-    let mut fetcher = FetchHandler::new(dag.clone());
+    let mut fetcher = FetchRequestHandler::new(dag.clone());
 
     let mut first_round_nodes = vec![];
 

--- a/consensus/src/dag/tests/fetcher_test.rs
+++ b/consensus/src/dag/tests/fetcher_test.rs
@@ -37,7 +37,7 @@ fn test_dag_fetcher_receiver() {
     // Round 2 - node 0
     let target_node = new_certified_node(2, signers[0].author(), vec![
         first_round_nodes[0].certificate(),
-        first_round_nodes[1].certificate()
+        first_round_nodes[1].certificate(),
     ]);
 
     let request = RemoteFetchRequest::new(

--- a/consensus/src/dag/tests/fetcher_test.rs
+++ b/consensus/src/dag/tests/fetcher_test.rs
@@ -1,0 +1,59 @@
+// Copyright © Aptos Foundation
+
+use super::{dag_test::MockStorage, helpers::new_node};
+use crate::dag::{
+    dag_fetcher::FetchHandler,
+    dag_store::Dag,
+    tests::helpers::new_certified_node,
+    types::{FetchResponse, RemoteFetchRequest},
+    RpcHandler,
+};
+use aptos_infallible::RwLock;
+use aptos_types::{epoch_state::EpochState, validator_verifier::random_validator_verifier};
+use claims::assert_ok_eq;
+use std::sync::Arc;
+
+#[test]
+fn test_dag_fetcher_receiver() {
+    let (signers, validator_verifier) = random_validator_verifier(4, None, false);
+    let epoch_state = Arc::new(EpochState {
+        epoch: 1,
+        verifier: validator_verifier,
+    });
+    let storage = Arc::new(MockStorage::new());
+    let dag = Arc::new(RwLock::new(Dag::new(epoch_state, storage)));
+
+    let mut fetcher = FetchHandler::new(dag.clone());
+
+    let mut first_round_nodes = vec![];
+
+    // Round 1 - nodes 0, 1, 2 links to vec![]
+    for signer in &signers[0..3] {
+        let node = new_certified_node(1, signer.author(), vec![]);
+        assert!(dag.write().add_node(node.clone()).is_ok());
+        first_round_nodes.push(node);
+    }
+
+    let target_node = new_node(2, 100, signers[0].author(), vec![]);
+
+    let request =
+        RemoteFetchRequest::new(target_node.metadata().clone(), 1, vec![vec![false; 4]], 4);
+    assert_eq!(
+        fetcher.process(request).unwrap_err().to_string(),
+        "not enough nodes to satisfy request"
+    );
+
+    // Round 1 - node 3
+    {
+        let node = new_certified_node(1, signers[3].author(), vec![]);
+        assert!(dag.write().add_node(node.clone()).is_ok());
+        first_round_nodes.push(node);
+    }
+
+    let request =
+        RemoteFetchRequest::new(target_node.metadata().clone(), 1, vec![vec![false; 4]], 4);
+    assert_ok_eq!(
+        fetcher.process(request),
+        FetchResponse::new(0, first_round_nodes)
+    );
+}

--- a/consensus/src/dag/tests/fetcher_test.rs
+++ b/consensus/src/dag/tests/fetcher_test.rs
@@ -40,17 +40,14 @@ fn test_dag_fetcher_receiver() {
     ]);
 
     let request = RemoteFetchRequest::new(
-        target_node.metadata().clone(),
+        target_node.epoch(),
+        target_node
+            .parents()
+            .iter()
+            .map(|parent| parent.metadata().clone())
+            .collect(),
         DagSnapshotBitmask::new(1, vec![vec![false; 4]]),
     );
-    assert_eq!(
-        fetcher.process(request.clone()).unwrap_err().to_string(),
-        "target node is not present"
-    );
-
-    // Add Round 2 - node 0
-    assert!(dag.write().add_node(target_node.clone()).is_ok());
-
     assert_ok_eq!(
         fetcher.process(request),
         FetchResponse::new(1, vec![first_round_nodes[0].clone()])

--- a/consensus/src/dag/tests/fetcher_test.rs
+++ b/consensus/src/dag/tests/fetcher_test.rs
@@ -21,9 +21,9 @@ fn test_dag_fetcher_receiver() {
         verifier: validator_verifier,
     });
     let storage = Arc::new(MockStorage::new());
-    let dag = Arc::new(RwLock::new(Dag::new(epoch_state, storage)));
+    let dag = Arc::new(RwLock::new(Dag::new(epoch_state.clone(), storage)));
 
-    let mut fetcher = FetchRequestHandler::new(dag.clone());
+    let mut fetcher = FetchRequestHandler::new(dag.clone(), epoch_state);
 
     let mut first_round_nodes = vec![];
 
@@ -36,7 +36,8 @@ fn test_dag_fetcher_receiver() {
 
     // Round 2 - node 0
     let target_node = new_certified_node(2, signers[0].author(), vec![
-        first_round_nodes[0].certificate()
+        first_round_nodes[0].certificate(),
+        first_round_nodes[1].certificate()
     ]);
 
     let request = RemoteFetchRequest::new(
@@ -46,11 +47,11 @@ fn test_dag_fetcher_receiver() {
             .iter()
             .map(|parent| parent.metadata().clone())
             .collect(),
-        DagSnapshotBitmask::new(1, vec![vec![false; 4]]),
+        DagSnapshotBitmask::new(1, vec![vec![true, false]]),
     );
     assert_ok_eq!(
         fetcher.process(request),
-        FetchResponse::new(1, vec![first_round_nodes[0].clone()])
+        FetchResponse::new(1, vec![first_round_nodes[1].clone()])
     );
 }
 

--- a/consensus/src/dag/tests/mod.rs
+++ b/consensus/src/dag/tests/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod dag_test;
+mod fetcher_test;
 mod helpers;
 mod reliable_broadcast_tests;
 mod types_test;

--- a/consensus/src/dag/tests/types_test.rs
+++ b/consensus/src/dag/tests/types_test.rs
@@ -3,7 +3,10 @@
 use super::helpers::new_node;
 use crate::dag::{
     tests::helpers::new_certified_node,
-    types::{CertifiedNode, Node, NodeCertificate, NodeMetadata, TDAGMessage},
+    types::{
+        CertifiedNode, DagSnapshotBitmask, Node, NodeCertificate, NodeMetadata, RemoteFetchRequest,
+        TDAGMessage,
+    },
 };
 use aptos_consensus_types::common::Payload;
 use aptos_crypto::HashValue;
@@ -80,4 +83,56 @@ fn test_certified_node_verify() {
             .to_string(),
         "unable to verify: Invalid bitvec from the multi-signature"
     );
+}
+
+#[test]
+fn test_remote_fetch_request() {
+    let (signers, validator_verifier) = random_validator_verifier(4, None, false);
+
+    let request = RemoteFetchRequest::new(
+        NodeMetadata::new_for_test(1, 3, signers[0].author(), 100, HashValue::random()),
+        DagSnapshotBitmask::new(1, vec![vec![false; 5]]),
+    );
+    assert_eq!(
+        request.verify(&validator_verifier).unwrap_err().to_string(),
+        "invalid bitmask: each round length is not equal to validator count"
+    );
+
+    let request = RemoteFetchRequest::new(
+        NodeMetadata::new_for_test(1, 1, signers[0].author(), 100, HashValue::random()),
+        DagSnapshotBitmask::new(1, vec![vec![false; signers.len()]]),
+    );
+    assert_eq!(
+        request.verify(&validator_verifier).unwrap_err().to_string(),
+        "target node round should be strictly higher than the last bitmark round"
+    );
+
+    let request = RemoteFetchRequest::new(
+        NodeMetadata::new_for_test(1, 2, signers[0].author(), 100, HashValue::random()),
+        DagSnapshotBitmask::new(1, vec![vec![false; signers.len()]]),
+    );
+    assert_ok!(request.verify(&validator_verifier));
+}
+
+#[test]
+fn test_dag_snapshot_bitmask() {
+    let bitmask = DagSnapshotBitmask::new(1, vec![vec![false, false, false, true]]);
+
+    assert!(!bitmask.has(1, 0));
+    assert!(bitmask.has(1, 3));
+    assert!(!bitmask.has(2, 0));
+    assert_eq!(bitmask.first_round(), 1);
+    assert_eq!(bitmask.last_round(), 1);
+
+    let bitmask = DagSnapshotBitmask::new(1, vec![vec![false, true, true, true], vec![
+        false, true, false, false,
+    ]]);
+
+    assert!(!bitmask.has(1, 0));
+    assert!(bitmask.has(1, 3));
+    assert!(!bitmask.has(2, 0));
+    assert!(bitmask.has(2, 1));
+    assert!(!bitmask.has(10, 10));
+    assert_eq!(bitmask.first_round(), 1);
+    assert_eq!(bitmask.last_round(), 2);
 }

--- a/consensus/src/dag/tests/types_test.rs
+++ b/consensus/src/dag/tests/types_test.rs
@@ -93,17 +93,7 @@ fn test_remote_fetch_request() {
         .map(|idx| {
             NodeMetadata::new_for_test(1, 3, signers[idx].author(), 100, HashValue::random())
         })
-        .collect();
-
-    let request = RemoteFetchRequest::new(
-        1,
-        vec![parents[0].clone()],
-        DagSnapshotBitmask::new(1, vec![vec![false; signers.len()]]),
-    );
-    assert_eq!(
-        request.verify(&validator_verifier).unwrap_err().to_string(),
-        "invalid voting power for provided parents"
-    );
+        .collect(); 
 
     let request = RemoteFetchRequest::new(
         1,
@@ -114,6 +104,13 @@ fn test_remote_fetch_request() {
         request.verify(&validator_verifier).unwrap_err().to_string(),
         "invalid bitmask: each round length is not equal to validator count"
     );
+
+    let request = RemoteFetchRequest::new(
+        1,
+        vec![parents[0].clone()],
+        DagSnapshotBitmask::new(1, vec![vec![false; signers.len()]]),
+    );
+    assert_ok!(request.verify(&validator_verifier));
 
     let request = RemoteFetchRequest::new(
         1,

--- a/consensus/src/dag/tests/types_test.rs
+++ b/consensus/src/dag/tests/types_test.rs
@@ -93,7 +93,7 @@ fn test_remote_fetch_request() {
         .map(|idx| {
             NodeMetadata::new_for_test(1, 3, signers[idx].author(), 100, HashValue::random())
         })
-        .collect(); 
+        .collect();
 
     let request = RemoteFetchRequest::new(
         1,

--- a/consensus/src/dag/tests/types_test.rs
+++ b/consensus/src/dag/tests/types_test.rs
@@ -102,7 +102,7 @@ fn test_remote_fetch_request() {
     );
     assert_eq!(
         request.verify(&validator_verifier).unwrap_err().to_string(),
-        "invalid voting power for target nodes"
+        "invalid voting power for provided parents"
     );
 
     let request = RemoteFetchRequest::new(
@@ -131,7 +131,6 @@ fn test_dag_snapshot_bitmask() {
     assert!(bitmask.has(1, 3));
     assert!(!bitmask.has(2, 0));
     assert_eq!(bitmask.first_round(), 1);
-    assert_eq!(bitmask.last_round(), 1);
 
     let bitmask = DagSnapshotBitmask::new(1, vec![vec![false, true, true, true], vec![
         false, true, false, false,
@@ -143,5 +142,4 @@ fn test_dag_snapshot_bitmask() {
     assert!(bitmask.has(2, 1));
     assert!(!bitmask.has(10, 10));
     assert_eq!(bitmask.first_round(), 1);
-    assert_eq!(bitmask.last_round(), 2);
 }

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -658,7 +658,7 @@ impl TDAGMessage for TestAck {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct DagSnapshotBitmask {
     bitmask: Vec<Vec<bool>>,
     first_round: Round,

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -218,7 +218,7 @@ impl Node {
         &self.parents
     }
 
-    pub fn parents_metadata_iter(&self) -> impl Iterator<Item = &NodeMetadata> {
+    pub fn parents_metadata(&self) -> impl Iterator<Item = &NodeMetadata> {
         self.parents().iter().map(|cert| &cert.metadata)
     }
 

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -510,13 +510,6 @@ impl RemoteFetchRequest {
 impl TDAGMessage for RemoteFetchRequest {
     fn verify(&self, verifier: &ValidatorVerifier) -> anyhow::Result<()> {
         ensure!(
-            verifier
-                .check_voting_power(self.parents.iter().map(|metadata| metadata.author()))
-                .is_ok(),
-            "invalid voting power for provided parents"
-        );
-
-        ensure!(
             self.exists_bitmask
                 .bitmask
                 .iter()

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -218,6 +218,10 @@ impl Node {
         &self.parents
     }
 
+    pub fn parents_metadata_iter(&self) -> impl Iterator<Item = &NodeMetadata> {
+        self.parents().iter().map(|cert| &cert.metadata)
+    }
+
     pub fn author(&self) -> &Author {
         self.metadata.author()
     }
@@ -481,7 +485,7 @@ impl BroadcastStatus for CertificateAckState {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct RemoteFetchRequest {
     epoch: u64,
-    parents: Vec<NodeMetadata>,
+    targets: Vec<NodeMetadata>,
     exists_bitmask: DagSnapshotBitmask,
 }
 
@@ -489,7 +493,7 @@ impl RemoteFetchRequest {
     pub fn new(epoch: u64, parents: Vec<NodeMetadata>, exists_bitmask: DagSnapshotBitmask) -> Self {
         Self {
             epoch,
-            parents,
+            targets: parents,
             exists_bitmask,
         }
     }
@@ -498,8 +502,8 @@ impl RemoteFetchRequest {
         self.epoch
     }
 
-    pub fn parents(&self) -> &[NodeMetadata] {
-        &self.parents
+    pub fn targets(&self) -> &[NodeMetadata] {
+        &self.targets
     }
 
     pub fn exists_bitmask(&self) -> &DagSnapshotBitmask {

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -691,10 +691,6 @@ impl DagSnapshotBitmask {
             .unwrap_or(false)
     }
 
-    pub fn last_round(&self) -> Round {
-        self.first_round + self.bitmask.len() as Round - 1
-    }
-
     pub fn first_round(&self) -> Round {
         self.first_round
     }


### PR DESCRIPTION
### Description

This PR adds the receiver-side logic for handling a remote node fetch request. For simplicity, a node will return an error if it is unable to fulfill the whole request. There should be some peer in the system that should be able to satisfy this request. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
 unit test