### PR TITLE
[api] Add consistent API testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,7 @@
 !**/*.mrb
 !**/*.errmap
 !config/src/config/test_data
+!aptos-move/
 !aptos-move/aptos-release-builder/data/release.yaml
 !aptos-move/aptos-release-builder/data/proposals/*
 !aptos-move/framework/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,6 +2991,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "serde 1.0.149",
+ "serde_json",
  "tiny-bip39",
  "tokio",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,7 @@ dependencies = [
  "aptos-rest-client",
  "aptos-sdk",
  "aptos-types",
+ "move-core-types",
  "once_cell",
  "rand 0.7.3",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-api-tester"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-api-types",
+ "aptos-rest-client",
+ "aptos-sdk",
+ "aptos-types",
+ "once_cell",
+ "rand 0.7.3",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "aptos-api-types"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-api-types",
+ "aptos-cached-packages",
  "aptos-rest-client",
  "aptos-sdk",
  "aptos-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "anyhow",
  "aptos-api-types",
  "aptos-cached-packages",
+ "aptos-framework",
  "aptos-rest-client",
  "aptos-sdk",
  "aptos-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
     "consensus/consensus-types",
     "consensus/safety-rules",
     "crates/aptos",
+    "crates/aptos-api-tester",
     "crates/aptos-bitvec",
     "crates/aptos-build-info",
     "crates/aptos-compression",

--- a/crates/aptos-api-tester/Cargo.toml
+++ b/crates/aptos-api-tester/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "aptos-api-tester"
+description = "Aptos developer API tester"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+aptos-sdk = { workspace = true }
+aptos-rest-client = { workspace = true }
+aptos-api-types = { workspace = true }
+aptos-types = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
+once_cell = { workspace = true }
+rand = { workspace = true }
+anyhow = { workspace = true }
+
+
+

--- a/crates/aptos-api-tester/Cargo.toml
+++ b/crates/aptos-api-tester/Cargo.toml
@@ -22,6 +22,4 @@ url = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }
 anyhow = { workspace = true }
-
-
-
+aptos-cached-packages = { workspace = true }

--- a/crates/aptos-api-tester/Cargo.toml
+++ b/crates/aptos-api-tester/Cargo.toml
@@ -24,3 +24,5 @@ rand = { workspace = true }
 anyhow = { workspace = true }
 aptos-cached-packages = { workspace = true }
 aptos-framework = { workspace = true }
+move-core-types = { workspace = true }
+

--- a/crates/aptos-api-tester/Cargo.toml
+++ b/crates/aptos-api-tester/Cargo.toml
@@ -23,3 +23,4 @@ once_cell = { workspace = true }
 rand = { workspace = true }
 anyhow = { workspace = true }
 aptos-cached-packages = { workspace = true }
+aptos-framework = { workspace = true }

--- a/crates/aptos-api-tester/Cargo.toml
+++ b/crates/aptos-api-tester/Cargo.toml
@@ -13,16 +13,15 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-aptos-sdk = { workspace = true }
-aptos-rest-client = { workspace = true }
-aptos-api-types = { workspace = true }
-aptos-types = { workspace = true }
-tokio = { workspace = true }
-url = { workspace = true }
-once_cell = { workspace = true }
-rand = { workspace = true }
 anyhow = { workspace = true }
+aptos-api-types = { workspace = true }
 aptos-cached-packages = { workspace = true }
 aptos-framework = { workspace = true }
+aptos-rest-client = { workspace = true }
+aptos-sdk = { workspace = true }
+aptos-types = { workspace = true }
 move-core-types = { workspace = true }
-
+once_cell = { workspace = true }
+rand = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -254,15 +254,6 @@ async fn probe_getaccountbalanceatversion_1() -> Result<&'static str> {
         return Ok(FAIL_WRONG_BALANCE_AT_VERSION);
     }
 
-<<<<<<< HEAD
-    // use the faucet to ensure that there exists a higher version number
-    faucet_client
-        .fund(giray.address(), 100_000_000)
-        .await
-        .context(ERROR_FAUCET_FUND)?;
-
-=======
->>>>>>> 84b40d670f (Add tests for get_account_balance_at_version)
     // ask for account balance with a higher version number
     let response = client
         .get_account_balance_at_version(giray2.address(), version + 1)

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -1,0 +1,181 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use anyhow::{Context, Result};
+use aptos_api_types::U64;
+use aptos_rest_client::{Client, FaucetClient};
+use aptos_sdk::types::LocalAccount;
+use aptos_types::account_address::AccountAddress;
+use aptos_types::transaction::authenticator::AuthenticationKey;
+use once_cell::sync::Lazy;
+use rand::Rng;
+use std::str::FromStr;
+use url::Url;
+
+// global parameters (todo: make into clap)
+static HAS_FAUCET_ACCESS: bool = true;
+
+// network urls
+static DEVNET_NODE_URL: Lazy<Url> =
+    Lazy::new(|| Url::parse("https://fullnode.devnet.aptoslabs.com").unwrap());
+static DEVNET_FAUCET_URL: Lazy<Url> =
+    Lazy::new(|| Url::parse("https://faucet.devnet.aptoslabs.com").unwrap());
+static TESTNET_NODE_URL: Lazy<Url> =
+    Lazy::new(|| Url::parse("https://fullnode.testnet.aptoslabs.com").unwrap());
+
+// static accounts to use
+static TEST_ACCOUNT_1: Lazy<AccountAddress> = Lazy::new(|| {
+    AccountAddress::from_hex_literal(
+        "0x7fed760c508a8885e1438c90f81dea6940ad53b05527fadddd3851f53342d7c4",
+    )
+    .unwrap()
+});
+static TEST_ACCOUNT_2: Lazy<AccountAddress> = Lazy::new(|| {
+    AccountAddress::from_hex_literal(
+        "0xf6cee5c359839a321a08af6b8cfe4a6e439db46f4942e21b6845aa57d770efdb",
+    )
+    .unwrap()
+});
+
+// return values
+static SKIP_NO_FAUCET_ACCESS: &str = "This test requires faucet access.";
+static ERROR_CLIENT_RESPONSE: &str = "Client responded with error.";
+static ERROR_FAUCET_FUND: &str = "Funding from faucet failed.";
+static ERROR_OTHER: &str = "Something went wrong.";
+static FAIL_WRONG_AUTH_KEY: &str = "Returned wrong authentication key.";
+static FAIL_WRONG_SEQ_NUMBER: &str = "Returned wrong sequence number.";
+static FAIL_WRONG_BALANCE: &str = "Returned wrong balance.";
+static SUCCESS: &str = "success";
+
+// Calls get_account on a newly created account. Requires faucet.
+async fn probe_getaccount_1() -> Result<&'static str> {
+    // check faucet access
+    if !HAS_FAUCET_ACCESS {
+        return Ok(SKIP_NO_FAUCET_ACCESS);
+    }
+
+    // create the rest client
+    let client = Client::new(DEVNET_NODE_URL.clone());
+    let faucet_client = FaucetClient::new(DEVNET_FAUCET_URL.clone(), DEVNET_NODE_URL.clone());
+
+    // create and fund an account
+    let giray = LocalAccount::generate(&mut rand::rngs::OsRng);
+    faucet_client
+        .fund(giray.address(), 100_000_000)
+        .await
+        .context(ERROR_FAUCET_FUND)?;
+
+    // ask for account data
+    let response = client
+        .get_account(giray.address())
+        .await
+        .context(ERROR_CLIENT_RESPONSE)?;
+    let response = response.inner();
+
+    // check authentication key
+    let expected_auth_key = giray.authentication_key();
+    let actual_auth_key = response.authentication_key;
+    if !(actual_auth_key == expected_auth_key) {
+        return Ok(FAIL_WRONG_AUTH_KEY);
+    }
+
+    // check sequence number
+    let expected_seq_num = giray.sequence_number();
+    let actual_seq_num = response.sequence_number;
+    if !(actual_seq_num == expected_seq_num) {
+        return Ok(FAIL_WRONG_SEQ_NUMBER);
+    }
+
+    Ok(SUCCESS)
+}
+
+// Calls get_account on a static account.
+async fn probe_getaccount_2() -> Result<&'static str> {
+    // create the rest client
+    let client = Client::new(TESTNET_NODE_URL.clone());
+
+    // ask for account data
+    let response = client
+        .get_account(*TEST_ACCOUNT_1)
+        .await
+        .context(ERROR_CLIENT_RESPONSE)?;
+    let response = response.inner();
+
+    // check authentication key
+    let expected_auth_key = AuthenticationKey::from_str(
+        "7fed760c508a8885e1438c90f81dea6940ad53b05527fadddd3851f53342d7c4",
+    )
+    .context(ERROR_OTHER)?;
+    let actual_auth_key = response.authentication_key;
+    if !(actual_auth_key == expected_auth_key) {
+        return Ok(FAIL_WRONG_AUTH_KEY);
+    }
+
+    // check sequence number
+    let expected_seq_num = 1;
+    let actual_seq_num = response.sequence_number;
+    if !(actual_seq_num == expected_seq_num) {
+        return Ok(FAIL_WRONG_SEQ_NUMBER);
+    }
+
+    Ok(SUCCESS)
+}
+
+// Calls get_account_balance on a newly created account. Requires faucet.
+async fn probe_getaccountbalance_1() -> Result<&'static str> {
+    // check faucet access
+    if !HAS_FAUCET_ACCESS {
+        return Ok(SKIP_NO_FAUCET_ACCESS);
+    }
+
+    // create the rest client
+    let client = Client::new(DEVNET_NODE_URL.clone());
+    let faucet_client = FaucetClient::new(DEVNET_FAUCET_URL.clone(), DEVNET_NODE_URL.clone());
+
+    // create and fund an account
+    let giray = LocalAccount::generate(&mut rand::rngs::OsRng);
+    faucet_client
+        .fund(giray.address(), 100_000_000)
+        .await
+        .context(ERROR_FAUCET_FUND)?;
+
+    // fund the account further with some random amount
+    let random_number: u64 = rand::thread_rng().gen_range(50_000_000, 100_000_000);
+    faucet_client.fund(giray.address(), random_number).await?;
+
+    // ask for account balance
+    let response = client
+        .get_account_balance(giray.address())
+        .await
+        .context(ERROR_CLIENT_RESPONSE)?;
+    let response = response.inner();
+
+    // check balance
+    let expected_balance = U64(100_000_000 + random_number);
+    let actual_balance = response.coin.value;
+    if !(actual_balance == expected_balance) {
+        return Ok(FAIL_WRONG_BALANCE);
+    }
+
+    Ok(SUCCESS)
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    match probe_getaccount_1().await {
+        Ok(result) => println!("{}", result),
+        Err(e) => println!("{}", e),
+    }
+    match probe_getaccount_2().await {
+        Ok(result) => println!("{}", result),
+        Err(e) => println!("{}", e),
+    }
+    match probe_getaccountbalance_1().await {
+        Ok(result) => println!("{}", result),
+        Err(e) => println!("{}", e),
+    }
+
+    Ok(())
+}

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -59,7 +59,7 @@ static FAIL_WRONG_LAST_VERSION: &str = "Returned wrong block last version.";
 static FAIL_WRONG_TRANSACTIONS: &str = "Returned wrong transactions.";
 static SUCCESS: &str = "success";
 
-// Calls get_account on a newly created account on devnet. Requires faucet.
+/// Calls get_account on a newly created account on devnet. Requires faucet.
 async fn probe_getaccount_1() -> Result<&'static str> {
     // check faucet access
     if !HAS_FAUCET_ACCESS {
@@ -108,7 +108,7 @@ async fn probe_getaccount_1() -> Result<&'static str> {
     Ok(SUCCESS)
 }
 
-// Calls get_account on a static account on testnet.
+/// Calls get_account on a static account on testnet.
 async fn probe_getaccount_2() -> Result<&'static str> {
     // create the rest client
     let client = Client::new(TESTNET_NODE_URL.clone());
@@ -147,7 +147,7 @@ async fn probe_getaccount_2() -> Result<&'static str> {
     Ok(SUCCESS)
 }
 
-// Calls get_account_balance on a newly created account on devnet. Requires faucet.
+/// Calls get_account_balance on a newly created account on devnet. Requires faucet.
 async fn probe_getaccountbalance_1() -> Result<&'static str> {
     // check faucet access
     if !HAS_FAUCET_ACCESS {
@@ -193,7 +193,7 @@ async fn probe_getaccountbalance_1() -> Result<&'static str> {
     Ok(SUCCESS)
 }
 
-// Calls get_account_balance on a static account on testnet.
+/// Calls get_account_balance on a static account on testnet.
 async fn probe_getaccountbalance_2() -> Result<&'static str> {
     // create the rest client
     let client = Client::new(TESTNET_NODE_URL.clone());
@@ -219,7 +219,7 @@ async fn probe_getaccountbalance_2() -> Result<&'static str> {
     Ok(SUCCESS)
 }
 
-// Calls get_account_balance_at_version on a newly created account on devnet. Requires faucet.
+/// Calls get_account_balance_at_version on a newly created account on devnet. Requires faucet.
 async fn probe_getaccountbalanceatversion_1() -> Result<&'static str> {
     // check faucet access
     if !HAS_FAUCET_ACCESS {
@@ -315,7 +315,7 @@ async fn probe_getaccountbalanceatversion_1() -> Result<&'static str> {
     Ok(SUCCESS)
 }
 
-// Calls get_account_balance_at_version on a static account on testnet.
+/// Calls get_account_balance_at_version on a static account on testnet.
 async fn probe_getaccountbalanceatversion_2() -> Result<&'static str> {
     // create the rest client
     let client = Client::new(TESTNET_NODE_URL.clone());
@@ -396,7 +396,7 @@ async fn probe_getaccountbalanceatversion_2() -> Result<&'static str> {
     Ok(SUCCESS)
 }
 
-// Calls get_block_by_height by setting with_transactions=False on a fixed block on testnet.
+/// Calls get_block_by_height by setting with_transactions=False on a fixed block on testnet.
 async fn probe_getblockbyheight_1() -> Result<&'static str> {
     // create the rest client
     let client: Client = Client::new(TESTNET_NODE_URL.clone());
@@ -418,6 +418,78 @@ async fn probe_getblockbyheight_1() -> Result<&'static str> {
         block_timestamp: U64(1688146946653187),
         first_version: U64(565538916),
         last_version: U64(565538919),
+        transactions: None,
+    };
+
+    ensure!(
+        actual_block.block_height == expected_block.block_height,
+        "{} expected {}, got {}",
+        FAIL_WRONG_BLOCK_HEIGHT,
+        expected_block.block_height,
+        actual_block.block_height,
+    );
+    ensure!(
+        actual_block.block_hash == expected_block.block_hash,
+        "{} expected {}, got {}",
+        FAIL_WRONG_BLOCK_HASH,
+        expected_block.block_hash,
+        actual_block.block_hash,
+    );
+    ensure!(
+        actual_block.block_timestamp == expected_block.block_timestamp,
+        "{} expected {}, got {}",
+        FAIL_WRONG_BLOCK_TIMESTAMP,
+        expected_block.block_timestamp,
+        actual_block.block_timestamp,
+    );
+    ensure!(
+        actual_block.first_version == expected_block.first_version,
+        "{} expected {}, got {}",
+        FAIL_WRONG_FIRST_VERSION,
+        expected_block.first_version,
+        actual_block.first_version,
+    );
+    ensure!(
+        actual_block.last_version == expected_block.last_version,
+        "{} expected {}, got {}",
+        FAIL_WRONG_LAST_VERSION,
+        expected_block.last_version,
+        actual_block.last_version,
+    );
+    ensure!(
+        actual_block.transactions == expected_block.transactions,
+        "{} expected {:?}, got {:?}",
+        FAIL_WRONG_TRANSACTIONS,
+        expected_block.transactions,
+        actual_block.transactions,
+    );
+
+    Ok(SUCCESS)
+}
+
+/// Calls get_block_by_version by setting with_transactions=False on a fixed block on testnet.
+/// The version belongs to a user transaction inside the block.
+async fn probe_getblockbyversion_1() -> Result<&'static str> {
+    // create the rest client
+    let client: Client = Client::new(TESTNET_NODE_URL.clone());
+
+    // ask for block
+    let response = client
+        .get_block_by_version(565767993, false)
+        .await
+        .context(ERROR_CLIENT_RESPONSE)?;
+
+    // check block
+    let actual_block = response.inner();
+    let expected_block = Block {
+        block_height: U64(98764388),
+        block_hash: HashValue::from_str(
+            "f1fcfd799f88a2526d649d5a2cf227c14b77ef374b5daf6fb5d4987c430a91dd",
+        )
+        .context(ERROR_OTHER)?,
+        block_timestamp: U64(1688165648699603),
+        first_version: U64(565767992),
+        last_version: U64(565767994),
         transactions: None,
     };
 
@@ -494,6 +566,10 @@ async fn main() -> Result<()> {
         Err(e) => println!("{:?}", e),
     }
     match probe_getblockbyheight_1().await {
+        Ok(result) => println!("{:?}", result),
+        Err(e) => println!("{:?}", e),
+    }
+    match probe_getblockbyversion_1().await {
         Ok(result) => println!("{:?}", result),
         Err(e) => println!("{:?}", e),
     }

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -3,9 +3,9 @@
 
 #![forbid(unsafe_code)]
 
-use anyhow::{Context, Result};
-use aptos_api_types::U64;
-use aptos_rest_client::{Client, FaucetClient};
+use anyhow::{ensure, Context, Result};
+use aptos_api_types::{Block, HashValue, U64};
+use aptos_rest_client::{Account, Client, FaucetClient};
 use aptos_sdk::coin_client::CoinClient;
 use aptos_sdk::types::LocalAccount;
 use aptos_types::account_address::AccountAddress;
@@ -16,7 +16,7 @@ use std::str::FromStr;
 use url::Url;
 
 // global parameters (todo: make into clap)
-static HAS_FAUCET_ACCESS: bool = true;
+static HAS_FAUCET_ACCESS: bool = false;
 
 // network urls
 static DEVNET_NODE_URL: Lazy<Url> =
@@ -27,6 +27,7 @@ static TESTNET_NODE_URL: Lazy<Url> =
     Lazy::new(|| Url::parse("https://fullnode.testnet.aptoslabs.com").unwrap());
 
 // static accounts to use
+// don't send coins to TEST_ACCOUNT_1
 static TEST_ACCOUNT_1: Lazy<AccountAddress> = Lazy::new(|| {
     AccountAddress::from_hex_literal(
         "0x7fed760c508a8885e1438c90f81dea6940ad53b05527fadddd3851f53342d7c4",
@@ -50,9 +51,15 @@ static FAIL_WRONG_AUTH_KEY: &str = "Returned wrong authentication key.";
 static FAIL_WRONG_SEQ_NUMBER: &str = "Returned wrong sequence number.";
 static FAIL_WRONG_BALANCE: &str = "Returned wrong balance.";
 static FAIL_WRONG_BALANCE_AT_VERSION: &str = "Returned wrong balance at the given version.";
+static FAIL_WRONG_BLOCK_HEIGHT: &str = "Returned wrong block height.";
+static FAIL_WRONG_BLOCK_HASH: &str = "Returned wrong block hash.";
+static FAIL_WRONG_BLOCK_TIMESTAMP: &str = "Returned wrong block timestamp.";
+static FAIL_WRONG_FIRST_VERSION: &str = "Returned wrong block first version.";
+static FAIL_WRONG_LAST_VERSION: &str = "Returned wrong block last version.";
+static FAIL_WRONG_TRANSACTIONS: &str = "Returned wrong transactions.";
 static SUCCESS: &str = "success";
 
-// Calls get_account on a newly created account. Requires faucet.
+// Calls get_account on a newly created account on devnet. Requires faucet.
 async fn probe_getaccount_1() -> Result<&'static str> {
     // check faucet access
     if !HAS_FAUCET_ACCESS {
@@ -75,26 +82,33 @@ async fn probe_getaccount_1() -> Result<&'static str> {
         .get_account(giray.address())
         .await
         .context(ERROR_CLIENT_RESPONSE)?;
-    let response = response.inner();
 
-    // check authentication key
-    let expected_auth_key = giray.authentication_key();
-    let actual_auth_key = response.authentication_key;
-    if !(actual_auth_key == expected_auth_key) {
-        return Ok(FAIL_WRONG_AUTH_KEY);
-    }
+    // check account data
+    let expected_account = Account {
+        authentication_key: giray.authentication_key(),
+        sequence_number: giray.sequence_number(),
+    };
+    let actual_account = response.inner();
 
-    // check sequence number
-    let expected_seq_num = giray.sequence_number();
-    let actual_seq_num = response.sequence_number;
-    if !(actual_seq_num == expected_seq_num) {
-        return Ok(FAIL_WRONG_SEQ_NUMBER);
-    }
+    ensure!(
+        expected_account.authentication_key == actual_account.authentication_key,
+        "{} expected {}, got {}",
+        FAIL_WRONG_AUTH_KEY,
+        expected_account.authentication_key,
+        actual_account.authentication_key
+    );
+    ensure!(
+        expected_account.sequence_number == actual_account.sequence_number,
+        "{} expected {}, got {}",
+        FAIL_WRONG_SEQ_NUMBER,
+        expected_account.sequence_number,
+        actual_account.sequence_number
+    );
 
     Ok(SUCCESS)
 }
 
-// Calls get_account on a static account.
+// Calls get_account on a static account on testnet.
 async fn probe_getaccount_2() -> Result<&'static str> {
     // create the rest client
     let client = Client::new(TESTNET_NODE_URL.clone());
@@ -104,29 +118,36 @@ async fn probe_getaccount_2() -> Result<&'static str> {
         .get_account(*TEST_ACCOUNT_1)
         .await
         .context(ERROR_CLIENT_RESPONSE)?;
-    let response = response.inner();
 
-    // check authentication key
-    let expected_auth_key = AuthenticationKey::from_str(
-        "7fed760c508a8885e1438c90f81dea6940ad53b05527fadddd3851f53342d7c4",
-    )
-    .context(ERROR_OTHER)?;
-    let actual_auth_key = response.authentication_key;
-    if !(actual_auth_key == expected_auth_key) {
-        return Ok(FAIL_WRONG_AUTH_KEY);
-    }
+    // check account data
+    let expected_account = Account {
+        authentication_key: AuthenticationKey::from_str(
+            "7fed760c508a8885e1438c90f81dea6940ad53b05527fadddd3851f53342d7c4",
+        )
+        .context(ERROR_OTHER)?,
+        sequence_number: 1,
+    };
+    let actual_account = response.inner();
 
-    // check sequence number
-    let expected_seq_num = 1;
-    let actual_seq_num = response.sequence_number;
-    if !(actual_seq_num == expected_seq_num) {
-        return Ok(FAIL_WRONG_SEQ_NUMBER);
-    }
+    ensure!(
+        expected_account.authentication_key == actual_account.authentication_key,
+        "{} expected {}, got {}",
+        FAIL_WRONG_AUTH_KEY,
+        expected_account.authentication_key,
+        actual_account.authentication_key
+    );
+    ensure!(
+        expected_account.sequence_number == actual_account.sequence_number,
+        "{} expected {}, got {}",
+        FAIL_WRONG_SEQ_NUMBER,
+        expected_account.sequence_number,
+        actual_account.sequence_number
+    );
 
     Ok(SUCCESS)
 }
 
-// Calls get_account_balance on a newly created account. Requires faucet.
+// Calls get_account_balance on a newly created account on devnet. Requires faucet.
 async fn probe_getaccountbalance_1() -> Result<&'static str> {
     // check faucet access
     if !HAS_FAUCET_ACCESS {
@@ -146,26 +167,33 @@ async fn probe_getaccountbalance_1() -> Result<&'static str> {
 
     // fund the account further with some random amount
     let random_number: u64 = rand::thread_rng().gen_range(50_000_000, 100_000_000);
-    faucet_client.fund(giray.address(), random_number).await?;
+    faucet_client
+        .fund(giray.address(), random_number)
+        .await
+        .context(ERROR_FAUCET_FUND)?;
 
     // ask for account balance
     let response = client
         .get_account_balance(giray.address())
         .await
         .context(ERROR_CLIENT_RESPONSE)?;
-    let response = response.inner();
 
     // check balance
     let expected_balance = U64(100_000_000 + random_number);
-    let actual_balance = response.coin.value;
-    if !(actual_balance == expected_balance) {
-        return Ok(FAIL_WRONG_BALANCE);
-    }
+    let actual_balance = response.inner().coin.value;
+
+    ensure!(
+        expected_balance == actual_balance,
+        "{} expected {}, got {}",
+        FAIL_WRONG_BALANCE,
+        expected_balance,
+        actual_balance,
+    );
 
     Ok(SUCCESS)
 }
 
-// Calls get_account_balance on a static account.
+// Calls get_account_balance on a static account on testnet.
 async fn probe_getaccountbalance_2() -> Result<&'static str> {
     // create the rest client
     let client = Client::new(TESTNET_NODE_URL.clone());
@@ -175,19 +203,23 @@ async fn probe_getaccountbalance_2() -> Result<&'static str> {
         .get_account_balance(*TEST_ACCOUNT_1)
         .await
         .context(ERROR_CLIENT_RESPONSE)?;
-    let response = response.inner();
 
     // check balance
     let expected_balance = U64(176_767_177);
-    let actual_balance = response.coin.value;
-    if !(actual_balance == expected_balance) {
-        return Ok(FAIL_WRONG_BALANCE);
-    }
+    let actual_balance = response.inner().coin.value;
+
+    ensure!(
+        expected_balance == actual_balance,
+        "{} expected {}, got {}",
+        FAIL_WRONG_BALANCE,
+        expected_balance,
+        actual_balance,
+    );
 
     Ok(SUCCESS)
 }
 
-// Calls get_account_balance_at_version on a newly created account. Requires faucet.
+// Calls get_account_balance_at_version on a newly created account on devnet. Requires faucet.
 async fn probe_getaccountbalanceatversion_1() -> Result<&'static str> {
     // check faucet access
     if !HAS_FAUCET_ACCESS {
@@ -231,47 +263,59 @@ async fn probe_getaccountbalanceatversion_1() -> Result<&'static str> {
         .get_account_balance_at_version(giray2.address(), version - 1)
         .await
         .context(ERROR_CLIENT_RESPONSE)?;
-    let response = response.inner();
 
     // check balance before transaction
     let expected_balance = U64(100_000_000);
-    let actual_balance = response.coin.value;
-    if !(actual_balance == expected_balance) {
-        return Ok(FAIL_WRONG_BALANCE_AT_VERSION);
-    }
+    let actual_balance = response.inner().coin.value;
+
+    ensure!(
+        expected_balance == actual_balance,
+        "{} expected {}, got {}",
+        FAIL_WRONG_BALANCE_AT_VERSION,
+        expected_balance,
+        actual_balance,
+    );
 
     // ask for account balance with the given version number
     let response = client
         .get_account_balance_at_version(giray2.address(), version)
         .await
         .context(ERROR_CLIENT_RESPONSE)?;
-    let response = response.inner();
 
     // check balance right after transaction
     let expected_balance = U64(100_001_000);
-    let actual_balance = response.coin.value;
-    if !(actual_balance == expected_balance) {
-        return Ok(FAIL_WRONG_BALANCE_AT_VERSION);
-    }
+    let actual_balance = response.inner().coin.value;
+
+    ensure!(
+        expected_balance == actual_balance,
+        "{} expected {}, got {}",
+        FAIL_WRONG_BALANCE_AT_VERSION,
+        expected_balance,
+        actual_balance,
+    );
 
     // ask for account balance with a higher version number
     let response = client
         .get_account_balance_at_version(giray2.address(), version + 1)
         .await
         .context(ERROR_CLIENT_RESPONSE)?;
-    let response = response.inner();
 
     // check balance long after transaction
     let expected_balance = U64(100_001_000);
-    let actual_balance = response.coin.value;
-    if !(actual_balance == expected_balance) {
-        return Ok(FAIL_WRONG_BALANCE_AT_VERSION);
-    }
+    let actual_balance = response.inner().coin.value;
+
+    ensure!(
+        expected_balance == actual_balance,
+        "{} expected {}, got {}",
+        FAIL_WRONG_BALANCE_AT_VERSION,
+        expected_balance,
+        actual_balance,
+    );
 
     Ok(SUCCESS)
 }
 
-// Calls get_account_balance_at_version on a static account.
+// Calls get_account_balance_at_version on a static account on testnet.
 async fn probe_getaccountbalanceatversion_2() -> Result<&'static str> {
     // create the rest client
     let client = Client::new(TESTNET_NODE_URL.clone());
@@ -286,51 +330,139 @@ async fn probe_getaccountbalanceatversion_2() -> Result<&'static str> {
     // check balance before funding
     let expected_balance = U64(200_000_000);
     let actual_balance = response.coin.value;
-    if !(actual_balance == expected_balance) {
-        return Ok(FAIL_WRONG_BALANCE_AT_VERSION);
-    }
+
+    ensure!(
+        expected_balance == actual_balance,
+        "{} expected {}, got {}",
+        FAIL_WRONG_BALANCE_AT_VERSION,
+        expected_balance,
+        actual_balance,
+    );
 
     // ask for account balance right after funding
     let response = client
         .get_account_balance_at_version(*TEST_ACCOUNT_1, 564_589_720)
         .await
         .context(ERROR_CLIENT_RESPONSE)?;
-    let response = response.inner();
 
     // check balance right after funding
     let expected_balance = U64(300_000_000);
-    let actual_balance = response.coin.value;
-    if !(actual_balance == expected_balance) {
-        return Ok(FAIL_WRONG_BALANCE_AT_VERSION);
-    }
+    let actual_balance = response.inner().coin.value;
+
+    ensure!(
+        expected_balance == actual_balance,
+        "{} expected {}, got {}",
+        FAIL_WRONG_BALANCE_AT_VERSION,
+        expected_balance,
+        actual_balance,
+    );
 
     // ask for account balance long after funding
     let response = client
         .get_account_balance_at_version(*TEST_ACCOUNT_1, 564_589_721)
         .await
         .context(ERROR_CLIENT_RESPONSE)?;
-    let response = response.inner();
 
     // check balance right after funding
     let expected_balance = U64(300_000_000);
-    let actual_balance = response.coin.value;
-    if !(actual_balance == expected_balance) {
-        return Ok(FAIL_WRONG_BALANCE_AT_VERSION);
-    }
+    let actual_balance = response.inner().coin.value;
+
+    ensure!(
+        expected_balance == actual_balance,
+        "{} expected {}, got {}",
+        FAIL_WRONG_BALANCE_AT_VERSION,
+        expected_balance,
+        actual_balance,
+    );
 
     // ask for account balance right after transfer
     let response = client
         .get_account_balance_at_version(*TEST_ACCOUNT_1, 564_591_130)
         .await
         .context(ERROR_CLIENT_RESPONSE)?;
-    let response = response.inner();
 
     // check balance right after funding
     let expected_balance = U64(176_767_177);
-    let actual_balance = response.coin.value;
-    if !(actual_balance == expected_balance) {
-        return Ok(FAIL_WRONG_BALANCE_AT_VERSION);
-    }
+    let actual_balance = response.inner().coin.value;
+
+    ensure!(
+        expected_balance == actual_balance,
+        "{} expected {}, got {}",
+        FAIL_WRONG_BALANCE_AT_VERSION,
+        expected_balance,
+        actual_balance,
+    );
+
+    Ok(SUCCESS)
+}
+
+// Calls get_block_by_height by setting with_transactions=False on a fixed block on testnet.
+async fn probe_getblockbyheight_1() -> Result<&'static str> {
+    // create the rest client
+    let client: Client = Client::new(TESTNET_NODE_URL.clone());
+
+    // ask for block
+    let response = client
+        .get_block_by_height(98669388, false)
+        .await
+        .context(ERROR_CLIENT_RESPONSE)?;
+
+    // check block
+    let actual_block = response.inner();
+    let expected_block = Block {
+        block_height: U64(98669388),
+        block_hash: HashValue::from_str(
+            "b40362602dccfa1dccebb94adfd4c06d4b0ffe1eadb07659556744db3fe1d0e5",
+        )
+        .context(ERROR_OTHER)?,
+        block_timestamp: U64(1688146946653187),
+        first_version: U64(565538916),
+        last_version: U64(565538919),
+        transactions: None,
+    };
+
+    ensure!(
+        actual_block.block_height == expected_block.block_height,
+        "{} expected {}, got {}",
+        FAIL_WRONG_BLOCK_HEIGHT,
+        expected_block.block_height,
+        actual_block.block_height,
+    );
+    ensure!(
+        actual_block.block_hash == expected_block.block_hash,
+        "{} expected {}, got {}",
+        FAIL_WRONG_BLOCK_HASH,
+        expected_block.block_hash,
+        actual_block.block_hash,
+    );
+    ensure!(
+        actual_block.block_timestamp == expected_block.block_timestamp,
+        "{} expected {}, got {}",
+        FAIL_WRONG_BLOCK_TIMESTAMP,
+        expected_block.block_timestamp,
+        actual_block.block_timestamp,
+    );
+    ensure!(
+        actual_block.first_version == expected_block.first_version,
+        "{} expected {}, got {}",
+        FAIL_WRONG_FIRST_VERSION,
+        expected_block.first_version,
+        actual_block.first_version,
+    );
+    ensure!(
+        actual_block.last_version == expected_block.last_version,
+        "{} expected {}, got {}",
+        FAIL_WRONG_LAST_VERSION,
+        expected_block.last_version,
+        actual_block.last_version,
+    );
+    ensure!(
+        actual_block.transactions == expected_block.transactions,
+        "{} expected {:?}, got {:?}",
+        FAIL_WRONG_TRANSACTIONS,
+        expected_block.transactions,
+        actual_block.transactions,
+    );
 
     Ok(SUCCESS)
 }
@@ -338,27 +470,31 @@ async fn probe_getaccountbalanceatversion_2() -> Result<&'static str> {
 #[tokio::main]
 async fn main() -> Result<()> {
     match probe_getaccount_1().await {
-        Ok(result) => println!("{}", result),
-        Err(e) => println!("{}", e),
+        Ok(result) => println!("{:?}", result),
+        Err(e) => println!("{:?}", e),
     }
     match probe_getaccount_2().await {
-        Ok(result) => println!("{}", result),
-        Err(e) => println!("{}", e),
+        Ok(result) => println!("{:?}", result),
+        Err(e) => println!("{:?}", e),
     }
     match probe_getaccountbalance_1().await {
-        Ok(result) => println!("{}", result),
-        Err(e) => println!("{}", e),
+        Ok(result) => println!("{:?}", result),
+        Err(e) => println!("{:?}", e),
     }
     match probe_getaccountbalance_2().await {
-        Ok(result) => println!("{}", result),
-        Err(e) => println!("{}", e),
+        Ok(result) => println!("{:?}", result),
+        Err(e) => println!("{:?}", e),
     }
     match probe_getaccountbalanceatversion_1().await {
-        Ok(result) => println!("{}", result),
+        Ok(result) => println!("{:?}", result),
         Err(e) => println!("{:?}", e),
     }
     match probe_getaccountbalanceatversion_2().await {
-        Ok(result) => println!("{}", result),
+        Ok(result) => println!("{:?}", result),
+        Err(e) => println!("{:?}", e),
+    }
+    match probe_getblockbyheight_1().await {
+        Ok(result) => println!("{:?}", result),
         Err(e) => println!("{:?}", e),
     }
 

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -254,12 +254,15 @@ async fn probe_getaccountbalanceatversion_1() -> Result<&'static str> {
         return Ok(FAIL_WRONG_BALANCE_AT_VERSION);
     }
 
+<<<<<<< HEAD
     // use the faucet to ensure that there exists a higher version number
     faucet_client
         .fund(giray.address(), 100_000_000)
         .await
         .context(ERROR_FAUCET_FUND)?;
 
+=======
+>>>>>>> 84b40d670f (Add tests for get_account_balance_at_version)
     // ask for account balance with a higher version number
     let response = client
         .get_account_balance_at_version(giray2.address(), version + 1)

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -6,6 +6,7 @@
 use anyhow::{Context, Result};
 use aptos_api_types::U64;
 use aptos_rest_client::{Client, FaucetClient};
+use aptos_sdk::coin_client::CoinClient;
 use aptos_sdk::types::LocalAccount;
 use aptos_types::account_address::AccountAddress;
 use aptos_types::transaction::authenticator::AuthenticationKey;
@@ -44,9 +45,11 @@ static SKIP_NO_FAUCET_ACCESS: &str = "This test requires faucet access.";
 static ERROR_CLIENT_RESPONSE: &str = "Client responded with error.";
 static ERROR_FAUCET_FUND: &str = "Funding from faucet failed.";
 static ERROR_OTHER: &str = "Something went wrong.";
+static ERROR_COIN_TRANSFER: &str = "Coin transfer failed.";
 static FAIL_WRONG_AUTH_KEY: &str = "Returned wrong authentication key.";
 static FAIL_WRONG_SEQ_NUMBER: &str = "Returned wrong sequence number.";
 static FAIL_WRONG_BALANCE: &str = "Returned wrong balance.";
+static FAIL_WRONG_BALANCE_AT_VERSION: &str = "Returned wrong balance at the given version.";
 static SUCCESS: &str = "success";
 
 // Calls get_account on a newly created account. Requires faucet.
@@ -175,10 +178,164 @@ async fn probe_getaccountbalance_2() -> Result<&'static str> {
     let response = response.inner();
 
     // check balance
-    let expected_balance = U64(176767177);
+    let expected_balance = U64(176_767_177);
     let actual_balance = response.coin.value;
     if !(actual_balance == expected_balance) {
         return Ok(FAIL_WRONG_BALANCE);
+    }
+
+    Ok(SUCCESS)
+}
+
+// Calls get_account_balance_at_version on a newly created account. Requires faucet.
+async fn probe_getaccountbalanceatversion_1() -> Result<&'static str> {
+    // check faucet access
+    if !HAS_FAUCET_ACCESS {
+        return Ok(SKIP_NO_FAUCET_ACCESS);
+    }
+
+    // create the rest client
+    let client = Client::new(DEVNET_NODE_URL.clone());
+    let faucet_client = FaucetClient::new(DEVNET_FAUCET_URL.clone(), DEVNET_NODE_URL.clone());
+    let coin_client = CoinClient::new(&client);
+
+    // create and fund an account
+    let mut giray = LocalAccount::generate(&mut rand::rngs::OsRng);
+    faucet_client
+        .fund(giray.address(), 100_000_000)
+        .await
+        .context(ERROR_FAUCET_FUND)?;
+
+    // create and fund second account
+    let giray2 = LocalAccount::generate(&mut rand::rngs::OsRng);
+    faucet_client
+        .fund(giray2.address(), 100_000_000)
+        .await
+        .context(ERROR_FAUCET_FUND)?;
+
+    // transfer coins from first account to the second
+    let txn_hash = coin_client
+        .transfer(&mut giray, giray2.address(), 1_000, None)
+        .await
+        .context(ERROR_COIN_TRANSFER)?;
+    let response = client
+        .wait_for_transaction(&txn_hash)
+        .await
+        .context(ERROR_COIN_TRANSFER)?;
+
+    // get transaction version number
+    let version = response.inner().version().context(ERROR_COIN_TRANSFER)?;
+
+    // ask for account balance with a lower version number
+    let response = client
+        .get_account_balance_at_version(giray2.address(), version - 1)
+        .await
+        .context(ERROR_CLIENT_RESPONSE)?;
+    let response = response.inner();
+
+    // check balance before transaction
+    let expected_balance = U64(100_000_000);
+    let actual_balance = response.coin.value;
+    if !(actual_balance == expected_balance) {
+        return Ok(FAIL_WRONG_BALANCE_AT_VERSION);
+    }
+
+    // ask for account balance with the given version number
+    let response = client
+        .get_account_balance_at_version(giray2.address(), version)
+        .await
+        .context(ERROR_CLIENT_RESPONSE)?;
+    let response = response.inner();
+
+    // check balance right after transaction
+    let expected_balance = U64(100_001_000);
+    let actual_balance = response.coin.value;
+    if !(actual_balance == expected_balance) {
+        return Ok(FAIL_WRONG_BALANCE_AT_VERSION);
+    }
+
+    // use the faucet to ensure that there exists a higher version number
+    faucet_client
+        .fund(giray.address(), 100_000_000)
+        .await
+        .context(ERROR_FAUCET_FUND)?;
+
+    // ask for account balance with a higher version number
+    let response = client
+        .get_account_balance_at_version(giray2.address(), version + 1)
+        .await
+        .context(ERROR_CLIENT_RESPONSE)?;
+    let response = response.inner();
+
+    // check balance long after transaction
+    let expected_balance = U64(100_001_000);
+    let actual_balance = response.coin.value;
+    if !(actual_balance == expected_balance) {
+        return Ok(FAIL_WRONG_BALANCE_AT_VERSION);
+    }
+
+    Ok(SUCCESS)
+}
+
+// Calls get_account_balance_at_version on a static account.
+async fn probe_getaccountbalanceatversion_2() -> Result<&'static str> {
+    // create the rest client
+    let client = Client::new(TESTNET_NODE_URL.clone());
+
+    // ask for account balance before funding
+    let response = client
+        .get_account_balance_at_version(*TEST_ACCOUNT_1, 564_589_719)
+        .await
+        .context(ERROR_CLIENT_RESPONSE)?;
+    let response = response.inner();
+
+    // check balance before funding
+    let expected_balance = U64(200_000_000);
+    let actual_balance = response.coin.value;
+    if !(actual_balance == expected_balance) {
+        return Ok(FAIL_WRONG_BALANCE_AT_VERSION);
+    }
+
+    // ask for account balance right after funding
+    let response = client
+        .get_account_balance_at_version(*TEST_ACCOUNT_1, 564_589_720)
+        .await
+        .context(ERROR_CLIENT_RESPONSE)?;
+    let response = response.inner();
+
+    // check balance right after funding
+    let expected_balance = U64(300_000_000);
+    let actual_balance = response.coin.value;
+    if !(actual_balance == expected_balance) {
+        return Ok(FAIL_WRONG_BALANCE_AT_VERSION);
+    }
+
+    // ask for account balance long after funding
+    let response = client
+        .get_account_balance_at_version(*TEST_ACCOUNT_1, 564_589_721)
+        .await
+        .context(ERROR_CLIENT_RESPONSE)?;
+    let response = response.inner();
+
+    // check balance right after funding
+    let expected_balance = U64(300_000_000);
+    let actual_balance = response.coin.value;
+    if !(actual_balance == expected_balance) {
+        return Ok(FAIL_WRONG_BALANCE_AT_VERSION);
+    }
+
+    // ask for account balance right after transfer
+    let response = client
+        .get_account_balance_at_version(*TEST_ACCOUNT_1, 564_591_130)
+        .await
+        .context(ERROR_CLIENT_RESPONSE)?;
+    let response = response.inner();
+
+    // check balance right after funding
+    let expected_balance = U64(176_767_177);
+    let actual_balance = response.coin.value;
+    if !(actual_balance == expected_balance) {
+        return Ok(FAIL_WRONG_BALANCE_AT_VERSION);
     }
 
     Ok(SUCCESS)
@@ -201,6 +358,14 @@ async fn main() -> Result<()> {
     match probe_getaccountbalance_2().await {
         Ok(result) => println!("{}", result),
         Err(e) => println!("{}", e),
+    }
+    match probe_getaccountbalanceatversion_1().await {
+        Ok(result) => println!("{}", result),
+        Err(e) => println!("{:?}", e),
+    }
+    match probe_getaccountbalanceatversion_2().await {
+        Ok(result) => println!("{}", result),
+        Err(e) => println!("{:?}", e),
     }
 
     Ok(())

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -162,6 +162,28 @@ async fn probe_getaccountbalance_1() -> Result<&'static str> {
     Ok(SUCCESS)
 }
 
+// Calls get_account_balance on a static account.
+async fn probe_getaccountbalance_2() -> Result<&'static str> {
+    // create the rest client
+    let client = Client::new(TESTNET_NODE_URL.clone());
+
+    // ask for account balance
+    let response = client
+        .get_account_balance(*TEST_ACCOUNT_1)
+        .await
+        .context(ERROR_CLIENT_RESPONSE)?;
+    let response = response.inner();
+
+    // check balance
+    let expected_balance = U64(176767177);
+    let actual_balance = response.coin.value;
+    if !(actual_balance == expected_balance) {
+        return Ok(FAIL_WRONG_BALANCE);
+    }
+
+    Ok(SUCCESS)
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     match probe_getaccount_1().await {
@@ -173,6 +195,10 @@ async fn main() -> Result<()> {
         Err(e) => println!("{}", e),
     }
     match probe_getaccountbalance_1().await {
+        Ok(result) => println!("{}", result),
+        Err(e) => println!("{}", e),
+    }
+    match probe_getaccountbalance_2().await {
         Ok(result) => println!("{}", result),
         Err(e) => println!("{}", e),
     }

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -106,11 +106,11 @@ async fn test_cointransfer(
     };
 
     // transfer coins to static account
-    let txn_hash = match coin_client.transfer(account, address, amount, None).await {
+    let pending_txn = match coin_client.transfer(account, address, amount, None).await {
         Ok(txn) => txn,
         Err(e) => return TestResult::Error(e),
     };
-    let response = match client.wait_for_transaction(&txn_hash).await {
+    let response = match client.wait_for_transaction(&pending_txn).await {
         Ok(response) => response,
         Err(e) => return TestResult::Error(e.into()),
     };
@@ -156,7 +156,7 @@ async fn test_mintnft(
 ) -> TestResult {
     // create collection
     let collection_name = "test collection";
-    let txn_hash = match token_client
+    let pending_txn = match token_client
         .create_collection(
             account,
             &collection_name,
@@ -170,14 +170,13 @@ async fn test_mintnft(
         Ok(txn) => txn,
         Err(e) => return TestResult::Error(e),
     };
-    match client.wait_for_transaction(&txn_hash).await {
+    match client.wait_for_transaction(&pending_txn).await {
         Ok(_) => {},
         Err(e) => return TestResult::Error(e.into()),
     }
 
     // create token
-    let address = &account.address();
-    let txn_hash = match token_client
+    let pending_txn = match token_client
         .create_token(
             account,
             &collection_name,
@@ -186,12 +185,7 @@ async fn test_mintnft(
             10,
             "token",
             10,
-            address,
-            0,
-            0,
-            Box::new(vec![]),
-            Box::new(vec![]),
-            Box::new(vec![]),
+            None,
             None,
         )
         .await
@@ -199,7 +193,7 @@ async fn test_mintnft(
         Ok(txn) => txn,
         Err(e) => return TestResult::Error(e),
     };
-    match client.wait_for_transaction(&txn_hash).await {
+    match client.wait_for_transaction(&pending_txn).await {
         Ok(_) => {},
         Err(e) => return TestResult::Error(e.into()),
     }

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -217,6 +217,7 @@ async fn testnet_1() -> Result<()> {
     // create and fund account for tests
     let mut giray = LocalAccount::generate(&mut rand::rngs::OsRng);
     faucet_client.fund(giray.address(), 100_000_000).await?;
+    println!("{:?}", giray.address());
 
     // Step 1: Test new account creation and funding
     // this test is critical to pass for the next tests

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -145,7 +145,6 @@ async fn test_cointransfer(
         return TestResult::Fail("wrong balance at version before the coin transfer");
     }
 
-    // TODO: do we want to check transaction details returned by the API?
     TestResult::Success
 }
 
@@ -197,6 +196,13 @@ async fn test_mintnft(
         Ok(_) => {},
         Err(e) => return TestResult::Error(e.into()),
     }
+
+    // check collection metadata
+    let collection_data = match token_client.get_collection_data(account.address(), &collection_name).await {
+        Ok(txn) => txn,
+        Err(e) => return TestResult::Error(e),
+    };
+    println!("{:?}", collection_data);
 
     TestResult::Success
 }

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -179,6 +179,8 @@ async fn test_mintnft(
     }
 
     // create token
+    let token_name = "test token".to_string();
+
     let pending_txn = match token_client
         .create_token(
             account,
@@ -202,15 +204,8 @@ async fn test_mintnft(
     }
 
     // check collection metadata
-    let actual_collection_data = match token_client
-        .get_collection_data(account.address(), &collection_name)
-        .await
-    {
-        Ok(txn) => txn,
-        Err(e) => return TestResult::Error(e),
-    };
     let expected_collection_data = CollectionData {
-        name: collection_name,
+        name: collection_name.clone(),
         description: collection_description,
         uri: collection_uri,
         maximum: collection_maximum,
@@ -220,10 +215,27 @@ async fn test_mintnft(
             uri: false,
         },
     };
+    let actual_collection_data = match token_client
+        .get_collection_data(account.address(), &collection_name)
+        .await
+    {
+        Ok(data) => data,
+        Err(e) => return TestResult::Error(e),
+    };
 
     if expected_collection_data != actual_collection_data {
         return TestResult::Fail("wrong collection data");
     }
+
+    // check token metadata
+    let actual_token_data = match token_client
+        .get_token_data(account.address(), &collection_name, &token_name)
+        .await
+    {
+        Ok(data) => data,
+        Err(e) => return TestResult::Error(e),
+    };
+    println!("{:?}", actual_token_data);
 
     TestResult::Success
 }

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -131,45 +131,6 @@ async fn probe_getaccount_1() -> TestResult {
     TestResult::Success
 }
 
-/// Calls get_account on a static account on testnet.
-async fn probe_getaccount_2() -> Result<&'static str> {
-    // create the rest client
-    let client = Client::new(TESTNET_NODE_URL.clone());
-
-    // ask for account data
-    let response = client
-        .get_account(*TEST_ACCOUNT_1)
-        .await
-        .context(ERROR_CLIENT_RESPONSE)?;
-
-    // check account data
-    let expected_account = Account {
-        authentication_key: AuthenticationKey::from_str(
-            "7fed760c508a8885e1438c90f81dea6940ad53b05527fadddd3851f53342d7c4",
-        )
-        .context(ERROR_OTHER)?,
-        sequence_number: 1,
-    };
-    let actual_account = response.inner();
-
-    ensure!(
-        expected_account.authentication_key == actual_account.authentication_key,
-        "{} expected {}, got {}",
-        FAIL_WRONG_AUTH_KEY,
-        expected_account.authentication_key,
-        actual_account.authentication_key
-    );
-    ensure!(
-        expected_account.sequence_number == actual_account.sequence_number,
-        "{} expected {}, got {}",
-        FAIL_WRONG_SEQ_NUMBER,
-        expected_account.sequence_number,
-        actual_account.sequence_number
-    );
-
-    Ok(SUCCESS)
-}
-
 /// Calls get_account_balance on a newly created account on devnet. Requires faucet.
 async fn probe_getaccountbalance_1() -> Result<&'static str> {
     // check faucet access
@@ -203,32 +164,6 @@ async fn probe_getaccountbalance_1() -> Result<&'static str> {
 
     // check balance
     let expected_balance = U64(100_000_000 + random_number);
-    let actual_balance = response.inner().coin.value;
-
-    ensure!(
-        expected_balance == actual_balance,
-        "{} expected {}, got {}",
-        FAIL_WRONG_BALANCE,
-        expected_balance,
-        actual_balance,
-    );
-
-    Ok(SUCCESS)
-}
-
-/// Calls get_account_balance on a static account on testnet.
-async fn probe_getaccountbalance_2() -> Result<&'static str> {
-    // create the rest client
-    let client = Client::new(TESTNET_NODE_URL.clone());
-
-    // ask for account balance
-    let response = client
-        .get_account_balance(*TEST_ACCOUNT_1)
-        .await
-        .context(ERROR_CLIENT_RESPONSE)?;
-
-    // check balance
-    let expected_balance = U64(176_767_177);
     let actual_balance = response.inner().coin.value;
 
     ensure!(
@@ -325,87 +260,6 @@ async fn probe_getaccountbalanceatversion_1() -> Result<&'static str> {
 
     // check balance long after transaction
     let expected_balance = U64(100_001_000);
-    let actual_balance = response.inner().coin.value;
-
-    ensure!(
-        expected_balance == actual_balance,
-        "{} expected {}, got {}",
-        FAIL_WRONG_BALANCE_AT_VERSION,
-        expected_balance,
-        actual_balance,
-    );
-
-    Ok(SUCCESS)
-}
-
-/// Calls get_account_balance_at_version on a static account on testnet.
-async fn probe_getaccountbalanceatversion_2() -> Result<&'static str> {
-    // create the rest client
-    let client = Client::new(TESTNET_NODE_URL.clone());
-
-    // ask for account balance before funding
-    let response = client
-        .get_account_balance_at_version(*TEST_ACCOUNT_1, 564_589_719)
-        .await
-        .context(ERROR_CLIENT_RESPONSE)?;
-    let response = response.inner();
-
-    // check balance before funding
-    let expected_balance = U64(200_000_000);
-    let actual_balance = response.coin.value;
-
-    ensure!(
-        expected_balance == actual_balance,
-        "{} expected {}, got {}",
-        FAIL_WRONG_BALANCE_AT_VERSION,
-        expected_balance,
-        actual_balance,
-    );
-
-    // ask for account balance right after funding
-    let response = client
-        .get_account_balance_at_version(*TEST_ACCOUNT_1, 564_589_720)
-        .await
-        .context(ERROR_CLIENT_RESPONSE)?;
-
-    // check balance right after funding
-    let expected_balance = U64(300_000_000);
-    let actual_balance = response.inner().coin.value;
-
-    ensure!(
-        expected_balance == actual_balance,
-        "{} expected {}, got {}",
-        FAIL_WRONG_BALANCE_AT_VERSION,
-        expected_balance,
-        actual_balance,
-    );
-
-    // ask for account balance long after funding
-    let response = client
-        .get_account_balance_at_version(*TEST_ACCOUNT_1, 564_589_721)
-        .await
-        .context(ERROR_CLIENT_RESPONSE)?;
-
-    // check balance right after funding
-    let expected_balance = U64(300_000_000);
-    let actual_balance = response.inner().coin.value;
-
-    ensure!(
-        expected_balance == actual_balance,
-        "{} expected {}, got {}",
-        FAIL_WRONG_BALANCE_AT_VERSION,
-        expected_balance,
-        actual_balance,
-    );
-
-    // ask for account balance right after transfer
-    let response = client
-        .get_account_balance_at_version(*TEST_ACCOUNT_1, 564_591_130)
-        .await
-        .context(ERROR_CLIENT_RESPONSE)?;
-
-    // check balance right after funding
-    let expected_balance = U64(176_767_177);
     let actual_balance = response.inner().coin.value;
 
     ensure!(
@@ -592,23 +446,11 @@ async fn testnet_1() -> Result<&'static str> {
 #[tokio::main]
 async fn main() -> Result<()> {
     println!("{:?}", probe_getaccount_1().await);
-    match probe_getaccount_2().await {
-        Ok(result) => println!("{:?}", result),
-        Err(e) => println!("{:?}", e),
-    }
     match probe_getaccountbalance_1().await {
         Ok(result) => println!("{:?}", result),
         Err(e) => println!("{:?}", e),
     }
-    match probe_getaccountbalance_2().await {
-        Ok(result) => println!("{:?}", result),
-        Err(e) => println!("{:?}", e),
-    }
     match probe_getaccountbalanceatversion_1().await {
-        Ok(result) => println!("{:?}", result),
-        Err(e) => println!("{:?}", e),
-    }
-    match probe_getaccountbalanceatversion_2().await {
         Ok(result) => println!("{:?}", result),
         Err(e) => println!("{:?}", e),
     }

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -387,7 +387,7 @@ async fn test_mintnft(
 async fn publish_module(client: &Client, account: &mut LocalAccount) -> Result<HexEncodedBytes> {
     // get file to compile
     let move_dir =
-        PathBuf::from("/Users/ngk/Documents/aptos-core/aptos-move/move-examples/hello_blockchain");
+        PathBuf::from("./aptos-move/move-examples/hello_blockchain");
 
     // insert address
     let mut named_addresses: BTreeMap<String, AccountAddress> = BTreeMap::new();

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -300,6 +300,12 @@ async fn test_mintnft(
         Err(e) => return TestResult::Error(e),
     };
 
+    // check that token store isn't initialized for the receiver
+    match token_client.get_token(receiver.address(), &collection_name, &token_name).await {
+        Ok(_) => return TestResult::Fail("found tokens for receiver when shouldn't"),
+        Err(_) => {},
+    }
+
     if expected_sender_token_balance != actual_sender_token_balance {
         return TestResult::Fail("wrong token balance");
     }

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, Result};
 use aptos_api_types::U64;
 use aptos_rest_client::{Account, Client, FaucetClient};
 use aptos_sdk::coin_client::CoinClient;
-use aptos_sdk::token_client::{TokenClient, CollectionData, MutabilityConfig};
+use aptos_sdk::token_client::{CollectionData, MutabilityConfig, TokenClient};
 use aptos_sdk::types::LocalAccount;
 use aptos_types::account_address::AccountAddress;
 use once_cell::sync::Lazy;
@@ -202,7 +202,10 @@ async fn test_mintnft(
     }
 
     // check collection metadata
-    let actual_collection_data = match token_client.get_collection_data(account.address(), &collection_name).await {
+    let actual_collection_data = match token_client
+        .get_collection_data(account.address(), &collection_name)
+        .await
+    {
         Ok(txn) => txn,
         Err(e) => return TestResult::Error(e),
     };

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -167,6 +167,10 @@ async fn test_cointransfer(
     Ok(TestResult::Success)
 }
 
+/// Tests nft transfer. Checks that:
+///   - collection data exists
+///   - token data exists
+///   - token balance reflects transferred amount
 async fn test_mintnft(
     client: &Client,
     token_client: &TokenClient<'_>,

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -134,7 +134,7 @@ async fn test_cointransfer(
             .value,
     );
 
-    // transfer coins to static account
+    // transfer coins to second account
     let pending_txn = coin_client
         .transfer(account, receiver, amount, None)
         .await?;

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -215,7 +215,7 @@ async fn test_mintnft(
         name: collection_name.clone(),
         description: collection_description,
         uri: collection_uri,
-        maximum: collection_maximum,
+        maximum: U64(collection_maximum),
         mutability_config: CollectionMutabilityConfig {
             description: false,
             maximum: false,
@@ -239,7 +239,7 @@ async fn test_mintnft(
         name: token_name.clone(),
         description: token_description,
         uri: token_uri,
-        maximum: token_maximum,
+        maximum: U64(token_maximum),
         mutability_config: TokenMutabilityConfig {
             description: false,
             maximum: false,
@@ -247,13 +247,13 @@ async fn test_mintnft(
             royalty: false,
             uri: false,
         },
-        supply: token_supply,
+        supply: U64(token_supply),
         royalty: RoyaltyOptions {
-            royalty_payee_address: account.address(),
-            royalty_points_denominator: 0,
-            royalty_points_numerator: 0,
+            payee_address: account.address(),
+            royalty_points_denominator: U64(0),
+            royalty_points_numerator: U64(0),
         },
-        largest_property_version: 0,
+        largest_property_version: U64(0),
     };
     let actual_token_data = match token_client
         .get_token_data(account.address(), &collection_name, &token_name)

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -293,7 +293,12 @@ async fn test_mintnft(
     // check token balance for the sender
     let expected_sender_token_balance = U64(8);
     let actual_sender_token_balance = match token_client
-        .get_token(account.address(), &collection_name, &token_name)
+        .get_token(
+            account.address(),
+            account.address(),
+            &collection_name,
+            &token_name,
+        )
         .await
     {
         Ok(data) => data.amount,
@@ -301,7 +306,15 @@ async fn test_mintnft(
     };
 
     // check that token store isn't initialized for the receiver
-    match token_client.get_token(receiver.address(), &collection_name, &token_name).await {
+    match token_client
+        .get_token(
+            receiver.address(),
+            account.address(),
+            &collection_name,
+            &token_name,
+        )
+        .await
+    {
         Ok(_) => return TestResult::Fail("found tokens for receiver when shouldn't"),
         Err(_) => {},
     }

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -168,10 +168,10 @@ async fn test_accountdata(client: &Client, account: &LocalAccount) -> TestResult
     };
     let actual_account = response.inner();
 
-    if !(expected_account.authentication_key == actual_account.authentication_key) {
+    if expected_account.authentication_key != actual_account.authentication_key {
         return TestResult::Fail("wrong authentication key");
     }
-    if !(expected_account.sequence_number == actual_account.sequence_number) {
+    if expected_account.sequence_number != actual_account.sequence_number {
         return TestResult::Fail("wrong sequence number");
     }
 
@@ -194,7 +194,7 @@ async fn test_accountbalance(
     let expected_balance = U64(expected_balance);
     let actual_balance = response.inner().coin.value;
 
-    if !(expected_balance == actual_balance) {
+    if expected_balance != actual_balance {
         return TestResult::Fail("wrong balance");
     }
 
@@ -220,7 +220,7 @@ async fn test_cointransfer(
         Ok(txn) => txn,
         Err(e) => return TestResult::Error(e),
     };
-    let response = match client.wait_for_transaction(&txn_hash).await {
+    let _ = match client.wait_for_transaction(&txn_hash).await {
         Ok(response) => response,
         Err(e) => return TestResult::Error(e.into()),
     };
@@ -232,7 +232,7 @@ async fn test_cointransfer(
         Err(e) => return TestResult::Error(e.into()),
     };
 
-    if !(expected_receiver_balance == actual_receiver_balance) {
+    if expected_receiver_balance != actual_receiver_balance {
         return TestResult::Fail("wrong balance after coin transfer");
     }
 

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -5,33 +5,29 @@
 
 mod utils;
 
-use std::collections::BTreeMap;
-use std::future::Future;
-use std::path::PathBuf;
-use std::time::Instant;
-
+use crate::utils::{TestFailure, TestLog, TestResult};
 use anyhow::{anyhow, Result};
 use aptos_api_types::{HexEncodedBytes, U64};
 use aptos_cached_packages::aptos_stdlib::EntryFunctionCall;
 use aptos_framework::{BuildOptions, BuiltPackage};
 use aptos_rest_client::{Account, Client, FaucetClient};
-use aptos_sdk::bcs;
-use aptos_sdk::coin_client::CoinClient;
-use aptos_sdk::token_client::{
-    build_and_submit_transaction, CollectionData, CollectionMutabilityConfig, RoyaltyOptions,
-    TokenClient, TokenData, TokenMutabilityConfig, TransactionOptions,
+use aptos_sdk::{
+    bcs,
+    coin_client::CoinClient,
+    token_client::{
+        build_and_submit_transaction, CollectionData, CollectionMutabilityConfig, RoyaltyOptions,
+        TokenClient, TokenData, TokenMutabilityConfig, TransactionOptions,
+    },
+    types::LocalAccount,
 };
-use aptos_sdk::types::LocalAccount;
-use aptos_types::account_address::AccountAddress;
-use aptos_types::transaction::{EntryFunction, TransactionPayload};
-use move_core_types::ident_str;
-use move_core_types::language_storage::ModuleId;
+use aptos_types::{
+    account_address::AccountAddress,
+    transaction::{EntryFunction, TransactionPayload},
+};
+use move_core_types::{ident_str, language_storage::ModuleId};
 use once_cell::sync::Lazy;
+use std::{collections::BTreeMap, future::Future, path::PathBuf, time::Instant};
 use url::Url;
-
-use utils::TestFailure;
-use utils::TestLog;
-use utils::TestResult;
 
 // network urls
 static DEVNET_NODE_URL: Lazy<Url> =

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -416,6 +416,7 @@ async fn set_message(client: &Client, account: &mut LocalAccount, message: &str)
     Ok(())
 }
 
+/// Helper function that gets back the result of the interaction.
 async fn get_message(client: &Client, address: AccountAddress) -> Option<String> {
     let resource = match client
         .get_account_resource(
@@ -433,6 +434,8 @@ async fn get_message(client: &Client, address: AccountAddress) -> Option<String>
 
 /// Tests module publishing and interaction. Checks that:
 ///   - module data exists
+///   - can interact with module
+///   - resources reflect interaction
 async fn test_module(
     client: &Client,
     account: &mut LocalAccount,
@@ -488,9 +491,8 @@ async fn test_flows(client: Client, faucet_client: FaucetClient) -> Result<()> {
 
     // Test new account creation and funding
     // this test is critical to pass for the next tests
-    match handle_result(test_newaccount(&client, &giray, 100_000_000)).await {
-        Err(_) => return Err(anyhow!("returning early because new account test failed")),
-        _ => {},
+    if let Err(_) = handle_result(test_newaccount(&client, &giray, 100_000_000)).await {
+        return Err(anyhow!("returning early because new account test failed"));
     }
 
     // Flow 1: Coin transfer
@@ -512,7 +514,7 @@ async fn test_flows(client: Client, faucet_client: FaucetClient) -> Result<()> {
     ))
     .await;
 
-    // Flow 3: NFT transfer
+    // Flow 3: Publishing module
     let _ = handle_result(test_module(&client, &mut giray)).await;
 
     Ok(())

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, Result};
 use aptos_api_types::U64;
 use aptos_rest_client::{Account, Client, FaucetClient};
 use aptos_sdk::coin_client::CoinClient;
-use aptos_sdk::token_client::{CollectionData, MutabilityConfig, TokenClient};
+use aptos_sdk::token_client::{CollectionData, CollectionMutabilityConfig, TokenClient};
 use aptos_sdk::types::LocalAccount;
 use aptos_types::account_address::AccountAddress;
 use once_cell::sync::Lazy;
@@ -209,7 +209,7 @@ async fn test_mintnft(
         description: collection_description,
         uri: collection_uri,
         maximum: collection_maximum,
-        mutability_config: MutabilityConfig {
+        mutability_config: CollectionMutabilityConfig {
             description: false,
             maximum: false,
             uri: false,

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -267,6 +267,20 @@ async fn test_mintnft(
         return TestResult::Fail("wrong token data");
     }
 
+    // get token balance
+    let expected_token_balance = U64(10);
+    let actual_token_balance = match token_client
+        .get_token(account.address(), &collection_name, &token_name)
+        .await
+    {
+        Ok(data) => data.amount,
+        Err(e) => return TestResult::Error(e),
+    };
+
+    if expected_token_balance != actual_token_balance {
+        return TestResult::Fail("wrong token balance");
+    }
+
     TestResult::Success
 }
 

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -336,7 +336,7 @@ async fn test_mintnft(
     }
 
     // check that token store isn't initialized for the receiver
-    if let Ok(_) = token_client
+    if token_client
         .get_token(
             receiver.address(),
             account.address(),
@@ -344,6 +344,7 @@ async fn test_mintnft(
             &token_name,
         )
         .await
+        .is_ok()
     {
         return Err(TestFailure::Fail(
             "found tokens for receiver when shouldn't",
@@ -386,8 +387,7 @@ async fn test_mintnft(
 /// Helper function that publishes module and returns the bytecode.
 async fn publish_module(client: &Client, account: &mut LocalAccount) -> Result<HexEncodedBytes> {
     // get file to compile
-    let move_dir =
-        PathBuf::from("./aptos-move/move-examples/hello_blockchain");
+    let move_dir = PathBuf::from("./aptos-move/move-examples/hello_blockchain");
 
     // insert address
     let mut named_addresses: BTreeMap<String, AccountAddress> = BTreeMap::new();

--- a/crates/aptos-api-tester/src/utils.rs
+++ b/crates/aptos-api-tester/src/utils.rs
@@ -1,0 +1,33 @@
+// Copyright © Aptos Foundation
+
+use aptos_rest_client::error::RestError;
+
+#[derive(Debug)]
+pub struct TestLog {
+    pub result: TestResult,
+    pub time: f64,
+}
+
+#[derive(Debug)]
+pub enum TestResult {
+    Success,
+    Fail(TestFailure),
+}
+
+#[derive(Debug)]
+pub enum TestFailure {
+    Fail(&'static str),
+    Error(anyhow::Error),
+}
+
+impl From<RestError> for TestFailure {
+    fn from(e: RestError) -> TestFailure {
+        TestFailure::Error(e.into())
+    }
+}
+
+impl From<anyhow::Error> for TestFailure {
+    fn from(e: anyhow::Error) -> TestFailure {
+        TestFailure::Error(e)
+    }
+}

--- a/crates/aptos-rest-client/src/types.rs
+++ b/crates/aptos-rest-client/src/types.rs
@@ -40,7 +40,7 @@ where
     parse_struct_tag(&s).map_err(D::Error::custom)
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct Account {
     #[serde(deserialize_with = "deserialize_from_prefixed_hex_string")]
     pub authentication_key: AuthenticationKey,

--- a/docker/builder/build-tools.sh
+++ b/docker/builder/build-tools.sh
@@ -26,6 +26,7 @@ cargo build --locked --profile=$PROFILE \
     -p aptos-indexer-grpc-file-store \
     -p aptos-indexer-grpc-data-service \
     -p aptos-indexer-grpc-post-processor \
+    -p aptos-api-tester \
     "$@"
 
 # After building, copy the binaries we need to `dist` since the `target` directory is used as docker cache mount and only available during the RUN step
@@ -44,6 +45,7 @@ BINS=(
     aptos-indexer-grpc-file-store
     aptos-indexer-grpc-data-service
     aptos-indexer-grpc-post-processor
+    aptos-api-tester
 )
 
 mkdir dist

--- a/docker/builder/tools.Dockerfile
+++ b/docker/builder/tools.Dockerfile
@@ -34,7 +34,7 @@ COPY --link --from=tools-builder /aptos/dist/aptos-transaction-emitter /usr/loca
 COPY --link --from=tools-builder /aptos/dist/aptos-api-tester /usr/local/bin/aptos-api-tester
 
 # Copy the example module to publish for api-tester
-COPY ../../aptos-move/move-examples/hello_blockchain .
+COPY ./aptos-move/move-examples/hello_blockchain .
 
 ### Get Aptos Move releases for genesis ceremony
 RUN mkdir -p /aptos-framework/move

--- a/docker/builder/tools.Dockerfile
+++ b/docker/builder/tools.Dockerfile
@@ -34,7 +34,7 @@ COPY --link --from=tools-builder /aptos/dist/aptos-transaction-emitter /usr/loca
 COPY --link --from=tools-builder /aptos/dist/aptos-api-tester /usr/local/bin/aptos-api-tester
 
 # Copy the example module to publish for api-tester
-COPY ./aptos-move/move-examples/hello_blockchain .
+COPY --link --from=tools-builder /aptos/aptos-move /aptos-move
 
 ### Get Aptos Move releases for genesis ceremony
 RUN mkdir -p /aptos-framework/move

--- a/docker/builder/tools.Dockerfile
+++ b/docker/builder/tools.Dockerfile
@@ -33,6 +33,9 @@ COPY --link --from=tools-builder /aptos/dist/aptos-fn-check-client /usr/local/bi
 COPY --link --from=tools-builder /aptos/dist/aptos-transaction-emitter /usr/local/bin/aptos-transaction-emitter
 COPY --link --from=tools-builder /aptos/dist/aptos-api-tester /usr/local/bin/aptos-api-tester
 
+# Copy the example module to publish for api-tester
+COPY ../../aptos-move/move-examples/hello_blockchain .
+
 ### Get Aptos Move releases for genesis ceremony
 RUN mkdir -p /aptos-framework/move
 COPY --link --from=tools-builder /aptos/dist/head.mrb /aptos-framework/move/head.mrb

--- a/docker/builder/tools.Dockerfile
+++ b/docker/builder/tools.Dockerfile
@@ -31,6 +31,7 @@ COPY --link --from=tools-builder /aptos/dist/aptos /usr/local/bin/aptos
 COPY --link --from=tools-builder /aptos/dist/aptos-openapi-spec-generator /usr/local/bin/aptos-openapi-spec-generator
 COPY --link --from=tools-builder /aptos/dist/aptos-fn-check-client /usr/local/bin/aptos-fn-check-client
 COPY --link --from=tools-builder /aptos/dist/aptos-transaction-emitter /usr/local/bin/aptos-transaction-emitter
+COPY --link --from=tools-builder /aptos/dist/aptos-api-tester /usr/local/bin/aptos-api-tester
 
 ### Get Aptos Move releases for genesis ceremony
 RUN mkdir -p /aptos-framework/move

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -25,6 +25,7 @@ ed25519-dalek-bip32 = { workspace = true }
 move-core-types = { workspace = true }
 rand_core = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 tiny-bip39 = { workspace = true }
 
 [dev-dependencies]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -24,6 +24,8 @@ pub use bcs;
 
 pub mod coin_client;
 
+pub mod token_client;
+
 pub mod crypto {
     pub use aptos_crypto::*;
 }

--- a/sdk/src/token_client.rs
+++ b/sdk/src/token_client.rs
@@ -2,20 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    bcs,
-    move_types::{identifier::Identifier, language_storage::ModuleId},
     rest_client::{Client as ApiClient, PendingTransaction},
-    transaction_builder::{TransactionBuilder, TransactionFactory},
+    transaction_builder::TransactionFactory,
     types::{
         account_address::AccountAddress,
         chain_id::ChainId,
-        transaction::{EntryFunction, TransactionPayload},
         LocalAccount,
     },
 };
 use anyhow::{Context, Result};
 use aptos_cached_packages::aptos_token_sdk_builder::EntryFunctionCall;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Clone, Debug)]
 pub struct TokenClient<'a> {
@@ -27,6 +23,18 @@ impl<'a> TokenClient<'a> {
         Self { api_client }
     }
 
+    async fn get_chain_id(&self) -> Result<ChainId> {
+        let id = self
+            .api_client
+            .get_index()
+            .await
+            .context("Failed to get chain ID")?
+            .inner()
+            .chain_id;
+
+        Ok(ChainId::new(id))
+    }
+
     pub async fn create_collection(
         &self,
         account: &mut LocalAccount,
@@ -36,19 +44,9 @@ impl<'a> TokenClient<'a> {
         max_amount: u64,
         options: Option<TransactionOptions>,
     ) -> Result<PendingTransaction> {
-        let options = options.unwrap_or_default();
-
-        // get chain id
-        let chain_id = self
-            .api_client
-            .get_index()
-            .await
-            .context("Failed to get chain ID")?
-            .inner()
-            .chain_id;
-
         // create factory
-        let factory = TransactionFactory::new(ChainId::new(chain_id))
+        let options = options.unwrap_or_default();
+        let factory = TransactionFactory::new(self.get_chain_id().await?)
             .with_gas_unit_price(options.gas_unit_price)
             .with_max_gas_amount(options.max_gas_amount)
             .with_transaction_expiration_time(options.timeout_secs);
@@ -88,60 +86,53 @@ impl<'a> TokenClient<'a> {
         supply: u64,
         uri: &str,
         max_amount: u64,
-        royalty_payee_address: &AccountAddress,
-        royalty_points_denominator: u64,
-        royalty_points_numerator: u64,
-        property_keys: Box<Vec<&str>>,
-        property_values: Box<Vec<&str>>,
-        property_types: Box<Vec<&str>>,
+        royalty_options: Option<RoyaltyOptions>,
         options: Option<TransactionOptions>,
     ) -> Result<PendingTransaction> {
+        // create factory
         let options = options.unwrap_or_default();
+        let factory = TransactionFactory::new(self.get_chain_id().await?)
+            .with_gas_unit_price(options.gas_unit_price)
+            .with_max_gas_amount(options.max_gas_amount)
+            .with_transaction_expiration_time(options.timeout_secs);
 
-        let chain_id = self
-            .api_client
-            .get_index()
-            .await
-            .context("Failed to get chain ID")?
-            .inner()
-            .chain_id;
-        let transaction_builder = TransactionBuilder::new(
-            TransactionPayload::EntryFunction(EntryFunction::new(
-                ModuleId::new(
-                    AccountAddress::from_hex_literal("0x3").unwrap(),
-                    Identifier::new("token").unwrap(),
-                ),
-                Identifier::new("create_token_script").unwrap(),
-                vec![],
-                vec![
-                    bcs::to_bytes(&collection_name).unwrap(),
-                    bcs::to_bytes(&name).unwrap(),
-                    bcs::to_bytes(&description).unwrap(),
-                    bcs::to_bytes(&supply).unwrap(),
-                    bcs::to_bytes(&max_amount).unwrap(),
-                    bcs::to_bytes(&uri).unwrap(),
-                    bcs::to_bytes(&royalty_payee_address).unwrap(),
-                    bcs::to_bytes(&royalty_points_denominator).unwrap(),
-                    bcs::to_bytes(&royalty_points_numerator).unwrap(),
-                    bcs::to_bytes(&vec![false, false, false, false, false]).unwrap(),
-                    bcs::to_bytes(property_keys.as_ref()).unwrap(),
-                    // TODO: this is wrong
-                    bcs::to_bytes(property_values.as_ref()).unwrap(),
-                    bcs::to_bytes(property_types.as_ref()).unwrap(),
-                ],
-            )),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_secs()
-                + options.timeout_secs,
-            ChainId::new(chain_id),
-        )
-        .sender(account.address())
-        .sequence_number(account.sequence_number())
-        .max_gas_amount(options.max_gas_amount)
-        .gas_unit_price(options.gas_unit_price);
-        let signed_txn = account.sign_with_transaction_builder(transaction_builder);
+        // set default royalty options
+        let royalty_options = match royalty_options {
+            Some(opt) => opt,
+            None => RoyaltyOptions {
+                royalty_payee_address: account.address(),
+                royalty_points_denominator: 0,
+                royalty_points_numerator: 0,
+            },
+        };
+
+        // create payload
+        let payload = EntryFunctionCall::TokenCreateTokenScript {
+            collection: collection_name.to_owned().into_bytes(),
+            name: name.to_owned().into_bytes(),
+            description: description.to_owned().into_bytes(),
+            balance: supply,
+            maximum: max_amount,
+            uri: uri.to_owned().into_bytes(),
+            royalty_payee_address: royalty_options.royalty_payee_address,
+            royalty_points_denominator: royalty_options.royalty_points_denominator,
+            royalty_points_numerator: royalty_options.royalty_points_numerator,
+            mutate_setting: vec![false, false, false, false, false],
+            // todo: add property support
+            property_keys: vec![],
+            property_values: vec![],
+            property_types: vec![],
+        }
+        .encode();
+
+        // create transaction
+        let builder = factory
+            .payload(payload)
+            .sender(account.address())
+            .sequence_number(account.sequence_number());
+        let signed_txn = account.sign_with_transaction_builder(builder);
+
+        // submit and return
         Ok(self
             .api_client
             .submit(&signed_txn)
@@ -169,4 +160,10 @@ impl Default for TransactionOptions {
             timeout_secs: 10,
         }
     }
+}
+
+pub struct RoyaltyOptions {
+    pub royalty_payee_address: AccountAddress,
+    pub royalty_points_denominator: u64,
+    pub royalty_points_numerator: u64,
 }

--- a/sdk/src/token_client.rs
+++ b/sdk/src/token_client.rs
@@ -339,16 +339,16 @@ pub struct TokenDataResponse {
     largest_property_version: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct TokenData {
-    name: String,
-    description: String,
-    uri: String,
-    maximum: u64,
-    supply: u64,
-    royalty: RoyaltyOptions,
-    mutability_config: TokenMutabilityConfig,
-    largest_property_version: u64,
+    pub name: String,
+    pub description: String,
+    pub uri: String,
+    pub maximum: u64,
+    pub supply: u64,
+    pub royalty: RoyaltyOptions,
+    pub mutability_config: TokenMutabilityConfig,
+    pub largest_property_version: u64,
 }
 
 #[derive(Deserialize)]
@@ -358,14 +358,14 @@ pub struct RoyaltyOptionsResponse {
     royalty_points_numerator: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct RoyaltyOptions {
     pub royalty_payee_address: AccountAddress,
     pub royalty_points_denominator: u64,
     pub royalty_points_numerator: u64,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub struct TokenMutabilityConfig {
     pub description: bool,
     pub maximum: bool,

--- a/sdk/src/token_client.rs
+++ b/sdk/src/token_client.rs
@@ -272,12 +272,13 @@ impl<'a> TokenClient<'a> {
     /// Retrieves the information for a given token.
     pub async fn get_token(
         &self,
+        account: AccountAddress,
         creator: AccountAddress,
         collection_name: &str,
         token_name: &str,
     ) -> Result<Token> {
         // get handle for tokens
-        let handle = match self.get_tokens_handle(creator).await {
+        let handle = match self.get_tokens_handle(account).await {
             Some(s) => AccountAddress::from_hex_literal(&s)?,
             None => return Err(anyhow!("Couldn't retrieve handle for tokens")),
         };

--- a/sdk/src/token_client.rs
+++ b/sdk/src/token_client.rs
@@ -9,7 +9,6 @@ use crate::{
 use anyhow::{anyhow, Context, Result};
 use aptos_cached_packages::aptos_token_sdk_builder::EntryFunctionCall;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 #[derive(Clone, Debug)]
 pub struct TokenClient<'a> {

--- a/sdk/src/token_client.rs
+++ b/sdk/src/token_client.rs
@@ -20,6 +20,7 @@ impl<'a> TokenClient<'a> {
         Self { api_client }
     }
 
+    /// Gets chain ID for use in submitting transactions.
     async fn get_chain_id(&self) -> Result<ChainId> {
         let id = self
             .api_client
@@ -32,6 +33,8 @@ impl<'a> TokenClient<'a> {
         Ok(ChainId::new(id))
     }
 
+    /// Helper function to get the handle address of collection_data for 0x3::token::Collections
+    /// resources.
     async fn get_collection_data_handle(&self, address: AccountAddress) -> Option<String> {
         if let Ok(response) = self
             .api_client
@@ -52,6 +55,7 @@ impl<'a> TokenClient<'a> {
         }
     }
 
+    /// Creates a collection with the given fields.
     pub async fn create_collection(
         &self,
         account: &mut LocalAccount,
@@ -94,6 +98,7 @@ impl<'a> TokenClient<'a> {
             .into_inner())
     }
 
+    /// Creates a token with the given fields. Does not support property keys.
     pub async fn create_token(
         &self,
         account: &mut LocalAccount,
@@ -158,6 +163,7 @@ impl<'a> TokenClient<'a> {
             .into_inner())
     }
 
+    /// Retrieves collection data from the API.
     pub async fn get_collection_data(
         &self,
         creator: AccountAddress,

--- a/sdk/src/token_client.rs
+++ b/sdk/src/token_client.rs
@@ -210,9 +210,7 @@ impl<'a> TokenClient<'a> {
             .await?
             .into_inner();
 
-        // reconstruct from strings
-        let response: CollectionData = serde_json::from_value(value)?;
-        Ok(response)
+        Ok(serde_json::from_value(value)?)
     }
 
     /// Retrieves token metadata from the API.
@@ -247,9 +245,7 @@ impl<'a> TokenClient<'a> {
             .await?
             .into_inner();
 
-        // reconstruct from strings
-        let response: TokenData = serde_json::from_value(value.clone())?;
-        Ok(response)
+        Ok(serde_json::from_value(value)?)
     }
 }
 

--- a/sdk/src/token_client.rs
+++ b/sdk/src/token_client.rs
@@ -150,8 +150,13 @@ impl<'a> TokenClient<'a> {
         .encode();
 
         // create and submit transaction
-        build_and_submit_transaction(self.api_client, account, payload, options.unwrap_or_default())
-            .await
+        build_and_submit_transaction(
+            self.api_client,
+            account,
+            payload,
+            options.unwrap_or_default(),
+        )
+        .await
     }
 
     /// Creates a token with the given fields. Does not support property keys.
@@ -197,8 +202,13 @@ impl<'a> TokenClient<'a> {
         .encode();
 
         // create and submit transaction
-        build_and_submit_transaction(self.api_client, account, payload, options.unwrap_or_default())
-            .await
+        build_and_submit_transaction(
+            self.api_client,
+            account,
+            payload,
+            options.unwrap_or_default(),
+        )
+        .await
     }
 
     /// Retrieves collection metadata from the API.
@@ -321,8 +331,13 @@ impl<'a> TokenClient<'a> {
         .encode();
 
         // create and submit transaction
-        build_and_submit_transaction(self.api_client, account, payload, options.unwrap_or_default())
-            .await
+        build_and_submit_transaction(
+            self.api_client,
+            account,
+            payload,
+            options.unwrap_or_default(),
+        )
+        .await
     }
 
     pub async fn claim_token(
@@ -346,8 +361,13 @@ impl<'a> TokenClient<'a> {
         .encode();
 
         // create and submit transaction
-        build_and_submit_transaction(self.api_client, account, payload, options.unwrap_or_default())
-            .await
+        build_and_submit_transaction(
+            self.api_client,
+            account,
+            payload,
+            options.unwrap_or_default(),
+        )
+        .await
     }
 }
 


### PR DESCRIPTION
### Description

This PR introduces consistent API testing where we run a consistent load through the network mimicking various user flows. See [proposal](https://www.notion.so/aptoslabs/API-Flow-Testing-Proposal-ae3424ce6e15433fa69f7c9dd99db037) for more high level information.

Changes:
* Created `aptos-api-tester` crate which runs 4 user flows:
  * Account creation
  * Coin transfer
  * NFT transfer
  * Module publishing, and outputs results to stdout.
* Added `token-client` to the SDK with the methods needed to run [Your First NFT](https://aptos.dev/tutorials/your-first-nft).
  * mirroring the [typescript SDK](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/typescript/sdk/src/plugins/token_client.ts) and the rust [coin client](https://github.com/aptos-labs/aptos-core/blob/main/sdk/src/coin_client.rs) by using [existing builders](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/cached-packages/src/aptos_token_sdk_builder.rs)
* Added `PartialEq` to `aptos_rest_client::Account` for testing.
* Added the crate to the `tools` docker image to run with GCP Cloud Run.

Changes to follow (next PR):
* Build push-style metrics logging in the crate.

### Test Plan
The crate is manually run and will be scheduled to run periodically in Cloud Run.