### PR TITLE
[api] Fix transitive dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "move-resource-viewer",
  "poem",
  "poem-openapi",
+ "poem-openapi-derive",
  "serde 1.0.149",
  "serde_json",
 ]

--- a/api/types/Cargo.toml
+++ b/api/types/Cargo.toml
@@ -31,5 +31,6 @@ move-core-types = { workspace = true }
 move-resource-viewer = { workspace = true }
 poem = { workspace = true }
 poem-openapi = { workspace = true }
+poem-openapi-derive = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
### Description
This was blocking the SDK usage, so this fixes it so that it can be properly consumed

### Test Plan
Built a sample app with the patch
```
 cargo build
    Updating git repository `https://github.com/aptos-labs/merlin`
    Finished dev [unoptimized + debuginfo] target(s) in 1.71s
```
Without
```
error[E0405]: cannot find trait `ToYAML` in module `poem_openapi::types`
   --> /Users/greg/.cargo/git/checkouts/aptos-core-8f3268fcf79e1f38/62ca66e/api/types/src/wrappers.rs:92:47
    |
92  | #[derive(Clone, Copy, Debug, Deserialize, Eq, Object, PartialEq, Serialize)]
    |                                               ^^^^^^ help: a trait with a similar name exists: `ToXML`
    |
   ::: /Users/greg/.cargo/registry/src/index.crates.io-6f17d22bba15001f/poem-openapi-2.0.11/src/types/mod.rs:152:1
    |
152 | pub trait ToXML: Type {
    | --------------------- similarly named trait `ToXML` defined here
    |
    = note: this error originates in the derive macro `Object` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0405`.
error: could not compile `aptos-api-types` (lib) due to 114 previous errors
warning: build failed, waiting for other jobs to finish...

```