### PR TITLE
[Move] Add a function to add source code after publish

### DIFF
--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -98,6 +98,7 @@ jobs:
   # to be land blocking for any PR on the aptos repo. This is why we run those tests
   # separate from test-sdk-confirm-client-generated-publish.
   run-indexer-tests:
+    needs: [permission-check]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3


### PR DESCRIPTION
### Description
Package size always doubles with source code and it's really easy to exceed the transaction limit of 64 KB. Deployers can publish code without the source but they currently can add them later. This adds a function that allowing adding the source code separately.

### Test Plan
Manual tests
