### PR TITLE
[Executor] Refactor / Improve mock tests (also gas limit)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
  "criterion",
  "crossbeam",
  "dashmap",
+ "itertools",
  "move-binary-format",
  "num_cpus",
  "once_cell",

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -130,15 +130,8 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         );
     }
 
-    /// Return the amount of gas consumed by the transaction.
-    fn gas_used(&self) -> u64 {
-        self.committed_output
-            .get()
-            .map_or(0, |output| output.gas_used())
-    }
-
-    // Return the fee statement of the transaction.
-    // Should never be called after vm_output is consumed.
+    /// Return the fee statement of the transaction.
+    /// Should never be called after vm_output is consumed.
     fn fee_statement(&self) -> FeeStatement {
         self.vm_output
             .lock()

--- a/aptos-move/block-executor/Cargo.toml
+++ b/aptos-move/block-executor/Cargo.toml
@@ -24,6 +24,7 @@ aptos-types = { workspace = true }
 aptos-vm-logging = { workspace = true }
 arc-swap = { workspace = true }
 bcs = { workspace = true }
+claims = { workspace = true }
 criterion = { workspace = true, optional = true }
 crossbeam = { workspace = true }
 dashmap = { workspace = true }
@@ -36,8 +37,8 @@ proptest-derive = { workspace = true, optional = true }
 rayon = { workspace = true }
 
 [dev-dependencies]
-claims = { workspace = true }
 criterion = { workspace = true }
+itertools = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 rand = { workspace = true }

--- a/aptos-move/block-executor/benches/scheduler_benches.rs
+++ b/aptos-move/block-executor/benches/scheduler_benches.rs
@@ -1,8 +1,9 @@
 // Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // Run this bencher via `cargo bench --features fuzzing`.
-use aptos_parallel_executor::proptest_types::bencher::Bencher;
+use aptos_block_executor::proptest_types::bencher::Bencher;
 use criterion::{criterion_group, criterion_main, Criterion};
 use proptest::prelude::*;
 

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -5,7 +5,7 @@
 use crate::{
     counters,
     counters::{
-        GasType, PARALLEL_EXECUTION_SECONDS, RAYON_EXECUTION_SECONDS, TASK_EXECUTE_SECONDS,
+        PARALLEL_EXECUTION_SECONDS, RAYON_EXECUTION_SECONDS, TASK_EXECUTE_SECONDS,
         TASK_VALIDATE_SECONDS, VM_INIT_SECONDS, WORK_WITH_TASK_SECONDS,
     },
     errors::*,
@@ -109,130 +109,6 @@ where
             transaction_commit_hook,
             phantom: PhantomData,
         }
-    }
-
-    fn update_parallel_block_gas_counters(
-        accumulated_fee_statement: &FeeStatement,
-        num_committed: usize,
-    ) {
-        counters::observe_parallel_execution_block_gas(
-            accumulated_fee_statement.gas_used(),
-            GasType::TOTAL_GAS,
-        );
-        counters::observe_parallel_execution_block_gas(
-            accumulated_fee_statement.execution_gas_used(),
-            GasType::EXECUTION_GAS,
-        );
-        counters::observe_parallel_execution_block_gas(
-            accumulated_fee_statement.io_gas_used(),
-            GasType::IO_GAS,
-        );
-        counters::observe_parallel_execution_block_gas(
-            accumulated_fee_statement.storage_gas_used(),
-            GasType::STORAGE_GAS,
-        );
-        counters::observe_parallel_execution_block_gas(
-            accumulated_fee_statement.execution_gas_used()
-                + accumulated_fee_statement.io_gas_used(),
-            GasType::NON_STORAGE_GAS,
-        );
-        counters::observe_parallel_execution_block_gas(
-            accumulated_fee_statement.storage_fee_used(),
-            GasType::STORAGE_FEE,
-        );
-        counters::BLOCK_COMMITTED_TXNS
-            .with_label_values(&[counters::Mode::PARALLEL])
-            .observe(num_committed as f64);
-    }
-
-    fn update_parallel_txn_gas_counters(txn_fee_statements: &Vec<FeeStatement>) {
-        for fee_statement in txn_fee_statements {
-            counters::observe_parallel_execution_txn_gas(
-                fee_statement.gas_used(),
-                GasType::TOTAL_GAS,
-            );
-            counters::observe_parallel_execution_txn_gas(
-                fee_statement.execution_gas_used(),
-                GasType::EXECUTION_GAS,
-            );
-            counters::observe_parallel_execution_txn_gas(
-                fee_statement.io_gas_used(),
-                GasType::IO_GAS,
-            );
-            counters::observe_parallel_execution_txn_gas(
-                fee_statement.storage_gas_used(),
-                GasType::STORAGE_GAS,
-            );
-            counters::observe_parallel_execution_txn_gas(
-                fee_statement.execution_gas_used() + fee_statement.io_gas_used(),
-                GasType::NON_STORAGE_GAS,
-            );
-            counters::observe_parallel_execution_txn_gas(
-                fee_statement.storage_fee_used(),
-                GasType::STORAGE_FEE,
-            );
-        }
-    }
-
-    fn update_sequential_block_gas_counters(
-        accumulated_fee_statement: &FeeStatement,
-        num_committed: usize,
-    ) {
-        counters::observe_sequential_execution_block_gas(
-            accumulated_fee_statement.gas_used(),
-            GasType::TOTAL_GAS,
-        );
-        counters::observe_sequential_execution_block_gas(
-            accumulated_fee_statement.execution_gas_used(),
-            GasType::EXECUTION_GAS,
-        );
-        counters::observe_sequential_execution_block_gas(
-            accumulated_fee_statement.io_gas_used(),
-            GasType::IO_GAS,
-        );
-        counters::observe_sequential_execution_block_gas(
-            accumulated_fee_statement.storage_gas_used(),
-            GasType::STORAGE_GAS,
-        );
-        counters::observe_sequential_execution_block_gas(
-            accumulated_fee_statement.execution_gas_used()
-                + accumulated_fee_statement.io_gas_used(),
-            GasType::NON_STORAGE_GAS,
-        );
-        counters::observe_sequential_execution_block_gas(
-            accumulated_fee_statement.storage_fee_used(),
-            GasType::STORAGE_FEE,
-        );
-        counters::BLOCK_COMMITTED_TXNS
-            .with_label_values(&[counters::Mode::PARALLEL])
-            .observe(num_committed as f64);
-    }
-
-    fn update_sequential_txn_gas_counters(fee_statement: &FeeStatement) {
-        counters::observe_sequential_execution_txn_gas(
-            fee_statement.gas_used(),
-            GasType::TOTAL_GAS,
-        );
-        counters::observe_sequential_execution_txn_gas(
-            fee_statement.execution_gas_used(),
-            GasType::EXECUTION_GAS,
-        );
-        counters::observe_sequential_execution_txn_gas(
-            fee_statement.io_gas_used(),
-            GasType::IO_GAS,
-        );
-        counters::observe_sequential_execution_txn_gas(
-            fee_statement.storage_gas_used(),
-            GasType::STORAGE_GAS,
-        );
-        counters::observe_sequential_execution_txn_gas(
-            fee_statement.execution_gas_used() + fee_statement.io_gas_used(),
-            GasType::NON_STORAGE_GAS,
-        );
-        counters::observe_sequential_execution_txn_gas(
-            fee_statement.storage_fee_used(),
-            GasType::STORAGE_FEE,
-        );
     }
 
     fn execute(
@@ -393,63 +269,68 @@ where
             // Iterate round robin over workers to do commit_hook.
             *worker_idx = (*worker_idx + 1) % post_commit_txs.len();
 
-            // Committed the last transaction, BlockSTM finishes execution.
-            if txn_idx as usize + 1 == scheduler.num_txns() as usize {
-                *scheduler_task = SchedulerTask::Done;
+            if let Some(fee_statement) = last_input_output.fee_statement(txn_idx) {
+                // For committed txns with Success status, calculate the accumulated gas costs.
+                accumulated_fee_statement.add_fee_statement(&fee_statement);
+                txn_fee_statements.push(fee_statement);
 
-                Self::update_parallel_block_gas_counters(
+                if let Some(per_block_gas_limit) = maybe_block_gas_limit {
+                    // When the accumulated execution and io gas of the committed txns exceeds
+                    // PER_BLOCK_GAS_LIMIT, early halt BlockSTM. Storage gas does not count towards
+                    // the per block gas limit, as we measure execution related cost here.
+                    let accumulated_non_storage_gas = accumulated_fee_statement
+                        .execution_gas_used()
+                        + accumulated_fee_statement.io_gas_used();
+                    if accumulated_non_storage_gas >= per_block_gas_limit {
+                        counters::EXCEED_PER_BLOCK_GAS_LIMIT_COUNT
+                            .with_label_values(&[counters::Mode::PARALLEL])
+                            .inc();
+                        info!(
+                            "[BlockSTM]: Parallel execution early halted due to \
+                             accumulated_non_storage_gas {} >= PER_BLOCK_GAS_LIMIT {}",
+                            accumulated_non_storage_gas, per_block_gas_limit,
+                        );
+
+                        // Set the execution output status to be SkipRest, to skip the rest of the txns.
+                        last_input_output.update_to_skip_rest(txn_idx);
+                    }
+                }
+            }
+
+            // Committed the last transaction, BlockSTM finishes execution.
+            if txn_idx + 1 == scheduler.num_txns()
+                || last_input_output.block_truncated_at_idx(txn_idx)
+            {
+                if txn_idx + 1 == scheduler.num_txns() {
+                    assert!(
+                        !matches!(scheduler_task, SchedulerTask::ExecutionTask(_, _)),
+                        "All transactions can be committed, can't have execution task"
+                    );
+
+                    // The caller should finish the worker loop.
+                    *scheduler_task = SchedulerTask::Done;
+                }
+
+                // Either all txn committed, or a committed txn caused an early halt.
+                scheduler.halt();
+
+                counters::update_parallel_block_gas_counters(
                     accumulated_fee_statement,
                     (txn_idx + 1) as usize,
                 );
-                Self::update_parallel_txn_gas_counters(txn_fee_statements);
-                info!(
-                    "[BlockSTM]: Parallel execution completed, all {} txns committed.",
-                    txn_idx + 1
-                );
-                break;
-            }
+                counters::update_parallel_txn_gas_counters(txn_fee_statements);
 
-            // For committed txns with Success status, calculate the accumulated gas costs.
-            // For committed txns with Abort or SkipRest status, early halt BlockSTM.
-            match last_input_output.fee_statement(txn_idx) {
-                Some(fee_statement) => {
-                    accumulated_fee_statement.add_fee_statement(&fee_statement);
-                    txn_fee_statements.push(fee_statement);
-                },
-                None => {
-                    scheduler.halt();
-
-                    Self::update_parallel_block_gas_counters(
-                        accumulated_fee_statement,
-                        (txn_idx + 1) as usize,
-                    );
-                    Self::update_parallel_txn_gas_counters(txn_fee_statements);
-                    info!("[BlockSTM]: Parallel execution early halted due to Abort or SkipRest txn, {} txns committed.", txn_idx + 1);
-                    break;
-                },
-            };
-
-            if let Some(per_block_gas_limit) = maybe_block_gas_limit {
-                // When the accumulated execution and io gas of the committed txns exceeds PER_BLOCK_GAS_LIMIT, early halt BlockSTM.
-                // Storage gas does not count towards the per block gas limit, as we measure execution related cost here.
                 let accumulated_non_storage_gas = accumulated_fee_statement.execution_gas_used()
                     + accumulated_fee_statement.io_gas_used();
-                if accumulated_non_storage_gas >= per_block_gas_limit {
-                    // Set the execution output status to be SkipRest, to skip the rest of the txns.
-                    last_input_output.update_to_skip_rest(txn_idx);
-                    scheduler.halt();
-
-                    Self::update_parallel_block_gas_counters(
-                        accumulated_fee_statement,
-                        (txn_idx + 1) as usize,
-                    );
-                    Self::update_parallel_txn_gas_counters(txn_fee_statements);
-                    counters::EXCEED_PER_BLOCK_GAS_LIMIT_COUNT
-                        .with_label_values(&[counters::Mode::PARALLEL])
-                        .inc();
-                    info!("[BlockSTM]: Parallel execution early halted due to accumulated_non_storage_gas {} >= PER_BLOCK_GAS_LIMIT {}, {} txns committed", accumulated_non_storage_gas, per_block_gas_limit, txn_idx);
-                    break;
-                }
+                info!(
+                    "[BlockSTM]: Parallel execution completed. {} out of {} txns committed. \
+		     accumulated_non_storage_gas = {}, limit = {:?}",
+                    txn_idx + 1,
+                    scheduler.num_txns(),
+                    accumulated_non_storage_gas,
+                    maybe_block_gas_limit,
+                );
+                break;
             }
 
             // Remark: When early halting the BlockSTM, we have to make sure the current / new tasks
@@ -751,7 +632,8 @@ where
                     // Calculating the accumulated gas costs of the committed txns.
                     let fee_statement = output.fee_statement();
                     accumulated_fee_statement.add_fee_statement(&fee_statement);
-                    Self::update_sequential_txn_gas_counters(&fee_statement);
+                    counters::update_sequential_txn_gas_counters(&fee_statement);
+
                     // No delta writes are needed for sequential execution.
                     output.incorporate_delta_writes(vec![]);
                     //
@@ -768,10 +650,8 @@ where
                     return Err(Error::UserError(err));
                 },
             }
-
             // When the txn is a SkipRest txn, halt sequential execution.
             if must_skip {
-                info!("[Execution]: Sequential execution early halted due to SkipRest txn, {} txns committed.", ret.len());
                 break;
             }
 
@@ -784,20 +664,32 @@ where
                     counters::EXCEED_PER_BLOCK_GAS_LIMIT_COUNT
                         .with_label_values(&[counters::Mode::SEQUENTIAL])
                         .inc();
-                    info!("[Execution]: Sequential execution early halted due to accumulated_non_storage_gas {} >= PER_BLOCK_GAS_LIMIT {}, {} txns committed", accumulated_non_storage_gas, per_block_gas_limit, ret.len());
+                    info!(
+                        "[Execution]: Sequential execution early halted due to \
+                        accumulated_non_storage_gas {} >= PER_BLOCK_GAS_LIMIT {}, {} txns committed.",
+                        accumulated_non_storage_gas,
+                        per_block_gas_limit,
+                        ret.len()
+                    );
                     break;
                 }
             }
         }
 
         if ret.len() == num_txns {
+            let accumulated_non_storage_gas = accumulated_fee_statement.execution_gas_used()
+                + accumulated_fee_statement.io_gas_used();
             info!(
-                "[Execution]: Sequential execution completed, all {} txns committed.",
-                ret.len()
+                "[Execution]: Sequential execution completed. \
+		 {} out of {} txns committed. accumulated_non_storage_gas = {}, limit = {:?}",
+                ret.len(),
+                num_txns,
+                accumulated_non_storage_gas,
+                self.maybe_block_gas_limit,
             );
         }
 
-        Self::update_sequential_block_gas_counters(&accumulated_fee_statement, ret.len());
+        counters::update_sequential_block_gas_counters(&accumulated_fee_statement, ret.len());
         ret.resize_with(num_txns, E::Output::skip_output);
         Ok(ret)
     }

--- a/aptos-move/block-executor/src/proptest_types/baseline.rs
+++ b/aptos-move/block-executor/src/proptest_types/baseline.rs
@@ -1,0 +1,270 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// This file implements the baseline evaluation, performed sequentially, the output
+/// of which is used to test the results of the block executor. The baseline must be
+/// evaluated after the block executor has completed, as the transaction type used
+/// for testing tracks the incarnation number, which is used to emulate dynamic behavior.
+/// Dynamic behavior means that when a transaction is re-executed, it might read
+/// different values and end up with a completely different behavior (be it read set,
+/// write set, or executed code). In the tests, behavior changes based on the incarnation
+/// number, and hence it is crucial for the baseline to know the final incarnation number
+/// of each transaction of the tested block executor execution.
+use crate::{
+    errors::{Error as BlockExecutorError, Result as BlockExecutorResult},
+    proptest_types::types::{MockOutput, MockTransaction, STORAGE_AGGREGATOR_VALUE},
+};
+use aptos_aggregator::{delta_change_set::serialize, transaction::AggregatorValue};
+use aptos_types::write_set::TransactionWrite;
+use claims::{assert_matches, assert_none, assert_some_eq};
+use itertools::izip;
+use std::{collections::HashMap, fmt::Debug, hash::Hash, result::Result, sync::atomic::Ordering};
+
+// TODO: extend to derived values, and code.
+#[derive(Clone)]
+enum BaselineValue<V> {
+    GenericWrite(V),
+    Aggregator(u128),
+    Empty,
+}
+
+// TODO: instead of the same Error on aggregator overflow / underflow, add a way to tell
+// from the error and test it.
+// enum AggregatorError {
+//    Overflow,
+//    Underflow,
+// }
+
+impl<V: Debug + Clone + PartialEq + Eq + TransactionWrite> BaselineValue<V> {
+    // Compare to the read results during block execution.
+    pub(crate) fn assert_read_result(&self, bytes_read: &Option<Vec<u8>>) {
+        match (self, bytes_read) {
+            (BaselineValue::GenericWrite(v), Some(bytes)) => {
+                assert_some_eq!(v.extract_raw_bytes(), *bytes);
+            },
+            (BaselineValue::GenericWrite(v), None) => {
+                assert_none!(v.extract_raw_bytes());
+            },
+            (BaselineValue::Aggregator(aggr_value), Some(bytes)) => {
+                assert_eq!(serialize(aggr_value), *bytes);
+            },
+            (BaselineValue::Aggregator(_), None) => unreachable!(
+                "Deleted or non-existent value from storage can't match aggregator value"
+            ),
+            (BaselineValue::Empty, Some(bytes)) => {
+                assert_eq!(serialize(&STORAGE_AGGREGATOR_VALUE), *bytes);
+            },
+            (BaselineValue::Empty, None) => (),
+        }
+    }
+}
+
+// The status of the baseline execution.
+#[derive(Debug)]
+enum BaselineStatus {
+    Success,
+    Aborted,
+    SkipRest,
+    GasLimitExceeded,
+}
+
+/// Sequential baseline of execution result for dummy transaction, containing a vector
+/// of BaselineValues for the reads of the (latest incarnation of the dummy) transaction.
+/// The size of the vector should be equal to the size of the block if the block execution
+/// was successful. Otherwise, it is the index of a transaction where the block execution
+/// stopped, e.g. due to gas limit, abort, or reconfiguration (skip rest status). It also
+/// contains resolved values for each of the deltas produced by the dummy transaction.
+///
+/// For both read_values and resolved_deltas the keys are not included because they are
+/// in the same order as the reads and deltas in the Transaction::Write.
+pub(crate) struct BaselineOutput<V> {
+    status: BaselineStatus,
+    read_values: Vec<Result<Vec<BaselineValue<V>>, ()>>,
+    resolved_deltas: Vec<Result<Vec<u128>, ()>>,
+}
+
+impl<V: Debug + Clone + PartialEq + Eq + TransactionWrite> BaselineOutput<V> {
+    /// Must be invoked after parallel execution to have incarnation information set and
+    /// work with dynamic read/writes.
+    pub(crate) fn generate<K: Hash + Clone + Eq>(
+        txns: &[MockTransaction<K, V>],
+        maybe_block_gas_limit: Option<u64>,
+    ) -> Self {
+        let mut current_world = HashMap::<K, BaselineValue<_>>::new();
+        let mut accumulated_gas = 0;
+
+        let mut status = BaselineStatus::Success;
+        let mut read_values = vec![];
+        let mut resolved_deltas = vec![];
+        for txn in txns.iter() {
+            match txn {
+                MockTransaction::Abort => {
+                    status = BaselineStatus::Aborted;
+                    break;
+                },
+                MockTransaction::SkipRest => {
+                    // In executor, SkipRest skips from the next index. Test assumes it's an empty
+                    // transaction, so create a successful empty reads and deltas.
+                    read_values.push(Ok(vec![]));
+                    resolved_deltas.push(Ok(vec![]));
+
+                    status = BaselineStatus::SkipRest;
+                    break;
+                },
+                MockTransaction::Write {
+                    incarnation_counter,
+                    incarnation_behaviors,
+                } => {
+                    // Determine the behavior of the latest incarnation of the transaction. The index
+                    // is based on the value of the incarnation counter prior to the fetch_add during
+                    // the last mock execution, and is >= 1 because there is at least one execution.
+                    let last_incarnation = (incarnation_counter.load(Ordering::SeqCst) - 1)
+                        % incarnation_behaviors.len();
+
+                    match incarnation_behaviors[last_incarnation]
+                        .deltas
+                        .iter()
+                        .map(|(k, delta)| {
+                            let base = match current_world
+                                .entry(k.clone())
+                                .or_insert(BaselineValue::Empty)
+                            {
+                                // Get base value from the latest write.
+                                BaselineValue::GenericWrite(w_value) => {
+                                    AggregatorValue::from_write(w_value)
+                                        .expect("Delta to a non-existent aggregator")
+                                        .into()
+                                },
+                                // Get base value from latest resolved aggregator value.
+                                BaselineValue::Aggregator(value) => *value,
+                                // Storage always gets resolved to a default constant.
+                                BaselineValue::Empty => STORAGE_AGGREGATOR_VALUE,
+                            };
+
+                            delta
+                                .apply_to(base)
+                                .map(|resolved_value| (k.clone(), resolved_value))
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                    {
+                        Ok(txn_resolved_deltas) => {
+                            // Update the read_values and resolved_deltas. Performing reads here is
+                            // correct because written_ and resolved_ worlds have not been updated.
+                            read_values.push(Ok(incarnation_behaviors[last_incarnation]
+                                .reads
+                                .iter()
+                                .map(|k| {
+                                    current_world
+                                        .entry(k.clone())
+                                        .or_insert(BaselineValue::Empty)
+                                        .clone()
+                                })
+                                .collect()));
+
+                            resolved_deltas.push(Ok(txn_resolved_deltas
+                                .into_iter()
+                                .map(|(k, v)| {
+                                    // In this case transaction did not fail due to delta application
+                                    // errors, and thus we should update written_ and resolved_ worlds.
+                                    current_world.insert(k, BaselineValue::Aggregator(v));
+                                    v
+                                })
+                                .collect()));
+
+                            // We ensure that the latest state is always reflected in exactly one of
+                            // the hashmaps, by possibly removing an element from the other Hashmap.
+                            for (k, v) in incarnation_behaviors[last_incarnation].writes.iter() {
+                                current_world
+                                    .insert(k.clone(), BaselineValue::GenericWrite(v.clone()));
+                            }
+
+                            // Apply gas.
+                            accumulated_gas += incarnation_behaviors[last_incarnation].gas;
+                            if let Some(block_gas_limit) = maybe_block_gas_limit {
+                                if accumulated_gas >= block_gas_limit {
+                                    status = BaselineStatus::GasLimitExceeded;
+                                    break;
+                                }
+                            }
+                        },
+                        Err(_) => {
+                            // Transaction does not take effect and we record delta application failure.
+                            read_values.push(Err(()));
+                            resolved_deltas.push(Err(()));
+                        },
+                    }
+                },
+            }
+        }
+
+        Self {
+            status,
+            read_values,
+            resolved_deltas,
+        }
+    }
+
+    // Used for testing, hence the function asserts the correctness conditions within
+    // itself to be easily traceable in case of an error.
+    pub(crate) fn assert_output<K: Debug>(
+        &self,
+        results: &BlockExecutorResult<Vec<MockOutput<K, V>>, usize>,
+    ) {
+        match results {
+            Ok(results) => {
+                let committed = self.read_values.len();
+                assert_eq!(self.resolved_deltas.len(), committed);
+
+                // Check read values & delta writes.
+                izip!(
+                    results.iter().take(committed),
+                    self.read_values.iter(),
+                    self.resolved_deltas.iter()
+                )
+                .for_each(|(output, reads, resolved_deltas)| {
+                    reads
+                        .as_ref()
+                        .expect("Aggregator failures not yet tested")
+                        .iter()
+                        .zip(output.2.iter())
+                        .for_each(|(baseline_read, result_read)| {
+                            baseline_read.assert_read_result(result_read)
+                        });
+
+                    resolved_deltas
+                        .as_ref()
+                        .expect("Aggregator failures not yet tested")
+                        .iter()
+                        .zip(output.3.get().expect("Delta writes must be set").iter())
+                        .for_each(|(baseline_delta_write, (_, result_delta_write))| {
+                            assert_eq!(
+                                *baseline_delta_write,
+                                AggregatorValue::from_write(result_delta_write)
+                                    .expect("Delta to a non-existent aggregator")
+                                    .into()
+                            );
+                        });
+                });
+
+                results.iter().skip(committed).for_each(|output| {
+                    // Ensure the transaction is skipped based on the output.
+                    assert_eq!(output.0.len(), 0);
+                    assert_eq!(output.1.len(), 0);
+                    assert_eq!(output.2.len(), 0);
+                    assert_eq!(output.4, 0);
+
+                    // Implies that materialize_delta_writes was never called, as should
+                    // be for skipped transactions.
+                    assert_none!(output.3.get());
+                });
+            },
+            Err(BlockExecutorError::UserError(idx)) => {
+                assert_matches!(&self.status, BaselineStatus::Aborted);
+                assert_eq!(*idx, self.read_values.len());
+                assert_eq!(*idx, self.resolved_deltas.len());
+            },
+            Err(BlockExecutorError::ModulePathReadWrite) => unimplemented!("not tested here"),
+        }
+    }
+}

--- a/aptos-move/block-executor/src/proptest_types/bencher.rs
+++ b/aptos-move/block-executor/src/proptest_types/bencher.rs
@@ -4,9 +4,12 @@
 
 use crate::{
     executor::BlockExecutor,
-    proptest_types::types::{
-        EmptyDataView, ExpectedOutput, KeyType, Output, Task, Transaction, TransactionGen,
-        TransactionGenParams, ValueType,
+    proptest_types::{
+        baseline::BaselineOutput,
+        types::{
+            EmptyDataView, KeyType, MockOutput, MockTask, MockTransaction, TransactionGen,
+            TransactionGenParams, ValueType,
+        },
     },
     txn_commit_hook::NoOpTransactionCommitHook,
 };
@@ -35,8 +38,8 @@ pub(crate) struct BencherState<
 > where
     Vec<u8>: From<V>,
 {
-    transactions: Vec<Transaction<KeyType<K>, ValueType<V>>>,
-    expected_output: ExpectedOutput<ValueType<V>>,
+    transactions: Vec<MockTransaction<KeyType<K>, ValueType<V>>>,
+    baseline_output: BaselineOutput<ValueType<V>>,
 }
 
 impl<K, V> Bencher<K, V>
@@ -102,11 +105,11 @@ where
             .map(|txn_gen| txn_gen.materialize(&key_universe, (false, false)))
             .collect();
 
-        let expected_output = ExpectedOutput::generate_baseline(&transactions, None, None);
+        let baseline_output = BaselineOutput::generate(&transactions, None);
 
         Self {
             transactions,
-            expected_output,
+            baseline_output,
         }
     }
 
@@ -123,14 +126,14 @@ where
         );
 
         let output = BlockExecutor::<
-            Transaction<KeyType<K>, ValueType<V>>,
-            Task<KeyType<K>, ValueType<V>>,
+            MockTransaction<KeyType<K>, ValueType<V>>,
+            MockTask<KeyType<K>, ValueType<V>>,
             EmptyDataView<KeyType<K>, ValueType<V>>,
-            NoOpTransactionCommitHook<Output<KeyType<K>, ValueType<V>>, usize>,
+            NoOpTransactionCommitHook<MockOutput<KeyType<K>, ValueType<V>>, usize>,
             ExecutableTestType,
         >::new(num_cpus::get(), executor_thread_pool, None, None)
         .execute_transactions_parallel((), &self.transactions, &data_view);
 
-        self.expected_output.assert_output(&output);
+        self.baseline_output.assert_output(&output);
     }
 }

--- a/aptos-move/block-executor/src/proptest_types/mod.rs
+++ b/aptos-move/block-executor/src/proptest_types/mod.rs
@@ -2,7 +2,8 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod baseline;
 pub mod bencher;
 #[cfg(test)]
 mod tests;
-pub mod types;
+pub(crate) mod types;

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -5,9 +5,12 @@
 use crate::{
     errors::Error,
     executor::BlockExecutor,
-    proptest_types::types::{
-        DeltaDataView, EmptyDataView, ExpectedOutput, KeyType, Output, Task, Transaction,
-        TransactionGen, TransactionGenParams, ValueType,
+    proptest_types::{
+        baseline::BaselineOutput,
+        types::{
+            DeltaDataView, EmptyDataView, KeyType, MockOutput, MockTask, MockTransaction,
+            TransactionGen, TransactionGenParams, ValueType, MAX_GAS_PER_TXN,
+        },
     },
     txn_commit_hook::NoOpTransactionCommitHook,
 };
@@ -44,10 +47,10 @@ fn run_transactions<K, V>(
 
     let length = transactions.len();
     for i in abort_transactions {
-        *transactions.get_mut(i.index(length)).unwrap() = Transaction::Abort;
+        *transactions.get_mut(i.index(length)).unwrap() = MockTransaction::Abort;
     }
     for i in skip_rest_transactions {
-        *transactions.get_mut(i.index(length)).unwrap() = Transaction::SkipRest;
+        *transactions.get_mut(i.index(length)).unwrap() = MockTransaction::SkipRest;
     }
 
     let data_view = EmptyDataView::<KeyType<K>, ValueType<V>> {
@@ -63,10 +66,10 @@ fn run_transactions<K, V>(
 
     for _ in 0..num_repeat {
         let output = BlockExecutor::<
-            Transaction<KeyType<K>, ValueType<V>>,
-            Task<KeyType<K>, ValueType<V>>,
+            MockTransaction<KeyType<K>, ValueType<V>>,
+            MockTask<KeyType<K>, ValueType<V>>,
             EmptyDataView<KeyType<K>, ValueType<V>>,
-            NoOpTransactionCommitHook<Output<KeyType<K>, ValueType<V>>, usize>,
+            NoOpTransactionCommitHook<MockOutput<KeyType<K>, ValueType<V>>, usize>,
             ExecutableTestType,
         >::new(
             num_cpus::get(),
@@ -81,9 +84,7 @@ fn run_transactions<K, V>(
             continue;
         }
 
-        let baseline =
-            ExpectedOutput::generate_baseline(&transactions, None, maybe_block_gas_limit);
-        baseline.assert_output(&output);
+        BaselineOutput::generate(&transactions, maybe_block_gas_limit).assert_output(&output);
     }
 }
 
@@ -200,10 +201,10 @@ fn deltas_writes_mixed_with_block_gas_limit(num_txns: usize, maybe_block_gas_lim
 
     for _ in 0..20 {
         let output = BlockExecutor::<
-            Transaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
-            Task<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
+            MockTransaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
+            MockTask<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             DeltaDataView<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
-            NoOpTransactionCommitHook<Output<KeyType<[u8; 32]>, ValueType<[u8; 32]>>, usize>,
+            NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, ValueType<[u8; 32]>>, usize>,
             ExecutableTestType,
         >::new(
             num_cpus::get(),
@@ -213,9 +214,7 @@ fn deltas_writes_mixed_with_block_gas_limit(num_txns: usize, maybe_block_gas_lim
         )
         .execute_transactions_parallel((), &transactions, &data_view);
 
-        let baseline =
-            ExpectedOutput::generate_baseline(&transactions, None, maybe_block_gas_limit);
-        baseline.assert_output(&output);
+        BaselineOutput::generate(&transactions, maybe_block_gas_limit).assert_output(&output);
     }
 }
 
@@ -253,10 +252,10 @@ fn deltas_resolver_with_block_gas_limit(num_txns: usize, maybe_block_gas_limit: 
 
     for _ in 0..20 {
         let output = BlockExecutor::<
-            Transaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
-            Task<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
+            MockTransaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
+            MockTask<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             DeltaDataView<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
-            NoOpTransactionCommitHook<Output<KeyType<[u8; 32]>, ValueType<[u8; 32]>>, usize>,
+            NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, ValueType<[u8; 32]>>, usize>,
             ExecutableTestType,
         >::new(
             num_cpus::get(),
@@ -266,19 +265,7 @@ fn deltas_resolver_with_block_gas_limit(num_txns: usize, maybe_block_gas_limit: 
         )
         .execute_transactions_parallel((), &transactions, &data_view);
 
-        let delta_writes = output
-            .as_ref()
-            .expect("Must be success")
-            .iter()
-            .map(|out| out.delta_writes())
-            .collect();
-
-        let baseline = ExpectedOutput::generate_baseline(
-            &transactions,
-            Some(delta_writes),
-            maybe_block_gas_limit,
-        );
-        baseline.assert_output(&output);
+        BaselineOutput::generate(&transactions, maybe_block_gas_limit).assert_output(&output);
     }
 }
 
@@ -389,27 +376,19 @@ fn publishing_fixed_params_with_block_gas_limit(
 
     // Adjust the writes of txn indices[0] to contain module write to key 42.
     let w_index = indices[0].index(num_txns);
-    *transactions.get_mut(w_index).unwrap() = match transactions.get_mut(w_index).unwrap() {
-        Transaction::Write {
-            incarnation,
-            reads,
-            writes_and_deltas,
+    match transactions.get_mut(w_index).unwrap() {
+        MockTransaction::Write {
+            incarnation_counter: _,
+            incarnation_behaviors,
         } => {
-            let mut new_writes_and_deltas = vec![];
-            for (incarnation_writes, incarnation_deltas) in writes_and_deltas {
-                assert!(!incarnation_writes.is_empty());
-                let val = incarnation_writes[0].1.clone();
-                let insert_idx = indices[1].index(incarnation_writes.len());
-                incarnation_writes.insert(insert_idx, (KeyType(universe[42], true), val));
-                new_writes_and_deltas
-                    .push((incarnation_writes.clone(), incarnation_deltas.clone()));
-            }
-
-            Transaction::Write {
-                incarnation: incarnation.clone(),
-                reads: reads.clone(),
-                writes_and_deltas: new_writes_and_deltas,
-            }
+            incarnation_behaviors.iter_mut().for_each(|behavior| {
+                assert!(!behavior.writes.is_empty());
+                let insert_idx = indices[1].index(behavior.writes.len());
+                let val = behavior.writes[0].1.clone();
+                behavior
+                    .writes
+                    .insert(insert_idx, (KeyType(universe[42], true), val));
+            });
         },
         _ => {
             unreachable!();
@@ -429,10 +408,10 @@ fn publishing_fixed_params_with_block_gas_limit(
 
     // Confirm still no intersection
     let output = BlockExecutor::<
-        Transaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
-        Task<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
+        MockTransaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
+        MockTask<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
         DeltaDataView<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
-        NoOpTransactionCommitHook<Output<KeyType<[u8; 32]>, ValueType<[u8; 32]>>, usize>,
+        NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, ValueType<[u8; 32]>>, usize>,
         ExecutableTestType,
     >::new(
         num_cpus::get(),
@@ -445,25 +424,18 @@ fn publishing_fixed_params_with_block_gas_limit(
 
     // Adjust the reads of txn indices[2] to contain module read to key 42.
     let r_index = indices[2].index(num_txns);
-    *transactions.get_mut(r_index).unwrap() = match transactions.get_mut(r_index).unwrap() {
-        Transaction::Write {
-            incarnation,
-            reads,
-            writes_and_deltas,
+    match transactions.get_mut(r_index).unwrap() {
+        MockTransaction::Write {
+            incarnation_counter: _,
+            incarnation_behaviors,
         } => {
-            let mut new_reads = vec![];
-            for incarnation_reads in reads {
-                assert!(!incarnation_reads.is_empty());
-                let insert_idx = indices[3].index(incarnation_reads.len());
-                incarnation_reads.insert(insert_idx, KeyType(universe[42], true));
-                new_reads.push(incarnation_reads.clone());
-            }
-
-            Transaction::Write {
-                incarnation: incarnation.clone(),
-                reads: new_reads,
-                writes_and_deltas: writes_and_deltas.clone(),
-            }
+            incarnation_behaviors.iter_mut().for_each(|behavior| {
+                assert!(!behavior.reads.is_empty());
+                let insert_idx = indices[3].index(behavior.reads.len());
+                behavior
+                    .reads
+                    .insert(insert_idx, KeyType(universe[42], true));
+            });
         },
         _ => {
             unreachable!();
@@ -479,17 +451,17 @@ fn publishing_fixed_params_with_block_gas_limit(
 
     for _ in 0..200 {
         let output = BlockExecutor::<
-            Transaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
-            Task<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
+            MockTransaction<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
+            MockTask<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
             DeltaDataView<KeyType<[u8; 32]>, ValueType<[u8; 32]>>,
-            NoOpTransactionCommitHook<Output<KeyType<[u8; 32]>, ValueType<[u8; 32]>>, usize>,
+            NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, ValueType<[u8; 32]>>, usize>,
             ExecutableTestType,
         >::new(
             num_cpus::get(),
             executor_thread_pool.clone(),
-            Some(max(w_index, r_index) as u64 + 1),
+            Some(max(w_index, r_index) as u64 * MAX_GAS_PER_TXN + 1),
             None,
-        ) // Ensure enough gas limit to commit the module txns
+        ) // Ensure enough gas limit to commit the module txns (4 is maximum gas per txn)
         .execute_transactions_parallel((), &transactions, &data_view);
 
         assert_eq!(output.unwrap_err(), Error::ModulePathReadWrite);
@@ -540,7 +512,7 @@ proptest! {
         abort_transactions in vec(any::<Index>(), 0),
         skip_rest_transactions in vec(any::<Index>(), 0),
     ) {
-        run_transactions(&universe, transaction_gen, abort_transactions, skip_rest_transactions, 1, (false, false), Some(rand::thread_rng().gen_range(0, 5000) as u64));
+        run_transactions(&universe, transaction_gen, abort_transactions, skip_rest_transactions, 1, (false, false), Some(rand::thread_rng().gen_range(0, 5000 * MAX_GAS_PER_TXN / 2)));
     }
 
     #[test]
@@ -550,7 +522,7 @@ proptest! {
         abort_transactions in vec(any::<Index>(), 5),
         skip_rest_transactions in vec(any::<Index>(), 0),
     ) {
-        run_transactions(&universe, transaction_gen, abort_transactions, skip_rest_transactions, 1, (false, false), Some(rand::thread_rng().gen_range(0, 10) as u64));
+        run_transactions(&universe, transaction_gen, abort_transactions, skip_rest_transactions, 1, (false, false), Some(rand::thread_rng().gen_range(0, 10 * MAX_GAS_PER_TXN / 2)));
     }
 
     #[test]
@@ -560,7 +532,7 @@ proptest! {
         abort_transactions in vec(any::<Index>(), 0),
         skip_rest_transactions in vec(any::<Index>(), 5),
     ) {
-        run_transactions(&universe, transaction_gen, abort_transactions, skip_rest_transactions, 1, (false, false), Some(rand::thread_rng().gen_range(0, 5000) as u64));
+        run_transactions(&universe, transaction_gen, abort_transactions, skip_rest_transactions, 1, (false, false), Some(rand::thread_rng().gen_range(0, 5000 * MAX_GAS_PER_TXN / 2)));
     }
 
     #[test]
@@ -570,7 +542,7 @@ proptest! {
         abort_transactions in vec(any::<Index>(), 5),
         skip_rest_transactions in vec(any::<Index>(), 5),
     ) {
-        run_transactions(&universe, transaction_gen, abort_transactions, skip_rest_transactions, 1, (false, false), Some(rand::thread_rng().gen_range(0, 5000) as u64));
+        run_transactions(&universe, transaction_gen, abort_transactions, skip_rest_transactions, 1, (false, false), Some(rand::thread_rng().gen_range(0, 5000 * MAX_GAS_PER_TXN / 2)));
     }
 
     #[test]
@@ -580,7 +552,7 @@ proptest! {
         abort_transactions in vec(any::<Index>(), 3),
         skip_rest_transactions in vec(any::<Index>(), 3),
     ) {
-        run_transactions(&universe, transaction_gen, abort_transactions, skip_rest_transactions, 1, (false, false), Some(rand::thread_rng().gen_range(0, 5000) as u64));
+        run_transactions(&universe, transaction_gen, abort_transactions, skip_rest_transactions, 1, (false, false), Some(rand::thread_rng().gen_range(0, 5000 * MAX_GAS_PER_TXN / 2)));
     }
 }
 
@@ -588,6 +560,7 @@ proptest! {
 fn dynamic_read_writes_with_block_gas_limit_test() {
     dynamic_read_writes_with_block_gas_limit(
         3000,
+        // TODO: here and below, use proptest randomness, not thread_rng.
         Some(rand::thread_rng().gen_range(0, 3000) as u64),
     );
     dynamic_read_writes_with_block_gas_limit(3000, Some(0));
@@ -604,7 +577,10 @@ fn deltas_writes_mixed_with_block_gas_limit_test() {
 
 #[test]
 fn deltas_resolver_with_block_gas_limit_test() {
-    deltas_resolver_with_block_gas_limit(1000, Some(rand::thread_rng().gen_range(0, 1000) as u64));
+    deltas_resolver_with_block_gas_limit(
+        1000,
+        Some(rand::thread_rng().gen_range(0, 1000 * MAX_GAS_PER_TXN / 2)),
+    );
     deltas_resolver_with_block_gas_limit(1000, Some(0));
 }
 
@@ -622,7 +598,7 @@ fn module_publishing_fallback_with_block_gas_limit_test() {
     module_publishing_fallback_with_block_gas_limit(
         3000,
         // Need to execute at least 2 txns to trigger module publishing fallback
-        Some(rand::thread_rng().gen_range(1, 3000) as u64),
+        Some(rand::thread_rng().gen_range(1, 3000 * MAX_GAS_PER_TXN / 2)),
     );
 }
 
@@ -633,7 +609,7 @@ fn module_publishing_races_with_block_gas_limit_test() {
     for _ in 0..5 {
         publishing_fixed_params_with_block_gas_limit(
             300,
-            Some(rand::thread_rng().gen_range(0, 300) as u64),
+            Some(rand::thread_rng().gen_range(0, 300 * MAX_GAS_PER_TXN / 2)),
         );
     }
 }

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -2,12 +2,9 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    errors::{Error, Result},
-    task::{ExecutionStatus, ExecutorTask, Transaction as TransactionType, TransactionOutput},
-};
+use crate::task::{ExecutionStatus, ExecutorTask, Transaction, TransactionOutput};
 use aptos_aggregator::{
-    delta_change_set::{delta_add, delta_sub, deserialize, serialize, DeltaOp},
+    delta_change_set::{delta_add, delta_sub, serialize, DeltaOp},
     transaction::AggregatorValue,
 };
 use aptos_mvhashmap::types::TxnIndex;
@@ -20,12 +17,12 @@ use aptos_types::{
     state_store::{state_storage_usage::StateStorageUsage, state_value::StateValue},
     write_set::{TransactionWrite, WriteOp},
 };
-use claims::{assert_none, assert_ok};
+use claims::assert_ok;
 use once_cell::sync::OnceCell;
 use proptest::{arbitrary::Arbitrary, collection::vec, prelude::*, proptest, sample::Index};
 use proptest_derive::Arbitrary;
 use std::{
-    collections::{hash_map::DefaultHasher, BTreeSet, HashMap},
+    collections::{hash_map::DefaultHasher, BTreeSet},
     convert::TryInto,
     fmt::Debug,
     hash::{Hash, Hasher},
@@ -36,9 +33,10 @@ use std::{
     },
 };
 
-// Should not be possible to overflow or underflow, as each delta is at
-// most 100 in the tests.
+// Should not be possible to overflow or underflow, as each delta is at most 100 in the tests.
+// TODO: extend to delta failures.
 pub(crate) const STORAGE_AGGREGATOR_VALUE: u128 = 100001;
+pub(crate) const MAX_GAS_PER_TXN: u64 = 4;
 
 pub(crate) struct DeltaDataView<K, V> {
     pub(crate) phantom: PhantomData<(K, V)>,
@@ -53,7 +51,6 @@ where
 
     /// Gets the state value for a given state key.
     fn get_state_value(&self, _: &K) -> anyhow::Result<Option<StateValue>> {
-        // When aggregator value has to be resolved from storage, pretend it is 100.
         Ok(Some(StateValue::new_legacy(serialize(
             &STORAGE_AGGREGATOR_VALUE,
         ))))
@@ -164,50 +161,74 @@ impl<V: Into<Vec<u8>> + Debug + Clone + Eq + Send + Sync + Arbitrary> Transactio
 }
 
 #[derive(Clone, Copy)]
-pub struct TransactionGenParams {
-    /// Each transaction's write-set consists of between 1 and write_size-1 many writes.
-    pub write_size: usize,
+pub(crate) struct TransactionGenParams {
     /// Each transaction's read-set consists of between 1 and read_size-1 many reads.
-    pub read_size: usize,
-    /// The number of different read- and write-sets that an execution of the transaction may have
-    /// is going to be between 1 and read_write_alternatives-1, i.e. read_write_alternatives = 2
-    /// corresponds to a static transaction, while read_write_alternatives > 1 may lead to dynamic
-    /// behavior when executing different incarnations of the transaction.
-    pub read_write_alternatives: usize,
+    read_size: usize,
+    /// Each mock execution will produce between 1 and output_size-1 many writes and deltas.
+    output_size: usize,
+    /// The number of different incarnation behaviors that a mock execution of the transaction
+    /// may exhibit. For instance, incarnation_alternatives = 1 corresponds to a "static"
+    /// mock execution behavior regardless of the incarnation, while value > 1 may lead to "dynamic",
+    /// i.e. different behavior when executing different incarnations of the transaction.
+    incarnation_alternatives: usize,
 }
 
 #[derive(Arbitrary, Debug, Clone)]
 #[proptest(params = "TransactionGenParams")]
-pub struct TransactionGen<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + 'static> {
-    /// Generate keys and values for possible write-sets based on above transaction gen parameters.
-    #[proptest(
-        strategy = "vec(vec((any::<Index>(), any::<V>()), 1..params.write_size), 1..params.read_write_alternatives)"
-    )]
-    keys_modified: Vec<Vec<(Index, V)>>,
+pub(crate) struct TransactionGen<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + 'static> {
     /// Generate keys for possible read-sets of the transaction based on the above parameters.
     #[proptest(
-        strategy = "vec(vec(any::<Index>(), 1..params.read_size), 1..params.read_write_alternatives)"
+        strategy = "vec(vec(any::<Index>(), 1..params.read_size), params.incarnation_alternatives)"
     )]
-    keys_read: Vec<Vec<Index>>,
+    reads: Vec<Vec<Index>>,
+    /// Generate keys and values for possible write-sets based on above transaction gen parameters.
+    /// Based on how the test is configured, some of these "writes" will convert to deltas.
+    #[proptest(
+        strategy = "vec(vec((any::<Index>(), any::<V>()), 1..params.output_size), \
+		    params.incarnation_alternatives)"
+    )]
+    modifications: Vec<Vec<(Index, V)>>,
+    /// Generate gas for different incarnations of the transactions.
+    #[proptest(strategy = "vec(any::<Index>(), params.incarnation_alternatives)")]
+    gas: Vec<Index>,
 }
 
-/// A naive transaction that could be used to test the correctness and throughput of the system.
+/// Describes behavior of a particular incarnation of a mock transaction, as keys to be read,
+/// as well as writes, deltas and total execution gas charged for this incarnation. Note that
+/// writes, deltas and gas become part of the output directly (as part of the mock execution of
+/// a given incarnation), so the output of an incarnation does not depend on the values read, which
+/// is a limitation for the testing framework. However, IncarnationBehavior allows different
+/// behaviors to be exhibited by different incarnations during parallel execution, which happens
+/// first and also records the latest incarnations of each transaction (that is committed).
+/// Then we can generate the baseline by sequentially executing the behavior prescribed for
+/// those latest incarnations.
+#[derive(Clone, Debug)]
+pub(crate) struct MockIncarnation<K, V> {
+    /// A vector of keys to be read during mock incarnation execution.
+    pub(crate) reads: Vec<K>,
+    /// A vector of keys and corresponding values to be written during mock incarnation execution.
+    pub(crate) writes: Vec<(K, V)>,
+    /// A vector of keys and corresponding deltas to be produced during mock incarnation execution.
+    pub(crate) deltas: Vec<(K, DeltaOp)>,
+    /// total execution gas to be charged for mock incarnation execution.
+    pub(crate) gas: u64,
+}
+
+/// A mock transaction that could be used to test the correctness and throughput of the system.
 /// To test transaction behavior where reads and writes might be dynamic (depend on previously
 /// read values), different read and writes sets are generated and used depending on the incarnation
 /// counter value. Each execution of the transaction increments the incarnation counter, and its
 /// value determines the index for choosing the read & write sets of the particular execution.
-#[derive(Debug, Clone)]
-pub enum Transaction<K, V> {
+#[derive(Clone, Debug)]
+pub(crate) enum MockTransaction<K, V> {
     Write {
-        /// Incarnation counter for dynamic behavior i.e. incarnations differ in reads and writes.
-        incarnation: Arc<AtomicUsize>,
-        /// Vector of all possible write-sets and delta-sets of transaction execution (chosen round-robin
-        /// depending on the incarnation counter value). Each write set is a vector describing writes, each
-        /// to a key with a provided value. Each delta-set contains keys and the corresponding DeltaOps.
-        writes_and_deltas: Vec<(Vec<(K, V)>, Vec<(K, DeltaOp)>)>,
-        /// Vector of all possible read-sets of the transaction execution (chosen round-robin depending
-        /// on the incarnation counter value). Each read set is a vector of keys that are read.
-        reads: Vec<Vec<K>>,
+        /// Incarnation counter, increased during each mock (re-)execution. Allows tracking the final
+        /// incarnation for each mock transaction, whose behavior should be reproduced for baseline.
+        /// Arc-ed only due to Clone, TODO: clean up the Clone requirement.
+        incarnation_counter: Arc<AtomicUsize>,
+        /// A vector of mock behaviors prescribed for each incarnation of the transaction, chosen
+        /// round robin depending on the incarnation counter value).
+        incarnation_behaviors: Vec<MockIncarnation<K, V>>,
     },
     /// Skip the execution of trailing transactions.
     SkipRest,
@@ -215,12 +236,29 @@ pub enum Transaction<K, V> {
     Abort,
 }
 
+impl<K, V> MockTransaction<K, V> {
+    pub(crate) fn from_behavior(behavior: MockIncarnation<K, V>) -> Self {
+        Self::Write {
+            incarnation_counter: Arc::new(AtomicUsize::new(0)),
+            incarnation_behaviors: vec![behavior],
+        }
+    }
+
+    pub(crate) fn from_behaviors(behaviors: Vec<MockIncarnation<K, V>>) -> Self {
+        Self::Write {
+            incarnation_counter: Arc::new(AtomicUsize::new(0)),
+            incarnation_behaviors: behaviors,
+        }
+    }
+}
+
+// TODO: try and test different strategies.
 impl TransactionGenParams {
     pub fn new_dynamic() -> Self {
         TransactionGenParams {
-            write_size: 5,
             read_size: 10,
-            read_write_alternatives: 4,
+            output_size: 5,
+            incarnation_alternatives: 5,
         }
     }
 }
@@ -228,21 +266,28 @@ impl TransactionGenParams {
 impl Default for TransactionGenParams {
     fn default() -> Self {
         TransactionGenParams {
-            write_size: 5,
             read_size: 10,
-            read_write_alternatives: 2,
+            output_size: 5,
+            incarnation_alternatives: 1,
         }
     }
 }
 
+// TODO: move generation to separate file.
+// TODO: consider adding writes to reads (read-before-write). Similar behavior to the Move-VM
+// and may force more testing (since we check read results).
 impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> TransactionGen<V> {
+    // TODO: disentangle writes and deltas.
     fn writes_and_deltas_from_gen<K: Clone + Hash + Debug + Eq + Ord>(
         universe: &[K],
         gen: Vec<Vec<(Index, V)>>,
         module_write_fn: &dyn Fn(usize) -> bool,
         delta_fn: &dyn Fn(usize, &V) -> Option<DeltaOp>,
         allow_deletes: bool,
-    ) -> Vec<(Vec<(KeyType<K>, ValueType<V>)>, Vec<(KeyType<K>, DeltaOp)>)> {
+    ) -> Vec<(
+        /* writes = */ Vec<(KeyType<K>, ValueType<V>)>,
+        /* deltas = */ Vec<(KeyType<K>, DeltaOp)>,
+    )> {
         let mut ret = vec![];
         for write_gen in gen.into_iter() {
             let mut keys_modified = BTreeSet::new();
@@ -294,40 +339,75 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
         ret
     }
 
-    pub fn materialize<K: Clone + Hash + Debug + Eq + Ord>(
+    fn gas_from_gen(gas_gen: Vec<Index>) -> Vec<u64> {
+        // TODO: generalize gas charging.
+        gas_gen
+            .into_iter()
+            .map(|idx| idx.index(MAX_GAS_PER_TXN as usize + 1) as u64)
+            .collect()
+    }
+
+    fn new_mock_write_txn<K: Clone + Hash + Debug + Eq + Ord>(
+        self,
+        universe: &[K],
+        module_read_fn: &dyn Fn(usize) -> bool,
+        module_write_fn: &dyn Fn(usize) -> bool,
+        delta_fn: &dyn Fn(usize, &V) -> Option<DeltaOp>,
+        allow_deletes: bool,
+    ) -> MockTransaction<KeyType<K>, ValueType<V>> {
+        let reads = Self::reads_from_gen(universe, self.reads, &module_read_fn);
+        let gas = Self::gas_from_gen(self.gas);
+
+        let behaviors = Self::writes_and_deltas_from_gen(
+            universe,
+            self.modifications,
+            &module_write_fn,
+            &delta_fn,
+            allow_deletes,
+        )
+        .into_iter()
+        .zip(reads.into_iter())
+        .zip(gas.into_iter())
+        .map(|(((writes, deltas), reads), gas)| MockIncarnation {
+            reads,
+            writes,
+            deltas,
+            gas,
+        })
+        .collect();
+
+        MockTransaction::from_behaviors(behaviors)
+    }
+
+    pub(crate) fn materialize<K: Clone + Hash + Debug + Eq + Ord>(
         self,
         universe: &[K],
         // Are writes and reads module access (same access path).
         module_access: (bool, bool),
-    ) -> Transaction<KeyType<K>, ValueType<V>> {
-        let is_module_write = |_| -> bool { module_access.0 };
+    ) -> MockTransaction<KeyType<K>, ValueType<V>> {
         let is_module_read = |_| -> bool { module_access.1 };
+        let is_module_write = |_| -> bool { module_access.0 };
         let is_delta = |_, _: &V| -> Option<DeltaOp> { None };
-
         // Module deletion isn't allowed.
         let allow_deletes = !(module_access.0 || module_access.1);
 
-        Transaction::Write {
-            incarnation: Arc::new(AtomicUsize::new(0)),
-            writes_and_deltas: Self::writes_and_deltas_from_gen(
-                universe,
-                self.keys_modified,
-                &is_module_write,
-                &is_delta,
-                allow_deletes,
-            ),
-            reads: Self::reads_from_gen(universe, self.keys_read, &is_module_read),
-        }
+        self.new_mock_write_txn(
+            universe,
+            &is_module_read,
+            &is_module_write,
+            &is_delta,
+            allow_deletes,
+        )
     }
 
-    pub fn materialize_with_deltas<K: Clone + Hash + Debug + Eq + Ord>(
+    pub(crate) fn materialize_with_deltas<K: Clone + Hash + Debug + Eq + Ord>(
         self,
         universe: &[K],
         delta_threshold: usize,
         allow_deletes: bool,
-    ) -> Transaction<KeyType<K>, ValueType<V>> {
-        let is_module_write = |_| -> bool { false };
+    ) -> MockTransaction<KeyType<K>, ValueType<V>> {
         let is_module_read = |_| -> bool { false };
+        let is_module_write = |_| -> bool { false };
         let is_delta = |i, v: &V| -> Option<DeltaOp> {
             if i >= delta_threshold {
                 let val = AggregatorValue::from_write(&ValueType(v.clone(), true))
@@ -345,20 +425,16 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
             }
         };
 
-        Transaction::Write {
-            incarnation: Arc::new(AtomicUsize::new(0)),
-            writes_and_deltas: Self::writes_and_deltas_from_gen(
-                universe,
-                self.keys_modified,
-                &is_module_write,
-                &is_delta,
-                allow_deletes,
-            ),
-            reads: Self::reads_from_gen(universe, self.keys_read, &is_module_read),
-        }
+        self.new_mock_write_txn(
+            universe,
+            &is_module_read,
+            &is_module_write,
+            &is_delta,
+            allow_deletes,
+        )
     }
 
-    pub fn materialize_disjoint_module_rw<K: Clone + Hash + Debug + Eq + Ord>(
+    pub(crate) fn materialize_disjoint_module_rw<K: Clone + Hash + Debug + Eq + Ord>(
         self,
         universe: &[K],
         // keys generated with indices from read_threshold to write_threshold will be
@@ -367,30 +443,26 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
         // writes. This way there will be module accesses but no intersection.
         read_threshold: usize,
         write_threshold: usize,
-    ) -> Transaction<KeyType<K>, ValueType<V>> {
+    ) -> MockTransaction<KeyType<K>, ValueType<V>> {
         assert!(read_threshold < universe.len());
         assert!(write_threshold > read_threshold);
         assert!(write_threshold < universe.len());
 
-        let is_module_write = |i| -> bool { i >= write_threshold };
         let is_module_read = |i| -> bool { i >= read_threshold && i < write_threshold };
+        let is_module_write = |i| -> bool { i >= write_threshold };
         let is_delta = |_, _: &V| -> Option<DeltaOp> { None };
 
-        Transaction::Write {
-            incarnation: Arc::new(AtomicUsize::new(0)),
-            writes_and_deltas: Self::writes_and_deltas_from_gen(
-                universe,
-                self.keys_modified,
-                &is_module_write,
-                &is_delta,
-                false, // Module deletion isn't allowed
-            ),
-            reads: Self::reads_from_gen(universe, self.keys_read, &is_module_read),
-        }
+        self.new_mock_write_txn(
+            universe,
+            &is_module_read,
+            &is_module_write,
+            &is_delta,
+            false, // Module deletion isn't allowed
+        )
     }
 }
 
-impl<K, V> TransactionType for Transaction<K, V>
+impl<K, V> Transaction for MockTransaction<K, V>
 where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
     V: Debug + Send + Sync + Debug + Clone + TransactionWrite + 'static,
@@ -400,27 +472,27 @@ where
 }
 
 ///////////////////////////////////////////////////////////////////////////
-// Naive transaction executor implementation.
+// Mock transaction executor implementation.
 ///////////////////////////////////////////////////////////////////////////
 
 #[derive(Default)]
-pub struct Task<K, V>(PhantomData<(K, V)>);
+pub(crate) struct MockTask<K, V>(PhantomData<(K, V)>);
 
-impl<K, V> Task<K, V> {
+impl<K, V> MockTask<K, V> {
     pub fn new() -> Self {
         Self(PhantomData)
     }
 }
 
-impl<K, V> ExecutorTask for Task<K, V>
+impl<K, V> ExecutorTask for MockTask<K, V>
 where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
     V: Send + Sync + Debug + Clone + TransactionWrite + 'static,
 {
     type Argument = ();
     type Error = usize;
-    type Output = Output<K, V>;
-    type Txn = Transaction<K, V>;
+    type Output = MockOutput<K, V>;
+    type Txn = MockTransaction<K, V>;
 
     fn init(_argument: Self::Argument) -> Self {
         Self::new()
@@ -434,69 +506,57 @@ where
         _materialize_deltas: bool,
     ) -> ExecutionStatus<Self::Output, Self::Error> {
         match txn {
-            Transaction::Write {
-                incarnation,
-                reads,
-                writes_and_deltas,
+            MockTransaction::Write {
+                incarnation_counter,
+                incarnation_behaviors,
             } => {
                 // Use incarnation counter value as an index to determine the read-
                 // and write-sets of the execution. Increment incarnation counter to
                 // simulate dynamic behavior when there are multiple possible read-
                 // and write-sets (i.e. each are selected round-robin).
-                let idx = incarnation.fetch_add(1, Ordering::SeqCst);
-                let read_idx = idx % reads.len();
-                let write_idx = idx % writes_and_deltas.len();
+                let idx = incarnation_counter.fetch_add(1, Ordering::SeqCst);
+
+                let behavior = &incarnation_behaviors[idx % incarnation_behaviors.len()];
 
                 // Reads
                 let mut reads_result = vec![];
-                for k in reads[read_idx].iter() {
+                for k in behavior.reads.iter() {
                     // TODO: later test errors as well? (by fixing state_view behavior).
                     match view.get_state_value_bytes(k) {
                         Ok(v) => reads_result.push(v),
                         Err(_) => reads_result.push(None),
                     }
                 }
-                ExecutionStatus::Success(Output(
-                    writes_and_deltas[write_idx].0.clone(),
-                    writes_and_deltas[write_idx].1.clone(),
+                ExecutionStatus::Success(MockOutput(
+                    behavior.writes.clone(),
+                    behavior.deltas.clone(),
                     reads_result,
                     OnceCell::new(),
+                    behavior.gas,
                 ))
             },
-            Transaction::SkipRest => ExecutionStatus::SkipRest(Output::skip_output()),
-            Transaction::Abort => ExecutionStatus::Abort(txn_idx as usize),
+            MockTransaction::SkipRest => ExecutionStatus::SkipRest(MockOutput::skip_output()),
+            MockTransaction::Abort => ExecutionStatus::Abort(txn_idx as usize),
         }
     }
 }
 
 #[derive(Debug)]
-pub struct Output<K, V>(
-    Vec<(K, V)>,
-    Vec<(K, DeltaOp)>,
-    Vec<Option<Vec<u8>>>,
+// TODO: name members.
+pub(crate) struct MockOutput<K, V>(
+    pub(crate) Vec<(K, V)>,
+    pub(crate) Vec<(K, DeltaOp)>,
+    pub(crate) Vec<Option<Vec<u8>>>,
     pub(crate) OnceCell<Vec<(K, WriteOp)>>,
+    pub(crate) u64,
 );
 
-impl<K, V> Output<K, V>
+impl<K, V> TransactionOutput for MockOutput<K, V>
 where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
     V: Send + Sync + Debug + Clone + TransactionWrite + 'static,
 {
-    pub(crate) fn delta_writes(&self) -> Vec<(K, WriteOp)> {
-        if self.3.get().is_some() {
-            self.3.get().cloned().expect("Delta writes must be set")
-        } else {
-            Vec::new()
-        }
-    }
-}
-
-impl<K, V> TransactionOutput for Output<K, V>
-where
-    K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
-    V: Send + Sync + Debug + Clone + TransactionWrite + 'static,
-{
-    type Txn = Transaction<K, V>;
+    type Txn = MockTransaction<K, V>;
 
     fn get_writes(&self) -> Vec<(K, V)> {
         self.0.clone()
@@ -507,236 +567,24 @@ where
     }
 
     fn skip_output() -> Self {
-        Self(vec![], vec![], vec![], OnceCell::new())
+        Self(
+            /*writes = */ vec![],
+            /*deltas = */ vec![],
+            /*read results = */ vec![],
+            /*materialized delta writes = */ OnceCell::new(),
+            /*gas = */ 0,
+        )
     }
 
     fn incorporate_delta_writes(&self, delta_writes: Vec<(K, WriteOp)>) {
         assert_ok!(self.3.set(delta_writes));
     }
 
-    fn gas_used(&self) -> u64 {
-        1
-    }
-
     fn fee_statement(&self) -> FeeStatement {
-        FeeStatement::new(1, 1, 0, 0, 0)
-    }
-}
-
-///////////////////////////////////////////////////////////////////////////
-// Sequential Baseline implementation.
-///////////////////////////////////////////////////////////////////////////
-
-/// Sequential baseline of execution result for dummy transaction.
-pub enum ExpectedOutput<V> {
-    Aborted(usize),
-    SkipRest(usize, Vec<Vec<(Option<V>, Option<u128>)>>),
-    Success(Vec<Vec<(Option<V>, Option<u128>)>>),
-    DeltaFailure(usize, Vec<Vec<(Option<V>, Option<u128>)>>),
-    ExceedBlockGasLimit(usize, Vec<Vec<(Option<V>, Option<u128>)>>),
-}
-
-impl<V: Debug + Clone + PartialEq + Eq + TransactionWrite> ExpectedOutput<V> {
-    /// Must be invoked after parallel execution to work with dynamic read/writes.
-    pub fn generate_baseline<K: Hash + Clone + Eq>(
-        txns: &[Transaction<K, V>],
-        resolved_deltas: Option<Vec<Vec<(K, WriteOp)>>>,
-        maybe_block_gas_limit: Option<u64>,
-    ) -> Self {
-        let mut current_world = HashMap::new();
-        // Delta world stores the latest u128 value of delta aggregator. When empty, the
-        // value is derived based on deserializing current_world, or falling back to
-        // STORAGE_AGGREGATOR_VAL.
-        let mut delta_world = HashMap::new();
-        let mut accumulated_gas = 0;
-
-        let mut result_vec = vec![];
-        for (idx, txn) in txns.iter().enumerate() {
-            let delta_writes_at_idx = resolved_deltas.as_ref().map(|delta_writes| {
-                delta_writes[idx]
-                    .iter()
-                    .cloned()
-                    .collect::<HashMap<K, WriteOp>>()
-            });
-
-            match txn {
-                Transaction::Abort => return Self::Aborted(idx),
-                Transaction::Write {
-                    incarnation,
-                    writes_and_deltas,
-                    reads,
-                } => {
-                    // Determine the read and write sets of the latest incarnation
-                    // of the transaction. The index for choosing the read and
-                    // write sets is based on the value of the incarnation counter
-                    // prior to the fetch_add during the last execution.
-                    let incarnation = incarnation.load(Ordering::SeqCst);
-
-                    if reads.len() == 1 || writes_and_deltas.len() == 1 {
-                        assert!(incarnation > 0, "must run after parallel execution");
-                    }
-
-                    // Determine the read-, delta- and write-sets of the latest
-                    // incarnation during parallel execution to use for the baseline.
-                    let read_set = &reads[(incarnation - 1) % reads.len()];
-                    let (write_set, delta_set) =
-                        &writes_and_deltas[(incarnation - 1) % writes_and_deltas.len()];
-
-                    let mut result = vec![];
-                    for k in read_set.iter() {
-                        result.push((current_world.get(k).cloned(), delta_world.get(k).cloned()));
-                    }
-
-                    // We ensure that the latest state is always reflected in exactly one of
-                    // the hashmaps, by possibly removing an element from the other Hashmap.
-                    for (k, v) in write_set.iter() {
-                        delta_world.remove(k);
-                        current_world.insert(k.clone(), v.clone());
-                    }
-
-                    for (k, delta) in delta_set.iter() {
-                        let latest_write = current_world.remove(k);
-
-                        match delta_writes_at_idx.as_ref() {
-                            Some(delta_writes) => {
-                                assert_eq!(delta_writes.len(), delta_set.len());
-                                delta_world.insert(
-                                    k.clone(),
-                                    AggregatorValue::from_write(delta_writes.get(k).unwrap())
-                                        .unwrap()
-                                        .into(),
-                                );
-                            },
-                            None => {
-                                let base = match (&latest_write, delta_world.remove(k)) {
-                                    (Some(_), Some(_)) => {
-                                        unreachable!(
-                                            "Must record latest value or resolved delta, not both"
-                                        );
-                                    },
-                                    // Get base value from the latest write.
-                                    (Some(w_value), None) => AggregatorValue::from_write(w_value)
-                                        .map(|value| value.into()),
-                                    // Get base value from latest resolved aggregator value.
-                                    (None, Some(value)) => Some(value),
-                                    // Storage always gets resolved to a default constant.
-                                    (None, None) => Some(STORAGE_AGGREGATOR_VALUE),
-                                };
-
-                                match base {
-                                    Some(base) => {
-                                        let applied_delta = delta.apply_to(base);
-                                        if applied_delta.is_err() {
-                                            return Self::DeltaFailure(idx, result_vec);
-                                        }
-                                        delta_world.insert(k.clone(), applied_delta.unwrap());
-                                    },
-                                    None => {
-                                        // Latest write was a deletion, can't resolve any delta to
-                                        // it, must keep the deletion as the latest Op.
-                                        current_world.insert(k.clone(), latest_write.unwrap());
-                                    },
-                                }
-                            },
-                        }
-                    }
-
-                    result_vec.push(result);
-
-                    // In unit tests, the gas_used of any txn is set to be 1.
-                    accumulated_gas += 1;
-                    if let Some(block_gas_limit) = maybe_block_gas_limit {
-                        if accumulated_gas >= block_gas_limit {
-                            return Self::ExceedBlockGasLimit(idx, result_vec);
-                        }
-                    }
-                },
-                Transaction::SkipRest => return Self::SkipRest(idx, result_vec),
-            }
-        }
-        Self::Success(result_vec)
-    }
-
-    fn check_result(expected_results: &[(Option<V>, Option<u128>)], results: &[Option<Vec<u8>>]) {
-        expected_results
-            .iter()
-            .zip(results.iter())
-            .for_each(|(expected_result, result)| match result {
-                Some(value) => match expected_result {
-                    (Some(v), None) => {
-                        assert_eq!(v.extract_raw_bytes().unwrap(), *value);
-                    },
-                    (None, Some(v)) => {
-                        assert_eq!(serialize(v), *value);
-                    },
-                    (Some(_), Some(_)) => unreachable!(),
-                    (None, None) => {
-                        assert_eq!(deserialize(value), STORAGE_AGGREGATOR_VALUE);
-                    },
-                },
-                None => {
-                    if let Some(val) = &expected_result.0 {
-                        assert_none!(val.extract_raw_bytes());
-                    }
-                    assert_eq!(expected_result.1, None);
-                },
-            })
-    }
-
-    // Used for testing, hence the function asserts the correctness conditions within
-    // itself to be easily traceable in case of an error.
-    pub fn assert_output<K>(&self, results: &Result<Vec<Output<K, V>>, usize>) {
-        match (self, results) {
-            (Self::Aborted(i), Err(Error::UserError(idx))) => {
-                assert_eq!(i, idx);
-            },
-            (Self::SkipRest(skip_at, expected_results), Ok(results)) => {
-                // Check_result asserts internally, so no need to return a bool.
-                results
-                    .iter()
-                    .take(*skip_at)
-                    .zip(expected_results.iter())
-                    .for_each(|(Output(_, _, result, _), expected_results)| {
-                        Self::check_result(expected_results, result)
-                    });
-
-                results
-                    .iter()
-                    .skip(*skip_at)
-                    .for_each(|Output(_, _, result, _)| assert!(result.is_empty()))
-            },
-            (Self::ExceedBlockGasLimit(last_committed, expected_results), Ok(results)) => {
-                // Check_result asserts internally, so no need to return a bool.
-                results
-                    .iter()
-                    .take(*last_committed + 1)
-                    .zip(expected_results.iter())
-                    .for_each(|(Output(_, _, result, _), expected_results)| {
-                        Self::check_result(expected_results, result)
-                    });
-
-                results
-                    .iter()
-                    .skip(*last_committed + 1)
-                    .for_each(|Output(_, _, result, _)| assert!(result.is_empty()))
-            },
-            (Self::DeltaFailure(fail_idx, expected_results), Ok(results)) => {
-                // Check_result asserts internally, so no need to return a bool.
-                results
-                    .iter()
-                    .take(*fail_idx)
-                    .zip(expected_results.iter())
-                    .for_each(|(Output(_, _, result, _), expected_results)| {
-                        Self::check_result(expected_results, result)
-                    });
-            },
-            (Self::Success(expected_results), Ok(results)) => results
-                .iter()
-                .zip(expected_results.iter())
-                .for_each(|(Output(_, _, result, _), expected_result)| {
-                    Self::check_result(expected_result, result);
-                }),
-            _ => panic!("Incomparable execution outcomes"),
-        }
+        // First argument is supposed to be total (not important for the test though).
+        // Next two arguments are different kinds of execution gas that are counted
+        // towards the block limit. We split the total into two pieces for these arguments.
+        // TODO: add variety to generating fee statement based on total gas (self.4).
+        FeeStatement::new(self.4, self.4 / 2, (self.4 + 1) / 2, 0, 0)
     }
 }

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -94,9 +94,6 @@ pub trait TransactionOutput: Send + Sync + Debug {
         delta_writes: Vec<(<Self::Txn as Transaction>::Key, WriteOp)>,
     );
 
-    /// Return the amount of gas consumed by the transaction.
-    fn gas_used(&self) -> u64;
-
     /// Return the fee statement of the transaction.
     fn fee_statement(&self) -> FeeStatement;
 }

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -4,8 +4,12 @@
 
 use crate::{
     executor::BlockExecutor,
-    proptest_types::types::{
-        DeltaDataView, ExpectedOutput, KeyType, Output, Task, Transaction, ValueType,
+    proptest_types::{
+        baseline::BaselineOutput,
+        types::{
+            DeltaDataView, KeyType, MockIncarnation, MockOutput, MockTask, MockTransaction,
+            ValueType,
+        },
     },
     scheduler::{DependencyResult, ExecutionTaskType, Scheduler, SchedulerTask},
     txn_commit_hook::NoOpTransactionCommitHook,
@@ -19,15 +23,12 @@ use aptos_types::{
 use claims::{assert_matches, assert_some_eq};
 use rand::{prelude::*, random};
 use std::{
-    cmp::min,
-    collections::BTreeMap,
-    fmt::Debug,
-    hash::Hash,
-    marker::PhantomData,
-    sync::{atomic::AtomicUsize, Arc},
+    cmp::min, collections::BTreeMap, fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc,
 };
 
-fn run_and_assert<K, V>(transactions: Vec<Transaction<K, V>>)
+// TODO: add unit test for block gas limit!
+
+fn run_and_assert<K, V>(transactions: Vec<MockTransaction<K, V>>)
 where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
     V: Send + Sync + Debug + Clone + Eq + TransactionWrite + 'static,
@@ -44,15 +45,15 @@ where
     );
 
     let output = BlockExecutor::<
-        Transaction<K, V>,
-        Task<K, V>,
+        MockTransaction<K, V>,
+        MockTask<K, V>,
         DeltaDataView<K, V>,
-        NoOpTransactionCommitHook<Output<K, V>, usize>,
+        NoOpTransactionCommitHook<MockOutput<K, V>, usize>,
         ExecutableTestType,
     >::new(num_cpus::get(), executor_thread_pool, None, None)
     .execute_transactions_parallel((), &transactions, &data_view);
 
-    let baseline = ExpectedOutput::generate_baseline(&transactions, None, None);
+    let baseline = BaselineOutput::generate(&transactions, None);
     baseline.assert_output(&output);
 }
 
@@ -70,32 +71,36 @@ fn empty_block() {
 #[test]
 fn delta_counters() {
     let key = KeyType(random::<[u8; 32]>(), false);
-    let mut transactions = vec![Transaction::Write {
-        incarnation: Arc::new(AtomicUsize::new(0)),
-        reads: vec![vec![]],
-        writes_and_deltas: vec![(vec![(key, random_value(false))], vec![])],
-    }];
+    let mut transactions = vec![MockTransaction::from_behavior(MockIncarnation {
+        reads: vec![],
+        writes: vec![(key, random_value(false))],
+        deltas: vec![],
+        gas: 1,
+    })];
 
     for _ in 0..50 {
-        transactions.push(Transaction::Write {
-            incarnation: Arc::new(AtomicUsize::new(0)),
-            reads: vec![vec![key]],
-            writes_and_deltas: vec![(vec![], vec![(key, delta_add(5, u128::MAX))])],
-        });
+        transactions.push(MockTransaction::from_behavior(MockIncarnation {
+            reads: vec![key],
+            writes: vec![],
+            deltas: vec![(key, delta_add(5, u128::MAX))],
+            gas: 1,
+        }));
     }
 
-    transactions.push(Transaction::Write {
-        incarnation: Arc::new(AtomicUsize::new(0)),
-        reads: vec![vec![]],
-        writes_and_deltas: vec![(vec![(key, random_value(false))], vec![])],
-    });
+    transactions.push(MockTransaction::from_behavior(MockIncarnation {
+        reads: vec![],
+        writes: vec![(key, random_value(false))],
+        deltas: vec![],
+        gas: 1,
+    }));
 
     for _ in 0..50 {
-        transactions.push(Transaction::Write {
-            incarnation: Arc::new(AtomicUsize::new(0)),
-            reads: vec![vec![key]],
-            writes_and_deltas: vec![(vec![], vec![(key, delta_sub(2, u128::MAX))])],
-        });
+        transactions.push(MockTransaction::from_behavior(MockIncarnation {
+            reads: vec![key],
+            writes: vec![],
+            deltas: vec![(key, delta_sub(2, u128::MAX))],
+            gas: 1,
+        }));
     }
 
     run_and_assert(transactions)
@@ -112,12 +117,12 @@ fn delta_chains() {
 
     for i in 0..500 {
         transactions.push(
-            Transaction::Write::<KeyType<[u8; 32]>, ValueType<[u8; 32]>> {
-                incarnation: Arc::new(AtomicUsize::new(0)),
-                reads: vec![keys.clone()],
-                writes_and_deltas: vec![(
-                    vec![],
-                    keys.iter()
+            MockTransaction::<KeyType<[u8; 32]>, ValueType<[u8; 32]>>::from_behavior(
+                MockIncarnation {
+                    reads: keys.clone(),
+                    writes: vec![],
+                    deltas: keys
+                        .iter()
                         .enumerate()
                         .filter_map(|(j, k)| match (i + j) % 2 == 0 {
                             true => Some((
@@ -138,9 +143,10 @@ fn delta_chains() {
                             false => None,
                         })
                         .collect(),
-                )],
-            },
-        )
+                    gas: 1,
+                },
+            ),
+        );
     }
 
     run_and_assert(transactions)
@@ -157,11 +163,12 @@ fn cycle_transactions() {
     for _ in 0..TOTAL_KEY_NUM {
         let key = random::<[u8; 32]>();
         for _ in 0..WRITES_PER_KEY {
-            transactions.push(Transaction::Write {
-                incarnation: Arc::new(AtomicUsize::new(0)),
-                reads: vec![vec![KeyType(key, false)]],
-                writes_and_deltas: vec![(vec![(KeyType(key, false), random_value(false))], vec![])],
-            })
+            transactions.push(MockTransaction::from_behavior(MockIncarnation {
+                reads: vec![KeyType(key, false)],
+                writes: vec![(KeyType(key, false), random_value(false))],
+                deltas: vec![],
+                gas: 1,
+            }));
         }
     }
     run_and_assert(transactions)
@@ -178,18 +185,20 @@ fn one_reads_all_barrier() {
         .collect();
     for _ in 0..NUM_BLOCKS {
         for key in &keys {
-            transactions.push(Transaction::Write {
-                incarnation: Arc::new(AtomicUsize::new(0)),
-                reads: vec![vec![*key]],
-                writes_and_deltas: vec![(vec![(*key, random_value(false))], vec![])],
-            })
+            transactions.push(MockTransaction::from_behavior(MockIncarnation {
+                reads: vec![*key],
+                writes: vec![(*key, random_value(false))],
+                deltas: vec![],
+                gas: 1,
+            }));
         }
         // One transaction reading the write results of every prior transactions in the block.
-        transactions.push(Transaction::Write {
-            incarnation: Arc::new(AtomicUsize::new(0)),
-            reads: vec![keys.clone()],
-            writes_and_deltas: vec![(vec![], vec![])],
-        })
+        transactions.push(MockTransaction::from_behavior(MockIncarnation {
+            reads: keys.clone(),
+            writes: vec![],
+            deltas: vec![],
+            gas: 1,
+        }));
     }
     run_and_assert(transactions)
 }
@@ -202,23 +211,23 @@ fn one_writes_all_barrier() {
         .collect();
     for _ in 0..NUM_BLOCKS {
         for key in &keys {
-            transactions.push(Transaction::Write {
-                incarnation: Arc::new(AtomicUsize::new(0)),
-                reads: vec![vec![*key]],
-                writes_and_deltas: vec![(vec![(*key, random_value(false))], vec![])],
-            })
+            transactions.push(MockTransaction::from_behavior(MockIncarnation {
+                reads: vec![*key],
+                writes: vec![(*key, random_value(false))],
+                deltas: vec![],
+                gas: 1,
+            }));
         }
         // One transaction writing to the write results of every prior transactions in the block.
-        transactions.push(Transaction::Write {
-            incarnation: Arc::new(AtomicUsize::new(0)),
-            reads: vec![keys.clone()],
-            writes_and_deltas: vec![(
-                keys.iter()
-                    .map(|key| (*key, random_value(false)))
-                    .collect::<Vec<_>>(),
-                vec![],
-            )],
-        })
+        transactions.push(MockTransaction::from_behavior(MockIncarnation {
+            reads: keys.clone(),
+            writes: keys
+                .iter()
+                .map(|key| (*key, random_value(false)))
+                .collect::<Vec<_>>(),
+            deltas: vec![],
+            gas: 1,
+        }));
     }
     run_and_assert(transactions)
 }
@@ -232,14 +241,15 @@ fn early_aborts() {
 
     for _ in 0..NUM_BLOCKS {
         for key in &keys {
-            transactions.push(Transaction::Write {
-                incarnation: Arc::new(AtomicUsize::new(0)),
-                reads: vec![vec![*key]],
-                writes_and_deltas: vec![(vec![(*key, random_value(false))], vec![])],
-            })
+            transactions.push(MockTransaction::from_behavior(MockIncarnation {
+                reads: vec![*key],
+                writes: vec![(*key, random_value(false))],
+                deltas: vec![],
+                gas: 1,
+            }));
         }
         // One transaction that triggers an abort
-        transactions.push(Transaction::Abort)
+        transactions.push(MockTransaction::Abort)
     }
     run_and_assert(transactions)
 }
@@ -253,14 +263,15 @@ fn early_skips() {
 
     for _ in 0..NUM_BLOCKS {
         for key in &keys {
-            transactions.push(Transaction::Write {
-                incarnation: Arc::new(AtomicUsize::new(0)),
-                reads: vec![vec![*key]],
-                writes_and_deltas: vec![(vec![(*key, random_value(false))], vec![])],
-            })
+            transactions.push(MockTransaction::from_behavior(MockIncarnation {
+                reads: vec![*key],
+                writes: vec![(*key, random_value(false))],
+                deltas: vec![],
+                gas: 1,
+            }));
         }
         // One transaction that triggers an abort
-        transactions.push(Transaction::SkipRest)
+        transactions.push(MockTransaction::SkipRest)
     }
     run_and_assert(transactions)
 }

--- a/aptos-move/mvhashmap/src/versioned_data.rs
+++ b/aptos-move/mvhashmap/src/versioned_data.rs
@@ -123,26 +123,26 @@ impl<V: TransactionWrite> VersionedValue<V> {
                 (EntryCell::Write(incarnation, data), Some(accumulator)) => {
                     // Deltas were applied. We must deserialize the value
                     // of the write and apply the aggregated delta accumulator.
-
-                    // None if data represents deletion. Otherwise, panics if the
-                    // data can't be resolved to an aggregator value.
-                    let maybe_value = AggregatorValue::from_write(data.as_ref());
-
-                    if maybe_value.is_none() {
-                        // Resolve to the write if the WriteOp was deletion
-                        // (MoveVM will observe 'deletion'). This takes precedence
-                        // over any speculative delta accumulation errors on top.
-                        let write_version = (*idx, *incarnation);
-                        return Ok(Versioned(write_version, data.clone()));
-                    }
-                    return accumulator
-                        .map_err(|_| DeltaApplicationFailure)
-                        .and_then(|a| {
-                            // Apply accumulated delta to resolve the aggregator value.
-                            a.apply_to(maybe_value.unwrap().into())
-                                .map(|result| Resolved(result))
+                    return match AggregatorValue::from_write(data.as_ref()) {
+                        None => {
+                            // Resolve to the write if the WriteOp was deletion
+                            // (MoveVM will observe 'deletion'). This takes precedence
+                            // over any speculative delta accumulation errors on top.
+                            let write_version = (*idx, *incarnation);
+                            Ok(Versioned(write_version, data.clone()))
+                        },
+                        Some(value) => {
+                            // Panics if the data can't be resolved to an aggregator value.
+                            accumulator
                                 .map_err(|_| DeltaApplicationFailure)
-                        });
+                                .and_then(|a| {
+                                    // Apply accumulated delta to resolve the aggregator value.
+                                    a.apply_to(value.into())
+                                        .map(|result| Resolved(result))
+                                        .map_err(|_| DeltaApplicationFailure)
+                                })
+                        },
+                    };
                 },
                 (EntryCell::Delta(delta, maybe_shortcut), Some(accumulator)) => {
                     if let Some(shortcut_value) = maybe_shortcut {
@@ -270,12 +270,13 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite> VersionedData<K, V> {
         }));
     }
 
-    // When a transaction is committed, this method can be called for its delta outputs to add
-    // a 'shortcut' to the corresponding materialized aggregator value, so any subsequent reads
-    // do not have to traverse below the index. It must be guaranteed by the caller that the
-    // data recorded below this index will not change after the call, and that the corresponding
-    // transaction has indeed produced a delta recorded at the given key.
-    // If the result is None, it means the base value hadn't been set.
+    /// When a transaction is committed, this method can be called for its delta outputs to add
+    /// a 'shortcut' to the corresponding materialized aggregator value, so any subsequent reads
+    /// do not have to traverse below the index. It must be guaranteed by the caller that the
+    /// data recorded below this index will not change after the call, and that the corresponding
+    /// transaction has indeed produced a delta recorded at the given key.
+    ///
+    /// If the result is Err(op), it means the base value to apply DeltaOp op hadn't been set.
     pub(crate) fn materialize_delta(&self, key: &K, txn_idx: TxnIndex) -> Result<u128, DeltaOp> {
         let mut v = self.values.get_mut(key).expect("Path must exist");
 
@@ -290,7 +291,10 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite> VersionedData<K, V> {
                 Ok(value)
             },
             Err(MVDataError::Unresolved(op)) => Err(op),
-            _ => unreachable!("Must be a delta at key = {:?}, txn_idx = {}", key, txn_idx),
+            _ => unreachable!(
+                "Must resolve delta at key = {:?}, txn_idx = {}",
+                key, txn_idx
+            ),
         }
     }
 }


### PR DESCRIPTION
Our biggest pride, the mock tests for block executor, got in a rather messy state overtime due to constantly adding more and more coverage in ad-hoc ways (no named members, ad-hoc ways to get coverage, e.g. dynamic r/w behavior for different incarnations, aggregator deltas, etc). This makes it hard to maintain, extend, and in fact to support new features - including aggregator failures (or promises) and code cache. Here is a first attempt to address it by a refactor, moved out baseline generation, adjusted names, cleaned up structure, added some todos. Definitely easier to test for example delta failures now, but will be making some more follow-up changes - sending this one to keep PR sizes manageable. 

Other improvements:
- gas testing now charges different gas for different incarnations, also charges both io and execution gas that are both counted (previously was only one of them and always set to 1).
- in some cases the gas of the last transaction wouldn't be counted for monitoring, should be fixed.
- moved gas counter related things to counters.rs to declutter executor.rs
- removed unnecessary trait method .gas_used that doesn't seem to be used anywhere.
- cleaned up generation and testing for different incarnation behaviors.

What's left:
- MockTransaction generation should be factored out and cleaned up, in particular, we should disentangle generating writes and deltas.
- Mock Execution should also be factored out and cleaned up. We should also add reads to writes (read-before-write), maybe as a configuration parameter (but the real system currently behaves so). 
- MockOutput could also use some love (e.g. unnamed parameters)
- How the threadpools are used needs to be improved, when running on high concurrency, the tests shouldn't be running concurrently.
- We should ensure that like before, tests do not take more than 60s, this way, seeing the warning means a regression and is an useful signal.
- of course the new tests for code handling (as a part of the new loader integration) and new aggregator features.

We also want to set-up a daily long-running correctness test and contended load land-blocking performance test, but the latter can wait until some planned performance fixes.