### PR TITLE
Fix dead links to Move book on docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ For development environment setup and first build, see [Building Aptos From Sour
 
 ### Code Style, Hints, and Testing
 
-Refer to our Coding Guidelines for the [Move](./developer-docs-site/docs/guides/move-guides/book/coding-conventions.md) and [Rust](./developer-docs-site/docs/contribute/rust-coding-guidelines.md) programming languages for detailed guidance about how to contribute to the project.
+Refer to our Coding Guidelines for the [Move](./developer-docs-site/docs/move/book/coding-conventions.md) and [Rust](./developer-docs-site/docs/contribute/rust-coding-guidelines.md) programming languages for detailed guidance about how to contribute to the project.
 
 ### Documentation
 

--- a/aptos-move/framework/aptos-framework/doc/account.md
+++ b/aptos-move/framework/aptos-framework/doc/account.md
@@ -2971,4 +2971,4 @@ The guid_creation_num of the Account is up to MAX_U64.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/aggregator.md
+++ b/aptos-move/framework/aptos-framework/doc/aggregator.md
@@ -421,4 +421,4 @@ Destroys an aggregator and removes it from its <code>AggregatorFactory</code>.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/aggregator_factory.md
+++ b/aptos-move/framework/aptos-framework/doc/aggregator_factory.md
@@ -295,4 +295,4 @@ AggregatorFactory existed under the @aptos_framework when Creating a new aggrega
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/aptos_account.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_account.md
@@ -835,4 +835,4 @@ Check if the AptosCoin under the address existed.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/aptos_coin.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_coin.md
@@ -588,4 +588,4 @@ Claim the delegated mint capability and destroy the delegated token.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/aptos_governance.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_governance.md
@@ -2687,4 +2687,4 @@ verify_only
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/block.md
+++ b/aptos-move/framework/aptos-framework/doc/block.md
@@ -849,4 +849,4 @@ The CurrentTimeMicroseconds existed under the @aptos_framework.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/chain_id.md
+++ b/aptos-move/framework/aptos-framework/doc/chain_id.md
@@ -147,4 +147,4 @@ Return the chain ID of this instance.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/chain_status.md
+++ b/aptos-move/framework/aptos-framework/doc/chain_status.md
@@ -281,4 +281,4 @@ Helper function to assert genesis state.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/code.md
+++ b/aptos-move/framework/aptos-framework/doc/code.md
@@ -1037,4 +1037,4 @@ Native function to initiate module loading, including a list of allowed dependen
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/coin.md
+++ b/aptos-move/framework/aptos-framework/doc/coin.md
@@ -2778,4 +2778,4 @@ Account is not frozen and sufficient balance.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/consensus_config.md
+++ b/aptos-move/framework/aptos-framework/doc/consensus_config.md
@@ -184,4 +184,4 @@ When setting now time must be later than last_reconfiguration_time.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/create_signer.md
+++ b/aptos-move/framework/aptos-framework/doc/create_signer.md
@@ -76,4 +76,4 @@ Convert address to singer and return.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/delegation_pool.md
+++ b/aptos-move/framework/aptos-framework/doc/delegation_pool.md
@@ -3722,4 +3722,4 @@ shares pools, assign commission to operator and eventually prepare delegation po
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/event.md
+++ b/aptos-move/framework/aptos-framework/doc/event.md
@@ -315,4 +315,4 @@ Native function use opaque.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/execution_config.md
+++ b/aptos-move/framework/aptos-framework/doc/execution_config.md
@@ -132,4 +132,4 @@ When setting now time must be later than last_reconfiguration_time.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/fungible_asset.md
@@ -2016,4 +2016,4 @@ Decrease the supply of a fungible asset by burning.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/gas_schedule.md
+++ b/aptos-move/framework/aptos-framework/doc/gas_schedule.md
@@ -329,4 +329,4 @@ This can be called by on-chain governance to update the gas schedule.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/genesis.md
+++ b/aptos-move/framework/aptos-framework/doc/genesis.md
@@ -907,4 +907,4 @@ The last step of genesis.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/governance_proposal.md
+++ b/aptos-move/framework/aptos-framework/doc/governance_proposal.md
@@ -135,4 +135,4 @@ Useful for AptosGovernance to create an empty proposal as proof.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/guid.md
+++ b/aptos-move/framework/aptos-framework/doc/guid.md
@@ -338,4 +338,4 @@ Return true if the GUID's ID is <code>id</code>
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/managed_coin.md
+++ b/aptos-move/framework/aptos-framework/doc/managed_coin.md
@@ -344,4 +344,4 @@ Updating <code>Account.guid_creation_num</code> will not overflow.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/multisig_account.md
+++ b/aptos-move/framework/aptos-framework/doc/multisig_account.md
@@ -2791,4 +2791,4 @@ Add new owners, remove owners to remove, update signatures required.
 </details>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/object.md
+++ b/aptos-move/framework/aptos-framework/doc/object.md
@@ -1886,4 +1886,4 @@ Return true if the provided address has indirect or direct ownership of the prov
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/optional_aggregator.md
+++ b/aptos-move/framework/aptos-framework/doc/optional_aggregator.md
@@ -1079,4 +1079,4 @@ The integer exists and the aggregator does not exist when destroy the integer.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/overview.md
+++ b/aptos-move/framework/aptos-framework/doc/overview.md
@@ -57,4 +57,4 @@ This is the reference documentation of the Aptos framework.
 -  [`0x1::voting`](voting.md#0x1_voting)
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
+++ b/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
@@ -595,4 +595,4 @@ Transfer <code>amount</code> of FA from the primary store of <code>from</code> t
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/reconfiguration.md
+++ b/aptos-move/framework/aptos-framework/doc/reconfiguration.md
@@ -665,4 +665,4 @@ Should equal to 0
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/resource_account.md
+++ b/aptos-move/framework/aptos-framework/doc/resource_account.md
@@ -528,4 +528,4 @@ the SignerCapability.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/stake.md
+++ b/aptos-move/framework/aptos-framework/doc/stake.md
@@ -4251,4 +4251,4 @@ Returns validator's next epoch voting power, including pending_active, active, a
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/staking_config.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_config.md
@@ -1366,4 +1366,4 @@ Abort at any condition in StakingRewardsConfigValidationAborts.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/staking_contract.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_contract.md
@@ -2622,4 +2622,4 @@ a staking_contract exists for the staker/operator pair.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/staking_proxy.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_proxy.md
@@ -460,4 +460,4 @@ Then abort if the resource is not exist
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/state_storage.md
+++ b/aptos-move/framework/aptos-framework/doc/state_storage.md
@@ -385,4 +385,4 @@ aborts if StateStorageUsage already exists.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/storage_gas.md
+++ b/aptos-move/framework/aptos-framework/doc/storage_gas.md
@@ -1558,4 +1558,4 @@ A non decreasing curve must ensure that next is greater than cur.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/system_addresses.md
+++ b/aptos-move/framework/aptos-framework/doc/system_addresses.md
@@ -517,4 +517,4 @@ Return true if <code>addr</code> is either the VM address or an Aptos Framework 
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/timestamp.md
+++ b/aptos-move/framework/aptos-framework/doc/timestamp.md
@@ -273,4 +273,4 @@ Gets the current time in seconds.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/transaction_context.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_context.md
@@ -327,4 +327,4 @@ the generated unique address wrapped in the AUID class.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/transaction_fee.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_fee.md
@@ -735,4 +735,4 @@ Aborts if <code><a href="transaction_fee.md#0x1_transaction_fee_AptosCoinCapabil
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/transaction_validation.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_validation.md
@@ -968,4 +968,4 @@ Skip transaction_fee::burn_fee verification.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/util.md
+++ b/aptos-move/framework/aptos-framework/doc/util.md
@@ -98,4 +98,4 @@ owned.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/version.md
+++ b/aptos-move/framework/aptos-framework/doc/version.md
@@ -271,4 +271,4 @@ This module turns on <code>aborts_if_is_strict</code>, so need to add spec for t
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/vesting.md
+++ b/aptos-move/framework/aptos-framework/doc/vesting.md
@@ -3519,4 +3519,4 @@ This address should be deterministic for the same admin and vesting contract cre
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/voting.md
+++ b/aptos-move/framework/aptos-framework/doc/voting.md
@@ -2012,4 +2012,4 @@ Return true if the voting period of the given proposal has already ended.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc_template/references.md
+++ b/aptos-move/framework/aptos-framework/doc_template/references.md
@@ -1,1 +1,1 @@
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/any.md
+++ b/aptos-move/framework/aptos-stdlib/doc/any.md
@@ -223,4 +223,4 @@ Returns the type name of this Any
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/big_vector.md
+++ b/aptos-move/framework/aptos-stdlib/doc/big_vector.md
@@ -1032,4 +1032,4 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/bls12381.md
+++ b/aptos-move/framework/aptos-stdlib/doc/bls12381.md
@@ -1316,4 +1316,4 @@ Does not abort.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/bls12381_algebra.md
+++ b/aptos-move/framework/aptos-stdlib/doc/bls12381_algebra.md
@@ -628,4 +628,4 @@ Full specification is defined in https://datatracker.ietf.org/doc/html/draft-irt
 </details>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/capability.md
+++ b/aptos-move/framework/aptos-stdlib/doc/capability.md
@@ -578,4 +578,4 @@ Helper specification function to obtain the delegates of a capability.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/comparator.md
+++ b/aptos-move/framework/aptos-stdlib/doc/comparator.md
@@ -384,4 +384,4 @@ Provides a framework for comparing two elements
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/copyable_any.md
+++ b/aptos-move/framework/aptos-stdlib/doc/copyable_any.md
@@ -213,4 +213,4 @@ Returns the type name of this Any
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/crypto_algebra.md
+++ b/aptos-move/framework/aptos-stdlib/doc/crypto_algebra.md
@@ -1728,4 +1728,4 @@ NOTE: some hashing methods do not accept a <code>dst</code> and will abort if a 
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/debug.md
+++ b/aptos-move/framework/aptos-stdlib/doc/debug.md
@@ -234,4 +234,4 @@ Module providing debug functionality.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/ed25519.md
+++ b/aptos-move/framework/aptos-stdlib/doc/ed25519.md
@@ -867,4 +867,4 @@ Returns <code><b>false</b></code> if either:
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/fixed_point64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/fixed_point64.md
@@ -1332,4 +1332,4 @@ TODO: worked in the past but started to time out since last z3 update
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/from_bcs.md
+++ b/aptos-move/framework/aptos-stdlib/doc/from_bcs.md
@@ -362,4 +362,4 @@ owned.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/hash.md
+++ b/aptos-move/framework/aptos-stdlib/doc/hash.md
@@ -620,4 +620,4 @@ Returns the BLAKE2B-256 hash of <code>bytes</code>.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/math128.md
+++ b/aptos-move/framework/aptos-stdlib/doc/math128.md
@@ -599,4 +599,4 @@ to the most correct value up to last digit
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/math64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/math64.md
@@ -554,4 +554,4 @@ to the most correct value up to last digit
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/math_fixed.md
+++ b/aptos-move/framework/aptos-stdlib/doc/math_fixed.md
@@ -330,4 +330,4 @@ to the most correct value up to last digit
 </details>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/math_fixed64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/math_fixed64.md
@@ -325,4 +325,4 @@ to the most correct value up to last digit
 </details>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/multi_ed25519.md
+++ b/aptos-move/framework/aptos-stdlib/doc/multi_ed25519.md
@@ -1186,4 +1186,4 @@ Returns <code><b>false</b></code> if either:
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/overview.md
+++ b/aptos-move/framework/aptos-stdlib/doc/overview.md
@@ -43,4 +43,4 @@ This is the reference documentation of the Aptos standard library.
 -  [`0x1::type_info`](type_info.md#0x1_type_info)
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/pool_u64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/pool_u64.md
@@ -1287,4 +1287,4 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/pool_u64_unbound.md
+++ b/aptos-move/framework/aptos-stdlib/doc/pool_u64_unbound.md
@@ -1330,4 +1330,4 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/ristretto255.md
+++ b/aptos-move/framework/aptos-stdlib/doc/ristretto255.md
@@ -2692,4 +2692,4 @@ WARNING: This function can only be called with P = RistrettoPoint and S = Scalar
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/secp256k1.md
+++ b/aptos-move/framework/aptos-stdlib/doc/secp256k1.md
@@ -429,4 +429,4 @@ and returns <code>([], <b>false</b>)</code> otherwise.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/simple_map.md
+++ b/aptos-move/framework/aptos-stdlib/doc/simple_map.md
@@ -1026,4 +1026,4 @@ Remove a key/value pair from the map. The key must exist.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/smart_table.md
+++ b/aptos-move/framework/aptos-stdlib/doc/smart_table.md
@@ -1071,4 +1071,4 @@ Update <code>target_bucket_size</code>.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/smart_vector.md
+++ b/aptos-move/framework/aptos-stdlib/doc/smart_vector.md
@@ -1019,4 +1019,4 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/string_utils.md
+++ b/aptos-move/framework/aptos-stdlib/doc/string_utils.md
@@ -745,4 +745,4 @@ Formatting with a rust-like format string, eg. <code><a href="string_utils.md#0x
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/table.md
+++ b/aptos-move/framework/aptos-stdlib/doc/table.md
@@ -776,4 +776,4 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/table_with_length.md
+++ b/aptos-move/framework/aptos-stdlib/doc/table_with_length.md
@@ -681,4 +681,4 @@ Returns true iff <code><a href="table.md#0x1_table">table</a></code> contains an
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc/type_info.md
+++ b/aptos-move/framework/aptos-stdlib/doc/type_info.md
@@ -453,4 +453,4 @@ analysis of vector size dynamism.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-stdlib/doc_template/references.md
+++ b/aptos-move/framework/aptos-stdlib/doc_template/references.md
@@ -1,1 +1,1 @@
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-token-objects/doc/aptos_token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/aptos_token.md
@@ -1571,4 +1571,4 @@ With an existing collection, directly mint a soul bound token into the recipient
 </details>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-token-objects/doc/collection.md
+++ b/aptos-move/framework/aptos-token-objects/doc/collection.md
@@ -1106,4 +1106,4 @@ Provides the count of the current selection if supply tracking is used
 </details>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-token-objects/doc/overview.md
+++ b/aptos-move/framework/aptos-token-objects/doc/overview.md
@@ -19,4 +19,4 @@ This is the reference documentation of the Aptos Token Objects framework.
 -  [`0x4::token`](token.md#0x4_token)
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-token-objects/doc/property_map.md
+++ b/aptos-move/framework/aptos-token-objects/doc/property_map.md
@@ -1212,4 +1212,4 @@ Removes a property from the map, ensuring that it does in fact exist
 </details>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-token-objects/doc/royalty.md
+++ b/aptos-move/framework/aptos-token-objects/doc/royalty.md
@@ -398,4 +398,4 @@ Creates a new royalty, verifying that it is a valid percentage
 </details>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-token-objects/doc/token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/token.md
@@ -1008,4 +1008,4 @@ Extracts the tokens address from a BurnRef.
 </details>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-token-objects/doc_template/references.md
+++ b/aptos-move/framework/aptos-token-objects/doc_template/references.md
@@ -1,1 +1,1 @@
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-token/doc/overview.md
+++ b/aptos-move/framework/aptos-token/doc/overview.md
@@ -19,4 +19,4 @@ This is the reference documentation of the Aptos Token framework.
 -  [`0x3::token_transfers`](token_transfers.md#0x3_token_transfers)
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-token/doc/property_map.md
+++ b/aptos-move/framework/aptos-token/doc/property_map.md
@@ -1366,4 +1366,4 @@ Abort according to the code
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-token/doc/token.md
+++ b/aptos-move/framework/aptos-token/doc/token.md
@@ -6182,4 +6182,4 @@ Deprecated function
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-token/doc/token_coin_swap.md
+++ b/aptos-move/framework/aptos-token/doc/token_coin_swap.md
@@ -630,4 +630,4 @@ Cancel token listing for a fixed amount
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-token/doc/token_event_store.md
+++ b/aptos-move/framework/aptos-token/doc/token_event_store.md
@@ -1211,4 +1211,4 @@ number of registered events
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-token/doc/token_transfers.md
+++ b/aptos-move/framework/aptos-token/doc/token_transfers.md
@@ -795,4 +795,4 @@ Get the amount from sender token
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-token/doc_template/references.md
+++ b/aptos-move/framework/aptos-token/doc_template/references.md
@@ -1,1 +1,1 @@
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/move-stdlib/doc/acl.md
+++ b/aptos-move/framework/move-stdlib/doc/acl.md
@@ -317,4 +317,4 @@ assert! that the ACL has the address.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/move-stdlib/doc/bcs.md
+++ b/aptos-move/framework/move-stdlib/doc/bcs.md
@@ -56,4 +56,4 @@ Native function which is defined in the prover's prelude.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/move-stdlib/doc/bit_vector.md
+++ b/aptos-move/framework/move-stdlib/doc/bit_vector.md
@@ -473,4 +473,4 @@ sequence, then <code>0</code> is returned.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/move-stdlib/doc/error.md
+++ b/aptos-move/framework/move-stdlib/doc/error.md
@@ -497,4 +497,4 @@ Functions to construct a canonical error code of the given category.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -1444,4 +1444,4 @@ Helper to check whether a feature flag is enabled.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/move-stdlib/doc/fixed_point32.md
+++ b/aptos-move/framework/move-stdlib/doc/fixed_point32.md
@@ -881,4 +881,4 @@ Returns the value of a FixedPoint32 to the nearest integer.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/move-stdlib/doc/hash.md
+++ b/aptos-move/framework/move-stdlib/doc/hash.md
@@ -62,4 +62,4 @@ as in the Move prover's prelude.
 </details>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/move-stdlib/doc/option.md
+++ b/aptos-move/framework/move-stdlib/doc/option.md
@@ -1327,4 +1327,4 @@ because it's 0 for "none" or 1 for "some".
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/move-stdlib/doc/overview.md
+++ b/aptos-move/framework/move-stdlib/doc/overview.md
@@ -26,4 +26,4 @@ For on overview of the Move language, see the [Move Book][move-book].
 -  [`0x1::vector`](vector.md#0x1_vector)
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/move-stdlib/doc/signer.md
+++ b/aptos-move/framework/move-stdlib/doc/signer.md
@@ -91,4 +91,4 @@ Return true only if <code>a</code> is a transaction signer address. This is a sp
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/move-stdlib/doc/string.md
+++ b/aptos-move/framework/move-stdlib/doc/string.md
@@ -549,4 +549,4 @@ Computes the index of the first occurrence of a string. Returns <code><a href="s
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/move-stdlib/doc/vector.md
+++ b/aptos-move/framework/move-stdlib/doc/vector.md
@@ -1917,4 +1917,4 @@ Check if <code>v</code> contains <code>e</code>.
 </code></pre>
 
 
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/move-stdlib/doc_template/references.md
+++ b/aptos-move/framework/move-stdlib/doc_template/references.md
@@ -1,1 +1,1 @@
-[move-book]: https://aptos.dev/guides/move-guides/book/SUMMARY
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/move-examples/mint_nft/4-Getting-Production-Ready/sources/create_nft_getting_production_ready.move
+++ b/aptos-move/move-examples/mint_nft/4-Getting-Production-Ready/sources/create_nft_getting_production_ready.move
@@ -24,7 +24,7 @@
 ///
 /// Move unit tests
 /// We added a few unit tests to make sure that our code is working as expected. For more information on how to write
-/// Move unit tests, see: https://aptos.dev/guides/move-guides/book/unit-testing
+/// Move unit tests, see: https://aptos.dev/move/book/unit-testing
 ///
 /// - How to interact with this module
 /// 1. Configure the admin account name address in Move.toml file.

--- a/aptos-move/move-examples/move-tutorial/README.md
+++ b/aptos-move/move-examples/move-tutorial/README.md
@@ -120,11 +120,11 @@ aptos move compile
     aptos move init --name <pkg_name>
     ```
 * Move code can also live in a number of other places. See the [Move
-  book](../../../developer-docs-site/docs/guides/move-guides/book/packages.md) for more information on the
+  book](../../../developer-docs-site/docs/move/book/packages.md) for more information on the
   Move package system.
 * More information on the `Move.toml` file can also be found in the [Package](../../../developer-docs-site/docs/move/book/packages.md#movetoml) section of the Move book.
 * Move also supports the idea of [named
-  addresses](../../../developer-docs-site/docs/guides/move-guides/book/address.md#named-addresses); Named
+  addresses](../../../developer-docs-site/docs/move/book/address.md#named-addresses); Named
   addresses are a way to parameterize Move source code so that you can compile
   the module using different values for `named_addr` to get different bytecode
   that you can deploy, depending on what address(es) you control. They are used quite frequently, and can be defined in the `Move.toml` file in the `[addresses]` section, like so:
@@ -150,7 +150,7 @@ aptos move compile
     [`public(friend)`](../../../developer-docs-site/docs/move/book/friends.md).
     A function marked as `entry` can be called as a transaction.
 * `move_to` is one of the [five different global storage
-  operators](../../../developer-docs-site/docs/guides/move-guides/book/global-storage-operators.md).
+  operators](../../../developer-docs-site/docs/move/book/global-storage-operators.md).
 </details>
 
 ## Step 2: Adding unit tests to my first Move module<span id="Step2"><span>


### PR DESCRIPTION
### Description
Move book on GitHub should have been moved to `/docs/move/book` at some point, leaving a bunch of death links across the markdown files. Those links are properly redirected on the aptos.dev site whereas they won't work inside the docs meant to be read on GH, like the Move tutorial.