### PR TITLE
[Move prover] Some fixes in the prover and the specs

### DIFF
--- a/.github/workflows/prover-daily-test.yaml
+++ b/.github/workflows/prover-daily-test.yaml
@@ -38,5 +38,7 @@ jobs:
           echo "/home/runner/bin" | tee -a $GITHUB_PATH
           echo "/home/runner/.dotnet" | tee -a $GITHUB_PATH
           echo "/home/runner/.dotnet/tools" | tee -a $GITHUB_PATH
-      - run: MVP_TEST_INCONSISTENCY=1 cargo test -p aptos-move-examples --release -- --include-ignored prover
-      - run: MVP_TEST_INCONSISTENCY=1 cargo test -p aptos-framework --release -- --include-ignored prover
+      - run: MVP_TEST_DISALLOW_TIMEOUT_OVERWRITE=1 MVP_TEST_VC_TIMEOUT=1200 cargo test -p aptos-move-examples --release -- --include-ignored prover
+      - run: MVP_TEST_DISALLOW_TIMEOUT_OVERWRITE=1 MVP_TEST_VC_TIMEOUT=1200 cargo test -p aptos-framework --release -- --include-ignored prover
+      - run: MVP_TEST_DISALLOW_TIMEOUT_OVERWRITE=1 MVP_TEST_VC_TIMEOUT=1200 MVP_TEST_INCONSISTENCY=1 cargo test -p aptos-move-examples --release -- --include-ignored prover
+      - run: MVP_TEST_DISALLOW_TIMEOUT_OVERWRITE=1 MVP_TEST_VC_TIMEOUT=1200 MVP_TEST_INCONSISTENCY=1 cargo test -p aptos-framework --release -- --include-ignored prover

--- a/aptos-move/framework/aptos-framework/doc/aptos_coin.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_coin.md
@@ -588,4 +588,15 @@ Claim the delegated mint capability and destroy the delegated token.
 </code></pre>
 
 
+
+
+<a name="0x1_aptos_coin_ExistsAptosCoin"></a>
+
+
+<pre><code><b>schema</b> <a href="aptos_coin.md#0x1_aptos_coin_ExistsAptosCoin">ExistsAptosCoin</a> {
+    <b>requires</b> <b>exists</b>&lt;<a href="coin.md#0x1_coin_CoinInfo">coin::CoinInfo</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">AptosCoin</a>&gt;&gt;(@aptos_framework);
+}
+</code></pre>
+
+
 [move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/aptos_governance.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_governance.md
@@ -2365,7 +2365,8 @@ Address @aptos_framework must exist ApprovedExecutionHashes and GovernancePropos
 
 
 
-<pre><code><b>requires</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>();
+<pre><code><b>pragma</b> verify = <b>false</b>;
+<b>requires</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>();
 <b>include</b> <a href="aptos_governance.md#0x1_aptos_governance_VotingIsProposalResolvableAbortsif">VotingIsProposalResolvableAbortsif</a>;
 <b>let</b> voting_forum = <b>global</b>&lt;<a href="voting.md#0x1_voting_VotingForum">voting::VotingForum</a>&lt;GovernanceProposal&gt;&gt;(@aptos_framework);
 <b>let</b> proposal = <a href="../../aptos-stdlib/doc/table.md#0x1_table_spec_get">table::spec_get</a>(voting_forum.proposals, proposal_id);
@@ -2473,7 +2474,8 @@ Address @aptos_framework must exist ApprovedExecutionHashes and GovernancePropos
 
 
 
-<pre><code><b>aborts_if</b> !<a href="system_addresses.md#0x1_system_addresses_is_aptos_framework_address">system_addresses::is_aptos_framework_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework));
+<pre><code><b>pragma</b> verify_duration_estimate = 120;
+<b>aborts_if</b> !<a href="system_addresses.md#0x1_system_addresses_is_aptos_framework_address">system_addresses::is_aptos_framework_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework));
 <b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
 <b>requires</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>();
 <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">stake::ValidatorFees</a>&gt;(@aptos_framework);

--- a/aptos-move/framework/aptos-framework/doc/execution_config.md
+++ b/aptos-move/framework/aptos-framework/doc/execution_config.md
@@ -127,7 +127,6 @@ When setting now time must be later than last_reconfiguration_time.
 <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
 <b>aborts_if</b> !<a href="system_addresses.md#0x1_system_addresses_is_aptos_framework_address">system_addresses::is_aptos_framework_address</a>(addr);
 <b>aborts_if</b> !(len(config) &gt; 0);
-<b>requires</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>();
 <b>requires</b> <a href="timestamp.md#0x1_timestamp_spec_now_microseconds">timestamp::spec_now_microseconds</a>() &gt;= <a href="reconfiguration.md#0x1_reconfiguration_last_reconfiguration_time">reconfiguration::last_reconfiguration_time</a>();
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/reconfiguration.md
+++ b/aptos-move/framework/aptos-framework/doc/reconfiguration.md
@@ -598,18 +598,14 @@ Make sure the caller is admin and check the resource DisableReconfiguration.
 
 <pre><code><b>pragma</b> verify_duration_estimate = 120;
 <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorFees">stake::ValidatorFees</a>&gt;(@aptos_framework);
-<b>requires</b> <b>exists</b>&lt;CoinInfo&lt;AptosCoin&gt;&gt;(@aptos_framework);
 <b>include</b> <a href="transaction_fee.md#0x1_transaction_fee_RequiresCollectedFeesPerValueLeqBlockAptosSupply">transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply</a>;
-<b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">staking_config::StakingRewardsConfigRequirement</a>;
+<b>include</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_periodical_reward_rate_decrease_enabled">features::spec_periodical_reward_rate_decrease_enabled</a>() ==&gt; <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigEnabledRequirement">staking_config::StakingRewardsConfigEnabledRequirement</a>;
+<b>include</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_collect_and_distribute_gas_fees_enabled">features::spec_collect_and_distribute_gas_fees_enabled</a>() ==&gt; <a href="aptos_coin.md#0x1_aptos_coin_ExistsAptosCoin">aptos_coin::ExistsAptosCoin</a>;
 <b>aborts_if</b> <b>false</b>;
 <b>let</b> success = !(<a href="chain_status.md#0x1_chain_status_is_genesis">chain_status::is_genesis</a>() || <a href="timestamp.md#0x1_timestamp_spec_now_microseconds">timestamp::spec_now_microseconds</a>() == 0 || !<a href="reconfiguration.md#0x1_reconfiguration_reconfiguration_enabled">reconfiguration_enabled</a>())
     && <a href="timestamp.md#0x1_timestamp_spec_now_microseconds">timestamp::spec_now_microseconds</a>() != <b>global</b>&lt;<a href="reconfiguration.md#0x1_reconfiguration_Configuration">Configuration</a>&gt;(@aptos_framework).last_reconfiguration_time;
 <b>ensures</b> success ==&gt; <b>global</b>&lt;<a href="reconfiguration.md#0x1_reconfiguration_Configuration">Configuration</a>&gt;(@aptos_framework).epoch == <b>old</b>(<b>global</b>&lt;<a href="reconfiguration.md#0x1_reconfiguration_Configuration">Configuration</a>&gt;(@aptos_framework).epoch) + 1;
 <b>ensures</b> !success ==&gt; <b>global</b>&lt;<a href="reconfiguration.md#0x1_reconfiguration_Configuration">Configuration</a>&gt;(@aptos_framework).epoch == <b>old</b>(<b>global</b>&lt;<a href="reconfiguration.md#0x1_reconfiguration_Configuration">Configuration</a>&gt;(@aptos_framework).epoch);
-<b>ensures</b> (success && <a href="event.md#0x1_event_counter">event::counter</a>&lt;<a href="reconfiguration.md#0x1_reconfiguration_NewEpochEvent">NewEpochEvent</a>&gt;(<b>old</b>(<b>global</b>&lt;<a href="reconfiguration.md#0x1_reconfiguration_Configuration">Configuration</a>&gt;(@aptos_framework)).events) &lt;
-    MAX_U64) ==&gt;
-    <a href="event.md#0x1_event_counter">event::counter</a>&lt;<a href="reconfiguration.md#0x1_reconfiguration_NewEpochEvent">NewEpochEvent</a>&gt;(<b>global</b>&lt;<a href="reconfiguration.md#0x1_reconfiguration_Configuration">Configuration</a>&gt;(@aptos_framework).events) ==
-        <a href="event.md#0x1_event_counter">event::counter</a>&lt;<a href="reconfiguration.md#0x1_reconfiguration_NewEpochEvent">NewEpochEvent</a>&gt;(<b>old</b>(<b>global</b>&lt;<a href="reconfiguration.md#0x1_reconfiguration_Configuration">Configuration</a>&gt;(@aptos_framework)).events) + 1;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/staking_contract.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_contract.md
@@ -2077,7 +2077,7 @@ Staking_contract exists the stacker/operator pair.
 Staking_contract exists the stacker/operator pair.
 
 
-<pre><code><b>pragma</b> verify_duration_estimate = 1000;
+<pre><code><b>pragma</b> verify = <b>false</b>;
 <b>let</b> staking_contracts = <b>global</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker).staking_contracts;
 <b>let</b> <a href="staking_contract.md#0x1_staking_contract">staking_contract</a> = <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_spec_get">simple_map::spec_get</a>(staking_contracts, operator);
 <b>include</b> <a href="staking_contract.md#0x1_staking_contract_ContractExistsAbortsIf">ContractExistsAbortsIf</a>;
@@ -2142,7 +2142,7 @@ Staking_contract exists the stacker/operator pair.
 Account is not frozen and sufficient to withdraw.
 
 
-<pre><code><b>pragma</b> verify_duration_estimate = 1000;
+<pre><code><b>pragma</b> verify = <b>false</b>;
 <b>include</b> <a href="staking_contract.md#0x1_staking_contract_PreconditionsInCreateContract">PreconditionsInCreateContract</a>;
 <b>include</b> <a href="staking_contract.md#0x1_staking_contract_WithdrawAbortsIf">WithdrawAbortsIf</a>&lt;AptosCoin&gt; {<a href="account.md#0x1_account">account</a>: staker};
 <b>include</b> <a href="staking_contract.md#0x1_staking_contract_Create_Staking_Contract_With_Coins_Abortsif">Create_Staking_Contract_With_Coins_Abortsif</a>;
@@ -2164,7 +2164,7 @@ Initialize Store resource if this is the first time the staker has delegated to 
 Cannot create the staking contract if it already exists.
 
 
-<pre><code><b>pragma</b> verify_duration_estimate = 1000;
+<pre><code><b>pragma</b> verify = <b>false</b>;
 <b>include</b> <a href="staking_contract.md#0x1_staking_contract_PreconditionsInCreateContract">PreconditionsInCreateContract</a>;
 <b>let</b> amount = coins.value;
 <b>include</b> <a href="staking_contract.md#0x1_staking_contract_Create_Staking_Contract_With_Coins_Abortsif">Create_Staking_Contract_With_Coins_Abortsif</a> { amount };
@@ -2185,7 +2185,7 @@ Account is not frozen and sufficient to withdraw.
 Staking_contract exists the stacker/operator pair.
 
 
-<pre><code><b>pragma</b> verify_duration_estimate = 1000;
+<pre><code><b>pragma</b> verify = <b>false</b>;
 <b>include</b> <a href="stake.md#0x1_stake_ResourceRequirement">stake::ResourceRequirement</a>;
 <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker);
 <b>include</b> <a href="staking_contract.md#0x1_staking_contract_ContractExistsAbortsIf">ContractExistsAbortsIf</a> { staker: staker_address };

--- a/aptos-move/framework/aptos-framework/doc/voting.md
+++ b/aptos-move/framework/aptos-framework/doc/voting.md
@@ -1704,7 +1704,8 @@ Return true if the voting period of the given proposal has already ended.
 
 
 
-<pre><code><b>requires</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>();
+<pre><code><b>pragma</b> verify = <b>false</b>;
+<b>requires</b> <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>();
 <b>pragma</b> aborts_if_is_partial;
 <b>include</b> <a href="voting.md#0x1_voting_AbortsIfNotContainProposalID">AbortsIfNotContainProposalID</a>&lt;ProposalType&gt;;
 <b>aborts_if</b> !std::string::spec_internal_check_utf8(<a href="voting.md#0x1_voting_IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY">IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY</a>);

--- a/aptos-move/framework/aptos-framework/sources/aptos_coin.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_coin.spec.move
@@ -40,4 +40,9 @@ spec aptos_framework::aptos_coin {
     spec find_delegation(addr: address): Option<u64> {
         aborts_if !exists<Delegations>(@core_resources);
     }
+
+    spec schema ExistsAptosCoin {
+        requires exists<coin::CoinInfo<AptosCoin>>(@aptos_framework);
+    }
+
 }

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.spec.move
@@ -541,6 +541,7 @@ spec aptos_framework::aptos_governance {
         use aptos_framework::aptos_coin::AptosCoin;
         use aptos_framework::transaction_fee;
 
+        pragma verify_duration_estimate = 120; // TODO: set because of timeout (property proved)
         aborts_if !system_addresses::is_aptos_framework_address(signer::address_of(aptos_framework));
 
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
@@ -711,6 +712,7 @@ spec aptos_framework::aptos_governance {
 
     spec resolve_multi_step_proposal(proposal_id: u64, signer_address: address, next_execution_hash: vector<u8>): signer {
         use aptos_framework::chain_status;
+        pragma verify = false; // TODO: set because of a possible bug in boogie that needs further investigation
         requires chain_status::is_operating();
 
         // verify voting::resolve_proposal_v2

--- a/aptos-move/framework/aptos-framework/sources/configs/execution_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/execution_config.spec.move
@@ -7,7 +7,6 @@ spec aptos_framework::execution_config {
     /// Ensure the caller is admin
     /// When setting now time must be later than last_reconfiguration_time.
     spec set(account: &signer, config: vector<u8>) {
-        use aptos_framework::chain_status;
         use aptos_framework::timestamp;
         use std::signer;
 
@@ -17,7 +16,6 @@ spec aptos_framework::execution_config {
         aborts_if !system_addresses::is_aptos_framework_address(addr);
         aborts_if !(len(config) > 0);
 
-        requires chain_status::is_operating();
         requires timestamp::spec_now_microseconds() >= reconfiguration::last_reconfiguration_time();
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/staking_contract.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.spec.move
@@ -20,8 +20,8 @@ spec aptos_framework::staking_contract {
 
     /// Staking_contract exists the stacker/operator pair.
     spec staking_contract_amounts(staker: address, operator: address): (u64, u64, u64) {
-        // TODO: set because of timeout (property proved)
-        pragma verify_duration_estimate = 1000;
+        // TODO: set because of timeout
+        pragma verify = false;
         let staking_contracts = global<Store>(staker).staking_contracts;
         let staking_contract = simple_map::spec_get(staking_contracts, operator);
 
@@ -56,8 +56,8 @@ spec aptos_framework::staking_contract {
         commission_percentage: u64,
         contract_creation_seed: vector<u8>,
     ) {
-        // TODO: set because of timeout (property proved)
-        pragma verify_duration_estimate = 1000;
+        // TODO: set because of timeout
+        pragma verify = false;
         include PreconditionsInCreateContract;
         include WithdrawAbortsIf<AptosCoin> {account: staker};
         include Create_Staking_Contract_With_Coins_Abortsif;
@@ -74,8 +74,8 @@ spec aptos_framework::staking_contract {
         commission_percentage: u64,
         contract_creation_seed: vector<u8>,
     ): address {
-        // TODO: set because of timeout (property proved)
-        pragma verify_duration_estimate = 1000;
+        // TODO: set because of timeout
+        pragma verify = false;
         include PreconditionsInCreateContract;
 
         let amount = coins.value;
@@ -85,8 +85,8 @@ spec aptos_framework::staking_contract {
     /// Account is not frozen and sufficient to withdraw.
     /// Staking_contract exists the stacker/operator pair.
     spec add_stake(staker: &signer, operator: address, amount: u64) {
-        // TODO: set because of timeout (property proved)
-        pragma verify_duration_estimate = 1000;
+        // TODO: set because of timeout
+        pragma verify = false;
 
         // preconditions
         include stake::ResourceRequirement;

--- a/aptos-move/framework/aptos-framework/sources/voting.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/voting.spec.move
@@ -170,7 +170,9 @@ spec aptos_framework::voting {
         proposal_id: u64,
         next_execution_hash: vector<u8>,
     ) {
+        // TODO: set because of a possible bug in boogie that needs further investigation
         use aptos_framework::chain_status;
+        pragma verify = false;
         // Ensures existence of Timestamp
         requires chain_status::is_operating();
 

--- a/aptos-move/framework/aptos-stdlib/doc/smart_vector.md
+++ b/aptos-move/framework/aptos-stdlib/doc/smart_vector.md
@@ -994,7 +994,7 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 
 
 
-<pre><code><b>pragma</b> verify_duration_estimate = 120;
+<pre><code><b>pragma</b> verify = <b>false</b>;
 <b>aborts_if</b> i &gt;= <a href="smart_vector.md#0x1_smart_vector_length">length</a>(v);
 <b>aborts_if</b> <a href="../../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(v.big_vec) && (
     (<a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(v.inline_vec) + <a href="big_vector.md#0x1_big_vector_length">big_vector::length</a>&lt;T&gt;(<a href="../../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(v.big_vec))) &gt; MAX_U64

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_vector.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_vector.spec.move
@@ -54,7 +54,7 @@ spec aptos_std::smart_vector {
     }
 
     spec swap_remove {
-        pragma verify_duration_estimate = 120; // TODO: set because of timeout (property proved)
+        pragma verify = false; // TODO: set because of timeout
         aborts_if i >= length(v);
         aborts_if option::is_some(v.big_vec) && (
             (vector::length(v.inline_vec) + big_vector::length<T>(option::borrow(v.big_vec))) > MAX_U64

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -1456,6 +1456,17 @@ Helper to check whether a feature flag is enabled.
 
 
 
+
+<a name="0x1_features_spec_collect_and_distribute_gas_fees_enabled"></a>
+
+
+<pre><code><b>fun</b> <a href="features.md#0x1_features_spec_collect_and_distribute_gas_fees_enabled">spec_collect_and_distribute_gas_fees_enabled</a>(): bool {
+   <a href="features.md#0x1_features_spec_is_enabled">spec_is_enabled</a>(<a href="features.md#0x1_features_COLLECT_AND_DISTRIBUTE_GAS_FEES">COLLECT_AND_DISTRIBUTE_GAS_FEES</a>)
+}
+</code></pre>
+
+
+
 <a name="@Specification_1_set"></a>
 
 ### Function `set`

--- a/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
@@ -45,6 +45,10 @@ spec std::features {
         spec_is_enabled(FEE_PAYER_ENABLED)
     }
 
+    spec fun spec_collect_and_distribute_gas_fees_enabled(): bool {
+        spec_is_enabled(COLLECT_AND_DISTRIBUTE_GAS_FEES)
+    }
+
     spec periodical_reward_rate_decrease_enabled {
         pragma opaque;
         aborts_if [abstract] false;

--- a/aptos-move/framework/src/prover.rs
+++ b/aptos-move/framework/src/prover.rs
@@ -48,9 +48,19 @@ pub struct ProverOptions {
     #[clap(long, default_value_t = 40)]
     pub vc_timeout: usize,
 
+    /// Whether to disable global timeout overwrite
+    /// With this flag set to true, the value set by "--vc-timeout" will be used globally
+    #[clap(long, default_value_t = false)]
+    pub disallow_global_timeout_to_be_overwritten: bool,
+
     /// Whether to check consistency of specs by injecting impossible assertions.
     #[clap(long)]
     pub check_inconsistency: bool,
+
+    /// Whether to treat abort as inconsistency when checking consistency.
+    /// Need to work together with check-inconsistency
+    #[clap(long)]
+    pub unconditional_abort_as_inconsistency: bool,
 
     /// Whether to keep loops as they are and pass them on to the underlying solver.
     #[clap(long)]
@@ -84,7 +94,9 @@ impl Default for ProverOptions {
             random_seed: 0,
             proc_cores: 4,
             vc_timeout: 40,
+            disallow_global_timeout_to_be_overwritten: false,
             check_inconsistency: false,
+            unconditional_abort_as_inconsistency: false,
             keep_loops: false,
             loop_unroll: None,
             stable_test_output: false,
@@ -167,6 +179,7 @@ impl ProverOptions {
                 dump_bytecode: self.dump,
                 dump_cfg: false,
                 check_inconsistency: self.check_inconsistency,
+                unconditional_abort_as_inconsistency: self.unconditional_abort_as_inconsistency,
                 skip_loop_analysis: self.keep_loops,
                 ..Default::default()
             },
@@ -177,6 +190,7 @@ impl ProverOptions {
                 stratification_depth: self.stratification_depth,
                 proc_cores: self.proc_cores,
                 vc_timeout: self.vc_timeout,
+                global_timeout_overwrite: !self.disallow_global_timeout_to_be_overwritten,
                 keep_artifacts: self.dump,
                 stable_test_output: self.stable_test_output,
                 z3_trace_file: if self.dump {

--- a/aptos-move/framework/tests/move_prover_tests.rs
+++ b/aptos-move/framework/tests/move_prover_tests.rs
@@ -4,6 +4,12 @@
 use aptos_framework::prover::ProverOptions;
 use std::{collections::BTreeMap, path::PathBuf};
 
+const ENV_TEST_INCONSISTENCY: &str = "MVP_TEST_INCONSISTENCY";
+const ENV_TEST_UNCONDITIONAL_ABORT_AS_INCONSISTENCY: &str =
+    "MVP_TEST_UNCONDITIONAL_ABORT_AS_INCONSISTENCY";
+const ENV_TEST_DISALLOW_TIMEOUT_OVERWRITE: &str = "MVP_TEST_DISALLOW_TIMEOUT_OVERWRITE";
+const ENV_TEST_VC_TIMEOUT: &str = "MVP_TEST_VC_TIMEOUT";
+
 // Note: to run these tests, use:
 //
 //   cargo test -- --include-ignored prover
@@ -23,7 +29,7 @@ pub fn read_env_var(v: &str) -> String {
 
 pub fn run_prover_for_pkg(path_to_pkg: impl Into<String>) {
     let pkg_path = path_in_crate(path_to_pkg);
-    let options = ProverOptions::default_for_test();
+    let mut options = ProverOptions::default_for_test();
     let no_tools = read_env_var("BOOGIE_EXE").is_empty()
         || !options.cvc5 && read_env_var("Z3_EXE").is_empty()
         || options.cvc5 && read_env_var("CVC5_EXE").is_empty();
@@ -35,6 +41,16 @@ pub fn run_prover_for_pkg(path_to_pkg: impl Into<String>) {
         use \"-- --skip prover\" to filter out the prover tests"
         );
     } else {
+        let inconsistency_flag = read_env_var(ENV_TEST_INCONSISTENCY) == "1";
+        let unconditional_abort_inconsistency_flag =
+            read_env_var(ENV_TEST_UNCONDITIONAL_ABORT_AS_INCONSISTENCY) == "1";
+        let disallow_timeout_overwrite = read_env_var(ENV_TEST_DISALLOW_TIMEOUT_OVERWRITE) == "1";
+        options.check_inconsistency = inconsistency_flag;
+        options.unconditional_abort_as_inconsistency = unconditional_abort_inconsistency_flag;
+        options.disallow_global_timeout_to_be_overwritten = disallow_timeout_overwrite;
+        options.vc_timeout = read_env_var(ENV_TEST_VC_TIMEOUT)
+            .parse::<usize>()
+            .unwrap_or(options.vc_timeout);
         options
             .prove(false, pkg_path.as_path(), BTreeMap::default(), None)
             .unwrap()

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -94,7 +94,11 @@ impl<'env> BoogieTranslator<'env> {
         let estimate_timeout_opt = fun_target
             .func_env
             .get_num_pragma(VERIFY_DURATION_ESTIMATE_PRAGMA);
-        let default_timeout = estimate_timeout_opt.unwrap_or(options.vc_timeout);
+        let default_timeout = if options.global_timeout_overwrite {
+            estimate_timeout_opt.unwrap_or(options.vc_timeout)
+        } else {
+            options.vc_timeout
+        };
         fun_target
             .func_env
             .get_num_pragma(TIMEOUT_PRAGMA)

--- a/third_party/move/move-prover/boogie-backend/src/options.rs
+++ b/third_party/move/move-prover/boogie-backend/src/options.rs
@@ -120,6 +120,8 @@ pub struct BoogieOptions {
     pub proc_cores: usize,
     /// A (soft) timeout for the solver, per verification condition, in seconds.
     pub vc_timeout: usize,
+    /// Whether allow local timeout overwrites the global one
+    pub global_timeout_overwrite: bool,
     /// Whether Boogie output and log should be saved.
     pub keep_artifacts: bool,
     /// Eager threshold for quantifier instantiation.
@@ -170,6 +172,7 @@ impl Default for BoogieOptions {
             random_seed: 1,
             proc_cores: 4,
             vc_timeout: 40,
+            global_timeout_overwrite: true,
             keep_artifacts: false,
             eager_threshold: 100,
             lazy_threshold: 100,


### PR DESCRIPTION
### Description

This PR does the following things:

- add the flag `--unconditional-abort-as-inconsistency` and `--disallow-global-timeout-to-be-overwritten` to `aptos move prove`;
- add a normal prover test to the daily prover test (in CI) with enough verification time so that all verification targets will be checked;
- add an inconsistency test to the daily prover test;
- fix some inconsistency issues in the specs;
- comment out problematic specs which needs further investigation.

close #9092 

