### PR TITLE
[TS SDK] Support local endpoint in Provider

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
   - Aggregate query suports token v2 activities - `getTokenActivitiesCount`
   - Support for sorting indexer queries - `orderBy` optional argument in `extraArgs` arguments
   - Support for get owned tokens by token address or token data id - `getOwnedTokensByTokenData`
+- Add support for local/custom networks without an indexer client
 
 ## 1.15.0 (2023-07-28)
 

--- a/ecosystem/typescript/sdk/src/providers/provider.ts
+++ b/ecosystem/typescript/sdk/src/providers/provider.ts
@@ -14,6 +14,10 @@ type NetworkWithCustom = Network | "CUSTOM";
  * This class holds both AptosClient and IndexerClient classes's methods and properties so we
  * can instantiate the Provider class and use it to query full node and/or Indexer.
  *
+ * NOTE: Indexer client can be undefined/not set when we use Network.LOCAL (since Indexer
+ * does not support local environment) or when we use a CUSTOM network to support applications
+ * that only use custom fullnode and not Indexer
+ *
  * @example An example of how to use this class with a live network
  * ```
  * const provider = new Provider(Network.DEVNET)
@@ -28,7 +32,7 @@ type NetworkWithCustom = Network | "CUSTOM";
  * const account = await provider.getAccount("0x123");
  * ```
  *
- * @example An example of how to use this class with a lcustom network.
+ * @example An example of how to use this class with a custom network.
  * ```
  * const provider = new Provider({fullnodeUrl:"my-fullnode-url",indexerUrl:"my-indexer-url"})
  * const account = await provider.getAccount("0x123");
@@ -36,7 +40,7 @@ type NetworkWithCustom = Network | "CUSTOM";
  * ```
  *
  * @param network enum of type Network - MAINNET | TESTNET | DEVNET | LOCAL or custom endpoints of type CustomEndpoints
- * @param config AptosClient config arg - additional configuration options for the generated Axios client.
+ * @param config optional ClientConfig config arg - additional configuration we can pass with the request to the server.
  */
 export class Provider {
   aptosClient: AptosClient;

--- a/ecosystem/typescript/sdk/src/providers/provider.ts
+++ b/ecosystem/typescript/sdk/src/providers/provider.ts
@@ -14,20 +14,34 @@ type NetworkWithCustom = Network | "CUSTOM";
  * This class holds both AptosClient and IndexerClient classes's methods and properties so we
  * can instantiate the Provider class and use it to query full node and/or Indexer.
  *
- * @example An example of how to use this class
+ * @example An example of how to use this class with a live network
  * ```
  * const provider = new Provider(Network.DEVNET)
  * const account = await provider.getAccount("0x123");
- * const accountNFTs = await provider.getAccountNFTs("0x123");
+ * const accountTokens = await provider.getOwnedTokens("0x123");
  * ```
  *
- * @param network enum of type Network - MAINNET | TESTNET | DEVENET or custom endpoints of type CustomEndpoints
+ * @example An example of how to use this class with a local network. Indexer
+ * doesn't support local network.
+ * ```
+ * const provider = new Provider(Network.LOCAL)
+ * const account = await provider.getAccount("0x123");
+ * ```
+ *
+ * @example An example of how to use this class with a lcustom network.
+ * ```
+ * const provider = new Provider({fullnodeUrl:"my-fullnode-url",indexerUrl:"my-indexer-url"})
+ * const account = await provider.getAccount("0x123");
+ * const accountTokens = await provider.getOwnedTokens("0x123");
+ * ```
+ *
+ * @param network enum of type Network - MAINNET | TESTNET | DEVNET | LOCAL or custom endpoints of type CustomEndpoints
  * @param config AptosClient config arg - additional configuration options for the generated Axios client.
  */
 export class Provider {
   aptosClient: AptosClient;
 
-  indexerClient: IndexerClient;
+  indexerClient?: IndexerClient;
 
   network: NetworkWithCustom;
 
@@ -45,12 +59,14 @@ export class Provider {
       this.network = network;
     }
 
-    if (!fullNodeUrl || !indexerUrl) {
-      throw new Error("network is not provided");
+    if (this.network === "CUSTOM" && !fullNodeUrl) {
+      throw new Error("fullnode url is not provided");
     }
 
+    if (indexerUrl) {
+      this.indexerClient = new IndexerClient(indexerUrl, config);
+    }
     this.aptosClient = new AptosClient(fullNodeUrl, config, doNotFixNodeUrl);
-    this.indexerClient = new IndexerClient(indexerUrl, config);
   }
 }
 
@@ -97,10 +113,5 @@ applyMixin(Provider, IndexerClient, "indexerClient");
 
 // use exhaustive type predicates
 function isCustomEndpoints(network: CustomEndpoints): network is CustomEndpoints {
-  return (
-    network.fullnodeUrl !== undefined &&
-    typeof network.fullnodeUrl === "string" &&
-    network.indexerUrl !== undefined &&
-    typeof network.indexerUrl === "string"
-  );
+  return network.fullnodeUrl !== undefined && typeof network.fullnodeUrl === "string";
 }

--- a/ecosystem/typescript/sdk/src/tests/e2e/provider.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/provider.test.ts
@@ -3,15 +3,35 @@ import { Network, NetworkToIndexerAPI, NetworkToNodeAPI } from "../../utils";
 
 describe("Provider", () => {
   it("uses provided network as API", async () => {
-    const provider = new Provider(Network.DEVNET);
-    expect(provider.aptosClient.nodeUrl).toBe(NetworkToNodeAPI[Network.DEVNET]);
-    expect(provider.indexerClient.endpoint).toBe(NetworkToIndexerAPI[Network.DEVNET]);
+    const providerDevnet = new Provider(Network.DEVNET);
+    expect(providerDevnet.aptosClient.nodeUrl).toBe(NetworkToNodeAPI[Network.DEVNET]);
+    expect(providerDevnet.indexerClient?.endpoint).toBe(NetworkToIndexerAPI[Network.DEVNET]);
+
+    const providerTestnet = new Provider(Network.TESTNET);
+    expect(providerTestnet.aptosClient.nodeUrl).toBe(NetworkToNodeAPI[Network.TESTNET]);
+    expect(providerTestnet.indexerClient?.endpoint).toBe(NetworkToIndexerAPI[Network.TESTNET]);
+
+    const providerMainnet = new Provider(Network.MAINNET);
+    expect(providerMainnet.aptosClient.nodeUrl).toBe(NetworkToNodeAPI[Network.MAINNET]);
+    expect(providerMainnet.indexerClient?.endpoint).toBe(NetworkToIndexerAPI[Network.MAINNET]);
   });
 
   it("uses custom endpoints as API", async () => {
     const provider = new Provider({ fullnodeUrl: "full-node-url", indexerUrl: "indexer-url" });
     expect(provider.aptosClient.nodeUrl).toBe("full-node-url/v1");
-    expect(provider.indexerClient.endpoint).toBe("indexer-url");
+    expect(provider.indexerClient?.endpoint).toBe("indexer-url");
+  });
+
+  it("does not set indexer client when indexer url is not provided with a custom network", async () => {
+    const provider = new Provider({ fullnodeUrl: "full-node-url" });
+    expect(provider.aptosClient.nodeUrl).toBe("full-node-url/v1");
+    expect(provider.indexerClient).toBe(undefined);
+  });
+
+  it("does not set indexer client when local netowrk is provided", async () => {
+    const provider = new Provider(Network.LOCAL);
+    expect(provider.aptosClient.nodeUrl).toBe(NetworkToNodeAPI[Network.LOCAL]);
+    expect(provider.indexerClient).toBe(undefined);
   });
 
   it("includes static methods", async () => {
@@ -19,10 +39,10 @@ describe("Provider", () => {
     expect(Provider).toHaveProperty("generateBCSSimulation");
   });
 
-  it("throws error when endpoint not provided", async () => {
+  it("throws error when fullnode url is not provided", async () => {
     expect(() => {
-      new Provider({ fullnodeUrl: "", indexerUrl: "" });
-    }).toThrow("network is not provided");
+      new Provider({ fullnodeUrl: "" });
+    }).toThrow("fullnode url is not provided");
   });
 
   it("has AptosClient method defined", () => {

--- a/ecosystem/typescript/sdk/src/utils/api-endpoints.ts
+++ b/ecosystem/typescript/sdk/src/utils/api-endpoints.ts
@@ -8,18 +8,21 @@ export const NetworkToNodeAPI: Record<string, string> = {
   mainnet: "https://fullnode.mainnet.aptoslabs.com/v1",
   testnet: "https://fullnode.testnet.aptoslabs.com/v1",
   devnet: "https://fullnode.devnet.aptoslabs.com/v1",
+  local: "http://localhost:8080/v1",
 };
 
 export const NodeAPIToNetwork: Record<string, string> = {
   "https://fullnode.mainnet.aptoslabs.com/v1": "mainnet",
   "https://fullnode.testnet.aptoslabs.com/v1": "testnet",
   "https://fullnode.devnet.aptoslabs.com/v1": "devnet",
+  "http://localhost:8080/v1": "local",
 };
 
 export enum Network {
   MAINNET = "mainnet",
   TESTNET = "testnet",
   DEVNET = "devnet",
+  LOCAL = "local",
 }
 
 export interface CustomEndpoints {


### PR DESCRIPTION
### Description
relive https://github.com/aptos-labs/aptos-core/pull/8850 - support `Network.LOCAL` enum for local development. It isn't ideal though, because an indexer client still exists, it just won't work correctly.
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
