### PR TITLE
[Execution][Sharding] Add support for global executor in sharding

### DIFF
--- a/aptos-move/aptos-transaction-benchmarks/src/transactions.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/transactions.rs
@@ -4,7 +4,9 @@
 
 use aptos_bitvec::BitVec;
 use aptos_block_executor::txn_commit_hook::NoOpTransactionCommitHook;
-use aptos_block_partitioner::sharded_block_partitioner::ShardedBlockPartitioner;
+use aptos_block_partitioner::{
+    sharded_block_partitioner::ShardedBlockPartitioner, BlockPartitionerConfig,
+};
 use aptos_crypto::HashValue;
 use aptos_language_e2e_tests::{
     account_universe::{AUTransactionGen, AccountPickStyle, AccountUniverse, AccountUniverseGen},
@@ -256,12 +258,14 @@ where
             let parallel_block_executor = Arc::new(ShardedBlockExecutor::new(client));
             (
                 Some(parallel_block_executor),
-                Some(ShardedBlockPartitioner::new(
-                    num_executor_shards,
-                    4,
-                    0.9,
-                    true,
-                )),
+                Some(
+                    BlockPartitionerConfig::default()
+                        .num_shards(num_executor_shards)
+                        .max_partitioning_rounds(4)
+                        .cross_shard_dep_avoid_threshold(0.9)
+                        .partition_last_round(true)
+                        .build(),
+                ),
             )
         };
 

--- a/aptos-move/aptos-transaction-benchmarks/src/transactions.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/transactions.rs
@@ -256,7 +256,12 @@ where
             let parallel_block_executor = Arc::new(ShardedBlockExecutor::new(client));
             (
                 Some(parallel_block_executor),
-                Some(ShardedBlockPartitioner::new(num_executor_shards)),
+                Some(ShardedBlockPartitioner::new(
+                    num_executor_shards,
+                    4,
+                    0.9,
+                    true,
+                )),
             )
         };
 
@@ -372,8 +377,6 @@ where
                     .into_iter()
                     .map(|txn| txn.into())
                     .collect::<Vec<AnalyzedTransaction>>(),
-                4,
-                0.9,
             );
             parallel_block_executor
                 .execute_block(

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -126,11 +126,8 @@ pub use crate::aptos_vm::AptosVM;
 use crate::sharded_block_executor::{executor_client::ExecutorClient, ShardedBlockExecutor};
 use aptos_state_view::StateView;
 use aptos_types::{
-    block_executor::partitioner::SubBlocksForShard,
-    transaction::{
-        analyzed_transaction::AnalyzedTransaction, SignedTransaction, Transaction,
-        TransactionOutput, VMValidatorResult,
-    },
+    block_executor::partitioner::PartitionedTransactions,
+    transaction::{SignedTransaction, Transaction, TransactionOutput, VMValidatorResult},
     vm_status::VMStatus,
 };
 use std::{marker::Sync, sync::Arc};
@@ -163,7 +160,7 @@ pub trait VMExecutor: Send + Sync {
     /// Executes a block of transactions using a sharded block executor and returns the results.
     fn execute_block_sharded<S: StateView + Sync + Send + 'static, E: ExecutorClient<S>>(
         sharded_block_executor: &ShardedBlockExecutor<S, E>,
-        block: Vec<SubBlocksForShard<AnalyzedTransaction>>,
+        transactions: PartitionedTransactions,
         state_view: Arc<S>,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<Vec<TransactionOutput>, VMStatus>;

--- a/aptos-move/aptos-vm/src/sharded_block_executor/counters.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/counters.rs
@@ -37,7 +37,7 @@ pub static WAIT_FOR_SHARDED_OUTPUT_SECONDS: Lazy<Histogram> = Lazy::new(|| {
         "wait_for_sharded_output_seconds",
         "Time to wait for sharded output in seconds",
     )
-        .unwrap()
+    .unwrap()
 });
 
 pub static SHARDED_BLOCK_EXECUTION_BY_ROUNDS_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {

--- a/aptos-move/aptos-vm/src/sharded_block_executor/counters.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/counters.rs
@@ -24,6 +24,14 @@ pub static SHARDED_BLOCK_EXECUTION_SECONDS: Lazy<Histogram> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static SHARDED_EXECUTION_RESULT_AGGREGATION_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "sharded_execution_result_aggregation_seconds",
+        "Time to aggregate the results of sharded execution in seconds",
+    )
+    .unwrap()
+});
+
 pub static SHARDED_BLOCK_EXECUTION_BY_ROUNDS_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "sharded_block_execution_by_rounds_seconds",

--- a/aptos-move/aptos-vm/src/sharded_block_executor/counters.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/counters.rs
@@ -2,7 +2,10 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_metrics_core::{register_histogram_vec, register_int_gauge, HistogramVec, IntGauge};
+use aptos_metrics_core::{
+    register_histogram, register_histogram_vec, register_int_gauge, Histogram, HistogramVec,
+    IntGauge,
+};
 use once_cell::sync::Lazy;
 
 pub static NUM_EXECUTOR_SHARDS: Lazy<IntGauge> = Lazy::new(|| {
@@ -13,9 +16,17 @@ pub static NUM_EXECUTOR_SHARDS: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static SHARDED_BLOCK_EXECUTION_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
+pub static SHARDED_BLOCK_EXECUTION_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
         "sharded_block_execution_seconds",
+        "Time to execute a block in sharded execution in seconds",
+    )
+    .unwrap()
+});
+
+pub static SHARDED_BLOCK_EXECUTION_BY_ROUNDS_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "sharded_block_execution_by_rounds_seconds",
         "Time to execute a sub block in sharded execution in seconds",
         &["shard_id", "round_id"]
     )

--- a/aptos-move/aptos-vm/src/sharded_block_executor/counters.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/counters.rs
@@ -31,12 +31,3 @@ pub static SHARDED_BLOCK_EXECUTOR_TXN_COUNT: Lazy<HistogramVec> = Lazy::new(|| {
     )
     .unwrap()
 });
-
-pub static CROSS_SHARD_STATE_VALUE_TIMER_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        "cross_shard_state_value_timer_seconds",
-        "Timer for various operations on the cross shard state view in seconds",
-        &["shard_id", "round_id", "op"]
-    )
-    .unwrap()
-});

--- a/aptos-move/aptos-vm/src/sharded_block_executor/counters.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/counters.rs
@@ -32,6 +32,14 @@ pub static SHARDED_EXECUTION_RESULT_AGGREGATION_SECONDS: Lazy<Histogram> = Lazy:
     .unwrap()
 });
 
+pub static WAIT_FOR_SHARDED_OUTPUT_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "wait_for_sharded_output_seconds",
+        "Time to wait for sharded output in seconds",
+    )
+        .unwrap()
+});
+
 pub static SHARDED_BLOCK_EXECUTION_BY_ROUNDS_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "sharded_block_execution_by_rounds_seconds",

--- a/aptos-move/aptos-vm/src/sharded_block_executor/executor_client.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/executor_client.rs
@@ -3,26 +3,43 @@
 
 use aptos_state_view::StateView;
 use aptos_types::{
-    block_executor::partitioner::SubBlocksForShard,
-    transaction::{analyzed_transaction::AnalyzedTransaction, TransactionOutput},
+    block_executor::partitioner::PartitionedTransactions, transaction::TransactionOutput,
 };
 use move_core_types::vm_status::VMStatus;
 use std::sync::Arc;
+
+pub struct ShardedExecutionOutput {
+    pub sharded_output: Vec<Vec<Vec<TransactionOutput>>>,
+    pub global_output: Vec<TransactionOutput>,
+}
+
+impl ShardedExecutionOutput {
+    pub fn new(
+        sharded_output: Vec<Vec<Vec<TransactionOutput>>>,
+        global_output: Vec<TransactionOutput>,
+    ) -> Self {
+        Self {
+            sharded_output,
+            global_output,
+        }
+    }
+
+    pub fn into_inner(self) -> (Vec<Vec<Vec<TransactionOutput>>>, Vec<TransactionOutput>) {
+        (self.sharded_output, self.global_output)
+    }
+}
 
 // Interface to communicate from the block executor coordinator to the executor shards.
 pub trait ExecutorClient<S: StateView + Sync + Send + 'static>: Send + Sync {
     fn num_shards(&self) -> usize;
 
-    // A non blocking call that sends the block to be executed by the executor shards.
+    // A blocking call that executes the transactions in the block. It returns the execution results from each shard
+    // and in the round order and also the global output.
     fn execute_block(
         &self,
         state_view: Arc<S>,
-        block: Vec<SubBlocksForShard<AnalyzedTransaction>>,
+        transactions: PartitionedTransactions,
         concurrency_level_per_shard: usize,
         maybe_block_gas_limit: Option<u64>,
-    );
-
-    // Blocking call that waits for the execution results from the executor shards. It returns the execution results
-    // from each shard and in the sub-block order.
-    fn get_execution_result(&self) -> Result<Vec<Vec<Vec<TransactionOutput>>>, VMStatus>;
+    ) -> Result<ShardedExecutionOutput, VMStatus>;
 }

--- a/aptos-move/aptos-vm/src/sharded_block_executor/global_executor.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/global_executor.rs
@@ -1,0 +1,62 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::sharded_block_executor::{
+    local_executor_shard::GlobalCrossShardClient, sharded_executor_service::ShardedExecutorService,
+};
+use aptos_logger::trace;
+use aptos_state_view::StateView;
+use aptos_types::{
+    block_executor::partitioner::{TransactionWithDependencies, GLOBAL_ROUND_ID},
+    transaction::{analyzed_transaction::AnalyzedTransaction, TransactionOutput},
+};
+use move_core_types::vm_status::VMStatus;
+use std::sync::Arc;
+
+pub struct GlobalExecutor<S: StateView + Sync + Send + 'static> {
+    global_cross_shard_client: Arc<GlobalCrossShardClient>,
+    executor_thread_pool: Arc<rayon::ThreadPool>,
+    phantom: std::marker::PhantomData<S>,
+}
+
+impl<S: StateView + Sync + Send + 'static> GlobalExecutor<S> {
+    pub fn new(cross_shard_client: Arc<GlobalCrossShardClient>, num_threads: usize) -> Self {
+        let executor_thread_pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                // We need two extra threads for the cross-shard commit receiver and the thread
+                // that is blocked on waiting for execute block to finish.
+                .num_threads(num_threads)
+                .build()
+                .unwrap(),
+        );
+        Self {
+            global_cross_shard_client: cross_shard_client,
+            executor_thread_pool,
+            phantom: std::marker::PhantomData,
+        }
+    }
+
+    pub fn execute_global_txns(
+        &self,
+        transactions: Vec<TransactionWithDependencies<AnalyzedTransaction>>,
+        state_view: &S,
+        concurrency_level: usize,
+        maybe_block_gas_limit: Option<u64>,
+    ) -> Result<Vec<TransactionOutput>, VMStatus> {
+        trace!("executing the last round in global executor",);
+        if transactions.is_empty() {
+            return Ok(vec![]);
+        }
+        ShardedExecutorService::execute_transactions_with_dependencies(
+            None,
+            self.executor_thread_pool.clone(),
+            transactions,
+            self.global_cross_shard_client.clone(),
+            None,
+            GLOBAL_ROUND_ID,
+            state_view,
+            concurrency_level,
+            maybe_block_gas_limit,
+        )
+    }
+}

--- a/aptos-move/aptos-vm/src/sharded_block_executor/global_executor.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/global_executor.rs
@@ -25,7 +25,7 @@ impl<S: StateView + Sync + Send + 'static> GlobalExecutor<S> {
             rayon::ThreadPoolBuilder::new()
                 // We need two extra threads for the cross-shard commit receiver and the thread
                 // that is blocked on waiting for execute block to finish.
-                .num_threads(num_threads)
+                .num_threads(num_threads + 2)
                 .build()
                 .unwrap(),
         );

--- a/aptos-move/aptos-vm/src/sharded_block_executor/local_executor_shard.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/local_executor_shard.rs
@@ -21,6 +21,7 @@ use aptos_types::{
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use move_core_types::vm_status::VMStatus;
 use std::{sync::Arc, thread};
+use crate::sharded_block_executor::counters::WAIT_FOR_SHARDED_OUTPUT_SECONDS;
 
 /// Executor service that runs on local machine and waits for commands from the coordinator and executes
 /// them in parallel.
@@ -146,6 +147,7 @@ impl<S: StateView + Sync + Send + 'static> LocalExecutorClient<S> {
     }
 
     fn get_output_from_shards(&self) -> Result<Vec<Vec<Vec<TransactionOutput>>>, VMStatus> {
+        let _timer = WAIT_FOR_SHARDED_OUTPUT_SECONDS.start_timer();
         trace!("LocalExecutorClient Waiting for results");
         let mut results = vec![];
         for (i, rx) in self.result_rxs.iter().enumerate() {

--- a/aptos-move/aptos-vm/src/sharded_block_executor/local_executor_shard.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/local_executor_shard.rs
@@ -3,6 +3,7 @@
 
 use crate::sharded_block_executor::{
     coordinator_client::CoordinatorClient,
+    counters::WAIT_FOR_SHARDED_OUTPUT_SECONDS,
     cross_shard_client::CrossShardClient,
     executor_client::{ExecutorClient, ShardedExecutionOutput},
     global_executor::GlobalExecutor,
@@ -21,7 +22,6 @@ use aptos_types::{
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use move_core_types::vm_status::VMStatus;
 use std::{sync::Arc, thread};
-use crate::sharded_block_executor::counters::WAIT_FOR_SHARDED_OUTPUT_SECONDS;
 
 /// Executor service that runs on local machine and waits for commands from the coordinator and executes
 /// them in parallel.

--- a/aptos-move/aptos-vm/src/sharded_block_executor/local_executor_shard.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/local_executor_shard.rs
@@ -187,6 +187,8 @@ impl<S: StateView + Sync + Send + 'static> ExecutorClient<S> for LocalExecutorCl
         // global transactions will be blocked for cross shard transaction results. This hopefully will help with
         // finishing the global transactions faster but we need to evaluate if this causes thread contention. If it
         // does, then we can simply move this call to the end of the function.
+        let sharded_output = self.get_output_from_shards()?;
+
         let global_output = self.global_executor.execute_global_txns(
             global_txns,
             state_view.as_ref(),
@@ -194,7 +196,6 @@ impl<S: StateView + Sync + Send + 'static> ExecutorClient<S> for LocalExecutorCl
             maybe_block_gas_limit,
         )?;
 
-        let sharded_output = self.get_output_from_shards()?;
         Ok(ShardedExecutionOutput::new(sharded_output, global_output))
     }
 }

--- a/aptos-move/aptos-vm/src/sharded_block_executor/local_executor_shard.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/local_executor_shard.rs
@@ -62,8 +62,8 @@ impl<S: StateView + Sync + Send + 'static> LocalExecutorService<S> {
             cross_shard_tx.clone(),
             cross_shard_rx,
         ));
-        // Limit the number of global executor threads to 24 as parallel execution doesn't scale well beyond that.
-        let executor_threads = num_cpus::get().min(24);
+        // Limit the number of global executor threads to 32 as parallel execution doesn't scale well beyond that.
+        let executor_threads = num_cpus::get().min(32);
         let global_executor = GlobalExecutor::new(cross_shard_client, executor_threads);
         (global_executor, cross_shard_tx)
     }

--- a/aptos-move/aptos-vm/src/sharded_block_executor/local_executor_shard.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/local_executor_shard.rs
@@ -1,16 +1,22 @@
 // Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::sharded_block_executor::{
-    coordinator_client::CoordinatorClient, cross_shard_client::CrossShardClient,
-    executor_client::ExecutorClient, messages::CrossShardMsg,
-    sharded_executor_service::ShardedExecutorService, ExecutorShardCommand,
+    coordinator_client::CoordinatorClient,
+    cross_shard_client::CrossShardClient,
+    executor_client::{ExecutorClient, ShardedExecutionOutput},
+    global_executor::GlobalExecutor,
+    messages::CrossShardMsg,
+    sharded_executor_service::ShardedExecutorService,
+    ExecutorShardCommand,
 };
-use aptos_block_partitioner::sharded_block_partitioner::MAX_ALLOWED_PARTITIONING_ROUNDS;
 use aptos_logger::trace;
 use aptos_state_view::StateView;
 use aptos_types::{
-    block_executor::partitioner::{RoundId, ShardId, SubBlocksForShard},
-    transaction::{analyzed_transaction::AnalyzedTransaction, TransactionOutput},
+    block_executor::partitioner::{
+        PartitionedTransactions, RoundId, ShardId, GLOBAL_ROUND_ID, MAX_ALLOWED_PARTITIONING_ROUNDS,
+    },
+    transaction::TransactionOutput,
 };
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use move_core_types::vm_status::VMStatus;
@@ -50,10 +56,23 @@ impl<S: StateView + Sync + Send + 'static> LocalExecutorService<S> {
         }
     }
 
+    fn setup_global_executor() -> (GlobalExecutor<S>, Sender<CrossShardMsg>) {
+        let (cross_shard_tx, cross_shard_rx) = unbounded();
+        let cross_shard_client = Arc::new(GlobalCrossShardClient::new(
+            cross_shard_tx.clone(),
+            cross_shard_rx,
+        ));
+        // Limit the number of global executor threads to 24 as parallel execution doesn't scale well beyond that.
+        let executor_threads = num_cpus::get().min(24);
+        let global_executor = GlobalExecutor::new(cross_shard_client, executor_threads);
+        (global_executor, cross_shard_tx)
+    }
+
     pub fn setup_local_executor_shards(
         num_shards: usize,
         num_threads: Option<usize>,
     ) -> LocalExecutorClient<S> {
+        let (global_executor, global_cross_shard_tx) = Self::setup_global_executor();
         let num_threads = num_threads
             .unwrap_or_else(|| (num_cpus::get() as f64 / num_shards as f64).ceil() as usize);
         let (command_txs, command_rxs): (
@@ -83,8 +102,11 @@ impl<S: StateView + Sync + Send + 'static> LocalExecutorService<S> {
             .zip(cross_shard_msg_rxs.into_iter())
             .enumerate()
             .map(|(shard_id, ((command_rx, result_tx), cross_shard_rxs))| {
-                let cross_shard_client =
-                    LocalCrossShardClient::new(cross_shard_msg_txs.clone(), cross_shard_rxs);
+                let cross_shard_client = LocalCrossShardClient::new(
+                    global_cross_shard_tx.clone(),
+                    cross_shard_msg_txs.clone(),
+                    cross_shard_rxs,
+                );
                 Self::new(
                     shard_id as ShardId,
                     num_shards,
@@ -95,7 +117,7 @@ impl<S: StateView + Sync + Send + 'static> LocalExecutorService<S> {
                 )
             })
             .collect();
-        LocalExecutorClient::new(command_txs, result_rxs, executor_shards)
+        LocalExecutorClient::new(command_txs, result_rxs, executor_shards, global_executor)
     }
 }
 
@@ -104,8 +126,8 @@ pub struct LocalExecutorClient<S: StateView + Sync + Send + 'static> {
     command_txs: Vec<Sender<ExecutorShardCommand<S>>>,
     // Channels to receive execution results from the executor shards.
     result_rxs: Vec<Receiver<Result<Vec<Vec<TransactionOutput>>, VMStatus>>>,
-
     executor_services: Vec<LocalExecutorService<S>>,
+    global_executor: GlobalExecutor<S>,
 }
 
 impl<S: StateView + Sync + Send + 'static> LocalExecutorClient<S> {
@@ -113,12 +135,26 @@ impl<S: StateView + Sync + Send + 'static> LocalExecutorClient<S> {
         command_tx: Vec<Sender<ExecutorShardCommand<S>>>,
         result_rx: Vec<Receiver<Result<Vec<Vec<TransactionOutput>>, VMStatus>>>,
         executor_shards: Vec<LocalExecutorService<S>>,
+        global_executor: GlobalExecutor<S>,
     ) -> Self {
         Self {
             command_txs: command_tx,
             result_rxs: result_rx,
             executor_services: executor_shards,
+            global_executor,
         }
+    }
+
+    fn get_output_from_shards(&self) -> Result<Vec<Vec<Vec<TransactionOutput>>>, VMStatus> {
+        trace!("LocalExecutorClient Waiting for results");
+        let mut results = vec![];
+        for (i, rx) in self.result_rxs.iter().enumerate() {
+            results.push(
+                rx.recv()
+                    .unwrap_or_else(|_| panic!("Did not receive output from shard {}", i))?,
+            );
+        }
+        Ok(results)
     }
 }
 
@@ -130,12 +166,13 @@ impl<S: StateView + Sync + Send + 'static> ExecutorClient<S> for LocalExecutorCl
     fn execute_block(
         &self,
         state_view: Arc<S>,
-        block: Vec<SubBlocksForShard<AnalyzedTransaction>>,
+        transactions: PartitionedTransactions,
         concurrency_level_per_shard: usize,
         maybe_block_gas_limit: Option<u64>,
-    ) {
-        assert_eq!(block.len(), self.num_shards());
-        for (i, sub_blocks_for_shard) in block.into_iter().enumerate() {
+    ) -> Result<ShardedExecutionOutput, VMStatus> {
+        assert_eq!(transactions.num_shards(), self.num_shards());
+        let (sub_blocks, global_txns) = transactions.into();
+        for (i, sub_blocks_for_shard) in sub_blocks.into_iter().enumerate() {
             self.command_txs[i]
                 .send(ExecutorShardCommand::ExecuteSubBlocks(
                     state_view.clone(),
@@ -145,18 +182,20 @@ impl<S: StateView + Sync + Send + 'static> ExecutorClient<S> for LocalExecutorCl
                 ))
                 .unwrap();
         }
-    }
 
-    fn get_execution_result(&self) -> Result<Vec<Vec<Vec<TransactionOutput>>>, VMStatus> {
-        trace!("LocalExecutorClient Waiting for results");
-        let mut results = vec![];
-        for (i, rx) in self.result_rxs.iter().enumerate() {
-            results.push(
-                rx.recv()
-                    .unwrap_or_else(|_| panic!("Did not receive output from shard {}", i))?,
-            );
-        }
-        Ok(results)
+        // This means that we are executing the global transactions concurrently with the individual shards but the
+        // global transactions will be blocked for cross shard transaction results. This hopefully will help with
+        // finishing the global transactions faster but we need to evaluate if this causes thread contention. If it
+        // does, then we can simply move this call to the end of the function.
+        let global_output = self.global_executor.execute_global_txns(
+            global_txns,
+            state_view.as_ref(),
+            concurrency_level_per_shard,
+            maybe_block_gas_limit,
+        )?;
+
+        let sharded_output = self.get_output_from_shards()?;
+        Ok(ShardedExecutionOutput::new(sharded_output, global_output))
     }
 }
 
@@ -201,7 +240,43 @@ impl<S: StateView + Sync + Send + 'static> CoordinatorClient<S> for LocalCoordin
     }
 }
 
+/// A cross shard client used by the global shard to receive cross-shard messages from other shards.
+pub struct GlobalCrossShardClient {
+    // Sender of global cross-shard message, used for sending Stop message to self.
+    global_message_tx: Sender<CrossShardMsg>,
+    // The receiver of cross-shard messages from other shards
+    global_message_rx: Receiver<CrossShardMsg>,
+}
+
+impl GlobalCrossShardClient {
+    pub fn new(message_tx: Sender<CrossShardMsg>, message_rx: Receiver<CrossShardMsg>) -> Self {
+        Self {
+            global_message_tx: message_tx,
+            global_message_rx: message_rx,
+        }
+    }
+}
+
+impl CrossShardClient for GlobalCrossShardClient {
+    fn send_global_msg(&self, msg: CrossShardMsg) {
+        self.global_message_tx.send(msg).unwrap()
+    }
+
+    fn send_cross_shard_msg(&self, _shard_id: ShardId, _round: RoundId, _msg: CrossShardMsg) {
+        unreachable!("Global shard client should not send cross-shard messages")
+    }
+
+    fn receive_cross_shard_msg(&self, current_round: RoundId) -> CrossShardMsg {
+        assert_eq!(
+            current_round, GLOBAL_ROUND_ID,
+            "Global shard client should only receive cross-shard messages in global round"
+        );
+        self.global_message_rx.recv().unwrap()
+    }
+}
+
 pub struct LocalCrossShardClient {
+    global_message_tx: Sender<CrossShardMsg>,
     // The senders of cross-shard messages to other shards per round.
     message_txs: Vec<Vec<Sender<CrossShardMsg>>>,
     // The receivers of cross shard messages from other shards per round.
@@ -210,10 +285,12 @@ pub struct LocalCrossShardClient {
 
 impl LocalCrossShardClient {
     pub fn new(
+        global_message_tx: Sender<CrossShardMsg>,
         cross_shard_txs: Vec<Vec<Sender<CrossShardMsg>>>,
         cross_shard_rxs: Vec<Receiver<CrossShardMsg>>,
     ) -> Self {
         Self {
+            global_message_tx,
             message_txs: cross_shard_txs,
             message_rxs: cross_shard_rxs,
         }
@@ -221,6 +298,10 @@ impl LocalCrossShardClient {
 }
 
 impl CrossShardClient for LocalCrossShardClient {
+    fn send_global_msg(&self, msg: CrossShardMsg) {
+        self.global_message_tx.send(msg).unwrap()
+    }
+
     fn send_cross_shard_msg(&self, shard_id: ShardId, round: RoundId, msg: CrossShardMsg) {
         self.message_txs[shard_id][round].send(msg).unwrap()
     }

--- a/aptos-move/aptos-vm/src/sharded_block_executor/local_executor_shard.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/local_executor_shard.rs
@@ -187,8 +187,6 @@ impl<S: StateView + Sync + Send + 'static> ExecutorClient<S> for LocalExecutorCl
         // global transactions will be blocked for cross shard transaction results. This hopefully will help with
         // finishing the global transactions faster but we need to evaluate if this causes thread contention. If it
         // does, then we can simply move this call to the end of the function.
-        let sharded_output = self.get_output_from_shards()?;
-
         let global_output = self.global_executor.execute_global_txns(
             global_txns,
             state_view.as_ref(),
@@ -196,6 +194,7 @@ impl<S: StateView + Sync + Send + 'static> ExecutorClient<S> for LocalExecutorCl
             maybe_block_gas_limit,
         )?;
 
+        let sharded_output = self.get_output_from_shards()?;
         Ok(ShardedExecutionOutput::new(sharded_output, global_output))
     }
 }

--- a/aptos-move/aptos-vm/src/sharded_block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/mod.rs
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::sharded_block_executor::{
-    counters::{NUM_EXECUTOR_SHARDS, SHARDED_BLOCK_EXECUTION_SECONDS},
+    counters::{
+        NUM_EXECUTOR_SHARDS, SHARDED_BLOCK_EXECUTION_SECONDS,
+        SHARDED_EXECUTION_RESULT_AGGREGATION_SECONDS,
+    },
     executor_client::ExecutorClient,
 };
 use aptos_logger::{info, trace};
@@ -90,6 +93,7 @@ impl<S: StateView + Sync + Send + 'static, C: ExecutorClient<S>> ShardedBlockExe
             .into_inner();
         // wait for all remote executors to send the result back and append them in order by shard id
         trace!("ShardedBlockExecutor Received all results");
+        let _aggregation_timer = SHARDED_EXECUTION_RESULT_AGGREGATION_SECONDS.start_timer();
         let num_rounds = sharded_output[0].len();
         let mut aggregated_results = vec![];
         let mut ordered_results = vec![vec![]; num_executor_shards * num_rounds];

--- a/aptos-move/aptos-vm/src/sharded_block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/mod.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::sharded_block_executor::{
-    counters::NUM_EXECUTOR_SHARDS, executor_client::ExecutorClient,
+    counters::{NUM_EXECUTOR_SHARDS, SHARDED_BLOCK_EXECUTION_SECONDS},
+    executor_client::ExecutorClient,
 };
 use aptos_logger::{info, trace};
 use aptos_state_view::StateView;
@@ -69,6 +70,7 @@ impl<S: StateView + Sync + Send + 'static, C: ExecutorClient<S>> ShardedBlockExe
         concurrency_level_per_shard: usize,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
+        let _timer = SHARDED_BLOCK_EXECUTION_SECONDS.start_timer();
         let num_executor_shards = self.executor_client.num_shards();
         NUM_EXECUTOR_SHARDS.set(num_executor_shards as i64);
         assert_eq!(

--- a/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
@@ -14,12 +14,14 @@ use crate::{
 use aptos_logger::{info, trace};
 use aptos_state_view::StateView;
 use aptos_types::{
-    block_executor::partitioner::{ShardId, SubBlock, SubBlocksForShard},
+    block_executor::partitioner::{
+        ShardId, SubBlock, SubBlocksForShard, TransactionWithDependencies,
+    },
     transaction::{analyzed_transaction::AnalyzedTransaction, TransactionOutput},
 };
 use futures::{channel::oneshot, executor::block_on};
 use move_core_types::vm_status::VMStatus;
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 
 pub struct ShardedExecutorService<S: StateView + Sync + Send + 'static> {
     shard_id: ShardId,
@@ -54,23 +56,6 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
         }
     }
 
-    fn create_cross_shard_state_view<'a>(
-        &self,
-        base_view: &'a S,
-        sub_block: &SubBlock<AnalyzedTransaction>,
-        round_id: usize,
-    ) -> CrossShardStateView<'a, S> {
-        let mut cross_shard_state_key = HashSet::new();
-        for txn in &sub_block.transactions {
-            for (_, storage_locations) in txn.cross_shard_dependencies.required_edges_iter() {
-                for storage_location in storage_locations {
-                    cross_shard_state_key.insert(storage_location.clone().into_state_key());
-                }
-            }
-        }
-        CrossShardStateView::new(self.shard_id, round_id, cross_shard_state_key, base_view)
-    }
-
     fn execute_sub_block(
         &self,
         sub_block: SubBlock<AnalyzedTransaction>,
@@ -86,15 +71,42 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
         );
         let cross_shard_commit_sender =
             CrossShardCommitSender::new(self.shard_id, self.cross_shard_client.clone(), &sub_block);
+        Self::execute_transactions_with_dependencies(
+            Some(self.shard_id),
+            self.executor_thread_pool.clone(),
+            sub_block.into_transactions_with_deps(),
+            self.cross_shard_client.clone(),
+            Some(cross_shard_commit_sender),
+            round,
+            state_view,
+            concurrency_level,
+            maybe_block_gas_limit,
+        )
+    }
 
+    pub fn execute_transactions_with_dependencies(
+        shard_id: Option<ShardId>, // None means execution on global shard
+        executor_thread_pool: Arc<rayon::ThreadPool>,
+        transactions: Vec<TransactionWithDependencies<AnalyzedTransaction>>,
+        cross_shard_client: Arc<dyn CrossShardClient>,
+        cross_shard_commit_sender: Option<CrossShardCommitSender>,
+        round: usize,
+        state_view: &S,
+        concurrency_level: usize,
+        maybe_block_gas_limit: Option<u64>,
+    ) -> Result<Vec<TransactionOutput>, VMStatus> {
         let (callback, callback_receiver) = oneshot::channel();
 
-        let cross_shard_state_view =
-            Arc::new(self.create_cross_shard_state_view(state_view, &sub_block, round));
+        let cross_shard_state_view = Arc::new(CrossShardStateView::create_cross_shard_state_view(
+            shard_id,
+            round,
+            state_view,
+            &transactions,
+        ));
+
         let cross_shard_state_view_clone = cross_shard_state_view.clone();
-        let cross_shard_client = self.cross_shard_client.clone();
         let cross_shard_client_clone = cross_shard_client.clone();
-        self.executor_thread_pool.scope(|s| {
+        executor_thread_pool.clone().scope(|s| {
             s.spawn(move |_| {
                 CrossShardCommitReceiver::start(
                     cross_shard_state_view_clone,
@@ -104,28 +116,33 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
             });
             s.spawn(move |_| {
                 let ret = BlockAptosVM::execute_block(
-                    self.executor_thread_pool.clone(),
-                    sub_block
-                        .into_txns()
+                    executor_thread_pool,
+                    transactions
                         .into_iter()
-                        .map(|txn| txn.into_txn())
+                        .map(|txn| txn.into_txn().into_txn())
                         .collect(),
                     cross_shard_state_view.as_ref(),
                     concurrency_level,
                     maybe_block_gas_limit,
-                    Some(cross_shard_commit_sender),
+                    cross_shard_commit_sender,
                 );
-                trace!(
-                    "executed sub block for shard {} and round {}",
-                    self.shard_id,
-                    round
-                );
-                // Send a self message to stop the cross-shard commit receiver.
-                cross_shard_client_clone.send_cross_shard_msg(
-                    self.shard_id,
-                    round,
-                    CrossShardMsg::StopMsg,
-                );
+                if let Some(shard_id) = shard_id {
+                    trace!(
+                        "executed sub block for shard {} and round {}",
+                        shard_id,
+                        round
+                    );
+                    // Send a self message to stop the cross-shard commit receiver.
+                    cross_shard_client_clone.send_cross_shard_msg(
+                        shard_id,
+                        round,
+                        CrossShardMsg::StopMsg,
+                    );
+                } else {
+                    trace!("executed block for global shard and round {}", round);
+                    // Send a self message to stop the cross-shard commit receiver.
+                    cross_shard_client_clone.send_global_msg(CrossShardMsg::StopMsg);
+                }
                 callback.send(ret).unwrap();
             });
         });

--- a/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
@@ -4,7 +4,7 @@ use crate::{
     block_executor::BlockAptosVM,
     sharded_block_executor::{
         coordinator_client::CoordinatorClient,
-        counters::{SHARDED_BLOCK_EXECUTION_SECONDS, SHARDED_BLOCK_EXECUTOR_TXN_COUNT},
+        counters::{SHARDED_BLOCK_EXECUTION_BY_ROUNDS_SECONDS, SHARDED_BLOCK_EXECUTOR_TXN_COUNT},
         cross_shard_client::{CrossShardClient, CrossShardCommitReceiver, CrossShardCommitSender},
         cross_shard_state_view::CrossShardStateView,
         messages::CrossShardMsg,
@@ -156,7 +156,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
     ) -> Result<Vec<Vec<TransactionOutput>>, VMStatus> {
         let mut result = vec![];
         for (round, sub_block) in transactions.into_sub_blocks().into_iter().enumerate() {
-            let _timer = SHARDED_BLOCK_EXECUTION_SECONDS
+            let _timer = SHARDED_BLOCK_EXECUTION_BY_ROUNDS_SECONDS
                 .with_label_values(&[&self.shard_id.to_string(), &round.to_string()])
                 .start_timer();
             SHARDED_BLOCK_EXECUTOR_TXN_COUNT

--- a/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
@@ -98,8 +98,6 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
         let (callback, callback_receiver) = oneshot::channel();
 
         let cross_shard_state_view = Arc::new(CrossShardStateView::create_cross_shard_state_view(
-            shard_id,
-            round,
             state_view,
             &transactions,
         ));

--- a/aptos-move/aptos-vm/src/sharded_block_executor/test_utils.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/test_utils.rs
@@ -11,7 +11,7 @@ use aptos_language_e2e_tests::{
     executor::FakeExecutor,
 };
 use aptos_types::{
-    block_executor::partitioner::SubBlocksForShard,
+    block_executor::partitioner::PartitionedTransactions,
     state_store::state_key::StateKeyInner,
     transaction::{analyzed_transaction::AnalyzedTransaction, Transaction, TransactionOutput},
 };
@@ -112,8 +112,8 @@ pub fn test_sharded_block_executor_no_conflict<E: ExecutorClient<FakeDataStore>>
     for _ in 0..num_txns {
         transactions.push(generate_non_conflicting_p2p(&mut executor).0)
     }
-    let partitioner = ShardedBlockPartitioner::new(num_shards);
-    let partitioned_txns = partitioner.partition(transactions.clone(), 2, 0.9);
+    let partitioner = ShardedBlockPartitioner::new(num_shards, 2, 0.9, false);
+    let partitioned_txns = partitioner.partition(transactions.clone());
     let sharded_txn_output = sharded_block_executor
         .execute_block(
             Arc::new(executor.data_store().clone()),
@@ -158,10 +158,10 @@ pub fn sharded_block_executor_with_conflict<E: ExecutorClient<FakeDataStore>>(
         }
     }
 
-    let partitioner = ShardedBlockPartitioner::new(num_shards);
-    let partitioned_txns = partitioner.partition(transactions.clone(), 8, 0.9);
+    let partitioner = ShardedBlockPartitioner::new(num_shards, 8, 0.9, false);
+    let partitioned_txns = partitioner.partition(transactions.clone());
 
-    let execution_ordered_txns = SubBlocksForShard::flatten(partitioned_txns.clone())
+    let execution_ordered_txns = PartitionedTransactions::flatten(partitioned_txns.clone())
         .into_iter()
         .map(|t| t.into_txn())
         .collect();
@@ -209,10 +209,10 @@ pub fn sharded_block_executor_with_random_transfers<E: ExecutorClient<FakeDataSt
         transactions.push(txn)
     }
 
-    let partitioner = ShardedBlockPartitioner::new(num_shards);
-    let partitioned_txns = partitioner.partition(transactions.clone(), 8, 0.9);
+    let partitioner = ShardedBlockPartitioner::new(num_shards, 8, 0.9, false);
+    let partitioned_txns = partitioner.partition(transactions.clone());
 
-    let execution_ordered_txns = SubBlocksForShard::flatten(partitioned_txns.clone())
+    let execution_ordered_txns = PartitionedTransactions::flatten(partitioned_txns.clone())
         .into_iter()
         .map(|t| t.into_txn())
         .collect();

--- a/aptos-move/aptos-vm/src/sharded_block_executor/tests.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/tests.rs
@@ -1,53 +1,87 @@
 // Copyright © Aptos Foundation
 
 use crate::{
-    sharded_block_executor::{local_executor_shard::LocalExecutorService, test_utils},
+    sharded_block_executor::{
+        local_executor_shard::{LocalExecutorClient, LocalExecutorService},
+        test_utils,
+    },
     ShardedBlockExecutor,
 };
+use aptos_state_view::StateView;
 use rand::{rngs::OsRng, Rng};
+
+fn setup_sharded_block_executor<S: StateView + Sync + Send + 'static>(
+    num_shards: usize,
+    num_threads_per_shard: Option<usize>,
+) -> ShardedBlockExecutor<S, LocalExecutorClient<S>> {
+    let client =
+        LocalExecutorService::setup_local_executor_shards(num_shards, num_threads_per_shard);
+    ShardedBlockExecutor::new(client)
+}
 
 #[test]
 fn test_sharded_block_executor_no_conflict() {
-    let num_shards = 8;
-    let client = LocalExecutorService::setup_local_executor_shards(num_shards, Some(2));
-    let sharded_block_executor = ShardedBlockExecutor::new(client);
-    test_utils::test_sharded_block_executor_no_conflict(sharded_block_executor);
+    for last_round_partition in [true, false].iter() {
+        let sharded_block_executor = setup_sharded_block_executor(8, Some(4));
+        test_utils::test_sharded_block_executor_no_conflict(
+            sharded_block_executor,
+            *last_round_partition,
+        );
+    }
 }
 
 #[test]
 // Sharded execution with cross shard conflict doesn't work for now because we don't have
 // cross round dependency tracking yet.
 fn test_sharded_block_executor_with_conflict_parallel() {
-    let num_shards = 7;
-    let client = LocalExecutorService::setup_local_executor_shards(num_shards, Some(4));
-    let sharded_block_executor = ShardedBlockExecutor::new(client);
-    test_utils::sharded_block_executor_with_conflict(sharded_block_executor, 4);
+    for last_round_partition in [true, false].iter() {
+        let sharded_block_executor = setup_sharded_block_executor(7, Some(4));
+        test_utils::sharded_block_executor_with_conflict(
+            sharded_block_executor,
+            4,
+            *last_round_partition,
+        );
+    }
 }
 
 #[test]
 fn test_sharded_block_executor_with_conflict_sequential() {
-    let num_shards = 7;
-    let client = LocalExecutorService::setup_local_executor_shards(num_shards, Some(1));
-    let sharded_block_executor = ShardedBlockExecutor::new(client);
-    test_utils::sharded_block_executor_with_conflict(sharded_block_executor, 1)
+    for last_round_partition in [true, false].iter() {
+        let sharded_block_executor = setup_sharded_block_executor(7, Some(1));
+        test_utils::sharded_block_executor_with_conflict(
+            sharded_block_executor,
+            1,
+            *last_round_partition,
+        )
+    }
 }
 
 #[test]
 fn test_sharded_block_executor_with_random_transfers_parallel() {
-    let mut rng = OsRng;
-    let max_num_shards = 32;
-    let num_shards = rng.gen_range(1, max_num_shards);
-    let client = LocalExecutorService::setup_local_executor_shards(num_shards, Some(4));
-    let sharded_block_executor = ShardedBlockExecutor::new(client);
-    test_utils::sharded_block_executor_with_random_transfers(sharded_block_executor, 4)
+    for last_round_partition in [true, false].iter() {
+        let mut rng = OsRng;
+        let max_num_shards = 32;
+        let num_shards = rng.gen_range(1, max_num_shards);
+        let sharded_block_executor = setup_sharded_block_executor(num_shards, Some(4));
+        test_utils::sharded_block_executor_with_random_transfers(
+            sharded_block_executor,
+            4,
+            *last_round_partition,
+        );
+    }
 }
 
 #[test]
 fn test_sharded_block_executor_with_random_transfers_sequential() {
-    let mut rng = OsRng;
-    let max_num_shards = 32;
-    let num_shards = rng.gen_range(1, max_num_shards);
-    let client = LocalExecutorService::setup_local_executor_shards(num_shards, Some(1));
-    let sharded_block_executor = ShardedBlockExecutor::new(client);
-    test_utils::sharded_block_executor_with_random_transfers(sharded_block_executor, 1)
+    for last_round_partition in [true, false].iter() {
+        let mut rng = OsRng;
+        let max_num_shards = 32;
+        let num_shards = rng.gen_range(1, max_num_shards);
+        let sharded_block_executor = setup_sharded_block_executor(num_shards, Some(1));
+        test_utils::sharded_block_executor_with_random_transfers(
+            sharded_block_executor,
+            1,
+            *last_round_partition,
+        )
+    }
 }

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -600,7 +600,9 @@ where
         base_view: &S,
     ) -> Result<Vec<E::Output>, E::Error> {
         let num_txns = signature_verified_block.len();
+        let init_timer = VM_INIT_SECONDS.start_timer();
         let executor = E::init(executor_arguments);
+        drop(init_timer);
         let data_map = UnsyncMap::new();
 
         let mut ret = Vec::with_capacity(num_txns);

--- a/execution/block-partitioner/src/lib.rs
+++ b/execution/block-partitioner/src/lib.rs
@@ -4,33 +4,3 @@
 
 pub mod sharded_block_partitioner;
 pub mod test_utils;
-
-use aptos_types::transaction::Transaction;
-
-pub trait BlockPartitioner: Send + Sync {
-    fn partition(&self, transactions: Vec<Transaction>, num_shards: usize)
-        -> Vec<Vec<Transaction>>;
-}
-
-/// An implementation of partitioner that splits the transactions into equal-sized chunks.
-pub struct UniformPartitioner {}
-
-impl BlockPartitioner for UniformPartitioner {
-    fn partition(
-        &self,
-        transactions: Vec<Transaction>,
-        num_shards: usize,
-    ) -> Vec<Vec<Transaction>> {
-        let total_txns = transactions.len();
-        if total_txns == 0 {
-            return vec![];
-        }
-        let txns_per_shard = (total_txns as f64 / num_shards as f64).ceil() as usize;
-
-        let mut result = Vec::new();
-        for chunk in transactions.chunks(txns_per_shard) {
-            result.push(chunk.to_vec());
-        }
-        result
-    }
-}

--- a/execution/block-partitioner/src/lib.rs
+++ b/execution/block-partitioner/src/lib.rs
@@ -2,5 +2,61 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::sharded_block_partitioner::ShardedBlockPartitioner;
+use aptos_types::block_executor::partitioner::RoundId;
+
 pub mod sharded_block_partitioner;
 pub mod test_utils;
+
+pub struct BlockPartitionerConfig {
+    num_shards: usize,
+    max_partitioning_rounds: RoundId,
+    cross_shard_dep_avoid_threshold: f32,
+    partition_last_round: bool,
+}
+
+impl BlockPartitionerConfig {
+    pub fn new() -> Self {
+        BlockPartitionerConfig {
+            num_shards: 0,
+            max_partitioning_rounds: 3,
+            cross_shard_dep_avoid_threshold: 0.9,
+            partition_last_round: false,
+        }
+    }
+
+    pub fn num_shards(mut self, num_shards: usize) -> Self {
+        self.num_shards = num_shards;
+        self
+    }
+
+    pub fn max_partitioning_rounds(mut self, max_partitioning_rounds: RoundId) -> Self {
+        self.max_partitioning_rounds = max_partitioning_rounds;
+        self
+    }
+
+    pub fn cross_shard_dep_avoid_threshold(mut self, threshold: f32) -> Self {
+        self.cross_shard_dep_avoid_threshold = threshold;
+        self
+    }
+
+    pub fn partition_last_round(mut self, partition_last_round: bool) -> Self {
+        self.partition_last_round = partition_last_round;
+        self
+    }
+
+    pub fn build(self) -> ShardedBlockPartitioner {
+        ShardedBlockPartitioner::new(
+            self.num_shards,
+            self.max_partitioning_rounds,
+            self.cross_shard_dep_avoid_threshold,
+            self.partition_last_round,
+        )
+    }
+}
+
+impl Default for BlockPartitionerConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/execution/block-partitioner/src/main.rs
+++ b/execution/block-partitioner/src/main.rs
@@ -48,12 +48,12 @@ fn main() {
         })
         .collect();
 
-    let partitioner = ShardedBlockPartitioner::new(args.num_shards);
+    let partitioner = ShardedBlockPartitioner::new(args.num_shards, 2, 0.9, true);
     for _ in 0..args.num_blocks {
         let transactions = transactions.clone();
         println!("Starting to partition");
         let now = Instant::now();
-        partitioner.partition(transactions, 2, 0.9);
+        partitioner.partition(transactions);
         let elapsed = now.elapsed();
         println!("Time taken to partition: {:?}", elapsed);
     }

--- a/execution/block-partitioner/src/main.rs
+++ b/execution/block-partitioner/src/main.rs
@@ -1,8 +1,8 @@
 // Copyright © Aptos Foundation
 
 use aptos_block_partitioner::{
-    sharded_block_partitioner::ShardedBlockPartitioner,
     test_utils::{create_signed_p2p_transaction, generate_test_account, TestAccount},
+    BlockPartitionerConfig,
 };
 use aptos_types::transaction::analyzed_transaction::AnalyzedTransaction;
 use clap::Parser;
@@ -48,7 +48,12 @@ fn main() {
         })
         .collect();
 
-    let partitioner = ShardedBlockPartitioner::new(args.num_shards, 2, 0.9, true);
+    let partitioner = BlockPartitionerConfig::default()
+        .num_shards(args.num_shards)
+        .max_partitioning_rounds(2)
+        .cross_shard_dep_avoid_threshold(0.9)
+        .partition_last_round(true)
+        .build();
     for _ in 0..args.num_blocks {
         let transactions = transactions.clone();
         println!("Starting to partition");

--- a/execution/block-partitioner/src/sharded_block_partitioner/mod.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/mod.rs
@@ -14,7 +14,10 @@ use crate::sharded_block_partitioner::{
 };
 use aptos_logger::{error, info};
 use aptos_types::{
-    block_executor::partitioner::{RoundId, ShardId, SubBlocksForShard, TxnIndex},
+    block_executor::partitioner::{
+        PartitionedTransactions, RoundId, ShardId, SubBlocksForShard, TxnIndex, GLOBAL_ROUND_ID,
+        MAX_ALLOWED_PARTITIONING_ROUNDS,
+    },
     transaction::analyzed_transaction::AnalyzedTransaction,
 };
 use counters::BLOCK_PARTITIONING_SECONDS;
@@ -107,16 +110,26 @@ mod partitioning_shard;
 /// ```
 ///
 ///
-pub static MAX_ALLOWED_PARTITIONING_ROUNDS: usize = 8;
 pub struct ShardedBlockPartitioner {
     num_shards: usize,
+    max_partitioning_rounds: RoundId,
+    /// `cross_shard_dep_avoid_threshold` is the maximum fraction of transactions we try to avoid cross shard dependencies. Once we reach
+    /// this fraction, we terminate early and add cross-shard dependencies to the remaining transactions.
+    cross_shard_dep_avoid_threshold: f32,
+    /// If true, the last round is partitioned and executed in a sharded manner. Otherwise, the last round is executed in global executor.
+    partition_last_round: bool,
     control_txs: Vec<Sender<ControlMsg>>,
     result_rxs: Vec<Receiver<PartitioningResp>>,
     shard_threads: Vec<thread::JoinHandle<()>>,
 }
 
 impl ShardedBlockPartitioner {
-    pub fn new(num_shards: usize) -> Self {
+    pub fn new(
+        num_shards: usize,
+        max_partitioning_rounds: RoundId,
+        cross_shard_dep_avoid_threshold: f32,
+        partition_last_round: bool,
+    ) -> Self {
         info!(
             "Creating a new sharded block partitioner with {} shards",
             num_shards
@@ -154,6 +167,9 @@ impl ShardedBlockPartitioner {
         }
         Self {
             num_shards,
+            max_partitioning_rounds,
+            cross_shard_dep_avoid_threshold,
+            partition_last_round,
             control_txs,
             result_rxs,
             shard_threads: shard_join_handles,
@@ -303,25 +319,20 @@ impl ShardedBlockPartitioner {
     /// `max_partitioning_rounds` is the maximum number of partitioning rounds we allow.
     /// `cross_shard_dep_avoid_threshold` is the maximum fraction of transactions we try to avoid cross shard dependencies. Once we reach
     /// this fraction, we terminate early and add cross-shard dependencies to the remaining transactions.
-    pub fn partition(
-        &self,
-        transactions: Vec<AnalyzedTransaction>,
-        max_partitioning_rounds: RoundId,
-        cross_shard_dep_avoid_threshold: f32,
-    ) -> Vec<SubBlocksForShard<AnalyzedTransaction>> {
+    pub fn partition(&self, transactions: Vec<AnalyzedTransaction>) -> PartitionedTransactions {
         let _timer = BLOCK_PARTITIONING_SECONDS.start_timer();
         let total_txns = transactions.len();
         assert!(
-            max_partitioning_rounds >= 1,
+            self.max_partitioning_rounds >= 1,
             "max_partitioning_rounds must be > 0"
         );
         assert!(
-            max_partitioning_rounds <= MAX_ALLOWED_PARTITIONING_ROUNDS,
+            self.max_partitioning_rounds <= MAX_ALLOWED_PARTITIONING_ROUNDS,
             "max_partitioning_rounds must be <= {}",
             MAX_ALLOWED_PARTITIONING_ROUNDS
         );
         if total_txns == 0 {
-            return vec![];
+            return PartitionedTransactions::empty();
         }
 
         // First round, we filter all transactions with cross-shard dependencies
@@ -341,7 +352,7 @@ impl ShardedBlockPartitioner {
             frozen_sub_blocks.push(SubBlocksForShard::empty(shard_id))
         }
         let mut current_round = 0;
-        for round_id in 0..max_partitioning_rounds - 1 {
+        for round_id in 0..self.max_partitioning_rounds - 1 {
             let _timer = BLOCK_PARTITIONING_MISC_TIMERS_SECONDS
                 .with_label_values(&[format!("round_{round_id}").as_str()])
                 .start_timer();
@@ -374,34 +385,63 @@ impl ShardedBlockPartitioner {
                 .sum::<usize>();
             // If there are no remaining transactions, we can stop partitioning
             if num_remaining_txns == 0 {
-                return frozen_sub_blocks;
+                return PartitionedTransactions::new(frozen_sub_blocks, vec![]);
             }
 
             if num_remaining_txns as f32 / total_txns as f32
-                <= 1_f32 - cross_shard_dep_avoid_threshold
+                <= 1_f32 - self.cross_shard_dep_avoid_threshold
             {
                 break;
             }
         }
         let _duration = timer.stop_and_record();
-
-        let timer = BLOCK_PARTITIONING_MISC_TIMERS_SECONDS
+        let _timer = BLOCK_PARTITIONING_MISC_TIMERS_SECONDS
             .with_label_values(&["last_round"])
             .start_timer();
-        // We just add cross shard dependencies for remaining transactions.
-        let (frozen_sub_blocks, _, rejected_txns) = self.add_cross_shard_dependencies(
-            current_round_start_index,
-            txns_to_partition,
-            frozen_sub_blocks,
-            frozen_write_set_with_index,
-            current_round,
-        );
-
         // Assert rejected transactions are empty
-        assert!(rejected_txns.iter().all(|txns| txns.is_empty()));
-        let _duration = timer.stop_and_record();
+        if self.partition_last_round {
+            // We just add cross shard dependencies for remaining transactions.
+            let (frozen_sub_blocks, _, rejected_txns) = self.add_cross_shard_dependencies(
+                current_round_start_index,
+                txns_to_partition,
+                frozen_sub_blocks,
+                frozen_write_set_with_index,
+                current_round,
+            );
+            assert!(rejected_txns.iter().all(|txns| txns.is_empty()));
+            PartitionedTransactions::new(frozen_sub_blocks, vec![])
+        } else {
+            // If we don't partition the last round, we just flatten all the transactions into one shard and send it to
+            // the partitioner, so that we can add cross-shard dependencies.
+            let remaining_txns = txns_to_partition.into_iter().flatten().collect::<Vec<_>>();
 
-        frozen_sub_blocks
+            let mut txns_to_partition = vec![];
+            txns_to_partition.push(remaining_txns);
+            for _ in 1..self.num_shards {
+                txns_to_partition.push(vec![]);
+            }
+            let (mut frozen_sub_blocks, _, rejected_txns) = self.add_cross_shard_dependencies(
+                current_round_start_index,
+                txns_to_partition,
+                frozen_sub_blocks,
+                frozen_write_set_with_index,
+                GLOBAL_ROUND_ID,
+            );
+
+            assert!(rejected_txns.iter().all(|txns| txns.is_empty()));
+            let global_txns = frozen_sub_blocks[0]
+                .remove_last_sub_block()
+                .unwrap()
+                .into_iter()
+                .collect();
+            // Make sure last sub block in all other shards are empty and remove them.
+            frozen_sub_blocks[1..].iter_mut().for_each(|sub_blocks| {
+                let last = sub_blocks.remove_last_sub_block().unwrap();
+                assert!(last.is_empty());
+            });
+
+            PartitionedTransactions::new(frozen_sub_blocks, global_txns)
+        }
     }
 }
 
@@ -483,8 +523,8 @@ mod tests {
             &mut sender,
             receivers.iter().collect::<Vec<&TestAccount>>(),
         );
-        let partitioner = ShardedBlockPartitioner::new(4);
-        let sub_blocks = partitioner.partition(transactions.clone(), 2, 0.9);
+        let partitioner = ShardedBlockPartitioner::new(4, 2, 0.9, true);
+        let (sub_blocks, _) = partitioner.partition(transactions.clone()).into();
         assert_eq!(sub_blocks.len(), 4);
         // The first shard should contain all the transactions
         assert_eq!(sub_blocks[0].num_txns(), num_txns);
@@ -510,13 +550,14 @@ mod tests {
         for _ in 0..num_txns {
             transactions.push(create_non_conflicting_p2p_transaction())
         }
-        let partitioner = ShardedBlockPartitioner::new(num_shards);
-        let partitioned_txns = partitioner.partition(transactions.clone(), 2, 0.9);
-        assert_eq!(partitioned_txns.len(), num_shards);
+        let partitioner = ShardedBlockPartitioner::new(num_shards, 2, 0.9, true);
+        let partitioned_txns = partitioner.partition(transactions.clone());
+        assert_eq!(partitioned_txns.num_shards(), num_shards);
         // Verify that the transactions are in the same order as the original transactions and cross shard
         // dependencies are empty.
+        let (sub_blocks, _) = partitioned_txns.into();
         let mut current_index = 0;
-        for sub_blocks_for_shard in partitioned_txns.into_iter() {
+        for sub_blocks_for_shard in sub_blocks.into_iter() {
             assert_eq!(sub_blocks_for_shard.num_txns(), num_txns / num_shards);
             for txn in sub_blocks_for_shard.iter() {
                 assert_eq!(
@@ -563,8 +604,8 @@ mod tests {
         transactions.push(non_conflicting_transactions[non_conflicting_txn_index].clone());
         transactions.push(txns_from_sender[txn_from_sender_index].clone());
 
-        let partitioner = ShardedBlockPartitioner::new(num_shards);
-        let sub_blocks = partitioner.partition(transactions.clone(), 2, 0.9);
+        let partitioner = ShardedBlockPartitioner::new(num_shards, 2, 0.9, true);
+        let (sub_blocks, _) = partitioner.partition(transactions.clone()).into();
         assert_eq!(sub_blocks.len(), num_shards);
         assert_eq!(sub_blocks[0].num_sub_blocks(), 1);
         assert_eq!(sub_blocks[1].num_sub_blocks(), 1);
@@ -615,8 +656,8 @@ mod tests {
             transactions.push(create_signed_p2p_transaction(sender, vec![receiver]).remove(0));
         }
 
-        let partitioner = ShardedBlockPartitioner::new(num_shards);
-        let sub_blocks = partitioner.partition(transactions.clone(), 2, 0.9);
+        let partitioner = ShardedBlockPartitioner::new(num_shards, 2, 0.9, true);
+        let (sub_blocks, _) = partitioner.partition(transactions.clone()).into();
 
         let mut account_to_expected_seq_number: HashMap<AccountAddress, u64> = HashMap::new();
         SubBlocksForShard::flatten(sub_blocks)
@@ -670,8 +711,8 @@ mod tests {
             txn8.clone(),
         ];
 
-        let partitioner = ShardedBlockPartitioner::new(num_shards);
-        let partitioned_sub_blocks = partitioner.partition(transactions, 2, 0.9);
+        let partitioner = ShardedBlockPartitioner::new(num_shards, 2, 0.9, true);
+        let (partitioned_sub_blocks, _) = partitioner.partition(transactions).into();
         assert_eq!(partitioned_sub_blocks.len(), num_shards);
 
         // In first round of the partitioning, we should have txn0, txn1 and txn2 in shard 0 and
@@ -836,14 +877,15 @@ mod tests {
             transactions.push(analyzed_txn);
             accounts.push(sender)
         }
-        let partitioner = ShardedBlockPartitioner::new(num_shards);
-        let partitioned_txns = partitioner.partition(transactions, max_partitioning_rounds, 0.9);
+        let partitioner =
+            ShardedBlockPartitioner::new(num_shards, max_partitioning_rounds, 0.9, true);
+        let (sub_blocks, _) = partitioner.partition(transactions).into();
         // Build a map of storage location to corresponding shards in first round
         // and ensure that no storage location is present in more than one shard.
-        let num_partitioning_rounds = partitioned_txns[0].num_sub_blocks() - 1;
+        let num_partitioning_rounds = sub_blocks[0].num_sub_blocks() - 1;
         for round in 0..num_partitioning_rounds {
             let mut storage_location_to_shard_map = HashMap::new();
-            for (shard_id, sub_blocks_for_shard) in partitioned_txns.iter().enumerate() {
+            for (shard_id, sub_blocks_for_shard) in sub_blocks.iter().enumerate() {
                 let sub_block_for_round = sub_blocks_for_shard.get_sub_block(round).unwrap();
                 for txn in sub_block_for_round.iter() {
                     let analyzed_txn = txns_by_hash.get(&txn.txn().transaction().hash()).unwrap();

--- a/execution/block-partitioner/src/sharded_block_partitioner/mod.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/mod.rs
@@ -124,7 +124,7 @@ pub struct ShardedBlockPartitioner {
 }
 
 impl ShardedBlockPartitioner {
-    pub fn new(
+    pub(crate) fn new(
         num_shards: usize,
         max_partitioning_rounds: RoundId,
         cross_shard_dep_avoid_threshold: f32,

--- a/execution/executor-benchmark/src/block_partitioning.rs
+++ b/execution/executor-benchmark/src/block_partitioning.rs
@@ -23,6 +23,7 @@ impl BlockPartitioningStage {
         let maybe_partitioner = if num_shards <= 1 {
             None
         } else {
+            info!("Starting a sharded block partitioner with {} shards and last round partitioning {}", num_shards, partition_last_round);
             let partitioner =
                 ShardedBlockPartitioner::new(num_shards, 4, 0.95, partition_last_round);
             Some(partitioner)

--- a/execution/executor-benchmark/src/block_partitioning.rs
+++ b/execution/executor-benchmark/src/block_partitioning.rs
@@ -5,10 +5,7 @@ use aptos_block_partitioner::sharded_block_partitioner::ShardedBlockPartitioner;
 use aptos_crypto::HashValue;
 use aptos_logger::info;
 use aptos_types::{
-    block_executor::partitioner::{
-        CrossShardDependencies, ExecutableBlock, ExecutableTransactions, PartitionedTransactions,
-        TransactionWithDependencies,
-    },
+    block_executor::partitioner::{ExecutableBlock, ExecutableTransactions},
     transaction::Transaction,
 };
 use std::time::Instant;
@@ -47,28 +44,10 @@ impl BlockPartitioningStage {
             None => (block_id, txns).into(),
             Some(partitioner) => {
                 let last_txn = txns.pop().unwrap();
-                assert!(matches!(last_txn, Transaction::StateCheckpoint(_)));
                 let analyzed_transactions = txns.into_iter().map(|t| t.into()).collect();
-                let (mut sub_blocks, global_txns) =
-                    partitioner.partition(analyzed_transactions).into();
-                sub_blocks
-                    .last_mut()
-                    .unwrap()
-                    .sub_blocks
-                    .last_mut()
-                    .unwrap()
-                    .transactions
-                    .push(TransactionWithDependencies::new(
-                        last_txn.into(),
-                        CrossShardDependencies::default(),
-                    ));
-                ExecutableBlock::new(
-                    block_id,
-                    ExecutableTransactions::Sharded(PartitionedTransactions::new(
-                        sub_blocks,
-                        global_txns,
-                    )),
-                )
+                let mut partitioned_txns = partitioner.partition(analyzed_transactions);
+                partitioned_txns.add_checkpoint_txn(last_txn);
+                ExecutableBlock::new(block_id, ExecutableTransactions::Sharded(partitioned_txns))
             },
         };
         self.num_blocks_processed += 1;

--- a/execution/executor-benchmark/src/block_partitioning.rs
+++ b/execution/executor-benchmark/src/block_partitioning.rs
@@ -1,7 +1,9 @@
 // Copyright © Aptos Foundation
 
 use crate::pipeline::ExecuteBlockMessage;
-use aptos_block_partitioner::sharded_block_partitioner::ShardedBlockPartitioner;
+use aptos_block_partitioner::{
+    sharded_block_partitioner::ShardedBlockPartitioner, BlockPartitionerConfig,
+};
 use aptos_crypto::HashValue;
 use aptos_logger::info;
 use aptos_types::{
@@ -21,8 +23,12 @@ impl BlockPartitioningStage {
             None
         } else {
             info!("Starting a sharded block partitioner with {} shards and last round partitioning {}", num_shards, partition_last_round);
-            let partitioner =
-                ShardedBlockPartitioner::new(num_shards, 4, 0.95, partition_last_round);
+            let partitioner = BlockPartitionerConfig::default()
+                .num_shards(num_shards)
+                .max_partitioning_rounds(4)
+                .cross_shard_dep_avoid_threshold(0.95)
+                .partition_last_round(partition_last_round)
+                .build();
             Some(partitioner)
         };
 

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -168,6 +168,7 @@ pub fn run_benchmark<V>(
                 allow_aborts: false,
                 num_executor_shards: 1,
                 async_partitioning: false,
+                partition_last_round: false,
             },
         )
     });
@@ -571,6 +572,7 @@ mod tests {
                 allow_aborts: false,
                 num_executor_shards: 1,
                 async_partitioning: false,
+                partition_last_round: false,
             },
         );
 
@@ -598,6 +600,7 @@ mod tests {
                 allow_aborts: false,
                 num_executor_shards: 1,
                 async_partitioning: false,
+                partition_last_round: false,
             },
         );
     }

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -168,7 +168,7 @@ pub fn run_benchmark<V>(
                 allow_aborts: false,
                 num_executor_shards: 1,
                 async_partitioning: false,
-                partition_last_round: false,
+                use_global_executor: false,
             },
         )
     });
@@ -572,7 +572,7 @@ mod tests {
                 allow_aborts: false,
                 num_executor_shards: 1,
                 async_partitioning: false,
-                partition_last_round: false,
+                use_global_executor: false,
             },
         );
 
@@ -600,7 +600,7 @@ mod tests {
                 allow_aborts: false,
                 num_executor_shards: 1,
                 async_partitioning: false,
-                partition_last_round: false,
+                use_global_executor: false,
             },
         );
     }

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -96,6 +96,8 @@ pub struct PipelineOpt {
     num_executor_shards: usize,
     #[clap(long)]
     async_partitioning: bool,
+    #[clap(long)]
+    partition_last_round: bool,
 }
 
 impl PipelineOpt {
@@ -108,6 +110,7 @@ impl PipelineOpt {
             allow_aborts: self.allow_aborts,
             num_executor_shards: self.num_executor_shards,
             async_partitioning: self.async_partitioning,
+            partition_last_round: self.partition_last_round,
         }
     }
 }

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -97,7 +97,7 @@ pub struct PipelineOpt {
     #[clap(long)]
     async_partitioning: bool,
     #[clap(long)]
-    partition_last_round: bool,
+    use_global_executor: bool,
 }
 
 impl PipelineOpt {
@@ -110,7 +110,7 @@ impl PipelineOpt {
             allow_aborts: self.allow_aborts,
             num_executor_shards: self.num_executor_shards,
             async_partitioning: self.async_partitioning,
-            partition_last_round: self.partition_last_round,
+            use_global_executor: self.use_global_executor,
         }
     }
 }

--- a/execution/executor-benchmark/src/pipeline.rs
+++ b/execution/executor-benchmark/src/pipeline.rs
@@ -32,6 +32,7 @@ pub struct PipelineConfig {
     pub allow_aborts: bool,
     pub num_executor_shards: usize,
     pub async_partitioning: bool,
+    pub partition_last_round: bool,
 }
 
 pub struct Pipeline<V> {
@@ -90,7 +91,8 @@ where
 
         let mut join_handles = vec![];
 
-        let mut partitioning_stage = BlockPartitioningStage::new(num_partitioner_shards);
+        let mut partitioning_stage =
+            BlockPartitioningStage::new(num_partitioner_shards, config.partition_last_round);
 
         let mut exe = TransactionExecutor::new(
             executor_1,

--- a/execution/executor-benchmark/src/pipeline.rs
+++ b/execution/executor-benchmark/src/pipeline.rs
@@ -32,7 +32,7 @@ pub struct PipelineConfig {
     pub allow_aborts: bool,
     pub num_executor_shards: usize,
     pub async_partitioning: bool,
-    pub partition_last_round: bool,
+    pub use_global_executor: bool,
 }
 
 pub struct Pipeline<V> {
@@ -92,7 +92,7 @@ where
         let mut join_handles = vec![];
 
         let mut partitioning_stage =
-            BlockPartitioningStage::new(num_partitioner_shards, config.partition_last_round);
+            BlockPartitioningStage::new(num_partitioner_shards, !config.use_global_executor);
 
         let mut exe = TransactionExecutor::new(
             executor_1,

--- a/execution/executor-service/src/remote_cross_shard_client.rs
+++ b/execution/executor-service/src/remote_cross_shard_client.rs
@@ -1,8 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
-use aptos_block_partitioner::sharded_block_partitioner::MAX_ALLOWED_PARTITIONING_ROUNDS;
 use aptos_secure_net::network_controller::{Message, NetworkController};
-use aptos_types::block_executor::partitioner::{RoundId, ShardId};
+use aptos_types::block_executor::partitioner::{RoundId, ShardId, MAX_ALLOWED_PARTITIONING_ROUNDS};
 use aptos_vm::sharded_block_executor::{
     cross_shard_client::CrossShardClient, messages::CrossShardMsg,
 };
@@ -49,6 +48,10 @@ impl RemoteCrossShardClient {
 }
 
 impl CrossShardClient for RemoteCrossShardClient {
+    fn send_global_msg(&self, _msg: CrossShardMsg) {
+        todo!("Global cross shard message is not supported yet in remote execution mode")
+    }
+
     fn send_cross_shard_msg(&self, shard_id: ShardId, round: RoundId, msg: CrossShardMsg) {
         let input_message = bcs::to_bytes(&msg).unwrap();
         let tx = self.message_txs[shard_id][round].lock().unwrap();

--- a/execution/executor-service/src/test_utils.rs
+++ b/execution/executor-service/src/test_utils.rs
@@ -1,6 +1,6 @@
 // Copyright © Aptos Foundation
 
-use aptos_block_partitioner::sharded_block_partitioner::ShardedBlockPartitioner;
+use aptos_block_partitioner::BlockPartitionerConfig;
 use aptos_language_e2e_tests::{
     account::AccountData, common_transactions::peer_to_peer_txn, data_store::FakeDataStore,
     executor::FakeExecutor,
@@ -101,7 +101,12 @@ pub fn test_sharded_block_executor_no_conflict<E: ExecutorClient<FakeDataStore>>
     for _ in 0..num_txns {
         transactions.push(generate_non_conflicting_p2p(&mut executor).0)
     }
-    let partitioner = ShardedBlockPartitioner::new(num_shards, 2, 0.9, true);
+    let partitioner = BlockPartitionerConfig::default()
+        .num_shards(num_shards)
+        .max_partitioning_rounds(2)
+        .cross_shard_dep_avoid_threshold(0.9)
+        .partition_last_round(true)
+        .build();
     let partitioned_txns = partitioner.partition(transactions.clone());
     let sharded_txn_output = sharded_block_executor
         .execute_block(

--- a/execution/executor-service/src/test_utils.rs
+++ b/execution/executor-service/src/test_utils.rs
@@ -101,8 +101,8 @@ pub fn test_sharded_block_executor_no_conflict<E: ExecutorClient<FakeDataStore>>
     for _ in 0..num_txns {
         transactions.push(generate_non_conflicting_p2p(&mut executor).0)
     }
-    let partitioner = ShardedBlockPartitioner::new(num_shards);
-    let partitioned_txns = partitioner.partition(transactions.clone(), 2, 0.9);
+    let partitioner = ShardedBlockPartitioner::new(num_shards, 2, 0.9, true);
+    let partitioned_txns = partitioner.partition(transactions.clone());
     let sharded_txn_output = sharded_block_executor
         .execute_block(
             Arc::new(executor.data_store().clone()),

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -16,11 +16,8 @@ use aptos_storage_interface::{
 };
 use aptos_types::{
     account_config::CORE_CODE_ADDRESS,
-    block_executor::partitioner::{ExecutableTransactions, SubBlocksForShard},
-    transaction::{
-        analyzed_transaction::AnalyzedTransaction, ExecutionStatus, Transaction, TransactionOutput,
-        TransactionStatus,
-    },
+    block_executor::partitioner::{ExecutableTransactions, PartitionedTransactions},
+    transaction::{ExecutionStatus, Transaction, TransactionOutput, TransactionStatus},
 };
 use aptos_vm::{
     sharded_block_executor::{
@@ -66,11 +63,9 @@ impl ChunkOutput {
                     maybe_block_gas_limit,
                 )
             },
-            ExecutableTransactions::Sharded(block) => Self::by_transaction_execution_sharded::<V>(
-                block,
-                state_view,
-                maybe_block_gas_limit,
-            ),
+            ExecutableTransactions::Sharded(txns) => {
+                Self::by_transaction_execution_sharded::<V>(txns, state_view, maybe_block_gas_limit)
+            },
         }
     }
 
@@ -95,13 +90,13 @@ impl ChunkOutput {
     }
 
     pub fn by_transaction_execution_sharded<V: VMExecutor>(
-        block: Vec<SubBlocksForShard<AnalyzedTransaction>>,
+        transactions: PartitionedTransactions,
         state_view: CachedStateView,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<Self> {
         let state_view_arc = Arc::new(state_view);
         let transaction_outputs = Self::execute_block_sharded::<V>(
-            block.clone(),
+            transactions.clone(),
             state_view_arc.clone(),
             maybe_block_gas_limit,
         )?;
@@ -113,7 +108,7 @@ impl ChunkOutput {
         let state_view = Arc::try_unwrap(state_view_arc).unwrap();
 
         Ok(Self {
-            transactions: SubBlocksForShard::flatten(block)
+            transactions: PartitionedTransactions::flatten(transactions)
                 .into_iter()
                 .map(|t| t.into_txn())
                 .collect(),
@@ -185,13 +180,13 @@ impl ChunkOutput {
     }
 
     fn execute_block_sharded<V: VMExecutor>(
-        block: Vec<SubBlocksForShard<AnalyzedTransaction>>,
+        partitioned_txns: PartitionedTransactions,
         state_view: Arc<CachedStateView>,
         maybe_block_gas_limit: Option<u64>,
     ) -> Result<Vec<TransactionOutput>> {
         Ok(V::execute_block_sharded(
             SHARDED_BLOCK_EXECUTOR.lock().deref(),
-            block,
+            partitioned_txns,
             state_view,
             maybe_block_gas_limit,
         )?)

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -14,13 +14,10 @@ use aptos_storage_interface::{
     cached_state_view::CachedStateView, state_delta::StateDelta, DbReader, DbReaderWriter, DbWriter,
 };
 use aptos_types::{
-    block_executor::partitioner::{ExecutableTransactions, SubBlocksForShard},
+    block_executor::partitioner::{ExecutableTransactions, PartitionedTransactions},
     ledger_info::LedgerInfoWithSignatures,
     test_helpers::transaction_test_helpers::BLOCK_GAS_LIMIT,
-    transaction::{
-        analyzed_transaction::AnalyzedTransaction, Transaction, TransactionOutput,
-        TransactionToCommit, Version,
-    },
+    transaction::{Transaction, TransactionOutput, TransactionToCommit, Version},
     vm_status::VMStatus,
 };
 use aptos_vm::{
@@ -74,7 +71,7 @@ impl TransactionBlockExecutor for FakeVM {
 impl VMExecutor for FakeVM {
     fn execute_block_sharded<S: StateView + Send + Sync, E: ExecutorClient<S>>(
         _sharded_block_executor: &ShardedBlockExecutor<S, E>,
-        _block: Vec<SubBlocksForShard<AnalyzedTransaction>>,
+        _transactions: PartitionedTransactions,
         _state_view: Arc<S>,
         _maybe_block_gas_limit: Option<u64>,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -14,7 +14,7 @@ use aptos_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
     account_config::CORE_CODE_ADDRESS,
-    block_executor::partitioner::{ExecutableTransactions, SubBlocksForShard},
+    block_executor::partitioner::{ExecutableTransactions, PartitionedTransactions},
     chain_id::ChainId,
     contract_event::ContractEvent,
     event::EventKey,
@@ -24,9 +24,9 @@ use aptos_types::{
     },
     state_store::state_key::StateKey,
     transaction::{
-        analyzed_transaction::AnalyzedTransaction, ChangeSet, ExecutionStatus, RawTransaction,
-        Script, SignedTransaction, Transaction, TransactionArgument, TransactionOutput,
-        TransactionPayload, TransactionStatus, WriteSetPayload,
+        ChangeSet, ExecutionStatus, RawTransaction, Script, SignedTransaction, Transaction,
+        TransactionArgument, TransactionOutput, TransactionPayload, TransactionStatus,
+        WriteSetPayload,
     },
     vm_status::{StatusCode, VMStatus},
     write_set::{WriteOp, WriteSet, WriteSetMut},
@@ -212,7 +212,7 @@ impl VMExecutor for MockVM {
 
     fn execute_block_sharded<S: StateView + Sync + Send + 'static, E: ExecutorClient<S>>(
         _sharded_block_executor: &ShardedBlockExecutor<S, E>,
-        _block: Vec<SubBlocksForShard<AnalyzedTransaction>>,
+        _transactions: PartitionedTransactions,
         _state_view: Arc<S>,
         _maybe_block_gas_limit: Option<u64>,
     ) -> std::result::Result<Vec<TransactionOutput>, VMStatus> {

--- a/types/src/block_executor/partitioner.rs
+++ b/types/src/block_executor/partitioner.rs
@@ -451,6 +451,24 @@ impl PartitionedTransactions {
             + self.global_txns.len()
     }
 
+    pub fn add_checkpoint_txn(&mut self, last_txn: Transaction) {
+        assert!(matches!(last_txn, Transaction::StateCheckpoint(_)));
+        let txn_with_deps =
+            TransactionWithDependencies::new(last_txn.into(), CrossShardDependencies::default());
+        if !self.global_txns.is_empty() {
+            self.global_txns.push(txn_with_deps);
+        } else {
+            self.sharded_txns
+                .last_mut()
+                .unwrap()
+                .sub_blocks
+                .last_mut()
+                .unwrap()
+                .transactions
+                .push(txn_with_deps)
+        }
+    }
+
     pub fn flatten(transactions: PartitionedTransactions) -> Vec<AnalyzedTransaction> {
         SubBlocksForShard::flatten(transactions.sharded_txns)
             .into_iter()

--- a/types/src/block_executor/partitioner.rs
+++ b/types/src/block_executor/partitioner.rs
@@ -12,6 +12,9 @@ pub type ShardId = usize;
 pub type TxnIndex = usize;
 pub type RoundId = usize;
 
+pub static MAX_ALLOWED_PARTITIONING_ROUNDS: usize = 8;
+pub static GLOBAL_ROUND_ID: usize = MAX_ALLOWED_PARTITIONING_ROUNDS + 1;
+
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ShardedTxnIndex {
     pub txn_index: TxnIndex,
@@ -318,6 +321,10 @@ impl<T: Clone> SubBlocksForShard<T> {
         self.sub_blocks.get_mut(round)
     }
 
+    pub fn remove_last_sub_block(&mut self) -> Option<SubBlock<T>> {
+        self.sub_blocks.pop()
+    }
+
     // Flattens a vector of `SubBlocksForShard` into a vector of transactions in the order they
     // appear in the block.
     pub fn flatten(block: Vec<SubBlocksForShard<T>>) -> Vec<T> {
@@ -395,20 +402,79 @@ impl From<(HashValue, Vec<Transaction>)> for ExecutableBlock {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct PartitionedTransactions {
+    pub sharded_txns: Vec<SubBlocksForShard<AnalyzedTransaction>>,
+    pub global_txns: Vec<TransactionWithDependencies<AnalyzedTransaction>>,
+}
+
+impl PartitionedTransactions {
+    pub fn new(
+        sharded_txns: Vec<SubBlocksForShard<AnalyzedTransaction>>,
+        global_txns: Vec<TransactionWithDependencies<AnalyzedTransaction>>,
+    ) -> Self {
+        Self {
+            sharded_txns,
+            global_txns,
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self {
+            sharded_txns: Vec::new(),
+            global_txns: Vec::new(),
+        }
+    }
+
+    pub fn into(
+        self,
+    ) -> (
+        Vec<SubBlocksForShard<AnalyzedTransaction>>,
+        Vec<TransactionWithDependencies<AnalyzedTransaction>>,
+    ) {
+        (self.sharded_txns, self.global_txns)
+    }
+
+    pub fn num_shards(&self) -> usize {
+        self.sharded_txns.len()
+    }
+
+    pub fn sharded_txns(&self) -> &[SubBlocksForShard<AnalyzedTransaction>] {
+        &self.sharded_txns
+    }
+
+    pub fn num_txns(&self) -> usize {
+        self.sharded_txns
+            .iter()
+            .map(|sub_blocks| sub_blocks.num_txns())
+            .sum::<usize>()
+            + self.global_txns.len()
+    }
+
+    pub fn flatten(transactions: PartitionedTransactions) -> Vec<AnalyzedTransaction> {
+        SubBlocksForShard::flatten(transactions.sharded_txns)
+            .into_iter()
+            .chain(
+                transactions
+                    .global_txns
+                    .into_iter()
+                    .map(|txn| txn.into_txn()),
+            )
+            .collect()
+    }
+}
+
 // Represents the transactions in a block that are ready to be executed.
 pub enum ExecutableTransactions {
     Unsharded(Vec<Transaction>),
-    Sharded(Vec<SubBlocksForShard<AnalyzedTransaction>>),
+    Sharded(PartitionedTransactions),
 }
 
 impl ExecutableTransactions {
     pub fn num_transactions(&self) -> usize {
         match self {
             ExecutableTransactions::Unsharded(transactions) => transactions.len(),
-            ExecutableTransactions::Sharded(sub_blocks) => sub_blocks
-                .iter()
-                .map(|sub_block| sub_block.num_txns())
-                .sum(),
+            ExecutableTransactions::Sharded(partitioned_txns) => partitioned_txns.num_txns(),
         }
     }
 }


### PR DESCRIPTION
### Description

- Adds support for global execution in sharding. On a high level a `partition_last_round` flag has been added to the partitioner, if it is false, then the last round is added as a global round.  

- Cleaned up the partitioning API to returned `PartitionedTransactions`. This holds both partitioned txns and global txns. 

- Added support for the global executor in the local execution client. 

### Test Plan
UTs and ran the benchmark.  I am not making the global executor as default as I see around 5% TPS regression with this enabled by default. 
