### PR TITLE
[Mempool] Don't log times that are <= 0 for insertion time to block timestamp

### DIFF
--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -156,12 +156,14 @@ impl Mempool {
 
             let insertion_timestamp =
                 aptos_infallible::duration_since_epoch_at(&insertion_info.insertion_time);
-            counters::core_mempool_txn_commit_latency(
-                counters::COMMIT_ACCEPTED_BLOCK_LABEL,
-                insertion_info.submitted_by_label(),
-                bucket,
-                block_timestamp.saturating_sub(insertion_timestamp),
-            );
+            if let Some(insertion_to_block) = block_timestamp.checked_sub(insertion_timestamp) {
+                counters::core_mempool_txn_commit_latency(
+                    counters::COMMIT_ACCEPTED_BLOCK_LABEL,
+                    insertion_info.submitted_by_label(),
+                    bucket,
+                    insertion_to_block,
+                );
+            }
         }
     }
 


### PR DESCRIPTION
### Description

This happens due to retry/duplication and should be ignored (instead of logging time 0). This cleans up the metric a bit, especially for forge tests that have enough latency that causes frequent transaction retries.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
