### PR TITLE
[Python SDK] Add a token_transfer function to the python SDK

### DIFF
--- a/ecosystem/python/sdk/aptos_sdk/aptos_token_client.py
+++ b/ecosystem/python/sdk/aptos_sdk/aptos_token_client.py
@@ -9,8 +9,7 @@ from .account import Account
 from .account_address import AccountAddress
 from .async_client import RestClient
 from .bcs import Deserializer, Serializer
-from .transactions import (EntryFunction, TransactionArgument,
-                           TransactionPayload)
+from .transactions import EntryFunction, TransactionArgument, TransactionPayload
 from .type_tag import StructTag, TypeTag
 
 

--- a/ecosystem/python/sdk/aptos_sdk/aptos_token_client.py
+++ b/ecosystem/python/sdk/aptos_sdk/aptos_token_client.py
@@ -9,7 +9,8 @@ from .account import Account
 from .account_address import AccountAddress
 from .async_client import RestClient
 from .bcs import Deserializer, Serializer
-from .transactions import EntryFunction, TransactionArgument, TransactionPayload
+from .transactions import (EntryFunction, TransactionArgument,
+                           TransactionPayload)
 from .type_tag import StructTag, TypeTag
 
 
@@ -383,6 +384,7 @@ class AptosTokenClient:
 
         return TransactionPayload(payload)
 
+    # :!:>create_collection
     async def create_collection(
         self,
         creator: Account,
@@ -401,7 +403,7 @@ class AptosTokenClient:
         tokens_freezable_by_creator: bool,
         royalty_numerator: int,
         royalty_denominator: int,
-    ) -> str:
+    ) -> str:  # <:!:create_collection
         payload = AptosTokenClient.create_collection_payload(
             description,
             max_supply,
@@ -458,6 +460,7 @@ class AptosTokenClient:
 
         return TransactionPayload(payload)
 
+    # :!:>mint_token
     async def mint_token(
         self,
         creator: Account,
@@ -466,7 +469,7 @@ class AptosTokenClient:
         name: str,
         uri: str,
         properties: PropertyMap,
-    ) -> str:
+    ) -> str:  # <:!:mint_token
         payload = AptosTokenClient.mint_token_payload(
             collection, description, name, uri, properties
         )
@@ -514,6 +517,27 @@ class AptosTokenClient:
             creator, TransactionPayload(payload)
         )
         return await self.client.submit_bcs_transaction(signed_transaction)
+
+    # :!:>transfer_token
+    async def transfer_token(
+        self, sender: Account, token: AccountAddress, to: AccountAddress
+    ) -> str:
+        payload = EntryFunction.natural(
+            "0x1::object",
+            "transfer",
+            [TypeTag(StructTag.from_str("0x4::token::Token"))],
+            [
+                TransactionArgument(token, Serializer.struct),
+                TransactionArgument(to, Serializer.struct),
+            ],
+        )
+
+        signed_transaction = await self.client.create_bcs_signed_transaction(
+            sender, TransactionPayload(payload)
+        )
+        return await self.client.submit_bcs_transaction(
+            signed_transaction
+        )  # <:!:transfer_token
 
     async def burn_token(self, creator: Account, token: AccountAddress) -> str:
         payload = EntryFunction.natural(

--- a/ecosystem/python/sdk/aptos_sdk/aptos_token_client.py
+++ b/ecosystem/python/sdk/aptos_sdk/aptos_token_client.py
@@ -519,24 +519,9 @@ class AptosTokenClient:
 
     # :!:>transfer_token
     async def transfer_token(
-        self, sender: Account, token: AccountAddress, to: AccountAddress
+        self, owner: Account, token: AccountAddress, to: AccountAddress
     ) -> str:
-        payload = EntryFunction.natural(
-            "0x1::object",
-            "transfer",
-            [TypeTag(StructTag.from_str("0x4::token::Token"))],
-            [
-                TransactionArgument(token, Serializer.struct),
-                TransactionArgument(to, Serializer.struct),
-            ],
-        )
-
-        signed_transaction = await self.client.create_bcs_signed_transaction(
-            sender, TransactionPayload(payload)
-        )
-        return await self.client.submit_bcs_transaction(
-            signed_transaction
-        )  # <:!:transfer_token
+        return await self.client.transfer_object(owner, token, to) # <:!:transfer_token
 
     async def burn_token(self, creator: Account, token: AccountAddress) -> str:
         payload = EntryFunction.natural(

--- a/ecosystem/python/sdk/aptos_sdk/aptos_token_client.py
+++ b/ecosystem/python/sdk/aptos_sdk/aptos_token_client.py
@@ -521,7 +521,7 @@ class AptosTokenClient:
     async def transfer_token(
         self, owner: Account, token: AccountAddress, to: AccountAddress
     ) -> str:
-        return await self.client.transfer_object(owner, token, to) # <:!:transfer_token
+        return await self.client.transfer_object(owner, token, to)  # <:!:transfer_token
 
     async def burn_token(self, creator: Account, token: AccountAddress) -> str:
         payload = EntryFunction.natural(

--- a/ecosystem/python/sdk/aptos_sdk/async_client.py
+++ b/ecosystem/python/sdk/aptos_sdk/async_client.py
@@ -751,7 +751,7 @@ class RestClient:
             "0x3::token::CollectionData",
             collection_name,
         )
-    
+
     async def transfer_object(
         self, owner: Account, object: AccountAddress, to: AccountAddress
     ) -> str:

--- a/ecosystem/python/sdk/aptos_sdk/async_client.py
+++ b/ecosystem/python/sdk/aptos_sdk/async_client.py
@@ -751,6 +751,27 @@ class RestClient:
             "0x3::token::CollectionData",
             collection_name,
         )
+    
+    async def transfer_object(
+        self, owner: Account, object: AccountAddress, to: AccountAddress
+    ) -> str:
+        transaction_arguments = [
+            TransactionArgument(object, Serializer.struct),
+            TransactionArgument(to, Serializer.struct),
+        ]
+
+        payload = EntryFunction.natural(
+            "0x1::object",
+            "transfer_call",
+            [],
+            transaction_arguments,
+        )
+
+        signed_transaction = await self.create_bcs_signed_transaction(
+            owner,
+            TransactionPayload(payload),
+        )
+        return await self.submit_bcs_transaction(signed_transaction)
 
 
 class FaucetClient:

--- a/ecosystem/python/sdk/examples/aptos-token.py
+++ b/ecosystem/python/sdk/examples/aptos-token.py
@@ -5,7 +5,7 @@ import asyncio
 
 from aptos_sdk.account import Account
 from aptos_sdk.account_address import AccountAddress
-from aptos_sdk.aptos_token_client import AptosTokenClient, Property, PropertyMap
+from aptos_sdk.aptos_token_client import AptosTokenClient, Property, PropertyMap, Object
 from aptos_sdk.async_client import FaucetClient, RestClient
 
 from .common import FAUCET_URL, NODE_URL
@@ -106,6 +106,17 @@ async def main():
     await rest_client.wait_for_transaction(txn_hash)
     token_data = await token_client.read_object(token_addr)
     print(f"Alice's token: {token_data}")
+
+    print("\n=== Transferring the Token from Alice to Bob ===")
+    print(f"Alice: {alice.address()}")
+    print(f"Bob:   {bob.address()}")
+    print(f"Token: {token_addr}\n")
+    print(f"Owner: {token_data.resources[Object].owner}")
+    print("    ...transferring...    ")
+    txn_hash = await rest_client.transfer_object(alice, token_addr, bob.address())
+    await rest_client.wait_for_transaction(txn_hash)
+    token_data = await token_client.read_object(token_addr)
+    print(f"Owner: {token_data.resources[Object].owner}\n")
 
     await rest_client.close()
 

--- a/ecosystem/python/sdk/examples/aptos-token.py
+++ b/ecosystem/python/sdk/examples/aptos-token.py
@@ -5,7 +5,7 @@ import asyncio
 
 from aptos_sdk.account import Account
 from aptos_sdk.account_address import AccountAddress
-from aptos_sdk.aptos_token_client import AptosTokenClient, Property, PropertyMap, Object
+from aptos_sdk.aptos_token_client import AptosTokenClient, Object, Property, PropertyMap
 from aptos_sdk.async_client import FaucetClient, RestClient
 
 from .common import FAUCET_URL, NODE_URL


### PR DESCRIPTION
### Description

Adding a `token_transfer` function to the python client. It is really just an object transfer, but wasn't sure where to put an object transfer for now.

The transfer function and the extra documentation tags are for my next PR for the `your first non-fungible asset` tutorial that I'm updating ASAP.

----

e: Moved the transfer call to the rest client as a generic object_transfer function and updated the token_transfer function to call object_transfer. Added a simple example of it to the end of the `aptos-token.py` example:

```yaml
=== Transferring the Token from Alice to Bob ===
Alice: 0x8a6a0b29ae3ccbf00a2aba89612b19b265ad5162ccce9159b6af424774c45bae
Bob:   0x409dba9c7d4f4d6866071895fe79dbf7ba7db16486f47343ba4be0da849d76a9
Token: 0xd9f96e6cfd4eead5ba84b877b654de72fddf1ecba5abf8eba035be5721821df6

Owner: 0x8a6a0b29ae3ccbf00a2aba89612b19b265ad5162ccce9159b6af424774c45bae
    ...transferring...    
Owner: 0x409dba9c7d4f4d6866071895fe79dbf7ba7db16486f47343ba4be0da849d76a9
```