### PR TITLE
Add aptos-move-graphql-schema library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,10 @@ name = "Inflector"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "addr2line"
@@ -2720,6 +2724,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-move-graphql-schema"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-api-types",
+ "aptos-framework",
+ "aptos-move-graphql-scalars",
+ "aptos-move-graphql-test-helpers",
+ "async-graphql",
+ "clap 4.4.12",
+ "move-core-types",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "aptos-move-graphql-test-helpers"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "aptos-api-types",
+ "aptos-framework",
+ "aptos-types",
+ "move-binary-format",
+ "move-core-types",
+ "move-resource-viewer",
+]
+
+[[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
 dependencies = [
@@ -4627,6 +4660,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii_utils"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4715,6 +4754,80 @@ dependencies = [
  "blocking",
  "futures-lite 2.1.0",
  "once_cell",
+]
+
+[[package]]
+name = "async-graphql"
+version = "6.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298a5d587d6e6fdb271bf56af2dc325a80eb291fd0fc979146584b9a05494a8c"
+dependencies = [
+ "async-graphql-derive",
+ "async-graphql-parser",
+ "async-graphql-value",
+ "async-stream",
+ "async-trait",
+ "base64 0.13.1",
+ "bytes",
+ "fast_chemail",
+ "fnv",
+ "futures-util",
+ "handlebars",
+ "http",
+ "indexmap 2.1.0",
+ "mime",
+ "multer",
+ "num-traits",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "static_assertions",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "async-graphql-derive"
+version = "6.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f329c7eb9b646a72f70c9c4b516c70867d356ec46cb00dcac8ad343fd006b0"
+dependencies = [
+ "Inflector",
+ "async-graphql-parser",
+ "darling 0.20.3",
+ "proc-macro-crate 1.3.1",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "strum 0.25.0",
+ "syn 2.0.47",
+ "thiserror",
+]
+
+[[package]]
+name = "async-graphql-parser"
+version = "6.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6139181845757fd6a73fbb8839f3d036d7150b798db0e9bb3c6e83cdd65bd53b"
+dependencies = [
+ "async-graphql-value",
+ "pest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-graphql-value"
+version = "6.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323a5143f5bdd2030f45e3f2e0c821c9b1d36e79cf382129c64299c50a7f3750"
+dependencies = [
+ "bytes",
+ "indexmap 2.1.0",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -6517,8 +6630,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -6536,14 +6659,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "strsim 0.10.0",
+ "syn 2.0.47",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote 1.0.35",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core 0.20.3",
+ "quote 1.0.35",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -7525,6 +7673,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd"
 dependencies = [
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "fast_chemail"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
+dependencies = [
+ "ascii_utils",
 ]
 
 [[package]]
@@ -12252,7 +12409,7 @@ version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "274cf13f710999977a3c1e396c2a5000d104075a7127ce6470fbdae4706be621"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "http",
  "indexmap 1.9.3",
  "mime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,8 @@ members = [
     "crates/aptos-logger",
     "crates/aptos-metrics-core",
     "crates/aptos-move-graphql/scalars",
+    "crates/aptos-move-graphql/schema",
+    "crates/aptos-move-graphql/test-helpers",
     "crates/aptos-network-checker",
     "crates/aptos-node-identity",
     "crates/aptos-openapi",
@@ -363,6 +365,8 @@ aptos-metrics-core = { path = "crates/aptos-metrics-core" }
 aptos-move-debugger = { path = "aptos-move/aptos-debugger" }
 aptos-move-examples = { path = "aptos-move/move-examples" }
 aptos-move-graphql-scalars = { path = "crates/aptos-move-graphql/scalars" }
+aptos-move-graphql-schema = { path = "crates/aptos-move-graphql/schema" }
+aptos-move-graphql-test-helpers = { path = "crates/aptos-move-graphql/test-helpers" }
 aptos-mvhashmap = { path = "aptos-move/mvhashmap" }
 aptos-native-interface = { path = "aptos-move/aptos-native-interface" }
 aptos-netcore = { path = "network/netcore" }
@@ -441,6 +445,7 @@ nalgebra = "0.32"
 float-cmp = "0.9.0"
 again = "0.1.2"
 anyhow = "1.0.71"
+async-graphql = { version = "6.0.1", features = ["dynamic-schema"] }
 anstyle = "1.0.1"
 arc-swap = "1.6.0"
 arr_macro = "0.2.1"
@@ -529,7 +534,7 @@ glob = "0.3.0"
 goldenfile = "1.5.2"
 google-cloud-storage = "0.13.0"
 guppy = "0.17.0"
-handlebars = "4.2.2"
+handlebars = "4.3.7"
 heck = "0.4.1"
 hex = "0.4.3"
 hkdf = "0.10.0"

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -348,7 +348,7 @@ impl Serialize for MoveValue {
 }
 
 /// A Move struct tag for referencing an onchain struct type
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct MoveStructTag {
     pub address: Address,
     pub module: IdentifierWrapper,
@@ -479,7 +479,7 @@ impl TryFrom<MoveStructTag> for StructTag {
 }
 
 /// An enum of Move's possible types on-chain
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum MoveType {
     /// A bool type
     Bool,

--- a/crates/aptos-move-graphql/schema/Cargo.toml
+++ b/crates/aptos-move-graphql/schema/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "aptos-move-graphql-schema"
+description = "Build GraphQL schemas from Move modules"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+aptos-api-types = { workspace = true }
+aptos-move-graphql-scalars = { workspace = true }
+async-graphql = { workspace = true }
+clap = { workspace = true }
+move-core-types = { workspace = true }
+serde = { workspace = true }
+
+[dev-dependencies]
+aptos-framework = { workspace = true }
+aptos-move-graphql-test-helpers = { workspace = true }
+tokio = { workspace = true }

--- a/crates/aptos-move-graphql/schema/src/common.rs
+++ b/crates/aptos-move-graphql/schema/src/common.rs
@@ -1,0 +1,94 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use aptos_api_types::MoveModule;
+use aptos_move_graphql_scalars::ALL_CUSTOM_SCALARS_TYPE_NAMES;
+use async_graphql::dynamic::{Object, Scalar, Schema};
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+
+/// Defines functions common to all `SchemaBuilder`s.
+pub trait SchemaBuilderTrait {
+    /// Add modules that we have already retrieved.
+    fn add_modules(self, modules: Vec<MoveModule>) -> Self;
+
+    /// Add a module that we have already retreived.
+    fn add_module(self, module: MoveModule) -> Self;
+}
+
+/// These options influence how the schema builder and Move type parsers work.
+#[derive(Debug, Clone, Deserialize, Parser, Serialize)]
+pub struct BuilderOptions {
+    /// If true, Options will be represented as nullable values of the inner type
+    /// rather than an Option struct with a vector inside it.
+    #[clap(long)]
+    pub use_special_handling_for_option: bool,
+
+    /// If true, rather than only use fully qualified object names when necessary,
+    /// i.e. because there is a name collision, we will always use them.
+    #[clap(long)]
+    pub always_use_fully_qualifed_names: bool,
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for BuilderOptions {
+    fn default() -> Self {
+        Self {
+            // False for now because our APIs / indexer stack doesn't represent Options
+            // in a way that is compatible with this option.
+            use_special_handling_for_option: false,
+            // False by default because the fully qualified names are needlessly long
+            // and gross in the vast majority of cases.
+            always_use_fully_qualifed_names: false,
+        }
+    }
+}
+
+pub fn build_schema(objects: Vec<Object>) -> Result<Schema> {
+    let mut builder = Schema::build(objects[0].type_name(), None, None);
+    for object in objects.into_iter() {
+        builder = builder.register(object);
+    }
+
+    // Add our custom scalars.
+    for scalar in &*ALL_CUSTOM_SCALARS_TYPE_NAMES {
+        builder = builder.register(Scalar::new(*scalar));
+    }
+
+    let schema = builder.finish()?;
+
+    Ok(schema)
+}
+
+pub fn build_sdl(schema: &Schema) -> String {
+    let sdl = schema.sdl();
+
+    // Trim leading newlines.
+    let sdl = sdl.trim_start_matches('\n');
+
+    // Remove the schema section (everything starting with `schema {` and after}).
+    // We only want the types.
+    let sdl = sdl.split("schema {").next().unwrap();
+
+    // Remove all trailing newlines.
+    let sdl = sdl.trim_end_matches('\n');
+
+    // Return the schema with one trailing newline.
+    format!("{}\n", sdl)
+}
+
+/// Takes a list of elements that might be repeated and returns only the repeated items.
+pub(crate) fn repeated_elements<T: std::hash::Hash + Eq>(vec: Vec<T>) -> HashSet<T> {
+    let mut counts = HashMap::new();
+    for item in vec {
+        *counts.entry(item).or_insert(0) += 1;
+    }
+
+    counts
+        .into_iter()
+        .filter(|&(_, count)| count > 1)
+        .map(|(item, _)| item)
+        .collect()
+}

--- a/crates/aptos-move-graphql/schema/src/discover.rs
+++ b/crates/aptos-move-graphql/schema/src/discover.rs
@@ -1,0 +1,101 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use aptos_api_types::{MoveModule, MoveStruct, MoveType};
+use move_core_types::language_storage::{ModuleId, StructTag};
+use std::collections::{BTreeSet, HashSet};
+
+// TODO: The way the builder works now means we end up including more structs in the
+// final schema than we actually have to. When we process the top level modules we look
+// at what other structs from other modules the structs in the top level modules use.
+// We then go through those other modules and do the same. This means we might include
+// structs from those other modules that aren't actually used by the top level modules.
+// This continues recursively. To fix this the parse functions could return not just
+// new modules to fetch, but a list that restricts which structs we work on in those
+// modules. This is not necessary for the MVP though, the only downsides of the current
+// approach are the schema is sometimes larger than necessary and the odds of a name
+// collision (which causes us to use the fully qualified name) are slightly higher.
+
+pub struct MoveStructWithModuleId {
+    pub module_id: ModuleId,
+    pub struc: MoveStruct,
+}
+
+impl MoveStructWithModuleId {
+    pub fn struct_tag(&self) -> StructTag {
+        StructTag {
+            address: *self.module_id.address(),
+            module: self.module_id.name().into(),
+            name: self.struc.name.clone().into(),
+            // TODO: We don't currently handle structs with generic / phantom types.
+            type_params: vec![],
+        }
+    }
+}
+
+/// Return MoveStructs for all structs in a Move module and a set of modules we have to
+/// fetch based on structs in other modules that the structs in this module depend on.
+pub fn discover_structs_for_module(
+    module: MoveModule,
+) -> Result<(
+    // Structs to include in the schema.
+    Vec<MoveStructWithModuleId>,
+    // Any new Move modules we need to retrieve.
+    BTreeSet<ModuleId>,
+)> {
+    let mut structs = Vec::new();
+    let mut modules_to_retrieve = BTreeSet::new();
+
+    let module_id = ModuleId::new(module.address.into(), module.name.into());
+
+    for struc in module.structs.into_iter() {
+        let mut types_to_resolve = Vec::new();
+        let mut types_seen = HashSet::new();
+
+        // Seed types_to_resolve with the types this struct directly depends on.
+        for field in struc.fields.iter() {
+            types_to_resolve.push(field.typ.clone());
+        }
+
+        let struct_with_module_id = MoveStructWithModuleId {
+            module_id: module_id.clone(),
+            struc,
+        };
+
+        structs.push(struct_with_module_id);
+
+        // Go through the types recursively until we hit leaf types. As we do so,
+        // we add more modules to `modules_to_retrieve`. This way, we can ensure
+        // that we look up the types for all modules relevant to this struct.
+        while let Some(typ) = types_to_resolve.pop() {
+            if types_seen.contains(&typ) {
+                continue;
+            }
+            types_seen.insert(typ.clone());
+
+            // For types that refer to other types, add those to the list of types.
+            // This continues until we hit leaves / a cycle, which we know to do based
+            // on types_seen.
+            match typ {
+                MoveType::Vector { items: typ } => {
+                    types_to_resolve.push(*typ);
+                },
+                MoveType::Reference {
+                    mutable: _,
+                    to: typ,
+                } => {
+                    types_to_resolve.push(*typ);
+                },
+                MoveType::Struct(struct_tag) => {
+                    let module_id =
+                        ModuleId::new(struct_tag.address.into(), struct_tag.module.into());
+                    modules_to_retrieve.insert(module_id);
+                },
+                _other => {},
+            }
+        }
+    }
+
+    Ok((structs, modules_to_retrieve))
+}

--- a/crates/aptos-move-graphql/schema/src/lib.rs
+++ b/crates/aptos-move-graphql/schema/src/lib.rs
@@ -1,0 +1,14 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This crate exposes SchemaBuilders, tools that can build GraphQL schemas from Move
+//! modules. These schemas can then be used to power code generation to make working
+//! with Move resources easier.
+
+mod common;
+mod discover;
+mod local;
+mod parse;
+
+pub use common::{build_sdl, BuilderOptions, SchemaBuilderTrait};
+pub use local::SchemaBuilderLocal;

--- a/crates/aptos-move-graphql/schema/src/local.rs
+++ b/crates/aptos-move-graphql/schema/src/local.rs
@@ -1,0 +1,172 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    common::{build_schema, repeated_elements, BuilderOptions, SchemaBuilderTrait},
+    discover::{discover_structs_for_module, MoveStructWithModuleId},
+    parse::parse_structs,
+};
+use anyhow::{bail, Context as AnyhowContext, Result};
+use aptos_api_types::MoveModule;
+use async_graphql::dynamic::Schema;
+use move_core_types::language_storage::ModuleId;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+/// This struct provides a schema builder that works only with the packages that you
+/// give it. The obvious downside of this approach is if the schema builder finds a
+/// reference to a module that it doesn't have, it can't go fetch it. This is good
+/// for use in things like the CLI, where there is already a framework for fetching
+/// dependencies and compiling packages.
+#[derive(Clone, Debug)]
+pub struct SchemaBuilderLocal {
+    modules: BTreeMap<ModuleId, MoveModule>,
+    options: BuilderOptions,
+}
+
+impl SchemaBuilderLocal {
+    pub fn new(options: BuilderOptions) -> Self {
+        Self {
+            modules: BTreeMap::new(),
+            options,
+        }
+    }
+
+    /// Find all the structs we need to include in the schema.
+    fn discover_structs(&self) -> Result<Vec<MoveStructWithModuleId>> {
+        if self.modules.is_empty() {
+            anyhow::bail!("Cannot build Schema without any modules to lookup or add");
+        }
+
+        let mut structs: Vec<MoveStructWithModuleId> = Vec::new();
+        let mut modules_processed = BTreeSet::new();
+
+        let mut modules = self.modules.clone();
+
+        while let Some((module_id, module)) = modules.pop_first() {
+            // Because a module can be depended on multiple times, we keep record of
+            // which modules we have already processed so we don't process them again.
+            if modules_processed.contains(&module_id) {
+                continue;
+            }
+            modules_processed.insert(module_id.clone());
+
+            let (new_structs, modules_to_retrieve) = discover_structs_for_module(module)
+                .with_context(|| format!("Failed to parse module {}", module_id))?;
+
+            structs.extend(new_structs);
+
+            // Filter out modules we already have / have processed.
+            let modules_to_retrieve: HashSet<_> = modules_to_retrieve
+                .into_iter()
+                .filter(|module_id| {
+                    !self.modules.contains_key(module_id) && !modules_processed.contains(module_id)
+                })
+                .collect();
+
+            if !modules_to_retrieve.is_empty() {
+                bail!(
+                    "While processing {} references to modules not available \
+                    to the builder were found: {:?}. This makes it impossible \
+                    to comprehensively resolve types, and this builder is \
+                    unable to look up new modules, so it is impossible to \
+                    build a complete Schema.",
+                    module_id,
+                    modules_to_retrieve
+                );
+            }
+        }
+
+        Ok(structs)
+    }
+
+    pub fn build(&self) -> Result<Schema> {
+        let structs = self
+            .discover_structs()
+            .context("Discovery of module structs failed")?;
+
+        // Build a list of structs from different modules that have the same name. We
+        // will need to resolve the collision for these by using the fully qualified
+        // name (address, module, struct name) rather than just the struct name.
+        let repeated_struct_names =
+            repeated_elements(structs.iter().map(|s| s.struc.name.to_string()).collect());
+
+        // Build GraphQL objects from the structs.
+        let objects = parse_structs(structs, &repeated_struct_names, &self.options)
+            .context("Failed to build GraphQL objects from structs")?;
+
+        let schema = build_schema(objects).context("Failed to build Schema from objects")?;
+
+        Ok(schema)
+    }
+}
+
+impl SchemaBuilderTrait for SchemaBuilderLocal {
+    fn add_modules(mut self, modules: Vec<MoveModule>) -> Self {
+        for module in modules {
+            self = self.add_module(module)
+        }
+        self
+    }
+
+    fn add_module(mut self, module: MoveModule) -> Self {
+        self.modules.insert(
+            ModuleId::new(module.address.into(), module.name.clone().into()),
+            module,
+        );
+        self
+    }
+}
+
+impl Default for SchemaBuilderLocal {
+    fn default() -> Self {
+        Self::new(BuilderOptions::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aptos_move_graphql_test_helpers::compile_package;
+    use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn test_build_schema() -> Result<()> {
+        // Compile the hero package and all the packages we know it recursively depends on.
+        let mut modules = Vec::new();
+        for name in &[
+            "aptos-stdlib",
+            "move-stdlib",
+            "aptos-framework",
+            "aptos-token-objects",
+        ] {
+            let path =
+                PathBuf::try_from(format!("../../../aptos-move/framework/{}", name)).unwrap();
+            modules.extend(compile_package(path)?);
+        }
+        modules.extend(compile_package(
+            PathBuf::try_from("../../../aptos-move/move-examples/token_objects/hero").unwrap(),
+        )?);
+
+        let options = BuilderOptions {
+            use_special_handling_for_option: true,
+            always_use_fully_qualifed_names: false,
+        };
+        let schema = SchemaBuilderLocal::new(options)
+            .add_modules(modules)
+            .build()
+            .context("Failed to build Schema with all the modules")?;
+
+        let schema_str = schema.sdl();
+
+        // Assert that the structs with names that are used in other Move modules are
+        // given fully qualified names in the schema.
+        assert!(schema_str.contains("type _0x0000000000000000000000000000000000000000000000000000000000000001__pool_u64__Pool"));
+        assert!(schema_str.contains("type _0x0000000000000000000000000000000000000000000000000000000000000001__pool_u64_unbound__Pool"));
+
+        // Assert that the structs with names that are not used in other Move modules
+        // are not given fully qualified names in the schema.
+        assert!(schema_str.contains("type Hero"));
+
+        Ok(())
+    }
+}

--- a/crates/aptos-move-graphql/schema/src/parse.rs
+++ b/crates/aptos-move-graphql/schema/src/parse.rs
@@ -1,0 +1,375 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{common::BuilderOptions, discover::MoveStructWithModuleId};
+use anyhow::{bail, Context, Result};
+use aptos_api_types::MoveType;
+use aptos_move_graphql_scalars::{Address, Any, TypeName, U128, U16, U256, U32, U64, U8};
+use async_graphql::dynamic::{Field, FieldFuture, Object, TypeRef};
+use move_core_types::language_storage::{StructTag, CORE_CODE_ADDRESS};
+use std::collections::HashSet;
+
+// Type names that are reserved by GraphQL.
+pub const RESERVED_TYPE_NAMES: &[&str] = &[
+    TypeRef::INT,
+    TypeRef::FLOAT,
+    TypeRef::STRING,
+    TypeRef::BOOLEAN,
+    TypeRef::ID,
+];
+
+/// This function takes in a Vec of structs + information about which module they came
+/// from and returns a vec of GraphQL objects that can be used to build a schema. It
+/// is essential that `structs` and `repeated_struct_names` are in sync (came from the
+/// same set of modules) otherwise schema building might fail due to name collision.
+pub fn parse_structs(
+    structs: Vec<MoveStructWithModuleId>,
+    repeated_struct_names: &HashSet<String>,
+    options: &BuilderOptions,
+) -> Result<Vec<Object>> {
+    let mut objects = Vec::new();
+
+    // For each struct in the module build an Object to include in the schema.
+    for struc in structs {
+        let mut types_to_resolve = Vec::new();
+
+        let struct_tag = struc.struct_tag();
+
+        let mut object = Object::new(get_object_name(&struct_tag, repeated_struct_names, options));
+
+        for field in struc.struc.fields {
+            types_to_resolve.push(field.typ.clone());
+            let field_type = move_type_to_field_type(&field.typ, repeated_struct_names, options)
+                .with_context(|| {
+                    format!(
+                        "Failed to parse field {} of struct {}",
+                        field.name, struct_tag.name,
+                    )
+                })?;
+            // TODO: When we have an enhanced ABI with comments set Field.description.
+            let field = Field::new(
+                field.name.to_string(),
+                field_type,
+                // The resolved value doesn't matter. These Fields will be used to
+                // build an Object that we feed into a Schema only for the puspose of
+                // getting a schema file. We won't ever execute queries against this
+                // directly.
+                move |_| FieldFuture::new(async move { Ok(Some(())) }),
+            );
+            object = object.field(field);
+        }
+
+        objects.push(object);
+    }
+
+    Ok(objects)
+}
+
+/// This function takes a Move type and returns the corresponding GraphQL type. GraphQL
+/// nullability is quite interesting when it comes to vectors, for example you can have
+/// a non nullable vec with nullable values. Make sure to read up on GraphQL
+/// nullability before modifying this function.
+///
+/// This function has a variety of special behavior for certain Move types. Except for
+/// the special string handling, which is always enabled, everything else is
+/// configurable. For example, this function can "unpack" Options and represent them as
+/// nullable values of the inner type, rather than a struct with a vec inside it.
+///
+/// Any type that can be unpacked into something more easily consumable by a client
+/// should be handled here. Handling it here is only part of the picture though, the
+/// server must return the resource in a way that aligns with the configured client
+/// behavior.
+///
+/// The `repeated_struct_names` argument is used to determine whether to use the fully
+/// qualified name (address, module, struct name) or not (just struct name). See the
+/// `get_object_name` function to learn more about how we make this determination.
+pub fn move_type_to_field_type(
+    field_type: &MoveType,
+    repeated_struct_names: &HashSet<String>,
+    options: &BuilderOptions,
+) -> Result<TypeRef> {
+    match field_type {
+        MoveType::Bool => Ok(TypeRef::NonNull(Box::new(TypeRef::Named(
+            TypeRef::BOOLEAN.into(),
+        )))),
+        // You'll see that we use custom scalar types in the schema for these types.
+        // This doesn't directly affect the way we encode the responses. Indeed, we
+        // encode u8, u16, and u32 as ints and u64, u128, and u256 as strings in
+        // the messages over the wire. It is then up to the client to choose how
+        // to interpret these values. For Rust, aptos-move-graphql-scalars can be
+        // used to correctly handle these values.
+        MoveType::U8 => Ok(TypeRef::NonNull(Box::new(TypeRef::Named(
+            std::borrow::Cow::Borrowed(U8::type_name()),
+        )))),
+        MoveType::U16 => Ok(TypeRef::NonNull(Box::new(TypeRef::Named(
+            std::borrow::Cow::Borrowed(U16::type_name()),
+        )))),
+        MoveType::U32 => Ok(TypeRef::NonNull(Box::new(TypeRef::Named(
+            std::borrow::Cow::Borrowed(U32::type_name()),
+        )))),
+        MoveType::U64 => Ok(TypeRef::NonNull(Box::new(TypeRef::Named(
+            std::borrow::Cow::Borrowed(U64::type_name()),
+        )))),
+        MoveType::U128 => Ok(TypeRef::NonNull(Box::new(TypeRef::Named(
+            std::borrow::Cow::Borrowed(U128::type_name()),
+        )))),
+        MoveType::U256 => Ok(TypeRef::NonNull(Box::new(TypeRef::Named(
+            std::borrow::Cow::Borrowed(U256::type_name()),
+        )))),
+        MoveType::Address => Ok(TypeRef::NonNull(Box::new(TypeRef::Named(
+            std::borrow::Cow::Borrowed(Address::type_name()),
+        )))),
+        // TODO: Do we want special behavior for vectors of u8? What about other byte
+        // vectors? Okay yeah I know for vector<u8> at the least I want to represent
+        // this a different way. Sort of hard to differentiate between byte data and
+        // someone just wanting to store a small vec of u8 though, I wish we had some
+        // kind of bytes wrapper type. I can bring this up, though it's ofc too late
+        // in most cases.
+        MoveType::Vector { items: move_type } => {
+            Ok(TypeRef::NonNull(Box::new(TypeRef::List(Box::new(
+                move_type_to_field_type(move_type, repeated_struct_names, options)?,
+            )))))
+        },
+        MoveType::Struct(struct_tag) => {
+            // We have special handling for the following:
+            //   - Strings
+            //   - Options
+            //
+            // TODO: We should have special handling for the following as well:
+            //   - FixedPoint32,
+            //   - FixedPoint64
+            //   - Aggregator
+            let struct_tag = StructTag::try_from(struct_tag.clone())
+                .context("Unexpectedly failed to build StructTag")?;
+            if struct_tag.is_std_string(&CORE_CODE_ADDRESS) {
+                // We "unwrap" the string::String and just represent it as a string in
+                // the schema. The value builder will do the same, pulling the bytes
+                // out from the String and returning them as a normal UTF-8 string.
+                Ok(TypeRef::NonNull(Box::new(TypeRef::Named(
+                    TypeRef::STRING.into(),
+                ))))
+            } else if options.use_special_handling_for_option
+                && struct_tag.is_std_option(&CORE_CODE_ADDRESS)
+            {
+                // Extract the inner type of the Option and get the type of that.
+                // Because for all other Move types we return them as non-nullable we
+                // pull out the inner type and return just that, to indicate it could
+                // possibly be null.
+                let type_tag = struct_tag.type_params.into_iter().next().context(
+                    "Option unexpectedly had no generic type params, this should be impossible",
+                )?;
+                let move_type = MoveType::from(type_tag);
+                let field_type =
+                    move_type_to_field_type(&move_type, repeated_struct_names, options)?;
+                // There is no great way to represent Option<Option<T>> in a GraphQL
+                // schema. Theoretically we could add some artifical struct like `inner`
+                // to store the inner option, but in reality this pattern never gets
+                // used. Indeed, at the time of writing no Move code in aptos-move uses
+                // Option<Option<T>>. So we choose not to handle it.
+                if let TypeRef::NonNull(field_type) = field_type {
+                    Ok(*field_type)
+                } else {
+                    Err(anyhow::anyhow!(
+                        "Expected non-null type for Option inner type but got: {:?}. \
+                            Likely this means you have an Option<Option<T>>. The schema \
+                            generator does not support this.",
+                        field_type
+                    ))
+                }
+            } else {
+                // TODO: This needs to take generics into account.
+                Ok(TypeRef::NonNull(Box::new(TypeRef::Named(
+                    get_object_name(&struct_tag, repeated_struct_names, options).into(),
+                ))))
+            }
+        },
+        MoveType::GenericTypeParam { index: _ } => {
+            // TODO: Currently we're pretty much just declaring bankruptcy on generics.
+            // For example, if something uses a SimpleMap, the key and value will just
+            // be represented as Any even though they have actual types.
+            Ok(TypeRef::NonNull(Box::new(TypeRef::Named(
+                std::borrow::Cow::Borrowed(Any::type_name()),
+            ))))
+        },
+        // These types cannot appear in structs that we read from storage:
+        //   - Signer is not store
+        //   - References aren't store.
+        //   - Unparseable is only used on the input side
+        MoveType::Signer | MoveType::Reference { mutable: _, to: _ } | MoveType::Unparsable(_) => {
+            bail!(
+                "Type {:?} should not appear in a struct from storage",
+                field_type
+            )
+        },
+    }
+}
+
+/// Based on whether the struct name is repeated and the builder options, determine
+/// whether to use the fully qualified name (address, module, struct name) or not
+/// (just struct name).
+fn get_object_name(
+    struct_tag: &StructTag,
+    repeated_struct_names: &HashSet<String>,
+    options: &BuilderOptions,
+) -> String {
+    let struct_name = struct_tag.name.to_string();
+    let use_fully_qualified_name = options.always_use_fully_qualifed_names
+        || repeated_struct_names.contains(&struct_name)
+        || RESERVED_TYPE_NAMES.contains(&struct_name.as_str());
+    if use_fully_qualified_name {
+        get_fully_qualified_object_name(struct_tag)
+    } else {
+        struct_name
+    }
+}
+
+// TODO: It'd be good to use the named address instead of the raw address. Not a high
+// priority though since we only used the fully qualified name when there is a name
+// collision, which is fairly rare.
+fn get_fully_qualified_object_name(struct_tag: &StructTag) -> String {
+    format!(
+        "_{}__{}__{}",
+        struct_tag.address.to_standard_string(),
+        struct_tag.module,
+        struct_tag.name,
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use anyhow::Result;
+    use aptos_api_types::{Address, MoveStructTag};
+    use move_core_types::identifier::Identifier;
+    use std::str::FromStr;
+
+    fn build_function_options() -> BuilderOptions {
+        BuilderOptions {
+            use_special_handling_for_option: true,
+            always_use_fully_qualifed_names: false,
+        }
+    }
+
+    /// This function builds the following Move type:
+    ///
+    /// Option<T>
+    ///
+    /// In GraphQL schema syntax this is represented as `T`
+    fn build_option(inner: MoveType) -> MoveType {
+        MoveType::Struct(MoveStructTag {
+            address: Address::from_str("0x1").unwrap(),
+            module: Identifier::new("option").unwrap().into(),
+            name: Identifier::new("Option").unwrap().into(),
+            generic_type_params: vec![inner],
+        })
+    }
+
+    /// This function builds the following Move type:
+    ///
+    /// vector<u32>
+    ///
+    /// This is a mandatory vector filled with mandatory u32s.
+    ///
+    /// In GraphQL schema syntax this is represented as `[Int!]!`
+    fn build_vec_of_u32s() -> MoveType {
+        MoveType::Vector {
+            items: Box::new(MoveType::U32),
+        }
+    }
+
+    /// This function builds the following Move type:
+    ///
+    /// vector<vector<u32>>
+    ///
+    /// This is a mandatory vector filled with mandatory vectors filled with u32s.
+    ///
+    /// In GraphQL schema syntax this is represented as `[[Int!]!]!`
+    fn build_vec_of_vecs_of_u32s() -> MoveType {
+        MoveType::Vector {
+            items: Box::new(build_vec_of_u32s()),
+        }
+    }
+
+    /// This function builds the following Move type:
+    ///
+    /// vector<Option<vector<u32>>>
+    ///
+    /// So, it's a mandatory vector containing optional vectors filled with
+    /// mandatory u32s.
+    ///
+    /// In GraphQL schema syntax this is represented as `[[Int!]]!`
+    fn build_vec_of_optional_vecs_of_u32s() -> MoveType {
+        MoveType::Vector {
+            items: Box::new(build_option(build_vec_of_u32s())),
+        }
+    }
+
+    /// This function builds the following Move type:
+    ///
+    /// Option<vector<vector<Option<vector<u32>>>>>,
+    ///
+    /// So, it's an optional vector containing non-optional vectors filled with
+    /// optional vectors of mandatory u32s.
+    ///
+    /// In GraphQL schema syntax this is represented as `[[[Int!]]!]`
+    fn build_complex_type() -> MoveType {
+        build_option(MoveType::Vector {
+            items: Box::new(build_vec_of_optional_vecs_of_u32s()),
+        })
+    }
+
+    #[test]
+    fn test_option() -> Result<()> {
+        let options = build_function_options();
+        let testing_move_type = build_option(MoveType::U32);
+        let field_type = move_type_to_field_type(&testing_move_type, &HashSet::new(), &options)?;
+        assert_eq!(&field_type.to_string(), "U32");
+        Ok(())
+    }
+
+    /// See the comment in move_type_to_field_type for an explanation for why we
+    /// expect this to fail.
+    #[test]
+    fn test_option_of_option() -> Result<()> {
+        let options = build_function_options();
+        let testing_move_type = build_option(build_option(MoveType::U16));
+        assert!(move_type_to_field_type(&testing_move_type, &HashSet::new(), &options).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_vec_of_u32s() -> Result<()> {
+        let options = build_function_options();
+        let testing_move_type = build_vec_of_u32s();
+        let field_type = move_type_to_field_type(&testing_move_type, &HashSet::new(), &options)?;
+        assert_eq!(&field_type.to_string(), "[U32!]!");
+        Ok(())
+    }
+
+    #[test]
+    fn test_vec_of_vecs_of_u32s() -> Result<()> {
+        let options = build_function_options();
+        let testing_move_type = build_vec_of_vecs_of_u32s();
+        let field_type = move_type_to_field_type(&testing_move_type, &HashSet::new(), &options)?;
+        assert_eq!(&field_type.to_string(), "[[U32!]!]!");
+        Ok(())
+    }
+
+    #[test]
+    fn test_vec_of_optional_vecs_of_u32s() -> Result<()> {
+        let options = build_function_options();
+        let testing_move_type = build_vec_of_optional_vecs_of_u32s();
+        let field_type = move_type_to_field_type(&testing_move_type, &HashSet::new(), &options)?;
+        assert_eq!(&field_type.to_string(), "[[U32!]]!");
+        Ok(())
+    }
+
+    #[test]
+    fn test_complex_move_type() -> Result<()> {
+        let options = build_function_options();
+        let testing_move_type = build_complex_type();
+        let field_type = move_type_to_field_type(&testing_move_type, &HashSet::new(), &options)?;
+        assert_eq!(&field_type.to_string(), "[[[U32!]]!]");
+        Ok(())
+    }
+}

--- a/crates/aptos-move-graphql/test-helpers/Cargo.toml
+++ b/crates/aptos-move-graphql/test-helpers/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "aptos-move-graphql-test-helpers"
+description = "Common testing utils for aptos-move-graphql-*"
+version = "0.0.1"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+aptos-api-types = { workspace = true }
+aptos-framework = { workspace = true }
+aptos-types = { workspace = true }
+move-binary-format = { workspace = true }
+move-core-types = { workspace = true }
+move-resource-viewer = { workspace = true }

--- a/crates/aptos-move-graphql/test-helpers/src/lib.rs
+++ b/crates/aptos-move-graphql/test-helpers/src/lib.rs
@@ -1,0 +1,186 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use aptos_api_types::MoveModule;
+use aptos_framework::{BuildOptions, BuiltPackage};
+use aptos_types::account_address::AccountAddress;
+use move_binary_format::file_format::AbilitySet;
+use move_core_types::{
+    identifier::Identifier,
+    language_storage::{StructTag, TypeTag},
+};
+use move_resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
+use std::{collections::BTreeMap, path::PathBuf};
+
+// This function builds a Move struct for the sake of testing. The output loosely
+// matches the Tontine struct from banool/aptos-tontine:
+// https://github.com/banool/aptos-tontine/blob/923e5bef79841b9f068d1f4c4208bda891516d91/move/sources/tontine.move#L210
+pub fn build_tontine() -> AnnotatedMoveStruct {
+    let tontine_config = AnnotatedMoveValue::Struct(annotated_move_struct(
+        type_struct("0x789", "tontine", "Config"),
+        vec![
+            (
+                identifier("description"),
+                AnnotatedMoveValue::Struct(annotated_move_struct(
+                    type_struct("0x1", "string", "String"),
+                    vec![(
+                        identifier("bytes"),
+                        // The string "My Tontine" as UTF-8 bytes
+                        AnnotatedMoveValue::Bytes(vec![
+                            0x4D, 0x79, 0x20, 0x54, 0x6F, 0x6E, 0x74, 0x69, 0x6E, 0x65,
+                        ]),
+                    )],
+                )),
+            ),
+            (
+                identifier("per_member_amount_octa"),
+                AnnotatedMoveValue::U64(100000),
+            ),
+            (
+                identifier("delegation_pool"),
+                AnnotatedMoveValue::Struct(annotated_move_struct(
+                    type_struct("0x1", "option", "Option"),
+                    vec![(
+                        identifier("vec"),
+                        // The string "My Tontine" as UTF-8 bytes
+                        AnnotatedMoveValue::Vector(TypeTag::Address, vec![
+                            AnnotatedMoveValue::Address(address("0x123")),
+                        ]),
+                    )],
+                )),
+            ),
+        ],
+    ));
+
+    let member_data = AnnotatedMoveValue::Struct(annotated_move_struct(
+        type_struct("0x1", "simple_map", "SimpleMap"),
+        vec![(
+            identifier("data"),
+            AnnotatedMoveValue::Vector(
+                TypeTag::Struct(Box::new(StructTag {
+                    address: address("0x1"),
+                    module: identifier("simple_map"),
+                    name: identifier("Element"),
+                    type_params: vec![
+                        TypeTag::Address,
+                        TypeTag::Struct(Box::new(StructTag {
+                            address: address("0x789"),
+                            module: identifier("tontine"),
+                            name: identifier("MemberData"),
+                            type_params: vec![],
+                        })),
+                    ],
+                })),
+                vec![AnnotatedMoveValue::Struct(annotated_move_struct(
+                    type_struct("0x1", "simple_map", "Element"),
+                    vec![
+                        (
+                            identifier("key"),
+                            AnnotatedMoveValue::Address(address("0x123")),
+                        ),
+                        (
+                            identifier("value"),
+                            AnnotatedMoveValue::Struct(annotated_move_struct(
+                                type_struct("0x789", "tontine", "MemberData"),
+                                vec![
+                                    (
+                                        identifier("contributed_octa"),
+                                        AnnotatedMoveValue::U64(50000),
+                                    ),
+                                    (
+                                        identifier("reconfirmation_required"),
+                                        AnnotatedMoveValue::Bool(false),
+                                    ),
+                                ],
+                            )),
+                        ),
+                    ],
+                ))],
+            ),
+        )],
+    ));
+
+    annotated_move_struct(type_struct("0x789", "tontine", "Tontine"), vec![
+        (identifier("config"), tontine_config),
+        (
+            identifier("creation_time_secs"),
+            AnnotatedMoveValue::U64(1686829095),
+        ),
+        (identifier("member_data"), member_data),
+        (
+            identifier("fallback_executed"),
+            AnnotatedMoveValue::Bool(false),
+        ),
+        (identifier("funds_claimed_secs"), AnnotatedMoveValue::U64(0)),
+        (
+            identifier("funds_claimed_by"),
+            AnnotatedMoveValue::Struct(annotated_move_struct(
+                type_struct("0x1", "option", "Option"),
+                vec![(
+                    identifier("vec"),
+                    // Empty vec because no one has claimed the funds yet.
+                    AnnotatedMoveValue::Vector(TypeTag::Address, vec![]),
+                )],
+            )),
+        ),
+    ])
+}
+
+fn type_struct(addr: &str, module: &str, name: &str) -> StructTag {
+    type_struct_with_type_params(addr, module, name, vec![])
+}
+
+fn type_struct_with_type_params(
+    addr: &str,
+    module: &str,
+    name: &str,
+    type_params: Vec<TypeTag>,
+) -> StructTag {
+    StructTag {
+        address: address(addr),
+        module: identifier(module),
+        name: identifier(name),
+        type_params,
+    }
+}
+
+fn address(hex: &str) -> AccountAddress {
+    AccountAddress::from_hex_literal(hex).unwrap()
+}
+
+fn annotated_move_struct(
+    typ: StructTag,
+    values: Vec<(Identifier, AnnotatedMoveValue)>,
+) -> AnnotatedMoveStruct {
+    AnnotatedMoveStruct {
+        abilities: AbilitySet::EMPTY,
+        type_: typ,
+        value: values,
+    }
+}
+
+fn identifier(id: &str) -> Identifier {
+    Identifier::new(id).unwrap()
+}
+
+// Given the name of a Move package directory, compile it and return the compiled modules.
+//
+// TODO: Consider making something that memoizes this so we don't have to recompile the
+// same stuff for each test.
+pub fn compile_package(path: PathBuf) -> Result<Vec<MoveModule>> {
+    let mut named_addresses = BTreeMap::new();
+    named_addresses.insert("token_objects".to_string(), AccountAddress::TWO);
+    named_addresses.insert("hero".to_string(), AccountAddress::TWO);
+    let build_options = BuildOptions {
+        with_abis: true,
+        named_addresses,
+        ..Default::default()
+    };
+    let pack = BuiltPackage::build(path.clone(), build_options)
+        .with_context(|| format!("Failed to build package at {}", path.to_string_lossy()))?;
+    pack.extract_metadata_and_save()
+        .context("Failed to extract metadata and save")?;
+    let modules: Vec<MoveModule> = pack.modules().cloned().map(|m| m.into()).collect();
+    Ok(modules)
+}


### PR DESCRIPTION
### Stack
- Previous in stack: https://github.com/aptos-labs/aptos-core/pull/9404
- Next in stack: https://github.com/aptos-labs/aptos-core/pull/9406

### Description
This PR adds a library that consumes a set of Move modules and produces a GraphQL schema. For now it only outputs types, nothing in the way of fully built clients with read / write queries.

In short the way it works is this:
1. Find all the structs in all the modules. We ensure that all structs referenced are available in the provided modules.
2. Determine which structs need to use a fully qualified name (address + module name + struct name) vs just struct name. This is necessary to avoid name collisions with structs with the same name from other modules / reserved types in GraphQL.
3. Build a schema using the structs. As part of this, there is special handling for certain types such as String and Option. As it is now, only the special handling for String is enabled by default because that is how the API and indexer serialize Move resources as JSON. Additional special behaviour is all configurable, which we can enable as we evolve the way we represent Move resources from the API / txn stream service.

As you can see, there are a lot of TODOs marked in the code in this PR right now. I don't think any of those are necessary for landing an MVP here. Once / if we're happy with the state of PR I will open issues for these TODOs and link to them from the code.

### Test Plan
```
cd crates/aptos-move-graphql/schema
RUST_MIN_STACK=4297152 cargo test
```

I use this library successfully in the later PRs in this stack.