### PR TITLE
[framework] removing this resulted in incompatible framework revisions

### DIFF
--- a/aptos-move/framework/aptos-stdlib/Move.toml
+++ b/aptos-move/framework/aptos-stdlib/Move.toml
@@ -5,6 +5,7 @@ version = "1.0.0"
 [addresses]
 std = "0x1"
 aptos_std = "0x1"
+aptos_framework = "0x1"
 Extensions = "0x1" # For Prover to instantiate `{{Ext}}` in prelude.
 
 [dependencies]


### PR DESCRIPTION
Apparently if an application and its dependencies import aptos stdlib with and without this address set, it would break compilation, example:

{
  "Error": "Move compilation failed: Unable to resolve packages for
package 'Tsunami': While resolving dependency 'Switchboard' in package 'Tsunami': Unable to resolve package depen
dency 'Switchboard': While resolving dependency 'AptosStdlib' in package 'Switchboard': Unable to resolve package dependency 'AptosStdlib': Conflicting dependencies found: package '
AptosStdlib' conflicts with 'AptosStdlib'"
}

Adding it back and everything magically works...

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
