### PR TITLE
[framework] fix named addresses

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/aggregator/aggregator_factory.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator/aggregator_factory.move
@@ -7,7 +7,7 @@ module aptos_framework::aggregator_factory {
     use std::error;
 
     use aptos_framework::system_addresses;
-    use aptos_std::aggregator::Aggregator;
+    use aptos_framework::aggregator::Aggregator;
     use aptos_std::table::{Self, Table};
 
     friend aptos_framework::genesis;

--- a/aptos-move/framework/aptos-framework/sources/block.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/block.spec.move
@@ -1,6 +1,6 @@
 spec aptos_framework::block {
     spec module {
-        use aptos_std::chain_status;
+        use aptos_framework::chain_status;
         // After genesis, `BlockResource` exist.
         invariant [suspendable] chain_status::is_operating() ==> exists<BlockResource>(@aptos_framework);
     }

--- a/aptos-move/framework/aptos-framework/sources/object.move
+++ b/aptos-move/framework/aptos-framework/sources/object.move
@@ -21,11 +21,12 @@ module aptos_framework::object {
     use std::signer;
     use std::vector;
 
+    use aptos_std::from_bcs;
+
     use aptos_framework::account;
     use aptos_framework::transaction_context;
     use aptos_framework::create_signer::create_signer;
     use aptos_framework::event;
-    use aptos_framework::from_bcs;
     use aptos_framework::guid;
 
     friend aptos_framework::primary_fungible_store;

--- a/aptos-move/framework/aptos-framework/sources/staking_contract.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.spec.move
@@ -309,7 +309,7 @@ spec aptos_framework::staking_contract {
     }
 
     spec schema IncreaseLockupWithCapAbortsIf{
-        use std::timestamp;
+        use aptos_framework::timestamp;
         staker: address;
         operator: address;
 

--- a/aptos-move/framework/aptos-framework/sources/staking_proxy.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_proxy.spec.move
@@ -25,8 +25,8 @@ spec aptos_framework::staking_proxy {
     }
 
     spec set_staking_contract_operator(owner: &signer, old_operator: address, new_operator: address) {
+        use aptos_std::simple_map;
         use aptos_framework::staking_contract::{Store};
-        use aptos_framework::simple_map;
         // TODO: Verify timeout and can't verify `staking_contract::switch_operator`.
         pragma aborts_if_is_partial;
 

--- a/aptos-move/framework/aptos-framework/sources/state_storage.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/state_storage.spec.move
@@ -1,6 +1,6 @@
 spec aptos_framework::state_storage {
     spec module {
-        use aptos_std::chain_status;
+        use aptos_framework::chain_status;
         pragma verify = true;
         pragma aborts_if_is_strict;
         // After genesis, `StateStorageUsage` and `GasParameter` exist.
@@ -21,7 +21,7 @@ spec aptos_framework::state_storage {
     }
 
     spec on_new_block(epoch: u64) {
-        use aptos_std::chain_status;
+        use aptos_framework::chain_status;
         requires chain_status::is_operating();
         aborts_if false;
         ensures epoch == global<StateStorageUsage>(@aptos_framework).epoch;

--- a/aptos-move/framework/aptos-framework/sources/storage_gas.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/storage_gas.spec.move
@@ -27,7 +27,7 @@ spec aptos_framework::storage_gas {
     // -----------------
 
     spec module {
-        use aptos_std::chain_status;
+        use aptos_framework::chain_status;
         pragma verify = true;
         pragma aborts_if_is_strict;
         // After genesis, `StateStorageUsage` and `GasParameter` exist.
@@ -125,7 +125,7 @@ spec aptos_framework::storage_gas {
 
     /// Address @aptos_framework must exist StorageGasConfig and StorageGas and StateStorageUsage.
     spec on_reconfig {
-        use aptos_std::chain_status;
+        use aptos_framework::chain_status;
         requires chain_status::is_operating();
         aborts_if !exists<StorageGasConfig>(@aptos_framework);
         aborts_if !exists<StorageGas>(@aptos_framework);

--- a/aptos-move/framework/aptos-stdlib/Move.toml
+++ b/aptos-move/framework/aptos-stdlib/Move.toml
@@ -5,7 +5,6 @@ version = "1.0.0"
 [addresses]
 std = "0x1"
 aptos_std = "0x1"
-aptos_framework = "0x1"
 Extensions = "0x1" # For Prover to instantiate `{{Ext}}` in prelude.
 
 [dependencies]

--- a/aptos-move/framework/aptos-stdlib/sources/math128.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math128.move
@@ -3,8 +3,8 @@ module aptos_std::math128 {
 
     use std::fixed_point32::FixedPoint32;
     use std::fixed_point32;
-    use std::fixed_point64::FixedPoint64;
-    use std::fixed_point64;
+    use aptos_std::fixed_point64::FixedPoint64;
+    use aptos_std::fixed_point64;
 
     /// Abort value when an invalid argument is provided.
     const EINVALID_ARG_FLOOR_LOG2: u64 = 1;


### PR DESCRIPTION
because the frameworks share a common address, one can get away with using the named address incorrectly. this fixes many of those situations. this is a no-op at the bytecode level.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
