### PR TITLE
[gas] fix abstract gas cost for storage

### DIFF
--- a/aptos-move/aptos-vm-types/src/storage.rs
+++ b/aptos-move/aptos-vm-types/src/storage.rs
@@ -96,10 +96,6 @@ pub struct StoragePricingV2 {
 }
 
 impl StoragePricingV2 {
-    pub fn zeros() -> Self {
-        Self::new_without_storage_curves(LATEST_GAS_FEATURE_VERSION, &AptosGasParameters::zeros())
-    }
-
     pub fn new_with_storage_curves(
         feature_version: u64,
         storage_gas_schedule: &StorageGasSchedule,
@@ -114,22 +110,6 @@ impl StoragePricingV2 {
             per_byte_read: storage_gas_schedule.per_byte_read.into(),
             per_byte_create: storage_gas_schedule.per_byte_create.into(),
             per_byte_write: storage_gas_schedule.per_byte_write.into(),
-        }
-    }
-
-    pub fn new_without_storage_curves(
-        feature_version: u64,
-        gas_params: &AptosGasParameters,
-    ) -> Self {
-        Self {
-            feature_version,
-            free_write_bytes_quota: Self::get_free_write_bytes_quota(feature_version, gas_params),
-            per_item_read: gas_params.vm.txn.storage_io_per_state_slot_read,
-            per_item_create: gas_params.vm.txn.storage_io_per_state_slot_write,
-            per_item_write: gas_params.vm.txn.storage_io_per_state_slot_write,
-            per_byte_read: gas_params.vm.txn.storage_io_per_state_byte_read,
-            per_byte_create: gas_params.vm.txn.storage_io_per_state_byte_write,
-            per_byte_write: gas_params.vm.txn.storage_io_per_state_byte_write,
         }
     }
 
@@ -253,10 +233,10 @@ impl StoragePricing {
                     gas_params,
                 )),
             },
-            10.. => V2(StoragePricingV2::new_without_storage_curves(
+            10.. => V3(StoragePricingV3 {
                 feature_version,
-                gas_params,
-            )),
+                free_write_bytes_quota: gas_params.vm.txn.free_write_bytes_quota,
+            }),
         }
     }
 
@@ -424,9 +404,12 @@ impl StorageGasParameters {
         }
     }
 
-    pub fn free_and_unlimited() -> Self {
+    pub fn unlimited(free_write_bytes_quota: NumBytes) -> Self {
         Self {
-            pricing: StoragePricing::V2(StoragePricingV2::zeros()),
+            pricing: StoragePricing::V3(StoragePricingV3 {
+                feature_version: LATEST_GAS_FEATURE_VERSION,
+                free_write_bytes_quota,
+            }),
             change_set_configs: ChangeSetConfigs::unlimited_at_gas_feature_version(
                 LATEST_GAS_FEATURE_VERSION,
             ),

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -778,7 +778,7 @@ impl FakeExecutor {
                         //// TODO: fill in these with proper values
                         LATEST_GAS_FEATURE_VERSION,
                         InitialGasSchedule::initial(),
-                        StorageGasParameters::free_and_unlimited(),
+                        StorageGasParameters::unlimited(0.into()),
                         10000000000000,
                     ),
                     // coeff_buffer: BTreeMap::new(),

--- a/aptos-move/e2e-testsuite/Cargo.toml
+++ b/aptos-move/e2e-testsuite/Cargo.toml
@@ -19,7 +19,7 @@ aptos-crypto = { workspace = true }
 aptos-framework = { workspace = true }
 aptos-gas-algebra = { workspace = true }
 aptos-gas-meter = { workspace = true }
-aptos-gas-schedule = { workspace = true }
+aptos-gas-schedule = { workspace = true, features = ["testing"] }
 aptos-keygen = { workspace = true }
 aptos-language-e2e-tests = { workspace = true }
 aptos-logger = { workspace = true }

--- a/aptos-move/e2e-testsuite/src/tests/failed_transaction_tests.rs
+++ b/aptos-move/e2e-testsuite/src/tests/failed_transaction_tests.rs
@@ -38,7 +38,8 @@ fn failed_transaction_cleanup_test() {
     };
 
     let gas_params = AptosGasParameters::zeros();
-    let storage_gas_params = StorageGasParameters::free_and_unlimited();
+    let storage_gas_params =
+        StorageGasParameters::unlimited(gas_params.vm.txn.free_write_bytes_quota);
 
     let change_set_configs = storage_gas_params.change_set_configs.clone();
 


### PR DESCRIPTION
This fixes a bug in the original abstract gas implementation, allowing the io gas to be expressed as an abstract amount rather than a concrete one. This should not change the behavior of the production binary at all.