### PR TITLE
Add aptos move generate rust command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
  "aptos-types",
  "aptos-vm",
  "aptos-vm-genesis",
+ "async-graphql-reverse",
  "async-trait",
  "base64 0.13.1",
  "bcs 0.1.4",
@@ -726,7 +727,7 @@ dependencies = [
  "clap 4.4.12",
  "clap-verbosity-flag",
  "determinator",
- "env_logger",
+ "env_logger 0.10.1",
  "guppy",
  "log",
  "reqwest",
@@ -1641,7 +1642,7 @@ dependencies = [
  "aptos-node-checker",
  "aptos-sdk",
  "clap 4.4.12",
- "env_logger",
+ "env_logger 0.10.1",
  "futures",
  "gcp-bigquery-client",
  "reqwest",
@@ -3108,7 +3109,7 @@ dependencies = [
  "async-trait",
  "clap 4.4.12",
  "const_format",
- "env_logger",
+ "env_logger 0.10.1",
  "futures",
  "once_cell",
  "poem",
@@ -4817,6 +4818,30 @@ dependencies = [
  "pest",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "async-graphql-reverse"
+version = "0.6.0"
+source = "git+https://github.com/tacogips/async-graphql-reverse.git?rev=2e5e7758051f7ba57da3940e5bc75a4e80badf4c#2e5e7758051f7ba57da3940e5bc75a4e80badf4c"
+dependencies = [
+ "anyhow",
+ "async-graphql",
+ "async-graphql-parser",
+ "clap 3.2.25",
+ "derive_macro_tool",
+ "env_logger 0.8.4",
+ "heck 0.3.3",
+ "lazy_static",
+ "log",
+ "paste",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "serde",
+ "structopt",
+ "strum 0.21.0",
+ "syn 1.0.109",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -6836,6 +6861,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_macro_tool"
+version = "0.1.0"
+source = "git+https://github.com/tacogips/async-graphql-reverse.git?rev=2e5e7758051f7ba57da3940e5bc75a4e80badf4c#2e5e7758051f7ba57da3940e5bc75a4e80badf4c"
+dependencies = [
+ "chrono",
+ "quote 1.0.35",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7255,6 +7290,19 @@ dependencies = [
  "proc-macro2 1.0.75",
  "quote 1.0.35",
  "syn 2.0.47",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -9213,7 +9261,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap",
- "env_logger",
+ "env_logger 0.10.1",
  "indexmap 2.1.0",
  "is-terminal",
  "itoa",
@@ -14919,6 +14967,15 @@ dependencies = [
 
 [[package]]
 name = "strum"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+dependencies = [
+ "strum_macros 0.21.1",
+]
+
+[[package]]
+name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
@@ -14933,6 +14990,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
  "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -459,6 +459,7 @@ aptos-moving-average = { git = "https://github.com/aptos-labs/aptos-indexer-proc
 assert_approx_eq = "1.1.0"
 assert_unordered = "0.3.5"
 async-channel = "1.7.1"
+async-graphql-reverse = { git = "https://github.com/tacogips/async-graphql-reverse.git", rev = "2e5e7758051f7ba57da3940e5bc75a4e80badf4c" }
 async-mutex = "1.4.0"
 async-recursion = "1.0.5"
 async-stream = "0.3"

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -47,6 +47,7 @@ aptos-temppath = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true, features = ["testing"] }
 aptos-vm-genesis = { workspace = true }
+async-graphql-reverse = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 bcs = { workspace = true }

--- a/crates/aptos/src/move_tool/generate/mod.rs
+++ b/crates/aptos/src/move_tool/generate/mod.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+mod rust;
 mod schema;
 
 use crate::{
@@ -19,12 +20,14 @@ use clap::Subcommand;
 /// Generates schemas / code based on a Move module
 #[derive(Subcommand)]
 pub enum GenerateTool {
+    Rust(rust::GenerateRust),
     Schema(schema::GenerateSchema),
 }
 
 impl GenerateTool {
     pub async fn execute(self) -> CliResult {
         match self {
+            Self::Rust(tool) => tool.execute_serialized().await,
             Self::Schema(tool) => tool.execute_serialized().await,
         }
     }
@@ -47,6 +50,7 @@ pub fn build_schema_str(
             move_options.named_addresses(),
             move_options.bytecode_version,
             None,
+            false,
             false,
         )
     };

--- a/crates/aptos/src/move_tool/generate/rust.rs
+++ b/crates/aptos/src/move_tool/generate/rust.rs
@@ -1,0 +1,99 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::build_schema_str;
+use crate::{
+    common::types::{CliCommand, CliError, CliTypedResult, MovePackageDir},
+    move_tool::IncludedArtifactsArgs,
+};
+use aptos_move_graphql_schema::BuilderOptions;
+use async_graphql_reverse::{output_schema, parse_schema_file, Phase, RendererConfig};
+use async_trait::async_trait;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Generate a GraphQL schema based on the ABI of the compiled modules
+///
+/// aptos move generate rust
+///
+#[derive(Parser)]
+pub struct GenerateRust {
+    /// If provided the tool will use this schema. If not, it will build the schema
+    /// in a temporary location and use that.
+    #[clap(long, value_parser)]
+    schema: Option<PathBuf>,
+
+    /// Where to output the generated code.
+    #[clap(long)]
+    generate_to: PathBuf,
+
+    #[clap(flatten)]
+    included_artifacts_args: IncludedArtifactsArgs,
+
+    #[clap(flatten)]
+    move_options: MovePackageDir,
+
+    #[clap(flatten)]
+    builder_options: BuilderOptions,
+}
+
+#[async_trait]
+impl CliCommand<String> for GenerateRust {
+    fn command_name(&self) -> &'static str {
+        "GenerateRust"
+    }
+
+    async fn execute(self) -> CliTypedResult<String> {
+        let schema_path = match self.schema.clone() {
+            Some(path) => {
+                println!("Using schema at path: {}", path.display());
+                path
+            },
+            None => {
+                println!("No schema path provided, generating schema in temporary location...");
+                let schema = build_schema_str(
+                    &self.included_artifacts_args,
+                    &self.move_options,
+                    self.builder_options.clone(),
+                )?;
+                let schema_path = std::env::temp_dir().join("schema.graphql");
+
+                // Write the schema to the file.
+                std::fs::write(&schema_path, schema).map_err(|e| {
+                    CliError::UnexpectedError(format!("Failed to write schema: {:#}", e))
+                })?;
+                println!("Schema written to {}", schema_path.display());
+                schema_path
+            },
+        };
+
+        let renderer_config = self.build_renderer_config();
+
+        let structued_schema = parse_schema_file(&schema_path.to_string_lossy(), &renderer_config)?;
+
+        // Despite the name, this does not output a schema, it outputs based on one.
+        output_schema(
+            &self.generate_to.to_string_lossy(),
+            structued_schema,
+            renderer_config,
+        )?;
+
+        Ok(format!("Code generated in {}", self.generate_to.display()))
+    }
+}
+
+impl GenerateRust {
+    /// Build the config for use by async-graphql-reverse.
+    fn build_renderer_config(&self) -> RendererConfig {
+        RendererConfig {
+            phases: vec![Phase::Objects],
+            no_object_impl: true,
+            no_dependency_imports: true,
+            header: "use serde::{Deserialize, Serialize};use aptos_move_graphql_scalars::*;"
+                .to_string(),
+            additional_attributes: Some("Serialize, Deserialize".to_string()),
+            resolver_type: Some("field".to_string()),
+            ..Default::default()
+        }
+    }
+}


### PR DESCRIPTION
### Stack
- Previous in stack: https://github.com/aptos-labs/aptos-core/pull/9406
- Next in stack: N/A

### Description
This PR adds the `aptos move generate rust` subcommand to the CLI. With this you can generate Rust types based on the structs in a Move module. These Rust types can then be used in Rust code to deserialize the JSON representation of Move resources encoded in JSON, either from the API or in the context of an indexer processor, for example:
```
let first_arg = clean_entry_function_payload.arguments[0].clone();
let obj: _0x1__object__Object = serde_json::from_value(first_arg).unwrap();
let canvas_address = obj.inner;
```

### Test Plan
Tested manually for now. If we like the PR I can add a CLI E2E test.

From inside a Move package directory:
```
aptos move generate rust --named-addresses addr=0x3 --generate-to ../processor/src/generated
```

You get Rust code like this: https://gist.github.com/banool/e051e86884e73b45e47d2978d66b8351.