### PR TITLE
[ts-sdk] Export more types

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos Node SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Export all remaining types and functions in TS SDK
 
 ## 1.15.0 (2023-07-28)
 

--- a/ecosystem/typescript/sdk/src/account/aptos_account.ts
+++ b/ecosystem/typescript/sdk/src/account/aptos_account.ts
@@ -37,7 +37,7 @@ export class AptosAccount {
   }
 
   /**
-   * Test derive path
+   * Check's if the derive path is valid
    */
   static isValidPath(path: string): boolean {
     return /^m\/44'\/637'\/[0-9]+'\/[0-9]+'\/[0-9]+'+$/.test(path);

--- a/ecosystem/typescript/sdk/src/aptos_types/account_address.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/account_address.ts
@@ -4,6 +4,9 @@
 import { HexString, MaybeHexString } from "../utils";
 import { Serializer, Deserializer, Bytes } from "../bcs";
 
+/**
+ * Exported as TransactionBuilderTypes.AccountAddress
+ */
 export class AccountAddress {
   static readonly LENGTH: number = 32;
 

--- a/ecosystem/typescript/sdk/src/aptos_types/rotation_proof_challenge.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/rotation_proof_challenge.ts
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AccountAddress } from "./account_address";
-import { Serializer } from "../bcs";
+import {AnyNumber, Serializer} from "../bcs";
 
 export class RotationProofChallenge {
   constructor(
     public readonly accountAddress: AccountAddress,
     public readonly moduleName: string,
     public readonly structName: string,
-    public readonly sequenceNumber: number | bigint,
+    public readonly sequenceNumber: AnyNumber,
     public readonly originator: AccountAddress,
     public readonly currentAuthKey: AccountAddress,
     public readonly newPublicKey: Uint8Array,

--- a/ecosystem/typescript/sdk/src/aptos_types/rotation_proof_challenge.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/rotation_proof_challenge.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AccountAddress } from "./account_address";
-import {AnyNumber, Serializer} from "../bcs";
+import { AnyNumber, Serializer } from "../bcs";
 
 export class RotationProofChallenge {
   constructor(

--- a/ecosystem/typescript/sdk/src/index.ts
+++ b/ecosystem/typescript/sdk/src/index.ts
@@ -14,4 +14,4 @@ export * from "./utils/api-endpoints";
 export * from "./utils/hex_string";
 export * from "./utils/hd-key";
 export * from "./utils/property_map_serde";
-export {APTOS_COIN } from "./utils/misc"
+export { APTOS_COIN } from "./utils/misc";

--- a/ecosystem/typescript/sdk/src/index.ts
+++ b/ecosystem/typescript/sdk/src/index.ts
@@ -4,17 +4,14 @@
 export * from "./account";
 export * from "./providers";
 export * as BCS from "./bcs";
-export * from "./utils/hex_string";
 export * from "./plugins";
 export * from "./transaction_builder";
 export * from "./transactions";
 export * as TokenTypes from "./aptos_types/token_types";
 export * as Types from "./generated/index";
 export * from "./client";
-export { derivePath } from "./utils/hd-key";
-export {
-  deserializePropertyMap,
-  deserializeValueBasedOnTypeTag,
-  getPropertyValueRaw,
-} from "./utils/property_map_serde";
-export { Network, CustomEndpoints } from "./utils/api-endpoints";
+export * from "./utils/api-endpoints";
+export * from "./utils/hex_string";
+export * from "./utils/hd-key";
+export * from "./utils/property_map_serde";
+export {APTOS_COIN } from "./utils/misc"

--- a/ecosystem/typescript/sdk/src/plugins/ans_client.ts
+++ b/ecosystem/typescript/sdk/src/plugins/ans_client.ts
@@ -4,15 +4,15 @@ import { AptosAccount } from "../account";
 import { AccountAddress } from "../aptos_types";
 import { TransactionBuilderRemoteABI } from "../transaction_builder";
 
-const ansContractsMap: Record<string, string> = {
+export const ansContractsMap: Record<string, string> = {
   testnet: "0x5f8fd2347449685cf41d4db97926ec3a096eaf381332be4f1318ad4d16a8497c",
   mainnet: "0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c",
 };
 
 // Each name component can only have lowercase letters, number or hyphens, and cannot start or end with a hyphen.
-const nameComponentPattern = /^[a-z\d][a-z\d-]{1,61}[a-z\d]$/;
+export const nameComponentPattern = /^[a-z\d][a-z\d-]{1,61}[a-z\d]$/;
 
-const namePattern = new RegExp(
+export const namePattern = new RegExp(
   "^" +
     // Optional subdomain (cannot be followed by .apt)
     "(?:(?<subdomain>[^.]+)\\.(?!apt$))?" +
@@ -23,19 +23,19 @@ const namePattern = new RegExp(
     "$",
 );
 
-type ReverseLookupRegistryV1 = {
+export type ReverseLookupRegistryV1 = {
   registry: {
     handle: string;
   };
 };
 
-type NameRegistryV1 = {
+export type NameRegistryV1 = {
   registry: {
     handle: string;
   };
 };
 
-type AnsRegistry = {
+export type AnsRegistry = {
   expirationTimestampSeconds: number;
   target: string | null;
 };

--- a/ecosystem/typescript/sdk/src/plugins/aptos_token.ts
+++ b/ecosystem/typescript/sdk/src/plugins/aptos_token.ts
@@ -42,7 +42,7 @@ const PropertyTypeMap = {
 
 export type PropertyType = keyof typeof PropertyTypeMap;
 
-type FungibleTokenParameters = {
+export type FungibleTokenParameters = {
   owner: AptosAccount;
   tokenAddress: MaybeHexString;
   recipient: MaybeHexString;
@@ -50,7 +50,7 @@ type FungibleTokenParameters = {
   extraArgs?: OptionalTransactionArgs;
 };
 
-type NonFungibleTokenParameters = {
+export type NonFungibleTokenParameters = {
   owner: AptosAccount;
   tokenAddress: MaybeHexString;
   recipient: MaybeHexString;

--- a/ecosystem/typescript/sdk/src/plugins/fungible_asset_client.ts
+++ b/ecosystem/typescript/sdk/src/plugins/fungible_asset_client.ts
@@ -4,6 +4,7 @@ import * as Gen from "../generated/index";
 import { OptionalTransactionArgs, Provider } from "../providers";
 import { TransactionBuilderRemoteABI } from "../transaction_builder";
 import { MaybeHexString, HexString } from "../utils";
+import {AnyNumber} from "../bcs";
 
 export class FungibleAssetClient {
   provider: Provider;
@@ -85,7 +86,7 @@ export class FungibleAssetClient {
     sender: AptosAccount,
     fungibleAssetMetadataAddress: MaybeHexString,
     recipient: MaybeHexString,
-    amount: number | bigint,
+    amount: AnyNumber,
     extraArgs?: OptionalTransactionArgs,
   ): Promise<RawTransaction> {
     const builder = new TransactionBuilderRemoteABI(this.provider, {

--- a/ecosystem/typescript/sdk/src/plugins/fungible_asset_client.ts
+++ b/ecosystem/typescript/sdk/src/plugins/fungible_asset_client.ts
@@ -4,7 +4,7 @@ import * as Gen from "../generated/index";
 import { OptionalTransactionArgs, Provider } from "../providers";
 import { TransactionBuilderRemoteABI } from "../transaction_builder";
 import { MaybeHexString, HexString } from "../utils";
-import {AnyNumber} from "../bcs";
+import { AnyNumber } from "../bcs";
 
 export class FungibleAssetClient {
   provider: Provider;

--- a/ecosystem/typescript/sdk/src/providers/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/providers/aptos_client.ts
@@ -45,7 +45,7 @@ export interface OptionalTransactionArgs {
   providedSequenceNumber?: string | bigint;
 }
 
-interface PaginationArgs {
+export interface PaginationArgs {
   start?: AnyNumber;
   limit?: number;
 }

--- a/ecosystem/typescript/sdk/src/providers/index.ts
+++ b/ecosystem/typescript/sdk/src/providers/index.ts
@@ -1,18 +1,3 @@
-import { AnyNumber } from "../bcs/types";
-
 export * from "./indexer";
 export * from "./aptos_client";
 export * from "./provider";
-
-/**
- * Controls the number of results that are returned and the starting position of those results.
- * limit specifies the maximum number of items or records to return in a query result.
- * offset parameter specifies the starting position of the query result within the set of data.
- * For example, if you want to retrieve records 11-20,
- * you would set the offset parameter to 10 (i.e., the index of the first record to retrieve is 10)
- * and the limit parameter to 10 (i.e., the number of records to retrieve is 10))
- */
-export interface PaginationArgs {
-    offset?: AnyNumber;
-    limit?: number;
-}

--- a/ecosystem/typescript/sdk/src/providers/index.ts
+++ b/ecosystem/typescript/sdk/src/providers/index.ts
@@ -1,3 +1,18 @@
+import { AnyNumber } from "../bcs/types";
+
 export * from "./indexer";
 export * from "./aptos_client";
 export * from "./provider";
+
+/**
+ * Controls the number of results that are returned and the starting position of those results.
+ * limit specifies the maximum number of items or records to return in a query result.
+ * offset parameter specifies the starting position of the query result within the set of data.
+ * For example, if you want to retrieve records 11-20,
+ * you would set the offset parameter to 10 (i.e., the index of the first record to retrieve is 10)
+ * and the limit parameter to 10 (i.e., the number of records to retrieve is 10))
+ */
+export interface PaginationArgs {
+    offset?: AnyNumber;
+    limit?: number;
+}

--- a/ecosystem/typescript/sdk/src/providers/indexer.ts
+++ b/ecosystem/typescript/sdk/src/providers/indexer.ts
@@ -135,8 +135,8 @@ export class IndexerClient {
    * @returns GetAccountCurrentTokensQuery response type
    */
   async getAccountNFTs(
-      ownerAddress: MaybeHexString,
-      options?: IndexerPaginationArgs
+    ownerAddress: MaybeHexString,
+    options?: IndexerPaginationArgs,
   ): Promise<GetAccountCurrentTokensQuery> {
     const address = HexString.ensure(ownerAddress).hex();
     IndexerClient.validateAddress(address);
@@ -169,8 +169,8 @@ export class IndexerClient {
    * @returns GetAccountCoinsDataQuery response type
    */
   async getAccountCoinsData(
-      ownerAddress: MaybeHexString,
-      options?: IndexerPaginationArgs
+    ownerAddress: MaybeHexString,
+    options?: IndexerPaginationArgs,
   ): Promise<GetAccountCoinsDataQuery> {
     const address = HexString.ensure(ownerAddress).hex();
     IndexerClient.validateAddress(address);

--- a/ecosystem/typescript/sdk/src/providers/indexer.ts
+++ b/ecosystem/typescript/sdk/src/providers/indexer.ts
@@ -53,14 +53,14 @@ import { ApiError } from "./aptos_client";
  * you would set the offset parameter to 10 (i.e., the index of the first record to retrieve is 10)
  * and the limit parameter to 10 (i.e., the number of records to retrieve is 10))
  */
-interface PaginationArgs {
+export interface IndexerPaginationArgs {
   offset?: AnyNumber;
   limit?: number;
 }
 
-type TokenStandard = "v1" | "v2";
+export type TokenStandard = "v1" | "v2";
 
-type GraphqlQuery = {
+export type GraphqlQuery = {
   query: string;
   variables?: {};
 };
@@ -134,7 +134,10 @@ export class IndexerClient {
    * @param ownerAddress Hex-encoded 32 byte Aptos account address
    * @returns GetAccountCurrentTokensQuery response type
    */
-  async getAccountNFTs(ownerAddress: MaybeHexString, options?: PaginationArgs): Promise<GetAccountCurrentTokensQuery> {
+  async getAccountNFTs(
+      ownerAddress: MaybeHexString,
+      options?: IndexerPaginationArgs
+  ): Promise<GetAccountCurrentTokensQuery> {
     const address = HexString.ensure(ownerAddress).hex();
     IndexerClient.validateAddress(address);
     const graphqlQuery = {
@@ -151,7 +154,7 @@ export class IndexerClient {
    * @param idHash token id hash
    * @returns GetTokenActivitiesQuery response type
    */
-  async getTokenActivities(idHash: string, options?: PaginationArgs): Promise<GetTokenActivitiesQuery> {
+  async getTokenActivities(idHash: string, options?: IndexerPaginationArgs): Promise<GetTokenActivitiesQuery> {
     const graphqlQuery = {
       query: GetTokenActivities,
       variables: { idHash, offset: options?.offset, limit: options?.limit },
@@ -165,7 +168,10 @@ export class IndexerClient {
    * @param ownerAddress Owner address
    * @returns GetAccountCoinsDataQuery response type
    */
-  async getAccountCoinsData(ownerAddress: MaybeHexString, options?: PaginationArgs): Promise<GetAccountCoinsDataQuery> {
+  async getAccountCoinsData(
+      ownerAddress: MaybeHexString,
+      options?: IndexerPaginationArgs
+  ): Promise<GetAccountCoinsDataQuery> {
     const address = HexString.ensure(ownerAddress).hex();
     IndexerClient.validateAddress(address);
     const graphqlQuery = {
@@ -215,7 +221,7 @@ export class IndexerClient {
    */
   async getAccountTransactionsData(
     accountAddress: MaybeHexString,
-    options?: PaginationArgs,
+    options?: IndexerPaginationArgs,
   ): Promise<GetAccountTransactionsDataQuery> {
     const address = HexString.ensure(accountAddress).hex();
     IndexerClient.validateAddress(address);
@@ -390,7 +396,7 @@ export class IndexerClient {
    *
    * @returns GetUserTransactionsQuery response type
    */
-  async getUserTransactions(startVersion?: number, options?: PaginationArgs): Promise<GetUserTransactionsQuery> {
+  async getUserTransactions(startVersion?: number, options?: IndexerPaginationArgs): Promise<GetUserTransactionsQuery> {
     const graphqlQuery = {
       query: GetUserTransactions,
       variables: { start_version: startVersion, offset: options?.offset, limit: options?.limit },
@@ -430,7 +436,7 @@ export class IndexerClient {
     ownerAddress: MaybeHexString,
     extraArgs?: {
       tokenStandard?: TokenStandard;
-      options?: PaginationArgs;
+      options?: IndexerPaginationArgs;
     },
   ): Promise<GetOwnedTokensQuery> {
     const address = HexString.ensure(ownerAddress).hex();
@@ -468,7 +474,7 @@ export class IndexerClient {
     collectionAddress: string,
     extraArgs?: {
       tokenStandard?: TokenStandard;
-      options?: PaginationArgs;
+      options?: IndexerPaginationArgs;
     },
   ): Promise<GetTokenOwnedFromCollectionQuery> {
     const ownerHexAddress = HexString.ensure(ownerAddress).hex();
@@ -513,7 +519,7 @@ export class IndexerClient {
     creatorAddress: MaybeHexString,
     extraArgs?: {
       tokenStandard?: TokenStandard;
-      options?: PaginationArgs;
+      options?: IndexerPaginationArgs;
     },
   ): Promise<GetTokenOwnedFromCollectionQuery> {
     const collectionAddress = await this.getCollectionAddress(creatorAddress, collectionName, extraArgs);
@@ -536,7 +542,7 @@ export class IndexerClient {
     collectionName: string,
     extraArgs?: {
       tokenStandard?: TokenStandard;
-      options?: PaginationArgs;
+      options?: IndexerPaginationArgs;
     },
   ): Promise<GetCollectionDataQuery> {
     const address = HexString.ensure(creatorAddress).hex();
@@ -590,7 +596,7 @@ export class IndexerClient {
     ownerAddress: MaybeHexString,
     extraArgs?: {
       tokenStandard?: TokenStandard;
-      options?: PaginationArgs;
+      options?: IndexerPaginationArgs;
     },
   ): Promise<GetCollectionsWithOwnedTokensQuery> {
     const ownerHexAddress = HexString.ensure(ownerAddress).hex();

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -43,7 +43,7 @@ export { TypeTagParser } from "../aptos_types";
 const RAW_TRANSACTION_SALT = "APTOS::RawTransaction";
 const RAW_TRANSACTION_WITH_DATA_SALT = "APTOS::RawTransactionWithData";
 
-type AnyRawTransaction = RawTransaction | MultiAgentRawTransaction | FeePayerRawTransaction;
+export type AnyRawTransaction = RawTransaction | MultiAgentRawTransaction | FeePayerRawTransaction;
 
 /**
  * Function that takes in a Signing Message (serialized raw transaction)
@@ -155,7 +155,7 @@ export class TransactionBuilderMultiEd25519 extends TransactionBuilder<SigningFn
 /**
  * Config for creating raw transactions.
  */
-interface ABIBuilderConfig {
+export interface ABIBuilderConfig {
   sender: MaybeHexString | AccountAddress;
   sequenceNumber: Uint64 | string;
   gasUnitPrice: Uint64 | string;
@@ -323,7 +323,7 @@ export type RemoteABIBuilderConfig = Partial<Omit<ABIBuilderConfig, "sender">> &
   sender: MaybeHexString | AccountAddress;
 };
 
-interface AptosClientInterface {
+export interface AptosClientInterface {
   getAccountModules: (accountAddress: MaybeHexString) => Promise<Gen.MoveModuleBytecode[]>;
   getAccount: (accountAddress: MaybeHexString) => Promise<Gen.AccountData>;
   getChainId: () => Promise<number>;

--- a/ecosystem/typescript/sdk/src/utils/hd-key.ts
+++ b/ecosystem/typescript/sdk/src/utils/hd-key.ts
@@ -2,7 +2,6 @@ import nacl from "tweetnacl";
 import { hmac } from "@noble/hashes/hmac";
 import { sha512 } from "@noble/hashes/sha512";
 import { hexToBytes } from "@noble/hashes/utils";
-import {HexString, MaybeHexString} from "./hex_string";
 
 export type Keys = {
   key: Uint8Array;

--- a/ecosystem/typescript/sdk/src/utils/hd-key.ts
+++ b/ecosystem/typescript/sdk/src/utils/hd-key.ts
@@ -2,11 +2,9 @@ import nacl from "tweetnacl";
 import { hmac } from "@noble/hashes/hmac";
 import { sha512 } from "@noble/hashes/sha512";
 import { hexToBytes } from "@noble/hashes/utils";
+import {HexString, MaybeHexString} from "./hex_string";
 
-type Hex = string;
-type Path = string;
-
-type Keys = {
+export type Keys = {
   key: Uint8Array;
   chainCode: Uint8Array;
 };
@@ -18,7 +16,7 @@ const replaceDerive = (val: string): string => val.replace("'", "");
 const HMAC_KEY = "ed25519 seed";
 const HARDENED_OFFSET = 0x80000000;
 
-export const getMasterKeyFromSeed = (seed: Hex): Keys => {
+export const getMasterKeyFromSeed = (seed: string): Keys => {
   const h = hmac.create(sha512, HMAC_KEY);
   const I = h.update(hexToBytes(seed)).digest();
   const IL = I.slice(0, 32);
@@ -63,7 +61,7 @@ export const isValidPath = (path: string): boolean => {
     .some(Number.isNaN as any);
 };
 
-export const derivePath = (path: Path, seed: Hex, offset = HARDENED_OFFSET): Keys => {
+export const derivePath = (path: string, seed: string, offset = HARDENED_OFFSET): Keys => {
   if (!isValidPath(path)) {
     throw new Error("Invalid derivation path");
   }

--- a/ecosystem/typescript/sdk/src/utils/misc.ts
+++ b/ecosystem/typescript/sdk/src/utils/misc.ts
@@ -3,10 +3,6 @@
 
 import { VERSION } from "../version";
 
-export type Nullable<T> = { [P in keyof T]: T[P] | null };
-
-export type AnyObject = { [key: string]: any };
-
 export async function sleep(timeMs: number): Promise<null> {
   return new Promise((resolve) => {
     setTimeout(resolve, timeMs);
@@ -29,7 +25,7 @@ export function fixNodeUrl(nodeUrl: string): string {
 export const DEFAULT_MAX_GAS_AMOUNT = 200000;
 // Transaction expire timestamp
 export const DEFAULT_TXN_EXP_SEC_FROM_NOW = 20;
-// How long does SDK wait for txhn to finish
+// How long does SDK wait for txn to finish
 export const DEFAULT_TXN_TIMEOUT_SEC = 20;
 export const APTOS_COIN = "0x1::aptos_coin::AptosCoin";
 


### PR DESCRIPTION
### Description
There were a lot of types that were not being exported, and many users asked for them to be exported.  Any types that are not exported here are exported under `TransactionBuilderTypes`

Additionally, I cleaned up a few interfaces that were either not using the already defined types, or were less permissive than other places that took in the same values.
