### PR TITLE
[CLI][Ledger] update derivation path format doc

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -742,8 +742,8 @@ pub trait ParsePrivateKey {
 pub struct HardwareWalletOptions {
     /// Derivation Path of your account in hardware wallet
     ///
-    /// e.g format - [m/44'/637'/0'/0'/0]
-    /// Make sure your wallet is unblocked and have Aptos opened
+    /// e.g format - m/44\'/637\'/0\'/0\'/0\'
+    /// Make sure your wallet is unlocked and have Aptos opened
     #[clap(long)]
     pub derivation_path: Option<String>,
 


### PR DESCRIPTION
### Description

Looks like the format has causes some confusion. See reference - https://github.com/aptos-labs/aptos-core/issues/7906#issuecomment-1664226876

This PR updates the format comment

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

```
➜  aptos-core git:(feature_branch/cli_ledger_integration) ✗ aptos-debug init --ledger --profile ledger --derivation-path m/44\'/637\'/0\'/0\'/0\'

Configuring for profile ledger
Choose network from [devnet, testnet, mainnet, local, custom | defaults to devnet]

No network given, using devnet...
Using command line argument for derivation path m/44'/637'/0'/0'/0'
Account 59836ba1dd0c845713bdab34346688d6f1dba290dbf677929f2fc20593ba0cfb has been already found onchain

---
Aptos CLI is now set up for account 59836ba1dd0c845713bdab34346688d6f1dba290dbf677929f2fc20593ba0cfb as profile ledger!  Run `aptos --help` for more information about commands
{
  "Result": "Success"
}

```
