### PR TITLE
Reuse `collection` variable in hero.move example

### DIFF
--- a/aptos-move/move-examples/token_objects/hero/sources/hero.move
+++ b/aptos-move/move-examples/token_objects/hero/sources/hero.move
@@ -72,7 +72,7 @@ module token_objects::hero {
         );
 
         let on_chain_config = OnChainConfig {
-            collection: string::utf8(b"Hero Quest!"),
+            collection,
         };
         move_to(account, on_chain_config);
     }


### PR DESCRIPTION
### Description

Unnecessary repetition of `collection` variable in the `hero.move` example. 

### Test Plan

Unit test

```
/nix/store/1zwpbnxdb378kz4yrzfb1wq1xs2nis4i-aptos-cli-2.0.2/bin/aptos move test --filter hero
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY AptosTokenObjects
INCLUDING DEPENDENCY MoveStdlib
BUILDING TokenObjects
Running Move unit tests
[ PASS    ] 0x4::hero::test_hero_with_gem_weapon
Test result: OK. Total tests: 1; passed: 1; failed: 0
{
  "Result": "Success"
}

Process finished with exit code 0
```
