### PR TITLE
[dag] Integrate dag fetcher with RB node handler

### DIFF
--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -56,7 +56,11 @@ pub fn bootstrap_dag(
         time_service.clone(),
     ));
 
-    let dag = Arc::new(RwLock::new(Dag::new(epoch_state.clone(), storage.clone())));
+    let dag = Arc::new(RwLock::new(Dag::new(
+        epoch_state.clone(),
+        storage.clone(),
+        current_round,
+    )));
 
     let anchor_election = Box::new(RoundRobinAnchorElection::new(validators));
     let order_rule = OrderRule::new(
@@ -86,10 +90,15 @@ pub fn bootstrap_dag(
         time_service,
         storage.clone(),
         order_rule,
+        fetch_requester.clone(),
+    );
+    let rb_handler = NodeBroadcastHandler::new(
+        dag.clone(),
+        signer,
+        epoch_state.clone(),
+        storage.clone(),
         fetch_requester,
     );
-    let rb_handler =
-        NodeBroadcastHandler::new(dag.clone(), signer, epoch_state.clone(), storage.clone());
     let fetch_handler = FetchRequestHandler::new(dag, epoch_state.clone());
 
     let dag_handler = NetworkHandler::new(

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -10,6 +10,7 @@ use super::{
 };
 use crate::{
     dag::{
+        dag_fetcher::TFetchRequester,
         dag_store::Dag,
         types::{CertificateAckState, CertifiedNode, Node, NodeCertificate, SignatureBuilder},
     },

--- a/consensus/src/dag/dag_store.rs
+++ b/consensus/src/dag/dag_store.rs
@@ -45,10 +45,15 @@ pub struct Dag {
     /// Map between peer id to vector index
     author_to_index: HashMap<Author, usize>,
     storage: Arc<dyn DAGStorage>,
+    initial_round: Round,
 }
 
 impl Dag {
-    pub fn new(epoch_state: Arc<EpochState>, storage: Arc<dyn DAGStorage>) -> Self {
+    pub fn new(
+        epoch_state: Arc<EpochState>,
+        storage: Arc<dyn DAGStorage>,
+        initial_round: Round,
+    ) -> Self {
         let epoch = epoch_state.epoch;
         let author_to_index = epoch_state.verifier.address_to_validator_index().clone();
         let num_validators = author_to_index.len();
@@ -77,6 +82,7 @@ impl Dag {
             nodes_by_round,
             author_to_index,
             storage,
+            initial_round,
         }
     }
 
@@ -85,7 +91,7 @@ impl Dag {
             .nodes_by_round
             .first_key_value()
             .map(|(round, _)| round)
-            .unwrap_or(&0)
+            .unwrap_or(&self.initial_round)
     }
 
     pub fn highest_round(&self) -> Round {
@@ -93,7 +99,7 @@ impl Dag {
             .nodes_by_round
             .last_key_value()
             .map(|(round, _)| round)
-            .unwrap_or(&0)
+            .unwrap_or(&self.initial_round)
     }
 
     pub fn add_node(&mut self, node: CertifiedNode) -> anyhow::Result<()> {

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -72,9 +72,11 @@ fn test_certified_node_handler() {
         verifier: validator_verifier,
     });
     let storage = Arc::new(MockStorage::new());
-    let dag = Arc::new(RwLock::new(Dag::new(epoch_state.clone(), storage.clone())));
-
-    let zeroth_round_node = new_certified_node(0, signers[0].author(), vec![]);
+    let dag = Arc::new(RwLock::new(Dag::new(
+        epoch_state.clone(),
+        storage.clone(),
+        1,
+    )));
 
     let network_sender = Arc::new(MockNetworkSender {});
     let rb = Arc::new(ReliableBroadcast::new(
@@ -115,13 +117,14 @@ fn test_certified_node_handler() {
         fetch_requester,
     );
 
+    let first_round_node = new_certified_node(1, signers[0].author(), vec![]);
     // expect an ack for a valid message
-    assert_ok!(driver.process(zeroth_round_node.clone()));
+    assert_ok!(driver.process(first_round_node.clone()));
     // expect an ack if the same message is sent again
-    assert_ok_eq!(driver.process(zeroth_round_node), CertifiedAck::new(1));
+    assert_ok_eq!(driver.process(first_round_node), CertifiedAck::new(1));
 
-    let parent_node = new_certified_node(0, signers[1].author(), vec![]);
-    let invalid_node = new_certified_node(1, signers[0].author(), vec![parent_node.certificate()]);
+    let parent_node = new_certified_node(1, signers[1].author(), vec![]);
+    let invalid_node = new_certified_node(2, signers[0].author(), vec![parent_node.certificate()]);
     assert_eq!(
         driver.process(invalid_node).unwrap_err().to_string(),
         DagDriverError::MissingParents.to_string()

--- a/consensus/src/dag/tests/dag_test.rs
+++ b/consensus/src/dag/tests/dag_test.rs
@@ -102,7 +102,7 @@ fn setup() -> (Vec<ValidatorSigner>, Arc<EpochState>, Dag, Arc<MockStorage>) {
         verifier: validator_verifier,
     });
     let storage = Arc::new(MockStorage::new());
-    let dag = Dag::new(epoch_state.clone(), storage.clone());
+    let dag = Dag::new(epoch_state.clone(), storage.clone(), 1);
     (signers, epoch_state, dag, storage)
 }
 
@@ -190,7 +190,7 @@ fn test_dag_recover_from_storage() {
             assert!(dag.add_node(node).is_ok());
         }
     }
-    let new_dag = Dag::new(epoch_state.clone(), storage.clone());
+    let new_dag = Dag::new(epoch_state.clone(), storage.clone(), 1);
 
     for metadata in &metadatas {
         assert!(new_dag.exists(metadata));
@@ -201,7 +201,7 @@ fn test_dag_recover_from_storage() {
         verifier: epoch_state.verifier.clone(),
     });
 
-    let _new_epoch_dag = Dag::new(new_epoch_state, storage.clone());
+    let _new_epoch_dag = Dag::new(new_epoch_state, storage.clone(), 1);
     assert!(storage.certified_node_data.lock().is_empty());
 }
 

--- a/consensus/src/dag/tests/fetcher_test.rs
+++ b/consensus/src/dag/tests/fetcher_test.rs
@@ -21,7 +21,7 @@ fn test_dag_fetcher_receiver() {
         verifier: validator_verifier,
     });
     let storage = Arc::new(MockStorage::new());
-    let dag = Arc::new(RwLock::new(Dag::new(epoch_state.clone(), storage)));
+    let dag = Arc::new(RwLock::new(Dag::new(epoch_state.clone(), storage, 1)));
 
     let mut fetcher = FetchRequestHandler::new(dag.clone(), epoch_state);
 

--- a/consensus/src/dag/tests/order_rule_tests.rs
+++ b/consensus/src/dag/tests/order_rule_tests.rs
@@ -1,12 +1,13 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use super::helpers::new_certified_node;
 use crate::{
     dag::{
         anchor_election::RoundRobinAnchorElection,
         dag_store::Dag,
         order_rule::OrderRule,
-        tests::{dag_test::MockStorage, helpers::new_certified_node},
+        tests::dag_test::MockStorage,
         types::{NodeCertificate, NodeMetadata},
         CertifiedNode,
     },
@@ -153,7 +154,7 @@ proptest! {
             epoch: 1,
             verifier: validator_verifier,
         });
-        let mut dag = Dag::new(epoch_state.clone(), Arc::new(MockStorage::new()));
+        let mut dag = Dag::new(epoch_state.clone(), Arc::new(MockStorage::new()), 1);
         for round_nodes in &nodes {
             for node in round_nodes.iter().flatten() {
                 dag.add_node(node.clone()).unwrap();
@@ -231,7 +232,7 @@ fn test_order_rule_basic() {
         epoch: 1,
         verifier: validator_verifier,
     });
-    let mut dag = Dag::new(epoch_state.clone(), Arc::new(MockStorage::new()));
+    let mut dag = Dag::new(epoch_state.clone(), Arc::new(MockStorage::new()), 1);
     for round_nodes in &nodes {
         for node in round_nodes.iter().flatten() {
             dag.add_node(node.clone()).unwrap();


### PR DESCRIPTION
### Description

This PR integrates DAG fetcher to the RB node handler. Whenever the node is missing parents, the fetcher is requested to fetch those missing parents and their ancestors. To make sure the GCed DAG is not refetched, it changes the lowest_round in dag_store to provide the information.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Existing tests.
