### PR TITLE
Uses aptos-core x25519-dalek library with relaxed zeroize dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13656,8 +13656,7 @@ dependencies = [
 [[package]]
 name = "x25519-dalek"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2392b6b94a576b4e2bf3c5b2757d63f10ada8020a2e4d08ac849ebcf6ea8e077"
+source = "git+https://github.com/aptos-labs/x25519-dalek?branch=zeroize_v1#762a9501668d213daa4a1864fa1f9db22716b661"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -690,3 +690,4 @@ debug = true
 [patch.crates-io]
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccba" }
 merlin = { git = "https://github.com/aptos-labs/merlin" }
+x25519-dalek = { git = "https://github.com/aptos-labs/x25519-dalek", branch = "zeroize_v1" }


### PR DESCRIPTION
### Description
So there’s this fun thing in rust-landia where the cryptographic library we use - https://github.com/dalek-cryptography/x25519-dalek/issues/92 - where they’ve pinned a version of their zeroize dependency to a 
minor version, and have refused to backport relaxing that constraint for almost a year now. Instead they’ve been focused on their V2, which is in alpha. Other libraries have moved on from relying (at this 
point) on the very old version of zeroize , and more and more often you see zeroize > 1.4 . This creates a fun incompatibility!
A few of us have run into this now, trying to use libraries from aptos core in other services. This creates an interesting situation: either we have to use an alpha (pre-release- currently on rc3) version of a 
core cryptography library (which sounds very sketch), or we have to use much older versions of other dependencies (if any such exist). It’s affected indexer (twice now, in different services), and IC: it’s safe 
to assume any rust users in our ecosystem would also run into the same issues.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Existing build + tests