### PR TITLE
Fix node compatibility test CI

### DIFF
--- a/.github/workflows/node-api-compatibility-tests.yaml
+++ b/.github/workflows/node-api-compatibility-tests.yaml
@@ -114,8 +114,10 @@ jobs:
         if: ${{ !inputs.SKIP_JOB }}
 
       # Ensure any changes to the generated client were checked in.
-      - run: |
-          cd ./ecosystem/typescript/sdk && pnpm generate-client -o /tmp/generated_client
+      - run: cd ./ecosystem/typescript/sdk && pnpm generate-client -o /tmp/generated_client
+        if: ${{ !inputs.SKIP_JOB }}
+
+      - run:
           echo "If this step fails, run the following command locally to fix it:"
           echo "cd ecosystem/typescript/sdk && pnpm generate-client"
           git diff --no-index --ignore-space-at-eol --ignore-blank-lines ./ecosystem/typescript/sdk/src/generated/ /tmp/generated_client/


### PR DESCRIPTION
### Description
The issue was introduced by merging a bunch of `run` commands into one. How it used to work was:

1. `cd ./ecosystem/typescript/sdk && pnpm generate-client -o /tmp/generated_client`
2. `git diff --no-index --ignore-space-at-eol --ignore-blank-lines ./ecosystem/typescript/sdk/src/generated/ /tmp/generated_client/`

Now that they are merged, the `git diff` command in step 2 is trying to access `./ecosystem/typescript/sdk/src/generated/` but at this point we're already cd'd into this directory, so the path isn't there.

This PR fixes the issue by separating them into separate run commands again.

### Test Plan
Because this uses `workflow_dispatch` I'll have to do the thing where I switch to `pull_request` temporarily. Stay posted.

Update: The fix works, see a successful run here: https://github.com/aptos-labs/aptos-core/actions/runs/5826782139.