### PR TITLE
update cli release workflow

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -17,7 +17,7 @@ on:
       dry_run:
         type: boolean
         required: false
-        default: false
+        default: true
         description: "If true, the release will not be created"
 
 jobs:
@@ -94,7 +94,7 @@ jobs:
     permissions:
       contents: "write"
       pull-requests: "read"
-    if: ${{ inputs.dry_run }} == 'true'
+    if: ${{ inputs.dry_run }} == 'false'
     steps:
       - name: Download prebuilt binaries
         uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin@v3

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -94,7 +94,7 @@ jobs:
     permissions:
       contents: "write"
       pull-requests: "read"
-    if: ${{ github.event.inputs.dry_run }} == 'true'
+    if: ${{ inputs.dry_run }} == 'true'
     steps:
       - name: Download prebuilt binaries
         uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin@v3
@@ -104,8 +104,8 @@ jobs:
         uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # pin@v1.2.1
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ format('aptos-cli-v{0}', github.event.inputs.release_version) }}"
+          automatic_release_tag: "${{ format('aptos-cli-v{0}', inputs.release_version) }}"
           prerelease: false
-          title: "${{ format('Aptos CLI Release v{0}', github.event.inputs.release_version) }}"
+          title: "${{ format('Aptos CLI Release v{0}', inputs.release_version) }}"
           files: |
             aptos-cli-*.zip

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -6,18 +6,19 @@ name: "Release CLI"
 on:
   workflow_dispatch:
     inputs:
-      release_tag:
+      release_version:
         type: string
         required: true
-        description: "The release tag to create. E.g. `aptos-cli-v0.2.3`:"
+        description: "The release version. E.g. `0.2.3`:"
       source_git_ref_override:
         type: string
         required: false
         description: "GIT_SHA_OVERRIDE: Use this to override the Git SHA1, branch name (e.g. devnet) or tag to build the binaries from. Defaults to the workflow Git REV, but can be different than that:"
-      release_title:
-        type: string
+      dry_run:
+        type: boolean
         required: false
-        description: 'Name of the release, e.g. "Aptos CLI Release v0.2.3":'
+        default: false
+        description: "If true, the release will not be created"
 
 jobs:
   build-ubuntu20-binary:
@@ -93,6 +94,7 @@ jobs:
     permissions:
       contents: "write"
       pull-requests: "read"
+    if: ${{ github.event.inputs.dry_run }} == 'true'
     steps:
       - name: Download prebuilt binaries
         uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin@v3
@@ -102,8 +104,8 @@ jobs:
         uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # pin@v1.2.1
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ github.event.inputs.release_tag }}"
+          automatic_release_tag: "${{ format('aptos-cli-v{0}', github.event.inputs.release_version) }}"
           prerelease: false
-          title: "${{ github.event.inputs.release_title }}"
+          title: "${{ format('Aptos CLI Release v{0}', github.event.inputs.release_version) }}"
           files: |
             aptos-cli-*.zip


### PR DESCRIPTION
### Description

Update CLI Release work flow

1. updated `release_tag` to `release_version`
2. Use formatting on actual release tag and title
3. Add `dry_run` boolean to allow dry_run instead of actual release

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
