### PR TITLE
[release-builder] Make release builder use a relative path for raw script

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -41,7 +41,7 @@ proposals:
       discussion_url: "https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-28.md"
     execution_mode: MultiStep
     update_sequence:
-    - RawScript: /aptos/aptos-move/aptos-release-builder/data/proposals/aip_28_initialization.move
+    - RawScript: aptos-move/aptos-release-builder/data/proposals/aip_28_initialization.move
     - FeatureFlag:
         enabled:
           - partial_governance_voting

--- a/aptos-move/aptos-release-builder/src/components/mod.rs
+++ b/aptos-move/aptos-release-builder/src/components/mod.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use self::framework::FrameworkReleaseConfig;
-use crate::{aptos_framework_path, components::feature_flags::Features, release_builder_path};
-use anyhow::{anyhow, bail, Result};
+use crate::{aptos_core_path, aptos_framework_path, components::feature_flags::Features};
+use anyhow::{anyhow, bail, Context, Result};
 use aptos::governance::GenerateExecutionHash;
 use aptos_rest_client::Client;
 use aptos_temppath::TempPath;
@@ -205,7 +205,7 @@ impl ReleaseEntry {
                 }
             },
             ReleaseEntry::RawScript(script_path) => {
-                let base_path = release_builder_path().join(script_path.as_path());
+                let base_path = aptos_core_path().join(script_path.as_path());
                 let file_name = base_path
                     .file_name()
                     .and_then(|name| name.to_str())
@@ -213,7 +213,8 @@ impl ReleaseEntry {
                         anyhow!("Unable to obtain file name for proposal: {:?}", script_path)
                     })?
                     .to_string();
-                let file_content = std::fs::read_to_string(base_path)?;
+                let file_content = std::fs::read_to_string(base_path)
+                    .with_context(|| format!("Unable to read file: {}", script_path.display()))?;
 
                 if let ExecutionMode::MultiStep = execution_mode {
                     // Render the hash for multi step proposal.
@@ -340,6 +341,19 @@ impl ReleaseConfig {
 
         // Create directories for source and metadata.
         let mut source_dir = base_path.to_path_buf();
+
+        // If source dir doesnt exist create it, if it does exist error
+        if !source_dir.exists() {
+            println!("Creating source directory: {:?}", source_dir);
+            std::fs::create_dir(source_dir.as_path()).map_err(|err| {
+                anyhow!(
+                    "Fail to create folder for source: {} {:?}",
+                    source_dir.display(),
+                    err
+                )
+            })?;
+        }
+
         source_dir.push("sources");
 
         std::fs::create_dir(source_dir.as_path())

--- a/aptos-move/aptos-release-builder/src/lib.rs
+++ b/aptos-move/aptos-release-builder/src/lib.rs
@@ -54,9 +54,3 @@ pub(crate) fn aptos_framework_path() -> PathBuf {
     path.push("aptos-move/framework/aptos-framework");
     path
 }
-
-pub(crate) fn release_builder_path() -> PathBuf {
-    let mut path = aptos_core_path();
-    path.push("aptos-move/aptos-release-builder");
-    path
-}

--- a/aptos-move/aptos-release-builder/src/main.rs
+++ b/aptos-move/aptos-release-builder/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::Context;
 use aptos_crypto::{ed25519::Ed25519PrivateKey, ValidCryptoMaterialStringExt};
 use aptos_release_builder::{
     initialize_aptos_core_path,
@@ -71,7 +71,7 @@ pub enum InputOptions {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() {
     let args = Argument::parse();
     initialize_aptos_core_path(args.aptos_core_path.clone());
 
@@ -80,11 +80,15 @@ async fn main() -> Result<()> {
         Commands::GenerateProposals {
             release_config,
             output_dir,
-        } => aptos_release_builder::ReleaseConfig::load_config(release_config.as_path())?
-            .generate_release_proposal_scripts(output_dir.as_path()),
-        Commands::WriteDefault { output_path } => {
-            aptos_release_builder::ReleaseConfig::default().save_config(output_path.as_path())
-        },
+        } => aptos_release_builder::ReleaseConfig::load_config(release_config.as_path())
+            .with_context(|| "Failed to load release config".to_string())
+            .unwrap()
+            .generate_release_proposal_scripts(output_dir.as_path())
+            .with_context(|| "Failed to generate release proposal scripts".to_string())
+            .unwrap(),
+        Commands::WriteDefault { output_path } => aptos_release_builder::ReleaseConfig::default()
+            .save_config(output_path.as_path())
+            .unwrap(),
         Commands::ValidateProposals {
             release_config,
             input_option,
@@ -94,7 +98,8 @@ async fn main() -> Result<()> {
             output_dir,
         } => {
             let config =
-                aptos_release_builder::ReleaseConfig::load_config(release_config.as_path())?;
+                aptos_release_builder::ReleaseConfig::load_config(release_config.as_path())
+                    .unwrap();
 
             let root_key_path = aptos_temppath::TempPath::new();
             root_key_path.create_as_file().unwrap();
@@ -104,21 +109,25 @@ async fn main() -> Result<()> {
                     aptos_release_builder::validate::NetworkConfig::new_from_dir(
                         endpoint.clone(),
                         test_dir.as_path(),
-                    )?
+                    )
+                    .unwrap()
                 },
                 InputOptions::FromArgs {
                     root_key,
                     validator_address,
                     validator_key,
                 } => {
-                    let root_key = Ed25519PrivateKey::from_encoded_string(&root_key)?;
-                    let validator_key = Ed25519PrivateKey::from_encoded_string(&validator_key)?;
-                    let validator_account = AccountAddress::from_hex(validator_address.as_bytes())?;
+                    let root_key = Ed25519PrivateKey::from_encoded_string(&root_key).unwrap();
+                    let validator_key =
+                        Ed25519PrivateKey::from_encoded_string(&validator_key).unwrap();
+                    let validator_account =
+                        AccountAddress::from_hex(validator_address.as_bytes()).unwrap();
 
                     let mut root_key_path = root_key_path.path().to_path_buf();
                     root_key_path.set_extension("key");
 
-                    std::fs::write(root_key_path.as_path(), bcs::to_bytes(&root_key)?)?;
+                    std::fs::write(root_key_path.as_path(), bcs::to_bytes(&root_key).unwrap())
+                        .unwrap();
 
                     aptos_release_builder::validate::NetworkConfig {
                         root_key_path,
@@ -135,30 +144,34 @@ async fn main() -> Result<()> {
             if mint_to_validator {
                 let chain_id = aptos_rest_client::Client::new(endpoint)
                     .get_ledger_information()
-                    .await?
+                    .await
+                    .unwrap()
                     .inner()
                     .chain_id;
 
                 if chain_id == ChainId::mainnet().id() || chain_id == ChainId::testnet().id() {
-                    anyhow::bail!("Mint to mainnet/testnet is not allowed");
+                    panic!("Mint to mainnet/testnet is not allowed");
                 }
 
-                network_config.mint_to_validator().await?;
+                network_config.mint_to_validator().await.unwrap();
             }
 
             network_config
                 .set_fast_resolve(FAST_RESOLUTION_TIME)
-                .await?;
+                .await
+                .unwrap();
             aptos_release_builder::validate::validate_config_and_generate_release(
                 config,
                 network_config.clone(),
                 output_dir,
             )
-            .await?;
+            .await
+            .unwrap();
             // Reset resolution time back to normal after resolution
             network_config
                 .set_fast_resolve(DEFAULT_RESOLUTION_TIME)
                 .await
+                .unwrap()
         },
     }
 }


### PR DESCRIPTION
Currently this absolute path only works from within a docker image

This change makes the path relative and possible to run from elsewhere

Test Plan:
```
RUST_BACKTRACE=1 cargo run --profile performance -p aptos-release-builder \
    generate-proposals \
    --release-config aptos-move/aptos-release-builder/data/release.yaml --output-dir banana
```
