### PR TITLE
[Helm] Fix templating of aptos-vector-log-agent

### DIFF
--- a/terraform/helm/vector-log-agent/templates/secrets.yaml
+++ b/terraform/helm/vector-log-agent/templates/secrets.yaml
@@ -9,4 +9,5 @@ data:
   {{- range $key, $value := $secretKeyValuePairs }}
     {{ $key }}: {{ $value | b64enc }}
   {{- end }}
+---
 {{- end }}


### PR DESCRIPTION
### Description

The lack of a terminator means that Helm was effectively generating a single resource with duplicated fields, and K8s does not signal an error when applying such a malformed resource, which means that latter fields (in this case the loki-credentials secret) overrode the earlier ones.

Example:

```
apiVersion: v1
kind: Secret
metadata:
  name: humio-credentials
  namespace: vector
apiVersion: v1
kind: Secret
metadata:
  name: loki-credentials
  namespace: vector
```

### Test Plan

Deployed manually to cluster `aptos-devtestnet/aptos-pfn`.