### PR TITLE
Explicitize that the txn_seq_num param on the epilogue is unused

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -498,9 +498,11 @@ impl AptosVMImpl {
         gas_remaining: Gas,
         txn_data: &TransactionMetadata,
     ) -> VMResult<()> {
-        let txn_sequence_number = txn_data.sequence_number();
         let txn_gas_price = txn_data.gas_unit_price();
         let txn_max_gas_units = txn_data.max_gas_amount();
+        // TODO(aldenhu): repurpose this to be the amount of the storage fee refund.
+        let unused = 0;
+
         // We can unconditionally do this as this condition can only be true if the prologue
         // accepted it, in which case the gas payer feature is enabled.
         if let Some(fee_payer) = txn_data.fee_payer() {
@@ -511,7 +513,7 @@ impl AptosVMImpl {
                 serialize_values(&vec![
                     MoveValue::Signer(txn_data.sender),
                     MoveValue::Address(fee_payer),
-                    MoveValue::U64(txn_sequence_number),
+                    MoveValue::U64(unused),
                     MoveValue::U64(txn_gas_price.into()),
                     MoveValue::U64(txn_max_gas_units.into()),
                     MoveValue::U64(gas_remaining.into()),
@@ -526,7 +528,7 @@ impl AptosVMImpl {
                 vec![],
                 serialize_values(&vec![
                     MoveValue::Signer(txn_data.sender),
-                    MoveValue::U64(txn_sequence_number),
+                    MoveValue::U64(unused),
                     MoveValue::U64(txn_gas_price.into()),
                     MoveValue::U64(txn_max_gas_units.into()),
                     MoveValue::U64(gas_remaining.into()),


### PR DESCRIPTION
With this we can go through all historical txns to make sure.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
replay: https://github.com/aptos-labs/aptos-core/actions/runs/5815138842
