### PR TITLE
[docker] Do not overwrite release images unless we want to overwrite them

### DIFF
--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -10,6 +10,9 @@ on:
         required: false
         type: string
         description: the git sha to use for the image tag. If not provided, the git sha of the triggering branch will be used
+      OVERWRITE:
+        type: boolean
+        description: Whether or not we should overwrite images
   workflow_dispatch:
     inputs:
       image_tag_prefix:
@@ -21,6 +24,9 @@ on:
         required: false
         type: string
         description: the git sha to use for the image tag. If not provided, the git sha of the triggering branch will be used
+      OVERWRITE:
+        type: boolean
+        description: Whether or not we should overwrite images
 
 permissions:
   contents: read
@@ -62,4 +68,5 @@ jobs:
           GCP_DOCKER_ARTIFACT_REPO_US: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO_US }}
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ECR_ACCOUNT_NUM }}
           IMAGE_TAG_PREFIX: ${{ inputs.image_tag_prefix }}
+          OVERWRITE: ${{ inputs.OVERWRITE }}
         run: ./docker/release-images.mjs --wait-for-image-seconds=3600

--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -34,6 +34,7 @@ jobs:
 
   # This job determines which files were changed
   file_change_determinator:
+    needs: [permission-check]
     runs-on: ubuntu-latest
     outputs:
       only_docs_changed: ${{ steps.determine_file_changes.outputs.only_docs_changed }}


### PR DESCRIPTION
Previously this overwrote a tag, this should be fine except for release tags

This ensures that we dont overwrite a release tag unless we want to by specifying the overwrite option

Test Plan: running action in GH, run script locally
