### PR TITLE
Run vector tests that were unintentionally not run

### DIFF
--- a/aptos-move/framework/move-stdlib/tests/vector_tests.move
+++ b/aptos-move/framework/move-stdlib/tests/vector_tests.move
@@ -855,6 +855,7 @@ module std::vector_tests {
         assert!(&v == &vector[2, 4, 3, 1, 5], 1);
     }
 
+    #[test]
     fun test_stable_partition() {
         let v:vector<u64> = vector[1, 2, 3, 4, 5];
 
@@ -868,6 +869,7 @@ module std::vector_tests {
         assert!(&v == &vector[2, 4, 1, 3, 5], 1);
     }
 
+    #[test]
     fun test_insert() {
         let v:vector<u64> = vector[1, 2, 3, 4, 5];
 


### PR DESCRIPTION
### Description
Looks like `#[test]` was omitted accidentally. This PR fixes that.

### Test Plan
```
$ aptos move test | grep test_stable_partition
[ PASS    ] 0x1::vector_tests::test_stable_partition
$ aptos move test | grep test_insert
[ PASS    ] 0x1::string_tests::test_insert
[ PASS    ] 0x1::vector_tests::test_insert
[ PASS    ] 0x1::vector_tests::test_insert_out_of_bounds
```
