### PR TITLE
[forge] tag k8s resources with testsuite name

### DIFF
--- a/testsuite/exp
+++ b/testsuite/exp
@@ -38,6 +38,9 @@ WORKFLOW_WATCH_TIMEOUT_SECS = 30 * 60  # 30 min build timeout
 
 VALIDATOR_TESTING_IMAGE_NAME = "validator-testing"
 
+FORGE_DEFAULT_TEST_SUITE = "land_blocking"
+FORGE_DEFAULT_CLUSTER_NAME = "aptos-forge-exp-0"
+
 
 def cleanup_and_exit(git: Git, exit_code: int, cleanup_branch: str = None) -> None:
     """Clean up dangling resources like temporary exp branch, and exit with the given code."""
@@ -189,7 +192,8 @@ def workflow_dispatch_forge(
     branch: str,
     git_sha: str,
     duration: int = 480,
-    test_suite: str = "land_blocking",
+    test_suite: str = FORGE_DEFAULT_TEST_SUITE,
+    cluster_name: str = FORGE_DEFAULT_CLUSTER_NAME,
     dry_run: bool = False,
     wait: bool = False,
 ) -> bool:
@@ -209,6 +213,8 @@ def workflow_dispatch_forge(
         f"FORGE_RUNNER_DURATION_SECS={str(duration)}",
         "--field",
         f"FORGE_TEST_SUITE={test_suite}",
+        "--field",
+        f"FORGE_CLUSTER_NAME={cluster_name}",
     ]
     log.info(
         "%s: $ %s",

--- a/testsuite/fixtures/forge-test-runner-template.fixture
+++ b/testsuite/fixtures/forge-test-runner-template.fixture
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: forge-test-runner
     forge-namespace: forge-potato
     forge-image-tag: forge_asdf
+    forge-test-suite: banana
 spec:
   restartPolicy: Never
   serviceAccountName: forge
@@ -30,6 +31,8 @@ spec:
       env:
         - name: FORGE_TRIGGERED_BY
           value: github-actions
+        - name: FORGE_TEST_SUITE
+          value: banana
         - name: PROMETHEUS_URL
           valueFrom:
             secretKeyRef:

--- a/testsuite/fixtures/forge-test-runner-template.fixture
+++ b/testsuite/fixtures/forge-test-runner-template.fixture
@@ -8,6 +8,7 @@ metadata:
     forge-namespace: forge-potato
     forge-image-tag: forge_asdf
     forge-test-suite: banana
+    forge-username: banana-eater
 spec:
   restartPolicy: Never
   serviceAccountName: forge
@@ -33,6 +34,8 @@ spec:
           value: github-actions
         - name: FORGE_TEST_SUITE
           value: banana
+        - name: FORGE_USERNAME
+          value: banana-eater
         - name: PROMETHEUS_URL
           valueFrom:
             secretKeyRef:

--- a/testsuite/forge-test-runner-template.yaml
+++ b/testsuite/forge-test-runner-template.yaml
@@ -8,6 +8,7 @@ metadata:
     forge-namespace: {FORGE_NAMESPACE}
     forge-image-tag: {FORGE_IMAGE_TAG}
     forge-test-suite: {FORGE_TEST_SUITE}
+    forge-username: {FORGE_USERNAME}
 spec:
   restartPolicy: Never
   serviceAccountName: forge
@@ -33,6 +34,8 @@ spec:
           value: {FORGE_TRIGGERED_BY}
         - name: FORGE_TEST_SUITE
           value: {FORGE_TEST_SUITE}
+        - name: FORGE_USERNAME
+          value: {FORGE_USERNAME}
         - name: PROMETHEUS_URL
           valueFrom:
             secretKeyRef:

--- a/testsuite/forge-test-runner-template.yaml
+++ b/testsuite/forge-test-runner-template.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: forge-test-runner
     forge-namespace: {FORGE_NAMESPACE}
     forge-image-tag: {FORGE_IMAGE_TAG}
+    forge-test-suite: {FORGE_TEST_SUITE}
 spec:
   restartPolicy: Never
   serviceAccountName: forge
@@ -30,6 +31,8 @@ spec:
       env:
         - name: FORGE_TRIGGERED_BY
           value: {FORGE_TRIGGERED_BY}
+        - name: FORGE_TEST_SUITE
+          value: {FORGE_TEST_SUITE}
         - name: PROMETHEUS_URL
           valueFrom:
             secretKeyRef:

--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -262,6 +262,7 @@ class ForgeContext:
     upgrade_image_tag: str
     forge_cluster: ForgeCluster
     forge_test_suite: str
+    forge_username: str
     forge_blocking: bool
 
     github_actions: str
@@ -723,6 +724,7 @@ class K8sForgeRunner(ForgeRunner):
             FORGE_ARGS=" ".join(context.forge_args),
             FORGE_TRIGGERED_BY=forge_triggered_by,
             FORGE_TEST_SUITE=sanitize_k8s_resource_name(context.forge_test_suite),
+            FORGE_USERNAME=sanitize_k8s_resource_name(context.forge_username),
             VALIDATOR_NODE_SELECTOR=validator_node_selector,
             KUBECONFIG=MULTIREGION_KUBECONFIG_PATH,
             MULTIREGION_KUBECONFIG_DIR=MULTIREGION_KUBECONFIG_DIR,
@@ -985,7 +987,8 @@ def image_exists(
         ).succeeded()
     else:
         raise Exception(f"Unknown cloud repo type: {cloud}")
-    
+
+
 def sanitize_k8s_resource_name(resource: str, max_length: int = 63) -> str:
     sanitized_resource = ""
     for i, c in enumerate(resource):
@@ -1477,6 +1480,8 @@ def test(
 
     log.debug("forge_args: %s", forge_args)
 
+    # use the github actor username if possible
+    forge_username = os.getenv("GITHUB_ACTOR") or "unknown-username"
     forge_context = ForgeContext(
         shell=shell,
         filesystem=filesystem,
@@ -1493,6 +1498,7 @@ def test(
         forge_namespace=forge_namespace,
         forge_cluster=forge_cluster,
         forge_test_suite=forge_test_suite,
+        forge_username=forge_username,
         forge_blocking=forge_blocking == "true",
         github_actions=github_actions,
         github_job_url=f"{github_server_url}/{github_repository}/actions/runs/{github_run_id}"

--- a/testsuite/forge/src/backend/k8s/cluster_helper.rs
+++ b/testsuite/forge/src/backend/k8s/cluster_helper.rs
@@ -6,10 +6,10 @@ use crate::{
     get_fullnodes, get_validators, k8s_wait_genesis_strategy, k8s_wait_nodes_strategy,
     nodes_healthcheck, wait_stateful_set, ForgeRunnerMode, GenesisConfigFn, K8sApi, K8sNode,
     NodeConfigFn, ReadWrite, Result, APTOS_NODE_HELM_CHART_PATH, APTOS_NODE_HELM_RELEASE_NAME,
-    DEFAULT_ROOT_KEY, FORGE_KEY_SEED, FULLNODE_HAPROXY_SERVICE_SUFFIX, FULLNODE_SERVICE_SUFFIX,
-    GENESIS_HELM_CHART_PATH, GENESIS_HELM_RELEASE_NAME, HELM_BIN, KUBECTL_BIN,
-    MANAGEMENT_CONFIGMAP_PREFIX, NAMESPACE_CLEANUP_THRESHOLD_SECS, POD_CLEANUP_THRESHOLD_SECS,
-    VALIDATOR_HAPROXY_SERVICE_SUFFIX, VALIDATOR_SERVICE_SUFFIX,
+    DEFAULT_ROOT_KEY, DEFAULT_TEST_SUITE_NAME, FORGE_KEY_SEED, FULLNODE_HAPROXY_SERVICE_SUFFIX,
+    FULLNODE_SERVICE_SUFFIX, GENESIS_HELM_CHART_PATH, GENESIS_HELM_RELEASE_NAME, HELM_BIN,
+    KUBECTL_BIN, MANAGEMENT_CONFIGMAP_PREFIX, NAMESPACE_CLEANUP_THRESHOLD_SECS,
+    POD_CLEANUP_THRESHOLD_SECS, VALIDATOR_HAPROXY_SERVICE_SUFFIX, VALIDATOR_SERVICE_SUFFIX,
 };
 use again::RetryPolicy;
 use anyhow::{anyhow, bail, format_err};
@@ -622,6 +622,11 @@ pub fn construct_node_helm_values(
     value["haproxy"]["enabled"] = enable_haproxy.into();
     value["labels"]["forge-namespace"] = make_k8s_label(kube_namespace).into();
     value["labels"]["forge-image-tag"] = make_k8s_label(image_tag).into();
+
+    // if present, tag the node with the test suite name
+    let suite_name = env::var("FORGE_TEST_SUITE").unwrap_or(DEFAULT_TEST_SUITE_NAME.to_string());
+    value["labels"]["forge-test-suite"] = make_k8s_label(suite_name).into();
+
     if let Some(config_fn) = node_helm_config_fn {
         (config_fn)(&mut value);
     }
@@ -656,6 +661,10 @@ pub fn construct_genesis_helm_values(
     value["genesis"]["fullnode"]["internal_host_suffix"] = fullnode_internal_host_suffix.into();
     value["labels"]["forge-namespace"] = make_k8s_label(kube_namespace).into();
     value["labels"]["forge-image-tag"] = make_k8s_label(genesis_image_tag).into();
+
+    // if present, tag the node with the test suite name
+    let suite_name = env::var("FORGE_TEST_SUITE").unwrap_or(DEFAULT_TEST_SUITE_NAME.to_string());
+    value["labels"]["forge-test-suite"] = make_k8s_label(suite_name).into();
 
     if let Some(config_fn) = genesis_helm_config_fn {
         (config_fn)(&mut value);
@@ -1090,6 +1099,7 @@ haproxy:
 labels:
   forge-namespace: forge-123
   forge-image-tag: image
+  forge-test-suite: unknown-testsuite
 ";
         assert_eq!(node_helm_values, expected_helm_values);
     }
@@ -1123,6 +1133,7 @@ genesis:
 labels:
   forge-namespace: forge-123
   forge-image-tag: genesis_image
+  forge-test-suite: unknown-testsuite
 ";
         assert_eq!(genesis_helm_values, expected_helm_values);
         println!("{}", genesis_helm_values);

--- a/testsuite/forge/src/backend/k8s/cluster_helper.rs
+++ b/testsuite/forge/src/backend/k8s/cluster_helper.rs
@@ -6,10 +6,11 @@ use crate::{
     get_fullnodes, get_validators, k8s_wait_genesis_strategy, k8s_wait_nodes_strategy,
     nodes_healthcheck, wait_stateful_set, ForgeRunnerMode, GenesisConfigFn, K8sApi, K8sNode,
     NodeConfigFn, ReadWrite, Result, APTOS_NODE_HELM_CHART_PATH, APTOS_NODE_HELM_RELEASE_NAME,
-    DEFAULT_ROOT_KEY, DEFAULT_TEST_SUITE_NAME, FORGE_KEY_SEED, FULLNODE_HAPROXY_SERVICE_SUFFIX,
-    FULLNODE_SERVICE_SUFFIX, GENESIS_HELM_CHART_PATH, GENESIS_HELM_RELEASE_NAME, HELM_BIN,
-    KUBECTL_BIN, MANAGEMENT_CONFIGMAP_PREFIX, NAMESPACE_CLEANUP_THRESHOLD_SECS,
-    POD_CLEANUP_THRESHOLD_SECS, VALIDATOR_HAPROXY_SERVICE_SUFFIX, VALIDATOR_SERVICE_SUFFIX,
+    DEFAULT_ROOT_KEY, DEFAULT_TEST_SUITE_NAME, DEFAULT_USERNAME, FORGE_KEY_SEED,
+    FULLNODE_HAPROXY_SERVICE_SUFFIX, FULLNODE_SERVICE_SUFFIX, GENESIS_HELM_CHART_PATH,
+    GENESIS_HELM_RELEASE_NAME, HELM_BIN, KUBECTL_BIN, MANAGEMENT_CONFIGMAP_PREFIX,
+    NAMESPACE_CLEANUP_THRESHOLD_SECS, POD_CLEANUP_THRESHOLD_SECS, VALIDATOR_HAPROXY_SERVICE_SUFFIX,
+    VALIDATOR_SERVICE_SUFFIX,
 };
 use again::RetryPolicy;
 use anyhow::{anyhow, bail, format_err};
@@ -623,9 +624,11 @@ pub fn construct_node_helm_values(
     value["labels"]["forge-namespace"] = make_k8s_label(kube_namespace).into();
     value["labels"]["forge-image-tag"] = make_k8s_label(image_tag).into();
 
-    // if present, tag the node with the test suite name
+    // if present, tag the node with the test suite name and username
     let suite_name = env::var("FORGE_TEST_SUITE").unwrap_or(DEFAULT_TEST_SUITE_NAME.to_string());
     value["labels"]["forge-test-suite"] = make_k8s_label(suite_name).into();
+    let username = env::var("FORGE_USERNAME").unwrap_or(DEFAULT_USERNAME.to_string());
+    value["labels"]["forge-username"] = make_k8s_label(username).into();
 
     if let Some(config_fn) = node_helm_config_fn {
         (config_fn)(&mut value);
@@ -662,9 +665,11 @@ pub fn construct_genesis_helm_values(
     value["labels"]["forge-namespace"] = make_k8s_label(kube_namespace).into();
     value["labels"]["forge-image-tag"] = make_k8s_label(genesis_image_tag).into();
 
-    // if present, tag the node with the test suite name
+    // if present, tag the node with the test suite name and username
     let suite_name = env::var("FORGE_TEST_SUITE").unwrap_or(DEFAULT_TEST_SUITE_NAME.to_string());
     value["labels"]["forge-test-suite"] = make_k8s_label(suite_name).into();
+    let username = env::var("FORGE_USERNAME").unwrap_or(DEFAULT_USERNAME.to_string());
+    value["labels"]["forge-username"] = make_k8s_label(username).into();
 
     if let Some(config_fn) = genesis_helm_config_fn {
         (config_fn)(&mut value);
@@ -1100,6 +1105,7 @@ labels:
   forge-namespace: forge-123
   forge-image-tag: image
   forge-test-suite: unknown-testsuite
+  forge-username: unknown-username
 ";
         assert_eq!(node_helm_values, expected_helm_values);
     }
@@ -1134,6 +1140,7 @@ labels:
   forge-namespace: forge-123
   forge-image-tag: genesis_image
   forge-test-suite: unknown-testsuite
+  forge-username: unknown-username
 ";
         assert_eq!(genesis_helm_values, expected_helm_values);
         println!("{}", genesis_helm_values);

--- a/testsuite/forge/src/backend/k8s/constants.rs
+++ b/testsuite/forge/src/backend/k8s/constants.rs
@@ -51,3 +51,4 @@ pub const VALIDATOR_0_DATA_PERSISTENT_VOLUME_CLAIM_PREFIX: &str = "aptos-node-0-
 
 // metadata about the cluster
 pub const DEFAULT_TEST_SUITE_NAME: &str = "unknown-testsuite";
+pub const DEFAULT_USERNAME: &str = "unknown-username";

--- a/testsuite/forge/src/backend/k8s/constants.rs
+++ b/testsuite/forge/src/backend/k8s/constants.rs
@@ -48,3 +48,6 @@ pub const HAPROXY_SERVICE_SUFFIX: &str = "lb";
 pub const VALIDATOR_0_STATEFUL_SET_NAME: &str = "aptos-node-0-validator";
 pub const VALIDATOR_0_GENESIS_SECRET_PREFIX: &str = "aptos-node-0-genesis";
 pub const VALIDATOR_0_DATA_PERSISTENT_VOLUME_CLAIM_PREFIX: &str = "aptos-node-0-validator";
+
+// metadata about the cluster
+pub const DEFAULT_TEST_SUITE_NAME: &str = "unknown-testsuite";

--- a/testsuite/forge/src/backend/k8s/fullnode.rs
+++ b/testsuite/forge/src/backend/k8s/fullnode.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     get_stateful_set_image, make_k8s_label, K8sNode, ReadWrite, Result, Version,
-    DEFAULT_TEST_SUITE_NAME, REST_API_SERVICE_PORT,
+    DEFAULT_TEST_SUITE_NAME, DEFAULT_USERNAME, REST_API_SERVICE_PORT,
     VALIDATOR_0_DATA_PERSISTENT_VOLUME_CLAIM_PREFIX, VALIDATOR_0_GENESIS_SECRET_PREFIX,
     VALIDATOR_0_STATEFUL_SET_NAME,
 };
@@ -124,16 +124,15 @@ fn create_fullnode_persistent_volume_claim(
 }
 
 fn create_fullnode_labels(fullnode_name: String) -> BTreeMap<String, String> {
-    // if present, tag the node with the test suite name
+    // if present, tag the node with the test suite name and username
     let suite_name = env::var("FORGE_TEST_SUITE").unwrap_or(DEFAULT_TEST_SUITE_NAME.to_string());
+    let username = env::var("FORGE_USERNAME").unwrap_or(DEFAULT_USERNAME.to_string());
 
     [
         ("app.kubernetes.io/name".to_string(), "fullnode".to_string()),
         ("app.kubernetes.io/instance".to_string(), fullnode_name),
-        (
-            "forge-test-suite".to_string(),
-            make_k8s_label(suite_name).into(),
-        ),
+        ("forge-test-suite".to_string(), make_k8s_label(suite_name)),
+        ("forge-username".to_string(), make_k8s_label(username)),
         (
             "app.kubernetes.io/part-of".to_string(),
             "forge-pfn".to_string(),

--- a/testsuite/forge/src/backend/k8s/fullnode.rs
+++ b/testsuite/forge/src/backend/k8s/fullnode.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    get_stateful_set_image, K8sNode, ReadWrite, Result, Version, REST_API_SERVICE_PORT,
+    get_stateful_set_image, make_k8s_label, K8sNode, ReadWrite, Result, Version,
+    DEFAULT_TEST_SUITE_NAME, REST_API_SERVICE_PORT,
     VALIDATOR_0_DATA_PERSISTENT_VOLUME_CLAIM_PREFIX, VALIDATOR_0_GENESIS_SECRET_PREFIX,
     VALIDATOR_0_STATEFUL_SET_NAME,
 };
@@ -31,6 +32,7 @@ use k8s_openapi::{
 use kube::api::{ObjectMeta, PostParams};
 use std::{
     collections::BTreeMap,
+    env,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     path::PathBuf,
     sync::Arc,
@@ -122,9 +124,16 @@ fn create_fullnode_persistent_volume_claim(
 }
 
 fn create_fullnode_labels(fullnode_name: String) -> BTreeMap<String, String> {
+    // if present, tag the node with the test suite name
+    let suite_name = env::var("FORGE_TEST_SUITE").unwrap_or(DEFAULT_TEST_SUITE_NAME.to_string());
+
     [
         ("app.kubernetes.io/name".to_string(), "fullnode".to_string()),
         ("app.kubernetes.io/instance".to_string(), fullnode_name),
+        (
+            "forge-test-suite".to_string(),
+            make_k8s_label(suite_name).into(),
+        ),
         (
             "app.kubernetes.io/part-of".to_string(),
             "forge-pfn".to_string(),

--- a/testsuite/forge_test.py
+++ b/testsuite/forge_test.py
@@ -162,6 +162,7 @@ def fake_context(
             name="tomato", kubeconf="kubeconf", is_multiregion=multiregion
         ),
         forge_test_suite="banana",
+        forge_username="banana-eater",
         forge_blocking=True,
         github_actions="false",
         github_job_url="https://banana",


### PR DESCRIPTION
### Description

Tag k8s resources created by Forge with `forge-test-suite` label. This is done via environment variable rather than passing it through directly to the K8sSwarm for simplicity. The label is passed through to the k8s backend of Forge and applied via helm value

This allows for better o11y as well as cost attribution

### Test Plan

Existing unit tests for forge python wrapper and forge rust crate updated (test fixtures match)

Use `exp` script to trigger Forge job:
* Job link: https://github.com/aptos-labs/aptos-core/actions/runs/5540565917/jobs/10112826407
* Humio logs show the label is applied: https://cloud.us.humio.com/k8s/search?live=false&query=%22forge-test-suite%22&start=1d&tz=America%2FLos_Angeles
<img width="1033" alt="image" src="https://github.com/aptos-labs/aptos-core/assets/12578616/4dff73a5-1ffc-415d-9901-b2f4862b2c9b">

<!-- Please provide us with clear details for verifying that your changes work. -->
