### PR TITLE
Improve clarity of comments on token.move

### DIFF
--- a/aptos-move/framework/aptos-token-objects/doc/token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/token.md
@@ -479,7 +479,7 @@ additional specialization.
 
 ## Function `create_token_address`
 
-Generates the collections address based upon the creators address and the collection's name
+Generates the token's address based upon the creator's address, the collection's name and the token's name.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_create_token_address">create_token_address</a>(creator: &<b>address</b>, <a href="collection.md#0x4_collection">collection</a>: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, name: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <b>address</b>
@@ -504,7 +504,7 @@ Generates the collections address based upon the creators address and the collec
 
 ## Function `create_token_seed`
 
-Named objects are derived from a seed, the collection's seed is its name.
+Named objects are derived from a seed, the token's seed is its name appended to the collection's name.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="token.md#0x4_token_create_token_seed">create_token_seed</a>(<a href="collection.md#0x4_collection">collection</a>: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, name: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;

--- a/aptos-move/framework/aptos-token-objects/sources/token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/token.move
@@ -157,12 +157,12 @@ module aptos_token_objects::token {
         constructor_ref
     }
 
-    /// Generates the collections address based upon the creators address and the collection's name
+    /// Generates the token's address based upon the creator's address, the collection's name and the token's name.
     public fun create_token_address(creator: &address, collection: &String, name: &String): address {
         object::create_object_address(creator, create_token_seed(collection, name))
     }
 
-    /// Named objects are derived from a seed, the collection's seed is its name.
+    /// Named objects are derived from a seed, the token's seed is its name appended to the collection's name.
     public fun create_token_seed(collection: &String, name: &String): vector<u8> {
         assert!(string::length(name) <= MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
         let seed = *string::bytes(collection);


### PR DESCRIPTION
### Description
The comments describing two functions in token.move seem to have been copied over from the equivalent in collection.move. This PR simply updates them for the context of a token instead of a collection.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
