### PR TITLE
Turn on txn dedup and quorum store at genesis (#8459)

### DIFF
--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -46,7 +46,7 @@ impl OnChainExecutionConfig {
 /// This is used when on-chain config is not initialized.
 impl Default for OnChainExecutionConfig {
     fn default() -> Self {
-        OnChainExecutionConfig::V1(ExecutionConfigV1::default())
+        OnChainExecutionConfig::V3(ExecutionConfigV3::default())
     }
 }
 
@@ -108,7 +108,7 @@ impl Default for ExecutionConfigV3 {
         Self {
             transaction_shuffler_type: TransactionShufflerType::NoShuffling,
             block_gas_limit: None,
-            transaction_deduper_type: TransactionDeduperType::NoDedup,
+            transaction_deduper_type: TransactionDeduperType::TxnHashAndAuthenticatorV1,
         }
     }
 }


### PR DESCRIPTION
### Description

This turns on the enabled features as defaults in genesis. The original PR was in v1.5 branch only, now adding to v1.6 and main.

(Note, revert of f313b5be43d6918a5456e738d8c7f67c7e9160fa was also applied, but it was a noop)

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
