### PR TITLE
Cleanup OnChainExecutionConfig and update to V4

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/mod.rs
+++ b/aptos-move/aptos-release-builder/src/components/mod.rs
@@ -10,8 +10,7 @@ use aptos_temppath::TempPath;
 use aptos_types::{
     account_config::CORE_CODE_ADDRESS,
     on_chain_config::{
-        ExecutionConfigV1, GasScheduleV2, OnChainConfig, OnChainConsensusConfig,
-        OnChainExecutionConfig, TransactionShufflerType, Version,
+        GasScheduleV2, OnChainConfig, OnChainConsensusConfig, OnChainExecutionConfig, Version,
     },
 };
 use futures::executor::block_on;
@@ -508,10 +507,7 @@ impl Default for ReleaseConfig {
                             disabled: vec![],
                         }),
                         ReleaseEntry::Consensus(OnChainConsensusConfig::default()),
-                        ReleaseEntry::Execution(OnChainExecutionConfig::V1(ExecutionConfigV1 {
-                            transaction_shuffler_type:
-                                TransactionShufflerType::DeprecatedSenderAwareV1(32),
-                        })),
+                        ReleaseEntry::Execution(OnChainExecutionConfig::default_for_genesis()),
                         ReleaseEntry::RawScript(PathBuf::from(
                             "data/proposals/empty_multi_step.move",
                         )),

--- a/consensus/src/transaction_shuffler.rs
+++ b/consensus/src/transaction_shuffler.rs
@@ -6,7 +6,7 @@ use aptos_logger::info;
 use aptos_types::{
     on_chain_config::{
         TransactionShufflerType,
-        TransactionShufflerType::{DeprecatedSenderAwareV1, NoShuffling, SenderAwareV2},
+        TransactionShufflerType::{NoShuffling, SenderAwareV1},
     },
     transaction::SignedTransaction,
 };
@@ -34,11 +34,7 @@ pub fn create_transaction_shuffler(
             info!("Using no-op transaction shuffling");
             Arc::new(NoOpShuffler {})
         },
-        DeprecatedSenderAwareV1(_) => {
-            info!("Using no-op sender aware shuffling v1");
-            Arc::new(NoOpShuffler {})
-        },
-        SenderAwareV2(confict_window_size) => {
+        SenderAwareV1(confict_window_size) => {
             info!(
                 "Using sender aware transaction shuffling with conflict window size {}",
                 confict_window_size

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -26,9 +26,9 @@ use aptos_types::{
     account_config::CORE_CODE_ADDRESS,
     network_address::DnsName,
     on_chain_config::{
-        ConsensusConfigV1, ExecutionConfigV1, LeaderReputationType, OnChainConsensusConfig,
-        OnChainExecutionConfig, ProposerAndVoterConfig, ProposerElectionType,
-        TransactionShufflerType, ValidatorSet,
+        ConsensusConfigV1, DeprecatedExecutionConfigV1, LeaderReputationType,
+        OnChainConsensusConfig, OnChainExecutionConfig, ProposerAndVoterConfig,
+        ProposerElectionType, TransactionShufflerType, ValidatorSet,
     },
     PeerId,
 };
@@ -382,14 +382,15 @@ async fn test_onchain_shuffling_change() {
 
     assert_eq!(
         current_execution_config.transaction_shuffler_type(),
-        TransactionShufflerType::SenderAwareV2(32),
+        TransactionShufflerType::SenderAwareV1(32),
     );
 
     assert_reordering(&mut swarm, true).await;
 
-    let execution_config_with_shuffling = OnChainExecutionConfig::V1(ExecutionConfigV1 {
-        transaction_shuffler_type: TransactionShufflerType::NoShuffling,
-    });
+    let execution_config_with_shuffling =
+        OnChainExecutionConfig::DeprecatedV1(DeprecatedExecutionConfigV1 {
+            transaction_shuffler_type: TransactionShufflerType::NoShuffling,
+        });
 
     let update_execution_config_script = format!(
         r#"

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -19,7 +19,9 @@ use aptos_sdk::move_types::language_storage::StructTag;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{AccountResource, CORE_CODE_ADDRESS},
-    on_chain_config::{ExecutionConfigV2, OnChainExecutionConfig, TransactionShufflerType},
+    on_chain_config::{
+        ExecutionConfigV4, OnChainExecutionConfig, TransactionDeduperType, TransactionShufflerType,
+    },
     transaction::{authenticator::AuthenticationKey, SignedTransaction, Transaction},
 };
 use std::{convert::TryFrom, str::FromStr, sync::Arc, time::Duration};
@@ -208,9 +210,10 @@ async fn test_gas_estimation_txns_limit() {
 async fn test_gas_estimation_gas_used_limit() {
     let mut swarm = SwarmBuilder::new_local(1)
         .with_init_genesis_config(Arc::new(|conf| {
-            conf.execution_config = OnChainExecutionConfig::V2(ExecutionConfigV2 {
+            conf.execution_config = OnChainExecutionConfig::V4(ExecutionConfigV4 {
                 transaction_shuffler_type: TransactionShufflerType::NoShuffling,
                 block_gas_limit: Some(1),
+                transaction_deduper_type: TransactionDeduperType::NoDedup,
             });
         }))
         .with_init_config(Arc::new(|_, conf, _| {

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -154,8 +154,10 @@ mod test {
 
     #[test]
     fn test_config_serialization() {
-        let config = OnChainExecutionConfig::DeprecatedV1(DeprecatedExecutionConfigV1 {
+        let config = OnChainExecutionConfig::V4(ExecutionConfigV4 {
             transaction_shuffler_type: TransactionShufflerType::SenderAwareV1(32),
+            block_gas_limit: None,
+            transaction_deduper_type: TransactionDeduperType::NoDedup,
         });
 
         let s = serde_yaml::to_string(&config).unwrap();
@@ -165,11 +167,12 @@ mod test {
             TransactionShufflerType::SenderAwareV1(32)
         ));
 
-        // V2 test with random per-block gas limit
+        // random per-block gas limit
         let rand_gas_limit = rand::thread_rng().gen_range(0, 1000000) as u64;
-        let config = OnChainExecutionConfig::DeprecatedV2(DeprecatedExecutionConfigV2 {
+        let config = OnChainExecutionConfig::V4(ExecutionConfigV4 {
             transaction_shuffler_type: TransactionShufflerType::SenderAwareV1(32),
             block_gas_limit: Some(rand_gas_limit),
+            transaction_deduper_type: TransactionDeduperType::NoDedup,
         });
 
         let s = serde_yaml::to_string(&config).unwrap();
@@ -180,10 +183,11 @@ mod test {
         ));
         assert!(result.block_gas_limit() == Some(rand_gas_limit));
 
-        // V2 test with no per-block gas limit
-        let config = OnChainExecutionConfig::DeprecatedV2(DeprecatedExecutionConfigV2 {
+        // no per-block gas limit
+        let config = OnChainExecutionConfig::V4(ExecutionConfigV4 {
             transaction_shuffler_type: TransactionShufflerType::SenderAwareV1(32),
             block_gas_limit: None,
+            transaction_deduper_type: TransactionDeduperType::NoDedup,
         });
 
         let s = serde_yaml::to_string(&config).unwrap();
@@ -197,8 +201,10 @@ mod test {
 
     #[test]
     fn test_config_onchain_payload() {
-        let execution_config = OnChainExecutionConfig::DeprecatedV1(DeprecatedExecutionConfigV1 {
+        let execution_config = OnChainExecutionConfig::V4(ExecutionConfigV4 {
             transaction_shuffler_type: TransactionShufflerType::SenderAwareV1(32),
+            block_gas_limit: None,
+            transaction_deduper_type: TransactionDeduperType::NoDedup,
         });
 
         let mut configs = HashMap::new();
@@ -216,11 +222,12 @@ mod test {
             TransactionShufflerType::SenderAwareV1(32)
         ));
 
-        // V2 test with random per-block gas limit
+        // random per-block gas limit
         let rand_gas_limit = rand::thread_rng().gen_range(0, 1000000) as u64;
-        let execution_config = OnChainExecutionConfig::DeprecatedV2(DeprecatedExecutionConfigV2 {
+        let execution_config = OnChainExecutionConfig::V4(ExecutionConfigV4 {
             transaction_shuffler_type: TransactionShufflerType::SenderAwareV1(32),
             block_gas_limit: Some(rand_gas_limit),
+            transaction_deduper_type: TransactionDeduperType::NoDedup,
         });
 
         let mut configs = HashMap::new();
@@ -239,10 +246,11 @@ mod test {
         ));
         assert!(result.block_gas_limit() == Some(rand_gas_limit));
 
-        // V2 test with no per-block gas limit
-        let execution_config = OnChainExecutionConfig::DeprecatedV2(DeprecatedExecutionConfigV2 {
+        // no per-block gas limit
+        let execution_config = OnChainExecutionConfig::V4(ExecutionConfigV4 {
             transaction_shuffler_type: TransactionShufflerType::SenderAwareV1(32),
             block_gas_limit: None,
+            transaction_deduper_type: TransactionDeduperType::NoDedup,
         });
 
         let mut configs = HashMap::new();

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -40,8 +40,8 @@ pub use self::{
         ProposerElectionType,
     },
     execution_config::{
-        ExecutionConfigV1, ExecutionConfigV2, OnChainExecutionConfig, TransactionDeduperType,
-        TransactionShufflerType,
+        DeprecatedExecutionConfigV1, DeprecatedExecutionConfigV2, ExecutionConfigV4,
+        OnChainExecutionConfig, TransactionDeduperType, TransactionShufflerType,
     },
     gas_schedule::{GasSchedule, GasScheduleV2, StorageGasSchedule},
     timed_features::{TimedFeatureFlag, TimedFeatureOverride, TimedFeatures},


### PR DESCRIPTION
### Description

All versions before registration are now prefixed with `Deprecated` and always return shuffle and gas limit as off. The next governance should update to V4.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
