### PR TITLE
Fix the broken links in docs by changing client.py to async_client.py

### DIFF
--- a/developer-docs-site/docs/tutorials/first-transaction.md
+++ b/developer-docs-site/docs/tutorials/first-transaction.md
@@ -346,7 +346,7 @@ Breaking the above down into pieces:
 
 Behind the scenes the Python SDK generates, signs, and submits a transaction:
 ```python
-:!: static/sdks/python/aptos_sdk/client.py bcs_transfer
+:!: static/sdks/python/aptos_sdk/async_client.py bcs_transfer
 ```
 
 Breaking the above down into pieces:

--- a/developer-docs-site/docs/tutorials/your-first-nft.md
+++ b/developer-docs-site/docs/tutorials/your-first-nft.md
@@ -321,9 +321,9 @@ Your application will call `create_collection`:
 :!: static/sdks/python/examples/simple-nft.py section_4
 ```
 
-The is the function signature of `create_collection`. It returns a transaction hash:
+This is the function signature of `create_collection`. It returns a transaction hash:
 ```python
-:!: static/sdks/python/aptos_sdk/client.py create_collection
+:!: static/sdks/python/aptos_sdk/async_client.py create_collection
 ```
   </TabItem>
   <TabItem value="rust" label="Rust">
@@ -360,7 +360,7 @@ Your application will call `create_token`:
 
 The is the function signature of `create_token`. It returns a transaction hash:
 ```python
-:!: static/sdks/python/aptos_sdk/client.py create_token
+:!: static/sdks/python/aptos_sdk/async_client.py create_token
 ```
   </TabItem>
   <TabItem value="rust" label="Rust">
@@ -408,7 +408,7 @@ To read a token's metadata:
 
 Here's how `get_token_data` queries the token metadata:
 ```python
-:!: static/sdks/python/aptos_sdk/client.py read_token_data_table
+:!: static/sdks/python/aptos_sdk/async_client.py read_token_data_table
 ```
 
   </TabItem>

--- a/ecosystem/python/sdk/aptos_sdk/async_client.py
+++ b/ecosystem/python/sdk/aptos_sdk/async_client.py
@@ -486,9 +486,7 @@ class RestClient:
         signed_transaction = await self.create_bcs_signed_transaction(
             sender, TransactionPayload(payload), sequence_number=sequence_number
         )
-        return await self.submit_bcs_transaction(signed_transaction)
-
-    # <:!:bcs_transfer
+        return await self.submit_bcs_transaction(signed_transaction)  # <:!:bcs_transfer
 
     #
     # Token transaction wrappers


### PR DESCRIPTION
### Description

The deletion of `client.py` from the Python SDK broke some of the links in the docs so it would no longer build. Changed `client.py` to `async_client.py` and it's fixed.

### Test Plan

`cd ~/aptos-core/developer-docs-site && pnpm install && pnpm build && pnpm start`
