### PR TITLE
[gha] prevent indexer grpc integration tests from cancelling on push

### DIFF
--- a/.github/workflows/indexer-grpc-integration-tests.yaml
+++ b/.github/workflows/indexer-grpc-integration-tests.yaml
@@ -12,8 +12,9 @@ permissions:
 
 # cancel redundant builds
 concurrency:
-  # cancel redundant builds on PRs (only on PR, not on branches)
-  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.ref) || github.sha }}
+  # for push events we use `github.sha` in the concurrency group and don't really cancel each other out/limit concurrency
+  # for pull_request events newer jobs cancel earlier jobs to save on CI etc.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Description

Previously successive pushes to main branch cancelled previous jobs if they were still running. For example: https://github.com/aptos-labs/aptos-core/actions/runs/5615073388/job/15214560994

Use more of less the same concurrency rules as the main `docker-build-test.yaml` workflow

### Test Plan

CI on pull_request_target once it lands.

<!-- Please provide us with clear details for verifying that your changes work. -->
