### PR TITLE
Add functions that allow using vector like a set

### DIFF
--- a/aptos-move/framework/move-stdlib/doc/vector.md
+++ b/aptos-move/framework/move-stdlib/doc/vector.md
@@ -36,9 +36,12 @@ the return on investment didn't seem worth it for these simple functions.
 -  [Function `index_of`](#0x1_vector_index_of)
 -  [Function `find`](#0x1_vector_find)
 -  [Function `insert`](#0x1_vector_insert)
+-  [Function `push_unique`](#0x1_vector_push_unique)
 -  [Function `remove`](#0x1_vector_remove)
 -  [Function `remove_value`](#0x1_vector_remove_value)
 -  [Function `swap_remove`](#0x1_vector_swap_remove)
+-  [Function `find_remove`](#0x1_vector_find_remove)
+-  [Function `find_remove_by`](#0x1_vector_find_remove_by)
 -  [Function `for_each`](#0x1_vector_for_each)
 -  [Function `for_each_reverse`](#0x1_vector_for_each_reverse)
 -  [Function `for_each_ref`](#0x1_vector_for_each_ref)
@@ -679,6 +682,38 @@ Aborts if out of bounds.
 
 </details>
 
+<a name="0x1_vector_push_unique"></a>
+
+## Function `push_unique`
+
+Push a new element to the back of the vector if it is not already in the vector.
+This is O(n) in the worst case and preserves ordering of elements in the vector.
+Return <code><b>true</b></code> if <code>key</code> did not already exist in the vector and <code><b>false</b></code> otherwise.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_push_unique">push_unique</a>&lt;Element: drop&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_push_unique">push_unique</a>&lt;Element: drop&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element): bool {
+    <b>if</b> (<a href="vector.md#0x1_vector_contains">contains</a>(v, &e)) {
+        <b>false</b>
+    } <b>else</b> {
+        <a href="vector.md#0x1_vector_push_back">push_back</a>(v, e);
+        <b>true</b>
+    }
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x1_vector_remove"></a>
 
 ## Function `remove`
@@ -772,6 +807,76 @@ Aborts if <code>i</code> is out of bounds.
     <b>let</b> last_idx = <a href="vector.md#0x1_vector_length">length</a>(v) - 1;
     <a href="vector.md#0x1_vector_swap">swap</a>(v, i, last_idx);
     <a href="vector.md#0x1_vector_pop_back">pop_back</a>(v)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_find_remove"></a>
+
+## Function `find_remove`
+
+Remove the first occurrence of a given value in the vector <code>v</code> and return it in
+a vector, swapping the last element in the vector with the removed item.
+This is O(n) + O(1) and does NOT preserve ordering of elements in the vector.
+This returns an empty vector if the value isn't present in the vector.
+Note that this cannot return an option as option uses vector and there'd be a
+circular dependency between option and vector.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_find_remove">find_remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, val: &Element): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> inline <b>fun</b> <a href="vector.md#0x1_vector_find_remove">find_remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, val: &Element): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt; {
+    <b>let</b> (found, index) = <a href="vector.md#0x1_vector_index_of">index_of</a>(v, val);
+    <b>if</b> (found) {
+        <a href="vector.md#0x1_vector">vector</a>[<a href="vector.md#0x1_vector_swap_remove">swap_remove</a>(v, index)]
+    } <b>else</b> {
+       <a href="vector.md#0x1_vector">vector</a>[]
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_find_remove_by"></a>
+
+## Function `find_remove_by`
+
+Remove the first value that matches the predicate f in the vector <code>v</code> and return
+it in a vector, swapping the last element in the vector with the removed item.
+This is O(n) + O(1) and does NOT preserve ordering of elements in the vector.
+This returns an empty vector if the value isn't present in the vector.
+Note that this cannot return an option as option uses vector and there'd be a
+circular dependency between option and vector.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_find_remove_by">find_remove_by</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |&Element|bool): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> inline <b>fun</b> <a href="vector.md#0x1_vector_find_remove_by">find_remove_by</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, f: |&Element|bool): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt; {
+    <b>let</b> (found, index) = <a href="vector.md#0x1_vector_find">find</a>(v, |x| f(x));
+    <b>if</b> (found) {
+        <a href="vector.md#0x1_vector">vector</a>[<a href="vector.md#0x1_vector_swap_remove">swap_remove</a>(v, index)]
+    } <b>else</b> {
+       <a href="vector.md#0x1_vector">vector</a>[]
+    }
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/vector.move
+++ b/aptos-move/framework/move-stdlib/sources/vector.move
@@ -211,6 +211,18 @@ module std::vector {
         pragma intrinsic = true;
     }
 
+    /// Push a new element to the back of the vector if it is not already in the vector.
+    /// This is O(n) in the worst case and preserves ordering of elements in the vector.
+    /// Return `true` if `key` did not already exist in the vector and `false` otherwise.
+    public fun push_unique<Element: drop>(v: &mut vector<Element>, e: Element): bool {
+        if (contains(v, &e)) {
+            false
+        } else {
+            push_back(v, e);
+            true
+        }
+    }
+
     /// Remove the `i`th element of the vector `v`, shifting all subsequent elements.
     /// This is O(n) and preserves ordering of elements in the vector.
     /// Aborts if `i` is out of bounds.
@@ -258,6 +270,36 @@ module std::vector {
     }
     spec swap_remove {
         pragma intrinsic = true;
+    }
+
+    /// Remove the first occurrence of a given value in the vector `v` and return it in
+    /// a vector, swapping the last element in the vector with the removed item.
+    /// This is O(n) + O(1) and does NOT preserve ordering of elements in the vector.
+    /// This returns an empty vector if the value isn't present in the vector.
+    /// Note that this cannot return an option as option uses vector and there'd be a
+    /// circular dependency between option and vector.
+    public inline fun find_remove<Element>(v: &mut vector<Element>, val: &Element): vector<Element> {
+        let (found, index) = index_of(v, val);
+        if (found) {
+            vector[swap_remove(v, index)]
+        } else {
+           vector[]
+        }
+    }
+
+    /// Remove the first value that matches the predicate f in the vector `v` and return
+    /// it in a vector, swapping the last element in the vector with the removed item.
+    /// This is O(n) + O(1) and does NOT preserve ordering of elements in the vector.
+    /// This returns an empty vector if the value isn't present in the vector.
+    /// Note that this cannot return an option as option uses vector and there'd be a
+    /// circular dependency between option and vector.
+    public inline fun find_remove_by<Element>(v: &mut vector<Element>, f: |&Element|bool): vector<Element> {
+        let (found, index) = find(v, |x| f(x));
+        if (found) {
+            vector[swap_remove(v, index)]
+        } else {
+           vector[]
+        }
     }
 
     /// Apply the function to each element in the vector, consuming it.

--- a/aptos-move/framework/move-stdlib/tests/vector_tests.move
+++ b/aptos-move/framework/move-stdlib/tests/vector_tests.move
@@ -888,6 +888,45 @@ module std::vector_tests {
         vector::insert(&mut v,6, 6);
     }
 
+    #[test]
+    fun test_push_unique() {
+        let v:vector<u64> = vector[1, 2, 3, 4, 5];
+
+        let pushed = vector::push_unique(&mut v, 1);
+        assert!(&v == &vector[1, 2, 3, 4, 5], 1);
+        assert!(!pushed, 1);
+
+        let pushed = vector::push_unique(&mut v, 8);
+        assert!(&v == &vector[1, 2, 3, 4, 5, 8], 1);
+        assert!(pushed, 1);
+    }
+
+    #[test]
+    fun test_find_remove() {
+        let v: vector<u64> = vector[2, 3, 7, 4, 7, 5];
+
+        let out = vector::find_remove(&mut v, &7);
+        assert!(out == vector[7], 1);
+        assert!(v == vector[2, 3, 5, 4, 7], 1);
+
+        let out = vector::find_remove(&mut v, &9);
+        assert!(out == vector[], 1);
+        assert!(v == vector[2, 3, 5, 4, 7], 1);
+    }
+
+    #[test]
+    fun test_find_remove_by() {
+        let v: vector<u64> = vector[2, 3, 7, 4, 7, 5];
+
+        let out = vector::find_remove_by(&mut v, |x| *x > 6);
+        assert!(out == vector[7], 1);
+        assert!(&v == &vector[2, 3, 5, 4, 7], 1);
+
+        let out = vector::find_remove_by(&mut v, |x| *x < 1);
+        assert!(out == vector[], 1);
+        assert!(&v == &vector[2, 3, 5, 4, 7], 1);
+    }
+
     #[test_only]
     struct MoveOnly {}
 


### PR DESCRIPTION
### Description
These new functions make it possible to easily use `vector` as a set, removing the need for something like a SimpleSet (which just wraps a vector).

`push_unique` is just contains + push_back in a single function, which is what people using vector with unique elements have to do today themselves.

`swap_remove_value` provides a more efficient, unstable method for removing an item from a vector, which is fine if you're using the vector as a traditional set with no ordering of values.

I'm not sure if I should change the code in third_party too, it seems out of date compared to this version of vector.

### Test Plan
From `aptos-move/framework/move-stdlib`
```
$ aptos move test | grep -E 'test_push_unique|test_find_remove'
[ PASS    ] 0x1::vector_tests::test_find_remove
[ PASS    ] 0x1::vector_tests::test_find_remove_by
[ PASS    ] 0x1::vector_tests::test_push_unique
```