### PR TITLE
remove block gas limit from release v1.6

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -23,18 +23,6 @@ proposals:
     - FeatureFlag:
         enabled:
           - gas_payer_enabled
-  - name: enable_block_gas_limit
-    metadata:
-      title: "Enable Block Gas Limit"
-      description: "AIP-33: The block gas limit is a feature that terminates block execution when the gas consumed by the committed prefix of transactions exceeds the limit, thus providing predictable latency."
-      discussion_url: "https://github.com/aptos-foundation/AIPs/issues/132"
-    execution_mode: MultiStep
-    update_sequence:
-    - Execution:
-        V2:
-          transaction_shuffler_type:
-            sender_aware_v1: 32
-          block_gas_limit : 35000
   - name: enable_aptos_unique_identifiers
     metadata:
       title: "Enable Aptos Unique Identifiers"


### PR DESCRIPTION
### Description
Since execution config is not registered yet, removing this should take no effect. 


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
