### PR TITLE
[GHA] Skip expensive tests on docs only changes.

### DIFF
--- a/.github/actions/file-change-determinator/action.yaml
+++ b/.github/actions/file-change-determinator/action.yaml
@@ -1,0 +1,16 @@
+name: File Change Determinator
+description: Runs the file change determinator (to identify which files changed in a pull request)
+outputs:
+  only_docs_changed:
+    description: "Returns true if only docs files were changed in the pull request"
+    value: ${{ steps.doc_change_determinator.outputs.should_skip }}
+
+runs:
+  using: composite
+  steps:
+    # Run the docs only change determinator
+    - id: doc_change_determinator
+      continue-on-error: true # Avoid skipping any checks if this job fails (see: https://github.com/fkirc/skip-duplicate-actions/issues/301)
+      uses: fkirc/skip-duplicate-actions@v5
+      with:
+        paths_ignore: '["**/*.md", "developer-docs-site/**"]'

--- a/.github/actions/general-lints/action.yaml
+++ b/.github/actions/general-lints/action.yaml
@@ -1,0 +1,56 @@
+name: General Lints
+description: Runs all general lints. This includes all linters except rust and docs lints.
+inputs:
+  GIT_CREDENTIALS:
+    description: "Optional credentials to pass to git. Useful if you need to pull private repos for dependencies"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    # Checkout the repository
+    - uses: actions/checkout@v3
+
+    # Install shellcheck and run it on the dev_setup.sh script
+    - name: Run shell lints
+      run: |
+        sudo apt-get install shellcheck --assume-yes --no-install-recommends
+        shellcheck scripts/dev_setup.sh
+      shell: bash
+
+    # Run the python setup and run the python SDK linters
+    - name: Run python setup
+      uses: ./.github/actions/python-setup
+      with:
+        pyproject_directory: ecosystem/python/sdk
+
+    # Run the python SDK linters
+    - name: Run ecosystem python lint
+      run: make -C ecosystem/python/sdk fmt && ./scripts/fail_if_modified_files.sh
+      shell: bash
+
+    # Run the python lints and tests
+    - name: Run python lints and tests
+      uses: ./.github/actions/python-lint-tests
+
+    # Setup node
+    - name: Setup node
+      uses: actions/setup-node@v3
+      with:
+        node-version-file: .node-version
+
+    # Setup pnpm
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v2
+      with:
+        version: 8.2.0
+
+    # Install packages for examples and run package build, lint and tests
+    - name: Run ecosystem lint
+      run: |
+        cd ./ecosystem/typescript/sdk/examples/typescript && pnpm install && cd -
+        cd ./ecosystem/typescript/sdk/examples/javascript && pnpm install && cd -
+        cd ./ecosystem/typescript/sdk && pnpm install && cd -
+        cd ./ecosystem/typescript/sdk && pnpm lint && cd -
+        cd ./ecosystem/typescript/sdk && pnpm fmt:check && cd -
+      shell: bash

--- a/.github/actions/python-lint-tests/action.yaml
+++ b/.github/actions/python-lint-tests/action.yaml
@@ -1,0 +1,48 @@
+name: Run Python Tests
+description: Runs all Python tests
+inputs:
+  GIT_SHA:
+    description: "Optional git sha to checkout"
+    required: false
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      with:
+        ref: ${{ inputs.GIT_SHA }}
+        # Get enough commits to compare to
+        fetch-depth: 100
+
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@60f4aabced9b4718c75acef86d42ffb631c4403a # pin@v29.0.3
+
+    - uses: ./.github/actions/python-setup
+      with:
+        pyproject_directory: testsuite
+
+    - name: Should run tests
+      run: ./testrun determinator.py changed-files --github-output-key SHOULD_RUN --pattern 'testsuite/.*py' ${{steps.changed-files.outputs.all_changed_files }}
+      id: should-run-tests
+      working-directory: testsuite
+      shell: bash
+
+    - name: Run python static type checker
+      if: steps.should-run-tests.outputs.SHOULD_RUN == 'true'
+      run: poetry run pyright
+      working-directory: testsuite
+      shell: bash
+
+    - name: Run python fmt
+      if: steps.should-run-tests.outputs.SHOULD_RUN == 'true'
+      run: poetry run black --check --diff .
+      working-directory: testsuite
+      shell: bash
+
+    - name: Run python unit tests
+      if: steps.should-run-tests.outputs.SHOULD_RUN == 'true'
+      run: find . -name '*test.py' | xargs poetry run python -m unittest
+      working-directory: testsuite
+      shell: bash

--- a/.github/actions/rust-lints/action.yaml
+++ b/.github/actions/rust-lints/action.yaml
@@ -1,0 +1,27 @@
+name: Rust Lints
+description: Runs all Rust linters
+inputs:
+  GIT_CREDENTIALS:
+    description: "Optional credentials to pass to git. Useful if you need to pull private repos for dependencies"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    # Checkout the repository and setup the rust toolchain
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
+    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+      with:
+        GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
+
+    # Run the pre-commit checks
+    - uses: pre-commit/action@v3.0.0
+
+    # Run the rust linters and cargo checks
+    - name: Run cargo sort and rust lint checks
+      shell: bash
+      run: |
+        cargo install cargo-sort
+        scripts/rust_lint.sh --check

--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -21,7 +21,7 @@ runs:
 
     - name: install protoc and related tools
       shell: bash
-      run: scripts/dev_setup.sh -b -r
+      run: scripts/dev_setup.sh -b -r -y -P -J
 
     - run: echo "/home/runner/.cargo/bin" | tee -a $GITHUB_PATH
       shell: bash

--- a/.github/actions/rust-smoke-tests/action.yaml
+++ b/.github/actions/rust-smoke-tests/action.yaml
@@ -1,0 +1,49 @@
+name: Rust Smoke Tests
+description: Runs all Rust smoke tests
+inputs:
+  GIT_CREDENTIALS:
+    description: "Optional credentials to pass to git. Useful if you need to pull private repos for dependencies"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    # Checkout the repository and setup the rust toolchain
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
+    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+      with:
+        GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
+
+    # Install nextest
+    - uses: taiki-e/install-action@v1.5.6
+      with:
+        tool: nextest
+
+    # Run a postgres database
+    - name: Run postgres database
+      run: docker run --detach -p 5432:5432 cimg/postgres:14.2
+      shell: bash
+
+    # Run the rust smoke tests
+    - name: Run rust smoke tests
+      # Prebuild the aptos-node binary so that tests don't start before the node is built.
+      # Also, prebuild the aptos-node binary as a separate step to avoid feature unification issues.
+      # Note: --test-threads is intentionally set to reduce resource contention in ci jobs. Increasing this, increases job failures and retries.
+      run: cargo build --locked --package=aptos-node --features=failpoints,indexer --release && LOCAL_SWARM_NODE_RELEASE=1 cargo nextest run --release --profile ci --package smoke-test --test-threads 6 --retries 3
+      shell: bash
+      env:
+        INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
+
+    # We always try to create the artifact, but it only creates on flaky or failed smoke tests -- when the directories are empty.
+    - name: Upload smoke test logs for failed and flaky tests
+      if: ${{ failure() || success() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: failed-smoke-test-logs
+        # Retain all smoke test data except for the db (which may be large).
+        path: |
+          /tmp/.tmp*
+          !/tmp/.tmp*/**/db/
+        retention-days: 14

--- a/.github/actions/rust-unit-tests/action.yaml
+++ b/.github/actions/rust-unit-tests/action.yaml
@@ -1,0 +1,51 @@
+name: Rust Unit Tests
+description: Runs all Rust unit tests
+inputs:
+  GIT_CREDENTIALS:
+    description: "Optional credentials to pass to git. Useful if you need to pull private repos for dependencies"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    # Checkout the repository and setup the rust toolchain
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
+    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+      with:
+        GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
+
+    # Check the VM features
+    - name: Check VM features
+      run: cargo test --locked --features check-vm-features -p aptos-node
+      shell: bash
+
+    # Run the rust doc tests
+    - name: Run rust doc tests
+      run: cargo test --locked --doc --workspace --exclude aptos-node-checker
+      shell: bash
+
+    # Install nextest
+    - uses: taiki-e/install-action@v1.5.6
+      with:
+        tool: nextest
+
+    # Run a postgres database
+    - name: Run postgres database
+      run: docker run --detach -p 5432:5432 cimg/postgres:14.2
+      shell: bash
+
+    # Run the rust unit tests
+    - name: Run all unit tests
+      run: cargo nextest run --profile ci --locked --workspace --exclude smoke-test --exclude aptos-testcases --retries 3 --no-fail-fast
+      shell: bash
+      env:
+        INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
+        RUST_MIN_STACK: 4297152
+        MVP_TEST_ON_CI: true
+        SOLC_EXE: /home/runner/bin/solc
+        Z3_EXE: /home/runner/bin/z3
+        CVC5_EXE: /home/runner/bin/cvc5
+        DOTNET_ROOT: /home/runner/.dotnet
+        BOOGIE_EXE: /home/runner/.dotnet/tools/boogie

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -24,6 +24,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # This job determines which files were changed
+  file_change_determinator:
+    runs-on: ubuntu-latest
+    outputs:
+      only_docs_changed: ${{ steps.determine_file_changes.outputs.only_docs_changed }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run the file change determinator
+        id: determine_file_changes
+        uses: ./.github/actions/file-change-determinator
+
+  # Run all general lints (i.e., non-rust and docs lints). This will be a PR required job.
+  general-lints:
+    needs: file_change_determinator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+      - name: Run general lints
+        uses: ./.github/actions/general-lints
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - run: echo "Skipping general lints! Unrelated changes detected."
+        if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
+
+  # TODO: remove this once the new jobs land
   scripts-lint:
     runs-on: ubuntu-latest
     steps:
@@ -31,6 +58,7 @@ jobs:
       - run: sudo apt-get install shellcheck --assume-yes --no-install-recommends
       - run: shellcheck scripts/dev_setup.sh
 
+  # TODO: remove this once the new jobs land
   ecosystem-lint:
     runs-on: ubuntu-latest
     steps:
@@ -49,6 +77,7 @@ jobs:
       - run: cd ./ecosystem/typescript/sdk && pnpm lint
       - run: cd ./ecosystem/typescript/sdk && pnpm fmt:check
 
+  # TODO: remove this once the new jobs land
   ecosystem-python-lint:
     runs-on: ubuntu-latest
     steps:
@@ -58,6 +87,7 @@ jobs:
           pyproject_directory: ecosystem/python/sdk
       - run: make -C ecosystem/python/sdk fmt && ./scripts/fail_if_modified_files.sh
 
+  # Run the docs linter. This is a PR required job.
   docs-lint:
     runs-on: ubuntu-latest
     steps:
@@ -66,15 +96,17 @@ jobs:
         with:
           node-version-file: .node-version
       - uses: pnpm/action-setup@v2
-
       - run: pnpm lint
         working-directory: developer-docs-site
       - run: sudo apt update -y && sudo apt install -y aspell aspell-en
       - run: pnpm spellcheck
         working-directory: developer-docs-site
 
+  # Run the crypto hasher domain separation checks
   rust-cryptohasher-domain-separation-check:
+    needs: file_change_determinator
     runs-on: high-perf-docker
+    if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
@@ -83,6 +115,52 @@ jobs:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - run: python3 scripts/check-cryptohasher-symbols.py
 
+  # Run all rust lints. This will be a PR required job.
+  rust-lints:
+    needs: file_change_determinator
+    runs-on: high-perf-docker
+    steps:
+      - uses: actions/checkout@v3
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+      - name: Run rust lints
+        uses: ./.github/actions/rust-lints
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - run: echo "Skipping rust lints! Unrelated changes detected."
+        if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
+
+  # Run all rust smoke tests. This will be a PR required job.
+  rust-smoke-tests:
+    needs: file_change_determinator
+    runs-on: high-perf-docker
+    steps:
+      - uses: actions/checkout@v3
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+      - name: Run rust smoke tests
+        uses: ./.github/actions/rust-smoke-tests
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - run: echo "Skipping rust smoke tests! Unrelated changes detected."
+        if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
+
+  # Run all rust unit tests. This will be a PR required job.
+  rust-unit-tests:
+    needs: file_change_determinator
+    runs-on: high-perf-docker
+    steps:
+      - uses: actions/checkout@v3
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+      - name: Run rust unit tests
+        uses: ./.github/actions/rust-unit-tests
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - run: echo "Skipping rust unit tests! Unrelated changes detected."
+        if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
+
+  # TODO: remove this once the new jobs land
   rust-lint:
     runs-on: high-perf-docker
     steps:
@@ -94,6 +172,7 @@ jobs:
       - run: cargo install cargo-sort
       - run: scripts/rust_lint.sh --check
 
+  # TODO: remove this once the new jobs land
   rust-doc-test:
     runs-on: high-perf-docker
     steps:
@@ -105,6 +184,7 @@ jobs:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - run: cargo test --locked --doc --workspace --exclude aptos-node-checker
 
+  # TODO: remove this once the new jobs land
   rust-unit-test:
     runs-on: high-perf-docker
     steps:
@@ -130,10 +210,10 @@ jobs:
           DOTNET_ROOT: /home/runner/.dotnet
           BOOGIE_EXE: /home/runner/.dotnet/tools/boogie
 
+  # Run the consensus only unit tests
   rust-consensus-only-unit-test:
     runs-on: high-perf-docker
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
+    if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
       - uses: actions/checkout@v3
         with:
@@ -148,8 +228,10 @@ jobs:
         env:
           RUST_MIN_STACK: 4297152
 
+  # Run the rust network performance unit tests
   rust-network-perf-unit-test:
     runs-on: high-perf-docker
+    if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
       - uses: actions/checkout@v3
         with:
@@ -164,6 +246,7 @@ jobs:
           cargo nextest run --locked -p aptos-peer-monitoring-service-client --no-fail-fast -F network-perf-test
           cargo nextest run --locked -p aptos-peer-monitoring-service-server --no-fail-fast -F network-perf-test
 
+  # TODO: remove this once the new jobs land
   rust-smoke-test:
     runs-on: high-perf-docker
     steps:
@@ -194,9 +277,10 @@ jobs:
             !/tmp/.tmp*/**/db/
           retention-days: 14
 
+  # Run the consensus only smoke test
   rust-consensus-only-smoke-test:
     runs-on: high-perf-docker
-    if: ${{ !github.ref || github.ref != 'aptos-node-v1.2.0' }}
+    if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
@@ -221,8 +305,10 @@ jobs:
             !/tmp/.tmp*/**/db/
           retention-days: 14
 
+  # Run the network performance smoke test
   rust-network-perf-smoke-test:
     runs-on: high-perf-docker
+    if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
@@ -247,6 +333,7 @@ jobs:
             !/tmp/.tmp*/**/db/
           retention-days: 14
 
+  # TODO: remove this once the new jobs land
   check-vm-features:
     runs-on: high-perf-docker
     steps:
@@ -256,5 +343,6 @@ jobs:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - run: cargo test --locked --features check-vm-features -p aptos-node
 
+  # TODO: remove this once the new jobs land
   python-lint-test:
     uses: ./.github/workflows/python-lint-test.yaml

--- a/.github/workflows/workflow-run-execution-performance.yaml
+++ b/.github/workflows/workflow-run-execution-performance.yaml
@@ -29,50 +29,85 @@ on:
         description: The name of the runner to use for the test.
 
 jobs:
+  # This job determines which files were changed
+  file_change_determinator:
+    runs-on: ubuntu-latest
+    outputs:
+      only_docs_changed: ${{ steps.determine_file_changes.outputs.only_docs_changed }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run the file change determinator
+        id: determine_file_changes
+        uses: ./.github/actions/file-change-determinator
+
+  # Run sequential execution performance tests
   sequential-execution-performance:
+    needs: file_change_determinator
     timeout-minutes: 30
     runs-on: ${{ inputs.RUNNER_NAME }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ inputs.GIT_SHA }}
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
 
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
 
       - name: Run sequential execution benchmark in performance build mode
         shell: bash
         run: testsuite/sequential_execution_performance.py
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
 
+      - run: echo "Skipping sequential execution performance! Unrelated changes detected."
+        if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
+
+  # Run parallel execution performance tests
   parallel-execution-performance:
+    needs: file_change_determinator
     timeout-minutes: 60
     runs-on: ${{ inputs.RUNNER_NAME }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ inputs.GIT_SHA }}
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
 
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
 
       - name: Run parallel execution benchmark in performance build mode
         shell: bash
         run: testsuite/parallel_execution_performance.py
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
 
+      - run: echo "Skipping parallel execution performance! Unrelated changes detected."
+        if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
+
+  # Run single node execution performance tests
   single-node-performance:
+    needs: file_change_determinator
     timeout-minutes: 60
     runs-on: ${{ inputs.RUNNER_NAME }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ inputs.GIT_SHA }}
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
 
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
 
       - name: Run single node execution benchmark in performance build mode
         shell: bash
         run: TABULATE_INSTALL=lib-only pip install tabulate && testsuite/single_node_performance.py
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+
+      - run: echo "Skipping single node execution performance! Unrelated changes detected."
+        if: needs.file_change_determinator.outputs.only_docs_changed == 'true'


### PR DESCRIPTION
### Description
This PR updates our GHA to avoid running the expensive code related tests on changes that are docs only. Essentially the PR:
- Adds a new file change determinator job using this [action](https://github.com/marketplace/actions/skip-duplicate-actions). Right now, I'm just checking for docs changes (e.g., `*.md` or only changes to `/developer-docs-site`).
- If the job identifies that only docs have changed:
  - We skip running expensive and not required tests (e.g., performance tests, consensus tests, etc.)
  - We still run expensive and required tests, but they essentially become a no-op (e.g., smoke tests, rust unit tests, linters, etc.). This way, all required jobs still pass but they're empty.

Note: in the PR, I've moved somethings into new files (e.g., `rust_lint`, `rust_unit_tests` , `rust_smoke_tests`, etc.). This is mainly so that it's easy to skip these actions as units (instead of having ugly if-else branches in our workflows).

Once this PR lands, I'll follow up by: (i) removing the old "required tests"; (ii) updating the "required test" list to include these; and (iii) extending the checks to avoid skipping the other expensive tests.

### Test Plan
Existing test infrastructure and manual runs.