### PR TITLE
[release-builder] Increase lockup before executing proposals

### DIFF
--- a/aptos-move/aptos-release-builder/src/validate.rs
+++ b/aptos-move/aptos-release-builder/src/validate.rs
@@ -7,6 +7,7 @@ use aptos::{
     common::types::CliCommand,
     governance::{ExecuteProposal, SubmitProposal, SubmitVote},
     move_tool::{RunFunction, RunScript},
+    stake::IncreaseLockup,
 };
 use aptos_api_types::U64;
 use aptos_crypto::ed25519::Ed25519PrivateKey;
@@ -355,6 +356,18 @@ impl NetworkConfig {
     }
 }
 
+async fn increase_lockup(validator_address: &str, validator_key: &str) -> Result<()> {
+    let args = vec![
+        "--private-key",
+        validator_key,
+        "--sender-account",
+        validator_address,
+        "--assume-yes",
+    ];
+    IncreaseLockup::parse_from(args).execute().await?;
+    Ok(())
+}
+
 async fn execute_release(
     release_config: ReleaseConfig,
     network_config: NetworkConfig,
@@ -371,6 +384,14 @@ async fn execute_release(
     };
     release_config.generate_release_proposal_scripts(proposal_folder)?;
 
+    // Increase lockup
+    increase_lockup(
+        network_config.validator_account.to_string().as_str(),
+        network_config.validator_key.to_string().as_str(),
+    )
+    .await?;
+
+    // Execute proposals
     for proposal in &release_config.proposals {
         let mut proposal_path = proposal_folder.to_path_buf();
         proposal_path.push("sources");


### PR DESCRIPTION
Increase the lockup before executing proposals

Currently the release flow started consistently failing because we need to increase the lockup

This ensures that the lockup is sufficient before executing transactions

Test Plan: not sure how to test other than by running against testnet???

Please advise
