### PR TITLE
[dag] sign metadata and rename signature to vote

### DIFF
--- a/consensus/src/consensusdb/mod.rs
+++ b/consensus/src/consensusdb/mod.rs
@@ -7,7 +7,7 @@ mod consensusdb_test;
 mod schema;
 
 use crate::{
-    dag::{CertifiedNode, Node, NodeDigestSignature, NodeId},
+    dag::{CertifiedNode, Node, NodeId, Vote},
     error::DbError,
 };
 use anyhow::Result;
@@ -17,7 +17,7 @@ use aptos_logger::prelude::*;
 use aptos_schemadb::{Options, ReadOptions, SchemaBatch, DB, DEFAULT_COLUMN_FAMILY_NAME};
 use schema::{
     block::BlockSchema,
-    dag::{CertifiedNodeSchema, NodeDigestSignatureSchema, NodeSchema},
+    dag::{CertifiedNodeSchema, DagVoteSchema, NodeSchema},
     quorum_certificate::QCSchema,
     single_entry::{SingleEntryKey, SingleEntrySchema},
     BLOCK_CF_NAME, CERTIFIED_NODE_CF_NAME, NODE_CF_NAME, QC_CF_NAME, SINGLE_ENTRY_CF_NAME,
@@ -205,29 +205,23 @@ impl ConsensusDB {
         self.commit(batch)
     }
 
-    pub fn save_node_signature(
-        &self,
-        node_id: &NodeId,
-        node_digest_signature: &NodeDigestSignature,
-    ) -> Result<(), DbError> {
+    pub fn save_dag_vote(&self, node_id: &NodeId, vote: &Vote) -> Result<(), DbError> {
         let batch = SchemaBatch::new();
-        batch.put::<NodeDigestSignatureSchema>(node_id, node_digest_signature)?;
+        batch.put::<DagVoteSchema>(node_id, vote)?;
         self.commit(batch)
     }
 
-    pub fn get_node_signatures(&self) -> Result<HashMap<NodeId, NodeDigestSignature>, DbError> {
-        let mut iter = self
-            .db
-            .iter::<NodeDigestSignatureSchema>(ReadOptions::default())?;
+    pub fn get_dag_votes(&self) -> Result<HashMap<NodeId, Vote>, DbError> {
+        let mut iter = self.db.iter::<DagVoteSchema>(ReadOptions::default())?;
         iter.seek_to_first();
-        Ok(iter.collect::<Result<HashMap<NodeId, NodeDigestSignature>>>()?)
+        Ok(iter.collect::<Result<HashMap<NodeId, Vote>>>()?)
     }
 
-    pub fn delete_node_signatures(&self, node_ids: Vec<NodeId>) -> Result<(), DbError> {
+    pub fn delete_dag_votes(&self, node_ids: Vec<NodeId>) -> Result<(), DbError> {
         let batch = SchemaBatch::new();
         node_ids
             .iter()
-            .try_for_each(|node_id| batch.delete::<NodeDigestSignatureSchema>(node_id))?;
+            .try_for_each(|node_id| batch.delete::<DagVoteSchema>(node_id))?;
         self.commit(batch)
     }
 

--- a/consensus/src/consensusdb/schema/dag/mod.rs
+++ b/consensus/src/consensusdb/schema/dag/mod.rs
@@ -9,7 +9,7 @@
 //! |   digest   |   node/certified node    |
 //! ```
 
-use crate::dag::{CertifiedNode, Node, NodeDigestSignature, NodeId};
+use crate::dag::{CertifiedNode, Node, NodeId, Vote};
 use anyhow::Result;
 use aptos_crypto::HashValue;
 use aptos_schemadb::{
@@ -42,16 +42,11 @@ impl ValueCodec<NodeSchema> for Node {
     }
 }
 
-pub const NODE_DIGEST_SIGNATURE_CF_NAME: ColumnFamilyName = "node_digest_signature";
+pub const DAG_VOTE_CF_NAME: ColumnFamilyName = "dag_vote";
 
-define_schema!(
-    NodeDigestSignatureSchema,
-    NodeId,
-    NodeDigestSignature,
-    NODE_DIGEST_SIGNATURE_CF_NAME
-);
+define_schema!(DagVoteSchema, NodeId, Vote, DAG_VOTE_CF_NAME);
 
-impl KeyCodec<NodeDigestSignatureSchema> for NodeId {
+impl KeyCodec<DagVoteSchema> for NodeId {
     fn encode_key(&self) -> Result<Vec<u8>> {
         Ok(bcs::to_bytes(&self)?)
     }
@@ -61,7 +56,7 @@ impl KeyCodec<NodeDigestSignatureSchema> for NodeId {
     }
 }
 
-impl ValueCodec<NodeDigestSignatureSchema> for NodeDigestSignature {
+impl ValueCodec<DagVoteSchema> for Vote {
     fn encode_value(&self) -> Result<Vec<u8>> {
         Ok(bcs::to_bytes(&self)?)
     }

--- a/consensus/src/dag/mod.rs
+++ b/consensus/src/dag/mod.rs
@@ -16,4 +16,4 @@ mod tests;
 mod types;
 
 pub use dag_network::RpcHandler;
-pub use types::{CertifiedNode, DAGNetworkMessage, Node, NodeDigestSignature, NodeId};
+pub use types::{CertifiedNode, DAGNetworkMessage, Node, NodeId, Vote};

--- a/consensus/src/dag/storage.rs
+++ b/consensus/src/dag/storage.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{types::NodeDigestSignature, NodeId};
+use super::{types::Vote, NodeId};
 use crate::{
     consensusdb::ConsensusDB,
     dag::{CertifiedNode, Node},
@@ -15,15 +15,11 @@ pub trait DAGStorage {
 
     fn delete_node(&self, digest: HashValue) -> anyhow::Result<()>;
 
-    fn save_node_signature(
-        &self,
-        node_id: &NodeId,
-        node_digest_signature: &NodeDigestSignature,
-    ) -> anyhow::Result<()>;
+    fn save_vote(&self, node_id: &NodeId, vote: &Vote) -> anyhow::Result<()>;
 
-    fn get_node_signatures(&self) -> anyhow::Result<HashMap<NodeId, NodeDigestSignature>>;
+    fn get_votes(&self) -> anyhow::Result<HashMap<NodeId, Vote>>;
 
-    fn delete_node_signatures(&self, node_ids: Vec<NodeId>) -> anyhow::Result<()>;
+    fn delete_votes(&self, node_ids: Vec<NodeId>) -> anyhow::Result<()>;
 
     fn save_certified_node(&self, node: &CertifiedNode) -> anyhow::Result<()>;
 
@@ -41,20 +37,16 @@ impl DAGStorage for ConsensusDB {
         Ok(self.delete_node(digest)?)
     }
 
-    fn save_node_signature(
-        &self,
-        node_id: &NodeId,
-        node_digest_signature: &NodeDigestSignature,
-    ) -> anyhow::Result<()> {
-        Ok(self.save_node_signature(node_id, node_digest_signature)?)
+    fn save_vote(&self, node_id: &NodeId, vote: &Vote) -> anyhow::Result<()> {
+        Ok(self.save_dag_vote(node_id, vote)?)
     }
 
-    fn get_node_signatures(&self) -> anyhow::Result<HashMap<NodeId, NodeDigestSignature>> {
-        Ok(self.get_node_signatures()?)
+    fn get_votes(&self) -> anyhow::Result<HashMap<NodeId, Vote>> {
+        Ok(self.get_dag_votes()?)
     }
 
-    fn delete_node_signatures(&self, node_ids: Vec<NodeId>) -> anyhow::Result<()> {
-        Ok(self.delete_node_signatures(node_ids)?)
+    fn delete_votes(&self, node_ids: Vec<NodeId>) -> anyhow::Result<()> {
+        Ok(self.delete_dag_votes(node_ids)?)
     }
 
     fn save_certified_node(&self, node: &CertifiedNode) -> anyhow::Result<()> {

--- a/consensus/src/dag/tests/dag_test.rs
+++ b/consensus/src/dag/tests/dag_test.rs
@@ -6,7 +6,7 @@ use crate::dag::{
     storage::DAGStorage,
     tests::helpers::new_certified_node,
     types::{CertifiedNode, Node},
-    NodeDigestSignature, NodeId,
+    NodeId, Vote,
 };
 use anyhow::Ok;
 use aptos_crypto::HashValue;
@@ -16,7 +16,7 @@ use std::{collections::HashMap, sync::Arc};
 
 pub struct MockStorage {
     node_data: Mutex<HashMap<HashValue, Node>>,
-    node_signature_data: Mutex<HashMap<NodeId, NodeDigestSignature>>,
+    vote_data: Mutex<HashMap<NodeId, Vote>>,
     certified_node_data: Mutex<HashMap<HashValue, CertifiedNode>>,
 }
 
@@ -24,7 +24,7 @@ impl MockStorage {
     pub fn new() -> Self {
         Self {
             node_data: Mutex::new(HashMap::new()),
-            node_signature_data: Mutex::new(HashMap::new()),
+            vote_data: Mutex::new(HashMap::new()),
             certified_node_data: Mutex::new(HashMap::new()),
         }
     }
@@ -41,24 +41,18 @@ impl DAGStorage for MockStorage {
         Ok(())
     }
 
-    fn save_node_signature(
-        &self,
-        node_id: &NodeId,
-        node_digest_signature: &NodeDigestSignature,
-    ) -> anyhow::Result<()> {
-        self.node_signature_data
-            .lock()
-            .insert(node_id.clone(), node_digest_signature.clone());
+    fn save_vote(&self, node_id: &NodeId, vote: &Vote) -> anyhow::Result<()> {
+        self.vote_data.lock().insert(node_id.clone(), vote.clone());
         Ok(())
     }
 
-    fn get_node_signatures(&self) -> anyhow::Result<HashMap<NodeId, NodeDigestSignature>> {
-        Ok(self.node_signature_data.lock().clone())
+    fn get_votes(&self) -> anyhow::Result<HashMap<NodeId, Vote>> {
+        Ok(self.vote_data.lock().clone())
     }
 
-    fn delete_node_signatures(&self, node_ids: Vec<crate::dag::NodeId>) -> anyhow::Result<()> {
+    fn delete_votes(&self, node_ids: Vec<NodeId>) -> anyhow::Result<()> {
         for node_id in node_ids {
-            self.node_signature_data.lock().remove(&node_id);
+            self.vote_data.lock().remove(&node_id);
         }
         Ok(())
     }


### PR DESCRIPTION
Now we're signing the metadata instead of only the digest itself, so that we can verify the parents links correctly. Also rename the signature to Vote hopefully more understandable.
