### PR TITLE
[TS SDK] create account and hex data modules

### DIFF
--- a/ecosystem/typescript/sdk_v2/src/account/account.ts
+++ b/ecosystem/typescript/sdk_v2/src/account/account.ts
@@ -1,0 +1,98 @@
+import nacl from "tweetnacl";
+import * as bip39 from "@scure/bip39";
+import { bytesToHex } from "@noble/hashes/utils";
+import { Hex } from "../types";
+import { derivePath, Memoize, HexData } from "../utils";
+import { AuthenticationKey, Ed25519PublicKey } from "../crypto";
+
+export class Account {
+  /**
+   * A private key and public key, associated with the given account
+   */
+  private signingKey: nacl.SignKeyPair;
+
+  /**
+   * Address associated with the given account
+   */
+  private accountAddress: AccountAddress;
+
+  /**
+   * Creates new account instance.
+   * @param privateKeyBytes  Private key from which account key pair will be generated.
+   * If not specified, new key pair is going to be created.
+   */
+  constructor(privateKeyBytes?: Uint8Array) {
+    if (privateKeyBytes) {
+      this.signingKey = nacl.sign.keyPair.fromSeed(privateKeyBytes.slice(0, 32));
+    } else {
+      this.signingKey = nacl.sign.keyPair();
+    }
+    this.accountAddress = new AccountAddress(this.authKey().toBytes());
+  }
+
+  getPublicKey(): Uint8Array {
+    return this.signingKey.publicKey;
+  }
+
+  getPrivateKey(): Uint8Array {
+    return this.signingKey.secretKey;
+  }
+
+  public get address(): string {
+    return this.accountAddress;
+  }
+
+  withPrivateKeyAndAddress(privateKeyBytes: Uint8Array, address: Hex) {
+    this.accountAddress = new AccountAddress(HexData.validate(address).toBytes());
+    this.signingKey = nacl.sign.keyPair.fromSeed(privateKeyBytes.slice(0, 32));
+  }
+
+  /**
+   * Check's if the derive path is valid
+   */
+  static isValidPath(path: string): boolean {
+    return /^m\/44'\/637'\/[0-9]+'\/[0-9]+'\/[0-9]+'+$/.test(path);
+  }
+
+  /**
+   * Creates new account with bip44 path and mnemonics,
+   * @param path. (e.g. m/44'/637'/0'/0'/0')
+   * Detailed description: {@link https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki}
+   * @param mnemonics.
+   * @returns AptosAccount
+   */
+  static fromDerivePath(path: string, mnemonics: string): Account {
+    if (!Account.isValidPath(path)) {
+      throw new Error("Invalid derivation path");
+    }
+
+    const normalizeMnemonics = mnemonics
+      .trim()
+      .split(/\s+/)
+      .map((part) => part.toLowerCase())
+      .join(" ");
+
+    const { key } = derivePath(path, bytesToHex(bip39.mnemonicToSeedSync(normalizeMnemonics)));
+
+    return new Account(key);
+  }
+
+  sign(data: Hex): HexData {
+    const buffer = HexData.validate(data).toBytes();
+    const signature = nacl.sign.detached(buffer, this.signingKey.secretKey);
+    return HexData.fromBytes(signature);
+  }
+
+  verifySignature(message: Hex, signature: Hex): boolean {
+    const rawMessage = HexData.validate(message).toBytes();
+    const rawSignature = HexData.validate(signature).toBytes();
+    return nacl.sign.detached.verify(rawMessage, rawSignature, this.signingKey.publicKey);
+  }
+
+  @Memoize()
+  authKey(): HexData {
+    const pubKey = new Ed25519PublicKey(this.signingKey.publicKey);
+    const authKey = AuthenticationKey.fromEd25519PublicKey(pubKey);
+    return authKey.derivedAddress();
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/account/index.ts
+++ b/ecosystem/typescript/sdk_v2/src/account/index.ts
@@ -1,0 +1,1 @@
+export * from "./account";

--- a/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
@@ -1,0 +1,73 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
+import { Bytes } from "../bcs";
+import { MultiEd25519PublicKey } from "./multi_ed25519";
+import { Ed25519PublicKey } from "./ed25519";
+import { HexData } from "../utils";
+
+/**
+ * Each account stores an authentication key. Authentication key enables account owners to rotate
+ * their private key(s) associated with the account without changing the address that hosts their account.
+ * @see {@link * https://aptos.dev/concepts/accounts | Account Basics}
+ *
+ * Account addresses can be derived from AuthenticationKey
+ */
+export class AuthenticationKey {
+  static readonly LENGTH: number = 32;
+
+  static readonly MULTI_ED25519_SCHEME: number = 1;
+
+  static readonly ED25519_SCHEME: number = 0;
+
+  static readonly DERIVE_RESOURCE_ACCOUNT_SCHEME: number = 255;
+
+  readonly bytes: Bytes;
+
+  constructor(bytes: Bytes) {
+    if (bytes.length !== AuthenticationKey.LENGTH) {
+      throw new Error("Expected a byte array of length 32");
+    }
+    this.bytes = bytes;
+  }
+
+  /**
+   * Converts a K-of-N MultiEd25519PublicKey to AuthenticationKey with:
+   * `auth_key = sha3-256(p_1 | … | p_n | K | 0x01)`. `K` represents the K-of-N required for
+   * authenticating the transaction. `0x01` is the 1-byte scheme for multisig.
+   */
+  static fromMultiEd25519PublicKey(publicKey: MultiEd25519PublicKey): AuthenticationKey {
+    const pubKeyBytes = publicKey.toBytes();
+
+    const bytes = new Uint8Array(pubKeyBytes.length + 1);
+    bytes.set(pubKeyBytes);
+    bytes.set([AuthenticationKey.MULTI_ED25519_SCHEME], pubKeyBytes.length);
+
+    const hash = sha3Hash.create();
+    hash.update(bytes);
+
+    return new AuthenticationKey(hash.digest());
+  }
+
+  static fromEd25519PublicKey(publicKey: Ed25519PublicKey): AuthenticationKey {
+    const pubKeyBytes = publicKey.value;
+
+    const bytes = new Uint8Array(pubKeyBytes.length + 1);
+    bytes.set(pubKeyBytes);
+    bytes.set([AuthenticationKey.ED25519_SCHEME], pubKeyBytes.length);
+
+    const hash = sha3Hash.create();
+    hash.update(bytes);
+
+    return new AuthenticationKey(hash.digest());
+  }
+
+  /**
+   * Derives an account address from AuthenticationKey. Since current AccountAddress is 32 bytes,
+   * AuthenticationKey bytes are directly translated to AccountAddress.
+   */
+  derivedAddress(): HexData {
+    return HexData.fromBytes(this.bytes);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
@@ -1,0 +1,49 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Bytes, Deserializer, Serializer } from "../bcs";
+
+export class Ed25519PublicKey {
+  static readonly LENGTH: number = 32;
+
+  readonly value: Bytes;
+
+  constructor(value: Bytes) {
+    if (value.length !== Ed25519PublicKey.LENGTH) {
+      throw new Error(`Ed25519PublicKey length should be ${Ed25519PublicKey.LENGTH}`);
+    }
+    this.value = value;
+  }
+
+  toBytes(): Bytes {
+    return this.value;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeBytes(this.value);
+  }
+
+  static deserialize(deserializer: Deserializer): Ed25519PublicKey {
+    const value = deserializer.deserializeBytes();
+    return new Ed25519PublicKey(value);
+  }
+}
+
+export class Ed25519Signature {
+  static readonly LENGTH = 64;
+
+  constructor(public readonly value: Bytes) {
+    if (value.length !== Ed25519Signature.LENGTH) {
+      throw new Error(`Ed25519Signature length should be ${Ed25519Signature.LENGTH}`);
+    }
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeBytes(this.value);
+  }
+
+  static deserialize(deserializer: Deserializer): Ed25519Signature {
+    const value = deserializer.deserializeBytes();
+    return new Ed25519Signature(value);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/crypto/index.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/index.ts
@@ -1,0 +1,3 @@
+export * from "./ed25519";
+export * from "./authentication_key";
+export * from "./multi_ed25519";

--- a/ecosystem/typescript/sdk_v2/src/crypto/multi_ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/multi_ed25519.ts
@@ -1,0 +1,158 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable no-bitwise */
+import { Bytes, Deserializer, Seq, Serializer, Uint8 } from "../bcs";
+import { Ed25519PublicKey, Ed25519Signature } from "./ed25519";
+
+/**
+ * MultiEd25519 currently supports at most 32 signatures.
+ */
+const MAX_SIGNATURES_SUPPORTED = 32;
+
+export class MultiEd25519PublicKey {
+  /**
+   * Public key for a K-of-N multisig transaction. A K-of-N multisig transaction means that for such a
+   * transaction to be executed, at least K out of the N authorized signers have signed the transaction
+   * and passed the check conducted by the chain.
+   *
+   * @see {@link
+   * https://aptos.dev/guides/creating-a-signed-transaction#multisignature-transactions | Creating a Signed Transaction}
+   *
+   * @param public_keys A list of public keys
+   * @param threshold At least "threshold" signatures must be valid
+   */
+  constructor(public readonly public_keys: Seq<Ed25519PublicKey>, public readonly threshold: Uint8) {
+    if (threshold > MAX_SIGNATURES_SUPPORTED) {
+      throw new Error(`"threshold" cannot be larger than ${MAX_SIGNATURES_SUPPORTED}`);
+    }
+  }
+
+  /**
+   * Converts a MultiEd25519PublicKey into bytes with: bytes = p1_bytes | ... | pn_bytes | threshold
+   */
+  toBytes(): Bytes {
+    const bytes = new Uint8Array(this.public_keys.length * Ed25519PublicKey.LENGTH + 1);
+    this.public_keys.forEach((k: Ed25519PublicKey, i: number) => {
+      bytes.set(k.value, i * Ed25519PublicKey.LENGTH);
+    });
+
+    bytes[this.public_keys.length * Ed25519PublicKey.LENGTH] = this.threshold;
+
+    return bytes;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeBytes(this.toBytes());
+  }
+
+  static deserialize(deserializer: Deserializer): MultiEd25519PublicKey {
+    const bytes = deserializer.deserializeBytes();
+    const threshold = bytes[bytes.length - 1];
+
+    const keys: Seq<Ed25519PublicKey> = [];
+
+    for (let i = 0; i < bytes.length - 1; i += Ed25519PublicKey.LENGTH) {
+      const begin = i;
+      keys.push(new Ed25519PublicKey(bytes.subarray(begin, begin + Ed25519PublicKey.LENGTH)));
+    }
+    return new MultiEd25519PublicKey(keys, threshold);
+  }
+}
+
+export class MultiEd25519Signature {
+  static BITMAP_LEN: Uint8 = 4;
+
+  /**
+   * Signature for a K-of-N multisig transaction.
+   *
+   * @see {@link
+   * https://aptos.dev/guides/creating-a-signed-transaction#multisignature-transactions | Creating a Signed Transaction}
+   *
+   * @param signatures A list of ed25519 signatures
+   * @param bitmap 4 bytes, at most 32 signatures are supported. If Nth bit value is `1`, the Nth
+   * signature should be provided in `signatures`. Bits are read from left to right
+   */
+  constructor(public readonly signatures: Seq<Ed25519Signature>, public readonly bitmap: Uint8Array) {
+    if (bitmap.length !== MultiEd25519Signature.BITMAP_LEN) {
+      throw new Error(`"bitmap" length should be ${MultiEd25519Signature.BITMAP_LEN}`);
+    }
+  }
+
+  /**
+   * Converts a MultiEd25519Signature into bytes with `bytes = s1_bytes | ... | sn_bytes | bitmap`
+   */
+  toBytes(): Bytes {
+    const bytes = new Uint8Array(this.signatures.length * Ed25519Signature.LENGTH + MultiEd25519Signature.BITMAP_LEN);
+    this.signatures.forEach((k: Ed25519Signature, i: number) => {
+      bytes.set(k.value, i * Ed25519Signature.LENGTH);
+    });
+
+    bytes.set(this.bitmap, this.signatures.length * Ed25519Signature.LENGTH);
+
+    return bytes;
+  }
+
+  /**
+   * Helper method to create a bitmap out of the specified bit positions
+   * @param bits The bitmap positions that should be set. A position starts at index 0.
+   * Valid position should range between 0 and 31.
+   * @example
+   * Here's an example of valid `bits`
+   * ```
+   * [0, 2, 31]
+   * ```
+   * `[0, 2, 31]` means the 1st, 3rd and 32nd bits should be set in the bitmap.
+   * The result bitmap should be 0b1010000000000000000000000000001
+   *
+   * @returns bitmap that is 32bit long
+   */
+  static createBitmap(bits: Seq<Uint8>): Uint8Array {
+    // Bits are read from left to right. e.g. 0b10000000 represents the first bit is set in one byte.
+    // The decimal value of 0b10000000 is 128.
+    const firstBitInByte = 128;
+    const bitmap = new Uint8Array([0, 0, 0, 0]);
+
+    // Check if duplicates exist in bits
+    const dupCheckSet = new Set();
+
+    bits.forEach((bit: number) => {
+      if (bit >= MAX_SIGNATURES_SUPPORTED) {
+        throw new Error(`Invalid bit value ${bit}.`);
+      }
+
+      if (dupCheckSet.has(bit)) {
+        throw new Error("Duplicated bits detected.");
+      }
+
+      dupCheckSet.add(bit);
+
+      const byteOffset = Math.floor(bit / 8);
+
+      let byte = bitmap[byteOffset];
+
+      byte |= firstBitInByte >> bit % 8;
+
+      bitmap[byteOffset] = byte;
+    });
+
+    return bitmap;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeBytes(this.toBytes());
+  }
+
+  static deserialize(deserializer: Deserializer): MultiEd25519Signature {
+    const bytes = deserializer.deserializeBytes();
+    const bitmap = bytes.subarray(bytes.length - 4);
+
+    const sigs: Seq<Ed25519Signature> = [];
+
+    for (let i = 0; i < bytes.length - bitmap.length; i += Ed25519Signature.LENGTH) {
+      const begin = i;
+      sigs.push(new Ed25519Signature(bytes.subarray(begin, begin + Ed25519Signature.LENGTH)));
+    }
+    return new MultiEd25519Signature(sigs, bitmap);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/types/index.ts
+++ b/ecosystem/typescript/sdk_v2/src/types/index.ts
@@ -1,1 +1,2 @@
 export type AnyNumber = number | bigint;
+export type Hex = string | Uint8Array;

--- a/ecosystem/typescript/sdk_v2/src/utils/hd-key.ts
+++ b/ecosystem/typescript/sdk_v2/src/utils/hd-key.ts
@@ -1,0 +1,76 @@
+import nacl from "tweetnacl";
+import { hmac } from "@noble/hashes/hmac";
+import { sha512 } from "@noble/hashes/sha512";
+import { hexToBytes } from "@noble/hashes/utils";
+
+export type Keys = {
+  key: Uint8Array;
+  chainCode: Uint8Array;
+};
+
+const pathRegex = /^m(\/[0-9]+')+$/;
+
+const replaceDerive = (val: string): string => val.replace("'", "");
+
+const HMAC_KEY = "ed25519 seed";
+const HARDENED_OFFSET = 0x80000000;
+
+export const getMasterKeyFromSeed = (seed: string): Keys => {
+  const h = hmac.create(sha512, HMAC_KEY);
+  const I = h.update(hexToBytes(seed)).digest();
+  const IL = I.slice(0, 32);
+  const IR = I.slice(32);
+  return {
+    key: IL,
+    chainCode: IR,
+  };
+};
+
+export const CKDPriv = ({ key, chainCode }: Keys, index: number): Keys => {
+  const buffer = new ArrayBuffer(4);
+  new DataView(buffer).setUint32(0, index);
+  const indexBytes = new Uint8Array(buffer);
+  const zero = new Uint8Array([0]);
+  const data = new Uint8Array([...zero, ...key, ...indexBytes]);
+
+  const I = hmac.create(sha512, chainCode).update(data).digest();
+  const IL = I.slice(0, 32);
+  const IR = I.slice(32);
+  return {
+    key: IL,
+    chainCode: IR,
+  };
+};
+
+export const getPublicKey = (privateKey: Uint8Array, withZeroByte = true): Uint8Array => {
+  const keyPair = nacl.sign.keyPair.fromSeed(privateKey);
+  const signPk = keyPair.secretKey.subarray(32);
+  const zero = new Uint8Array([0]);
+  return withZeroByte ? new Uint8Array([...zero, ...signPk]) : signPk;
+};
+
+export const isValidPath = (path: string): boolean => {
+  if (!pathRegex.test(path)) {
+    return false;
+  }
+  return !path
+    .split("/")
+    .slice(1)
+    .map(replaceDerive)
+    .some(Number.isNaN as any);
+};
+
+export const derivePath = (path: string, seed: string, offset = HARDENED_OFFSET): Keys => {
+  if (!isValidPath(path)) {
+    throw new Error("Invalid derivation path");
+  }
+
+  const { key, chainCode } = getMasterKeyFromSeed(seed);
+  const segments = path
+    .split("/")
+    .slice(1)
+    .map(replaceDerive)
+    .map((el) => parseInt(el, 10));
+
+  return segments.reduce((parentKeys, segment) => CKDPriv(parentKeys, segment + offset), { key, chainCode });
+};

--- a/ecosystem/typescript/sdk_v2/src/utils/hexData.ts
+++ b/ecosystem/typescript/sdk_v2/src/utils/hexData.ts
@@ -1,0 +1,55 @@
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
+import { Hex } from "../types";
+
+export class HexData {
+  private hexData: Uint8Array;
+
+  constructor(hex: Uint8Array) {
+    this.hexData = hex;
+  }
+
+  public get hex(): Uint8Array {
+    return this.hexData;
+  }
+
+  static validate(hex: Hex) {
+    const hexString = hex.toString();
+    if (hexString.startsWith("0x")) {
+      return new HexData(HexData.fromString(hexString).toBytes());
+    }
+    return new HexData(HexData.fromString(`0x${hexString}`).toBytes());
+  }
+
+  static fromBytes(hex: Uint8Array): HexData {
+    return new HexData(hex);
+  }
+
+  static fromString(hex: string): HexData {
+    return new HexData(hexToBytes(hex));
+  }
+
+  toBytes(): Uint8Array {
+    return Uint8Array.from(hexToBytes(HexData.noPrefix(this.hexData)));
+  }
+
+  toString(): string {
+    return bytesToHex(this.toBytes());
+  }
+
+  /**
+   * Trimmes extra zeroes in the begining of a string
+   * @returns Inner hexString without leading zeroes
+   * @example
+   * ```
+   *  new HexString("0x000000string").toShortString(); // result = "0xstring"
+   * ```
+   */
+  toShortString(): string {
+    const trimmed = this.toString().replace(/^0x0*/, "");
+    return `0x${trimmed}`;
+  }
+
+  static noPrefix(hex: Hex): string {
+    return hex.toString().slice(2);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/utils/index.ts
+++ b/ecosystem/typescript/sdk_v2/src/utils/index.ts
@@ -1,0 +1,3 @@
+export * from "./hd-key";
+export * from "./memoize-decorator";
+export * from "./hexData";

--- a/ecosystem/typescript/sdk_v2/src/utils/memoize-decorator.ts
+++ b/ecosystem/typescript/sdk_v2/src/utils/memoize-decorator.ts
@@ -1,0 +1,151 @@
+/**
+ * Credits to https://github.com/darrylhodgins/typescript-memoize
+ */
+
+/* eslint-disable no-param-reassign */
+/* eslint-disable no-restricted-syntax */
+
+interface MemoizeArgs {
+  // ttl in milliseconds for cached items. After `ttlMs`, cached items are evicted automatically. If no `ttlMs`
+  // is provided, cached items won't get auto-evicted.
+  ttlMs?: number;
+  // produces the cache key based on `args`.
+  hashFunction?: boolean | ((...args: any[]) => any);
+  // cached items can be taged with `tags`. `tags` can be used to evict cached items
+  tags?: string[];
+}
+
+export function Memoize(args?: MemoizeArgs | MemoizeArgs["hashFunction"]) {
+  let hashFunction: MemoizeArgs["hashFunction"];
+  let ttlMs: MemoizeArgs["ttlMs"];
+  let tags: MemoizeArgs["tags"];
+
+  if (typeof args === "object") {
+    hashFunction = args.hashFunction;
+    ttlMs = args.ttlMs;
+    tags = args.tags;
+  } else {
+    hashFunction = args;
+  }
+
+  return (target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<any>) => {
+    if (descriptor.value != null) {
+      descriptor.value = getNewFunction(descriptor.value, hashFunction, ttlMs, tags);
+    } else if (descriptor.get != null) {
+      descriptor.get = getNewFunction(descriptor.get, hashFunction, ttlMs, tags);
+    } else {
+      throw new Error("Only put a Memoize() decorator on a method or get accessor.");
+    }
+  };
+}
+
+export function MemoizeExpiring(ttlMs: number, hashFunction?: MemoizeArgs["hashFunction"]) {
+  return Memoize({
+    ttlMs,
+    hashFunction,
+  });
+}
+
+const clearCacheTagsMap: Map<string, Map<any, any>[]> = new Map();
+
+export function clear(tags: string[]): number {
+  const cleared: Set<Map<any, any>> = new Set();
+  for (const tag of tags) {
+    const maps = clearCacheTagsMap.get(tag);
+    if (maps) {
+      for (const mp of maps) {
+        if (!cleared.has(mp)) {
+          mp.clear();
+          cleared.add(mp);
+        }
+      }
+    }
+  }
+  return cleared.size;
+}
+
+function getNewFunction(
+  originalMethod: () => void,
+  hashFunction?: MemoizeArgs["hashFunction"],
+  ttlMs: number = 0,
+  tags?: MemoizeArgs["tags"],
+) {
+  const propMapName = Symbol("__memoized_map__");
+
+  // The function returned here gets called instead of originalMethod.
+  // eslint-disable-next-line func-names
+  return function (...args: any[]) {
+    let returnedValue: any;
+
+    // @ts-ignore
+    const that: any = this;
+
+    // Get or create map
+    // eslint-disable-next-line no-prototype-builtins
+    if (!that.hasOwnProperty(propMapName)) {
+      Object.defineProperty(that, propMapName, {
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: new Map<any, any>(),
+      });
+    }
+    const myMap: Map<any, any> = that[propMapName];
+
+    if (Array.isArray(tags)) {
+      for (const tag of tags) {
+        if (clearCacheTagsMap.has(tag)) {
+          clearCacheTagsMap.get(tag)!.push(myMap);
+        } else {
+          clearCacheTagsMap.set(tag, [myMap]);
+        }
+      }
+    }
+
+    if (hashFunction || args.length > 0 || ttlMs > 0) {
+      let hashKey: any;
+
+      // If true is passed as first parameter, will automatically use every argument, passed to string
+      if (hashFunction === true) {
+        hashKey = args.map((a) => a.toString()).join("!");
+      } else if (hashFunction) {
+        hashKey = hashFunction.apply(that, args);
+      } else {
+        // eslint-disable-next-line prefer-destructuring
+        hashKey = args[0];
+      }
+
+      const timestampKey = `${hashKey}__timestamp`;
+      let isExpired: boolean = false;
+      if (ttlMs > 0) {
+        if (!myMap.has(timestampKey)) {
+          // "Expired" since it was never called before
+          isExpired = true;
+        } else {
+          const timestamp = myMap.get(timestampKey);
+          isExpired = Date.now() - timestamp > ttlMs;
+        }
+      }
+
+      if (myMap.has(hashKey) && !isExpired) {
+        returnedValue = myMap.get(hashKey);
+      } else {
+        returnedValue = originalMethod.apply(that, args as any);
+        myMap.set(hashKey, returnedValue);
+        if (ttlMs > 0) {
+          myMap.set(timestampKey, Date.now());
+        }
+      }
+    } else {
+      const hashKey = that;
+      if (myMap.has(hashKey)) {
+        returnedValue = myMap.get(hashKey);
+      } else {
+        returnedValue = originalMethod.apply(that, args as any);
+        myMap.set(hashKey, returnedValue);
+      }
+    }
+
+    return returnedValue;
+  };
+}


### PR DESCRIPTION
### Description
- create `Account` module, a class that holds privateKey and publicKey and performs  operations like create a wallet (new, from existing private key, from mnemonics), sign, verify signature, etc
- create `HexData`, a class that handles validation, standardization, etc for non account address hex string data - public key, private key, txn hex, etc.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
