### PR TITLE
[Indexer] Add transactions by address indexing

### DIFF
--- a/crates/indexer/migrations/2023-07-13-060328_transactions_by_address/down.sql
+++ b/crates/indexer/migrations/2023-07-13-060328_transactions_by_address/down.sql
@@ -1,0 +1,10 @@
+-- This file should undo anything in `up.sql`
+DROP INDEX IF EXISTS at_version_index;
+DROP INDEX IF EXISTS at_insat_index;
+DROP TABLE IF EXISTS account_transactions;
+ALTER TABLE objects
+ALTER COLUMN owner_address DROP NOT NULL;
+ALTER TABLE objects
+ALTER COLUMN guid_creation_num DROP NOT NULL;
+ALTER TABLE objects
+ALTER COLUMN allow_ungated_transfer DROP NOT NULL;

--- a/crates/indexer/migrations/2023-07-13-060328_transactions_by_address/up.sql
+++ b/crates/indexer/migrations/2023-07-13-060328_transactions_by_address/up.sql
@@ -1,0 +1,20 @@
+-- Your SQL goes here
+-- Records transactions - account pairs. Account here can represent 
+-- user account, resource account, or object account.
+CREATE TABLE IF NOT EXISTS account_transactions (
+  transaction_version BIGINT NOT NULL,
+  account_address VARCHAR(66) NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (account_address, transaction_version)
+);
+CREATE INDEX IF NOT EXISTS at_version_index ON account_transactions (transaction_version DESC);
+CREATE INDEX IF NOT EXISTS at_insat_index ON account_transactions (inserted_at);
+ALTER TABLE objects
+ALTER COLUMN owner_address
+SET NOT NULL;
+ALTER TABLE objects
+ALTER COLUMN guid_creation_num
+SET NOT NULL;
+ALTER TABLE objects
+ALTER COLUMN allow_ungated_transfer
+SET NOT NULL;

--- a/crates/indexer/src/models/coin_models/account_transactions.rs
+++ b/crates/indexer/src/models/coin_models/account_transactions.rs
@@ -1,0 +1,136 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use crate::{
+    models::{
+        token_models::v2_token_utils::ObjectWithMetadata, user_transactions::UserTransaction,
+    },
+    schema::account_transactions,
+    util::standardize_address,
+};
+use aptos_api_types::{DeleteResource, Event, Transaction, WriteResource, WriteSetChange};
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+pub type AccountTransactionPK = (String, i64);
+
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(account_address, transaction_version))]
+#[diesel(table_name = account_transactions)]
+pub struct AccountTransaction {
+    pub transaction_version: i64,
+    pub account_address: String,
+}
+
+impl AccountTransaction {
+    /// This table will record every transaction that touch an account which could be
+    /// a user account, an object, or a resource account.
+    /// We will consider all transactions that modify a resource or event associated with a particular account.
+    /// We will do 1 level of redirection for now (e.g. if it's an object, we will record the owner as account address).
+    /// We will also consider transactions that the account signed or is part of a multi sig / multi agent.
+    /// TODO: recursively find the parent account of an object
+    /// TODO: include table items in the detection path
+    pub fn from_transaction(
+        transaction: &Transaction,
+    ) -> anyhow::Result<HashMap<AccountTransactionPK, Self>> {
+        let (events, wscs, signatures, txn_version) = match transaction {
+            Transaction::UserTransaction(inner) => (
+                &inner.events,
+                &inner.info.changes,
+                UserTransaction::get_signatures(inner, inner.info.version.0 as i64, 0),
+                inner.info.version.0 as i64,
+            ),
+            Transaction::GenesisTransaction(inner) => (
+                &inner.events,
+                &inner.info.changes,
+                vec![],
+                inner.info.version.0 as i64,
+            ),
+            Transaction::BlockMetadataTransaction(inner) => (
+                &inner.events,
+                &inner.info.changes,
+                vec![],
+                inner.info.version.0 as i64,
+            ),
+            _ => {
+                return Ok(HashMap::new());
+            },
+        };
+        let mut account_transactions = HashMap::new();
+        for sig in &signatures {
+            account_transactions.insert((sig.signer.clone(), txn_version), Self {
+                transaction_version: txn_version,
+                account_address: sig.signer.clone(),
+            });
+        }
+        for event in events {
+            account_transactions.extend(Self::from_event(event, txn_version));
+        }
+        for wsc in wscs {
+            match wsc {
+                WriteSetChange::DeleteResource(res) => {
+                    account_transactions.extend(Self::from_delete_resource(res, txn_version)?);
+                },
+                WriteSetChange::WriteResource(res) => {
+                    account_transactions.extend(Self::from_write_resource(res, txn_version)?);
+                },
+                _ => {},
+            }
+        }
+        Ok(account_transactions)
+    }
+
+    /// Base case, record event account address. We don't really have to worry about
+    /// objects here because it'll be taken care of in the resource section
+    fn from_event(event: &Event, txn_version: i64) -> HashMap<AccountTransactionPK, Self> {
+        let account_address = standardize_address(&event.guid.account_address.to_string());
+        HashMap::from([((account_address.clone(), txn_version), Self {
+            transaction_version: txn_version,
+            account_address,
+        })])
+    }
+
+    /// Base case, record resource account. If the resource is an object, then we record the owner as well
+    /// This handles partial deletes as well
+    fn from_write_resource(
+        write_resource: &WriteResource,
+        txn_version: i64,
+    ) -> anyhow::Result<HashMap<AccountTransactionPK, Self>> {
+        let mut result = HashMap::new();
+        let account_address = standardize_address(&write_resource.address.to_string());
+        result.insert((account_address.clone(), txn_version), Self {
+            transaction_version: txn_version,
+            account_address,
+        });
+        if let Some(inner) = &ObjectWithMetadata::from_write_resource(write_resource, txn_version)?
+        {
+            result.insert((inner.object_core.get_owner_address(), txn_version), Self {
+                transaction_version: txn_version,
+                account_address: inner.object_core.get_owner_address(),
+            });
+        }
+        Ok(result)
+    }
+
+    /// Base case, record resource account.
+    /// TODO: If the resource is an object, then we need to look for the latest owner. This isn't really possible
+    /// right now given we have parallel threads so it'll be very difficult to ensure that we have the correct
+    /// latest owner
+    fn from_delete_resource(
+        delete_resource: &DeleteResource,
+        txn_version: i64,
+    ) -> anyhow::Result<HashMap<AccountTransactionPK, Self>> {
+        let mut result = HashMap::new();
+        let account_address = standardize_address(&delete_resource.address.to_string());
+        result.insert((account_address.clone(), txn_version), Self {
+            transaction_version: txn_version,
+            account_address,
+        });
+        Ok(result)
+    }
+}

--- a/crates/indexer/src/models/coin_models/mod.rs
+++ b/crates/indexer/src/models/coin_models/mod.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod account_transactions;
 pub mod coin_activities;
 pub mod coin_balances;
 pub mod coin_infos;

--- a/crates/indexer/src/models/user_transactions.rs
+++ b/crates/indexer/src/models/user_transactions.rs
@@ -92,20 +92,29 @@ impl UserTransaction {
                 },
                 epoch,
             },
-            txn.request
-                .signature
-                .as_ref()
-                .map(|s| {
-                    Signature::from_user_transaction(
-                        s,
-                        &txn.request.sender.to_string(),
-                        version,
-                        block_height,
-                    )
-                    .unwrap()
-                })
-                .unwrap_or_default(), // empty vec if signature is None
+            Self::get_signatures(txn, version, block_height),
         )
+    }
+
+    /// Empty vec if signature is None
+    pub fn get_signatures(
+        txn: &APIUserTransaction,
+        version: i64,
+        block_height: i64,
+    ) -> Vec<Signature> {
+        txn.request
+            .signature
+            .as_ref()
+            .map(|s| {
+                Signature::from_user_transaction(
+                    s,
+                    &txn.request.sender.to_string(),
+                    version,
+                    block_height,
+                )
+                .unwrap()
+            })
+            .unwrap_or_default() // empty vec if signature is None
     }
 }
 

--- a/crates/indexer/src/models/user_transactions.rs
+++ b/crates/indexer/src/models/user_transactions.rs
@@ -114,7 +114,7 @@ impl UserTransaction {
                 )
                 .unwrap()
             })
-            .unwrap_or_default() // empty vec if signature is None
+            .unwrap_or_default()
     }
 }
 

--- a/crates/indexer/src/models/v2_objects.rs
+++ b/crates/indexer/src/models/v2_objects.rs
@@ -5,13 +5,18 @@
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::unused_unit)]
 
-use super::token_models::v2_token_utils::ObjectWithMetadata;
+use super::token_models::{
+    collection_datas::{QUERY_RETRIES, QUERY_RETRY_DELAY_MS},
+    v2_token_utils::ObjectWithMetadata,
+};
 use crate::{
+    database::PgPoolConnection,
     models::move_resources::MoveResource,
     schema::{current_objects, objects},
 };
-use aptos_api_types::{DeleteResource, Transaction, WriteResource, WriteSetChange};
+use aptos_api_types::{DeleteResource, WriteResource};
 use bigdecimal::BigDecimal;
+use diesel::prelude::*;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -19,66 +24,49 @@ use std::collections::HashMap;
 // PK of current_objects, i.e. object_address
 pub type CurrentObjectPK = String;
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(transaction_version, write_set_change_index))]
 #[diesel(table_name = objects)]
 pub struct Object {
     pub transaction_version: i64,
     pub write_set_change_index: i64,
     pub object_address: String,
-    pub owner_address: Option<String>,
+    pub owner_address: String,
     pub state_key_hash: String,
-    pub guid_creation_num: Option<BigDecimal>,
-    pub allow_ungated_transfer: Option<bool>,
+    pub guid_creation_num: BigDecimal,
+    pub allow_ungated_transfer: bool,
     pub is_deleted: bool,
 }
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(object_address))]
 #[diesel(table_name = current_objects)]
 pub struct CurrentObject {
     pub object_address: String,
-    pub owner_address: Option<String>,
+    pub owner_address: String,
     pub state_key_hash: String,
-    pub allow_ungated_transfer: Option<bool>,
-    pub last_guid_creation_num: Option<BigDecimal>,
+    pub allow_ungated_transfer: bool,
+    pub last_guid_creation_num: BigDecimal,
     pub last_transaction_version: i64,
     pub is_deleted: bool,
 }
 
+#[derive(Debug, Deserialize, Identifiable, Queryable, Serialize)]
+#[diesel(primary_key(object_address))]
+#[diesel(table_name = current_objects)]
+pub struct CurrentObjectQuery {
+    pub object_address: String,
+    pub owner_address: String,
+    pub state_key_hash: String,
+    pub allow_ungated_transfer: bool,
+    pub last_guid_creation_num: BigDecimal,
+    pub last_transaction_version: i64,
+    pub is_deleted: bool,
+    pub inserted_at: chrono::NaiveDateTime,
+}
+
 impl Object {
-    /// Only parsing 0x1 ObjectCore from transactions
-    pub fn from_transaction(
-        transaction: &Transaction,
-    ) -> (Vec<Self>, HashMap<CurrentObjectPK, CurrentObject>) {
-        if let Transaction::UserTransaction(user_txn) = transaction {
-            let mut objects = vec![];
-            let mut current_objects: HashMap<String, CurrentObject> = HashMap::new();
-            let txn_version = user_txn.info.version.0 as i64;
-
-            for (index, wsc) in user_txn.info.changes.iter().enumerate() {
-                let index = index as i64;
-                let maybe_object_combo = match wsc {
-                    WriteSetChange::DeleteResource(inner) => {
-                        Self::from_delete_resource(inner, txn_version, index).unwrap()
-                    },
-                    WriteSetChange::WriteResource(inner) => {
-                        Self::from_write_resource(inner, txn_version, index).unwrap()
-                    },
-                    _ => None,
-                };
-                if let Some((object, current_object)) = maybe_object_combo {
-                    objects.push(object);
-                    current_objects.insert(current_object.object_address.clone(), current_object);
-                }
-            }
-            (objects, current_objects)
-        } else {
-            Default::default()
-        }
-    }
-
-    fn from_write_resource(
+    pub fn from_write_resource(
         write_resource: &WriteResource,
         txn_version: i64,
         write_set_change_index: i64,
@@ -96,18 +84,18 @@ impl Object {
                     transaction_version: txn_version,
                     write_set_change_index,
                     object_address: resource.address.clone(),
-                    owner_address: Some(object_core.get_owner_address()),
+                    owner_address: object_core.get_owner_address(),
                     state_key_hash: resource.state_key_hash.clone(),
-                    guid_creation_num: Some(object_core.guid_creation_num.clone()),
-                    allow_ungated_transfer: Some(object_core.allow_ungated_transfer),
+                    guid_creation_num: object_core.guid_creation_num.clone(),
+                    allow_ungated_transfer: object_core.allow_ungated_transfer,
                     is_deleted: false,
                 },
                 CurrentObject {
                     object_address: resource.address,
-                    owner_address: Some(object_core.get_owner_address()),
+                    owner_address: object_core.get_owner_address(),
                     state_key_hash: resource.state_key_hash,
-                    allow_ungated_transfer: Some(object_core.allow_ungated_transfer),
-                    last_guid_creation_num: Some(object_core.guid_creation_num.clone()),
+                    allow_ungated_transfer: object_core.allow_ungated_transfer,
+                    last_guid_creation_num: object_core.guid_creation_num.clone(),
                     last_transaction_version: txn_version,
                     is_deleted: false,
                 },
@@ -120,35 +108,52 @@ impl Object {
     /// This should never really happen since it's very difficult to delete the entire resource group
     /// currently. We actually need a better way of detecting whether an object is deleted since there
     /// is likely no delete resource write set change.
-    fn from_delete_resource(
+    pub fn from_delete_resource(
         delete_resource: &DeleteResource,
         txn_version: i64,
         write_set_change_index: i64,
+        object_mapping: &HashMap<CurrentObjectPK, CurrentObject>,
+        conn: &mut PgPoolConnection,
     ) -> anyhow::Result<Option<(Self, CurrentObject)>> {
-        if delete_resource.resource.to_string() == "0x1::object::ObjectCore" {
+        if delete_resource.resource.to_string() == "0x1::object::ObjectGroup" {
             let resource = MoveResource::from_delete_resource(
                 delete_resource,
                 0, // Placeholder, this isn't used anyway
                 txn_version,
                 0, // Placeholder, this isn't used anyway
             );
+            let previous_object = if let Some(object) = object_mapping.get(&resource.address) {
+                object.clone()
+            } else {
+                match Self::get_object_owner(conn, &resource.address) {
+                    Ok(owner) => owner,
+                    Err(_) => {
+                        aptos_logger::error!(
+                            transaction_version = txn_version,
+                            lookup_key = &resource.address,
+                            "Missing object owner for object. You probably should backfill db.",
+                        );
+                        return Ok(None);
+                    },
+                }
+            };
             Ok(Some((
                 Self {
                     transaction_version: txn_version,
                     write_set_change_index,
                     object_address: resource.address.clone(),
-                    owner_address: None,
+                    owner_address: previous_object.owner_address.clone(),
                     state_key_hash: resource.state_key_hash.clone(),
-                    guid_creation_num: None,
-                    allow_ungated_transfer: None,
+                    guid_creation_num: previous_object.last_guid_creation_num.clone(),
+                    allow_ungated_transfer: previous_object.allow_ungated_transfer,
                     is_deleted: true,
                 },
                 CurrentObject {
                     object_address: resource.address,
-                    owner_address: None,
+                    owner_address: previous_object.owner_address.clone(),
                     state_key_hash: resource.state_key_hash,
-                    allow_ungated_transfer: None,
-                    last_guid_creation_num: None,
+                    last_guid_creation_num: previous_object.last_guid_creation_num.clone(),
+                    allow_ungated_transfer: previous_object.allow_ungated_transfer,
                     last_transaction_version: txn_version,
                     is_deleted: true,
                 },
@@ -156,5 +161,45 @@ impl Object {
         } else {
             Ok(None)
         }
+    }
+
+    /// This is actually not great because object owner can change. The best we can do now though
+    fn get_object_owner(
+        conn: &mut PgPoolConnection,
+        object_address: &str,
+    ) -> anyhow::Result<CurrentObject> {
+        let mut retried = 0;
+        while retried < QUERY_RETRIES {
+            retried += 1;
+            match CurrentObjectQuery::get_by_address(object_address, conn) {
+                Ok(res) => {
+                    return Ok(CurrentObject {
+                        object_address: res.object_address,
+                        owner_address: res.owner_address,
+                        state_key_hash: res.state_key_hash,
+                        allow_ungated_transfer: res.allow_ungated_transfer,
+                        last_guid_creation_num: res.last_guid_creation_num,
+                        last_transaction_version: res.last_transaction_version,
+                        is_deleted: res.is_deleted,
+                    })
+                },
+                Err(_) => {
+                    std::thread::sleep(std::time::Duration::from_millis(QUERY_RETRY_DELAY_MS));
+                },
+            }
+        }
+        Err(anyhow::anyhow!("Failed to get object owner"))
+    }
+}
+
+impl CurrentObjectQuery {
+    /// TODO: Change this to a KV store
+    pub fn get_by_address(
+        object_address: &str,
+        conn: &mut PgPoolConnection,
+    ) -> diesel::QueryResult<Self> {
+        current_objects::table
+            .filter(current_objects::object_address.eq(object_address))
+            .first::<Self>(conn)
     }
 }

--- a/crates/indexer/src/models/v2_objects.rs
+++ b/crates/indexer/src/models/v2_objects.rs
@@ -105,9 +105,9 @@ impl Object {
         }
     }
 
-    /// This should never really happen since it's very difficult to delete the entire resource group
-    /// currently. We actually need a better way of detecting whether an object is deleted since there
-    /// is likely no delete resource write set change.
+    /// This handles the case where the entire object is deleted
+    /// TODO: We need to detect if an object is only partially deleted
+    /// using KV store
     pub fn from_delete_resource(
         delete_resource: &DeleteResource,
         txn_version: i64,

--- a/crates/indexer/src/processors/coin_processor.rs
+++ b/crates/indexer/src/processors/coin_processor.rs
@@ -10,6 +10,7 @@ use crate::{
         transaction_processor::TransactionProcessor,
     },
     models::coin_models::{
+        account_transactions::AccountTransaction,
         coin_activities::{CoinActivity, CurrentCoinBalancePK},
         coin_balances::{CoinBalance, CurrentCoinBalance},
         coin_infos::{CoinInfo, CoinInfoQuery},
@@ -53,12 +54,14 @@ fn insert_to_db_impl(
     coin_balances: &[CoinBalance],
     current_coin_balances: &[CurrentCoinBalance],
     coin_supply: &[CoinSupply],
+    account_transactions: &[AccountTransaction],
 ) -> Result<(), diesel::result::Error> {
     insert_coin_activities(conn, coin_activities)?;
     insert_coin_infos(conn, coin_infos)?;
     insert_coin_balances(conn, coin_balances)?;
     insert_current_coin_balances(conn, current_coin_balances)?;
     insert_coin_supply(conn, coin_supply)?;
+    insert_account_transactions(conn, account_transactions)?;
     Ok(())
 }
 
@@ -72,6 +75,7 @@ fn insert_to_db(
     coin_balances: Vec<CoinBalance>,
     current_coin_balances: Vec<CurrentCoinBalance>,
     coin_supply: Vec<CoinSupply>,
+    account_transactions: Vec<AccountTransaction>,
 ) -> Result<(), diesel::result::Error> {
     aptos_logger::trace!(
         name = name,
@@ -90,6 +94,7 @@ fn insert_to_db(
                 &coin_balances,
                 &current_coin_balances,
                 &coin_supply,
+                &account_transactions,
             )
         }) {
         Ok(_) => Ok(()),
@@ -101,6 +106,8 @@ fn insert_to_db(
                 let coin_infos = clean_data_for_db(coin_infos, true);
                 let coin_balances = clean_data_for_db(coin_balances, true);
                 let current_coin_balances = clean_data_for_db(current_coin_balances, true);
+                let coin_supply = clean_data_for_db(coin_supply, true);
+                let account_transactions = clean_data_for_db(account_transactions, true);
 
                 insert_to_db_impl(
                     pg_conn,
@@ -109,6 +116,7 @@ fn insert_to_db(
                     &coin_balances,
                     &current_coin_balances,
                     &coin_supply,
+                    &account_transactions,
                 )
             }),
     }
@@ -132,11 +140,7 @@ fn insert_coin_activities(
                     event_creation_number,
                     event_sequence_number,
                 ))
-                .do_update()
-                .set((
-                    inserted_at.eq(excluded(inserted_at)),
-                    event_index.eq(excluded(event_index)),
-                )),
+                .do_nothing(),
             None,
         )?;
     }
@@ -240,6 +244,26 @@ fn insert_coin_supply(
     Ok(())
 }
 
+fn insert_account_transactions(
+    conn: &mut PgConnection,
+    item_to_insert: &[AccountTransaction],
+) -> Result<(), diesel::result::Error> {
+    use schema::account_transactions::dsl::*;
+
+    let chunks = get_chunks(item_to_insert.len(), AccountTransaction::field_count());
+    for (start_ind, end_ind) in chunks {
+        execute_with_better_error(
+            conn,
+            diesel::insert_into(schema::account_transactions::table)
+                .values(&item_to_insert[start_ind..end_ind])
+                .on_conflict((transaction_version, account_address))
+                .do_nothing(),
+            None,
+        )?;
+    }
+    Ok(())
+}
+
 #[async_trait]
 impl TransactionProcessor for CoinTransactionProcessor {
     fn name(&self) -> &'static str {
@@ -265,6 +289,8 @@ impl TransactionProcessor for CoinTransactionProcessor {
             HashMap::new();
         let mut all_coin_supply = vec![];
 
+        let mut account_transactions = HashMap::new();
+
         for txn in &transactions {
             let (
                 mut coin_activities,
@@ -281,16 +307,25 @@ impl TransactionProcessor for CoinTransactionProcessor {
                 all_coin_infos.entry(key).or_insert(value);
             }
             all_current_coin_balances.extend(current_coin_balances);
+
+            account_transactions.extend(AccountTransaction::from_transaction(txn).unwrap());
         }
         let mut all_coin_infos = all_coin_infos.into_values().collect::<Vec<CoinInfo>>();
         let mut all_current_coin_balances = all_current_coin_balances
             .into_values()
             .collect::<Vec<CurrentCoinBalance>>();
+        let mut account_transactions = account_transactions
+            .into_values()
+            .collect::<Vec<AccountTransaction>>();
 
         // Sort by PK
         all_coin_infos.sort_by(|a, b| a.coin_type.cmp(&b.coin_type));
         all_current_coin_balances.sort_by(|a, b| {
             (&a.owner_address, &a.coin_type).cmp(&(&b.owner_address, &b.coin_type))
+        });
+        account_transactions.sort_by(|a, b| {
+            (&a.transaction_version, &a.account_address)
+                .cmp(&(&b.transaction_version, &b.account_address))
         });
 
         let tx_result = insert_to_db(
@@ -303,6 +338,7 @@ impl TransactionProcessor for CoinTransactionProcessor {
             all_coin_balances,
             all_current_coin_balances,
             all_coin_supply,
+            account_transactions,
         );
         match tx_result {
             Ok(_) => Ok(ProcessingResult::new(

--- a/crates/indexer/src/processors/default_processor.rs
+++ b/crates/indexer/src/processors/default_processor.rs
@@ -23,7 +23,7 @@ use crate::{
     },
     schema,
 };
-use aptos_api_types::Transaction;
+use aptos_api_types::{Transaction, WriteSetChange};
 use async_trait::async_trait;
 use diesel::{pg::upsert::excluded, result::Error, ExpressionMethods, PgConnection};
 use field_count::FieldCount;
@@ -481,6 +481,8 @@ impl TransactionProcessor for DefaultTransactionProcessor {
         start_version: u64,
         end_version: u64,
     ) -> Result<ProcessingResult, TransactionProcessingError> {
+        let mut conn = self.get_conn();
+
         let (txns, txn_details, events, write_set_changes, wsc_details) =
             TransactionModel::from_transactions(&transactions);
 
@@ -527,9 +529,49 @@ impl TransactionProcessor for DefaultTransactionProcessor {
         let mut all_objects = vec![];
         let mut all_current_objects = HashMap::new();
         for txn in &transactions {
-            let (mut objects, current_objects) = Object::from_transaction(txn);
-            all_objects.append(&mut objects);
-            all_current_objects.extend(current_objects);
+            let (changes, txn_version) = match txn {
+                Transaction::UserTransaction(user_txn) => (
+                    user_txn.info.changes.clone(),
+                    user_txn.info.version.0 as i64,
+                ),
+                Transaction::BlockMetadataTransaction(bmt_txn) => {
+                    (bmt_txn.info.changes.clone(), bmt_txn.info.version.0 as i64)
+                },
+                _ => continue,
+            };
+
+            for (index, wsc) in changes.iter().enumerate() {
+                let index = index as i64;
+                match wsc {
+                    WriteSetChange::WriteResource(inner) => {
+                        if let Some((object, current_object)) =
+                            &Object::from_write_resource(inner, txn_version, index).unwrap()
+                        {
+                            all_objects.push(object.clone());
+                            all_current_objects
+                                .insert(object.object_address.clone(), current_object.clone());
+                        }
+                    },
+                    WriteSetChange::DeleteResource(inner) => {
+                        // Passing all_current_objects into the function so that we can get the owner of the deleted
+                        // resource if it was handled in the same batch
+                        if let Some((object, current_object)) = Object::from_delete_resource(
+                            inner,
+                            txn_version,
+                            index,
+                            &all_current_objects,
+                            &mut conn,
+                        )
+                        .unwrap()
+                        {
+                            all_objects.push(object.clone());
+                            all_current_objects
+                                .insert(object.object_address.clone(), current_object.clone());
+                        }
+                    },
+                    _ => {},
+                }
+            }
         }
         // Getting list of values and sorting by pk in order to avoid postgres deadlock since we're doing multi threaded db writes
         let mut current_table_items = current_table_items
@@ -546,7 +588,6 @@ impl TransactionProcessor for DefaultTransactionProcessor {
         table_metadata.sort_by(|a, b| a.handle.cmp(&b.handle));
         all_current_objects.sort_by(|a, b| a.object_address.cmp(&b.object_address));
 
-        let mut conn = self.get_conn();
         let tx_result = insert_to_db(
             &mut conn,
             self.name(),

--- a/crates/indexer/src/processors/default_processor.rs
+++ b/crates/indexer/src/processors/default_processor.rs
@@ -526,6 +526,8 @@ impl TransactionProcessor for DefaultTransactionProcessor {
         }
 
         // TODO, merge this loop with above
+        // Moving object handling here because we need a single object
+        // map through transactions for lookups
         let mut all_objects = vec![];
         let mut all_current_objects = HashMap::new();
         for txn in &transactions {

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -3,6 +3,15 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    account_transactions (account_address, transaction_version) {
+        transaction_version -> Int8,
+        #[max_length = 66]
+        account_address -> Varchar,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     block_metadata_transactions (version) {
         version -> Int8,
         block_height -> Int8,
@@ -583,11 +592,11 @@ diesel::table! {
         #[max_length = 66]
         object_address -> Varchar,
         #[max_length = 66]
-        owner_address -> Nullable<Varchar>,
+        owner_address -> Varchar,
         #[max_length = 66]
         state_key_hash -> Varchar,
-        guid_creation_num -> Nullable<Numeric>,
-        allow_ungated_transfer -> Nullable<Bool>,
+        guid_creation_num -> Numeric,
+        allow_ungated_transfer -> Bool,
         is_deleted -> Bool,
         inserted_at -> Timestamp,
     }
@@ -927,6 +936,7 @@ diesel::table! {
 }
 
 diesel::allow_tables_to_appear_in_same_query!(
+    account_transactions,
     block_metadata_transactions,
     coin_activities,
     coin_balances,

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/migrations/2023-07-13-060328_transactions_by_address/down.sql
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/migrations/2023-07-13-060328_transactions_by_address/down.sql
@@ -1,0 +1,10 @@
+-- This file should undo anything in `up.sql`
+DROP INDEX IF EXISTS at_version_index;
+DROP INDEX IF EXISTS at_insat_index;
+DROP TABLE IF EXISTS account_transactions;
+ALTER TABLE objects
+ALTER COLUMN owner_address DROP NOT NULL;
+ALTER TABLE objects
+ALTER COLUMN guid_creation_num DROP NOT NULL;
+ALTER TABLE objects
+ALTER COLUMN allow_ungated_transfer DROP NOT NULL;

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/migrations/2023-07-13-060328_transactions_by_address/up.sql
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/migrations/2023-07-13-060328_transactions_by_address/up.sql
@@ -1,0 +1,20 @@
+-- Your SQL goes here
+-- Records transactions - account pairs. Account here can represent 
+-- user account, resource account, or object account.
+CREATE TABLE IF NOT EXISTS account_transactions (
+  transaction_version BIGINT NOT NULL,
+  account_address VARCHAR(66) NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (account_address, transaction_version)
+);
+CREATE INDEX IF NOT EXISTS at_version_index ON account_transactions (transaction_version DESC);
+CREATE INDEX IF NOT EXISTS at_insat_index ON account_transactions (inserted_at);
+ALTER TABLE objects
+ALTER COLUMN owner_address
+SET NOT NULL;
+ALTER TABLE objects
+ALTER COLUMN guid_creation_num
+SET NOT NULL;
+ALTER TABLE objects
+ALTER COLUMN allow_ungated_transfer
+SET NOT NULL;

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/coin_models/account_transactions.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/coin_models/account_transactions.rs
@@ -1,0 +1,144 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use crate::{
+    models::{
+        default_models::user_transactions::UserTransaction,
+        token_models::v2_token_utils::ObjectWithMetadata,
+    },
+    schema::account_transactions,
+    utils::util::standardize_address,
+};
+use aptos_protos::transaction::v1::{
+    transaction::TxnData, write_set_change::Change, DeleteResource, Event, Transaction,
+    WriteResource,
+};
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+pub type AccountTransactionPK = (String, i64);
+
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(account_address, transaction_version))]
+#[diesel(table_name = account_transactions)]
+pub struct AccountTransaction {
+    pub transaction_version: i64,
+    pub account_address: String,
+}
+
+impl AccountTransaction {
+    /// This table will record every transaction that touch an account which could be
+    /// a user account, an object, or a resource account.
+    /// We will consider all transactions that modify a resource or event associated with a particular account.
+    /// We will do 1 level of redirection for now (e.g. if it's an object, we will record the owner as account address).
+    /// We will also consider transactions that the account signed or is part of a multi sig / multi agent.
+    /// TODO: recursively find the parent account of an object
+    /// TODO: include table items in the detection path
+    pub fn from_transaction(transaction: &Transaction) -> HashMap<AccountTransactionPK, Self> {
+        let txn_version = transaction.version as i64;
+        let txn_data = transaction
+            .txn_data
+            .as_ref()
+            .unwrap_or_else(|| panic!("Txn Data doesn't exit for version {}", txn_version));
+        let transaction_info = transaction.info.as_ref().unwrap_or_else(|| {
+            panic!("Transaction info doesn't exist for version {}", txn_version)
+        });
+        let wscs = &transaction_info.changes;
+        let (events, signatures) = match txn_data {
+            TxnData::User(inner) => (
+                &inner.events,
+                UserTransaction::get_signatures(
+                    inner.request.as_ref().unwrap_or_else(|| {
+                        panic!("User request doesn't exist for version {}", txn_version)
+                    }),
+                    txn_version,
+                    transaction.block_height as i64,
+                ),
+            ),
+            TxnData::Genesis(inner) => (&inner.events, vec![]),
+            TxnData::BlockMetadata(inner) => (&inner.events, vec![]),
+            _ => {
+                return HashMap::new();
+            },
+        };
+        let mut account_transactions = HashMap::new();
+        for sig in &signatures {
+            account_transactions.insert((sig.signer.clone(), txn_version), Self {
+                transaction_version: txn_version,
+                account_address: sig.signer.clone(),
+            });
+        }
+        for event in events {
+            account_transactions.extend(Self::from_event(event, txn_version));
+        }
+        for wsc in wscs {
+            match wsc.change.as_ref().unwrap() {
+                Change::DeleteResource(res) => {
+                    account_transactions
+                        .extend(Self::from_delete_resource(res, txn_version).unwrap());
+                },
+                Change::WriteResource(res) => {
+                    account_transactions
+                        .extend(Self::from_write_resource(res, txn_version).unwrap());
+                },
+                _ => {},
+            }
+        }
+        account_transactions
+    }
+
+    /// Base case, record event account address. We don't really have to worry about
+    /// objects here because it'll be taken care of in the resource section
+    fn from_event(event: &Event, txn_version: i64) -> HashMap<AccountTransactionPK, Self> {
+        let account_address =
+            standardize_address(event.key.as_ref().unwrap().account_address.as_str());
+        HashMap::from([((account_address.clone(), txn_version), Self {
+            transaction_version: txn_version,
+            account_address,
+        })])
+    }
+
+    /// Base case, record resource account. If the resource is an object, then we record the owner as well
+    /// This handles partial deletes as well
+    fn from_write_resource(
+        write_resource: &WriteResource,
+        txn_version: i64,
+    ) -> anyhow::Result<HashMap<AccountTransactionPK, Self>> {
+        let mut result = HashMap::new();
+        let account_address = standardize_address(write_resource.address.as_str());
+        result.insert((account_address.clone(), txn_version), Self {
+            transaction_version: txn_version,
+            account_address,
+        });
+        if let Some(inner) = &ObjectWithMetadata::from_write_resource(write_resource, txn_version)?
+        {
+            result.insert((inner.object_core.get_owner_address(), txn_version), Self {
+                transaction_version: txn_version,
+                account_address: inner.object_core.get_owner_address(),
+            });
+        }
+        Ok(result)
+    }
+
+    /// Base case, record resource account.
+    /// TODO: If the resource is an object, then we need to look for the latest owner. This isn't really possible
+    /// right now given we have parallel threads so it'll be very difficult to ensure that we have the correct
+    /// latest owner
+    fn from_delete_resource(
+        delete_resource: &DeleteResource,
+        txn_version: i64,
+    ) -> anyhow::Result<HashMap<AccountTransactionPK, Self>> {
+        let mut result = HashMap::new();
+        let account_address = standardize_address(delete_resource.address.as_str());
+        result.insert((account_address.clone(), txn_version), Self {
+            transaction_version: txn_version,
+            account_address,
+        });
+        Ok(result)
+    }
+}

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/coin_models/coin_balances.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/coin_models/coin_balances.rs
@@ -52,7 +52,6 @@ impl CoinBalance {
     ) -> anyhow::Result<Option<(Self, CurrentCoinBalance, EventToCoinType)>> {
         match &CoinResource::from_write_resource(write_resource, txn_version)? {
             Some(CoinResource::CoinStoreResource(inner)) => {
-                tracing::info!("CoinStoreResource found: {:?}", write_resource);
                 let coin_info_type = &CoinInfoType::from_move_type(
                     &write_resource.r#type.as_ref().unwrap().generic_type_params[0],
                     write_resource.type_str.as_ref(),

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/coin_models/mod.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/coin_models/mod.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod account_transactions;
 pub mod coin_activities;
 pub mod coin_balances;
 pub mod coin_infos;

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/default_models/user_transactions.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/default_models/user_transactions.rs
@@ -19,7 +19,8 @@ use crate::{
     },
 };
 use aptos_protos::{
-    transaction::v1::UserTransaction as UserTransactionPB, util::timestamp::Timestamp,
+    transaction::v1::{UserTransaction as UserTransactionPB, UserTransactionRequest},
+    util::timestamp::Timestamp,
 };
 use bigdecimal::BigDecimal;
 use field_count::FieldCount;
@@ -105,15 +106,24 @@ impl UserTransaction {
                     .unwrap_or_default(),
                 epoch,
             },
-            user_request
-                .signature
-                .as_ref()
-                .map(|s| {
-                    Signature::from_user_transaction(s, &user_request.sender, version, block_height)
-                        .unwrap()
-                })
-                .unwrap_or_default(), // empty vec if signature is None
+            Self::get_signatures(user_request, version, block_height),
         )
+    }
+
+    /// Empty vec if signature is None
+    pub fn get_signatures(
+        user_request: &UserTransactionRequest,
+        version: i64,
+        block_height: i64,
+    ) -> Vec<Signature> {
+        user_request
+            .signature
+            .as_ref()
+            .map(|s| {
+                Signature::from_user_transaction(s, &user_request.sender, version, block_height)
+                    .unwrap()
+            })
+            .unwrap_or_default()
     }
 }
 

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/stake_models/delegator_balances.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/stake_models/delegator_balances.rs
@@ -121,10 +121,20 @@ impl CurrentDelegatorBalance {
             {
                 Some(pool_address) => pool_address,
                 None => {
-                    Self::get_staking_pool_from_inactive_share_handle(conn, &inactive_pool_handle)
-                        .context(format!("Failed to get staking pool address from inactive share handle {}, txn version {}",
-                        inactive_pool_handle, txn_version
-                    ))?
+                    match Self::get_staking_pool_from_inactive_share_handle(
+                        conn,
+                        &inactive_pool_handle,
+                    ) {
+                        Ok(pool) => pool,
+                        Err(_) => {
+                            tracing::error!(
+                                transaction_version = txn_version,
+                                lookup_key = &inactive_pool_handle,
+                                "Failed to get staking pool address from inactive share handle. You probably should backfill db.",
+                            );
+                            return Ok(None);
+                        },
+                    }
                 },
             };
             let delegator_address = standardize_address(&write_table_item.key.to_string());

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/token_models/v2_token_activities.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/token_models/v2_token_activities.rs
@@ -93,7 +93,7 @@ impl TokenActivityV2 {
                     true
                 } else {
                     // Look up in the db
-                    TokenDataV2::is_address_token(conn, &maybe_token_data_id)?
+                    TokenDataV2::is_address_token(conn, &maybe_token_data_id)
                 };
                 if !is_token {
                     return Ok(None);

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/token_models/v2_token_datas.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/token_models/v2_token_datas.rs
@@ -235,18 +235,18 @@ impl TokenDataV2 {
     /// Try to see if an address is a token. We'll try a few times in case there is a race condition,
     /// and if we can't find after 3 times, we'll assume that it's not a token.
     /// TODO: An improvement is that we'll make another query to see if address is a coin.
-    pub fn is_address_token(conn: &mut PgPoolConnection, address: &str) -> anyhow::Result<bool> {
+    pub fn is_address_token(conn: &mut PgPoolConnection, address: &str) -> bool {
         let mut retried = 0;
         while retried < QUERY_RETRIES {
             retried += 1;
             match Self::get_by_token_data_id(conn, address) {
-                Ok(_) => return Ok(true),
+                Ok(_) => return true,
                 Err(_) => {
                     std::thread::sleep(std::time::Duration::from_millis(QUERY_RETRY_DELAY_MS));
                 },
             }
         }
-        Ok(false)
+        false
     }
 
     /// TODO: Change this to a KV store

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/token_models/v2_token_ownerships.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/src/models/token_models/v2_token_ownerships.rs
@@ -286,7 +286,20 @@ impl TokenOwnershipV2 {
             {
                 Some(inner) => inner.clone(),
                 None => {
-                    CurrentTokenOwnershipV2Query::get_nft_by_token_data_id(conn, token_address)?
+                    match CurrentTokenOwnershipV2Query::get_nft_by_token_data_id(
+                        conn,
+                        token_address,
+                    ) {
+                        Ok(nft) => nft,
+                        Err(_) => {
+                            tracing::error!(
+                                transaction_version = txn_version,
+                                lookup_key = &token_address,
+                                "Failed to find NFT for burned token. You probably should backfill db."
+                            );
+                            return Ok(None);
+                        },
+                    }
                 },
             };
 

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/src/processors/coin_processor.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/src/processors/coin_processor.rs
@@ -4,6 +4,7 @@
 use super::processor_trait::{ProcessingResult, ProcessorTrait};
 use crate::{
     models::coin_models::{
+        account_transactions::AccountTransaction,
         coin_activities::{CoinActivity, CurrentCoinBalancePK},
         coin_balances::{CoinBalance, CurrentCoinBalance},
         coin_infos::{CoinInfo, CoinInfoQuery},
@@ -52,12 +53,14 @@ fn insert_to_db_impl(
     coin_balances: &[CoinBalance],
     current_coin_balances: &[CurrentCoinBalance],
     coin_supply: &[CoinSupply],
+    account_transactions: &[AccountTransaction],
 ) -> Result<(), diesel::result::Error> {
     insert_coin_activities(conn, coin_activities)?;
     insert_coin_infos(conn, coin_infos)?;
     insert_coin_balances(conn, coin_balances)?;
     insert_current_coin_balances(conn, current_coin_balances)?;
     insert_coin_supply(conn, coin_supply)?;
+    insert_account_transactions(conn, account_transactions)?;
     Ok(())
 }
 
@@ -71,6 +74,7 @@ fn insert_to_db(
     coin_balances: Vec<CoinBalance>,
     current_coin_balances: Vec<CurrentCoinBalance>,
     coin_supply: Vec<CoinSupply>,
+    account_transactions: Vec<AccountTransaction>,
 ) -> Result<(), diesel::result::Error> {
     tracing::trace!(
         name = name,
@@ -89,6 +93,7 @@ fn insert_to_db(
                 &coin_balances,
                 &current_coin_balances,
                 &coin_supply,
+                &account_transactions,
             )
         }) {
         Ok(_) => Ok(()),
@@ -100,6 +105,8 @@ fn insert_to_db(
                 let coin_infos = clean_data_for_db(coin_infos, true);
                 let coin_balances = clean_data_for_db(coin_balances, true);
                 let current_coin_balances = clean_data_for_db(current_coin_balances, true);
+                let coin_supply = clean_data_for_db(coin_supply, true);
+                let account_transactions = clean_data_for_db(account_transactions, true);
 
                 insert_to_db_impl(
                     pg_conn,
@@ -108,6 +115,7 @@ fn insert_to_db(
                     &coin_balances,
                     &current_coin_balances,
                     &coin_supply,
+                    &account_transactions,
                 )
             }),
     }
@@ -131,11 +139,7 @@ fn insert_coin_activities(
                     event_creation_number,
                     event_sequence_number,
                 ))
-                .do_update()
-                .set((
-                    inserted_at.eq(excluded(inserted_at)),
-                    event_index.eq(excluded(event_index)),
-                )),
+                .do_nothing(),
             None,
         )?;
     }
@@ -239,6 +243,26 @@ fn insert_coin_supply(
     Ok(())
 }
 
+fn insert_account_transactions(
+    conn: &mut PgConnection,
+    item_to_insert: &[AccountTransaction],
+) -> Result<(), diesel::result::Error> {
+    use schema::account_transactions::dsl::*;
+
+    let chunks = get_chunks(item_to_insert.len(), AccountTransaction::field_count());
+    for (start_ind, end_ind) in chunks {
+        execute_with_better_error(
+            conn,
+            diesel::insert_into(schema::account_transactions::table)
+                .values(&item_to_insert[start_ind..end_ind])
+                .on_conflict((transaction_version, account_address))
+                .do_nothing(),
+            None,
+        )?;
+    }
+    Ok(())
+}
+
 #[async_trait]
 impl ProcessorTrait for CoinTransactionProcessor {
     fn name(&self) -> &'static str {
@@ -264,6 +288,8 @@ impl ProcessorTrait for CoinTransactionProcessor {
             HashMap::new();
         let mut all_coin_supply = vec![];
 
+        let mut account_transactions = HashMap::new();
+
         for txn in &transactions {
             let (
                 mut coin_activities,
@@ -280,16 +306,25 @@ impl ProcessorTrait for CoinTransactionProcessor {
                 all_coin_infos.entry(key).or_insert(value);
             }
             all_current_coin_balances.extend(current_coin_balances);
+
+            account_transactions.extend(AccountTransaction::from_transaction(txn));
         }
         let mut all_coin_infos = all_coin_infos.into_values().collect::<Vec<CoinInfo>>();
         let mut all_current_coin_balances = all_current_coin_balances
             .into_values()
             .collect::<Vec<CurrentCoinBalance>>();
+        let mut account_transactions = account_transactions
+            .into_values()
+            .collect::<Vec<AccountTransaction>>();
 
         // Sort by PK
         all_coin_infos.sort_by(|a, b| a.coin_type.cmp(&b.coin_type));
         all_current_coin_balances.sort_by(|a, b| {
             (&a.owner_address, &a.coin_type).cmp(&(&b.owner_address, &b.coin_type))
+        });
+        account_transactions.sort_by(|a, b| {
+            (&a.transaction_version, &a.account_address)
+                .cmp(&(&b.transaction_version, &b.account_address))
         });
 
         let tx_result = insert_to_db(
@@ -302,6 +337,7 @@ impl ProcessorTrait for CoinTransactionProcessor {
             all_coin_balances,
             all_current_coin_balances,
             all_coin_supply,
+            account_transactions,
         );
         match tx_result {
             Ok(_) => Ok((start_version, end_version)),

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/src/processors/default_processor.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/src/processors/default_processor.rs
@@ -21,7 +21,7 @@ use crate::{
     },
 };
 use anyhow::bail;
-use aptos_protos::transaction::v1::Transaction;
+use aptos_protos::transaction::v1::{write_set_change::Change, Transaction};
 use async_trait::async_trait;
 use diesel::{pg::upsert::excluded, result::Error, ExpressionMethods, PgConnection};
 use field_count::FieldCount;
@@ -472,6 +472,7 @@ impl ProcessorTrait for DefaultTransactionProcessor {
         start_version: u64,
         end_version: u64,
     ) -> anyhow::Result<ProcessingResult> {
+        let mut conn = self.get_conn();
         let (txns, txn_details, events, write_set_changes, wsc_details) =
             TransactionModel::from_transactions(&transactions);
 
@@ -515,12 +516,54 @@ impl ProcessorTrait for DefaultTransactionProcessor {
         }
 
         // TODO, merge this loop with above
+        // Moving object handling here because we need a single object
+        // map through transactions for lookups
         let mut all_objects = vec![];
         let mut all_current_objects = HashMap::new();
         for txn in &transactions {
-            let (mut objects, current_objects) = Object::from_transaction(txn);
-            all_objects.append(&mut objects);
-            all_current_objects.extend(current_objects);
+            let txn_version = txn.version as i64;
+            let changes = &txn
+                .info
+                .as_ref()
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Transaction info doesn't exist! Transaction {}",
+                        txn_version
+                    )
+                })
+                .changes;
+            for (index, wsc) in changes.iter().enumerate() {
+                let index: i64 = index as i64;
+                match wsc.change.as_ref().unwrap() {
+                    Change::WriteResource(inner) => {
+                        if let Some((object, current_object)) =
+                            &Object::from_write_resource(inner, txn_version, index).unwrap()
+                        {
+                            all_objects.push(object.clone());
+                            all_current_objects
+                                .insert(object.object_address.clone(), current_object.clone());
+                        }
+                    },
+                    Change::DeleteResource(inner) => {
+                        // Passing all_current_objects into the function so that we can get the owner of the deleted
+                        // resource if it was handled in the same batch
+                        if let Some((object, current_object)) = Object::from_delete_resource(
+                            inner,
+                            txn_version,
+                            index,
+                            &all_current_objects,
+                            &mut conn,
+                        )
+                        .unwrap()
+                        {
+                            all_objects.push(object.clone());
+                            all_current_objects
+                                .insert(object.object_address.clone(), current_object.clone());
+                        }
+                    },
+                    _ => {},
+                };
+            }
         }
         // Getting list of values and sorting by pk in order to avoid postgres deadlock since we're doing multi threaded db writes
         let mut current_table_items = current_table_items
@@ -536,7 +579,6 @@ impl ProcessorTrait for DefaultTransactionProcessor {
         table_metadata.sort_by(|a, b| a.handle.cmp(&b.handle));
         all_current_objects.sort_by(|a, b| a.object_address.cmp(&b.object_address));
 
-        let mut conn = self.get_conn();
         let tx_result = insert_to_db(
             &mut conn,
             self.name(),

--- a/ecosystem/indexer-grpc/indexer-grpc-parser/src/schema.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-parser/src/schema.rs
@@ -3,6 +3,15 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    account_transactions (account_address, transaction_version) {
+        transaction_version -> Int8,
+        #[max_length = 66]
+        account_address -> Varchar,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     block_metadata_transactions (version) {
         version -> Int8,
         block_height -> Int8,
@@ -583,11 +592,11 @@ diesel::table! {
         #[max_length = 66]
         object_address -> Varchar,
         #[max_length = 66]
-        owner_address -> Nullable<Varchar>,
+        owner_address -> Varchar,
         #[max_length = 66]
         state_key_hash -> Varchar,
-        guid_creation_num -> Nullable<Numeric>,
-        allow_ungated_transfer -> Nullable<Bool>,
+        guid_creation_num -> Numeric,
+        allow_ungated_transfer -> Bool,
         is_deleted -> Bool,
         inserted_at -> Timestamp,
     }
@@ -916,6 +925,7 @@ diesel::table! {
 }
 
 diesel::allow_tables_to_appear_in_same_query!(
+    account_transactions,
     block_metadata_transactions,
     coin_activities,
     coin_balances,


### PR DESCRIPTION
### Description
It's nice to have a dedicated table to get all transactions that touch an address instead of a view. I'm adding this to the coin_processor because the coin processor already needs to process every transaction. We don't want this to be in default processor currently because we've had instances where default processor takes forever to run migrations and it stalls explorer and wallet.

What qualifies as a transaction associated with an address: 
1. account signed or is part of a multi sig / multi agent
2. account resources / events are directly modified
3. account owns an object where resources / events are modified (only 1 degree)

I called out a bunch of TODOs here. Notably what we're currently unable to do: 
* Recursively find owner of an object
* Find an owner of an object that was deleted
* Find owner of a table, recursively or not

P.S. This PR also fixes a bug where we're not actually recording object deletes. 

### Test Plan
![image](https://github.com/aptos-labs/aptos-core/assets/11738325/7de72271-05be-4e92-9c65-a12376251c60)
