### PR TITLE
[GHA] Small tweaks to target determinator.

### DIFF
--- a/.github/actions/file-change-determinator/action.yaml
+++ b/.github/actions/file-change-determinator/action.yaml
@@ -13,4 +13,5 @@ runs:
       continue-on-error: true # Avoid skipping any checks if this job fails (see: https://github.com/fkirc/skip-duplicate-actions/issues/301)
       uses: fkirc/skip-duplicate-actions@v5
       with:
+        skip_after_successful_duplicate: false # Don't skip if the action is a duplicate (this may cause false positives)
         paths_ignore: '["**/*.md", "developer-docs-site/**"]'

--- a/.github/actions/general-lints/action.yaml
+++ b/.github/actions/general-lints/action.yaml
@@ -10,6 +10,8 @@ runs:
   steps:
     # Checkout the repository
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
 
     # Install shellcheck and run it on the dev_setup.sh script
     - name: Run shell lints


### PR DESCRIPTION
### Description
This PR offers two tiny tweaks to the file change determinator and lint workflows. Specifically, we want to disable `skip_after_successful_duplicate` because it produce false positives (i.e., job skips where we don't want it).

### Test Plan
Existing test infrastructure.