### PR TITLE
internal indexer: parse tables in resource groups

### DIFF
--- a/storage/indexer/src/lib.rs
+++ b/storage/indexer/src/lib.rs
@@ -35,7 +35,7 @@ use move_core_types::{
 };
 use move_resource_viewer::{AnnotatedMoveValue, MoveValueAnnotator};
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     convert::TryInto,
     sync::{atomic::Ordering, Arc},
 };
@@ -166,7 +166,7 @@ impl<'a> TableInfoParser<'a> {
                     match path {
                         Path::Code(_) => (),
                         Path::Resource(struct_tag) => self.parse_struct(struct_tag, bytes)?,
-                        Path::ResourceGroup(_struct_tag) => (),
+                        Path::ResourceGroup(_struct_tag) => self.parse_resource_group(bytes)?,
                     }
                 },
                 StateKeyInner::TableItem { handle, .. } => self.parse_table_item(*handle, bytes)?,
@@ -182,6 +182,15 @@ impl<'a> TableInfoParser<'a> {
                 .annotator
                 .view_value(&TypeTag::Struct(Box::new(struct_tag)), bytes)?,
         )
+    }
+
+    fn parse_resource_group(&mut self, bytes: &[u8]) -> Result<()> {
+        type ResourceGroup = BTreeMap<StructTag, Vec<u8>>;
+
+        for (struct_tag, bytes) in bcs::from_bytes::<ResourceGroup>(bytes)? {
+            self.parse_struct(struct_tag, &bytes)?;
+        }
+        Ok(())
     }
 
     fn parse_table_item(&mut self, handle: TableHandle, bytes: &'a [u8]) -> Result<()> {


### PR DESCRIPTION
### Description

The internal indexer didn't get updated with resource groups introduction.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
