### PR TITLE
[gha] remove helm-lint from lint-test

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -258,6 +258,3 @@ jobs:
 
   python-lint-test:
     uses: ./.github/workflows/python-lint-test.yaml
-
-  helm-lint:
-    uses: ./.github/workflows/helm-lint.yaml


### PR DESCRIPTION
### Description

Related to #9322 . All references to the deleted workflow need to be removed on main

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
