### PR TITLE
[exp] fix arg passing for forge gha

### DIFF
--- a/testsuite/exp
+++ b/testsuite/exp
@@ -193,7 +193,6 @@ def workflow_dispatch_forge(
     git_sha: str,
     duration: int = 480,
     test_suite: str = FORGE_DEFAULT_TEST_SUITE,
-    cluster_name: str = FORGE_DEFAULT_CLUSTER_NAME,
     dry_run: bool = False,
     wait: bool = False,
 ) -> bool:
@@ -214,7 +213,7 @@ def workflow_dispatch_forge(
         "--field",
         f"FORGE_TEST_SUITE={test_suite}",
         "--field",
-        f"FORGE_CLUSTER_NAME={cluster_name}",
+        f"FORGE_CLUSTER_NAME={FORGE_DEFAULT_CLUSTER_NAME}",
     ]
     log.info(
         "%s: $ %s",
@@ -380,9 +379,10 @@ def run(
             shell,
             new_exp_git_branch,
             git_sha,
-            forge_runner_duration_secs,
-            forge_test_suite,
-            dry_run,
+            duration=forge_runner_duration_secs,
+            test_suite=forge_test_suite,
+            dry_run=dry_run,
+            wait=wait,
         )
         if not forge_workflow_dispatch_status:
             log.error("Forge test workflow failed")


### PR DESCRIPTION
### Description

Use named args for `workflow_dispatch_forge`, which was previously broken.

### Test Plan

New unit test for this, and run `exp`

<!-- Please provide us with clear details for verifying that your changes work. -->
