### PR TITLE
Add get_state_value_u128 method to TStateView

### DIFF
--- a/aptos-move/aptos-aggregator/src/delta_change_set.rs
+++ b/aptos-move/aptos-aggregator/src/delta_change_set.rs
@@ -187,13 +187,12 @@ impl DeltaOp {
     ) -> anyhow::Result<WriteOp, VMStatus> {
         // In case storage fails to fetch the value, return immediately.
         let maybe_value = state_view
-            .get_state_value_bytes(state_key)
+            .get_state_value_u128(state_key)
             .map_err(|e| VMStatus::error(StatusCode::STORAGE_ERROR, Some(e.to_string())))?;
 
         // Otherwise we have to apply delta to the storage value.
         match maybe_value {
-            Some(bytes) => {
-                let base = deserialize(&bytes);
+            Some(base) => {
                 self.apply_to(base)
                     .map_err(|partial_error| {
                         // If delta application fails, transform partial VM

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -15,7 +15,7 @@ use crate::{
     txn_last_input_output::TxnLastInputOutput,
     view::{LatestView, MVHashMapView},
 };
-use aptos_aggregator::delta_change_set::{deserialize, serialize};
+use aptos_aggregator::delta_change_set::serialize;
 use aptos_logger::{debug, info};
 use aptos_mvhashmap::{
     types::{MVDataError, MVDataOutput, TxnIndex, Version},
@@ -365,10 +365,9 @@ where
                 .materialize_delta(&k, txn_idx)
                 .unwrap_or_else(|op| {
                     let storage_value = base_view
-                        .get_state_value_bytes(&k)
-                        .expect("No base value for committed delta in storage")
-                        .map(|bytes| deserialize(&bytes))
-                        .expect("Cannot deserialize base value for committed delta");
+                        .get_state_value_u128(&k)
+                        .expect("Error reading the base value for committed delta in storage")
+                        .expect("No base value for committed delta in storage");
 
                     versioned_cache.set_aggregator_base_value(&k, storage_value);
                     op.apply_to(storage_value)

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -8,7 +8,7 @@ use crate::{
     txn_last_input_output::ReadDescriptor,
 };
 use anyhow::Result;
-use aptos_aggregator::delta_change_set::{deserialize, serialize};
+use aptos_aggregator::delta_change_set::serialize;
 use aptos_logger::error;
 use aptos_mvhashmap::{
     types::{MVDataError, MVDataOutput, MVModulesError, MVModulesOutput, TxnIndex},
@@ -249,11 +249,10 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TStateView
                     let mut mv_value = map.fetch_data(state_key, self.txn_idx);
 
                     if matches!(mv_value, ReadResult::Unresolved) {
-                        let from_storage =
-                            self.base_view.get_state_value_bytes(state_key)?.map_or(
-                                Err(VMStatus::error(StatusCode::STORAGE_ERROR, None)),
-                                |bytes| Ok(deserialize(&bytes)),
-                            )?;
+                        let from_storage = self
+                            .base_view
+                            .get_state_value_u128(state_key)?
+                            .ok_or(VMStatus::error(StatusCode::STORAGE_ERROR, None))?;
 
                         // Store base value in the versioned data-structure directly, so subsequent
                         // reads can be resolved to U128 directly without storage calls.

--- a/storage/state-view/src/lib.rs
+++ b/storage/state-view/src/lib.rs
@@ -36,6 +36,14 @@ pub trait TStateView {
         StateViewId::Miscellaneous
     }
 
+    /// Tries to interpret the state value as u128.
+    fn get_state_value_u128(&self, state_key: &Self::Key) -> Result<Option<u128>> {
+        match self.get_state_value_bytes(state_key)? {
+            Some(bytes) => Ok(Some(bcs::from_bytes(&bytes)?)),
+            None => Ok(None),
+        }
+    }
+
     /// Gets the state value bytes for a given state key.
     fn get_state_value_bytes(&self, state_key: &Self::Key) -> Result<Option<Vec<u8>>> {
         let val_opt = self.get_state_value(state_key)?;


### PR DESCRIPTION
Adds `get_state_value_u128` to `TStateView`.
It helps to clean up the code a bit when working with accumulators.
More importantly, it helps to avoid unnecessary serialization and deserialization in some cases, when one `TStateView` wraps around another as the base `TStateView` may already internally store the value as an integer.
I am using such wrappers extensively in the upcoming fast path executor.
