### PR TITLE
[Network] Parallelize message serialization tasks.

### DIFF
--- a/aptos-node/src/network.rs
+++ b/aptos-node/src/network.rs
@@ -291,6 +291,7 @@ fn register_client_and_service_with_network<
 ) -> ApplicationNetworkHandle<T> {
     let (network_sender, network_events) = network_builder.add_client_and_service(
         &application_config,
+        network_config.max_parallel_serialization_tasks,
         network_config.max_parallel_deserialization_tasks,
     );
     ApplicationNetworkHandle {

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -119,6 +119,8 @@ pub struct NetworkConfig {
     pub outbound_rate_limit_config: Option<RateLimitConfig>,
     /// The maximum size of an inbound or outbound message (it may be divided into multiple frame)
     pub max_message_size: usize,
+    /// The maximum number of parallel message serialization tasks that can run (per application)
+    pub max_parallel_serialization_tasks: Option<usize>,
     /// The maximum number of parallel message deserialization tasks that can run (per application)
     pub max_parallel_deserialization_tasks: Option<usize>,
 }
@@ -161,11 +163,12 @@ impl NetworkConfig {
             inbound_tx_buffer_size_bytes: Some(INBOUND_TCP_TX_BUFFER_SIZE),
             outbound_rx_buffer_size_bytes: Some(OUTBOUND_TCP_RX_BUFFER_SIZE),
             outbound_tx_buffer_size_bytes: Some(OUTBOUND_TCP_TX_BUFFER_SIZE),
+            max_parallel_serialization_tasks: None,
             max_parallel_deserialization_tasks: None,
         };
 
-        // Configure the number of parallel deserialization tasks
-        config.configure_num_deserialization_tasks();
+        // Configure the number of parallel serialization/deserialization tasks
+        config.configure_num_serialization_tasks();
 
         // Prepare the identity based on the identity format
         config.prepare_identity();
@@ -173,10 +176,14 @@ impl NetworkConfig {
         config
     }
 
-    /// Configures the number of parallel deserialization tasks
-    /// based on the number of CPU cores of the machine. This is
+    /// Configures the number of parallel serialization/deserialization
+    /// tasks based on the number of CPU cores of the machine. This is
     /// only done if the config does not specify a value.
-    fn configure_num_deserialization_tasks(&mut self) {
+    fn configure_num_serialization_tasks(&mut self) {
+        if self.max_parallel_serialization_tasks.is_none() {
+            self.max_parallel_serialization_tasks = Some(num_cpus::get());
+        }
+
         if self.max_parallel_deserialization_tasks.is_none() {
             self.max_parallel_deserialization_tasks = Some(num_cpus::get());
         }
@@ -507,22 +514,52 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_num_parallel_deserialization_tasks() {
-        // Create a default network config and verify the number of deserialization tasks
+    fn test_num_parallel_serialization_tasks() {
+        // Create a default network config and verify the number of tasks
         let network_config = NetworkConfig::default();
+        assert_eq!(
+            network_config.max_parallel_serialization_tasks,
+            Some(num_cpus::get())
+        );
         assert_eq!(
             network_config.max_parallel_deserialization_tasks,
             Some(num_cpus::get())
         );
 
-        // Create a network config with the number of deserialization tasks set to 1
+        // Create a network config and specify the number of serialization tasks
+        let max_parallel_serialization_tasks = 55;
         let mut network_config = NetworkConfig {
-            max_parallel_deserialization_tasks: Some(1),
+            max_parallel_serialization_tasks: Some(max_parallel_serialization_tasks),
             ..NetworkConfig::default()
         };
 
-        // Configure the number of deserialization tasks and verify that it is not overridden
-        network_config.configure_num_deserialization_tasks();
-        assert_eq!(network_config.max_parallel_deserialization_tasks, Some(1));
+        // Configure the number of tasks and verify that it is not overridden
+        network_config.configure_num_serialization_tasks();
+        assert_eq!(
+            network_config.max_parallel_serialization_tasks,
+            Some(max_parallel_serialization_tasks)
+        );
+        assert_eq!(
+            network_config.max_parallel_deserialization_tasks,
+            Some(num_cpus::get())
+        );
+
+        // Create a network config and specify the number of deserialization tasks
+        let max_parallel_deserialization_tasks = 100;
+        let mut network_config = NetworkConfig {
+            max_parallel_deserialization_tasks: Some(max_parallel_deserialization_tasks),
+            ..NetworkConfig::default()
+        };
+
+        // Configure the number of tasks and verify that it is not overridden
+        network_config.configure_num_serialization_tasks();
+        assert_eq!(
+            network_config.max_parallel_serialization_tasks,
+            Some(num_cpus::get())
+        );
+        assert_eq!(
+            network_config.max_parallel_deserialization_tasks,
+            Some(max_parallel_deserialization_tasks)
+        );
     }
 }

--- a/consensus/src/experimental/tests/buffer_manager_tests.rs
+++ b/consensus/src/experimental/tests/buffer_manager_tests.rs
@@ -99,6 +99,7 @@ pub fn prepare_buffer_manager() -> (
     let network_sender = network::NetworkSender::new(
         PeerManagerRequestSender::new(network_reqs_tx),
         ConnectionRequestSender::new(connection_reqs_tx),
+        None,
     );
     let network_client = NetworkClient::new(
         DIRECT_SEND.into(),

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -596,6 +596,7 @@ mod tests {
             let network_sender = network::NetworkSender::new(
                 PeerManagerRequestSender::new(network_reqs_tx),
                 ConnectionRequestSender::new(connection_reqs_tx),
+                None,
             );
             let network_client = NetworkClient::new(
                 DIRECT_SEND.into(),
@@ -702,6 +703,7 @@ mod tests {
             let network_sender = network::NetworkSender::new(
                 PeerManagerRequestSender::new(network_reqs_tx),
                 ConnectionRequestSender::new(connection_reqs_tx),
+                None,
             );
 
             let network_client = NetworkClient::new(

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -128,6 +128,7 @@ fn create_node_for_fuzzing() -> RoundManager {
     let network_sender = network::NetworkSender::new(
         PeerManagerRequestSender::new(network_reqs_tx),
         ConnectionRequestSender::new(connection_reqs_tx),
+        None,
     );
     let network_client = NetworkClient::new(
         DIRECT_SEND.into(),

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -200,6 +200,7 @@ impl NodeSetup {
         let network_sender = network::NetworkSender::new(
             PeerManagerRequestSender::new(network_reqs_tx),
             ConnectionRequestSender::new(connection_reqs_tx),
+            None,
         );
         let network_client = NetworkClient::new(
             DIRECT_SEND.into(),

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -87,6 +87,7 @@ impl SMRNode {
         let network_sender = network::NetworkSender::new(
             PeerManagerRequestSender::new(network_reqs_tx),
             ConnectionRequestSender::new(connection_reqs_tx),
+            None,
         );
         let network_client = NetworkClient::new(
             DIRECT_SEND.into(),

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -112,6 +112,7 @@ impl MockSharedMempool {
         let network_sender = NetworkSender::new(
             PeerManagerRequestSender::new(network_reqs_tx),
             ConnectionRequestSender::new(connection_reqs_tx),
+            None,
         );
         let network_events = NetworkEvents::new(network_notifs_rx, conn_notifs_rx, None);
         let (ac_client, client_events) = mpsc::channel(1_024);

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -572,6 +572,7 @@ fn setup_node_network_interface(
     let network_sender = NetworkSender::new(
         PeerManagerRequestSender::new(network_reqs_tx),
         ConnectionRequestSender::new(connection_reqs_tx),
+        None,
     );
     let network_events = NetworkEvents::new(network_notifs_rx, conn_status_rx, None);
 

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -543,6 +543,7 @@ fn setup_network(
     let network_sender = NetworkSender::new(
         PeerManagerRequestSender::new(reqs_outbound_sender),
         ConnectionRequestSender::new(connection_outbound_sender),
+        None,
     );
     let network_events =
         NetworkEvents::new(reqs_inbound_receiver, connection_inbound_receiver, None);

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -207,6 +207,7 @@ impl NetworkBuilder {
             config.ping_interval_ms,
             config.ping_timeout_ms,
             config.ping_failures_tolerated,
+            config.max_parallel_serialization_tasks,
             config.max_parallel_deserialization_tasks,
         );
 
@@ -416,11 +417,13 @@ impl NetworkBuilder {
         ping_interval_ms: u64,
         ping_timeout_ms: u64,
         ping_failures_tolerated: u64,
+        max_parallel_serialization_tasks: Option<usize>,
         max_parallel_deserialization_tasks: Option<usize>,
     ) -> &mut Self {
         // Initialize and start HealthChecker.
         let (hc_network_tx, hc_network_rx) = self.add_client_and_service(
             &health_checker::health_checker_network_config(),
+            max_parallel_serialization_tasks,
             max_parallel_deserialization_tasks,
         );
         self.health_checker_builder = Some(HealthCheckerBuilder::new(
@@ -446,10 +449,14 @@ impl NetworkBuilder {
     pub fn add_client_and_service<SenderT: NewNetworkSender, EventsT: NewNetworkEvents>(
         &mut self,
         config: &NetworkApplicationConfig,
+        max_parallel_serialization_tasks: Option<usize>,
         max_parallel_deserialization_tasks: Option<usize>,
     ) -> (SenderT, EventsT) {
         (
-            self.add_client(&config.network_client_config),
+            self.add_client(
+                &config.network_client_config,
+                max_parallel_serialization_tasks,
+            ),
             self.add_service(
                 &config.network_service_config,
                 max_parallel_deserialization_tasks,
@@ -459,9 +466,17 @@ impl NetworkBuilder {
 
     /// Register a new client application with the network. Return the client
     /// interface for sending messages.
-    fn add_client<SenderT: NewNetworkSender>(&mut self, config: &NetworkClientConfig) -> SenderT {
+    fn add_client<SenderT: NewNetworkSender>(
+        &mut self,
+        config: &NetworkClientConfig,
+        max_parallel_serialization_tasks: Option<usize>,
+    ) -> SenderT {
         let (peer_mgr_reqs_tx, connection_reqs_tx) = self.peer_manager_builder.add_client(config);
-        SenderT::new(peer_mgr_reqs_tx, connection_reqs_tx)
+        SenderT::new(
+            peer_mgr_reqs_tx,
+            connection_reqs_tx,
+            max_parallel_serialization_tasks,
+        )
     }
 
     /// Register a new service application with the network. Return the service

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -111,7 +111,7 @@ pub fn setup_network() -> DummyNetwork {
     );
 
     let (listener_sender, mut listener_events) = network_builder
-        .add_client_and_service::<_, DummyNetworkEvents>(&dummy_network_config(), None);
+        .add_client_and_service::<_, DummyNetworkEvents>(&dummy_network_config(), None, None);
     network_builder.build(runtime.handle().clone()).start();
     let listener_network_client = NetworkClient::new(
         vec![TEST_DIRECT_SEND_PROTOCOL],
@@ -144,7 +144,7 @@ pub fn setup_network() -> DummyNetwork {
     );
 
     let (dialer_sender, mut dialer_events) = network_builder
-        .add_client_and_service::<_, DummyNetworkEvents>(&dummy_network_config(), None);
+        .add_client_and_service::<_, DummyNetworkEvents>(&dummy_network_config(), None, None);
     network_builder.build(runtime.handle().clone()).start();
     let dialer_network_client = NetworkClient::new(
         vec![TEST_DIRECT_SEND_PROTOCOL],

--- a/network/peer-monitoring-service/client/src/tests/mock.rs
+++ b/network/peer-monitoring-service/client/src/tests/mock.rs
@@ -54,6 +54,7 @@ impl MockMonitoringServer {
             let network_sender = NetworkSender::new(
                 PeerManagerRequestSender::new(peer_manager_request_sender),
                 ConnectionRequestSender::new(connection_request_sender),
+                None,
             );
 
             // Store the channels and network sender

--- a/network/src/application/tests.rs
+++ b/network/src/application/tests.rs
@@ -772,6 +772,7 @@ fn create_network_sender_and_events(
         let network_sender = NetworkSender::new(
             PeerManagerRequestSender::new(outbound_request_sender),
             ConnectionRequestSender::new(connection_outbound_sender),
+            None,
         );
         let network_events =
             NetworkEvents::new(inbound_request_receiver, connection_inbound_receiver, None);

--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -52,6 +52,7 @@ impl TestHarness {
         let network_sender = NetworkSender::new(
             PeerManagerRequestSender::new(peer_mgr_reqs_tx),
             ConnectionRequestSender::new(connection_reqs_tx),
+            None,
         );
         let hc_network_rx =
             HealthCheckerNetworkEvents::new(peer_mgr_notifs_rx, connection_notifs_rx, None);

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -8,7 +8,7 @@ pub use crate::protocols::rpc::error::RpcError;
 use crate::{
     error::NetworkError,
     peer_manager::{
-        ConnectionNotification, ConnectionRequestSender, PeerManagerNotification,
+        ConnectionNotification, ConnectionRequestSender, PeerManagerError, PeerManagerNotification,
         PeerManagerRequestSender,
     },
     transport::ConnectionMetadata,
@@ -33,7 +33,7 @@ pub trait Message: DeserializeOwned + Serialize {}
 impl<T: DeserializeOwned + Serialize> Message for T {}
 
 // TODO: do we want to make this configurable?
-const MAX_DESERIALIZATION_QUEUE_SIZE_PER_PEER: usize = 50;
+const MAX_SERIALIZATION_QUEUE_SIZE_PER_APPLICATION: usize = 500;
 
 /// Events received by network clients in a validator
 ///
@@ -157,7 +157,7 @@ impl NetworkApplicationConfig {
 pub struct NetworkEvents<TMessage> {
     #[pin]
     event_stream: Select<
-        aptos_channel::Receiver<PeerId, Event<TMessage>>,
+        aptos_channel::Receiver<(), Event<TMessage>>,
         Map<
             aptos_channel::Receiver<PeerId, ConnectionNotification>,
             fn(ConnectionNotification) -> Event<TMessage>,
@@ -184,7 +184,7 @@ impl<TMessage: Message + Send + 'static> NewNetworkEvents for NetworkEvents<TMes
         // Create a channel for deserialized messages
         let (deserialized_message_sender, deserialized_message_receiver) = aptos_channel::new(
             QueueStyle::FIFO,
-            MAX_DESERIALIZATION_QUEUE_SIZE_PER_PEER,
+            MAX_SERIALIZATION_QUEUE_SIZE_PER_APPLICATION,
             None,
         );
 
@@ -197,17 +197,15 @@ impl<TMessage: Message + Send + 'static> NewNetworkEvents for NetworkEvents<TMes
                 .for_each_concurrent(
                     max_parallel_deserialization_tasks,
                     move |peer_manager_notification| {
-                        // Get the peer ID for the notification
                         let deserialized_message_sender = deserialized_message_sender.clone();
-                        let peer_id_for_notification = peer_manager_notification.get_peer_id();
 
                         // Spawn a new blocking task to deserialize the message
                         tokio::task::spawn_blocking(move || {
                             if let Some(deserialized_message) =
                                 peer_mgr_notif_to_event(peer_manager_notification)
                             {
-                                if let Err(error) = deserialized_message_sender
-                                    .push(peer_id_for_notification, deserialized_message)
+                                if let Err(error) =
+                                    deserialized_message_sender.push((), deserialized_message)
                                 {
                                     warn!(
                                         "Failed to send deserialized message to receiver: {:?}",
@@ -298,6 +296,13 @@ impl<TMessage> FusedStream for NetworkEvents<TMessage> {
     }
 }
 
+/// A simple enum that contains a message and send request, where the
+/// message needs to be serialized before being sent.
+enum MessageSerializationRequest<TMessage> {
+    SendToPeer(PeerId, ProtocolId, TMessage),
+    SendToManyPeers(Vec<PeerId>, ProtocolId, TMessage),
+}
+
 /// `NetworkSender` is the generic interface from upper network applications to
 /// the lower network layer. It provides the full API for network applications,
 /// including sending direct-send messages, sending rpc requests, as well as
@@ -311,11 +316,11 @@ impl<TMessage> FusedStream for NetworkEvents<TMessage> {
 /// interface they need.
 ///
 /// Provide Protobuf wrapper over `[peer_manager::PeerManagerRequestSender]`
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct NetworkSender<TMessage> {
     peer_mgr_reqs_tx: PeerManagerRequestSender,
     connection_reqs_tx: ConnectionRequestSender,
-    _marker: PhantomData<TMessage>,
+    serializing_message_sender: aptos_channel::Sender<(), MessageSerializationRequest<TMessage>>,
 }
 
 /// Trait specifying the signature for `new()` `NetworkSender`s
@@ -323,18 +328,87 @@ pub trait NewNetworkSender {
     fn new(
         peer_mgr_reqs_tx: PeerManagerRequestSender,
         connection_reqs_tx: ConnectionRequestSender,
+        max_parallel_serialization_tasks: Option<usize>,
     ) -> Self;
 }
 
-impl<TMessage> NewNetworkSender for NetworkSender<TMessage> {
+impl<TMessage: Message + Send + 'static> NewNetworkSender for NetworkSender<TMessage> {
     fn new(
         peer_mgr_reqs_tx: PeerManagerRequestSender,
         connection_reqs_tx: ConnectionRequestSender,
+        max_parallel_serialization_tasks: Option<usize>,
     ) -> Self {
+        // Create a channel for serializing messages
+        let (serializing_message_sender, serializing_message_receiver) = aptos_channel::new(
+            QueueStyle::FIFO,
+            MAX_SERIALIZATION_QUEUE_SIZE_PER_APPLICATION,
+            None,
+        );
+
+        // Serialize the peer manager notifications in parallel (for each
+        // network application) and send them to the peer manager. Note: this
+        // may cause out of order message sending, but applications
+        // should already be handling this on the receiving end.
+        let peer_mgr_reqs_tx_clone = peer_mgr_reqs_tx.clone();
+        tokio::spawn(async move {
+            serializing_message_receiver
+                .for_each_concurrent(
+                    max_parallel_serialization_tasks,
+                    move |message_serialization_request| {
+                        let peer_mgr_reqs_tx = peer_mgr_reqs_tx_clone.clone();
+
+                        // Spawn a new blocking task to serialize the
+                        // messages and send them to the peer manager.
+                        tokio::task::spawn_blocking(move || {
+                            match message_serialization_request {
+                                MessageSerializationRequest::SendToPeer(
+                                    peer_id,
+                                    protocol_id,
+                                    message,
+                                ) => {
+                                    // Serialize and send the message to the specified peer
+                                    let serialize_and_send_result =
+                                        protocol_id.to_bytes(&message).map(|message_bytes| {
+                                            peer_mgr_reqs_tx.send_to(
+                                                peer_id,
+                                                protocol_id,
+                                                message_bytes.into(),
+                                            )
+                                        });
+
+                                    // Log any potential errors
+                                    log_serialize_and_send_errors(serialize_and_send_result);
+                                },
+                                MessageSerializationRequest::SendToManyPeers(
+                                    peer_ids,
+                                    protocol_id,
+                                    message,
+                                ) => {
+                                    // Serialize and send the message to the specified peers
+                                    let serialize_and_send_result =
+                                        protocol_id.to_bytes(&message).map(|message_bytes| {
+                                            peer_mgr_reqs_tx.send_to_many(
+                                                peer_ids.into_iter(),
+                                                protocol_id,
+                                                message_bytes.into(),
+                                            )
+                                        });
+
+                                    // Log any potential errors
+                                    log_serialize_and_send_errors(serialize_and_send_result);
+                                },
+                            }
+                        })
+                        .map(|_| ())
+                    },
+                )
+                .await
+        });
+
         Self {
             peer_mgr_reqs_tx,
             connection_reqs_tx,
-            _marker: PhantomData,
+            serializing_message_sender,
         }
     }
 }
@@ -355,18 +429,21 @@ impl<TMessage> NetworkSender<TMessage> {
     }
 }
 
-impl<TMessage: Message> NetworkSender<TMessage> {
+impl<TMessage: Message + Send + 'static> NetworkSender<TMessage> {
     /// Send a protobuf message to a single recipient. Provides a wrapper over
     /// `[peer_manager::PeerManagerRequestSender::send_to]`.
     pub fn send_to(
         &self,
         recipient: PeerId,
-        protocol: ProtocolId,
+        protocol_id: ProtocolId,
         message: TMessage,
     ) -> Result<(), NetworkError> {
-        let mdata = protocol.to_bytes(&message)?.into();
-        self.peer_mgr_reqs_tx.send_to(recipient, protocol, mdata)?;
-        Ok(())
+        // Create and send the message serialization request
+        let message_send_request =
+            MessageSerializationRequest::SendToPeer(recipient, protocol_id, message);
+        self.serializing_message_sender
+            .push((), message_send_request)
+            .map_err(|error| error.into())
     }
 
     /// Send a protobuf message to a many recipients. Provides a wrapper over
@@ -374,14 +451,18 @@ impl<TMessage: Message> NetworkSender<TMessage> {
     pub fn send_to_many(
         &self,
         recipients: impl Iterator<Item = PeerId>,
-        protocol: ProtocolId,
+        protocol_id: ProtocolId,
         message: TMessage,
     ) -> Result<(), NetworkError> {
-        // Serialize message.
-        let mdata = protocol.to_bytes(&message)?.into();
-        self.peer_mgr_reqs_tx
-            .send_to_many(recipients, protocol, mdata)?;
-        Ok(())
+        // Create and send the message serialization request
+        let message_send_request = MessageSerializationRequest::SendToManyPeers(
+            recipients.collect(),
+            protocol_id,
+            message,
+        );
+        self.serializing_message_sender
+            .push((), message_send_request)
+            .map_err(|error| error.into())
     }
 
     /// Send a protobuf rpc request to a single recipient while handling
@@ -390,18 +471,43 @@ impl<TMessage: Message> NetworkSender<TMessage> {
     pub async fn send_rpc(
         &self,
         recipient: PeerId,
-        protocol: ProtocolId,
-        req_msg: TMessage,
+        protocol_id: ProtocolId,
+        message: TMessage,
         timeout: Duration,
     ) -> Result<TMessage, RpcError> {
-        // serialize request
-        let req_data = protocol.to_bytes(&req_msg)?.into();
-        let res_data = self
+        // Note: we do not use the serialization channel when sending RPC
+        // requests because we block the task until the response is received.
+        // Instead, we do everything inline here.
+
+        // Spawn a blocking task to perform serialization
+        let protocol_id_copy = protocol_id;
+        let message_bytes =
+            tokio::task::spawn_blocking(move || protocol_id_copy.to_bytes(&message)).await??;
+
+        // Send the request to the peer manager and wait for the response
+        let response_bytes = self
             .peer_mgr_reqs_tx
-            .send_rpc(recipient, protocol, req_data, timeout)
+            .send_rpc(recipient, protocol_id, message_bytes.into(), timeout)
             .await?;
-        let res_msg: TMessage = protocol.from_bytes(&res_data)?;
-        Ok(res_msg)
+
+        // Spawn a blocking task to perform deserialization
+        let protocol_id_copy = protocol_id;
+        let response_message =
+            tokio::task::spawn_blocking(move || protocol_id_copy.from_bytes(&response_bytes))
+                .await?;
+
+        // Return the response
+        response_message.map_err(|error| error.into())
+    }
+}
+
+impl<TMessage> Debug for NetworkSender<TMessage> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "NetworkSender {{ peer_mgr_reqs_tx: {:?}, connection_reqs_tx: {:?} }}",
+            self.peer_mgr_reqs_tx, self.connection_reqs_tx
+        )
     }
 }
 
@@ -414,5 +520,22 @@ pub trait SerializedRequest {
     /// `ProtocolId`.  See: [`ProtocolId::from_bytes`]
     fn to_message<TMessage: DeserializeOwned>(&self) -> anyhow::Result<TMessage> {
         self.protocol_id().from_bytes(self.data())
+    }
+}
+
+/// A helper method that logs any errors that occur when
+/// serializing and sending a message.
+fn log_serialize_and_send_errors(
+    serialize_and_send_result: Result<Result<(), PeerManagerError>, anyhow::Error>,
+) {
+    match serialize_and_send_result {
+        Ok(send_result) => {
+            if let Err(send_error) = send_result {
+                warn!("Failed to send message! Error: {:?}", send_error);
+            }
+        },
+        Err(serialize_error) => {
+            warn!("Failed to serialize message! Error: {:?}", serialize_error);
+        },
     }
 }

--- a/network/src/protocols/rpc/error.rs
+++ b/network/src/protocols/rpc/error.rs
@@ -53,6 +53,7 @@ impl From<PeerManagerError> for RpcError {
         }
     }
 }
+
 impl From<oneshot::Canceled> for RpcError {
     fn from(_: oneshot::Canceled) -> Self {
         RpcError::UnexpectedResponseChannelCancel
@@ -62,5 +63,11 @@ impl From<oneshot::Canceled> for RpcError {
 impl From<tokio::time::error::Elapsed> for RpcError {
     fn from(_err: tokio::time::error::Elapsed) -> RpcError {
         RpcError::TimedOut
+    }
+}
+
+impl From<tokio::task::JoinError> for RpcError {
+    fn from(err: tokio::task::JoinError) -> RpcError {
+        RpcError::Error(anyhow!("JoinError: {:?}", err))
     }
 }

--- a/state-sync/aptos-data-client/src/tests/mock.rs
+++ b/state-sync/aptos-data-client/src/tests/mock.rs
@@ -64,6 +64,7 @@ impl MockNetwork {
         let network_sender = NetworkSender::new(
             PeerManagerRequestSender::new(peer_mgr_reqs_tx),
             ConnectionRequestSender::new(connection_reqs_tx),
+            None,
         );
         let networks = networks
             .unwrap_or_else(|| vec![NetworkId::Validator, NetworkId::Vfn, NetworkId::Public]);


### PR DESCRIPTION
### Description
This PR updates the networking code to perform message serialization in parallel. Specifically:

1. We use `for_each_concurrent` to spawn up to a fixed number of threads to perform message serialization in parallel (per application). Now, whenever an application (e.g., consensus or mempool) sends a direct send message (to one or multiple peers), the message is sent to this task, to be serialized and then sent to the peer manager.
    
    The benefit of this is: (i) serialization is moved off the application thread, allowing the application thread to return to other work earlier; (ii) serialization is done using a blocking thread (which makes more sense, because it does not yield and may be expensive with large messages); and (iii) serialization can be performed in parallel, because the serialization task works using multiple threads.

2. We also update RPC requests to use blocking threads to perform serialization and deserialization. Note, RPC requests cannot make use of the new serialization task because they are blocking by nature, and thus applications (e.g., state sync), must already account for this fact (i.e., perform and handle RPC requests on different threads at the application layer).

Note: it's interesting to point out that the recent PR that added support for [parallel message deserialization](https://github.com/aptos-labs/aptos-core/pull/8762) only did so for: (i) incoming direct send messages; and (ii) incoming RPC requests. Deserialization of RPC responses are handled by case (2) above.

This PR offers two commits:
1. Perform message serialization in parallel.
2. Refactor some of the task logic into methods.

### Test Plan
Existing test infrastructure.