### PR TITLE
[rosetta] add withdraw undelegated stake operation when parsing delegation_pool::withdraw txn

### DIFF
--- a/crates/aptos-rosetta/src/types/move_types.rs
+++ b/crates/aptos-rosetta/src/types/move_types.rs
@@ -27,6 +27,7 @@ pub const STORE_RESOURCE: &str = "Store";
 pub const STAKING_GROUP_UPDATE_COMMISSION_RESOURCE: &str = "StakingGroupUpdateCommissionEvent";
 pub const VESTING_RESOURCE: &str = "Vesting";
 pub const DELEGATION_POOL_RESOURCE: &str = "DelegationPool";
+pub const WITHDRAW_STAKE_EVENT: &str = "WithdrawStakeEvent";
 
 pub const CREATE_ACCOUNT_FUNCTION: &str = "create_account";
 pub const TRANSFER_FUNCTION: &str = "transfer";
@@ -238,7 +239,7 @@ pub struct UndelegationEvent {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct WithdrawUndelegedEvent {
+pub struct WithdrawUndelegedEvent {
     pub pool_address: AccountAddress,
     pub delegator_address: AccountAddress,
     pub amount_withdrawn: u64,


### PR DESCRIPTION
### Description
Currently we are parsing withdraw unbonded transaction operations into simple deposit and withdrawals. This makes it impossible to distinguish transfers from withdraw unbonded. This PR introduces a dummy operation without an amount to indicate this is a withdrawal tx for unbonded funds.

### Test Plan
Ran Rosetta locally and parsed https://explorer.aptoslabs.com/txn/580239001/userTxnOverview?network=testnet into (notice operation with id 3)

```
  {
      "transaction_identifier": {
          "hash": "49b6112248397313114c9cf769d06f06fed59e54dd634e1bc27fe9388d92f3c7"
      },
      "operations": [
          {
              "operation_identifier": {
                  "index": 0
              },
              "type": "withdraw",
              "status": "success",
              "account": {
                  "address": "bd50bb20e1972747db365c3a6e31255d78867c6b8df9877ea6054bb335dd6031"
              },
              "amount": {
                  "value": "-1500030134",
                  "currency": {
                      "symbol": "APT",
                      "decimals": 8,
                      "metadata": {
                          "move_type": "0x1::aptos_coin::AptosCoin"
                      }
                  }
              }
          },
          {
              "operation_identifier": {
                  "index": 1
              },
              "type": "deposit",
              "status": "success",
              "account": {
                  "address": "bd50bb20e1972747db365c3a6e31255d78867c6b8df9877ea6054bb335dd6031"
              },
              "amount": {
                  "value": "1500030134",
                  "currency": {
                      "symbol": "APT",
                      "decimals": 8,
                      "metadata": {
                          "move_type": "0x1::aptos_coin::AptosCoin"
                      }
                  }
              }
          },
          {
              "operation_identifier": {
                  "index": 2
              },
              "type": "deposit",
              "status": "success",
              "account": {
                  "address": "ccaecb1a3d4e5f4301277de79c5ed4f5ba8cea15ce8dbc04e5b0b0307786a885"
              },
              "amount": {
                  "value": "1500030134",
                  "currency": {
                      "symbol": "APT",
                      "decimals": 8,
                      "metadata": {
                          "move_type": "0x1::aptos_coin::AptosCoin"
                      }
                  }
              }
          },
          {
              "operation_identifier": {
                  "index": 3
              },
              "type": "withdraw_undelegated_funds",
              "status": "success",
              "account": {
                  "address": "ccaecb1a3d4e5f4301277de79c5ed4f5ba8cea15ce8dbc04e5b0b0307786a885"
              },
              "metadata": {
                  "amount": "1500030134",
                  "pool_address": {
                      "address": "bd50bb20e1972747db365c3a6e31255d78867c6b8df9877ea6054bb335dd6031"
                  }
              }
          },
          {
              "operation_identifier": {
                  "index": 4
              },
              "type": "fee",
              "status": "success",
              "account": {
                  "address": "ccaecb1a3d4e5f4301277de79c5ed4f5ba8cea15ce8dbc04e5b0b0307786a885"
              },
              "amount": {
                  "value": "-2500",
                  "currency": {
                      "symbol": "APT",
                      "decimals": 8,
                      "metadata": {
                          "move_type": "0x1::aptos_coin::AptosCoin"
                      }
                  }
              }
          }
      ],
      "metadata": {
          "transaction_type": "User",
          "version": "580239001",
          "failed": false,
          "vm_status": "Success"
      }
  }
```
