### PR TITLE
[NFT Metadata Crawler] Dockerize Parser

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,6 +27,7 @@
 !api/doc/
 !crates/indexer/migrations/**/*.sql
 !ecosystem/indexer-grpc/indexer-grpc-parser/migrations/**/*.sql
+!ecosystem/nft-metadata-crawler-parser/migrations/**/*.sql
 !terraform/helm/aptos-node/
 !terraform/helm/genesis/
 !testsuite/forge/src/backend/k8s/

--- a/docker/builder/build-tools.sh
+++ b/docker/builder/build-tools.sh
@@ -26,6 +26,7 @@ cargo build --locked --profile=$PROFILE \
     -p aptos-indexer-grpc-file-store \
     -p aptos-indexer-grpc-data-service \
     -p aptos-indexer-grpc-post-processor \
+    -p aptos-nft-metadata-crawler-parser \
     "$@"
 
 # After building, copy the binaries we need to `dist` since the `target` directory is used as docker cache mount and only available during the RUN step
@@ -44,6 +45,7 @@ BINS=(
     aptos-indexer-grpc-file-store
     aptos-indexer-grpc-data-service
     aptos-indexer-grpc-post-processor
+    aptos-nft-metadata-crawler-parser
 )
 
 mkdir dist

--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -58,6 +58,7 @@ group "all" {
     "telemetry-service",
     "indexer-grpc",
     "validator-testing",
+    "nft-metadata-crawler",
   ])
 }
 
@@ -211,6 +212,15 @@ target "indexer-grpc" {
   target     = "indexer-grpc"
   cache-to   = generate_cache_to("indexer-grpc")
   tags       = generate_tags("indexer-grpc")
+}
+
+target "nft-metadata-crawler" {
+  inherits   = ["_common"]
+  target     = "nft-metadata-crawler"
+  dockerfile = "docker/builder/nft-metadata-crawler.Dockerfile"
+  tags       = generate_tags("nft-metadata-crawler")
+  cache-from = generate_cache_from("nft-metadata-crawler")
+  cache-to   = generate_cache_to("nft-metadata-crawler")
 }
 
 function "generate_cache_from" {

--- a/docker/builder/nft-metadata-crawler.Dockerfile
+++ b/docker/builder/nft-metadata-crawler.Dockerfile
@@ -1,0 +1,30 @@
+### NFT Metadata Crawler Image ###
+
+FROM tools-builder
+
+FROM debian-base AS nft-metadata-crawler
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \   
+    apt-get update && apt-get install --no-install-recommends -y \    
+        libssl1.1 \
+        ca-certificates \
+        net-tools \
+        tcpdump \
+        iproute2 \
+        netcat \
+        libpq-dev \
+        curl
+
+COPY --link --from=tools-builder /aptos/dist/aptos-nft-metadata-crawler-parser /usr/local/bin/aptos-nft-metadata-crawler-parser
+
+# The health check port
+EXPOSE 8080
+
+# add build info
+ARG GIT_TAG
+ENV GIT_TAG ${GIT_TAG}
+ARG GIT_BRANCH
+ENV GIT_BRANCH ${GIT_BRANCH}
+ARG GIT_SHA
+ENV GIT_SHA ${GIT_SHA}

--- a/docker/builder/nft-metadata-crawler.Dockerfile
+++ b/docker/builder/nft-metadata-crawler.Dockerfile
@@ -20,11 +20,3 @@ COPY --link --from=tools-builder /aptos/dist/aptos-nft-metadata-crawler-parser /
 
 # The health check port
 EXPOSE 8080
-
-# add build info
-ARG GIT_TAG
-ENV GIT_TAG ${GIT_TAG}
-ARG GIT_BRANCH
-ENV GIT_BRANCH ${GIT_BRANCH}
-ARG GIT_SHA
-ENV GIT_SHA ${GIT_SHA}


### PR DESCRIPTION
### Description
Add nft metadata crawler parser to the aptos-core docker build process to integrate deployment with CI

### Test Plan
Was able to successfully build image using the remote builder by running `./docker-bake-rust-all.sh nft-metadata-crawler`

Fixes EI-254