### PR TITLE
[compiler v2] Fix bugs around compilation of vector code

### DIFF
--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -523,7 +523,7 @@ impl<'a> FunctionGenerator<'a> {
             let idx = self.gen.function_instantiation_index(
                 &fun_ctx.module,
                 &fun_ctx.loc,
-                fun_ctx.fun.func_env,
+                &fun_ctx.module.env.get_function(id),
                 inst.to_vec(),
             );
             self.emit(FF::Bytecode::CallGeneric(idx))

--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -512,7 +512,16 @@ impl<'a> FunctionGenerator<'a> {
     ) {
         let fun_ctx = ctx.fun_ctx;
         self.abstract_push_args(ctx, source);
-        if inst.is_empty() {
+        if let Some(opcode) = ctx.fun_ctx.module.get_well_known_function_code(
+            &ctx.fun_ctx.loc,
+            id,
+            Some(
+                self.gen
+                    .signature(&ctx.fun_ctx.module, &ctx.fun_ctx.loc, inst.to_vec()),
+            ),
+        ) {
+            self.emit(opcode)
+        } else if inst.is_empty() {
             let idx = self.gen.function_index(
                 &fun_ctx.module,
                 &fun_ctx.loc,

--- a/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
@@ -22,6 +22,9 @@ impl FunctionTargetProcessor for LiveVarAnalysisProcessor {
         mut data: FunctionData,
         _scc_opt: Option<&[FunctionEnv]>,
     ) -> FunctionData {
+        if fun_env.is_native() {
+            return data;
+        }
         // Call the existing live-var analysis from the move-prover.
         let target = FunctionTarget::new(fun_env, &data);
         let offset_to_live_refs = livevar_analysis::LiveVarAnnotation::from_map(

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/reference_conversion.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/reference_conversion.exp
@@ -1,0 +1,46 @@
+// ---- Model Dump
+module 0x42::reference_conversion {
+    private fun deref(r: &u64) {
+        Deref(r)
+    }
+    private fun use_it() {
+        {
+          let x: u64 = 42;
+          {
+            let r: &mut u64 = Borrow(Mutable)(x);
+            r = 43;
+            reference_conversion::deref(r)
+          }
+        }
+    }
+} // end 0x42::reference_conversion
+
+============ initial bytecode ================
+
+[variant baseline]
+fun reference_conversion::deref($t0: &u64): u64 {
+     var $t1: u64
+  0: $t1 := read_ref($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun reference_conversion::use_it(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: &mut u64
+     var $t5: u64
+     var $t6: &u64
+  0: $t2 := 42
+  1: $t1 := move($t2)
+  2: $t4 := borrow_local($t1)
+  3: $t3 := move($t4)
+  4: $t5 := 43
+  5: write_ref($t3, $t5)
+  6: $t6 := freeze_ref($t3)
+  7: $t0 := reference_conversion::deref($t6)
+  8: return $t0
+}

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/reference_conversion.move
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/reference_conversion.move
@@ -1,0 +1,15 @@
+module 0x42::reference_conversion {
+
+    fun deref(r: &u64): u64 {
+        *r
+    }
+
+    fun use_it(): u64 {
+        let x = 42;
+        let r = &mut x;
+        *r = 43;
+        deref(r)
+    }
+
+
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.exp
@@ -1,0 +1,58 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun Test::foo($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := Test::identity<u64>($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun Test::identity<#0>($t0: #0): #0 {
+     var $t1: #0
+  0: $t1 := move($t0)
+  1: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun Test::foo($t0: u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := Test::identity<u64>($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun Test::identity<#0>($t0: #0): #0 {
+     var $t1: #0
+     # live vars: $t0
+  0: $t1 := move($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v6
+module 42.Test {
+
+
+foo(Arg0: u64): u64 {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Call identity<u64>(u64): u64
+	2: Ret
+}
+identity<Ty0>(Arg0: Ty0): Ty0 {
+B0:
+	0: MoveLoc[0](Arg0: Ty0)
+	1: StLoc[1](loc0: Ty0)
+	2: MoveLoc[1](loc0: Ty0)
+	3: Ret
+}
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.move
@@ -1,0 +1,9 @@
+module 0x42::Test {
+    fun identity<T>(x: T): T {
+        x
+    }
+
+    fun foo(x: u64): u64 {
+        identity(x)
+    }
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+
+==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.exp
@@ -1,3 +1,584 @@
 processed 2 tasks
 
+task 0 'publish'. lines 1-65:
+
+
+
 ==> Compiler v2 delivered same results!
+
+>>> V1 Compiler {
+== BEGIN Bytecode ==
+// Move bytecode v6
+module 42.heap {
+
+
+array_equals(Arg0: &vector<u64>, Arg1: &vector<u64>): bool {
+L0:	loc2: u64
+B0:
+	0: CopyLoc[0](Arg0: &vector<u64>)
+	1: VecLen(7)
+	2: StLoc[3](loc1: u64)
+	3: CopyLoc[1](Arg1: &vector<u64>)
+	4: VecLen(7)
+	5: StLoc[4](loc2: u64)
+	6: CopyLoc[3](loc1: u64)
+	7: MoveLoc[4](loc2: u64)
+	8: Neq
+	9: BrFalse(16)
+B1:
+	10: MoveLoc[1](Arg1: &vector<u64>)
+	11: Pop
+	12: MoveLoc[0](Arg0: &vector<u64>)
+	13: Pop
+	14: LdFalse
+	15: Ret
+B2:
+	16: LdU64(0)
+	17: StLoc[2](loc0: u64)
+B3:
+	18: CopyLoc[2](loc0: u64)
+	19: CopyLoc[3](loc1: u64)
+	20: Lt
+	21: BrFalse(44)
+B4:
+	22: Branch(23)
+B5:
+	23: CopyLoc[0](Arg0: &vector<u64>)
+	24: CopyLoc[2](loc0: u64)
+	25: VecImmBorrow(7)
+	26: ReadRef
+	27: CopyLoc[1](Arg1: &vector<u64>)
+	28: CopyLoc[2](loc0: u64)
+	29: VecImmBorrow(7)
+	30: ReadRef
+	31: Neq
+	32: BrFalse(39)
+B6:
+	33: MoveLoc[1](Arg1: &vector<u64>)
+	34: Pop
+	35: MoveLoc[0](Arg0: &vector<u64>)
+	36: Pop
+	37: LdFalse
+	38: Ret
+B7:
+	39: MoveLoc[2](loc0: u64)
+	40: LdU64(1)
+	41: Add
+	42: StLoc[2](loc0: u64)
+	43: Branch(18)
+B8:
+	44: MoveLoc[1](Arg1: &vector<u64>)
+	45: Pop
+	46: MoveLoc[0](Arg0: &vector<u64>)
+	47: Pop
+	48: LdTrue
+	49: Ret
+}
+create1(): vector<u64> {
+B0:
+	0: LdConst[0](Vector(U64): [6, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0])
+	1: Ret
+}
+create2(): vector<u64> {
+B0:
+	0: LdConst[1](Vector(U64): [6, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0])
+	1: Ret
+}
+public main() {
+L0:	loc0: vector<u64>
+L1:	loc1: vector<u64>
+L2:	loc2: vector<u64>
+B0:
+	0: Call create1(): vector<u64>
+	1: StLoc[0](loc0: vector<u64>)
+	2: Call create2(): vector<u64>
+	3: StLoc[1](loc1: vector<u64>)
+	4: ImmBorrowLoc[0](loc0: vector<u64>)
+	5: Call vcopy(&vector<u64>): vector<u64>
+	6: StLoc[2](loc2: vector<u64>)
+	7: ImmBorrowLoc[0](loc0: vector<u64>)
+	8: ImmBorrowLoc[2](loc2: vector<u64>)
+	9: Call array_equals(&vector<u64>, &vector<u64>): bool
+	10: BrFalse(12)
+B1:
+	11: Branch(14)
+B2:
+	12: LdU64(23)
+	13: Abort
+B3:
+	14: ImmBorrowLoc[1](loc1: vector<u64>)
+	15: ImmBorrowLoc[1](loc1: vector<u64>)
+	16: Call array_equals(&vector<u64>, &vector<u64>): bool
+	17: BrFalse(19)
+B4:
+	18: Branch(21)
+B5:
+	19: LdU64(29)
+	20: Abort
+B6:
+	21: MutBorrowLoc[0](loc0: vector<u64>)
+	22: Call sort(&mut vector<u64>)
+	23: ImmBorrowLoc[1](loc1: vector<u64>)
+	24: ImmBorrowLoc[0](loc0: vector<u64>)
+	25: Call array_equals(&vector<u64>, &vector<u64>): bool
+	26: BrFalse(28)
+B7:
+	27: Branch(30)
+B8:
+	28: LdU64(31)
+	29: Abort
+B9:
+	30: ImmBorrowLoc[0](loc0: vector<u64>)
+	31: ImmBorrowLoc[1](loc1: vector<u64>)
+	32: Call array_equals(&vector<u64>, &vector<u64>): bool
+	33: BrFalse(35)
+B10:
+	34: Branch(37)
+B11:
+	35: LdU64(29)
+	36: Abort
+B12:
+	37: ImmBorrowLoc[0](loc0: vector<u64>)
+	38: ImmBorrowLoc[2](loc2: vector<u64>)
+	39: Call array_equals(&vector<u64>, &vector<u64>): bool
+	40: Not
+	41: BrFalse(43)
+B13:
+	42: Branch(45)
+B14:
+	43: LdU64(31)
+	44: Abort
+B15:
+	45: Ret
+}
+sort(Arg0: &mut vector<u64>) {
+L0:	loc1: u64
+L1:	loc2: &mut vector<u64>
+L2:	loc3: u64
+L3:	loc4: u64
+L4:	loc5: u64
+B0:
+	0: LdU64(0)
+	1: StLoc[5](loc4: u64)
+B1:
+	2: CopyLoc[5](loc4: u64)
+	3: CopyLoc[0](Arg0: &mut vector<u64>)
+	4: FreezeRef
+	5: VecLen(7)
+	6: Lt
+	7: BrFalse(54)
+B2:
+	8: Branch(9)
+B3:
+	9: CopyLoc[5](loc4: u64)
+	10: LdU64(1)
+	11: Add
+	12: StLoc[6](loc5: u64)
+B4:
+	13: CopyLoc[6](loc5: u64)
+	14: CopyLoc[0](Arg0: &mut vector<u64>)
+	15: FreezeRef
+	16: VecLen(7)
+	17: Lt
+	18: BrFalse(49)
+B5:
+	19: Branch(20)
+B6:
+	20: CopyLoc[0](Arg0: &mut vector<u64>)
+	21: CopyLoc[5](loc4: u64)
+	22: StLoc[2](loc1: u64)
+	23: StLoc[1](loc0: &mut vector<u64>)
+	24: CopyLoc[0](Arg0: &mut vector<u64>)
+	25: CopyLoc[6](loc5: u64)
+	26: StLoc[4](loc3: u64)
+	27: StLoc[3](loc2: &mut vector<u64>)
+	28: MoveLoc[1](loc0: &mut vector<u64>)
+	29: FreezeRef
+	30: MoveLoc[2](loc1: u64)
+	31: VecImmBorrow(7)
+	32: ReadRef
+	33: MoveLoc[3](loc2: &mut vector<u64>)
+	34: FreezeRef
+	35: MoveLoc[4](loc3: u64)
+	36: VecImmBorrow(7)
+	37: ReadRef
+	38: Gt
+	39: BrFalse(44)
+B7:
+	40: CopyLoc[0](Arg0: &mut vector<u64>)
+	41: CopyLoc[5](loc4: u64)
+	42: CopyLoc[6](loc5: u64)
+	43: VecSwap(7)
+B8:
+	44: MoveLoc[6](loc5: u64)
+	45: LdU64(1)
+	46: Add
+	47: StLoc[6](loc5: u64)
+	48: Branch(13)
+B9:
+	49: MoveLoc[5](loc4: u64)
+	50: LdU64(1)
+	51: Add
+	52: StLoc[5](loc4: u64)
+	53: Branch(2)
+B10:
+	54: MoveLoc[0](Arg0: &mut vector<u64>)
+	55: Pop
+	56: Ret
+}
+vcopy(Arg0: &vector<u64>): vector<u64> {
+L0:	loc1: u64
+L1:	loc2: vector<u64>
+B0:
+	0: VecPack(7, 0)
+	1: StLoc[3](loc2: vector<u64>)
+	2: LdU64(0)
+	3: StLoc[1](loc0: u64)
+	4: CopyLoc[0](Arg0: &vector<u64>)
+	5: VecLen(7)
+	6: StLoc[2](loc1: u64)
+B1:
+	7: CopyLoc[1](loc0: u64)
+	8: CopyLoc[2](loc1: u64)
+	9: Lt
+	10: BrFalse(23)
+B2:
+	11: Branch(12)
+B3:
+	12: MutBorrowLoc[3](loc2: vector<u64>)
+	13: CopyLoc[0](Arg0: &vector<u64>)
+	14: CopyLoc[1](loc0: u64)
+	15: VecImmBorrow(7)
+	16: ReadRef
+	17: VecPushBack(7)
+	18: MoveLoc[1](loc0: u64)
+	19: LdU64(1)
+	20: Add
+	21: StLoc[1](loc0: u64)
+	22: Branch(7)
+B4:
+	23: MoveLoc[0](Arg0: &vector<u64>)
+	24: Pop
+	25: MoveLoc[3](loc2: vector<u64>)
+	26: Ret
+}
+}
+== END Bytecode ==
+
+task 1 'run'. lines 67-73:
+
+== BEGIN Bytecode ==
+// Move bytecode v6
+script {
+use 0000000000000000000000000000000000000000000000000000000000000042::heap;
+
+
+
+
+main() {
+B0:
+	0: Call heap::main()
+	1: Ret
+}
+}
+== END Bytecode ==
+}
+
+>>> V2 Compiler {
+== BEGIN Bytecode ==
+// Move bytecode v6
+module 42.heap {
+
+
+array_equals(Arg0: &vector<u64>, Arg1: &vector<u64>): bool {
+L0:	loc2: u64
+L1:	loc3: u64
+B0:
+	0: CopyLoc[0](Arg0: &vector<u64>)
+	1: VecLen(2)
+	2: StLoc[2](loc0: u64)
+	3: CopyLoc[1](Arg1: &vector<u64>)
+	4: VecLen(2)
+	5: StLoc[3](loc1: u64)
+	6: CopyLoc[2](loc0: u64)
+	7: MoveLoc[3](loc1: u64)
+	8: Neq
+	9: BrFalse(13)
+B1:
+	10: LdConst[0](Bool: [0])
+	11: Ret
+B2:
+	12: Branch(13)
+B3:
+	13: LdConst[1](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	14: StLoc[4](loc2: u64)
+B4:
+	15: CopyLoc[4](loc2: u64)
+	16: CopyLoc[2](loc0: u64)
+	17: Lt
+	18: BrFalse(39)
+B5:
+	19: CopyLoc[0](Arg0: &vector<u64>)
+	20: CopyLoc[4](loc2: u64)
+	21: VecImmBorrow(2)
+	22: ReadRef
+	23: CopyLoc[1](Arg1: &vector<u64>)
+	24: CopyLoc[4](loc2: u64)
+	25: VecImmBorrow(2)
+	26: ReadRef
+	27: Neq
+	28: BrFalse(32)
+B6:
+	29: LdConst[0](Bool: [0])
+	30: Ret
+B7:
+	31: Branch(32)
+B8:
+	32: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	33: StLoc[5](loc3: u64)
+	34: MoveLoc[4](loc2: u64)
+	35: MoveLoc[5](loc3: u64)
+	36: Add
+	37: StLoc[4](loc2: u64)
+	38: Branch(40)
+B9:
+	39: Branch(41)
+B10:
+	40: Branch(15)
+B11:
+	41: LdConst[3](Bool: [1])
+	42: Ret
+}
+create1(): vector<u64> {
+B0:
+	0: LdConst[4](U64: [3, 0, 0, 0, 0, 0, 0, 0])
+	1: LdConst[5](U64: [2, 0, 0, 0, 0, 0, 0, 0])
+	2: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	3: LdConst[6](U64: [5, 0, 0, 0, 0, 0, 0, 0])
+	4: LdConst[7](U64: [8, 0, 0, 0, 0, 0, 0, 0])
+	5: LdConst[8](U64: [4, 0, 0, 0, 0, 0, 0, 0])
+	6: VecPack(2, 6)
+	7: Ret
+}
+create2(): vector<u64> {
+B0:
+	0: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	1: LdConst[5](U64: [2, 0, 0, 0, 0, 0, 0, 0])
+	2: LdConst[4](U64: [3, 0, 0, 0, 0, 0, 0, 0])
+	3: LdConst[8](U64: [4, 0, 0, 0, 0, 0, 0, 0])
+	4: LdConst[6](U64: [5, 0, 0, 0, 0, 0, 0, 0])
+	5: LdConst[7](U64: [8, 0, 0, 0, 0, 0, 0, 0])
+	6: VecPack(2, 6)
+	7: Ret
+}
+public main() {
+L0:	loc0: vector<u64>
+L1:	loc1: vector<u64>
+L2:	loc2: vector<u64>
+B0:
+	0: Call create1(): vector<u64>
+	1: StLoc[0](loc0: vector<u64>)
+	2: Call create2(): vector<u64>
+	3: StLoc[1](loc1: vector<u64>)
+	4: ImmBorrowLoc[0](loc0: vector<u64>)
+	5: Call vcopy(&vector<u64>): vector<u64>
+	6: StLoc[2](loc2: vector<u64>)
+	7: ImmBorrowLoc[0](loc0: vector<u64>)
+	8: ImmBorrowLoc[2](loc2: vector<u64>)
+	9: Call array_equals(&vector<u64>, &vector<u64>): bool
+	10: BrFalse(12)
+B1:
+	11: Branch(14)
+B2:
+	12: LdConst[9](U64: [23, 0, 0, 0, 0, 0, 0, 0])
+	13: Abort
+B3:
+	14: ImmBorrowLoc[1](loc1: vector<u64>)
+	15: ImmBorrowLoc[1](loc1: vector<u64>)
+	16: Call array_equals(&vector<u64>, &vector<u64>): bool
+	17: BrFalse(19)
+B4:
+	18: Branch(21)
+B5:
+	19: LdConst[10](U64: [29, 0, 0, 0, 0, 0, 0, 0])
+	20: Abort
+B6:
+	21: MutBorrowLoc[0](loc0: vector<u64>)
+	22: Call sort(&mut vector<u64>)
+	23: ImmBorrowLoc[1](loc1: vector<u64>)
+	24: ImmBorrowLoc[0](loc0: vector<u64>)
+	25: Call array_equals(&vector<u64>, &vector<u64>): bool
+	26: BrFalse(28)
+B7:
+	27: Branch(30)
+B8:
+	28: LdConst[11](U64: [31, 0, 0, 0, 0, 0, 0, 0])
+	29: Abort
+B9:
+	30: ImmBorrowLoc[0](loc0: vector<u64>)
+	31: ImmBorrowLoc[1](loc1: vector<u64>)
+	32: Call array_equals(&vector<u64>, &vector<u64>): bool
+	33: BrFalse(35)
+B10:
+	34: Branch(37)
+B11:
+	35: LdConst[10](U64: [29, 0, 0, 0, 0, 0, 0, 0])
+	36: Abort
+B12:
+	37: ImmBorrowLoc[0](loc0: vector<u64>)
+	38: ImmBorrowLoc[2](loc2: vector<u64>)
+	39: Call array_equals(&vector<u64>, &vector<u64>): bool
+	40: Not
+	41: BrFalse(43)
+B13:
+	42: Branch(45)
+B14:
+	43: LdConst[11](U64: [31, 0, 0, 0, 0, 0, 0, 0])
+	44: Abort
+B15:
+	45: Ret
+}
+sort(Arg0: &mut vector<u64>) {
+L0:	loc1: u64
+L1:	loc2: u64
+L2:	loc3: u64
+L3:	loc4: u64
+L4:	loc5: u64
+L5:	loc6: u64
+B0:
+	0: LdConst[1](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	1: StLoc[1](loc0: u64)
+B1:
+	2: CopyLoc[0](Arg0: &mut vector<u64>)
+	3: FreezeRef
+	4: VecLen(2)
+	5: StLoc[2](loc1: u64)
+	6: CopyLoc[1](loc0: u64)
+	7: MoveLoc[2](loc1: u64)
+	8: Lt
+	9: BrFalse(57)
+B2:
+	10: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	11: StLoc[3](loc2: u64)
+	12: CopyLoc[1](loc0: u64)
+	13: MoveLoc[3](loc2: u64)
+	14: Add
+	15: StLoc[4](loc3: u64)
+B3:
+	16: CopyLoc[0](Arg0: &mut vector<u64>)
+	17: FreezeRef
+	18: VecLen(2)
+	19: StLoc[5](loc4: u64)
+	20: CopyLoc[4](loc3: u64)
+	21: MoveLoc[5](loc4: u64)
+	22: Lt
+	23: BrFalse(48)
+B4:
+	24: CopyLoc[0](Arg0: &mut vector<u64>)
+	25: FreezeRef
+	26: CopyLoc[1](loc0: u64)
+	27: VecImmBorrow(2)
+	28: ReadRef
+	29: CopyLoc[0](Arg0: &mut vector<u64>)
+	30: FreezeRef
+	31: CopyLoc[4](loc3: u64)
+	32: VecImmBorrow(2)
+	33: ReadRef
+	34: Gt
+	35: BrFalse(41)
+B5:
+	36: CopyLoc[0](Arg0: &mut vector<u64>)
+	37: CopyLoc[1](loc0: u64)
+	38: CopyLoc[4](loc3: u64)
+	39: VecSwap(2)
+	40: Branch(41)
+B6:
+	41: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	42: StLoc[6](loc5: u64)
+	43: MoveLoc[4](loc3: u64)
+	44: MoveLoc[6](loc5: u64)
+	45: Add
+	46: StLoc[4](loc3: u64)
+	47: Branch(49)
+B7:
+	48: Branch(50)
+B8:
+	49: Branch(16)
+B9:
+	50: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	51: StLoc[7](loc6: u64)
+	52: MoveLoc[1](loc0: u64)
+	53: MoveLoc[7](loc6: u64)
+	54: Add
+	55: StLoc[1](loc0: u64)
+	56: Branch(58)
+B10:
+	57: Branch(59)
+B11:
+	58: Branch(2)
+B12:
+	59: Ret
+}
+vcopy(Arg0: &vector<u64>): vector<u64> {
+L0:	loc1: u64
+L1:	loc2: u64
+L2:	loc3: u64
+L3:	loc4: vector<u64>
+B0:
+	0: VecPack(2, 0)
+	1: StLoc[1](loc0: vector<u64>)
+	2: LdConst[1](U64: [0, 0, 0, 0, 0, 0, 0, 0])
+	3: StLoc[2](loc1: u64)
+	4: CopyLoc[0](Arg0: &vector<u64>)
+	5: VecLen(2)
+	6: StLoc[3](loc2: u64)
+B1:
+	7: CopyLoc[2](loc1: u64)
+	8: CopyLoc[3](loc2: u64)
+	9: Lt
+	10: BrFalse(24)
+B2:
+	11: MutBorrowLoc[1](loc0: vector<u64>)
+	12: CopyLoc[0](Arg0: &vector<u64>)
+	13: CopyLoc[2](loc1: u64)
+	14: VecImmBorrow(2)
+	15: ReadRef
+	16: VecPushBack(2)
+	17: LdConst[2](U64: [1, 0, 0, 0, 0, 0, 0, 0])
+	18: StLoc[4](loc3: u64)
+	19: MoveLoc[2](loc1: u64)
+	20: MoveLoc[4](loc3: u64)
+	21: Add
+	22: StLoc[2](loc1: u64)
+	23: Branch(25)
+B3:
+	24: Branch(26)
+B4:
+	25: Branch(7)
+B5:
+	26: MoveLoc[1](loc0: vector<u64>)
+	27: StLoc[5](loc4: vector<u64>)
+	28: MoveLoc[5](loc4: vector<u64>)
+	29: Ret
+}
+}
+== END Bytecode ==
+
+task 1 'run'. lines 67-73:
+
+== BEGIN Bytecode ==
+// Move bytecode v6
+script {
+use 0000000000000000000000000000000000000000000000000000000000000042::heap;
+
+
+
+
+main() {
+B0:
+	0: Call heap::main()
+	1: Ret
+}
+}
+== END Bytecode ==
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.move
@@ -1,0 +1,73 @@
+//# publish
+module 0x42::heap {
+    use std::vector;
+
+    fun create1(): vector<u64> {
+        vector<u64>[3, 2, 1, 5, 8, 4]
+    }
+
+    fun create2(): vector<u64> {
+        vector<u64>[1, 2, 3, 4, 5, 8]
+    }
+
+    fun vcopy(x: &vector<u64>): vector<u64> {
+        let y : vector<u64> = vector::empty<u64>();
+        let i : u64 = 0;
+        let l : u64 = vector::length<u64>(x);
+        while (i < l) {
+            vector::push_back<u64>(&mut y, *vector::borrow<u64>(x, i));
+            i = i + 1;
+        };
+        y
+    }
+
+    fun sort(x: &mut vector<u64>) {
+        let i: u64 = 0;
+        while (i < vector::length<u64>(x)) {
+            let j: u64 = i + 1;
+            while (j < vector::length<u64>(x)) {
+                if (*vector::borrow<u64>(x, i) > *vector::borrow<u64>(x, j)) {
+                    vector::swap<u64>(x, i, j)
+                };
+                j = j + 1;
+            };
+            i = i + 1;
+        }
+    }
+
+    fun array_equals(x: &vector<u64>, y: &vector<u64>): bool {
+        let l1: u64 = vector::length<u64>(x);
+        let l2: u64 = vector::length<u64>(y);
+        if (l1 != l2) {
+            return false
+        };
+        let i: u64 = 0;
+        while (i < l1) {
+            if (*vector::borrow<u64>(x, i) != *vector::borrow<u64>(y, i)) {
+                return false
+            };
+            i = i + 1;
+        };
+        true
+    }
+
+    public fun main() {
+        let x: vector<u64> = create1();
+        let y: vector<u64> = create2();
+        let z: vector<u64> = vcopy(&x);
+        assert!(array_equals(&x, &z), 23);
+        assert!(array_equals(&y, &y), 29);
+        sort(&mut x);
+        assert!(array_equals(&y, &x), 31);
+        assert!(array_equals(&x, &y), 29);
+        assert!(!array_equals(&x, &z), 31);
+    }
+}
+
+//# run
+script {
+use 0x42::heap::main;
+fun mymain() {
+    main();
+}
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/sorter.move
@@ -1,4 +1,4 @@
-//# publish
+//# publish --print-bytecode
 module 0x42::heap {
     use std::vector;
 
@@ -64,7 +64,7 @@ module 0x42::heap {
     }
 }
 
-//# run
+//# run --print-bytecode
 script {
 use 0x42::heap::main;
 fun mymain() {

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/evaluation_order/arg_order.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/evaluation_order/arg_order.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+
+==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/evaluation_order/arg_order.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/evaluation_order/arg_order.move
@@ -1,0 +1,18 @@
+//# publish
+module 0x42::test {
+    public fun two_args(x: u64, b: bool): u64 {
+        if (b) {
+            x
+        } else {
+            0
+        }
+    }
+}
+
+//# run
+script {
+    use 0x42::test::two_args;
+    fun mymain() {
+        assert!(two_args(42, true) == 42, 1);
+    }
+}

--- a/third_party/move/testing-infra/transactional-test-runner/src/tasks.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/tasks.rs
@@ -233,6 +233,8 @@ pub struct PublishCommand {
     pub gas_budget: Option<u64>,
     #[clap(long = "syntax")]
     pub syntax: Option<SyntaxChoice>,
+    #[clap(long = "print-bytecode")]
+    pub print_bytecode: bool,
 }
 
 #[derive(Debug, Parser)]
@@ -261,6 +263,8 @@ pub struct RunCommand<ExtraValueArgs: ParsableValue> {
     pub syntax: Option<SyntaxChoice>,
     #[clap(name = "NAME", value_parser = parse_qualified_module_access)]
     pub name: Option<(ParsedAddress, Identifier, Identifier)>,
+    #[clap(long = "print-bytecode")]
+    pub print_bytecode: bool,
 }
 
 #[derive(Debug, Parser)]


### PR DESCRIPTION
This fixes a few bugs and closes #9629

- Usage of precompiled stdlib in transactional tests: v2 compiler currently (and probably never) supports precompiled modules, working around this
- Stack-based bytecode generator created wrong target on generic function calls
- Needed to make implicit conversion from `&mut` to `&` explicit in generated bytecode via Freeze operation

Added some additional tests while debugging this.
