### PR TITLE
remove redundant test

### DIFF
--- a/ecosystem/typescript/sdk/src/tests/e2e/client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/client.test.ts
@@ -3,25 +3,6 @@ import { VERSION } from "../../version";
 import { getTransaction, longTestTimeout, NODE_URL } from "../unit/test_helper.test";
 
 test(
-  "server response should include cookies",
-  async () => {
-    try {
-      const response = await aptosRequest({
-        // use devnet as localnet doesnt set cookies
-        url: "https://fullnode.devnet.aptoslabs.com/v1",
-        method: "GET",
-        originMethod: "test cookies",
-      });
-      expect(response.headers).toHaveProperty("set-cookie");
-    } catch (error: any) {
-      // should not get here
-      expect(true).toBe(false);
-    }
-  },
-  longTestTimeout,
-);
-
-test(
   "call should include x-aptos-client header",
   async () => {
     try {


### PR DESCRIPTION
### Description
This test is not really a SDK test but more an API test. if we really want to test the sdk, we should probably mock the response, and then check if on second request cookies are still there.
Having this test here can block CI when devnet is down
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
