### PR TITLE
[indexer] handle edge case of self transfer token v2

### DIFF
--- a/crates/indexer/src/models/token_models/v2_token_ownerships.rs
+++ b/crates/indexer/src/models/token_models/v2_token_ownerships.rs
@@ -164,6 +164,10 @@ impl TokenOwnershipV2 {
 
         // check if token was transferred
         if let Some((event_index, transfer_event)) = &metadata.transfer_event {
+            // If it's a self transfer then skip
+            if transfer_event.get_to_address() == transfer_event.get_from_address() {
+                return Ok(Some((ownership, current_ownership, None, None)));
+            }
             Ok(Some((
                 ownership,
                 current_ownership,


### PR DESCRIPTION
### Description
If there is a self transfer of token v2, we currently soft delete the token from the user's account. However, this should just be a noop

Need to backfill testnet from transaction version 514946350 and mainnet from transaction version 169213813

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
