### PR TITLE
[Move examples] Add an example module for token-lockup-based voting with a decreasing voting power over time

### DIFF
--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -98,6 +98,7 @@ jobs:
   # to be land blocking for any PR on the aptos repo. This is why we run those tests
   # separate from test-sdk-confirm-client-generated-publish.
   run-indexer-tests:
+    needs: [permission-check]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3

--- a/aptos-move/move-examples/vote_lockup/Move.toml
+++ b/aptos-move/move-examples/vote_lockup/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "VoteLockup"
+version = "0.0.0"
+
+[addresses]
+aptos_framework = "0x1"
+deployer = "_"
+vote_lockup = "_"
+
+[dependencies]
+AptosFramework = { local = "../../framework/aptos-framework" }

--- a/aptos-move/move-examples/vote_lockup/sources/epoch.move
+++ b/aptos-move/move-examples/vote_lockup/sources/epoch.move
@@ -1,0 +1,28 @@
+module vote_lockup::epoch {
+    use aptos_framework::timestamp;
+
+    #[view]
+    public fun now(): u64 {
+        to_epoch(timestamp::now_seconds())
+    }
+
+    public inline fun duration(): u64 {
+        // Equal to EPOCH_DURATION. Inline functions cannot use constants defined in their module.
+        86400
+    }
+
+    public inline fun to_epoch(timestamp_secs: u64): u64 {
+        // Equal to EPOCH_DURATION. Inline functions cannot use constants defined in their module.
+        timestamp_secs / duration()
+    }
+
+    public inline fun to_seconds(epoch: u64): u64 {
+        // Equal to EPOCH_DURATION. Inline functions cannot use constants defined in their module.
+        epoch * duration()
+    }
+
+    #[test_only]
+    public fun fast_forward(epochs: u64) {
+        aptos_framework::timestamp::fast_forward_seconds(epochs * duration());
+    }
+}

--- a/aptos-move/move-examples/vote_lockup/sources/package_manager.move
+++ b/aptos-move/move-examples/vote_lockup/sources/package_manager.move
@@ -1,0 +1,66 @@
+module vote_lockup::package_manager {
+    use aptos_framework::account::{Self, SignerCapability};
+    use aptos_framework::resource_account;
+    use aptos_std::smart_table::{Self, SmartTable};
+    use std::string::String;
+
+    friend vote_lockup::vote;
+    friend vote_lockup::voting_token;
+
+    /// Stores permission config such as SignerCapability for controlling the resource account.
+    struct PermissionConfig has key {
+        /// Required to obtain the resource account signer.
+        signer_cap: SignerCapability,
+        /// Track the addresses created by the modules in this package.
+        addresses: SmartTable<String, address>,
+    }
+
+    /// Initialize PermissionConfig to establish control over the resource account.
+    /// This function is invoked only when this package is deployed the first time.
+    fun init_module(package_signer: &signer) {
+        let signer_cap = resource_account::retrieve_resource_account_cap(package_signer, @deployer);
+        move_to(package_signer, PermissionConfig {
+            addresses: smart_table::new<String, address>(),
+            signer_cap,
+        });
+    }
+
+    /// Can be called by friended modules to obtain the resource account signer.
+    public(friend) fun get_signer(): signer acquires PermissionConfig {
+        let signer_cap = &borrow_global<PermissionConfig>(@vote_lockup).signer_cap;
+        account::create_signer_with_capability(signer_cap)
+    }
+
+    /// Can be called by friended modules to keep track of a system address.
+    public(friend) fun add_address(name: String, object: address) acquires PermissionConfig {
+        let addresses = &mut borrow_global_mut<PermissionConfig>(@vote_lockup).addresses;
+        smart_table::add(addresses, name, object);
+    }
+
+    public fun address_exists(name: String): bool acquires PermissionConfig {
+        smart_table::contains(&safe_permission_config().addresses, name)
+    }
+
+    public fun get_address(name: String): address acquires PermissionConfig {
+        let addresses = &borrow_global<PermissionConfig>(@vote_lockup).addresses;
+        *smart_table::borrow(addresses, name)
+    }
+
+    inline fun safe_permission_config(): &PermissionConfig acquires PermissionConfig {
+        borrow_global<PermissionConfig>(@vote_lockup)
+    }
+
+    #[test_only]
+    public fun initialize_for_test(deployer: &signer) {
+        let deployer_addr = std::signer::address_of(deployer);
+        if (!exists<PermissionConfig>(deployer_addr)) {
+            aptos_framework::timestamp::set_time_has_started_for_testing(&account::create_signer_for_test(@0x1));
+
+            account::create_account_for_test(deployer_addr);
+            move_to(deployer, PermissionConfig {
+                addresses: smart_table::new<String, address>(),
+                signer_cap: account::create_test_signer_cap(deployer_addr),
+            });
+        };
+    }
+}

--- a/aptos-move/move-examples/vote_lockup/sources/tests/test_helpers.move
+++ b/aptos-move/move-examples/vote_lockup/sources/tests/test_helpers.move
@@ -1,0 +1,15 @@
+#[test_only]
+module vote_lockup::test_helpers {
+    use aptos_framework::account;
+    use aptos_framework::timestamp;
+    use vote_lockup::epoch;
+    use vote_lockup::package_manager;
+    use vote_lockup::vote;
+
+    public fun set_up() {
+        timestamp::set_time_has_started_for_testing(&account::create_signer_for_test(@0x1));
+        epoch::fast_forward(100);
+        package_manager::initialize_for_test(&account::create_signer_for_test(@0xcafe));
+        vote::initialize();
+    }
+}

--- a/aptos-move/move-examples/vote_lockup/sources/tests/vote_tests.move
+++ b/aptos-move/move-examples/vote_lockup/sources/tests/vote_tests.move
@@ -1,0 +1,141 @@
+#[test_only]
+module vote_lockup::vote_tests {
+    use aptos_framework::fungible_asset;
+    use aptos_framework::object::{Self, Object};
+    use aptos_framework::primary_fungible_store;
+    use std::signer;
+    use std::vector;
+    use vote_lockup::epoch;
+    use vote_lockup::test_helpers;
+    use vote_lockup::vote::{Self, VotingCertificate};
+    use vote_lockup::voting_token;
+
+    #[test(voter_1 = @0xcafe, voter_2 = @0xdead)]
+    fun test_create_and_withdraw_lock(voter_1: &signer, voter_2: &signer) {
+        test_helpers::set_up();
+        let voting_tokens = voting_token::test_mint(1020);
+        // Create a lock from an account's primary store.
+        let voter_1_addr = signer::address_of(voter_1);
+        primary_fungible_store::deposit(voter_1_addr, voting_tokens);
+        assert!(voting_token::balance(voter_1_addr) == 1020, 0);
+        let voter_1_certificate = vote::create_lock(voter_1, 520, 100);
+
+        // Create a lock from direct $VOTING tokens.
+        let voter_2_certificate = mint_and_create_lock(voter_2, 100, 50);
+
+        // The certificates should contain $VOTING for the amount deposited.
+        assert!(voting_token::balance(voter_1_addr) == 500, 0);
+        let voter_2_addr = signer::address_of(voter_2);
+        assert!(voting_token::balance(voter_2_addr) == 0, 0);
+        verify_balances_and_manifested_total_supply(
+            vector[voter_1_certificate, voter_2_certificate],
+            vector[520, 100],
+            vector[100, 50],
+        );
+
+        // Fast forward to unlock and withdraw.
+        epoch::fast_forward(50);
+        vote::withdraw_entry(voter_2, voter_2_certificate);
+        assert!(voting_token::balance(voter_2_addr) == 100, 0);
+        // One certificate still remains with 50 epochs of lockup.
+        verify_balances_and_manifested_total_supply(vector[voter_1_certificate],vector[520],vector[50]);
+        epoch::fast_forward(50);
+        assert!(vote::total_voting_power() == 0, 0);
+        vote::withdraw_entry(voter_1, voter_1_certificate);
+        assert!(voting_token::balance(voter_1_addr) == 1020, 0);
+
+        // Check that the certificate objects has been deleted.
+        verify_is_deleted(voter_1_certificate);
+        verify_is_deleted(voter_2_certificate);
+    }
+
+    #[test(voter_1 = @0xcafe)]
+    fun test_extend_lockup_and_increase_amount(voter_1: &signer) {
+        test_helpers::set_up();
+        // Original certificate is locked for 100 epochs.
+        let voting_certificate = mint_and_create_lock(voter_1, 520, 104);
+        verify_balances_and_manifested_total_supply(vector[voting_certificate], vector[520], vector[104]);
+
+        // Fast forward 50 epochs so the certificate is only locked for another 50. Extend the lock to 100 epochs and
+        // verify.
+        epoch::fast_forward(52);
+        verify_balances_and_manifested_total_supply(vector[voting_certificate], vector[520], vector[52]);
+        vote::extend_lockup(voter_1, voting_certificate, 104);
+        verify_balances_and_manifested_total_supply(vector[voting_certificate], vector[520], vector[104]);
+
+        // Fast forward another 50 epochs. certificate lock should have 50 epochs remaining. Increase the amount and
+        // verify.
+        epoch::fast_forward(52);
+        vote::increase_amount_with(voting_certificate, voting_token::test_mint(520));
+        verify_balances_and_manifested_total_supply(vector[voting_certificate], vector[1040], vector[52]);
+    }
+
+    #[test(voter_1 = @0xcafe)]
+    #[expected_failure(abort_code = 5, location = vote_lockup::vote)]
+    fun test_cannot_withdraw_locked_tokens(voter_1: &signer) {
+        test_helpers::set_up();
+        let voting_certificate = mint_and_create_lock(voter_1, 500, 100);
+        assert!(vote::get_lockup_expiration_epoch(voting_certificate) == 200, 0);
+        epoch::fast_forward(98);
+        // Should fail because only 98 epochs have passed while the lockup is for 100.
+        vote::withdraw_entry(voter_1, voting_certificate);
+    }
+
+    #[test(voter_1 = @0xcafe)]
+    #[expected_failure(abort_code = 65539, location = aptos_framework::fungible_asset)]
+    fun test_cannot_extract_tokens_from_certificate(voter_1: &signer) {
+        test_helpers::set_up();
+        let voting_certificate = mint_and_create_lock(voter_1, 500, 100);
+        fungible_asset::deposit(voting_certificate, fungible_asset::withdraw(voter_1, voting_certificate, 1));
+    }
+
+    #[test(voter_1 = @0xcafe)]
+    #[expected_failure(abort_code = 65539, location = aptos_framework::fungible_asset)]
+    fun test_cannot_deposit_tokens_into_certificate(voter_1: &signer) {
+        test_helpers::set_up();
+        let voting_certificate = mint_and_create_lock(voter_1, 500, 100);
+        fungible_asset::deposit(voting_certificate, voting_token::test_mint(100));
+    }
+
+    fun verify_balances_and_manifested_total_supply(
+        certificates: vector<Object<VotingCertificate>>,
+        locked_amounts: vector<u64>,
+        remaining_locked_epochs: vector<u64>,
+    ) {
+        let curr_epoch = epoch::now();
+        let epoch = curr_epoch;
+        let max_lockup_epochs = vote::max_lockup_epochs();
+        while (epoch <= curr_epoch + max_lockup_epochs + 1) {
+            let total_balance = 0;
+            vector::enumerate_ref(&locked_amounts, |i, amount| {
+                let amount: u64 = *amount;
+                let remaining_lockup_epochs = *vector::borrow(&remaining_locked_epochs, i);
+                let lockup_end = curr_epoch + remaining_lockup_epochs;
+                let certificate: Object<VotingCertificate> = *vector::borrow(&certificates, i);
+                assert!(fungible_asset::balance(certificate) == amount, 0);
+                assert!(vote::remaining_lockup_epochs(certificate) == remaining_lockup_epochs, 0);
+                assert!(vote::get_lockup_expiration_epoch(certificate) == lockup_end, 0);
+                let balance_at_epoch = vote::get_voting_power_at_epoch(certificate, epoch);
+                if (epoch >= lockup_end) {
+                    assert!(balance_at_epoch == 0, 0);
+                } else {
+                    let expected_balance = amount * (lockup_end - epoch) / max_lockup_epochs;
+                    assert!(balance_at_epoch == expected_balance, 0);
+                    total_balance = total_balance + expected_balance;
+                };
+            });
+            assert!((total_balance as u128) == vote::total_voting_power_at(epoch), 0);
+            epoch = epoch + 1;
+        }
+    }
+
+    public fun mint_and_create_lock(owner: &signer, amount: u64, lockup_epochs: u64): Object<VotingCertificate> {
+        vote::create_lock_with(voting_token::test_mint(amount), lockup_epochs, signer::address_of(owner))
+    }
+
+    fun verify_is_deleted(certificate: Object<VotingCertificate>) {
+        let certificate_address = object::object_address(&certificate);
+        assert!(!vote::certificate_exists(certificate_address), 0);
+        assert!(!object::is_object(certificate_address), 0);
+    }
+}

--- a/aptos-move/move-examples/vote_lockup/sources/tests/voting_token_tests.move
+++ b/aptos-move/move-examples/vote_lockup/sources/tests/voting_token_tests.move
@@ -1,0 +1,35 @@
+#[test_only]
+module vote_lockup::voting_token_tests {
+    use aptos_framework::fungible_asset;
+    use aptos_framework::primary_fungible_store;
+    use vote_lockup::test_helpers;
+    use vote_lockup::voting_token;
+    use std::signer;
+
+    #[test(sender = @0x123, recipient = @0xdead)]
+    fun test_e2e(sender: &signer, recipient: &signer) {
+        test_helpers::set_up();
+        let tokens = voting_token::mint(1000);
+        assert!(fungible_asset::amount(&tokens) == 1000, 0);
+        let sender_addr = signer::address_of(sender);
+        primary_fungible_store::deposit(sender_addr, tokens);
+        let token = voting_token::token();
+        assert!(primary_fungible_store::balance(sender_addr, token) == 1000, 0);
+        let recipient_addr = signer::address_of(recipient);
+        primary_fungible_store::transfer(sender, token, recipient_addr, 500);
+        assert!(primary_fungible_store::balance(sender_addr, token) == 500, 0);
+        assert!(primary_fungible_store::balance(recipient_addr, token) == 500, 0);
+        let tokens = primary_fungible_store::withdraw(recipient, token, 500);
+        voting_token::burn(tokens);
+        assert!(primary_fungible_store::balance(recipient_addr, token) == 0, 0);
+        voting_token::transfer(
+            primary_fungible_store::primary_store(sender_addr, token),
+            primary_fungible_store::primary_store(recipient_addr, token),
+            500,
+        );
+        assert!(primary_fungible_store::balance(sender_addr, token) == 0, 0);
+        assert!(primary_fungible_store::balance(recipient_addr, token) == 500, 0);
+        voting_token::disable_transfer(primary_fungible_store::primary_store(recipient_addr, token));
+        assert!(primary_fungible_store::is_frozen(recipient_addr, token), 0);
+    }
+}

--- a/aptos-move/move-examples/vote_lockup/sources/vote.move
+++ b/aptos-move/move-examples/vote_lockup/sources/vote.move
@@ -1,0 +1,384 @@
+/// This is an example module that shows a lockup-based voting system. The flow works as below:
+///
+/// 1. Users can lock up $VOTING to receive a voting certificate in exchange. The voting certificate is an object that
+/// can be freely transferred. The longer the lockup duration, the higher the voting power a certificate will have.
+/// Over time, as remaining lockup duration decreases, the certiticate's voting power will also decrease linearly.
+/// Users get 100% of voting power (equal to amount of $VOTING locked) when locking for the max lockup duration. If they
+/// lock for half the max lockup duration, they get 50% of voting power, and so on. Developers can tweak this formula
+/// if needed to achieve a different multiplier. Note that voting power only decreases at the end of each epoch (duration
+/// can be customized) instead of continuously over time.
+/// 2. Users can vote by calling the rest of the system, which can check how much voting power the certificate currently
+/// has remaining and what the current total voting power is across all certificates. This allows the system to calculate
+/// the percentage of voting power a certificate has and use that to determine the weight of the vote.
+/// 3. Users can also extend the lockup of a certificate or add more $VOTING to it. In this case, the voting power will
+/// be recalculated based on the new lockup duration and amount.
+/// 4. Once the lockup has expired, the users can withdraw their $VOTING from the certificate. This also destroys the
+/// certificate.
+///
+/// Note that the voting power cannot be changed for the current epoch when locked amount or lockup duration changes.
+/// If this is a desired behavior, developers can update the code to allow this.
+///
+/// Calculating the remaining voting power of a certificate is simple but calculating the total voting power across all
+/// certificates is more complicated as they can all have different lockup durations and amounts. To solve this, this
+/// module tracks and updates the total voting power of all certificates all the way until the current time + max lockup
+/// duration. This operation can result in a max of 365 steps, which is why we use a SmartTable to optimize gas. This
+/// approach is usually prohibitively expensive on other chains, but on Aptos, this is cheap and fast.
+module vote_lockup::vote {
+    use aptos_framework::fungible_asset::{Self, FungibleAsset};
+    use aptos_framework::object::{Self, DeleteRef, Object};
+    use aptos_framework::primary_fungible_store;
+    use aptos_std::smart_table::{Self, SmartTable};
+    use std::signer;
+    use vote_lockup::epoch;
+    use vote_lockup::package_manager;
+    use vote_lockup::voting_token;
+
+    // 1 epoch is 1 day.
+    const MIN_LOCKUP_EPOCHS: u64 = 24;
+    const MAX_LOCKUP_EPOCHS: u64 = 104;
+
+    /// Only $VOTING are accepted.
+    const EONLY_VOTING_ACCEPTED: u64 = 1;
+    /// The given lockup period is shorter than the minimum allowed.
+    const ELOCKUP_TOO_SHORT: u64 = 2;
+    /// The given lockup period is longer than the maximum allowed.
+    const ELOCKUP_TOO_LONG: u64 = 3;
+    /// The given certificate is not owned by the given signer.
+    const ENOT_CERTIFICATE_OWNER: u64 = 4;
+    /// The lockup period for the given certificate has not expired yet.
+    const ELOCKUP_HAS_NOT_EXPIRED: u64 = 5;
+    /// Either locked amount or lockup duration or both has to increase.
+    const EINVALID_LOCKUP_CHANGE: u64 = 6;
+    /// The new lockup period has to be strictly longer than the old one.
+    const ELOCKUP_MUST_BE_EXTENDED: u64 = 7;
+    /// The amount to lockup must be more than zero.
+    const EINVALID_AMOUNT: u64 = 8;
+    /// Voting power and total supply can only be looked up for the current epoch or in the future.
+    const ECANNOT_LOOK_UP_PAST_VOTING_POWER: u64 = 9;
+
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    /// Core resource for a voting certificate that stores locked $VOTING and allows users to vote with a voting power
+    /// that increases the higher the remaining lockup time (decreasing over time if lockup is not extended).
+    struct VotingCertificate has key {
+        locked_amount: u64,
+        end_epoch: u64,
+        // Required to destroy the certificate later during withdrawal.
+        delete_ref: DeleteRef,
+    }
+
+    /// Important data structure that tracks the total voting power across all certificates. This is updated for every
+    /// certificate creation or lockup/amount changes.
+    struct VoteConfig has key {
+        // This is the total voting power across all voting certificates, multiplied by max_lockup_epochs to minimize
+        // rounding error.
+        // Total voting power is computed for each epoch until the maximum number of epochs allowed from the last
+        // user's lockup update. If there's no value, the supply is zero because all lockups have already expired.
+        // We store this as a SmartTable to optimize gas.
+        unscaled_total_voting_power_per_epoch: SmartTable<u64, u128>,
+    }
+
+    public entry fun initialize() {
+        if (is_initialized()) {
+            return
+        };
+        voting_token::initialize();
+        move_to(&package_manager::get_signer(), VoteConfig {
+            unscaled_total_voting_power_per_epoch: smart_table::new(),
+        });
+    }
+
+    #[view]
+    public fun is_initialized(): bool {
+        exists<VoteConfig>(@vote_lockup)
+    }
+
+    #[view]
+    /// Returns the current remaining voting power of the given certificate.
+    public fun get_voting_power(certificate: Object<VotingCertificate>): u64 acquires VotingCertificate {
+        get_voting_power_at_epoch(certificate, epoch::now())
+    }
+
+    #[view]
+    /// Returns the remaining voting power of the given certificate at the given epoch.
+    public fun get_voting_power_at_epoch(certificate: Object<VotingCertificate>, epoch: u64): u64 acquires VotingCertificate {
+        assert!(epoch >= epoch::now(), ECANNOT_LOOK_UP_PAST_VOTING_POWER);
+        let token_data = safe_certificate(&certificate);
+        let lockup_end_epoch = token_data.end_epoch;
+        if (lockup_end_epoch <= epoch) {
+            0
+        } else {
+            token_data.locked_amount * (lockup_end_epoch - epoch) / MAX_LOCKUP_EPOCHS
+        }
+    }
+
+    #[view]
+    /// Returns the current total voting power across all certificates.
+    public fun total_voting_power(): u128 acquires VoteConfig {
+        total_voting_power_at(epoch::now())
+    }
+
+    #[view]
+    /// Returns the total voting power across all certificates at the given epoch.
+    public fun total_voting_power_at(epoch: u64): u128 acquires VoteConfig {
+        assert!(epoch >= epoch::now(), ECANNOT_LOOK_UP_PAST_VOTING_POWER);
+        let total_voting_power_per_epoch = &safe_vote_config().unscaled_total_voting_power_per_epoch;
+        let unscaled_voting_power = *smart_table::borrow_with_default(total_voting_power_per_epoch, epoch, &0);
+        unscaled_voting_power / (MAX_LOCKUP_EPOCHS as u128)
+    }
+
+    #[view]
+    /// Returns the number of epochs until the given certificate's lockup expires.
+    public fun remaining_lockup_epochs(certificate: Object<VotingCertificate>): u64 acquires VotingCertificate {
+        let end_epoch = get_lockup_expiration_epoch(certificate);
+        let current_epoch = epoch::now();
+        if (end_epoch <= current_epoch) {
+            0
+        } else {
+            end_epoch - current_epoch
+        }
+    }
+
+    #[view]
+    /// Returns the epoch number when the given certificate's lockup expires.
+    public fun get_lockup_expiration_epoch(certificate: Object<VotingCertificate>): u64 acquires VotingCertificate {
+        safe_certificate(&certificate).end_epoch
+    }
+
+    #[view]
+    /// Return the timestamp (in seconds) when the given certificate's lockup expires.
+    public fun get_lockup_expiration_time(certificate: Object<VotingCertificate>): u64 acquires VotingCertificate {
+        epoch::to_seconds(get_lockup_expiration_epoch(certificate))
+    }
+
+    #[view]
+    /// Return true if a given address is a certificate object.
+    public fun certificate_exists(certificate: address): bool {
+        exists<VotingCertificate>(certificate)
+    }
+
+    #[view]
+    /// Return the maximum number of epochs a lockup can be created for.
+    public fun max_lockup_epochs(): u64 {
+        MAX_LOCKUP_EPOCHS
+    }
+
+    /// Mint a voting certificate and lock $VOTING from the owner's primary store.
+    public entry fun create_lock_entry(owner: &signer, amount: u64, lockup_epochs: u64) acquires VoteConfig {
+        create_lock(owner, amount, lockup_epochs);
+    }
+
+    public entry fun create_lock_for(
+        owner: &signer,
+        amount: u64,
+        lockup_epochs: u64,
+        recipient: address,
+    ) acquires VoteConfig {
+        let voting_tokens = primary_fungible_store::withdraw(owner, voting_token::token(), amount);
+        create_lock_with(voting_tokens, lockup_epochs, recipient);
+    }
+
+    /// Non-entry version that also returns a reference to the certificate object.
+    public fun create_lock(
+        owner: &signer,
+        amount: u64,
+        lockup_epochs: u64,
+    ): Object<VotingCertificate> acquires VoteConfig {
+        let voting_tokens = primary_fungible_store::withdraw(owner, voting_token::token(), amount);
+        create_lock_with(voting_tokens, lockup_epochs, signer::address_of(owner))
+    }
+
+    /// Create a lock with the given amount and lockup duration and send the certificate to the given recipient.
+    public fun create_lock_with(
+        tokens: FungibleAsset,
+        lockup_epochs: u64,
+        recipient: address,
+    ): Object<VotingCertificate> acquires VoteConfig {
+        let amount = fungible_asset::amount(&tokens);
+        assert!(amount > 0, EINVALID_AMOUNT);
+
+        validate_lockup_epochs(lockup_epochs);
+        let voting_token_metadata = voting_token::token();
+        assert!(
+            fungible_asset::asset_metadata(&tokens) == object::convert(voting_token_metadata),
+            EONLY_VOTING_ACCEPTED,
+        );
+
+        // Create a new certificate.
+        let package_signer = &package_manager::get_signer();
+        let certificate = &object::create_object_from_account(package_signer);
+        let certificate_signer = &object::generate_signer(certificate);
+        let lockup_end_epoch = epoch::now() + lockup_epochs;
+        move_to(certificate_signer, VotingCertificate {
+            locked_amount: amount,
+            end_epoch: lockup_end_epoch,
+            delete_ref: object::generate_delete_ref(certificate),
+        });
+
+        // Turn the certificate into a fungible store so we can store the locked up $VOTING there.
+        let certificate_as_store = fungible_asset::create_store(certificate, voting_token_metadata);
+        fungible_asset::deposit(certificate_as_store, tokens);
+        // Disable owner transfers to lock the $VOTING inside the certificate so it cannot be moved until the lockup
+        // has expired.
+        // This also prevents anyone from adding more $VOTING into the certificate token without going through the flow
+        // here.
+        voting_token::disable_transfer(certificate_as_store);
+
+        // Send the certificate to the recipient.
+        object::transfer(package_signer, certificate_as_store, recipient);
+
+        // Has to called for every function that modifies amount or lockup duration of any voting certificates.
+        // Always at the end of a function so we don't forget.
+        // Old amount is 0 because this is a new lockup.
+        update_manifested_total_supply(0, 0, amount, lockup_end_epoch);
+
+        object::object_from_constructor_ref(certificate)
+    }
+
+    /// Increase the lockup duration of a voting certificate by the given number of epochs. The new effective new lockup
+    /// end epoch would be current epoch + lockup epochs from now.
+    /// This can also be called for a voting certificate that has already expired to re-lock it.
+    public entry fun extend_lockup(
+        owner: &signer,
+        certificate: Object<VotingCertificate>,
+        lockup_epochs_from_now: u64,
+    ) acquires VoteConfig, VotingCertificate {
+        validate_lockup_epochs(lockup_epochs_from_now);
+        let certificate_data = owner_only_mut_certificate(owner, certificate);
+        let old_lockup_end_epoch = certificate_data.end_epoch;
+        let new_lockup_end_epoch = epoch::now() + lockup_epochs_from_now;
+        assert!(new_lockup_end_epoch > old_lockup_end_epoch, ELOCKUP_MUST_BE_EXTENDED);
+        certificate_data.end_epoch = new_lockup_end_epoch;
+        // Amount didn't change.
+        let locked_amount = certificate_data.locked_amount;
+
+        // Has to called for every function that modifies amount or lockup duration of any voting certificate.
+        // Always at the end of a function so we don't forget.
+        update_manifested_total_supply(locked_amount, old_lockup_end_epoch, locked_amount, new_lockup_end_epoch);
+    }
+
+    /// Add more $VOTING to a voting certificate.
+    public entry fun increase_amount(
+        owner: &signer,
+        certificate: Object<VotingCertificate>,
+        amount: u64,
+    ) acquires VoteConfig, VotingCertificate {
+        let voting_tokens = primary_fungible_store::withdraw(owner, voting_token::token(), amount);
+        increase_amount_with(certificate, voting_tokens);
+    }
+
+    /// Add more $VOTING to a voting certificate.
+    public fun increase_amount_with(
+        certificate: Object<VotingCertificate>,
+        tokens: FungibleAsset,
+    ) acquires VoteConfig, VotingCertificate {
+        let certificate_data = unchecked_mut_certificate(&certificate);
+        let amount = fungible_asset::amount(&tokens);
+        assert!(amount > 0, EINVALID_AMOUNT);
+        let old_amount = certificate_data.locked_amount;
+        let new_amount = old_amount + amount;
+        certificate_data.locked_amount = new_amount;
+        voting_token::deposit(certificate, tokens);
+
+        // Has to called for every function that modifies amount or lockup duration of any voting certificate.
+        // Always at the end of a function so we don't forget.
+        let end_epoch = certificate_data.end_epoch;
+        update_manifested_total_supply(old_amount, end_epoch, new_amount, end_epoch);
+    }
+
+    /// Withdraw the $VOTING from a voting certificate. The certificate must have expired.
+    public entry fun withdraw_entry(
+        owner: &signer,
+        certificate: Object<VotingCertificate>,
+    ) acquires VotingCertificate {
+        let assets = withdraw(owner, certificate);
+        primary_fungible_store::deposit(signer::address_of(owner), assets);
+    }
+
+    /// Withdraw the $VOTING from a voting certificate. The certificate must have expired.
+    public fun withdraw(
+        owner: &signer,
+        certificate: Object<VotingCertificate>,
+    ): FungibleAsset acquires VotingCertificate {
+        // Extract the unlocked $VOTING and burn the ve token.
+        let tokens = voting_token::withdraw(certificate, fungible_asset::balance(certificate));
+        let end_epoch = owner_only_destroy_certificate(owner, certificate);
+        // This would fail if the lockup has not expired yet.
+        assert!(end_epoch <= epoch::now(), ELOCKUP_HAS_NOT_EXPIRED);
+        tokens
+        // Withdraw doesn't need to update total voting power because this lockup should not have any effect on any
+        // epochs, including the current one, as it has already expired.
+    }
+
+    fun update_manifested_total_supply(
+        old_amount: u64,
+        old_lockup_end_epoch: u64,
+        new_amount: u64,
+        new_lockup_end_epoch: u64,
+    ) acquires VoteConfig {
+        assert!(
+            new_amount > old_amount || new_lockup_end_epoch > old_lockup_end_epoch,
+            EINVALID_LOCKUP_CHANGE,
+        );
+
+        // We only need to update the total supply starting from the current epoch since the total voting powers of
+        // past epochs are already set in stone.
+        let curr_epoch = epoch::now();
+        let total_voting_power_per_epoch = &mut unchecked_vote_config().unscaled_total_voting_power_per_epoch;
+        while (curr_epoch < new_lockup_end_epoch) {
+            // Old epoch delta can be zero if there was no previous lockup (old_amount = 0) or lockup has expired.
+            let old_epoch_delta = if (old_amount == 0 || old_lockup_end_epoch <= curr_epoch) {
+                0
+            } else {
+                old_amount * (old_lockup_end_epoch - curr_epoch)
+            };
+            let new_epoch_delta = new_amount * (new_lockup_end_epoch - curr_epoch);
+            // This cannot underflow due to the assertion that either the amount or the lockup duration or both must
+            // increase.
+            let voting_power_delta = ((new_epoch_delta - old_epoch_delta) as u128);
+            let total_voting_power = smart_table::borrow_mut_with_default(total_voting_power_per_epoch, curr_epoch, 0);
+            *total_voting_power = *total_voting_power + voting_power_delta;
+            curr_epoch = curr_epoch + 1;
+        }
+    }
+
+    inline fun owner_only_destroy_certificate(
+        owner: &signer,
+        certificate: Object<VotingCertificate>,
+    ): u64 acquires VotingCertificate {
+        assert!(object::is_owner(certificate, signer::address_of(owner)), ENOT_CERTIFICATE_OWNER);
+        let certificate_addr = object::object_address(&certificate);
+        let VotingCertificate { locked_amount: _, end_epoch, delete_ref } =
+            move_from<VotingCertificate>(certificate_addr);
+        object::delete(delete_ref);
+        end_epoch
+    }
+
+    inline fun owner_only_mut_certificate(
+        owner: &signer,
+        certificate: Object<VotingCertificate>,
+    ): &mut VotingCertificate acquires VotingCertificate {
+        assert!(object::is_owner(certificate, signer::address_of(owner)), ENOT_CERTIFICATE_OWNER);
+        unchecked_mut_certificate(&certificate)
+    }
+
+    inline fun safe_certificate(certificate: &Object<VotingCertificate>): &VotingCertificate acquires VotingCertificate {
+        borrow_global<VotingCertificate>(object::object_address(certificate))
+    }
+
+    inline fun safe_vote_config(): &VoteConfig {
+        borrow_global<VoteConfig>(@vote_lockup)
+    }
+
+    inline fun unchecked_mut_certificate(certificate: &Object<VotingCertificate>): &mut VotingCertificate acquires VotingCertificate {
+        borrow_global_mut<VotingCertificate>(object::object_address(certificate))
+    }
+
+    inline fun unchecked_vote_config(): &mut VoteConfig {
+        borrow_global_mut<VoteConfig>(@vote_lockup)
+    }
+
+    inline fun validate_lockup_epochs(lockup_epochs: u64) {
+        assert!(lockup_epochs >= MIN_LOCKUP_EPOCHS, ELOCKUP_TOO_SHORT);
+        assert!(lockup_epochs <= MAX_LOCKUP_EPOCHS, ELOCKUP_TOO_LONG);
+    }
+}

--- a/aptos-move/move-examples/vote_lockup/sources/voting_token.move
+++ b/aptos-move/move-examples/vote_lockup/sources/voting_token.move
@@ -1,0 +1,146 @@
+/// This is an example of a voting token and based on the managed_fungible_asset example from Aptos' move-examples.
+/// The mint and burn functions are friend-only so they can be called as part of a protocol's functionalities and flows.
+/// This also offers disable_transfer for the vote module to managed locked voting positions and transfer (via transfer
+/// ref) to allow bypassing the disable_transfer flag if needed. Vote module uses this to allow merging voting positions
+///
+/// Note that after deployment, deployer should call initialize() to create the token.
+///
+/// In this specific example, mint and burn are not called by the vote module.
+module vote_lockup::voting_token {
+    use aptos_framework::fungible_asset::{Self, MintRef, TransferRef, BurnRef, FungibleAsset, FungibleStore};
+    use aptos_framework::object::{Self, Object};
+    use aptos_framework::primary_fungible_store;
+    use std::signer;
+    use std::string;
+    use std::option;
+    use vote_lockup::package_manager;
+
+    friend vote_lockup::vote;
+
+    const TOKEN_NAME: vector<u8> = b"VOTING";
+    const TOKEN_SYMBOL: vector<u8> = b"VOTING";
+    const TOKEN_DECIMALS: u8 = 8;
+    const TOKEN_URI: vector<u8> = b"voting.apt";
+    const PROJECT_URI: vector<u8> = b"voting.apt";
+
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    /// Fungible asset refs used to manage the $VOTING token.
+    struct VotingToken has key {
+        burn_ref: BurnRef,
+        mint_ref: MintRef,
+        transfer_ref: TransferRef,
+    }
+
+    /// Deploy the $VOTING token. This can only be called once.
+    public entry fun initialize() {
+        if (is_initialized()) {
+            return
+        };
+
+        // Create the voting token as a fungible asset.
+        let voting_token_metadata = &object::create_named_object(&package_manager::get_signer(), TOKEN_NAME);
+        primary_fungible_store::create_primary_store_enabled_fungible_asset(
+            voting_token_metadata,
+            option::none(),
+            string::utf8(TOKEN_NAME),
+            string::utf8(TOKEN_SYMBOL),
+            TOKEN_DECIMALS,
+            string::utf8(TOKEN_URI),
+            string::utf8(PROJECT_URI),
+        );
+        let voting_token = &object::generate_signer(voting_token_metadata);
+        // Vote module needs transfer ref for locking voting tokens up.
+        // Mint/Burn are not directly used in this example but can be kept around for mint/burn functionalities.
+        // If not needed, developers can delete them.
+        move_to(voting_token, VotingToken {
+            burn_ref: fungible_asset::generate_burn_ref(voting_token_metadata),
+            mint_ref: fungible_asset::generate_mint_ref(voting_token_metadata),
+            transfer_ref: fungible_asset::generate_transfer_ref(voting_token_metadata),
+        });
+        package_manager::add_address(string::utf8(TOKEN_NAME), signer::address_of(voting_token));
+
+        // Developers can add any logic for preminting tokens at launch here.
+    }
+
+    #[view]
+    public fun is_initialized(): bool {
+        package_manager::address_exists(string::utf8(TOKEN_NAME))
+    }
+
+    #[view]
+    /// Return the address of the metadata that's created when this module is deployed.
+    public fun token_address(): address {
+        package_manager::get_address(string::utf8(TOKEN_NAME))
+    }
+
+    #[view]
+    /// Return the $VOTING token metadata object.
+    public fun token(): Object<VotingToken> {
+        object::address_to_object(token_address())
+    }
+
+    #[view]
+    /// Return the total supply of $VOTING tokens.
+    public fun total_supply(): u128 {
+        option::get_with_default(&fungible_asset::supply(token()), 0)
+    }
+
+    #[view]
+    /// Return the total supply of $VOTING tokens.
+    public fun balance(user: address): u64 {
+        primary_fungible_store::balance(user, token())
+    }
+
+    public(friend) fun mint(amount: u64): FungibleAsset acquires VotingToken {
+        fungible_asset::mint(&unchecked_token_refs().mint_ref, amount)
+    }
+
+    public(friend) fun burn(voting_tokens: FungibleAsset) acquires VotingToken {
+        fungible_asset::burn(&unchecked_token_refs().burn_ref, voting_tokens);
+    }
+
+    /// For depositing $VOTING into a fungible asset store. This can be the voting certificate, which cannot be
+    /// deposited into normally as it's frozen (no owner transfers).
+    public(friend) fun deposit<T: key>(store: Object<T>, voting_tokens: FungibleAsset) acquires VotingToken {
+        fungible_asset::deposit_with_ref(&unchecked_token_refs().transfer_ref, store, voting_tokens);
+    }
+
+    /// For withdrawing $VOTING from a voting certificate.
+    public(friend) fun withdraw<T: key>(store: Object<T>, amount: u64): FungibleAsset acquires VotingToken {
+        fungible_asset::withdraw_with_ref(&unchecked_token_refs().transfer_ref, store, amount)
+    }
+
+    /// For extracting $VOTING from the voting certificate when owner withdraws after the lockup has expired.
+    public(friend) fun transfer<T: key>(
+        from: Object<T>,
+        to: Object<FungibleStore>,
+        amount: u64,
+    ) acquires VotingToken {
+        let from = object::convert(from);
+        let transfer_ref = &unchecked_token_refs().transfer_ref;
+        fungible_asset::transfer_with_ref(transfer_ref, from, to, amount);
+    }
+
+    /// Used to lock $VOTING in when creating voting certificates.
+    public(friend) fun disable_transfer<T: key>(voting_store: Object<T>) acquires VotingToken {
+        let transfer_ref = &unchecked_token_refs().transfer_ref;
+        fungible_asset::set_frozen_flag(transfer_ref, voting_store, true);
+    }
+
+    inline fun unchecked_token_refs(): &VotingToken {
+        borrow_global<VotingToken>(token_address())
+    }
+
+    #[test_only]
+    friend vote_lockup::voting_token_tests;
+
+    #[test_only]
+    public fun test_mint(amount: u64): FungibleAsset acquires VotingToken {
+        mint(amount)
+    }
+
+    #[test_only]
+    public fun test_burn(tokens: FungibleAsset) acquires VotingToken {
+        burn(tokens)
+    }
+}


### PR DESCRIPTION
### Description
/// This is an example module that shows a lockup-based voting system. The flow works as below:
///
/// 1. Users can lock up $VOTING to receive a voting certificate in exchange. The voting certificate is an object that
/// can be freely transferred. The longer the lockup duration, the higher the voting power a certificate will have.
/// Over time, as remaining lockup duration decreases, the certiticate's voting power will also decrease linearly.
/// Users get 100% of voting power (equal to amount of $VOTING locked) when locking for the max lockup duration. If they
/// lock for half the max lockup duration, they get 50% of voting power, and so on. Developers can tweak this formula
/// if needed to achieve a different multiplier. Note that voting power only decreases at the end of each epoch (duration
/// can be customized) instead of continuously over time.
/// 2. Users can vote by calling the rest of the system, which can check how much voting power the certificate currently
/// has remaining and what the current total voting power is across all certificates. This allows the system to calculate
/// the percentage of voting power a certificate has and use that to determine the weight of the vote.
/// 3. Users can also extend the lockup of a certificate or add more $VOTING to it. In this case, the voting power will
/// be recalculated based on the new lockup duration and amount.
/// 4. Once the lockup has expired, the users can withdraw their $VOTING from the certificate. This also destroys the
/// certificate.
///
/// Note that the voting power cannot be changed for the current epoch when locked amount or lockup duration changes.
/// If this is a desired behavior, developers can update the code to allow this.
///
/// Calculating the remaining voting power of a certificate is simple but calculating the total voting power across all
/// certificates is more complicated as they can all have different lockup durations and amounts. To solve this, this
/// module tracks and updates the total voting power of all certificates all the way until the current time + max lockup
/// duration. This operation can result in a max of 365 steps, which is why we use a SmartTable to optimize gas. This
/// approach is usually prohibitively expensive on other chains, but on Aptos, this is cheap and fast.

### Test Plan
Unit tests + Manual deploy
