### PR TITLE
[TS SDK] fix flaky gets object test

### DIFF
--- a/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/aptos_client.test.ts
@@ -66,7 +66,11 @@ test(
       await aptosToken.createCollection(alice, "Alice's simple collection", "AliceCollection", "https://aptos.dev"),
       { checkSuccess: true },
     );
-    const objectAddress = ((txn as Gen.UserTransaction).changes[0] as WriteSetChange_WriteResource).address; // should be the new object address
+
+    const objectCore = (txn as Gen.UserTransaction).changes.find(
+      (change) => (change as Gen.WriteResource).data.type === "0x1::object::ObjectCore",
+    );
+    const objectAddress = (objectCore as WriteSetChange_WriteResource).address;
 
     const object = await provider.getAccountResource(objectAddress, "0x4::aptos_token::AptosCollection");
 


### PR DESCRIPTION
### Description
This test assumed that the ObjectCore resource is always the first element in the changes array - which is not always the case and made this test flaky
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
