### PR TITLE
[deps] Update clap dependency to be consistent across crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
  "base64 0.13.0",
  "bcs 0.1.4",
  "chrono",
- "clap 4.3.5",
+ "clap 4.3.21",
  "clap_complete",
  "codespan-reporting",
  "dirs",
@@ -467,7 +467,7 @@ dependencies = [
  "async-trait",
  "bcs 0.1.4",
  "bytes",
- "clap 4.3.5",
+ "clap 4.3.21",
  "csv",
  "futures",
  "itertools",
@@ -567,7 +567,7 @@ dependencies = [
  "aptos-metrics-core",
  "aptos-types",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "dashmap",
  "itertools",
  "move-core-types",
@@ -623,7 +623,7 @@ name = "aptos-cli-common"
 version = "1.0.0"
 dependencies = [
  "anstyle",
- "clap 4.3.5",
+ "clap 4.3.21",
  "clap_complete",
 ]
 
@@ -940,7 +940,7 @@ dependencies = [
  "bcs 0.1.4",
  "byteorder",
  "claims",
- "clap 4.3.5",
+ "clap 4.3.21",
  "dashmap",
  "itertools",
  "lru 0.7.8",
@@ -974,7 +974,7 @@ dependencies = [
  "aptos-types",
  "aptos-vm",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
 ]
 
 [[package]]
@@ -1025,7 +1025,7 @@ dependencies = [
  "aptos-temppath",
  "aptos-types",
  "async-trait",
- "clap 4.3.5",
+ "clap 4.3.21",
  "itertools",
  "owo-colors",
  "tokio",
@@ -1052,7 +1052,7 @@ dependencies = [
  "aptos-vm-logging",
  "aptos-vm-types",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "move-binary-format",
  "move-cli",
  "move-compiler",
@@ -1184,7 +1184,7 @@ dependencies = [
  "async-trait",
  "bcs 0.1.4",
  "chrono",
- "clap 4.3.5",
+ "clap 4.3.21",
  "indicatif 0.15.0",
  "itertools",
  "jemallocator",
@@ -1216,7 +1216,7 @@ dependencies = [
  "aptos-types",
  "aptos-vm",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "crossbeam-channel",
  "itertools",
  "num_cpus",
@@ -1285,7 +1285,7 @@ dependencies = [
  "aptos-faucet-core",
  "aptos-logger",
  "aptos-sdk",
- "clap 4.3.5",
+ "clap 4.3.21",
  "tokio",
 ]
 
@@ -1301,7 +1301,7 @@ dependencies = [
  "aptos-sdk",
  "async-trait",
  "captcha",
- "clap 4.3.5",
+ "clap 4.3.21",
  "deadpool-redis",
  "enum_dispatch",
  "futures",
@@ -1343,7 +1343,7 @@ dependencies = [
  "anyhow",
  "aptos-faucet-core",
  "aptos-logger",
- "clap 4.3.5",
+ "clap 4.3.21",
  "tokio",
 ]
 
@@ -1355,7 +1355,7 @@ dependencies = [
  "aptos-logger",
  "aptos-node-checker",
  "aptos-sdk",
- "clap 4.3.5",
+ "clap 4.3.21",
  "env_logger",
  "futures",
  "gcp-bigquery-client",
@@ -1392,7 +1392,7 @@ dependencies = [
  "aptos-transaction-generator-lib",
  "async-trait",
  "chrono",
- "clap 4.3.5",
+ "clap 4.3.21",
  "either",
  "futures",
  "hex",
@@ -1435,7 +1435,7 @@ dependencies = [
  "aptos-testcases",
  "async-trait",
  "chrono",
- "clap 4.3.5",
+ "clap 4.3.21",
  "futures",
  "jemallocator",
  "rand 0.7.3",
@@ -1477,7 +1477,7 @@ dependencies = [
  "bulletproofs",
  "byteorder",
  "claims",
- "clap 4.3.5",
+ "clap 4.3.21",
  "codespan-reporting",
  "curve25519-dalek-ng",
  "either",
@@ -1557,7 +1557,7 @@ dependencies = [
  "aptos-vault-client",
  "bcs 0.1.4",
  "byteorder",
- "clap 4.3.5",
+ "clap 4.3.21",
  "datatest-stable",
  "hex",
  "move-binary-format",
@@ -1598,7 +1598,7 @@ dependencies = [
  "aptos-types",
  "aptos-vm-types",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "float-cmp",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -1665,7 +1665,7 @@ dependencies = [
  "aptos-package-builder",
  "aptos-types",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "move-core-types",
  "move-model",
  "tempfile",
@@ -1737,7 +1737,7 @@ dependencies = [
  "bcs 0.1.4",
  "bigdecimal",
  "chrono",
- "clap 4.3.5",
+ "clap 4.3.21",
  "diesel",
  "diesel_migrations",
  "field_count",
@@ -1770,7 +1770,7 @@ dependencies = [
  "async-trait",
  "backoff",
  "base64 0.13.0",
- "clap 4.3.5",
+ "clap 4.3.21",
  "futures",
  "futures-core",
  "once_cell",
@@ -1799,7 +1799,7 @@ dependencies = [
  "aptos-runtimes",
  "async-trait",
  "base64 0.13.0",
- "clap 4.3.5",
+ "clap 4.3.21",
  "cloud-storage",
  "futures",
  "once_cell",
@@ -1826,7 +1826,7 @@ dependencies = [
  "aptos-moving-average",
  "aptos-runtimes",
  "async-trait",
- "clap 4.3.5",
+ "clap 4.3.21",
  "cloud-storage",
  "futures-util",
  "once_cell",
@@ -1912,7 +1912,7 @@ dependencies = [
  "async-trait",
  "backoff",
  "base64 0.13.0",
- "clap 4.3.5",
+ "clap 4.3.21",
  "futures",
  "futures-core",
  "futures-util",
@@ -1949,7 +1949,7 @@ dependencies = [
  "bcs 0.1.4",
  "bigdecimal",
  "chrono",
- "clap 4.3.5",
+ "clap 4.3.21",
  "diesel",
  "diesel_migrations",
  "field_count",
@@ -1980,7 +1980,7 @@ dependencies = [
  "backtrace",
  "base64 0.13.0",
  "chrono",
- "clap 4.3.5",
+ "clap 4.3.21",
  "futures",
  "hostname",
  "once_cell",
@@ -2004,7 +2004,7 @@ dependencies = [
  "aptos-runtimes",
  "async-trait",
  "backtrace",
- "clap 4.3.5",
+ "clap 4.3.21",
  "futures",
  "prometheus",
  "serde 1.0.149",
@@ -2028,7 +2028,7 @@ dependencies = [
  "backoff",
  "backtrace",
  "base64 0.13.0",
- "clap 4.3.5",
+ "clap 4.3.21",
  "cloud-storage",
  "futures",
  "futures-core",
@@ -2303,7 +2303,7 @@ dependencies = [
  "aptos-gas-schedule",
  "aptos-types",
  "aptos-vm",
- "clap 4.3.5",
+ "clap 4.3.21",
  "move-cli",
  "move-package",
  "move-prover",
@@ -2480,7 +2480,7 @@ dependencies = [
  "aptos-logger",
  "aptos-network",
  "aptos-types",
- "clap 4.3.5",
+ "clap 4.3.21",
  "futures",
  "serde 1.0.149",
  "tokio",
@@ -2524,7 +2524,7 @@ dependencies = [
  "backoff",
  "base64 0.13.0",
  "chrono",
- "clap 4.3.5",
+ "clap 4.3.21",
  "crossbeam-channel",
  "csv",
  "diesel",
@@ -2595,7 +2595,7 @@ dependencies = [
  "aptos-types",
  "aptos-vm",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "fail 0.5.0",
  "futures",
  "hex",
@@ -2625,7 +2625,7 @@ dependencies = [
  "aptos-sdk",
  "aptos-transaction-emitter-lib",
  "async-trait",
- "clap 4.3.5",
+ "clap 4.3.21",
  "const_format",
  "env_logger",
  "futures",
@@ -2699,7 +2699,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-storage-interface",
  "aptos-types",
- "clap 4.3.5",
+ "clap 4.3.21",
 ]
 
 [[package]]
@@ -2866,7 +2866,7 @@ dependencies = [
  "aptos-types",
  "aptos-vm-genesis",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "futures",
  "git2 0.16.1",
  "handlebars",
@@ -2927,7 +2927,7 @@ dependencies = [
  "aptos-types",
  "bcs 0.1.4",
  "bytes",
- "clap 4.3.5",
+ "clap 4.3.21",
  "futures",
  "hex",
  "move-binary-format",
@@ -2974,7 +2974,7 @@ dependencies = [
  "aptos-types",
  "aptos-warp-webserver",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "futures",
  "hex",
  "itertools",
@@ -2999,7 +2999,7 @@ dependencies = [
  "aptos-logger",
  "aptos-rosetta",
  "aptos-types",
- "clap 4.3.5",
+ "clap 4.3.21",
  "serde 1.0.149",
  "serde_json",
  "tokio",
@@ -3107,7 +3107,7 @@ dependencies = [
  "aptos-framework",
  "aptos-types",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "heck 0.3.3",
  "move-core-types",
  "once_cell",
@@ -3429,7 +3429,7 @@ dependencies = [
  "base64 0.13.0",
  "bcs 0.1.4",
  "chrono",
- "clap 4.3.5",
+ "clap 4.3.21",
  "debug-ignore",
  "flate2",
  "futures",
@@ -3523,7 +3523,7 @@ dependencies = [
  "aptos-types",
  "aptos-vm",
  "aptos-vm-logging",
- "clap 4.3.5",
+ "clap 4.3.21",
  "criterion",
  "criterion-cpu-time",
  "num_cpus",
@@ -3541,7 +3541,7 @@ dependencies = [
  "aptos-logger",
  "aptos-sdk",
  "aptos-transaction-emitter-lib",
- "clap 4.3.5",
+ "clap 4.3.21",
  "futures",
  "rand 0.7.3",
  "tokio",
@@ -3563,7 +3563,7 @@ dependencies = [
  "aptos-sdk",
  "aptos-transaction-generator-lib",
  "async-trait",
- "clap 4.3.5",
+ "clap 4.3.21",
  "futures",
  "itertools",
  "once_cell",
@@ -3585,7 +3585,7 @@ dependencies = [
  "aptos-logger",
  "aptos-sdk",
  "async-trait",
- "clap 4.3.5",
+ "clap 4.3.21",
  "move-binary-format",
  "once_cell",
  "rand 0.7.3",
@@ -3610,7 +3610,7 @@ dependencies = [
  "aptos-vm",
  "aptos-vm-genesis",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "datatest-stable",
  "hex",
  "move-binary-format",
@@ -3763,7 +3763,7 @@ dependencies = [
  "aptos-language-e2e-tests",
  "aptos-types",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-core-types",
@@ -3823,7 +3823,7 @@ dependencies = [
  "aptos-vm",
  "aptos-vm-genesis",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "glob",
  "move-binary-format",
  "move-core-types",
@@ -5033,24 +5033,23 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.5"
+version = "4.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2686c4115cb0810d9a984776e197823d08ec94f176549a89a9efded477c456dc"
+checksum = "c27cdf28c0f604ba3f512b0c9a409f8de8513e4816705deb0498b627e7c3a3fd"
 dependencies = [
  "clap_builder",
- "clap_derive 4.3.2",
+ "clap_derive 4.3.12",
  "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.5"
+version = "4.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e53afce1efce6ed1f633cf0e57612fe51db54a1ee4fd8f8503d078fe02d69ae"
+checksum = "08a9f1ab5e9f01a9b81f202e8562eb9a10de70abf9eaeac1be465c28b75aa4aa"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags 1.3.2",
  "clap_lex 0.5.0",
  "strsim 0.10.0",
 ]
@@ -5061,7 +5060,7 @@ version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6b5c519bab3ea61843a7923d074b04245624bb84a64a8c150f5deb014e388b"
 dependencies = [
- "clap 4.3.5",
+ "clap 4.3.21",
 ]
 
 [[package]]
@@ -5079,9 +5078,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.2"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2 1.0.64",
@@ -6781,7 +6780,7 @@ dependencies = [
  "aptos-network",
  "aptos-types",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "move-core-types",
  "rand 0.7.3",
  "serde 1.0.149",
@@ -7712,7 +7711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb7c1b80a1dfa604bb4a649a5c5aeef3d913f7c520cb42b40e534e8a61bcdfc"
 dependencies = [
  "ahash 0.8.3",
- "clap 4.3.5",
+ "clap 4.3.21",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap",
@@ -8370,7 +8369,7 @@ name = "listener"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "clap 4.3.5",
+ "clap 4.3.21",
  "tokio",
 ]
 
@@ -8699,7 +8698,7 @@ dependencies = [
  "anyhow",
  "aptos-framework",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "move-binary-format",
 ]
 
@@ -8735,7 +8734,7 @@ name = "move-analyzer"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "clap 4.3.5",
+ "clap 4.3.21",
  "codespan-reporting",
  "crossbeam",
  "derivative",
@@ -8845,7 +8844,7 @@ name = "move-bytecode-viewer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.3.5",
+ "clap 4.3.21",
  "crossterm 0.26.1",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -8862,7 +8861,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "codespan-reporting",
  "colored",
  "datatest-stable",
@@ -8924,7 +8923,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "codespan-reporting",
  "datatest-stable",
  "difference",
@@ -8962,7 +8961,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 3.2.23",
+ "clap 4.3.21",
  "codespan",
  "codespan-reporting",
  "datatest-stable",
@@ -9019,7 +9018,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "codespan",
  "colored",
  "move-binary-format",
@@ -9037,7 +9036,7 @@ name = "move-disassembler"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.3.5",
+ "clap 4.3.21",
  "colored",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -9104,7 +9103,7 @@ name = "move-explain"
 version = "0.1.0"
 dependencies = [
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "move-command-line-common",
  "move-core-types",
 ]
@@ -9115,7 +9114,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-verifier",
@@ -9212,7 +9211,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.3.5",
+ "clap 4.3.21",
  "colored",
  "datatest-stable",
  "dirs-next",
@@ -9253,7 +9252,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "clap 4.3.5",
+ "clap 4.3.21",
  "codespan",
  "codespan-reporting",
  "datatest-stable",
@@ -9432,7 +9431,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
- "clap 4.3.5",
+ "clap 4.3.21",
  "codespan",
  "codespan-reporting",
  "datatest-stable",
@@ -9474,7 +9473,7 @@ name = "move-transactional-test-runner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.3.5",
+ "clap 4.3.21",
  "colored",
  "datatest-stable",
  "difference",
@@ -9509,7 +9508,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "better_any",
- "clap 4.3.5",
+ "clap 4.3.21",
  "codespan-reporting",
  "colored",
  "datatest-stable",
@@ -11072,7 +11071,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.3.5",
+ "clap 4.3.21",
  "codespan-reporting",
  "hex",
  "itertools",
@@ -12017,7 +12016,7 @@ name = "sender"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "clap 4.3.5",
+ "clap 4.3.21",
  "event-listener",
  "quanta",
  "tokio",
@@ -12934,7 +12933,7 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 name = "test-generation"
 version = "0.1.0"
 dependencies = [
- "clap 4.3.5",
+ "clap 4.3.21",
  "crossbeam-channel",
  "getrandom 0.2.7",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -448,7 +448,7 @@ chrono = { version = "0.4.19", features = ["clock", "serde"] }
 cfg_block = "0.1.1"
 cfg-if = "1.0.0"
 claims = "0.7"
-clap = { version = "4.3.5", features = ["derive", "unstable-styles"] }
+clap = { version = "4.3.9", features = ["derive", "unstable-styles"] }
 clap_complete = "4.3.1"
 cloud-storage = { version = "0.11.1", features = ["global-client"] }
 codespan-reporting = "0.11.1"

--- a/third_party/move/documentation/examples/diem-framework/crates/cli/Cargo.toml
+++ b/third_party/move/documentation/examples/diem-framework/crates/cli/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.52"
-clap = { version = "4.3.5", features = ["derive"] }
+clap = { version = "4.3.9", features = ["derive"] }
 
 bcs = "0.1.4"
 move-cli = { path = "../../../../../tools/move-cli" }

--- a/third_party/move/evm/extract-ethereum-abi/Cargo.toml
+++ b/third_party/move/evm/extract-ethereum-abi/Cargo.toml
@@ -16,7 +16,7 @@ move-to-yul = { path = "../move-to-yul" }
 # external dependencies
 anyhow = "1.0.38"
 atty = "0.2.14"
-clap = { version = "4.3.5", features = ["derive", "env"] }
+clap = { version = "4.3.9", features = ["derive", "env"] }
 codespan = "0.11.1"
 codespan-reporting = "0.11.1"
 ethabi = "17.0.0"

--- a/third_party/move/evm/move-to-yul/Cargo.toml
+++ b/third_party/move/evm/move-to-yul/Cargo.toml
@@ -22,7 +22,7 @@ move-stackless-bytecode = { path = "../../move-prover/bytecode" }
 # external dependencies
 anyhow = "1.0.38"
 atty = "0.2.14"
-clap = { version = "4.3.5", features = ["derive", "env"] }
+clap = { version = "4.3.9", features = ["derive", "env"] }
 codespan = "0.11.1"
 codespan-reporting = "0.11.1"
 ethnum = "1.0.4"

--- a/third_party/move/move-analyzer/Cargo.toml
+++ b/third_party/move/move-analyzer/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.52"
-clap = { version = "4.3.5", features = ["derive"] }
+clap = { version = "4.3.9", features = ["derive"] }
 codespan-reporting = "0.11.1"
 crossbeam = "0.8"
 derivative = "2.2.0"

--- a/third_party/move/move-compiler-v2/Cargo.toml
+++ b/third_party/move/move-compiler-v2/Cargo.toml
@@ -17,7 +17,7 @@ move-model = { path = "../move-model" }
 move-stackless-bytecode = { path = "../move-prover/bytecode" }
 
 bcs = { workspace = true }
-clap = { version = "3.2.23", features = ["derive", "env"] }
+clap = { version = "4.3.9", features = ["derive", "env"] }
 codespan = "0.11.1"
 codespan-reporting = { version = "0.11.1", features = ["serde", "serialization"] }
 ethnum = "1.0.4"

--- a/third_party/move/move-compiler-v2/src/options.rs
+++ b/third_party/move/move-compiler-v2/src/options.rs
@@ -12,22 +12,17 @@ pub struct Options {
     /// Directories where to lookup dependencies.
     #[clap(
         short,
-        takes_value(true),
-        multiple_values(true),
-        multiple_occurrences(true)
+        num_args = 0..
     )]
     pub dependencies: Vec<String>,
     /// Named address mapping.
     #[clap(
         short,
-        takes_value(true),
-        multiple_values(true),
-        multiple_occurrences(true)
+        num_args = 0..
     )]
     pub named_address_mapping: Vec<String>,
     /// Output directory.
-    #[clap(short)]
-    #[clap(long, default_value = "")]
+    #[clap(short, long, default_value = "")]
     pub output_dir: String,
     /// Whether to dump intermediate bytecode for debugging.
     #[clap(long = "dump-bytecode")]
@@ -41,9 +36,7 @@ pub struct Options {
     #[clap(short)]
     #[clap(
         long = "experiment",
-        takes_value(true),
-        multiple_values(true),
-        multiple_occurrences(true)
+        num_args = 0..
     )]
     pub experiments: Vec<String>,
     /// Sources to compile (positional arg, therefore last)

--- a/third_party/move/move-compiler/Cargo.toml
+++ b/third_party/move/move-compiler/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.52"
-clap = { version = "4.3.5", features = ["derive"] }
+clap = { version = "4.3.9", features = ["derive"] }
 codespan-reporting = "0.11.1"
 difference = "2.0.0"
 hex = "0.4.3"

--- a/third_party/move/move-ir-compiler/Cargo.toml
+++ b/third_party/move/move-ir-compiler/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.52"
-clap = { version = "4.3.5", features = ["derive"] }
+clap = { version = "4.3.9", features = ["derive"] }
 move-binary-format = { path = "../move-binary-format" }
 move-bytecode-source-map = { path = "move-bytecode-source-map" }
 move-bytecode-verifier = { path = "../move-bytecode-verifier" }

--- a/third_party/move/move-prover/Cargo.toml
+++ b/third_party/move/move-prover/Cargo.toml
@@ -24,7 +24,7 @@ move-stackless-bytecode = { path = "bytecode" }
 # external dependencies
 async-trait = "0.1.42"
 atty = "0.2.14"
-clap = { version = "4.3.5", features = ["derive"] }
+clap = { version = "4.3.9", features = ["derive"] }
 codespan = "0.11.1"
 codespan-reporting = "0.11.1"
 futures = "0.3.12"

--- a/third_party/move/move-prover/lab/Cargo.toml
+++ b/third_party/move/move-prover/lab/Cargo.toml
@@ -20,7 +20,7 @@ z3tracer = "0.8.0"
 # external dependencies
 anyhow = "1.0.52"
 chrono = "0.4.19"
-clap = { version = "4.3.5", features = ["derive"] }
+clap = { version = "4.3.9", features = ["derive"] }
 codespan-reporting = "0.11.1"
 hex = "0.4.3"
 itertools = "0.10.0"

--- a/third_party/move/testing-infra/test-generation/Cargo.toml
+++ b/third_party/move/testing-infra/test-generation/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-clap = { version = "4.3.5", features = ["derive"] }
+clap = { version = "4.3.9", features = ["derive"] }
 crossbeam-channel = "0.5.0"
 getrandom = "0.2.2"
 hex = "0.4.3"

--- a/third_party/move/testing-infra/transactional-test-runner/Cargo.toml
+++ b/third_party/move/testing-infra/transactional-test-runner/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.52"
-clap = { version = "4.3.5", features = ["derive"] }
+clap = { version = "4.3.9", features = ["derive"] }
 colored = "2.0.0"
 move-binary-format = { path = "../../move-binary-format" }
 move-bytecode-source-map = { path = "../../move-ir-compiler/move-bytecode-source-map" }

--- a/third_party/move/tools/move-bytecode-viewer/Cargo.toml
+++ b/third_party/move/tools/move-bytecode-viewer/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.52"
-clap = { version = "4.3.5", features = ["derive"] }
+clap = { version = "4.3.9", features = ["derive"] }
 crossterm = "0.26.1"
 move-binary-format = { path = "../../move-binary-format" }
 move-bytecode-source-map = { path = "../../move-ir-compiler/move-bytecode-source-map" }

--- a/third_party/move/tools/move-cli/Cargo.toml
+++ b/third_party/move/tools/move-cli/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.52"
-clap = { version = "4.3.5", features = ["derive"] }
+clap = { version = "4.3.9", features = ["derive"] }
 codespan-reporting = "0.11.1"
 colored = "2.0.0"
 difference = "2.0.0"

--- a/third_party/move/tools/move-coverage/Cargo.toml
+++ b/third_party/move/tools/move-coverage/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.52"
-clap = { version = "4.3.5", features = ["derive"] }
+clap = { version = "4.3.9", features = ["derive"] }
 codespan = { version = "0.11.1", features = ["serialization"] }
 colored = "2.0.0"
 once_cell = "1.7.2"

--- a/third_party/move/tools/move-disassembler/Cargo.toml
+++ b/third_party/move/tools/move-disassembler/Cargo.toml
@@ -20,7 +20,7 @@ move-core-types = { path = "../../move-core/types" }
 move-coverage = { path = "../move-coverage" }
 move-ir-types = { path = "../../move-ir/types" }
 
-clap = { version = "4.3.5", features = ["derive"] }
+clap = { version = "4.3.9", features = ["derive"] }
 
 [features]
 default = []

--- a/third_party/move/tools/move-explain/Cargo.toml
+++ b/third_party/move/tools/move-explain/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-clap = { version = "4.3.5", features = ["derive"] }
+clap = { version = "4.3.9", features = ["derive"] }
 move-command-line-common = { path = "../../move-command-line-common" }
 move-core-types = { path = "../../move-core/types" }
 

--- a/third_party/move/tools/move-package/Cargo.toml
+++ b/third_party/move/tools/move-package/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.52"
-clap = { version = "4.3.5", features = ["derive"] }
+clap = { version = "4.3.9", features = ["derive"] }
 colored = "2.0.0"
 dirs-next = "2.0.0"
 itertools = "0.10.0"

--- a/third_party/move/tools/move-unit-test/Cargo.toml
+++ b/third_party/move/tools/move-unit-test/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.52"
 better_any = "0.1.1"
-clap = { version = "4.3.5", features = ["derive"] }
+clap = { version = "4.3.9", features = ["derive"] }
 codespan-reporting = "0.11.1"
 colored = "2.0.0"
 evm-exec-utils = { path = "../../evm/exec-utils", optional = true }


### PR DESCRIPTION
### Description
This mainly just cleans up a little compiler v2 interfacing so all of the codebase is on the same version of clap.  It should just make every input a 0 or more argument input, and if there are any that you want fixed, feel free to call them out.

### Test Plan
build seems to work, let's see how CI handles it.
