### PR TITLE
[GHA] Ensure that rust tools are installed.

### DIFF
--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -21,7 +21,7 @@ runs:
 
     - name: install protoc and related tools
       shell: bash
-      run: scripts/dev_setup.sh -b -r -y -P -J
+      run: scripts/dev_setup.sh -b -r -y -P -J -t
 
     - run: echo "/home/runner/.cargo/bin" | tee -a $GITHUB_PATH
       shell: bash


### PR DESCRIPTION
### Description
This PR adds a missing flag to the `dev_setup.sh` script run as part of the `rust-setup` GHA.

### Test Plan
Existing test infrastructure.