### PR TITLE
[TS SDK] Return txn data on success and txn failure reason on failure

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 ## Unreleased
 
 - Add support for a fee payer transaction
+- Return transaction message error when transaction has failed when `checkSuccess` is set to true
 
 ## 1.16.0 (2023-08-02)
 

--- a/ecosystem/typescript/sdk/src/providers/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/providers/aptos_client.ts
@@ -759,7 +759,7 @@ export class AptosClient {
     }
     if (!(lastTxn as any)?.success) {
       throw new FailedTransactionError(
-        `Transaction ${txnHash} committed to the blockchain but execution failed`,
+        `Transaction ${txnHash} failed with an error: ${(lastTxn as any).vm_status}`,
         lastTxn,
       );
     }


### PR DESCRIPTION
### Description
The sdk provides a way to return the txn data when it succeed, added an example/test on how to use it.

For when a txn has failed, we throw an error with the txn hash and the failure reason message - Error class is a bit weird as it only outputs the "message" prop, unless we wrap it with try/catch and then we can get access to the other class properties, it feels like a big change for this use case and that should be good for now. 
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
