### PR TITLE
[Storage Service] Reduce storage summary config interval.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -185,7 +185,7 @@ impl Default for StorageServiceConfig {
             max_transaction_output_chunk_size: MAX_TRANSACTION_OUTPUT_CHUNK_SIZE,
             min_time_to_ignore_peers_secs: 300, // 5 minutes
             request_moderator_refresh_interval_ms: 1000, // 1 second
-            storage_summary_refresh_interval_ms: 500,
+            storage_summary_refresh_interval_ms: 100, // Optimal for <= 10 blocks per second
         }
     }
 }


### PR DESCRIPTION
### Description
This PR reduces the storage summary refresh interval to 100ms. This is optimal for environments that have <= 10 blocks per second.

### Test Plan
Existing test infrastructure and manual forge runs to verify performance.