### PR TITLE
[exp] make it work from a fork

### DIFF
--- a/testsuite/exp
+++ b/testsuite/exp
@@ -21,6 +21,7 @@ from email.policy import default
 import json
 from typing import List, Tuple
 import click
+import re
 import sys
 import time
 
@@ -29,7 +30,7 @@ from test_framework.git import Git
 from test_framework.logging import log, init_logging
 from forge import image_exists
 
-APTOS_CORE_REPO = "https://github.com/aptos-labs/aptos-core.git"
+UPSTREAM_APTOS_CORE_REPO = "aptos-labs/aptos-core"
 DOCKER_RUST_BUILD_WORKFLOW_NAME = "workflow-run-docker-rust-build.yaml"
 FORGE_WORKFLOW_NAME = "adhoc-forge.yaml"
 EXP_GIT_BRANCH_PREFIX = "exp/"
@@ -92,6 +93,8 @@ def wait_for_workflow(shell: Shell, branch: str, workflow_name: str) -> bool:
         "databaseId",
         "--jq",
         ".[0].databaseId",
+        "--repo",
+        UPSTREAM_APTOS_CORE_REPO,
     ]
     gh_run_list_cmd_ret = shell.run(gh_run_list_cmd)
     # get the URL
@@ -116,6 +119,8 @@ def wait_for_workflow(shell: Shell, branch: str, workflow_name: str) -> bool:
             "view",
             workflow_run_id,
             "--log",  # Exit with non-zero status if run fails
+            "--repo",
+            UPSTREAM_APTOS_CORE_REPO,
         ]
         gh_run_view_cmd_ret = shell.run(gh_run_view_cmd)
         if gh_run_view_cmd_ret.succeeded():
@@ -161,6 +166,8 @@ def workflow_dispatch_docker_build(
         f"PROFILE={profile}",
         "--field",
         f"BUILD_ADDL_TESTING_IMAGES={build_addl_testing_images}",
+        "--repo",
+        UPSTREAM_APTOS_CORE_REPO,
     ]
     log.info(
         "%s: $ %s",
@@ -214,6 +221,8 @@ def workflow_dispatch_forge(
         f"FORGE_TEST_SUITE={test_suite}",
         "--field",
         f"FORGE_CLUSTER_NAME={FORGE_DEFAULT_CLUSTER_NAME}",
+        "--repo",
+        UPSTREAM_APTOS_CORE_REPO,
     ]
     log.info(
         "%s: $ %s",
@@ -242,6 +251,10 @@ def workflow_dispatch_forge(
 
 def ensure_git_status(git: Git, ignore_uncommitted_changes: bool) -> Tuple[str, str]:
     """Ensure that the git status is clean and return the git SHA and branch name of the experimental branch"""
+
+    aptos_core_repo = git.get_repo_from_remote("origin")
+    aptos_core_repo_url = f"https://github.com/{aptos_core_repo}.git"
+
     current_git_branch = git.branch()
     new_exp_git_branch = (
         EXP_GIT_BRANCH_PREFIX + current_git_branch
@@ -264,12 +277,12 @@ def ensure_git_status(git: Git, ignore_uncommitted_changes: bool) -> Tuple[str, 
         log.info("ERROR: Failed to create exp branch %s: %s", new_exp_git_branch, e)
         cleanup_and_exit(git, 1, cleanup_branch=new_exp_git_branch)
 
-    if not git.branch_matches_remote(APTOS_CORE_REPO, current_git_branch):
+    if not git.branch_matches_remote(aptos_core_repo_url, current_git_branch):
         log.info("ERROR: Not synced with remote. Please push to a remote branch")
         log.info(
             "%s (local) != %s (remote)",
             git.get_commit_hash(current_git_branch),
-            git.resolve_remote_ref(APTOS_CORE_REPO, current_git_branch),
+            git.resolve_remote_ref(aptos_core_repo_url, current_git_branch),
         )
         cleanup_and_exit(git, 1, cleanup_branch=new_exp_git_branch)
 
@@ -345,6 +358,22 @@ def run(
     shell = LocalShell()
     git = Git(shell)
 
+    # disclaimer if we're on a fork
+    get_repo_from_remote_ret = git.get_repo_from_remote("origin")
+    is_fork = False
+    if get_repo_from_remote_ret != UPSTREAM_APTOS_CORE_REPO:
+        log.info(
+            f"WARNING: You are running this script from a fork of {UPSTREAM_APTOS_CORE_REPO}."
+        )
+        log.info("WARNING: This script will push a new branch to your fork.")
+        log.info(
+            f"WARNING: It will run core code from your local changes, BUT will execute workflows from the main branch of the upstream {UPSTREAM_APTOS_CORE_REPO}."
+        )
+        log.info(
+            "WARNING: If you wish to test workflow changes, please make a branch on the upstream, rather than a fork, and run exp from there."
+        )
+        is_fork = True
+
     git_sha, new_exp_git_branch = ensure_git_status(git, ignore_uncommitted_changes)
     features = ",".join(features)
     profile = profile
@@ -358,7 +387,7 @@ def run(
         )
         docker_build_workflow_dispatch_status = workflow_dispatch_docker_build(
             shell,
-            new_exp_git_branch,
+            new_exp_git_branch if not is_fork else "main",
             git_sha,
             features,
             profile,
@@ -377,7 +406,7 @@ def run(
         log.info("Running forge!!!")
         forge_workflow_dispatch_status = workflow_dispatch_forge(
             shell,
-            new_exp_git_branch,
+            new_exp_git_branch if not is_fork else "main",
             git_sha,
             duration=forge_runner_duration_secs,
             test_suite=forge_test_suite,
@@ -403,6 +432,8 @@ def list_exp():
         DOCKER_RUST_BUILD_WORKFLOW_NAME,
         "--user",
         username,
+        "--repo",
+        UPSTREAM_APTOS_CORE_REPO,
     ]
     gh_workflow_list_cmd_ret = shell.run(gh_workflow_list_cmd)
     list_out = json.dumps(

--- a/testsuite/test_framework/git.py
+++ b/testsuite/test_framework/git.py
@@ -1,5 +1,6 @@
 # A wrapper around git operations
 
+import re
 from dataclasses import dataclass
 from typing import Generator, Optional
 from .shell import Shell, RunResult
@@ -59,3 +60,17 @@ class Git:
 
     def get_commit_hash(self, ref: str) -> str:
         return self.run(["rev-parse", ref]).unwrap().decode().strip()
+
+    def get_remote(self, remote_name: str = "origin") -> str:
+        return self.run(["remote", "get-url", remote_name]).unwrap().decode().strip()
+
+    def get_repo_from_remote(self, remote_name: str = "origin") -> str:
+        remote_url = self.get_remote(remote_name)
+        remote_match = re.match(
+            r"(?:git@github\.com:|https://github\.com/)(?P<org_name>[^/]+)/(?P<repo_name>[^/]+).git",
+            remote_url,
+            re.VERBOSE,
+        )
+        if remote_match is None:
+            raise Exception(f"Could not parse remote {remote_name}")
+        return f"{remote_match.group('org_name')}/{remote_match.group('repo_name')}"

--- a/testsuite/test_framework/git_test.py
+++ b/testsuite/test_framework/git_test.py
@@ -1,0 +1,29 @@
+import unittest
+from .git import Git
+from .shell import FakeCommand, RunResult, Shell, SpyShell
+
+
+class SpyTests(unittest.TestCase):
+    def test_get_repo_from_remote_git(self):
+        shell: Shell = SpyShell(
+            [
+                FakeCommand(
+                    "git remote get-url origin",
+                    RunResult(0, b"git@github.com:banana-corp/aptos-core.git"),
+                )
+            ]
+        )
+        git: Git = Git(shell)
+        self.assertEqual(git.get_repo_from_remote("origin"), "banana-corp/aptos-core")
+
+    def test_get_repo_from_remote_http(self):
+        shell: Shell = SpyShell(
+            [
+                FakeCommand(
+                    "git remote get-url origin",
+                    RunResult(0, b"https://github.com/kiwi-corp/aptos-core.git"),
+                )
+            ]
+        )
+        git: Git = Git(shell)
+        self.assertEqual(git.get_repo_from_remote("origin"), "kiwi-corp/aptos-core")


### PR DESCRIPTION
### Description

Make the `exp` script work from a fork. It should more or less function the same, with one caveat:

From a fork, you cannot test changes to the workflows themselves (for security reasons). If you want to test a change to a workflow, you can run `exp` from a branch in `aptos-core` itself.

### Test Plan

New unit tests. Also run `exp` from a fork. 

```
Code/rustielin-aptos-core/testsuite  rustielin/exp-from-fork ✔                                                      0m  
▶ poetry run python exp run                 
[Fri, 28 Jul 2023 17:17:01] INFO [exp.run:365] WARNING: You are running this script from a fork of aptos-labs/aptos-core.
[Fri, 28 Jul 2023 17:17:01] INFO [exp.run:368] WARNING: This script will push a new branch to your fork.
[Fri, 28 Jul 2023 17:17:01] INFO [exp.run:369] WARNING: It will run core code from your local changes, BUT will execute workflows from the main branch of the upstream aptos-labs/aptos-core.
[Fri, 28 Jul 2023 17:17:01] INFO [exp.run:372] WARNING: If you wish to test workflow changes, please make a branch on the upstream, rather than a fork, and run exp from there.
[Fri, 28 Jul 2023 17:17:02] INFO [exp.try_push_new_branch:57] Branch exp/rustielin/exp-from-fork already exists. Overriding its local state.
[Fri, 28 Jul 2023 17:17:02] INFO [exp.try_push_new_branch:61] Creating branch exp/rustielin/exp-from-fork
[Fri, 28 Jul 2023 17:17:02] INFO [exp.try_push_new_branch:63] Pushing branch exp/rustielin/exp-from-fork
[Fri, 28 Jul 2023 17:17:03] INFO [exp.try_push_new_branch:66] Successfully created new branch exp/rustielin/exp-from-fork
Error: fetching manifest us-west1-docker.pkg.dev/aptos-global/aptos-internal/validator-testing:077564b14a8816108a3c265d34082cbbea20d6da: GET https://us-west1-docker.pkg.dev/v2/aptos-global/aptos-internal/validator-testing/manifests/077564b14a8816108a3c265d34082cbbea20d6da: MANIFEST_UNKNOWN: Failed to fetch "077564b14a8816108a3c265d34082cbbea20d6da"
[Fri, 28 Jul 2023 17:17:06] INFO [exp.run:385] !!!Image validator-testing:077564b14a8816108a3c265d34082cbbea20d6da does not exist, will build it first...
[Fri, 28 Jul 2023 17:17:06] INFO [exp.workflow_dispatch_docker_build:149] GIT_SHA: 077564b14a8816108a3c265d34082cbbea20d6da
[Fri, 28 Jul 2023 17:17:06] INFO [exp.workflow_dispatch_docker_build:150] FEATURES: 
[Fri, 28 Jul 2023 17:17:06] INFO [exp.workflow_dispatch_docker_build:151] PROFILE: release
[Fri, 28 Jul 2023 17:17:06] INFO [exp.workflow_dispatch_docker_build:152] BUILD_ADDL_TESTING_IMAGES: true
[Fri, 28 Jul 2023 17:17:06] INFO [exp.workflow_dispatch_docker_build:172] Running command: $ gh workflow run workflow-run-docker-rust-build.yaml --ref main --field GIT_SHA=077564b14a8816108a3c265d34082cbbea20d6da --field FEATURES= --field PROFILE=release --field BUILD_ADDL_TESTING_IMAGES=true --repo aptos-labs/aptos-core
[Fri, 28 Jul 2023 17:17:06] INFO [exp.workflow_dispatch_docker_build:181] All workflow runs: https://github.com/aptos-labs/aptos-core/actions/workflows/workflow-run-docker-rust-build.yaml
[Fri, 28 Jul 2023 17:17:16] INFO [exp.workflow_dispatch_docker_build:188] Successfully triggered docker build workflow
[Fri, 28 Jul 2023 17:17:16] INFO [exp.run:400] !!!Image validator-testing:077564b14a8816108a3c265d34082cbbea20d6da built successfully
[Fri, 28 Jul 2023 17:17:16] INFO [exp.run:401] !!!To trigger Forge tests with the same image, run: $ poetry run ./forge.py --image-tag 077564b14a8816108a3c265d34082cbbea20d6da --forge-image-tag 077564b14a8816108a3c265d34082cbbea20d6da
```


The workflow runs on `aptos-core`, and checks out code from my fork. The workflow is from the `main` branch on `aptos-core`.

https://github.com/aptos-labs/aptos-core/actions/runs/5697385692

You can see from the logs that it checks out this commit: `077564b14a8816108a3c265d34082cbbea20d6da`, which:
* [exists on my fork](https://github.com/rustielin/aptos-core/commit/077564b14a8816108a3c265d34082cbbea20d6da)
* [but not on the upstream yet](https://github.com/aptos-labs/aptos-core/commit/077564b14a8816108a3c265d34082cbbea20d6da)

<!-- Please provide us with clear details for verifying that your changes work. -->
