### PR TITLE
Update system-integrators-guide.md

### DIFF
--- a/developer-docs-site/docs/guides/system-integrators-guide.md
+++ b/developer-docs-site/docs/guides/system-integrators-guide.md
@@ -98,7 +98,7 @@ At creation, an [Aptos account](https://github.com/aptos-labs/aptos-core/blob/88
 * An [event handle](../concepts/events.md) for all new types of coins added to the account.
 * An event handle for all key rotations for the account.
 
-Read more about [Accounts](../concepts/accounts.md) and [set one up](https://github.com/aptos-labs/aptos-core/blob/main/developer-docs-site/docs/concepts/accounts.md#creating-an-account).
+Read more about [Accounts](../concepts/accounts.md) and [set one up](../tools/aptos-cli/use-cli/use-aptos-cli.md#initialize-local-configuration-and-create-an-account).
 
 ## Transactions
 

--- a/developer-docs-site/docs/guides/system-integrators-guide.md
+++ b/developer-docs-site/docs/guides/system-integrators-guide.md
@@ -98,7 +98,7 @@ At creation, an [Aptos account](https://github.com/aptos-labs/aptos-core/blob/88
 * An [event handle](../concepts/events.md) for all new types of coins added to the account.
 * An event handle for all key rotations for the account.
 
-Read more about [Accounts](../concepts/accounts.md) and [set one up](../tools/aptos-cli/use-cli/use-aptos-cli#initialize-local-configuration-and-create-an-account).
+Read more about [Accounts](../concepts/accounts.md) and [set one up](https://github.com/aptos-labs/aptos-core/blob/main/developer-docs-site/docs/concepts/accounts.md#creating-an-account).
 
 ## Transactions
 


### PR DESCRIPTION
https://aptos.dev/guides/system-integrators-guide/#accounts-on-aptos "set one up" link doesn't work

changed on correct one

<a href="https://ibb.co/bLBjms3"><img src="https://i.ibb.co/825nsrB/3.jpg" alt="3" border="0"></a>
<a href="https://ibb.co/LrZtyvz"><img src="https://i.ibb.co/r3w6hvG/4.jpg" alt="4" border="0"></a>
