### PR TITLE
Re-enable dedup and shuffling as defaults (for test networks)

### DIFF
--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -118,7 +118,7 @@ pub fn encode_aptos_mainnet_genesis_transaction(
 
     // On-chain genesis process.
     let consensus_config = OnChainConsensusConfig::default();
-    let execution_config = OnChainExecutionConfig::default();
+    let execution_config = OnChainExecutionConfig::default_for_genesis();
     let gas_schedule = default_gas_schedule();
     initialize(
         &mut session,
@@ -794,7 +794,7 @@ pub fn generate_test_genesis(
             employee_vesting_period_duration: 5 * 60, // 5 minutes
         },
         &OnChainConsensusConfig::default(),
-        &OnChainExecutionConfig::default(),
+        &OnChainExecutionConfig::default_for_genesis(),
         &default_gas_schedule(),
     );
     (genesis, test_validators)
@@ -816,7 +816,7 @@ pub fn generate_mainnet_genesis(
         ChainId::test(),
         &mainnet_genesis_config(),
         &OnChainConsensusConfig::default(),
-        &OnChainExecutionConfig::default(),
+        &OnChainExecutionConfig::default_for_genesis(),
         &default_gas_schedule(),
     );
     (genesis, test_validators)

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -816,7 +816,8 @@ impl EpochManager {
         match self.storage.start() {
             LivenessStorageData::FullRecoveryData(initial_data) => {
                 let consensus_config = onchain_consensus_config.unwrap_or_default();
-                let execution_config = onchain_execution_config.unwrap_or_default();
+                let execution_config = onchain_execution_config
+                    .unwrap_or_else(|_| OnChainExecutionConfig::default_if_missing());
                 self.quorum_store_enabled = self.enable_quorum_store(&consensus_config);
                 self.recovery_mode = false;
                 self.start_round_manager(

--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -27,10 +27,7 @@ use aptos_keygen::KeyGen;
 use aptos_logger::prelude::*;
 use aptos_types::{
     chain_id::ChainId,
-    on_chain_config::{
-        ExecutionConfigV1, GasScheduleV2, OnChainConsensusConfig, OnChainExecutionConfig,
-        TransactionShufflerType,
-    },
+    on_chain_config::{GasScheduleV2, OnChainConsensusConfig, OnChainExecutionConfig},
     transaction::Transaction,
     waypoint::Waypoint,
 };
@@ -613,10 +610,7 @@ impl Builder {
             employee_vesting_start: None,
             employee_vesting_period_duration: None,
             consensus_config: OnChainConsensusConfig::default(),
-            // Enable transaction shuffling by default in integration tests and Forge.
-            execution_config: OnChainExecutionConfig::V1(ExecutionConfigV1 {
-                transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
-            }),
+            execution_config: OnChainExecutionConfig::default_for_test(),
             gas_schedule: default_gas_schedule(),
         };
         if let Some(init_genesis_config) = &self.init_genesis_config {

--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -610,7 +610,7 @@ impl Builder {
             employee_vesting_start: None,
             employee_vesting_period_duration: None,
             consensus_config: OnChainConsensusConfig::default(),
-            execution_config: OnChainExecutionConfig::default(),
+            execution_config: OnChainExecutionConfig::default_for_test(),
             gas_schedule: default_gas_schedule(),
         };
         if let Some(init_genesis_config) = &self.init_genesis_config {

--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -610,7 +610,7 @@ impl Builder {
             employee_vesting_start: None,
             employee_vesting_period_duration: None,
             consensus_config: OnChainConsensusConfig::default(),
-            execution_config: OnChainExecutionConfig::default_for_test(),
+            execution_config: OnChainExecutionConfig::default_for_genesis(),
             gas_schedule: default_gas_schedule(),
         };
         if let Some(init_genesis_config) = &self.init_genesis_config {

--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -610,7 +610,7 @@ impl Builder {
             employee_vesting_start: None,
             employee_vesting_period_duration: None,
             consensus_config: OnChainConsensusConfig::default(),
-            execution_config: OnChainExecutionConfig::default_for_test(),
+            execution_config: OnChainExecutionConfig::default(),
             gas_schedule: default_gas_schedule(),
         };
         if let Some(init_genesis_config) = &self.init_genesis_config {

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -255,7 +255,7 @@ pub fn fetch_mainnet_genesis_info(git_options: GitOptions) -> CliTypedResult<Mai
             employee_vesting_start: layout.employee_vesting_start,
             employee_vesting_period_duration: layout.employee_vesting_period_duration,
             consensus_config: OnChainConsensusConfig::default(),
-            execution_config: OnChainExecutionConfig::default(),
+            execution_config: OnChainExecutionConfig::default_for_genesis(),
             gas_schedule: default_gas_schedule(),
         },
     )?)
@@ -295,7 +295,7 @@ pub fn fetch_genesis_info(git_options: GitOptions) -> CliTypedResult<GenesisInfo
             employee_vesting_start: layout.employee_vesting_start,
             employee_vesting_period_duration: layout.employee_vesting_period_duration,
             consensus_config: OnChainConsensusConfig::default(),
-            execution_config: OnChainExecutionConfig::default_for_test(),
+            execution_config: OnChainExecutionConfig::default_for_genesis(),
             gas_schedule: default_gas_schedule(),
         },
     )?)

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -34,9 +34,7 @@ use aptos_genesis::{
 use aptos_logger::info;
 use aptos_types::{
     account_address::{AccountAddress, AccountAddressWithChecks},
-    on_chain_config::{
-        ExecutionConfigV1, OnChainConsensusConfig, OnChainExecutionConfig, TransactionShufflerType,
-    },
+    on_chain_config::{OnChainConsensusConfig, OnChainExecutionConfig},
 };
 use aptos_vm_genesis::{default_gas_schedule, AccountBalance, EmployeePool};
 use async_trait::async_trait;
@@ -297,9 +295,7 @@ pub fn fetch_genesis_info(git_options: GitOptions) -> CliTypedResult<GenesisInfo
             employee_vesting_start: layout.employee_vesting_start,
             employee_vesting_period_duration: layout.employee_vesting_period_duration,
             consensus_config: OnChainConsensusConfig::default(),
-            execution_config: OnChainExecutionConfig::V1(ExecutionConfigV1 {
-                transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
-            }),
+            execution_config: OnChainExecutionConfig::default_for_test(),
             gas_schedule: default_gas_schedule(),
         },
     )?)

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -295,7 +295,7 @@ pub fn fetch_genesis_info(git_options: GitOptions) -> CliTypedResult<GenesisInfo
             employee_vesting_start: layout.employee_vesting_start,
             employee_vesting_period_duration: layout.employee_vesting_period_duration,
             consensus_config: OnChainConsensusConfig::default(),
-            execution_config: OnChainExecutionConfig::default_for_test(),
+            execution_config: OnChainExecutionConfig::default(),
             gas_schedule: default_gas_schedule(),
         },
     )?)

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -295,7 +295,7 @@ pub fn fetch_genesis_info(git_options: GitOptions) -> CliTypedResult<GenesisInfo
             employee_vesting_start: layout.employee_vesting_start,
             employee_vesting_period_duration: layout.employee_vesting_period_duration,
             consensus_config: OnChainConsensusConfig::default(),
-            execution_config: OnChainExecutionConfig::default(),
+            execution_config: OnChainExecutionConfig::default_for_test(),
             gas_schedule: default_gas_schedule(),
         },
     )?)

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -19,7 +19,7 @@ use aptos_sdk::move_types::language_storage::StructTag;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{AccountResource, CORE_CODE_ADDRESS},
-    on_chain_config::{ExecutionConfigV2, OnChainExecutionConfig},
+    on_chain_config::{ExecutionConfigV2, OnChainExecutionConfig, TransactionShufflerType},
     transaction::{authenticator::AuthenticationKey, SignedTransaction, Transaction},
 };
 use std::{convert::TryFrom, str::FromStr, sync::Arc, time::Duration};
@@ -209,8 +209,8 @@ async fn test_gas_estimation_gas_used_limit() {
     let mut swarm = SwarmBuilder::new_local(1)
         .with_init_genesis_config(Arc::new(|conf| {
             conf.execution_config = OnChainExecutionConfig::V2(ExecutionConfigV2 {
+                transaction_shuffler_type: TransactionShufflerType::NoShuffling,
                 block_gas_limit: Some(1),
-                ..Default::default()
             });
         }))
         .with_init_config(Arc::new(|_, conf, _| {

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -41,6 +41,14 @@ impl OnChainExecutionConfig {
             OnChainExecutionConfig::V3(config) => config.transaction_deduper_type.clone(),
         }
     }
+
+    // TODO: Remove and replace all calls with default once shuffler is enabled in all networks
+    pub fn default_for_test() -> Self {
+        OnChainExecutionConfig::V3(ExecutionConfigV3 {
+            transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
+            ..Default::default()
+        })
+    }
 }
 
 /// This is used when on-chain config is not initialized.

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -14,6 +14,7 @@ pub enum OnChainExecutionConfig {
     /// To maintain backwards compatibility on replay, we must ensure that any new features resolve
     /// to previous behavior (before OnChainExecutionConfig was registered) in case of Missing.
     Missing,
+    // Reminder: Add V4 and future versions here, after Missing (order matters for enums).
 }
 
 /// The public interface that exposes all values with safe fallback.
@@ -52,7 +53,11 @@ impl OnChainExecutionConfig {
     /// The default values to use for new networks, e.g., devnet, forge.
     /// Features that are ready for deployment can be enabled here.
     pub fn default_for_genesis() -> Self {
-        OnChainExecutionConfig::V3(ExecutionConfigV3::default())
+        OnChainExecutionConfig::V3(ExecutionConfigV3 {
+            transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
+            block_gas_limit: Some(35000),
+            transaction_deduper_type: TransactionDeduperType::TxnHashAndAuthenticatorV1,
+        })
     }
 
     /// The default values to use when on-chain config is not initialized.
@@ -85,27 +90,10 @@ pub struct ExecutionConfigV1 {
     pub transaction_shuffler_type: TransactionShufflerType,
 }
 
-impl Default for ExecutionConfigV1 {
-    fn default() -> Self {
-        Self {
-            transaction_shuffler_type: TransactionShufflerType::NoShuffling,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct ExecutionConfigV2 {
     pub transaction_shuffler_type: TransactionShufflerType,
     pub block_gas_limit: Option<u64>,
-}
-
-impl Default for ExecutionConfigV2 {
-    fn default() -> Self {
-        Self {
-            transaction_shuffler_type: TransactionShufflerType::NoShuffling,
-            block_gas_limit: None,
-        }
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
@@ -113,16 +101,6 @@ pub struct ExecutionConfigV3 {
     pub transaction_shuffler_type: TransactionShufflerType,
     pub block_gas_limit: Option<u64>,
     pub transaction_deduper_type: TransactionDeduperType,
-}
-
-impl Default for ExecutionConfigV3 {
-    fn default() -> Self {
-        Self {
-            transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
-            block_gas_limit: Some(35000),
-            transaction_deduper_type: TransactionDeduperType::TxnHashAndAuthenticatorV1,
-        }
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -52,11 +52,7 @@ impl OnChainExecutionConfig {
     /// The default values to use for new networks, e.g., devnet, forge.
     /// Features that are ready for deployment can be enabled here.
     pub fn default_for_genesis() -> Self {
-        OnChainExecutionConfig::V3(ExecutionConfigV3 {
-            transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
-            block_gas_limit: Some(35000),
-            ..Default::default()
-        })
+        OnChainExecutionConfig::V3(ExecutionConfigV3::default())
     }
 
     /// The default values to use when on-chain config is not initialized.
@@ -122,8 +118,8 @@ pub struct ExecutionConfigV3 {
 impl Default for ExecutionConfigV3 {
     fn default() -> Self {
         Self {
-            transaction_shuffler_type: TransactionShufflerType::NoShuffling,
-            block_gas_limit: None,
+            transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
+            block_gas_limit: Some(35000),
             transaction_deduper_type: TransactionDeduperType::TxnHashAndAuthenticatorV1,
         }
     }

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -41,6 +41,14 @@ impl OnChainExecutionConfig {
             OnChainExecutionConfig::V3(config) => config.transaction_deduper_type.clone(),
         }
     }
+
+    // TODO: Remove and replace all calls with default once shuffler is enabled in all networks
+    pub fn default_for_test() -> Self {
+        OnChainExecutionConfig::V3(ExecutionConfigV3 {
+            transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
+            ..Default::default()
+        })
+    }
 }
 
 /// This is used when on-chain config is not initialized.
@@ -106,7 +114,7 @@ pub struct ExecutionConfigV3 {
 impl Default for ExecutionConfigV3 {
     fn default() -> Self {
         Self {
-            transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
+            transaction_shuffler_type: TransactionShufflerType::NoShuffling,
             block_gas_limit: None,
             transaction_deduper_type: TransactionDeduperType::TxnHashAndAuthenticatorV1,
         }

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -41,14 +41,6 @@ impl OnChainExecutionConfig {
             OnChainExecutionConfig::V3(config) => config.transaction_deduper_type.clone(),
         }
     }
-
-    // TODO: Remove and replace all calls with default once shuffler is enabled in all networks
-    pub fn default_for_test() -> Self {
-        OnChainExecutionConfig::V3(ExecutionConfigV3 {
-            transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
-            ..Default::default()
-        })
-    }
 }
 
 /// This is used when on-chain config is not initialized.
@@ -114,7 +106,7 @@ pub struct ExecutionConfigV3 {
 impl Default for ExecutionConfigV3 {
     fn default() -> Self {
         Self {
-            transaction_shuffler_type: TransactionShufflerType::NoShuffling,
+            transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
             block_gas_limit: None,
             transaction_deduper_type: TransactionDeduperType::TxnHashAndAuthenticatorV1,
         }


### PR DESCRIPTION
### Description

Introduce a new `Missing` version for `OnChainExecutionConfig` that will maintain backwards compatibility for before the config was registered. Use this when the config is missing from epoch manager.

Otherwise, use `default_for_genesis` for all new networks e.g., forge, devnet.

### Test Plan

Observe that e2e tests use both shuffle and dedup.
