### PR TITLE
[Examples] Account authentication key rotation with the CLI, Typescript and Python SDKs

### DIFF
--- a/developer-docs-site/docs/guides/account-management/key-rotation.md
+++ b/developer-docs-site/docs/guides/account-management/key-rotation.md
@@ -14,7 +14,7 @@ In this guide, we show examples for how to rotate an account's authentication ke
 
 Here are the installation links for the SDKs we will cover in this example:
 
-* [Aptos CLI](../../tools/install-cli)
+* [Aptos CLI](../../tools/aptos-cli)
 * [Typescript SDK](../../sdks/ts-sdk/index)
 * [Python SDK](../../sdks/python-sdk)
 

--- a/developer-docs-site/docs/guides/account-management/key-rotation.md
+++ b/developer-docs-site/docs/guides/account-management/key-rotation.md
@@ -1,14 +1,14 @@
 ---
-title: "Key Rotation"
+title: "Rotating an authentication key"
 id: "key-rotation"
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Aptos Move accounts have authentication keys that are separate from their public address. This means you can rotate an account's private key to give control of it to another account without changing the initial account's public address.
+Aptos Move accounts have a public address, an authentication key, a public key, and a private key. The public address is permanent, always matching the account's initial authentication key.
 
-After rotating the key, the controlling account can sign transactions for the initial account.
+The Aptos account model facilitates the unique ability to rotate an account's private key. Since an account's address is the *initial* authentication key, the ability to sign for an account can be transferred to another private key without changing its public address.
 
 In this guide, we show examples for how to rotate an account's authentication key using a few of the various Aptos SDKs.
 
@@ -26,14 +26,16 @@ Some of the following examples use private keys. Do not share your private keys 
 <Tabs groupId="examples">
   <TabItem value="CLI" label="CLI">
 
+Run the following to initialize two test profiles. Leave the inputs blank both times you're prompted for a private key.
+
 ```shell title="Initialize two test profiles on devnet"
-echo "devnet" | aptos init --profile rotate-1
-echo "devnet" | aptos init --profile rotate-2
+aptos init --profile test_profile_1 --network devnet --assume-yes
+aptos init --profile test_profile_2 --network devnet --assume-yes
 ```
-```shell title="Rotate the authentication key for rotate-1 to rotate-2's authentication key"
-aptos account rotate-key --profile rotate-1 --new-private-key <ROTATE_2_PRIVATE_KEY>
+```shell title="Rotate the authentication key for test_profile_1 to test_profile_2's authentication key"
+aptos account rotate-key --profile test_profile_1 --new-private-key <TEST_PROFILE_2_PRIVATE_KEY>
 ```
-:::info Where do I get the private key for a profile?
+:::info Where do I view the private key for a profile?
 Public, private, and authentication keys for Aptos CLI profiles are stored in `~/.aptos/config.yaml` if your config is set to `Global` and `<local_directory>/.aptos/config.yaml` if it's set to `Workspace`.
 
 To see your config settings, run `aptos config show-global-config`.
@@ -49,18 +51,22 @@ yes
 ...
 
 Enter the name for the profile
-rotate-1-new
+test_profile_1_rotated
 
-Profile rotate-1-new is saved.
+Profile test_profile_1_rotated is saved.
 ```
-You can now use the profile like any other account. The private key for `rotate-1-new` will match `rotate-2` in the `~/.aptos/config.yaml` file and the `Authentication Key` on the account will match the `Authentication Key` of `rotate-2` on-chain.
+You can now use the profile like any other account.
+
+In your `config.yaml` file, `test_profile_1_rotated` will retain its original public address but have a new public and private key that matches `test_profile_2`.
+
+The authentication keys aren't shown in the `config.yaml` file, but we can verify the change with the following commands:
 
 ```shell title="Verify the authentication keys are now equal with view functions"
-# View the authentication key of `rotate-1-new`
-aptos move view --function-id 0x1::account::get_authentication_key --args address:rotate-1-new
+# View the authentication key of `test_profile_1_rotated`
+aptos move view --function-id 0x1::account::get_authentication_key --args address:test_profile_1_rotated
 
-# View the authentication key of `rotate-2`, it should equal the above.
-aptos move view --function-id 0x1::account::get_authentication_key --args address:rotate-2
+# View the authentication key of `test_profile_2`, it should equal the above.
+aptos move view --function-id 0x1::account::get_authentication_key --args address:test_profile_2
 ```
 
 ```json title="Example output from the previous two commands"
@@ -79,14 +85,15 @@ aptos move view --function-id 0x1::account::get_authentication_key --args addres
 
   <TabItem value="typescript" label="Typescript">
 
-View the full example for this code [here](https://github.com/aptos-labs/aptos-core/ecosystem/typescript/sdk/examples/typescript/rotate_key.ts).
-
 This program creates two accounts on devnet, Alice and Bob, funds them, then rotates the Alice's authentication key to that of Bob's.
+
+View the full example for this code [here](https://github.com/aptos-labs/aptos-core/tree/main/ecosystem/typescript/sdk/examples/typescript/rotate_key.ts).
 
 The function to rotate is very simple:
 ```typescript title="Typescript SDK rotate authentication key function"
 :!: static/sdks/typescript/examples/typescript-esm/rotate_key.ts rotate_key
 ```
+Commands to run the example script:
 ```shell title="Navigate to the typescript SDK directory, install dependencies and run rotate_key.ts"
 cd ~/aptos-core/ecosystem/typescript/sdk/examples/typescript-esm
 pnpm install && pnpm rotate_key
@@ -105,9 +112,15 @@ Bob                0x1c06...ac3bb3     0x1c06...ac3bb3      0xf2be...9486aa     
   </TabItem>
   <TabItem value="python" label="Python">
 
+This program creates two accounts on devnet, Alice and Bob, funds them, then rotates the Alice's authentication key to that of Bob's.
+
+View the full example for this code [here](https://github.com/aptos-labs/aptos-core/tree/main/ecosystem/python/sdk/examples/rotate-key.py).
+
+Here's the relevant code that rotates Alice's keys to Bob's:
 ```python title="Python SDK rotate authentication key function"
 :!: static/sdks/python/examples/rotate-key.py rotate_key
 ```
+Commands to run the example script:
 ```shell title="Navigate to the python SDK directory, install dependencies and run rotate_key.ts"
 cd ~/aptos-core/ecosystem/python/sdk
 poetry install && poetry run python -m examples.rotate-key

--- a/developer-docs-site/docs/guides/resource-accounts/key-rotation.md
+++ b/developer-docs-site/docs/guides/resource-accounts/key-rotation.md
@@ -14,9 +14,9 @@ In this guide, we show examples for how to rotate an account's authentication ke
 
 Here are the installation links for the SDKs we will cover in this example:
 
-* [Aptos CLI](../../tools/install-cli/)
+* [Aptos CLI](../../tools/install-cli)
 * [Typescript SDK](../../sdks/ts-sdk/index)
-* [Python SDK](../../sdks/python-sdk/index)
+* [Python SDK](../../sdks/python-sdk)
 
 :::warning
 Some of the following examples use private keys. Do not share your private keys with anyone.
@@ -92,15 +92,15 @@ cd ~/aptos-core/ecosystem/typescript/sdk/examples/typescript-esm
 pnpm install && pnpm rotate_key
 ```
 ```shell title="rotate_key.ts output"
-Account          Address           Auth Key           Private Key     
--------------------------------------------------------------------
-Alice            0x8dcc...7dbe    '0x8dcc...7dbe'    '0x1cec...cc88'
-Bob              0x36eb...9b6c     0x36eb...9b6c      0x9d7c...0610   
- 
+Account            Address             Auth Key             Private Key          Public Key         
+------------------------------------------------------------------------------------------------
+Alice              0x213d...031013    '0x213d...031013'    '0x00a4...b2887b'    '0x859e...08d2a9'
+Bob                0x1c06...ac3bb3     0x1c06...ac3bb3      0xf2be...9486aa      0xbbc1...abb808    
+
 ...rotating...
 
-Alice            0x8dcc...7dbe    '0x36eb...9b6c'    '0x9d7c...0610'
-Bob              0x36eb...9b6c     0x36eb...9b6c      0x9d7c...0610   
+Alice              0x213d...031013    '0x1c06...ac3bb3'    '0xf2be...9486aa'    '0xbbc1...abb808'
+Bob                0x1c06...ac3bb3     0x1c06...ac3bb3      0xf2be...9486aa      0xbbc1...abb808 
 ```
   </TabItem>
   <TabItem value="python" label="Python">
@@ -112,16 +112,16 @@ Bob              0x36eb...9b6c     0x36eb...9b6c      0x9d7c...0610
 cd ~/aptos-core/ecosystem/python/sdk
 poetry install && poetry run python -m examples.rotate-key
 ```
-```shell title="rotate_key.ts output"
-Account            Address             Auth Key             Private Key        
-------------------------------------------------------------------------
-Alice              0x3e58...2b6243    '0x3e58...2b6243'    '0xb927...f4264d'    
-Bob                0xe39d...adf91f     0xe39d...adf91f      0xb2cd...a5c415    
+```shell title="rotate_key.py output"
+Account            Address             Auth Key             Private Key          Public Key         
+------------------------------------------------------------------------------------------------
+Alice              0x213d...031013    '0x213d...031013'    '0x00a4...b2887b'    '0x859e...08d2a9'
+Bob                0x1c06...ac3bb3     0x1c06...ac3bb3      0xf2be...9486aa      0xbbc1...abb808    
 
 ...rotating...
 
-Alice              0x3e58...2b6243    '0xe39d...adf91f'    '0xb2cd...a5c415'    
-Bob                0xe39d...adf91f     0xe39d...adf91f      0xb2cd...a5c415  
+Alice              0x213d...031013    '0x1c06...ac3bb3'    '0xf2be...9486aa'    '0xbbc1...abb808'
+Bob                0x1c06...ac3bb3     0x1c06...ac3bb3      0xf2be...9486aa      0xbbc1...abb808 
 ```
 
   </TabItem>

--- a/developer-docs-site/docs/guides/resource-accounts/key-rotation.md
+++ b/developer-docs-site/docs/guides/resource-accounts/key-rotation.md
@@ -10,14 +10,13 @@ Aptos Move accounts have authentication keys that are separate from their public
 
 After rotating the key, the controlling account can sign transactions for the initial account.
 
-In this guide, we show examples for how to rotate an account's authentication key using the various Aptos SDKs.
+In this guide, we show examples for how to rotate an account's authentication key using a few of the various Aptos SDKs.
 
-If you haven't installed the SDKs, you can do so at the following links:
+Here are the installation links for the SDKs we will cover in this example:
 
 * [Aptos CLI](../../tools/install-cli/)
 * [Typescript SDK](../../sdks/ts-sdk/index)
 * [Python SDK](../../sdks/python-sdk/index)
-* [Rust SDK](../../sdks/rust-sdk/index)
 
 :::warning
 Some of the following examples use private keys. Do not share your private keys with anyone.
@@ -34,8 +33,10 @@ echo "devnet" | aptos init --profile rotate-2
 ```shell title="Rotate the authentication key for rotate-1 to rotate-2's authentication key"
 aptos account rotate-key --profile rotate-1 --new-private-key <ROTATE_2_PRIVATE_KEY>
 ```
-:::tip Where do I get the private key for a profile?
-Public, private, and authentication keys for Aptos CLI profiles are stored in `~/.aptos/config.yaml`.
+:::info Where do I get the private key for a profile?
+Public, private, and authentication keys for Aptos CLI profiles are stored in `~/.aptos/config.yaml` if your config is set to `Global` and `<local_directory>/.aptos/config.yaml` if it's set to `Workspace`.
+
+To see your config settings, run `aptos config show-global-config`.
 :::
 
 ```shell title="Confirm yes and create a new profile so that you can continue to sign for the resource account"
@@ -122,12 +123,6 @@ Bob                0xe39d...adf91f     0xe39d...adf91f      0xb2cd...a5c415
 Alice              0x3e58...2b6243    '0xe39d...adf91f'    '0xb2cd...a5c415'    
 Bob                0xe39d...adf91f     0xe39d...adf91f      0xb2cd...a5c415  
 ```
-
-  </TabItem>
-
-  <TabItem value="rust" label="Rust">
-
-    Coming soon.
 
   </TabItem>
 </Tabs>

--- a/developer-docs-site/docs/guides/resource-accounts/key-rotation.md
+++ b/developer-docs-site/docs/guides/resource-accounts/key-rotation.md
@@ -1,0 +1,133 @@
+---
+title: "Key Rotation"
+id: "key-rotation"
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Aptos Move accounts have authentication keys that are separate from their public address. This means you can rotate an account's private key to give control of it to another account without changing the initial account's public address.
+
+After rotating the key, the controlling account can sign transactions for the initial account.
+
+In this guide, we show examples for how to rotate an account's authentication key using the various Aptos SDKs.
+
+If you haven't installed the SDKs, you can do so at the following links:
+
+* [Aptos CLI](../../tools/install-cli/)
+* [Typescript SDK](../../sdks/ts-sdk/index)
+* [Python SDK](../../sdks/python-sdk/index)
+* [Rust SDK](../../sdks/rust-sdk/index)
+
+:::warning
+Some of the following examples use private keys. Do not share your private keys with anyone.
+:::
+
+## How to rotate an account's authentication key
+<Tabs groupId="examples">
+  <TabItem value="CLI" label="CLI">
+
+```shell title="Initialize two test profiles on devnet"
+echo "devnet" | aptos init --profile rotate-1
+echo "devnet" | aptos init --profile rotate-2
+```
+```shell title="Rotate the authentication key for rotate-1 to rotate-2's authentication key"
+aptos account rotate-key --profile rotate-1 --new-private-key <ROTATE_2_PRIVATE_KEY>
+```
+:::tip Where do I get the private key for a profile?
+Public, private, and authentication keys for Aptos CLI profiles are stored in `~/.aptos/config.yaml`.
+:::
+
+```shell title="Confirm yes and create a new profile so that you can continue to sign for the resource account"
+Do you want to submit a transaction for a range of [52000 - 78000] Octas at a gas unit price of 100 Octas? [yes/no] >
+yes
+...
+
+Do you want to create a profile for the new key? [yes/no] >
+yes
+...
+
+Enter the name for the profile
+rotate-1-new
+
+Profile rotate-1-new is saved.
+```
+You can now use the profile like any other account. The private key for `rotate-1-new` will match `rotate-2` in the `~/.aptos/config.yaml` file and the `Authentication Key` on the account will match the `Authentication Key` of `rotate-2` on-chain.
+
+```shell title="Verify the authentication keys are now equal with view functions"
+# View the authentication key of `rotate-1-new`
+aptos move view --function-id 0x1::account::get_authentication_key --args address:rotate-1-new
+
+# View the authentication key of `rotate-2`, it should equal the above.
+aptos move view --function-id 0x1::account::get_authentication_key --args address:rotate-2
+```
+
+```json title="Example output from the previous two commands"
+{
+  "Result": [
+    "0x458fba533b84717c91897cab05047c1dd7ac2ea73e75c77281781f5b7fec180c"
+  ]
+}
+{
+  "Result": [
+    "0x458fba533b84717c91897cab05047c1dd7ac2ea73e75c77281781f5b7fec180c"
+  ]
+}
+```
+  </TabItem>
+
+  <TabItem value="typescript" label="Typescript">
+
+View the full example for this code [here](https://github.com/aptos-labs/aptos-core/ecosystem/typescript/sdk/examples/typescript/rotate_key.ts).
+
+This program creates two accounts on devnet, Alice and Bob, funds them, then rotates the Alice's authentication key to that of Bob's.
+
+The function to rotate is very simple:
+```typescript title="Typescript SDK rotate authentication key function"
+:!: static/sdks/typescript/examples/typescript-esm/rotate_key.ts rotate_key
+```
+```shell title="Navigate to the typescript SDK directory, install dependencies and run rotate_key.ts"
+cd ~/aptos-core/ecosystem/typescript/sdk/examples/typescript-esm
+pnpm install && pnpm rotate_key
+```
+```shell title="rotate_key.ts output"
+Account          Address           Auth Key           Private Key     
+-------------------------------------------------------------------
+Alice            0x8dcc...7dbe    '0x8dcc...7dbe'    '0x1cec...cc88'
+Bob              0x36eb...9b6c     0x36eb...9b6c      0x9d7c...0610   
+ 
+...rotating...
+
+Alice            0x8dcc...7dbe    '0x36eb...9b6c'    '0x9d7c...0610'
+Bob              0x36eb...9b6c     0x36eb...9b6c      0x9d7c...0610   
+```
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python title="Python SDK rotate authentication key function"
+:!: static/sdks/python/examples/rotate-key.py rotate_key
+```
+```shell title="Navigate to the python SDK directory, install dependencies and run rotate_key.ts"
+cd ~/aptos-core/ecosystem/python/sdk
+poetry install && poetry run python -m examples.rotate-key
+```
+```shell title="rotate_key.ts output"
+Account            Address             Auth Key             Private Key        
+------------------------------------------------------------------------
+Alice              0x3e58...2b6243    '0x3e58...2b6243'    '0xb927...f4264d'    
+Bob                0xe39d...adf91f     0xe39d...adf91f      0xb2cd...a5c415    
+
+...rotating...
+
+Alice              0x3e58...2b6243    '0xe39d...adf91f'    '0xb2cd...a5c415'    
+Bob                0xe39d...adf91f     0xe39d...adf91f      0xb2cd...a5c415  
+```
+
+  </TabItem>
+
+  <TabItem value="rust" label="Rust">
+
+    Coming soon.
+
+  </TabItem>
+</Tabs>

--- a/developer-docs-site/docusaurus.config.js
+++ b/developer-docs-site/docusaurus.config.js
@@ -159,6 +159,10 @@ const config = {
               to: "/category/nft",
             },
             {
+              label: "Examples",
+              to: "/category/examples",
+            },
+            {
               label: "Build E2E Dapp on Aptos",
               to: "tutorials/build-e2e-dapp/e2e-dapp-index",
             },

--- a/developer-docs-site/sidebars.js
+++ b/developer-docs-site/sidebars.js
@@ -347,7 +347,7 @@ const sidebars = {
         keywords: ["examples"],
       },
       items: [
-        "guides/resource-accounts/key-rotation",
+        "guides/account-management/key-rotation",
       ],
     },
     {

--- a/developer-docs-site/sidebars.js
+++ b/developer-docs-site/sidebars.js
@@ -336,6 +336,22 @@ const sidebars = {
     },
     {
       type: "category",
+      label: "Examples",
+      collapsible: true,
+      collapsed: true,
+      link: {
+        type: "generated-index",
+        title: "Examples",
+        description: "Examples for all the various concepts and tooling used to build on Aptos.",
+        slug: "/category/examples",
+        keywords: ["examples"],
+      },
+      items: [
+        "guides/resource-accounts/key-rotation",
+      ],
+    },
+    {
+      type: "category",
       label: "Build E2E Dapp with Aptos",
       link: { type: "doc", id: "tutorials/build-e2e-dapp/index" },
       collapsible: true,

--- a/developer-docs-site/sidebars.js
+++ b/developer-docs-site/sidebars.js
@@ -346,9 +346,7 @@ const sidebars = {
         slug: "/category/examples",
         keywords: ["examples"],
       },
-      items: [
-        "guides/account-management/key-rotation",
-      ],
+      items: ["guides/account-management/key-rotation"],
     },
     {
       type: "category",

--- a/ecosystem/python/sdk/examples/rotate-key.py
+++ b/ecosystem/python/sdk/examples/rotate-key.py
@@ -37,7 +37,7 @@ async def rotate_auth_key_ed_25519_payload(
     rotation_proof_challenge = RotationProofChallenge(
         sequence_number=await rest_client.account_sequence_number(from_account.address()),
         originator=from_account.address(),
-        current_auth_key=from_account.address(),
+        current_auth_key=from_account.auth_key(),
         new_public_key=to_account.public_key().key.encode(),
     )
 

--- a/ecosystem/python/sdk/examples/rotate-key.py
+++ b/ecosystem/python/sdk/examples/rotate-key.py
@@ -1,0 +1,105 @@
+import asyncio
+import subprocess
+import time
+
+from aptos_sdk.account import Account, RotationProofChallenge
+from aptos_sdk.account_address import AccountAddress
+from aptos_sdk.authenticator import Authenticator, MultiEd25519Authenticator
+from aptos_sdk.bcs import Serializer
+from aptos_sdk.async_client import FaucetClient, RestClient
+from aptos_sdk.transactions import (
+    EntryFunction,
+    RawTransaction,
+    Script,
+    ScriptArgument,
+    SignedTransaction,
+    TransactionArgument,
+    TransactionPayload,
+)
+from aptos_sdk.type_tag import StructTag, TypeTag
+
+from .common import FAUCET_URL, NODE_URL
+
+WIDTH = 19
+
+def truncate(address: str) -> str:
+    return address[0:6] + '...' + address[-6:]
+
+def format_account_info(account: Account) -> str:
+    vals = [str(account.address()), account.auth_key(), account.private_key.hex()]
+    return ''.join([truncate(v).ljust(WIDTH, ' ') for v in vals])
+
+async def rotate_auth_key_ed_25519_payload(
+    rest_client: RestClient,
+    from_account: Account,
+    to_account: Account
+) -> TransactionPayload:
+    rotation_proof_challenge = RotationProofChallenge(
+        sequence_number=await rest_client.account_sequence_number(from_account.address()),
+        originator=from_account.address(),
+        current_auth_key=from_account.address(),
+        new_public_key=to_account.public_key().key.encode(),
+    )
+
+    serializer = Serializer()
+    rotation_proof_challenge.serialize(serializer)
+    rotation_proof_challenge_bcs = serializer.output()
+
+    proof_signed_by_from = from_account.sign(rotation_proof_challenge_bcs).data()
+    proof_signed_by_to = to_account.sign(rotation_proof_challenge_bcs).data()
+
+    from_scheme = Authenticator.ED25519
+    from_public_key_bytes = from_account.public_key().key.encode()
+    to_scheme = Authenticator.ED25519
+    to_public_key_bytes = to_account.public_key().key.encode()
+
+    entry_function = EntryFunction.natural(
+        module="0x1::account",
+        function="rotate_authentication_key",
+        ty_args=[],
+        args=[
+            TransactionArgument(from_scheme, Serializer.u8),
+            TransactionArgument(from_public_key_bytes, Serializer.to_bytes),
+            TransactionArgument(to_scheme, Serializer.u8),
+            TransactionArgument(to_public_key_bytes, Serializer.to_bytes),
+            TransactionArgument(proof_signed_by_from, Serializer.to_bytes),
+            TransactionArgument(proof_signed_by_to, Serializer.to_bytes),
+        ],
+    )
+
+    return TransactionPayload(entry_function)
+
+
+async def main():
+    rest_client = RestClient(NODE_URL)
+    faucet_client = FaucetClient(FAUCET_URL, rest_client)
+    alice = Account.generate()
+    bob = Account.generate()
+
+    await faucet_client.fund_account(alice.address(), 10_000_000)
+    await faucet_client.fund_account(bob.address(), 10_000_000)
+    print('\n' + 'Account'.ljust(WIDTH, " ") + 'Address'.ljust(WIDTH, " ") + 'Auth Key'.ljust(WIDTH, " ") + 'Private Key'.ljust(WIDTH, " "))
+    print('------------------------------------------------------------------------')
+    print('Alice'.ljust(WIDTH, " ") + format_account_info(alice))
+    print('Bob'.ljust(WIDTH, " ") + format_account_info(bob))
+
+    print("\n...rotating...\n")
+
+    # :!:>rotate_key
+    payload = await rotate_auth_key_ed_25519_payload(rest_client, alice, bob)
+
+    signed_transaction = await rest_client.create_bcs_signed_transaction(
+        alice, payload
+    ) # <:!:rotate_key
+
+    tx_hash = await rest_client.submit_bcs_transaction(signed_transaction)
+    await rest_client.wait_for_transaction(tx_hash)
+
+    alice = Account(alice.address(), bob.private_key)
+
+    print('Alice'.ljust(WIDTH, " ") + format_account_info(alice))
+    print('Bob'.ljust(WIDTH, " ") +  format_account_info(bob))
+    print()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ecosystem/python/sdk/examples/rotate-key.py
+++ b/ecosystem/python/sdk/examples/rotate-key.py
@@ -11,9 +11,11 @@ from aptos_sdk.transactions import (
     TransactionArgument,
     TransactionPayload,
 )
+
 from .common import FAUCET_URL, NODE_URL
 
 WIDTH = 19
+
 
 def truncate(address: str) -> str:
     return address[0:6] + "..." + address[-6:]

--- a/ecosystem/typescript/sdk/examples/typescript-esm/package.json
+++ b/ecosystem/typescript/sdk/examples/typescript-esm/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "build": "rm -rf dist/* && tsc -p .",
-    "test": "pnpm build && node ./dist/index.js"
+    "test": "pnpm build && node ./dist/index.js",
+    "rotate_key": "ts-node --esm rotate_key.ts"
   },
   "keywords": [],
   "author": "",
@@ -15,6 +16,8 @@
     "aptos": "latest"
   },
   "devDependencies": {
+    "@types/node": "18.6.2",
+    "ts-node": "10.9.1",
     "typescript": "4.8.2"
   }
 }

--- a/ecosystem/typescript/sdk/examples/typescript-esm/pnpm-lock.yaml
+++ b/ecosystem/typescript/sdk/examples/typescript-esm/pnpm-lock.yaml
@@ -1,16 +1,49 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   aptos:
     specifier: latest
-    version: 1.7.2
+    version: 1.11.0
 
 devDependencies:
+  '@types/node':
+    specifier: 18.6.2
+    version: 18.6.2
+  ts-node:
+    specifier: 10.9.1
+    version: 10.9.1(@types/node@18.6.2)(typescript@4.8.2)
   typescript:
     specifier: 4.8.2
     version: 4.8.2
 
 packages:
+
+  /@cspotcode/source-map-support@0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    dev: true
+
+  /@jridgewell/resolve-uri@3.1.1:
+    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/sourcemap-codec@1.4.15:
+    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+    dev: true
+
+  /@jridgewell/trace-mapping@0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
 
   /@noble/hashes@1.1.3:
     resolution: {integrity: sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==}
@@ -27,8 +60,39 @@ packages:
       '@scure/base': 1.1.1
     dev: false
 
-  /aptos@1.7.2:
-    resolution: {integrity: sha512-unM7bPbu3UGoVB/EhTvA+QDo8nqb6pDfqttsKwC7nYavQnl4t5dxCoFfIFcbijBtSOTfo4is5ldi4Uz4cY9ESA==}
+  /@tsconfig/node10@1.0.9:
+    resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
+    dev: true
+
+  /@tsconfig/node12@1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: true
+
+  /@tsconfig/node14@1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
+
+  /@tsconfig/node16@1.0.4:
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+    dev: true
+
+  /@types/node@18.6.2:
+    resolution: {integrity: sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ==}
+    dev: true
+
+  /acorn-walk@8.2.0:
+    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
+  /acorn@8.10.0:
+    resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /aptos@1.11.0:
+    resolution: {integrity: sha512-hLoyocm3Mv9JQadUObgAJHI4OLJvg2UguOb5Hz7HBbZ05UrpKSCPPX4jTF5UJVlW8HS8b6QQT5dYYXLQHPosqg==}
     engines: {node: '>=11.0.0'}
     dependencies:
       '@noble/hashes': 1.1.3
@@ -39,6 +103,10 @@ packages:
     transitivePeerDependencies:
       - debug
     dev: false
+
+  /arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    dev: true
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -60,10 +128,19 @@ packages:
       delayed-stream: 1.0.0
     dev: false
 
+  /create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
+
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
     dev: false
+
+  /diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+    dev: true
 
   /follow-redirects@1.15.2:
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
@@ -84,6 +161,10 @@ packages:
       mime-types: 2.1.35
     dev: false
 
+  /make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: true
+
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -96,6 +177,37 @@ packages:
       mime-db: 1.52.0
     dev: false
 
+  /ts-node@10.9.1(@types/node@18.6.2)(typescript@4.8.2):
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 18.6.2
+      acorn: 8.10.0
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.8.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
   /tweetnacl@1.0.3:
     resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
     dev: false
@@ -104,4 +216,13 @@ packages:
     resolution: {integrity: sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: true
+
+  /v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: true
+
+  /yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
     dev: true

--- a/ecosystem/typescript/sdk/examples/typescript-esm/rotate_key.ts
+++ b/ecosystem/typescript/sdk/examples/typescript-esm/rotate_key.ts
@@ -1,6 +1,7 @@
 import { AptosAccount, FaucetClient, Network, Provider, HexString } from 'aptos';
 
-export const NODE_URL = "https://fullnode.devnet.aptoslabs.com";
+const NODE_URL = process.env.APTOS_NODE_URL || "https://fullnode.devnet.aptoslabs.com";
+const FAUCET_URL = process.env.APTOS_FAUCET_URL || "https://faucet.devnet.aptoslabs.com";
 export const FAUCET_URL = "https://faucet.devnet.aptoslabs.com";
 
 function truncate(address: HexString): string {

--- a/ecosystem/typescript/sdk/examples/typescript-esm/rotate_key.ts
+++ b/ecosystem/typescript/sdk/examples/typescript-esm/rotate_key.ts
@@ -1,7 +1,7 @@
 import { AptosAccount, FaucetClient, Network, Provider, HexString } from 'aptos';
 
-const NODE_URL = process.env.APTOS_NODE_URL || "https://fullnode.devnet.aptoslabs.com";
-const FAUCET_URL = process.env.APTOS_FAUCET_URL || "https://faucet.devnet.aptoslabs.com";
+const NETWORK = Network.DEVNET;
+const FAUCET_URL = `https://faucet.${NETWORK}.aptoslabs.com`;
 const WIDTH = 16;
 const APTOS_COIN_DECIMALS = 8;
 
@@ -13,7 +13,8 @@ function formatAccountInfo(account: AptosAccount): string {
     const vals: any[] = [
         account.address(),
         account.authKey(),
-        HexString.fromUint8Array(account.signingKey.secretKey)
+        HexString.fromUint8Array(account.signingKey.secretKey),
+        HexString.fromUint8Array(account.signingKey.publicKey)
     ];
 
     return vals.map(v => {
@@ -23,8 +24,8 @@ function formatAccountInfo(account: AptosAccount): string {
 
 
 (async() => {
-    const provider = new Provider({fullnodeUrl: NODE_URL});
-    const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
+    const provider = new Provider(NETWORK);
+    const faucetClient = new FaucetClient(provider.aptosClient.nodeUrl, FAUCET_URL);
 
     // :!:>create_accounts
     const alice = new AptosAccount();
@@ -33,8 +34,8 @@ function formatAccountInfo(account: AptosAccount): string {
     await faucetClient.fundAccount(alice.address(), 1 * Math.pow(10, APTOS_COIN_DECIMALS));
     await faucetClient.fundAccount(bob.address(), 1 * Math.pow(10, APTOS_COIN_DECIMALS));
 
-    console.log(`\n${'Account'.padEnd(WIDTH)} ${'Address'.padEnd(WIDTH)} ${'Auth Key'.padEnd(WIDTH)} ${'Private Key'.padEnd(WIDTH)}`)
-    console.log(`-------------------------------------------------------------------`)
+    console.log(`\n${'Account'.padEnd(WIDTH)} ${'Address'.padEnd(WIDTH)} ${'Auth Key'.padEnd(WIDTH)} ${'Private Key'.padEnd(WIDTH)} ${'Public Key'.padEnd(WIDTH)}`)
+    console.log(`---------------------------------------------------------------------------------`)
     console.log(`${'alice'.padEnd(WIDTH)} ${formatAccountInfo(alice)}`);
     console.log(`${'bob'.padEnd(WIDTH)} ${formatAccountInfo(bob)}`);
     console.log('\n...rotating...'.padStart(WIDTH));

--- a/ecosystem/typescript/sdk/examples/typescript-esm/rotate_key.ts
+++ b/ecosystem/typescript/sdk/examples/typescript-esm/rotate_key.ts
@@ -1,0 +1,56 @@
+import { AptosAccount, FaucetClient, Network, Provider, HexString } from 'aptos';
+
+export const NODE_URL = "https://fullnode.devnet.aptoslabs.com";
+export const FAUCET_URL = "https://faucet.devnet.aptoslabs.com";
+
+function truncate(address: HexString): string {
+    return `${address.toString().substring(0, 6)}...${address.toString().substring(address.toString().length - 4, address.toString().length)}`
+}
+
+function formatAccountInfo(account: AptosAccount): string {
+    const vals: any[] = [
+        account.address(),
+        account.authKey(),
+        HexString.fromUint8Array(account.signingKey.secretKey)
+    ];
+
+    return vals.map(v => {
+        return truncate(v).padEnd(WIDTH)
+    }).join(' ');
+}
+
+const WIDTH = 16;
+
+(async() => {
+    const provider = new Provider(Network.DEVNET);
+    const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
+
+    // :!:>create_accounts
+    const alice = new AptosAccount();
+    const bob = new AptosAccount(); // <:!:create_accounts
+    
+    await faucetClient.fundAccount(alice.address(), 1 * Math.pow(10, 8));
+    await faucetClient.fundAccount(bob.address(), 1 * Math.pow(10, 8));
+
+    console.log(`\n${'Account'.padEnd(WIDTH)} ${'Address'.padEnd(WIDTH)} ${'Auth Key'.padEnd(WIDTH)} ${'Private Key'.padEnd(WIDTH)}`)
+    console.log(`-------------------------------------------------------------------`)
+    console.log(`${'alice'.padEnd(WIDTH)} ${formatAccountInfo(alice)}`);
+    console.log(`${'bob'.padEnd(WIDTH)} ${formatAccountInfo(bob)}`);
+    console.log('\n...rotating...'.padStart(WIDTH));
+    
+    // Rotate the key!
+    // :!:>rotate_key
+    const response = await provider.aptosClient.rotateAuthKeyEd25519(
+        alice,
+        bob.signingKey.secretKey
+    );// <:!:rotate_key
+
+    // We must create a new instance of AptosAccount because the private key has changed.
+    const aliceNew = new AptosAccount(
+        bob.signingKey.secretKey,
+        alice.address() // NOTE: Without this argument, this would be bob, not aliceNew. You must specify the address since the private key matches multiple accounts now
+    )
+
+    console.log(`\n${'alice'.padEnd(WIDTH)} ${formatAccountInfo(aliceNew)}`);
+    console.log(`${'bob'.padEnd(WIDTH)} ${formatAccountInfo(bob)}\n`);
+})();

--- a/ecosystem/typescript/sdk/examples/typescript-esm/rotate_key.ts
+++ b/ecosystem/typescript/sdk/examples/typescript-esm/rotate_key.ts
@@ -23,7 +23,7 @@ function formatAccountInfo(account: AptosAccount): string {
 const WIDTH = 16;
 
 (async() => {
-    const provider = new Provider(Network.DEVNET);
+    const provider = new Provider({fullnodeUrl: NODE_URL});
     const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
 
     // :!:>create_accounts

--- a/ecosystem/typescript/sdk/examples/typescript-esm/rotate_key.ts
+++ b/ecosystem/typescript/sdk/examples/typescript-esm/rotate_key.ts
@@ -2,7 +2,8 @@ import { AptosAccount, FaucetClient, Network, Provider, HexString } from 'aptos'
 
 const NODE_URL = process.env.APTOS_NODE_URL || "https://fullnode.devnet.aptoslabs.com";
 const FAUCET_URL = process.env.APTOS_FAUCET_URL || "https://faucet.devnet.aptoslabs.com";
-export const FAUCET_URL = "https://faucet.devnet.aptoslabs.com";
+const WIDTH = 16;
+const APTOS_COIN_DECIMALS = 8;
 
 function truncate(address: HexString): string {
     return `${address.toString().substring(0, 6)}...${address.toString().substring(address.toString().length - 4, address.toString().length)}`
@@ -20,7 +21,6 @@ function formatAccountInfo(account: AptosAccount): string {
     }).join(' ');
 }
 
-const WIDTH = 16;
 
 (async() => {
     const provider = new Provider({fullnodeUrl: NODE_URL});
@@ -30,8 +30,8 @@ const WIDTH = 16;
     const alice = new AptosAccount();
     const bob = new AptosAccount(); // <:!:create_accounts
     
-    await faucetClient.fundAccount(alice.address(), 1 * Math.pow(10, 8));
-    await faucetClient.fundAccount(bob.address(), 1 * Math.pow(10, 8));
+    await faucetClient.fundAccount(alice.address(), 1 * Math.pow(10, APTOS_COIN_DECIMALS));
+    await faucetClient.fundAccount(bob.address(), 1 * Math.pow(10, APTOS_COIN_DECIMALS));
 
     console.log(`\n${'Account'.padEnd(WIDTH)} ${'Address'.padEnd(WIDTH)} ${'Auth Key'.padEnd(WIDTH)} ${'Private Key'.padEnd(WIDTH)}`)
     console.log(`-------------------------------------------------------------------`)

--- a/ecosystem/typescript/sdk/examples/typescript-esm/rotate_key.ts
+++ b/ecosystem/typescript/sdk/examples/typescript-esm/rotate_key.ts
@@ -1,4 +1,4 @@
-import { AptosAccount, FaucetClient, Network, Provider, HexString } from 'aptos';
+import { AptosAccount, FaucetClient, Network, Provider, HexString } from "aptos";
 
 const NETWORK = Network.DEVNET;
 const FAUCET_URL = `https://faucet.${NETWORK}.aptoslabs.com`;
@@ -6,53 +6,57 @@ const WIDTH = 16;
 const APTOS_COIN_DECIMALS = 8;
 
 function truncate(address: HexString): string {
-    return `${address.toString().substring(0, 6)}...${address.toString().substring(address.toString().length - 4, address.toString().length)}`
+  return `${address.toString().substring(0, 6)}...${address
+    .toString()
+    .substring(address.toString().length - 4, address.toString().length)}`;
 }
 
 function formatAccountInfo(account: AptosAccount): string {
-    const vals: any[] = [
-        account.address(),
-        account.authKey(),
-        HexString.fromUint8Array(account.signingKey.secretKey),
-        HexString.fromUint8Array(account.signingKey.publicKey)
-    ];
+  const vals: any[] = [
+    account.address(),
+    account.authKey(),
+    HexString.fromUint8Array(account.signingKey.secretKey),
+    HexString.fromUint8Array(account.signingKey.publicKey),
+  ];
 
-    return vals.map(v => {
-        return truncate(v).padEnd(WIDTH)
-    }).join(' ');
+  return vals
+    .map((v) => {
+      return truncate(v).padEnd(WIDTH);
+    })
+    .join(" ");
 }
 
+(async () => {
+  const provider = new Provider(NETWORK);
+  const faucetClient = new FaucetClient(provider.aptosClient.nodeUrl, FAUCET_URL);
 
-(async() => {
-    const provider = new Provider(NETWORK);
-    const faucetClient = new FaucetClient(provider.aptosClient.nodeUrl, FAUCET_URL);
+  // :!:>create_accounts
+  const alice = new AptosAccount();
+  const bob = new AptosAccount(); // <:!:create_accounts
 
-    // :!:>create_accounts
-    const alice = new AptosAccount();
-    const bob = new AptosAccount(); // <:!:create_accounts
-    
-    await faucetClient.fundAccount(alice.address(), 1 * Math.pow(10, APTOS_COIN_DECIMALS));
-    await faucetClient.fundAccount(bob.address(), 1 * Math.pow(10, APTOS_COIN_DECIMALS));
+  await faucetClient.fundAccount(alice.address(), 1 * Math.pow(10, APTOS_COIN_DECIMALS));
+  await faucetClient.fundAccount(bob.address(), 1 * Math.pow(10, APTOS_COIN_DECIMALS));
 
-    console.log(`\n${'Account'.padEnd(WIDTH)} ${'Address'.padEnd(WIDTH)} ${'Auth Key'.padEnd(WIDTH)} ${'Private Key'.padEnd(WIDTH)} ${'Public Key'.padEnd(WIDTH)}`)
-    console.log(`---------------------------------------------------------------------------------`)
-    console.log(`${'alice'.padEnd(WIDTH)} ${formatAccountInfo(alice)}`);
-    console.log(`${'bob'.padEnd(WIDTH)} ${formatAccountInfo(bob)}`);
-    console.log('\n...rotating...'.padStart(WIDTH));
-    
-    // Rotate the key!
-    // :!:>rotate_key
-    const response = await provider.aptosClient.rotateAuthKeyEd25519(
-        alice,
-        bob.signingKey.secretKey
-    );// <:!:rotate_key
+  console.log(
+    `\n${"Account".padEnd(WIDTH)} ${"Address".padEnd(WIDTH)} ${"Auth Key".padEnd(WIDTH)} ${"Private Key".padEnd(
+      WIDTH,
+    )} ${"Public Key".padEnd(WIDTH)}`,
+  );
+  console.log(`---------------------------------------------------------------------------------`);
+  console.log(`${"alice".padEnd(WIDTH)} ${formatAccountInfo(alice)}`);
+  console.log(`${"bob".padEnd(WIDTH)} ${formatAccountInfo(bob)}`);
+  console.log("\n...rotating...".padStart(WIDTH));
 
-    // We must create a new instance of AptosAccount because the private key has changed.
-    const aliceNew = new AptosAccount(
-        bob.signingKey.secretKey,
-        alice.address() // NOTE: Without this argument, this would be bob, not aliceNew. You must specify the address since the private key matches multiple accounts now
-    )
+  // Rotate the key!
+  // :!:>rotate_key
+  const response = await provider.aptosClient.rotateAuthKeyEd25519(alice, bob.signingKey.secretKey); // <:!:rotate_key
 
-    console.log(`\n${'alice'.padEnd(WIDTH)} ${formatAccountInfo(aliceNew)}`);
-    console.log(`${'bob'.padEnd(WIDTH)} ${formatAccountInfo(bob)}\n`);
+  // We must create a new instance of AptosAccount because the private key has changed.
+  const aliceNew = new AptosAccount(
+    bob.signingKey.secretKey,
+    alice.address(), // NOTE: Without this argument, this would be bob, not aliceNew. You must specify the address since the private key matches multiple accounts now
+  );
+
+  console.log(`\n${"alice".padEnd(WIDTH)} ${formatAccountInfo(aliceNew)}`);
+  console.log(`${"bob".padEnd(WIDTH)} ${formatAccountInfo(bob)}\n`);
 })();


### PR DESCRIPTION
### Description

Added examples of how to rotate an account's authentication key with an accompanying simple page in the docs that covers how to run the code and the relevant code snippets.

The intention here is to very briefly explain how to do things, not to explain all of the concepts involved in the process. This will be used later in the resource accounts tutorial, for example.

### Test Plan

Run the examples in the docs page by copying and pasting the commands