### PR TITLE
[ts-sdk example] Adding an example for rotation offer capability and signer offer capability with signed structs

### DIFF
--- a/ecosystem/typescript/sdk/examples/typescript-esm/offer_capabilities.ts
+++ b/ecosystem/typescript/sdk/examples/typescript-esm/offer_capabilities.ts
@@ -1,0 +1,137 @@
+import { AptosAccount, FaucetClient, Network, Provider, HexString, TxnBuilderTypes, BCS, Types } from "aptos";
+import assert from "assert";
+
+const NETWORK = Network.DEVNET;
+const FAUCET_URL = process.env.APTOS_FAUCET_URL || "https://faucet.devnet.aptoslabs.com";
+const APTOS_COIN_DECIMALS = 8;
+
+const CORE_CODE_ADDRESS = new HexString("0x0000000000000000000000000000000000000000000000000000000000000001");
+const ED25519_ACCOUNT_SCHEME = 0;
+
+// Works for both SignerCapabilityOffer and RotationCapabilityOffer.
+// The structName changes and chainId isn't used in SignerCapabilityOffer
+type CapabilityOfferProofChallengeV2 = {
+  accountAddress: TxnBuilderTypes.AccountAddress;
+  moduleName: string;
+  structName: string;
+  chainId?: number; // not used in SignerCapabilityOffer
+  sequenceNumber: number;
+  sourceAddress: TxnBuilderTypes.AccountAddress;
+  recipientAddress: TxnBuilderTypes.AccountAddress;
+};
+
+const createAndFundAliceAndBob = async (
+  faucetClient: FaucetClient,
+): Promise<{ alice: AptosAccount; bob: AptosAccount }> => {
+  console.log(`-------------------  Creating and funding a new Bob & Alice  -------------------`);
+  const alice = new AptosAccount();
+  const bob = new AptosAccount();
+  await faucetClient.fundAccount(alice.address(), 1 * Math.pow(10, APTOS_COIN_DECIMALS));
+  await faucetClient.fundAccount(bob.address(), 1 * Math.pow(10, APTOS_COIN_DECIMALS));
+  console.log({
+    alice: alice.address().toString(),
+    bob: bob.address().toString(),
+  });
+  return {
+    alice,
+    bob,
+  };
+};
+
+(async () => {
+  const provider = new Provider(NETWORK);
+  const faucetClient = new FaucetClient(provider.aptosClient.nodeUrl, FAUCET_URL);
+
+  // Offer rotation capability
+  {
+    // Create and fund two new accounts
+    const { alice, bob } = await createAndFundAliceAndBob(faucetClient);
+    // Note that the rotation capability offer needs the chainId
+    console.log(`-------------------  RotationCapabilityOfferProofChallengeV2 ------------------`);
+    const { hash, version, success, payload } = await signStructAndSubmitTransaction(
+      provider,
+      alice,
+      "offer_rotation_capability",
+      {
+        accountAddress: TxnBuilderTypes.AccountAddress.fromHex(CORE_CODE_ADDRESS),
+        moduleName: "account",
+        structName: "RotationCapabilityOfferProofChallengeV2",
+        chainId: await provider.aptosClient.getChainId(),
+        sequenceNumber: Number((await provider.aptosClient.getAccount(alice.address())).sequence_number),
+        sourceAddress: TxnBuilderTypes.AccountAddress.fromHex(alice.address()),
+        recipientAddress: TxnBuilderTypes.AccountAddress.fromHex(bob.address()),
+      },
+    );
+    console.log({ hash, version, success, payload });
+    const { data } = await provider.aptosClient.getAccountResource(alice.address(), "0x1::account::Account");
+    const offerFor = (data as any).rotation_capability_offer.for.vec[0];
+    console.log({ rotation_capability_offer: { for: offerFor }, bob: bob.address().toString() });
+    assert(offerFor.toString() == bob.address().toString(), "Bob's address should be in the rotation capability offer");
+  }
+
+  // Offer signer capability
+  {
+    // Create and fund two new accounts
+    const { alice, bob } = await createAndFundAliceAndBob(faucetClient);
+    // Note that the signer capability offer doesn't require the chainId
+    console.log(`-------------------  SignerCapabilityOfferProofChallengeV2 -------------------`);
+    const { hash, version, success, payload } = await signStructAndSubmitTransaction(
+      provider,
+      alice,
+      "offer_signer_capability",
+      {
+        accountAddress: TxnBuilderTypes.AccountAddress.fromHex(CORE_CODE_ADDRESS),
+        moduleName: "account",
+        structName: "SignerCapabilityOfferProofChallengeV2",
+        sequenceNumber: Number((await provider.aptosClient.getAccount(alice.address())).sequence_number),
+        sourceAddress: TxnBuilderTypes.AccountAddress.fromHex(alice.address()),
+        recipientAddress: TxnBuilderTypes.AccountAddress.fromHex(bob.address()),
+      },
+    );
+    console.log({ hash, version, success, payload });
+    const { data } = await provider.aptosClient.getAccountResource(alice.address(), "0x1::account::Account");
+    const offerFor = (data as any).signer_capability_offer.for.vec[0];
+    console.log({ signer_capability_offer: { for: offerFor }, bob: bob.address().toString() });
+    assert(offerFor.toString() == bob.address().toString(), "Bob's address should be in the signer capability offer");
+  }
+})();
+
+const signStructAndSubmitTransaction = async (
+  provider: Provider,
+  signer: AptosAccount,
+  funcName: string,
+  struct: CapabilityOfferProofChallengeV2,
+): Promise<any> => {
+  // The proof bytes are just the individual BCS serialized
+  // data concatenated into a single byte array.
+  const proofBytes = new Uint8Array([
+    ...BCS.bcsToBytes(struct.accountAddress),
+    ...BCS.bcsSerializeStr(struct.moduleName),
+    ...BCS.bcsSerializeStr(struct.structName),
+    ...(struct.chainId ? BCS.bcsSerializeU8(struct.chainId) : []),
+    ...BCS.bcsSerializeUint64(struct.sequenceNumber),
+    ...BCS.bcsToBytes(struct.sourceAddress),
+    ...BCS.bcsToBytes(struct.recipientAddress),
+  ]);
+
+  // This is the actual signature of the struct.
+  const signedMessage = signer.signBuffer(proofBytes).toUint8Array();
+
+  // Note the hard-coded account scheme. You may need to accomodate MultiEd25519.
+  const payload = new TxnBuilderTypes.TransactionPayloadEntryFunction(
+    TxnBuilderTypes.EntryFunction.natural(
+      `0x1::account`,
+      funcName,
+      [],
+      [
+        BCS.bcsSerializeBytes(signedMessage),
+        BCS.bcsSerializeU8(ED25519_ACCOUNT_SCHEME),
+        BCS.bcsSerializeBytes(signer.pubKey().toUint8Array()),
+        BCS.bcsToBytes(struct.recipientAddress),
+      ],
+    ),
+  );
+
+  const txn = await provider.generateSignSubmitTransaction(signer, payload);
+  return (await provider.waitForTransactionWithResult(txn)) as Types.UserTransaction;
+};

--- a/ecosystem/typescript/sdk/examples/typescript-esm/offer_capabilities.ts
+++ b/ecosystem/typescript/sdk/examples/typescript-esm/offer_capabilities.ts
@@ -47,11 +47,11 @@ const createAndFundAliceAndBob = async (
   // Offer Alice's rotation capability to Bob
   {
     // Construct the RotationCapabilityOfferProofChallengeV2 struct
-    const rotationCapabilityOffer: CapabilityOfferProofChallengeV2 = {
+    const rotationCapProof: CapabilityOfferProofChallengeV2 = {
       accountAddress: moduleAddress,
       moduleName: "account",
       structName: "RotationCapabilityOfferProofChallengeV2",
-      sequenceNumber: Number((await provider.getAccount(alice.address())).sequence_number),
+      sequenceNumber: Number((await provider.getAccount(alice.address())).sequence_number), // Get latest sequence number
       sourceAddress: aliceAccountAddress,
       recipientAddress: bobAccountAddress,
       chainId,
@@ -60,12 +60,7 @@ const createAndFundAliceAndBob = async (
     console.log(`\n---------------  RotationCapabilityOfferProofChallengeV2 --------------\n`);
 
     // Sign the BCS-serialized struct, submit the transaction, and wait for the result.
-    const res = await signStructAndSubmitTransaction(
-      provider,
-      alice,
-      "offer_rotation_capability",
-      rotationCapabilityOffer,
-    );
+    const res = await signStructAndSubmitTransaction(provider, alice, "offer_rotation_capability", rotationCapProof);
 
     // Print the relevant transaction submission info
     const { hash, version, success, payload } = res;
@@ -85,11 +80,11 @@ const createAndFundAliceAndBob = async (
   // Offer Alice's signer capability to Bob
   {
     // Construct the SignerCapabilityOfferProofChallengeV2 struct
-    const signerCapabilityOffer: CapabilityOfferProofChallengeV2 = {
+    const signerCapProof: CapabilityOfferProofChallengeV2 = {
       accountAddress: moduleAddress,
       moduleName: "account",
       structName: "SignerCapabilityOfferProofChallengeV2",
-      sequenceNumber: Number((await provider.getAccount(alice.address())).sequence_number),
+      sequenceNumber: Number((await provider.getAccount(alice.address())).sequence_number), // Get latest sequence number
       sourceAddress: aliceAccountAddress,
       recipientAddress: bobAccountAddress,
       // Note no chainId, the signer capability offer doesn't require it. We leave it undefined
@@ -98,7 +93,7 @@ const createAndFundAliceAndBob = async (
     console.log(`\n---------------  SignerCapabilityOfferProofChallengeV2 ---------------\n`);
 
     // Sign the BCS-serialized struct, submit the transaction, and wait for the result.
-    const res = await signStructAndSubmitTransaction(provider, alice, "offer_signer_capability", signerCapabilityOffer);
+    const res = await signStructAndSubmitTransaction(provider, alice, "offer_signer_capability", signerCapProof);
 
     // Print the relevant transaction submission info
     const { hash, version, success, payload } = res;

--- a/ecosystem/typescript/sdk/examples/typescript-esm/offer_capabilities.ts
+++ b/ecosystem/typescript/sdk/examples/typescript-esm/offer_capabilities.ts
@@ -57,7 +57,7 @@ const createAndFundAliceAndBob = async (
         moduleName: "account",
         structName: "RotationCapabilityOfferProofChallengeV2",
         chainId: await provider.aptosClient.getChainId(),
-        sequenceNumber: Number((await provider.aptosClient.getAccount(alice.address())).sequence_number),
+        sequenceNumber: Number((await provider.getAccount(alice.address())).sequence_number),
         sourceAddress: TxnBuilderTypes.AccountAddress.fromHex(alice.address()),
         recipientAddress: TxnBuilderTypes.AccountAddress.fromHex(bob.address()),
       },

--- a/ecosystem/typescript/sdk/examples/typescript-esm/offer_capabilities.ts
+++ b/ecosystem/typescript/sdk/examples/typescript-esm/offer_capabilities.ts
@@ -10,10 +10,10 @@ type CapabilityOfferProofChallengeV2 = {
   accountAddress: TxnBuilderTypes.AccountAddress;
   moduleName: string;
   structName: string;
-  chainId?: number; // not used in SignerCapabilityOffer
   sequenceNumber: number;
   sourceAddress: TxnBuilderTypes.AccountAddress;
   recipientAddress: TxnBuilderTypes.AccountAddress;
+  chainId?: number; // not used in SignerCapabilityOffer
 };
 
 const createAndFundAliceAndBob = async (
@@ -52,10 +52,10 @@ const createAndFundAliceAndBob = async (
         accountAddress: TxnBuilderTypes.AccountAddress.fromHex(CORE_CODE_ADDRESS),
         moduleName: "account",
         structName: "RotationCapabilityOfferProofChallengeV2",
-        chainId: await provider.aptosClient.getChainId(),
         sequenceNumber: Number((await provider.getAccount(alice.address())).sequence_number),
         sourceAddress: TxnBuilderTypes.AccountAddress.fromHex(alice.address()),
         recipientAddress: TxnBuilderTypes.AccountAddress.fromHex(bob.address()),
+        chainId: await provider.aptosClient.getChainId(),
       },
     );
     console.log({ hash, version, success, payload });
@@ -100,6 +100,7 @@ const signStructAndSubmitTransaction = async (
 ): Promise<any> => {
   // The proof bytes are just the individual BCS serialized
   // data concatenated into a single byte array.
+  // Note that the proof bytes must be constructed in this specific order- the order of the struct data on-chain.
   const proofBytes = new Uint8Array([
     ...BCS.bcsToBytes(struct.accountAddress),
     ...BCS.bcsSerializeStr(struct.moduleName),

--- a/ecosystem/typescript/sdk/examples/typescript-esm/offer_capabilities.ts
+++ b/ecosystem/typescript/sdk/examples/typescript-esm/offer_capabilities.ts
@@ -19,7 +19,7 @@ type CapabilityOfferProofChallengeV2 = {
 const createAndFundAliceAndBob = async (
   faucetClient: FaucetClient,
 ): Promise<{ alice: AptosAccount; bob: AptosAccount }> => {
-  console.log(`-------------------  Creating and funding a new Bob & Alice  -------------------`);
+  console.log(`---------------  Creating and funding a new Bob & Alice  ---------------`);
   const alice = new AptosAccount();
   const bob = new AptosAccount();
   await faucetClient.fundAccount(alice.address(), 100_000_000);
@@ -43,7 +43,7 @@ const createAndFundAliceAndBob = async (
     // Create and fund two new accounts
     const { alice, bob } = await createAndFundAliceAndBob(faucetClient);
     // Note that the rotation capability offer needs the chainId
-    console.log(`-------------------  RotationCapabilityOfferProofChallengeV2 ------------------`);
+    console.log(`---------------  RotationCapabilityOfferProofChallengeV2 --------------`);
     const { hash, version, success, payload } = await signStructAndSubmitTransaction(
       provider,
       alice,
@@ -70,7 +70,7 @@ const createAndFundAliceAndBob = async (
     // Create and fund two new accounts
     const { alice, bob } = await createAndFundAliceAndBob(faucetClient);
     // Note that the signer capability offer doesn't require the chainId
-    console.log(`-------------------  SignerCapabilityOfferProofChallengeV2 -------------------`);
+    console.log(`---------------  SignerCapabilityOfferProofChallengeV2 ---------------`);
     const { hash, version, success, payload } = await signStructAndSubmitTransaction(
       provider,
       alice,

--- a/ecosystem/typescript/sdk/examples/typescript-esm/offer_capabilities.ts
+++ b/ecosystem/typescript/sdk/examples/typescript-esm/offer_capabilities.ts
@@ -1,10 +1,6 @@
 import { AptosAccount, FaucetClient, Network, Provider, HexString, TxnBuilderTypes, BCS, Types } from "aptos";
 import assert from "assert";
 
-const NETWORK = Network.DEVNET;
-const FAUCET_URL = process.env.APTOS_FAUCET_URL || "https://faucet.devnet.aptoslabs.com";
-const APTOS_COIN_DECIMALS = 8;
-
 const CORE_CODE_ADDRESS = new HexString("0x0000000000000000000000000000000000000000000000000000000000000001");
 const ED25519_ACCOUNT_SCHEME = 0;
 
@@ -26,8 +22,8 @@ const createAndFundAliceAndBob = async (
   console.log(`-------------------  Creating and funding a new Bob & Alice  -------------------`);
   const alice = new AptosAccount();
   const bob = new AptosAccount();
-  await faucetClient.fundAccount(alice.address(), 1 * Math.pow(10, APTOS_COIN_DECIMALS));
-  await faucetClient.fundAccount(bob.address(), 1 * Math.pow(10, APTOS_COIN_DECIMALS));
+  await faucetClient.fundAccount(alice.address(), 100_000_000);
+  await faucetClient.fundAccount(bob.address(), 100_000_000);
   console.log({
     alice: alice.address().toString(),
     bob: bob.address().toString(),
@@ -39,8 +35,8 @@ const createAndFundAliceAndBob = async (
 };
 
 (async () => {
-  const provider = new Provider(NETWORK);
-  const faucetClient = new FaucetClient(provider.aptosClient.nodeUrl, FAUCET_URL);
+  const provider = new Provider(Network.DEVNET);
+  const faucetClient = new FaucetClient(provider.aptosClient.nodeUrl, "https://faucet.devnet.aptoslabs.com");
 
   // Offer rotation capability
   {

--- a/ecosystem/typescript/sdk/examples/typescript-esm/package.json
+++ b/ecosystem/typescript/sdk/examples/typescript-esm/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "rm -rf dist/* && tsc -p .",
     "test": "pnpm build && node ./dist/index.js",
+    "offer_capabilities": "ts-node --esm offer_capabilities.ts",
     "rotate_key": "ts-node --esm rotate_key.ts"
   },
   "keywords": [],


### PR DESCRIPTION
### Description

It is sort of unclear how to sign Move structs with the typescript SDK, this PR is two examples that should make it more clear.

It is also an example of how to use the `account::offer_rotate_capability` and `account::offer_signer_capability` Move functions.

Note that for some reason the assertion failed for me a few times even though the offer was correct. Not sure what was going on there or how to reproduce it. It was on localnet, I thought it was a stale sequence number at first but wasn't able to produce the error again after casting the addresses to strings

### Test Plan

`cd ~/aptos-core/ecosystem/typescript/sdk/examples/typescript-esm && pnpm run offer_capabilities`

The scripts assert at the end that the account's resources reflect the new offers (Alice offers to Bob).