### PR TITLE
[TS SDK] Support network and API endpoints on `AptosConfig`

### DIFF
--- a/ecosystem/typescript/sdk_v2/package.json
+++ b/ecosystem/typescript/sdk_v2/package.json
@@ -25,7 +25,8 @@
     "_build:cjs": "tsup src/index.ts --format cjs --dts --out-dir dist/cjs",
     "_build:types": "tsup src/types/index.ts --dts --out-dir dist/types",
     "generate-openapi-response-types": "openapi -i ../../../../api/doc/spec.yaml -o ./src/types/generated --exportCore=false --exportServices=false",
-    "lint": "eslint \"**/*.ts\""
+    "lint": "eslint \"**/*.ts\"",
+    "test": "pnpm jest"
   },
   "dependencies": {
     "@aptos-labs/aptos-client": "^0.0.2",

--- a/ecosystem/typescript/sdk_v2/src/api/aptos_config.ts
+++ b/ecosystem/typescript/sdk_v2/src/api/aptos_config.ts
@@ -1,9 +1,23 @@
 import { ClientConfig } from "../client/types";
+import { NetworkToNodeAPI, NetworkToFaucetAPI, NetworkToIndexerAPI, Network } from "../utils/api-endpoints";
+import { DEFAULT_NETWORK } from "../utils/const";
 
 export class AptosConfig {
+  readonly network?: Network;
+
+  readonly fullnode?: string;
+
+  readonly faucet?: string;
+
+  readonly indexer?: string;
+
   readonly clientConfig?: ClientConfig;
 
   constructor(config?: AptosConfig) {
+    this.network = config?.network ?? DEFAULT_NETWORK;
+    this.fullnode = config?.fullnode ?? NetworkToNodeAPI[this.network];
+    this.faucet = config?.faucet ?? NetworkToFaucetAPI[this.network];
+    this.indexer = config?.indexer ?? NetworkToIndexerAPI[this.network];
     this.clientConfig = config?.clientConfig ?? {};
   }
 }

--- a/ecosystem/typescript/sdk_v2/src/utils/api-endpoints.ts
+++ b/ecosystem/typescript/sdk_v2/src/utils/api-endpoints.ts
@@ -1,0 +1,27 @@
+export const NetworkToIndexerAPI: Record<string, string> = {
+  mainnet: "https://indexer.mainnet.aptoslabs.com/v1/graphql",
+  testnet: "https://indexer-testnet.staging.gcp.aptosdev.com/v1/graphql",
+  devnet: "https://indexer-devnet.staging.gcp.aptosdev.com/v1/graphql",
+};
+
+export const NetworkToNodeAPI: Record<string, string> = {
+  mainnet: "https://fullnode.mainnet.aptoslabs.com/v1",
+  testnet: "https://fullnode.testnet.aptoslabs.com/v1",
+  devnet: "https://fullnode.devnet.aptoslabs.com/v1",
+  local: "http://localhost:8080/v1",
+};
+
+export const NetworkToFaucetAPI: Record<string, string> = {
+  mainnet: "https://faucet.mainnet.aptoslabs.com",
+  testnet: "https://faucet.testnet.aptoslabs.com",
+  devnet: "https://faucet.devnet.aptoslabs.com",
+  local: "http://localhost:8081",
+};
+
+export enum Network {
+  MAINNET = "mainnet",
+  TESTNET = "testnet",
+  DEVNET = "devnet",
+  LOCAL = "local",
+  CUSTOM = "custom",
+}

--- a/ecosystem/typescript/sdk_v2/src/utils/const.ts
+++ b/ecosystem/typescript/sdk_v2/src/utils/const.ts
@@ -1,3 +1,3 @@
 import { Network } from "./api-endpoints";
 
-export const DEFAULT_NETWORK = Network.TESTNET;
+export const DEFAULT_NETWORK = Network.DEVNET;

--- a/ecosystem/typescript/sdk_v2/src/utils/const.ts
+++ b/ecosystem/typescript/sdk_v2/src/utils/const.ts
@@ -1,0 +1,3 @@
+import { Network } from "./api-endpoints";
+
+export const DEFAULT_NETWORK = Network.TESTNET;

--- a/ecosystem/typescript/sdk_v2/tests/unit/aptos_config.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/aptos_config.test.ts
@@ -1,0 +1,59 @@
+import { Aptos, AptosConfig } from "../../src";
+import { Network } from "../../src/utils/api-endpoints";
+
+describe("aptos config", () => {
+  test("it should set TESTNET network if network is not provided", async () => {
+    const aptos = new Aptos();
+    expect(aptos.config.network).toEqual("testnet");
+    expect(aptos.config.fullnode).toEqual("https://fullnode.testnet.aptoslabs.com/v1");
+    expect(aptos.config.faucet).toEqual("https://faucet.testnet.aptoslabs.com");
+    expect(aptos.config.indexer).toEqual("https://indexer-testnet.staging.gcp.aptosdev.com/v1/graphql");
+  });
+
+  test("it should set urls based on the provided network", async () => {
+    const settings: AptosConfig = {
+      network: Network.DEVNET,
+    };
+    const aptos = new Aptos(settings);
+    expect(aptos.config.network).toEqual("devnet");
+    expect(aptos.config.fullnode).toEqual("https://fullnode.devnet.aptoslabs.com/v1");
+    expect(aptos.config.faucet).toEqual("https://faucet.devnet.aptoslabs.com");
+    expect(aptos.config.indexer).toEqual("https://indexer-devnet.staging.gcp.aptosdev.com/v1/graphql");
+  });
+
+  test("it should set urls based on a local network", async () => {
+    const settings: AptosConfig = {
+      network: Network.LOCAL,
+    };
+    const aptos = new Aptos(settings);
+    expect(aptos.config.network).toEqual("local");
+    expect(aptos.config.fullnode).toEqual("http://localhost:8080/v1");
+    expect(aptos.config.faucet).toEqual("http://localhost:8081");
+    expect(aptos.config.indexer).toBeUndefined();
+  });
+
+  test("it should have undefined urls when network is custom and no urls provided", async () => {
+    const settings: AptosConfig = {
+      network: Network.CUSTOM,
+    };
+    const aptos = new Aptos(settings);
+    expect(aptos.config.network).toEqual("custom");
+    expect(aptos.config.fullnode).toBeUndefined();
+    expect(aptos.config.faucet).toBeUndefined();
+    expect(aptos.config.indexer).toBeUndefined();
+  });
+
+  test("it should set urls when network is custom and urls provided", async () => {
+    const settings: AptosConfig = {
+      network: Network.CUSTOM,
+      fullnode: "my-fullnode-url",
+      faucet: "my-faucet-url",
+      indexer: "my-indexer-url",
+    };
+    const aptos = new Aptos(settings);
+    expect(aptos.config.network).toEqual("custom");
+    expect(aptos.config.fullnode).toEqual("my-fullnode-url");
+    expect(aptos.config.faucet).toEqual("my-faucet-url");
+    expect(aptos.config.indexer).toEqual("my-indexer-url");
+  });
+});

--- a/ecosystem/typescript/sdk_v2/tests/unit/aptos_config.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/aptos_config.test.ts
@@ -2,23 +2,23 @@ import { Aptos, AptosConfig } from "../../src";
 import { Network } from "../../src/utils/api-endpoints";
 
 describe("aptos config", () => {
-  test("it should set TESTNET network if network is not provided", async () => {
+  test("it should set DEVNET network if network is not provided", async () => {
     const aptos = new Aptos();
-    expect(aptos.config.network).toEqual("testnet");
-    expect(aptos.config.fullnode).toEqual("https://fullnode.testnet.aptoslabs.com/v1");
-    expect(aptos.config.faucet).toEqual("https://faucet.testnet.aptoslabs.com");
-    expect(aptos.config.indexer).toEqual("https://indexer-testnet.staging.gcp.aptosdev.com/v1/graphql");
-  });
-
-  test("it should set urls based on the provided network", async () => {
-    const settings: AptosConfig = {
-      network: Network.DEVNET,
-    };
-    const aptos = new Aptos(settings);
     expect(aptos.config.network).toEqual("devnet");
     expect(aptos.config.fullnode).toEqual("https://fullnode.devnet.aptoslabs.com/v1");
     expect(aptos.config.faucet).toEqual("https://faucet.devnet.aptoslabs.com");
     expect(aptos.config.indexer).toEqual("https://indexer-devnet.staging.gcp.aptosdev.com/v1/graphql");
+  });
+
+  test("it should set urls based on the provided network", async () => {
+    const settings: AptosConfig = {
+      network: Network.TESTNET,
+    };
+    const aptos = new Aptos(settings);
+    expect(aptos.config.network).toEqual("testnet");
+    expect(aptos.config.fullnode).toEqual("https://fullnode.testnet.aptoslabs.com/v1");
+    expect(aptos.config.faucet).toEqual("https://faucet.testnet.aptoslabs.com");
+    expect(aptos.config.indexer).toEqual("https://indexer-testnet.staging.gcp.aptosdev.com/v1/graphql");
   });
 
   test("it should set urls based on a local network", async () => {


### PR DESCRIPTION
### Description
This PR adds support for network and API endpoints on `AptosConfig`. Once `Aptos` is initialized, a network and API endpoints are being set.

- Ability to initialize `Aptos` with no network and then it assigns a default one (testnet)
- Ability to initializes `Aptos` with a local/devnet/test/mainnet network, and the sdk assigns the network endpoint for each service (fullnode, faucet, indexer).
- Ability to initialize `Aptos` with a custom network - it expects the user to also provide the API endpoints.

This would be much simpler once API v2/gateway is ready.
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
