### PR TITLE
[gas] convert output to InternalGas cost

### DIFF
--- a/aptos-move/aptos-gas-calibration/src/main.rs
+++ b/aptos-move/aptos-gas-calibration/src/main.rs
@@ -17,13 +17,17 @@ use std::collections::BTreeMap;
 /// Automated Gas Calibration to calibrate Move bytecode and Native Functions
 #[derive(Parser, Debug)]
 struct Args {
-    /// Specific tests to run that match a pattern
+    /// Specific Calibration Function tests to run that match a given pattern
     #[clap(short, long, default_value = "")]
     pattern: String,
 
     /// Number of iterations to run each Calibration Function
     #[clap(short, long, default_value_t = 20)]
     iterations: u64,
+
+    /// Maximum execution time in milliseconds
+    #[clap(short, long, default_value_t = 300)]
+    max_execution_time: u64,
 }
 
 fn main() {
@@ -31,6 +35,7 @@ fn main() {
     let args = Args::parse();
     let pattern = &args.pattern;
     let iterations = args.iterations;
+    let max_execution_time = args.max_execution_time;
 
     println!(
         "Running each Calibration Function for {} iterations\n",
@@ -76,5 +81,6 @@ fn main() {
         &mut coeff_matrix,
         &mut const_matrix,
         measurements.equation_names,
+        max_execution_time,
     );
 }

--- a/aptos-move/aptos-gas-calibration/src/solve.rs
+++ b/aptos-move/aptos-gas-calibration/src/solve.rs
@@ -9,8 +9,11 @@ use crate::{
     },
     math_interface::generic_map,
 };
+use aptos_gas_schedule::{InitialGasSchedule, TransactionGasParameters};
 use nalgebra::DMatrix;
 use std::collections::BTreeMap;
+
+const MILLISECONDS_TO_MICROSECONDS: u64 = 1000;
 
 /// wrapper function to build a coefficient matrix
 ///
@@ -49,11 +52,13 @@ pub fn build_constant_matrix(input: Vec<u128>, nrows: usize, ncols: usize) -> DM
 /// * `input` - Collection of like-terms
 /// * `coeff_matrix` - Coefficient Matrix
 /// * `const_matrix` - Constant Matrix
+/// * `max_execution_time` - Configurable flag for max execution time of txn
 pub fn least_squares(
     input: Vec<BTreeMap<String, u64>>,
     coeff_matrix: &mut DMatrix<f64>,
     const_matrix: &mut DMatrix<f64>,
     equation_names: Vec<String>,
+    max_execution_time: u64,
 ) {
     let lss = compute_least_square_solutions(coeff_matrix, const_matrix);
     if let Ok(answer) = lss {
@@ -61,15 +66,6 @@ pub fn least_squares(
 
         let map = generic_map(input.clone());
         let keys: Vec<String> = map.keys().map(|key| key.to_string()).collect();
-
-        let nrows = x_hat.nrows();
-        let ncols = x_hat.ncols();
-        println!("where the gas parameter values are (microsecond per instruction):\n");
-        for i in 0..nrows {
-            for j in 0..ncols {
-                println!("{} {}", x_hat[(i, j)], keys[i]);
-            }
-        }
 
         // TODO: error handling with division zero that bubbles up
         let computed_time_and_outliers =
@@ -79,6 +75,8 @@ pub fn least_squares(
         report_computed_times(&equation_names, &computed_time_and_outliers);
 
         report_outliers(&equation_names, &computed_time_and_outliers);
+
+        convert_to_internal_gas_cost(&mut x_hat, max_execution_time, keys);
     } else {
         report_undetermined_gas_params(input, coeff_matrix, const_matrix);
     }
@@ -166,5 +164,36 @@ fn report_undetermined_gas_params(
                 println!("- gas parameter: {}\n", gas_param);
             }
         },
+    }
+}
+
+/// convert gas usage per instruction to gas cost (InternalGas)
+///
+/// ### Arguments
+///
+/// * `x_hat` - Least Squares Solution
+/// * `max_execution_time` - Configurable flag for max execution time of txn
+/// * `gas_params` - A vector representing all gas parameter names in the system
+fn convert_to_internal_gas_cost(
+    x_hat: &mut DMatrix<f64>,
+    max_execution_time: u64,
+    gas_params: Vec<String>,
+) {
+    let max_execution_gas = u64::from(TransactionGasParameters::initial().max_execution_gas);
+    let one_microsec_per_internal_gas =
+        (max_execution_gas / max_execution_time) / MILLISECONDS_TO_MICROSECONDS;
+
+    println!(
+        "\ninternal gas cost ({} InternalGas per 1µ):\n",
+        one_microsec_per_internal_gas
+    );
+
+    let nrows = x_hat.nrows();
+    let ncols = x_hat.ncols();
+    for i in 0..nrows {
+        for j in 0..ncols {
+            let internal_gas_cost = x_hat[(i, j)] * one_microsec_per_internal_gas as f64;
+            println!("{} = {}", gas_params[i], internal_gas_cost);
+        }
     }
 }


### PR DESCRIPTION
### Description

Currently the output isn't that helpful, as the numbers represent the gas usage per instruction. This PR converts these numbers to the InternalGas cost, which allows for future roadmap items like updating the gas schedule much easier. 

Before:
```
where the gas parameter values are (microsecond per instruction):

0.03320208133434005 ADD
0.02167781151796508 AND
0.03401204199678623 BIT_AND
```

After:
```
internal gas cost (66666 InternalGas per 1µ):

ADD = 2213.4499542351136
AND = 1445.17298265666
BIT_AND = 2267.446791757751
```
