### PR TITLE
[Storage Service] Add subscription stream support.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -154,10 +154,14 @@ pub struct StorageServiceConfig {
     pub max_network_channel_size: u64,
     /// Maximum number of bytes to send per network message
     pub max_network_chunk_bytes: u64,
+    /// Maximum number of active subscriptions (per peer)
+    pub max_num_active_subscriptions: u64,
     /// Maximum period (ms) of pending optimistic fetch requests
     pub max_optimistic_fetch_period_ms: u64,
     /// Maximum number of state keys and values per chunk
     pub max_state_chunk_size: u64,
+    /// Maximum period (ms) of pending subscription requests
+    pub max_subscription_period_ms: u64,
     /// Maximum number of transactions per chunk
     pub max_transaction_chunk_size: u64,
     /// Maximum number of transaction outputs per chunk
@@ -179,8 +183,10 @@ impl Default for StorageServiceConfig {
             max_lru_cache_size: 500, // At ~0.6MiB per chunk, this should take no more than 0.5GiB
             max_network_channel_size: 4000,
             max_network_chunk_bytes: MAX_MESSAGE_SIZE as u64,
+            max_num_active_subscriptions: 30,
             max_optimistic_fetch_period_ms: 5000, // 5 seconds
             max_state_chunk_size: MAX_STATE_CHUNK_SIZE,
+            max_subscription_period_ms: 30_000, // 30 seconds
             max_transaction_chunk_size: MAX_TRANSACTION_CHUNK_SIZE,
             max_transaction_output_chunk_size: MAX_TRANSACTION_OUTPUT_CHUNK_SIZE,
             min_time_to_ignore_peers_secs: 300, // 5 minutes

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -252,6 +252,8 @@ pub struct AptosDataClientConfig {
     pub max_response_timeout_ms: u64,
     /// Maximum number of state keys and values per chunk
     pub max_state_chunk_size: u64,
+    /// Maximum version lag we'll tolerate when sending subscription requests
+    pub max_subscription_version_lag: u64,
     /// Maximum number of transactions per chunk
     pub max_transaction_chunk_size: u64,
     /// Maximum number of transaction outputs per chunk
@@ -277,6 +279,7 @@ impl Default for AptosDataClientConfig {
             max_optimistic_fetch_version_lag: 50_000, // Assumes 5K TPS for 10 seconds, which should be plenty
             max_response_timeout_ms: 60_000,          // 60 seconds
             max_state_chunk_size: MAX_STATE_CHUNK_SIZE,
+            max_subscription_version_lag: 100_000, // Assumes 5K TPS for 20 seconds, which should be plenty
             max_transaction_chunk_size: MAX_TRANSACTION_CHUNK_SIZE,
             max_transaction_output_chunk_size: MAX_TRANSACTION_OUTPUT_CHUNK_SIZE,
             optimistic_fetch_timeout_ms: 5000, // 5 seconds

--- a/state-sync/storage-service/server/src/handler.rs
+++ b/state-sync/storage-service/server/src/handler.rs
@@ -7,13 +7,15 @@ use crate::{
     metrics,
     metrics::{
         increment_counter, start_timer, LRU_CACHE_HIT, LRU_CACHE_PROBE, OPTIMISTIC_FETCH_ADD,
+        SUBSCRIPTION_ADD, SUBSCRIPTION_FAILURE,
     },
     moderator::RequestModerator,
     network::ResponseSender,
     optimistic_fetch::OptimisticFetchRequest,
     storage::StorageReaderInterface,
+    subscription::{SubscriptionRequest, SubscriptionStreamRequests},
 };
-use aptos_config::network_id::PeerNetworkId;
+use aptos_config::{config::StorageServiceConfig, network_id::PeerNetworkId};
 use aptos_infallible::Mutex;
 use aptos_logger::{debug, error, sample, sample::SampleRate, trace, warn};
 use aptos_storage_service_types::{
@@ -32,7 +34,7 @@ use aptos_types::transaction::Version;
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use lru::LruCache;
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 /// Storage server constants
 const INVALID_REQUEST_LOG_FREQUENCY_SECS: u64 = 5; // The frequency to log invalid requests (secs)
@@ -49,6 +51,7 @@ pub struct Handler<T> {
     lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
     request_moderator: Arc<RequestModerator>,
     storage: T,
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
     time_service: TimeService,
 }
 
@@ -59,14 +62,16 @@ impl<T: StorageReaderInterface> Handler<T> {
         lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
         request_moderator: Arc<RequestModerator>,
         storage: T,
+        subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
         time_service: TimeService,
     ) -> Self {
         Self {
-            storage,
             cached_storage_server_summary,
             optimistic_fetches,
             lru_response_cache,
             request_moderator,
+            storage,
+            subscriptions,
             time_service,
         }
     }
@@ -75,6 +80,7 @@ impl<T: StorageReaderInterface> Handler<T> {
     /// request directly.
     pub fn process_request_and_respond(
         &self,
+        storage_service_config: StorageServiceConfig,
         peer_network_id: PeerNetworkId,
         request: StorageServiceRequest,
         response_sender: ResponseSender,
@@ -89,6 +95,17 @@ impl<T: StorageReaderInterface> Handler<T> {
         // Handle any optimistic fetch requests
         if request.data_request.is_optimistic_fetch() {
             self.handle_optimistic_fetch_request(peer_network_id, request, response_sender);
+            return;
+        }
+
+        // Handle any subscription requests
+        if request.data_request.is_subscription_request() {
+            self.handle_subscription_request(
+                storage_service_config,
+                peer_network_id,
+                request,
+                response_sender,
+            );
             return;
         }
 
@@ -229,6 +246,79 @@ impl<T: StorageReaderInterface> Handler<T> {
             &metrics::OPTIMISTIC_FETCH_EVENTS,
             peer_network_id.network_id(),
             OPTIMISTIC_FETCH_ADD.into(),
+        );
+    }
+
+    /// Handles the given subscription request. If a failure
+    /// occurs during handling, the client is notified.
+    pub fn handle_subscription_request(
+        &self,
+        storage_service_config: StorageServiceConfig,
+        peer_network_id: PeerNetworkId,
+        request: StorageServiceRequest,
+        response_sender: ResponseSender,
+    ) {
+        // Create a new subscription request
+        let subscription_request =
+            SubscriptionRequest::new(request.clone(), response_sender, self.time_service.clone());
+
+        // Grab the lock on the active subscriptions map
+        let mut subscriptions = self.subscriptions.lock();
+
+        // Get the existing stream ID and the request stream ID
+        let existing_stream_id =
+            subscriptions
+                .get_mut(&peer_network_id)
+                .map(|subscription_stream_requests| {
+                    subscription_stream_requests.subscription_stream_id()
+                });
+        let request_stream_id = subscription_request.subscription_stream_id();
+
+        // If the stream already exists, add the request to the stream. Otherwise, create a new one.
+        if existing_stream_id == Some(request_stream_id) {
+            // Add the request to the existing stream (the stream IDs match)
+            if let Some(existing_stream) = subscriptions.get_mut(&peer_network_id) {
+                if let Err((error, subscription_request)) = existing_stream
+                    .add_subscription_request(storage_service_config, subscription_request)
+                {
+                    // Something went wrong when adding the request to the stream
+                    sample!(
+                        SampleRate::Duration(Duration::from_secs(INVALID_REQUEST_LOG_FREQUENCY_SECS)),
+                        warn!(LogSchema::new(LogEntry::SubscriptionRequest)
+                            .error(&error)
+                            .peer_network_id(&peer_network_id)
+                            .request(&request)
+                        );
+                    );
+
+                    // Update the subscription metrics
+                    increment_counter(
+                        &metrics::SUBSCRIPTION_EVENTS,
+                        peer_network_id.network_id(),
+                        SUBSCRIPTION_FAILURE.into(),
+                    );
+
+                    // Notify the client of the failure
+                    self.send_response(
+                        request,
+                        Err(StorageServiceError::InvalidRequest(error.to_string())),
+                        subscription_request.take_response_sender(),
+                    );
+                    return;
+                }
+            }
+        } else {
+            // Create a new stream (either no stream exists, or we have a new stream ID)
+            let subscription_stream_requests =
+                SubscriptionStreamRequests::new(subscription_request, self.time_service.clone());
+            subscriptions.insert(peer_network_id, subscription_stream_requests);
+        }
+
+        // Update the subscription metrics
+        increment_counter(
+            &metrics::SUBSCRIPTION_EVENTS,
+            peer_network_id.network_id(),
+            SUBSCRIPTION_ADD.into(),
         );
     }
 

--- a/state-sync/storage-service/server/src/lib.rs
+++ b/state-sync/storage-service/server/src/lib.rs
@@ -7,6 +7,7 @@
 use crate::{
     logging::{LogEntry, LogSchema},
     network::StorageServiceNetworkEvents,
+    subscription::SubscriptionStreamRequests,
 };
 use aptos_bounded_executor::BoundedExecutor;
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
@@ -31,7 +32,7 @@ use handler::Handler;
 use lru::LruCache;
 use moderator::RequestModerator;
 use optimistic_fetch::OptimisticFetchRequest;
-use std::{ops::Deref, sync::Arc, time::Duration};
+use std::{collections::HashMap, ops::Deref, sync::Arc, time::Duration};
 use storage::StorageReaderInterface;
 use thiserror::Error;
 use tokio::runtime::Handle;
@@ -44,6 +45,7 @@ mod moderator;
 pub mod network;
 mod optimistic_fetch;
 pub mod storage;
+mod subscription;
 mod utils;
 
 #[cfg(test)]
@@ -75,6 +77,10 @@ pub struct StorageServiceServer<T> {
 
     // A set of active optimistic fetches for peers waiting for new data
     optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
+
+    // TODO: Reduce lock contention on the mutex.
+    // A set of active subscriptions for peers waiting for new data
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
 
     // A moderator for incoming peer requests
     request_moderator: Arc<RequestModerator>,
@@ -108,6 +114,7 @@ impl<T: StorageReaderInterface + Send + Sync> StorageServiceServer<T> {
         let lru_response_cache = Arc::new(Mutex::new(LruCache::new(
             storage_service_config.max_lru_cache_size as usize,
         )));
+        let subscriptions = Arc::new(Mutex::new(HashMap::new()));
         let request_moderator = Arc::new(RequestModerator::new(
             aptos_data_client_config,
             cached_storage_server_summary.clone(),
@@ -126,6 +133,7 @@ impl<T: StorageReaderInterface + Send + Sync> StorageServiceServer<T> {
             cached_storage_server_summary,
             lru_response_cache,
             optimistic_fetches,
+            subscriptions,
             request_moderator,
             storage_service_listener,
         }
@@ -133,17 +141,27 @@ impl<T: StorageReaderInterface + Send + Sync> StorageServiceServer<T> {
 
     /// Spawns all continuously running utility tasks
     async fn spawn_continuous_storage_summary_tasks(&mut self) {
-        // Create a channel to notify the optimistic fetch
-        // handler about updates to the cached storage summary.
-        let (cached_summary_update_notifier, cached_summary_update_listener) =
+        // Create channels to notify the optimistic fetch and subscription
+        // handlers about updates to the cached storage summary.
+        let (cache_update_notifier_optimistic_fetch, cache_update_listener_optimistic_fetch) =
+            aptos_channel::new(QueueStyle::LIFO, CACHED_SUMMARY_UPDATE_CHANNEL_SIZE, None);
+        let (cache_update_notifier_subscription, cache_update_listener_subscription) =
             aptos_channel::new(QueueStyle::LIFO, CACHED_SUMMARY_UPDATE_CHANNEL_SIZE, None);
 
         // Spawn the refresher for the storage summary cache
-        self.spawn_storage_summary_refresher(cached_summary_update_notifier)
+        let cache_update_notifiers = vec![
+            cache_update_notifier_optimistic_fetch.clone(),
+            cache_update_notifier_subscription.clone(),
+        ];
+        self.spawn_storage_summary_refresher(cache_update_notifiers)
             .await;
 
         // Spawn the optimistic fetch handler
-        self.spawn_optimistic_fetch_handler(cached_summary_update_listener)
+        self.spawn_optimistic_fetch_handler(cache_update_listener_optimistic_fetch)
+            .await;
+
+        // Spawn the subscription handler
+        self.spawn_subscription_handler(cache_update_listener_subscription)
             .await;
 
         // Spawn the refresher for the request moderator
@@ -153,7 +171,7 @@ impl<T: StorageReaderInterface + Send + Sync> StorageServiceServer<T> {
     /// Spawns a non-terminating task that refreshes the cached storage server summary
     async fn spawn_storage_summary_refresher(
         &mut self,
-        cached_summary_update_notifier: aptos_channel::Sender<(), CachedSummaryUpdateNotification>,
+        cache_update_notifiers: Vec<aptos_channel::Sender<(), CachedSummaryUpdateNotification>>,
     ) {
         // Clone all required components for the task
         let cached_storage_server_summary = self.cached_storage_server_summary.clone();
@@ -170,8 +188,6 @@ impl<T: StorageReaderInterface + Send + Sync> StorageServiceServer<T> {
         // Spawn the task
         self.bounded_executor
             .spawn(async move {
-                // TODO: consider removing the interval once we've tested the notifications
-
                 // Create a ticker for the refresh interval
                 let duration = Duration::from_millis(config.storage_summary_refresh_interval_ms);
                 let ticker = time_service.interval(duration);
@@ -186,7 +202,7 @@ impl<T: StorageReaderInterface + Send + Sync> StorageServiceServer<T> {
                                 cached_storage_server_summary.clone(),
                                 storage.clone(),
                                 config,
-                                cached_summary_update_notifier.clone(),
+                                cache_update_notifiers.clone(),
                             )
                         },
                         notification = storage_service_listener.select_next_some() => {
@@ -202,7 +218,7 @@ impl<T: StorageReaderInterface + Send + Sync> StorageServiceServer<T> {
                                 cached_storage_server_summary.clone(),
                                 storage.clone(),
                                 config,
-                                cached_summary_update_notifier.clone(),
+                                cache_update_notifiers.clone(),
                             )
                         },
                     }
@@ -227,13 +243,12 @@ impl<T: StorageReaderInterface + Send + Sync> StorageServiceServer<T> {
         let lru_response_cache = self.lru_response_cache.clone();
         let request_moderator = self.request_moderator.clone();
         let storage = self.storage.clone();
+        let subscriptions = self.subscriptions.clone();
         let time_service = self.time_service.clone();
 
         // Spawn the task
         self.bounded_executor
             .spawn(async move {
-                // TODO: consider removing the interval once we've tested the notifications
-
                 // Create a ticker for the refresh interval
                 let duration = Duration::from_millis(config.storage_summary_refresh_interval_ms);
                 let ticker = time_service.interval(duration);
@@ -252,12 +267,13 @@ impl<T: StorageReaderInterface + Send + Sync> StorageServiceServer<T> {
                                 lru_response_cache.clone(),
                                 request_moderator.clone(),
                                 storage.clone(),
+                                subscriptions.clone(),
                                 time_service.clone(),
                             ).await;
                         },
                         notification = cached_summary_update_listener.select_next_some() => {
                             trace!(LogSchema::new(LogEntry::ReceivedCacheUpdateNotification)
-                                .message(&format!("Received cache update notification! Highest synced version: {:?}", notification.highest_synced_version))
+                                .message(&format!("Received cache update notification for optimistic fetch handler! Highest synced version: {:?}", notification.highest_synced_version))
                             );
 
                             // Handle the optimistic fetches because of a cache update
@@ -269,6 +285,75 @@ impl<T: StorageReaderInterface + Send + Sync> StorageServiceServer<T> {
                                 lru_response_cache.clone(),
                                 request_moderator.clone(),
                                 storage.clone(),
+                                subscriptions.clone(),
+                                time_service.clone(),
+                            ).await;
+                        },
+                    }
+                }
+            })
+            .await;
+    }
+
+    /// Spawns a non-terminating task that handles subscriptions
+    async fn spawn_subscription_handler(
+        &mut self,
+        mut cached_summary_update_listener: aptos_channel::Receiver<
+            (),
+            CachedSummaryUpdateNotification,
+        >,
+    ) {
+        // Clone all required components for the task
+        let bounded_executor = self.bounded_executor.clone();
+        let cached_storage_server_summary = self.cached_storage_server_summary.clone();
+        let config = self.storage_service_config;
+        let optimistic_fetches = self.optimistic_fetches.clone();
+        let lru_response_cache = self.lru_response_cache.clone();
+        let request_moderator = self.request_moderator.clone();
+        let storage = self.storage.clone();
+        let subscriptions = self.subscriptions.clone();
+        let time_service = self.time_service.clone();
+
+        // Spawn the task
+        self.bounded_executor
+            .spawn(async move {
+                // Create a ticker for the refresh interval
+                let duration = Duration::from_millis(config.storage_summary_refresh_interval_ms);
+                let ticker = time_service.interval(duration);
+                futures::pin_mut!(ticker);
+
+                // Continuously handle the subscriptions
+                loop {
+                    futures::select! {
+                        _ = ticker.select_next_some() => {
+                            // Handle the subscriptions periodically
+                            handle_active_subscriptions(
+                                bounded_executor.clone(),
+                                cached_storage_server_summary.clone(),
+                                config,
+                                optimistic_fetches.clone(),
+                                lru_response_cache.clone(),
+                                request_moderator.clone(),
+                                storage.clone(),
+                                subscriptions.clone(),
+                                time_service.clone(),
+                            ).await;
+                        },
+                        notification = cached_summary_update_listener.select_next_some() => {
+                            trace!(LogSchema::new(LogEntry::ReceivedCacheUpdateNotification)
+                                .message(&format!("Received cache update notification for subscription handler! Highest synced version: {:?}", notification.highest_synced_version))
+                            );
+
+                            // Handle the subscriptions because of a cache update
+                            handle_active_subscriptions(
+                                bounded_executor.clone(),
+                                cached_storage_server_summary.clone(),
+                                config,
+                                optimistic_fetches.clone(),
+                                lru_response_cache.clone(),
+                                request_moderator.clone(),
+                                storage.clone(),
+                                subscriptions.clone(),
                                 time_service.clone(),
                             ).await;
                         },
@@ -331,8 +416,10 @@ impl<T: StorageReaderInterface + Send + Sync> StorageServiceServer<T> {
             // I/O-bound, so we want to spawn on the blocking thread pool to
             // avoid starving other async tasks on the same runtime.
             let storage = self.storage.clone();
+            let config = self.storage_service_config;
             let cached_storage_server_summary = self.cached_storage_server_summary.clone();
             let optimistic_fetches = self.optimistic_fetches.clone();
+            let subscriptions = self.subscriptions.clone();
             let lru_response_cache = self.lru_response_cache.clone();
             let request_moderator = self.request_moderator.clone();
             let time_service = self.time_service.clone();
@@ -344,9 +431,11 @@ impl<T: StorageReaderInterface + Send + Sync> StorageServiceServer<T> {
                         lru_response_cache,
                         request_moderator,
                         storage,
+                        subscriptions,
                         time_service,
                     )
                     .process_request_and_respond(
+                        config,
                         peer_network_id,
                         storage_service_request,
                         network_request.response_sender,
@@ -381,6 +470,7 @@ async fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
     lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
     request_moderator: Arc<RequestModerator>,
     storage: T,
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
     time_service: TimeService,
 ) {
     if let Err(error) = optimistic_fetch::handle_active_optimistic_fetches(
@@ -391,6 +481,7 @@ async fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
         lru_response_cache,
         request_moderator,
         storage,
+        subscriptions,
         time_service,
     )
     .await
@@ -401,14 +492,46 @@ async fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
     }
 }
 
+/// Handles the active subscriptions and logs any
+/// errors that were encountered.
+async fn handle_active_subscriptions<T: StorageReaderInterface>(
+    bounded_exector: BoundedExecutor,
+    cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
+    config: StorageServiceConfig,
+    optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
+    lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
+    request_moderator: Arc<RequestModerator>,
+    storage: T,
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
+    time_service: TimeService,
+) {
+    if let Err(error) = subscription::handle_active_subscriptions(
+        bounded_exector,
+        cached_storage_server_summary,
+        config,
+        optimistic_fetches,
+        lru_response_cache,
+        request_moderator,
+        storage,
+        subscriptions,
+        time_service,
+    )
+    .await
+    {
+        error!(LogSchema::new(LogEntry::SubscriptionRequest)
+            .error(&error)
+            .message("Failed to handle active subscriptions!"));
+    }
+}
+
 /// Refreshes the cached storage server summary and sends
-/// a notification via the given channel. If an error
+/// a notification via the given channels. If an error
 /// occurs, it is logged.
 pub(crate) fn refresh_cached_storage_summary<T: StorageReaderInterface>(
     cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     storage: T,
     storage_config: StorageServiceConfig,
-    cached_summary_update_notifier: aptos_channel::Sender<(), CachedSummaryUpdateNotification>,
+    cache_update_notifiers: Vec<aptos_channel::Sender<(), CachedSummaryUpdateNotification>>,
 ) {
     // Fetch the new data summary from storage
     let new_data_summary = match storage.get_data_summary() {
@@ -448,17 +571,20 @@ pub(crate) fn refresh_cached_storage_summary<T: StorageReaderInterface>(
             .get_synced_ledger_info_version();
         let update_notification = CachedSummaryUpdateNotification::new(highest_synced_version);
 
-        // Send the notification via the notifier
-        if let Err(error) = cached_summary_update_notifier.push((), update_notification) {
-            error!(LogSchema::new(LogEntry::StorageSummaryRefresh)
-                .error(&Error::StorageErrorEncountered(error.to_string()))
-                .message("Failed to send an update notification for the new cached summary!"));
+        // Send a notification via each notifier channel
+        for cached_summary_update_notifier in cache_update_notifiers {
+            if let Err(error) = cached_summary_update_notifier.push((), update_notification) {
+                error!(LogSchema::new(LogEntry::StorageSummaryRefresh)
+                    .error(&Error::StorageErrorEncountered(error.to_string()))
+                    .message("Failed to send an update notification for the new cached summary!"));
+            }
         }
     }
 }
 
 /// A simple notification sent to the optimistic fetch handler that the
 /// cached storage summary has been updated with the specified version.
+#[derive(Clone, Copy)]
 pub struct CachedSummaryUpdateNotification {
     highest_synced_version: Option<u64>,
 }

--- a/state-sync/storage-service/server/src/logging.rs
+++ b/state-sync/storage-service/server/src/logging.rs
@@ -47,4 +47,7 @@ pub enum LogEntry {
     SentStorageResponse,
     StorageServiceError,
     StorageSummaryRefresh,
+    SubscriptionRefresh,
+    SubscriptionRequest,
+    SubscriptionResponse,
 }

--- a/state-sync/storage-service/server/src/metrics.rs
+++ b/state-sync/storage-service/server/src/metrics.rs
@@ -14,6 +14,9 @@ pub const LRU_CACHE_HIT: &str = "lru_cache_hit";
 pub const LRU_CACHE_PROBE: &str = "lru_cache_probe";
 pub const OPTIMISTIC_FETCH_ADD: &str = "optimistic_fetch_add";
 pub const OPTIMISTIC_FETCH_EXPIRE: &str = "optimistic_fetch_expire";
+pub const SUBSCRIPTION_ADD: &str = "subscription_add";
+pub const SUBSCRIPTION_EXPIRE: &str = "subscription_expire";
+pub const SUBSCRIPTION_FAILURE: &str = "subscription_failure";
 
 /// Gauge for tracking the number of actively ignored peers
 pub static IGNORED_PEER_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
@@ -121,6 +124,36 @@ pub static STORAGE_REQUEST_PROCESSING_LATENCY: Lazy<HistogramVec> = Lazy::new(||
     register_histogram_vec!(
         "aptos_storage_service_server_request_latency",
         "Time it takes to process a storage service request",
+        &["network_id", "request_type"]
+    )
+    .unwrap()
+});
+
+/// Gauge for tracking the number of active subscriptions
+pub static SUBSCRIPTION_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_storage_service_server_subscription_count",
+        "Gauge for tracking the number of active subscriptions",
+        &["network_id"]
+    )
+    .unwrap()
+});
+
+/// Counter for subscription events
+pub static SUBSCRIPTION_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_storage_service_server_subscription_event",
+        "Counters related to subscription events",
+        &["network_id", "event"]
+    )
+    .unwrap()
+});
+
+/// Time it takes to process a subscription request
+pub static SUBSCRIPTION_LATENCIES: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "aptos_storage_service_server_subscription_latency",
+        "Time it takes to process a subscription request",
         &["network_id", "request_type"]
     )
     .unwrap()

--- a/state-sync/storage-service/server/src/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/optimistic_fetch.rs
@@ -524,6 +524,8 @@ async fn identify_ready_and_invalid_optimistic_fetches<T: StorageReaderInterface
                 }
             })
             .await;
+
+        // Add the task to the list of active tasks
         active_tasks.push(active_task);
     }
 

--- a/state-sync/storage-service/server/src/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/optimistic_fetch.rs
@@ -8,6 +8,7 @@ use crate::{
     moderator::RequestModerator,
     network::ResponseSender,
     storage::StorageReaderInterface,
+    subscription::SubscriptionStreamRequests,
     utils, LogEntry, LogSchema,
 };
 use aptos_bounded_executor::BoundedExecutor;
@@ -52,11 +53,6 @@ impl OptimisticFetchRequest {
             fetch_start_time: time_service.now(),
             time_service,
         }
-    }
-
-    /// Returns the response sender and consumes the request
-    pub fn get_response_sender(self) -> ResponseSender {
-        self.response_sender
     }
 
     /// Creates a new storage service request to satisfy the optimistic fetch
@@ -170,9 +166,14 @@ impl OptimisticFetchRequest {
             .as_millis();
         elapsed_time > timeout_ms as u128
     }
+
+    /// Returns the response sender and consumes the request
+    pub fn take_response_sender(self) -> ResponseSender {
+        self.response_sender
+    }
 }
 
-/// Handles ready optimistic fetches
+/// Handles active and ready optimistic fetches
 pub(crate) async fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
     bounded_executor: BoundedExecutor,
     cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
@@ -181,6 +182,7 @@ pub(crate) async fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
     lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
     request_moderator: Arc<RequestModerator>,
     storage: T,
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
     time_service: TimeService,
 ) -> Result<(), Error> {
     // Update the number of active optimistic fetches
@@ -195,6 +197,7 @@ pub(crate) async fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
         lru_response_cache.clone(),
         request_moderator.clone(),
         storage.clone(),
+        subscriptions.clone(),
         time_service.clone(),
     )
     .await?;
@@ -208,6 +211,7 @@ pub(crate) async fn handle_active_optimistic_fetches<T: StorageReaderInterface>(
         lru_response_cache,
         request_moderator,
         storage,
+        subscriptions,
         time_service,
         peers_with_ready_optimistic_fetches,
     )
@@ -226,6 +230,7 @@ async fn handle_ready_optimistic_fetches<T: StorageReaderInterface>(
     lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
     request_moderator: Arc<RequestModerator>,
     storage: T,
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
     time_service: TimeService,
     peers_with_ready_optimistic_fetches: Vec<(PeerNetworkId, LedgerInfoWithSignatures)>,
 ) {
@@ -241,6 +246,7 @@ async fn handle_ready_optimistic_fetches<T: StorageReaderInterface>(
             let lru_response_cache = lru_response_cache.clone();
             let request_moderator = request_moderator.clone();
             let storage = storage.clone();
+            let subscriptions = subscriptions.clone();
             let time_service = time_service.clone();
 
             // Spawn a blocking task to handle the optimistic fetch
@@ -250,18 +256,32 @@ async fn handle_ready_optimistic_fetches<T: StorageReaderInterface>(
                     let optimistic_fetch_start_time = optimistic_fetch.fetch_start_time;
                     let optimistic_fetch_request = optimistic_fetch.request.clone();
 
+                    // Get the storage service request for the missing data
+                    let missing_data_request = match optimistic_fetch
+                        .get_storage_request_for_missing_data(config, &target_ledger_info)
+                    {
+                        Ok(storage_service_request) => storage_service_request,
+                        Err(error) => {
+                            // Failed to get the storage service request
+                            warn!(LogSchema::new(LogEntry::OptimisticFetchResponse)
+                                .error(&Error::UnexpectedErrorEncountered(error.to_string())));
+                            return;
+                        },
+                    };
+
                     // Notify the peer of the new data
                     if let Err(error) = utils::notify_peer_of_new_data(
                         cached_storage_server_summary.clone(),
-                        config,
                         optimistic_fetches.clone(),
+                        subscriptions.clone(),
                         lru_response_cache.clone(),
                         request_moderator.clone(),
                         storage.clone(),
                         time_service.clone(),
                         &peer_network_id,
-                        optimistic_fetch,
+                        missing_data_request,
                         target_ledger_info,
+                        optimistic_fetch.take_response_sender(),
                     ) {
                         warn!(LogSchema::new(LogEntry::OptimisticFetchResponse)
                             .error(&Error::UnexpectedErrorEncountered(error.to_string())));
@@ -294,6 +314,7 @@ pub(crate) async fn get_peers_with_ready_optimistic_fetches<T: StorageReaderInte
     lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
     request_moderator: Arc<RequestModerator>,
     storage: T,
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
     time_service: TimeService,
 ) -> aptos_storage_service_types::Result<Vec<(PeerNetworkId, LedgerInfoWithSignatures)>, Error> {
     // Fetch the latest storage summary and highest synced version
@@ -315,6 +336,7 @@ pub(crate) async fn get_peers_with_ready_optimistic_fetches<T: StorageReaderInte
         config,
         cached_storage_server_summary,
         optimistic_fetches.clone(),
+        subscriptions,
         lru_response_cache,
         request_moderator,
         storage,
@@ -345,6 +367,7 @@ async fn identify_expired_invalid_and_ready_fetches<T: StorageReaderInterface>(
     config: StorageServiceConfig,
     cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
     lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
     request_moderator: Arc<RequestModerator>,
     storage: T,
@@ -387,6 +410,7 @@ async fn identify_expired_invalid_and_ready_fetches<T: StorageReaderInterface>(
             bounded_executor,
             cached_storage_server_summary,
             optimistic_fetches,
+            subscriptions,
             lru_response_cache,
             request_moderator,
             storage,
@@ -412,6 +436,7 @@ async fn identify_ready_and_invalid_optimistic_fetches<T: StorageReaderInterface
     bounded_executor: BoundedExecutor,
     cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
     lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
     request_moderator: Arc<RequestModerator>,
     storage: T,
@@ -437,6 +462,7 @@ async fn identify_ready_and_invalid_optimistic_fetches<T: StorageReaderInterface
         let cached_storage_server_summary = cached_storage_server_summary.clone();
         let highest_synced_ledger_info = highest_synced_ledger_info.clone();
         let optimistic_fetches = optimistic_fetches.clone();
+        let subscriptions = subscriptions.clone();
         let lru_response_cache = lru_response_cache.clone();
         let request_moderator = request_moderator.clone();
         let storage = storage.clone();
@@ -445,7 +471,7 @@ async fn identify_ready_and_invalid_optimistic_fetches<T: StorageReaderInterface
         let peers_with_ready_optimistic_fetches = peers_with_ready_optimistic_fetches.clone();
 
         // Spawn a blocking task to determine if the optimistic fetch is ready or
-        // invalid. We do this because each entry requires reading from storage.
+        // invalid. We do this because each entry may require reading from storage.
         let active_task = bounded_executor
             .spawn_blocking(move || {
                 // Check if we have synced beyond the highest known version
@@ -456,6 +482,7 @@ async fn identify_ready_and_invalid_optimistic_fetches<T: StorageReaderInterface
                         let epoch_ending_ledger_info = match utils::get_epoch_ending_ledger_info(
                             cached_storage_server_summary.clone(),
                             optimistic_fetches.clone(),
+                            subscriptions.clone(),
                             highest_known_epoch,
                             lru_response_cache.clone(),
                             request_moderator.clone(),

--- a/state-sync/storage-service/server/src/subscription.rs
+++ b/state-sync/storage-service/server/src/subscription.rs
@@ -1,0 +1,926 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    error::Error,
+    metrics,
+    metrics::{increment_counter, SUBSCRIPTION_EXPIRE},
+    moderator::RequestModerator,
+    network::ResponseSender,
+    optimistic_fetch::OptimisticFetchRequest,
+    storage::StorageReaderInterface,
+    utils, LogEntry, LogSchema,
+};
+use aptos_bounded_executor::BoundedExecutor;
+use aptos_config::{
+    config::StorageServiceConfig,
+    network_id::{NetworkId, PeerNetworkId},
+};
+use aptos_infallible::Mutex;
+use aptos_logger::{error, warn};
+use aptos_storage_service_types::{
+    requests::{
+        DataRequest, StorageServiceRequest, TransactionOutputsWithProofRequest,
+        TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
+    },
+    responses::{DataResponse, StorageServerSummary, StorageServiceResponse},
+};
+use aptos_time_service::{TimeService, TimeServiceTrait};
+use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
+use arc_swap::ArcSwap;
+use dashmap::DashMap;
+use futures::future::join_all;
+use lru::LruCache;
+use std::{
+    cmp::min,
+    collections::{BTreeMap, HashMap},
+    fmt::Debug,
+    ops::Deref,
+    sync::Arc,
+    time::Instant,
+};
+
+/// A single subscription request that is part of a stream
+pub struct SubscriptionRequest {
+    request: StorageServiceRequest,  // The original request
+    response_sender: ResponseSender, // The sender along which to send the response
+    request_start_time: Instant,     // The time the request started (i.e., when it was received)
+}
+
+impl SubscriptionRequest {
+    pub fn new(
+        request: StorageServiceRequest,
+        response_sender: ResponseSender,
+        time_service: TimeService,
+    ) -> Self {
+        Self {
+            request,
+            response_sender,
+            request_start_time: time_service.now(),
+        }
+    }
+
+    /// Creates a new storage service request to satisfy the request
+    /// using the new data at the specified `target_ledger_info`.
+    fn get_storage_request_for_missing_data(
+        &self,
+        config: StorageServiceConfig,
+        known_version: u64,
+        target_ledger_info: &LedgerInfoWithSignatures,
+    ) -> aptos_storage_service_types::Result<StorageServiceRequest, Error> {
+        // Calculate the number of versions to fetch
+        let target_version = target_ledger_info.ledger_info().version();
+        let mut num_versions_to_fetch =
+            target_version.checked_sub(known_version).ok_or_else(|| {
+                Error::UnexpectedErrorEncountered(
+                    "Number of versions to fetch has overflown!".into(),
+                )
+            })?;
+
+        // Bound the number of versions to fetch by the maximum chunk size
+        num_versions_to_fetch = min(
+            num_versions_to_fetch,
+            self.max_chunk_size_for_request(config),
+        );
+
+        // Calculate the start and end versions
+        let start_version = known_version.checked_add(1).ok_or_else(|| {
+            Error::UnexpectedErrorEncountered("Start version has overflown!".into())
+        })?;
+        let end_version = known_version
+            .checked_add(num_versions_to_fetch)
+            .ok_or_else(|| {
+                Error::UnexpectedErrorEncountered("End version has overflown!".into())
+            })?;
+
+        // Create the storage request
+        let data_request = match &self.request.data_request {
+            DataRequest::SubscribeTransactionOutputsWithProof(_) => {
+                DataRequest::GetTransactionOutputsWithProof(TransactionOutputsWithProofRequest {
+                    proof_version: target_version,
+                    start_version,
+                    end_version,
+                })
+            },
+            DataRequest::SubscribeTransactionsWithProof(request) => {
+                DataRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
+                    proof_version: target_version,
+                    start_version,
+                    end_version,
+                    include_events: request.include_events,
+                })
+            },
+            DataRequest::SubscribeTransactionsOrOutputsWithProof(request) => {
+                DataRequest::GetTransactionsOrOutputsWithProof(
+                    TransactionsOrOutputsWithProofRequest {
+                        proof_version: target_version,
+                        start_version,
+                        end_version,
+                        include_events: request.include_events,
+                        max_num_output_reductions: request.max_num_output_reductions,
+                    },
+                )
+            },
+            request => unreachable!("Unexpected subscription request: {:?}", request),
+        };
+        let storage_request =
+            StorageServiceRequest::new(data_request, self.request.use_compression);
+        Ok(storage_request)
+    }
+
+    /// Returns the highest version known by the peer
+    fn highest_known_version(&self) -> u64 {
+        match &self.request.data_request {
+            DataRequest::SubscribeTransactionOutputsWithProof(request) => request.known_version,
+            DataRequest::SubscribeTransactionsWithProof(request) => request.known_version,
+            DataRequest::SubscribeTransactionsOrOutputsWithProof(request) => request.known_version,
+            request => unreachable!("Unexpected subscription request: {:?}", request),
+        }
+    }
+
+    /// Returns the highest epoch known by the peer
+    fn highest_known_epoch(&self) -> u64 {
+        match &self.request.data_request {
+            DataRequest::SubscribeTransactionOutputsWithProof(request) => request.known_epoch,
+            DataRequest::SubscribeTransactionsWithProof(request) => request.known_epoch,
+            DataRequest::SubscribeTransactionsOrOutputsWithProof(request) => request.known_epoch,
+            request => unreachable!("Unexpected subscription request: {:?}", request),
+        }
+    }
+
+    /// Returns the maximum chunk size for the request
+    /// depending on the request type.
+    fn max_chunk_size_for_request(&self, config: StorageServiceConfig) -> u64 {
+        match &self.request.data_request {
+            DataRequest::SubscribeTransactionOutputsWithProof(_) => {
+                config.max_transaction_output_chunk_size
+            },
+            DataRequest::SubscribeTransactionsWithProof(_) => config.max_transaction_chunk_size,
+            DataRequest::SubscribeTransactionsOrOutputsWithProof(_) => {
+                config.max_transaction_output_chunk_size
+            },
+            request => unreachable!("Unexpected subscription request: {:?}", request),
+        }
+    }
+
+    /// Returns the subscription stream id for the request
+    pub fn subscription_stream_id(&self) -> u64 {
+        match &self.request.data_request {
+            DataRequest::SubscribeTransactionOutputsWithProof(request) => {
+                request.subscription_stream_id
+            },
+            DataRequest::SubscribeTransactionsWithProof(request) => request.subscription_stream_id,
+            DataRequest::SubscribeTransactionsOrOutputsWithProof(request) => {
+                request.subscription_stream_id
+            },
+            request => unreachable!("Unexpected subscription request: {:?}", request),
+        }
+    }
+
+    /// Returns the subscription stream index for the request
+    fn subscription_stream_index(&self) -> u64 {
+        match &self.request.data_request {
+            DataRequest::SubscribeTransactionOutputsWithProof(request) => {
+                request.subscription_stream_index
+            },
+            DataRequest::SubscribeTransactionsWithProof(request) => {
+                request.subscription_stream_index
+            },
+            DataRequest::SubscribeTransactionsOrOutputsWithProof(request) => {
+                request.subscription_stream_index
+            },
+            request => unreachable!("Unexpected subscription request: {:?}", request),
+        }
+    }
+
+    /// Returns the response sender and consumes the request
+    pub fn take_response_sender(self) -> ResponseSender {
+        self.response_sender
+    }
+}
+
+impl Debug for SubscriptionRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "SubscriptionRequest: {{ request_start_time: {:?}, request: {:?} }}",
+            self.request_start_time, self.request
+        )
+    }
+}
+
+/// A set of subscription requests that together form a stream
+pub struct SubscriptionStreamRequests {
+    highest_known_version: u64, // The highest version known by the peer (at this point in the stream)
+    highest_known_epoch: u64,   // The highest epoch known by the peer (at this point in the stream)
+
+    next_index_to_serve: u64, // The next subscription stream request index to serve
+    pending_subscription_requests: BTreeMap<u64, SubscriptionRequest>, // The pending subscription requests by stream index
+    subscription_stream_id: u64, // The unique stream ID (as specified by the client)
+
+    last_stream_update_time: Instant, // The last time the stream was updated
+    time_service: TimeService,        // The time service
+}
+
+impl SubscriptionStreamRequests {
+    pub fn new(subscription_request: SubscriptionRequest, time_service: TimeService) -> Self {
+        // Extract the relevant information from the request
+        let highest_known_version = subscription_request.highest_known_version();
+        let highest_known_epoch = subscription_request.highest_known_epoch();
+        let subscription_stream_id = subscription_request.subscription_stream_id();
+
+        // Create a new set of pending subscription requests using the first request
+        let mut pending_subscription_requests = BTreeMap::new();
+        pending_subscription_requests.insert(
+            subscription_request.subscription_stream_index(),
+            subscription_request,
+        );
+
+        Self {
+            highest_known_version,
+            highest_known_epoch,
+            next_index_to_serve: 0,
+            pending_subscription_requests,
+            subscription_stream_id,
+            last_stream_update_time: time_service.now(),
+            time_service,
+        }
+    }
+
+    /// Adds a subscription request to the existing stream. If this operation
+    /// fails, the request is returned to the caller so that the client
+    /// can be notified of the error.
+    pub fn add_subscription_request(
+        &mut self,
+        storage_service_config: StorageServiceConfig,
+        subscription_request: SubscriptionRequest,
+    ) -> Result<(), (Error, SubscriptionRequest)> {
+        // Verify that the subscription request stream ID is valid
+        let subscription_stream_id = subscription_request.subscription_stream_id();
+        if subscription_stream_id != self.subscription_stream_id {
+            return Err((
+                Error::InvalidRequest(format!(
+                    "The subscription request stream ID is invalid! Expected: {:?}, found: {:?}",
+                    self.subscription_stream_id, subscription_stream_id
+                )),
+                subscription_request,
+            ));
+        }
+
+        // Verify that the subscription request index is valid
+        let subscription_request_index = subscription_request.subscription_stream_index();
+        if subscription_request_index < self.next_index_to_serve {
+            return Err((
+                Error::InvalidRequest(format!(
+                    "The subscription request index is too low! Next index to serve: {:?}, found: {:?}",
+                    self.next_index_to_serve, subscription_request_index
+                )),
+                subscription_request,
+            ));
+        }
+
+        // Verify that the request known version and epoch are valid
+        let request_known_version = subscription_request.highest_known_version();
+        let request_known_epoch = subscription_request.highest_known_epoch();
+        if let Some(first_pending_request) = self.first_pending_request() {
+            let pending_known_version = first_pending_request.highest_known_version();
+            let pending_known_epoch = first_pending_request.highest_known_epoch();
+
+            // Verify the new and pending requests have the same known version and epoch
+            if (request_known_version != pending_known_version)
+                || (request_known_epoch != pending_known_epoch)
+            {
+                return Err((
+                    Error::InvalidRequest(format!(
+                        "The subscription request known version and epoch are invalid! Expected: ({:?}), found: ({:?})",
+                        (pending_known_version, pending_known_epoch), (request_known_version, request_known_epoch)
+                    )),
+                    subscription_request,
+                ));
+            }
+        }
+
+        // Verify that the number of active subscriptions respects the maximum
+        let max_num_active_subscriptions =
+            storage_service_config.max_num_active_subscriptions as usize;
+        if self.pending_subscription_requests.len() >= max_num_active_subscriptions {
+            return Err((
+                Error::InvalidRequest(format!(
+                    "The maximum number of active subscriptions has been reached! Max: {:?}, found: {:?}",
+                    max_num_active_subscriptions, self.pending_subscription_requests.len()
+                )),
+                subscription_request,
+            ));
+        }
+
+        // Insert the subscription request into the pending requests
+        let existing_request = self.pending_subscription_requests.insert(
+            subscription_request.subscription_stream_index(),
+            subscription_request,
+        );
+
+        // Refresh the last stream update time
+        self.refresh_last_stream_update_time();
+
+        // If a pending request already existed, return the previous request to the caller
+        if let Some(existing_request) = existing_request {
+            return Err((
+                Error::InvalidRequest(format!(
+                    "Overwriting an existing subscription request for the given index: {:?}",
+                    subscription_request_index
+                )),
+                existing_request,
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Returns a reference to the first pending subscription request
+    /// in the stream (if it exists).
+    pub fn first_pending_request(&self) -> Option<&SubscriptionRequest> {
+        self.pending_subscription_requests
+            .first_key_value()
+            .map(|(_, request)| request)
+    }
+
+    /// Returns true iff the subscription stream has expired.
+    /// There are two ways a stream can expire: (i) the first
+    /// pending request has been blocked for too long; or (ii)
+    /// the stream has been idle for too long.
+    fn is_expired(&self, timeout_ms: u64) -> bool {
+        // Determine the time when the stream was first blocked
+        let time_when_first_blocked =
+            if let Some(subscription_request) = self.first_pending_request() {
+                subscription_request.request_start_time // The stream is blocked on the first pending request
+            } else {
+                self.last_stream_update_time // The stream is idle and hasn't been updated in a while
+            };
+
+        // Verify the stream hasn't been blocked for too long
+        let current_time = self.time_service.now();
+        let elapsed_time = current_time
+            .duration_since(time_when_first_blocked)
+            .as_millis();
+        elapsed_time > (timeout_ms as u128)
+    }
+
+    /// Returns true iff there is at least one pending request
+    /// and that request is ready to be served (i.e., it has the
+    /// same index as the next index to serve).
+    fn first_request_ready_to_be_served(&self) -> bool {
+        if let Some(subscription_request) = self.first_pending_request() {
+            subscription_request.subscription_stream_index() == self.next_index_to_serve
+        } else {
+            false
+        }
+    }
+
+    /// Removes the first pending subscription request from the stream
+    /// and returns it (if it exists).
+    fn pop_first_pending_request(&mut self) -> Option<SubscriptionRequest> {
+        self.pending_subscription_requests
+            .pop_first()
+            .map(|(_, request)| request)
+    }
+
+    /// Refreshes the last stream update time to the current time
+    fn refresh_last_stream_update_time(&mut self) {
+        self.last_stream_update_time = self.time_service.now();
+    }
+
+    /// Returns the unique stream id for the stream
+    pub fn subscription_stream_id(&self) -> u64 {
+        self.subscription_stream_id
+    }
+
+    /// Updates the highest known version and epoch for the stream
+    /// using the latest data response that was sent to the client.
+    fn update_known_version_and_epoch(
+        &mut self,
+        data_response: &DataResponse,
+    ) -> Result<(), Error> {
+        // Determine the number of data items and target ledger info sent to the client
+        let (num_data_items, target_ledger_info) = match data_response {
+            DataResponse::NewTransactionOutputsWithProof((
+                transaction_output_list,
+                target_ledger_info,
+            )) => (
+                transaction_output_list.transactions_and_outputs.len(),
+                target_ledger_info,
+            ),
+            DataResponse::NewTransactionsWithProof((transaction_list, target_ledger_info)) => {
+                (transaction_list.transactions.len(), target_ledger_info)
+            },
+            DataResponse::NewTransactionsOrOutputsWithProof((
+                (transaction_list, transaction_output_list),
+                target_ledger_info,
+            )) => {
+                if let Some(transaction_list) = transaction_list {
+                    (transaction_list.transactions.len(), target_ledger_info)
+                } else if let Some(transaction_output_list) = transaction_output_list {
+                    (
+                        transaction_output_list.transactions_and_outputs.len(),
+                        target_ledger_info,
+                    )
+                } else {
+                    return Err(Error::UnexpectedErrorEncountered(format!(
+                        "New transactions or outputs response is missing data: {:?}",
+                        data_response
+                    )));
+                }
+            },
+            _ => {
+                return Err(Error::UnexpectedErrorEncountered(format!(
+                    "Unexpected data response type: {:?}",
+                    data_response
+                )))
+            },
+        };
+
+        // Update the highest known version
+        self.highest_known_version += num_data_items as u64;
+
+        // Update the highest known epoch if we've now hit an epoch ending ledger info
+        if self.highest_known_version == target_ledger_info.ledger_info().version()
+            && target_ledger_info.ledger_info().ends_epoch()
+        {
+            self.highest_known_epoch += 1;
+        }
+
+        // Update the next index to serve
+        self.next_index_to_serve += 1;
+
+        // Refresh the last stream update time
+        self.refresh_last_stream_update_time();
+
+        Ok(())
+    }
+}
+
+/// Handles active and ready subscription
+pub(crate) async fn handle_active_subscriptions<T: StorageReaderInterface>(
+    bounded_executor: BoundedExecutor,
+    cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
+    config: StorageServiceConfig,
+    optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
+    lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
+    request_moderator: Arc<RequestModerator>,
+    storage: T,
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
+    time_service: TimeService,
+) -> Result<(), Error> {
+    // Update the number of active subscriptions
+    update_active_subscription_metrics(subscriptions.clone());
+
+    // Identify the peers with ready subscriptions
+    let peers_with_ready_subscriptions = get_peers_with_ready_subscriptions(
+        bounded_executor.clone(),
+        config,
+        cached_storage_server_summary.clone(),
+        optimistic_fetches.clone(),
+        lru_response_cache.clone(),
+        request_moderator.clone(),
+        storage.clone(),
+        subscriptions.clone(),
+        time_service.clone(),
+    )
+    .await?;
+
+    // Remove and handle the ready subscriptions
+    handle_ready_subscriptions(
+        bounded_executor,
+        cached_storage_server_summary,
+        config,
+        optimistic_fetches,
+        lru_response_cache,
+        request_moderator,
+        storage,
+        subscriptions,
+        time_service,
+        peers_with_ready_subscriptions,
+    )
+    .await;
+
+    Ok(())
+}
+
+/// Handles the ready subscriptions by removing them from the
+/// active map and notifying the peer of the new data.
+async fn handle_ready_subscriptions<T: StorageReaderInterface>(
+    bounded_executor: BoundedExecutor,
+    cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
+    config: StorageServiceConfig,
+    optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
+    lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
+    request_moderator: Arc<RequestModerator>,
+    storage: T,
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
+    time_service: TimeService,
+    peers_with_ready_subscriptions: Vec<(PeerNetworkId, LedgerInfoWithSignatures)>,
+) {
+    for (peer_network_id, target_ledger_info) in peers_with_ready_subscriptions {
+        // Remove the subscription from the active subscription stream
+        let subscription_request_and_known_version =
+            subscriptions.clone().lock().get_mut(&peer_network_id).map(
+                |subscription_stream_requests| {
+                    (
+                        subscription_stream_requests.pop_first_pending_request(),
+                        subscription_stream_requests.highest_known_version,
+                    )
+                },
+            );
+
+        // Handle the subscription
+        if let Some((Some(subscription_request), known_version)) =
+            subscription_request_and_known_version
+        {
+            // Clone all required components for the task
+            let cached_storage_server_summary = cached_storage_server_summary.clone();
+            let optimistic_fetches = optimistic_fetches.clone();
+            let lru_response_cache = lru_response_cache.clone();
+            let request_moderator = request_moderator.clone();
+            let storage = storage.clone();
+            let subscriptions = subscriptions.clone();
+            let time_service = time_service.clone();
+
+            // Spawn a blocking task to handle the subscription
+            bounded_executor
+                .spawn_blocking(move || {
+                    // Get the subscription start time and request
+                    let subscription_start_time = subscription_request.request_start_time;
+                    let subscription_data_request = subscription_request.request.clone();
+
+                    // Get the storage service request for the missing data
+                    let missing_data_request = match subscription_request
+                        .get_storage_request_for_missing_data(
+                            config,
+                            known_version,
+                            &target_ledger_info,
+                        ) {
+                        Ok(storage_service_request) => storage_service_request,
+                        Err(error) => {
+                            // Failed to get the storage service request
+                            warn!(LogSchema::new(LogEntry::OptimisticFetchResponse)
+                                .error(&Error::UnexpectedErrorEncountered(error.to_string())));
+                            return;
+                        },
+                    };
+
+                    // Notify the peer of the new data
+                    match utils::notify_peer_of_new_data(
+                        cached_storage_server_summary,
+                        optimistic_fetches,
+                        subscriptions.clone(),
+                        lru_response_cache,
+                        request_moderator,
+                        storage,
+                        time_service.clone(),
+                        &peer_network_id,
+                        missing_data_request,
+                        target_ledger_info,
+                        subscription_request.take_response_sender(),
+                    ) {
+                        Ok(data_response) => {
+                            // Update the streams known version and epoch
+                            if let Some(subscription_stream_requests) =
+                                subscriptions.lock().get_mut(&peer_network_id)
+                            {
+                                // Update the known version and epoch for the stream
+                                subscription_stream_requests
+                                    .update_known_version_and_epoch(&data_response)
+                                    .unwrap_or_else(|error| {
+                                        warn!(LogSchema::new(LogEntry::SubscriptionResponse)
+                                            .error(&Error::UnexpectedErrorEncountered(
+                                                error.to_string()
+                                            )));
+                                    });
+
+                                // Update the subscription latency metric
+                                let subscription_duration =
+                                    time_service.now().duration_since(subscription_start_time);
+                                metrics::observe_value_with_label(
+                                    &metrics::SUBSCRIPTION_LATENCIES,
+                                    peer_network_id.network_id(),
+                                    &subscription_data_request.get_label(),
+                                    subscription_duration.as_secs_f64(),
+                                );
+                            }
+                        },
+                        Err(error) => {
+                            warn!(LogSchema::new(LogEntry::SubscriptionResponse)
+                                .error(&Error::UnexpectedErrorEncountered(error.to_string())));
+                        },
+                    }
+                })
+                .await;
+        }
+    }
+}
+
+/// Identifies the subscriptions that can be handled now.
+/// Returns the list of peers that made those subscriptions
+/// alongside the ledger info at the target version for the peer.
+pub(crate) async fn get_peers_with_ready_subscriptions<T: StorageReaderInterface>(
+    bounded_executor: BoundedExecutor,
+    config: StorageServiceConfig,
+    cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
+    optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
+    lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
+    request_moderator: Arc<RequestModerator>,
+    storage: T,
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
+    time_service: TimeService,
+) -> aptos_storage_service_types::Result<Vec<(PeerNetworkId, LedgerInfoWithSignatures)>, Error> {
+    // Fetch the latest storage summary and highest synced version
+    let latest_storage_summary = cached_storage_server_summary.load().clone();
+    let highest_synced_ledger_info = match &latest_storage_summary.data_summary.synced_ledger_info {
+        Some(ledger_info) => ledger_info.clone(),
+        None => return Ok(vec![]),
+    };
+    let highest_synced_version = highest_synced_ledger_info.ledger_info().version();
+    let highest_synced_epoch = highest_synced_ledger_info.ledger_info().epoch();
+
+    // Identify the peers with expired, invalid and ready subscriptions
+    let (
+        peers_with_expired_subscriptions,
+        peers_with_invalid_subscriptions,
+        peers_with_ready_subscriptions,
+    ) = identify_expired_invalid_and_ready_subscriptions(
+        bounded_executor,
+        config,
+        cached_storage_server_summary.clone(),
+        optimistic_fetches.clone(),
+        subscriptions.clone(),
+        lru_response_cache.clone(),
+        request_moderator.clone(),
+        storage.clone(),
+        time_service.clone(),
+        highest_synced_ledger_info,
+        highest_synced_version,
+        highest_synced_epoch,
+    )
+    .await;
+
+    // Remove the expired subscriptions
+    remove_expired_subscriptions(subscriptions.clone(), peers_with_expired_subscriptions);
+
+    // Remove the invalid subscriptions
+    remove_invalid_subscriptions(subscriptions.clone(), peers_with_invalid_subscriptions);
+
+    // Return the ready subscriptions
+    Ok(peers_with_ready_subscriptions)
+}
+
+/// Identifies the expired, invalid and ready subscriptions
+/// from the active map. Returns each peer list separately.
+async fn identify_expired_invalid_and_ready_subscriptions<T: StorageReaderInterface>(
+    bounded_executor: BoundedExecutor,
+    config: StorageServiceConfig,
+    cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
+    optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
+    lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
+    request_moderator: Arc<RequestModerator>,
+    storage: T,
+    time_service: TimeService,
+    highest_synced_ledger_info: LedgerInfoWithSignatures,
+    highest_synced_version: Version,
+    highest_synced_epoch: u64,
+) -> (
+    Vec<PeerNetworkId>,
+    Vec<PeerNetworkId>,
+    Vec<(PeerNetworkId, LedgerInfoWithSignatures)>,
+) {
+    // Gather the highest synced version and epoch for each peer
+    // that has an active subscription ready to be served.
+    let mut peers_and_highest_synced_data = HashMap::new();
+    let mut peers_with_expired_subscriptions = vec![];
+    for (peer_network_id, subscription_stream_requests) in subscriptions.lock().iter() {
+        // Gather the peer's highest synced version and epoch
+        if !subscription_stream_requests.is_expired(config.max_subscription_period_ms) {
+            // Ensure that the first request is ready to be served
+            if subscription_stream_requests.first_request_ready_to_be_served() {
+                let highest_known_version = subscription_stream_requests.highest_known_version;
+                let highest_known_epoch = subscription_stream_requests.highest_known_epoch;
+
+                // Save the peer's version and epoch
+                peers_and_highest_synced_data.insert(
+                    *peer_network_id,
+                    (highest_known_version, highest_known_epoch),
+                );
+            }
+        } else {
+            // The request has expired -- there's nothing to do
+            peers_with_expired_subscriptions.push(*peer_network_id);
+        }
+    }
+
+    // Identify the peers with ready and invalid subscriptions
+    let (peers_with_ready_subscriptions, peers_with_invalid_subscriptions) =
+        identify_ready_and_invalid_subscriptions(
+            bounded_executor,
+            cached_storage_server_summary,
+            optimistic_fetches,
+            subscriptions,
+            lru_response_cache,
+            request_moderator,
+            storage,
+            time_service,
+            highest_synced_ledger_info,
+            highest_synced_version,
+            highest_synced_epoch,
+            peers_and_highest_synced_data,
+        )
+        .await;
+
+    // Return all peer lists
+    (
+        peers_with_expired_subscriptions,
+        peers_with_invalid_subscriptions,
+        peers_with_ready_subscriptions,
+    )
+}
+
+/// Identifies the ready and invalid subscriptions from the given
+/// map of peers and their highest synced versions and epochs.
+async fn identify_ready_and_invalid_subscriptions<T: StorageReaderInterface>(
+    bounded_executor: BoundedExecutor,
+    cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
+    optimistic_fetches: Arc<DashMap<PeerNetworkId, OptimisticFetchRequest>>,
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
+    lru_response_cache: Arc<Mutex<LruCache<StorageServiceRequest, StorageServiceResponse>>>,
+    request_moderator: Arc<RequestModerator>,
+    storage: T,
+    time_service: TimeService,
+    highest_synced_ledger_info: LedgerInfoWithSignatures,
+    highest_synced_version: Version,
+    highest_synced_epoch: u64,
+    peers_and_highest_synced_data: HashMap<PeerNetworkId, (u64, u64)>,
+) -> (
+    Vec<(PeerNetworkId, LedgerInfoWithSignatures)>,
+    Vec<PeerNetworkId>,
+) {
+    // Create the peer lists for ready and invalid subscriptions
+    let peers_with_ready_subscriptions = Arc::new(Mutex::new(vec![]));
+    let peers_with_invalid_subscriptions = Arc::new(Mutex::new(vec![]));
+
+    // Go through all peers and highest synced data and identify the relevant entries
+    let mut active_tasks = vec![];
+    for (peer_network_id, (highest_known_version, highest_known_epoch)) in
+        peers_and_highest_synced_data.into_iter()
+    {
+        // Clone all required components for the task
+        let cached_storage_server_summary = cached_storage_server_summary.clone();
+        let highest_synced_ledger_info = highest_synced_ledger_info.clone();
+        let optimistic_fetches = optimistic_fetches.clone();
+        let subscriptions = subscriptions.clone();
+        let lru_response_cache = lru_response_cache.clone();
+        let request_moderator = request_moderator.clone();
+        let storage = storage.clone();
+        let time_service = time_service.clone();
+        let peers_with_invalid_subscriptions = peers_with_invalid_subscriptions.clone();
+        let peers_with_ready_subscriptions = peers_with_ready_subscriptions.clone();
+
+        // Spawn a blocking task to determine if the subscription is ready or
+        // invalid. We do this because each entry may require reading from storage.
+        let active_task = bounded_executor
+            .spawn_blocking(move || {
+                // Check if we have synced beyond the highest known version
+                if highest_known_version < highest_synced_version {
+                    if highest_known_epoch < highest_synced_epoch {
+                        // Fetch the epoch ending ledger info from storage (the
+                        // peer needs to sync to their epoch ending ledger info).
+                        let epoch_ending_ledger_info = match utils::get_epoch_ending_ledger_info(
+                            cached_storage_server_summary.clone(),
+                            optimistic_fetches.clone(),
+                            subscriptions.clone(),
+                            highest_known_epoch,
+                            lru_response_cache.clone(),
+                            request_moderator.clone(),
+                            &peer_network_id,
+                            storage.clone(),
+                            time_service.clone(),
+                        ) {
+                            Ok(epoch_ending_ledger_info) => epoch_ending_ledger_info,
+                            Err(error) => {
+                                // Log the failure to fetch the epoch ending ledger info
+                                error!(LogSchema::new(LogEntry::SubscriptionRefresh)
+                                    .error(&error)
+                                    .message(&format!(
+                                    "Failed to get the epoch ending ledger info for epoch: {:?} !",
+                                    highest_known_epoch
+                                )));
+
+                                return;
+                            },
+                        };
+
+                        // Check that we haven't been sent an invalid subscription request
+                        // (i.e., a request that does not respect an epoch boundary).
+                        if epoch_ending_ledger_info.ledger_info().version() <= highest_known_version
+                        {
+                            peers_with_invalid_subscriptions
+                                .lock()
+                                .push(peer_network_id);
+                        } else {
+                            peers_with_ready_subscriptions
+                                .lock()
+                                .push((peer_network_id, epoch_ending_ledger_info));
+                        }
+                    } else {
+                        peers_with_ready_subscriptions
+                            .lock()
+                            .push((peer_network_id, highest_synced_ledger_info.clone()));
+                    };
+                }
+            })
+            .await;
+        active_tasks.push(active_task);
+    }
+
+    // Wait for all the active tasks to complete
+    join_all(active_tasks).await;
+
+    // Gather the invalid and ready subscriptions
+    let peers_with_invalid_subscriptions = peers_with_invalid_subscriptions.lock().deref().clone();
+    let peers_with_ready_subscriptions = peers_with_ready_subscriptions.lock().deref().clone();
+
+    (
+        peers_with_ready_subscriptions,
+        peers_with_invalid_subscriptions,
+    )
+}
+
+/// Removes the expired subscription streams from the active map
+fn remove_expired_subscriptions(
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
+    peers_with_expired_subscriptions: Vec<PeerNetworkId>,
+) {
+    for peer_network_id in peers_with_expired_subscriptions {
+        if subscriptions.lock().remove(&peer_network_id).is_some() {
+            increment_counter(
+                &metrics::SUBSCRIPTION_EVENTS,
+                peer_network_id.network_id(),
+                SUBSCRIPTION_EXPIRE.into(),
+            );
+        }
+    }
+}
+
+/// Removes the invalid subscription streams from the active map
+fn remove_invalid_subscriptions(
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
+    peers_with_invalid_subscriptions: Vec<PeerNetworkId>,
+) {
+    for peer_network_id in peers_with_invalid_subscriptions {
+        if let Some(subscription_stream_requests) = subscriptions.lock().remove(&peer_network_id) {
+            warn!(LogSchema::new(LogEntry::SubscriptionRefresh)
+                .error(&Error::InvalidRequest(
+                    "Mismatch between known version and epoch!".into()
+                ))
+                .message(&format!(
+                    "Dropping invalid subscription stream with ID: {:?}!",
+                    subscription_stream_requests.subscription_stream_id
+                )));
+        }
+    }
+}
+
+/// Updates the active subscription metrics for each network
+fn update_active_subscription_metrics(
+    subscriptions: Arc<Mutex<HashMap<PeerNetworkId, SubscriptionStreamRequests>>>,
+) {
+    // Calculate the total number of subscriptions for each network
+    let mut num_validator_subscriptions = 0;
+    let mut num_vfn_subscriptions = 0;
+    let mut num_public_subscriptions = 0;
+    for subscription_stream_requests in subscriptions.lock().iter() {
+        // Get the peer network ID
+        let peer_network_id = subscription_stream_requests.0;
+
+        // Increment the number of subscriptions for the peer's network
+        match peer_network_id.network_id() {
+            NetworkId::Validator => num_validator_subscriptions += 1,
+            NetworkId::Vfn => num_vfn_subscriptions += 1,
+            NetworkId::Public => num_public_subscriptions += 1,
+        }
+    }
+
+    // Update the number of active subscriptions for each network
+    metrics::set_gauge(
+        &metrics::SUBSCRIPTION_COUNT,
+        NetworkId::Validator.as_str(),
+        num_validator_subscriptions as u64,
+    );
+    metrics::set_gauge(
+        &metrics::SUBSCRIPTION_COUNT,
+        NetworkId::Vfn.as_str(),
+        num_vfn_subscriptions as u64,
+    );
+    metrics::set_gauge(
+        &metrics::SUBSCRIPTION_COUNT,
+        NetworkId::Public.as_str(),
+        num_public_subscriptions as u64,
+    );
+}

--- a/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
@@ -30,7 +30,7 @@ use dashmap::DashMap;
 use futures::channel::oneshot;
 use lru::LruCache;
 use rand::{rngs::OsRng, Rng};
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 use tokio::runtime::Handle;
 
 #[tokio::test]
@@ -78,6 +78,7 @@ async fn test_peers_with_ready_optimistic_fetches() {
         storage_service_config,
         time_service.clone(),
     ));
+    let subscriptions = Arc::new(Mutex::new(HashMap::new()));
 
     // Verify that there are no peers with ready optimistic fetches
     let peers_with_ready_optimistic_fetches =
@@ -89,6 +90,7 @@ async fn test_peers_with_ready_optimistic_fetches() {
             lru_response_cache.clone(),
             request_moderator.clone(),
             storage_reader.clone(),
+            subscriptions.clone(),
             time_service.clone(),
         )
         .await
@@ -109,6 +111,7 @@ async fn test_peers_with_ready_optimistic_fetches() {
             lru_response_cache.clone(),
             request_moderator.clone(),
             storage_reader.clone(),
+            subscriptions.clone(),
             time_service.clone(),
         )
         .await
@@ -135,6 +138,7 @@ async fn test_peers_with_ready_optimistic_fetches() {
             lru_response_cache,
             request_moderator,
             storage_reader,
+            subscriptions,
             time_service,
         )
         .await
@@ -171,6 +175,7 @@ async fn test_remove_expired_optimistic_fetches() {
         storage_service_config,
         time_service.clone(),
     ));
+    let subscriptions = Arc::new(Mutex::new(HashMap::new()));
 
     // Create the first batch of test optimistic fetches
     let num_optimistic_fetches_in_batch = 10;
@@ -200,6 +205,7 @@ async fn test_remove_expired_optimistic_fetches() {
             lru_response_cache.clone(),
             request_moderator.clone(),
             storage.clone(),
+            subscriptions.clone(),
             time_service.clone(),
         )
         .await
@@ -233,6 +239,7 @@ async fn test_remove_expired_optimistic_fetches() {
             lru_response_cache.clone(),
             request_moderator.clone(),
             storage.clone(),
+            subscriptions.clone(),
             time_service.clone(),
         )
         .await
@@ -253,6 +260,7 @@ async fn test_remove_expired_optimistic_fetches() {
             lru_response_cache,
             request_moderator,
             storage.clone(),
+            subscriptions,
             time_service.clone(),
         )
         .await

--- a/state-sync/storage-service/server/src/tests/storage_summary.rs
+++ b/state-sync/storage-service/server/src/tests/storage_summary.rs
@@ -62,7 +62,7 @@ async fn test_refresh_cached_storage_summary() {
         cached_storage_server_summary.clone(),
         storage_reader.clone(),
         storage_service_config,
-        cached_summary_update_notifier.clone(),
+        vec![cached_summary_update_notifier.clone()],
     );
 
     // Verify that the cached summary update listener is notified
@@ -102,7 +102,7 @@ async fn test_refresh_cached_storage_summary() {
         cached_storage_server_summary.clone(),
         storage_reader.clone(),
         storage_service_config,
-        cached_summary_update_notifier.clone(),
+        vec![cached_summary_update_notifier.clone()],
     );
 
     // Verify that the cached summary update listener is notified
@@ -129,7 +129,7 @@ async fn test_refresh_cached_storage_summary() {
         cached_storage_server_summary.clone(),
         storage_reader.clone(),
         storage_service_config,
-        cached_summary_update_notifier.clone(),
+        vec![cached_summary_update_notifier.clone()],
     );
 
     // Verify that the cached summary update listener is notified

--- a/state-sync/storage-service/types/src/requests.rs
+++ b/state-sync/storage-service/types/src/requests.rs
@@ -174,9 +174,7 @@ pub struct TransactionsOrOutputsWithProofRequest {
 /// outputs with a corresponding proof.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct SubscribeTransactionOutputsWithProofRequest {
-    pub known_version: u64,             // The highest known output version
-    pub known_epoch: u64,               // The highest known epoch
-    pub subscription_stream_id: u64,    // The unique id of the subscription stream
+    pub subscription_stream_metadata: SubscriptionStreamMetadata, // The metadata for the subscription stream request
     pub subscription_stream_index: u64, // The request index of the subscription stream
 }
 
@@ -184,21 +182,24 @@ pub struct SubscribeTransactionOutputsWithProofRequest {
 /// or outputs with a corresponding proof.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct SubscribeTransactionsOrOutputsWithProofRequest {
-    pub known_version: u64,             // The highest known version
-    pub known_epoch: u64,               // The highest known epoch
+    pub subscription_stream_metadata: SubscriptionStreamMetadata, // The metadata for the subscription stream request
+    pub subscription_stream_index: u64, // The request index of the subscription stream
     pub include_events: bool,           // Whether or not to include events in the response
     pub max_num_output_reductions: u64, // The max num of output reductions before transactions are returned
-    pub subscription_stream_id: u64,    // The unique id of the subscription stream
-    pub subscription_stream_index: u64, // The request index of the subscription stream
 }
 
 /// A storage service request for subscribing to transactions
 /// with a corresponding proof.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct SubscribeTransactionsWithProofRequest {
-    pub known_version: u64,             // The highest known transaction version
-    pub known_epoch: u64,               // The highest known epoch
-    pub include_events: bool,           // Whether or not to include events in the response
-    pub subscription_stream_id: u64,    // The unique id of the subscription stream
+    pub subscription_stream_metadata: SubscriptionStreamMetadata, // The metadata for the subscription stream request
     pub subscription_stream_index: u64, // The request index of the subscription stream
+    pub include_events: bool,           // Whether or not to include events in the response
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct SubscriptionStreamMetadata {
+    pub known_version_at_stream_start: u64, // The highest known transaction version at stream start
+    pub known_epoch_at_stream_start: u64,   // The highest known epoch at stream start
+    pub subscription_stream_id: u64,        // The unique id of the subscription stream
 }

--- a/state-sync/storage-service/types/src/requests.rs
+++ b/state-sync/storage-service/types/src/requests.rs
@@ -44,6 +44,9 @@ pub enum DataRequest {
     GetTransactionsWithProof(TransactionsWithProofRequest), // Fetches a list of transactions with a proof
     GetNewTransactionsOrOutputsWithProof(NewTransactionsOrOutputsWithProofRequest), // Optimistically fetches new transactions or outputs
     GetTransactionsOrOutputsWithProof(TransactionsOrOutputsWithProofRequest), // Fetches a list of transactions or outputs with a proof
+    SubscribeTransactionOutputsWithProof(SubscribeTransactionOutputsWithProofRequest), // Subscribes to transaction outputs with a proof
+    SubscribeTransactionsOrOutputsWithProof(SubscribeTransactionsOrOutputsWithProofRequest), // Subscribes to transactions or outputs with a proof
+    SubscribeTransactionsWithProof(SubscribeTransactionsWithProofRequest), // Subscribes to transactions with a proof
 }
 
 impl DataRequest {
@@ -63,11 +66,14 @@ impl DataRequest {
                 "get_new_transactions_or_outputs_with_proof"
             },
             Self::GetTransactionsOrOutputsWithProof(_) => "get_transactions_or_outputs_with_proof",
+            Self::SubscribeTransactionOutputsWithProof(_) => {
+                "subscribe_transaction_outputs_with_proof"
+            },
+            Self::SubscribeTransactionsOrOutputsWithProof(_) => {
+                "subscribe_transactions_or_outputs_with_proof"
+            },
+            Self::SubscribeTransactionsWithProof(_) => "subscribe_transactions_with_proof",
         }
-    }
-
-    pub fn is_storage_summary_request(&self) -> bool {
-        matches!(self, &Self::GetStorageServerSummary)
     }
 
     pub fn is_optimistic_fetch(&self) -> bool {
@@ -78,6 +84,16 @@ impl DataRequest {
 
     pub fn is_protocol_version_request(&self) -> bool {
         matches!(self, &Self::GetServerProtocolVersion)
+    }
+
+    pub fn is_storage_summary_request(&self) -> bool {
+        matches!(self, &Self::GetStorageServerSummary)
+    }
+
+    pub fn is_subscription_request(&self) -> bool {
+        matches!(self, &Self::SubscribeTransactionOutputsWithProof(_))
+            || matches!(self, &Self::SubscribeTransactionsWithProof(_))
+            || matches!(self, Self::SubscribeTransactionsOrOutputsWithProof(_))
     }
 }
 
@@ -152,4 +168,37 @@ pub struct TransactionsOrOutputsWithProofRequest {
     pub end_version: u64,     // The ending version of the transaction/output list (inclusive)
     pub include_events: bool, // Whether or not to include events (if transactions are returned)
     pub max_num_output_reductions: u64, // The max num of output reductions before transactions are returned
+}
+
+/// A storage service request for subscribing to transaction
+/// outputs with a corresponding proof.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct SubscribeTransactionOutputsWithProofRequest {
+    pub known_version: u64,             // The highest known output version
+    pub known_epoch: u64,               // The highest known epoch
+    pub subscription_stream_id: u64,    // The unique id of the subscription stream
+    pub subscription_stream_index: u64, // The request index of the subscription stream
+}
+
+/// A storage service request for subscribing to transactions
+/// or outputs with a corresponding proof.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct SubscribeTransactionsOrOutputsWithProofRequest {
+    pub known_version: u64,             // The highest known version
+    pub known_epoch: u64,               // The highest known epoch
+    pub include_events: bool,           // Whether or not to include events in the response
+    pub max_num_output_reductions: u64, // The max num of output reductions before transactions are returned
+    pub subscription_stream_id: u64,    // The unique id of the subscription stream
+    pub subscription_stream_index: u64, // The request index of the subscription stream
+}
+
+/// A storage service request for subscribing to transactions
+/// with a corresponding proof.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct SubscribeTransactionsWithProofRequest {
+    pub known_version: u64,             // The highest known transaction version
+    pub known_epoch: u64,               // The highest known epoch
+    pub include_events: bool,           // Whether or not to include events in the response
+    pub subscription_stream_id: u64,    // The unique id of the subscription stream
+    pub subscription_stream_index: u64, // The request index of the subscription stream
 }

--- a/state-sync/storage-service/types/src/responses.rs
+++ b/state-sync/storage-service/types/src/responses.rs
@@ -536,12 +536,24 @@ impl DataSummary {
 
                 can_serve_txns && can_serve_outputs && can_create_proof
             },
-            SubscribeTransactionOutputsWithProof(request) => self
-                .can_service_subscription_request(aptos_data_client_config, request.known_version),
-            SubscribeTransactionsOrOutputsWithProof(request) => self
-                .can_service_subscription_request(aptos_data_client_config, request.known_version),
-            SubscribeTransactionsWithProof(request) => self
-                .can_service_subscription_request(aptos_data_client_config, request.known_version),
+            SubscribeTransactionOutputsWithProof(request) => {
+                let known_version = request
+                    .subscription_stream_metadata
+                    .known_version_at_stream_start;
+                self.can_service_subscription_request(aptos_data_client_config, known_version)
+            },
+            SubscribeTransactionsOrOutputsWithProof(request) => {
+                let known_version = request
+                    .subscription_stream_metadata
+                    .known_version_at_stream_start;
+                self.can_service_subscription_request(aptos_data_client_config, known_version)
+            },
+            SubscribeTransactionsWithProof(request) => {
+                let known_version = request
+                    .subscription_stream_metadata
+                    .known_version_at_stream_start;
+                self.can_service_subscription_request(aptos_data_client_config, known_version)
+            },
         }
     }
 

--- a/state-sync/storage-service/types/src/responses.rs
+++ b/state-sync/storage-service/types/src/responses.rs
@@ -7,7 +7,8 @@ use crate::{
         GetNewTransactionsOrOutputsWithProof, GetNewTransactionsWithProof,
         GetNumberOfStatesAtVersion, GetServerProtocolVersion, GetStateValuesWithProof,
         GetStorageServerSummary, GetTransactionOutputsWithProof, GetTransactionsOrOutputsWithProof,
-        GetTransactionsWithProof,
+        GetTransactionsWithProof, SubscribeTransactionOutputsWithProof,
+        SubscribeTransactionsOrOutputsWithProof, SubscribeTransactionsWithProof,
     },
     responses::Error::DegenerateRangeError,
     Epoch, StorageServiceRequest, COMPRESSION_SUFFIX_LABEL,
@@ -535,6 +536,12 @@ impl DataSummary {
 
                 can_serve_txns && can_serve_outputs && can_create_proof
             },
+            SubscribeTransactionOutputsWithProof(request) => self
+                .can_service_subscription_request(aptos_data_client_config, request.known_version),
+            SubscribeTransactionsOrOutputsWithProof(request) => self
+                .can_service_subscription_request(aptos_data_client_config, request.known_version),
+            SubscribeTransactionsWithProof(request) => self
+                .can_service_subscription_request(aptos_data_client_config, request.known_version),
         }
     }
 
@@ -545,6 +552,21 @@ impl DataSummary {
         known_version: u64,
     ) -> bool {
         let max_version_lag = aptos_data_client_config.max_optimistic_fetch_version_lag;
+        self.check_synced_version_lag(known_version, max_version_lag)
+    }
+
+    /// Returns true iff the subscription data request can be serviced
+    fn can_service_subscription_request(
+        &self,
+        aptos_data_client_config: &AptosDataClientConfig,
+        known_version: u64,
+    ) -> bool {
+        let max_version_lag = aptos_data_client_config.max_subscription_version_lag;
+        self.check_synced_version_lag(known_version, max_version_lag)
+    }
+
+    /// Returns true iff the synced version is within the given lag range
+    fn check_synced_version_lag(&self, known_version: u64, max_version_lag: u64) -> bool {
         self.synced_ledger_info
             .as_ref()
             .map(|li| (li.ledger_info().version() + max_version_lag) > known_version)

--- a/state-sync/storage-service/types/src/tests.rs
+++ b/state-sync/storage-service/types/src/tests.rs
@@ -5,8 +5,10 @@ use crate::{
     requests::{
         DataRequest, EpochEndingLedgerInfoRequest, NewTransactionOutputsWithProofRequest,
         NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
-        StateValuesWithProofRequest, TransactionOutputsWithProofRequest,
-        TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
+        StateValuesWithProofRequest, SubscribeTransactionOutputsWithProofRequest,
+        SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
+        TransactionOutputsWithProofRequest, TransactionsOrOutputsWithProofRequest,
+        TransactionsWithProofRequest,
     },
     responses::{CompleteDataRange, DataSummary, ProtocolMetadata},
     Epoch, StorageServiceRequest,
@@ -125,6 +127,54 @@ fn test_data_summary_service_optimistic_fetch() {
             highest_synced_version + (max_optimistic_fetch_version_lag * 2),
         ];
         verify_can_service_optimistic_fetch_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            known_versions,
+            false,
+        );
+    }
+}
+
+#[test]
+fn test_data_summary_service_subscription() {
+    // Create a data client config with the specified max subscription lag
+    let max_subscription_version_lag = 1000;
+    let data_client_config = AptosDataClientConfig {
+        max_subscription_version_lag,
+        ..Default::default()
+    };
+
+    // Create a data summary with the specified synced ledger info version
+    let highest_synced_version = 50_000;
+    let data_summary = DataSummary {
+        synced_ledger_info: Some(create_ledger_info_at_version(highest_synced_version)),
+        ..Default::default()
+    };
+
+    // Verify the different requests that can be serviced
+    for compression in [true, false] {
+        // Test the known versions that are within the subscription lag
+        let known_versions = vec![
+            highest_synced_version,
+            highest_synced_version + (max_subscription_version_lag / 2),
+            highest_synced_version + max_subscription_version_lag - 1,
+        ];
+        verify_can_service_subscription_requests(
+            &data_client_config,
+            &data_summary,
+            compression,
+            known_versions,
+            true,
+        );
+
+        // Test the known versions that are outside the subscription lag
+        let known_versions = vec![
+            highest_synced_version + max_subscription_version_lag,
+            highest_synced_version + max_subscription_version_lag + 1,
+            highest_synced_version + (max_subscription_version_lag * 2),
+        ];
+        verify_can_service_subscription_requests(
             &data_client_config,
             &data_summary,
             compression,
@@ -455,27 +505,27 @@ fn create_optimistic_fetch_request(
     use_compression: bool,
 ) -> StorageServiceRequest {
     // Generate a random number
-    let random_number: u64 = thread_rng().gen();
+    let random_number = get_random_u64();
 
     // Determine the data request type based on the random number
     let data_request = if random_number % 3 == 0 {
         DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
             known_version,
-            known_epoch: 1,
+            known_epoch: get_random_u64(),
             include_events: false,
         })
     } else if random_number % 3 == 1 {
         DataRequest::GetNewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest {
             known_version,
-            known_epoch: 1,
+            known_epoch: get_random_u64(),
         })
     } else {
         DataRequest::GetNewTransactionsOrOutputsWithProof(
             NewTransactionsOrOutputsWithProofRequest {
                 known_version,
-                known_epoch: 1,
+                known_epoch: get_random_u64(),
                 include_events: false,
-                max_num_output_reductions: 0,
+                max_num_output_reductions: get_random_u64(),
             },
         )
     };
@@ -495,6 +545,44 @@ fn create_outputs_request(
             start_version,
             end_version,
         });
+    StorageServiceRequest::new(data_request, use_compression)
+}
+
+/// Creates a new subscription request
+fn create_subscription_request(known_version: u64, use_compression: bool) -> StorageServiceRequest {
+    // Generate a random number
+    let random_number = get_random_u64();
+
+    // Determine the data request type based on the random number
+    let data_request = if random_number % 3 == 0 {
+        DataRequest::SubscribeTransactionsWithProof(SubscribeTransactionsWithProofRequest {
+            known_version,
+            known_epoch: get_random_u64(),
+            include_events: false,
+            subscription_stream_id: get_random_u64(),
+            subscription_stream_index: get_random_u64(),
+        })
+    } else if random_number % 3 == 1 {
+        DataRequest::SubscribeTransactionOutputsWithProof(
+            SubscribeTransactionOutputsWithProofRequest {
+                known_version,
+                known_epoch: get_random_u64(),
+                subscription_stream_id: get_random_u64(),
+                subscription_stream_index: get_random_u64(),
+            },
+        )
+    } else {
+        DataRequest::SubscribeTransactionsOrOutputsWithProof(
+            SubscribeTransactionsOrOutputsWithProofRequest {
+                known_version,
+                known_epoch: get_random_u64(),
+                include_events: false,
+                max_num_output_reductions: get_random_u64(),
+                subscription_stream_id: get_random_u64(),
+                subscription_stream_index: get_random_u64(),
+            },
+        )
+    };
     StorageServiceRequest::new(data_request, use_compression)
 }
 
@@ -555,6 +643,11 @@ fn create_state_values_request_at_version(
     create_state_values_request(version, 0, 1000, use_compression)
 }
 
+/// Generates a random u64
+fn get_random_u64() -> u64 {
+    thread_rng().gen()
+}
+
 /// Verifies the serviceability of the epoch ending request ranges against
 /// the specified data summary. If `expect_service` is true, then the
 /// request should be serviceable.
@@ -606,6 +699,25 @@ fn verify_can_service_state_chunk_requests(
     for version in versions {
         // Create the state chunk request
         let request = create_state_values_request_at_version(version, use_compression);
+
+        // Verify the serviceability of the request
+        verify_serviceability(data_client_config, data_summary, request, expect_service);
+    }
+}
+
+/// Verifies the serviceability of the subscription versions against
+/// the specified data summary. If `expect_service` is true, then the
+/// request should be serviceable.
+fn verify_can_service_subscription_requests(
+    data_client_config: &AptosDataClientConfig,
+    data_summary: &DataSummary,
+    compression: bool,
+    known_versions: Vec<Version>,
+    expect_service: bool,
+) {
+    for known_version in known_versions {
+        // Create the subscription request
+        let request = create_subscription_request(known_version, compression);
 
         // Verify the serviceability of the request
         verify_serviceability(data_client_config, data_summary, request, expect_service);

--- a/state-sync/storage-service/types/src/tests.rs
+++ b/state-sync/storage-service/types/src/tests.rs
@@ -7,8 +7,8 @@ use crate::{
         NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
         StateValuesWithProofRequest, SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
-        TransactionOutputsWithProofRequest, TransactionsOrOutputsWithProofRequest,
-        TransactionsWithProofRequest,
+        SubscriptionStreamMetadata, TransactionOutputsWithProofRequest,
+        TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
     },
     responses::{CompleteDataRange, DataSummary, ProtocolMetadata},
     Epoch, StorageServiceRequest,
@@ -550,35 +550,36 @@ fn create_outputs_request(
 
 /// Creates a new subscription request
 fn create_subscription_request(known_version: u64, use_compression: bool) -> StorageServiceRequest {
+    // Create a new subscription stream metadata
+    let subscription_stream_metadata = SubscriptionStreamMetadata {
+        known_version_at_stream_start: known_version,
+        known_epoch_at_stream_start: get_random_u64(),
+        subscription_stream_id: get_random_u64(),
+    };
+
     // Generate a random number
     let random_number = get_random_u64();
 
     // Determine the data request type based on the random number
     let data_request = if random_number % 3 == 0 {
         DataRequest::SubscribeTransactionsWithProof(SubscribeTransactionsWithProofRequest {
-            known_version,
-            known_epoch: get_random_u64(),
+            subscription_stream_metadata,
             include_events: false,
-            subscription_stream_id: get_random_u64(),
             subscription_stream_index: get_random_u64(),
         })
     } else if random_number % 3 == 1 {
         DataRequest::SubscribeTransactionOutputsWithProof(
             SubscribeTransactionOutputsWithProofRequest {
-                known_version,
-                known_epoch: get_random_u64(),
-                subscription_stream_id: get_random_u64(),
+                subscription_stream_metadata,
                 subscription_stream_index: get_random_u64(),
             },
         )
     } else {
         DataRequest::SubscribeTransactionsOrOutputsWithProof(
             SubscribeTransactionsOrOutputsWithProofRequest {
-                known_version,
-                known_epoch: get_random_u64(),
+                subscription_stream_metadata,
                 include_events: false,
                 max_num_output_reductions: get_random_u64(),
-                subscription_stream_id: get_random_u64(),
                 subscription_stream_index: get_random_u64(),
             },
         )


### PR DESCRIPTION
Note: a lot of this PR is boilerplate (based on the existing optimistic fetch implementation).

### Description
This PR adds subscription stream support to the storage service. Specifically, it allows clients to: (i) send multiple subscription requests to the server; (ii) have the server hold those requests in a pending queue; and (iii) serve those requests (in order, one at a time) with new data, as new data is made available (e.g., locally committed). This is similar to the existing optimistic fetch functionality, but it allows the clients to have multiple in-flight requests at once (to emulate the behaviour of the server "streaming" transaction chunks to the client).

The PR offers several commits:
1. Add support for the new request types (including a new test to ensure serviceability of the requests by the server).
2. Add subscription stream support to the server, including: (i) a handler for each subscription request that verifies the request and places it into a pending queue; and (ii) a handler that periodically runs to service pending subscription requests with new data. Note: much of this code is taken from the existing optimistic fetch functionality and modified/extended.

### Test Plan
Existing test infrastructure. I will fast follow this PR with another PR that adds a new set of unit tests for the subscription functionality.