### PR TITLE
[Forge] PFN should have a container name of fullnode, not validator

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -500,7 +500,7 @@ fn single_test_suite(
     let single_test_suite = match test_name {
         // Land-blocking tests to be run on every PR:
         "land_blocking" => land_blocking_test_suite(duration), // to remove land_blocking, superseeded by the below
-        "realistic_env_max_load" => pfn_performance(duration, true, true),
+        "realistic_env_max_load" => realistic_env_max_load_test(duration, test_cmd, 7, 5),
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),
         // Rest of the tests:

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -500,7 +500,7 @@ fn single_test_suite(
     let single_test_suite = match test_name {
         // Land-blocking tests to be run on every PR:
         "land_blocking" => land_blocking_test_suite(duration), // to remove land_blocking, superseeded by the below
-        "realistic_env_max_load" => realistic_env_max_load_test(duration, test_cmd, 7, 5),
+        "realistic_env_max_load" => pfn_performance(duration, true, true),
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),
         // Rest of the tests:

--- a/testsuite/forge/src/backend/k8s/fullnode.rs
+++ b/testsuite/forge/src/backend/k8s/fullnode.rs
@@ -190,6 +190,7 @@ fn create_fullnode_container(
                 ..VolumeMount::default()
             },
         ]),
+        name: "fullnode".to_string(),
         // specifically, inherit resources, env,ports, securityContext from the validator's container
         ..validator_container.clone()
     })


### PR DESCRIPTION
### Description

### Test Plan

Confirm the PFN is no longer labeled a validator in grafana system dashboard and humio.
