### PR TITLE
[Storage Service] Small renames, refactors and test cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3232,6 +3232,7 @@ dependencies = [
  "claims",
  "num-traits 0.2.15",
  "proptest",
+ "rand 0.7.3",
  "serde 1.0.149",
  "thiserror",
 ]

--- a/aptos-node/src/state_sync.rs
+++ b/aptos-node/src/state_sync.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::network::ApplicationNetworkInterfaces;
-use aptos_config::config::{NodeConfig, StateSyncConfig, StorageServiceConfig};
+use aptos_config::config::{NodeConfig, StateSyncConfig};
 use aptos_consensus_notifications::ConsensusNotifier;
 use aptos_data_client::client::AptosDataClient;
 use aptos_data_streaming_service::{
@@ -117,7 +117,7 @@ pub fn start_state_sync_and_get_notification_handles(
 
     // Start the state sync storage service
     let storage_service_runtime = setup_state_sync_storage_service(
-        node_config.state_sync.storage_service,
+        node_config.state_sync,
         peers_and_metadata,
         network_service_events,
         &db_rw,
@@ -202,7 +202,7 @@ fn setup_aptos_data_client(
 
 /// Sets up the state sync storage service runtime
 fn setup_state_sync_storage_service(
-    config: StorageServiceConfig,
+    config: StateSyncConfig,
     peers_and_metadata: Arc<PeersAndMetadata>,
     network_service_events: NetworkServiceEvents<StorageServiceMessage>,
     db_rw: &DbReaderWriter,
@@ -212,7 +212,7 @@ fn setup_state_sync_storage_service(
     let storage_service_runtime = aptos_runtimes::spawn_named_runtime("stor-server".into(), None);
 
     // Spawn the state sync storage service servers on the runtime
-    let storage_reader = StorageReader::new(config, Arc::clone(&db_rw.reader));
+    let storage_reader = StorageReader::new(config.storage_service, Arc::clone(&db_rw.reader));
     let service = StorageServiceServer::new(
         config,
         storage_service_runtime.handle().clone(),

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -246,6 +246,8 @@ pub struct AptosDataClientConfig {
     pub max_num_in_flight_regular_polls: u64,
     /// Maximum number of output reductions before transactions are returned
     pub max_num_output_reductions: u64,
+    /// Maximum version lag we'll tolerate when sending optimistic fetch requests
+    pub max_optimistic_fetch_version_lag: u64,
     /// Maximum timeout (in ms) when waiting for a response (after exponential increases)
     pub max_response_timeout_ms: u64,
     /// Maximum number of state keys and values per chunk
@@ -272,7 +274,8 @@ impl Default for AptosDataClientConfig {
             max_num_in_flight_priority_polls: 10,
             max_num_in_flight_regular_polls: 10,
             max_num_output_reductions: 0,
-            max_response_timeout_ms: 60_000, // 60 seconds
+            max_optimistic_fetch_version_lag: 50_000, // Assumes 5K TPS for 10 seconds, which should be plenty
+            max_response_timeout_ms: 60_000,          // 60 seconds
             max_state_chunk_size: MAX_STATE_CHUNK_SIZE,
             max_transaction_chunk_size: MAX_TRANSACTION_CHUNK_SIZE,
             max_transaction_output_chunk_size: MAX_TRANSACTION_OUTPUT_CHUNK_SIZE,

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -254,10 +254,10 @@ pub struct AptosDataClientConfig {
     pub max_transaction_chunk_size: u64,
     /// Maximum number of transaction outputs per chunk
     pub max_transaction_output_chunk_size: u64,
+    /// Timeout (in ms) when waiting for an optimistic fetch response
+    pub optimistic_fetch_timeout_ms: u64,
     /// First timeout (in ms) when waiting for a response
     pub response_timeout_ms: u64,
-    /// Timeout (in ms) when waiting for a subscription response
-    pub subscription_timeout_ms: u64,
     /// Interval (in ms) between data summary poll loop executions
     pub summary_poll_loop_interval_ms: u64,
     /// Whether or not to request compression for incoming data
@@ -272,12 +272,12 @@ impl Default for AptosDataClientConfig {
             max_num_in_flight_priority_polls: 10,
             max_num_in_flight_regular_polls: 10,
             max_num_output_reductions: 0,
-            max_response_timeout_ms: 60000, // 60 seconds
+            max_response_timeout_ms: 60_000, // 60 seconds
             max_state_chunk_size: MAX_STATE_CHUNK_SIZE,
             max_transaction_chunk_size: MAX_TRANSACTION_CHUNK_SIZE,
             max_transaction_output_chunk_size: MAX_TRANSACTION_OUTPUT_CHUNK_SIZE,
-            response_timeout_ms: 10000,    // 10 seconds
-            subscription_timeout_ms: 5000, // 5 seconds
+            optimistic_fetch_timeout_ms: 5000, // 5 seconds
+            response_timeout_ms: 10_000,       // 10 seconds
             summary_poll_loop_interval_ms: 200,
             use_compression: true,
         }

--- a/state-sync/aptos-data-client/src/peer_states.rs
+++ b/state-sync/aptos-data-client/src/peer_states.rs
@@ -148,10 +148,11 @@ impl PeerStates {
             return true;
         }
 
+        // Check if the peer can service the request
         self.peer_to_state
             .get(peer)
             .and_then(PeerState::storage_summary_if_not_ignored)
-            .map(|summary| summary.can_service(request))
+            .map(|summary| summary.can_service(&self.data_client_config, request))
             .unwrap_or(false)
     }
 

--- a/state-sync/aptos-data-client/src/tests/priority.rs
+++ b/state-sync/aptos-data-client/src/tests/priority.rs
@@ -6,15 +6,12 @@ use crate::{
     tests::{mock::MockNetwork, utils},
 };
 use aptos_config::{
-    config::{BaseConfig, RoleType},
+    config::{AptosDataClientConfig, BaseConfig, RoleType},
     network_id::NetworkId,
 };
-use aptos_storage_service_types::{
-    requests::{
-        DataRequest, NewTransactionOutputsWithProofRequest, NewTransactionsWithProofRequest,
-        StorageServiceRequest, TransactionOutputsWithProofRequest,
-    },
-    responses::OPTIMISTIC_FETCH_VERSION_LAG,
+use aptos_storage_service_types::requests::{
+    DataRequest, NewTransactionOutputsWithProofRequest, NewTransactionsWithProofRequest,
+    StorageServiceRequest, TransactionOutputsWithProofRequest,
 };
 use claims::assert_matches;
 
@@ -148,7 +145,14 @@ async fn prioritized_peer_request_selection() {
 #[tokio::test]
 async fn prioritized_peer_optimistic_fetch_selection() {
     ::aptos_logger::Logger::init_for_testing();
-    let (mut mock_network, _, client, _) = MockNetwork::new(None, None, None);
+
+    // Create a data client with a max version lag of 100
+    let max_optimistic_fetch_version_lag = 100;
+    let data_client_config = AptosDataClientConfig {
+        max_optimistic_fetch_version_lag,
+        ..Default::default()
+    };
+    let (mut mock_network, _, client, _) = MockNetwork::new(None, Some(data_client_config), None);
 
     // Create test data
     let known_version = 10000000;
@@ -209,7 +213,7 @@ async fn prioritized_peer_optimistic_fetch_selection() {
         // Update the priority peer to be too far behind and verify it is not selected
         client.update_summary(
             priority_peer_1,
-            utils::create_storage_summary(known_version - OPTIMISTIC_FETCH_VERSION_LAG),
+            utils::create_storage_summary(known_version - max_optimistic_fetch_version_lag),
         );
         assert_eq!(
             client.choose_peer_for_request(&storage_request),
@@ -219,7 +223,7 @@ async fn prioritized_peer_optimistic_fetch_selection() {
         // Update the regular peer to be too far behind and verify neither is selected
         client.update_summary(
             regular_peer_1,
-            utils::create_storage_summary(known_version - (OPTIMISTIC_FETCH_VERSION_LAG * 2)),
+            utils::create_storage_summary(known_version - (max_optimistic_fetch_version_lag * 2)),
         );
         assert_matches!(
             client.choose_peer_for_request(&storage_request),

--- a/state-sync/aptos-data-client/src/tests/priority.rs
+++ b/state-sync/aptos-data-client/src/tests/priority.rs
@@ -146,7 +146,7 @@ async fn prioritized_peer_request_selection() {
 }
 
 #[tokio::test]
-async fn prioritized_peer_subscription_selection() {
+async fn prioritized_peer_optimistic_fetch_selection() {
     ::aptos_logger::Logger::init_for_testing();
     let (mut mock_network, _, client, _) = MockNetwork::new(None, None, None);
 
@@ -154,7 +154,7 @@ async fn prioritized_peer_subscription_selection() {
     let known_version = 10000000;
     let known_epoch = 10;
 
-    // Ensure the properties hold for both subscription requests
+    // Ensure the properties hold for both optimistic fetch requests
     let new_transactions_request =
         DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
             known_version,

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_service.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_service.rs
@@ -755,7 +755,7 @@ async fn test_notifications_epoch_ending_multiple_streams() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_notifications_subscribe_outputs() {
+async fn test_notifications_optimistic_fetch_outputs() {
     // Create a new streaming client and service
     let streaming_client = create_streaming_client_and_service_with_data_delay();
 
@@ -806,7 +806,7 @@ async fn test_notifications_subscribe_outputs() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_notifications_subscribe_transactions() {
+async fn test_notifications_optimistic_fetch_transactions() {
     // Create a new streaming client and service
     let streaming_client = create_streaming_client_and_service_with_data_delay();
 

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
@@ -141,7 +141,7 @@ impl MockAptosDataClient {
         thread::sleep(Duration::from_millis(create_range_random_u64(10, 50)));
     }
 
-    fn emulate_subscription_expiration(&self) -> aptos_data_client::error::Error {
+    fn emulate_optimistic_fetch_expiration(&self) -> aptos_data_client::error::Error {
         thread::sleep(Duration::from_secs(MAX_NOTIFICATION_TIMEOUT_SECS));
         aptos_data_client::error::Error::TimeoutWaitingForResponse("RPC timed out!".into())
     }
@@ -164,7 +164,7 @@ impl MockAptosDataClient {
     fn verify_request_timeout(
         &self,
         request_timeout_ms: u64,
-        is_subscription_request: bool,
+        is_optimistic_fetch_request: bool,
         data_request: DataRequest,
     ) {
         if self.skip_timeout_verification {
@@ -172,8 +172,8 @@ impl MockAptosDataClient {
         }
 
         // Verify the given timeout for the request
-        let expected_timeout = if is_subscription_request {
-            self.aptos_data_client_config.subscription_timeout_ms
+        let expected_timeout = if is_optimistic_fetch_request {
+            self.aptos_data_client_config.optimistic_fetch_timeout_ms
         } else {
             let min_timeout = self.aptos_data_client_config.response_timeout_ms;
             let max_timeout = self.aptos_data_client_config.max_response_timeout_ms;
@@ -371,7 +371,7 @@ impl AptosDataClientInterface for MockAptosDataClient {
                 target_ledger_info,
             )))
         } else {
-            Err(self.emulate_subscription_expiration())
+            Err(self.emulate_optimistic_fetch_expiration())
         }
     }
 
@@ -434,7 +434,7 @@ impl AptosDataClientInterface for MockAptosDataClient {
                 target_ledger_info,
             )))
         } else {
-            Err(self.emulate_subscription_expiration())
+            Err(self.emulate_optimistic_fetch_expiration())
         }
     }
 

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -7,7 +7,10 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
-use aptos_config::{config::StorageServiceConfig, network_id::NetworkId};
+use aptos_config::{
+    config::{StateSyncConfig, StorageServiceConfig},
+    network_id::NetworkId,
+};
 use aptos_crypto::HashValue;
 use aptos_network::{
     application::{interface::NetworkServiceEvents, storage::PeersAndMetadata},
@@ -72,10 +75,14 @@ impl MockClient {
     ) {
         utils::initialize_logger();
 
+        // Create the state sync config
+        let mut state_sync_config = StateSyncConfig::default();
+        let storage_service_config = storage_config.unwrap_or_default();
+        state_sync_config.storage_service = storage_service_config;
+
         // Create the storage reader
-        let storage_config = storage_config.unwrap_or_default();
         let storage_reader = StorageReader::new(
-            storage_config,
+            storage_service_config,
             Arc::new(db_reader.unwrap_or_else(create_mock_db_reader)),
         );
 
@@ -84,10 +91,11 @@ impl MockClient {
         let mut network_and_events = HashMap::new();
         let mut peer_manager_notifiers = HashMap::new();
         for network_id in network_ids.clone() {
-            let queue_cfg =
-                aptos_channel::Config::new(storage_config.max_network_channel_size as usize)
-                    .queue_style(QueueStyle::FIFO)
-                    .counters(&metrics::PENDING_STORAGE_SERVER_NETWORK_EVENTS);
+            let queue_cfg = aptos_channel::Config::new(
+                storage_service_config.max_network_channel_size as usize,
+            )
+            .queue_style(QueueStyle::FIFO)
+            .counters(&metrics::PENDING_STORAGE_SERVER_NETWORK_EVENTS);
             let (peer_manager_notifier, peer_manager_notification_receiver) = queue_cfg.build();
             let (_, connection_notification_receiver) = queue_cfg.build();
 
@@ -111,7 +119,7 @@ impl MockClient {
         let executor = tokio::runtime::Handle::current();
         let mock_time_service = TimeService::mock();
         let storage_server = StorageServiceServer::new(
-            storage_config,
+            state_sync_config,
             executor,
             storage_reader,
             mock_time_service.clone(),

--- a/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
@@ -10,7 +10,10 @@ use crate::{
     tests::{mock, utils},
 };
 use aptos_bounded_executor::BoundedExecutor;
-use aptos_config::{config::StorageServiceConfig, network_id::PeerNetworkId};
+use aptos_config::{
+    config::{AptosDataClientConfig, StorageServiceConfig},
+    network_id::PeerNetworkId,
+};
 use aptos_infallible::Mutex;
 use aptos_storage_service_types::{
     requests::{
@@ -69,6 +72,7 @@ async fn test_peers_with_ready_optimistic_fetches() {
         Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
     let lru_response_cache = Arc::new(Mutex::new(LruCache::new(0)));
     let request_moderator = Arc::new(RequestModerator::new(
+        AptosDataClientConfig::default(),
         cached_storage_server_summary.clone(),
         mock::create_peers_and_metadata(vec![]),
         storage_service_config,
@@ -161,6 +165,7 @@ async fn test_remove_expired_optimistic_fetches() {
         Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
     let lru_response_cache = Arc::new(Mutex::new(LruCache::new(0)));
     let request_moderator = Arc::new(RequestModerator::new(
+        AptosDataClientConfig::default(),
         cached_storage_server_summary.clone(),
         mock::create_peers_and_metadata(vec![]),
         storage_service_config,

--- a/state-sync/storage-service/types/Cargo.toml
+++ b/state-sync/storage-service/types/Cargo.toml
@@ -25,3 +25,4 @@ thiserror = { workspace = true }
 [dev-dependencies]
 claims = { workspace = true }
 proptest = { workspace = true }
+rand = { workspace = true }

--- a/state-sync/storage-service/types/src/responses.rs
+++ b/state-sync/storage-service/types/src/responses.rs
@@ -13,7 +13,9 @@ use crate::{
     Epoch, StorageServiceRequest, COMPRESSION_SUFFIX_LABEL,
 };
 use aptos_compression::{metrics::CompressionClient, CompressedData, CompressionError};
-use aptos_config::config::{StorageServiceConfig, MAX_APPLICATION_MESSAGE_SIZE};
+use aptos_config::config::{
+    AptosDataClientConfig, StorageServiceConfig, MAX_APPLICATION_MESSAGE_SIZE,
+};
 use aptos_types::{
     epoch_change::EpochChangeProof,
     ledger_info::LedgerInfoWithSignatures,
@@ -29,11 +31,6 @@ use std::{
     fmt::{Display, Formatter},
 };
 use thiserror::Error;
-
-/// The version lag we'll tolerate when considering if a peer is eligible
-/// to handle an optimistic fetch for new data. This value is set assuming
-/// 5k TPS for a 10 second delay, which should be more than enough.
-pub const OPTIMISTIC_FETCH_VERSION_LAG: u64 = 50_000;
 
 #[derive(Clone, Debug, Deserialize, Error, PartialEq, Eq, Serialize)]
 pub enum Error {
@@ -359,8 +356,15 @@ pub struct StorageServerSummary {
 }
 
 impl StorageServerSummary {
-    pub fn can_service(&self, request: &StorageServiceRequest) -> bool {
-        self.protocol_metadata.can_service(request) && self.data_summary.can_service(request)
+    pub fn can_service(
+        &self,
+        aptos_data_client_config: &AptosDataClientConfig,
+        request: &StorageServiceRequest,
+    ) -> bool {
+        self.protocol_metadata.can_service(request)
+            && self
+                .data_summary
+                .can_service(aptos_data_client_config, request)
     }
 }
 
@@ -420,7 +424,11 @@ pub struct DataSummary {
 
 impl DataSummary {
     /// Returns true iff the request can be serviced
-    pub fn can_service(&self, request: &StorageServiceRequest) -> bool {
+    pub fn can_service(
+        &self,
+        aptos_data_client_config: &AptosDataClientConfig,
+        request: &StorageServiceRequest,
+    ) -> bool {
         match &request.data_request {
             GetServerProtocolVersion | GetStorageServerSummary => true,
             GetEpochEndingLedgerInfos(request) => {
@@ -434,10 +442,10 @@ impl DataSummary {
                     .unwrap_or(false)
             },
             GetNewTransactionOutputsWithProof(request) => {
-                self.can_service_optimistic_request(request.known_version)
+                self.can_service_optimistic_request(aptos_data_client_config, request.known_version)
             },
             GetNewTransactionsWithProof(request) => {
-                self.can_service_optimistic_request(request.known_version)
+                self.can_service_optimistic_request(aptos_data_client_config, request.known_version)
             },
             GetNumberOfStatesAtVersion(version) => self
                 .states
@@ -500,7 +508,7 @@ impl DataSummary {
                 can_serve_txns && can_create_proof
             },
             GetNewTransactionsOrOutputsWithProof(request) => {
-                self.can_service_optimistic_request(request.known_version)
+                self.can_service_optimistic_request(aptos_data_client_config, request.known_version)
             },
             GetTransactionsOrOutputsWithProof(request) => {
                 let desired_range =
@@ -531,10 +539,15 @@ impl DataSummary {
     }
 
     /// Returns true iff the optimistic data request can be serviced
-    fn can_service_optimistic_request(&self, known_version: u64) -> bool {
+    fn can_service_optimistic_request(
+        &self,
+        aptos_data_client_config: &AptosDataClientConfig,
+        known_version: u64,
+    ) -> bool {
+        let max_version_lag = aptos_data_client_config.max_optimistic_fetch_version_lag;
         self.synced_ledger_info
             .as_ref()
-            .map(|li| (li.ledger_info().version() + OPTIMISTIC_FETCH_VERSION_LAG) > known_version)
+            .map(|li| (li.ledger_info().version() + max_version_lag) > known_version)
             .unwrap_or(false)
     }
 

--- a/state-sync/storage-service/types/src/tests.rs
+++ b/state-sync/storage-service/types/src/tests.rs
@@ -3,13 +3,15 @@
 
 use crate::{
     requests::{
-        DataRequest, EpochEndingLedgerInfoRequest, StateValuesWithProofRequest,
-        TransactionOutputsWithProofRequest, TransactionsOrOutputsWithProofRequest,
-        TransactionsWithProofRequest,
+        DataRequest, EpochEndingLedgerInfoRequest, NewTransactionOutputsWithProofRequest,
+        NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
+        StateValuesWithProofRequest, TransactionOutputsWithProofRequest,
+        TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
     },
     responses::{CompleteDataRange, DataSummary, ProtocolMetadata},
     Epoch, StorageServiceRequest,
 };
+use aptos_config::config::AptosDataClientConfig;
 use aptos_crypto::hash::HashValue;
 use aptos_types::{
     aggregate_signature::AggregateSignature,
@@ -19,198 +21,373 @@ use aptos_types::{
 };
 use claims::{assert_err, assert_ok};
 use proptest::{arbitrary::any, prelude::*};
+use rand::{thread_rng, Rng};
 
 #[test]
-fn test_complete_data_range() {
-    // good ranges
+fn test_complete_data_ranges() {
+    // Test valid data ranges
     assert_ok!(CompleteDataRange::new(0, 0));
     assert_ok!(CompleteDataRange::new(10, 10));
     assert_ok!(CompleteDataRange::new(10, 20));
     assert_ok!(CompleteDataRange::new(u64::MAX, u64::MAX));
 
-    // degenerate ranges
+    // Test degenerate data ranges
     assert_err!(CompleteDataRange::new(1, 0));
     assert_err!(CompleteDataRange::new(20, 10));
     assert_err!(CompleteDataRange::new(u64::MAX, 0));
     assert_err!(CompleteDataRange::new(u64::MAX, 1));
 
-    // range length overflow edge case
+    // Test the overflow edge cases
     assert_ok!(CompleteDataRange::new(1, u64::MAX));
     assert_ok!(CompleteDataRange::new(0, u64::MAX - 1));
     assert_err!(CompleteDataRange::new(0, u64::MAX));
 }
 
 #[test]
-fn test_data_summary_can_service_epochs_request() {
-    let summary = DataSummary {
-        epoch_ending_ledger_infos: Some(create_range(100, 200)),
+fn test_data_summary_service_epoch_ending_ledger_infos() {
+    // Create a data client config and data summary
+    let data_client_config = AptosDataClientConfig::default();
+    let data_summary = DataSummary {
+        epoch_ending_ledger_infos: Some(create_data_range(100, 200)),
         ..Default::default()
     };
 
+    // Verify the different requests that can be serviced
     for compression in [true, false] {
-        // in range, can service
-        assert!(summary.can_service(&epochs_request(100, 200, compression)));
-        assert!(summary.can_service(&epochs_request(125, 175, compression)));
-        assert!(summary.can_service(&epochs_request(100, 100, compression)));
-        assert!(summary.can_service(&epochs_request(150, 150, compression)));
-        assert!(summary.can_service(&epochs_request(200, 200, compression)));
+        // Test the valid data ranges
+        let valid_ranges = vec![(100, 200), (125, 175), (100, 100), (150, 150), (200, 200)];
+        verify_can_service_epoch_ending_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            valid_ranges,
+            true,
+        );
 
-        // out of range, can't service
-        assert!(!summary.can_service(&epochs_request(99, 200, compression)));
-        assert!(!summary.can_service(&epochs_request(100, 201, compression)));
-        assert!(!summary.can_service(&epochs_request(50, 250, compression)));
-        assert!(!summary.can_service(&epochs_request(50, 150, compression)));
-        assert!(!summary.can_service(&epochs_request(150, 250, compression)));
+        // Test the missing data ranges
+        let invalid_ranges = vec![(99, 200), (100, 201), (50, 250), (50, 150), (150, 250)];
+        verify_can_service_epoch_ending_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            invalid_ranges,
+            false,
+        );
 
-        // degenerate range, can't service
-        assert!(!summary.can_service(&epochs_request(150, 149, compression)));
+        // Test degenerate data ranges
+        let degenerate_ranges = vec![(200, 199), (200, 100), (150, 149)];
+        verify_can_service_epoch_ending_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            degenerate_ranges,
+            false,
+        );
     }
 }
 
 #[test]
-fn test_data_summary_can_service_txns_request() {
-    let summary = DataSummary {
-        synced_ledger_info: Some(create_mock_ledger_info(250)),
-        transactions: Some(create_range(100, 200)),
+fn test_data_summary_service_optimistic_fetch() {
+    // Create a data client config with the specified max optimistic fetch lag
+    let max_optimistic_fetch_version_lag = 1000;
+    let data_client_config = AptosDataClientConfig {
+        max_optimistic_fetch_version_lag,
         ..Default::default()
     };
 
+    // Create a data summary with the specified synced ledger info version
+    let highest_synced_version = 50_000;
+    let data_summary = DataSummary {
+        synced_ledger_info: Some(create_ledger_info_at_version(highest_synced_version)),
+        ..Default::default()
+    };
+
+    // Verify the different requests that can be serviced
     for compression in [true, false] {
-        // in range, can service
-        assert!(summary.can_service(&txns_request(225, 100, 200, compression)));
-        assert!(summary.can_service(&txns_request(225, 125, 175, compression)));
-        assert!(summary.can_service(&txns_request(225, 100, 100, compression)));
-        assert!(summary.can_service(&txns_request(225, 150, 150, compression)));
-        assert!(summary.can_service(&txns_request(225, 200, 200, compression)));
-        assert!(summary.can_service(&txns_request(250, 200, 200, compression)));
+        // Test the known versions that are within the optimistic fetch lag
+        let known_versions = vec![
+            highest_synced_version,
+            highest_synced_version + (max_optimistic_fetch_version_lag / 2),
+            highest_synced_version + max_optimistic_fetch_version_lag - 1,
+        ];
+        verify_can_service_optimistic_fetch_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            known_versions,
+            true,
+        );
 
-        // out of range, can't service
-        assert!(!summary.can_service(&txns_request(225, 99, 200, compression)));
-        assert!(!summary.can_service(&txns_request(225, 100, 201, compression)));
-        assert!(!summary.can_service(&txns_request(225, 50, 250, compression)));
-        assert!(!summary.can_service(&txns_request(225, 50, 150, compression)));
-        assert!(!summary.can_service(&txns_request(225, 150, 250, compression)));
-
-        assert!(!summary.can_service(&txns_request(300, 100, 200, compression)));
-        assert!(!summary.can_service(&txns_request(300, 125, 175, compression)));
-        assert!(!summary.can_service(&txns_request(300, 100, 100, compression)));
-        assert!(!summary.can_service(&txns_request(300, 150, 150, compression)));
-        assert!(!summary.can_service(&txns_request(300, 200, 200, compression)));
-        assert!(!summary.can_service(&txns_request(251, 200, 200, compression)));
+        // Test the known versions that are outside the optimistic fetch lag
+        let known_versions = vec![
+            highest_synced_version + max_optimistic_fetch_version_lag,
+            highest_synced_version + max_optimistic_fetch_version_lag + 1,
+            highest_synced_version + (max_optimistic_fetch_version_lag * 2),
+        ];
+        verify_can_service_optimistic_fetch_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            known_versions,
+            false,
+        );
     }
 }
 
 #[test]
-fn test_data_summary_can_service_txn_outputs_request() {
-    let summary = DataSummary {
-        synced_ledger_info: Some(create_mock_ledger_info(250)),
-        transaction_outputs: Some(create_range(100, 200)),
+fn test_data_summary_service_transactions() {
+    // Create a data client config and data summary
+    let data_client_config = AptosDataClientConfig::default();
+    let data_summary = DataSummary {
+        synced_ledger_info: Some(create_ledger_info_at_version(250)),
+        transactions: Some(create_data_range(100, 200)),
         ..Default::default()
     };
 
+    // Verify the different requests that can be serviced
     for compression in [true, false] {
-        // in range and can provide proof => can service
-        assert!(summary.can_service(&outputs_request(225, 100, 200, compression)));
-        assert!(summary.can_service(&outputs_request(225, 125, 175, compression)));
-        assert!(summary.can_service(&outputs_request(225, 100, 100, compression)));
-        assert!(summary.can_service(&outputs_request(225, 150, 150, compression)));
-        assert!(summary.can_service(&outputs_request(225, 200, 200, compression)));
-        assert!(summary.can_service(&outputs_request(250, 200, 200, compression)));
+        // Test the valid data ranges and proofs
+        let valid_ranges_and_proofs = vec![
+            (100, 200, 225),
+            (125, 175, 225),
+            (100, 100, 225),
+            (150, 150, 225),
+            (200, 200, 225),
+            (200, 200, 250),
+        ];
+        verify_can_service_transaction_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            valid_ranges_and_proofs,
+            true,
+        );
 
-        // can provide proof, but out of range => cannot service
-        assert!(!summary.can_service(&outputs_request(225, 99, 200, compression)));
-        assert!(!summary.can_service(&outputs_request(225, 100, 201, compression)));
-        assert!(!summary.can_service(&outputs_request(225, 50, 250, compression)));
-        assert!(!summary.can_service(&outputs_request(225, 50, 150, compression)));
-        assert!(!summary.can_service(&outputs_request(225, 150, 250, compression)));
+        // Test the missing data ranges and proofs
+        let missing_data_ranges = vec![
+            (99, 200, 225),
+            (100, 201, 225),
+            (50, 250, 225),
+            (50, 150, 225),
+            (150, 250, 225),
+        ];
+        verify_can_service_transaction_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            missing_data_ranges,
+            false,
+        );
 
-        // in range, but cannot provide proof => cannot service
-        assert!(!summary.can_service(&outputs_request(300, 100, 200, compression)));
-        assert!(!summary.can_service(&outputs_request(300, 125, 175, compression)));
-        assert!(!summary.can_service(&outputs_request(300, 100, 100, compression)));
-        assert!(!summary.can_service(&outputs_request(300, 150, 150, compression)));
-        assert!(!summary.can_service(&outputs_request(300, 200, 200, compression)));
-        assert!(!summary.can_service(&outputs_request(251, 200, 200, compression)));
-
-        // invalid range
-        assert!(!summary.can_service(&outputs_request(225, 175, 125, compression)));
+        // Test the invalid data ranges and proofs
+        let invalid_proof_versions = vec![
+            (100, 200, 300),
+            (125, 175, 300),
+            (100, 100, 300),
+            (150, 150, 300),
+            (200, 200, 300),
+            (200, 200, 251),
+        ];
+        verify_can_service_transaction_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            invalid_proof_versions,
+            false,
+        );
     }
 }
 
 #[test]
-fn test_data_summary_can_service_txns_or_outputs_request() {
-    let summary = DataSummary {
-        synced_ledger_info: Some(create_mock_ledger_info(250)),
-        transactions: Some(create_range(50, 200)),
-        transaction_outputs: Some(create_range(100, 250)),
+fn test_data_summary_service_transaction_outputs() {
+    // Create a data client config and data summary
+    let data_client_config = AptosDataClientConfig::default();
+    let data_summary = DataSummary {
+        synced_ledger_info: Some(create_ledger_info_at_version(250)),
+        transaction_outputs: Some(create_data_range(100, 200)),
         ..Default::default()
     };
 
+    // Verify the different requests that can be serviced
     for compression in [true, false] {
-        // in range (for txns and outputs) and can provide proof => can service
-        assert!(summary.can_service(&txns_or_outputs_request(225, 100, 200, compression)));
-        assert!(summary.can_service(&txns_or_outputs_request(225, 125, 175, compression)));
-        assert!(summary.can_service(&txns_or_outputs_request(225, 100, 100, compression)));
-        assert!(summary.can_service(&txns_or_outputs_request(225, 150, 150, compression)));
-        assert!(summary.can_service(&txns_or_outputs_request(225, 200, 200, compression)));
-        assert!(summary.can_service(&txns_or_outputs_request(250, 200, 200, compression)));
+        // Test the valid data ranges and proofs
+        let valid_ranges_and_proofs = vec![
+            (100, 200, 225),
+            (125, 175, 225),
+            (100, 100, 225),
+            (150, 150, 225),
+            (200, 200, 225),
+            (200, 200, 250),
+        ];
+        verify_can_service_output_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            valid_ranges_and_proofs,
+            true,
+        );
 
-        // in range (for txns but not outputs) and can provide proof => cannot service
-        assert!(!summary.can_service(&txns_or_outputs_request(225, 51, 200, compression)));
-        assert!(!summary.can_service(&txns_or_outputs_request(225, 99, 100, compression)));
-        assert!(!summary.can_service(&txns_or_outputs_request(225, 51, 71, compression)));
+        // Test the missing data ranges and proofs
+        let missing_data_ranges = vec![
+            (99, 200, 225),
+            (100, 201, 225),
+            (50, 250, 225),
+            (50, 150, 225),
+            (150, 250, 225),
+        ];
+        verify_can_service_output_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            missing_data_ranges,
+            false,
+        );
 
-        // in range (for outputs but not txns) and can provide proof => cannot service
-        assert!(!summary.can_service(&txns_or_outputs_request(225, 200, 202, compression)));
-        assert!(!summary.can_service(&txns_or_outputs_request(225, 150, 201, compression)));
-        assert!(!summary.can_service(&txns_or_outputs_request(225, 201, 225, compression)));
+        // Test the valid data ranges and invalid proofs
+        let invalid_proof_versions = vec![
+            (100, 200, 300),
+            (125, 175, 300),
+            (100, 100, 300),
+            (150, 150, 300),
+            (200, 200, 300),
+            (200, 200, 251),
+        ];
+        verify_can_service_output_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            invalid_proof_versions,
+            false,
+        );
 
-        // can provide proof, but out of range => cannot service
-        assert!(!summary.can_service(&txns_or_outputs_request(225, 99, 200, compression)));
-        assert!(!summary.can_service(&txns_or_outputs_request(225, 100, 201, compression)));
-        assert!(!summary.can_service(&txns_or_outputs_request(225, 50, 250, compression)));
-        assert!(!summary.can_service(&txns_or_outputs_request(225, 50, 150, compression)));
-        assert!(!summary.can_service(&txns_or_outputs_request(225, 150, 250, compression)));
+        // Test the invalid data ranges and proofs
+        let invalid_ranges = vec![(175, 125, 225), (201, 200, 201), (202, 200, 200)];
+        verify_can_service_output_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            invalid_ranges,
+            false,
+        );
+    }
+}
 
-        // in range, but cannot provide proof => cannot service
-        assert!(!summary.can_service(&txns_or_outputs_request(300, 100, 200, compression)));
-        assert!(!summary.can_service(&txns_or_outputs_request(300, 125, 175, compression)));
-        assert!(!summary.can_service(&txns_or_outputs_request(300, 100, 100, compression)));
-        assert!(!summary.can_service(&txns_or_outputs_request(300, 150, 150, compression)));
-        assert!(!summary.can_service(&txns_or_outputs_request(300, 200, 200, compression)));
-        assert!(!summary.can_service(&txns_or_outputs_request(251, 200, 200, compression)));
+#[test]
+fn test_data_summary_service_transactions_or_outputs() {
+    // Create a data client config and data summary
+    let data_client_config = AptosDataClientConfig::default();
+    let data_summary = DataSummary {
+        synced_ledger_info: Some(create_ledger_info_at_version(250)),
+        transactions: Some(create_data_range(50, 200)),
+        transaction_outputs: Some(create_data_range(100, 250)),
+        ..Default::default()
+    };
 
-        // invalid range
-        assert!(!summary.can_service(&outputs_request(225, 175, 125, compression)));
+    // Verify the different requests that can be serviced
+    for compression in [true, false] {
+        // Test the valid data ranges and proofs
+        let valid_ranges_and_proofs = vec![
+            (100, 200, 225),
+            (125, 175, 225),
+            (100, 100, 225),
+            (150, 150, 225),
+            (200, 200, 225),
+            (200, 200, 250),
+        ];
+        verify_can_service_transaction_or_output_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            valid_ranges_and_proofs,
+            true,
+        );
+
+        // Test the missing output ranges and proofs
+        let missing_output_ranges = vec![(51, 200, 225), (99, 100, 225), (51, 71, 225)];
+        verify_can_service_transaction_or_output_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            missing_output_ranges,
+            false,
+        );
+
+        // Test the missing transaction ranges and proofs
+        let missing_transaction_ranges = vec![(200, 202, 225), (150, 201, 225), (201, 225, 225)];
+        verify_can_service_transaction_or_output_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            missing_transaction_ranges,
+            false,
+        );
+
+        // Test the valid data ranges and invalid proofs
+        let invalid_proof_versions = vec![
+            (100, 200, 300),
+            (125, 175, 300),
+            (100, 100, 300),
+            (150, 150, 300),
+            (200, 200, 300),
+            (200, 200, 251),
+        ];
+        verify_can_service_transaction_or_output_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            invalid_proof_versions,
+            false,
+        );
+
+        // Test the invalid data ranges and proofs
+        let invalid_ranges = vec![(175, 125, 225), (201, 200, 201), (202, 200, 200)];
+        verify_can_service_transaction_or_output_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            invalid_ranges,
+            false,
+        );
     }
 }
 
 #[test]
 fn test_data_summary_can_service_state_chunk_request() {
-    let summary = DataSummary {
-        synced_ledger_info: Some(create_mock_ledger_info(250)),
-        states: Some(create_range(100, 300)),
+    // Create a data client config and data summary
+    let data_client_config = AptosDataClientConfig::default();
+    let data_summary = DataSummary {
+        synced_ledger_info: Some(create_ledger_info_at_version(250)),
+        states: Some(create_data_range(100, 300)),
         ..Default::default()
     };
 
+    // Verify the different requests that can be serviced
     for compression in [true, false] {
-        // in range and can provide proof => can service
-        assert!(summary.can_service(&states_request(100, compression)));
-        assert!(summary.can_service(&states_request(200, compression)));
-        assert!(summary.can_service(&states_request(250, compression)));
+        // Test the valid request versions
+        let valid_request_versions = vec![100, 200, 250];
+        verify_can_service_state_chunk_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            valid_request_versions,
+            true,
+        );
 
-        // in range, but cannot provide proof => cannot service
-        assert!(!summary.can_service(&states_request(251, compression)));
-        assert!(!summary.can_service(&states_request(300, compression)));
-
-        // can provide proof, but out of range ==> cannot service
-        assert!(!summary.can_service(&states_request(50, compression)));
-        assert!(!summary.can_service(&states_request(99, compression)));
+        // Test invalid request versions
+        let invalid_request_versions = vec![50, 99, 251, 300];
+        verify_can_service_state_chunk_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            invalid_request_versions,
+            false,
+        );
     }
 }
 
 #[test]
-fn test_protocol_metadata_can_service() {
+fn test_protocol_metadata_service() {
+    // Create the protocol metadata
     let metadata = ProtocolMetadata {
         max_transaction_chunk_size: 100,
         max_epoch_chunk_size: 100,
@@ -218,18 +395,19 @@ fn test_protocol_metadata_can_service() {
         max_state_chunk_size: 100,
     };
 
+    // Verify the different requests that can be serviced
     for compression in [true, false] {
         // Requests with smaller chunk sizes can be serviced
-        assert!(metadata.can_service(&txns_request(200, 100, 101, compression)));
-        assert!(metadata.can_service(&epochs_request(100, 199, compression)));
-        assert!(metadata.can_service(&outputs_request(200, 100, 100, compression)));
-        assert!(metadata.can_service(&state_values_request(200, 100, 199, compression)));
+        assert!(metadata.can_service(&create_transactions_request(200, 100, 101, compression)));
+        assert!(metadata.can_service(&create_epoch_ending_request(100, 199, compression)));
+        assert!(metadata.can_service(&create_outputs_request(200, 100, 100, compression)));
+        assert!(metadata.can_service(&create_state_values_request(200, 100, 199, compression)));
 
         // Requests with larger chunk sizes (beyond the max) can also be serviced
-        assert!(metadata.can_service(&txns_request(200, 100, 1000, compression)));
-        assert!(metadata.can_service(&epochs_request(100, 10000, compression)));
-        assert!(metadata.can_service(&outputs_request(200, 100, 9999989, compression)));
-        assert!(metadata.can_service(&state_values_request(200, 100, 200, compression)));
+        assert!(metadata.can_service(&create_transactions_request(200, 100, 1000, compression)));
+        assert!(metadata.can_service(&create_epoch_ending_request(100, 10000, compression)));
+        assert!(metadata.can_service(&create_outputs_request(200, 100, 9999989, compression)));
+        assert!(metadata.can_service(&create_state_values_request(200, 100, 200, compression)));
     }
 }
 
@@ -238,12 +416,30 @@ proptest! {
 
     #[test]
     fn test_data_summary_length_invariant(range in any::<CompleteDataRange<u64>>()) {
-        // should not panic
-        let _ = range.len();
+        let _ = range.len(); // This should not panic
     }
 }
 
-fn create_mock_ledger_info(version: Version) -> LedgerInfoWithSignatures {
+/// Creates a new data range using the specified bounds
+fn create_data_range(lowest: u64, highest: u64) -> CompleteDataRange<u64> {
+    CompleteDataRange::new(lowest, highest).unwrap()
+}
+
+/// Creates a request for epoch ending ledger infos
+fn create_epoch_ending_request(
+    start: Epoch,
+    end: Epoch,
+    use_compression: bool,
+) -> StorageServiceRequest {
+    let data_request = DataRequest::GetEpochEndingLedgerInfos(EpochEndingLedgerInfoRequest {
+        start_epoch: start,
+        expected_end_epoch: end,
+    });
+    StorageServiceRequest::new(data_request, use_compression)
+}
+
+/// Creates a new ledger info at the given version
+fn create_ledger_info_at_version(version: Version) -> LedgerInfoWithSignatures {
     LedgerInfoWithSignatures::new(
         LedgerInfo::new(
             BlockInfo::new(0, 0, HashValue::zero(), HashValue::zero(), version, 0, None),
@@ -253,34 +449,41 @@ fn create_mock_ledger_info(version: Version) -> LedgerInfoWithSignatures {
     )
 }
 
-fn create_range(lowest: u64, highest: u64) -> CompleteDataRange<u64> {
-    CompleteDataRange::new(lowest, highest).unwrap()
-}
-
-fn epochs_request(start: Epoch, end: Epoch, use_compression: bool) -> StorageServiceRequest {
-    let data_request = DataRequest::GetEpochEndingLedgerInfos(EpochEndingLedgerInfoRequest {
-        start_epoch: start,
-        expected_end_epoch: end,
-    });
-    StorageServiceRequest::new(data_request, use_compression)
-}
-
-fn txns_request(
-    proof: Version,
-    start: Version,
-    end: Version,
+/// Creates a new optimistic request
+fn create_optimistic_fetch_request(
+    known_version: u64,
     use_compression: bool,
 ) -> StorageServiceRequest {
-    let data_request = DataRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
-        proof_version: proof,
-        start_version: start,
-        end_version: end,
-        include_events: true,
-    });
+    // Generate a random number
+    let random_number: u64 = thread_rng().gen();
+
+    // Determine the data request type based on the random number
+    let data_request = if random_number % 3 == 0 {
+        DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
+            known_version,
+            known_epoch: 1,
+            include_events: false,
+        })
+    } else if random_number % 3 == 1 {
+        DataRequest::GetNewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest {
+            known_version,
+            known_epoch: 1,
+        })
+    } else {
+        DataRequest::GetNewTransactionsOrOutputsWithProof(
+            NewTransactionsOrOutputsWithProofRequest {
+                known_version,
+                known_epoch: 1,
+                include_events: false,
+                max_num_output_reductions: 0,
+            },
+        )
+    };
     StorageServiceRequest::new(data_request, use_compression)
 }
 
-fn outputs_request(
+/// Creates a request for transaction outputs
+fn create_outputs_request(
     proof_version: Version,
     start_version: Version,
     end_version: Version,
@@ -295,7 +498,24 @@ fn outputs_request(
     StorageServiceRequest::new(data_request, use_compression)
 }
 
-fn txns_or_outputs_request(
+/// Creates a request for transactions
+fn create_transactions_request(
+    proof: Version,
+    start: Version,
+    end: Version,
+    use_compression: bool,
+) -> StorageServiceRequest {
+    let data_request = DataRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
+        proof_version: proof,
+        start_version: start,
+        end_version: end,
+        include_events: true,
+    });
+    StorageServiceRequest::new(data_request, use_compression)
+}
+
+/// Creates a request for transactions or outputs
+fn create_transactions_or_outputs_request(
     proof: Version,
     start: Version,
     end: Version,
@@ -312,7 +532,8 @@ fn txns_or_outputs_request(
     StorageServiceRequest::new(data_request, use_compression)
 }
 
-fn state_values_request(
+/// Creates a request for state values
+fn create_state_values_request(
     version: Version,
     start_index: u64,
     end_index: u64,
@@ -326,6 +547,148 @@ fn state_values_request(
     StorageServiceRequest::new(data_request, use_compression)
 }
 
-fn states_request(version: Version, use_compression: bool) -> StorageServiceRequest {
-    state_values_request(version, 0, 1000, use_compression)
+/// Creates a request for state values at a given version
+fn create_state_values_request_at_version(
+    version: Version,
+    use_compression: bool,
+) -> StorageServiceRequest {
+    create_state_values_request(version, 0, 1000, use_compression)
+}
+
+/// Verifies the serviceability of the epoch ending request ranges against
+/// the specified data summary. If `expect_service` is true, then the
+/// request should be serviceable.
+fn verify_can_service_epoch_ending_requests(
+    data_client_config: &AptosDataClientConfig,
+    data_summary: &DataSummary,
+    compression: bool,
+    epoch_ranges: Vec<(Epoch, Epoch)>,
+    expect_service: bool,
+) {
+    for (start_epoch, end_epoch) in epoch_ranges {
+        // Create the epoch ending request
+        let request = create_epoch_ending_request(start_epoch, end_epoch, compression);
+
+        // Verify the serviceability of the request
+        verify_serviceability(data_client_config, data_summary, request, expect_service);
+    }
+}
+
+/// Verifies the serviceability of the optimistic fetch versions against
+/// the specified data summary. If `expect_service` is true, then the
+/// request should be serviceable.
+fn verify_can_service_optimistic_fetch_requests(
+    data_client_config: &AptosDataClientConfig,
+    data_summary: &DataSummary,
+    compression: bool,
+    known_versions: Vec<Version>,
+    expect_service: bool,
+) {
+    for known_version in known_versions {
+        // Create the optimistic fetch request
+        let request = create_optimistic_fetch_request(known_version, compression);
+
+        // Verify the serviceability of the request
+        verify_serviceability(data_client_config, data_summary, request, expect_service);
+    }
+}
+
+/// Verifies the serviceability of the state chunk request versions
+/// against the specified data summary. If `expect_service` is true,
+/// then the request should be serviceable.
+fn verify_can_service_state_chunk_requests(
+    data_client_config: &AptosDataClientConfig,
+    data_summary: &DataSummary,
+    use_compression: bool,
+    versions: Vec<u64>,
+    expect_service: bool,
+) {
+    for version in versions {
+        // Create the state chunk request
+        let request = create_state_values_request_at_version(version, use_compression);
+
+        // Verify the serviceability of the request
+        verify_serviceability(data_client_config, data_summary, request, expect_service);
+    }
+}
+
+/// Verifies the serviceability of the transaction request ranges against
+/// the specified data summary. If `expect_service` is true, then the
+/// request should be serviceable.
+fn verify_can_service_transaction_requests(
+    data_client_config: &AptosDataClientConfig,
+    data_summary: &DataSummary,
+    use_compression: bool,
+    transaction_ranges: Vec<(u64, u64, u64)>,
+    expect_service: bool,
+) {
+    for (start_version, end_version, proof_version) in transaction_ranges {
+        // Create the transaction request
+        let request =
+            create_transactions_request(proof_version, start_version, end_version, use_compression);
+
+        // Verify the serviceability of the request
+        verify_serviceability(data_client_config, data_summary, request, expect_service);
+    }
+}
+
+/// Verifies the serviceability of the transaction or output request
+/// ranges against the specified data summary. If `expect_service` is
+/// true, then the request should be serviceable.
+fn verify_can_service_transaction_or_output_requests(
+    data_client_config: &AptosDataClientConfig,
+    data_summary: &DataSummary,
+    use_compression: bool,
+    transaction_ranges: Vec<(u64, u64, u64)>,
+    expect_service: bool,
+) {
+    for (start_version, end_version, proof_version) in transaction_ranges {
+        // Create the transaction or output request
+        let request = create_transactions_or_outputs_request(
+            proof_version,
+            start_version,
+            end_version,
+            use_compression,
+        );
+
+        // Verify the serviceability of the request
+        verify_serviceability(data_client_config, data_summary, request, expect_service);
+    }
+}
+
+/// Verifies the serviceability of the output request ranges against
+/// the specified data summary. If `expect_service` is true, then the
+/// request should be serviceable.
+fn verify_can_service_output_requests(
+    data_client_config: &AptosDataClientConfig,
+    data_summary: &DataSummary,
+    use_compression: bool,
+    output_ranges: Vec<(u64, u64, u64)>,
+    expect_service: bool,
+) {
+    for (start_version, end_version, proof_version) in output_ranges {
+        // Create the output request
+        let request =
+            create_outputs_request(proof_version, start_version, end_version, use_compression);
+
+        // Verify the serviceability of the request
+        verify_serviceability(data_client_config, data_summary, request, expect_service);
+    }
+}
+
+/// A simple helper method to verify the serviceability of a request
+fn verify_serviceability(
+    data_client_config: &AptosDataClientConfig,
+    data_summary: &DataSummary,
+    request: StorageServiceRequest,
+    expect_service: bool,
+) {
+    let can_service = data_summary.can_service(data_client_config, &request);
+
+    // Assert that the serviceability matches the expectation
+    if expect_service {
+        assert!(can_service);
+    } else {
+        assert!(!can_service);
+    }
 }


### PR DESCRIPTION
Note: (i) nothing should logically change in this PR; and (ii) this PR is based on https://github.com/aptos-labs/aptos-core/pull/9021.

### Description
This PR offers several small renames, refactors and test cleanups, each in their own commit:
1. Replace `subscription` terminology in the Aptos Data Client with `optimistic fetch` (as this is more accurate and consistent with the storage service nomenclature).
2. Make the optimistic fetch lag configurable in the data client config (as opposed to hard-coded in the file).
3. Clean up the storage service types tests and add a missing test for optimistic fetch versions.

### Test Plan
Existing and new test infrastructure.