### PR TITLE
[Forge] Tweak HAProxy TPS requirement.

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1498,7 +1498,7 @@ fn realistic_env_max_load_test(
                 .init_gas_price_multiplier(20),
             inner_success_criteria: SuccessCriteria::new(
                 if ha_proxy {
-                    4700
+                    4600
                 } else if long_running {
                     5500
                 } else {


### PR DESCRIPTION
### Description
This PR tweaks the TPS requirement for the HAProxy test (from `4700` to `4600`). This is because we recently reduced the number of machines for this test and have seen at least one ["unwanted"](https://github.com/aptos-labs/aptos-core/actions/runs/5573747214/jobs/10181487488) failure, i.e.:

```
TPS requirement for inner traffic failed. Average TPS 4654, minimum TPS requirement 4700.
Full stats: committed: 4654 txn/s, submitted: 4656 txn/s, expired: 2 txn/s, latency: 7720 ms,
(p50: 6600 ms, p90: 11100 ms, p99: 26200 ms), latency samples: 2746095
```

### Test Plan
Existing test infrastructure.