### PR TITLE
[dag] Integrate Order Rule with dag driver

### DIFF
--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -2,7 +2,7 @@
 
 use super::{
     dag_driver::DagDriver, dag_fetcher::FetchRequestHandler, dag_network::DAGNetworkSender,
-    storage::DAGStorage, types::TDAGMessage,
+    order_rule::OrderRule, storage::DAGStorage, types::TDAGMessage,
 };
 use crate::{
     dag::{
@@ -45,6 +45,7 @@ impl NetworkHandler {
         _dag_network_sender: Arc<dyn DAGNetworkSender>,
         rb_network_sender: Arc<dyn RBNetworkSender<DAGMessage>>,
         time_service: TimeService,
+        order_rule: OrderRule,
     ) -> Self {
         let rb = Arc::new(ReliableBroadcast::new(
             epoch_state.verifier.get_ordered_account_addresses().clone(),
@@ -69,6 +70,7 @@ impl NetworkHandler {
                 1,
                 time_service,
                 storage,
+                order_rule,
             ),
             epoch_state: epoch_state.clone(),
             fetch_receiver: FetchRequestHandler::new(dag, epoch_state),

--- a/consensus/src/dag/order_rule.rs
+++ b/consensus/src/dag/order_rule.rs
@@ -46,8 +46,8 @@ impl OrderRule {
         (r1 ^ r2) & 1 == 0
     }
 
-    pub fn process_new_node(&mut self, node: &CertifiedNode) {
-        let round = node.round();
+    pub fn process_new_node(&mut self, node_metadata: &NodeMetadata) {
+        let round = node_metadata.round();
         // If the node comes from the proposal round in the current instance, it can't trigger any ordering
         if round <= self.lowest_unordered_anchor_round
             || Self::check_parity(round, self.lowest_unordered_anchor_round)

--- a/consensus/src/dag/tests/order_rule_tests.rs
+++ b/consensus/src/dag/tests/order_rule_tests.rs
@@ -167,7 +167,7 @@ proptest! {
                     let dag = Arc::new(RwLock::new(dag.clone()));
                     let (mut order_rule, mut receiver) = create_order_rule(epoch_state.clone(), dag);
                     for idx in seq {
-                        order_rule.process_new_node(&flatten_nodes[idx]);
+                        order_rule.process_new_node(flatten_nodes[idx].metadata());
                     }
                     let mut ordered = vec![];
                     while let Ok(Some(mut ordered_nodes)) = receiver.try_next() {
@@ -241,7 +241,7 @@ fn test_order_rule_basic() {
     let dag = Arc::new(RwLock::new(dag.clone()));
     let (mut order_rule, mut receiver) = create_order_rule(epoch_state, dag);
     for node in nodes.iter().flatten().flatten() {
-        order_rule.process_new_node(node);
+        order_rule.process_new_node(node.metadata());
     }
     let expected_order = vec![
         // anchor (1, 0) has 1 votes, anchor (3, 1) has 2 votes and a path to (1, 0)


### PR DESCRIPTION
### Description

This PR integrates the Order rule with the DAG driver. Whenever the dag driver adds a certified node to the DAG, it calls the order rule to try and commit nodes that have enough voting power.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Existing tests.
