### PR TITLE
Make indexer_grpc_local.py work regardless of which directory it is invoked from

### DIFF
--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -5,3 +5,15 @@ This directory contains a mix of test utilities written in both Python and Rust
 * Forge Wrapper - a set of Python utilities to schedule and manage Forge jobs on supported kubernetes clusters
 * Testcases - Forge test cases
 * Verify - Python utilities used to invoke replay-verify and module-verify workflows
+
+## Debugging
+If you run into an issue like this:
+```
+no match for platform in manifest: not found
+```
+
+It is likely because you're on an ARM machine. Try running your command with `DOCKER_DEFAULT_PLATFORM=linux/amd64`, e.g.
+```
+DOCKER_DEFAULT_PLATFORM=linux/amd64 poetry run python indexer_grpc_local.py start
+```
+

--- a/testsuite/indexer_grpc_local.py
+++ b/testsuite/indexer_grpc_local.py
@@ -232,6 +232,12 @@ def wipe(context: SystemContext) -> None:
 
 
 def main() -> None:
+    # Change to the root of aptos-core.
+    abspath = os.path.abspath(__file__)
+    dname = os.path.dirname(abspath)
+    os.chdir(dname)
+    os.chdir("..")
+
     # set envs based on platform, if it's not already overriden
     if not os.environ.get("REDIS_IMAGE_REPO"):
         if platform.system() == "Darwin":


### PR DESCRIPTION
### Description
Running this script didn't work if you did it from testsuite/. With this it does.

### Test Plan
Before:
```
stat /Users/dport/a/core/testsuite/docker/compose/indexer-grpc/docker-compose.yaml: no such file or directory
```

After:
```
[Wed, 26 Jul 2023 16:28:01] INFO [indexer_grpc_local.py.wait_for_indexer_grpc_progress:170] Attempting to stream from indexer grpc for 10s
[Wed, 26 Jul 2023 16:28:11] INFO [indexer_grpc_local.py.wait_for_indexer_grpc_progress:208] Stream finished successfully
```
