### PR TITLE
[CLI] fix vector args in CLI

### DIFF
--- a/aptos-move/move-examples/cli-e2e-tests/common/sources/cli_e2e_tests.move
+++ b/aptos-move/move-examples/cli-e2e-tests/common/sources/cli_e2e_tests.move
@@ -267,6 +267,21 @@ module addr::cli_e2e_tests {
         (num64, num128, num256)
     }
 
+    #[view]
+    public fun test_vector(
+        input_u8: vector<u8>,
+        input_u16: vector<u16>,
+        input_u32: vector<u32>,
+        input_u64: vector<u64>,
+        input_u128: vector<u128>,
+        input_u256: vector<u256>,
+        input_addr: vector<address>,
+        input_bool: vector<bool>,
+        input_string: vector<String>,
+    ): (vector<u8>, vector<u16>, vector<u32>, vector<u64>, vector<u128>, vector<u256>, vector<address>, vector<bool>, vector<String>) {
+        (input_u8, input_u16, input_u32, input_u64, input_u128, input_u256, input_addr, input_bool, input_string)
+    }
+
     inline fun get_hero(creator: &address, collection: &String, name: &String): (Object<Hero>, &Hero) {
         let token_address = token::create_token_address(
             creator,

--- a/crates/aptos/e2e/cases/move.py
+++ b/crates/aptos/e2e/cases/move.py
@@ -233,3 +233,31 @@ def test_move_view(run_helper: RunHelper, test_name=None):
         raise TestError(
             f"View function [test_big_number] did not return correct result"
         )
+
+    # Test view function with with vector arguments
+    # Follow 2 lines are for testing vector of u16-u256
+    response = run_helper.run_command(
+        test_name,
+        [
+            "aptos",
+            "move",
+            "view",
+            "--assume-yes",
+            "--function-id",
+            "default::cli_e2e_tests::test_vector",
+            "--args",
+            "string:1234",  # Notice this is testing u8 vector instead of actual string
+            f"u16:[1,2]",
+            f"u32:[1,2]",
+            f"u64:[1,2]",
+            f"u128:[1,2]",
+            f"u256:[1,2]",
+            f'address:["0x123","0x456"]',
+            "bool:[true,false]",
+            'string:["abc","efg"]',
+        ],
+    )
+
+    response = json.loads(response.stdout)
+    if response["Result"] == None or len(response["Result"]) != 9:
+        raise TestError(f"View function [test_vector] did not return correct result")

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -1531,8 +1531,33 @@ impl ArgWithType {
                 _ => serde_json::to_value(bcs::from_bytes::<T>(&self.arg)?)
                     .map_err(|err| CliError::UnexpectedError(err.to_string())),
             },
-            1 => serde_json::to_value(bcs::from_bytes::<Vec<T>>(&self.arg)?)
-                .map_err(|err| CliError::UnexpectedError(err.to_string())),
+            1 => match self._ty.clone() {
+                FunctionArgType::U64 => {
+                    let u64_vector: Vec<u64> = bcs::from_bytes::<Vec<u64>>(&self.arg)?;
+                    let string_vector: Vec<String> =
+                        u64_vector.iter().map(ToString::to_string).collect();
+                    serde_json::to_value(string_vector)
+                        .map_err(|err| CliError::UnexpectedError(err.to_string()))
+                },
+                FunctionArgType::U128 => {
+                    let u128_vector: Vec<u128> = bcs::from_bytes::<Vec<u128>>(&self.arg)?;
+                    let string_vector: Vec<String> =
+                        u128_vector.iter().map(ToString::to_string).collect();
+                    serde_json::to_value(string_vector)
+                        .map_err(|err| CliError::UnexpectedError(err.to_string()))
+                },
+                FunctionArgType::U256 => {
+                    let u256_vector: Vec<U256> = bcs::from_bytes::<Vec<U256>>(&self.arg)?;
+                    let string_vector: Vec<String> =
+                        u256_vector.iter().map(ToString::to_string).collect();
+                    serde_json::to_value(string_vector)
+                        .map_err(|err| CliError::UnexpectedError(err.to_string()))
+                },
+                FunctionArgType::Raw => serde_json::to_value(&self.arg)
+                    .map_err(|err| CliError::UnexpectedError(err.to_string())),
+                _ => serde_json::to_value(bcs::from_bytes::<Vec<T>>(&self.arg)?)
+                    .map_err(|err| CliError::UnexpectedError(err.to_string())),
+            },
 
             2 => serde_json::to_value(bcs::from_bytes::<Vec<Vec<T>>>(&self.arg)?)
                 .map_err(|err| CliError::UnexpectedError(err.to_string())),


### PR DESCRIPTION
### Description

CLI view function vector arg is broken due to the nested vector PR couple months ago. When you attempt to view a function using vector, it will return the following error

`"Error": "API error: API error Error(InvalidInput): parse arguments[0] failed`

Because you have to implicitly convert u64-256 to string.

This PR fix the vector args problem. 
NOTE: This only fix 1 depth level vector

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

```
2023-07-19 10:29:25,967 - INFO - These tests passed:
2023-07-19 10:29:25,967 - INFO - test_metrics_accessible
2023-07-19 10:29:25,967 - INFO - test_init
2023-07-19 10:29:25,967 - INFO - test_config_show_profiles
2023-07-19 10:29:25,967 - INFO - test_account_fund_with_faucet
2023-07-19 10:29:25,967 - INFO - test_account_create
2023-07-19 10:29:25,967 - INFO - test_account_lookup_address
2023-07-19 10:29:25,967 - INFO - test_aptos_header_included
2023-07-19 10:29:25,967 - INFO - test_move_compile
2023-07-19 10:29:25,968 - INFO - test_move_compile_script
2023-07-19 10:29:25,968 - INFO - test_move_publish
2023-07-19 10:29:25,968 - INFO - test_move_run
2023-07-19 10:29:25,968 - INFO - test_move_view
2023-07-19 10:29:25,968 - INFO - All tests passed!
```
