### PR TITLE
[forge][land blocking] recalibrate latency limits

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1532,10 +1532,10 @@ fn realistic_env_max_load_test(
                 .add_latency_threshold(3.4, LatencyType::P50)
                 .add_latency_threshold(4.5, LatencyType::P90)
                 .add_latency_breakdown_threshold(LatencyBreakdownThreshold::new_strict(vec![
-                    (LatencyBreakdownSlice::QsBatchToPos, 0.3),
-                    (LatencyBreakdownSlice::QsPosToProposal, 0.25),
+                    (LatencyBreakdownSlice::QsBatchToPos, 0.35),
+                    (LatencyBreakdownSlice::QsPosToProposal, 0.5),
                     (LatencyBreakdownSlice::ConsensusProposalToOrdered, 0.8),
-                    (LatencyBreakdownSlice::ConsensusOrderedToCommit, 0.6),
+                    (LatencyBreakdownSlice::ConsensusOrderedToCommit, 0.65),
                 ]))
                 .add_chain_progress(StateProgressThreshold {
                     max_no_progress_secs: 10.0,

--- a/testsuite/forge/src/interface/prometheus_metrics.rs
+++ b/testsuite/forge/src/interface/prometheus_metrics.rs
@@ -21,6 +21,10 @@ impl MetricSamples {
             .unwrap_or_default()
     }
 
+    pub fn avg_sample(&self) -> f64 {
+        self.0.iter().map(|s| s.value()).sum::<f64>() / self.0.len() as f64
+    }
+
     pub fn get(&self) -> &Vec<Sample> {
         &self.0
     }
@@ -88,6 +92,10 @@ pub struct LatencyBreakdown(BTreeMap<LatencyBreakdownSlice, MetricSamples>);
 impl LatencyBreakdown {
     pub fn new(latency: BTreeMap<LatencyBreakdownSlice, MetricSamples>) -> Self {
         Self(latency)
+    }
+
+    pub fn keys(&self) -> Vec<LatencyBreakdownSlice> {
+        self.0.keys().cloned().collect()
     }
 
     pub fn get_samples(&self, slice: &LatencyBreakdownSlice) -> &MetricSamples {

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -184,14 +184,31 @@ impl NetworkTest for dyn NetworkLoadTest {
 
         let phased = stats_by_phase.len() > 1;
         for (phase, phase_stats) in stats_by_phase.iter().enumerate() {
-            ctx.report.report_txn_stats(
-                if phased {
-                    format!("{}_phase_{}", self.name(), phase)
-                } else {
-                    self.name().to_string()
-                },
-                &phase_stats.emitter_stats,
-            );
+            let test_name = if phased {
+                format!("{}_phase_{}", self.name(), phase)
+            } else {
+                self.name().to_string()
+            };
+            ctx.report
+                .report_txn_stats(test_name, &phase_stats.emitter_stats);
+            ctx.report.report_text(format!(
+                "Latency breakdown for phase {}: {:?}",
+                phase,
+                phase_stats
+                    .latency_breakdown
+                    .keys()
+                    .into_iter()
+                    .map(|slice| {
+                        let slice_samples = phase_stats.latency_breakdown.get_samples(&slice);
+                        format!(
+                            "{:?}: max: {}, avg: {}",
+                            slice,
+                            slice_samples.max_sample(),
+                            slice_samples.avg_sample()
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            ));
         }
 
         let end_timestamp = SystemTime::now()
@@ -339,8 +356,11 @@ impl dyn NetworkLoadTest {
                 phase_timing[i].end_unixtime_s,
             ))?;
             info!(
-                "Latency breakdown: from {} to {}: {:?}",
-                phase_timing[i].start_unixtime_s, phase_timing[i].end_unixtime_s, latency_breakdown
+                "Latency breakdown details for phase {}: from {} to {}: {:?}",
+                i,
+                phase_timing[i].start_unixtime_s,
+                phase_timing[i].end_unixtime_s,
+                latency_breakdown
             );
             stats_by_phase_filtered.push(LoadTestPhaseStats {
                 emitter_stats: cur.clone(),

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -201,7 +201,7 @@ impl NetworkTest for dyn NetworkLoadTest {
                     .map(|slice| {
                         let slice_samples = phase_stats.latency_breakdown.get_samples(&slice);
                         format!(
-                            "{:?}: max: {}, avg: {}",
+                            "{:?}: max: {:.3}, avg: {:.3}",
                             slice,
                             slice_samples.max_sample(),
                             slice_samples.avg_sample()


### PR DESCRIPTION
There were a few sporadic failures on landblocking PRs. increasing limits, and printing them better.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
