### PR TITLE
[Forge] Reduce swarm sizes for various forge jobs.

### DIFF
--- a/.github/workflows/forge-pfn.yaml
+++ b/.github/workflows/forge-pfn.yaml
@@ -1,7 +1,5 @@
-# Continuously run specialized forge tests against the latest main branch.
-# These tests run less frequently than regular forge tests (i.e., stable
-# and unstable).
-name: Continuous Forge Tests - Specialized
+# Continuously run PFN forge tests against the latest main branch
+name: Continuous Forge Tests - Public Fullnodes
 
 permissions:
   issues: write
@@ -23,10 +21,10 @@ on:
         type: string
         description: The git SHA1 to checkout. This affects the Forge test runner that is used. If not specified, the latest main will be used
   schedule:
-    - cron: "0 6 */2 * *" # The main branch cadence. This runs every other day at 6am UTC.
+    - cron: "0 8 */2 * *" # The main branch cadence. This runs every other day at 8am UTC.
   pull_request:
     paths:
-      - ".github/workflows/forge-specialized.yaml"
+      - ".github/workflows/forge-pfn.yaml"
       - "testsuite/find_latest_image.py"
   push:
     branches:
@@ -188,58 +186,4 @@ jobs:
       FORGE_NAMESPACE: forge-pfn-performance-with-realistic-env-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
       FORGE_TEST_SUITE: pfn_performance_with_realistic_env
-      POST_TO_SLACK: true
-
-  ### State sync tests
-
-  # Measures state sync performance for validators (output syncing)
-  run-forge-state-sync-perf-validator-test:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-state-sync-perf-validator-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
-      FORGE_TEST_SUITE: state_sync_perf_validators
-      POST_TO_SLACK: true
-
-  # Measures state sync performance for validator fullnodes (execution syncing)
-  run-forge-state-sync-perf-fullnode-execute-test:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-execute-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
-      FORGE_TEST_SUITE: state_sync_perf_fullnodes_execute_transactions
-      POST_TO_SLACK: true
-
-  # Measures state sync performance for validator fullnodes (fast syncing)
-  run-forge-state-sync-perf-fullnode-fast-sync-test:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-fast-sync-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
-      FORGE_TEST_SUITE: state_sync_perf_fullnodes_fast_sync
-      POST_TO_SLACK: true
-
-  # Measures state sync performance for validator fullnodes (output syncing)
-  run-forge-state-sync-perf-fullnode-apply-test:
-    if: ${{ github.event_name != 'pull_request' }}
-    needs: determine-test-metadata
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-apply-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
-      FORGE_TEST_SUITE: state_sync_perf_fullnodes_apply_outputs
       POST_TO_SLACK: true

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -120,7 +120,7 @@ jobs:
       IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_NAMESPACE: forge-realistic-env-max-load-long-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 7200
-      FORGE_TEST_SUITE: realistic_env_max_load
+      FORGE_TEST_SUITE: realistic_env_max_load_large
       POST_TO_SLACK: true
 
   run-forge-realistic-env-load-sweep:

--- a/.github/workflows/forge-state-sync.yaml
+++ b/.github/workflows/forge-state-sync.yaml
@@ -1,0 +1,163 @@
+# Continuously run state sync forge tests against the latest main branch
+name: Continuous Forge Tests - State Sync
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+  id-token: write
+  actions: write # Required for workflow cancellation via check-aptos-core
+
+on:
+  # Allow triggering manually
+  workflow_dispatch:
+    inputs:
+      IMAGE_TAG:
+        required: false
+        type: string
+        description: The docker image tag to test. This may be a git SHA1, or a tag like "<branch>_<git SHA1>". If not specified, Forge will find the latest build based on the git history (starting from GIT_SHA input)
+      GIT_SHA:
+        required: false
+        type: string
+        description: The git SHA1 to checkout. This affects the Forge test runner that is used. If not specified, the latest main will be used
+  schedule:
+    - cron: "0 6 */3 * *" # The main branch cadence. This runs every three days at 6am UTC.
+  pull_request:
+    paths:
+      - ".github/workflows/forge-state-sync.yaml"
+      - "testsuite/find_latest_image.py"
+  push:
+    branches:
+      - aptos-release-v* # The aptos release branches
+
+env:
+  AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  IMAGE_TAG: ${{ inputs.IMAGE_TAG }} # This is only used for workflow_dispatch, otherwise defaults to empty
+  AWS_REGION: us-west-2
+
+jobs:
+  # This job determines the image tag and branch to test, and passes them to the other jobs.
+  # NOTE: this may be better as a separate workflow as the logic is quite complex but generalizable.
+  determine-test-metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      IMAGE_TAG: ${{ steps.determine-test-image-tag.outputs.IMAGE_TAG }}
+      BRANCH: ${{ steps.determine-test-branch.outputs.BRANCH }}
+    steps:
+      - name: Determine branch based on cadence
+        id: determine-test-branch
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            if [[ "${{ github.event.schedule }}" == "0 6 */2 * *" ]]; then
+              echo "Branch: main"
+              echo "BRANCH=main" >> $GITHUB_OUTPUT
+            else
+              echo "Unknown schedule: ${{ github.event.schedule }}"
+              exit 1
+            fi
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+              echo "Branch: ${{ github.ref_name }}"
+              echo "BRANCH=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "Using GIT_SHA"
+            # on workflow_dispatch, this will simply use the inputs.GIT_SHA given (or the default)
+            # on pull_request, this will default to null and the following "checkout" step will use the PR's base branch
+            echo "BRANCH=${{ inputs.GIT_SHA }}" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          ref: ${{ steps.determine-test-branch.outputs.BRANCH }}
+          fetch-depth: 0
+
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
+        with:
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
+
+      # find_latest_images.py requires docker utilities and having authenticated to internal docker image registries
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+        id: docker-setup
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          EXPORT_GCP_PROJECT_VARIABLES: "false"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+
+      - uses: ./.github/actions/python-setup
+        with:
+          pyproject_directory: testsuite
+
+      - name: Determine image tag
+        id: determine-test-image-tag
+        # Forge relies on the default and failpoints variants
+        run: ./testrun find_latest_image.py --variant failpoints --variant performance
+        shell: bash
+        working-directory: testsuite
+
+      - name: Write summary
+        run: |
+          IMAGE_TAG=${{ steps.determine-test-image-tag.outputs.IMAGE_TAG }}
+          BRANCH=${{ steps.determine-test-branch.outputs.BRANCH }}
+          if [ -n "${BRANCH}" ]; then
+            echo "BRANCH: [${BRANCH}](https://github.com/${{ github.repository }}/tree/${BRANCH})" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "IMAGE_TAG: [${IMAGE_TAG}](https://github.com/${{ github.repository }}/commit/${IMAGE_TAG})" >> $GITHUB_STEP_SUMMARY
+
+  ### State sync tests
+
+  # Measures state sync performance for validators (output syncing)
+  run-forge-state-sync-perf-validator-test:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-state-sync-perf-validator-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
+      FORGE_TEST_SUITE: state_sync_perf_validators
+      POST_TO_SLACK: true
+
+  # Measures state sync performance for validator fullnodes (execution syncing)
+  run-forge-state-sync-perf-fullnode-execute-test:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-execute-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
+      FORGE_TEST_SUITE: state_sync_perf_fullnodes_execute_transactions
+      POST_TO_SLACK: true
+
+  # Measures state sync performance for validator fullnodes (fast syncing)
+  run-forge-state-sync-perf-fullnode-fast-sync-test:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-fast-sync-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
+      FORGE_TEST_SUITE: state_sync_perf_fullnodes_fast_sync
+      POST_TO_SLACK: true
+
+  # Measures state sync performance for validator fullnodes (output syncing)
+  run-forge-state-sync-perf-fullnode-apply-test:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: determine-test-metadata
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-apply-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      FORGE_RUNNER_DURATION_SECS: 1800 # Run for 30 minutes
+      FORGE_TEST_SUITE: state_sync_perf_fullnodes_apply_outputs
+      POST_TO_SLACK: true

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1880,8 +1880,8 @@ fn pfn_const_tps(
     add_network_emulation: bool,
 ) -> ForgeConfig {
     ForgeConfig::default()
-        .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
-        .with_initial_fullnode_count(10)
+        .with_initial_validator_count(NonZeroUsize::new(7).unwrap())
+        .with_initial_fullnode_count(7)
         .with_emit_job(EmitJobRequest::default().mode(EmitJobMode::ConstTps { tps: 100 }))
         .add_network_test(PFNPerformance::new(add_cpu_chaos, add_network_emulation))
         .with_genesis_helm_config_fn(Arc::new(|helm_values| {
@@ -1924,8 +1924,8 @@ fn pfn_performance(
 
     // Create the forge config
     ForgeConfig::default()
-        .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
-        .with_initial_fullnode_count(10)
+        .with_initial_validator_count(NonZeroUsize::new(7).unwrap())
+        .with_initial_fullnode_count(7)
         .add_network_test(PFNPerformance::new(add_cpu_chaos, add_network_emulation))
         .with_genesis_helm_config_fn(Arc::new(|helm_values| {
             // Require frequent epoch changes

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -665,7 +665,7 @@ fn large_db_simple_test() -> ForgeConfig {
 
 fn twin_validator_test() -> ForgeConfig {
     ForgeConfig::default()
-        .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
+        .with_initial_validator_count(NonZeroUsize::new(7).unwrap())
         .with_initial_fullnode_count(5)
         .add_network_test(TwinValidatorTest)
         .with_genesis_helm_config_fn(Arc::new(|helm_values| {
@@ -690,7 +690,7 @@ fn twin_validator_test() -> ForgeConfig {
 
 fn state_sync_failures_catching_up() -> ForgeConfig {
     changing_working_quorum_test_helper(
-        10,
+        7,
         300,
         3000,
         2500,
@@ -709,7 +709,7 @@ fn state_sync_failures_catching_up() -> ForgeConfig {
 
 fn state_sync_slow_processing_catching_up() -> ForgeConfig {
     changing_working_quorum_test_helper(
-        10,
+        7,
         300,
         3000,
         2500,
@@ -1174,10 +1174,10 @@ fn fullnode_reboot_stress_test() -> ForgeConfig {
 
 fn validator_reboot_stress_test() -> ForgeConfig {
     ForgeConfig::default()
-        .with_initial_validator_count(NonZeroUsize::new(15).unwrap())
+        .with_initial_validator_count(NonZeroUsize::new(7).unwrap())
         .with_initial_fullnode_count(1)
         .add_network_test(ValidatorRebootStressTest {
-            num_simultaneously: 3,
+            num_simultaneously: 2,
             down_time_secs: 5.0,
             pause_secs: 5.0,
         })

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1291,7 +1291,7 @@ fn network_partition() -> ForgeConfig {
 
 fn compat() -> ForgeConfig {
     ForgeConfig::default()
-        .with_initial_validator_count(NonZeroUsize::new(5).unwrap())
+        .with_initial_validator_count(NonZeroUsize::new(4).unwrap())
         .add_network_test(SimpleValidatorUpgrade)
         .with_success_criteria(SuccessCriteria::new(5000).add_wait_for_catchup_s(240))
         .with_genesis_helm_config_fn(Arc::new(|helm_values| {
@@ -1301,7 +1301,7 @@ fn compat() -> ForgeConfig {
 
 fn upgrade() -> ForgeConfig {
     ForgeConfig::default()
-        .with_initial_validator_count(NonZeroUsize::new(5).unwrap())
+        .with_initial_validator_count(NonZeroUsize::new(4).unwrap())
         .add_network_test(FrameworkUpgrade)
         .with_success_criteria(SuccessCriteria::new(5000).add_wait_for_catchup_s(240))
         .with_genesis_helm_config_fn(Arc::new(|helm_values| {
@@ -1472,8 +1472,8 @@ fn realistic_env_max_load_test(duration: Duration, test_cmd: &TestCommand) -> Fo
     let duration_secs = duration.as_secs();
     let long_running = duration_secs >= 2400;
     ForgeConfig::default()
-        .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
-        .with_initial_fullnode_count(10)
+        .with_initial_validator_count(NonZeroUsize::new(7).unwrap())
+        .with_initial_fullnode_count(5)
         .add_network_test(wrap_with_realistic_env(TwoTrafficsTest {
             inner_traffic: EmitJobRequest::default()
                 .mode(EmitJobMode::MaxLoad {

--- a/testsuite/testcases/src/modifiers.rs
+++ b/testsuite/testcases/src/modifiers.rs
@@ -253,11 +253,25 @@ pub fn create_swarm_cpu_stress(
     let group_cpu_stresses = peer_chunks
         .into_iter()
         .enumerate()
-        .map(|(idx, chunk)| GroupCpuStress {
-            name: format!("group-{}-cpu-stress", idx),
-            target_nodes: chunk,
-            num_workers: (cpu_chaos_config.num_groups - idx) as u64,
-            load_per_worker: cpu_chaos_config.load_per_worker,
+        .map(|(idx, chunk)| {
+            // Lower bound the number of workers
+            let num_workers = if cpu_chaos_config.num_groups > idx {
+                (cpu_chaos_config.num_groups - idx) as u64
+            } else {
+                1
+            };
+
+            // Create the cpu stress for the group
+            info!(
+                "Creating CPU stress for group {} with {} workers",
+                idx, num_workers
+            );
+            GroupCpuStress {
+                name: format!("group-{}-cpu-stress", idx),
+                target_nodes: chunk,
+                num_workers,
+                load_per_worker: cpu_chaos_config.load_per_worker,
+            }
         })
         .collect();
 

--- a/testsuite/testcases/src/public_fullnode_performance.rs
+++ b/testsuite/testcases/src/public_fullnode_performance.rs
@@ -97,7 +97,7 @@ impl NetworkLoadTest for PFNPerformance {
     /// the swarm; and (ii) use those PFNs as the load destination.
     fn setup(&self, ctx: &mut NetworkContext) -> Result<LoadDestination> {
         // Add the PFNs to the swarm
-        let num_pfns = 10;
+        let num_pfns = 7;
         let pfn_peer_ids = create_and_add_pfns(ctx, num_pfns)?;
 
         // Add CPU chaos to the swarm


### PR DESCRIPTION
### Description
This PR reduces the swarm sizes used by the various forge jobs (to help reduce forge contention and costs). Specifically, the PR contains the following commits:
1. [Land blocking]: Reduce `compat` and `framework_upgrade` validator counts (from 5 to 4, i.e., 3f+1, where f=1); and (ii) reduce `realistic_env_max_load` validators (from 20 to 7, i.e., f=2) and VFNs (from 10 to 5).
2. [PFN]: Reduce the PFN validators (from 20 to 7, i.e., f=2), VFNs (from 10 to 7), and PFNs (from 10 to 7).
3. [Specialized]: Split the `specialized` forge workflow into two separate workflows: (i) a PFN workflow that runs every 2 days; and (ii) a state sync workflow that runs every 3 days.
4. [Unstable] Reduce the `unstable` forge workflow validators (from 20/15/10 to 7, i.e., f=2).
5. [Stable] For the `stable` jobs, we only reduce a few of the swarms sizes such that we still maintain a good variety of tests, i.e., there are currently 12 `stable` jobs, and we're now testing a wide variety of validators counts (i.e., 20->7) and VFN counts (10->7).

### Test Plan
Existing test infrastructure.