### PR TITLE
[CLI] fix u64 to u256 input args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -556,7 +556,7 @@ sha3 = "0.9.1"
 siphasher = "0.3.10"
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_bytes = "0.11.6"
-serde_json = { version = "1.0.81", features = ["preserve_order"] }
+serde_json = { version = "1.0.81", features = ["preserve_order", "arbitrary_precision"] } # Note: arbitrary_precision is required to parse u256 in JSON
 serde_repr = "0.1"
 serde_merge = "0.1.3"
 serde-name = "0.1.1"

--- a/api/goldens/aptos_api__tests__invalid_post_request_test__test_invalid_entry_function_argument_address_type.json
+++ b/api/goldens/aptos_api__tests__invalid_post_request_test__test_invalid_entry_function_argument_address_type.json
@@ -1,5 +1,5 @@
 {
-  "message": "The given transaction is invalid: Failed to parse transaction payload: parse arguments[0] failed, expect string<address>, caused by error: invalid type: integer `1`, expected a string",
+  "message": "The given transaction is invalid: Failed to parse transaction payload: parse arguments[0] failed, expect string<address>, caused by error: invalid type: number, expected a string",
   "error_code": "invalid_input",
   "vm_error_code": null
 }

--- a/aptos-move/move-examples/cli-e2e-tests/common/sources/cli_e2e_tests.move
+++ b/aptos-move/move-examples/cli-e2e-tests/common/sources/cli_e2e_tests.move
@@ -259,8 +259,13 @@ module addr::cli_e2e_tests {
 
     // The following functions are used to test input args
     #[view]
-    public fun test_u64(n: u64): u64 {
-        n
+    public fun test_big_number(
+        u64: u64,
+        _u128: u128,
+        _u256: u256,
+    ): u64 {
+        // Just return u64 number, we mainly use this to display the number in the test
+        u64
     }
 
     inline fun get_hero(creator: &address, collection: &String, name: &String): (Object<Hero>, &Hero) {

--- a/aptos-move/move-examples/cli-e2e-tests/common/sources/cli_e2e_tests.move
+++ b/aptos-move/move-examples/cli-e2e-tests/common/sources/cli_e2e_tests.move
@@ -257,6 +257,12 @@ module addr::cli_e2e_tests {
         }
     }
 
+    // The following functions are used to test input args
+    #[view]
+    public fun test_u64(n: u64): u64 {
+        n
+    }
+
     inline fun get_hero(creator: &address, collection: &String, name: &String): (Object<Hero>, &Hero) {
         let token_address = token::create_token_address(
             creator,

--- a/aptos-move/move-examples/cli-e2e-tests/common/sources/cli_e2e_tests.move
+++ b/aptos-move/move-examples/cli-e2e-tests/common/sources/cli_e2e_tests.move
@@ -260,12 +260,11 @@ module addr::cli_e2e_tests {
     // The following functions are used to test input args
     #[view]
     public fun test_big_number(
-        u64: u64,
-        _u128: u128,
-        _u256: u256,
-    ): u64 {
-        // Just return u64 number, we mainly use this to display the number in the test
-        u64
+        num64: u64,
+        num128: u128,
+        num256: u256,
+    ): (u64, u128, u256) {
+        (num64, num128, num256)
     }
 
     inline fun get_hero(creator: &address, collection: &String, name: &String): (Object<Hero>, &Hero) {

--- a/crates/aptos/e2e/cases/move.py
+++ b/crates/aptos/e2e/cases/move.py
@@ -200,9 +200,13 @@ def test_move_view(run_helper: RunHelper, test_name=None):
     response = json.loads(response.stdout)
     if response["Result"] == None or response["Result"][0] != True:
         raise TestError("View function did not return correct result")
-    
+
     # Test view function with with big number arguments
-    expected_number = 18446744073709551615
+    expected_u64 = 18446744073709551615
+    expected_128 = 340282366920938463463374607431768211455
+    expected_256 = (
+        115792089237316195423570985008687907853269984665640564039457584007913129639935
+    )
     response = run_helper.run_command(
         test_name,
         [
@@ -213,12 +217,19 @@ def test_move_view(run_helper: RunHelper, test_name=None):
             "--function-id",
             "default::cli_e2e_tests::test_big_number",
             "--args",
-            f"u64:{expected_number}",
-            "u128:340282366920938463463374607431768211455",
-            "u256:115792089237316195423570985008687907853269984665640564039457584007913129639935", # Important to test this big number
+            f"u64:{expected_u64}",
+            f"u128:{expected_128}",
+            f"u256:{expected_256}",  # Important to test this big number
         ],
     )
-    
+
     response = json.loads(response.stdout)
-    if response["Result"] == None or response["Result"][0] != f"{expected_number}":
-        raise TestError(f"View function [test_big_number] did not return correct result")
+    if (
+        response["Result"] == None
+        or response["Result"][0] != f"{expected_u64}"
+        or response["Result"][1] != f"{expected_128}"
+        or response["Result"][2] != f"{expected_256}"
+    ):
+        raise TestError(
+            f"View function [test_big_number] did not return correct result"
+        )

--- a/crates/aptos/e2e/cases/move.py
+++ b/crates/aptos/e2e/cases/move.py
@@ -202,7 +202,7 @@ def test_move_view(run_helper: RunHelper, test_name=None):
         raise TestError("View function did not return correct result")
     
     # Test view function with with u64 argument
-    expected_u64 = 123
+    expected_number = 123
     response = run_helper.run_command(
         test_name,
         [
@@ -211,12 +211,14 @@ def test_move_view(run_helper: RunHelper, test_name=None):
             "view",
             "--assume-yes",
             "--function-id",
-            "default::cli_e2e_tests::test_u64",
+            "default::cli_e2e_tests::test_big_number",
             "--args",
-            f"u64:{expected_u64}",
+            f"u64:{expected_number}",
+            "u128:123456",
+            "u256:340282366920938463463374607431768211455", # Important to test this big number
         ],
     )
     
     response = json.loads(response.stdout)
-    if response["Result"] == None or response["Result"][0] != "123":
-        raise TestError(f"View function [test_u64] did not return correct result")
+    if response["Result"] == None or response["Result"][0] != f"{expected_number}":
+        raise TestError(f"View function [test_big_number] did not return correct result")

--- a/crates/aptos/e2e/cases/move.py
+++ b/crates/aptos/e2e/cases/move.py
@@ -200,3 +200,23 @@ def test_move_view(run_helper: RunHelper, test_name=None):
     response = json.loads(response.stdout)
     if response["Result"] == None or response["Result"][0] != True:
         raise TestError("View function did not return correct result")
+    
+    # Test view function with with u64 argument
+    expected_u64 = 123
+    response = run_helper.run_command(
+        test_name,
+        [
+            "aptos",
+            "move",
+            "view",
+            "--assume-yes",
+            "--function-id",
+            "default::cli_e2e_tests::test_u64",
+            "--args",
+            f"u64:{expected_u64}",
+        ],
+    )
+    
+    response = json.loads(response.stdout)
+    if response["Result"] == None or response["Result"][0] != "123":
+        raise TestError(f"View function [test_u64] did not return correct result")

--- a/crates/aptos/e2e/cases/move.py
+++ b/crates/aptos/e2e/cases/move.py
@@ -201,8 +201,8 @@ def test_move_view(run_helper: RunHelper, test_name=None):
     if response["Result"] == None or response["Result"][0] != True:
         raise TestError("View function did not return correct result")
     
-    # Test view function with with u64 argument
-    expected_number = 123
+    # Test view function with with big number arguments
+    expected_number = 18446744073709551615
     response = run_helper.run_command(
         test_name,
         [
@@ -214,8 +214,8 @@ def test_move_view(run_helper: RunHelper, test_name=None):
             "default::cli_e2e_tests::test_big_number",
             "--args",
             f"u64:{expected_number}",
-            "u128:123456",
-            "u256:340282366920938463463374607431768211455", # Important to test this big number
+            "u128:340282366920938463463374607431768211455",
+            "u256:115792089237316195423570985008687907853269984665640564039457584007913129639935", # Important to test this big number
         ],
     )
     

--- a/crates/aptos/e2e/main.py
+++ b/crates/aptos/e2e/main.py
@@ -126,11 +126,11 @@ def run_tests(run_helper):
     test_aptos_header_included(run_helper)
 
     # Run move subcommand group tests.
-    test_move_view(run_helper)
     test_move_compile(run_helper)
     test_move_compile_script(run_helper)
     test_move_publish(run_helper)
     test_move_run(run_helper)
+    test_move_view(run_helper)
 
 
 def main():

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -1513,8 +1513,24 @@ impl ArgWithType {
         &'a self,
     ) -> CliTypedResult<serde_json::Value> {
         match self._vector_depth {
-            0 => serde_json::to_value(bcs::from_bytes::<T>(&self.arg)?)
-                .map_err(|err| CliError::UnexpectedError(err.to_string())),
+            0 => match self._ty.clone() {
+                FunctionArgType::U64 => {
+                    serde_json::to_value(bcs::from_bytes::<u64>(&self.arg)?.to_string())
+                        .map_err(|err| CliError::UnexpectedError(err.to_string()))
+                },
+                FunctionArgType::U128 => {
+                    serde_json::to_value(bcs::from_bytes::<u128>(&self.arg)?.to_string())
+                        .map_err(|err| CliError::UnexpectedError(err.to_string()))
+                },
+                FunctionArgType::U256 => {
+                    serde_json::to_value(bcs::from_bytes::<U256>(&self.arg)?.to_string())
+                        .map_err(|err| CliError::UnexpectedError(err.to_string()))
+                },
+                FunctionArgType::Raw => serde_json::to_value(&self.arg)
+                    .map_err(|err| CliError::UnexpectedError(err.to_string())),
+                _ => serde_json::to_value(bcs::from_bytes::<T>(&self.arg)?)
+                    .map_err(|err| CliError::UnexpectedError(err.to_string())),
+            },
             1 => serde_json::to_value(bcs::from_bytes::<Vec<T>>(&self.arg)?)
                 .map_err(|err| CliError::UnexpectedError(err.to_string())),
 


### PR DESCRIPTION
### Description

This fix the issue #8982  when parsing u64, u128 and u256 args from the CLI. This was originally broken by the nested vector PR #7790  If we look at the changes carefully, we were explicitly casting to string `.to_string()` for u62 - u256, on the `.to_json()` method, but the nested vector PR missed this part.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

**All tested on devnet**

Created a move func and tested make sure u64 works
```
➜  hello_blockchain git:(main) aptos-debug move view --function-id default::message::test_u64 --args u64:1
{
  "Result": [
    "1"
  ]
}

➜  devnet git:(jin/fix_u64_u128_u256_args) ✗ aptos-debug move view --function-id \
devnet::cli_e2e_tests::test_big_number \
--args \
u64:123 \  
u128:12345 \ 
u256:340282366920938463463374607431768211455 
{
  "Result": [
    "123"
  ]
}

```

Make sure nested u64 on using "move run" still works
```
➜  e2e git:(main) ✗ aptos move run \
--function-id default::cli_args::test_nested_u64 \
--args \
'u64:[[1, 2], [3], [4]]'
Do you want to submit a transaction for a range of [200 - 300] Octas at a gas unit price of 100 Octas? [yes/no] >
yes
{
  "Result": {
    "transaction_hash": "0xc323b96a8d4585ce0e4c7e62ccab8b2adec8bdd55cf682db1dfc31ef47e4e4ca",
    "gas_used": 2,
    "gas_unit_price": 100,
    "sender": "e6fc96a9464ef0a85fd7146fdbae0a48c5930e44d5552ebca90ad0d0a2c7636c",
    "sequence_number": 9,
    "success": true,
    "timestamp_us": 1689526892222664,
    "version": 17439203,
    "vm_status": "Executed successfully"
  }
}
```

Unit Test
```
2023-07-18 09:53:21,086 - INFO - These tests passed:
2023-07-18 09:53:21,086 - INFO - test_metrics_accessible
2023-07-18 09:53:21,086 - INFO - test_init
2023-07-18 09:53:21,086 - INFO - test_config_show_profiles
2023-07-18 09:53:21,086 - INFO - test_account_fund_with_faucet
2023-07-18 09:53:21,086 - INFO - test_account_create
2023-07-18 09:53:21,086 - INFO - test_account_lookup_address
2023-07-18 09:53:21,086 - INFO - test_aptos_header_included
2023-07-18 09:53:21,086 - INFO - test_move_compile
2023-07-18 09:53:21,086 - INFO - test_move_compile_script
2023-07-18 09:53:21,086 - INFO - test_move_publish
2023-07-18 09:53:21,086 - INFO - test_move_run
2023-07-18 09:53:21,086 - INFO - test_move_view
2023-07-18 09:53:21,086 - INFO - All tests passed!
```