### PR TITLE
 [Python SDK] Make from_str strict, add from_str_relaxed

### DIFF
--- a/ecosystem/python/sdk/CHANGELOG.md
+++ b/ecosystem/python/sdk/CHANGELOG.md
@@ -3,16 +3,17 @@
 All notable changes to the Aptos Python SDK will be captured in this file. This changelog is written by hand for now.
 
 ## 0.7.0
-- Port remaining sync examples to async (hello-blockchain, multisig, your-coin)
-- Updated token client to use events to acquire minted tokens
-- Update many dependencies and set Python 3.8.1 as the minimum requirement
-- Add support for an experimental chunked uploader
-- Add experimental support for the Aptos CLI enabling local end-to-end testing, package building, and package integration tests
+- **[Breaking Change]**: The `from_str` function on `AccountAddress` has been updated to conform to the strict parsing described by [AIP-40](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md). For the relaxed parsing behavior of this function prior to this change, use `AccountAddress.from_str_relaxed`.
 - **[Breaking Change]**: Rewrote the large package publisher to support large modules too
 - **[Breaking Change]**: Delete sync client
 - **[Breaking Change]**: Removed the `hex` function from `AccountAddress`. Instead of `addr.hex()` use `str(addr)`.
 - **[Breaking Change]**: The string representation of `AccountAddress` now conforms to [AIP-40](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md).
 - **[Breaking Change]**: `AccountAddress.from_hex` and `PrivateKey.from_hex` have been renamed to `from_str`.
+- Port remaining sync examples to async (hello-blockchain, multisig, your-coin)
+- Updated token client to use events to acquire minted tokens
+- Update many dependencies and set Python 3.8.1 as the minimum requirement
+- Add support for an experimental chunked uploader
+- Add experimental support for the Aptos CLI enabling local end-to-end testing, package building, and package integration tests
 
 ## 0.6.4
 - Change sync client library from httpX to requests due to latency concerns.

--- a/ecosystem/python/sdk/aptos_sdk/account_address.py
+++ b/ecosystem/python/sdk/aptos_sdk/account_address.py
@@ -18,6 +18,12 @@ class AuthKeyScheme:
     DeriveResourceAccountAddress: bytes = b"\xFF"
 
 
+class ParseAddressError(Exception):
+    """
+    There was an error parsing an address.
+    """
+
+
 class AccountAddress:
     address: bytes
     LENGTH: int = 32
@@ -26,7 +32,7 @@ class AccountAddress:
         self.address = address
 
         if len(address) != AccountAddress.LENGTH:
-            raise Exception("Expected address of length 32")
+            raise ParseAddressError("Expected address of length 32")
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, AccountAddress):
@@ -75,10 +81,112 @@ class AccountAddress:
 
     @staticmethod
     def from_str(address: str) -> AccountAddress:
+        """
+        NOTE: This function has strict parsing behavior. For relaxed behavior, please use
+        `from_string_relaxed` function.
+
+        Creates an instance of AccountAddress from a hex string.
+
+        This function allows only the strictest formats defined by AIP-40. In short this
+        means only the following formats are accepted:
+        - LONG
+        - SHORT for special addresses
+
+        Where:
+        - LONG is defined as 0x + 64 hex characters.
+        - SHORT for special addresses is 0x0 to 0xf inclusive without padding zeroes.
+
+        This means the following are not accepted:
+        - SHORT for non-special addresses.
+        - Any address without a leading 0x.
+
+        Learn more about the different address formats by reading AIP-40:
+        https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md.
+
+        Parameters:
+        - address (str): A hex string representing an account address.
+
+        Returns:
+        - AccountAddress: An instance of AccountAddress.
+        """
+        # Assert the string starts with 0x.
+        if not address.startswith("0x"):
+            raise RuntimeError("Hex string must start with a leading 0x.")
+
+        out = AccountAddress.from_str_relaxed(address)
+
+        # Check if the address is in LONG form. If it is not, this is only allowed for
+        # special addresses, in which case we check it is in proper SHORT form.
+        if len(address) != AccountAddress.LENGTH * 2 + 2:
+            if not out.is_special():
+                raise RuntimeError(
+                    "The given hex string is not a special address, it must be represented "
+                    "as 0x + 64 chars."
+                )
+            else:
+                # 0x + one hex char is the only valid SHORT form for special addresses.
+                if len(address) != 3:
+                    raise RuntimeError(
+                        "The given hex string is a special address not in LONG form, "
+                        "it must be 0x0 to 0xf without padding zeroes."
+                    )
+
+        # Assert that only special addresses can use short form.
+        if len(address[2:]) != AccountAddress.LENGTH * 2 and not out.is_special():
+            raise RuntimeError(
+                "Padding zeroes are not allowed, the address must be represented as "
+                "0x0 to 0xf for special addresses or 0x + 64 chars for all other addresses."
+            )
+
+        return out
+
+    @staticmethod
+    def from_str_relaxed(address: str) -> AccountAddress:
+        """
+        NOTE: This function has relaxed parsing behavior. For strict behavior, please use
+        the `from_string` function. Where possible, use `from_string` rather than this
+        function. `from_string_relaxed` is only provided for backwards compatibility.
+
+        Creates an instance of AccountAddress from a hex string.
+
+        This function allows all formats defined by AIP-40. In short, this means the
+        following formats are accepted:
+        - LONG, with or without leading 0x
+        - SHORT, with or without leading 0x
+
+        Where:
+        - LONG is 64 hex characters.
+        - SHORT is 1 to 63 hex characters inclusive.
+        - Padding zeroes are allowed, e.g., 0x0123 is valid.
+
+        Learn more about the different address formats by reading AIP-40:
+        https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md.
+
+        Parameters:
+        - address (str): A hex string representing an account address.
+
+        Returns:
+        - AccountAddress: An instance of AccountAddress.
+        """
         addr = address
 
+        # Strip 0x prefix if present.
         if address[0:2] == "0x":
             addr = address[2:]
+
+        # Assert the address is at least one hex char long.
+        if len(addr) < 1:
+            raise RuntimeError(
+                "Hex string is too short, must be 1 to 64 chars long, excluding the "
+                "leading 0x."
+            )
+
+        # Assert the address is at most 64 hex chars long.
+        if len(addr) > 64:
+            raise RuntimeError(
+                "Hex string is too long, must be 1 to 64 chars long, excluding the "
+                "leading 0x."
+            )
 
         if len(addr) < AccountAddress.LENGTH * 2:
             pad = "0" * (AccountAddress.LENGTH * 2 - len(addr))
@@ -150,6 +258,100 @@ class AccountAddress:
         serializer.fixed_bytes(self.address)
 
 
+###
+### Tests
+###
+
+
+from dataclasses import dataclass
+
+
+@dataclass(init=True, frozen=True)
+class TestAddresses:
+    shortWith0x: str
+    shortWithout0x: str
+    longWith0x: str
+    longWithout0x: str
+    bytes: bytes
+
+
+ADDRESS_ZERO = TestAddresses(
+    shortWith0x="0x0",
+    shortWithout0x="0",
+    longWith0x="0x0000000000000000000000000000000000000000000000000000000000000000",
+    longWithout0x="0000000000000000000000000000000000000000000000000000000000000000",
+    bytes=bytes([0] * 32),
+)
+
+ADDRESS_F = TestAddresses(
+    shortWith0x="0xf",
+    shortWithout0x="f",
+    longWith0x="0x000000000000000000000000000000000000000000000000000000000000000f",
+    longWithout0x="000000000000000000000000000000000000000000000000000000000000000f",
+    bytes=bytes([0] * 31 + [15]),
+)
+
+ADDRESS_F_PADDED_SHORT_FORM = TestAddresses(
+    shortWith0x="0x0f",
+    shortWithout0x="0f",
+    # The rest of these below are the same as for ADDRESS_F.
+    longWith0x="0x000000000000000000000000000000000000000000000000000000000000000f",
+    longWithout0x="000000000000000000000000000000000000000000000000000000000000000f",
+    bytes=bytes([0] * 31 + [15]),
+)
+
+ADDRESS_TEN = TestAddresses(
+    shortWith0x="0x10",
+    shortWithout0x="10",
+    longWith0x="0x0000000000000000000000000000000000000000000000000000000000000010",
+    longWithout0x="0000000000000000000000000000000000000000000000000000000000000010",
+    bytes=bytes([0] * 31 + [16]),
+)
+
+ADDRESS_OTHER = TestAddresses(
+    shortWith0x="0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0",
+    shortWithout0x="ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0",
+    longWith0x="0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0",
+    longWithout0x="ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0",
+    bytes=bytes(
+        [
+            202,
+            132,
+            50,
+            121,
+            227,
+            66,
+            113,
+            68,
+            206,
+            173,
+            94,
+            77,
+            89,
+            153,
+            163,
+            208,
+            202,
+            132,
+            50,
+            121,
+            227,
+            66,
+            113,
+            68,
+            206,
+            173,
+            94,
+            77,
+            89,
+            153,
+            163,
+            208,
+        ]
+    ),
+)
+
+
 class Test(unittest.TestCase):
     def test_multi_ed25519(self):
         private_key_1 = ed25519.PrivateKey.from_str(
@@ -162,39 +364,39 @@ class Test(unittest.TestCase):
             [private_key_1.public_key(), private_key_2.public_key()], 1
         )
 
-        expected = AccountAddress.from_str(
+        expected = AccountAddress.from_str_relaxed(
             "835bb8c5ee481062946b18bbb3b42a40b998d6bf5316ca63834c959dc739acf0"
         )
         actual = AccountAddress.from_multi_ed25519(multisig_public_key)
         self.assertEqual(actual, expected)
 
     def test_resource_account(self):
-        base_address = AccountAddress.from_str("b0b")
-        expected = AccountAddress.from_str(
+        base_address = AccountAddress.from_str_relaxed("b0b")
+        expected = AccountAddress.from_str_relaxed(
             "ee89f8c763c27f9d942d496c1a0dcf32d5eacfe78416f9486b8db66155b163b0"
         )
         actual = AccountAddress.for_resource_account(base_address, b"\x0b\x00\x0b")
         self.assertEqual(actual, expected)
 
     def test_named_object(self):
-        base_address = AccountAddress.from_str("b0b")
-        expected = AccountAddress.from_str(
+        base_address = AccountAddress.from_str_relaxed("b0b")
+        expected = AccountAddress.from_str_relaxed(
             "f417184602a828a3819edf5e36285ebef5e4db1ba36270be580d6fd2d7bcc321"
         )
         actual = AccountAddress.for_named_object(base_address, b"bob's collection")
         self.assertEqual(actual, expected)
 
     def test_collection(self):
-        base_address = AccountAddress.from_str("b0b")
-        expected = AccountAddress.from_str(
+        base_address = AccountAddress.from_str_relaxed("b0b")
+        expected = AccountAddress.from_str_relaxed(
             "f417184602a828a3819edf5e36285ebef5e4db1ba36270be580d6fd2d7bcc321"
         )
         actual = AccountAddress.for_named_collection(base_address, "bob's collection")
         self.assertEqual(actual, expected)
 
     def test_token(self):
-        base_address = AccountAddress.from_str("b0b")
-        expected = AccountAddress.from_str(
+        base_address = AccountAddress.from_str_relaxed("b0b")
+        expected = AccountAddress.from_str_relaxed(
             "e20d1f22a5400ba7be0f515b7cbd00edc42dbcc31acc01e31128b2b5ddb3c56e"
         )
         actual = AccountAddress.for_named_token(
@@ -206,7 +408,7 @@ class Test(unittest.TestCase):
         # Test special address: 0x0
         self.assertEqual(
             str(
-                AccountAddress.from_str(
+                AccountAddress.from_str_relaxed(
                     "0x0000000000000000000000000000000000000000000000000000000000000000"
                 )
             ),
@@ -216,7 +418,7 @@ class Test(unittest.TestCase):
         # Test special address: 0x1
         self.assertEqual(
             str(
-                AccountAddress.from_str(
+                AccountAddress.from_str_relaxed(
                     "0x0000000000000000000000000000000000000000000000000000000000000001"
                 )
             ),
@@ -226,7 +428,7 @@ class Test(unittest.TestCase):
         # Test special address: 0x4
         self.assertEqual(
             str(
-                AccountAddress.from_str(
+                AccountAddress.from_str_relaxed(
                     "0x0000000000000000000000000000000000000000000000000000000000000004"
                 )
             ),
@@ -236,7 +438,7 @@ class Test(unittest.TestCase):
         # Test special address: 0xf
         self.assertEqual(
             str(
-                AccountAddress.from_str(
+                AccountAddress.from_str_relaxed(
                     "0x000000000000000000000000000000000000000000000000000000000000000f"
                 )
             ),
@@ -245,7 +447,7 @@ class Test(unittest.TestCase):
 
         # Test special address from short no 0x: d
         self.assertEqual(
-            str(AccountAddress.from_str("d")),
+            str(AccountAddress.from_str_relaxed("d")),
             "0xd",
         )
 
@@ -253,7 +455,7 @@ class Test(unittest.TestCase):
         # 0x0000000000000000000000000000000000000000000000000000000000000010
         value = "0x0000000000000000000000000000000000000000000000000000000000000010"
         self.assertEqual(
-            str(AccountAddress.from_str(value)),
+            str(AccountAddress.from_str_relaxed(value)),
             value,
         )
 
@@ -261,7 +463,7 @@ class Test(unittest.TestCase):
         # 0x000000000000000000000000000000000000000000000000000000000000001f
         value = "0x000000000000000000000000000000000000000000000000000000000000001f"
         self.assertEqual(
-            str(AccountAddress.from_str(value)),
+            str(AccountAddress.from_str_relaxed(value)),
             value,
         )
 
@@ -269,7 +471,7 @@ class Test(unittest.TestCase):
         # 0x00000000000000000000000000000000000000000000000000000000000000a0
         value = "0x00000000000000000000000000000000000000000000000000000000000000a0"
         self.assertEqual(
-            str(AccountAddress.from_str(value)),
+            str(AccountAddress.from_str_relaxed(value)),
             value,
         )
 
@@ -277,7 +479,7 @@ class Test(unittest.TestCase):
         # ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0
         value = "ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0"
         self.assertEqual(
-            str(AccountAddress.from_str(value)),
+            str(AccountAddress.from_str_relaxed(value)),
             f"0x{value}",
         )
 
@@ -285,7 +487,7 @@ class Test(unittest.TestCase):
         # 1000000000000000000000000000000000000000000000000000000000000000
         value = "1000000000000000000000000000000000000000000000000000000000000000"
         self.assertEqual(
-            str(AccountAddress.from_str(value)),
+            str(AccountAddress.from_str_relaxed(value)),
             f"0x{value}",
         )
 
@@ -294,6 +496,153 @@ class Test(unittest.TestCase):
         # 0f00000000000000000000000000000000000000000000000000000000000000
         value = "0f00000000000000000000000000000000000000000000000000000000000000"
         self.assertEqual(
-            str(AccountAddress.from_str(value)),
+            str(AccountAddress.from_str_relaxed(value)),
             f"0x{value}",
+        )
+
+    def test_from_str_relaxed(self):
+        # Demonstrate that all formats are accepted for 0x0.
+        self.assertEqual(
+            str(AccountAddress.from_str_relaxed(ADDRESS_ZERO.longWith0x)),
+            ADDRESS_ZERO.shortWith0x,
+        )
+        self.assertEqual(
+            str(AccountAddress.from_str_relaxed(ADDRESS_ZERO.longWithout0x)),
+            ADDRESS_ZERO.shortWith0x,
+        )
+        self.assertEqual(
+            str(AccountAddress.from_str_relaxed(ADDRESS_ZERO.shortWith0x)),
+            ADDRESS_ZERO.shortWith0x,
+        )
+        self.assertEqual(
+            str(AccountAddress.from_str_relaxed(ADDRESS_ZERO.shortWithout0x)),
+            ADDRESS_ZERO.shortWith0x,
+        )
+
+        # Demonstrate that all formats are accepted for 0xf.
+        self.assertEqual(
+            str(AccountAddress.from_str_relaxed(ADDRESS_F.longWith0x)),
+            ADDRESS_F.shortWith0x,
+        )
+        self.assertEqual(
+            str(AccountAddress.from_str_relaxed(ADDRESS_F.longWithout0x)),
+            ADDRESS_F.shortWith0x,
+        )
+        self.assertEqual(
+            str(AccountAddress.from_str_relaxed(ADDRESS_F.shortWith0x)),
+            ADDRESS_F.shortWith0x,
+        )
+        self.assertEqual(
+            str(AccountAddress.from_str_relaxed(ADDRESS_F.shortWithout0x)),
+            ADDRESS_F.shortWith0x,
+        )
+
+        # Demonstrate that padding zeroes are allowed for 0x0f.
+        self.assertEqual(
+            str(
+                AccountAddress.from_str_relaxed(ADDRESS_F_PADDED_SHORT_FORM.shortWith0x)
+            ),
+            ADDRESS_F.shortWith0x,
+        )
+        self.assertEqual(
+            str(
+                AccountAddress.from_str_relaxed(
+                    ADDRESS_F_PADDED_SHORT_FORM.shortWithout0x
+                )
+            ),
+            ADDRESS_F.shortWith0x,
+        )
+
+        # Demonstrate that all formats are accepted for 0x10.
+        self.assertEqual(
+            str(AccountAddress.from_str_relaxed(ADDRESS_TEN.longWith0x)),
+            ADDRESS_TEN.longWith0x,
+        )
+        self.assertEqual(
+            str(AccountAddress.from_str_relaxed(ADDRESS_TEN.longWithout0x)),
+            ADDRESS_TEN.longWith0x,
+        )
+        self.assertEqual(
+            str(AccountAddress.from_str_relaxed(ADDRESS_TEN.shortWith0x)),
+            ADDRESS_TEN.longWith0x,
+        )
+        self.assertEqual(
+            str(AccountAddress.from_str_relaxed(ADDRESS_TEN.shortWithout0x)),
+            ADDRESS_TEN.longWith0x,
+        )
+
+        # Demonstrate that all formats are accepted for other addresses.
+        self.assertEqual(
+            str(AccountAddress.from_str_relaxed(ADDRESS_OTHER.longWith0x)),
+            ADDRESS_OTHER.longWith0x,
+        )
+        self.assertEqual(
+            str(AccountAddress.from_str_relaxed(ADDRESS_OTHER.longWithout0x)),
+            ADDRESS_OTHER.longWith0x,
+        )
+
+    def test_from_str(self):
+        # Demonstrate that only LONG and SHORT are accepted for 0x0.
+        self.assertEqual(
+            str(AccountAddress.from_str(ADDRESS_ZERO.longWith0x)),
+            ADDRESS_ZERO.shortWith0x,
+        )
+        self.assertRaises(
+            RuntimeError, AccountAddress.from_str, ADDRESS_ZERO.longWithout0x
+        )
+        self.assertEqual(
+            str(AccountAddress.from_str(ADDRESS_ZERO.shortWith0x)),
+            ADDRESS_ZERO.shortWith0x,
+        )
+        self.assertRaises(
+            RuntimeError, AccountAddress.from_str, ADDRESS_ZERO.shortWithout0x
+        )
+
+        # Demonstrate that only LONG and SHORT are accepted for 0xf.
+        self.assertEqual(
+            str(AccountAddress.from_str(ADDRESS_F.longWith0x)), ADDRESS_F.shortWith0x
+        )
+        self.assertRaises(
+            RuntimeError, AccountAddress.from_str, ADDRESS_F.longWithout0x
+        )
+        self.assertEqual(
+            str(AccountAddress.from_str(ADDRESS_F.shortWith0x)), ADDRESS_F.shortWith0x
+        )
+        self.assertRaises(
+            RuntimeError, AccountAddress.from_str, ADDRESS_F.shortWithout0x
+        )
+
+        # Demonstrate that padding zeroes are not allowed for 0x0f.
+        self.assertRaises(
+            RuntimeError,
+            AccountAddress.from_str,
+            ADDRESS_F_PADDED_SHORT_FORM.shortWith0x,
+        )
+        self.assertRaises(
+            RuntimeError,
+            AccountAddress.from_str,
+            ADDRESS_F_PADDED_SHORT_FORM.shortWithout0x,
+        )
+
+        # Demonstrate that only LONG format is accepted for 0x10.
+        self.assertEqual(
+            str(AccountAddress.from_str(ADDRESS_TEN.longWith0x)), ADDRESS_TEN.longWith0x
+        )
+        self.assertRaises(
+            RuntimeError, AccountAddress.from_str, ADDRESS_TEN.longWithout0x
+        )
+        self.assertRaises(
+            RuntimeError, AccountAddress.from_str, ADDRESS_TEN.shortWith0x
+        )
+        self.assertRaises(
+            RuntimeError, AccountAddress.from_str, ADDRESS_TEN.shortWithout0x
+        )
+
+        # Demonstrate that only LONG format is accepted for other addresses.
+        self.assertEqual(
+            str(AccountAddress.from_str(ADDRESS_OTHER.longWith0x)),
+            ADDRESS_OTHER.longWith0x,
+        )
+        self.assertRaises(
+            RuntimeError, AccountAddress.from_str, ADDRESS_OTHER.longWithout0x
         )


### PR DESCRIPTION
### Description
In this PR the `from_str` function on `AccountAddress` has been updated to conform to the strict parsing described by [AIP-40](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md). For the relaxed parsing behavior of this function prior to this change, folks can use `AccountAddress.from_str_relaxed`.

Whereas with Rust we will almost certainly keep `from_str` the relaxed variant for now, with Python we're still at 0.x.x, so we're at greater liberty to make changes like this. Open to contrary thoughts though.

### Test Plan
```
poetry run python -m unittest aptos_sdk/account_address.py
```
