### PR TITLE
[Python][SDK] Make string representation of AccountAddress conform to AIP-40

### DIFF
--- a/ecosystem/python/sdk/CHANGELOG.md
+++ b/ecosystem/python/sdk/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the Aptos Python SDK will be captured in this file. This 
 ## 0.6.4
 - Change sync client library from httpX to requests due to latency concerns.
 
+## 0.7.0
+- **[Breaking Change]**: Removed the `hex` function from `AccountAddress`. Instead of `addr.hex()` use `str(addr)`.
+- **[Breaking Change]**: The string representation of `AccountAddress` now conforms to [AIP-40](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md).
+
 ## 0.6.2
 - Added custom header "x-aptos-client" to both sync/async RestClient
 

--- a/ecosystem/python/sdk/CHANGELOG.md
+++ b/ecosystem/python/sdk/CHANGELOG.md
@@ -3,7 +3,10 @@
 All notable changes to the Aptos Python SDK will be captured in this file. This changelog is written by hand for now.
 
 ## 0.7.0
-- Delete sync client
+- **[Breaking Change]**: Removed the `hex` function from `AccountAddress`. Instead of `addr.hex()` use `str(addr)`.
+- **[Breaking Change]**: The string representation of `AccountAddress` now conforms to [AIP-40](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md).
+- **[Breaking Change]**: `AccountAddress.from_hex` and `PrivateKey.from_hex` have been renamed to `from_str`.
+- **[Breaking Change]**: Delete sync client
 - Port remaining sync examples to async (hello-blockchain, multisig, your-coin)
 - Updated token client to use events to acquire minted tokens
 - Update many dependencies and set Python 3.8.1 as the minimum requirement
@@ -11,10 +14,6 @@ All notable changes to the Aptos Python SDK will be captured in this file. This 
 
 ## 0.6.4
 - Change sync client library from httpX to requests due to latency concerns.
-
-## 0.7.0
-- **[Breaking Change]**: Removed the `hex` function from `AccountAddress`. Instead of `addr.hex()` use `str(addr)`.
-- **[Breaking Change]**: The string representation of `AccountAddress` now conforms to [AIP-40](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md).
 
 ## 0.6.2
 - Added custom header "x-aptos-client" to both sync/async RestClient

--- a/ecosystem/python/sdk/aptos_sdk/account.py
+++ b/ecosystem/python/sdk/aptos_sdk/account.py
@@ -55,8 +55,8 @@ class Account:
 
     def store(self, path: str):
         data = {
-            "account_address": self.account_address.hex(),
-            "private_key": self.private_key.hex(),
+            "account_address": str(self.account_address),
+            "private_key": str(self.private_key),
         }
         with open(path, "w") as file:
             json.dump(data, file)
@@ -68,8 +68,7 @@ class Account:
 
     def auth_key(self) -> str:
         """Returns the auth_key for the associated account"""
-
-        return AccountAddress.from_key(self.private_key.public_key()).hex()
+        return str(AccountAddress.from_key(self.private_key.public_key()))
 
     def sign(self, data: bytes) -> ed25519.Signature:
         return self.private_key.sign(data)
@@ -120,7 +119,7 @@ class Test(unittest.TestCase):
 
         self.assertEqual(start, load)
         # Auth key and Account address should be the same at start
-        self.assertEqual(start.address().hex(), start.auth_key())
+        self.assertEqual(str(start.address()), start.auth_key())
 
     def test_key(self):
         message = b"test message"

--- a/ecosystem/python/sdk/aptos_sdk/account.py
+++ b/ecosystem/python/sdk/aptos_sdk/account.py
@@ -40,7 +40,7 @@ class Account:
 
     @staticmethod
     def load_key(key: str) -> Account:
-        private_key = ed25519.PrivateKey.from_hex(key)
+        private_key = ed25519.PrivateKey.from_str(key)
         account_address = AccountAddress.from_key(private_key.public_key())
         return Account(account_address, private_key)
 
@@ -49,8 +49,8 @@ class Account:
         with open(path) as file:
             data = json.load(file)
         return Account(
-            AccountAddress.from_hex(data["account_address"]),
-            ed25519.PrivateKey.from_hex(data["private_key"]),
+            AccountAddress.from_str(data["account_address"]),
+            ed25519.PrivateKey.from_str(data["private_key"]),
         )
 
     def store(self, path: str):
@@ -80,7 +80,7 @@ class Account:
 
 
 class RotationProofChallenge:
-    type_info_account_address: AccountAddress = AccountAddress.from_hex("0x1")
+    type_info_account_address: AccountAddress = AccountAddress.from_str("0x1")
     type_info_module_name: str = "account"
     type_info_struct_name: str = "RotationProofChallenge"
     sequence_number: int

--- a/ecosystem/python/sdk/aptos_sdk/account_address.py
+++ b/ecosystem/python/sdk/aptos_sdk/account_address.py
@@ -25,8 +25,6 @@ class AccountAddress:
     def __init__(self, address: bytes):
         self.address = address
 
-        # Note: The correctness of is_special relies on this check. Be careful when
-        # changing anything about this function.
         if len(address) != AccountAddress.LENGTH:
             raise Exception("Expected address of length 32")
 
@@ -36,9 +34,6 @@ class AccountAddress:
         return self.address == other.address
 
     def __str__(self):
-        return self.hex()
-
-    def to_standard_string(self):
         """
         Represent an account address in a way that is compliant with the v1 address
         standard. The standard is defined as part of AIP-40, read more here:
@@ -66,7 +61,7 @@ class AccountAddress:
         Returns whether the address is a "special" address. Addresses are considered
         special if the first 63 characters of the hex string are zero. In other words,
         an address is special if the first 31 bytes are zero and the last byte is
-        smaller than than `0b10000` (16). In other words, special is defined as an address
+        smaller than `0b10000` (16). In other words, special is defined as an address
         that matches the following regex: `^0x0{63}[0-9a-f]$`. In short form this means
         the addresses in the range from `0x0` to `0xf` (inclusive) are special.
 
@@ -74,13 +69,6 @@ class AccountAddress:
         https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md
         """
         return all(b == 0 for b in self.address[:-1]) and self.address[-1] < 0b10000
-
-    def hex(self) -> str:
-        """
-        NOTE: Prefer to_standard_string for representing instances of AccountAddress
-        as strings.
-        """
-        return f"0x{self.address.hex()}"
 
     @staticmethod
     def from_hex(address: str) -> AccountAddress:
@@ -214,93 +202,95 @@ class Test(unittest.TestCase):
     def test_to_standard_string(self):
         # Test special address: 0x0
         self.assertEqual(
-            AccountAddress.from_hex(
-                "0x0000000000000000000000000000000000000000000000000000000000000000"
-            ).to_standard_string(),
+            str(
+                AccountAddress.from_hex(
+                    "0x0000000000000000000000000000000000000000000000000000000000000000"
+                )
+            ),
             "0x0",
         )
 
         # Test special address: 0x1
         self.assertEqual(
-            AccountAddress.from_hex(
-                "0x0000000000000000000000000000000000000000000000000000000000000001"
-            ).to_standard_string(),
+            str(
+                AccountAddress.from_hex(
+                    "0x0000000000000000000000000000000000000000000000000000000000000001"
+                )
+            ),
             "0x1",
         )
 
         # Test special address: 0x4
         self.assertEqual(
-            AccountAddress.from_hex(
-                "0x0000000000000000000000000000000000000000000000000000000000000004"
-            ).to_standard_string(),
+            str(
+                AccountAddress.from_hex(
+                    "0x0000000000000000000000000000000000000000000000000000000000000004"
+                )
+            ),
             "0x4",
         )
 
         # Test special address: 0xf
         self.assertEqual(
-            AccountAddress.from_hex(
-                "0x000000000000000000000000000000000000000000000000000000000000000f"
-            ).to_standard_string(),
+            str(
+                AccountAddress.from_hex(
+                    "0x000000000000000000000000000000000000000000000000000000000000000f"
+                )
+            ),
             "0xf",
         )
 
         # Test special address from short no 0x: d
         self.assertEqual(
-            AccountAddress.from_hex("d").to_standard_string(),
+            str(AccountAddress.from_hex("d")),
             "0xd",
         )
 
         # Test non-special address from long:
         # 0x0000000000000000000000000000000000000000000000000000000000000010
+        value = "0x0000000000000000000000000000000000000000000000000000000000000010"
         self.assertEqual(
-            AccountAddress.from_hex(
-                "0x0000000000000000000000000000000000000000000000000000000000000010"
-            ).to_standard_string(),
-            "0x0000000000000000000000000000000000000000000000000000000000000010",
+            str(AccountAddress.from_hex(value)),
+            value,
         )
 
         # Test non-special address from long:
         # 0x000000000000000000000000000000000000000000000000000000000000001f
+        value = "0x000000000000000000000000000000000000000000000000000000000000001f"
         self.assertEqual(
-            AccountAddress.from_hex(
-                "0x000000000000000000000000000000000000000000000000000000000000001f"
-            ).to_standard_string(),
-            "0x000000000000000000000000000000000000000000000000000000000000001f",
+            str(AccountAddress.from_hex(value)),
+            value,
         )
 
         # Test non-special address from long:
         # 0x00000000000000000000000000000000000000000000000000000000000000a0
+        value = "0x00000000000000000000000000000000000000000000000000000000000000a0"
         self.assertEqual(
-            AccountAddress.from_hex(
-                "0x00000000000000000000000000000000000000000000000000000000000000a0"
-            ).to_standard_string(),
-            "0x00000000000000000000000000000000000000000000000000000000000000a0",
+            str(AccountAddress.from_hex(value)),
+            value,
         )
 
         # Test non-special address from long no 0x:
         # ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0
+        value = "ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0"
         self.assertEqual(
-            AccountAddress.from_hex(
-                "ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0"
-            ).to_standard_string(),
-            "0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0",
+            str(AccountAddress.from_hex(value)),
+            f"0x{value}",
         )
 
         # Test non-special address from long no 0x:
         # 1000000000000000000000000000000000000000000000000000000000000000
+        value = "1000000000000000000000000000000000000000000000000000000000000000"
         self.assertEqual(
-            AccountAddress.from_hex(
-                "1000000000000000000000000000000000000000000000000000000000000000"
-            ).to_standard_string(),
-            "0x1000000000000000000000000000000000000000000000000000000000000000",
+            str(AccountAddress.from_hex(value)),
+            f"0x{value}",
         )
 
         # Demonstrate that neither leading nor trailing zeroes get trimmed for
         # non-special addresses:
         # 0f00000000000000000000000000000000000000000000000000000000000000
+        value = "0f00000000000000000000000000000000000000000000000000000000000000"
         self.assertEqual(
-            AccountAddress.from_hex(
-                "0f00000000000000000000000000000000000000000000000000000000000000"
-            ).to_standard_string(),
-            "0x0f00000000000000000000000000000000000000000000000000000000000000",
+            str(AccountAddress.from_hex(value)),
+            f"0x{value}",
         )

--- a/ecosystem/python/sdk/aptos_sdk/account_address.py
+++ b/ecosystem/python/sdk/aptos_sdk/account_address.py
@@ -71,7 +71,7 @@ class AccountAddress:
         return all(b == 0 for b in self.address[:-1]) and self.address[-1] < 0b10000
 
     @staticmethod
-    def from_hex(address: str) -> AccountAddress:
+    def from_str(address: str) -> AccountAddress:
         addr = address
 
         if address[0:2] == "0x":
@@ -149,49 +149,49 @@ class AccountAddress:
 
 class Test(unittest.TestCase):
     def test_multi_ed25519(self):
-        private_key_1 = ed25519.PrivateKey.from_hex(
+        private_key_1 = ed25519.PrivateKey.from_str(
             "4e5e3be60f4bbd5e98d086d932f3ce779ff4b58da99bf9e5241ae1212a29e5fe"
         )
-        private_key_2 = ed25519.PrivateKey.from_hex(
+        private_key_2 = ed25519.PrivateKey.from_str(
             "1e70e49b78f976644e2c51754a2f049d3ff041869c669523ba95b172c7329901"
         )
         multisig_public_key = ed25519.MultiPublicKey(
             [private_key_1.public_key(), private_key_2.public_key()], 1
         )
 
-        expected = AccountAddress.from_hex(
+        expected = AccountAddress.from_str(
             "835bb8c5ee481062946b18bbb3b42a40b998d6bf5316ca63834c959dc739acf0"
         )
         actual = AccountAddress.from_multi_ed25519(multisig_public_key)
         self.assertEqual(actual, expected)
 
     def test_resource_account(self):
-        base_address = AccountAddress.from_hex("b0b")
-        expected = AccountAddress.from_hex(
+        base_address = AccountAddress.from_str("b0b")
+        expected = AccountAddress.from_str(
             "ee89f8c763c27f9d942d496c1a0dcf32d5eacfe78416f9486b8db66155b163b0"
         )
         actual = AccountAddress.for_resource_account(base_address, b"\x0b\x00\x0b")
         self.assertEqual(actual, expected)
 
     def test_named_object(self):
-        base_address = AccountAddress.from_hex("b0b")
-        expected = AccountAddress.from_hex(
+        base_address = AccountAddress.from_str("b0b")
+        expected = AccountAddress.from_str(
             "f417184602a828a3819edf5e36285ebef5e4db1ba36270be580d6fd2d7bcc321"
         )
         actual = AccountAddress.for_named_object(base_address, b"bob's collection")
         self.assertEqual(actual, expected)
 
     def test_collection(self):
-        base_address = AccountAddress.from_hex("b0b")
-        expected = AccountAddress.from_hex(
+        base_address = AccountAddress.from_str("b0b")
+        expected = AccountAddress.from_str(
             "f417184602a828a3819edf5e36285ebef5e4db1ba36270be580d6fd2d7bcc321"
         )
         actual = AccountAddress.for_named_collection(base_address, "bob's collection")
         self.assertEqual(actual, expected)
 
     def test_token(self):
-        base_address = AccountAddress.from_hex("b0b")
-        expected = AccountAddress.from_hex(
+        base_address = AccountAddress.from_str("b0b")
+        expected = AccountAddress.from_str(
             "e20d1f22a5400ba7be0f515b7cbd00edc42dbcc31acc01e31128b2b5ddb3c56e"
         )
         actual = AccountAddress.for_named_token(
@@ -203,7 +203,7 @@ class Test(unittest.TestCase):
         # Test special address: 0x0
         self.assertEqual(
             str(
-                AccountAddress.from_hex(
+                AccountAddress.from_str(
                     "0x0000000000000000000000000000000000000000000000000000000000000000"
                 )
             ),
@@ -213,7 +213,7 @@ class Test(unittest.TestCase):
         # Test special address: 0x1
         self.assertEqual(
             str(
-                AccountAddress.from_hex(
+                AccountAddress.from_str(
                     "0x0000000000000000000000000000000000000000000000000000000000000001"
                 )
             ),
@@ -223,7 +223,7 @@ class Test(unittest.TestCase):
         # Test special address: 0x4
         self.assertEqual(
             str(
-                AccountAddress.from_hex(
+                AccountAddress.from_str(
                     "0x0000000000000000000000000000000000000000000000000000000000000004"
                 )
             ),
@@ -233,7 +233,7 @@ class Test(unittest.TestCase):
         # Test special address: 0xf
         self.assertEqual(
             str(
-                AccountAddress.from_hex(
+                AccountAddress.from_str(
                     "0x000000000000000000000000000000000000000000000000000000000000000f"
                 )
             ),
@@ -242,7 +242,7 @@ class Test(unittest.TestCase):
 
         # Test special address from short no 0x: d
         self.assertEqual(
-            str(AccountAddress.from_hex("d")),
+            str(AccountAddress.from_str("d")),
             "0xd",
         )
 
@@ -250,7 +250,7 @@ class Test(unittest.TestCase):
         # 0x0000000000000000000000000000000000000000000000000000000000000010
         value = "0x0000000000000000000000000000000000000000000000000000000000000010"
         self.assertEqual(
-            str(AccountAddress.from_hex(value)),
+            str(AccountAddress.from_str(value)),
             value,
         )
 
@@ -258,7 +258,7 @@ class Test(unittest.TestCase):
         # 0x000000000000000000000000000000000000000000000000000000000000001f
         value = "0x000000000000000000000000000000000000000000000000000000000000001f"
         self.assertEqual(
-            str(AccountAddress.from_hex(value)),
+            str(AccountAddress.from_str(value)),
             value,
         )
 
@@ -266,7 +266,7 @@ class Test(unittest.TestCase):
         # 0x00000000000000000000000000000000000000000000000000000000000000a0
         value = "0x00000000000000000000000000000000000000000000000000000000000000a0"
         self.assertEqual(
-            str(AccountAddress.from_hex(value)),
+            str(AccountAddress.from_str(value)),
             value,
         )
 
@@ -274,7 +274,7 @@ class Test(unittest.TestCase):
         # ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0
         value = "ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0"
         self.assertEqual(
-            str(AccountAddress.from_hex(value)),
+            str(AccountAddress.from_str(value)),
             f"0x{value}",
         )
 
@@ -282,7 +282,7 @@ class Test(unittest.TestCase):
         # 1000000000000000000000000000000000000000000000000000000000000000
         value = "1000000000000000000000000000000000000000000000000000000000000000"
         self.assertEqual(
-            str(AccountAddress.from_hex(value)),
+            str(AccountAddress.from_str(value)),
             f"0x{value}",
         )
 
@@ -291,6 +291,6 @@ class Test(unittest.TestCase):
         # 0f00000000000000000000000000000000000000000000000000000000000000
         value = "0f00000000000000000000000000000000000000000000000000000000000000"
         self.assertEqual(
-            str(AccountAddress.from_hex(value)),
+            str(AccountAddress.from_str(value)),
             f"0x{value}",
         )

--- a/ecosystem/python/sdk/aptos_sdk/account_sequence_number.py
+++ b/ecosystem/python/sdk/aptos_sdk/account_sequence_number.py
@@ -178,7 +178,7 @@ class Test(unittest.IsolatedAsyncioTestCase):
 
         rest_client = RestClient("https://fullnode.devnet.aptoslabs.com/v1")
         account_sequence_number = AccountSequenceNumber(
-            rest_client, AccountAddress.from_hex("b0b")
+            rest_client, AccountAddress.from_str("b0b")
         )
         last_seq_num = 0
         for seq_num in range(5):

--- a/ecosystem/python/sdk/aptos_sdk/aptos_token_client.py
+++ b/ecosystem/python/sdk/aptos_sdk/aptos_token_client.py
@@ -27,7 +27,7 @@ class Object:
     def parse(resource: dict[str, Any]) -> Object:
         return Object(
             resource["allow_ungated_transfer"],
-            AccountAddress.from_hex(resource["owner"]),
+            AccountAddress.from_str(resource["owner"]),
         )
 
     def __str__(self) -> str:
@@ -54,7 +54,7 @@ class Collection:
     @staticmethod
     def parse(resource: dict[str, Any]) -> Collection:
         return Collection(
-            AccountAddress.from_hex(resource["creator"]),
+            AccountAddress.from_str(resource["creator"]),
             resource["description"],
             resource["name"],
             resource["uri"],
@@ -81,7 +81,7 @@ class Royalty:
         return Royalty(
             resource["numerator"],
             resource["denominator"],
-            AccountAddress.from_hex(resource["payee_address"]),
+            AccountAddress.from_str(resource["payee_address"]),
         )
 
 
@@ -114,7 +114,7 @@ class Token:
     @staticmethod
     def parse(resource: dict[str, Any]):
         return Token(
-            AccountAddress.from_hex(resource["collection"]["inner"]),
+            AccountAddress.from_str(resource["collection"]["inner"]),
             int(resource["index"]),
             resource["description"],
             resource["name"],
@@ -618,5 +618,5 @@ class AptosTokenClient:
         for event in output["events"]:
             if event["type"] != "0x4::collection::MintEvent":
                 continue
-            mints.append(AccountAddress.from_hex(event["data"]["token"]))
+            mints.append(AccountAddress.from_str(event["data"]["token"]))
         return mints

--- a/ecosystem/python/sdk/aptos_sdk/async_client.py
+++ b/ecosystem/python/sdk/aptos_sdk/async_client.py
@@ -673,7 +673,7 @@ class RestClient:
 
         token_id = {
             "token_data_id": {
-                "creator": creator.hex(),
+                "creator": str(creator),
                 "collection": collection_name,
                 "name": token_name,
             },
@@ -720,7 +720,7 @@ class RestClient:
         token_data_handle = resource["data"]["token_data"]["handle"]
 
         token_data_id = {
-            "creator": creator.hex(),
+            "creator": str(creator),
             "collection": collection_name,
             "name": token_name,
         }
@@ -759,7 +759,7 @@ class FaucetClient:
     async def close(self):
         await self.rest_client.close()
 
-    async def fund_account(self, address: str, amount: int):
+    async def fund_account(self, address: AccountAddress, amount: int):
         """This creates an account if it does not exist and mints the specified amount of
         coins into that account."""
         response = await self.rest_client.client.post(

--- a/ecosystem/python/sdk/aptos_sdk/ed25519.py
+++ b/ecosystem/python/sdk/aptos_sdk/ed25519.py
@@ -28,7 +28,7 @@ class PrivateKey:
         return self.hex()
 
     @staticmethod
-    def from_hex(value: str) -> PrivateKey:
+    def from_str(value: str) -> PrivateKey:
         if value[0:2] == "0x":
             value = value[2:]
         return PrivateKey(SigningKey(bytes.fromhex(value)))
@@ -248,10 +248,10 @@ class Test(unittest.TestCase):
 
     def test_multisig(self):
         # Generate signatory private keys.
-        private_key_1 = PrivateKey.from_hex(
+        private_key_1 = PrivateKey.from_str(
             "4e5e3be60f4bbd5e98d086d932f3ce779ff4b58da99bf9e5241ae1212a29e5fe"
         )
-        private_key_2 = PrivateKey.from_hex(
+        private_key_2 = PrivateKey.from_str(
             "1e70e49b78f976644e2c51754a2f049d3ff041869c669523ba95b172c7329901"
         )
         # Generate multisig public key with threshold of 1.

--- a/ecosystem/python/sdk/aptos_sdk/package_publisher.py
+++ b/ecosystem/python/sdk/aptos_sdk/package_publisher.py
@@ -13,7 +13,7 @@ from .transactions import EntryFunction, TransactionArgument, TransactionPayload
 MAX_TRANSACTION_SIZE: int = 62000
 
 # The location of the large package publisher
-MODULE_ADDRESS: AccountAddress = AccountAddress.from_hex(
+MODULE_ADDRESS: AccountAddress = AccountAddress.from_str(
     "0xd20f305e3090a24c00524604dc2a42925a75c67aa6020d33033d516cf0878c4a"
 )
 

--- a/ecosystem/python/sdk/aptos_sdk/transaction_worker.py
+++ b/ecosystem/python/sdk/aptos_sdk/transaction_worker.py
@@ -182,7 +182,7 @@ class TransactionQueue:
 class Test(unittest.IsolatedAsyncioTestCase):
     async def test_common_path(self):
         transaction_arguments = [
-            TransactionArgument(AccountAddress.from_hex("b0b"), Serializer.struct),
+            TransactionArgument(AccountAddress.from_str("b0b"), Serializer.struct),
             TransactionArgument(100, Serializer.u64),
         ]
         payload = EntryFunction.natural(

--- a/ecosystem/python/sdk/aptos_sdk/transactions.py
+++ b/ecosystem/python/sdk/aptos_sdk/transactions.py
@@ -402,7 +402,7 @@ class ModuleId:
     @staticmethod
     def from_str(module_id: str) -> ModuleId:
         split = module_id.split("::")
-        return ModuleId(AccountAddress.from_hex(split[0]), split[1])
+        return ModuleId(AccountAddress.from_str(split[0]), split[1])
 
     @staticmethod
     def deserialize(deserializer: Deserializer) -> ModuleId:
@@ -534,11 +534,11 @@ class Test(unittest.TestCase):
         amount_input = 5000
 
         # Accounts and crypto
-        sender_private_key = ed25519.PrivateKey.from_hex(sender_key_input)
+        sender_private_key = ed25519.PrivateKey.from_str(sender_key_input)
         sender_public_key = sender_private_key.public_key()
         sender_account_address = AccountAddress.from_key(sender_public_key)
 
-        receiver_private_key = ed25519.PrivateKey.from_hex(receiver_key_input)
+        receiver_private_key = ed25519.PrivateKey.from_str(receiver_key_input)
         receiver_public_key = receiver_private_key.public_key()
         receiver_account_address = AccountAddress.from_key(receiver_public_key)
 
@@ -604,11 +604,11 @@ class Test(unittest.TestCase):
         chain_id_input = 4
 
         # Accounts and crypto
-        sender_private_key = ed25519.PrivateKey.from_hex(sender_key_input)
+        sender_private_key = ed25519.PrivateKey.from_str(sender_key_input)
         sender_public_key = sender_private_key.public_key()
         sender_account_address = AccountAddress.from_key(sender_public_key)
 
-        receiver_private_key = ed25519.PrivateKey.from_hex(receiver_key_input)
+        receiver_private_key = ed25519.PrivateKey.from_str(receiver_key_input)
         receiver_public_key = receiver_private_key.public_key()
         receiver_account_address = AccountAddress.from_key(receiver_public_key)
 

--- a/ecosystem/python/sdk/aptos_sdk/type_tag.py
+++ b/ecosystem/python/sdk/aptos_sdk/type_tag.py
@@ -320,7 +320,7 @@ class StructTag:
                 name += letter
 
         split = name.split("::")
-        return StructTag(AccountAddress.from_hex(split[0]), split[1], split[2], [])
+        return StructTag(AccountAddress.from_str(split[0]), split[1], split[2], [])
 
     def variant(self):
         return TypeTag.STRUCT

--- a/ecosystem/python/sdk/examples/multisig.py
+++ b/ecosystem/python/sdk/examples/multisig.py
@@ -180,7 +180,7 @@ async def main():
 
     deedee = Account.generate()
 
-    while deedee.address().hex()[2:4] != "dd":
+    while str(deedee.address())[2:4] != "dd":
         deedee = Account.generate()
 
     print(f"Deedee's address:    {deedee.address()}")
@@ -256,7 +256,7 @@ async def main():
     print(f"Auth key pre-rotation: {account_data['authentication_key']}")
 
     tx_hash = await rest_client.submit_bcs_transaction(signed_transaction)
-    rest_client.wait_for_transaction(tx_hash)
+    await rest_client.wait_for_transaction(tx_hash)
     print(f"Transaction hash:      {tx_hash}")
 
     account_data = await rest_client.account(deedee.address())
@@ -274,7 +274,7 @@ async def main():
         f"aptos move compile "
         f"--save-metadata "
         f"--package-dir {packages_dir}genesis "
-        f"--named-addresses upgrade_and_govern={deedee.address().hex()}"
+        f"--named-addresses upgrade_and_govern={str(deedee.address())}"
     )
 
     print(f"Running aptos CLI command: {command}\n")
@@ -351,7 +351,7 @@ async def main():
         f"aptos move compile "
         f"--save-metadata "
         f"--package-dir {packages_dir}upgrade "
-        f"--named-addresses upgrade_and_govern={deedee.address().hex()}"
+        f"--named-addresses upgrade_and_govern={str(deedee.address())}"
     )
 
     print(f"Running aptos CLI command: {command}\n")

--- a/ecosystem/python/sdk/examples/read-aggregator.py
+++ b/ecosystem/python/sdk/examples/read-aggregator.py
@@ -3,6 +3,7 @@
 
 import asyncio
 
+from aptos_sdk.account_address import AccountAddress
 from aptos_sdk.async_client import RestClient
 
 from .common import NODE_URL
@@ -11,7 +12,9 @@ from .common import NODE_URL
 async def main():
     rest_client = RestClient(NODE_URL)
     total_apt = await rest_client.aggregator_value(
-        "0x1", "0x1::coin::CoinInfo<0x1::aptos_coin::AptosCoin>", ["supply"]
+        AccountAddress.from_str("0x1"),
+        "0x1::coin::CoinInfo<0x1::aptos_coin::AptosCoin>",
+        ["supply"],
     )
     print(f"Total circulating APT: {total_apt}")
     await rest_client.close()

--- a/ecosystem/python/sdk/examples/simulate-transfer-coin.py
+++ b/ecosystem/python/sdk/examples/simulate-transfer-coin.py
@@ -43,12 +43,12 @@ async def main():
         alice, TransactionPayload(payload)
     )
 
-    print("\n=== Simulate before creatng Bob's Account ===")
+    print("\n=== Simulate before creating Bob's Account ===")
     output = await rest_client.simulate_transaction(transaction, alice)
     assert output[0]["vm_status"] != "Executed successfully", "This shouldn't succeed"
     print(json.dumps(output, indent=4, sort_keys=True))
 
-    print("\n=== Simulate after creatng Bob's Account ===")
+    print("\n=== Simulate after creating Bob's Account ===")
     await faucet_client.fund_account(bob.address(), 0)
     output = await rest_client.simulate_transaction(transaction, alice)
     assert output[0]["vm_status"] == "Executed successfully", "This should succeed"


### PR DESCRIPTION
### Description
This PR adds the `to_standard_string` function which formats AccountAddress instances as strings in a way that is compliant with AIP 40.

See also https://github.com/aptos-labs/aptos-core/pull/8727.

### Test Plan
```
make test
```
```
make examples
poetry run python -m examples.multisig
```
