### PR TITLE
[txn emitter] allow reuse of accounts using seed, also add a mode to exclusively create accounts

### DIFF
--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -70,10 +70,6 @@ pub struct ClusterArgs {
     #[clap(long, conflicts_with = "targets")]
     pub targets_file: Option<String>,
 
-    /// If set, try to use public peers instead of localhost.
-    #[clap(long)]
-    pub reuse_accounts: bool,
-
     #[clap(long, default_value_t = ChainId::test())]
     pub chain_id: ChainId,
 
@@ -188,6 +184,28 @@ pub struct EmitArgs {
     //   basically creating a new source account (to then create seed accounts from).
     #[clap(long)]
     pub coordination_delay_between_instances: Option<u64>,
+
+    #[clap(long)]
+    pub account_minter_seed: Option<String>,
+
+    #[clap(long)]
+    pub coins_per_account_override: Option<u64>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Parser, Serialize)]
+pub struct CreateAccountsArgs {
+    /// Number of accounts to create
+    #[clap(long)]
+    pub count: usize,
+
+    /// The amount of gas needed to create an account
+    #[clap(long)]
+    pub max_gas_per_txn: u64,
+
+    /// Optional seed, which is compatible with emit-tx. If no seed is provided, a random seed is
+    /// used and printed.
+    #[clap(long)]
+    pub account_minter_seed: Option<String>,
 }
 
 fn parse_target(target: &str) -> Result<Url> {

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -30,6 +30,7 @@ use rand_core::SeedableRng;
 use std::{
     cmp::{max, min},
     collections::{HashMap, HashSet},
+    str::FromStr,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -125,7 +126,6 @@ pub struct EmitJobRequest {
     gas_price: u64,
     init_gas_price_multiplier: u64,
 
-    reuse_accounts: bool,
     mint_to_root: bool,
 
     txn_expiration_time_secs: u64,
@@ -142,6 +142,9 @@ pub struct EmitJobRequest {
     coordination_delay_between_instances: Duration,
 
     latency_polling_interval: Duration,
+
+    account_minter_seed: Option<[u8; 32]>,
+    coins_per_account_override: Option<u64>,
 }
 
 impl Default for EmitJobRequest {
@@ -155,7 +158,6 @@ impl Default for EmitJobRequest {
             max_gas_per_txn: aptos_global_constants::MAX_GAS_AMOUNT,
             gas_price: aptos_global_constants::GAS_UNIT_PRICE,
             init_gas_price_multiplier: 10,
-            reuse_accounts: false,
             mint_to_root: false,
             txn_expiration_time_secs: 60,
             init_expiration_multiplier: 3.0,
@@ -166,6 +168,8 @@ impl Default for EmitJobRequest {
             prompt_before_spending: false,
             coordination_delay_between_instances: Duration::from_secs(0),
             latency_polling_interval: Duration::from_millis(300),
+            account_minter_seed: None,
+            coins_per_account_override: None,
         }
     }
 }
@@ -237,11 +241,6 @@ impl EmitJobRequest {
         self
     }
 
-    pub fn reuse_accounts(mut self) -> Self {
-        self.reuse_accounts = true;
-        self
-    }
-
     pub fn txn_expiration_time_secs(mut self, txn_expiration_time_secs: u64) -> Self {
         self.txn_expiration_time_secs = txn_expiration_time_secs;
         self
@@ -262,6 +261,16 @@ impl EmitJobRequest {
 
     pub fn latency_polling_interval(mut self, latency_polling_interval: Duration) -> Self {
         self.latency_polling_interval = latency_polling_interval;
+        self
+    }
+
+    pub fn account_minter_seed(mut self, seed_string: &str) -> Self {
+        self.account_minter_seed = Some(parse_seed(seed_string));
+        self
+    }
+
+    pub fn coins_per_account_override(mut self, coins: u64) -> Self {
+        self.coins_per_account_override = Some(coins);
         self
     }
 
@@ -575,41 +584,35 @@ impl TxnEmitter {
             .with_transaction_expiration_time(mode_params.txn_expiration_time_secs)
             .with_gas_unit_price(req.gas_price)
             .with_max_gas_amount(req.max_gas_per_txn);
+
         let init_expiration_time =
             (mode_params.txn_expiration_time_secs as f64 * req.init_expiration_multiplier) as u64;
         let init_txn_factory = txn_factory
             .clone()
             .with_gas_unit_price(req.gas_price * req.init_gas_price_multiplier)
             .with_transaction_expiration_time(init_expiration_time);
-        let seed = self.rng.gen();
-        info!(
-            "AccountMinter Seed (can be passed in to reuse accounts): {:?}",
-            seed
-        );
-        let mut account_minter = AccountMinter::new(
-            root_account,
-            init_txn_factory.clone(),
-            StdRng::from_seed(seed),
-        );
         let init_retries: usize =
             usize::try_from(init_expiration_time / req.init_retry_interval.as_secs()).unwrap();
-        info!(
-            "Using reliable/retriable init transaction executor with {} retries, every {}s",
+        let seed = req.account_minter_seed.unwrap_or_else(|| self.rng.gen());
+        let mut all_accounts = create_accounts(
+            root_account,
+            &init_txn_factory,
+            &req,
+            mode_params.max_submit_batch_size,
+            seed,
+            num_accounts,
             init_retries,
-            req.init_retry_interval.as_secs_f32()
-        );
+        )
+        .await?;
+        let stop = Arc::new(AtomicBool::new(false));
+        let stats = Arc::new(DynamicStatsTracking::new(stats_tracking_phases));
+        let tokio_handle = Handle::current();
+
         let txn_executor = RestApiReliableTransactionSubmitter {
             rest_clients: req.rest_clients.clone(),
             max_retries: init_retries,
             retry_after: req.init_retry_interval,
         };
-        let mut all_accounts = account_minter
-            .create_accounts(&txn_executor, &req, &mode_params, num_accounts)
-            .await?;
-        let stop = Arc::new(AtomicBool::new(false));
-        let stats = Arc::new(DynamicStatsTracking::new(stats_tracking_phases));
-        let tokio_handle = Handle::current();
-
         let (txn_generator_creator, _, _) = create_txn_generator_creator(
             &req.transaction_mix_per_phase,
             &mut all_accounts,
@@ -984,4 +987,49 @@ pub fn gen_transfer_txn_request(
     sender.sign_with_transaction_builder(
         txn_factory.payload(aptos_stdlib::aptos_coin_transfer(*receiver, num_coins)),
     )
+}
+
+pub fn parse_seed(seed_string: &str) -> [u8; 32] {
+    // Remove the brackets and spaces
+    let cleaned_string = seed_string
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .replace(' ', "");
+
+    // Parse the cleaned string into a vector
+    let parsed_vector: Result<Vec<u8>, _> = cleaned_string.split(',').map(u8::from_str).collect();
+
+    <[u8; 32]>::try_from(parsed_vector.expect("failed to parse seed"))
+        .expect("failed to convert to array")
+}
+
+pub async fn create_accounts(
+    root_account: &mut LocalAccount,
+    txn_factory: &TransactionFactory,
+    req: &EmitJobRequest,
+    max_submit_batch_size: usize,
+    seed: [u8; 32],
+    num_accounts: usize,
+    retries: usize,
+) -> Result<Vec<LocalAccount>> {
+    info!(
+        "Using reliable/retriable init transaction executor with {} retries, every {}s",
+        retries,
+        req.init_retry_interval.as_secs_f32()
+    );
+
+    info!(
+        "AccountMinter Seed (reuse accounts by passing into --account-minter-seed): {:?}",
+        seed
+    );
+    let mut account_minter =
+        AccountMinter::new(root_account, txn_factory.clone(), StdRng::from_seed(seed));
+    let txn_executor = RestApiReliableTransactionSubmitter {
+        rest_clients: req.rest_clients.clone(),
+        max_retries: retries,
+        retry_after: req.init_retry_interval,
+    };
+    account_minter
+        .create_accounts(&txn_executor, req, max_submit_batch_size, num_accounts)
+        .await
 }

--- a/crates/transaction-emitter-lib/src/lib.rs
+++ b/crates/transaction-emitter-lib/src/lib.rs
@@ -10,7 +10,7 @@ mod instance;
 mod wrappers;
 
 // These are the top level things you should need to run the emitter.
-pub use args::{ClusterArgs, CoinSourceArgs, EmitArgs};
+pub use args::{ClusterArgs, CoinSourceArgs, CreateAccountsArgs, EmitArgs};
 // We export these if you want finer grained control.
 pub use cluster::Cluster;
 pub use emitter::{
@@ -18,4 +18,4 @@ pub use emitter::{
     stats::{TxnStats, TxnStatsRate},
     EmitJob, EmitJobMode, EmitJobRequest, EmitModeParams, TxnEmitter,
 };
-pub use wrappers::{emit_transactions, emit_transactions_with_cluster};
+pub use wrappers::{create_accounts_command, emit_transactions, emit_transactions_with_cluster};

--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -161,6 +161,7 @@ pub async fn create_accounts_command(
             .expected_gas_per_txn(create_accounts_args.max_gas_per_txn)
             .max_gas_per_txn(create_accounts_args.max_gas_per_txn)
             .coins_per_account_override(0)
+            .expected_max_txns(0)
             .prompt_before_spending();
     let seed = match &create_accounts_args.account_minter_seed {
         Some(str) => parse_seed(str),

--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -4,14 +4,18 @@
 use crate::{
     args::{ClusterArgs, EmitArgs},
     cluster::Cluster,
-    emitter::{stats::TxnStats, EmitJobMode, EmitJobRequest, TxnEmitter},
+    emitter::{
+        create_accounts, parse_seed, stats::TxnStats, EmitJobMode, EmitJobRequest, TxnEmitter,
+    },
     instance::Instance,
+    CreateAccountsArgs,
 };
 use anyhow::{bail, Context, Result};
+use aptos_config::config::DEFAULT_MAX_SUBMIT_TRANSACTION_BATCH_SIZE;
 use aptos_logger::{error, info};
 use aptos_sdk::transaction_builder::TransactionFactory;
 use aptos_transaction_generator_lib::args::TransactionTypeArg;
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::time::{Duration, Instant};
 
 pub async fn emit_transactions(
@@ -22,7 +26,7 @@ pub async fn emit_transactions(
         let cluster = Cluster::try_from_cluster_args(cluster_args)
             .await
             .context("Failed to build cluster")?;
-        emit_transactions_with_cluster(&cluster, emit_args, cluster_args.reuse_accounts).await
+        emit_transactions_with_cluster(&cluster, emit_args).await
     } else {
         let initial_delay_after_minting = emit_args.coordination_delay_between_instances.unwrap();
         let start_time = Instant::now();
@@ -49,12 +53,7 @@ pub async fn emit_transactions(
                 .await
                 .context("Failed to build cluster")?;
 
-            let result = emit_transactions_with_cluster(
-                &cluster,
-                &cur_emit_args,
-                cluster_args.reuse_accounts,
-            )
-            .await;
+            let result = emit_transactions_with_cluster(&cluster, &cur_emit_args).await;
             match result {
                 Ok(value) => return Ok(value),
                 Err(e) => {
@@ -69,7 +68,6 @@ pub async fn emit_transactions(
 pub async fn emit_transactions_with_cluster(
     cluster: &Cluster,
     args: &EmitArgs,
-    reuse_accounts: bool,
 ) -> Result<TxnStats> {
     let emitter_mode = EmitJobMode::create(args.mempool_backlog, args.target_tps);
 
@@ -98,9 +96,7 @@ pub async fn emit_transactions_with_cluster(
             .coordination_delay_between_instances(Duration::from_secs(
                 args.coordination_delay_between_instances.unwrap_or(0),
             ));
-    if reuse_accounts {
-        emit_job_request = emit_job_request.reuse_accounts();
-    }
+
     if let Some(max_transactions_per_account) = args.max_transactions_per_account {
         emit_job_request =
             emit_job_request.max_transactions_per_account(max_transactions_per_account);
@@ -128,6 +124,14 @@ pub async fn emit_transactions_with_cluster(
         emit_job_request = emit_job_request.prompt_before_spending();
     }
 
+    if let Some(seed) = &args.account_minter_seed {
+        emit_job_request = emit_job_request.account_minter_seed(seed);
+    }
+
+    if let Some(coins) = args.coins_per_account_override {
+        emit_job_request = emit_job_request.coins_per_account_override(coins);
+    }
+
     let stats = emitter
         .emit_txn_for_with_stats(
             &mut coin_source_account,
@@ -137,4 +141,40 @@ pub async fn emit_transactions_with_cluster(
         )
         .await?;
     Ok(stats)
+}
+
+pub async fn create_accounts_command(
+    cluster_args: &ClusterArgs,
+    create_accounts_args: &CreateAccountsArgs,
+) -> Result<()> {
+    let cluster = Cluster::try_from_cluster_args(cluster_args)
+        .await
+        .context("Failed to build cluster")?;
+    let client = cluster.random_instance().rest_client();
+    let mut coin_source_account = cluster.load_coin_source_account(&client).await?;
+    let txn_factory = TransactionFactory::new(cluster.chain_id)
+        .with_transaction_expiration_time(60)
+        .with_max_gas_amount(create_accounts_args.max_gas_per_txn);
+    let emit_job_request =
+        EmitJobRequest::new(cluster.all_instances().map(Instance::rest_client).collect())
+            .init_gas_price_multiplier(1)
+            .expected_gas_per_txn(create_accounts_args.max_gas_per_txn)
+            .max_gas_per_txn(create_accounts_args.max_gas_per_txn)
+            .coins_per_account_override(0)
+            .prompt_before_spending();
+    let seed = match &create_accounts_args.account_minter_seed {
+        Some(str) => parse_seed(str),
+        None => StdRng::from_entropy().gen(),
+    };
+    create_accounts(
+        &mut coin_source_account,
+        &txn_factory,
+        &emit_job_request,
+        DEFAULT_MAX_SUBMIT_TRANSACTION_BATCH_SIZE,
+        seed,
+        create_accounts_args.count,
+        4,
+    )
+    .await?;
+    Ok(())
 }

--- a/crates/transaction-emitter/src/main.rs
+++ b/crates/transaction-emitter/src/main.rs
@@ -6,7 +6,9 @@ mod diag;
 
 use anyhow::{Context, Result};
 use aptos_logger::{Level, Logger};
-use aptos_transaction_emitter_lib::{emit_transactions, Cluster, ClusterArgs, EmitArgs};
+use aptos_transaction_emitter_lib::{
+    create_accounts_command, emit_transactions, Cluster, ClusterArgs, CreateAccountsArgs, EmitArgs,
+};
 use clap::{Parser, Subcommand};
 use diag::diag;
 
@@ -22,6 +24,9 @@ enum TxnEmitterCommand {
     /// we mint many accounts and then hit the target peer(s) with transactions,
     /// recording stats as we go.
     EmitTx(EmitTx),
+
+    /// Create test accounts, for use with EmitTx
+    CreateAccounts(CreateAccounts),
 
     /// This runs the transaction emitter in diag mode, where the focus is on
     /// FullNodes instead of ValidatorNodes. This performs a simple health check.
@@ -39,6 +44,15 @@ struct EmitTx {
 
     #[clap(flatten)]
     emit_args: EmitArgs,
+}
+
+#[derive(Parser, Debug)]
+struct CreateAccounts {
+    #[clap(flatten)]
+    cluster_args: ClusterArgs,
+
+    #[clap(flatten)]
+    create_accounts_args: CreateAccountsArgs,
 }
 
 #[derive(Parser, Debug)]
@@ -68,6 +82,13 @@ pub async fn main() -> Result<()> {
                 .unwrap();
             println!("Total stats: {}", stats);
             println!("Average rate: {}", stats.rate());
+            Ok(())
+        },
+        TxnEmitterCommand::CreateAccounts(args) => {
+            create_accounts_command(&args.cluster_args, &args.create_accounts_args)
+                .await
+                .map_err(|e| panic!("Create accounts failed {:?}", e))
+                .unwrap();
             Ok(())
         },
         TxnEmitterCommand::Diag(args) => {

--- a/ecosystem/node-checker/src/checker/tps.rs
+++ b/ecosystem/node-checker/src/checker/tps.rs
@@ -126,7 +126,6 @@ impl Checker for TpsChecker {
         let cluster_config = ClusterArgs {
             targets: Some(vec![target_url; self.config.repeat_target_count]),
             targets_file: None,
-            reuse_accounts: false,
             coin_source_args: self.config.coin_source_args.clone(),
             chain_id,
         };
@@ -134,7 +133,7 @@ impl Checker for TpsChecker {
             .await
             .map_err(TpsCheckerError::BuildClusterError)?;
 
-        let stats = emit_transactions_with_cluster(&cluster, &self.config.emit_config, false)
+        let stats = emit_transactions_with_cluster(&cluster, &self.config.emit_config)
             .await
             .map_err(TpsCheckerError::TransactionEmitterError)?;
 


### PR DESCRIPTION
### Description

Account creation is a pretty expensive part of the emitter, so allow reuse. Note, the seed allows re-creation of all private keys of the test accounts, so must be kept safe (e.g., in gcloud secrets).

Also create an exclusive `create-accounts` mode for separating out account creation and thus making it easier to exactly specify the gas to use in each step.

### Test Plan

Run `% cargo run -p aptos-transaction-emitter --release -- create-accounts -t https://fullnode.testnet.aptoslabs.com --coin-source-key ${APT_KEY} --chain-id testnet --count 1 --max-gas-per-txn 1009` and check output via explorer.
