### PR TITLE
[TS SDK] bump version to 1.17.0

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 
 ## Unreleased
 
+## 1.17.0 (2023-08-04)
+
 - Add support for a fee payer transaction
 - Return transaction message error when transaction has failed when `checkSuccess` is set to true
 

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -86,5 +86,5 @@
     "typedoc": "^0.23.20",
     "typescript": "4.8.2"
   },
-  "version": "1.16.0"
+  "version": "1.17.0"
 }

--- a/ecosystem/typescript/sdk/src/version.ts
+++ b/ecosystem/typescript/sdk/src/version.ts
@@ -1,2 +1,2 @@
 // hardcoded for now, we would want to have it injected dynamically
-export const VERSION = "1.16.0";
+export const VERSION = "1.17.0";


### PR DESCRIPTION
### Description
- Add support for a fee payer transaction
- Return transaction message error when transaction has failed when `checkSuccess` is set to true
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
