### PR TITLE
[move-vm] Cache ability in runtime types

### DIFF
--- a/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
+++ b/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
@@ -254,7 +254,7 @@ fn construct_arg(
     use move_vm_types::loaded_data::runtime_types::Type::*;
     match ty {
         Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address => Ok(arg),
-        Vector(_) | Struct { index: _ } | StructInstantiation { index: _, ty_args: _ } => {
+        Vector(_) | Struct { .. } | StructInstantiation { .. } => {
             let mut cursor = Cursor::new(&arg[..]);
             let mut new_arg = vec![];
             let mut max_invocations = 10; // Read from config in the future

--- a/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
+++ b/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
@@ -196,7 +196,7 @@ pub(crate) fn is_valid_txn_arg(
     match typ {
         Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address => true,
         Vector(inner) => is_valid_txn_arg(session, inner, allowed_structs),
-        Struct(idx) | StructInstantiation(idx, _) => {
+        Struct { index: idx } | StructInstantiation { index: idx, ty_args: _ } => {
             if let Some(st) = session.get_struct_type(*idx) {
                 let full_name = format!("{}::{}", st.module.short_str_lossless(), st.name);
                 allowed_structs.contains_key(&full_name)
@@ -254,7 +254,7 @@ fn construct_arg(
     use move_vm_types::loaded_data::runtime_types::Type::*;
     match ty {
         Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address => Ok(arg),
-        Vector(_) | Struct(_) | StructInstantiation(_, _) => {
+        Vector(_) | Struct { index: _ } | StructInstantiation { index: _, ty_args: _ } => {
             let mut cursor = Cursor::new(&arg[..]);
             let mut new_arg = vec![];
             let mut max_invocations = 10; // Read from config in the future
@@ -322,7 +322,7 @@ pub(crate) fn recursively_construct_arg(
                 len -= 1;
             }
         },
-        Struct(idx) | StructInstantiation(idx, _) => {
+        Struct { index: idx } | StructInstantiation { index: idx, ty_args: _ } => {
             // validate the struct value, we use `expect()` because that check was already
             // performed in `is_valid_txn_arg`
             let st = session

--- a/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
+++ b/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
@@ -196,7 +196,7 @@ pub(crate) fn is_valid_txn_arg(
     match typ {
         Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address => true,
         Vector(inner) => is_valid_txn_arg(session, inner, allowed_structs),
-        Struct { index: idx } | StructInstantiation { index: idx, ty_args: _ } => {
+        Struct { index: idx, .. } | StructInstantiation { index: idx, .. } => {
             if let Some(st) = session.get_struct_type(*idx) {
                 let full_name = format!("{}::{}", st.module.short_str_lossless(), st.name);
                 allowed_structs.contains_key(&full_name)
@@ -322,7 +322,7 @@ pub(crate) fn recursively_construct_arg(
                 len -= 1;
             }
         },
-        Struct { index: idx } | StructInstantiation { index: idx, ty_args: _ } => {
+        Struct { index: idx, .. } | StructInstantiation { index: idx, .. } => {
             // validate the struct value, we use `expect()` because that check was already
             // performed in `is_valid_txn_arg`
             let st = session

--- a/aptos-move/framework/src/natives/string_utils.rs
+++ b/aptos-move/framework/src/natives/string_utils.rs
@@ -404,7 +404,7 @@ fn native_format_list(
                 match_list_ty(context, list_ty, "Cons")?;
 
                 // We know that the type is a list, so we can safely unwrap
-                let ty_args = if let Type::StructInstantiation { index: _, ty_args } = list_ty {
+                let ty_args = if let Type::StructInstantiation { ty_args, .. } = list_ty {
                     ty_args
                 } else {
                     unreachable!()

--- a/aptos-move/framework/src/natives/string_utils.rs
+++ b/aptos-move/framework/src/natives/string_utils.rs
@@ -404,7 +404,7 @@ fn native_format_list(
                 match_list_ty(context, list_ty, "Cons")?;
 
                 // We know that the type is a list, so we can safely unwrap
-                let ty_args = if let Type::StructInstantiation(_, ty_args) = list_ty {
+                let ty_args = if let Type::StructInstantiation { index: _, ty_args } = list_ty {
                     ty_args
                 } else {
                     unreachable!()

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1043,7 +1043,7 @@ fn check_depth_of_type_impl(
         Type::Reference(ty) | Type::MutableReference(ty) | Type::Vector(ty) => {
             check_depth_of_type_impl(resolver, ty, max_depth, check_depth!(1))?
         },
-        Type::Struct(si) => {
+        Type::Struct { index: si } => {
             let struct_type = resolver.loader().get_struct_type(*si).ok_or_else(|| {
                 PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                     .with_message("Struct Definition not resolved".to_string())
@@ -1055,7 +1055,7 @@ fn check_depth_of_type_impl(
                 .solve(&[]))
         },
         // NB: substitution must be performed before calling this function
-        Type::StructInstantiation(si, ty_args) => {
+        Type::StructInstantiation { index: si, ty_args } => {
             // Calculate depth of all type arguments, and make sure they themselves are not too deep.
             let ty_arg_depths = ty_args
                 .iter()

--- a/third_party/move/move-vm/runtime/src/loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader.rs
@@ -276,6 +276,11 @@ impl ModuleCache {
         let module = module.self_id();
         StructType {
             fields: vec![],
+            type_phantom_constraint: struct_handle
+                .type_parameters
+                .iter()
+                .map(|ty| ty.is_phantom)
+                .collect(),
             field_names,
             abilities,
             type_parameters,
@@ -415,7 +420,10 @@ impl ModuleCache {
                     module.identifier_at(module_handle.name).to_owned(),
                 );
                 let def_idx = resolver(struct_name, &module_id)?;
-                Type::Struct { index: def_idx }
+                Type::Struct {
+                    index: def_idx,
+                    ability: struct_handle.abilities,
+                }
             },
             SignatureToken::StructInstantiation(sh_idx, tys) => {
                 let type_parameters: Vec<_> = tys
@@ -432,7 +440,13 @@ impl ModuleCache {
                 let def_idx = resolver(struct_name, &module_id)?;
                 Type::StructInstantiation {
                     index: def_idx,
+                    base_ability: struct_handle.abilities,
                     ty_args: type_parameters,
+                    is_phantom_params: struct_handle
+                        .type_parameters
+                        .iter()
+                        .map(|ty| ty.is_phantom)
+                        .collect(),
                 }
             },
         };
@@ -540,7 +554,9 @@ impl ModuleCache {
                 inner
             },
             Type::TyParam(ty_idx) => DepthFormula::type_parameter(*ty_idx),
-            Type::Struct { index: cache_idx } => {
+            Type::Struct {
+                index: cache_idx, ..
+            } => {
                 let mut struct_formula = self.calculate_depth_of_struct(*cache_idx, depth_cache)?;
                 debug_assert!(struct_formula.terms.is_empty());
                 struct_formula.scale(1);
@@ -549,6 +565,7 @@ impl ModuleCache {
             Type::StructInstantiation {
                 index: cache_idx,
                 ty_args,
+                ..
             } => {
                 let ty_arg_map = ty_args
                     .iter()
@@ -870,11 +887,13 @@ impl Loader {
             | (Type::Vector(ret_inner), Type::Vector(expected_inner)) => {
                 Self::match_return_type(ret_inner, expected_inner, map)
             },
+            // Abilities will not contribute to the equality check as they ought to cache the same value.
             // For structs the both need to be the same struct.
             (
-                Type::Struct { index: ret_idx },
+                Type::Struct { index: ret_idx, .. },
                 Type::Struct {
                     index: expected_idx,
+                    ..
                 },
             ) => *ret_idx == *expected_idx,
             // For struct instantiations we need to additionally match all type arguments
@@ -882,10 +901,12 @@ impl Loader {
                 Type::StructInstantiation {
                     index: ret_idx,
                     ty_args: ret_fields,
+                    ..
                 },
                 Type::StructInstantiation {
                     index: expected_idx,
                     ty_args: expected_fields,
+                    ..
                 },
             ) => {
                 *ret_idx == *expected_idx
@@ -917,14 +938,8 @@ impl Loader {
             | (Type::Bool, _)
             | (Type::Address, _)
             | (Type::Signer, _)
-            | (Type::Struct { index: _ }, _)
-            | (
-                Type::StructInstantiation {
-                    index: _,
-                    ty_args: _,
-                },
-                _,
-            )
+            | (Type::Struct { .. }, _)
+            | (Type::StructInstantiation { .. }, _)
             | (Type::Vector(_), _)
             | (Type::MutableReference(_), _)
             | (Type::Reference(_), _) => false,
@@ -1201,7 +1216,10 @@ impl Loader {
                     .resolve_struct_by_name(&struct_tag.name, &module_id)
                     .map_err(|e| e.finish(Location::Undefined))?;
                 if struct_type.type_parameters.is_empty() && struct_tag.type_params.is_empty() {
-                    Type::Struct { index: idx }
+                    Type::Struct {
+                        index: idx,
+                        ability: struct_type.abilities,
+                    }
                 } else {
                     let mut type_params = vec![];
                     for ty_param in &struct_tag.type_params {
@@ -1212,6 +1230,8 @@ impl Loader {
                     Type::StructInstantiation {
                         index: idx,
                         ty_args: type_params,
+                        base_ability: struct_type.abilities,
+                        is_phantom_params: struct_type.type_phantom_constraint.clone(),
                     }
                 }
             },
@@ -1532,8 +1552,8 @@ impl Loader {
                 }
             },
             Type::StructInstantiation {
-                index: _,
                 ty_args: struct_inst,
+                ..
             } => {
                 let mut sum_nodes = 1u64;
                 for ty in ty_args.iter().chain(struct_inst.iter()) {
@@ -1546,7 +1566,7 @@ impl Loader {
             Type::Address
             | Type::Bool
             | Type::Signer
-            | Type::Struct { index: _ }
+            | Type::Struct { .. }
             | Type::TyParam(_)
             | Type::U8
             | Type::U16
@@ -1602,8 +1622,19 @@ impl Loader {
         )
     }
 
-    pub(crate) fn get_struct_type(&self, idx: CachedStructIndex) -> Option<Arc<StructType>> {
-        self.module_cache.read().structs.get(idx.0).map(Arc::clone)
+    pub(crate) fn get_struct_type(
+        &self,
+        idx: CachedStructIndex,
+    ) -> PartialVMResult<Arc<StructType>> {
+        self.module_cache
+            .read()
+            .structs
+            .get(idx.0)
+            .map(Arc::clone)
+            .ok_or_else(|| {
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message("Struct Definition not resolved".to_string())
+            })
     }
 
     pub(crate) fn abilities(&self, ty: &Type) -> PartialVMResult<AbilitySet> {
@@ -1630,23 +1661,20 @@ impl Loader {
                 vec![false],
                 vec![self.abilities(ty)?],
             ),
-            Type::Struct { index: idx } => Ok(self.module_cache.read().struct_at(*idx).abilities),
+            Type::Struct { ability, .. } => Ok(*ability),
             Type::StructInstantiation {
-                index: idx,
-                ty_args: type_args,
+                ty_args,
+                base_ability,
+                is_phantom_params,
+                ..
             } => {
-                let struct_type = self.module_cache.read().struct_at(*idx);
-                let declared_phantom_parameters = struct_type
-                    .type_parameters
-                    .iter()
-                    .map(|param| param.is_phantom);
-                let type_argument_abilities = type_args
+                let type_argument_abilities = ty_args
                     .iter()
                     .map(|arg| self.abilities(arg))
                     .collect::<PartialVMResult<Vec<_>>>()?;
                 AbilitySet::polymorphic_abilities(
-                    struct_type.abilities,
-                    declared_phantom_parameters,
+                    *base_ability,
+                    is_phantom_params.iter().map(|b| *b),
                     type_argument_abilities,
                 )
             },
@@ -1755,12 +1783,15 @@ impl<'a> Resolver<'a> {
     // Type resolution
     //
 
-    pub(crate) fn get_struct_type(&self, idx: StructDefinitionIndex) -> Type {
+    pub(crate) fn get_struct_type(&self, idx: StructDefinitionIndex) -> PartialVMResult<Type> {
         let struct_def = match &self.binary {
             BinaryType::Module(module) => module.struct_at(idx),
             BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
         };
-        Type::Struct { index: struct_def }
+        Ok(Type::Struct {
+            index: struct_def,
+            ability: self.loader.get_struct_type(struct_def)?.abilities,
+        })
     }
 
     pub(crate) fn instantiate_generic_type(
@@ -1785,6 +1816,8 @@ impl<'a> Resolver<'a> {
             }
         }
 
+        let index = struct_inst.def;
+        let struct_ = self.loader.get_struct_type(index)?;
         Ok(Type::StructInstantiation {
             index: struct_inst.def,
             ty_args: struct_inst
@@ -1792,6 +1825,8 @@ impl<'a> Resolver<'a> {
                 .iter()
                 .map(|ty| self.subst(ty, ty_args))
                 .collect::<PartialVMResult<_>>()?,
+            base_ability: struct_.abilities,
+            is_phantom_params: struct_.type_phantom_constraint.clone(),
         })
     }
 
@@ -1800,15 +1835,7 @@ impl<'a> Resolver<'a> {
             BinaryType::Module(module) => &module.field_handles[idx.0 as usize],
             BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
         };
-        Ok(self
-            .loader
-            .get_struct_type(handle.owner)
-            .ok_or_else(|| {
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message("Struct Definition not resolved".to_string())
-            })?
-            .fields[handle.offset]
-            .clone())
+        Ok(self.loader.get_struct_type(handle.owner)?.fields[handle.offset].clone())
     }
 
     pub(crate) fn instantiate_generic_field(
@@ -1820,13 +1847,7 @@ impl<'a> Resolver<'a> {
             BinaryType::Module(module) => &module.field_instantiations[idx.0 as usize],
             BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
         };
-        let struct_type = self
-            .loader
-            .get_struct_type(field_instantiation.owner)
-            .ok_or_else(|| {
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message("Struct Definition not resolved".to_string())
-            })?;
+        let struct_type = self.loader.get_struct_type(field_instantiation.owner)?;
 
         let instantiation_types = field_instantiation
             .instantiation
@@ -1844,10 +1865,7 @@ impl<'a> Resolver<'a> {
             BinaryType::Module(module) => module.struct_at(idx),
             BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
         };
-        self.loader.get_struct_type(idx).ok_or_else(|| {
-            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                .with_message("Struct Definition not resolved".to_string())
-        })
+        self.loader.get_struct_type(idx)
     }
 
     pub(crate) fn instantiate_generic_struct_fields(
@@ -1859,13 +1877,7 @@ impl<'a> Resolver<'a> {
             BinaryType::Module(module) => module.struct_instantiation_at(idx.0),
             BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
         };
-        let struct_type = self
-            .loader
-            .get_struct_type(struct_inst.def)
-            .ok_or_else(|| {
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message("Struct Definition not resolved".to_string())
-            })?;
+        let struct_type = self.loader.get_struct_type(struct_inst.def)?;
 
         let instantiation_types = struct_inst
             .instantiation
@@ -1935,10 +1947,15 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    pub(crate) fn field_handle_to_struct(&self, idx: FieldHandleIndex) -> Type {
+    pub(crate) fn field_handle_to_struct(&self, idx: FieldHandleIndex) -> PartialVMResult<Type> {
         match &self.binary {
-            BinaryType::Module(module) => Type::Struct {
-                index: module.field_handles[idx.0 as usize].owner,
+            BinaryType::Module(module) => {
+                let index = module.field_handles[idx.0 as usize].owner;
+                let struct_ = self.loader.get_struct_type(index)?;
+                Ok(Type::Struct {
+                    index,
+                    ability: struct_.abilities,
+                })
             },
             BinaryType::Script(_) => unreachable!("Scripts cannot have field instructions"),
         }
@@ -1950,14 +1967,20 @@ impl<'a> Resolver<'a> {
         args: &[Type],
     ) -> PartialVMResult<Type> {
         match &self.binary {
-            BinaryType::Module(module) => Ok(Type::StructInstantiation {
-                index: module.field_instantiations[idx.0 as usize].owner,
-                ty_args: module.field_instantiations[idx.0 as usize]
-                    .instantiation
-                    .iter()
-                    .map(|ty| ty.subst(args))
-                    .collect::<PartialVMResult<Vec<_>>>()?,
-            }),
+            BinaryType::Module(module) => {
+                let index = module.field_instantiations[idx.0 as usize].owner;
+                let struct_ = self.loader.get_struct_type(index)?;
+                Ok(Type::StructInstantiation {
+                    index,
+                    ty_args: module.field_instantiations[idx.0 as usize]
+                        .instantiation
+                        .iter()
+                        .map(|ty| ty.subst(args))
+                        .collect::<PartialVMResult<Vec<_>>>()?,
+                    base_ability: struct_.abilities,
+                    is_phantom_params: struct_.type_phantom_constraint.clone(),
+                })
+            },
             BinaryType::Script(_) => unreachable!("Scripts cannot have field instructions"),
         }
     }
@@ -2819,12 +2842,13 @@ impl Loader {
             Type::Address => TypeTag::Address,
             Type::Signer => TypeTag::Signer,
             Type::Vector(ty) => TypeTag::Vector(Box::new(self.type_to_type_tag(ty)?)),
-            Type::Struct { index: gidx } => {
+            Type::Struct { index: gidx, .. } => {
                 TypeTag::Struct(Box::new(self.struct_gidx_to_type_tag(*gidx, &[])?))
             },
             Type::StructInstantiation {
                 index: gidx,
                 ty_args,
+                ..
             } => TypeTag::Struct(Box::new(self.struct_gidx_to_type_tag(*gidx, ty_args)?)),
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                 return Err(
@@ -2844,7 +2868,7 @@ impl Loader {
                     result += 1;
                     todo.push(ty);
                 },
-                Type::StructInstantiation { index: _, ty_args } => {
+                Type::StructInstantiation { ty_args, .. } => {
                     result += 1;
                     todo.extend(ty_args.iter())
                 },
@@ -2959,13 +2983,14 @@ impl Loader {
                     depth + 1,
                 )?))
             },
-            Type::Struct { index: gidx } => {
+            Type::Struct { index: gidx, .. } => {
                 *count += 1;
                 MoveTypeLayout::Struct(self.struct_gidx_to_type_layout(*gidx, &[], count, depth)?)
             },
             Type::StructInstantiation {
                 index: gidx,
                 ty_args,
+                ..
             } => {
                 *count += 1;
                 MoveTypeLayout::Struct(
@@ -3061,12 +3086,13 @@ impl Loader {
             Type::Vector(ty) => MoveTypeLayout::Vector(Box::new(
                 self.type_to_fully_annotated_layout_impl(ty, count, depth + 1)?,
             )),
-            Type::Struct { index: gidx } => MoveTypeLayout::Struct(
+            Type::Struct { index: gidx, .. } => MoveTypeLayout::Struct(
                 self.struct_gidx_to_fully_annotated_layout(*gidx, &[], count, depth)?,
             ),
             Type::StructInstantiation {
                 index: gidx,
                 ty_args,
+                ..
             } => MoveTypeLayout::Struct(
                 self.struct_gidx_to_fully_annotated_layout(*gidx, ty_args, count, depth)?,
             ),

--- a/third_party/move/move-vm/runtime/src/loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader.rs
@@ -415,7 +415,7 @@ impl ModuleCache {
                     module.identifier_at(module_handle.name).to_owned(),
                 );
                 let def_idx = resolver(struct_name, &module_id)?;
-                Type::Struct(def_idx)
+                Type::Struct { index: def_idx }
             },
             SignatureToken::StructInstantiation(sh_idx, tys) => {
                 let type_parameters: Vec<_> = tys
@@ -430,7 +430,10 @@ impl ModuleCache {
                     module.identifier_at(module_handle.name).to_owned(),
                 );
                 let def_idx = resolver(struct_name, &module_id)?;
-                Type::StructInstantiation(def_idx, type_parameters)
+                Type::StructInstantiation {
+                    index: def_idx,
+                    ty_args: type_parameters,
+                }
             },
         };
         Ok(res)
@@ -537,13 +540,16 @@ impl ModuleCache {
                 inner
             },
             Type::TyParam(ty_idx) => DepthFormula::type_parameter(*ty_idx),
-            Type::Struct(cache_idx) => {
+            Type::Struct { index: cache_idx } => {
                 let mut struct_formula = self.calculate_depth_of_struct(*cache_idx, depth_cache)?;
                 debug_assert!(struct_formula.terms.is_empty());
                 struct_formula.scale(1);
                 struct_formula
             },
-            Type::StructInstantiation(cache_idx, ty_args) => {
+            Type::StructInstantiation {
+                index: cache_idx,
+                ty_args,
+            } => {
                 let ty_arg_map = ty_args
                     .iter()
                     .enumerate()
@@ -865,11 +871,22 @@ impl Loader {
                 Self::match_return_type(ret_inner, expected_inner, map)
             },
             // For structs the both need to be the same struct.
-            (Type::Struct(ret_idx), Type::Struct(expected_idx)) => *ret_idx == *expected_idx,
+            (
+                Type::Struct { index: ret_idx },
+                Type::Struct {
+                    index: expected_idx,
+                },
+            ) => *ret_idx == *expected_idx,
             // For struct instantiations we need to additionally match all type arguments
             (
-                Type::StructInstantiation(ret_idx, ret_fields),
-                Type::StructInstantiation(expected_idx, expected_fields),
+                Type::StructInstantiation {
+                    index: ret_idx,
+                    ty_args: ret_fields,
+                },
+                Type::StructInstantiation {
+                    index: expected_idx,
+                    ty_args: expected_fields,
+                },
             ) => {
                 *ret_idx == *expected_idx
                     && ret_fields.len() == expected_fields.len()
@@ -900,8 +917,14 @@ impl Loader {
             | (Type::Bool, _)
             | (Type::Address, _)
             | (Type::Signer, _)
-            | (Type::Struct(_), _)
-            | (Type::StructInstantiation(_, _), _)
+            | (Type::Struct { index: _ }, _)
+            | (
+                Type::StructInstantiation {
+                    index: _,
+                    ty_args: _,
+                },
+                _,
+            )
             | (Type::Vector(_), _)
             | (Type::MutableReference(_), _)
             | (Type::Reference(_), _) => false,
@@ -1178,7 +1201,7 @@ impl Loader {
                     .resolve_struct_by_name(&struct_tag.name, &module_id)
                     .map_err(|e| e.finish(Location::Undefined))?;
                 if struct_type.type_parameters.is_empty() && struct_tag.type_params.is_empty() {
-                    Type::Struct(idx)
+                    Type::Struct { index: idx }
                 } else {
                     let mut type_params = vec![];
                     for ty_param in &struct_tag.type_params {
@@ -1186,7 +1209,10 @@ impl Loader {
                     }
                     self.verify_ty_args(struct_type.type_param_constraints(), &type_params)
                         .map_err(|e| e.finish(Location::Undefined))?;
-                    Type::StructInstantiation(idx, type_params)
+                    Type::StructInstantiation {
+                        index: idx,
+                        ty_args: type_params,
+                    }
                 }
             },
         })
@@ -1505,7 +1531,10 @@ impl Loader {
                     return Err(PartialVMError::new(StatusCode::TOO_MANY_TYPE_NODES));
                 }
             },
-            Type::StructInstantiation(_, struct_inst) => {
+            Type::StructInstantiation {
+                index: _,
+                ty_args: struct_inst,
+            } => {
                 let mut sum_nodes = 1u64;
                 for ty in ty_args.iter().chain(struct_inst.iter()) {
                     sum_nodes = sum_nodes.saturating_add(self.count_type_nodes(ty));
@@ -1517,7 +1546,7 @@ impl Loader {
             Type::Address
             | Type::Bool
             | Type::Signer
-            | Type::Struct(_)
+            | Type::Struct { index: _ }
             | Type::TyParam(_)
             | Type::U8
             | Type::U16
@@ -1596,13 +1625,16 @@ impl Loader {
                 "Unexpected TyParam type after translating from TypeTag to Type".to_string(),
             )),
 
-            Type::Vector(ty) => {
-                AbilitySet::polymorphic_abilities(AbilitySet::VECTOR, vec![false], vec![
-                    self.abilities(ty)?
-                ])
-            },
-            Type::Struct(idx) => Ok(self.module_cache.read().struct_at(*idx).abilities),
-            Type::StructInstantiation(idx, type_args) => {
+            Type::Vector(ty) => AbilitySet::polymorphic_abilities(
+                AbilitySet::VECTOR,
+                vec![false],
+                vec![self.abilities(ty)?],
+            ),
+            Type::Struct { index: idx } => Ok(self.module_cache.read().struct_at(*idx).abilities),
+            Type::StructInstantiation {
+                index: idx,
+                ty_args: type_args,
+            } => {
                 let struct_type = self.module_cache.read().struct_at(*idx);
                 let declared_phantom_parameters = struct_type
                     .type_parameters
@@ -1728,7 +1760,7 @@ impl<'a> Resolver<'a> {
             BinaryType::Module(module) => module.struct_at(idx),
             BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
         };
-        Type::Struct(struct_def)
+        Type::Struct { index: struct_def }
     }
 
     pub(crate) fn instantiate_generic_type(
@@ -1753,14 +1785,14 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        Ok(Type::StructInstantiation(
-            struct_inst.def,
-            struct_inst
+        Ok(Type::StructInstantiation {
+            index: struct_inst.def,
+            ty_args: struct_inst
                 .instantiation
                 .iter()
                 .map(|ty| self.subst(ty, ty_args))
                 .collect::<PartialVMResult<_>>()?,
-        ))
+        })
     }
 
     pub(crate) fn get_field_type(&self, idx: FieldHandleIndex) -> PartialVMResult<Type> {
@@ -1905,7 +1937,9 @@ impl<'a> Resolver<'a> {
 
     pub(crate) fn field_handle_to_struct(&self, idx: FieldHandleIndex) -> Type {
         match &self.binary {
-            BinaryType::Module(module) => Type::Struct(module.field_handles[idx.0 as usize].owner),
+            BinaryType::Module(module) => Type::Struct {
+                index: module.field_handles[idx.0 as usize].owner,
+            },
             BinaryType::Script(_) => unreachable!("Scripts cannot have field instructions"),
         }
     }
@@ -1916,14 +1950,14 @@ impl<'a> Resolver<'a> {
         args: &[Type],
     ) -> PartialVMResult<Type> {
         match &self.binary {
-            BinaryType::Module(module) => Ok(Type::StructInstantiation(
-                module.field_instantiations[idx.0 as usize].owner,
-                module.field_instantiations[idx.0 as usize]
+            BinaryType::Module(module) => Ok(Type::StructInstantiation {
+                index: module.field_instantiations[idx.0 as usize].owner,
+                ty_args: module.field_instantiations[idx.0 as usize]
                     .instantiation
                     .iter()
                     .map(|ty| ty.subst(args))
                     .collect::<PartialVMResult<Vec<_>>>()?,
-            )),
+            }),
             BinaryType::Script(_) => unreachable!("Scripts cannot have field instructions"),
         }
     }
@@ -2785,12 +2819,13 @@ impl Loader {
             Type::Address => TypeTag::Address,
             Type::Signer => TypeTag::Signer,
             Type::Vector(ty) => TypeTag::Vector(Box::new(self.type_to_type_tag(ty)?)),
-            Type::Struct(gidx) => {
+            Type::Struct { index: gidx } => {
                 TypeTag::Struct(Box::new(self.struct_gidx_to_type_tag(*gidx, &[])?))
             },
-            Type::StructInstantiation(gidx, ty_args) => {
-                TypeTag::Struct(Box::new(self.struct_gidx_to_type_tag(*gidx, ty_args)?))
-            },
+            Type::StructInstantiation {
+                index: gidx,
+                ty_args,
+            } => TypeTag::Struct(Box::new(self.struct_gidx_to_type_tag(*gidx, ty_args)?)),
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                 return Err(
                     PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
@@ -2809,7 +2844,7 @@ impl Loader {
                     result += 1;
                     todo.push(ty);
                 },
-                Type::StructInstantiation(_, ty_args) => {
+                Type::StructInstantiation { index: _, ty_args } => {
                     result += 1;
                     todo.extend(ty_args.iter())
                 },
@@ -2924,11 +2959,14 @@ impl Loader {
                     depth + 1,
                 )?))
             },
-            Type::Struct(gidx) => {
+            Type::Struct { index: gidx } => {
                 *count += 1;
                 MoveTypeLayout::Struct(self.struct_gidx_to_type_layout(*gidx, &[], count, depth)?)
             },
-            Type::StructInstantiation(gidx, ty_args) => {
+            Type::StructInstantiation {
+                index: gidx,
+                ty_args,
+            } => {
                 *count += 1;
                 MoveTypeLayout::Struct(
                     self.struct_gidx_to_type_layout(*gidx, ty_args, count, depth)?,
@@ -3023,10 +3061,13 @@ impl Loader {
             Type::Vector(ty) => MoveTypeLayout::Vector(Box::new(
                 self.type_to_fully_annotated_layout_impl(ty, count, depth + 1)?,
             )),
-            Type::Struct(gidx) => MoveTypeLayout::Struct(
+            Type::Struct { index: gidx } => MoveTypeLayout::Struct(
                 self.struct_gidx_to_fully_annotated_layout(*gidx, &[], count, depth)?,
             ),
-            Type::StructInstantiation(gidx, ty_args) => MoveTypeLayout::Struct(
+            Type::StructInstantiation {
+                index: gidx,
+                ty_args,
+            } => MoveTypeLayout::Struct(
                 self.struct_gidx_to_fully_annotated_layout(*gidx, ty_args, count, depth)?,
             ),
             Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {

--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -408,7 +408,7 @@ impl<'r, 'l> Session<'r, 'l> {
     /// Fetch a struct type from cache, if the index is in bounds
     /// Helpful when paired with load_type, or any other API that returns 'Type'
     pub fn get_struct_type(&self, index: CachedStructIndex) -> Option<Arc<StructType>> {
-        self.move_vm.runtime.loader().get_struct_type(index)
+        self.move_vm.runtime.loader().get_struct_type(index).ok()
     }
 
     /// Gets the abilities for this type, at it's particular instantiation

--- a/third_party/move/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/third_party/move/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -390,23 +390,27 @@ fn deprecated_bad_signatures() -> Vec<Signature> {
 fn good_signatures_and_arguments() -> Vec<(Signature, Vec<MoveValue>)> {
     vec![
         // U128 arg
-        (Signature(vec![SignatureToken::U128]), vec![
-            MoveValue::U128(0),
-        ]),
+        (
+            Signature(vec![SignatureToken::U128]),
+            vec![MoveValue::U128(0)],
+        ),
         // U8 arg
         (Signature(vec![SignatureToken::U8]), vec![MoveValue::U8(0)]),
         // U16 arg
-        (Signature(vec![SignatureToken::U16]), vec![MoveValue::U16(
-            0,
-        )]),
+        (
+            Signature(vec![SignatureToken::U16]),
+            vec![MoveValue::U16(0)],
+        ),
         // U32 arg
-        (Signature(vec![SignatureToken::U32]), vec![MoveValue::U32(
-            0,
-        )]),
+        (
+            Signature(vec![SignatureToken::U32]),
+            vec![MoveValue::U32(0)],
+        ),
         // U256 arg
-        (Signature(vec![SignatureToken::U256]), vec![
-            MoveValue::U256(U256::zero()),
-        ]),
+        (
+            Signature(vec![SignatureToken::U256]),
+            vec![MoveValue::U256(U256::zero())],
+        ),
         // All constants
         (
             Signature(vec![SignatureToken::Vector(Box::new(SignatureToken::Bool))]),

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -113,7 +113,7 @@ impl DepthFormula {
 pub struct StructType {
     pub fields: Vec<Type>,
     pub field_names: Vec<Identifier>,
-    pub type_phantom_constraint: Vec<bool>,
+    pub phantom_ty_args_mask: Vec<bool>,
     pub abilities: AbilitySet,
     pub type_parameters: Vec<StructTypeParameter>,
     pub name: Identifier,
@@ -147,8 +147,8 @@ pub enum Type {
     StructInstantiation {
         index: CachedStructIndex,
         ty_args: Vec<Type>,
-        base_ability: AbilitySet,
-        is_phantom_params: Vec<bool>,
+        base_ability_set: AbilitySet,
+        phantom_ty_args_mask: Vec<bool>,
     },
     Reference(Box<Type>),
     MutableReference(Box<Type>),
@@ -199,8 +199,8 @@ impl Type {
             Type::StructInstantiation {
                 index: def_idx,
                 ty_args: instantiation,
-                base_ability,
-                is_phantom_params,
+                base_ability_set: base_ability,
+                phantom_ty_args_mask: is_phantom_params,
             } => {
                 let mut inst = vec![];
                 for ty in instantiation {
@@ -209,8 +209,8 @@ impl Type {
                 Type::StructInstantiation {
                     index: *def_idx,
                     ty_args: inst,
-                    base_ability: *base_ability,
-                    is_phantom_params: is_phantom_params.clone(),
+                    base_ability_set: *base_ability,
+                    phantom_ty_args_mask: is_phantom_params.clone(),
                 }
             },
         };

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -1966,15 +1966,9 @@ fn check_elem_layout(ty: &Type, v: &Container) -> PartialVMResult<()> {
 
         (Type::Vector(_), Container::Vec(_)) => Ok(()),
 
-        (Type::Struct { index: _ }, Container::Vec(_))
+        (Type::Struct { .. }, Container::Vec(_))
         | (Type::Signer, Container::Vec(_))
-        | (
-            Type::StructInstantiation {
-                index: _,
-                ty_args: _,
-            },
-            Container::Vec(_),
-        ) => Ok(()),
+        | (Type::StructInstantiation { .. }, Container::Vec(_)) => Ok(()),
 
         (Type::Reference(_), _) | (Type::MutableReference(_), _) | (Type::TyParam(_), _) => Err(
             PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
@@ -1991,21 +1985,14 @@ fn check_elem_layout(ty: &Type, v: &Container) -> PartialVMResult<()> {
         | (Type::Address, _)
         | (Type::Signer, _)
         | (Type::Vector(_), _)
-        | (Type::Struct { index: _ }, _)
-        | (
-            Type::StructInstantiation {
-                index: _,
-                ty_args: _,
-            },
-            _,
-        ) => Err(
-            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
-                format!(
-                    "vector elem layout mismatch, expected {:?}, got {:?}",
-                    ty, v
-                ),
-            ),
-        ),
+        | (Type::Struct { .. }, _)
+        | (Type::StructInstantiation { .. }, _) => Err(PartialVMError::new(
+            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
+        )
+        .with_message(format!(
+            "vector elem layout mismatch, expected {:?}, got {:?}",
+            ty, v
+        ))),
     }
 }
 
@@ -2211,10 +2198,11 @@ impl Vector {
 
             Type::Signer
             | Type::Vector(_)
-            | Type::Struct { index: _ }
+            | Type::Struct { .. }
             | Type::StructInstantiation {
                 index: _,
                 ty_args: _,
+                ..
             } => Value(ValueImpl::Container(Container::Vec(Rc::new(RefCell::new(
                 elements.into_iter().map(|v| v.0).collect(),
             ))))),


### PR DESCRIPTION
### Description

Cache the ability in runtime types. There are two major purpose for this change:
1. For better performance: paranoid mode will now get the ability of type directly from the type itself, rather than performing multiple queries into the loader, which should save us some query/lock time.
  - The query situation could become a lot worse if we switch to the dynamic loading schema as we will no longer have access to cheap structure indexing.
2. The second reason is a lot more nuanced. This is a crucial step for the future loader refactor:
  - In the current implementation, getting the ability of a type requires loading the entire structure. For a struct it means that we need to load the definition module.
  - However, the ability information of struct is actually available at caller side: the `StructHandle` should have all the ability information we need.
  - This PR will change the logic for getting ability information from the module definition site to module reference side. With this change, we no longer need to load the transitive dependencies of types. Which is crucial as we switch towards a dynamic loading schema.

One thing to note here is that we are now need to be very careful about the cross module linking checks. VM will need to make sure that the struct handle has the exact same ability information as the definition site. Right now this is enforced by the dependencies verifier:
- Script: https://github.com/aptos-labs/aptos-core/blob/0cdd064c2df6b254e4da9d7d8b7b4e20b6af45fe/third_party/move/move-vm/runtime/src/loader.rs#L795
- Module: https://github.com/aptos-labs/aptos-core/blob/0cdd064c2df6b254e4da9d7d8b7b4e20b6af45fe/third_party/move/move-vm/runtime/src/loader.rs#L1387

This change of logic will essentially make those checks to be the single point of failure which may violate the merit of the paranoid type checker. However, I don't quite see an easy way to avoid this issue. If the source of truth of a struct's ability information has to come from the struct declaration site, getting ability of struct will then require loading up the transitive dependency closure of a struct definition, which is against the whole idea of dynamic loading.

### Test Plan

Paranoid test should suceed. 