### PR TITLE
Add aptos move generate schema command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,7 @@ dependencies = [
  "aptos-ledger",
  "aptos-logger",
  "aptos-move-debugger",
+ "aptos-move-graphql-schema",
  "aptos-network-checker",
  "aptos-node",
  "aptos-protos 1.1.2",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -35,6 +35,7 @@ aptos-keygen = { workspace = true }
 aptos-ledger = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-move-debugger = { workspace = true }
+aptos-move-graphql-schema = { workspace = true }
 aptos-network-checker = { workspace = true }
 aptos-node = { workspace = true }
 aptos-protos = { workspace = true }

--- a/crates/aptos/src/move_tool/generate/mod.rs
+++ b/crates/aptos/src/move_tool/generate/mod.rs
@@ -1,0 +1,74 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+mod schema;
+
+use crate::{
+    common::types::{CliCommand, CliError, MovePackageDir},
+    move_tool::IncludedArtifactsArgs,
+    CliResult,
+};
+use anyhow::Result;
+use aptos_api_types::MoveModule;
+use aptos_framework::{BuildOptions, BuiltPackage};
+use aptos_move_graphql_schema::{
+    build_sdl, BuilderOptions, SchemaBuilderLocal, SchemaBuilderTrait,
+};
+use clap::Subcommand;
+
+/// Generates schemas / code based on a Move module
+#[derive(Subcommand)]
+pub enum GenerateTool {
+    Schema(schema::GenerateSchema),
+}
+
+impl GenerateTool {
+    pub async fn execute(self) -> CliResult {
+        match self {
+            Self::Schema(tool) => tool.execute_serialized().await,
+        }
+    }
+}
+
+/// Build a Move package and generate a GraphQL schema from it for its types.
+/// This returns the schema as a string in the GraphQL SDL.
+pub fn build_schema_str(
+    included_artifacts_args: &IncludedArtifactsArgs,
+    move_options: &MovePackageDir,
+    builder_options: BuilderOptions,
+) -> Result<String> {
+    let dev = false;
+    let build_options = BuildOptions {
+        install_dir: move_options.output_dir.clone(),
+        with_abis: true,
+        ..included_artifacts_args.included_artifacts.build_options(
+            dev,
+            move_options.skip_fetch_latest_git_deps,
+            move_options.named_addresses(),
+            move_options.bytecode_version,
+            None,
+            false,
+        )
+    };
+
+    let package_dir = move_options.get_package_path()?;
+
+    // Build the package.
+    let package = BuiltPackage::build(package_dir.clone(), build_options)
+        .map_err(|e| CliError::MoveCompilationError(format!("{:#}", e)))?;
+
+    // Convert the modules into MoveModule.
+    let modules = package
+        .all_modules()
+        .cloned()
+        .map(MoveModule::from)
+        .collect();
+
+    // Build the Schema struct.
+    let schema = SchemaBuilderLocal::new(builder_options)
+        .add_modules(modules)
+        .build()
+        .map_err(|e| CliError::UnexpectedError(format!("Failed to build schema: {:#}", e)))?;
+
+    Ok(build_sdl(&schema))
+}

--- a/crates/aptos/src/move_tool/generate/schema.rs
+++ b/crates/aptos/src/move_tool/generate/schema.rs
@@ -1,0 +1,65 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::build_schema_str;
+use crate::{
+    common::types::{CliCommand, CliError, CliTypedResult, MovePackageDir},
+    move_tool::IncludedArtifactsArgs,
+};
+use aptos_move_graphql_schema::BuilderOptions;
+use async_trait::async_trait;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Generate a GraphQL schema based on the ABI of the compiled modules.
+///
+/// aptos move generate schema
+///
+#[derive(Parser)]
+pub struct GenerateSchema {
+    /// Where to write the schema file. If not given the schema will be written to the
+    /// package directory.
+    #[clap(long, value_parser)]
+    schema_path: Option<PathBuf>,
+
+    /// The filename of the schema.
+    #[clap(long, default_value = "schema.graphql")]
+    schema_fname: String,
+
+    #[clap(flatten)]
+    included_artifacts_args: IncludedArtifactsArgs,
+
+    #[clap(flatten)]
+    move_options: MovePackageDir,
+
+    #[clap(flatten)]
+    builder_options: BuilderOptions,
+}
+
+#[async_trait]
+impl CliCommand<String> for GenerateSchema {
+    fn command_name(&self) -> &'static str {
+        "GenerateSchema"
+    }
+
+    async fn execute(self) -> CliTypedResult<String> {
+        let package_dir = self.move_options.get_package_path()?;
+
+        let sdl = build_schema_str(
+            &self.included_artifacts_args,
+            &self.move_options,
+            self.builder_options.clone(),
+        )?;
+
+        let schema_path = self
+            .schema_path
+            .unwrap_or(package_dir)
+            .join(&self.schema_fname);
+
+        // Write the schema to the file.
+        std::fs::write(&schema_path, sdl)
+            .map_err(|e| CliError::UnexpectedError(format!("Failed to write schema: {:#}", e)))?;
+
+        Ok(format!("Schema written to {}", schema_path.display()))
+    }
+}

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -4,6 +4,7 @@
 mod aptos_debug_natives;
 pub mod coverage;
 mod disassembler;
+mod generate;
 mod manifest;
 pub mod package_hooks;
 mod show;
@@ -83,6 +84,8 @@ pub enum MoveTool {
     Disassemble(Disassemble),
     Document(DocumentPackage),
     Download(DownloadPackage),
+    #[clap(subcommand)]
+    Generate(generate::GenerateTool),
     Init(InitPackage),
     List(ListPackage),
     Prove(ProvePackage),
@@ -110,6 +113,7 @@ impl MoveTool {
             MoveTool::Disassemble(tool) => tool.execute_serialized().await,
             MoveTool::Document(tool) => tool.execute_serialized().await,
             MoveTool::Download(tool) => tool.execute_serialized().await,
+            MoveTool::Generate(tool) => tool.execute().await,
             MoveTool::Init(tool) => tool.execute_serialized_success().await,
             MoveTool::List(tool) => tool.execute_serialized().await,
             MoveTool::Prove(tool) => tool.execute_serialized().await,


### PR DESCRIPTION
### Stack
- Previous in stack: https://github.com/aptos-labs/aptos-core/pull/9405
- Next in stack: https://github.com/aptos-labs/aptos-core/pull/9407

### Description
This PR adds `aptos move generate schema`, which lets you generate a GraphQL schema with types that correspond to the structs in a Move module.

### Test Plan
Tested manually for now. If we like the PR I can add a CLI E2E test.

From inside a Move package directory:
```
aptos move generate schema --named-addresses addr=0x3
```

You get a schema like this: https://gist.github.com/banool/cbfbb0956c155ef018ef7da353a43323.