### PR TITLE
[Mempool] optimize fullnode broadcast hops for latency

### DIFF
--- a/mempool/src/logging.rs
+++ b/mempool/src/logging.rs
@@ -116,6 +116,7 @@ pub struct LogSchema<'a> {
     #[schema(debug)]
     batch_id: Option<&'a MultiBatchId>,
     backpressure: Option<bool>,
+    num_txns: Option<usize>,
 }
 
 impl<'a> LogSchema<'a> {
@@ -143,6 +144,7 @@ impl<'a> LogSchema<'a> {
             upstream_network: None,
             batch_id: None,
             backpressure: None,
+            num_txns: None,
         }
     }
 }

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -481,11 +481,12 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
 
         // Log all the metrics
         let latency = start_time.elapsed();
-        trace!(
+        debug!(
             LogSchema::event_log(LogEntry::BroadcastTransaction, LogEvent::Success)
                 .peer(&peer)
                 .batch_id(&batch_id)
                 .backpressure(scheduled_backoff)
+                .num_txns(num_txns)
         );
         let network_id = peer.network_id();
         counters::shared_mempool_broadcast_size(network_id, num_txns);

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -70,7 +70,7 @@ pub(crate) async fn execute_broadcast<NetworkClient, TransactionValidator>(
                 .peer(&peer)
                 .error(&error)),
                 _ => {
-                    trace!("{:?}", err)
+                    debug!("{:?}", err)
                 },
             }
         }

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -500,7 +500,7 @@ fn single_test_suite(
     let single_test_suite = match test_name {
         // Land-blocking tests to be run on every PR:
         "land_blocking" => land_blocking_test_suite(duration), // to remove land_blocking, superseeded by the below
-        "realistic_env_max_load" => pfn_performance(duration, true, true),
+        "realistic_env_max_load" => pfn_const_tps(duration, true, true),
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),
         // Rest of the tests:

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -500,7 +500,7 @@ fn single_test_suite(
     let single_test_suite = match test_name {
         // Land-blocking tests to be run on every PR:
         "land_blocking" => land_blocking_test_suite(duration), // to remove land_blocking, superseeded by the below
-        "realistic_env_max_load" => pfn_const_tps(duration, true, true),
+        "realistic_env_max_load" => pfn_performance(duration, true, true),
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),
         // Rest of the tests:

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -500,7 +500,7 @@ fn single_test_suite(
     let single_test_suite = match test_name {
         // Land-blocking tests to be run on every PR:
         "land_blocking" => land_blocking_test_suite(duration), // to remove land_blocking, superseeded by the below
-        "realistic_env_max_load" => realistic_env_max_load_test(duration, test_cmd, 7, 5),
+        "realistic_env_max_load" => pfn_const_tps(duration, true, true),
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),
         // Rest of the tests:

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -500,7 +500,7 @@ fn single_test_suite(
     let single_test_suite = match test_name {
         // Land-blocking tests to be run on every PR:
         "land_blocking" => land_blocking_test_suite(duration), // to remove land_blocking, superseeded by the below
-        "realistic_env_max_load" => pfn_const_tps(duration, true, true),
+        "realistic_env_max_load" => realistic_env_max_load_test(duration, test_cmd, 7, 5),
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),
         // Rest of the tests:


### PR DESCRIPTION
### Description

* Increase single fullnode max throughput from 4K TPS to 6K TPS (max batch size 200 -> 300, scheduled every 50 ms)
* Increase throughput when broadcast RTT is large, by increasing the number of outstanding requests. E.g., previously an RTT of 500 ms with 2 outstanding requests, meant only 2 requests could be made every 500 ms.

### Test Plan

Run forge with PFNs and network emulation, observe that `Avg Insertion-to-Broadcast-Batched` on PFNs drops significantly, from 1-2 s for some PFNs to < 200 ms.
