### PR TITLE
fix SerializeKey/DeserializeKey macros to work for generic structs

### DIFF
--- a/crates/aptos-crypto-derive/src/lib.rs
+++ b/crates/aptos-crypto-derive/src/lib.rs
@@ -151,8 +151,12 @@ pub fn deserialize_key(source: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(source).expect("Incorrect macro input");
     let name = &ast.ident;
     let name_string = name.to_string();
+    let (impl_generics, ty_generics, where_clause) = &ast.generics.split_for_impl();
+
     let gen = quote! {
-        impl<'de> ::serde::Deserialize<'de> for #name {
+        impl<'de, #impl_generics> ::serde::Deserialize<'de> for #name #ty_generics
+        #where_clause
+        {
             fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
             where
                 D: ::serde::Deserializer<'de>,
@@ -170,7 +174,7 @@ pub fn deserialize_key(source: TokenStream) -> TokenStream {
                     struct Value<'a>(&'a [u8]);
 
                     let value = Value::deserialize(deserializer)?;
-                    #name::try_from(value.0).map_err(|s| {
+                    #name #ty_generics::try_from(value.0).map_err(|s| {
                         <D::Error as ::serde::de::Error>::custom(format!("{} with {}", s, #name_string))
                     })
                 }
@@ -185,9 +189,11 @@ pub fn deserialize_key(source: TokenStream) -> TokenStream {
 pub fn serialize_key(source: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(source).expect("Incorrect macro input");
     let name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = &ast.generics.split_for_impl();
     let name_string = name.to_string();
+
     let gen = quote! {
-        impl ::serde::Serialize for #name {
+        impl #impl_generics ::serde::Serialize for #name #ty_generics #where_clause {
             fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
             where
                 S: ::serde::Serializer,

--- a/crates/aptos-crypto/src/unit_tests/mod.rs
+++ b/crates/aptos-crypto/src/unit_tests/mod.rs
@@ -12,3 +12,4 @@ mod hash_test;
 mod hkdf_test;
 mod multi_ed25519_test;
 mod noise_test;
+mod serialize_key;

--- a/crates/aptos-crypto/src/unit_tests/serialize_key.rs
+++ b/crates/aptos-crypto/src/unit_tests/serialize_key.rs
@@ -1,0 +1,45 @@
+// Copyright © Aptos Foundation
+
+use crate::{CryptoMaterialError, ValidCryptoMaterial, ValidCryptoMaterialStringExt};
+use aptos_crypto_derive::{SerializeKey, DeserializeKey};
+
+#[derive(SerializeKey, DeserializeKey)]
+struct Test {
+    field: u64
+}
+
+impl ValidCryptoMaterial for Test {
+    fn to_bytes(&self) -> Vec<u8> {
+        vec![]
+    }
+}
+
+impl TryFrom<&[u8]> for Test {
+    type Error = CryptoMaterialError;
+
+    fn try_from(_: &[u8]) -> Result<Self, Self::Error> {
+        Err(CryptoMaterialError::DeserializationError)
+    }
+}
+
+#[test]
+fn test_deserialize_key_on_generic_struct() {
+    #[derive(SerializeKey, DeserializeKey)]
+    struct TestGenerics<SubType> {
+        field: SubType
+    }
+
+    impl<SubType: ValidCryptoMaterial> ValidCryptoMaterial for TestGenerics<SubType> {
+        fn to_bytes(&self) -> Vec<u8> {
+            self.field.to_bytes()
+        }
+    }
+
+    impl<SubType: ValidCryptoMaterial> TryFrom<&[u8]> for TestGenerics<SubType> {
+        type Error = CryptoMaterialError;
+
+        fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+            SubType::try_from(bytes).map(|field| TestGenerics { field })
+        }
+    }
+}


### PR DESCRIPTION
### Description

Much like https://github.com/aptos-labs/aptos-core/pull/9117.

Currently cannot get this to work. `DeserializeKey` is trickier to get right: see the `serialize_key.rs` test currently failing below.

Also, a bit confused about whether the `serde` name of the `Value` struct, in the `deserialize_key` procedural macro, needs to be changed to account for the type params also.

```
alinush@macbook [~/repos/aptos-core/crates/aptos-crypto] (alin/fix-serializekey-macros) $ cargo test
   Compiling aptos-crypto v0.0.3 (/Users/alinush/repos/aptos-core/crates/aptos-crypto)
error: expected one of `#`, `>`, `const`, identifier, or lifetime, found `<`
  --> crates/aptos-crypto/src/unit_tests/serialize_key.rs:28:24
   |
28 |     struct TestGenerics<SubType> {
   |                        ^ expected one of `#`, `>`, `const`, identifier, or lifetime

error: proc-macro derive produced unparsable tokens
  --> crates/aptos-crypto/src/unit_tests/serialize_key.rs:27:28
   |
27 |     #[derive(SerializeKey, DeserializeKey)]
   |                            ^^^^^^^^^^^^^^

error[E0277]: the trait bound `for<'de> TestGenerics<SubType>: test_utils::_::_serde::Deserialize<'de>` is not satisfied
  --> crates/aptos-crypto/src/unit_tests/serialize_key.rs:32:64
   |
32 |     impl<SubType: ValidCryptoMaterial> ValidCryptoMaterial for TestGenerics<SubType> {
   |                                                                ^^^^^^^^^^^^^^^^^^^^^ the trait `for<'de> test_utils::_::_serde::Deserialize<'de>` is not implemented for `TestGenerics<SubType>`
   |
   = help: the following other types implement trait `test_utils::_::_serde::Deserialize<'de>`:
             <&'a Path as test_utils::_::_serde::Deserialize<'de>>
             <&'a [u8] as test_utils::_::_serde::Deserialize<'de>>
             <&'a serde_bytes::Bytes as test_utils::_::_serde::Deserialize<'de>>
             <&'a str as test_utils::_::_serde::Deserialize<'de>>
             <() as test_utils::_::_serde::Deserialize<'de>>
             <(T0, T1) as test_utils::_::_serde::Deserialize<'de>>
             <(T0, T1, T2) as test_utils::_::_serde::Deserialize<'de>>
             <(T0, T1, T2, T3) as test_utils::_::_serde::Deserialize<'de>>
           and 189 others
   = note: required for `TestGenerics<SubType>` to implement `DeserializeOwned`
note: required by a bound in `traits::ValidCryptoMaterial`
  --> crates/aptos-crypto/src/traits.rs:63:72
   |
61 | pub trait ValidCryptoMaterial:
   |           ------------------- required by a bound in this trait
62 |     // The for<'a> exactly matches the assumption "deserializable from any lifetime".
63 |     for<'a> TryFrom<&'a [u8], Error=CryptoMaterialError> + Serialize + DeserializeOwned
   |                                                                        ^^^^^^^^^^^^^^^^ required by this bound in `ValidCryptoMaterial`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `aptos-crypto` (lib test) due to 3 previous errors
```