### PR TITLE
[GHA] Reduce various automated jobs.

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,9 +1,8 @@
 name: "CodeQL"
 
 on:
-  schedule:
-    # Every day at 10:15am UTC aka 3:15am PT
-    - cron: "15 10 * * *"
+  # Allow triggering manually
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -2,11 +2,6 @@ name: Test Coverage
 on:
   workflow_dispatch:
   workflow_call:
-  schedule:
-    # every day at 9am PST
-    - cron: "0 16 * * *"
-  pull_request:
-    types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
 
 env:
   CARGO_INCREMENTAL: "0"

--- a/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
+++ b/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
@@ -1,9 +1,6 @@
 name: "Find Packages with undeclared feature dependencies"
 on:
   workflow_dispatch:
-  schedule:
-    # every day at 3am PST
-    - cron: "0 10 * * *"
 
 jobs:
   find-packages-with-undeclared-feature-dependencies:

--- a/.github/workflows/prover-daily-test.yaml
+++ b/.github/workflows/prover-daily-test.yaml
@@ -2,9 +2,9 @@ name: "Prover Daily Test"
 on:
   # Allow us to manually run this specific workflow without a PR
   workflow_dispatch:
-  # Until enabled on all PRs, run continuously at the beginning of each hour
+  # Until enabled on all PRs, run twice a week
   schedule:
-    - cron: "14 14 * * *"
+    - cron: "14 14 */3 * *"
 
 env:
   CARGO_INCREMENTAL: "0"

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -7,7 +7,7 @@ on:
 
   # Run every day at 12pm UTC
   schedule:
-    - cron: "0 12 * * *" # The main branch cadence. This runs every day at 12pm UTC.
+    - cron: "0 12 * * 3" # This runs once a week at 12pm UTC.
 
   # Run if a pull request touches this file
   pull_request:


### PR DESCRIPTION
Note: this PR builds on https://github.com/aptos-labs/aptos-core/pull/9503.

### Description
This PR reduces the frequency of various GHA jobs and schedules:
1. `CodeQL`: This job has been broken for several weeks. So, the PR disables the scheduled runs and allows manual invocations.
2. `Test Coverage`: This job hasn't worked in a long time. So, the PR disables the scheduled runs.
3. `Find Packages with undeclared feature dependencies`: This job also hasn't worked in a long time. So, the PR disables the scheduled runs.
4. `Prover Daily Test`: This job broke around 1.5 weeks ago. The PR reduces the frequency from daily to bi-weekly.
5. `Windows Build`: This PR reduces the frequency of the build job from daily to weekly. Daily shouldn't be needed(?).

### Test Plan
Existing test infrastructure.