### PR TITLE
[TS SDK v2] Add equality methods for Hex and AccountAddress

### DIFF
--- a/ecosystem/typescript/sdk_v2/src/core/account_address.ts
+++ b/ecosystem/typescript/sdk_v2/src/core/account_address.ts
@@ -358,4 +358,16 @@ export class AccountAddress {
       };
     }
   }
+
+  /**
+   * Return whether AccountAddresses are equal. AccountAddresses are considered equal
+   * if their underlying byte data is identical.
+   *
+   * @param other The AccountAddress to compare to.
+   * @returns true if the AccountAddresses are equal, false if not.
+   */
+  equals(other: AccountAddress): boolean {
+    if (this.data.length !== other.data.length) return false;
+    return this.data.every((value, index) => value === other.data[index]);
+  }
 }

--- a/ecosystem/typescript/sdk_v2/src/core/hex.ts
+++ b/ecosystem/typescript/sdk_v2/src/core/hex.ts
@@ -162,4 +162,16 @@ export class Hex {
       };
     }
   }
+
+  /**
+   * Return whether Hex instances are equal. Hex instances are considered equal if
+   * their underlying byte data is identical.
+   *
+   * @param other The Hex instance to compare to.
+   * @returns true if the Hex instances are equal, false if not.
+   */
+  equals(other: Hex): boolean {
+    if (this.data.length !== other.data.length) return false;
+    return this.data.every((value, index) => value === other.data[index]);
+  }
 }

--- a/ecosystem/typescript/sdk_v2/tests/unit/account_address.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/account_address.test.ts
@@ -79,7 +79,7 @@ const ADDRESS_OTHER: Addresses = {
 
 // These tests show that fromStringRelaxed works happily parses all formats.
 describe("AccountAddress fromStringRelaxed", () => {
-  it("parses special address: 0x0", async () => {
+  it("parses special address: 0x0", () => {
     expect(AccountAddress.fromStringRelaxed({ input: ADDRESS_ZERO.longWith0x }).toString()).toBe(
       ADDRESS_ZERO.shortWith0x,
     );
@@ -94,7 +94,7 @@ describe("AccountAddress fromStringRelaxed", () => {
     );
   });
 
-  it("parses special address: 0x1", async () => {
+  it("parses special address: 0x1", () => {
     expect(AccountAddress.fromStringRelaxed({ input: ADDRESS_ONE.longWith0x }).toString()).toBe(
       ADDRESS_ONE.shortWith0x,
     );
@@ -109,7 +109,7 @@ describe("AccountAddress fromStringRelaxed", () => {
     );
   });
 
-  it("parses special address: 0xf", async () => {
+  it("parses special address: 0xf", () => {
     expect(AccountAddress.fromStringRelaxed({ input: ADDRESS_F.longWith0x }).toString()).toBe(ADDRESS_F.shortWith0x);
     expect(AccountAddress.fromStringRelaxed({ input: ADDRESS_F.longWithout0x }).toString()).toBe(ADDRESS_F.shortWith0x);
     expect(AccountAddress.fromStringRelaxed({ input: ADDRESS_F.shortWith0x }).toString()).toBe(ADDRESS_F.shortWith0x);
@@ -118,7 +118,7 @@ describe("AccountAddress fromStringRelaxed", () => {
     );
   });
 
-  it("parses special address with padded short form: 0x0f", async () => {
+  it("parses special address with padded short form: 0x0f", () => {
     expect(AccountAddress.fromStringRelaxed({ input: ADDRESS_F_PADDED_SHORT_FORM.shortWith0x }).toString()).toBe(
       ADDRESS_F.shortWith0x,
     );
@@ -127,7 +127,7 @@ describe("AccountAddress fromStringRelaxed", () => {
     );
   });
 
-  it("parses non-special address: 0x10", async () => {
+  it("parses non-special address: 0x10", () => {
     expect(AccountAddress.fromStringRelaxed({ input: ADDRESS_TEN.longWith0x }).toString()).toBe(ADDRESS_TEN.longWith0x);
     expect(AccountAddress.fromStringRelaxed({ input: ADDRESS_TEN.longWithout0x }).toString()).toBe(
       ADDRESS_TEN.longWith0x,
@@ -140,7 +140,7 @@ describe("AccountAddress fromStringRelaxed", () => {
     );
   });
 
-  it("parses non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", async () => {
+  it("parses non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", () => {
     expect(AccountAddress.fromStringRelaxed({ input: ADDRESS_OTHER.longWith0x }).toString()).toBe(
       ADDRESS_OTHER.longWith0x,
     );
@@ -153,47 +153,47 @@ describe("AccountAddress fromStringRelaxed", () => {
 // These tests show that fromString only parses addresses with a leading 0x and only
 // SHORT if it is a special address.
 describe("AccountAddress fromString", () => {
-  it("parses special address: 0x0", async () => {
+  it("parses special address: 0x0", () => {
     expect(AccountAddress.fromString({ input: ADDRESS_ZERO.longWith0x }).toString()).toBe(ADDRESS_ZERO.shortWith0x);
     expect(() => AccountAddress.fromString({ input: ADDRESS_ZERO.longWithout0x })).toThrow();
     expect(AccountAddress.fromString({ input: ADDRESS_ZERO.shortWith0x }).toString()).toBe(ADDRESS_ZERO.shortWith0x);
     expect(() => AccountAddress.fromString({ input: ADDRESS_ZERO.shortWithout0x })).toThrow();
   });
 
-  it("parses special address: 0x1", async () => {
+  it("parses special address: 0x1", () => {
     expect(AccountAddress.fromString({ input: ADDRESS_ONE.longWith0x }).toString()).toBe(ADDRESS_ONE.shortWith0x);
     expect(() => AccountAddress.fromString({ input: ADDRESS_ONE.longWithout0x })).toThrow();
     expect(AccountAddress.fromString({ input: ADDRESS_ONE.shortWith0x }).toString()).toBe(ADDRESS_ONE.shortWith0x);
     expect(() => AccountAddress.fromString({ input: ADDRESS_ONE.shortWithout0x })).toThrow();
   });
 
-  it("parses special address: 0xf", async () => {
+  it("parses special address: 0xf", () => {
     expect(AccountAddress.fromString({ input: ADDRESS_F.longWith0x }).toString()).toBe(ADDRESS_F.shortWith0x);
     expect(() => AccountAddress.fromString({ input: ADDRESS_F.longWithout0x })).toThrow();
     expect(AccountAddress.fromString({ input: ADDRESS_F.shortWith0x }).toString()).toBe(ADDRESS_F.shortWith0x);
     expect(() => AccountAddress.fromString({ input: ADDRESS_F.shortWithout0x })).toThrow();
   });
 
-  it("throws when parsing special address with padded short form: 0x0f", async () => {
+  it("throws when parsing special address with padded short form: 0x0f", () => {
     expect(() => AccountAddress.fromString({ input: ADDRESS_F_PADDED_SHORT_FORM.shortWith0x })).toThrow();
     expect(() => AccountAddress.fromString({ input: ADDRESS_F_PADDED_SHORT_FORM.shortWithout0x })).toThrow();
   });
 
-  it("parses non-special address: 0x10", async () => {
+  it("parses non-special address: 0x10", () => {
     expect(AccountAddress.fromString({ input: ADDRESS_TEN.longWith0x }).toString()).toBe(ADDRESS_TEN.longWith0x);
     expect(() => AccountAddress.fromString({ input: ADDRESS_TEN.longWithout0x })).toThrow();
     expect(() => AccountAddress.fromString({ input: ADDRESS_TEN.shortWith0x })).toThrow();
     expect(() => AccountAddress.fromString({ input: ADDRESS_TEN.shortWithout0x })).toThrow();
   });
 
-  it("parses non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", async () => {
+  it("parses non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", () => {
     expect(AccountAddress.fromString({ input: ADDRESS_OTHER.longWith0x }).toString()).toBe(ADDRESS_OTHER.longWith0x);
     expect(() => AccountAddress.fromString({ input: ADDRESS_OTHER.longWithout0x })).toThrow();
   });
 });
 
 describe("AccountAddress fromHexInput", () => {
-  it("parses special address: 0x1", async () => {
+  it("parses special address: 0x1", () => {
     expect(AccountAddress.fromHexInput({ input: ADDRESS_ONE.longWith0x }).toString()).toBe(ADDRESS_ONE.shortWith0x);
     expect(() => AccountAddress.fromHexInput({ input: ADDRESS_ONE.longWithout0x })).toThrow();
     expect(AccountAddress.fromHexInput({ input: ADDRESS_ONE.shortWith0x }).toString()).toBe(ADDRESS_ONE.shortWith0x);
@@ -201,7 +201,7 @@ describe("AccountAddress fromHexInput", () => {
     expect(AccountAddress.fromHexInput({ input: ADDRESS_ONE.bytes }).toString()).toBe(ADDRESS_ONE.shortWith0x);
   });
 
-  it("parses non-special address: 0x10", async () => {
+  it("parses non-special address: 0x10", () => {
     expect(AccountAddress.fromHexInput({ input: ADDRESS_TEN.longWith0x }).toString()).toBe(ADDRESS_TEN.longWith0x);
     expect(() => AccountAddress.fromHexInput({ input: ADDRESS_TEN.longWithout0x })).toThrow();
     expect(() => AccountAddress.fromHexInput({ input: ADDRESS_TEN.shortWith0x })).toThrow();
@@ -209,7 +209,7 @@ describe("AccountAddress fromHexInput", () => {
     expect(AccountAddress.fromHexInput({ input: ADDRESS_TEN.bytes }).toString()).toBe(ADDRESS_TEN.longWith0x);
   });
 
-  it("parses non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", async () => {
+  it("parses non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", () => {
     expect(AccountAddress.fromHexInput({ input: ADDRESS_OTHER.longWith0x }).toString()).toBe(ADDRESS_OTHER.longWith0x);
     expect(() => AccountAddress.fromHexInput({ input: ADDRESS_OTHER.longWithout0x })).toThrow();
     expect(AccountAddress.fromHexInput({ input: ADDRESS_OTHER.bytes }).toString()).toBe(ADDRESS_OTHER.shortWith0x);
@@ -217,7 +217,7 @@ describe("AccountAddress fromHexInput", () => {
 });
 
 describe("AccountAddress fromHexInputRelaxed", () => {
-  it("parses special address: 0x1", async () => {
+  it("parses special address: 0x1", () => {
     expect(AccountAddress.fromHexInputRelaxed({ input: ADDRESS_ONE.longWith0x }).toString()).toBe(
       ADDRESS_ONE.shortWith0x,
     );
@@ -233,7 +233,7 @@ describe("AccountAddress fromHexInputRelaxed", () => {
     expect(AccountAddress.fromHexInputRelaxed({ input: ADDRESS_ONE.bytes }).toString()).toBe(ADDRESS_ONE.shortWith0x);
   });
 
-  it("parses non-special address: 0x10", async () => {
+  it("parses non-special address: 0x10", () => {
     expect(AccountAddress.fromHexInputRelaxed({ input: ADDRESS_TEN.longWith0x }).toString()).toBe(
       ADDRESS_TEN.longWith0x,
     );
@@ -249,7 +249,7 @@ describe("AccountAddress fromHexInputRelaxed", () => {
     expect(AccountAddress.fromHexInputRelaxed({ input: ADDRESS_TEN.bytes }).toString()).toBe(ADDRESS_TEN.longWith0x);
   });
 
-  it("parses non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", async () => {
+  it("parses non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", () => {
     expect(AccountAddress.fromHexInputRelaxed({ input: ADDRESS_OTHER.longWith0x }).toString()).toBe(
       ADDRESS_OTHER.longWith0x,
     );
@@ -263,15 +263,15 @@ describe("AccountAddress fromHexInputRelaxed", () => {
 });
 
 describe("AccountAddress toUint8Array", () => {
-  it("correctly returns bytes for special address: 0x1", async () => {
+  it("correctly returns bytes for special address: 0x1", () => {
     expect(AccountAddress.fromHexInput({ input: ADDRESS_ONE.longWith0x }).toUint8Array()).toEqual(ADDRESS_ONE.bytes);
   });
 
-  it("correctly returns bytes for  non-special address: 0x10", async () => {
+  it("correctly returns bytes for  non-special address: 0x10", () => {
     expect(AccountAddress.fromHexInput({ input: ADDRESS_TEN.longWith0x }).toUint8Array()).toEqual(ADDRESS_TEN.bytes);
   });
 
-  it("correctly returns bytes for  non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", async () => {
+  it("correctly returns bytes for  non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", () => {
     expect(AccountAddress.fromHexInput({ input: ADDRESS_OTHER.longWith0x }).toUint8Array()).toEqual(
       ADDRESS_OTHER.bytes,
     );
@@ -279,44 +279,43 @@ describe("AccountAddress toUint8Array", () => {
 });
 
 describe("AccountAddress toStringWithoutPrefix", () => {
-  it("formats special address correctly: 0x0", async () => {
+  it("formats special address correctly: 0x0", () => {
     const addr = AccountAddress.fromString({ input: ADDRESS_ZERO.shortWith0x });
     expect(addr.toStringWithoutPrefix()).toBe(ADDRESS_ZERO.shortWithout0x);
   });
 
-  it("formats non-special address correctly: 0x10", async () => {
+  it("formats non-special address correctly: 0x10", () => {
     const addr = AccountAddress.fromString({ input: ADDRESS_TEN.longWith0x });
     expect(addr.toStringWithoutPrefix()).toBe(ADDRESS_TEN.longWithout0x);
   });
 });
 
 describe("AccountAddress toStringLong", () => {
-  it("formats special address correctly: 0x0", async () => {
+  it("formats special address correctly: 0x0", () => {
     const addr = AccountAddress.fromString({ input: ADDRESS_ZERO.shortWith0x });
     expect(addr.toStringLong()).toBe(ADDRESS_ZERO.longWith0x);
   });
 
-  it("formats non-special address correctly: 0x10", async () => {
+  it("formats non-special address correctly: 0x10", () => {
     const addr = AccountAddress.fromString({ input: ADDRESS_TEN.longWith0x });
     expect(addr.toStringLong()).toBe(ADDRESS_TEN.longWith0x);
   });
 });
 
 describe("AccountAddress toStringLongWithoutPrefix", () => {
-  it("formats special address correctly: 0x0", async () => {
-    console.log(AccountAddress.fromHexInput({ input: ADDRESS_ZERO.shortWith0x }).toUint8Array());
+  it("formats special address correctly: 0x0", () => {
     const addr = AccountAddress.fromString({ input: ADDRESS_ZERO.shortWith0x });
     expect(addr.toStringLongWithoutPrefix()).toBe(ADDRESS_ZERO.longWithout0x);
   });
 
-  it("formats non-special address correctly: 0x10", async () => {
+  it("formats non-special address correctly: 0x10", () => {
     const addr = AccountAddress.fromString({ input: ADDRESS_TEN.longWith0x });
     expect(addr.toStringLongWithoutPrefix()).toBe(ADDRESS_TEN.longWithout0x);
   });
 });
 
 describe("AccountAddress other parsing", () => {
-  it("throws exception when initiating from too long hex string", async () => {
+  it("throws exception when initiating from too long hex string", () => {
     expect(() => {
       AccountAddress.fromString({ input: `${ADDRESS_ONE.longWith0x}1` });
     }).toThrow("Hex string is too long, must be 1 to 64 chars long, excluding the leading 0x.");
@@ -335,7 +334,7 @@ describe("AccountAddress other parsing", () => {
     expect(() => AccountAddress.fromString({ input: "0za" })).toThrow();
   });
 
-  it("isValid is false if too long with 0xf", async () => {
+  it("isValid is false if too long with 0xf", () => {
     const { valid, invalidReason, invalidReasonMessage } = AccountAddress.isValid({
       input: `0x00${ADDRESS_F.longWithout0x}`,
     });
@@ -344,10 +343,16 @@ describe("AccountAddress other parsing", () => {
     expect(invalidReasonMessage).toBe("Hex string is too long, must be 1 to 64 chars long, excluding the leading 0x.");
   });
 
-  it("isValid is true if account address string is valid", async () => {
+  it("isValid is true if account address string is valid", () => {
     const { valid, invalidReason, invalidReasonMessage } = AccountAddress.isValid({ input: ADDRESS_F.longWith0x });
     expect(valid).toBe(true);
     expect(invalidReason).toBeUndefined();
     expect(invalidReasonMessage).toBeUndefined();
+  });
+
+  it("compares equality with equals as expected", () => {
+    const addressOne = AccountAddress.fromStringRelaxed({ input: "0x123" });
+    const addressTwo = AccountAddress.fromStringRelaxed({ input: "0x123" });
+    expect(addressOne.equals(addressTwo)).toBeTruthy();
   });
 });

--- a/ecosystem/typescript/sdk_v2/tests/unit/hex.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/hex.test.ts
@@ -90,3 +90,9 @@ test("isValid returns false when parsing hex of invalid length", () => {
   expect(result.invalidReason).toBe(HexInvalidReason.INVALID_LENGTH);
   expect(result.invalidReasonMessage).toBe("Hex string must be an even number of hex characters.");
 });
+
+test("compares equality with equals as expected", () => {
+  const hexOne = Hex.fromString({ str: "0x11" });
+  const hexTwo = Hex.fromString({ str: "0x11" });
+  expect(hexOne.equals(hexTwo)).toBeTruthy();
+});


### PR DESCRIPTION
### Description
Due to the magic of JS, `===` will return false for instances of these classes that have the same underlying data, and sadly there is nothing we can do about that. To remedy that, we offer these `equals` methods to help with comparing instances of these classes.

### Test Plan
```
npx jest -- tests/unit/*
```
