### PR TITLE
[move-ir-compiler] add Nop token support

### DIFF
--- a/third_party/move/move-ir-compiler/move-ir-to-bytecode/src/compiler.rs
+++ b/third_party/move/move-ir-compiler/move-ir-to-bytecode/src/compiler.rs
@@ -1523,6 +1523,10 @@ fn compile_call(
                     function_frame.pop()?;
                     function_frame.push()?;
                 },
+                Builtin::Nop => {
+                    push_instr!(call.loc, Bytecode::Nop);
+                    function_frame.pop()?;
+                },
             }
         },
         FunctionCall_::ModuleFunctionCall {

--- a/third_party/move/move-ir-compiler/move-ir-to-bytecode/syntax/src/lexer.rs
+++ b/third_party/move/move-ir-compiler/move-ir-to-bytecode/syntax/src/lexer.rs
@@ -114,6 +114,7 @@ pub enum Tok {
     LSquare,
     RSquare,
     PeriodPeriod,
+    Nop,
 }
 
 impl Tok {
@@ -492,6 +493,7 @@ fn get_name_token(name: &str) -> Tok {
         "succeeds_if" => Tok::SucceedsIf,
         "synthetic" => Tok::Synthetic,
         "true" => Tok::True,
+        "nop" => Tok::Nop,
         _ => Tok::NameValue,
     }
 }

--- a/third_party/move/move-ir-compiler/move-ir-to-bytecode/syntax/src/syntax.rs
+++ b/third_party/move/move-ir-compiler/move-ir-to-bytecode/syntax/src/syntax.rs
@@ -471,7 +471,8 @@ fn parse_qualified_function_name(
         | Tok::ToU32
         | Tok::ToU64
         | Tok::ToU128
-        | Tok::ToU256 => {
+        | Tok::ToU256
+        | Tok::Nop => {
             let f = parse_builtin(tokens)?;
             FunctionCall_::Builtin(f)
         },
@@ -618,7 +619,8 @@ fn parse_call_or_term_(tokens: &mut Lexer) -> Result<Exp_, ParseError<Loc, anyho
         | Tok::ToU32
         | Tok::ToU64
         | Tok::ToU128
-        | Tok::ToU256 => {
+        | Tok::ToU256
+        | Tok::Nop => {
             let f = parse_qualified_function_name(tokens)?;
             let exp = parse_call_or_term(tokens)?;
             Ok(Exp_::FunctionCall(f, Box::new(exp)))
@@ -876,6 +878,10 @@ fn parse_builtin(tokens: &mut Lexer) -> Result<Builtin, ParseError<Loc, anyhow::
         Tok::ToU256 => {
             tokens.advance()?;
             Ok(Builtin::ToU256)
+        },
+        Tok::Nop => {
+            tokens.advance()?;
+            Ok(Builtin::Nop)
         },
         t => Err(ParseError::InvalidToken {
             location: current_token_loc(tokens),

--- a/third_party/move/move-ir-compiler/transactional-tests/tests/bytecode-generation/statements/nop.exp
+++ b/third_party/move/move-ir-compiler/transactional-tests/tests/bytecode-generation/statements/nop.exp
@@ -1,0 +1,19 @@
+processed 1 task
+
+task 0 'print-bytecode'. lines 1-14:
+// Move bytecode v6
+module cafe.Nop {
+
+
+nop_valid() {
+B0:
+	0: Nop
+	1: Ret
+}
+nop_invalid() {
+B0:
+	0: Nop
+	1: Pop
+	2: Ret
+}
+}

--- a/third_party/move/move-ir-compiler/transactional-tests/tests/bytecode-generation/statements/nop.mvir
+++ b/third_party/move/move-ir-compiler/transactional-tests/tests/bytecode-generation/statements/nop.mvir
@@ -1,0 +1,14 @@
+//# print-bytecode --input=module
+module 0xcafe.Nop {
+    nop_valid() {
+    label b0:
+        (nop());
+        return;
+    }
+
+    nop_invalid() {
+    label b0:
+        _ = (nop());
+        return;
+    }    
+}

--- a/third_party/move/move-ir/types/src/ast.rs
+++ b/third_party/move/move-ir/types/src/ast.rs
@@ -445,6 +445,8 @@ pub enum Builtin {
     ToU128,
     /// Cast an integer into u256.
     ToU256,
+    /// `nop noplabel`
+    Nop,
 }
 
 /// Enum for different function calls
@@ -1519,6 +1521,7 @@ impl fmt::Display for Builtin {
             Builtin::ToU64 => write!(f, "to_u64"),
             Builtin::ToU128 => write!(f, "to_u128"),
             Builtin::ToU256 => write!(f, "to_u256"),
+            Builtin::Nop => write!(f, "nop;"),
         }
     }
 }


### PR DESCRIPTION
### Description
Closes #9416 

Discussion: Nop has an optional NopLabel, although it is unclear the exact purpose/usage of this.

### Test Plan
See `transactional-tests/tests/bytecode-genereation/statements/nop.mvir`

Run `cargo run -- -m ./transactional-tests/tests/bytecode-generation/statements/nop.mvir`

Run `cargo run -p aptos -- move disassemble --bytecode-path ./transactional-tests/tests/bytecode-generation/statements/nop.mv`

To see that the Nop token is included in the bytecode generation

Output:
```
// Move bytecode v6
module cafe.Nop {
nop_valid() {
B0:
	0: Nop
	1: Ret
}
nop_invalid() {
B0:
	0: Nop
	1: Pop
	2: Ret
}
}
```