### PR TITLE
[CLI] Disallow "rotating" to same private key

### DIFF
--- a/crates/aptos/src/account/key_rotation.rs
+++ b/crates/aptos/src/account/key_rotation.rs
@@ -104,6 +104,12 @@ impl CliCommand<RotateSummary> for RotateKey {
 
         let (current_private_key, sender_address) = self.txn_options.get_key_and_address()?;
 
+        if new_private_key == current_private_key {
+            return Err(CliError::CommandArgumentError(
+                "New private key cannot be the same as the current private key".to_string(),
+            ));
+        }
+
         // Get sequence number for account
         let sequence_number = self.txn_options.sequence_number(sender_address).await?;
         let auth_key = self.txn_options.auth_key(sender_address).await?;


### PR DESCRIPTION
### Description
It isn't harmful that we allow this, it's just there is no point in allowing it.

### Test Plan
```
$ ~/a/core/target/debug/aptos account rotate-key --private-key 0x98b22207d27a4b843e833f292a7f7ea8bb29829a0db018b2db6444636061aea9 --new-private-key 0x98b22207d27a4b843e833f292a7f7ea8bb29829a0db018b2db6444636061aea9 --url https://fullnode.testnet.aptoslabs.com
{
  "Error": "Invalid arguments: New private key cannot be the same as the current private key"
}
```
