### PR TITLE
[Aptos Node] Bump aptos-node crate to 1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,7 +2378,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-node"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "aptos-api",

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos-node"
 description = "Aptos node"
-version = "1.5.0"
+version = "1.6.0"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
### Description
This PR bumps the `aptos-node` crate version to 1.6.

### Test Plan
Existing test infrastructure.