### PR TITLE
[CLI] Update build_cli_release.ps1 to include openssl

### DIFF
--- a/scripts/cli/build_cli_release.ps1
+++ b/scripts/cli/build_cli_release.ps1
@@ -11,9 +11,18 @@
 $NAME="aptos-cli"
 $CRATE_NAME="aptos"
 $CARGO_PATH="crates\$CRATE_NAME\Cargo.toml"
+$Env:VCPKG_ROOT = 'C:\vcpkg\'
 
 # Get the version of the CLI from its Cargo.toml.
 $VERSION = Get-Content $CARGO_PATH | Select-String -Pattern '^\w*version = "(\d*\.\d*.\d*)"' | % {"$($_.matches.groups[1])"}
+
+# Install the developer tools
+echo "Installing developer tools"
+PowerShell -ExecutionPolicy Bypass -File scripts/windows_dev_setup.ps1
+
+# Note: This is required to bypass openssl isssue on Windows.
+echo "Installing OpenSSL"
+vcpkg install openssl:x64-windows-static-md --clean-after-build
 
 # Build the CLI.
 echo "Building release $VERSION of $NAME for Windows"


### PR DESCRIPTION
### Description

Update the build script to make sure `openssl` install correctly. Otherwise we will see the following error when running the windows build

error: failed to run custom build command for `openssl-sys v0.9.85`

```
Caused by:
  process didn't exit successfully: `D:\a\aptos-core\aptos-core\target\cli\build\openssl-sys-c16c984f65a02d8a\build-script-main` (exit code: 101)
  --- stdout
  cargo:rerun-if-env-changed=X86_64_PC_WINDOWS_MSVC_OPENSSL_LIB_DIR
  X86_64_PC_WINDOWS_MSVC_OPENSSL_LIB_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_LIB_DIR
  OPENSSL_LIB_DIR unset
  cargo:rerun-if-env-changed=X86_64_PC_WINDOWS_MSVC_OPENSSL_INCLUDE_DIR
  X86_64_PC_WINDOWS_MSVC_OPENSSL_INCLUDE_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR
  OPENSSL_INCLUDE_DIR unset
  cargo:rerun-if-env-changed=X86_64_PC_WINDOWS_MSVC_OPENSSL_DIR
  X86_64_PC_WINDOWS_MSVC_OPENSSL_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_DIR
  OPENSSL_DIR unset
  note: vcpkg did not find openssl: Could not find Vcpkg tree: No vcpkg installation found. Set the VCPKG_ROOT environment variable or run 'vcpkg integrate install'

  --- stderr
  thread 'main' panicked at '

  Could not find directory of OpenSSL installation, and this `-sys` crate cannot
  proceed without this knowledge. If OpenSSL is installed and this crate had
  trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
  compilation process.

  Make sure you also have the development packages of openssl installed.
  For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.

  If you're in a situation where you think the directory *should* be found
  automatically, please open a bug at https://github.com/sfackler/rust-openssl
  and include information about your system as well as this message.

  $HOST = x86_64-pc-windows-msvc
  $TARGET = x86_64-pc-windows-msvc
  openssl-sys = 0.9.85


  It looks like you're compiling for MSVC but we couldn't detect an OpenSSL
  installation. If there isn't one installed then you can try the rust-openssl
  README for more information about how to download precompiled binaries of
  OpenSSL:

  https://github.com/sfackler/rust-openssl#windows

  ', C:\Users\runneradmin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\openssl-sys-0.9.85\build\find_normal.rs:190:5
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
Compressing CLI to aptos-cli-2.0.3-Windows-x86_64.zip
Compress-Archive: D:\a\aptos-core\aptos-core\scripts\cli\build_cli_release.ps1:32
Line |
  32 |  Compress-Archive -Path target\cli\$CRATE_NAME.exe -DestinationPath $Z …
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | The path 'target\cli\aptos.exe' either does not exist or is not a valid file system path.

Error: Process completed with exit code 1.
```

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Did a dry run and make sure it build successfully 

https://github.com/aptos-labs/aptos-core/actions/runs/5757104296
