### PR TITLE
[aptos-release-builder] Print out on chain configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2785,6 +2785,8 @@ dependencies = [
  "serde 1.0.149",
  "serde_json",
  "serde_yaml 0.8.26",
+ "strum",
+ "strum_macros",
  "tempfile",
  "tokio",
  "url",

--- a/aptos-move/aptos-release-builder/Cargo.toml
+++ b/aptos-move/aptos-release-builder/Cargo.toml
@@ -38,6 +38,8 @@ once_cell = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -6,6 +6,8 @@ use anyhow::Result;
 use aptos_types::on_chain_config::{FeatureFlag as AptosFeatureFlag, Features as AptosFeatures};
 use move_model::{code_writer::CodeWriter, emit, emitln, model::Loc};
 use serde::{Deserialize, Serialize};
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
 
 #[derive(Clone, Deserialize, PartialEq, Eq, Serialize, Debug)]
 pub struct Features {
@@ -15,7 +17,7 @@ pub struct Features {
     pub disabled: Vec<FeatureFlag>,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, Hash)]
+#[derive(Clone, Debug, Deserialize, EnumIter, PartialEq, Eq, Serialize, Hash)]
 #[allow(non_camel_case_types)]
 #[serde(rename_all = "snake_case")]
 pub enum FeatureFlag {
@@ -226,5 +228,20 @@ impl Features {
                 .disabled
                 .iter()
                 .any(|f| on_chain_features.is_enabled(AptosFeatureFlag::from(f.clone())))
+    }
+}
+
+impl From<&AptosFeatures> for Features {
+    fn from(features: &AptosFeatures) -> Features {
+        let mut enabled = vec![];
+        let mut disabled = vec![];
+        for feature in FeatureFlag::iter() {
+            if features.is_enabled(AptosFeatureFlag::from(feature.clone())) {
+                enabled.push(feature);
+            } else {
+                disabled.push(feature);
+            }
+        }
+        Features { enabled, disabled }
     }
 }

--- a/aptos-move/aptos-release-builder/src/components/mod.rs
+++ b/aptos-move/aptos-release-builder/src/components/mod.rs
@@ -310,28 +310,32 @@ fn fetch_and_equals<T: OnChainConfig + PartialEq>(
 ) -> Result<bool> {
     match client {
         Some(client) => {
-            let config = T::deserialize_into_config(
-                block_on(async {
-                    client
-                        .get_account_resource_bytes(
-                            CORE_CODE_ADDRESS,
-                            format!(
-                                "{}::{}::{}",
-                                T::ADDRESS,
-                                T::MODULE_IDENTIFIER,
-                                T::TYPE_IDENTIFIER
-                            )
-                            .as_str(),
-                        )
-                        .await
-                })?
-                .inner(),
-            )?;
+            let config = fetch_config::<T>(client)?;
 
             Ok(&config == expected)
         },
         None => Ok(false),
     }
+}
+
+pub fn fetch_config<T: OnChainConfig>(client: &Client) -> Result<T> {
+    T::deserialize_into_config(
+        block_on(async {
+            client
+                .get_account_resource_bytes(
+                    CORE_CODE_ADDRESS,
+                    format!(
+                        "{}::{}::{}",
+                        T::ADDRESS,
+                        T::MODULE_IDENTIFIER,
+                        T::TYPE_IDENTIFIER
+                    )
+                    .as_str(),
+                )
+                .await
+        })?
+        .inner(),
+    )
 }
 
 impl ReleaseConfig {

--- a/aptos-move/aptos-release-builder/src/main.rs
+++ b/aptos-move/aptos-release-builder/src/main.rs
@@ -57,6 +57,9 @@ pub enum Commands {
         /// Url endpoint for the desired network. e.g: https://fullnode.mainnet.aptoslabs.com/v1.
         #[clap(short, long)]
         endpoint: url::Url,
+        /// Whether to print out the full gas schedule.
+        #[clap(short, long)]
+        print_gas_schedule: bool,
     },
 }
 
@@ -170,7 +173,10 @@ async fn main() -> Result<()> {
                 .set_fast_resolve(DEFAULT_RESOLUTION_TIME)
                 .await
         },
-        Commands::PrintConfigs { endpoint } => {
+        Commands::PrintConfigs {
+            endpoint,
+            print_gas_schedule,
+        } => {
             use aptos_types::on_chain_config::*;
 
             let client = aptos_rest_client::Client::new(endpoint);
@@ -184,12 +190,11 @@ async fn main() -> Result<()> {
                 }
             }
 
-            print_configs!(
-                OnChainConsensusConfig,
-                OnChainExecutionConfig,
-                Version,
-                GasScheduleV2
-            );
+            print_configs!(OnChainConsensusConfig, OnChainExecutionConfig, Version);
+
+            if print_gas_schedule {
+                print_configs!(GasScheduleV2, StorageGasSchedule);
+            }
 
             // Print Activated Features
             let features = fetch_config::<Features>(&client)?;

--- a/aptos-move/aptos-release-builder/src/main.rs
+++ b/aptos-move/aptos-release-builder/src/main.rs
@@ -22,16 +22,19 @@ pub struct Argument {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
+    /// Generate sets of governance proposals based on the release_config file passed in
     GenerateProposals {
         #[clap(short, long)]
         release_config: PathBuf,
         #[clap(short, long)]
         output_dir: PathBuf,
     },
+    /// Generate sets of governance proposals with default release config.
     WriteDefault {
         #[clap(short, long)]
         output_path: PathBuf,
     },
+    /// Execute governance proposals generated from a given release config.
     ValidateProposals {
         /// Path to the config to be released.
         #[clap(short, long)]
@@ -49,7 +52,9 @@ pub enum Commands {
         #[clap(long)]
         mint_to_validator: bool,
     },
+    /// Print out current values of on chain configs.
     PrintConfigs {
+        /// Url endpoint for the desired network. e.g: https://fullnode.mainnet.aptoslabs.com/v1.
         #[clap(short, long)]
         endpoint: url::Url,
     },


### PR DESCRIPTION
### Description

Added an command to print out on chain configs.

### Test Plan

Tested with following command: 
```
cargo run -- print-configs --endpoint https://fullnode.mainnet.aptoslabs.com/v1
```

And it printed out the values of configs properly
