### PR TITLE
[Configuration] Remove the need for maintaining an on-chain config registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,6 +1054,7 @@ dependencies = [
 name = "aptos-event-notifications"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "aptos-channels",
  "aptos-crypto",
  "aptos-db",
@@ -3754,6 +3755,7 @@ dependencies = [
  "aptos-cached-packages",
  "aptos-crypto",
  "aptos-db",
+ "aptos-event-notifications",
  "aptos-executor-test-helpers",
  "aptos-gas-meter",
  "aptos-gas-schedule",

--- a/aptos-node/src/services.rs
+++ b/aptos-node/src/services.rs
@@ -6,7 +6,7 @@ use aptos_build_info::build_information;
 use aptos_config::config::NodeConfig;
 use aptos_consensus::network_interface::ConsensusMsg;
 use aptos_consensus_notifications::ConsensusNotifier;
-use aptos_event_notifications::ReconfigNotificationListener;
+use aptos_event_notifications::{DbBackedOnChainConfig, ReconfigNotificationListener};
 use aptos_indexer_grpc_fullnode::runtime::bootstrap as bootstrap_indexer_grpc;
 use aptos_logger::{debug, telemetry_log_writer::TelemetryLog, LoggerFilterUpdater};
 use aptos_mempool::{network::MempoolSyncMsg, MempoolClientRequest, QuorumStoreRequest};
@@ -79,7 +79,7 @@ pub fn bootstrap_api_and_indexer(
 pub fn start_consensus_runtime(
     node_config: &mut NodeConfig,
     db_rw: DbReaderWriter,
-    consensus_reconfig_subscription: Option<ReconfigNotificationListener>,
+    consensus_reconfig_subscription: Option<ReconfigNotificationListener<DbBackedOnChainConfig>>,
     consensus_network_interfaces: ApplicationNetworkInterfaces<ConsensusMsg>,
     consensus_notifier: ConsensusNotifier,
     consensus_to_mempool_sender: Sender<QuorumStoreRequest>,
@@ -103,7 +103,7 @@ pub fn start_consensus_runtime(
 pub fn start_mempool_runtime_and_get_consensus_sender(
     node_config: &mut NodeConfig,
     db_rw: &DbReaderWriter,
-    mempool_reconfig_subscription: ReconfigNotificationListener,
+    mempool_reconfig_subscription: ReconfigNotificationListener<DbBackedOnChainConfig>,
     network_interfaces: ApplicationNetworkInterfaces<MempoolSyncMsg>,
     mempool_listener: MempoolNotificationListener,
     mempool_client_receiver: Receiver<MempoolClientRequest>,

--- a/aptos-node/src/state_sync.rs
+++ b/aptos-node/src/state_sync.rs
@@ -9,7 +9,9 @@ use aptos_data_streaming_service::{
     streaming_client::{new_streaming_service_client_listener_pair, StreamingServiceClient},
     streaming_service::DataStreamingService,
 };
-use aptos_event_notifications::{EventSubscriptionService, ReconfigNotificationListener};
+use aptos_event_notifications::{
+    DbBackedOnChainConfig, EventSubscriptionService, ReconfigNotificationListener,
+};
 use aptos_executor::chunk_executor::ChunkExecutor;
 use aptos_infallible::RwLock;
 use aptos_mempool_notifications::MempoolNotificationListener;
@@ -29,7 +31,7 @@ use aptos_storage_service_server::{
 };
 use aptos_storage_service_types::StorageServiceMessage;
 use aptos_time_service::TimeService;
-use aptos_types::{on_chain_config::ON_CHAIN_CONFIG_REGISTRY, waypoint::Waypoint};
+use aptos_types::waypoint::Waypoint;
 use aptos_vm::AptosVM;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
@@ -41,14 +43,12 @@ pub fn create_event_subscription_service(
     db_rw: &DbReaderWriter,
 ) -> (
     EventSubscriptionService,
-    ReconfigNotificationListener,
-    Option<ReconfigNotificationListener>,
+    ReconfigNotificationListener<DbBackedOnChainConfig>,
+    Option<ReconfigNotificationListener<DbBackedOnChainConfig>>,
 ) {
     // Create the event subscription service
-    let mut event_subscription_service = EventSubscriptionService::new(
-        ON_CHAIN_CONFIG_REGISTRY,
-        Arc::new(RwLock::new(db_rw.clone())),
-    );
+    let mut event_subscription_service =
+        EventSubscriptionService::new(Arc::new(RwLock::new(db_rw.clone())));
 
     // Create a reconfiguration subscription for mempool
     let mempool_reconfig_subscription = event_subscription_service

--- a/aptos-node/src/tests.rs
+++ b/aptos-node/src/tests.rs
@@ -7,9 +7,7 @@ use aptos_event_notifications::EventSubscriptionService;
 use aptos_infallible::RwLock;
 use aptos_storage_interface::{DbReader, DbReaderWriter, DbWriter};
 use aptos_temppath::TempPath;
-use aptos_types::{
-    chain_id::ChainId, on_chain_config::ON_CHAIN_CONFIG_REGISTRY, waypoint::Waypoint,
-};
+use aptos_types::{chain_id::ChainId, waypoint::Waypoint};
 use std::{fs, sync::Arc};
 
 /// A mock database implementing DbReader and DbWriter
@@ -31,10 +29,8 @@ fn test_mutual_authentication_validators() {
     validator_network.mutual_authentication = false;
 
     // Create an event subscription service
-    let mut event_subscription_service = EventSubscriptionService::new(
-        ON_CHAIN_CONFIG_REGISTRY,
-        Arc::new(RwLock::new(DbReaderWriter::new(MockDatabase {}))),
-    );
+    let mut event_subscription_service =
+        EventSubscriptionService::new(Arc::new(RwLock::new(DbReaderWriter::new(MockDatabase {}))));
 
     // Set up the networks and gather the application network handles. This should panic.
     let peers_and_metadata = network::create_peers_and_metadata(&node_config);

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -16,7 +16,7 @@ use crate::{
 use aptos_bounded_executor::BoundedExecutor;
 use aptos_config::config::NodeConfig;
 use aptos_consensus_notifications::ConsensusNotificationSender;
-use aptos_event_notifications::ReconfigNotificationListener;
+use aptos_event_notifications::{DbBackedOnChainConfig, ReconfigNotificationListener};
 use aptos_executor::block_executor::BlockExecutor;
 use aptos_logger::prelude::*;
 use aptos_mempool::QuorumStoreRequest;
@@ -35,7 +35,7 @@ pub fn start_consensus(
     state_sync_notifier: Arc<dyn ConsensusNotificationSender>,
     consensus_to_mempool_sender: mpsc::Sender<QuorumStoreRequest>,
     aptos_db: DbReaderWriter,
-    reconfig_events: ReconfigNotificationListener,
+    reconfig_events: ReconfigNotificationListener<DbBackedOnChainConfig>,
 ) -> Runtime {
     let runtime = aptos_runtimes::spawn_named_runtime("consensus".into(), None);
     let storage = Arc::new(StorageWriteProxy::new(node_config, aptos_db.reader.clone()));

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -38,7 +38,8 @@ use aptos_network::{
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     on_chain_config::{
-        ConsensusConfigV1, OnChainConfig, OnChainConfigPayload, OnChainConsensusConfig,
+        ConsensusConfigV1, InMemoryOnChainConfig, OnChainConfig, OnChainConfigPayload,
+        OnChainConsensusConfig,
         ProposerElectionType::{self, RoundProposer},
         ValidatorSet,
     },
@@ -125,7 +126,7 @@ impl SMRNode {
             // Requires double serialization, check deserialize_into_config for more details
             bcs::to_bytes(&bcs::to_bytes(&consensus_config).unwrap()).unwrap(),
         );
-        let payload = OnChainConfigPayload::new(1, Arc::new(configs));
+        let payload = OnChainConfigPayload::new(1, InMemoryOnChainConfig::new(configs));
 
         reconfig_sender
             .push((), ReconfigNotification {

--- a/mempool/src/logging.rs
+++ b/mempool/src/logging.rs
@@ -7,7 +7,7 @@ use anyhow::Error;
 use aptos_config::network_id::{NetworkId, PeerNetworkId};
 use aptos_logger::Schema;
 use aptos_mempool_notifications::MempoolCommitNotification;
-use aptos_types::{account_address::AccountAddress, on_chain_config::OnChainConfigPayload};
+use aptos_types::account_address::AccountAddress;
 use serde::Serialize;
 use std::{fmt, fmt::Write, time::SystemTime};
 
@@ -103,8 +103,6 @@ pub struct LogSchema<'a> {
     peer: Option<&'a PeerNetworkId>,
     is_upstream_peer: Option<bool>,
     #[schema(display)]
-    reconfig_update: Option<OnChainConfigPayload>,
-    #[schema(display)]
     txns: Option<TxnsLog>,
     account: Option<AccountAddress>,
     #[schema(display)]
@@ -134,7 +132,6 @@ impl<'a> LogSchema<'a> {
             error: None,
             peer: None,
             is_upstream_peer: None,
-            reconfig_update: None,
             account: None,
             txns: None,
             quorum_store_msg: None,

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -26,7 +26,7 @@ use aptos_network::application::interface::NetworkClientInterface;
 use aptos_storage_interface::state_view::LatestDbStateCheckpointView;
 use aptos_types::{
     mempool_status::{MempoolStatus, MempoolStatusCode},
-    on_chain_config::{OnChainConfigPayload, OnChainConsensusConfig},
+    on_chain_config::{OnChainConfigPayload, OnChainConfigProvider, OnChainConsensusConfig},
     transaction::SignedTransaction,
     vm_status::{DiscardedVMStatus, StatusCode},
 };
@@ -578,19 +578,20 @@ pub(crate) fn process_rejected_transactions(
 }
 
 /// Processes on-chain reconfiguration notifications.  Restarts validator with the new info.
-pub(crate) async fn process_config_update<V>(
-    config_update: OnChainConfigPayload,
+pub(crate) async fn process_config_update<V, P>(
+    config_update: OnChainConfigPayload<P>,
     validator: Arc<RwLock<V>>,
     broadcast_within_validator_network: Arc<RwLock<bool>>,
 ) where
     V: TransactionValidation,
+    P: OnChainConfigProvider,
 {
-    info!(
-        LogSchema::event_log(LogEntry::ReconfigUpdate, LogEvent::Process)
-            .reconfig_update(config_update.clone())
-    );
+    info!(LogSchema::event_log(
+        LogEntry::ReconfigUpdate,
+        LogEvent::Process
+    ));
 
-    if let Err(e) = validator.write().restart(config_update.clone()) {
+    if let Err(e) = validator.write().restart() {
         counters::VM_RECONFIG_UPDATE_FAIL_COUNT.inc();
         error!(LogSchema::event_log(LogEntry::ReconfigUpdate, LogEvent::VMUpdateFail).error(&e));
     }

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -29,7 +29,8 @@ use aptos_network::{
 };
 use aptos_storage_interface::{mock::MockDbReaderWriter, DbReaderWriter};
 use aptos_types::{
-    mempool_status::MempoolStatusCode, on_chain_config::OnChainConfigPayload,
+    mempool_status::MempoolStatusCode,
+    on_chain_config::{InMemoryOnChainConfig, OnChainConfigPayload},
     transaction::SignedTransaction,
 };
 use aptos_vm_validator::{
@@ -125,7 +126,10 @@ impl MockSharedMempool {
         reconfig_sender
             .push((), ReconfigNotification {
                 version: 1,
-                on_chain_configs: OnChainConfigPayload::new(1, Arc::new(HashMap::new())),
+                on_chain_configs: OnChainConfigPayload::new(
+                    1,
+                    InMemoryOnChainConfig::new(HashMap::new()),
+                ),
             })
             .unwrap();
         let peers_and_metadata = PeersAndMetadata::new(&[NetworkId::Validator]);

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -34,7 +34,10 @@ use aptos_network::{
     ProtocolId,
 };
 use aptos_storage_interface::mock::MockDbReaderWriter;
-use aptos_types::{on_chain_config::OnChainConfigPayload, PeerId};
+use aptos_types::{
+    on_chain_config::{InMemoryOnChainConfig, OnChainConfigPayload},
+    PeerId,
+};
 use aptos_vm_validator::mocks::mock_vm_validator::MockVMValidator;
 use enum_dispatch::enum_dispatch;
 use futures::{
@@ -609,7 +612,10 @@ fn start_node_mempool(
     reconfig_sender
         .push((), ReconfigNotification {
             version: 1,
-            on_chain_configs: OnChainConfigPayload::new(1, Arc::new(HashMap::new())),
+            on_chain_configs: OnChainConfigPayload::new(
+                1,
+                InMemoryOnChainConfig::new(HashMap::new()),
+            ),
         })
         .unwrap();
 

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -43,8 +43,10 @@ use aptos_network::{
 };
 use aptos_storage_interface::mock::MockDbReaderWriter;
 use aptos_types::{
-    account_address::AccountAddress, mempool_status::MempoolStatusCode,
-    on_chain_config::OnChainConfigPayload, transaction::SignedTransaction,
+    account_address::AccountAddress,
+    mempool_status::MempoolStatusCode,
+    on_chain_config::{InMemoryOnChainConfig, OnChainConfigPayload},
+    transaction::SignedTransaction,
 };
 use aptos_vm_validator::mocks::mock_vm_validator::MockVMValidator;
 use futures::{channel::oneshot, SinkExt};
@@ -595,7 +597,10 @@ fn setup_mempool(
     reconfig_sender
         .push((), ReconfigNotification {
             version: 1,
-            on_chain_configs: OnChainConfigPayload::new(1, Arc::new(HashMap::new())),
+            on_chain_configs: OnChainConfigPayload::new(
+                1,
+                InMemoryOnChainConfig::new(HashMap::new()),
+            ),
         })
         .unwrap();
 

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -20,7 +20,9 @@ use aptos_config::{
     network_id::NetworkContext,
 };
 use aptos_crypto::x25519::PublicKey;
-use aptos_event_notifications::{EventSubscriptionService, ReconfigNotificationListener};
+use aptos_event_notifications::{
+    DbBackedOnChainConfig, EventSubscriptionService, ReconfigNotificationListener,
+};
 use aptos_logger::prelude::*;
 use aptos_netcore::transport::tcp::TCPBufferCfg;
 use aptos_network::{
@@ -63,7 +65,7 @@ pub struct NetworkBuilder {
     executor: Option<Handle>,
     time_service: TimeService,
     network_context: NetworkContext,
-    discovery_listeners: Option<Vec<DiscoveryChangeListener>>,
+    discovery_listeners: Option<Vec<DiscoveryChangeListener<DbBackedOnChainConfig>>>,
     connectivity_manager_builder: Option<ConnectivityManagerBuilder>,
     health_checker_builder: Option<HealthCheckerBuilder>,
     peer_manager_builder: PeerManagerBuilder,
@@ -370,7 +372,7 @@ impl NetworkBuilder {
         &mut self,
         discovery_method: &DiscoveryMethod,
         pubkey: PublicKey,
-        reconfig_events: Option<ReconfigNotificationListener>,
+        reconfig_events: Option<ReconfigNotificationListener<DbBackedOnChainConfig>>,
     ) {
         let conn_mgr_reqs_tx = self
             .conn_mgr_reqs_tx()

--- a/network/discovery/src/file.rs
+++ b/network/discovery/src/file.rs
@@ -62,6 +62,7 @@ mod tests {
         config::{Peer, PeerRole},
         network_id::NetworkContext,
     };
+    use aptos_event_notifications::DbBackedOnChainConfig;
     use aptos_network::connectivity_manager::{ConnectivityRequest, DiscoverySource};
     use aptos_temppath::TempPath;
     use aptos_types::{network_address::NetworkAddress, PeerId};
@@ -78,7 +79,7 @@ mod tests {
             &aptos_network::counters::PENDING_CONNECTIVITY_MANAGER_REQUESTS,
         );
         let listener_task = async move {
-            let listener = DiscoveryChangeListener::file(
+            let listener = DiscoveryChangeListener::<DbBackedOnChainConfig>::file(
                 NetworkContext::mock(),
                 conn_mgr_reqs_tx,
                 path.as_ref().as_ref(),

--- a/state-sync/inter-component/event-notifications/Cargo.toml
+++ b/state-sync/inter-component/event-notifications/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+anyhow = { workspace = true }
 aptos-channels = { workspace = true }
 aptos-id-generator = { workspace = true }
 aptos-infallible = { workspace = true }

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
@@ -16,7 +16,8 @@ use aptos_data_client::client::AptosDataClient;
 use aptos_data_streaming_service::streaming_client::new_streaming_service_client_listener_pair;
 use aptos_db::AptosDB;
 use aptos_event_notifications::{
-    EventNotificationListener, EventSubscriptionService, ReconfigNotificationListener,
+    DbBackedOnChainConfig, EventNotificationListener, EventSubscriptionService,
+    ReconfigNotificationListener,
 };
 use aptos_executor::chunk_executor::ChunkExecutor;
 use aptos_executor_test_helpers::bootstrap_genesis;
@@ -29,7 +30,7 @@ use aptos_storage_service_notifications::StorageServiceNotificationListener;
 use aptos_time_service::TimeService;
 use aptos_types::{
     event::EventKey,
-    on_chain_config::{new_epoch_event_key, ON_CHAIN_CONFIG_REGISTRY},
+    on_chain_config::new_epoch_event_key,
     transaction::{Transaction, WriteSetPayload},
     waypoint::Waypoint,
 };
@@ -279,7 +280,7 @@ async fn create_validator_driver(
     UnboundedSender<CommitNotification>,
     ConsensusNotifier,
     MempoolNotificationListener,
-    ReconfigNotificationListener,
+    ReconfigNotificationListener<DbBackedOnChainConfig>,
     EventNotificationListener,
     StorageServiceNotificationListener,
     TimeService,
@@ -302,7 +303,7 @@ async fn create_full_node_driver(
     UnboundedSender<CommitNotification>,
     ConsensusNotifier,
     MempoolNotificationListener,
-    ReconfigNotificationListener,
+    ReconfigNotificationListener<DbBackedOnChainConfig>,
     EventNotificationListener,
     StorageServiceNotificationListener,
     TimeService,
@@ -323,7 +324,7 @@ async fn create_driver_for_tests(
     UnboundedSender<CommitNotification>,
     ConsensusNotifier,
     MempoolNotificationListener,
-    ReconfigNotificationListener,
+    ReconfigNotificationListener<DbBackedOnChainConfig>,
     EventNotificationListener,
     StorageServiceNotificationListener,
     TimeService,
@@ -342,10 +343,8 @@ async fn create_driver_for_tests(
     bootstrap_genesis::<AptosVM>(&db_rw, &genesis_txn).unwrap();
 
     // Create the event subscription service and subscribe to events and reconfigurations
-    let mut event_subscription_service = EventSubscriptionService::new(
-        ON_CHAIN_CONFIG_REGISTRY,
-        Arc::new(RwLock::new(db_rw.clone())),
-    );
+    let mut event_subscription_service =
+        EventSubscriptionService::new(Arc::new(RwLock::new(db_rw.clone())));
     let mut reconfiguration_subscriber = event_subscription_service
         .subscribe_to_reconfigurations()
         .unwrap();

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver_factory.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver_factory.rs
@@ -24,7 +24,6 @@ use aptos_storage_interface::DbReaderWriter;
 use aptos_storage_service_client::StorageServiceClient;
 use aptos_temppath::TempPath;
 use aptos_time_service::TimeService;
-use aptos_types::on_chain_config::ON_CHAIN_CONFIG_REGISTRY;
 use aptos_vm::AptosVM;
 use futures::{FutureExt, StreamExt};
 use std::{collections::HashMap, sync::Arc};
@@ -54,10 +53,8 @@ fn test_new_initialized_configs() {
     let (_, consensus_listener) = new_consensus_notifier_listener_pair(0);
 
     // Create the event subscription service and a reconfig subscriber
-    let mut event_subscription_service = EventSubscriptionService::new(
-        ON_CHAIN_CONFIG_REGISTRY,
-        Arc::new(RwLock::new(db_rw.clone())),
-    );
+    let mut event_subscription_service =
+        EventSubscriptionService::new(Arc::new(RwLock::new(db_rw.clone())));
     let mut reconfiguration_subscriber = event_subscription_service
         .subscribe_to_reconfigurations()
         .unwrap();

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/storage_synchronizer.rs
@@ -32,7 +32,6 @@ use aptos_storage_interface::DbReaderWriter;
 use aptos_storage_service_notifications::StorageServiceNotificationListener;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
-    on_chain_config::ON_CHAIN_CONFIG_REGISTRY,
     transaction::{TransactionOutputListWithProof, Version},
 };
 use claims::assert_matches;
@@ -538,10 +537,9 @@ fn create_storage_synchronizer(
     let (error_notification_sender, error_notification_listener) = ErrorNotificationListener::new();
 
     // Create the event subscription service
-    let event_subscription_service = Arc::new(Mutex::new(EventSubscriptionService::new(
-        ON_CHAIN_CONFIG_REGISTRY,
-        Arc::new(RwLock::new(mock_reader_writer.clone())),
-    )));
+    let event_subscription_service = Arc::new(Mutex::new(EventSubscriptionService::new(Arc::new(
+        RwLock::new(mock_reader_writer.clone()),
+    ))));
 
     // Create the mempool notification handler
     let (mempool_notification_sender, mempool_notification_listener) =

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -192,8 +192,7 @@ pub struct ProposerAndVoterConfig {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::on_chain_config::OnChainConfigPayload;
-    use std::sync::Arc;
+    use crate::on_chain_config::{InMemoryOnChainConfig, OnChainConfigPayload};
 
     #[test]
     fn test_config_yaml_serialization() {
@@ -246,7 +245,7 @@ mod test {
             bcs::to_bytes(&bcs::to_bytes(&consensus_config).unwrap()).unwrap(),
         );
 
-        let payload = OnChainConfigPayload::new(1, Arc::new(configs));
+        let payload = OnChainConfigPayload::new(1, InMemoryOnChainConfig::new(configs));
 
         let result: OnChainConsensusConfig = payload.get().unwrap();
         assert!(matches!(

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -131,9 +131,9 @@ pub enum TransactionDeduperType {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::on_chain_config::OnChainConfigPayload;
+    use crate::on_chain_config::{InMemoryOnChainConfig, OnChainConfigPayload};
     use rand::Rng;
-    use std::{collections::HashMap, sync::Arc};
+    use std::collections::HashMap;
 
     #[test]
     fn test_config_yaml_serialization() {
@@ -207,7 +207,7 @@ mod test {
             bcs::to_bytes(&bcs::to_bytes(&execution_config).unwrap()).unwrap(),
         );
 
-        let payload = OnChainConfigPayload::new(1, Arc::new(configs));
+        let payload = OnChainConfigPayload::new(1, InMemoryOnChainConfig::new(configs));
 
         let result: OnChainExecutionConfig = payload.get().unwrap();
         assert!(matches!(
@@ -229,7 +229,7 @@ mod test {
             bcs::to_bytes(&bcs::to_bytes(&execution_config).unwrap()).unwrap(),
         );
 
-        let payload = OnChainConfigPayload::new(1, Arc::new(configs));
+        let payload = OnChainConfigPayload::new(1, InMemoryOnChainConfig::new(configs));
 
         let result: OnChainExecutionConfig = payload.get().unwrap();
         assert!(matches!(
@@ -251,7 +251,7 @@ mod test {
             bcs::to_bytes(&bcs::to_bytes(&execution_config).unwrap()).unwrap(),
         );
 
-        let payload = OnChainConfigPayload::new(1, Arc::new(configs));
+        let payload = OnChainConfigPayload::new(1, InMemoryOnChainConfig::new(configs));
 
         let result: OnChainExecutionConfig = payload.get().unwrap();
         assert!(matches!(

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -5,7 +5,6 @@
 use crate::{
     access_path::AccessPath,
     account_config::CORE_CODE_ADDRESS,
-    chain_id::ChainId,
     event::{EventHandle, EventKey},
 };
 use anyhow::{format_err, Result};
@@ -16,7 +15,7 @@ use move_core_types::{
     move_resource::{MoveResource, MoveStructType},
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{collections::HashMap, fmt, sync::Arc};
+use std::{collections::HashMap, fmt, fmt::Debug, sync::Arc};
 
 mod approved_execution_hashes;
 mod aptos_features;
@@ -72,31 +71,43 @@ impl fmt::Display for ConfigID {
     }
 }
 
-/// This registry contains the list of on-chain configs that state sync
-/// uses to notify components (e.g., consensus, mempool and networking)
-/// on a reconfiguration event. New configs should be added here.
-///
-/// Note: if state sync is unable to find a config in storage (this is possible
-/// if a node only has old state), the notification will not contain the
-/// config value and the component will need to decide how to handle this.
-pub const ON_CHAIN_CONFIG_REGISTRY: &[ConfigID] = &[
-    ApprovedExecutionHashes::CONFIG_ID,
-    ValidatorSet::CONFIG_ID,
-    Version::CONFIG_ID,
-    OnChainConsensusConfig::CONFIG_ID,
-    ChainId::CONFIG_ID,
-    OnChainExecutionConfig::CONFIG_ID,
-];
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct OnChainConfigPayload {
-    epoch: u64,
-    configs: Arc<HashMap<ConfigID, Vec<u8>>>,
+pub trait OnChainConfigProvider: Debug + Clone + Send + Sync + 'static {
+    fn get<T: OnChainConfig>(&self) -> Result<T>;
 }
 
-impl OnChainConfigPayload {
-    pub fn new(epoch: u64, configs: Arc<HashMap<ConfigID, Vec<u8>>>) -> Self {
-        Self { epoch, configs }
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InMemoryOnChainConfig {
+    configs: HashMap<ConfigID, Vec<u8>>,
+}
+
+impl InMemoryOnChainConfig {
+    pub fn new(configs: HashMap<ConfigID, Vec<u8>>) -> Self {
+        Self { configs }
+    }
+}
+
+impl OnChainConfigProvider for InMemoryOnChainConfig {
+    fn get<T: OnChainConfig>(&self) -> Result<T> {
+        let bytes = self
+            .configs
+            .get(&T::CONFIG_ID)
+            .ok_or_else(|| format_err!("[on-chain cfg] config not in payload"))?;
+        T::deserialize_into_config(bytes)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct OnChainConfigPayload<P: OnChainConfigProvider> {
+    epoch: u64,
+    provider: Arc<P>,
+}
+
+impl<P: OnChainConfigProvider> OnChainConfigPayload<P> {
+    pub fn new(epoch: u64, provider: P) -> Self {
+        Self {
+            epoch,
+            provider: Arc::new(provider),
+        }
     }
 
     pub fn epoch(&self) -> u64 {
@@ -104,29 +115,7 @@ impl OnChainConfigPayload {
     }
 
     pub fn get<T: OnChainConfig>(&self) -> Result<T> {
-        let bytes = self
-            .configs
-            .get(&T::CONFIG_ID)
-            .ok_or_else(|| format_err!("[on-chain cfg] config not in payload"))?;
-        T::deserialize_into_config(bytes)
-    }
-
-    pub fn configs(&self) -> &HashMap<ConfigID, Vec<u8>> {
-        &self.configs
-    }
-}
-
-impl fmt::Display for OnChainConfigPayload {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut config_ids = "".to_string();
-        for id in self.configs.keys() {
-            config_ids += &id.to_string();
-        }
-        write!(
-            f,
-            "OnChainConfigPayload [epoch: {}, configs: {}]",
-            self.epoch, config_ids
-        )
+        self.provider.get()
     }
 }
 

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-event-notifications = { workspace = true }
 aptos-gas-meter = { workspace = true }
 aptos-scratchpad = { workspace = true }
 aptos-state-view = { workspace = true }
@@ -26,6 +27,7 @@ fail = { workspace = true }
 aptos-cached-packages = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-db = { workspace = true }
+aptos-event-notifications = { workspace = true }
 aptos-executor-test-helpers = { workspace = true }
 aptos-gas-schedule = { workspace = true, features = ["testing"] } 
 aptos-temppath = { workspace = true }

--- a/vm-validator/src/mocks/mock_vm_validator.rs
+++ b/vm-validator/src/mocks/mock_vm_validator.rs
@@ -7,7 +7,6 @@ use anyhow::Result;
 use aptos_state_view::StateView;
 use aptos_types::{
     account_address::AccountAddress,
-    on_chain_config::OnChainConfigPayload,
     transaction::{SignedTransaction, VMValidatorResult},
     vm_status::StatusCode,
 };
@@ -76,7 +75,7 @@ impl TransactionValidation for MockVMValidator {
         Ok(VMValidatorResult::new(ret, 0))
     }
 
-    fn restart(&mut self, _config: OnChainConfigPayload) -> Result<()> {
+    fn restart(&mut self) -> Result<()> {
         Ok(())
     }
 

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -12,7 +12,6 @@ use aptos_storage_interface::{
 use aptos_types::{
     account_address::AccountAddress,
     account_view::AccountView,
-    on_chain_config::OnChainConfigPayload,
     transaction::{SignedTransaction, VMValidatorResult},
 };
 use aptos_vm::AptosVM;
@@ -30,7 +29,7 @@ pub trait TransactionValidation: Send + Sync + Clone {
     fn validate_transaction(&self, _txn: SignedTransaction) -> Result<VMValidatorResult>;
 
     /// Restart the transaction validation instance
-    fn restart(&mut self, config: OnChainConfigPayload) -> Result<()>;
+    fn restart(&mut self) -> Result<()>;
 
     /// Notify about new commit
     fn notify_commit(&mut self);
@@ -77,7 +76,7 @@ impl TransactionValidation for VMValidator {
         Ok(self.vm.validate_transaction(txn, &self.state_view))
     }
 
-    fn restart(&mut self, _config: OnChainConfigPayload) -> Result<()> {
+    fn restart(&mut self) -> Result<()> {
         self.notify_commit();
 
         self.vm = AptosVM::new_for_validation(&self.state_view);


### PR DESCRIPTION
### Description

See https://github.com/aptos-labs/aptos-core/issues/9150 for more details

### Test Plan

Existing Unit tests.

Tested it by running `test_onchain_shuffling_change`, which toggles the shuffling flag and ensures that the txn shuffling actually takes place. 
