### PR TITLE
enable gke cost management

### DIFF
--- a/terraform/aptos-node/gcp/cluster.tf
+++ b/terraform/aptos-node/gcp/cluster.tf
@@ -8,6 +8,9 @@ resource "google_container_cluster" "aptos" {
   initial_node_count       = 1
   logging_service          = "logging.googleapis.com/kubernetes"
   monitoring_service       = "monitoring.googleapis.com/kubernetes"
+  cost_management_config {
+    enabled = true
+  }
 
   release_channel {
     channel = "REGULAR"

--- a/terraform/fullnode/gcp/cluster.tf
+++ b/terraform/fullnode/gcp/cluster.tf
@@ -16,6 +16,9 @@ resource "google_container_cluster" "aptos" {
   initial_node_count       = 1
   logging_service          = "logging.googleapis.com/kubernetes"
   monitoring_service       = "monitoring.googleapis.com/kubernetes"
+  cost_management_config {
+    enabled = true
+  }
 
   release_channel {
     channel = "REGULAR"


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d2ebb2</samp>

Enable cost management for `aptos-node` and `fullnode` clusters in GCP. This will help monitor and optimize the cloud spending for the `aptos-core` infrastructure.