### PR TITLE
add more logging to data service.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -545,7 +545,7 @@ rand = "0.7.3"
 rand_core = "0.5.1"
 random_word = "0.3.0"
 rayon = "1.5.2"
-redis = { version = "0.22.3", features = ["tokio-comp", "script"] }
+redis = { version = "0.22.3", features = ["tokio-comp", "script", "connection-manager"] }
 redis-test = { version = "0.1.1", features = ["aio"] }
 regex = "1.5.5"
 reqwest = { version = "0.11.11", features = [

--- a/docker/builder/indexer-grpc.Dockerfile
+++ b/docker/builder/indexer-grpc.Dockerfile
@@ -21,8 +21,10 @@ COPY --link --from=tools-builder /aptos/dist/aptos-indexer-grpc-post-processor /
 
 # The health check port
 EXPOSE 8080
-# The gRPC port
+# The gRPC non-TLS port
 EXPOSE 50051
+# The gRPC TLS port
+EXPOSE 50052
 
 ENV RUST_LOG_FORMAT=json
 

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/main.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/main.rs
@@ -109,6 +109,10 @@ impl RunnableConfig for IndexerGrpcDataServiceConfig {
                 .map_err(|e| anyhow::anyhow!(e))?
                 .next()
                 .ok_or_else(|| anyhow::anyhow!("Failed to parse grpc address"))?;
+            tracing::info!(
+                grpc_address = grpc_address.to_string().as_str(),
+                "[Data Service] Starting gRPC server with non-TLS."
+            );
             tasks.push(tokio::spawn(async move {
                 Server::builder()
                     .http2_keepalive_interval(Some(HTTP2_PING_INTERVAL_DURATION))
@@ -132,6 +136,10 @@ impl RunnableConfig for IndexerGrpcDataServiceConfig {
             let cert = tokio::fs::read(config.cert_path.clone()).await?;
             let key = tokio::fs::read(config.key_path.clone()).await?;
             let identity = tonic::transport::Identity::from_pem(cert, key);
+            tracing::info!(
+                grpc_address = grpc_address.to_string().as_str(),
+                "[Data Service] Starting gRPC server with TLS."
+            );
             tasks.push(tokio::spawn(async move {
                 Server::builder()
                     .http2_keepalive_interval(Some(HTTP2_PING_INTERVAL_DURATION))


### PR DESCRIPTION
### Description
* Add more logging to indexer grpc data service for TLS/non-TLS start-up.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
* Locally tested and it looks good.

<img width="403" alt="image" src="https://github.com/aptos-labs/aptos-core/assets/112209412/70922e69-e288-4cd7-8cfd-dfd908d43e09">
