### PR TITLE
[API] Return 410 when txn has been pruned, not 500

### DIFF
--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -614,7 +614,7 @@ impl Context {
             .context("Failed to convert transaction data from storage")
             .map_err(|err| {
                 E::internal_with_code(err, AptosErrorCode::InternalError, ledger_info)
-            })?;
+            })?; /g
 
         Ok(txns)
     }

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -614,7 +614,7 @@ impl Context {
             .context("Failed to convert transaction data from storage")
             .map_err(|err| {
                 E::internal_with_code(err, AptosErrorCode::InternalError, ledger_info)
-            })?; /g
+            })?;
 
         Ok(txns)
     }

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -12,8 +12,8 @@ use crate::{
     page::Page,
     response::{
         api_disabled, api_forbidden, transaction_not_found_by_hash,
-        transaction_not_found_by_version, BadRequestError, BasicError, BasicErrorWith404,
-        BasicResponse, BasicResponseStatus, BasicResult, BasicResultWith404,
+        transaction_not_found_by_version, version_pruned, BadRequestError, BasicError,
+        BasicErrorWith404, BasicResponse, BasicResponseStatus, BasicResult, BasicResultWith404,
         InsufficientStorageError, InternalError,
     },
     ApiTags,
@@ -700,15 +700,18 @@ impl TransactionsApi {
                     AptosErrorCode::InternalError,
                     &ledger_info,
                 )
-            })?
-            .context(format!(
-                "Failed to find transaction at version: {}",
-                version
-            ))
-            .map_err(|_| transaction_not_found_by_version(version.0, &ledger_info))?;
+            })?;
 
-        self.get_transaction_inner(accept_type, txn_data, &ledger_info)
-            .await
+        match txn_data {
+            GetByVersionResponse::Found(txn_data) => {
+                self.get_transaction_inner(accept_type, txn_data, &ledger_info)
+                    .await
+            },
+            GetByVersionResponse::VersionTooNew => {
+                Err(transaction_not_found_by_version(version.0, &ledger_info))
+            },
+            GetByVersionResponse::VersionTooOld => Err(version_pruned(version.0, &ledger_info)),
+        }
     }
 
     /// Converts a transaction into the outgoing type
@@ -766,11 +769,14 @@ impl TransactionsApi {
         &self,
         version: u64,
         ledger_info: &LedgerInfo,
-    ) -> anyhow::Result<Option<TransactionData>> {
+    ) -> anyhow::Result<GetByVersionResponse> {
         if version > ledger_info.version() {
-            return Ok(None);
+            return Ok(GetByVersionResponse::VersionTooNew);
         }
-        Ok(Some(
+        if version < ledger_info.oldest_version() {
+            return Ok(GetByVersionResponse::VersionTooOld);
+        }
+        Ok(GetByVersionResponse::Found(
             self.context
                 .get_transaction_by_version(version, ledger_info.version())?
                 .into(),
@@ -1324,4 +1330,10 @@ fn override_gas_parameters(
 
     // TODO: Check that signature is null, this would just be helpful for downstream use
     SignedTransaction::new_with_authenticator(raw_txn, signed_txn.authenticator())
+}
+
+enum GetByVersionResponse {
+    VersionTooNew,
+    VersionTooOld,
+    Found(TransactionData),
 }

--- a/api/types/src/ledger_info.rs
+++ b/api/types/src/ledger_info.rs
@@ -48,6 +48,10 @@ impl LedgerInfo {
         self.ledger_version.into()
     }
 
+    pub fn oldest_version(&self) -> u64 {
+        self.oldest_ledger_version.into()
+    }
+
     pub fn timestamp(&self) -> u64 {
         self.ledger_timestamp.into()
     }


### PR DESCRIPTION
### Description
A missing txn is not an internal server error, 410 is a more appropriate error code.

The long term fix is to make storage return typed errors, but this is a solid fix for now.

### Test Plan
Run a local testnet with a modified config where the pruning window is much shorter:
```
cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes --with-faucet --test-config-override ~/myfullnode.yaml
```

Config: https://gist.github.com/banool/7bf5f89cbd9ab999b16eb641413902a8.

Let it run for a while.

See that now instead of it being a 500, it is a 410 when a txn is missing:
```
curl -v localhost:8080/v1/transactions/by_version/1
```

Before:
```
< HTTP/1.1 500 Internal Server Error
{"message":"Failed to get transaction by version 1: Transaction at version 1 is pruned, min available version is 403.","error_code":"internal_error","vm_error_code":null}
```

After:
```
< HTTP/1.1 410 Gone
{"message":"Ledger version(1) has been pruned","error_code":"version_pruned","vm_error_code":null}
```

Unit testing:
```
cd api
cargo test
```