### PR TITLE
[compiler] Fix issue #8390: Compiling a move module causes an ICE (attempt to get base_type of Ref type in hlir translation)

### DIFF
--- a/third_party/move/move-compiler/src/hlir/translate.rs
+++ b/third_party/move/move-compiler/src/hlir/translate.rs
@@ -478,12 +478,9 @@ fn base_type(context: &Context, sp!(loc, nb_): N::Type) -> H::BaseType {
         NT::UnresolvedError => HB::UnresolvedError,
         NT::Anything => HB::Unreachable,
         NT::Ref(_, _) | NT::Unit => {
-            panic!(
-                "ICE type constraints failed {}:{}-{}",
-                loc.file_hash(),
-                loc.start(),
-                loc.end(),
-            )
+            // This can happen in bad source code; upstream constraint
+            // will fail and generate an appropriate error message.
+            HB::UnresolvedError
         },
     };
     sp(loc, b_)

--- a/third_party/move/move-compiler/tests/move_check/typing/pay_me_a_river.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/pay_me_a_river.exp
@@ -1,0 +1,9 @@
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_check/typing/pay_me_a_river.move:13:9
+   │
+ 8 │         let payments: &mut Payments;
+   │                       ------------- The type '&mut 0x8675309::M::Payments' does not have the ability 'key'
+   ·
+13 │         move_to(&asigner, payments);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to'
+

--- a/third_party/move/move-compiler/tests/move_check/typing/pay_me_a_river.move
+++ b/third_party/move/move-compiler/tests/move_check/typing/pay_me_a_river.move
@@ -1,0 +1,16 @@
+module 0x8675309::M {
+    struct Payments has key, drop  {
+	value: u64
+    }
+
+    public fun create_stream(asigner: signer): u64
+    {
+        let payments: &mut Payments;
+        payments = &mut Payments {
+	    // let payments: &mut Payments = Payments {
+	    value: 3
+        };
+        move_to(&asigner, payments);
+	payments.value
+    }
+}


### PR DESCRIPTION
### Description

Fix bug #8390: Compiling a Move module causes an ICE:

```
thread 'main' panicked at 'ICE type constraints failed 055d9d249126ed1feaea5910a42a9a8cd14d49fe0ba062d1ae05207482906c11:3035-3048', third_party\move\move-compiler\src\hlir\translate.rs:481:13
```

It turns out that buggy code can cause the HLIR translator to try to get the `base_type` of a Ref type, so this shouldn't cause an ICE.

### Test Plan

Added a minimal test case based on the original customer test case.
Showed that it yielded the same ICE on the current compiler.  With the
fix, we yield a slightly cryptic but infinitely more useful error
output "The type '&mut ...Payments' does not have the ability 'key'"
rather than an ICE crash.

Code inspection shows this case is only relevant when a panic would
have occurred previously.

