### PR TITLE
[TS SDK v2] Reject invalid SHORT form for special addresses in fromString

### DIFF
--- a/ecosystem/typescript/sdk_v2/src/core/account_address.ts
+++ b/ecosystem/typescript/sdk_v2/src/core/account_address.ts
@@ -208,14 +208,14 @@ export class AccountAddress {
     if (args.input.length != AccountAddress.LONG_STRING_LENGTH + 2) {
       if (!address.isSpecial()) {
         throw new ParsingError(
-          "Hex string is not a special address, it must be represented as 0x + 64 chars.",
+          "The given hex string is not a special address, it must be represented as 0x + 64 chars.",
           AddressInvalidReason.LONG_FORM_REQUIRED_UNLESS_SPECIAL,
         );
       } else {
         // 0x + one hex char is the only valid SHORT form for special addresses.
         if (args.input.length != 3) {
           throw new ParsingError(
-            "Hex string is a special address not in LONG form, it must be 0x0 to 0xf, no padding zeroes.",
+            "The given hex string is a special address not in LONG form, it must be 0x0 to 0xf with no padding zeroes.",
             AddressInvalidReason.INVALID_PADDING_ZEROES,
           );
         }

--- a/ecosystem/typescript/sdk_v2/src/core/account_address.ts
+++ b/ecosystem/typescript/sdk_v2/src/core/account_address.ts
@@ -182,7 +182,7 @@ export class AccountAddress {
    *
    * Where:
    * - LONG is defined as 0x + 64 hex characters.
-   * - SHORT for special addresses is 0x0 to 0xf inclusive, no padding zeroes.
+   * - SHORT for special addresses is 0x0 to 0xf inclusive without padding zeroes.
    *
    * This means the following are not accepted:
    * - SHORT for non-special addresses.
@@ -215,7 +215,7 @@ export class AccountAddress {
         // 0x + one hex char is the only valid SHORT form for special addresses.
         if (args.input.length != 3) {
           throw new ParsingError(
-            "The given hex string is a special address not in LONG form, it must be 0x0 to 0xf with no padding zeroes.",
+            "The given hex string is a special address not in LONG form, it must be 0x0 to 0xf without padding zeroes.",
             AddressInvalidReason.INVALID_PADDING_ZEROES,
           );
         }

--- a/ecosystem/typescript/sdk_v2/src/core/account_address.ts
+++ b/ecosystem/typescript/sdk_v2/src/core/account_address.ts
@@ -15,6 +15,7 @@ export enum AddressInvalidReason {
   TOO_LONG = "too_long",
   LEADING_ZERO_X_REQUIRED = "leading_zero_x_required",
   LONG_FORM_REQUIRED_UNLESS_SPECIAL = "long_form_required_unless_special",
+  INVALID_PADDING_ZEROES = "INVALID_PADDING_ZEROES",
 }
 
 /**
@@ -181,7 +182,7 @@ export class AccountAddress {
    *
    * Where:
    * - LONG is defined as 0x + 64 hex characters.
-   * - SHORT for special addresses is 0x0 to 0xf inclusive.
+   * - SHORT for special addresses is 0x0 to 0xf inclusive, no padding zeroes.
    *
    * This means the following are not accepted:
    * - SHORT for non-special addresses.
@@ -202,10 +203,29 @@ export class AccountAddress {
 
     const address = AccountAddress.fromStringRelaxed(args);
 
+    // Check if the address is in LONG form. If it is not, this is only allowed for
+    // special addresses, in which case we check it is in proper SHORT form.
+    if (args.input.length != AccountAddress.LONG_STRING_LENGTH + 2) {
+      if (!address.isSpecial()) {
+        throw new ParsingError(
+          "Hex string is not a special address, it must be represented as 0x + 64 chars.",
+          AddressInvalidReason.LONG_FORM_REQUIRED_UNLESS_SPECIAL,
+        );
+      } else {
+        // 0x + one hex char is the only valid SHORT form for special addresses.
+        if (args.input.length != 3) {
+          throw new ParsingError(
+            "Hex string is a special address not in LONG form, it must be 0x0 to 0xf, no padding zeroes.",
+            AddressInvalidReason.INVALID_PADDING_ZEROES,
+          );
+        }
+      }
+    }
+
     // Assert that only special addresses can use short form.
     if (args.input.slice(2).length !== this.LONG_STRING_LENGTH && !address.isSpecial()) {
       throw new ParsingError(
-        "Hex string is not a special address, it must be represented as 0x + 64 chars.",
+        "Padding zeroes are not allowed, the address must be represented as 0x0 to 0xf for special addresses or 0x + 64 chars for all other addresses.",
         AddressInvalidReason.LONG_FORM_REQUIRED_UNLESS_SPECIAL,
       );
     }
@@ -229,6 +249,7 @@ export class AccountAddress {
    * Where:
    * - LONG is 64 hex characters.
    * - SHORT is 1 to 63 hex characters inclusive.
+   * - Padding zeroes are allowed, e.g. 0x0123 is valid.
    *
    * Learn more about the different address formats by reading AIP-40:
    * https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md.

--- a/ecosystem/typescript/sdk_v2/tests/unit/account_address.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/account_address.test.ts
@@ -43,6 +43,16 @@ const ADDRESS_F: Addresses = {
   ]),
 };
 
+const ADDRESS_F_PADDED_SHORT_FORM: Addresses = {
+  shortWith0x: "0x0f",
+  shortWithout0x: "0f",
+  longWith0x: "0x000000000000000000000000000000000000000000000000000000000000000f",
+  longWithout0x: "000000000000000000000000000000000000000000000000000000000000000f",
+  bytes: new Uint8Array([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15,
+  ]),
+};
+
 // Non-special addresses.
 
 const ADDRESS_TEN: Addresses = {
@@ -108,6 +118,15 @@ describe("AccountAddress fromStringRelaxed", () => {
     );
   });
 
+  it("parses special address with padded short form: 0x0f", async () => {
+    expect(AccountAddress.fromStringRelaxed({ input: ADDRESS_F_PADDED_SHORT_FORM.shortWith0x }).toString()).toBe(
+      ADDRESS_F.shortWith0x,
+    );
+    expect(AccountAddress.fromStringRelaxed({ input: ADDRESS_F_PADDED_SHORT_FORM.shortWithout0x }).toString()).toBe(
+      ADDRESS_F.shortWith0x,
+    );
+  });
+
   it("parses non-special address: 0x10", async () => {
     expect(AccountAddress.fromStringRelaxed({ input: ADDRESS_TEN.longWith0x }).toString()).toBe(ADDRESS_TEN.longWith0x);
     expect(AccountAddress.fromStringRelaxed({ input: ADDRESS_TEN.longWithout0x }).toString()).toBe(
@@ -153,6 +172,11 @@ describe("AccountAddress fromString", () => {
     expect(() => AccountAddress.fromString({ input: ADDRESS_F.longWithout0x })).toThrow();
     expect(AccountAddress.fromString({ input: ADDRESS_F.shortWith0x }).toString()).toBe(ADDRESS_F.shortWith0x);
     expect(() => AccountAddress.fromString({ input: ADDRESS_F.shortWithout0x })).toThrow();
+  });
+
+  it("throws when parsing special address with padded short form: 0x0f", async () => {
+    expect(() => AccountAddress.fromString({ input: ADDRESS_F_PADDED_SHORT_FORM.shortWith0x })).toThrow();
+    expect(() => AccountAddress.fromString({ input: ADDRESS_F_PADDED_SHORT_FORM.shortWithout0x })).toThrow();
   });
 
   it("parses non-special address: 0x10", async () => {


### PR DESCRIPTION
### Description
In the v2 TS SDK the `fromString` function enforces strict parsing. As written though, it wasn't exactly spec compliant in that it allowed padding zeroes in addresses. This PR fixes that.

### Test Plan
```
npx jest -- tests/unit/account_address.test.ts
```
