### PR TITLE
[NFT Metadata Crawler] Set CDN URIs to existing ones when duplicates are detected

### DIFF
--- a/ecosystem/nft-metadata-crawler-parser/src/worker.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/worker.rs
@@ -263,11 +263,14 @@ impl Worker {
         // Deduplicate token_uri
         // Proceed if force or if token_uri has not been parsed
         if self.force
-            || NFTMetadataCrawlerURIsQuery::get_by_token_uri(
-                self.token_uri.clone(),
-                &mut self.conn,
-            )?
-            .is_none()
+            || NFTMetadataCrawlerURIsQuery::get_by_token_uri(self.token_uri.clone(), &mut self.conn)
+                .map_or(true, |uri| match uri {
+                    Some(uris) => {
+                        self.model.set_cdn_json_uri(uris.cdn_json_uri);
+                        false
+                    },
+                    None => true,
+                })
         {
             // Parse token_uri
             self.model.set_token_uri(self.token_uri.clone());


### PR DESCRIPTION
### Description
If a duplicate URI is detected, it should be skipped and its CDN URI should be set to the existing one. Adding functionality to the setting CDN URI part because it was previously left out. 

### Test Plan
Tested locally, works

Fixes EI-305
