### PR TITLE
[move-compiler v2] File-format generator first version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8562,6 +8562,7 @@ name = "move-compiler-v2"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bcs 0.1.4",
  "clap 3.2.23",
  "codespan",
  "codespan-reporting",
@@ -8569,7 +8570,10 @@ dependencies = [
  "ethnum",
  "itertools",
  "move-binary-format",
+ "move-command-line-common",
  "move-core-types",
+ "move-disassembler",
+ "move-ir-types",
  "move-model",
  "move-prover-test-utils",
  "move-stackless-bytecode",

--- a/third_party/move/move-compiler-v2/Cargo.toml
+++ b/third_party/move/move-compiler-v2/Cargo.toml
@@ -10,12 +10,13 @@ publish = false
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.62"
 move-binary-format = { path = "../move-binary-format" }
 move-core-types = { path = "../move-core/types" }
 move-model = { path = "../move-model" }
 move-stackless-bytecode = { path = "../move-prover/bytecode" }
 
-anyhow = "1.0.62"
+bcs = { workspace = true }
 clap = { version = "3.2.23", features = ["derive", "env"] }
 codespan = "0.11.1"
 codespan-reporting = { version = "0.11.1", features = ["serde", "serialization"] }
@@ -32,6 +33,9 @@ serde = { version = "1.0.124", features = ["derive"] }
 [dev-dependencies]
 anyhow = "1.0.52"
 datatest-stable = "0.1.1"
+move-command-line-common = { path = "../move-command-line-common" }
+move-disassembler = { path = "../tools/move-disassembler" }
+move-ir-types = { path = "../move-ir/types" }
 move-prover-test-utils = { path = "../move-prover/test-utils" }
 move-stdlib = { path = "../move-stdlib" }
 

--- a/third_party/move/move-compiler-v2/src/bytecode_pipeline.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_pipeline.rs
@@ -1,3 +1,0 @@
-// Copyright © Aptos Foundation
-// Parts of the project are originally copyright © Meta Platforms, Inc.
-// SPDX-License-Identifier: Apache-2.0

--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -1,0 +1,714 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::file_format_generator::{
+    module_generator::{ModuleContext, ModuleGenerator},
+    MAX_FUNCTION_DEF_COUNT, MAX_LOCAL_COUNT,
+};
+use move_binary_format::{
+    file_format as FF,
+    file_format::{
+        Ability, CodeOffset, LocalIndex, StructDefInstantiationIndex, StructDefinitionIndex,
+    },
+};
+use move_model::{
+    ast::TempIndex,
+    model::{FunId, FunctionEnv, Loc, QualifiedId, StructId, TypeParameter},
+    ty::{PrimitiveType, Type},
+};
+use move_stackless_bytecode::{
+    function_target::FunctionTarget,
+    function_target_pipeline::FunctionVariant,
+    stackless_bytecode::{Bytecode, Label, Operation},
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+pub struct FunctionGenerator<'a> {
+    /// The underlying module generator.
+    gen: &'a mut ModuleGenerator,
+    /// The set of temporaries which need to be pinned to locals because references are taken for
+    /// them. (The Move bytecode does not allow references to stack locations.) The invariant holds
+    /// that `temp in pinned ==> allocation[temp] == Local(_)`.
+    pinned: BTreeSet<TempIndex>,
+    /// A map from a temporary to the location where the value belonging to this temporary
+    /// is stored. A temporary can be either located on the stack or in a local.
+    location: BTreeMap<TempIndex, TempLocation>,
+    /// The value stack, represented by the temporaries which are represented on it.
+    stack: Vec<TempIndex>,
+    /// The locals which have been used so far. This contains the parameters of the function.
+    locals: Vec<Type>,
+    /// A map from branching labels to information about them.
+    label_info: BTreeMap<Label, LabelInfo>,
+    /// The generated code
+    code: Vec<FF::Bytecode>,
+}
+
+/// Immutable context for a function, seperated from the mutable generator state, to reduce
+/// borrow conflicts.
+#[derive(Clone)]
+pub struct FunctionContext<'env> {
+    /// The module context
+    pub module: ModuleContext<'env>,
+    /// Function target we are generating code for.
+    pub fun: FunctionTarget<'env>,
+    /// Location of the function for error messages.
+    pub loc: Loc,
+    /// Type parameters, cached here.
+    type_parameters: Vec<TypeParameter>,
+}
+
+#[derive(Debug, Copy, Clone)]
+/// Represents the current location of a temporary.
+enum TempLocation {
+    /// The temp is not stored in any local
+    None,
+    /// The temp is stored in a local of given index.
+    Local(LocalIndex),
+}
+
+/// Represents information about a label.
+#[derive(Debug, Default)]
+struct LabelInfo {
+    /// The references to this label, as seen so far, in terms of the code offset of the
+    /// instruction. The instruction pointed to will be any of `Branch`, `BrTrue`, or `BrFalse`.
+    references: BTreeSet<CodeOffset>,
+    /// The resolution of linking the label to a code offset.
+    resolution: Option<CodeOffset>,
+}
+
+impl<'a> FunctionGenerator<'a> {
+    /// Runs the function generator for the given function.
+    pub fn run<'b>(gen: &'a mut ModuleGenerator, ctx: &'b ModuleContext, fun_env: FunctionEnv<'b>) {
+        let loc = fun_env.get_loc();
+        let function = gen.function_index(ctx, &loc, &fun_env);
+        let visibility = fun_env.visibility();
+        let fun_count = gen.module.function_defs.len();
+        let (gen, code) = if !fun_env.is_native() {
+            let mut fun_gen = Self {
+                gen,
+                pinned: Default::default(),
+                location: Default::default(),
+                stack: vec![],
+                locals: vec![],
+                label_info: Default::default(),
+                code: vec![],
+            };
+            let target = ctx.targets.get_target(&fun_env, &FunctionVariant::Baseline);
+            let code = fun_gen.gen_code(&FunctionContext {
+                module: ctx.clone(),
+                fun: target,
+                loc: loc.clone(),
+                type_parameters: fun_env.get_type_parameters(),
+            });
+            (fun_gen.gen, Some(code))
+        } else {
+            (gen, None)
+        };
+        let def = FF::FunctionDefinition {
+            function,
+            visibility,
+            is_entry: fun_env.is_entry(),
+            acquires_global_resources: vec![],
+            code,
+        };
+        ctx.checked_bound(
+            loc,
+            fun_count, // gen.module.function_defs.len(),
+            MAX_FUNCTION_DEF_COUNT,
+            "defined function",
+        );
+        gen.module.function_defs.push(def)
+    }
+
+    /// Generates code for a function.
+    fn gen_code(&mut self, ctx: &FunctionContext<'_>) -> FF::CodeUnit {
+        // Initialize the abstract virtual machine
+        self.pinned = Self::referenced_temps(ctx);
+        self.location = (0..ctx.fun.get_parameter_count())
+            .map(|temp| (temp, TempLocation::Local(self.temp_to_local(ctx, temp))))
+            .collect();
+        self.locals = (0..ctx.fun.get_parameter_count())
+            .map(|temp| ctx.temp_type(temp).to_owned())
+            .collect();
+
+        // Walk the bytecode
+        let bytecode = ctx.fun.get_bytecode();
+        for i in 0..bytecode.len() {
+            let bc = &bytecode[i];
+            let next_bc = if i + 1 < bytecode.len() {
+                Some(&bytecode[i + 1])
+            } else {
+                None
+            };
+            self.gen_bytecode(ctx, bc, next_bc);
+        }
+
+        // At this point, all labels should be resolved, so link them.
+        for info in self.label_info.values() {
+            if let Some(label_offs) = info.resolution {
+                for ref_offs in &info.references {
+                    let ref_offs = *ref_offs;
+                    let code_ref = &mut self.code[ref_offs as usize];
+                    match code_ref {
+                        FF::Bytecode::Branch(_) => *code_ref = FF::Bytecode::Branch(label_offs),
+                        FF::Bytecode::BrTrue(_) => *code_ref = FF::Bytecode::BrTrue(label_offs),
+                        FF::Bytecode::BrFalse(_) => *code_ref = FF::Bytecode::BrFalse(label_offs),
+                        _ => {},
+                    }
+                }
+            } else {
+                ctx.internal_error("inconsistent bytecode label info")
+            }
+        }
+
+        // Deliver result
+        let locals = self.gen.signature(
+            &ctx.module,
+            &ctx.loc,
+            self.locals[ctx.fun.get_parameter_count()..].to_vec(),
+        );
+        FF::CodeUnit {
+            locals,
+            code: std::mem::take(&mut self.code),
+        }
+    }
+
+    /// Compute the set of temporaries which are referenced in borrow instructions.
+    fn referenced_temps(ctx: &FunctionContext) -> BTreeSet<TempIndex> {
+        let mut result = BTreeSet::new();
+        for bc in ctx.fun.get_bytecode() {
+            if let Bytecode::Call(_, _, Operation::BorrowLoc, args, _) = bc {
+                result.insert(args[0]);
+            }
+        }
+        result
+    }
+
+    /// Generate file-format bytecode from a stackless bytecode and an optional next bytecode
+    /// for peephole optimizations.
+    fn gen_bytecode(&mut self, ctx: &FunctionContext, bc: &Bytecode, next_bc: Option<&Bytecode>) {
+        match bc {
+            Bytecode::Assign(_, dest, source, _mode) => {
+                self.abstract_push_args(ctx, vec![*source]);
+                let local = self.temp_to_local(ctx, *dest);
+                self.emit(FF::Bytecode::StLoc(local));
+                self.abstract_pop(ctx)
+            },
+            Bytecode::Ret(_, result) => {
+                self.abstract_push_args(ctx, result);
+                self.emit(FF::Bytecode::Ret);
+                self.abstract_pop_n(ctx, result.len())
+            },
+            Bytecode::Call(_, dest, oper, source, None) => {
+                self.gen_operation(ctx, dest, oper, source)
+            },
+            Bytecode::Load(_, dest, cons) => {
+                let cons =
+                    self.gen
+                        .cons_index(&ctx.module, &ctx.loc, cons, ctx.fun.get_local_type(*dest));
+                self.emit(FF::Bytecode::LdConst(cons));
+                self.abstract_push_result(ctx, vec![*dest]);
+            },
+            Bytecode::Label(_, label) => self.define_label(*label),
+            Bytecode::Branch(_, if_true, if_false, cond) => {
+                self.abstract_push_args(ctx, vec![*cond]);
+                // Attempt to detect fallthrough, such that for
+                // ```
+                //   branch l1, l2, cond
+                //   l1: ...
+                // ```
+                // .. we generate adequate code.
+                let successor_label_opt = next_bc.and_then(|bc| {
+                    if let Bytecode::Label(_, l) = bc {
+                        Some(*l)
+                    } else {
+                        None
+                    }
+                });
+                if successor_label_opt == Some(*if_true) {
+                    self.add_label_reference(*if_false);
+                    self.emit(FF::Bytecode::BrFalse(0))
+                } else if successor_label_opt == Some(*if_false) {
+                    self.add_label_reference(*if_true);
+                    self.emit(FF::Bytecode::BrTrue(0))
+                } else {
+                    // No fallthrough
+                    self.add_label_reference(*if_false);
+                    self.emit(FF::Bytecode::BrFalse(0));
+                    self.add_label_reference(*if_true);
+                    self.emit(FF::Bytecode::BrTrue(0))
+                }
+                self.abstract_pop(ctx);
+                self.abstract_flush_stack(ctx, 0); // Empty stack on branch boundary
+            },
+            Bytecode::Jump(_, label) => {
+                self.add_label_reference(*label);
+                self.emit(FF::Bytecode::Branch(0));
+                self.abstract_flush_stack(ctx, 0); // Empty stack for branch boundary
+            },
+            Bytecode::Abort(_, temp) => {
+                self.abstract_push_args(ctx, vec![*temp]);
+                self.emit(FF::Bytecode::Abort)
+            },
+            Bytecode::Nop(_) => {
+                // do nothing -- labels are relative
+            },
+            Bytecode::SaveMem(_, _, _)
+            | Bytecode::Call(_, _, _, _, Some(_))
+            | Bytecode::SaveSpecVar(_, _, _)
+            | Bytecode::Prop(_, _, _) => ctx.internal_error("unexpected specification bytecode"),
+        }
+    }
+
+    /// Adds a reference to a label to the LabelInfo. This is used to link the labels final
+    /// value at the current code offset once it is resolved.
+    fn add_label_reference(&mut self, label: Label) {
+        let offset = self.code.len() as CodeOffset;
+        self.label_info
+            .entry(label)
+            .or_default()
+            .references
+            .insert(offset);
+    }
+
+    /// Sets the resolution of a lable to the current code offset.
+    fn define_label(&mut self, label: Label) {
+        let offset = self.code.len() as CodeOffset;
+        self.label_info.entry(label).or_default().resolution = Some(offset)
+    }
+
+    /// Generates code for an operation.
+    fn gen_operation(
+        &mut self,
+        ctx: &FunctionContext,
+        dest: &[TempIndex],
+        oper: &Operation,
+        source: &[TempIndex],
+    ) {
+        match oper {
+            Operation::Function(mid, fid, inst) => {
+                self.gen_call(ctx, dest, mid.qualified(*fid), inst, source);
+            },
+            Operation::Pack(mid, sid, inst) => {
+                self.gen_struct_oper(
+                    ctx,
+                    dest,
+                    mid.qualified(*sid),
+                    inst,
+                    source,
+                    FF::Bytecode::Pack,
+                    FF::Bytecode::PackGeneric,
+                );
+            },
+            Operation::Unpack(mid, sid, inst) => {
+                self.gen_struct_oper(
+                    ctx,
+                    dest,
+                    mid.qualified(*sid),
+                    inst,
+                    source,
+                    FF::Bytecode::Unpack,
+                    FF::Bytecode::UnpackGeneric,
+                );
+            },
+            Operation::MoveTo(mid, sid, inst) => {
+                self.gen_struct_oper(
+                    ctx,
+                    dest,
+                    mid.qualified(*sid),
+                    inst,
+                    source,
+                    FF::Bytecode::MoveTo,
+                    FF::Bytecode::MoveToGeneric,
+                );
+            },
+            Operation::MoveFrom(mid, sid, inst) => {
+                self.gen_struct_oper(
+                    ctx,
+                    dest,
+                    mid.qualified(*sid),
+                    inst,
+                    source,
+                    FF::Bytecode::MoveFrom,
+                    FF::Bytecode::MoveFromGeneric,
+                );
+            },
+            Operation::Exists(mid, sid, inst) => {
+                self.gen_struct_oper(
+                    ctx,
+                    dest,
+                    mid.qualified(*sid),
+                    inst,
+                    source,
+                    FF::Bytecode::Exists,
+                    FF::Bytecode::ExistsGeneric,
+                );
+            },
+            Operation::BorrowLoc => {
+                let local = self.temp_to_local(ctx, source[0]);
+                if ctx.fun.get_local_type(dest[0]).is_mutable_reference() {
+                    self.emit(FF::Bytecode::MutBorrowLoc(local))
+                } else {
+                    self.emit(FF::Bytecode::ImmBorrowLoc(local))
+                }
+                self.abstract_push_result(ctx, dest)
+            },
+            Operation::BorrowField(mid, sid, inst, offset) => {
+                self.gen_borrow_field(
+                    ctx,
+                    dest,
+                    mid.qualified(*sid),
+                    inst.clone(),
+                    *offset,
+                    source,
+                );
+            },
+            Operation::BorrowGlobal(mid, sid, inst) => {
+                let is_mut = ctx.fun.get_local_type(dest[0]).is_mutable_reference();
+                self.gen_struct_oper(
+                    ctx,
+                    dest,
+                    mid.qualified(*sid),
+                    inst,
+                    source,
+                    if is_mut {
+                        FF::Bytecode::MutBorrowGlobal
+                    } else {
+                        FF::Bytecode::ImmBorrowGlobal
+                    },
+                    if is_mut {
+                        FF::Bytecode::MutBorrowGlobalGeneric
+                    } else {
+                        FF::Bytecode::ImmBorrowGlobalGeneric
+                    },
+                )
+            },
+            Operation::Vector => {
+                let elem_type = if let Type::Vector(el) = ctx.fun.get_local_type(dest[0]) {
+                    el.as_ref().clone()
+                } else {
+                    ctx.internal_error("expected vector type");
+                    Type::new_prim(PrimitiveType::Bool)
+                };
+                let sign = self.gen.signature(&ctx.module, &ctx.loc, vec![elem_type]);
+                self.gen_builtin(
+                    ctx,
+                    dest,
+                    FF::Bytecode::VecPack(sign, source.len() as u64),
+                    source,
+                )
+            },
+            Operation::ReadRef => self.gen_builtin(ctx, dest, FF::Bytecode::ReadRef, source),
+            Operation::WriteRef => self.gen_builtin(ctx, dest, FF::Bytecode::WriteRef, source),
+            Operation::FreezeRef => self.gen_builtin(ctx, dest, FF::Bytecode::FreezeRef, source),
+            Operation::CastU8 => self.gen_builtin(ctx, dest, FF::Bytecode::CastU8, source),
+            Operation::CastU16 => self.gen_builtin(ctx, dest, FF::Bytecode::CastU16, source),
+            Operation::CastU32 => self.gen_builtin(ctx, dest, FF::Bytecode::CastU32, source),
+            Operation::CastU64 => self.gen_builtin(ctx, dest, FF::Bytecode::CastU64, source),
+            Operation::CastU128 => self.gen_builtin(ctx, dest, FF::Bytecode::CastU128, source),
+            Operation::CastU256 => self.gen_builtin(ctx, dest, FF::Bytecode::CastU256, source),
+            Operation::Not => self.gen_builtin(ctx, dest, FF::Bytecode::Not, source),
+            Operation::Add => self.gen_builtin(ctx, dest, FF::Bytecode::Add, source),
+            Operation::Sub => self.gen_builtin(ctx, dest, FF::Bytecode::Sub, source),
+            Operation::Mul => self.gen_builtin(ctx, dest, FF::Bytecode::Mul, source),
+            Operation::Div => self.gen_builtin(ctx, dest, FF::Bytecode::Div, source),
+            Operation::Mod => self.gen_builtin(ctx, dest, FF::Bytecode::Mod, source),
+            Operation::BitOr => self.gen_builtin(ctx, dest, FF::Bytecode::BitOr, source),
+            Operation::BitAnd => self.gen_builtin(ctx, dest, FF::Bytecode::BitAnd, source),
+            Operation::Xor => self.gen_builtin(ctx, dest, FF::Bytecode::Xor, source),
+            Operation::Shl => self.gen_builtin(ctx, dest, FF::Bytecode::Shl, source),
+            Operation::Shr => self.gen_builtin(ctx, dest, FF::Bytecode::Shr, source),
+            Operation::Lt => self.gen_builtin(ctx, dest, FF::Bytecode::Lt, source),
+            Operation::Gt => self.gen_builtin(ctx, dest, FF::Bytecode::Gt, source),
+            Operation::Le => self.gen_builtin(ctx, dest, FF::Bytecode::Le, source),
+            Operation::Ge => self.gen_builtin(ctx, dest, FF::Bytecode::Ge, source),
+            Operation::Or => self.gen_builtin(ctx, dest, FF::Bytecode::Or, source),
+            Operation::And => self.gen_builtin(ctx, dest, FF::Bytecode::And, source),
+            Operation::Eq => self.gen_builtin(ctx, dest, FF::Bytecode::Eq, source),
+            Operation::Neq => self.gen_builtin(ctx, dest, FF::Bytecode::Neq, source),
+
+            Operation::TraceLocal(_)
+            | Operation::TraceReturn(_)
+            | Operation::TraceAbort
+            | Operation::TraceExp(_, _)
+            | Operation::TraceGlobalMem(_)
+            | Operation::EmitEvent
+            | Operation::EventStoreDiverge
+            | Operation::OpaqueCallBegin(_, _, _)
+            | Operation::OpaqueCallEnd(_, _, _)
+            | Operation::GetField(_, _, _, _)
+            | Operation::GetGlobal(_, _, _)
+            | Operation::Uninit
+            | Operation::Destroy
+            | Operation::Havoc(_)
+            | Operation::Stop
+            | Operation::IsParent(_, _)
+            | Operation::WriteBack(_, _)
+            | Operation::UnpackRef
+            | Operation::PackRef
+            | Operation::UnpackRefDeep
+            | Operation::PackRefDeep => ctx.internal_error("unexpected specification opcode"),
+        }
+    }
+
+    /// Generates code for a function call.
+    fn gen_call(
+        &mut self,
+        ctx: &FunctionContext,
+        dest: &[TempIndex],
+        id: QualifiedId<FunId>,
+        inst: &[Type],
+        source: &[TempIndex],
+    ) {
+        self.abstract_push_args(ctx, source);
+        if inst.is_empty() {
+            let idx =
+                self.gen
+                    .function_index(&ctx.module, &ctx.loc, &ctx.module.env.get_function(id));
+            self.emit(FF::Bytecode::Call(idx))
+        } else {
+            let idx = self.gen.function_instantiation_index(
+                &ctx.module,
+                &ctx.loc,
+                ctx.fun.func_env,
+                inst.to_vec(),
+            );
+            self.emit(FF::Bytecode::CallGeneric(idx))
+        }
+        self.abstract_pop_n(ctx, source.len());
+        self.abstract_push_result(ctx, dest);
+    }
+
+    /// Generates for an operation which either takes a non-generic or generic struct index.
+    fn gen_struct_oper(
+        &mut self,
+        ctx: &FunctionContext,
+        dest: &[TempIndex],
+        id: QualifiedId<StructId>,
+        inst: &[Type],
+        source: &[TempIndex],
+        mk_simple: impl FnOnce(StructDefinitionIndex) -> FF::Bytecode,
+        mk_generic: impl FnOnce(StructDefInstantiationIndex) -> FF::Bytecode,
+    ) {
+        self.abstract_push_args(ctx, source);
+        let struct_env = &ctx.module.env.get_struct(id);
+        if inst.is_empty() {
+            let idx = self.gen.struct_def_index(&ctx.module, &ctx.loc, struct_env);
+            self.emit(mk_simple(idx))
+        } else {
+            let idx = self.gen.struct_def_instantiation_index(
+                &ctx.module,
+                &ctx.loc,
+                struct_env,
+                inst.to_vec(),
+            );
+            self.emit(mk_generic(idx))
+        }
+        self.abstract_pop_n(ctx, source.len());
+        self.abstract_push_result(ctx, dest);
+    }
+
+    /// Generate code for the borrow-field instruction.
+    fn gen_borrow_field(
+        &mut self,
+        ctx: &FunctionContext,
+        dest: &[TempIndex],
+        id: QualifiedId<StructId>,
+        inst: Vec<Type>,
+        offset: usize,
+        source: &[TempIndex],
+    ) {
+        self.abstract_push_args(ctx, source);
+        let struct_env = &ctx.module.env.get_struct(id);
+        let field_env = &struct_env.get_field_by_offset(offset);
+        let is_mut = ctx.fun.get_local_type(dest[0]).is_mutable_reference();
+        if inst.is_empty() {
+            let idx = self.gen.field_index(&ctx.module, &ctx.loc, field_env);
+            if is_mut {
+                self.emit(FF::Bytecode::MutBorrowField(idx))
+            } else {
+                self.emit(FF::Bytecode::ImmBorrowField(idx))
+            }
+        } else {
+            let idx = self
+                .gen
+                .field_inst_index(&ctx.module, &ctx.loc, field_env, inst);
+            if is_mut {
+                self.emit(FF::Bytecode::MutBorrowFieldGeneric(idx))
+            } else {
+                self.emit(FF::Bytecode::ImmBorrowFieldGeneric(idx))
+            }
+        }
+        self.abstract_pop_n(ctx, source.len());
+        self.abstract_push_result(ctx, dest);
+    }
+
+    /// Generate code for a general builtin instruction.
+    fn gen_builtin(
+        &mut self,
+        ctx: &FunctionContext,
+        dest: &[TempIndex],
+        bc: FF::Bytecode,
+        source: &[TempIndex],
+    ) {
+        self.abstract_push_args(ctx, source);
+        self.emit(bc);
+        self.abstract_pop_n(ctx, source.len());
+        self.abstract_push_result(ctx, dest)
+    }
+
+    /// Emits a file-format bytecode.
+    fn emit(&mut self, bc: FF::Bytecode) {
+        self.code.push(bc)
+    }
+
+    /// Ensure that on the abstract stack of the generator, the given temporaries are ready,
+    /// in order, to be consumed. Ideally those are already on the stack, but if they are not,
+    /// they will be made available.
+    fn abstract_push_args(&mut self, ctx: &FunctionContext, temps: impl AsRef<[TempIndex]>) {
+        /*
+        println!(
+            "enter: temps: {:?}\n  locations: {:?}\n  stack: {:?}",
+            temps.as_ref(),
+            self.location,
+            self.stack
+        );
+         */
+        // Compute the maximal prefix of `temps` which are already on the stack.
+        let temps = temps.as_ref();
+        let mut temps_to_push = temps;
+        for i in 0..temps.len() {
+            let end = temps.len() - i;
+            if end > self.stack.len() {
+                continue;
+            }
+            if self.stack.ends_with(&temps[0..end]) {
+                temps_to_push = &temps[end..temps.len()];
+                // println!("  temps_to_push: {:?}\n", temps_to_push);
+                break;
+            }
+        }
+        // However, the remaining temps in temps_to_push need to be stored in locals and not on the
+        // stack. Otherwise we need to flush the stack to reach them.
+        let mut stack_to_flush = self.stack.len();
+        for temp in temps_to_push {
+            if let Some(offs) = self.stack.iter().position(|t| t == temp) {
+                // The lowest point in the stack we need to flush.
+                stack_to_flush = std::cmp::min(offs, stack_to_flush);
+                // Unfortunately, whatever is on the stack already, needs to be flushed out and
+                // pushed again. (We really should introduce a ROTATE opcode to the Move VM)
+                temps_to_push = temps;
+            }
+        }
+        self.abstract_flush_stack(ctx, stack_to_flush);
+        // Finally, push `temps_to_push` onto the stack.
+        for temp in temps_to_push {
+            if let TempLocation::Local(local) = self.temp_location(*temp) {
+                if ctx.is_copyable(*temp) {
+                    self.emit(FF::Bytecode::CopyLoc(local))
+                } else {
+                    self.emit(FF::Bytecode::MoveLoc(local));
+                    self.set_temp_location(*temp, TempLocation::None);
+                }
+                self.stack.push(*temp)
+            } else {
+                ctx.internal_error("unexpected undefined temporary (moved value?)");
+            }
+        }
+        /*
+        println!(
+            "exit: locations: {:?}\n  stack: {:?}",
+            self.location, self.stack
+        );
+         */
+    }
+
+    /// Flush the abstract stack, ensuring that all values on the stack are stored in locals.
+    fn abstract_flush_stack(&mut self, ctx: &FunctionContext, top: usize) {
+        while self.stack.len() > top {
+            let temp = self.stack.pop().unwrap();
+            let local = self.new_local(ctx, ctx.fun.get_local_type(temp).to_owned());
+            self.emit(FF::Bytecode::StLoc(local));
+            self.set_temp_location(temp, TempLocation::Local(local));
+        }
+    }
+
+    /// Push the result of an operation to the abstract stack.
+    fn abstract_push_result(&mut self, _ctx: &FunctionContext, result: impl AsRef<[TempIndex]>) {
+        for temp in result.as_ref() {
+            self.stack.push(*temp);
+            self.set_temp_location(*temp, TempLocation::None);
+        }
+    }
+
+    /// Pop a value from the abstract stack.
+    fn abstract_pop(&mut self, ctx: &FunctionContext) {
+        if self.stack.pop().is_none() {
+            ctx.internal_error("unbalanced abstract stack")
+        }
+    }
+
+    /// Pop a number of values from the abstract stack.
+    fn abstract_pop_n(&mut self, ctx: &FunctionContext, cnt: usize) {
+        for _ in 0..cnt {
+            self.abstract_pop(ctx)
+        }
+    }
+
+    /// Creates a new local of type.
+    fn new_local(&mut self, ctx: &FunctionContext, ty: Type) -> LocalIndex {
+        let local = ctx
+            .module
+            .checked_bound(&ctx.loc, self.locals.len(), MAX_LOCAL_COUNT, "local")
+            as LocalIndex;
+        self.locals.push(ty);
+        local
+    }
+
+    /// Returns the current location of the temporary.
+    fn temp_location(&self, temp: TempIndex) -> TempLocation {
+        self.location
+            .get(&temp)
+            .cloned()
+            .unwrap_or(TempLocation::None)
+    }
+
+    /// Sets the location of the temporary.
+    fn set_temp_location(&mut self, temp: TempIndex, location: TempLocation) {
+        self.location.insert(temp, location);
+    }
+
+    /// Allocates a local for the given temporary
+    fn temp_to_local(&mut self, ctx: &FunctionContext, temp: TempIndex) -> LocalIndex {
+        if let Some(TempLocation::Local(idx)) = self.location.get(&temp) {
+            *idx
+        } else {
+            let idx = self.new_local(ctx, ctx.temp_type(temp).to_owned());
+            self.location.insert(temp, TempLocation::Local(idx));
+            idx
+        }
+    }
+}
+
+impl<'env> FunctionContext<'env> {
+    /// Emits an internal error for this function.
+    pub fn internal_error(&self, msg: impl AsRef<str>) {
+        self.module.internal_error(&self.loc, msg)
+    }
+
+    /// Gets the type of the temporary.
+    pub fn temp_type(&self, temp: TempIndex) -> &Type {
+        self.fun.get_local_type(temp)
+    }
+
+    /// Returns true of the given temporary can/should be copied when it is loaded onto the stack.
+    /// Currently, this is using the `Copy` ability, but in the future it may also use lifetime
+    /// analysis results to check whether the variable is still accessed.
+    pub fn is_copyable(&self, temp: TempIndex) -> bool {
+        self.module
+            .env
+            .type_abilities(self.temp_type(temp), &self.type_parameters)
+            .has_ability(Ability::Copy)
+    }
+}

--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -135,13 +135,11 @@ impl<'a> FunctionGenerator<'a> {
         // Walk the bytecode
         let bytecode = ctx.fun.get_bytecode();
         for i in 0..bytecode.len() {
-            let bc = &bytecode[i];
-            let next_bc = if i + 1 < bytecode.len() {
-                Some(&bytecode[i + 1])
+            if i + 1 < bytecode.len() {
+                self.gen_bytecode(ctx, &bytecode[i], Some(&bytecode[i + 1]))
             } else {
-                None
-            };
-            self.gen_bytecode(ctx, bc, next_bc);
+                self.gen_bytecode(ctx, &bytecode[i], None)
+            }
         }
 
         // At this point, all labels should be resolved, so link them.
@@ -567,14 +565,6 @@ impl<'a> FunctionGenerator<'a> {
     /// in order, to be consumed. Ideally those are already on the stack, but if they are not,
     /// they will be made available.
     fn abstract_push_args(&mut self, ctx: &FunctionContext, temps: impl AsRef<[TempIndex]>) {
-        /*
-        println!(
-            "enter: temps: {:?}\n  locations: {:?}\n  stack: {:?}",
-            temps.as_ref(),
-            self.location,
-            self.stack
-        );
-         */
         // Compute the maximal prefix of `temps` which are already on the stack.
         let temps = temps.as_ref();
         let mut temps_to_push = temps;
@@ -585,7 +575,6 @@ impl<'a> FunctionGenerator<'a> {
             }
             if self.stack.ends_with(&temps[0..end]) {
                 temps_to_push = &temps[end..temps.len()];
-                // println!("  temps_to_push: {:?}\n", temps_to_push);
                 break;
             }
         }
@@ -616,12 +605,6 @@ impl<'a> FunctionGenerator<'a> {
                 ctx.internal_error("unexpected undefined temporary (moved value?)");
             }
         }
-        /*
-        println!(
-            "exit: locations: {:?}\n  stack: {:?}",
-            self.location, self.stack
-        );
-         */
     }
 
     /// Flush the abstract stack, ensuring that all values on the stack are stored in locals.

--- a/third_party/move/move-compiler-v2/src/file_format_generator/mod.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/mod.rs
@@ -1,0 +1,42 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod function_generator;
+mod module_generator;
+
+use crate::file_format_generator::module_generator::ModuleContext;
+use module_generator::ModuleGenerator;
+use move_binary_format::file_format as FF;
+use move_model::model::GlobalEnv;
+use move_stackless_bytecode::function_target_pipeline::FunctionTargetsHolder;
+
+pub fn generate_file_format(
+    env: &GlobalEnv,
+    targets: &FunctionTargetsHolder,
+) -> Vec<FF::CompiledModule> {
+    let ctx = ModuleContext { env, targets };
+    let mut result = vec![];
+    for module_env in ctx.env.get_modules() {
+        if !module_env.is_target() {
+            continue;
+        }
+        result.push(ModuleGenerator::run(&ctx, &module_env));
+    }
+    result
+}
+
+const MAX_MODULE_COUNT: usize = FF::TableIndex::MAX as usize;
+const MAX_IDENTIFIER_COUNT: usize = FF::TableIndex::MAX as usize;
+const MAX_ADDRESS_COUNT: usize = FF::TableIndex::MAX as usize;
+const MAX_CONST_COUNT: usize = FF::TableIndex::MAX as usize;
+const MAX_STRUCT_COUNT: usize = FF::TableIndex::MAX as usize;
+const MAX_SIGNATURE_COUNT: usize = FF::TableIndex::MAX as usize;
+const MAX_STRUCT_DEF_COUNT: usize = FF::TableIndex::MAX as usize;
+const MAX_STRUCT_DEF_INST_COUNT: usize = FF::TableIndex::MAX as usize;
+const MAX_FIELD_COUNT: usize = FF::TableIndex::MAX as usize;
+const MAX_FIELD_INST_COUNT: usize = FF::TableIndex::MAX as usize;
+const MAX_FUNCTION_COUNT: usize = FF::TableIndex::MAX as usize;
+const MAX_FUNCTION_INST_COUNT: usize = FF::TableIndex::MAX as usize;
+const MAX_FUNCTION_DEF_COUNT: usize = FF::TableIndex::MAX as usize;
+const MAX_LOCAL_COUNT: usize = FF::LocalIndex::MAX as usize;

--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -1,0 +1,599 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::file_format_generator::{
+    function_generator::FunctionGenerator, MAX_ADDRESS_COUNT, MAX_CONST_COUNT, MAX_FIELD_COUNT,
+    MAX_FIELD_INST_COUNT, MAX_FUNCTION_COUNT, MAX_FUNCTION_INST_COUNT, MAX_IDENTIFIER_COUNT,
+    MAX_MODULE_COUNT, MAX_SIGNATURE_COUNT, MAX_STRUCT_COUNT, MAX_STRUCT_DEF_COUNT,
+    MAX_STRUCT_DEF_INST_COUNT,
+};
+use codespan_reporting::diagnostic::Severity;
+use move_binary_format::{file_format as FF, file_format_common};
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use move_model::{
+    model::{
+        FieldEnv, FunId, FunctionEnv, GlobalEnv, Loc, ModuleEnv, ModuleId, Parameter, QualifiedId,
+        StructEnv, StructId, TypeParameter, TypeParameterKind,
+    },
+    symbol::Symbol,
+    ty::{PrimitiveType, ReferenceKind, Type},
+};
+use move_stackless_bytecode::{
+    function_target_pipeline::FunctionTargetsHolder, stackless_bytecode::Constant,
+};
+use std::collections::BTreeMap;
+
+/// Internal state of the module code generator
+#[derive(Debug)]
+pub struct ModuleGenerator {
+    /// The module index for which we generate code.
+    module_idx: FF::ModuleHandleIndex,
+    /// A mapping from modules to indices.
+    module_to_idx: BTreeMap<ModuleId, FF::ModuleHandleIndex>,
+    /// A mapping from symbols to indices.
+    name_to_idx: BTreeMap<Symbol, FF::IdentifierIndex>,
+    /// A mapping from addresses to indices.
+    address_to_idx: BTreeMap<AccountAddress, FF::AddressIdentifierIndex>,
+    /// A mapping from functions to indices.
+    fun_to_idx: BTreeMap<QualifiedId<FunId>, FF::FunctionHandleIndex>,
+    /// A mapping from function instantiations to indices.
+    fun_inst_to_idx:
+        BTreeMap<(QualifiedId<FunId>, FF::SignatureIndex), FF::FunctionInstantiationIndex>,
+    /// A mapping from structs to indices.
+    struct_to_idx: BTreeMap<QualifiedId<StructId>, FF::StructHandleIndex>,
+    /// A mapping from function instantiations to indices.
+    struct_def_inst_to_idx:
+        BTreeMap<(QualifiedId<StructId>, FF::SignatureIndex), FF::StructDefInstantiationIndex>,
+    /// A mapping from fields to indices.
+    field_to_idx: BTreeMap<(QualifiedId<StructId>, usize), FF::FieldHandleIndex>,
+    /// A mapping from fields to indices.
+    field_inst_to_idx:
+        BTreeMap<(QualifiedId<StructId>, usize, FF::SignatureIndex), FF::FieldInstantiationIndex>,
+    /// A mapping from type sequences to signature indices.
+    types_to_signature: BTreeMap<Vec<Type>, FF::SignatureIndex>,
+    /// A mapping from constants sequences to pool indices.
+    cons_to_idx: BTreeMap<Constant, FF::ConstantPoolIndex>,
+    /// The file-format module we are building.
+    pub module: move_binary_format::CompiledModule,
+}
+
+/// Immutable context for a module code generation, seperated from the mutable generator
+/// state to reduce borrow conflicts.
+#[derive(Debug, Clone)]
+pub struct ModuleContext<'env> {
+    pub env: &'env GlobalEnv,
+    pub targets: &'env FunctionTargetsHolder,
+}
+
+impl<'env> AsRef<GlobalEnv> for ModuleContext<'env> {
+    fn as_ref(&self) -> &GlobalEnv {
+        self.env
+    }
+}
+
+impl ModuleGenerator {
+    pub fn run(ctx: &ModuleContext, module_env: &ModuleEnv) -> FF::CompiledModule {
+        let module = move_binary_format::CompiledModule {
+            version: file_format_common::VERSION_6,
+            self_module_handle_idx: FF::ModuleHandleIndex(0),
+            ..Default::default()
+        };
+        let mut gen = Self {
+            module_idx: FF::ModuleHandleIndex(0),
+            module_to_idx: Default::default(),
+            name_to_idx: Default::default(),
+            address_to_idx: Default::default(),
+            fun_to_idx: Default::default(),
+            struct_to_idx: Default::default(),
+            struct_def_inst_to_idx: Default::default(),
+            field_to_idx: Default::default(),
+            field_inst_to_idx: Default::default(),
+            types_to_signature: Default::default(),
+            cons_to_idx: Default::default(),
+            fun_inst_to_idx: Default::default(),
+            module,
+        };
+        gen.gen_module(ctx, module_env);
+        gen.module
+    }
+
+    /// Generates a module, visiting all of it's members.
+    fn gen_module(&mut self, ctx: &ModuleContext, module_env: &ModuleEnv<'_>) {
+        // Create the self module handle, at well known handle index 0
+        let loc = &module_env.get_loc();
+        self.module_index(ctx, loc, module_env.get_id());
+
+        for struct_env in module_env.get_structs() {
+            self.gen_struct(ctx, &struct_env)
+        }
+        for fun_env in module_env.get_functions() {
+            FunctionGenerator::run(self, ctx, fun_env);
+        }
+    }
+
+    /// Generate information for a struct.
+    fn gen_struct(&mut self, ctx: &ModuleContext, struct_env: &StructEnv<'_>) {
+        let loc = &struct_env.get_loc();
+        let struct_handle = self.struct_index(ctx, loc, struct_env);
+        let field_information = FF::StructFieldInformation::Declared(
+            struct_env
+                .get_fields()
+                .map(|f| {
+                    let name = self.name_index(ctx, loc, f.get_name());
+                    let signature =
+                        FF::TypeSignature(self.signature_token(ctx, loc, &f.get_type()));
+                    FF::FieldDefinition { name, signature }
+                })
+                .collect(),
+        );
+        let def = FF::StructDefinition {
+            struct_handle,
+            field_information,
+        };
+        ctx.checked_bound(
+            loc,
+            self.module.struct_defs.len(),
+            MAX_STRUCT_DEF_COUNT,
+            "struct",
+        );
+        self.module.struct_defs.push(def);
+    }
+
+    /// Obtains or creates an index for a signature, a sequence of types.
+    pub fn signature(
+        &mut self,
+        ctx: &ModuleContext,
+        loc: &Loc,
+        tys: Vec<Type>,
+    ) -> FF::SignatureIndex {
+        if let Some(idx) = self.types_to_signature.get(&tys) {
+            return *idx;
+        }
+        let tokens = tys
+            .iter()
+            .map(|ty| self.signature_token(ctx, loc, ty))
+            .collect::<Vec<_>>();
+        let idx = FF::SignatureIndex(ctx.checked_bound(
+            loc,
+            self.module.signatures.len(),
+            MAX_SIGNATURE_COUNT,
+            "signature",
+        ));
+        self.module.signatures.push(FF::Signature(tokens));
+        self.types_to_signature.entry(tys).or_insert(idx);
+        idx
+    }
+
+    /// Creates a signature token from a Move model type.
+    pub fn signature_token(
+        &mut self,
+        ctx: &ModuleContext,
+        loc: &Loc,
+        ty: &Type,
+    ) -> FF::SignatureToken {
+        use PrimitiveType::*;
+        use Type::*;
+        match ty {
+            Primitive(kind) => match kind {
+                Bool => FF::SignatureToken::Bool,
+                U8 => FF::SignatureToken::U8,
+                U16 => FF::SignatureToken::U16,
+                U32 => FF::SignatureToken::U32,
+                U64 => FF::SignatureToken::U64,
+                U128 => FF::SignatureToken::U128,
+                U256 => FF::SignatureToken::U256,
+                Address => FF::SignatureToken::Address,
+                Signer => FF::SignatureToken::Signer,
+                Num | Range | EventStore => {
+                    ctx.internal_error(loc, "unexpected specification type");
+                    FF::SignatureToken::Bool
+                },
+            },
+            Tuple(_) => {
+                ctx.internal_error(loc, "unexpected tuple type");
+                FF::SignatureToken::Bool
+            },
+            Vector(ty) => FF::SignatureToken::Vector(Box::new(self.signature_token(ctx, loc, ty))),
+            Struct(mid, sid, inst) => {
+                let handle = self.struct_index(ctx, loc, &ctx.env.get_struct(mid.qualified(*sid)));
+                if inst.is_empty() {
+                    FF::SignatureToken::Struct(handle)
+                } else {
+                    FF::SignatureToken::StructInstantiation(
+                        handle,
+                        inst.iter()
+                            .map(|t| self.signature_token(ctx, loc, t))
+                            .collect(),
+                    )
+                }
+            },
+            TypeParameter(p) => FF::SignatureToken::TypeParameter(*p),
+            Reference(kind, target_ty) => {
+                let target_ty = Box::new(self.signature_token(ctx, loc, target_ty));
+                match kind {
+                    ReferenceKind::Immutable => FF::SignatureToken::Reference(target_ty),
+                    ReferenceKind::Mutable => FF::SignatureToken::MutableReference(target_ty),
+                }
+            },
+            Fun(_, _) | TypeDomain(_) | ResourceDomain(_, _, _) | Error | Var(_) => {
+                ctx.internal_error(
+                    loc,
+                    format!(
+                        "unexpected type: {}",
+                        ty.display(&ctx.env.get_type_display_ctx())
+                    ),
+                );
+                FF::SignatureToken::Bool
+            },
+        }
+    }
+
+    /// Obtains or generates an identifier index for the given symbol.
+    pub fn module_index(
+        &mut self,
+        ctx: &ModuleContext,
+        loc: &Loc,
+        mod_id: ModuleId,
+    ) -> FF::ModuleHandleIndex {
+        if let Some(idx) = self.module_to_idx.get(&mod_id) {
+            return *idx;
+        }
+        let idx = FF::ModuleHandleIndex(ctx.checked_bound(
+            loc,
+            self.module.address_identifiers.len(),
+            MAX_MODULE_COUNT,
+            "module",
+        ));
+        let mod_env = &ctx.env.get_module(mod_id);
+        let mod_name = mod_env.get_name();
+        let address = self.address_index(ctx, loc, mod_name.addr().expect_numerical());
+        let name = self.name_index(ctx, loc, mod_name.name());
+        self.module
+            .module_handles
+            .push(FF::ModuleHandle { address, name });
+        self.module_to_idx.insert(mod_id, idx);
+        idx
+    }
+
+    /// Obtains or generates an identifier index for the given symbol.
+    pub fn name_index(
+        &mut self,
+        ctx: &ModuleContext,
+        loc: &Loc,
+        name: Symbol,
+    ) -> FF::IdentifierIndex {
+        if let Some(idx) = self.name_to_idx.get(&name) {
+            return *idx;
+        }
+        let ident =
+            if let Ok(ident) = Identifier::new(name.display(ctx.env.symbol_pool()).to_string()) {
+                ident
+            } else {
+                ctx.internal_error(
+                    loc,
+                    format!("invalid identifier {}", name.display(ctx.env.symbol_pool())),
+                );
+                Identifier::new("error").unwrap()
+            };
+        let idx = FF::IdentifierIndex(ctx.checked_bound(
+            loc,
+            self.module.identifiers.len(),
+            MAX_IDENTIFIER_COUNT,
+            "identifier",
+        ));
+        self.module.identifiers.push(ident);
+        self.name_to_idx.insert(name, idx);
+        idx
+    }
+
+    /// Obtains or generates an identifier index for the given symbol.
+    pub fn address_index(
+        &mut self,
+        ctx: &ModuleContext,
+        loc: &Loc,
+        addr: AccountAddress,
+    ) -> FF::AddressIdentifierIndex {
+        if let Some(idx) = self.address_to_idx.get(&addr) {
+            return *idx;
+        }
+        let idx = FF::AddressIdentifierIndex(ctx.checked_bound(
+            loc,
+            self.module.address_identifiers.len(),
+            MAX_ADDRESS_COUNT,
+            "address",
+        ));
+        self.module.address_identifiers.push(addr);
+        self.address_to_idx.insert(addr, idx);
+        idx
+    }
+
+    /// Obtains or generates a function index.
+    pub fn function_index(
+        &mut self,
+        ctx: &ModuleContext,
+        loc: &Loc,
+        fun_env: &FunctionEnv<'_>,
+    ) -> FF::FunctionHandleIndex {
+        if let Some(idx) = self.fun_to_idx.get(&fun_env.get_qualified_id()) {
+            return *idx;
+        }
+        let name = self.name_index(ctx, loc, fun_env.get_name());
+        let type_parameters = fun_env
+            .get_type_parameters()
+            .into_iter()
+            .map(|TypeParameter(_, TypeParameterKind { abilities, .. })| abilities)
+            .collect::<Vec<_>>();
+        let parameters = self.signature(
+            ctx,
+            loc,
+            fun_env
+                .get_parameters()
+                .iter()
+                .map(|Parameter(_, ty)| ty.to_owned())
+                .collect(),
+        );
+        let return_ = self.signature(
+            ctx,
+            loc,
+            fun_env.get_result_type().flatten().into_iter().collect(),
+        );
+        let handle = FF::FunctionHandle {
+            module: self.module_idx,
+            name,
+            type_parameters,
+            parameters,
+            return_,
+        };
+        let idx = FF::FunctionHandleIndex(ctx.checked_bound(
+            loc,
+            self.module.function_handles.len(),
+            MAX_FUNCTION_COUNT,
+            "used function",
+        ));
+        self.module.function_handles.push(handle);
+        self.fun_to_idx.insert(fun_env.get_qualified_id(), idx);
+        idx
+    }
+
+    pub fn function_instantiation_index(
+        &mut self,
+        ctx: &ModuleContext,
+        loc: &Loc,
+        fun_env: &FunctionEnv<'_>,
+        inst: Vec<Type>,
+    ) -> FF::FunctionInstantiationIndex {
+        let type_parameters = self.signature(ctx, loc, inst);
+        let cache_key = (fun_env.get_qualified_id(), type_parameters);
+        if let Some(idx) = self.fun_inst_to_idx.get(&cache_key) {
+            return *idx;
+        }
+        let handle = self.function_index(ctx, loc, fun_env);
+        let fun_inst = FF::FunctionInstantiation {
+            handle,
+            type_parameters,
+        };
+        let idx = FF::FunctionInstantiationIndex(ctx.checked_bound(
+            loc,
+            self.module.function_instantiations.len(),
+            MAX_FUNCTION_INST_COUNT,
+            "function instantiation",
+        ));
+        self.module.function_instantiations.push(fun_inst);
+        self.fun_inst_to_idx.insert(cache_key, idx);
+        idx
+    }
+
+    /// Obtains or generates a struct index.
+    pub fn struct_index(
+        &mut self,
+        ctx: &ModuleContext,
+        loc: &Loc,
+        struct_env: &StructEnv<'_>,
+    ) -> FF::StructHandleIndex {
+        if let Some(idx) = self.struct_to_idx.get(&struct_env.get_qualified_id()) {
+            return *idx;
+        }
+        let name = self.name_index(ctx, loc, struct_env.get_name());
+        let handle = FF::StructHandle {
+            module: self.module_idx,
+            name,
+            abilities: struct_env.get_abilities(),
+            type_parameters: struct_env
+                .get_type_parameters()
+                .iter()
+                .map(
+                    |TypeParameter(
+                        _sym,
+                        TypeParameterKind {
+                            abilities,
+                            is_phantom,
+                        },
+                    )| FF::StructTypeParameter {
+                        constraints: *abilities,
+                        is_phantom: *is_phantom,
+                    },
+                )
+                .collect(),
+        };
+        let idx = FF::StructHandleIndex(ctx.checked_bound(
+            loc,
+            self.module.struct_handles.len(),
+            MAX_STRUCT_COUNT,
+            "used structs",
+        ));
+        self.module.struct_handles.push(handle);
+        self.struct_to_idx
+            .insert(struct_env.get_qualified_id(), idx);
+        idx
+    }
+
+    /// Obtains a struct definition index.
+    pub fn struct_def_index(
+        &mut self,
+        ctx: &ModuleContext,
+        loc: &Loc,
+        struct_env: &StructEnv,
+    ) -> FF::StructDefinitionIndex {
+        let struct_idx = self.struct_index(ctx, loc, struct_env);
+        for (i, def) in self.module.struct_defs.iter().enumerate() {
+            if def.struct_handle == struct_idx {
+                return FF::StructDefinitionIndex::new(i as FF::TableIndex);
+            }
+        }
+        ctx.internal_error(loc, "struct not defined");
+        FF::StructDefinitionIndex(0)
+    }
+
+    /// Obtains or constructs a struct definition instantiation index.
+    pub fn struct_def_instantiation_index(
+        &mut self,
+        ctx: &ModuleContext,
+        loc: &Loc,
+        struct_env: &StructEnv,
+        inst: Vec<Type>,
+    ) -> FF::StructDefInstantiationIndex {
+        let type_parameters = self.signature(ctx, loc, inst);
+        let cache_key = (struct_env.get_qualified_id(), type_parameters);
+        if let Some(idx) = self.struct_def_inst_to_idx.get(&cache_key) {
+            return *idx;
+        }
+        let def = self.struct_def_index(ctx, loc, struct_env);
+        let struct_inst = FF::StructDefInstantiation {
+            def,
+            type_parameters,
+        };
+        let idx = FF::StructDefInstantiationIndex(ctx.checked_bound(
+            loc,
+            self.module.struct_def_instantiations.len(),
+            MAX_STRUCT_DEF_INST_COUNT,
+            "struct instantiation",
+        ));
+        self.module.struct_def_instantiations.push(struct_inst);
+        self.struct_def_inst_to_idx.insert(cache_key, idx);
+        idx
+    }
+
+    /// Obtains or creates a field handle index.
+    pub fn field_index(
+        &mut self,
+        ctx: &ModuleContext,
+        loc: &Loc,
+        field_env: &FieldEnv,
+    ) -> FF::FieldHandleIndex {
+        let key = (
+            field_env.struct_env.get_qualified_id(),
+            field_env.get_offset(),
+        );
+        if let Some(idx) = self.field_to_idx.get(&key) {
+            return *idx;
+        }
+        let field_idx = FF::FieldHandleIndex(ctx.checked_bound(
+            loc,
+            self.module.field_handles.len(),
+            MAX_FIELD_COUNT,
+            "field",
+        ));
+        let owner = self.struct_def_index(ctx, loc, &field_env.struct_env);
+        self.module.field_handles.push(FF::FieldHandle {
+            owner,
+            field: field_env.get_offset() as FF::MemberCount,
+        });
+        self.field_to_idx.insert(key, field_idx);
+        field_idx
+    }
+
+    /// Obtains or creates a field instantiation handle index.
+    pub fn field_inst_index(
+        &mut self,
+        ctx: &ModuleContext,
+        loc: &Loc,
+        field_env: &FieldEnv,
+        inst: Vec<Type>,
+    ) -> FF::FieldInstantiationIndex {
+        let type_parameters = self.signature(ctx, loc, inst);
+        let key = (
+            field_env.struct_env.get_qualified_id(),
+            field_env.get_offset(),
+            type_parameters,
+        );
+        if let Some(idx) = self.field_inst_to_idx.get(&key) {
+            return *idx;
+        }
+        let field_inst_idx = FF::FieldInstantiationIndex(ctx.checked_bound(
+            loc,
+            self.module.field_instantiations.len(),
+            MAX_FIELD_INST_COUNT,
+            "field instantiation",
+        ));
+        let handle = self.field_index(ctx, loc, field_env);
+        self.module
+            .field_instantiations
+            .push(FF::FieldInstantiation {
+                handle,
+                type_parameters,
+            });
+        self.field_inst_to_idx.insert(key, field_inst_idx);
+        field_inst_idx
+    }
+
+    /// Obtains or generates a constant index.
+    pub fn cons_index(
+        &mut self,
+        ctx: &ModuleContext,
+        loc: &Loc,
+        cons: &Constant,
+        ty: &Type,
+    ) -> FF::ConstantPoolIndex {
+        if let Some(idx) = self.cons_to_idx.get(cons) {
+            return *idx;
+        }
+        let data = cons
+            .to_move_value()
+            .simple_serialize()
+            .expect("serialization succeeds");
+        let ff_cons = FF::Constant {
+            type_: self.signature_token(ctx, loc, ty),
+            data,
+        };
+        let idx = FF::ConstantPoolIndex(ctx.checked_bound(
+            loc,
+            self.module.constant_pool.len(),
+            MAX_CONST_COUNT,
+            "constant",
+        ));
+        self.module.constant_pool.push(ff_cons);
+        self.cons_to_idx.insert(cons.clone(), idx);
+        idx
+    }
+}
+
+impl<'env> ModuleContext<'env> {
+    /// Emits an error at the location.
+    pub fn error(&self, loc: impl AsRef<Loc>, msg: impl AsRef<str>) {
+        self.env.diag(Severity::Error, loc.as_ref(), msg.as_ref())
+    }
+
+    /// Emits an internal error at the location.
+    pub fn internal_error(&self, loc: impl AsRef<Loc>, msg: impl AsRef<str>) {
+        self.env.diag(Severity::Bug, loc.as_ref(), msg.as_ref())
+    }
+
+    /// Check for a bound table index and report an error if its out of bound. All bounds
+    /// should be handled by this generator in a graceful and giving the user detail
+    /// information of the location.
+    pub fn checked_bound(
+        &self,
+        loc: impl AsRef<Loc>,
+        value: usize,
+        max: usize,
+        msg: &str,
+    ) -> FF::TableIndex {
+        if value >= max {
+            self.error(loc, format!("exceeded maximal {} count: {}", msg, max));
+            0
+        } else {
+            value as FF::TableIndex
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -533,7 +533,7 @@ impl ModuleGenerator {
     }
 
     /// Obtains or generates a constant index.
-    pub fn cons_index(
+    pub fn constant_index(
         &mut self,
         ctx: &ModuleContext,
         loc: &Loc,

--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -66,13 +66,8 @@ pub struct ModuleContext<'env> {
     pub targets: &'env FunctionTargetsHolder,
 }
 
-impl<'env> AsRef<GlobalEnv> for ModuleContext<'env> {
-    fn as_ref(&self) -> &GlobalEnv {
-        self.env
-    }
-}
-
 impl ModuleGenerator {
+    /// Runs generation of `CompiledModule`.
     pub fn run(ctx: &ModuleContext, module_env: &ModuleEnv) -> FF::CompiledModule {
         let module = move_binary_format::CompiledModule {
             version: file_format_common::VERSION_6,
@@ -98,7 +93,7 @@ impl ModuleGenerator {
         gen.module
     }
 
-    /// Generates a module, visiting all of it's members.
+    /// Generates a module, visiting all of its members.
     fn gen_module(&mut self, ctx: &ModuleContext, module_env: &ModuleEnv<'_>) {
         // Create the self module handle, at well known handle index 0
         let loc = &module_env.get_loc();
@@ -161,7 +156,7 @@ impl ModuleGenerator {
             "signature",
         ));
         self.module.signatures.push(FF::Signature(tokens));
-        self.types_to_signature.entry(tys).or_insert(idx);
+        self.types_to_signature.insert(tys, idx);
         idx
     }
 

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/assign.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/assign.exp
@@ -1,0 +1,95 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun assign::assign_field($t0: &mut assign::S, $t1: u64) {
+     var $t2: &mut u64
+  0: $t2 := borrow_field<assign::S>.f($t0)
+  1: write_ref($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun assign::assign_int($t0: &mut u64) {
+     var $t1: u64
+  0: $t1 := 42
+  1: write_ref($t0, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun assign::assign_pattern($t0: assign::S, $t1: u64, $t2: u64): u64 {
+     var $t3: u64
+     var $t4: assign::T
+  0: ($t1, $t4) := unpack assign::S($t0)
+  1: $t2 := unpack assign::T($t4)
+  2: $t3 := +($t1, $t2)
+  3: return $t3
+}
+
+
+[variant baseline]
+fun assign::assign_struct($t0: &mut assign::S) {
+     var $t1: assign::S
+     var $t2: u64
+     var $t3: assign::T
+     var $t4: u64
+  0: $t2 := 42
+  1: $t4 := 42
+  2: $t3 := pack assign::T($t4)
+  3: $t1 := pack assign::S($t2, $t3)
+  4: write_ref($t0, $t1)
+  5: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v6
+module 42.assign {
+struct T {
+	h: u64
+}
+struct S {
+	f: u64,
+	g: T
+}
+
+assign_field(Arg0: &mut S, Arg1: u64) {
+B0:
+	0: CopyLoc[0](Arg0: &mut S)
+	1: MutBorrowField[0](S.f: u64)
+	2: CopyLoc[1](Arg1: u64)
+	3: WriteRef
+	4: Ret
+}
+assign_int(Arg0: &mut u64) {
+B0:
+	0: LdConst[0](U64: [42, 0, 0, 0, 0, 0, 0, 0])
+	1: StLoc[1](loc0: u64)
+	2: CopyLoc[0](Arg0: &mut u64)
+	3: CopyLoc[1](loc0: u64)
+	4: WriteRef
+	5: Ret
+}
+assign_pattern(Arg0: S, Arg1: u64, Arg2: u64): u64 {
+B0:
+	0: MoveLoc[0](Arg0: S)
+	1: Unpack[1](S)
+	2: Unpack[0](T)
+	3: Add
+	4: Ret
+}
+assign_struct(Arg0: &mut S) {
+B0:
+	0: LdConst[0](U64: [42, 0, 0, 0, 0, 0, 0, 0])
+	1: LdConst[0](U64: [42, 0, 0, 0, 0, 0, 0, 0])
+	2: Pack[0](T)
+	3: Pack[1](S)
+	4: StLoc[1](loc0: S)
+	5: CopyLoc[0](Arg0: &mut S)
+	6: MoveLoc[1](loc0: S)
+	7: WriteRef
+	8: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/assign.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/assign.move
@@ -1,0 +1,28 @@
+module 0x42::assign {
+
+    struct S {
+        f: u64,
+        g: T
+    }
+
+    struct T {
+        h: u64
+    }
+
+    fun assign_int(x: &mut u64) {
+       *x = 42;
+    }
+
+    fun assign_struct(s: &mut S) {
+        *s = S { f: 42, g: T { h: 42 } };
+    }
+
+    fun assign_pattern(s: S, f: u64, h: u64): u64 {
+        S { f, g: T { h } } = s;
+        f + h
+    }
+
+    fun assign_field(s: &mut S, f: u64) {
+        s.f = f;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
@@ -1,0 +1,173 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun borrow::field($t0: &borrow::S): u64 {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+  0: $t3 := borrow_field<borrow::S>.f($t0)
+  1: $t2 := move($t3)
+  2: $t1 := read_ref($t2)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun borrow::local($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: &u64
+     var $t5: &u64
+  0: $t3 := 33
+  1: $t2 := move($t3)
+  2: $t5 := borrow_local($t2)
+  3: $t4 := move($t5)
+  4: $t1 := read_ref($t4)
+  5: return $t1
+}
+
+
+[variant baseline]
+fun borrow::param($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &u64
+  0: $t3 := borrow_local($t0)
+  1: $t2 := move($t3)
+  2: $t1 := read_ref($t2)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun borrow::mut_field($t0: &mut borrow::S): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: &mut u64
+     var $t4: u64
+  0: $t3 := borrow_field<borrow::S>.f($t0)
+  1: $t2 := move($t3)
+  2: $t4 := 22
+  3: write_ref($t2, $t4)
+  4: $t1 := read_ref($t2)
+  5: return $t1
+}
+
+
+[variant baseline]
+fun borrow::mut_local($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: &mut u64
+     var $t5: &mut u64
+     var $t6: u64
+  0: $t3 := 33
+  1: $t2 := move($t3)
+  2: $t5 := borrow_local($t2)
+  3: $t4 := move($t5)
+  4: $t6 := 22
+  5: write_ref($t4, $t6)
+  6: $t1 := read_ref($t4)
+  7: return $t1
+}
+
+
+[variant baseline]
+fun borrow::mut_param($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: &mut u64
+     var $t4: u64
+  0: $t3 := borrow_local($t0)
+  1: $t2 := move($t3)
+  2: $t4 := 22
+  3: write_ref($t2, $t4)
+  4: $t1 := read_ref($t2)
+  5: return $t1
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v6
+module 42.borrow {
+struct S {
+	f: u64
+}
+
+field(Arg0: &S): u64 {
+B0:
+	0: CopyLoc[0](Arg0: &S)
+	1: ImmBorrowField[0](S.f: u64)
+	2: StLoc[1](loc0: &u64)
+	3: CopyLoc[1](loc0: &u64)
+	4: ReadRef
+	5: Ret
+}
+local(Arg0: u64): u64 {
+L0:	loc1: &u64
+B0:
+	0: LdConst[0](U64: [33, 0, 0, 0, 0, 0, 0, 0])
+	1: StLoc[1](loc0: u64)
+	2: ImmBorrowLoc[1](loc0: u64)
+	3: StLoc[2](loc1: &u64)
+	4: CopyLoc[2](loc1: &u64)
+	5: ReadRef
+	6: Ret
+}
+param(Arg0: u64): u64 {
+B0:
+	0: ImmBorrowLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: &u64)
+	2: CopyLoc[1](loc0: &u64)
+	3: ReadRef
+	4: Ret
+}
+mut_field(Arg0: &mut S): u64 {
+L0:	loc1: u64
+B0:
+	0: CopyLoc[0](Arg0: &mut S)
+	1: MutBorrowField[0](S.f: u64)
+	2: StLoc[1](loc0: &mut u64)
+	3: LdConst[1](U64: [22, 0, 0, 0, 0, 0, 0, 0])
+	4: StLoc[2](loc1: u64)
+	5: CopyLoc[1](loc0: &mut u64)
+	6: CopyLoc[2](loc1: u64)
+	7: WriteRef
+	8: CopyLoc[1](loc0: &mut u64)
+	9: ReadRef
+	10: Ret
+}
+mut_local(Arg0: u64): u64 {
+L0:	loc1: &mut u64
+L1:	loc2: u64
+B0:
+	0: LdConst[0](U64: [33, 0, 0, 0, 0, 0, 0, 0])
+	1: StLoc[1](loc0: u64)
+	2: MutBorrowLoc[1](loc0: u64)
+	3: StLoc[2](loc1: &mut u64)
+	4: LdConst[1](U64: [22, 0, 0, 0, 0, 0, 0, 0])
+	5: StLoc[3](loc2: u64)
+	6: CopyLoc[2](loc1: &mut u64)
+	7: CopyLoc[3](loc2: u64)
+	8: WriteRef
+	9: CopyLoc[2](loc1: &mut u64)
+	10: ReadRef
+	11: Ret
+}
+mut_param(Arg0: u64): u64 {
+L0:	loc1: u64
+B0:
+	0: MutBorrowLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: &mut u64)
+	2: LdConst[1](U64: [22, 0, 0, 0, 0, 0, 0, 0])
+	3: StLoc[2](loc1: u64)
+	4: CopyLoc[1](loc0: &mut u64)
+	5: CopyLoc[2](loc1: u64)
+	6: WriteRef
+	7: CopyLoc[1](loc0: &mut u64)
+	8: ReadRef
+	9: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.move
@@ -1,0 +1,41 @@
+module 0x42::borrow {
+
+    struct S {
+        f: u64
+    }
+
+    fun param(param: u64): u64 {
+        let r = &param;
+        *r
+    }
+
+    fun local(param: u64): u64 {
+        let local: u64 = 33;
+        let r = &local;
+        *r
+    }
+
+    fun field(s: &S): u64 {
+        let r = &s.f;
+        *r
+    }
+
+    fun mut_param(param: u64): u64 {
+        let r = &mut param;
+        *r = 22;
+        *r
+    }
+
+    fun mut_local(param: u64): u64 {
+        let local: u64 = 33;
+        let r = &mut local;
+        *r = 22;
+        *r
+    }
+
+    fun mut_field(s: &mut S): u64 {
+        let r = &mut s.f;
+        *r = 22;
+        *r
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
@@ -1,0 +1,204 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun fields::read_ref($t0: &fields::S): u64 {
+     var $t1: u64
+     var $t2: &fields::T
+     var $t3: &u64
+  0: $t2 := borrow_field<fields::S>.g($t0)
+  1: $t3 := borrow_field<fields::T>.h($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun fields::read_val($t0: fields::S): u64 {
+     var $t1: u64
+     var $t2: &fields::T
+     var $t3: &fields::S
+     var $t4: &u64
+  0: $t3 := borrow_local($t0)
+  1: $t2 := borrow_field<fields::S>.g($t3)
+  2: $t4 := borrow_field<fields::T>.h($t2)
+  3: $t1 := read_ref($t4)
+  4: return $t1
+}
+
+
+[variant baseline]
+fun fields::write_local_direct(): fields::S {
+     var $t0: fields::S
+     var $t1: fields::S
+     var $t2: fields::S
+     var $t3: u64
+     var $t4: fields::T
+     var $t5: u64
+     var $t6: &mut u64
+     var $t7: &mut fields::T
+     var $t8: &mut fields::S
+     var $t9: u64
+  0: $t3 := 0
+  1: $t5 := 0
+  2: $t4 := pack fields::T($t5)
+  3: $t2 := pack fields::S($t3, $t4)
+  4: $t1 := move($t2)
+  5: $t8 := borrow_local($t1)
+  6: $t7 := borrow_field<fields::S>.g($t8)
+  7: $t6 := borrow_field<fields::T>.h($t7)
+  8: $t9 := 42
+  9: write_ref($t6, $t9)
+ 10: $t0 := move($t1)
+ 11: return $t0
+}
+
+
+[variant baseline]
+fun fields::write_local_via_ref(): fields::S {
+     var $t0: fields::S
+     var $t1: fields::S
+     var $t2: fields::S
+     var $t3: u64
+     var $t4: fields::T
+     var $t5: u64
+     var $t6: &mut fields::S
+     var $t7: &mut fields::S
+     var $t8: &mut u64
+     var $t9: &mut fields::T
+     var $t10: u64
+  0: $t3 := 0
+  1: $t5 := 0
+  2: $t4 := pack fields::T($t5)
+  3: $t2 := pack fields::S($t3, $t4)
+  4: $t1 := move($t2)
+  5: $t7 := borrow_local($t1)
+  6: $t6 := move($t7)
+  7: $t9 := borrow_field<fields::S>.g($t6)
+  8: $t8 := borrow_field<fields::T>.h($t9)
+  9: $t10 := 42
+ 10: write_ref($t8, $t10)
+ 11: $t0 := move($t1)
+ 12: return $t0
+}
+
+
+[variant baseline]
+fun fields::write_param($t0: &mut fields::S) {
+     var $t1: &mut u64
+     var $t2: &mut fields::T
+     var $t3: u64
+  0: $t2 := borrow_field<fields::S>.g($t0)
+  1: $t1 := borrow_field<fields::T>.h($t2)
+  2: $t3 := 42
+  3: write_ref($t1, $t3)
+  4: return ()
+}
+
+
+[variant baseline]
+fun fields::write_val($t0: fields::S): fields::S {
+     var $t1: fields::S
+     var $t2: &mut u64
+     var $t3: &mut fields::T
+     var $t4: &mut fields::S
+     var $t5: u64
+  0: $t4 := borrow_local($t0)
+  1: $t3 := borrow_field<fields::S>.g($t4)
+  2: $t2 := borrow_field<fields::T>.h($t3)
+  3: $t5 := 42
+  4: write_ref($t2, $t5)
+  5: $t1 := move($t0)
+  6: return $t1
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v6
+module 42.fields {
+struct T {
+	h: u64
+}
+struct S {
+	f: u64,
+	g: T
+}
+
+read_ref(Arg0: &S): u64 {
+B0:
+	0: CopyLoc[0](Arg0: &S)
+	1: ImmBorrowField[0](S.g: T)
+	2: ImmBorrowField[1](T.h: u64)
+	3: ReadRef
+	4: Ret
+}
+read_val(Arg0: S): u64 {
+B0:
+	0: ImmBorrowLoc[0](Arg0: S)
+	1: ImmBorrowField[0](S.g: T)
+	2: ImmBorrowField[1](T.h: u64)
+	3: ReadRef
+	4: Ret
+}
+write_local_direct(): S {
+L0:	loc0: S
+L1:	loc1: S
+B0:
+	0: LdConst[0](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	1: LdConst[0](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	2: Pack[0](T)
+	3: Pack[1](S)
+	4: StLoc[0](loc0: S)
+	5: MutBorrowLoc[0](loc0: S)
+	6: MutBorrowField[0](S.g: T)
+	7: MutBorrowField[1](T.h: u64)
+	8: LdConst[1](U64: [42, 0, 0, 0, 0, 0, 0, 0])
+	9: WriteRef
+	10: MoveLoc[0](loc0: S)
+	11: StLoc[1](loc1: S)
+	12: MoveLoc[1](loc1: S)
+	13: Ret
+}
+write_local_via_ref(): S {
+L0:	loc0: S
+L1:	loc1: &mut S
+L2:	loc2: S
+B0:
+	0: LdConst[0](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	1: LdConst[0](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	2: Pack[0](T)
+	3: Pack[1](S)
+	4: StLoc[0](loc0: S)
+	5: MutBorrowLoc[0](loc0: S)
+	6: StLoc[1](loc1: &mut S)
+	7: CopyLoc[1](loc1: &mut S)
+	8: MutBorrowField[0](S.g: T)
+	9: MutBorrowField[1](T.h: u64)
+	10: LdConst[1](U64: [42, 0, 0, 0, 0, 0, 0, 0])
+	11: WriteRef
+	12: MoveLoc[0](loc0: S)
+	13: StLoc[2](loc2: S)
+	14: MoveLoc[2](loc2: S)
+	15: Ret
+}
+write_param(Arg0: &mut S) {
+B0:
+	0: CopyLoc[0](Arg0: &mut S)
+	1: MutBorrowField[0](S.g: T)
+	2: MutBorrowField[1](T.h: u64)
+	3: LdConst[1](U64: [42, 0, 0, 0, 0, 0, 0, 0])
+	4: WriteRef
+	5: Ret
+}
+write_val(Arg0: S): S {
+B0:
+	0: MutBorrowLoc[0](Arg0: S)
+	1: MutBorrowField[0](S.g: T)
+	2: MutBorrowField[1](T.h: u64)
+	3: LdConst[1](U64: [42, 0, 0, 0, 0, 0, 0, 0])
+	4: WriteRef
+	5: MoveLoc[0](Arg0: S)
+	6: StLoc[1](loc0: S)
+	7: MoveLoc[1](loc0: S)
+	8: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/fields.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/fields.move
@@ -1,0 +1,41 @@
+module 0x42::fields {
+
+    struct S {
+        f: u64,
+        g: T
+    }
+
+    struct T {
+        h: u64
+    }
+
+    fun read_val(x: S): u64 {
+        x.g.h
+    }
+
+    fun read_ref(x: &S): u64 {
+        x.g.h
+    }
+
+    fun write_val(x: S): S {
+        x.g.h = 42;
+        x
+    }
+
+    fun write_param(x: &mut S) {
+        x.g.h = 42;
+    }
+
+    fun write_local_via_ref(): S {
+        let x = S { f: 0, g: T { h: 0 } };
+        let r = &mut x;
+        r.g.h = 42;
+        x
+    }
+
+    fun write_local_direct(): S {
+        let x = S { f: 0, g: T { h: 0 } };
+        x.g.h = 42;
+        x
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
@@ -1,0 +1,98 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun globals::check($t0: address): bool {
+     var $t1: bool
+  0: $t1 := exists<globals::R>($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun globals::publish($t0: &signer) {
+     var $t1: globals::R
+     var $t2: u64
+  0: $t2 := 1
+  1: $t1 := pack globals::R($t2)
+  2: move_to<globals::R>($t0, $t1)
+  3: return ()
+}
+
+
+[variant baseline]
+fun globals::read($t0: address): u64 {
+     var $t1: u64
+     var $t2: &globals::R
+     var $t3: &globals::R
+     var $t4: &u64
+  0: $t3 := borrow_global<globals::R>($t0)
+  1: $t2 := move($t3)
+  2: $t4 := borrow_field<globals::R>.f($t2)
+  3: $t1 := read_ref($t4)
+  4: return $t1
+}
+
+
+[variant baseline]
+fun globals::write($t0: address, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut globals::R
+     var $t4: &mut globals::R
+     var $t5: &mut u64
+     var $t6: u64
+  0: $t4 := borrow_global<globals::R>($t0)
+  1: $t3 := move($t4)
+  2: $t5 := borrow_field<globals::R>.f($t3)
+  3: $t6 := 2
+  4: write_ref($t5, $t6)
+  5: $t2 := 9
+  6: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v6
+module 42.globals {
+struct R has store {
+	f: u64
+}
+
+check(Arg0: address): bool {
+B0:
+	0: CopyLoc[0](Arg0: address)
+	1: Exists[0](R)
+	2: Ret
+}
+publish(Arg0: &signer) {
+B0:
+	0: LdConst[0](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	1: Pack[0](R)
+	2: StLoc[1](loc0: R)
+	3: CopyLoc[0](Arg0: &signer)
+	4: MoveLoc[1](loc0: R)
+	5: MoveTo[0](R)
+	6: Ret
+}
+read(Arg0: address): u64 {
+B0:
+	0: CopyLoc[0](Arg0: address)
+	1: ImmBorrowGlobal[0](R)
+	2: StLoc[1](loc0: &R)
+	3: CopyLoc[1](loc0: &R)
+	4: ImmBorrowField[0](R.f: u64)
+	5: ReadRef
+	6: Ret
+}
+write(Arg0: address, Arg1: u64): u64 {
+B0:
+	0: CopyLoc[0](Arg0: address)
+	1: MutBorrowGlobal[0](R)
+	2: StLoc[2](loc0: &mut R)
+	3: CopyLoc[2](loc0: &mut R)
+	4: MutBorrowField[0](R.f: u64)
+	5: LdConst[1](U64: [2, 0, 0, 0, 0, 0, 0, 0])
+	6: WriteRef
+	7: LdConst[2](U64: [9, 0, 0, 0, 0, 0, 0, 0])
+	8: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/globals.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/globals.move
@@ -1,0 +1,23 @@
+module 0x42::globals {
+
+    struct R has store { f: u64 }
+
+    fun publish(s: &signer) {
+        move_to(s, R{f: 1});
+    }
+
+    fun check(a: address): bool {
+        exists<R>(a)
+    }
+
+    fun read(a: address): u64 {
+        let r = borrow_global<R>(a);
+        r.f
+    }
+
+    fun write(a: address, x: u64): u64 {
+        let r = borrow_global_mut<R>(a);
+        r.f = 2;
+        9
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.exp
@@ -1,0 +1,128 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun if_else::if_else($t0: bool, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: if ($t0) goto 1 else goto 5
+  1: label L0
+  2: $t3 := 1
+  3: $t2 := +($t1, $t3)
+  4: goto 8
+  5: label L1
+  6: $t4 := 1
+  7: $t2 := -($t1, $t4)
+  8: label L2
+  9: return $t2
+}
+
+
+[variant baseline]
+fun if_else::if_else_nested($t0: bool, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+  0: if ($t0) goto 1 else goto 5
+  1: label L0
+  2: $t5 := 1
+  3: $t4 := +($t1, $t5)
+  4: goto 8
+  5: label L1
+  6: $t6 := 1
+  7: $t4 := -($t1, $t6)
+  8: label L2
+  9: $t7 := 10
+ 10: $t3 := >($t4, $t7)
+ 11: if ($t3) goto 12 else goto 16
+ 12: label L3
+ 13: $t8 := 2
+ 14: $t2 := *($t1, $t8)
+ 15: goto 19
+ 16: label L4
+ 17: $t9 := 2
+ 18: $t2 := /($t1, $t9)
+ 19: label L5
+ 20: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v6
+module 42.if_else {
+
+
+if_else(Arg0: bool, Arg1: u64): u64 {
+L0:	loc2: u64
+B0:
+	0: CopyLoc[0](Arg0: bool)
+	1: BrFalse(9)
+B1:
+	2: LdConst[0](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	3: StLoc[2](loc0: u64)
+	4: CopyLoc[1](Arg1: u64)
+	5: CopyLoc[2](loc0: u64)
+	6: Add
+	7: Branch(14)
+B2:
+	8: StLoc[3](loc1: u64)
+B3:
+	9: LdConst[0](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	10: StLoc[4](loc2: u64)
+	11: CopyLoc[1](Arg1: u64)
+	12: CopyLoc[4](loc2: u64)
+	13: Sub
+B4:
+	14: Ret
+}
+if_else_nested(Arg0: bool, Arg1: u64): u64 {
+L0:	loc2: u64
+L1:	loc3: u64
+L2:	loc4: u64
+L3:	loc5: u64
+B0:
+	0: CopyLoc[0](Arg0: bool)
+	1: BrFalse(9)
+B1:
+	2: LdConst[0](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	3: StLoc[2](loc0: u64)
+	4: CopyLoc[1](Arg1: u64)
+	5: CopyLoc[2](loc0: u64)
+	6: Add
+	7: Branch(14)
+B2:
+	8: StLoc[3](loc1: u64)
+B3:
+	9: LdConst[0](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	10: StLoc[4](loc2: u64)
+	11: CopyLoc[1](Arg1: u64)
+	12: CopyLoc[4](loc2: u64)
+	13: Sub
+B4:
+	14: LdConst[1](U64: [10, 0, 0, 0, 0, 0, 0, 0])
+	15: Gt
+	16: BrFalse(24)
+B5:
+	17: LdConst[2](U64: [2, 0, 0, 0, 0, 0, 0, 0])
+	18: StLoc[5](loc3: u64)
+	19: CopyLoc[1](Arg1: u64)
+	20: CopyLoc[5](loc3: u64)
+	21: Mul
+	22: Branch(29)
+B6:
+	23: StLoc[6](loc4: u64)
+B7:
+	24: LdConst[2](U64: [2, 0, 0, 0, 0, 0, 0, 0])
+	25: StLoc[7](loc5: u64)
+	26: CopyLoc[1](Arg1: u64)
+	27: CopyLoc[7](loc5: u64)
+	28: Div
+B8:
+	29: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.move
@@ -1,0 +1,10 @@
+module 0x42::if_else {
+
+    fun if_else(cond: bool, x: u64): u64 {
+        if (cond) x + 1 else x - 1
+    }
+
+    fun if_else_nested(cond: bool, x: u64): u64 {
+        if ((if (cond) x + 1 else x - 1) > 10) x * 2 else x / 2
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
@@ -1,0 +1,259 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun loops::nested_loop($t0: u64): u64 {
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+  0: label L0
+  1: $t3 := 0
+  2: $t2 := >($t0, $t3)
+  3: if ($t2) goto 4 else goto 25
+  4: label L2
+  5: label L5
+  6: $t5 := 10
+  7: $t4 := >($t0, $t5)
+  8: if ($t4) goto 9 else goto 15
+  9: label L7
+ 10: $t7 := 1
+ 11: $t6 := -($t0, $t7)
+ 12: $t0 := move($t6)
+ 13: goto 19
+ 14: goto 17
+ 15: label L8
+ 16: goto 19
+ 17: label L9
+ 18: goto 5
+ 19: label L6
+ 20: $t9 := 1
+ 21: $t8 := -($t0, $t9)
+ 22: $t0 := move($t8)
+ 23: goto 0
+ 24: goto 27
+ 25: label L3
+ 26: goto 29
+ 27: label L4
+ 28: goto 0
+ 29: label L1
+ 30: $t1 := move($t0)
+ 31: return $t1
+}
+
+
+[variant baseline]
+fun loops::while_loop($t0: u64): u64 {
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: label L0
+  1: $t3 := 0
+  2: $t2 := >($t0, $t3)
+  3: if ($t2) goto 4 else goto 9
+  4: label L2
+  5: $t5 := 1
+  6: $t4 := -($t0, $t5)
+  7: $t0 := move($t4)
+  8: goto 11
+  9: label L3
+ 10: goto 13
+ 11: label L4
+ 12: goto 0
+ 13: label L1
+ 14: $t1 := move($t0)
+ 15: return $t1
+}
+
+
+[variant baseline]
+fun loops::while_loop_with_break_and_continue($t0: u64): u64 {
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+  0: label L0
+  1: $t3 := 0
+  2: $t2 := >($t0, $t3)
+  3: if ($t2) goto 4 else goto 25
+  4: label L2
+  5: $t5 := 42
+  6: $t4 := ==($t0, $t5)
+  7: if ($t4) goto 8 else goto 11
+  8: label L5
+  9: goto 29
+ 10: goto 12
+ 11: label L6
+ 12: label L7
+ 13: $t7 := 21
+ 14: $t6 := ==($t0, $t7)
+ 15: if ($t6) goto 16 else goto 19
+ 16: label L8
+ 17: goto 0
+ 18: goto 20
+ 19: label L9
+ 20: label L10
+ 21: $t9 := 1
+ 22: $t8 := -($t0, $t9)
+ 23: $t0 := move($t8)
+ 24: goto 27
+ 25: label L3
+ 26: goto 29
+ 27: label L4
+ 28: goto 0
+ 29: label L1
+ 30: $t1 := move($t0)
+ 31: return $t1
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v6
+module 42.loops {
+
+
+nested_loop(Arg0: u64): u64 {
+L0:	loc1: u64
+L1:	loc2: u64
+L2:	loc3: u64
+L3:	loc4: u64
+B0:
+	0: LdConst[0](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	1: StLoc[1](loc0: u64)
+	2: CopyLoc[0](Arg0: u64)
+	3: CopyLoc[1](loc0: u64)
+	4: Gt
+	5: BrFalse(30)
+B1:
+	6: LdConst[1](U64: [10, 0, 0, 0, 0, 0, 0, 0])
+	7: StLoc[2](loc1: u64)
+	8: CopyLoc[0](Arg0: u64)
+	9: CopyLoc[2](loc1: u64)
+	10: Gt
+	11: BrFalse(20)
+B2:
+	12: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	13: StLoc[3](loc2: u64)
+	14: CopyLoc[0](Arg0: u64)
+	15: CopyLoc[3](loc2: u64)
+	16: Sub
+	17: StLoc[0](Arg0: u64)
+	18: Branch(22)
+B3:
+	19: Branch(21)
+B4:
+	20: Branch(22)
+B5:
+	21: Branch(6)
+B6:
+	22: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	23: StLoc[4](loc3: u64)
+	24: CopyLoc[0](Arg0: u64)
+	25: CopyLoc[4](loc3: u64)
+	26: Sub
+	27: StLoc[0](Arg0: u64)
+	28: Branch(0)
+B7:
+	29: Branch(31)
+B8:
+	30: Branch(32)
+B9:
+	31: Branch(0)
+B10:
+	32: CopyLoc[0](Arg0: u64)
+	33: StLoc[5](loc4: u64)
+	34: CopyLoc[5](loc4: u64)
+	35: Ret
+}
+while_loop(Arg0: u64): u64 {
+L0:	loc1: u64
+L1:	loc2: u64
+B0:
+	0: LdConst[0](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	1: StLoc[1](loc0: u64)
+	2: CopyLoc[0](Arg0: u64)
+	3: CopyLoc[1](loc0: u64)
+	4: Gt
+	5: BrFalse(13)
+B1:
+	6: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	7: StLoc[2](loc1: u64)
+	8: CopyLoc[0](Arg0: u64)
+	9: CopyLoc[2](loc1: u64)
+	10: Sub
+	11: StLoc[0](Arg0: u64)
+	12: Branch(14)
+B2:
+	13: Branch(15)
+B3:
+	14: Branch(0)
+B4:
+	15: CopyLoc[0](Arg0: u64)
+	16: StLoc[3](loc2: u64)
+	17: CopyLoc[3](loc2: u64)
+	18: Ret
+}
+while_loop_with_break_and_continue(Arg0: u64): u64 {
+L0:	loc1: u64
+L1:	loc2: u64
+L2:	loc3: u64
+L3:	loc4: u64
+B0:
+	0: LdConst[0](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	1: StLoc[1](loc0: u64)
+	2: CopyLoc[0](Arg0: u64)
+	3: CopyLoc[1](loc0: u64)
+	4: Gt
+	5: BrFalse(29)
+B1:
+	6: LdConst[3](U64: [42, 0, 0, 0, 0, 0, 0, 0])
+	7: StLoc[2](loc1: u64)
+	8: CopyLoc[0](Arg0: u64)
+	9: CopyLoc[2](loc1: u64)
+	10: Eq
+	11: BrFalse(14)
+B2:
+	12: Branch(31)
+B3:
+	13: Branch(14)
+B4:
+	14: LdConst[4](U64: [21, 0, 0, 0, 0, 0, 0, 0])
+	15: StLoc[3](loc2: u64)
+	16: CopyLoc[0](Arg0: u64)
+	17: CopyLoc[3](loc2: u64)
+	18: Eq
+	19: BrFalse(22)
+B5:
+	20: Branch(0)
+B6:
+	21: Branch(22)
+B7:
+	22: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	23: StLoc[4](loc3: u64)
+	24: CopyLoc[0](Arg0: u64)
+	25: CopyLoc[4](loc3: u64)
+	26: Sub
+	27: StLoc[0](Arg0: u64)
+	28: Branch(30)
+B8:
+	29: Branch(31)
+B9:
+	30: Branch(0)
+B10:
+	31: CopyLoc[0](Arg0: u64)
+	32: StLoc[5](loc4: u64)
+	33: CopyLoc[5](loc4: u64)
+	34: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/loop.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/loop.move
@@ -1,0 +1,32 @@
+module 0x42::loops {
+
+    fun while_loop(x: u64): u64 {
+        while (x > 0) {
+            x = x - 1;
+        };
+        x
+    }
+
+    fun while_loop_with_break_and_continue(x: u64): u64 {
+        while (x > 0) {
+            if (x == 42)
+                break;
+            if (x == 21)
+                continue;
+            x = x - 1;
+        };
+        x
+    }
+
+    fun nested_loop(x: u64): u64 {
+        while (x > 0) {
+            while (x > 10) {
+                x = x - 1;
+                break;
+            };
+            x = x - 1;
+            continue;
+        };
+        x
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/operators.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/operators.exp
@@ -1,0 +1,202 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun operators::arithm($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t6 := -($t0, $t1)
+  1: $t5 := /($t1, $t6)
+  2: $t4 := *($t5, $t1)
+  3: $t3 := %($t4, $t0)
+  4: $t2 := +($t0, $t3)
+  5: return $t2
+}
+
+
+[variant baseline]
+fun operators::bits($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t4 := <<($t0, $t1)
+  1: $t3 := &($t4, $t0)
+  2: $t6 := >>($t1, $t0)
+  3: $t5 := ^($t6, $t1)
+  4: $t2 := |($t3, $t5)
+  5: return $t2
+}
+
+
+[variant baseline]
+fun operators::bools($t0: bool, $t1: bool): bool {
+     var $t2: bool
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool
+     var $t7: bool
+     var $t8: bool
+     var $t9: bool
+     var $t10: bool
+     var $t11: bool
+     var $t12: bool
+  0: $t5 := &&($t0, $t1)
+  1: $t7 := !($t1)
+  2: $t6 := &&($t0, $t7)
+  3: $t4 := ||($t5, $t6)
+  4: $t9 := !($t0)
+  5: $t8 := &&($t9, $t1)
+  6: $t3 := ||($t4, $t8)
+  7: $t11 := !($t0)
+  8: $t12 := !($t1)
+  9: $t10 := &&($t11, $t12)
+ 10: $t2 := ||($t3, $t10)
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun operators::equality<#0>($t0: #0, $t1: #0): bool {
+     var $t2: bool
+  0: $t2 := ==($t0, $t1)
+  1: return $t2
+}
+
+
+[variant baseline]
+fun operators::inequality<#0>($t0: #0, $t1: #0): bool {
+     var $t2: bool
+  0: $t2 := !=($t0, $t1)
+  1: return $t2
+}
+
+
+[variant baseline]
+fun operators::order($t0: u64, $t1: u64): bool {
+     var $t2: bool
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool
+     var $t7: bool
+     var $t8: bool
+     var $t9: bool
+     var $t10: bool
+  0: $t5 := <($t0, $t1)
+  1: $t6 := <=($t0, $t1)
+  2: $t4 := &&($t5, $t6)
+  3: $t8 := >($t0, $t1)
+  4: $t7 := !($t8)
+  5: $t3 := &&($t4, $t7)
+  6: $t10 := >=($t0, $t1)
+  7: $t9 := !($t10)
+  8: $t2 := &&($t3, $t9)
+  9: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v6
+module 42.operators {
+
+
+arithm(Arg0: u64, Arg1: u64): u64 {
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: CopyLoc[1](Arg1: u64)
+	2: Sub
+	3: StLoc[2](loc0: u64)
+	4: CopyLoc[1](Arg1: u64)
+	5: CopyLoc[2](loc0: u64)
+	6: Div
+	7: CopyLoc[1](Arg1: u64)
+	8: Mul
+	9: CopyLoc[0](Arg0: u64)
+	10: Mod
+	11: StLoc[3](loc1: u64)
+	12: CopyLoc[0](Arg0: u64)
+	13: CopyLoc[3](loc1: u64)
+	14: Add
+	15: Ret
+}
+bits(Arg0: u64, Arg1: u64): u64 {
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: CopyLoc[1](Arg1: u64)
+	2: Shl
+	3: CopyLoc[0](Arg0: u64)
+	4: BitAnd
+	5: CopyLoc[1](Arg1: u64)
+	6: CopyLoc[0](Arg0: u64)
+	7: Shr
+	8: CopyLoc[1](Arg1: u64)
+	9: Xor
+	10: BitOr
+	11: Ret
+}
+bools(Arg0: bool, Arg1: bool): bool {
+B0:
+	0: CopyLoc[0](Arg0: bool)
+	1: CopyLoc[1](Arg1: bool)
+	2: And
+	3: CopyLoc[1](Arg1: bool)
+	4: Not
+	5: StLoc[2](loc0: bool)
+	6: CopyLoc[0](Arg0: bool)
+	7: CopyLoc[2](loc0: bool)
+	8: And
+	9: Or
+	10: CopyLoc[0](Arg0: bool)
+	11: Not
+	12: CopyLoc[1](Arg1: bool)
+	13: And
+	14: Or
+	15: CopyLoc[0](Arg0: bool)
+	16: Not
+	17: CopyLoc[1](Arg1: bool)
+	18: Not
+	19: And
+	20: Or
+	21: Ret
+}
+equality<Ty0>(Arg0: Ty0, Arg1: Ty0): bool {
+B0:
+	0: MoveLoc[0](Arg0: Ty0)
+	1: MoveLoc[1](Arg1: Ty0)
+	2: Eq
+	3: Ret
+}
+inequality<Ty0>(Arg0: Ty0, Arg1: Ty0): bool {
+B0:
+	0: MoveLoc[0](Arg0: Ty0)
+	1: MoveLoc[1](Arg1: Ty0)
+	2: Neq
+	3: Ret
+}
+order(Arg0: u64, Arg1: u64): bool {
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: CopyLoc[1](Arg1: u64)
+	2: Lt
+	3: CopyLoc[0](Arg0: u64)
+	4: CopyLoc[1](Arg1: u64)
+	5: Le
+	6: And
+	7: CopyLoc[0](Arg0: u64)
+	8: CopyLoc[1](Arg1: u64)
+	9: Gt
+	10: Not
+	11: And
+	12: CopyLoc[0](Arg0: u64)
+	13: CopyLoc[1](Arg1: u64)
+	14: Ge
+	15: Not
+	16: And
+	17: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/operators.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/operators.move
@@ -1,0 +1,25 @@
+module 0x42::operators {
+    fun arithm(x: u64, y: u64): u64 {
+        x + y / (x - y) * y % x
+    }
+
+    fun bits(x: u64, y: u64): u64 {
+        x << y & x | y >> x ^ y
+    }
+
+    fun bools(x: bool, y: bool): bool {
+        x && y || x && !y || !x && y || !x && !y
+    }
+
+    fun equality<T>(x: T, y: T): bool {
+        x == y
+    }
+
+    fun inequality<T>(x: T, y: T): bool {
+        x != y
+    }
+
+    fun order(x: u64, y: u64): bool {
+        x < y && x <= y && !(x > y) && !(x >= y)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.exp
@@ -1,0 +1,67 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun pack_unpack::pack($t0: u64, $t1: u64): pack_unpack::S {
+     var $t2: pack_unpack::S
+     var $t3: pack_unpack::T
+  0: $t3 := pack pack_unpack::T($t1)
+  1: $t2 := pack pack_unpack::S($t0, $t3)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun pack_unpack::unpack($t0: pack_unpack::S): (u64, u64) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: pack_unpack::T
+  0: ($t3, $t5) := unpack pack_unpack::S($t0)
+  1: $t4 := unpack pack_unpack::T($t5)
+  2: $t1 := move($t3)
+  3: $t2 := move($t4)
+  4: return ($t1, $t2)
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v6
+module 42.pack_unpack {
+struct T {
+	h: u64
+}
+struct S {
+	f: u64,
+	g: T
+}
+
+pack(Arg0: u64, Arg1: u64): S {
+B0:
+	0: CopyLoc[1](Arg1: u64)
+	1: Pack[0](T)
+	2: StLoc[2](loc0: T)
+	3: CopyLoc[0](Arg0: u64)
+	4: MoveLoc[2](loc0: T)
+	5: Pack[1](S)
+	6: Ret
+}
+unpack(Arg0: S): u64 * u64 {
+L0:	loc1: u64
+L1:	loc2: u64
+L2:	loc3: u64
+B0:
+	0: MoveLoc[0](Arg0: S)
+	1: Unpack[1](S)
+	2: Unpack[0](T)
+	3: StLoc[1](loc0: u64)
+	4: StLoc[2](loc1: u64)
+	5: CopyLoc[2](loc1: u64)
+	6: StLoc[3](loc2: u64)
+	7: CopyLoc[1](loc0: u64)
+	8: StLoc[4](loc3: u64)
+	9: CopyLoc[3](loc2: u64)
+	10: CopyLoc[4](loc3: u64)
+	11: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.move
@@ -1,0 +1,21 @@
+module 0x42::pack_unpack {
+
+    struct S {
+        f: u64,
+        g: T
+    }
+
+    struct T {
+        h: u64
+    }
+
+
+    fun pack(x: u64, y: u64): S {
+        S{f: x, g: T{h: y}}
+    }
+
+    fun unpack(s: S): (u64, u64) {
+        let S{f, g: T{h}} = s;
+        (f, h)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
@@ -1,0 +1,30 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun vector::create(): vector<u64> {
+     var $t0: vector<u64>
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t1 := 1
+  1: $t2 := 2
+  2: $t3 := 3
+  3: $t0 := vector($t1, $t2, $t3)
+  4: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v6
+module 42.vector {
+
+
+create(): vector<u64> {
+B0:
+	0: LdConst[0](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	1: LdConst[1](U64: [2, 0, 0, 0, 0, 0, 0, 0])
+	2: LdConst[2](U64: [3, 0, 0, 0, 0, 0, 0, 0])
+	3: VecPack(2, 3)
+	4: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/vector.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/vector.move
@@ -1,0 +1,5 @@
+module 0x42::vector {
+    fun create(): vector<u64> {
+        vector[1, 2, 3]
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -3,7 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
-use move_compiler_v2::Options;
+use move_binary_format::{binary_views::BinaryIndexedView, file_format as FF};
+use move_command_line_common::files::FileHash;
+use move_compiler_v2::{run_file_format_gen, Options};
+use move_disassembler::disassembler::Disassembler;
+use move_ir_types::location;
 use move_model::model::GlobalEnv;
 use move_prover_test_utils::{baseline_test, extract_test_directives};
 use move_stackless_bytecode::function_target_pipeline::FunctionTargetPipeline;
@@ -24,6 +28,8 @@ struct TestConfig {
     dump_ast: bool,
     /// A sequence of bytecode processors to run for this test.
     pipeline: FunctionTargetPipeline,
+    /// Whether we should generate file format from resulting bytecode
+    generate_file_format: bool,
 }
 
 fn path_from_crate_root(path: &str) -> String {
@@ -65,12 +71,21 @@ impl TestConfig {
                 check_only: true,
                 dump_ast: true,
                 pipeline: FunctionTargetPipeline::default(),
+                generate_file_format: false,
             }
         } else if path.contains("/bytecode-generator/") {
             Self {
                 check_only: false,
                 dump_ast: true,
                 pipeline: FunctionTargetPipeline::default(),
+                generate_file_format: false,
+            }
+        } else if path.contains("/file-format-generator/") {
+            Self {
+                check_only: false,
+                dump_ast: false,
+                pipeline: FunctionTargetPipeline::default(),
+                generate_file_format: true,
             }
         } else {
             panic!(
@@ -134,6 +149,17 @@ impl TestConfig {
                         ));
                     },
                 );
+                let ok = Self::check_diags(&mut test_output.borrow_mut(), &env);
+                if ok && self.generate_file_format {
+                    let mods = run_file_format_gen(&env, &targets);
+                    let out = &mut test_output.borrow_mut();
+                    out.push_str("\n============ disassembled file-format ==================\n");
+                    Self::check_diags(out, &env);
+                    for compiled_mod in mods {
+                        let cont = Self::disassemble(&compiled_mod)?;
+                        out.push_str(&cont)
+                    }
+                }
             }
         }
 
@@ -154,6 +180,14 @@ impl TestConfig {
         let ok = !env.has_errors();
         env.clear_diag();
         ok
+    }
+
+    fn disassemble(module: &FF::CompiledModule) -> anyhow::Result<String> {
+        let diss = Disassembler::from_view(
+            BinaryIndexedView::Module(module),
+            location::Loc::new(FileHash::empty(), 0, 0),
+        )?;
+        diss.disassemble()
     }
 }
 

--- a/third_party/move/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/third_party/move/move-prover/bytecode/src/stackless_bytecode.rs
@@ -6,7 +6,7 @@ use crate::function_target::FunctionTarget;
 use ethnum::U256;
 use itertools::Itertools;
 use move_binary_format::file_format::CodeOffset;
-use move_core_types::u256;
+use move_core_types::{u256, value::MoveValue};
 use move_model::{
     ast,
     ast::{Address, Exp, ExpData, MemoryLabel, TempIndex, TraceKind},
@@ -103,6 +103,34 @@ pub enum Constant {
 impl From<&u256::U256> for Constant {
     fn from(n: &u256::U256) -> Constant {
         Constant::U256(U256::from(n))
+    }
+}
+
+impl Constant {
+    /// Converts a constant into a `MoveValue` in the core types which also the runtime shares.
+    /// TODO: we should use MoveValue right away in the bytecode
+    pub fn to_move_value(&self) -> MoveValue {
+        match self {
+            Constant::Bool(x) => MoveValue::Bool(*x),
+            Constant::U8(x) => MoveValue::U8(*x),
+            Constant::U16(x) => MoveValue::U16(*x),
+            Constant::U32(x) => MoveValue::U32(*x),
+            Constant::U64(x) => MoveValue::U64(*x),
+            Constant::U128(x) => MoveValue::U128(*x),
+            Constant::U256(x) => {
+                MoveValue::U256(move_core_types::u256::U256::from_le_bytes(&x.to_le_bytes()))
+            },
+            Constant::Address(a) => MoveValue::Address(a.expect_numerical()),
+            Constant::ByteArray(v) => {
+                MoveValue::Vector(v.iter().map(|x| MoveValue::U8(*x)).collect())
+            },
+            Constant::AddressArray(v) => MoveValue::Vector(
+                v.iter()
+                    .map(|x| MoveValue::Address(x.expect_numerical()))
+                    .collect(),
+            ),
+            Constant::Vector(v) => MoveValue::Vector(v.iter().map(|x| x.to_move_value()).collect()),
+        }
     }
 }
 


### PR DESCRIPTION
This adds an initial version of the generation of the external representation of Move code, the so-called file format.

- Compiles from the register machine of the compiler IR into the stack machine the VM uses. Some attempts are made to optimize usage of the stack, though more can/must be done to optimize the stack machine code.
- Adds a set of basic tests, but more e2e execution tests should be added. (Subsequent PRs.)
- The translation can benefit from analysis results like live-var which allows it make smarter use of `CopyLoc` vs `MoveLoc` (to be added in the future)
