### PR TITLE
disable calico on GCP since it's legacy and causes lots of trouble

### DIFF
--- a/terraform/aptos-node/gcp/cluster.tf
+++ b/terraform/aptos-node/gcp/cluster.tf
@@ -53,8 +53,7 @@ resource "google_container_cluster" "aptos" {
   }
 
   network_policy {
-    enabled  = true
-    provider = "CALICO"
+    enabled = false
   }
 
   cluster_autoscaling {

--- a/terraform/fullnode/gcp/cluster.tf
+++ b/terraform/fullnode/gcp/cluster.tf
@@ -57,8 +57,7 @@ resource "google_container_cluster" "aptos" {
   }
 
   network_policy {
-    enabled  = true
-    provider = "CALICO"
+    enabled = false
   }
 
   cluster_autoscaling {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f76fddb</samp>

This pull request disables the network policy with the `CALICO` provider for the `aptos-node` and `fullnode` clusters in GCP. This is done to fix connectivity and performance issues caused by the plugin and to simplify the cluster configuration.