### PR TITLE
[ts-sdk] Fix default for coin client transfer and register on default

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos Node SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Fix default behavior for coin client to transfer and create account by default
 
 ## 1.17.0 (2023-08-04)
 

--- a/ecosystem/typescript/sdk/src/plugins/coin_client.ts
+++ b/ecosystem/typescript/sdk/src/plugins/coin_client.ts
@@ -87,7 +87,12 @@ export class CoinClient {
 
     // If we should create the receiver account if it doesn't exist on-chain,
     // use the `0x1::aptos_account::transfer` function.
-    const func = extraArgs?.createReceiverIfMissing ? "0x1::aptos_account::transfer_coins" : "0x1::coin::transfer";
+    let func: string;
+    if (extraArgs?.createReceiverIfMissing === undefined) {
+      func = "0x1::aptos_account::transfer_coins";
+    } else {
+      func = extraArgs?.createReceiverIfMissing ? "0x1::aptos_account::transfer_coins" : "0x1::coin::transfer";
+    }
 
     // Get the receiver address from the AptosAccount or MaybeHexString.
     const toAddress = getAddressFromAccountOrAddress(to);

--- a/ecosystem/typescript/sdk/src/plugins/coin_client.ts
+++ b/ecosystem/typescript/sdk/src/plugins/coin_client.ts
@@ -8,6 +8,8 @@ import { FungibleAssetClient } from "./fungible_asset_client";
 import { Provider } from "../providers";
 import { AccountAddress } from "../aptos_types";
 
+export const TRANSFER_COINS = "0x1::aptos_account::transfer_coins";
+export const COIN_TRANSFER = "0x1::coin::transfer";
 /**
  * Class for working with the coin module, such as transferring coins and
  * checking balances.
@@ -86,12 +88,12 @@ export class CoinClient {
     const coinTypeToTransfer = extraArgs?.coinType ?? APTOS_COIN;
 
     // If we should create the receiver account if it doesn't exist on-chain,
-    // use the `0x1::aptos_account::transfer` function.
+    // use the `0x1::aptos_account::transfer_coins` function.
     let func: string;
     if (extraArgs?.createReceiverIfMissing === undefined) {
-      func = "0x1::aptos_account::transfer_coins";
+      func = TRANSFER_COINS;
     } else {
-      func = extraArgs?.createReceiverIfMissing ? "0x1::aptos_account::transfer_coins" : "0x1::coin::transfer";
+      func = extraArgs?.createReceiverIfMissing ? TRANSFER_COINS : COIN_TRANSFER;
     }
 
     // Get the receiver address from the AptosAccount or MaybeHexString.

--- a/ecosystem/typescript/sdk/src/tests/e2e/coin_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/coin_client.test.ts
@@ -44,7 +44,7 @@ test(
       checkSuccess: true,
     });
 
-    expect(await coinClient.checkBalance(jemima.address().hex())).toBe(BigInt(2468));
+    expect(await coinClient.checkBalance(jemima.address().hex())).toBe(BigInt(1951));
     let txn3 = (await client.getTransactionByHash(txnHash3)) as Transaction_UserTransaction;
     expect((txn3.payload as EntryFunctionPayload).function).toBe(COIN_TRANSFER);
   },

--- a/ecosystem/typescript/sdk/src/tests/e2e/coin_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/coin_client.test.ts
@@ -4,7 +4,8 @@
 import { AptosClient } from "../../providers/aptos_client";
 import { getFaucetClient, longTestTimeout, NODE_URL } from "../unit/test_helper.test";
 import { AptosAccount } from "../../account/aptos_account";
-import { CoinClient } from "../../plugins/coin_client";
+import { COIN_TRANSFER, CoinClient, TRANSFER_COINS } from "../../plugins/coin_client";
+import { EntryFunctionPayload, Transaction_UserTransaction } from "../../generated";
 
 test(
   "transfer and checkBalance works",
@@ -18,18 +19,36 @@ test(
     await faucetClient.fundAccount(alice.address(), 100_000_000);
     await faucetClient.fundAccount(bob.address(), 0);
 
-    await client.waitForTransaction(await coinClient.transfer(alice, bob, 42), { checkSuccess: true });
+    const txnHash1 = await coinClient.transfer(alice, bob, 42);
+    await client.waitForTransaction(txnHash1, { checkSuccess: true });
 
     expect(await coinClient.checkBalance(bob)).toBe(BigInt(42));
+    let txn1 = (await client.getTransactionByHash(txnHash1)) as Transaction_UserTransaction;
+    expect((txn1.payload as EntryFunctionPayload).function).toBe(TRANSFER_COINS);
 
     // Test that `createReceiverIfMissing` works.
     const jemima = new AptosAccount();
-    await client.waitForTransaction(await coinClient.transfer(alice, jemima, 717, { createReceiverIfMissing: true }), {
+    const txnHash2 = await coinClient.transfer(alice, jemima, 717, { createReceiverIfMissing: true });
+    await client.waitForTransaction(txnHash2, {
       checkSuccess: true,
     });
 
     // Check that using a string address instead of an account works with `checkBalance`.
     expect(await coinClient.checkBalance(jemima.address().hex())).toBe(BigInt(717));
+    let txn2 = (await client.getTransactionByHash(txnHash2)) as Transaction_UserTransaction;
+    expect((txn2.payload as EntryFunctionPayload).function).toBe(TRANSFER_COINS);
+
+    // Test that `createReceiverIfMissing` works off
+    const nick = new AptosAccount();
+    const txnHash3 = await coinClient.transfer(alice, nick, 1234, { createReceiverIfMissing: false });
+    await client.waitForTransaction(txnHash3, {
+      checkSuccess: true,
+    });
+
+    // Check that using a string address instead of an account works with `checkBalance`.
+    expect(await coinClient.checkBalance(nick.address().hex())).toBe(BigInt(1234));
+    let txn3 = (await client.getTransactionByHash(txnHash3)) as Transaction_UserTransaction;
+    expect((txn3.payload as EntryFunctionPayload).function).toBe(COIN_TRANSFER);
   },
   longTestTimeout,
 );

--- a/ecosystem/typescript/sdk/src/tests/e2e/coin_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/coin_client.test.ts
@@ -38,15 +38,13 @@ test(
     let txn2 = (await client.getTransactionByHash(txnHash2)) as Transaction_UserTransaction;
     expect((txn2.payload as EntryFunctionPayload).function).toBe(TRANSFER_COINS);
 
-    // Test that `createReceiverIfMissing` works off
-    const nick = new AptosAccount();
-    const txnHash3 = await coinClient.transfer(alice, nick, 1234, { createReceiverIfMissing: false });
+    // Test that `createReceiverIfMissing` works off (has to already be registered
+    const txnHash3 = await coinClient.transfer(alice, jemima, 1234, { createReceiverIfMissing: false });
     await client.waitForTransaction(txnHash3, {
       checkSuccess: true,
     });
 
-    // Check that using a string address instead of an account works with `checkBalance`.
-    expect(await coinClient.checkBalance(nick.address().hex())).toBe(BigInt(1234));
+    expect(await coinClient.checkBalance(jemima.address().hex())).toBe(BigInt(2468));
     let txn3 = (await client.getTransactionByHash(txnHash3)) as Transaction_UserTransaction;
     expect((txn3.payload as EntryFunctionPayload).function).toBe(COIN_TRANSFER);
   },


### PR DESCRIPTION
### Description
Change default in the SDK to transfer with register.  Can still be turned off by specifying false