### PR TITLE
[cli] Allow faucet to be used without passing an extra account

### DIFF
--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -22,7 +22,7 @@ pub struct FundWithFaucet {
     ///
     /// If the account wasn't previously created, it will be created when being funded
     #[clap(long, value_parser = crate::common::types::load_account_arg)]
-    pub(crate) account: AccountAddress,
+    pub(crate) account: Option<AccountAddress>,
 
     /// Number of Octas to fund the account from the faucet
     ///
@@ -46,17 +46,22 @@ impl CliCommand<String> for FundWithFaucet {
     }
 
     async fn execute(self) -> CliTypedResult<String> {
+        let address = if let Some(account) = self.account {
+            account
+        } else {
+            self.profile_options.account_address()?
+        };
         let hashes = fund_account(
             self.faucet_options.faucet_url(&self.profile_options)?,
             self.amount,
-            self.account,
+            address,
         )
         .await?;
         let client = self.rest_options.client(&self.profile_options)?;
         wait_for_transactions(&client, hashes).await?;
         return Ok(format!(
             "Added {} Octas to account {}",
-            self.amount, self.account
+            self.amount, address
         ));
     }
 }

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -224,7 +224,7 @@ impl CliTestFramework {
     pub async fn fund_account(&self, index: usize, amount: Option<u64>) -> CliTypedResult<String> {
         FundWithFaucet {
             profile_options: Default::default(),
-            account: self.account_id(index),
+            account: Some(self.account_id(index)),
             faucet_options: self.faucet_options(),
             amount: amount.unwrap_or(DEFAULT_FUNDED_COINS),
             rest_options: self.rest_options(),


### PR DESCRIPTION
### Description
Let's you use faucet without the `--account`

### Test Plan
```
./target/debug/aptos account fund-with-faucet --profile devnet
{
  "Result": "Added 100000000 Octas to account b11affd5c514bb969e988710ef57813d9556cc1e3fe6dc9aa6a82b56aee53d98"
}
```