### PR TITLE
[refactoring] Remove unused genesis check from StateView

### DIFF
--- a/aptos-move/aptos-aggregator/src/delta_change_set.rs
+++ b/aptos-move/aptos-aggregator/src/delta_change_set.rs
@@ -567,10 +567,6 @@ mod test {
             )))
         }
 
-        fn is_genesis(&self) -> bool {
-            unreachable!()
-        }
-
         fn get_usage(&self) -> anyhow::Result<StateStorageUsage> {
             unreachable!()
         }

--- a/aptos-move/aptos-validator-interface/src/lib.rs
+++ b/aptos-move/aptos-validator-interface/src/lib.rs
@@ -192,10 +192,6 @@ impl TStateView for DebuggerStateView {
         self.get_state_value_internal(state_key, self.version)
     }
 
-    fn is_genesis(&self) -> bool {
-        false
-    }
-
     fn get_usage(&self) -> Result<StateStorageUsage> {
         unimplemented!()
     }

--- a/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
@@ -118,10 +118,6 @@ impl<'r> TStateView for ChangeSetStateView<'r> {
         }
     }
 
-    fn is_genesis(&self) -> bool {
-        unreachable!("Unexpected access to is_genesis()")
-    }
-
     fn get_usage(&self) -> Result<StateStorageUsage> {
         bail!("Unexpected access to get_usage()")
     }

--- a/aptos-move/aptos-vm/src/sharded_block_executor/cross_shard_state_view.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/cross_shard_state_view.rs
@@ -131,10 +131,6 @@ impl<'a, S: StateView + Sync + Send> TStateView for CrossShardStateView<'a, S> {
         self.base_view.get_state_value(state_key)
     }
 
-    fn is_genesis(&self) -> bool {
-        unimplemented!("is_genesis is not implemented for InMemoryStateView")
-    }
-
     fn get_usage(&self) -> Result<StateStorageUsage> {
         Ok(StateStorageUsage::new_untracked())
     }

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -63,10 +63,6 @@ where
         StateViewId::Miscellaneous
     }
 
-    fn is_genesis(&self) -> bool {
-        unreachable!();
-    }
-
     fn get_usage(&self) -> anyhow::Result<StateStorageUsage> {
         unreachable!();
     }
@@ -90,10 +86,6 @@ where
 
     fn id(&self) -> StateViewId {
         StateViewId::Miscellaneous
-    }
-
-    fn is_genesis(&self) -> bool {
-        unreachable!();
     }
 
     fn get_usage(&self) -> anyhow::Result<StateStorageUsage> {

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -292,10 +292,6 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> TStateView
         self.base_view.id()
     }
 
-    fn is_genesis(&self) -> bool {
-        self.base_view.is_genesis()
-    }
-
     fn get_usage(&self) -> Result<StateStorageUsage> {
         self.base_view.get_usage()
     }

--- a/aptos-move/e2e-tests/src/data_store.rs
+++ b/aptos-move/e2e-tests/src/data_store.rs
@@ -122,10 +122,6 @@ impl TStateView for FakeDataStore {
         Ok(self.state_data.get(state_key).cloned())
     }
 
-    fn is_genesis(&self) -> bool {
-        self.state_data.is_empty()
-    }
-
     fn get_usage(&self) -> Result<StateStorageUsage> {
         let mut usage = StateStorageUsage::new_untracked();
         for (k, v) in self.state_data.iter() {

--- a/aptos-move/vm-genesis/src/genesis_context.rs
+++ b/aptos-move/vm-genesis/src/genesis_context.rs
@@ -46,10 +46,6 @@ impl TStateView for GenesisStateView {
             .map(StateValue::new_legacy))
     }
 
-    fn is_genesis(&self) -> bool {
-        true
-    }
-
     fn get_usage(&self) -> Result<StateStorageUsage> {
         Ok(StateStorageUsage::zero())
     }

--- a/execution/executor/src/mock_vm/mock_vm_test.rs
+++ b/execution/executor/src/mock_vm/mock_vm_test.rs
@@ -28,10 +28,6 @@ impl TStateView for MockStateView {
         Ok(None)
     }
 
-    fn is_genesis(&self) -> bool {
-        false
-    }
-
     fn get_usage(&self) -> Result<StateStorageUsage> {
         Ok(StateStorageUsage::new_untracked())
     }

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -81,27 +81,6 @@ impl VMExecutor for MockVM {
         state_view: &impl StateView,
         _maybe_block_gas_limit: Option<u64>,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
-        if state_view.is_genesis() {
-            assert_eq!(
-                transactions.len(),
-                1,
-                "Genesis block should have only one transaction."
-            );
-            let output = TransactionOutput::new(
-                gen_genesis_writeset(),
-                // mock the validator set event
-                vec![ContractEvent::new(
-                    new_epoch_event_key(),
-                    0,
-                    TypeTag::Bool,
-                    bcs::to_bytes(&0).unwrap(),
-                )],
-                0,
-                KEEP_STATUS.clone(),
-            );
-            return Ok(vec![output]);
-        }
-
         // output_cache is used to store the output of transactions so they are visible to later
         // transactions.
         let mut output_cache = HashMap::new();

--- a/storage/state-view/src/in_memory_state_view.rs
+++ b/storage/state-view/src/in_memory_state_view.rs
@@ -29,10 +29,6 @@ impl TStateView for InMemoryStateView {
         Ok(self.state_data.get(state_key).cloned())
     }
 
-    fn is_genesis(&self) -> bool {
-        unimplemented!("is_genesis is not implemented for InMemoryStateView")
-    }
-
     fn get_usage(&self) -> Result<StateStorageUsage> {
         Ok(StateStorageUsage::new_untracked())
     }

--- a/storage/state-view/src/lib.rs
+++ b/storage/state-view/src/lib.rs
@@ -45,10 +45,6 @@ pub trait TStateView {
     /// Gets the state value for a given state key.
     fn get_state_value(&self, state_key: &Self::Key) -> Result<Option<StateValue>>;
 
-    /// VM needs this method to know whether the current state view is for genesis state creation.
-    /// Currently TransactionPayload::WriteSet is only valid for genesis state creation.
-    fn is_genesis(&self) -> bool;
-
     /// Get state storage usage info at epoch ending.
     fn get_usage(&self) -> Result<StateStorageUsage>;
 
@@ -86,10 +82,6 @@ where
 
     fn get_state_value(&self, state_key: &K) -> Result<Option<StateValue>> {
         self.deref().get_state_value(state_key)
-    }
-
-    fn is_genesis(&self) -> bool {
-        self.deref().is_genesis()
     }
 
     fn get_usage(&self) -> Result<StateStorageUsage> {

--- a/storage/storage-interface/src/cached_state_view.rs
+++ b/storage/storage-interface/src/cached_state_view.rs
@@ -222,10 +222,6 @@ impl TStateView for CachedStateView {
         Ok(value_opt.clone())
     }
 
-    fn is_genesis(&self) -> bool {
-        self.snapshot.is_none()
-    }
-
     fn get_usage(&self) -> Result<StateStorageUsage> {
         Ok(self.speculative_state.usage())
     }
@@ -265,10 +261,6 @@ impl TStateView for CachedDbStateView {
             .entry(state_key.clone())
             .or_insert_with(|| state_value_option);
         Ok(new_value.clone())
-    }
-
-    fn is_genesis(&self) -> bool {
-        self.db_state_view.is_genesis()
     }
 
     fn get_usage(&self) -> Result<StateStorageUsage> {

--- a/storage/storage-interface/src/state_view.rs
+++ b/storage/storage-interface/src/state_view.rs
@@ -35,10 +35,6 @@ impl TStateView for DbStateView {
         self.get(state_key)
     }
 
-    fn is_genesis(&self) -> bool {
-        self.version.is_none()
-    }
-
     fn get_usage(&self) -> Result<StateStorageUsage> {
         self.db.get_state_storage_usage(self.version)
     }


### PR DESCRIPTION
### Description

`is_genesis()` was defined in `StateView` but never used apart from a single test with `MockVM`.
But the test set it to false always... Removing it to have better view interfaces.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
