### PR TITLE
[docker] Remove indexer-grpc-parser from tools build to unbreak performance build

### DIFF
--- a/docker/builder/build-tools.sh
+++ b/docker/builder/build-tools.sh
@@ -25,7 +25,6 @@ cargo build --locked --profile=$PROFILE \
     -p aptos-indexer-grpc-cache-worker \
     -p aptos-indexer-grpc-file-store \
     -p aptos-indexer-grpc-data-service \
-    -p aptos-indexer-grpc-parser \
     -p aptos-indexer-grpc-post-processor \
     "$@"
 
@@ -44,7 +43,6 @@ BINS=(
     aptos-indexer-grpc-cache-worker
     aptos-indexer-grpc-file-store
     aptos-indexer-grpc-data-service
-    aptos-indexer-grpc-parser
     aptos-indexer-grpc-post-processor
 )
 

--- a/docker/builder/indexer-grpc.Dockerfile
+++ b/docker/builder/indexer-grpc.Dockerfile
@@ -17,7 +17,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 COPY --link --from=tools-builder /aptos/dist/aptos-indexer-grpc-cache-worker /usr/local/bin/aptos-indexer-grpc-cache-worker
 COPY --link --from=tools-builder /aptos/dist/aptos-indexer-grpc-file-store /usr/local/bin/aptos-indexer-grpc-file-store
 COPY --link --from=tools-builder /aptos/dist/aptos-indexer-grpc-data-service /usr/local/bin/aptos-indexer-grpc-data-service
-COPY --link --from=tools-builder /aptos/dist/aptos-indexer-grpc-parser /usr/local/bin/aptos-indexer-grpc-parser
 COPY --link --from=tools-builder /aptos/dist/aptos-indexer-grpc-post-processor /usr/local/bin/aptos-indexer-grpc-post-processor
 
 # The health check port


### PR DESCRIPTION
Currently performance build is segfaulting due to this target

Attempt to remove the target to fix the segfault

Test Plan: label PR with performance builds