### PR TITLE
[telemetry] loki ingest client

### DIFF
--- a/crates/aptos-telemetry-service/src/clients/loki.rs
+++ b/crates/aptos-telemetry-service/src/clients/loki.rs
@@ -1,0 +1,47 @@
+// Copyright © Aptos Foundation
+
+use crate::types::loki::LokiLog;
+use flate2::{write::GzEncoder, Compression};
+use reqwest::{Client as ReqwestClient, Url};
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
+
+#[derive(Clone)]
+pub struct LokiClient {
+    inner: ClientWithMiddleware,
+    base_url: Url,
+    basic_user: String,
+    basic_password: String,
+}
+
+impl LokiClient {
+    pub fn new(base_url: Url, basic_user: String, basic_password: String) -> Self {
+        let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
+        let inner = ClientBuilder::new(ReqwestClient::new())
+            .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+            .build();
+        Self {
+            inner,
+            base_url,
+            basic_user,
+            basic_password,
+        }
+    }
+
+    pub async fn ingest_log(&self, log: LokiLog) -> Result<reqwest::Response, anyhow::Error> {
+        let mut gzip_encoder = GzEncoder::new(Vec::new(), Compression::default());
+        serde_json::to_writer(&mut gzip_encoder, &log)
+            .map_err(|e| anyhow::anyhow!("unable to serialize json: {}", e))?;
+        let compressed_bytes = gzip_encoder.finish()?;
+
+        self.inner
+            .post(self.base_url.join("/loki/api/v1/push")?)
+            .basic_auth(self.basic_user.clone(), Some(self.basic_password.clone()))
+            .header("Content-Type", "application/json")
+            .header("Content-Encoding", "gzip")
+            .body(compressed_bytes)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to post metrics: {}", e))
+    }
+}

--- a/crates/aptos-telemetry-service/src/clients/mod.rs
+++ b/crates/aptos-telemetry-service/src/clients/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod humio;
+pub mod loki;
 
 pub mod victoria_metrics_api {
 

--- a/crates/aptos-telemetry-service/src/context.rs
+++ b/crates/aptos-telemetry-service/src/context.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    clients::{big_query::TableWriteClient, humio, victoria_metrics_api::Client as MetricsClient},
+    clients::{
+        big_query::TableWriteClient, humio, loki::LokiClient,
+        victoria_metrics_api::Client as MetricsClient,
+    },
     types::common::EpochedPeerStore,
     LogIngestConfig, MetricsEndpointsConfig,
 };
@@ -56,6 +59,7 @@ pub struct LogIngestClients {
     pub known_logs_ingest_client: humio::IngestClient,
     pub unknown_logs_ingest_client: humio::IngestClient,
     pub blacklist: Option<HashSet<PeerId>>,
+    pub loki_ingest_client: LokiClient,
 }
 
 impl From<LogIngestConfig> for LogIngestClients {
@@ -64,6 +68,7 @@ impl From<LogIngestConfig> for LogIngestClients {
             known_logs_ingest_client: config.known_logs_endpoint.make_client(),
             unknown_logs_ingest_client: config.unknown_logs_endpoint.make_client(),
             blacklist: config.blacklist_peers,
+            loki_ingest_client: config.loki_endpoint.make_client(),
         }
     }
 }

--- a/crates/aptos-telemetry-service/src/metrics.rs
+++ b/crates/aptos-telemetry-service/src/metrics.rs
@@ -39,6 +39,15 @@ pub(crate) static LOG_INGEST_BACKEND_REQUEST_DURATION: Lazy<HistogramVec> = Lazy
     .unwrap()
 });
 
+pub(crate) static LOKI_INGEST_REQUEST_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "telemetry_web_service_loki_ingest_request_duration",
+        "Number of loki log ingest requests by response code",
+        &["response_code"]
+    )
+    .unwrap()
+});
+
 pub(crate) static METRICS_INGEST_BACKEND_REQUEST_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "telemetry_web_service_metrics_ingest_backend_request_duration",

--- a/crates/aptos-telemetry-service/src/types/mod.rs
+++ b/crates/aptos-telemetry-service/src/types/mod.rs
@@ -119,3 +119,47 @@ pub mod humio {
         pub messages: Vec<String>,
     }
 }
+
+pub mod loki {
+    use serde::Serialize;
+    use std::{
+        collections::HashMap,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    #[derive(Serialize, Clone, Debug)]
+    pub struct LokiLogStream {
+        pub stream: HashMap<String, String>,
+        pub values: Vec<[String; 2]>,
+    }
+
+    impl LokiLogStream {
+        pub fn new(labels: HashMap<String, String>, messages: Vec<String>) -> Self {
+            let unix_timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("should work")
+                .as_nanos();
+            let values = messages
+                .into_iter()
+                .map(|message| [format!("{}", unix_timestamp), message])
+                .collect();
+            Self {
+                stream: labels,
+                values,
+            }
+        }
+    }
+
+    #[derive(Serialize, Clone, Debug)]
+    pub struct LokiLog {
+        pub streams: Vec<LokiLogStream>,
+    }
+
+    impl From<LokiLogStream> for LokiLog {
+        fn from(value: LokiLogStream) -> Self {
+            Self {
+                streams: vec![value],
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description

This PR adds loki ingest client for telemetry service to ingest logs into Grafana Loki.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Tested locally. and deployed in devnet and mainnet instances.
