### PR TITLE
[Sharding] Change the partitioner to return analyzed txn instead of txn

### DIFF
--- a/aptos-move/aptos-transaction-benchmarks/src/transactions.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/transactions.rs
@@ -14,7 +14,6 @@ use aptos_language_e2e_tests::{
     gas_costs::TXN_RESERVED,
 };
 use aptos_types::{
-    block_executor::partitioner::BlockExecutorTransactions,
     block_metadata::BlockMetadata,
     on_chain_config::{OnChainConfig, ValidatorSet},
     transaction::{analyzed_transaction::AnalyzedTransaction, Transaction},
@@ -349,7 +348,7 @@ where
             NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
         >(
             Arc::clone(&RAYON_EXEC_POOL),
-            BlockExecutorTransactions::Unsharded(transactions),
+            transactions,
             self.state_view.as_ref(),
             1,
             maybe_block_gas_limit,
@@ -394,7 +393,7 @@ where
                 NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
             >(
                 Arc::clone(&RAYON_EXEC_POOL),
-                BlockExecutorTransactions::Unsharded(transactions),
+                transactions,
                 self.state_view.as_ref(),
                 concurrency_level_per_shard,
                 maybe_block_gas_limit,

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -32,15 +32,15 @@ use aptos_state_view::StateView;
 use aptos_types::{
     account_config,
     account_config::new_block_event_key,
-    block_executor::partitioner::{BlockExecutorTransactions, SubBlocksForShard},
+    block_executor::partitioner::SubBlocksForShard,
     block_metadata::BlockMetadata,
     fee_statement::FeeStatement,
     on_chain_config::{new_epoch_event_key, FeatureFlag, TimedFeatureOverride},
     transaction::{
-        EntryFunction, ExecutionError, ExecutionStatus, ModuleBundle, Multisig,
-        MultisigTransactionPayload, SignatureCheckedTransaction, SignedTransaction, Transaction,
-        TransactionOutput, TransactionPayload, TransactionStatus, VMValidatorResult,
-        WriteSetPayload,
+        analyzed_transaction::AnalyzedTransaction, EntryFunction, ExecutionError, ExecutionStatus,
+        ModuleBundle, Multisig, MultisigTransactionPayload, SignatureCheckedTransaction,
+        SignedTransaction, Transaction, TransactionOutput, TransactionPayload, TransactionStatus,
+        VMValidatorResult, WriteSetPayload,
     },
     vm_status::{AbortLocation, StatusCode, VMStatus},
     write_set::WriteSet,
@@ -1514,7 +1514,7 @@ impl VMExecutor for AptosVM {
             NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
         >(
             Arc::clone(&RAYON_EXEC_POOL),
-            BlockExecutorTransactions::Unsharded(transactions),
+            transactions,
             state_view,
             Self::get_concurrency_level(),
             maybe_block_gas_limit,
@@ -1529,7 +1529,7 @@ impl VMExecutor for AptosVM {
 
     fn execute_block_sharded<S: StateView + Sync + Send + 'static>(
         sharded_block_executor: &ShardedBlockExecutor<S>,
-        transactions: Vec<SubBlocksForShard<Transaction>>,
+        transactions: Vec<SubBlocksForShard<AnalyzedTransaction>>,
         state_view: Arc<S>,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -26,9 +26,6 @@ use aptos_block_executor::{
 use aptos_infallible::Mutex;
 use aptos_state_view::{StateView, StateViewId};
 use aptos_types::{
-    block_executor::partitioner::{
-        BlockExecutorTransactions, SubBlock, SubBlocksForShard, TransactionWithDependencies,
-    },
     executable::ExecutableTestType,
     fee_statement::FeeStatement,
     state_store::state_key::StateKey,
@@ -152,51 +149,12 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
 pub struct BlockAptosVM();
 
 impl BlockAptosVM {
-    fn verify_transactions(
-        transactions: BlockExecutorTransactions<Transaction>,
-    ) -> BlockExecutorTransactions<PreprocessedTransaction> {
-        match transactions {
-            BlockExecutorTransactions::Unsharded(transactions) => {
-                let signature_verified_txns = transactions
-                    .into_par_iter()
-                    .with_min_len(25)
-                    .map(preprocess_transaction::<AptosVM>)
-                    .collect();
-                BlockExecutorTransactions::Unsharded(signature_verified_txns)
-            },
-            BlockExecutorTransactions::Sharded(sub_blocks) => {
-                let shard_id = sub_blocks.shard_id;
-                let signature_verified_sub_blocks = sub_blocks
-                    .into_sub_blocks()
-                    .into_par_iter()
-                    .map(|sub_block| {
-                        let start_index = sub_block.start_index;
-                        let verified_txns = sub_block
-                            .into_transactions_with_deps()
-                            .into_par_iter()
-                            .with_min_len(25)
-                            .map(|txn_with_deps| {
-                                let TransactionWithDependencies {
-                                    txn,
-                                    cross_shard_dependencies,
-                                } = txn_with_deps;
-                                let preprocessed_txn = preprocess_transaction::<AptosVM>(txn);
-                                TransactionWithDependencies::new(
-                                    preprocessed_txn,
-                                    cross_shard_dependencies,
-                                )
-                            })
-                            .collect();
-                        SubBlock::new(start_index, verified_txns)
-                    })
-                    .collect();
-
-                BlockExecutorTransactions::Sharded(SubBlocksForShard::new(
-                    shard_id,
-                    signature_verified_sub_blocks,
-                ))
-            },
-        }
+    fn verify_transactions(transactions: Vec<Transaction>) -> Vec<PreprocessedTransaction> {
+        transactions
+            .into_par_iter()
+            .with_min_len(25)
+            .map(preprocess_transaction::<AptosVM>)
+            .collect()
     }
 
     pub fn execute_block<
@@ -204,7 +162,7 @@ impl BlockAptosVM {
         L: TransactionCommitHook<Output = AptosTransactionOutput>,
     >(
         executor_thread_pool: Arc<ThreadPool>,
-        transactions: BlockExecutorTransactions<Transaction>,
+        transactions: Vec<Transaction>,
         state_view: &S,
         concurrency_level: usize,
         maybe_block_gas_limit: Option<u64>,
@@ -221,19 +179,11 @@ impl BlockAptosVM {
             executor_thread_pool.install(|| Self::verify_transactions(transactions));
         drop(signature_verification_timer);
 
-        let is_sharded_execution = matches!(
-            signature_verified_block,
-            BlockExecutorTransactions::Sharded(_)
-        );
-        let num_txns = signature_verified_block.num_txns();
-        if !is_sharded_execution && state_view.id() != StateViewId::Miscellaneous {
+        let num_txns = signature_verified_block.len();
+        if state_view.id() != StateViewId::Miscellaneous {
             // Speculation is disabled in Miscellaneous context, which is used by testing and
             // can even lead to concurrent execute_block invocations, leading to errors on flush.
             init_speculative_logs(num_txns);
-        }
-
-        if is_sharded_execution {
-            aptos_vm_logging::disable_speculative_logging();
         }
 
         BLOCK_EXECUTOR_CONCURRENCY.set(concurrency_level as i64);
@@ -261,7 +211,7 @@ impl BlockAptosVM {
                 // Flush the speculative logs of the committed transactions.
                 let pos = output_vec.partition_point(|o| !o.status().is_retry());
 
-                if !is_sharded_execution && state_view.id() != StateViewId::Miscellaneous {
+                if state_view.id() != StateViewId::Miscellaneous {
                     // Speculation is disabled in Miscellaneous context, which is used by testing and
                     // can even lead to concurrent execute_block invocations, leading to errors on flush.
                     flush_speculative_logs(pos);

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -127,7 +127,10 @@ use crate::sharded_block_executor::ShardedBlockExecutor;
 use aptos_state_view::StateView;
 use aptos_types::{
     block_executor::partitioner::SubBlocksForShard,
-    transaction::{SignedTransaction, Transaction, TransactionOutput, VMValidatorResult},
+    transaction::{
+        analyzed_transaction::AnalyzedTransaction, SignedTransaction, Transaction,
+        TransactionOutput, VMValidatorResult,
+    },
     vm_status::VMStatus,
 };
 use std::{marker::Sync, sync::Arc};
@@ -160,7 +163,7 @@ pub trait VMExecutor: Send + Sync {
     /// Executes a block of transactions using a sharded block executor and returns the results.
     fn execute_block_sharded<S: StateView + Sync + Send + 'static>(
         sharded_block_executor: &ShardedBlockExecutor<S>,
-        block: Vec<SubBlocksForShard<Transaction>>,
+        block: Vec<SubBlocksForShard<AnalyzedTransaction>>,
         state_view: Arc<S>,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<Vec<TransactionOutput>, VMStatus>;

--- a/aptos-move/aptos-vm/src/sharded_block_executor/cross_shard_client.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/cross_shard_client.rs
@@ -14,7 +14,7 @@ use aptos_state_view::StateView;
 use aptos_types::{
     block_executor::partitioner::{RoundId, ShardId, SubBlock},
     state_store::state_key::StateKey,
-    transaction::Transaction,
+    transaction::analyzed_transaction::AnalyzedTransaction,
     write_set::TransactionWrite,
 };
 use std::{
@@ -66,7 +66,7 @@ impl CrossShardCommitSender {
     pub fn new(
         shard_id: ShardId,
         message_txs: Arc<Vec<Vec<Mutex<Sender<CrossShardMsg>>>>>,
-        sub_block: &SubBlock<Transaction>,
+        sub_block: &SubBlock<AnalyzedTransaction>,
     ) -> Self {
         let mut dependent_edges = HashMap::new();
         let mut num_dependent_edges = 0;

--- a/aptos-move/aptos-vm/src/sharded_block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/mod.rs
@@ -7,7 +7,7 @@ use aptos_logger::{error, info, trace};
 use aptos_state_view::StateView;
 use aptos_types::{
     block_executor::partitioner::SubBlocksForShard,
-    transaction::{Transaction, TransactionOutput},
+    transaction::{analyzed_transaction::AnalyzedTransaction, TransactionOutput},
 };
 use block_executor_client::BlockExecutorClient;
 use move_core_types::vm_status::VMStatus;
@@ -40,7 +40,12 @@ pub struct ShardedBlockExecutor<S: StateView + Sync + Send + 'static> {
 }
 
 pub enum ExecutorShardCommand<S> {
-    ExecuteSubBlocks(Arc<S>, SubBlocksForShard<Transaction>, usize, Option<u64>),
+    ExecuteSubBlocks(
+        Arc<S>,
+        SubBlocksForShard<AnalyzedTransaction>,
+        usize,
+        Option<u64>,
+    ),
     Stop,
 }
 
@@ -81,7 +86,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedBlockExecutor<S> {
     pub fn execute_block(
         &self,
         state_view: Arc<S>,
-        block: Vec<SubBlocksForShard<Transaction>>,
+        block: Vec<SubBlocksForShard<AnalyzedTransaction>>,
         concurrency_level_per_shard: usize,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {

--- a/aptos-move/aptos-vm/src/sharded_block_executor/tests.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/tests.rs
@@ -171,7 +171,10 @@ fn sharded_block_executor_with_conflict(concurrency: usize) {
     let partitioner = ShardedBlockPartitioner::new(num_shards);
     let partitioned_txns = partitioner.partition(transactions.clone(), 8, 0.9);
 
-    let execution_ordered_txns = SubBlocksForShard::flatten(partitioned_txns.clone());
+    let execution_ordered_txns = SubBlocksForShard::flatten(partitioned_txns.clone())
+        .into_iter()
+        .map(|t| t.into_txn())
+        .collect::<Vec<_>>();
 
     let executor_clients =
         ShardedExecutorClient::create_sharded_executor_clients(num_shards, Some(concurrency));
@@ -231,7 +234,10 @@ fn sharded_block_executor_with_random_transfers(concurrency: usize) {
     let partitioner = ShardedBlockPartitioner::new(num_shards);
     let partitioned_txns = partitioner.partition(transactions.clone(), 8, 0.9);
 
-    let execution_ordered_txns = SubBlocksForShard::flatten(partitioned_txns.clone());
+    let execution_ordered_txns = SubBlocksForShard::flatten(partitioned_txns.clone())
+        .into_iter()
+        .map(|t| t.into_txn())
+        .collect::<Vec<_>>();
 
     let executor_clients =
         ShardedExecutorClient::create_sharded_executor_clients(num_shards, Some(concurrency));

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -23,10 +23,7 @@ use aptos_mvhashmap::{
     MVHashMap,
 };
 use aptos_state_view::TStateView;
-use aptos_types::{
-    block_executor::partitioner::BlockExecutorTransactions, executable::Executable,
-    fee_statement::FeeStatement, write_set::WriteOp,
-};
+use aptos_types::{executable::Executable, fee_statement::FeeStatement, write_set::WriteOp};
 use aptos_vm_logging::{clear_speculative_txn_logs, init_speculative_logs};
 use num_cpus;
 use rayon::ThreadPool;
@@ -805,20 +802,19 @@ where
     pub fn execute_block(
         &self,
         executor_arguments: E::Argument,
-        signature_verified_block: BlockExecutorTransactions<T>,
+        signature_verified_block: Vec<T>,
         base_view: &S,
     ) -> Result<Vec<E::Output>, E::Error> {
-        let signature_verified_txns = signature_verified_block.into_txns();
         let mut ret = if self.concurrency_level > 1 {
             self.execute_transactions_parallel(
                 executor_arguments,
-                &signature_verified_txns,
+                &signature_verified_block,
                 base_view,
             )
         } else {
             self.execute_transactions_sequential(
                 executor_arguments,
-                &signature_verified_txns,
+                &signature_verified_block,
                 base_view,
             )
         };
@@ -828,17 +824,17 @@ where
 
             // All logs from the parallel execution should be cleared and not reported.
             // Clear by re-initializing the speculative logs.
-            init_speculative_logs(signature_verified_txns.len());
+            init_speculative_logs(signature_verified_block.len());
 
             ret = self.execute_transactions_sequential(
                 executor_arguments,
-                &signature_verified_txns,
+                &signature_verified_block,
                 base_view,
             )
         }
         self.executor_thread_pool.spawn(move || {
             // Explicit async drops.
-            drop(signature_verified_txns);
+            drop(signature_verified_block);
         });
         ret
     }

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -31,7 +31,6 @@ use aptos_types::{
         new_block_event_key, AccountResource, CoinInfoResource, CoinStoreResource, NewBlockEvent,
         CORE_CODE_ADDRESS,
     },
-    block_executor::partitioner::BlockExecutorTransactions,
     block_metadata::BlockMetadata,
     chain_id::ChainId,
     on_chain_config::{
@@ -426,7 +425,7 @@ impl FakeExecutor {
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         BlockAptosVM::execute_block::<_, NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>>(
             self.executor_thread_pool.clone(),
-            BlockExecutorTransactions::Unsharded(txn_block),
+            txn_block,
             &self.data_store,
             usize::min(4, num_cpus::get()),
             None,

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -355,7 +355,7 @@ async fn test_commit_sync_race() {
 
         fn execute_block(
             &self,
-            _block: ExecutableBlock<Transaction>,
+            _block: ExecutableBlock,
             _parent_block_id: HashValue,
             _maybe_block_gas_limit: Option<u64>,
         ) -> Result<StateComputeResult, ExecutionError> {

--- a/execution/block-partitioner/src/sharded_block_partitioner/conflict_detector.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/conflict_detector.rs
@@ -6,10 +6,7 @@ use aptos_types::{
         CrossShardDependencies, RoundId, ShardId, ShardedTxnIndex, SubBlock,
         TransactionWithDependencies, TxnIndex,
     },
-    transaction::{
-        analyzed_transaction::{AnalyzedTransaction, StorageLocation},
-        Transaction,
-    },
+    transaction::analyzed_transaction::{AnalyzedTransaction, StorageLocation},
 };
 use std::{
     collections::{hash_map::DefaultHasher, HashSet},
@@ -141,7 +138,7 @@ impl CrossShardConflictDetector {
         current_round_rw_set_with_index: Arc<Vec<WriteSetWithTxnIndex>>,
         prev_round_rw_set_with_index: Arc<Vec<WriteSetWithTxnIndex>>,
         index_offset: TxnIndex,
-    ) -> (SubBlock<Transaction>, Vec<CrossShardDependencies>) {
+    ) -> (SubBlock<AnalyzedTransaction>, Vec<CrossShardDependencies>) {
         let mut frozen_txns = Vec::new();
         let mut cross_shard_dependencies = Vec::new();
         for txn in txns.into_iter() {
@@ -151,7 +148,7 @@ impl CrossShardConflictDetector {
                 prev_round_rw_set_with_index.clone(),
             );
             cross_shard_dependencies.push(dependency.clone());
-            frozen_txns.push(TransactionWithDependencies::new(txn.into_txn(), dependency));
+            frozen_txns.push(TransactionWithDependencies::new(txn, dependency));
         }
         (
             SubBlock::new(index_offset, frozen_txns),

--- a/execution/block-partitioner/src/sharded_block_partitioner/dependent_edges.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/dependent_edges.rs
@@ -9,7 +9,7 @@ use aptos_types::{
         CrossShardDependencies, CrossShardEdges, ShardId, ShardedTxnIndex, SubBlocksForShard,
         TxnIndex,
     },
-    transaction::Transaction,
+    transaction::analyzed_transaction::AnalyzedTransaction,
 };
 use itertools::Itertools;
 use std::{collections::HashMap, sync::Arc};
@@ -17,7 +17,7 @@ use std::{collections::HashMap, sync::Arc};
 pub struct DependentEdgeCreator {
     shard_id: ShardId,
     cross_shard_client: Arc<dyn CrossShardClientInterface>,
-    froze_sub_blocks: SubBlocksForShard<Transaction>,
+    froze_sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
     num_shards: usize,
     round_id: usize,
 }
@@ -34,7 +34,7 @@ impl DependentEdgeCreator {
     pub fn new(
         shard_id: ShardId,
         cross_shard_client: Arc<dyn CrossShardClientInterface>,
-        froze_sub_blocks: SubBlocksForShard<Transaction>,
+        froze_sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
         num_shards: usize,
         round_id: usize,
     ) -> Self {
@@ -159,7 +159,7 @@ impl DependentEdgeCreator {
         }
     }
 
-    pub fn into_frozen_sub_blocks(self) -> SubBlocksForShard<Transaction> {
+    pub fn into_frozen_sub_blocks(self) -> SubBlocksForShard<AnalyzedTransaction> {
         self.froze_sub_blocks
     }
 }
@@ -254,7 +254,7 @@ mod tests {
                 .iter()
                 .map(|txn_with_deps| {
                     TransactionWithDependencies::new(
-                        txn_with_deps.txn.transaction().clone(),
+                        txn_with_deps.txn.clone(),
                         txn_with_deps.cross_shard_dependencies.clone(),
                     )
                 })

--- a/execution/block-partitioner/src/sharded_block_partitioner/messages.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/messages.rs
@@ -3,7 +3,7 @@
 use crate::sharded_block_partitioner::dependency_analysis::WriteSetWithTxnIndex;
 use aptos_types::{
     block_executor::partitioner::{RoundId, SubBlocksForShard, TxnIndex},
-    transaction::{analyzed_transaction::AnalyzedTransaction, Transaction},
+    transaction::analyzed_transaction::AnalyzedTransaction,
 };
 use std::sync::Arc;
 
@@ -14,7 +14,7 @@ pub struct DiscardCrossShardDep {
     pub current_round_start_index: TxnIndex,
     // This is the frozen sub block for the current shard and is passed because we want to modify
     // it to add dependency back edges.
-    pub frozen_sub_blocks: SubBlocksForShard<Transaction>,
+    pub frozen_sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
     pub round_id: RoundId,
 }
 
@@ -23,7 +23,7 @@ impl DiscardCrossShardDep {
         transactions: Vec<AnalyzedTransaction>,
         prev_rounds_write_set_with_index: Arc<Vec<WriteSetWithTxnIndex>>,
         current_round_start_index: TxnIndex,
-        frozen_sub_blocks: SubBlocksForShard<Transaction>,
+        frozen_sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
         round_id: RoundId,
     ) -> Self {
         Self {
@@ -41,7 +41,7 @@ pub struct AddWithCrossShardDep {
     pub index_offset: TxnIndex,
     // The frozen dependencies in previous chunks.
     pub prev_rounds_write_set_with_index: Arc<Vec<WriteSetWithTxnIndex>>,
-    pub frozen_sub_blocks: SubBlocksForShard<Transaction>,
+    pub frozen_sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
     pub round_id: RoundId,
 }
 
@@ -50,7 +50,7 @@ impl AddWithCrossShardDep {
         transactions: Vec<AnalyzedTransaction>,
         index_offset: TxnIndex,
         prev_rounds_write_set_with_index: Arc<Vec<WriteSetWithTxnIndex>>,
-        frozen_sub_blocks: SubBlocksForShard<Transaction>,
+        frozen_sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
         round_id: RoundId,
     ) -> Self {
         Self {
@@ -64,14 +64,14 @@ impl AddWithCrossShardDep {
 }
 
 pub struct PartitioningResp {
-    pub frozen_sub_blocks: SubBlocksForShard<Transaction>,
+    pub frozen_sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
     pub write_set_with_index: WriteSetWithTxnIndex,
     pub discarded_txns: Vec<AnalyzedTransaction>,
 }
 
 impl PartitioningResp {
     pub fn new(
-        frozen_sub_blocks: SubBlocksForShard<Transaction>,
+        frozen_sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
         write_set_with_index: WriteSetWithTxnIndex,
         discarded_txns: Vec<AnalyzedTransaction>,
     ) -> Self {

--- a/execution/block-partitioner/src/sharded_block_partitioner/partitioning_shard.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/partitioning_shard.rs
@@ -12,7 +12,7 @@ use aptos_logger::trace;
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 use aptos_types::block_executor::partitioner::{ShardId, SubBlock, TransactionWithDependencies};
-use aptos_types::transaction::Transaction;
+use aptos_types::transaction::analyzed_transaction::AnalyzedTransaction;
 use std::sync::{
     mpsc::{Receiver, Sender},
     Arc,
@@ -97,10 +97,8 @@ impl PartitioningShard {
         let accepted_txns_with_dependencies = accepted_txns
             .into_iter()
             .zip(accepted_cross_shard_dependencies.into_iter())
-            .map(|(txn, dependencies)| {
-                TransactionWithDependencies::new(txn.into_txn(), dependencies)
-            })
-            .collect::<Vec<TransactionWithDependencies<Transaction>>>();
+            .map(|(txn, dependencies)| TransactionWithDependencies::new(txn, dependencies))
+            .collect::<Vec<TransactionWithDependencies<AnalyzedTransaction>>>();
 
         let mut frozen_sub_blocks = dependent_edge_creator.into_frozen_sub_blocks();
         NUM_PARTITIONED_TXNS

--- a/execution/executor-benchmark/src/block_partitioning.rs
+++ b/execution/executor-benchmark/src/block_partitioning.rs
@@ -41,7 +41,7 @@ impl BlockPartitioningStage {
             txns.len()
         );
         let block_id = HashValue::random();
-        let block: ExecutableBlock<Transaction> = match &self.maybe_partitioner {
+        let block: ExecutableBlock = match &self.maybe_partitioner {
             None => (block_id, txns).into(),
             Some(partitioner) => {
                 let last_txn = txns.pop().unwrap();
@@ -56,7 +56,7 @@ impl BlockPartitioningStage {
                     .unwrap()
                     .transactions
                     .push(TransactionWithDependencies::new(
-                        last_txn,
+                        last_txn.into(),
                         CrossShardDependencies::default(),
                     ));
                 ExecutableBlock::new(block_id, ExecutableTransactions::Sharded(sub_blocks))

--- a/execution/executor-benchmark/src/native_executor.rs
+++ b/execution/executor-benchmark/src/native_executor.rs
@@ -337,7 +337,7 @@ impl NativeExecutor {
 
 impl TransactionBlockExecutor for NativeExecutor {
     fn execute_transaction_block(
-        transactions: ExecutableTransactions<Transaction>,
+        transactions: ExecutableTransactions,
         state_view: CachedStateView,
         _maybe_block_gas_limit: Option<u64>,
     ) -> Result<ChunkOutput> {

--- a/execution/executor-benchmark/src/pipeline.rs
+++ b/execution/executor-benchmark/src/pipeline.rs
@@ -249,7 +249,7 @@ where
 pub struct ExecuteBlockMessage {
     pub current_block_start_time: Instant,
     pub partition_time: Duration,
-    pub block: ExecutableBlock<Transaction>,
+    pub block: ExecutableBlock,
 }
 
 /// Message from execution stage to commit stage.

--- a/execution/executor-benchmark/src/transaction_executor.rs
+++ b/execution/executor-benchmark/src/transaction_executor.rs
@@ -7,10 +7,7 @@ use aptos_crypto::hash::HashValue;
 use aptos_executor::block_executor::{BlockExecutor, TransactionBlockExecutor};
 use aptos_executor_types::BlockExecutorTrait;
 use aptos_logger::info;
-use aptos_types::{
-    block_executor::partitioner::ExecutableBlock,
-    transaction::{Transaction, Version},
-};
+use aptos_types::{block_executor::partitioner::ExecutableBlock, transaction::Version};
 use std::{
     sync::{mpsc, Arc},
     time::{Duration, Instant},
@@ -56,7 +53,7 @@ where
         &mut self,
         current_block_start_time: Instant,
         partition_time: Duration,
-        executable_block: ExecutableBlock<Transaction>,
+        executable_block: ExecutableBlock,
     ) {
         let execution_start_time = Instant::now();
         if self.maybe_first_block_start_time.is_none() {

--- a/execution/executor-service/src/lib.rs
+++ b/execution/executor-service/src/lib.rs
@@ -3,7 +3,7 @@
 use aptos_state_view::in_memory_state_view::InMemoryStateView;
 use aptos_types::{
     block_executor::partitioner::SubBlocksForShard,
-    transaction::{Transaction, TransactionOutput},
+    transaction::{analyzed_transaction::AnalyzedTransaction, TransactionOutput},
     vm_status::VMStatus,
 };
 use serde::{Deserialize, Serialize};
@@ -27,7 +27,7 @@ pub enum BlockExecutionRequest {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExecuteBlockCommand {
-    pub(crate) sub_blocks: SubBlocksForShard<Transaction>,
+    pub(crate) sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
     // Currently we only support the state view backed by in-memory hashmap, which means that
     // the controller needs to pre-read all the KV pairs from the storage and pass them to the
     // executor service. In the future, we will support other types of state view, e.g., the

--- a/execution/executor-service/src/remote_executor_client.rs
+++ b/execution/executor-service/src/remote_executor_client.rs
@@ -8,7 +8,7 @@ use aptos_secure_net::NetworkClient;
 use aptos_state_view::StateView;
 use aptos_types::{
     block_executor::partitioner::SubBlocksForShard,
-    transaction::{Transaction, TransactionOutput},
+    transaction::{analyzed_transaction::AnalyzedTransaction, TransactionOutput},
     vm_status::VMStatus,
 };
 use aptos_vm::sharded_block_executor::block_executor_client::BlockExecutorClient;
@@ -60,7 +60,7 @@ impl RemoteExecutorClient {
 impl BlockExecutorClient for RemoteExecutorClient {
     fn execute_block<S: StateView + Sync>(
         &self,
-        sub_blocks: SubBlocksForShard<Transaction>,
+        sub_blocks: SubBlocksForShard<AnalyzedTransaction>,
         state_view: &S,
         concurrency_level: usize,
         maybe_block_gas_limit: Option<u64>,

--- a/execution/executor-service/src/remote_executor_service.rs
+++ b/execution/executor-service/src/remote_executor_service.rs
@@ -93,14 +93,19 @@ mod tests {
         block_executor::partitioner::{
             CrossShardDependencies, SubBlock, SubBlocksForShard, TransactionWithDependencies,
         },
-        transaction::{ExecutionStatus, Transaction, TransactionOutput, TransactionStatus},
+        transaction::{
+            analyzed_transaction::AnalyzedTransaction, ExecutionStatus, Transaction,
+            TransactionOutput, TransactionStatus,
+        },
     };
     use aptos_vm::sharded_block_executor::{
         block_executor_client::BlockExecutorClient, ShardedBlockExecutor,
     };
     use std::sync::Arc;
 
-    fn generate_transactions(executor: &mut FakeExecutor) -> (Vec<Transaction>, AccountData) {
+    fn generate_transactions(
+        executor: &mut FakeExecutor,
+    ) -> (Vec<AnalyzedTransaction>, AccountData) {
         let sender = executor.create_raw_account_data(3_000_000_000, 10);
         let receiver = executor.create_raw_account_data(3_000_000_000, 10);
         executor.add_account_data(&sender);
@@ -109,35 +114,39 @@ mod tests {
         let transfer_amount = 1_000;
 
         // execute transaction
-        let txns: Vec<Transaction> = vec![
+        let txns: Vec<AnalyzedTransaction> = vec![
             Transaction::UserTransaction(peer_to_peer_txn(
                 sender.account(),
                 receiver.account(),
                 10,
                 transfer_amount,
                 100,
-            )),
+            ))
+            .into(),
             Transaction::UserTransaction(peer_to_peer_txn(
                 sender.account(),
                 receiver.account(),
                 11,
                 transfer_amount,
                 100,
-            )),
+            ))
+            .into(),
             Transaction::UserTransaction(peer_to_peer_txn(
                 sender.account(),
                 receiver.account(),
                 12,
                 transfer_amount,
                 100,
-            )),
+            ))
+            .into(),
             Transaction::UserTransaction(peer_to_peer_txn(
                 sender.account(),
                 receiver.account(),
                 13,
                 transfer_amount,
                 100,
-            )),
+            ))
+            .into(),
         ];
         (txns, receiver)
     }

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -90,7 +90,7 @@ pub trait BlockExecutorTrait: Send + Sync {
     /// Executes a block.
     fn execute_block(
         &self,
-        block: ExecutableBlock<Transaction>,
+        block: ExecutableBlock,
         parent_block_id: HashValue,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<StateComputeResult, Error>;

--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -27,7 +27,6 @@ use aptos_types::{
     block_executor::partitioner::{ExecutableBlock, ExecutableTransactions},
     ledger_info::LedgerInfoWithSignatures,
     state_store::state_value::StateValue,
-    transaction::Transaction,
 };
 use aptos_vm::AptosVM;
 use fail::fail_point;
@@ -35,7 +34,7 @@ use std::{marker::PhantomData, sync::Arc};
 
 pub trait TransactionBlockExecutor: Send + Sync {
     fn execute_transaction_block(
-        transactions: ExecutableTransactions<Transaction>,
+        transactions: ExecutableTransactions,
         state_view: CachedStateView,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<ChunkOutput>;
@@ -43,7 +42,7 @@ pub trait TransactionBlockExecutor: Send + Sync {
 
 impl TransactionBlockExecutor for AptosVM {
     fn execute_transaction_block(
-        transactions: ExecutableTransactions<Transaction>,
+        transactions: ExecutableTransactions,
         state_view: CachedStateView,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<ChunkOutput> {
@@ -107,7 +106,7 @@ where
 
     fn execute_block(
         &self,
-        block: ExecutableBlock<Transaction>,
+        block: ExecutableBlock,
         parent_block_id: HashValue,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<StateComputeResult, Error> {
@@ -177,7 +176,7 @@ where
 
     fn execute_block(
         &self,
-        block: ExecutableBlock<Transaction>,
+        block: ExecutableBlock,
         parent_block_id: HashValue,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<StateComputeResult, Error> {

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -17,7 +17,10 @@ use aptos_types::{
     block_executor::partitioner::{ExecutableTransactions, SubBlocksForShard},
     ledger_info::LedgerInfoWithSignatures,
     test_helpers::transaction_test_helpers::BLOCK_GAS_LIMIT,
-    transaction::{Transaction, TransactionOutput, TransactionToCommit, Version},
+    transaction::{
+        analyzed_transaction::AnalyzedTransaction, Transaction, TransactionOutput,
+        TransactionToCommit, Version,
+    },
     vm_status::VMStatus,
 };
 use aptos_vm::{sharded_block_executor::ShardedBlockExecutor, VMExecutor};
@@ -53,7 +56,7 @@ pub struct FakeVM;
 
 impl TransactionBlockExecutor for FakeVM {
     fn execute_transaction_block(
-        transactions: ExecutableTransactions<Transaction>,
+        transactions: ExecutableTransactions,
         state_view: CachedStateView,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<ChunkOutput> {
@@ -68,7 +71,7 @@ impl TransactionBlockExecutor for FakeVM {
 impl VMExecutor for FakeVM {
     fn execute_block_sharded<S: StateView + Send + Sync>(
         _sharded_block_executor: &ShardedBlockExecutor<S>,
-        _block: Vec<SubBlocksForShard<Transaction>>,
+        _block: Vec<SubBlocksForShard<AnalyzedTransaction>>,
         _state_view: Arc<S>,
         _maybe_block_gas_limit: Option<u64>,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -24,9 +24,9 @@ use aptos_types::{
     },
     state_store::state_key::StateKey,
     transaction::{
-        ChangeSet, ExecutionStatus, RawTransaction, Script, SignedTransaction, Transaction,
-        TransactionArgument, TransactionOutput, TransactionPayload, TransactionStatus,
-        WriteSetPayload,
+        analyzed_transaction::AnalyzedTransaction, ChangeSet, ExecutionStatus, RawTransaction,
+        Script, SignedTransaction, Transaction, TransactionArgument, TransactionOutput,
+        TransactionPayload, TransactionStatus, WriteSetPayload,
     },
     vm_status::{StatusCode, VMStatus},
     write_set::{WriteOp, WriteSet, WriteSetMut},
@@ -60,7 +60,7 @@ pub struct MockVM;
 
 impl TransactionBlockExecutor for MockVM {
     fn execute_transaction_block(
-        transactions: ExecutableTransactions<Transaction>,
+        transactions: ExecutableTransactions,
         state_view: CachedStateView,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<ChunkOutput> {
@@ -209,7 +209,7 @@ impl VMExecutor for MockVM {
 
     fn execute_block_sharded<S: StateView + Sync + Send + 'static>(
         _sharded_block_executor: &ShardedBlockExecutor<S>,
-        _block: Vec<SubBlocksForShard<Transaction>>,
+        _block: Vec<SubBlocksForShard<AnalyzedTransaction>>,
         _state_view: Arc<S>,
         _maybe_block_gas_limit: Option<u64>,
     ) -> std::result::Result<Vec<TransactionOutput>, VMStatus> {

--- a/types/src/block_executor/partitioner.rs
+++ b/types/src/block_executor/partitioner.rs
@@ -1,6 +1,9 @@
 // Copyright © Aptos Foundation
 
-use crate::transaction::{analyzed_transaction::StorageLocation, Transaction};
+use crate::transaction::{
+    analyzed_transaction::{AnalyzedTransaction, StorageLocation},
+    Transaction,
+};
 use aptos_crypto::HashValue;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -372,13 +375,13 @@ impl<T: Clone> TransactionWithDependencies<T> {
     }
 }
 
-pub struct ExecutableBlock<T> {
+pub struct ExecutableBlock {
     pub block_id: HashValue,
-    pub transactions: ExecutableTransactions<T>,
+    pub transactions: ExecutableTransactions,
 }
 
-impl<T: Clone> ExecutableBlock<T> {
-    pub fn new(block_id: HashValue, transactions: ExecutableTransactions<T>) -> Self {
+impl ExecutableBlock {
+    pub fn new(block_id: HashValue, transactions: ExecutableTransactions) -> Self {
         Self {
             block_id,
             transactions,
@@ -386,19 +389,19 @@ impl<T: Clone> ExecutableBlock<T> {
     }
 }
 
-impl<T: Clone> From<(HashValue, Vec<T>)> for ExecutableBlock<T> {
-    fn from((block_id, transactions): (HashValue, Vec<T>)) -> Self {
+impl From<(HashValue, Vec<Transaction>)> for ExecutableBlock {
+    fn from((block_id, transactions): (HashValue, Vec<Transaction>)) -> Self {
         Self::new(block_id, ExecutableTransactions::Unsharded(transactions))
     }
 }
 
 // Represents the transactions in a block that are ready to be executed.
-pub enum ExecutableTransactions<T> {
-    Unsharded(Vec<T>),
-    Sharded(Vec<SubBlocksForShard<T>>),
+pub enum ExecutableTransactions {
+    Unsharded(Vec<Transaction>),
+    Sharded(Vec<SubBlocksForShard<AnalyzedTransaction>>),
 }
 
-impl<T: Clone> ExecutableTransactions<T> {
+impl ExecutableTransactions {
     pub fn num_transactions(&self) -> usize {
         match self {
             ExecutableTransactions::Unsharded(transactions) => transactions.len(),
@@ -410,7 +413,7 @@ impl<T: Clone> ExecutableTransactions<T> {
     }
 }
 
-impl From<Vec<Transaction>> for ExecutableTransactions<Transaction> {
+impl From<Vec<Transaction>> for ExecutableTransactions {
     fn from(txns: Vec<Transaction>) -> Self {
         Self::Unsharded(txns)
     }

--- a/types/src/block_executor/partitioner.rs
+++ b/types/src/block_executor/partitioner.rs
@@ -418,34 +418,3 @@ impl From<Vec<Transaction>> for ExecutableTransactions {
         Self::Unsharded(txns)
     }
 }
-
-// Represents the transactions that are executed on a particular block executor shard. Unsharded
-// transactions represents the entire block. Sharded transactions represents the transactions
-// that are assigned to this shard.
-pub enum BlockExecutorTransactions<T> {
-    Unsharded(Vec<T>),
-    Sharded(SubBlocksForShard<T>),
-}
-
-impl<T: Clone> BlockExecutorTransactions<T> {
-    pub fn num_txns(&self) -> usize {
-        match self {
-            BlockExecutorTransactions::Unsharded(transactions) => transactions.len(),
-            BlockExecutorTransactions::Sharded(sub_blocks) => sub_blocks.num_txns(),
-        }
-    }
-
-    pub fn get_unsharded_transactions(&self) -> Option<&Vec<T>> {
-        match self {
-            BlockExecutorTransactions::Unsharded(transactions) => Some(transactions),
-            BlockExecutorTransactions::Sharded(_) => None,
-        }
-    }
-
-    pub fn into_txns(self) -> Vec<T> {
-        match self {
-            BlockExecutorTransactions::Unsharded(transactions) => transactions,
-            BlockExecutorTransactions::Sharded(sub_blocks) => sub_blocks.into_txns(),
-        }
-    }
-}

--- a/types/src/transaction/analyzed_transaction.rs
+++ b/types/src/transaction/analyzed_transaction.rs
@@ -17,7 +17,7 @@ use move_core_types::{
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AnalyzedTransaction {
     transaction: Transaction,
     /// Set of storage locations that are read by the transaction - this doesn't include location


### PR DESCRIPTION
### Description

- Change the partitioner to return analyzed txn instead of txn - this will be needed for remote execution support as we want the coordinators to read all the storage locations and pass it to the remote executors.

- Remove Sharded BlockExecutableTransaction support as the block executor is not aware of sharded vs unsharded execution today


### Test Plan

Existing UTs
