### PR TITLE
[aggregator_v2] add utility add()/sub() methods

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/aggregator_v2.md
+++ b/aptos-move/framework/aptos-framework/doc/aggregator_v2.md
@@ -8,17 +8,20 @@ This module provides an interface for aggregators (version 2).
 
 -  [Struct `Aggregator`](#0x1_aggregator_v2_Aggregator)
 -  [Struct `AggregatorSnapshot`](#0x1_aggregator_v2_AggregatorSnapshot)
+-  [Constants](#@Constants_0)
 -  [Function `limit`](#0x1_aggregator_v2_limit)
 -  [Function `create_aggregator`](#0x1_aggregator_v2_create_aggregator)
 -  [Function `try_add`](#0x1_aggregator_v2_try_add)
+-  [Function `add`](#0x1_aggregator_v2_add)
 -  [Function `try_sub`](#0x1_aggregator_v2_try_sub)
+-  [Function `sub`](#0x1_aggregator_v2_sub)
 -  [Function `read`](#0x1_aggregator_v2_read)
--  [Function `deferred_read`](#0x1_aggregator_v2_deferred_read)
--  [Function `deferred_read_convert_u64`](#0x1_aggregator_v2_deferred_read_convert_u64)
+-  [Function `snapshot`](#0x1_aggregator_v2_snapshot)
+-  [Function `snapshot_with_u64_limit`](#0x1_aggregator_v2_snapshot_with_u64_limit)
 -  [Function `read_snapshot`](#0x1_aggregator_v2_read_snapshot)
 
 
-<pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
+<pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 </code></pre>
 
 
@@ -85,6 +88,43 @@ across multiple transactions. See the module description for more details.
 
 </details>
 
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x1_aggregator_v2_EAGGREGATOR_OVERFLOW"></a>
+
+The value of aggregator overflows. Raised by uncoditional add() call
+
+
+<pre><code><b>const</b> <a href="aggregator_v2.md#0x1_aggregator_v2_EAGGREGATOR_OVERFLOW">EAGGREGATOR_OVERFLOW</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_aggregator_v2_EAGGREGATOR_UNDERFLOW"></a>
+
+The value of aggregator underflows (goes below zero). Raised by uncoditional sub call
+
+
+<pre><code><b>const</b> <a href="aggregator_v2.md#0x1_aggregator_v2_EAGGREGATOR_UNDERFLOW">EAGGREGATOR_UNDERFLOW</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x1_aggregator_v2_EAGGREGATOR_LIMIT_ABOVE_CAST_MAX"></a>
+
+Tried casting into a narrower type (i.e. u64), but aggregator range of valid values
+cannot fit (i.e. limit exceeds type::MAX).
+Raised by native code (i.e. inside snapshot_with_u64_limit())
+
+
+<pre><code><b>const</b> <a href="aggregator_v2.md#0x1_aggregator_v2_EAGGREGATOR_LIMIT_ABOVE_CAST_MAX">EAGGREGATOR_LIMIT_ABOVE_CAST_MAX</a>: u64 = 2;
+</code></pre>
+
+
+
 <a name="0x1_aggregator_v2_limit"></a>
 
 ## Function `limit`
@@ -137,7 +177,7 @@ Returns <code>limit</code> exceeding which aggregator overflows.
 ## Function `try_add`
 
 Adds <code>value</code> to aggregator.
-Returns <code><b>true</b></code> if the addition succeeded and <code><b>false</b></code> if it exceeded the limit.
+If addition would exceed the limit, <code><b>false</b></code> is returned, and aggregator value is left unchanged.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_try_add">try_add</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>, value: u128): bool
@@ -156,12 +196,36 @@ Returns <code><b>true</b></code> if the addition succeeded and <code><b>false</b
 
 </details>
 
+<a name="0x1_aggregator_v2_add"></a>
+
+## Function `add`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_add">add</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>, value: u128)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_add">add</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>, value: u128) {
+    <b>assert</b>!(<a href="aggregator_v2.md#0x1_aggregator_v2_try_add">try_add</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>, value), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="aggregator_v2.md#0x1_aggregator_v2_EAGGREGATOR_OVERFLOW">EAGGREGATOR_OVERFLOW</a>));
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x1_aggregator_v2_try_sub"></a>
 
 ## Function `try_sub`
 
 Subtracts <code>value</code> from aggregator.
-Returns <code><b>true</b></code> if the subtraction succeeded and <code><b>false</b></code> if it tried going below 0.
+If subtraction would result in a negative value, <code><b>false</b></code> is returned, and aggregator value is left unchanged.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_try_sub">try_sub</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>, value: u128): bool
@@ -174,6 +238,30 @@ Returns <code><b>true</b></code> if the subtraction succeeded and <code><b>false
 
 
 <pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_try_sub">try_sub</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>, value: u128): bool;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_aggregator_v2_sub"></a>
+
+## Function `sub`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_sub">sub</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>, value: u128)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_sub">sub</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>, value: u128) {
+    <b>assert</b>!(<a href="aggregator_v2.md#0x1_aggregator_v2_try_sub">try_sub</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>, value), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="aggregator_v2.md#0x1_aggregator_v2_EAGGREGATOR_UNDERFLOW">EAGGREGATOR_UNDERFLOW</a>));
+}
 </code></pre>
 
 
@@ -203,13 +291,13 @@ Returns a value stored in this aggregator.
 
 </details>
 
-<a name="0x1_aggregator_v2_deferred_read"></a>
+<a name="0x1_aggregator_v2_snapshot"></a>
 
-## Function `deferred_read`
+## Function `snapshot`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_deferred_read">deferred_read</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;u128&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_snapshot">snapshot</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;u128&gt;
 </code></pre>
 
 
@@ -218,20 +306,20 @@ Returns a value stored in this aggregator.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_deferred_read">deferred_read</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">AggregatorSnapshot</a>&lt;u128&gt;;
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_snapshot">snapshot</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">AggregatorSnapshot</a>&lt;u128&gt;;
 </code></pre>
 
 
 
 </details>
 
-<a name="0x1_aggregator_v2_deferred_read_convert_u64"></a>
+<a name="0x1_aggregator_v2_snapshot_with_u64_limit"></a>
 
-## Function `deferred_read_convert_u64`
+## Function `snapshot_with_u64_limit`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_deferred_read_convert_u64">deferred_read_convert_u64</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;u64&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_snapshot_with_u64_limit">snapshot_with_u64_limit</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">aggregator_v2::AggregatorSnapshot</a>&lt;u64&gt;
 </code></pre>
 
 
@@ -240,7 +328,7 @@ Returns a value stored in this aggregator.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_deferred_read_convert_u64">deferred_read_convert_u64</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>): Option&lt;<a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">AggregatorSnapshot</a>&lt;u64&gt;&gt;;
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_snapshot_with_u64_limit">snapshot_with_u64_limit</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>): <a href="aggregator_v2.md#0x1_aggregator_v2_AggregatorSnapshot">AggregatorSnapshot</a>&lt;u64&gt;;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/aggregator_v2/aggregator_v2.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator_v2/aggregator_v2.move
@@ -1,6 +1,17 @@
 /// This module provides an interface for aggregators (version 2).
 module aptos_framework::aggregator_v2 {
-    use std::option::{Self, Option};
+    use std::error;
+
+    /// The value of aggregator overflows. Raised by uncoditional add() call
+    const EAGGREGATOR_OVERFLOW: u64 = 1;
+
+    /// The value of aggregator underflows (goes below zero). Raised by uncoditional sub call
+    const EAGGREGATOR_UNDERFLOW: u64 = 2;
+
+    /// Tried casting into a narrower type (i.e. u64), but aggregator range of valid values
+    /// cannot fit (i.e. limit exceeds type::MAX).
+    /// Raised by native code (i.e. inside snapshot_with_u64_limit())
+    const EAGGREGATOR_LIMIT_ABOVE_CAST_MAX: u64 = 2;
 
     /// Represents an integer which supports parallel additions and subtractions
     /// across multiple transactions. See the module description for more details.
@@ -21,22 +32,34 @@ module aptos_framework::aggregator_v2 {
     public native fun create_aggregator(limit: u128): Aggregator;
 
     /// Adds `value` to aggregator.
-    /// Returns `true` if the addition succeeded and `false` if it exceeded the limit.
+    /// If addition would exceed the limit, `false` is returned, and aggregator value is left unchanged.
     public native fun try_add(aggregator: &mut Aggregator, value: u128): bool;
 
+    // Adds `value` to aggregator, uncoditionally.
+    // If addition would exceed the limit, EAGGREGATOR_OVERFLOW exception will be thrown
+    public fun add(aggregator: &mut Aggregator, value: u128) {
+        assert!(try_add(aggregator, value), error::out_of_range(EAGGREGATOR_OVERFLOW));
+    }
+
     /// Subtracts `value` from aggregator.
-    /// Returns `true` if the subtraction succeeded and `false` if it tried going below 0.
+    /// If subtraction would result in a negative value, `false` is returned, and aggregator value is left unchanged.
     public native fun try_sub(aggregator: &mut Aggregator, value: u128): bool;
+
+    // Adds `value` to aggregator, uncoditionally.
+    // If addition would exceed the limit, EAGGREGATOR_UNDERFLOW exception will be thrown
+    public fun sub(aggregator: &mut Aggregator, value: u128) {
+        assert!(try_sub(aggregator, value), error::out_of_range(EAGGREGATOR_UNDERFLOW));
+    }
 
     /// Returns a value stored in this aggregator.
     public native fun read(aggregator: &Aggregator): u128;
 
-    public native fun deferred_read(aggregator: &Aggregator): AggregatorSnapshot<u128>;
+    public native fun snapshot(aggregator: &Aggregator): AggregatorSnapshot<u128>;
 
     // Do automatic conversion to u64, if all possible values of aggregator fit it (i.e. limit is <= u64::MAX)
-    // If limit of the aggregator exceeds u64::MAX, this will return None)
-    // This doesn't check if actual value can be converted.
-    public native fun deferred_read_convert_u64(aggregator: &Aggregator): Option<AggregatorSnapshot<u64>>;
+    // If limit of the aggregator exceeds u64::MAX, this will throw an exception.
+    // This doesn't check if actual value can be converted, only if it can always be converted, based on the limit.
+    public native fun snapshot_with_u64_limit(aggregator: &Aggregator): AggregatorSnapshot<u64>;
 
     public native fun read_snapshot<Element>(snapshot: &AggregatorSnapshot<Element>): Element;
 }


### PR DESCRIPTION
and change narrower deferred read to also throw an exception, instead of returning an option.

In general, it allows simpler usage when we know it cannot overflow/underflow - https://github.com/igor-aptos/aptos-core/pull/5 

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
