### PR TITLE
[mempool] adjust default configs for PFNs, based on testnet observations

### DIFF
--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -60,11 +60,11 @@ impl Default for MempoolConfig {
         MempoolConfig {
             shared_mempool_tick_interval_ms: 50,
             shared_mempool_backoff_interval_ms: 30_000,
-            shared_mempool_batch_size: 100,
+            shared_mempool_batch_size: 200,
             shared_mempool_max_batch_bytes: MAX_APPLICATION_MESSAGE_SIZE as u64,
             shared_mempool_ack_timeout_ms: 2_000,
             shared_mempool_max_concurrent_inbound_syncs: 4,
-            max_broadcasts_per_peer: 1,
+            max_broadcasts_per_peer: 2,
             max_network_channel_size: 1024,
             mempool_snapshot_interval_secs: 180,
             capacity: 2_000_000,
@@ -110,7 +110,7 @@ impl ConfigOptimizer for MempoolConfig {
                 modified_config = true;
             }
 
-            // Set the max_broadcasts_per_peer to 4 (default is 1)
+            // Set the max_broadcasts_per_peer to 4 (default is 2)
             if local_mempool_config_yaml["max_broadcasts_per_peer"].is_null() {
                 mempool_config.max_broadcasts_per_peer = 4;
                 modified_config = true;
@@ -119,12 +119,6 @@ impl ConfigOptimizer for MempoolConfig {
             // Set the default_failovers to 0 (default is 1)
             if local_mempool_config_yaml["default_failovers"].is_null() {
                 mempool_config.default_failovers = 0;
-                modified_config = true;
-            }
-
-            // Set the shared_mempool_batch_size to 200 (default is 100)
-            if local_mempool_config_yaml["shared_mempool_batch_size"].is_null() {
-                mempool_config.shared_mempool_batch_size = 200;
                 modified_config = true;
             }
 
@@ -242,14 +236,10 @@ mod tests {
             mempool_config.shared_mempool_max_concurrent_inbound_syncs,
             4
         );
-        assert_eq!(mempool_config.max_broadcasts_per_peer, 1);
+        assert_eq!(mempool_config.max_broadcasts_per_peer, 2);
         assert_ne!(
             mempool_config.default_failovers,
             default_mempool_config.default_failovers
-        );
-        assert_ne!(
-            mempool_config.shared_mempool_batch_size,
-            default_mempool_config.shared_mempool_batch_size
         );
         assert_ne!(
             mempool_config.shared_mempool_tick_interval_ms,


### PR DESCRIPTION
### Description

* shared_mempool_batch_size: 100 -> 200
* max_broadcasts_per_peer: 1 -> 2

This will allow PFNs to have reasonable performance even with large RTT.

### Test Plan

Existing tests.
