### PR TITLE
[GHA] Move smoke tests to build + test, and gate execution tests.

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -23,7 +23,8 @@ name: "Build+Test Docker Images"
 on: # build on main branch OR when a PR is labeled with `CICD:build-images`
   # Allow us to run this specific workflow without a PR
   workflow_dispatch:
-  pull_request_target:
+  #pull_request_target:
+  pull_request: # TODO: remove this before landing! This is only to test!
     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
   push:
     branches:
@@ -108,6 +109,17 @@ jobs:
       gitSha: ${{ env.GIT_SHA }}
       targetCacheId: ${{ env.TARGET_CACHE_ID }}
       targetRegistry: ${{ env.TARGET_REGISTRY }}
+
+  # This job determines which files were changed
+  file_change_determinator:
+    runs-on: ubuntu-latest
+    outputs:
+      only_docs_changed: ${{ steps.determine_file_changes.outputs.only_docs_changed }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run the file change determinator
+        id: determine_file_changes
+        uses: ./.github/actions/file-change-determinator
 
   # This is a PR required job.
   rust-images:
@@ -227,6 +239,28 @@ jobs:
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+
+  # Run all rust smoke tests. This is a PR required job.
+  rust-smoke-tests:
+    needs: [permission-check, file_change_determinator]
+    runs-on: high-perf-docker
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run rust smoke tests
+        uses: ./.github/actions/rust-smoke-tests
+        if: |
+          !failure() && !cancelled() && needs.permission-check.result == 'success' &&
+          needs.file_change_determinator.outputs.only_docs_changed != 'true' && (
+            (github.event_name == 'push' && github.ref_name != 'main') ||
+            github.event_name == 'workflow_dispatch' ||
+            contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+            github.event.pull_request.auto_merge != null ||
+            contains(github.event.pull_request.body, '#e2e')
+          )
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - run: echo "Skipping rust smoke tests! Unrelated changes detected."
+        if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
 
   # This is a PR required job.
   forge-e2e-test:

--- a/.github/workflows/execution-performance.yaml
+++ b/.github/workflows/execution-performance.yaml
@@ -2,11 +2,20 @@ name: "execution-performance"
 on:
   workflow_dispatch:
   pull_request:
+    types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
   schedule:
     - cron: "0 12 * * *" # This runs every day at 12pm UTC.
 
 jobs:
   execution-performance:
+    if: |
+      (
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'schedule' ||
+        contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+        github.event.pull_request.auto_merge != null) ||
+        contains(github.event.pull_request.body, '#e2e'
+      )
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-execution-performance.yaml@main
     secrets: inherit
     with:

--- a/.github/workflows/indexer-grpc-integration-tests.yaml
+++ b/.github/workflows/indexer-grpc-integration-tests.yaml
@@ -1,6 +1,7 @@
 name: "Indexer gRPC Integration Tests"
 on:
-  pull_request_target:
+  #pull_request_target:
+  pull_request: # TODO: remove this before landing! This is only to test!
     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
   push:
     branches:
@@ -19,7 +20,6 @@ concurrency:
 
 jobs:
   permission-check:
-    if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests'))
     runs-on: ubuntu-latest
     steps:
       - name: Check repository permission for user which triggered workflow


### PR DESCRIPTION
### Description
This PR:
1. Moves the rust smoke tests to the build + test file, and ensures that it only runs under the same conditions as the land blocking forge tests. This has several benefits: (i) we'll only run these expensive tests when folks hit auto-merge, or use the  appropriate labels, thus helping to reduce/avoid unnecessary runs; and (ii) once @ibalajiarun's [determinator](https://github.com/aptos-labs/aptos-core/pull/9463) lands, we'll be able to give PR authors correctness signals much sooner (via the unit tests). The idea is that the unit tests should offer the first set of correctness signals to PR authors, before we run the more expensive tests.
2. Gates the performance execution tests to run under the same conditions as the land blocking forge tests, thus only running when folks hit auto-merge, or use the appropriate labels, thus helping to reduce/avoid unnecessary runs.

Once this PR lands, I'll make this smoke test job required and remove the old smoke test job (in the rust + lint file).

### Test Plan
Existing test infrastructure.