### PR TITLE
[dag] Handle certified node in DAG Driver

### DIFF
--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -1,7 +1,11 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{storage::DAGStorage, types::CertifiedAck, RpcHandler};
+use super::{
+    storage::DAGStorage,
+    types::{CertifiedAck, DAGMessage},
+    RpcHandler,
+};
 use crate::{
     dag::{
         dag_store::Dag,
@@ -20,8 +24,8 @@ use futures::{
     FutureExt,
 };
 use std::sync::Arc;
-use tokio_retry::strategy::ExponentialBackoff;
 use thiserror::Error as ThisError;
+use tokio_retry::strategy::ExponentialBackoff;
 
 #[derive(Debug, ThisError)]
 pub enum DagDriverError {
@@ -67,9 +71,12 @@ impl DagDriver {
     }
 
     pub fn try_enter_new_round(&mut self) {
+        // In case of a new epoch, kickstart building the DAG by entering the next round
+        // without any parents.
         if self.current_round == 0 {
             self.enter_new_round(vec![]);
         }
+        // TODO: add logic to handle building DAG from the middle, etc.
     }
 
     pub fn add_node(&mut self, node: CertifiedNode) -> anyhow::Result<()> {

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -66,6 +66,12 @@ impl DagDriver {
         }
     }
 
+    pub fn try_enter_new_round(&mut self) {
+        if self.current_round == 0 {
+            self.enter_new_round(vec![]);
+        }
+    }
+
     pub fn add_node(&mut self, node: CertifiedNode) -> anyhow::Result<()> {
         let mut dag_writer = self.dag.write();
         let round = node.metadata().round();

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{storage::DAGStorage, types::DAGMessage};
+use super::{storage::DAGStorage, types::CertifiedAck, RpcHandler};
 use crate::{
     dag::{
         dag_store::Dag,
@@ -10,6 +10,7 @@ use crate::{
     state_replication::PayloadClient,
     util::time_service::TimeService,
 };
+use anyhow::bail;
 use aptos_consensus_types::common::{Author, Payload};
 use aptos_infallible::RwLock;
 use aptos_reliable_broadcast::ReliableBroadcast;
@@ -20,6 +21,13 @@ use futures::{
 };
 use std::sync::Arc;
 use tokio_retry::strategy::ExponentialBackoff;
+use thiserror::Error as ThisError;
+
+#[derive(Debug, ThisError)]
+pub enum DagDriverError {
+    #[error("missing parents")]
+    MissingParents,
+}
 
 pub(crate) struct DagDriver {
     author: Author,
@@ -61,18 +69,21 @@ impl DagDriver {
     pub fn add_node(&mut self, node: CertifiedNode) -> anyhow::Result<()> {
         let mut dag_writer = self.dag.write();
         let round = node.metadata().round();
-        if dag_writer.all_exists(node.parents_metadata()) {
-            dag_writer.add_node(node)?;
-            if self.current_round == round {
-                let maybe_strong_links = dag_writer
-                    .get_strong_links_for_round(self.current_round, &self.epoch_state.verifier);
-                drop(dag_writer);
-                if let Some(strong_links) = maybe_strong_links {
-                    self.enter_new_round(strong_links);
-                }
+
+        if !dag_writer.all_exists(node.parents_metadata()) {
+            // TODO(ibalajiarun): implement fetching logic.
+            bail!(DagDriverError::MissingParents);
+        }
+
+        dag_writer.add_node(node)?;
+        if self.current_round == round {
+            let maybe_strong_links = dag_writer
+                .get_strong_links_for_round(self.current_round, &self.epoch_state.verifier);
+            drop(dag_writer);
+            if let Some(strong_links) = maybe_strong_links {
+                self.enter_new_round(strong_links);
             }
         }
-        // TODO: handle fetching missing dependencies
         Ok(())
     }
 
@@ -113,5 +124,24 @@ impl DagDriver {
         if let Some(prev_handle) = self.rb_abort_handle.replace(abort_handle) {
             prev_handle.abort();
         }
+    }
+}
+
+impl RpcHandler for DagDriver {
+    type Request = CertifiedNode;
+    type Response = CertifiedAck;
+
+    fn process(&mut self, node: Self::Request) -> anyhow::Result<Self::Response> {
+        let epoch = node.metadata().epoch();
+        {
+            let dag_reader = self.dag.read();
+            if dag_reader.exists(node.metadata()) {
+                return Ok(CertifiedAck::new(node.metadata().epoch()));
+            }
+        }
+
+        self.add_node(node)?;
+
+        Ok(CertifiedAck::new(epoch))
     }
 }

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -11,7 +11,6 @@ use crate::{
     },
     network::{IncomingDAGRequest, TConsensusMsg},
     state_replication::PayloadClient,
-    util::time_service::TimeService,
 };
 use anyhow::bail;
 use aptos_channels::aptos_channel;
@@ -20,6 +19,7 @@ use aptos_infallible::RwLock;
 use aptos_logger::{error, warn};
 use aptos_network::protocols::network::RpcError;
 use aptos_reliable_broadcast::{RBNetworkSender, ReliableBroadcast};
+use aptos_time_service::TimeService;
 use aptos_types::{epoch_state::EpochState, validator_signer::ValidatorSigner};
 use bytes::Bytes;
 use futures::StreamExt;
@@ -44,14 +44,13 @@ impl NetworkHandler {
         payload_client: Arc<dyn PayloadClient>,
         _dag_network_sender: Arc<dyn DAGNetworkSender>,
         rb_network_sender: Arc<dyn RBNetworkSender<DAGMessage>>,
-        time_service: Arc<dyn TimeService>,
-        aptos_time_service: aptos_time_service::TimeService,
+        time_service: TimeService,
     ) -> Self {
         let rb = Arc::new(ReliableBroadcast::new(
             epoch_state.verifier.get_ordered_account_addresses().clone(),
             rb_network_sender,
             ExponentialBackoff::from_millis(10),
-            aptos_time_service,
+            time_service.clone(),
         ));
         Self {
             dag_rpc_rx,

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -70,6 +70,8 @@ impl NetworkHandler {
     }
 
     async fn start(mut self) {
+        self.dag_driver.try_enter_new_round();        
+        
         // TODO(ibalajiarun): clean up Reliable Broadcast storage periodically.
         while let Some(msg) = self.dag_rpc_rx.next().await {
             if let Err(e) = self.process_rpc(msg).await {

--- a/consensus/src/dag/dag_network.rs
+++ b/consensus/src/dag/dag_network.rs
@@ -2,6 +2,7 @@
 
 use super::types::DAGMessage;
 use aptos_consensus_types::common::Author;
+use aptos_reliable_broadcast::RBNetworkSender;
 use aptos_time_service::{Interval, TimeService, TimeServiceTrait};
 use async_trait::async_trait;
 use futures::{
@@ -24,7 +25,7 @@ pub trait RpcHandler {
 }
 
 #[async_trait]
-pub trait DAGNetworkSender: Send + Sync {
+pub trait DAGNetworkSender: Send + Sync + RBNetworkSender<DAGMessage> {
     async fn send_rpc(
         &self,
         receiver: Author,

--- a/consensus/src/dag/reliable_broadcast.rs
+++ b/consensus/src/dag/reliable_broadcast.rs
@@ -1,11 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{
-    storage::DAGStorage,
-    types::{CertifiedAck, CertifiedNode},
-    NodeId,
-};
+use super::{storage::DAGStorage, NodeId};
 use crate::dag::{
     dag_network::RpcHandler,
     dag_store::Dag,
@@ -159,48 +155,5 @@ impl RpcHandler for NodeBroadcastHandler {
             },
             Some(ack) => Ok(ack.clone()),
         }
-    }
-}
-
-#[derive(Debug, ThisError)]
-pub enum CertifiedNodeHandleError {
-    #[error("node already exists")]
-    NodeExists,
-    #[error("missing parents")]
-    MissingParents,
-}
-
-pub struct CertifiedNodeHandler {
-    dag: Arc<RwLock<Dag>>,
-}
-
-impl CertifiedNodeHandler {
-    pub fn new(dag: Arc<RwLock<Dag>>) -> Self {
-        Self { dag }
-    }
-}
-
-impl RpcHandler for CertifiedNodeHandler {
-    type Request = CertifiedNode;
-    type Response = CertifiedAck;
-
-    fn process(&mut self, node: Self::Request) -> anyhow::Result<Self::Response> {
-        let epoch = node.metadata().epoch();
-        {
-            let dag_reader = self.dag.read();
-            if dag_reader.exists(node.metadata()) {
-                return Ok(CertifiedAck::new(node.metadata().epoch()));
-            }
-
-            if !dag_reader.all_exists(node.parents_metadata()) {
-                // TODO(ibalajiarun): implement fetching logic.
-                bail!(CertifiedNodeHandleError::MissingParents);
-            }
-        }
-
-        let mut dag_writer = self.dag.write();
-        dag_writer.add_node(node)?;
-
-        Ok(CertifiedAck::new(epoch))
     }
 }

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -10,11 +10,11 @@ use crate::{
         RpcHandler,
     },
     test_utils::MockPayloadManager,
-    util::mock_time_service::SimulatedTimeService,
 };
 use aptos_consensus_types::common::Author;
 use aptos_infallible::RwLock;
 use aptos_reliable_broadcast::{RBNetworkSender, ReliableBroadcast};
+use aptos_time_service::TimeService;
 use aptos_types::{epoch_state::EpochState, validator_verifier::random_validator_verifier};
 use async_trait::async_trait;
 use claims::{assert_ok, assert_ok_eq};
@@ -77,7 +77,7 @@ fn test_certified_node_handler() {
         ExponentialBackoff::from_millis(10),
         aptos_time_service::TimeService::mock(),
     ));
-    let time_service = Arc::new(SimulatedTimeService::new());
+    let time_service = TimeService::mock();
     let mut driver = DagDriver::new(
         signers[0].author(),
         epoch_state,

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -1,0 +1,86 @@
+use crate::{
+    dag::{
+        dag_driver::{DagDriver, DagDriverError},
+        dag_network::{DAGNetworkSender, RpcWithFallback},
+        dag_store::Dag,
+        reliable_broadcast::ReliableBroadcast,
+        tests::{dag_test::MockStorage, helpers::new_certified_node},
+        types::{CertifiedAck, DAGMessage},
+        RpcHandler,
+    },
+    test_utils::MockPayloadManager,
+    util::mock_time_service::SimulatedTimeService,
+};
+use aptos_consensus_types::common::Author;
+use aptos_infallible::RwLock;
+use aptos_types::{epoch_state::EpochState, validator_verifier::random_validator_verifier};
+use async_trait::async_trait;
+use claims::{assert_ok, assert_ok_eq};
+use std::{sync::Arc, time::Duration};
+
+struct MockNetworkSender {}
+
+#[async_trait]
+impl DAGNetworkSender for MockNetworkSender {
+    async fn send_rpc(
+        &self,
+        _receiver: Author,
+        _message: DAGMessage,
+        _timeout: Duration,
+    ) -> anyhow::Result<DAGMessage> {
+        unimplemented!()
+    }
+
+    /// Given a list of potential responders, sending rpc to get response from any of them and could
+    /// fallback to more in case of failures.
+    async fn send_rpc_with_fallbacks(
+        &self,
+        _responders: Vec<Author>,
+        _message: DAGMessage,
+        _retry_interval: Duration,
+        _rpc_timeout: Duration,
+    ) -> RpcWithFallback {
+        unimplemented!()
+    }
+}
+
+#[test]
+fn test_certified_node_handler() {
+    let (signers, validator_verifier) = random_validator_verifier(4, None, false);
+    let epoch_state = Arc::new(EpochState {
+        epoch: 1,
+        verifier: validator_verifier,
+    });
+    let storage = Arc::new(MockStorage::new());
+    let dag = Arc::new(RwLock::new(Dag::new(epoch_state.clone(), storage.clone())));
+
+    let zeroth_round_node = new_certified_node(0, signers[0].author(), vec![]);
+
+    let rb = Arc::new(ReliableBroadcast::new(
+        signers.iter().map(|s| s.author()).collect(),
+        Arc::new(MockNetworkSender {}),
+    ));
+    let time_service = Arc::new(SimulatedTimeService::new());
+    let mut driver = DagDriver::new(
+        signers[0].author(),
+        epoch_state,
+        dag,
+        Arc::new(MockPayloadManager::new(None)),
+        rb,
+        1,
+        time_service,
+        storage,
+    );
+
+    // expect an ack for a valid message
+    assert_ok!(driver.process(zeroth_round_node.clone()));
+    // expect an ack if the same message is sent again
+    assert_ok_eq!(driver.process(zeroth_round_node), CertifiedAck::new(1));
+
+    let parent_node = new_certified_node(0, signers[1].author(), vec![]);
+    let invalid_node = new_certified_node(1, signers[0].author(), vec![parent_node.certificate()]);
+    assert_eq!(
+        driver.process(invalid_node).unwrap_err().to_string(),
+        DagDriverError::MissingParents.to_string()
+    );
+}

--- a/consensus/src/dag/tests/dag_network_test.rs
+++ b/consensus/src/dag/tests/dag_network_test.rs
@@ -7,6 +7,7 @@ use crate::dag::{
 use anyhow::{anyhow, bail};
 use aptos_consensus_types::common::Author;
 use aptos_infallible::Mutex;
+use aptos_reliable_broadcast::RBNetworkSender;
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::validator_verifier::random_validator_verifier;
 use async_trait::async_trait;
@@ -25,6 +26,18 @@ enum TestPeerState {
 struct MockDAGNetworkSender {
     time_service: TimeService,
     test_peer_state: Arc<Mutex<HashMap<Author, TestPeerState>>>,
+}
+
+#[async_trait]
+impl RBNetworkSender<DAGMessage> for MockDAGNetworkSender {
+    async fn send_rb_rpc(
+        &self,
+        _receiver: Author,
+        _message: DAGMessage,
+        _timeout: Duration,
+    ) -> anyhow::Result<DAGMessage> {
+        unimplemented!()
+    }
 }
 
 #[async_trait]

--- a/consensus/src/dag/tests/mod.rs
+++ b/consensus/src/dag/tests/mod.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+mod dag_driver_tests;
 mod dag_network_test;
 mod dag_test;
 mod fetcher_test;

--- a/consensus/src/dag/tests/reliable_broadcast_tests.rs
+++ b/consensus/src/dag/tests/reliable_broadcast_tests.rs
@@ -3,16 +3,10 @@
 
 use crate::dag::{
     dag_store::Dag,
-    reliable_broadcast::{
-        CertifiedNodeHandleError, CertifiedNodeHandler, NodeBroadcastHandleError,
-        NodeBroadcastHandler,
-    },
+    reliable_broadcast::{NodeBroadcastHandleError, NodeBroadcastHandler},
     storage::DAGStorage,
-    tests::{
-        dag_test::MockStorage,
-        helpers::{new_certified_node, new_node},
-    },
-    types::{CertifiedAck, NodeCertificate},
+    tests::{dag_test::MockStorage, helpers::new_node},
+    types::NodeCertificate,
     NodeId, RpcHandler, Vote,
 };
 use aptos_infallible::RwLock;

--- a/consensus/src/dag/tests/types_test.rs
+++ b/consensus/src/dag/tests/types_test.rs
@@ -33,20 +33,20 @@ fn test_node_verify() {
         "invalid digest"
     );
 
-    // Well-formed round 0 node
-    let zeroth_round_node = new_node(0, 10, signers[0].author(), vec![]);
-    assert_ok!(zeroth_round_node.verify(&validator_verifier));
+    // Well-formed round 1 node
+    let first_round_node = new_node(1, 10, signers[0].author(), vec![]);
+    assert_ok!(first_round_node.verify(&validator_verifier));
 
-    // Round 1 node without parents
+    // Round 2 node without parents
     let node = new_node(2, 20, signers[0].author(), vec![]);
     assert_eq!(
         node.verify(&validator_verifier).unwrap_err().to_string(),
         "not enough parents to satisfy voting power",
     );
 
-    // Round 1
+    // Round 1 cert
     let parent_cert = NodeCertificate::new(
-        zeroth_round_node.metadata().clone(),
+        first_round_node.metadata().clone(),
         AggregateSignature::empty(),
     );
     let node = new_node(3, 20, signers[0].author(), vec![parent_cert]);

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -248,6 +248,8 @@ impl TDAGMessage for Node {
 
         let current_round = self.metadata().round();
 
+        ensure!(current_round > 0, "current round cannot be zero");
+
         if current_round == 1 {
             ensure!(self.parents().is_empty(), "invalid parents for round 1");
             return Ok(());

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -248,8 +248,8 @@ impl TDAGMessage for Node {
 
         let current_round = self.metadata().round();
 
-        if current_round == 0 {
-            ensure!(self.parents().is_empty(), "invalid parents for round 0");
+        if current_round == 1 {
+            ensure!(self.parents().is_empty(), "invalid parents for round 1");
             return Ok(());
         }
 

--- a/crates/reliable-broadcast/src/lib.rs
+++ b/crates/reliable-broadcast/src/lib.rs
@@ -11,7 +11,12 @@ pub trait RBMessage: Send + Sync + Clone {}
 
 #[async_trait]
 pub trait RBNetworkSender<M: RBMessage>: Send + Sync {
-    async fn send_rpc(&self, receiver: Author, message: M, timeout: Duration) -> anyhow::Result<M>;
+    async fn send_rb_rpc(
+        &self,
+        receiver: Author,
+        message: M,
+        timeout: Duration,
+    ) -> anyhow::Result<M>;
 }
 
 pub trait BroadcastStatus<M: RBMessage> {
@@ -74,7 +79,7 @@ where
                     (
                         receiver,
                         network_sender
-                            .send_rpc(receiver, message, Duration::from_millis(500))
+                            .send_rb_rpc(receiver, message, Duration::from_millis(500))
                             .await,
                     )
                 }

--- a/crates/reliable-broadcast/src/tests.rs
+++ b/crates/reliable-broadcast/src/tests.rs
@@ -87,7 +87,7 @@ where
     TestAck: TryFrom<M> + Into<M>,
     TestMessage: TryFrom<M, Error = anyhow::Error> + Into<M>,
 {
-    async fn send_rpc(
+    async fn send_rb_rpc(
         &self,
         receiver: Author,
         message: M,


### PR DESCRIPTION
### Description

This PR removes the `CertifiedNodeHandler` and instead implements the `RpcHandler` on DagDriver to handle `CertifiedNode`. 

Also, adds a method to trigger a new round from special case current round 0 from Dag Handler.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Existing tests fixed.