### PR TITLE
Improvements to executor benchmark metrics collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,6 +1150,7 @@ dependencies = [
  "aptos-jellyfish-merkle",
  "aptos-logger",
  "aptos-metrics-core",
+ "aptos-node-resource-metrics",
  "aptos-push-metrics",
  "aptos-schemadb",
  "aptos-scratchpad",

--- a/crates/aptos-push-metrics/src/lib.rs
+++ b/crates/aptos-push-metrics/src/lib.rs
@@ -22,7 +22,7 @@ use std::{
 use url::Url;
 
 const DEFAULT_PUSH_FREQUENCY_SECS: u64 = 15;
-const DEFAULT_DASHBOARD_BASE_URL: &str = "https://o11y.aptosdev.com/grafana/d/execution/execution";
+const DEFAULT_DASHBOARD_BASE_URL: &str = "https://aptoslabs.grafana.net/d/execution/execution";
 
 /// MetricsPusher provides a function to push a list of Metrics to a configurable
 /// pushgateway endpoint.
@@ -147,13 +147,13 @@ impl MetricsPusher {
         url.query_pairs_mut()
             .append_pair("from", &start_time)
             .append_pair("to", &end_time)
-            .append_pair("var-Datasource", "VictoriaMetrics Global")
+            .append_pair("var-Datasource", "fHo-R604z")
             .append_pair("var-metrics_source", "All")
             .append_pair("var-chain_name", chain_name)
             .append_pair("var-cluster", "All")
             .append_pair("var-namespace", namespace)
+            .append_pair("var-kubernetes_pod_name", "All")
             .append_pair("var-role", "All");
-
         url
     }
 

--- a/crates/node-resource-metrics/src/collectors/linux_collectors.rs
+++ b/crates/node-resource-metrics/src/collectors/linux_collectors.rs
@@ -14,7 +14,7 @@ use prometheus::{
 use std::collections::HashMap;
 
 const LINUX_SYSTEM_CPU_USAGE: &str = "linux_system_cpu_usage";
-const LINUX_CPU_METRICS_COUNT: usize = 10;
+const LINUX_CPU_METRICS_COUNT: usize = 11;
 const LINUX_CPU_STATE_LABEL: &str = "state";
 
 const LINUX_DISK_SUBSYSTEM: &str = "linux_disk";
@@ -108,6 +108,7 @@ impl Collector for LinuxCpuMetricsCollector {
         cpu_time_counter_opt!(mfs, cpu_time.steal_ms(), "steal_ms");
         cpu_time_counter_opt!(mfs, cpu_time.guest_ms(), "guest_ms");
         cpu_time_counter_opt!(mfs, cpu_time.guest_nice_ms(), "guest_nice_ms");
+        cpu_time_counter!(mfs, kernal_stats.ctxt, "context_switches");
 
         mfs
     }

--- a/crates/node-resource-metrics/src/lib.rs
+++ b/crates/node-resource-metrics/src/lib.rs
@@ -3,7 +3,7 @@
 
 use crate::collectors::BasicNodeInfoCollector;
 use aptos_infallible::Mutex;
-use aptos_logger::{warn};
+use aptos_logger::warn;
 use cfg_if::cfg_if;
 use collectors::{
     CollectorLatencyCollector, CpuMetricsCollector, DiskMetricsCollector, LoadAvgCollector,

--- a/crates/node-resource-metrics/src/lib.rs
+++ b/crates/node-resource-metrics/src/lib.rs
@@ -9,6 +9,8 @@ use collectors::{
     MemoryMetricsCollector, NetworkMetricsCollector, ProcessMetricsCollector,
 };
 use once_cell::sync::Lazy;
+use prometheus::core::Collector;
+use aptos_logger::error;
 
 mod collectors;
 
@@ -23,18 +25,27 @@ pub fn register_node_metrics_collector() {
         *registered = true;
     }
 
-    prometheus::register(Box::<CpuMetricsCollector>::default()).unwrap();
-    prometheus::register(Box::<MemoryMetricsCollector>::default()).unwrap();
-    prometheus::register(Box::<DiskMetricsCollector>::default()).unwrap();
-    prometheus::register(Box::<NetworkMetricsCollector>::default()).unwrap();
-    prometheus::register(Box::<LoadAvgCollector>::default()).unwrap();
-    prometheus::register(Box::<ProcessMetricsCollector>::default()).unwrap();
-    prometheus::register(Box::<BasicNodeInfoCollector>::default()).unwrap();
+
+
+    register_collector(Box::<CpuMetricsCollector>::default());
+    register_collector(Box::<MemoryMetricsCollector>::default());
+    register_collector(Box::<DiskMetricsCollector>::default());
+    register_collector(Box::<NetworkMetricsCollector>::default());
+    register_collector(Box::<LoadAvgCollector>::default());
+    register_collector(Box::<ProcessMetricsCollector>::default());
+    register_collector(Box::<BasicNodeInfoCollector>::default());
     cfg_if! {
         if #[cfg(all(target_os="linux"))] {
-            prometheus::register(Box::<collectors::LinuxCpuMetricsCollector>::default()).unwrap();
-            prometheus::register(Box::<collectors::LinuxDiskMetricsCollector>::default()).unwrap();
+            register_collector(Box::<collectors::LinuxCpuMetricsCollector>::default());
+            register_collector(Box::<collectors::LinuxDiskMetricsCollector>::default());
         }
     }
-    prometheus::register(Box::<CollectorLatencyCollector>::default()).unwrap();
+    register_collector(Box::<CollectorLatencyCollector>::default());
+}
+
+pub fn register_collector(c: Box<dyn Collector>) {
+    // If not okay, then log the error and continue.
+    prometheus::register(c).unwrap_or_else(|e| {
+        error!("Failed to register collector: {}", e);
+    });
 }

--- a/crates/node-resource-metrics/src/lib.rs
+++ b/crates/node-resource-metrics/src/lib.rs
@@ -3,7 +3,7 @@
 
 use crate::collectors::BasicNodeInfoCollector;
 use aptos_infallible::Mutex;
-use aptos_logger::error;
+use aptos_logger::{warn};
 use cfg_if::cfg_if;
 use collectors::{
     CollectorLatencyCollector, CpuMetricsCollector, DiskMetricsCollector, LoadAvgCollector,
@@ -44,6 +44,6 @@ pub fn register_node_metrics_collector() {
 pub fn register_collector(c: Box<dyn Collector>) {
     // If not okay, then log the error and continue.
     prometheus::register(c).unwrap_or_else(|e| {
-        error!("Failed to register collector: {}", e);
+        warn!("Failed to register collector: {}", e);
     });
 }

--- a/crates/node-resource-metrics/src/lib.rs
+++ b/crates/node-resource-metrics/src/lib.rs
@@ -3,6 +3,7 @@
 
 use crate::collectors::BasicNodeInfoCollector;
 use aptos_infallible::Mutex;
+use aptos_logger::error;
 use cfg_if::cfg_if;
 use collectors::{
     CollectorLatencyCollector, CpuMetricsCollector, DiskMetricsCollector, LoadAvgCollector,
@@ -10,7 +11,6 @@ use collectors::{
 };
 use once_cell::sync::Lazy;
 use prometheus::core::Collector;
-use aptos_logger::error;
 
 mod collectors;
 
@@ -24,8 +24,6 @@ pub fn register_node_metrics_collector() {
     } else {
         *registered = true;
     }
-
-
 
     register_collector(Box::<CpuMetricsCollector>::default());
     register_collector(Box::<MemoryMetricsCollector>::default());

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -26,6 +26,7 @@ aptos-infallible = { workspace = true }
 aptos-jellyfish-merkle = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
+aptos-node-resource-metrics = { workspace = true }
 aptos-push-metrics =  { workspace = true }
 aptos-schemadb = { workspace = true }
 aptos-scratchpad = { workspace = true }

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -322,13 +322,14 @@ fn main() {
             .unwrap()
             .as_millis() as i64,
     );
-    aptos_node_resource_metrics::register_node_metrics_collector();
-    let _mp = MetricsPusher::start_for_local_run("executor-benchmark");
-
     rayon::ThreadPoolBuilder::new()
         .thread_name(|index| format!("rayon-global-{}", index))
         .build_global()
         .expect("Failed to build rayon global thread pool.");
+
+    aptos_node_resource_metrics::register_node_metrics_collector();
+    let _mp = MetricsPusher::start_for_local_run("executor-benchmark");
+
     AptosVM::set_concurrency_level_once(opt.concurrency_level());
     AptosVM::set_num_shards_once(opt.pipeline_opt.num_executor_shards);
     NativeExecutor::set_concurrency_level_once(opt.concurrency_level());

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -322,6 +322,7 @@ fn main() {
             .unwrap()
             .as_millis() as i64,
     );
+    aptos_node_resource_metrics::register_node_metrics_collector();
     let _mp = MetricsPusher::start_for_local_run("executor-benchmark");
 
     rayon::ThreadPoolBuilder::new()


### PR DESCRIPTION
### Description

- Fix the metrics pusher link for executor benchmark.
- Start the node metrics collector for the benchmark to gather system information
- Add a context switch counter to the metrics collector.

### Test Plan

Run benchmark
