### PR TITLE
reduce the runner number in the replay verify

### DIFF
--- a/.github/workflows/workflow-run-replay-verify.yaml
+++ b/.github/workflows/workflow-run-replay-verify.yaml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ${{ inputs.RUNS_ON }}
     strategy:
         matrix:
-          number: [0, 1, 2, 3, 4, 5, 6, 7] # runner number
+          number: [0, 1] # runner number
     steps:
       - name: Echo Runner Number
         run: echo "Runner is ${{ matrix.number }}"
@@ -106,7 +106,7 @@ jobs:
 
       - name: Run replay-verify in parallel
         shell: bash
-        run: testsuite/replay_verify.py ${{ matrix.number }} 8 # first argument is the runner number, second argument is the total number of runners
+        run: testsuite/replay_verify.py ${{ matrix.number }} 2 # first argument is the runner number, second argument is the total number of runners
         env:
           BUCKET: ${{ inputs.BUCKET }}
           SUB_DIR: ${{ inputs.SUB_DIR }}


### PR DESCRIPTION
### Description
8 runners demands too much resource that can run out of resource. reduce it to 2 for now

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
