### PR TITLE
[cached packages] Use Yaml as a format for MRB (release bundles)

### DIFF
--- a/aptos-move/framework/cached-packages/src/lib.rs
+++ b/aptos-move/framework/cached-packages/src/lib.rs
@@ -10,15 +10,14 @@ pub mod aptos_token_objects_sdk_builder;
 pub mod aptos_token_sdk_builder;
 
 #[cfg(unix)]
-const HEAD_RELEASE_BUNDLE_BYTES: &[u8] =
-    include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/generated/head.mrb"));
+const HEAD_RELEASE_BUNDLE_STR: &str =
+    include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/generated/head.mrb"));
 #[cfg(windows)]
-const HEAD_RELEASE_BUNDLE_BYTES: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "\\generated\\head.mrb"));
+const HEAD_RELEASE_BUNDLE_STR: &str =
+    include_str!(concat!(env!("OUT_DIR"), "\\generated\\head.mrb"));
 
-static HEAD_RELEASE_BUNDLE: Lazy<ReleaseBundle> = Lazy::new(|| {
-    bcs::from_bytes::<ReleaseBundle>(HEAD_RELEASE_BUNDLE_BYTES).expect("bcs succeeds")
-});
+static HEAD_RELEASE_BUNDLE: Lazy<ReleaseBundle> =
+    Lazy::new(|| ReleaseBundle::read_str(HEAD_RELEASE_BUNDLE_STR).expect("deserialize succeeds"));
 
 /// Returns the release bundle for the current code.
 pub fn head_release_bundle() -> &'static ReleaseBundle {

--- a/aptos-move/framework/src/release_builder.rs
+++ b/aptos-move/framework/src/release_builder.rs
@@ -67,7 +67,7 @@ impl ReleaseOptions {
         }
         let bundle = ReleaseBundle::new(released_packages, source_paths);
         std::fs::create_dir_all(output.parent().unwrap())?;
-        std::fs::write(&output, bcs::to_bytes(&bundle)?)?;
+        bundle.write(output)?;
         Ok(())
     }
 

--- a/aptos-move/framework/src/release_bundle.rs
+++ b/aptos-move/framework/src/release_bundle.rs
@@ -42,14 +42,19 @@ impl ReleaseBundle {
 
     /// Read a release bundle from a file.
     pub fn read(file: PathBuf) -> anyhow::Result<ReleaseBundle> {
-        let content =
-            std::fs::read(&file).with_context(|| format!("while reading `{}`", file.display()))?;
-        Ok(bcs::from_bytes::<ReleaseBundle>(&content)?)
+        let content = std::fs::read_to_string(&file)
+            .with_context(|| format!("while reading `{}`", file.display()))?;
+        Ok(serde_yaml::from_str(&content)?)
+    }
+
+    /// Read a relase bundle from a string.
+    pub fn read_str(s: &str) -> anyhow::Result<ReleaseBundle> {
+        Ok(serde_yaml::from_str(s)?)
     }
 
     /// Write a release bundle to file
     pub fn write(&self, path: PathBuf) -> anyhow::Result<()> {
-        std::fs::write(&path, bcs::to_bytes(self)?)
+        std::fs::write(&path, serde_yaml::to_string(self)?)
             .with_context(|| format!("while writing `{}`", path.display()))?;
         Ok(())
     }


### PR DESCRIPTION
This is an attempt to reduce merge conflicts in the checked-in head.mrb file in `cached-packages`, using Yaml instead of BCS. Yaml should have a drastically better merge behavior. There is a 10x price in size to pay for .mrb, buts is yet for all our framework packages below 10mb.
