### PR TITLE
[CLI][e2e] Add node update consensus and network e2e

### DIFF
--- a/crates/aptos/e2e/cases/node.py
+++ b/crates/aptos/e2e/cases/node.py
@@ -39,3 +39,140 @@ def test_node_show_validator_set(run_helper: RunHelper, test_name=None):
         raise TestError(
             "Node show validator set command failed: Did not return account_address, consensus_public_key, or config"
         )
+
+
+@test_case
+def test_node_update_consensus_key(run_helper: RunHelper, test_name=None):
+    # run init a new profile
+    run_helper.run_command(
+        test_name,
+        [
+            "aptos",
+            "init",
+            "--assume-yes",
+            "--network",
+            "local",
+            "--profile",
+            "consensus",
+        ],
+        input="\n",
+    )
+
+    # run initialize stake to make sure stake pool created
+    run_helper.run_command(
+        test_name,
+        [
+            "aptos",
+            "stake",
+            "initialize-stake-owner",
+            "--profile",
+            "consensus",
+            "--initial-stake-amount",
+            "1",
+            "--assume-yes",
+        ],
+    )
+
+    # hardcode the bls12381 key
+    bls12381_public_key = "91067b73f284b4fa47141a023b4bbdc819e92a80058cbedfa2a39b43782c624eea1b281b0a8862aee23e77fb59a2ba75"
+    bls12381_pop = "857ddee36936599f98376ebc1a4d70a9ea9c066d27c03ff34300cc52ddea72760c3f8c8b8e423626cff585130d38370712945f48438ff24dcac0179dd4eb47389fd317395a36766490ce34c852b4b23fa8f0b55561275014ae56f79a86eff3ef"
+
+    # run the update consensus key command
+    response = run_helper.run_command(
+        test_name,
+        [
+            "aptos",
+            "node",
+            "update-consensus-key",
+            "--profile",
+            "consensus",
+            "--consensus-public-key",
+            bls12381_public_key,
+            "--proof-of-possession",
+            bls12381_pop,
+            "--assume-yes",
+        ],
+    )
+
+    result = json.loads(response.stdout)["Result"]
+    if result.get("success") == None or result.get("success") != True:
+        raise TestError("update-consensus-key command failed: Did not return success")
+
+    # Make sure consensus key is actually updated on chain
+    response = run_helper.run_command(
+        test_name,
+        [
+            "aptos",
+            "node",
+            "get-stake-pool",
+            "--profile",
+            "consensus",
+            "--owner-address",
+            "consensus",
+        ],
+    )
+
+    result = json.loads(response.stdout)["Result"]
+    if result[0] == None or result[0].get("consensus_public_key") == None:
+        raise TestError(f"Error: No consensus key on result")
+
+    if result[0].get("consensus_public_key") != f"0x{bls12381_public_key}":
+        raise TestError(
+            f"Error: Expected consensus key 0x{bls12381_public_key} but got {result[0].get('consensus_public_key')}"
+        )
+
+
+@test_case
+def test_node_update_validator_network_address(run_helper: RunHelper, test_name=None):
+    network_public_key = (
+        "657dac6c023b39b53b8ae5fdc13a1e1222dacde98165324e16086a6766821628"
+    )
+    network_host = "127.0.0.1"
+    network_port = "6180"
+
+    # run the update command
+    response = run_helper.run_command(
+        test_name,
+        [
+            "aptos",
+            "node",
+            "update-validator-network-addresses",
+            "--profile",
+            "consensus",  # Assume consensus profile is already created from test_node_update_consensus_key
+            "--validator-network-public-key",
+            network_public_key,
+            "--validator-host",
+            f"{network_host}:{network_port}",
+            "--assume-yes",
+        ],
+    )
+
+    result = json.loads(response.stdout)["Result"]
+    if result.get("success") == None or result.get("success") != True:
+        raise TestError(
+            "update-validator-network-addresses command failed: Did not return success"
+        )
+
+    # Make sure network address is actually updated on chain
+    response = run_helper.run_command(
+        test_name,
+        [
+            "aptos",
+            "node",
+            "get-stake-pool",
+            "--profile",
+            "consensus",
+            "--owner-address",
+            "consensus",
+        ],
+    )
+
+    result = json.loads(response.stdout)["Result"]
+    if result[0] == None or result[0].get("validator_network_addresses") == None:
+        raise TestError(f"Error: No [validator_network_addresses] key found on result")
+
+    expected_network_address = f"/ip4/{network_host}/tcp/{network_port}/noise-ik/0x{network_public_key}/handshake/0"
+    if result[0].get("validator_network_addresses")[0] != expected_network_address:
+        raise TestError(
+            f"Error: Expected validator network address [{expected_network_address}] but got [{result[0].get('validator_network_addresses')[0]}]"
+        )

--- a/crates/aptos/e2e/main.py
+++ b/crates/aptos/e2e/main.py
@@ -44,7 +44,11 @@ from cases.move import (
     test_move_run,
     test_move_view,
 )
-from cases.node import test_node_show_validator_set
+from cases.node import (
+    test_node_show_validator_set,
+    test_node_update_consensus_key,
+    test_node_update_validator_network_address,
+)
 from cases.stake import (
     test_stake_add_stake,
     test_stake_create_staking_contract,
@@ -158,6 +162,8 @@ def run_tests(run_helper):
 
     # Run node subcommand group tests.
     test_node_show_validator_set(run_helper)
+    test_node_update_consensus_key(run_helper)
+    test_node_update_validator_network_address(run_helper)
 
     # WARNING: This has to stay at the end, else key will get rotated
     test_account_rotate_key(run_helper)


### PR DESCRIPTION
### Description

Add the following 2 e2e tests
1. test_node_update_consensus_key
2. test_node_update_validator_network_address

Note: In the test, the `proof of possession key` are pre generated and hardcoded in test.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

```
➜  e2e git:(jin/update_local_testnet_initial_validator_stake) ✗ DOCKER_DEFAULT_PLATFORM=linux/amd64 poetry run python main.py --base-network testnet --test-cli-path ~/Projects/aptos-core/target/debug/aptos
Configuration file exists at /Users/jinhou/Library/Preferences/pypoetry, reusing this directory.

Consider moving TOML configuration files to /Users/jinhou/Library/Application Support/pypoetry, as support for the legacy directory will be removed in an upcoming release.
2023-08-01 17:11:12,225 - INFO - Trying to run aptos CLI local testnet from image: aptoslabs/tools:testnet
2023-08-01 17:11:15,613 - INFO - Running aptos CLI local testnet from image: aptoslabs/tools:testnet
2023-08-01 17:11:15,614 - INFO - Waiting for node and faucet APIs for aptos-tools-testnet to come up
2023-08-01 17:11:36,062 - INFO - Node and faucet APIs for aptos-tools-testnet came up
2023-08-01 17:11:37,233 - INFO - Running test: test_metrics_accessible
2023-08-01 17:11:37,340 - INFO - Running test: test_init
2023-08-01 17:11:40,675 - INFO - Running test: test_config_show_profiles
2023-08-01 17:11:41,291 - INFO - Running test: test_account_fund_with_faucet
2023-08-01 17:11:43,070 - INFO - Running test: test_account_create
2023-08-01 17:11:44,987 - INFO - Running test: test_account_lookup_address
2023-08-01 17:11:45,585 - INFO - Running test: test_aptos_header_included
2023-08-01 17:11:45,679 - INFO - Running test: test_move_compile
2023-08-01 17:11:53,326 - INFO - Running test: test_move_compile_script
2023-08-01 17:12:00,710 - INFO - Running test: test_move_publish
2023-08-01 17:12:11,597 - INFO - Running test: test_move_run
2023-08-01 17:12:14,624 - INFO - Running test: test_move_view
2023-08-01 17:12:17,256 - INFO - Running test: test_account_rotate_key
2023-08-01 17:12:20,396 - INFO - Running test: test_node_show_validator_set
2023-08-01 17:12:20,958 - INFO - Running test: test_node_update_consensus_key
2023-08-01 17:12:26,722 - INFO - Running test: test_node_update_validator_network_address
2023-08-01 17:12:29,526 - INFO - Stopping container: aptos-tools-testnet
2023-08-01 17:12:30,506 - INFO - Stopped container: aptos-tools-testnet
2023-08-01 17:12:30,507 - INFO - These tests passed:
2023-08-01 17:12:30,507 - INFO - test_metrics_accessible
2023-08-01 17:12:30,507 - INFO - test_init
2023-08-01 17:12:30,507 - INFO - test_config_show_profiles
2023-08-01 17:12:30,507 - INFO - test_account_fund_with_faucet
2023-08-01 17:12:30,507 - INFO - test_account_create
2023-08-01 17:12:30,507 - INFO - test_account_lookup_address
2023-08-01 17:12:30,507 - INFO - test_aptos_header_included
2023-08-01 17:12:30,507 - INFO - test_move_compile
2023-08-01 17:12:30,507 - INFO - test_move_compile_script
2023-08-01 17:12:30,507 - INFO - test_move_publish
2023-08-01 17:12:30,507 - INFO - test_move_run
2023-08-01 17:12:30,507 - INFO - test_move_view
2023-08-01 17:12:30,507 - INFO - test_account_rotate_key
2023-08-01 17:12:30,507 - INFO - test_node_show_validator_set
2023-08-01 17:12:30,507 - INFO - test_node_update_consensus_key
2023-08-01 17:12:30,507 - INFO - test_node_update_validator_network_address
2023-08-01 17:12:30,507 - INFO - All tests passed!
```
