### PR TITLE
enable cost management of gke clusters

### DIFF
--- a/terraform/aptos-node/gcp/cluster.tf
+++ b/terraform/aptos-node/gcp/cluster.tf
@@ -46,6 +46,10 @@ resource "google_container_cluster" "aptos" {
     workload_pool = "${var.project}.svc.id.goog"
   }
 
+  cost_management_config {
+    enabled = true
+  }
+
   addons_config {
     network_policy_config {
       disabled = false

--- a/terraform/fullnode/gcp/cluster.tf
+++ b/terraform/fullnode/gcp/cluster.tf
@@ -50,6 +50,10 @@ resource "google_container_cluster" "aptos" {
     workload_pool = "${var.project}.svc.id.goog"
   }
 
+  cost_management_config {
+    enabled = true
+  }
+
   addons_config {
     network_policy_config {
       disabled = false


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9391441</samp>

Enable cost management feature for `aptos-node` and `fullnode` clusters in GCP. This feature helps optimize resource usage and spending for the `aptos-core` node software.