### PR TITLE
[forge tests] put VFNs within emulated networks

### DIFF
--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -261,15 +261,23 @@ impl Swarm for K8sSwarm {
     }
 
     fn full_nodes<'a>(&'a self) -> Box<dyn Iterator<Item = &'a dyn FullNode> + 'a> {
-        Box::new(self.fullnodes.values().map(|v| v as &'a dyn FullNode))
+        let mut full_nodes: Vec<_> = self
+            .fullnodes
+            .values()
+            .map(|n| n as &'a dyn FullNode)
+            .collect();
+        full_nodes.sort_by_key(|n| n.index());
+        Box::new(full_nodes.into_iter())
     }
 
     fn full_nodes_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut dyn FullNode> + 'a> {
-        Box::new(
-            self.fullnodes
-                .values_mut()
-                .map(|v| v as &'a mut dyn FullNode),
-        )
+        let mut full_nodes: Vec<_> = self
+            .fullnodes
+            .values_mut()
+            .map(|n| n as &'a mut dyn FullNode)
+            .collect();
+        full_nodes.sort_by_key(|n| n.index());
+        Box::new(full_nodes.into_iter())
     }
 
     fn full_node(&self, id: PeerId) -> Option<&dyn FullNode> {

--- a/testsuite/testcases/src/modifiers.rs
+++ b/testsuite/testcases/src/modifiers.rs
@@ -249,6 +249,7 @@ pub fn create_swarm_cpu_stress(
     let cpu_chaos_config = cpu_chaos_config.unwrap_or_default();
 
     // Chunk the peers into groups and create a GroupCpuStress for each group
+    let all_peers = all_peers.iter().map(|id| vec![*id]).collect();
     let peer_chunks = chunk_peers(all_peers, cpu_chaos_config.num_groups);
     let group_cpu_stresses = peer_chunks
         .into_iter()

--- a/testsuite/testcases/src/public_fullnode_performance.rs
+++ b/testsuite/testcases/src/public_fullnode_performance.rs
@@ -59,6 +59,8 @@ impl PFNPerformance {
         let shuffled_peer_ids = self.gather_and_shuffle_peer_ids(swarm);
 
         // Create network emulation chaos for the swarm
+        // TODO: VFNs and VNs need to be colocated
+        let shuffled_peer_ids = shuffled_peer_ids.iter().map(|id| vec![*id]).collect();
         create_multi_region_swarm_network_chaos(shuffled_peer_ids, None)
     }
 


### PR DESCRIPTION
### Description

Today, in the land-blocking test, only validators are in emulated networks. This means VFNs:
* Have very low latency connection with validators. This is probably realistic, but we may want to test with some more latency. We can revisit if we need smaller latencies later.
* Have very low latency connection with each other. This means a state sync path from VN1 -> VFN1 -> VFN2 can be (much) faster than VN1 -> VN2 -> VFN2, which likely doesn't happen in practice.

Instead, we now add the VFNs into the emulated networks, making sure they're in the same region as their VN.

In addition, fixed the chunking so a 7 node network will be chunked into 4 networks as (2,2,2,1). Previously the chunking was (4,1,1,1).

### Test Plan

Run forge, observe that the VFN <-> VN RTT is ~100ms, and via logs observe that the nodes are chunked in a (2,2,2,1) configuration.