### PR TITLE
[gha] run ts sdk tests on latest main best effort

### DIFF
--- a/.github/actions/get-latest-docker-image-tag/action.yml
+++ b/.github/actions/get-latest-docker-image-tag/action.yml
@@ -1,0 +1,40 @@
+name: "Get the latest docker image"
+description: |
+  Get the latest built docker image from the given branch
+
+inputs:
+  branch:
+    description: "The branch to check"
+    required: true
+  variants:
+    description: "The variants to check, as a space-separated string, e.g. 'performance failpoints'"
+    required: false
+
+outputs:
+  IMAGE_TAG:
+    description: "The latest docker image tag for the given branch and variants"
+    value: ${{ steps.determine-test-image-tag.outputs.IMAGE_TAG }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      with:
+        ref: ${{ inputs.branch }}
+        path: checkout_branch
+        fetch-depth: 0
+    - uses: ./checkout_branch/.github/actions/python-setup # use python-setup from that branch
+      with:
+        pyproject_directory: checkout_branch/testsuite
+    - name: Determine image tag
+      id: determine-test-image-tag
+      # Forge relies on the default and failpoints variants
+      run: |
+        variants=(${{ inputs.variants }}) # split the variants string into an array
+        variants_args=()
+        for variant in "${variants[@]}"; do
+          variants_args+=("--variant" "$variant")
+        done
+        ./testrun find_latest_image.py "${variants_args[@]}"
+      shell: bash
+      working-directory: checkout_branch/testsuite # the checkout_branch is a subdirectory

--- a/.github/actions/run-ts-sdk-e2e-tests/action.yaml
+++ b/.github/actions/run-ts-sdk-e2e-tests/action.yaml
@@ -2,8 +2,8 @@ name: "Run SDK E2E tests"
 description: |
   Run the SDK E2E tests against a local testnet built from a particular release branch
 inputs:
-  NETWORK:
-    description: "The network to use for running the local testnet, one of devnet / testnet / mainnet"
+  BRANCH:
+    description: "The branch to use for running the local testnet"
     required: true
   GCP_DOCKER_ARTIFACT_REPO:
     description: "The GCP Docker artifact repository"
@@ -19,7 +19,16 @@ runs:
         registry-url: "https://registry.npmjs.org"
     - uses: pnpm/action-setup@537643d491d20c2712d11533497cb47b2d0eb9d5 # pin https://github.com/pnpm/action-setup/releases/tag/v2.2.3
 
+    # Find a docker image to use for the testnet.
+    - uses: ./.github/actions/get-latest-docker-image-tag
+      id: get-docker-image-tag
+      with:
+        branch: ${{ inputs.BRANCH }}
+
     # Set up the necessary env vars for the test suite.
+    - run: echo "DOCKER_IMAGE=${{ inputs.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ steps.get-docker-image-tag.outputs.IMAGE_TAG }}" >>.env
+      shell: bash
+      working-directory: ./ecosystem/typescript/sdk
     - run: echo "APTOS_NODE_URL=http://127.0.0.1:8080/v1" >> .env
       shell: bash
       working-directory: ./ecosystem/typescript/sdk
@@ -32,12 +41,6 @@ runs:
     - run: echo "ANS_TEST_ACCOUNT_ADDRESS=585fc9f0f0c54183b039ffc770ca282ebd87307916c215a3e692f2f8e4305e82" >> .env
       shell: bash
       working-directory: ./ecosystem/typescript/sdk
-    - run: echo "DOCKER_IMAGE=${{ inputs.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.NETWORK }}" >>.env
-      shell: bash
-      working-directory: ./ecosystem/typescript/sdk
-    - run: echo "NETWORK=${{ inputs.NETWORK }}" >> .env
-      shell: bash
-      working-directory: ./ecosystem/typescript/sdk
 
     # Run package install. If install fails, it probably means the updated lockfile was
     # not included in the commit.
@@ -48,7 +51,7 @@ runs:
     # Run a local testnet.
     - uses: ./.github/actions/run-local-testnet
       with:
-        IMAGE_TAG: ${{ inputs.NETWORK }}
+        IMAGE_TAG: ${{ steps.get-docker-image-tag.outputs.IMAGE_TAG }}
         GCP_DOCKER_ARTIFACT_REPO: ${{ inputs.GCP_DOCKER_ARTIFACT_REPO }}
 
     # Run the TS SDK tests.

--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -32,7 +32,7 @@ jobs:
           required-permission: write
           comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
 
-  run-tests-devnet:
+  run-tests-main-branch:
     needs: [permission-check]
     runs-on: high-perf-docker
     steps:
@@ -49,47 +49,7 @@ jobs:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - uses: ./.github/actions/run-ts-sdk-e2e-tests
         with:
-          NETWORK: devnet
-          GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
-
-  run-tests-testnet:
-    needs: [permission-check]
-    runs-on: high-perf-docker
-    steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-        with:
-          ref: ${{ env.GIT_SHA }}
-      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
-        with:
-          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
-          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
-      - uses: ./.github/actions/run-ts-sdk-e2e-tests
-        with:
-          NETWORK: testnet
-          GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
-
-  run-tests-mainnet:
-    needs: [permission-check]
-    runs-on: high-perf-docker
-    steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-        with:
-          ref: ${{ env.GIT_SHA }}
-      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
-        with:
-          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
-          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
-      - uses: ./.github/actions/run-ts-sdk-e2e-tests
-        with:
-          NETWORK: mainnet
+          BRANCH: main
           GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
 
   # Run the TS SDK indexer tests. Note: Unlike the above tests where everything is self


### PR DESCRIPTION
### Description

Run TS SDK tests against a local testnet spun up via docker against the latest docker image built on main. A new composite action called `get-latest-docker-image-tag` gets the latest image built on a given branch. It checks out the given branch and uses the existing `find_latest_image.py` script to crawl the git history and check which commits have images built.

### Test Plan

CI run on push: https://github.com/aptos-labs/aptos-core/actions/runs/5548754559/jobs/10132092825?pr=9090

<!-- Please provide us with clear details for verifying that your changes work. -->
