### PR TITLE
[release-builder] Make release builder use a relative path for raw script

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -53,7 +53,7 @@ proposals:
       discussion_url: "https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-28.md"
     execution_mode: MultiStep
     update_sequence:
-    - RawScript: /aptos/aptos-move/aptos-release-builder/data/proposals/aip_28_initialization.move
+    - RawScript: aptos-move/aptos-release-builder/data/proposals/aip_28_initialization.move
     - FeatureFlag:
         enabled:
           - partial_governance_voting

--- a/aptos-move/aptos-release-builder/src/lib.rs
+++ b/aptos-move/aptos-release-builder/src/lib.rs
@@ -54,9 +54,3 @@ pub(crate) fn aptos_framework_path() -> PathBuf {
     path.push("aptos-move/framework/aptos-framework");
     path
 }
-
-pub(crate) fn release_builder_path() -> PathBuf {
-    let mut path = aptos_core_path();
-    path.push("aptos-move/aptos-release-builder");
-    path
-}


### PR DESCRIPTION
Currently this absolute path only works from within a docker image

This change makes the path relative and possible to run from elsewhere

Test Plan:
```
RUST_BACKTRACE=1 cargo run --profile performance -p aptos-release-builder \
    generate-proposals \
    --release-config aptos-move/aptos-release-builder/data/release.yaml --output-dir banana
```

Pull Request: https://github.com/aptos-labs/aptos-core/pull/9529
