### PR TITLE
Update system-integrators-guide.md

### DIFF
--- a/developer-docs-site/docs/guides/system-integrators-guide.md
+++ b/developer-docs-site/docs/guides/system-integrators-guide.md
@@ -502,7 +502,7 @@ To learn more about coin creation, make ["Your First Coin"](../tutorials/first-c
 
 ## Integrating with the faucet
 
-This tutorial is for SDK and wallet developers who want to integrate with the [Aptos Faucet](https://github.com/aptos-labs/aptos-core/tree/main/crates/aptos-faucet). If you are a dapp developer, you should access the faucet through an existing [SDK](../tutorials/first-transaction.md) or [CLI](../tools/aptos-cli/use-cli/use-aptos-cli#initialize-local-configuration-and-create-an-account) instead.
+This tutorial is for SDK and wallet developers who want to integrate with the [Aptos Faucet](https://github.com/aptos-labs/aptos-core/tree/main/crates/aptos-faucet). If you are a dapp developer, you should access the faucet through an existing [SDK](../tutorials/first-transaction.md) or [CLI](../tools/aptos-cli/use-cli/use-aptos-cli.md#initialize-local-configuration-and-create-an-account) instead.
 
 ### Differences between devnet and testnet
 What are the differences between devnet and testnet? Effectively none. In the past, the testnet faucet had a Captcha in front of it, making it unqueryable by normal means. This is no longer true.


### PR DESCRIPTION
CLI link didn't work (added .md)

Can't open the "CLI" link on github and https://aptos.dev/guides/system-integrators-guide/#integrating-with-the-faucet

added .md in the end of "use-aptos-cli"

<a href="https://ibb.co/gZZ9LD0"><img src="https://i.ibb.co/d44MwQN/1.jpg" alt="1" border="0"></a>
<a href="https://ibb.co/tKfm9d7"><img src="https://i.ibb.co/DWXVZqx/2.jpg" alt="2" border="0"></a>
