### PR TITLE
[Execution Benchmark] Remove spot runners and reduce frequency.

### DIFF
--- a/.github/workflows/execution-performance.yaml
+++ b/.github/workflows/execution-performance.yaml
@@ -2,9 +2,8 @@ name: "execution-performance"
 on:
   workflow_dispatch:
   pull_request:
-  schedule: 
-    # Run every four hours
-    - cron: "0 */4 * * *"
+  schedule:
+    - cron: "0 12 * * *" # This runs every day at 12pm UTC.
 
 jobs:
   execution-performance:
@@ -13,10 +12,3 @@ jobs:
     with:
       GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       RUNNER_NAME: executor-benchmark-runner
-
-  spot-runner-execution-performance:
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-execution-performance.yaml@main
-    secrets: inherit
-    with:
-      GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      RUNNER_NAME: spot-runner

--- a/.github/workflows/workflow-run-execution-performance.yaml
+++ b/.github/workflows/workflow-run-execution-performance.yaml
@@ -25,7 +25,6 @@ on:
         default: executor-benchmark-runner 
         type: choice
         options:
-        - spot-runner
         - executor-benchmark-runner
         description: The name of the runner to use for the test.
 


### PR DESCRIPTION
### Description
This PR removes the spot runner execution benchmark mode and reduces the job frequency from every 4 hours to daily. We shouldn't need to run it every 4 hours given that it runs on each PR 😄 

### Test Plan
Existing test infrastructure.