### PR TITLE
[GHA] Rollback Continue migrating away from non-required tests.

### DIFF
--- a/.github/workflows/check-sdk-examples.yaml
+++ b/.github/workflows/check-sdk-examples.yaml
@@ -16,7 +16,7 @@ jobs:
   # whereas we run the test-sdk-confirm-client-generated-publish against a node
   # built from the same commit and run as part of that CI job.
   run-examples:
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     runs-on: ubuntu-latest
     env:
       APTOS_NODE_URL: https://fullnode.devnet.aptoslabs.com
@@ -46,7 +46,7 @@ jobs:
           command: cd ./ecosystem/typescript/sdk/examples/javascript && pnpm install && pnpm test
 
   run-python-examples:
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     runs-on: ubuntu-latest
     env:
       APTOS_NODE_URL: https://fullnode.devnet.aptoslabs.com/v1

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -109,7 +109,6 @@ jobs:
       targetCacheId: ${{ env.TARGET_CACHE_ID }}
       targetRegistry: ${{ env.TARGET_REGISTRY }}
 
-  # This is a PR required job.
   rust-images:
     needs: [permission-check, determine-docker-build-metadata]
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
@@ -183,7 +182,6 @@ jobs:
       BUILD_ADDL_TESTING_IMAGES: true
       TARGET_REGISTRY: ${{ needs.determine-docker-build-metadata.outputs.targetRegistry }}
 
-  # This is a PR required job.
   node-api-compatibility-tests:
     needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
     if: |
@@ -199,7 +197,6 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
 
-  # This is a PR required job.
   cli-e2e-tests:
     needs: [permission-check, rust-images, determine-docker-build-metadata] # runs with the default release docker build variant "rust-images"
     if: |
@@ -228,7 +225,6 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
 
-  # This is a PR required job.
   forge-e2e-test:
     needs:
       - permission-check
@@ -259,7 +255,7 @@ jobs:
       # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
       FORGE_NAMESPACE: forge-e2e-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
 
-  # Run e2e compat test against testnet branch. This is a PR required job.
+  # Run e2e compat test against testnet branch
   forge-compat-test:
     needs:
       - permission-check
@@ -287,7 +283,7 @@ jobs:
       COMMENT_HEADER: forge-compat
       FORGE_NAMESPACE: forge-compat-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
 
-  # Run forge framework upgradability test. This is a PR required job.
+  # Run forge framework upgradability test
   forge-framework-upgrade-test:
     needs:
       - permission-check

--- a/.github/workflows/faucet-tests.yaml
+++ b/.github/workflows/faucet-tests.yaml
@@ -25,7 +25,7 @@ jobs:
           comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
 
   run-tests-devnet:
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     needs: [permission-check]
     runs-on: high-perf-docker
     steps:
@@ -44,7 +44,7 @@ jobs:
           GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
 
   run-tests-testnet:
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     needs: [permission-check]
     runs-on: high-perf-docker
     permissions:

--- a/.github/workflows/indexer-grpc-integration-tests.yaml
+++ b/.github/workflows/indexer-grpc-integration-tests.yaml
@@ -18,8 +18,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Note on the job-level `if` conditions:
+  # This workflow is designed such that we run subsequent jobs only when a 'push'
+  # triggered the workflow or on 'pull_request's which have set auto_merge=true
+  # or have the label "CICD:run-e2e-tests".
   permission-check:
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     runs-on: ubuntu-latest
     steps:
       - name: Check repository permission for user which triggered workflow
@@ -29,7 +33,7 @@ jobs:
           comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
 
   run-tests-local-testnet:
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     needs: [permission-check]
     runs-on: high-perf-docker
     env:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -70,7 +70,7 @@ jobs:
   rust-cryptohasher-domain-separation-check:
     needs: file_change_determinator
     runs-on: high-perf-docker
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -215,3 +215,7 @@ jobs:
             /tmp/.tmp*
             !/tmp/.tmp*/**/db/
           retention-days: 14
+
+  # TODO: remove this once the new jobs land
+  python-lint-test:
+    uses: ./.github/workflows/python-lint-test.yaml

--- a/.github/workflows/python-lint-test.yaml
+++ b/.github/workflows/python-lint-test.yaml
@@ -1,0 +1,46 @@
+name: "Run Python Tests"
+
+on:
+  workflow_call:
+    inputs:
+      GIT_SHA:
+        required: false
+        type: string
+
+jobs:
+  python-unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        with:
+          ref: ${{ inputs.GIT_SHA }}
+          # Get enough commits to compare to
+          fetch-depth: 100
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@60f4aabced9b4718c75acef86d42ffb631c4403a # pin@v29.0.3
+
+      - uses: ./.github/actions/python-setup
+        with:
+          pyproject_directory: testsuite
+
+      - name: Should run tests
+        run: ./testrun determinator.py changed-files --github-output-key SHOULD_RUN --pattern 'testsuite/.*py' ${{steps.changed-files.outputs.all_changed_files }}
+        id: should-run-tests
+        working-directory: testsuite
+
+      - name: Run python static type checker
+        if: steps.should-run-tests.outputs.SHOULD_RUN == 'true'
+        run: poetry run pyright
+        working-directory: testsuite
+
+      - name: Run python fmt
+        if: steps.should-run-tests.outputs.SHOULD_RUN == 'true'
+        run: poetry run black --check --diff .
+        working-directory: testsuite
+
+      - name: Run python unit tests
+        if: steps.should-run-tests.outputs.SHOULD_RUN == 'true'
+        run: find . -name '*test.py' | xargs poetry run python -m unittest
+        working-directory: testsuite

--- a/.github/workflows/run-gas-calibration.yaml
+++ b/.github/workflows/run-gas-calibration.yaml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   run-gas-calibration:
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     runs-on: high-perf-docker
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rust-client-tests.yaml
+++ b/.github/workflows/rust-client-tests.yaml
@@ -29,7 +29,7 @@ jobs:
           comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
 
   run-tests-devnet:
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     needs: [permission-check]
     runs-on: high-perf-docker
     steps:
@@ -48,7 +48,7 @@ jobs:
           GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
 
   run-tests-testnet:
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     needs: [permission-check]
     runs-on: high-perf-docker
     steps:
@@ -67,7 +67,7 @@ jobs:
           GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
 
   run-tests-mainnet:
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     needs: [permission-check]
     runs-on: high-perf-docker
     steps:

--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -32,28 +32,15 @@ jobs:
           required-permission: write
           comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
 
-  # This job determines which files were changed
-  file_change_determinator:
-    runs-on: ubuntu-latest
-    outputs:
-      only_docs_changed: ${{ steps.determine_file_changes.outputs.only_docs_changed }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run the file change determinator
-        id: determine_file_changes
-        uses: ./.github/actions/file-change-determinator
-
-  # This is a PR required job.
+  # This is a required job for each pull request.
   run-tests-main-branch:
-    needs: [permission-check, file_change_determinator]
+    needs: [permission-check]
     runs-on: high-perf-docker
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
-        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         with:
           ref: ${{ env.GIT_SHA }}
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
-        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
@@ -62,12 +49,9 @@ jobs:
           AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - uses: ./.github/actions/run-ts-sdk-e2e-tests
-        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         with:
           BRANCH: main
           GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
-      - run: echo "Skipping the tests on the main branch! Unrelated changes detected."
-        if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
 
   # Run the TS SDK indexer tests. Note: Unlike the above tests where everything is self
   # contained because we run a local testnet, these tests operate against the

--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -59,7 +59,7 @@ jobs:
   # to be land blocking for any PR on the aptos repo. This is why we run those tests
   # separate from test-sdk-confirm-client-generated-publish.
   run-indexer-tests:
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     needs: [permission-check]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description
This PR reverts a previous PR: https://github.com/aptos-labs/aptos-core/pull/9545.

Created using:
```
git revert 181a0f07710466c4d1e9795473c8a75573417738
git revert d9733dbbd0508625aa277b2d784ed762585ee912
```

### Test Plan
Existing test infrastructure.