### PR TITLE
[GHA] Skip non-required tests in PRs and reduce scheduled jobs.

### DIFF
--- a/.github/workflows/check-sdk-examples.yaml
+++ b/.github/workflows/check-sdk-examples.yaml
@@ -1,6 +1,7 @@
 name: "Check SDK examples"
 on:
   pull_request:
+    types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
   push:
     branches:
       - devnet

--- a/.github/workflows/check-sdk-examples.yaml
+++ b/.github/workflows/check-sdk-examples.yaml
@@ -15,6 +15,7 @@ jobs:
   # whereas we run the test-sdk-confirm-client-generated-publish against a node
   # built from the same commit and run as part of that CI job.
   run-examples:
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     runs-on: ubuntu-latest
     env:
       APTOS_NODE_URL: https://fullnode.devnet.aptoslabs.com
@@ -44,6 +45,7 @@ jobs:
           command: cd ./ecosystem/typescript/sdk/examples/javascript && pnpm install && pnpm test
 
   run-python-examples:
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     runs-on: ubuntu-latest
     env:
       APTOS_NODE_URL: https://fullnode.devnet.aptoslabs.com/v1

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -6,7 +6,7 @@ on:
     # every day at 9am PST
     - cron: "0 16 * * *"
   pull_request:
-    types: [ labeled, opened, synchronize, reopened ]
+    types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
 
 env:
   CARGO_INCREMENTAL: "0"

--- a/.github/workflows/faucet-tests.yaml
+++ b/.github/workflows/faucet-tests.yaml
@@ -25,6 +25,7 @@ jobs:
           comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
 
   run-tests-devnet:
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     needs: [permission-check]
     runs-on: high-perf-docker
     steps:
@@ -43,6 +44,7 @@ jobs:
           GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
 
   run-tests-testnet:
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     needs: [permission-check]
     runs-on: high-perf-docker
     permissions:

--- a/.github/workflows/forge-pfn.yaml
+++ b/.github/workflows/forge-pfn.yaml
@@ -20,8 +20,6 @@ on:
         required: false
         type: string
         description: The git SHA1 to checkout. This affects the Forge test runner that is used. If not specified, the latest main will be used
-  schedule:
-    - cron: "0 3 */2 * *" # The main branch cadence. This runs every other day at 3am UTC.
   pull_request:
     paths:
       - ".github/workflows/forge-pfn.yaml"
@@ -52,16 +50,11 @@ jobs:
         id: determine-test-branch
         run: |
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            if [[ "${{ github.event.schedule }}" == "0 3 */2 * *" ]]; then
-              echo "Branch: main"
-              echo "BRANCH=main" >> $GITHUB_OUTPUT
-            else
-              echo "Unknown schedule: ${{ github.event.schedule }}"
-              exit 1
-            fi
+            echo "Unknown schedule: ${{ github.event.schedule }}"
+            exit 1
           elif [[ "${{ github.event_name }}" == "push" ]]; then
-              echo "Branch: ${{ github.ref_name }}"
-              echo "BRANCH=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "Branch: ${{ github.ref_name }}"
+            echo "BRANCH=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           else
             echo "Using GIT_SHA"
             # on workflow_dispatch, this will simply use the inputs.GIT_SHA given (or the default)

--- a/.github/workflows/forge-state-sync.yaml
+++ b/.github/workflows/forge-state-sync.yaml
@@ -20,8 +20,6 @@ on:
         required: false
         type: string
         description: The git SHA1 to checkout. This affects the Forge test runner that is used. If not specified, the latest main will be used
-  schedule:
-    - cron: "0 14 */3 * *" # The main branch cadence. This runs every three days at 2pm UTC.
   pull_request:
     paths:
       - ".github/workflows/forge-state-sync.yaml"
@@ -50,16 +48,11 @@ jobs:
         id: determine-test-branch
         run: |
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            if [[ "${{ github.event.schedule }}" == "0 14 */3 * *" ]]; then
-              echo "Branch: main"
-              echo "BRANCH=main" >> $GITHUB_OUTPUT
-            else
-              echo "Unknown schedule: ${{ github.event.schedule }}"
-              exit 1
-            fi
+            echo "Unknown schedule: ${{ github.event.schedule }}"
+            exit 1
           elif [[ "${{ github.event_name }}" == "push" ]]; then
-              echo "Branch: ${{ github.ref_name }}"
-              echo "BRANCH=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "Branch: ${{ github.ref_name }}"
+            echo "BRANCH=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           else
             echo "Using GIT_SHA"
             # on workflow_dispatch, this will simply use the inputs.GIT_SHA given (or the default)

--- a/.github/workflows/forge-unstable.yaml
+++ b/.github/workflows/forge-unstable.yaml
@@ -20,8 +20,6 @@ on:
         required: false
         type: string
         description: The git SHA1 to checkout. This affects the Forge test runner that is used. If not specified, the latest main will be used
-  schedule:
-    - cron: "0 12 * * *" # The main branch cadence. This runs every day at 12pm UTC.
   pull_request:
     paths:
       - ".github/workflows/forge-unstable.yaml"
@@ -48,13 +46,8 @@ jobs:
         id: determine-test-branch
         run: |
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            if [[ "${{ github.event.schedule }}" == "0 12 * * *" ]]; then
-              echo "Branch: main"
-              echo "BRANCH=main" >> $GITHUB_OUTPUT
-            else
-              echo "Unknown schedule: ${{ github.event.schedule }}"
-              exit 1
-            fi
+            echo "Unknown schedule: ${{ github.event.schedule }}"
+            exit 1
           else
             echo "Using GIT_SHA"
             # on workflow_dispatch, this will simply use the inputs.GIT_SHA given (or the default)

--- a/.github/workflows/fullnode-execute-devnet-stable.yaml
+++ b/.github/workflows/fullnode-execute-devnet-stable.yaml
@@ -6,7 +6,7 @@ name: "fullnode-execute-devnet-stable"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 1 * * *" # Once a day, at 01:30 (UTC)
+    - cron: "30 1 */3 * *" # Once every three days, at 01:30 (UTC)
 
 permissions:
   contents: read

--- a/.github/workflows/fullnode-fast-mainnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-stable.yaml
@@ -6,7 +6,7 @@ name: "fullnode-fast-mainnet-stable"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 2 * * *" # Once a day, at 02:30 (UTC)
+    - cron: "30 2 */3 * *" # Once every three days, at 02:30 (UTC)
 
 permissions:
   contents: read

--- a/.github/workflows/fullnode-fast-testnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-testnet-stable.yaml
@@ -6,7 +6,7 @@ name: "fullnode-fast-testnet-stable"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 3 * * *" # Once a day, at 03:30 (UTC)
+    - cron: "30 3 */3 * *" # Once every three days, at 03:30 (UTC)
 
 permissions:
   contents: read

--- a/.github/workflows/fullnode-intelligent-devnet-main.yaml
+++ b/.github/workflows/fullnode-intelligent-devnet-main.yaml
@@ -7,7 +7,7 @@ name: "fullnode-intelligent-devnet-main"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "* 4 * * *" # Once a day, at 04:00 (UTC)
+    - cron: "* 4 */3 * *" # Once every three days, at 04:00 (UTC)
 
 permissions:
   contents: read

--- a/.github/workflows/fullnode-intelligent-mainnet-main.yaml
+++ b/.github/workflows/fullnode-intelligent-mainnet-main.yaml
@@ -7,7 +7,7 @@ name: "fullnode-intelligent-mainnet-main"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 4 * * *" # Once a day, at 04:30 (UTC)
+    - cron: "30 4 */3 * *" # Once every three days, at 04:30 (UTC)
 
 permissions:
   contents: read

--- a/.github/workflows/fullnode-intelligent-testnet-main.yaml
+++ b/.github/workflows/fullnode-intelligent-testnet-main.yaml
@@ -7,7 +7,7 @@ name: "fullnode-intelligent-testnet-main"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 5 * * *" # Once a day, at 05:30 (UTC)
+    - cron: "30 5 */3 * *" # Once every three days, at 05:30 (UTC)
 
 permissions:
   contents: read

--- a/.github/workflows/indexer-grpc-integration-tests.yaml
+++ b/.github/workflows/indexer-grpc-integration-tests.yaml
@@ -23,6 +23,7 @@ jobs:
   # triggered the workflow or on 'pull_request's which have set auto_merge=true
   # or have the label "CICD:run-e2e-tests".
   permission-check:
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     runs-on: ubuntu-latest
     steps:
       - name: Check repository permission for user which triggered workflow
@@ -32,6 +33,7 @@ jobs:
           comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
 
   run-tests-local-testnet:
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     needs: [permission-check]
     runs-on: high-perf-docker
     env:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -106,7 +106,7 @@ jobs:
   rust-cryptohasher-domain-separation-check:
     needs: file_change_determinator
     runs-on: high-perf-docker
-    if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
@@ -231,7 +231,7 @@ jobs:
   # Run the rust network performance unit tests
   rust-network-perf-unit-test:
     runs-on: high-perf-docker
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
+    if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     steps:
       - uses: actions/checkout@v3
         with:
@@ -308,7 +308,7 @@ jobs:
   # Run the network performance smoke test
   rust-network-perf-smoke-test:
     runs-on: high-perf-docker
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
+    if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     steps:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
@@ -336,6 +336,7 @@ jobs:
   # TODO: remove this once the new jobs land
   check-vm-features:
     runs-on: high-perf-docker
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     steps:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,6 +1,7 @@
 name: "Lint+Test"
 on:
   pull_request:
+    types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
   push:
     branches:
       - main

--- a/.github/workflows/prover-test.yaml
+++ b/.github/workflows/prover-test.yaml
@@ -1,7 +1,7 @@
 name: "Prover Test"
 on:
    pull_request:
-     types: [ labeled, opened, synchronize, reopened, auto_merge_enabled ]
+     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
      paths:
        - '**.move'
        - 'Cargo.toml'

--- a/.github/workflows/run-gas-calibration.yaml
+++ b/.github/workflows/run-gas-calibration.yaml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   run-gas-calibration:
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     runs-on: high-perf-docker
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run-gas-calibration.yaml
+++ b/.github/workflows/run-gas-calibration.yaml
@@ -1,6 +1,7 @@
 name: "Gas Calibration"
 on:
   pull_request:
+    types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
   push:
     branches:
       - main

--- a/.github/workflows/rust-client-tests.yaml
+++ b/.github/workflows/rust-client-tests.yaml
@@ -29,6 +29,7 @@ jobs:
           comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
 
   run-tests-devnet:
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     needs: [permission-check]
     runs-on: high-perf-docker
     steps:
@@ -47,6 +48,7 @@ jobs:
           GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
 
   run-tests-testnet:
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     needs: [permission-check]
     runs-on: high-perf-docker
     steps:
@@ -65,6 +67,7 @@ jobs:
           GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
 
   run-tests-mainnet:
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     needs: [permission-check]
     runs-on: high-perf-docker
     steps:

--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -32,6 +32,7 @@ jobs:
           required-permission: write
           comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
 
+  # This is a required job for each pull request.
   run-tests-main-branch:
     needs: [permission-check]
     runs-on: high-perf-docker
@@ -58,6 +59,7 @@ jobs:
   # to be land blocking for any PR on the aptos repo. This is why we run those tests
   # separate from test-sdk-confirm-client-generated-publish.
   run-indexer-tests:
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     needs: [permission-check]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description

This PR offers several changes (each in their commit):
1. To avoid running unnecessary tests on each PR, we skip non-required (i.e., non-land blocking) tests. If PR authors still want to run these tests, they can add the PR label `CICD:non-required-tests`.
2. We remove the scheduled runs of non-critical forge tests. Currently, only the `stable` forge tests are considered critical and high-signal. Other tests are less stable, flaky and really only need to be run on an adhoc basis (e.g., to test performance improvements, etc.). Going forward, we may want to change this (e.g., introduce separate categories of forge jobs, split up the stable jobs, etc.). But, until then, it makes sense to disable the nightly runs and just use ad-hoc scheduling for now.
3. We reduce the schedule frequency of several non-critical fullnode sync jobs (from daily, to every 3 days).
4. Add new PR labels to the non-required jobs file (to ensure jobs run when labels are added).

### Test Plan
Existing test infrastructure.