### PR TITLE
[Dev Docs] Add small note about target-version in backup docs.

### DIFF
--- a/developer-docs-site/docs/nodes/full-node/aptos-db-restore.md
+++ b/developer-docs-site/docs/nodes/full-node/aptos-db-restore.md
@@ -90,6 +90,11 @@ aptos node bootstrap-db \
 --command-adapter-config /path/to/s3-public.yaml \
 --target-db-dir /path/to/local/db
 ```
+
+:::tip
+If you don't specify the target_version (via `--target-version`), the tool will use the latest version in the backup as the target version.
+:::
+
 Disable the pruner in the node config to prevent the early history from being pruned when you start the node.
 ```Yaml
 storage:


### PR DESCRIPTION
### Description
This PR updates the dev docs with a small note about specifying the `target-version` in the db-restore docs.

### Test Plan
Manual verification.