### PR TITLE
[Block Executor] Refactor view & output traits & mvhashmap

### DIFF
--- a/aptos-move/aptos-vm-types/src/change_set.rs
+++ b/aptos-move/aptos-vm-types/src/change_set.rs
@@ -13,8 +13,8 @@ use aptos_types::{
 use move_binary_format::errors::Location;
 use move_core_types::vm_status::{err_msg, StatusCode, VMStatus};
 use std::collections::{
-    btree_map::Entry::{Occupied, Vacant},
-    BTreeMap,
+    hash_map::Entry::{Occupied, Vacant},
+    HashMap,
 };
 
 /// A change set produced by the VM.
@@ -23,10 +23,10 @@ use std::collections::{
 /// VM. For storage backends, use `ChangeSet`.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct VMChangeSet {
-    resource_write_set: BTreeMap<StateKey, WriteOp>,
-    module_write_set: BTreeMap<StateKey, WriteOp>,
-    aggregator_write_set: BTreeMap<StateKey, WriteOp>,
-    aggregator_delta_set: BTreeMap<StateKey, DeltaOp>,
+    resource_write_set: HashMap<StateKey, WriteOp>,
+    module_write_set: HashMap<StateKey, WriteOp>,
+    aggregator_write_set: HashMap<StateKey, WriteOp>,
+    aggregator_delta_set: HashMap<StateKey, DeltaOp>,
     events: Vec<ContractEvent>,
 }
 
@@ -49,19 +49,19 @@ macro_rules! squash_writes_pair {
 impl VMChangeSet {
     pub fn empty() -> Self {
         Self {
-            resource_write_set: BTreeMap::new(),
-            module_write_set: BTreeMap::new(),
-            aggregator_write_set: BTreeMap::new(),
-            aggregator_delta_set: BTreeMap::new(),
+            resource_write_set: HashMap::new(),
+            module_write_set: HashMap::new(),
+            aggregator_write_set: HashMap::new(),
+            aggregator_delta_set: HashMap::new(),
             events: vec![],
         }
     }
 
     pub fn new(
-        resource_write_set: BTreeMap<StateKey, WriteOp>,
-        module_write_set: BTreeMap<StateKey, WriteOp>,
-        aggregator_write_set: BTreeMap<StateKey, WriteOp>,
-        aggregator_delta_set: BTreeMap<StateKey, DeltaOp>,
+        resource_write_set: HashMap<StateKey, WriteOp>,
+        module_write_set: HashMap<StateKey, WriteOp>,
+        aggregator_write_set: HashMap<StateKey, WriteOp>,
+        aggregator_delta_set: HashMap<StateKey, DeltaOp>,
         events: Vec<ContractEvent>,
         checker: &dyn CheckChangeSet,
     ) -> anyhow::Result<Self, VMStatus> {
@@ -92,8 +92,8 @@ impl VMChangeSet {
 
         // There should be no aggregator writes if we have a change set from
         // storage.
-        let mut resource_write_set = BTreeMap::new();
-        let mut module_write_set = BTreeMap::new();
+        let mut resource_write_set = HashMap::new();
+        let mut module_write_set = HashMap::new();
 
         for (state_key, write_op) in write_set {
             if matches!(state_key.inner(), StateKeyInner::AccessPath(ap) if ap.is_code()) {
@@ -109,8 +109,8 @@ impl VMChangeSet {
         let change_set = Self {
             resource_write_set,
             module_write_set,
-            aggregator_write_set: BTreeMap::new(),
-            aggregator_delta_set: BTreeMap::new(),
+            aggregator_write_set: HashMap::new(),
+            aggregator_delta_set: HashMap::new(),
             events,
         };
         checker.check_change_set(&change_set)?;
@@ -166,11 +166,11 @@ impl VMChangeSet {
             .chain(self.aggregator_write_set.iter_mut())
     }
 
-    pub fn resource_write_set(&self) -> &BTreeMap<StateKey, WriteOp> {
+    pub fn resource_write_set(&self) -> &HashMap<StateKey, WriteOp> {
         &self.resource_write_set
     }
 
-    pub fn module_write_set(&self) -> &BTreeMap<StateKey, WriteOp> {
+    pub fn module_write_set(&self) -> &HashMap<StateKey, WriteOp> {
         &self.module_write_set
     }
 
@@ -183,11 +183,11 @@ impl VMChangeSet {
             .extend(additional_aggregator_writes)
     }
 
-    pub fn aggregator_write_set(&self) -> &BTreeMap<StateKey, WriteOp> {
+    pub fn aggregator_v1_write_set(&self) -> &HashMap<StateKey, WriteOp> {
         &self.aggregator_write_set
     }
 
-    pub fn aggregator_delta_set(&self) -> &BTreeMap<StateKey, DeltaOp> {
+    pub fn aggregator_v1_delta_set(&self) -> &HashMap<StateKey, DeltaOp> {
         &self.aggregator_delta_set
     }
 
@@ -216,23 +216,23 @@ impl VMChangeSet {
             aggregator_delta_set
                 .into_iter()
                 .map(into_write)
-                .collect::<anyhow::Result<BTreeMap<StateKey, WriteOp>, VMStatus>>()?;
+                .collect::<anyhow::Result<HashMap<StateKey, WriteOp>, VMStatus>>()?;
         aggregator_write_set.extend(materialized_aggregator_delta_set.into_iter());
 
         Ok(Self {
             resource_write_set,
             module_write_set,
             aggregator_write_set,
-            aggregator_delta_set: BTreeMap::new(),
+            aggregator_delta_set: HashMap::new(),
             events,
         })
     }
 
     fn squash_additional_aggregator_changes(
-        aggregator_write_set: &mut BTreeMap<StateKey, WriteOp>,
-        aggregator_delta_set: &mut BTreeMap<StateKey, DeltaOp>,
-        additional_aggregator_write_set: BTreeMap<StateKey, WriteOp>,
-        additional_aggregator_delta_set: BTreeMap<StateKey, DeltaOp>,
+        aggregator_write_set: &mut HashMap<StateKey, WriteOp>,
+        aggregator_delta_set: &mut HashMap<StateKey, DeltaOp>,
+        additional_aggregator_write_set: HashMap<StateKey, WriteOp>,
+        additional_aggregator_delta_set: HashMap<StateKey, DeltaOp>,
     ) -> anyhow::Result<(), VMStatus> {
         use WriteOp::*;
 
@@ -312,8 +312,8 @@ impl VMChangeSet {
     }
 
     fn squash_additional_writes(
-        write_set: &mut BTreeMap<StateKey, WriteOp>,
-        additional_write_set: BTreeMap<StateKey, WriteOp>,
+        write_set: &mut HashMap<StateKey, WriteOp>,
+        additional_write_set: HashMap<StateKey, WriteOp>,
     ) -> anyhow::Result<(), VMStatus> {
         for (key, additional_write_op) in additional_write_set.into_iter() {
             match write_set.entry(key) {

--- a/aptos-move/aptos-vm-types/src/output.rs
+++ b/aptos-move/aptos-vm-types/src/output.rs
@@ -74,7 +74,7 @@ impl VMOutput {
         // First, check if output of transaction should be discarded or delta
         // change set is empty. In both cases, we do not need to apply any
         // deltas and can return immediately.
-        if self.status().is_discarded() || self.change_set().aggregator_delta_set().is_empty() {
+        if self.status().is_discarded() || self.change_set().aggregator_v1_delta_set().is_empty() {
             return Ok(self);
         }
 
@@ -96,7 +96,7 @@ impl VMOutput {
         debug_assert!(
             materialized_output
                 .change_set()
-                .aggregator_delta_set()
+                .aggregator_v1_delta_set()
                 .is_empty(),
             "Aggregator deltas must be empty after materialization."
         );
@@ -114,12 +114,12 @@ impl VMOutput {
         // We should have a materialized delta for every delta in the output.
         assert_eq!(
             materialized_deltas.len(),
-            self.change_set().aggregator_delta_set().len()
+            self.change_set().aggregator_v1_delta_set().len()
         );
         debug_assert!(
             materialized_deltas
                 .iter()
-                .all(|(k, _)| self.change_set().aggregator_delta_set().contains_key(k)),
+                .all(|(k, _)| self.change_set().aggregator_v1_delta_set().contains_key(k)),
             "Materialized aggregator writes contain a key which does not exist in delta set."
         );
         self.change_set

--- a/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
@@ -20,7 +20,7 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
     vm_status::{StatusCode, VMStatus},
 };
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 /// Testcases:
 /// ```text
@@ -89,7 +89,7 @@ macro_rules! write_set_2 {
 
 macro_rules! expected_write_set {
     ($d:ident) => {
-        BTreeMap::from([
+        HashMap::from([
             mock_create(format!("0{}", $d), 0),
             mock_modify(format!("1{}", $d), 1),
             mock_delete(format!("2{}", $d)),
@@ -164,23 +164,23 @@ fn test_successful_squash() {
         &expected_write_set!(descriptor)
     );
 
-    let expected_aggregator_write_set = BTreeMap::from([
+    let expected_aggregator_write_set = HashMap::from([
         mock_create("18a", 136),
         mock_modify("19a", 138),
         mock_modify("22a", 122),
         mock_delete("23a"),
     ]);
-    let expected_aggregator_delta_set = BTreeMap::from([
+    let expected_aggregator_delta_set = HashMap::from([
         mock_add("15a", 15),
         mock_add("16a", 116),
         mock_add("17a", 134),
     ]);
     assert_eq!(
-        change_set.aggregator_write_set(),
+        change_set.aggregator_v1_write_set(),
         &expected_aggregator_write_set
     );
     assert_eq!(
-        change_set.aggregator_delta_set(),
+        change_set.aggregator_v1_delta_set(),
         &expected_aggregator_delta_set
     );
 }

--- a/aptos-move/aptos-vm-types/src/tests/test_output.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_output.rs
@@ -12,7 +12,7 @@ use aptos_types::{
 };
 use claims::{assert_err, assert_matches, assert_ok};
 use move_core_types::vm_status::{AbortLocation, VMStatus};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 fn assert_eq_outputs(vm_output: &VMOutput, txn_output: TransactionOutput) {
     let vm_output_writes = &vm_output
@@ -77,8 +77,7 @@ fn test_ok_output_equality_with_deltas() {
         .clone()
         .into_transaction_output_with_materialized_deltas(vec![mock_modify("3", 400)]);
 
-    let expected_aggregator_write_set =
-        BTreeMap::from([mock_modify("2", 2), mock_modify("3", 400)]);
+    let expected_aggregator_write_set = HashMap::from([mock_modify("2", 2), mock_modify("3", 400)]);
     assert_eq!(
         materialized_vm_output.change_set().resource_write_set(),
         vm_output.change_set().resource_write_set()
@@ -88,12 +87,14 @@ fn test_ok_output_equality_with_deltas() {
         vm_output.change_set().module_write_set()
     );
     assert_eq!(
-        materialized_vm_output.change_set().aggregator_write_set(),
+        materialized_vm_output
+            .change_set()
+            .aggregator_v1_write_set(),
         &expected_aggregator_write_set
     );
     assert!(materialized_vm_output
         .change_set()
-        .aggregator_delta_set()
+        .aggregator_v1_delta_set()
         .is_empty());
     assert_eq!(
         vm_output.fee_statement(),

--- a/aptos-move/aptos-vm-types/src/tests/utils.rs
+++ b/aptos-move/aptos-vm-types/src/tests/utils.rs
@@ -10,7 +10,7 @@ use aptos_types::{
     write_set::WriteOp,
 };
 use move_core_types::vm_status::VMStatus;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 pub(crate) struct MockChangeSetChecker;
 
@@ -57,10 +57,10 @@ pub(crate) fn build_change_set(
     aggregator_delta_set: impl IntoIterator<Item = (StateKey, DeltaOp)>,
 ) -> VMChangeSet {
     VMChangeSet::new(
-        BTreeMap::from_iter(resource_write_set),
-        BTreeMap::from_iter(module_write_set),
-        BTreeMap::from_iter(aggregator_write_set),
-        BTreeMap::from_iter(aggregator_delta_set),
+        HashMap::from_iter(resource_write_set),
+        HashMap::from_iter(module_write_set),
+        HashMap::from_iter(aggregator_write_set),
+        HashMap::from_iter(aggregator_delta_set),
         vec![],
         &MockChangeSetChecker,
     )

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1239,7 +1239,7 @@ impl AptosVM {
         change_set: &VMChangeSet,
     ) -> Result<(), VMStatus> {
         assert!(
-            change_set.aggregator_write_set().is_empty(),
+            change_set.aggregator_v1_write_set().is_empty(),
             "Waypoint change set should not have any aggregator writes."
         );
 

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -38,7 +38,7 @@ use aptos_vm_types::output::VMOutput;
 use move_core_types::vm_status::VMStatus;
 use once_cell::sync::OnceCell;
 use rayon::{prelude::*, ThreadPool};
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 impl BlockExecutorTransaction for PreprocessedTransaction {
     type Event = ContractEvent;
@@ -86,31 +86,54 @@ impl BlockExecutorTransactionOutput for AptosTransactionOutput {
         Self::new(VMOutput::empty_with_status(TransactionStatus::Retry))
     }
 
+    // TODO: get rid of the cloning data-structures in the following APIs.
+
     /// Should never be called after incorporate_delta_writes, as it
     /// will consume vm_output to prepare an output with deltas.
-    fn get_writes(&self) -> Vec<(StateKey, WriteOp)> {
+    fn resource_write_set(&self) -> HashMap<StateKey, WriteOp> {
         self.vm_output
             .lock()
             .as_ref()
             .expect("Output to be set to get writes")
             .change_set()
-            .write_set_iter()
-            .map(|(key, op)| (key.clone(), op.clone()))
-            .collect()
+            .resource_write_set()
+            .clone()
     }
 
     /// Should never be called after incorporate_delta_writes, as it
     /// will consume vm_output to prepare an output with deltas.
-    fn get_deltas(&self) -> Vec<(StateKey, DeltaOp)> {
+    fn module_write_set(&self) -> HashMap<StateKey, WriteOp> {
+        self.vm_output
+            .lock()
+            .as_ref()
+            .expect("Output to be set to get writes")
+            .change_set()
+            .module_write_set()
+            .clone()
+    }
+
+    /// Should never be called after incorporate_delta_writes, as it
+    /// will consume vm_output to prepare an output with deltas.
+    fn aggregator_v1_write_set(&self) -> HashMap<StateKey, WriteOp> {
+        self.vm_output
+            .lock()
+            .as_ref()
+            .expect("Output to be set to get writes")
+            .change_set()
+            .aggregator_v1_write_set()
+            .clone()
+    }
+
+    /// Should never be called after incorporate_delta_writes, as it
+    /// will consume vm_output to prepare an output with deltas.
+    fn aggregator_v1_delta_set(&self) -> HashMap<StateKey, DeltaOp> {
         self.vm_output
             .lock()
             .as_ref()
             .expect("Output to be set to get deltas")
             .change_set()
-            .aggregator_delta_set()
-            .iter()
-            .map(|(key, op)| (key.clone(), *op))
-            .collect()
+            .aggregator_v1_delta_set()
+            .clone()
     }
 
     /// Should never be called after incorporate_delta_writes, as it

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -75,7 +75,7 @@ impl<'a, S: 'a + StateView + Sync> ExecutorTask for AptosExecutorTask<'a, S> {
         {
             Ok((vm_status, mut vm_output, sender)) => {
                 if materialize_deltas {
-                    // TODO: Integrate delta application failure.
+                    // TODO: Integrate aggregator v2.
                     vm_output = vm_output
                         .try_materialize(view)
                         .expect("Delta materialization failed");

--- a/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/respawned_session.rs
@@ -100,7 +100,7 @@ impl<'r> TStateView for ChangeSetStateView<'r> {
 
     fn get_state_value(&self, state_key: &Self::Key) -> Result<Option<StateValue>> {
         // TODO: `get_state_value` should differentiate between different write types.
-        match self.change_set.aggregator_delta_set().get(state_key) {
+        match self.change_set.aggregator_v1_delta_set().get(state_key) {
             Some(delta_op) => Ok(delta_op
                 .try_into_write_op(self.base, state_key)?
                 .as_state_value()),
@@ -130,7 +130,7 @@ mod test {
     use aptos_language_e2e_tests::data_store::FakeDataStore;
     use aptos_types::write_set::WriteOp;
     use aptos_vm_types::check_change_set::CheckChangeSet;
-    use std::collections::BTreeMap;
+    use std::collections::HashMap;
 
     /// A mock for testing. Always succeeds on checking a change set.
     struct NoOpChangeSetChecker;
@@ -167,23 +167,23 @@ mod test {
         base_view.set_legacy(key("aggregator_both"), serialize(&60));
         base_view.set_legacy(key("aggregator_delta_set"), serialize(&70));
 
-        let resource_write_set = BTreeMap::from([
+        let resource_write_set = HashMap::from([
             (key("resource_both"), write(80)),
             (key("resource_write_set"), write(90)),
         ]);
 
-        let module_write_set = BTreeMap::from([
+        let module_write_set = HashMap::from([
             (key("module_both"), write(100)),
             (key("module_write_set"), write(110)),
         ]);
 
-        let aggregator_write_set = BTreeMap::from([
+        let aggregator_write_set = HashMap::from([
             (key("aggregator_both"), write(120)),
             (key("aggregator_write_set"), write(130)),
         ]);
 
         let aggregator_delta_set =
-            BTreeMap::from([(key("aggregator_delta_set"), delta_add(1, 1000))]);
+            HashMap::from([(key("aggregator_delta_set"), delta_add(1, 1000))]);
 
         let change_set = VMChangeSet::new(
             resource_write_set,

--- a/aptos-move/aptos-vm/src/move_vm_ext/session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session.rs
@@ -35,7 +35,7 @@ use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::BorrowMut,
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     ops::{Deref, DerefMut},
     sync::Arc,
 };
@@ -316,10 +316,10 @@ impl<'r, 'l> SessionExt<'r, 'l> {
             new_slot_metadata,
         };
 
-        let mut resource_write_set = BTreeMap::new();
-        let mut module_write_set = BTreeMap::new();
-        let mut aggregator_write_set = BTreeMap::new();
-        let mut aggregator_delta_set = BTreeMap::new();
+        let mut resource_write_set = HashMap::new();
+        let mut module_write_set = HashMap::new();
+        let mut aggregator_write_set = HashMap::new();
+        let mut aggregator_delta_set = HashMap::new();
 
         for (addr, account_changeset) in change_set.into_inner() {
             let (modules, resources) = account_changeset.into_inner();

--- a/aptos-move/block-executor/src/proptest_types/bencher.rs
+++ b/aptos-move/block-executor/src/proptest_types/bencher.rs
@@ -40,7 +40,7 @@ pub(crate) struct BencherState<
     Vec<u8>: From<V>,
 {
     transactions: Vec<MockTransaction<KeyType<K>, ValueType<V>, E>>,
-    baseline_output: BaselineOutput<ValueType<V>>,
+    baseline_output: BaselineOutput<KeyType<K>, ValueType<V>>,
 }
 
 impl<K, V, E> Bencher<K, V, E>

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -339,7 +339,7 @@ fn module_publishing_fallback_with_block_gas_limit(
         vec![],
         vec![],
         2,
-        (false, true),
+        (true, false),
         maybe_block_gas_limit,
     );
     run_transactions::<[u8; 32], [u8; 32], MockEvent>(

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -25,7 +25,7 @@ use once_cell::sync::OnceCell;
 use proptest::{arbitrary::Arbitrary, collection::vec, prelude::*, proptest, sample::Index};
 use proptest_derive::Arbitrary;
 use std::{
-    collections::{hash_map::DefaultHasher, BTreeSet},
+    collections::{hash_map::DefaultHasher, BTreeSet, HashMap},
     convert::TryInto,
     fmt::Debug,
     hash::{Hash, Hasher},
@@ -555,7 +555,6 @@ where
 #[derive(Debug)]
 
 pub(crate) struct MockOutput<K, V, E> {
-    // TODO: Split writes into resources & modules.
     pub(crate) writes: Vec<(K, V)>,
     pub(crate) deltas: Vec<(K, DeltaOp)>,
     pub(crate) events: Vec<E>,
@@ -572,12 +571,30 @@ where
 {
     type Txn = MockTransaction<K, V, E>;
 
-    fn get_writes(&self) -> Vec<(K, V)> {
-        self.writes.clone()
+    fn resource_write_set(&self) -> HashMap<K, V> {
+        self.writes
+            .iter()
+            .filter(|(k, _)| k.module_path().is_none())
+            .cloned()
+            .collect()
     }
 
-    fn get_deltas(&self) -> Vec<(K, DeltaOp)> {
-        self.deltas.clone()
+    fn module_write_set(&self) -> HashMap<K, V> {
+        self.writes
+            .iter()
+            .filter(|(k, _)| k.module_path().is_some())
+            .cloned()
+            .collect()
+    }
+
+    // Aggregator v1 writes are included in resource_write_set for tests (writes are produced
+    // for all keys including ones for v1_aggregators without distinguishing).
+    fn aggregator_v1_write_set(&self) -> HashMap<K, V> {
+        HashMap::new()
+    }
+
+    fn aggregator_v1_delta_set(&self) -> HashMap<K, DeltaOp> {
+        self.deltas.iter().cloned().collect()
     }
 
     fn get_events(&self) -> Vec<E> {

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -11,7 +11,7 @@ use aptos_types::{
     fee_statement::FeeStatement,
     write_set::{TransactionWrite, WriteOp},
 };
-use std::{fmt::Debug, hash::Hash};
+use std::{collections::HashMap, fmt::Debug, hash::Hash};
 
 /// The execution result of a transaction
 #[derive(Debug)]
@@ -74,16 +74,22 @@ pub trait TransactionOutput: Send + Sync + Debug {
     /// Type of transaction and its associated key and value.
     type Txn: Transaction;
 
-    /// Get the writes of a transaction from its output.
-    fn get_writes(
+    /// Get the writes of a transaction from its output, separately for resources, modules and
+    /// aggregator_v1.
+    fn resource_write_set(
         &self,
-    ) -> Vec<(
-        <Self::Txn as Transaction>::Key,
-        <Self::Txn as Transaction>::Value,
-    )>;
+    ) -> HashMap<<Self::Txn as Transaction>::Key, <Self::Txn as Transaction>::Value>;
+
+    fn module_write_set(
+        &self,
+    ) -> HashMap<<Self::Txn as Transaction>::Key, <Self::Txn as Transaction>::Value>;
+
+    fn aggregator_v1_write_set(
+        &self,
+    ) -> HashMap<<Self::Txn as Transaction>::Key, <Self::Txn as Transaction>::Value>;
 
     /// Get the aggregator deltas of a transaction from its output.
-    fn get_deltas(&self) -> Vec<(<Self::Txn as Transaction>::Key, DeltaOp)>;
+    fn aggregator_v1_delta_set(&self) -> HashMap<<Self::Txn as Transaction>::Key, DeltaOp>;
 
     /// Get the events of a transaction from its output.
     fn get_events(&self) -> Vec<<Self::Txn as Transaction>::Event>;

--- a/aptos-move/mvhashmap/src/lib.rs
+++ b/aptos-move/mvhashmap/src/lib.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    types::{MVDataError, MVDataOutput, MVModulesError, MVModulesOutput, TxnIndex, Version},
+    types::{MVDataError, MVDataOutput, MVModulesError, MVModulesOutput, TxnIndex},
     versioned_data::VersionedData,
     versioned_modules::VersionedModules,
 };
@@ -55,31 +55,12 @@ impl<K: ModulePath + Hash + Clone + Eq + Debug, V: TransactionWrite, X: Executab
         (self.data, self.modules)
     }
 
-    /// Mark an entry from transaction 'txn_idx' at access path 'key' as an estimated write
-    /// (for future incarnation). Will panic if the entry is not in the data-structure.
-    pub fn mark_estimate(&self, key: &K, txn_idx: TxnIndex) {
-        match key.module_path() {
-            Some(_) => self.modules.mark_estimate(key, txn_idx),
-            None => self.data.mark_estimate(key, txn_idx),
-        }
+    pub fn data(&self) -> &VersionedData<K, V> {
+        &self.data
     }
 
-    /// Delete an entry from transaction 'txn_idx' at access path 'key'. Will panic
-    /// if the corresponding entry does not exist.
-    pub fn delete(&self, key: &K, txn_idx: TxnIndex) {
-        // This internally deserializes the path, TODO: fix.
-        match key.module_path() {
-            Some(_) => self.modules.delete(key, txn_idx),
-            None => self.data.delete(key, txn_idx),
-        };
-    }
-
-    /// Add a versioned write at a specified key, in data or modules map according to the key.
-    pub fn write(&self, key: K, version: Version, value: V) {
-        match key.module_path() {
-            Some(_) => self.modules.write(key, version.0, value),
-            None => self.data.write(key, version, value),
-        }
+    pub fn modules(&self) -> &VersionedModules<K, V, X> {
+        &self.modules
     }
 
     // -----------------------------------------------

--- a/aptos-move/mvhashmap/src/unit_tests/mod.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/mod.rs
@@ -113,7 +113,7 @@ fn create_write_read_placeholder_struct() {
     assert_eq!(Err(NotFound), r_db);
 
     // Write by txn 10.
-    mvtbl.write(ap1.clone(), (10, 1), value_for(10, 1));
+    mvtbl.data().write(ap1.clone(), (10, 1), value_for(10, 1));
 
     // Reads that should go the DB return Err(NotFound)
     let r_db = mvtbl.fetch_data(&ap1, 9);
@@ -136,8 +136,8 @@ fn create_write_read_placeholder_struct() {
     assert_eq!(Ok(Resolved(u128_for(10, 1) + 11 + 12 - (61 + 13))), r_sum);
 
     // More writes.
-    mvtbl.write(ap1.clone(), (12, 0), value_for(12, 0));
-    mvtbl.write(ap1.clone(), (8, 3), value_for(8, 3));
+    mvtbl.data().write(ap1.clone(), (12, 0), value_for(12, 0));
+    mvtbl.data().write(ap1.clone(), (8, 3), value_for(8, 3));
 
     // Verify reads.
     let r_12 = mvtbl.fetch_data(&ap1, 15);
@@ -148,7 +148,7 @@ fn create_write_read_placeholder_struct() {
     assert_eq!(Ok(Versioned((8, 3), arc_value_for(8, 3))), r_8);
 
     // Mark the entry written by 10 as an estimate.
-    mvtbl.mark_estimate(&ap1, 10);
+    mvtbl.data().mark_estimate(&ap1, 10);
 
     // Read for txn 11 must observe a dependency.
     let r_10 = mvtbl.fetch_data(&ap1, 11);
@@ -159,25 +159,25 @@ fn create_write_read_placeholder_struct() {
     assert_eq!(Err(Dependency(10)), r_11);
 
     // Delete the entry written by 10, write to a different ap.
-    mvtbl.delete(&ap1, 10);
-    mvtbl.write(ap2.clone(), (10, 2), value_for(10, 2));
+    mvtbl.data().delete(&ap1, 10);
+    mvtbl.data().write(ap2.clone(), (10, 2), value_for(10, 2));
 
     // Read by txn 11 no longer observes entry from txn 10.
     let r_8 = mvtbl.fetch_data(&ap1, 11);
     assert_eq!(Ok(Versioned((8, 3), arc_value_for(8, 3))), r_8);
 
     // Reads, writes for ap2 and ap3.
-    mvtbl.write(ap2.clone(), (5, 0), value_for(5, 0));
-    mvtbl.write(ap3.clone(), (20, 4), value_for(20, 4));
+    mvtbl.data().write(ap2.clone(), (5, 0), value_for(5, 0));
+    mvtbl.data().write(ap3.clone(), (20, 4), value_for(20, 4));
     let r_5 = mvtbl.fetch_data(&ap2, 10);
     assert_eq!(Ok(Versioned((5, 0), arc_value_for(5, 0))), r_5);
     let r_20 = mvtbl.fetch_data(&ap3, 21);
     assert_eq!(Ok(Versioned((20, 4), arc_value_for(20, 4))), r_20);
 
     // Clear ap1 and ap3.
-    mvtbl.delete(&ap1, 12);
-    mvtbl.delete(&ap1, 8);
-    mvtbl.delete(&ap3, 20);
+    mvtbl.data().delete(&ap1, 12);
+    mvtbl.data().delete(&ap1, 8);
+    mvtbl.data().delete(&ap3, 20);
 
     // Reads from ap1 and ap3 go to db.
     match_unresolved(
@@ -200,7 +200,7 @@ fn create_write_read_placeholder_struct() {
     let val = value_for(10, 3);
     // sub base sub_for for which should underflow.
     let sub_base = AggregatorValue::from_write(&val).unwrap().into();
-    mvtbl.write(ap2.clone(), (10, 3), val);
+    mvtbl.data().write(ap2.clone(), (10, 3), val);
     mvtbl.add_delta(ap2.clone(), 30, delta_sub(30 + sub_base, u128::MAX));
     let r_31 = mvtbl.fetch_data(&ap2, 31);
     assert_eq!(Err(DeltaApplicationFailure), r_31);

--- a/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
@@ -205,8 +205,9 @@ where
         })
         .collect::<Vec<_>>();
     for (key, idx) in versions_to_write {
-        map.write(KeyType(key.clone()), (idx as TxnIndex, 0), Value(None));
-        map.mark_estimate(&KeyType(key), idx as TxnIndex);
+        map.data()
+            .write(KeyType(key.clone()), (idx as TxnIndex, 0), Value(None));
+        map.data().mark_estimate(&KeyType(key), idx as TxnIndex);
     }
 
     let current_idx = AtomicUsize::new(0);
@@ -283,10 +284,11 @@ where
                         }
                     },
                     Operator::Remove => {
-                        map.write(KeyType(key.clone()), (idx as TxnIndex, 1), Value(None));
+                        map.data()
+                            .write(KeyType(key.clone()), (idx as TxnIndex, 1), Value(None));
                     },
                     Operator::Insert(v) => {
-                        map.write(
+                        map.data().write(
                             KeyType(key.clone()),
                             (idx as TxnIndex, 1),
                             Value(Some(v.clone())),

--- a/aptos-move/mvhashmap/src/versioned_data.rs
+++ b/aptos-move/mvhashmap/src/versioned_data.rs
@@ -223,7 +223,9 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite> VersionedData<K, V> {
             .insert(txn_idx, CachePadded::new(Entry::new_delta_from(delta)));
     }
 
-    pub(crate) fn mark_estimate(&self, key: &K, txn_idx: TxnIndex) {
+    /// Mark an entry from transaction 'txn_idx' at access path 'key' as an estimated write
+    /// (for future incarnation). Will panic if the entry is not in the data-structure.
+    pub fn mark_estimate(&self, key: &K, txn_idx: TxnIndex) {
         let mut v = self.values.get_mut(key).expect("Path must exist");
         v.versioned_map
             .get_mut(&txn_idx)
@@ -231,7 +233,9 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite> VersionedData<K, V> {
             .mark_estimate();
     }
 
-    pub(crate) fn delete(&self, key: &K, txn_idx: TxnIndex) {
+    /// Delete an entry from transaction 'txn_idx' at access path 'key'. Will panic
+    /// if the corresponding entry does not exist.
+    pub fn delete(&self, key: &K, txn_idx: TxnIndex) {
         // TODO: investigate logical deletion.
         let mut v = self.values.get_mut(key).expect("Path must exist");
         assert!(
@@ -251,7 +255,8 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite> VersionedData<K, V> {
             .unwrap_or(Err(MVDataError::NotFound))
     }
 
-    pub(crate) fn write(&self, key: K, version: Version, data: V) {
+    /// Versioned write of data at a given key (and version).
+    pub fn write(&self, key: K, version: Version, data: V) {
         let (txn_idx, incarnation) = version;
 
         let mut v = self.values.entry(key).or_default();

--- a/aptos-move/mvhashmap/src/versioned_modules.rs
+++ b/aptos-move/mvhashmap/src/versioned_modules.rs
@@ -107,7 +107,9 @@ impl<K: Hash + Clone + Eq, V: TransactionWrite, X: Executable> VersionedModules<
         }
     }
 
-    pub(crate) fn mark_estimate(&self, key: &K, txn_idx: TxnIndex) {
+    /// Mark an entry from transaction 'txn_idx' at access path 'key' as an estimated write
+    /// (for future incarnation). Will panic if the entry is not in the data-structure.
+    pub fn mark_estimate(&self, key: &K, txn_idx: TxnIndex) {
         let mut v = self.values.get_mut(key).expect("Path must exist");
         v.versioned_map
             .get_mut(&txn_idx)
@@ -115,20 +117,21 @@ impl<K: Hash + Clone + Eq, V: TransactionWrite, X: Executable> VersionedModules<
             .mark_estimate();
     }
 
-    pub(crate) fn write(&self, key: K, txn_idx: TxnIndex, data: V) {
+    /// Versioned write of module at a given key (and version).
+    pub fn write(&self, key: K, txn_idx: TxnIndex, data: V) {
         let mut v = self.values.entry(key).or_default();
         v.versioned_map
             .insert(txn_idx, CachePadded::new(Entry::new_write_from(data)));
     }
 
-    pub(crate) fn store_executable(&self, key: &K, descriptor_hash: HashValue, executable: X) {
+    pub fn store_executable(&self, key: &K, descriptor_hash: HashValue, executable: X) {
         let mut v = self.values.get_mut(key).expect("Path must exist");
         v.executables
             .entry(descriptor_hash)
             .or_insert_with(|| Arc::new(executable));
     }
 
-    pub(crate) fn fetch_module(
+    pub fn fetch_module(
         &self,
         key: &K,
         txn_idx: TxnIndex,
@@ -147,7 +150,9 @@ impl<K: Hash + Clone + Eq, V: TransactionWrite, X: Executable> VersionedModules<
         }
     }
 
-    pub(crate) fn delete(&self, key: &K, txn_idx: TxnIndex) {
+    /// Delete an entry from transaction 'txn_idx' at access path 'key'. Will panic
+    /// if the corresponding entry does not exist.
+    pub fn delete(&self, key: &K, txn_idx: TxnIndex) {
         // TODO: investigate logical deletion.
         let mut v = self.values.get_mut(key).expect("Path must exist");
         assert!(

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -160,7 +160,7 @@ pub fn encode_aptos_mainnet_genesis_transaction(
     // not deltas. The second session only publishes the framework module bundle, which should not
     // produce deltas either.
     assert!(
-        change_set.aggregator_delta_set().is_empty(),
+        change_set.aggregator_v1_delta_set().is_empty(),
         "non-empty delta change set in genesis"
     );
     assert!(!change_set.write_set_iter().any(|(_, op)| op.is_deletion()));
@@ -270,7 +270,7 @@ pub fn encode_genesis_change_set(
     // not deltas. The second session only publishes the framework module bundle, which should not
     // produce deltas either.
     assert!(
-        change_set.aggregator_delta_set().is_empty(),
+        change_set.aggregator_v1_delta_set().is_empty(),
         "non-empty delta change set in genesis"
     );
 

--- a/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
+++ b/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
@@ -139,7 +139,7 @@ where
     };
 
     // Genesis never produces the delta change set.
-    assert!(change_set.aggregator_delta_set().is_empty());
+    assert!(change_set.aggregator_v1_delta_set().is_empty());
     change_set
         .try_into_storage_change_set()
         .expect("Conversion from VMChangeSet into ChangeSet should always succeed")

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -287,6 +287,7 @@ impl WriteSetV0 {
 /// This is separate because it goes through validation before becoming an immutable `WriteSet`.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct WriteSetMut {
+    // TODO: Change to HashMap with a stable iterator for serialization.
     write_set: BTreeMap<StateKey, WriteOp>,
 }
 


### PR DESCRIPTION
Refactor in order to:
- Better encapsulate the state in LatestView, in particular, support the counter that is shared among worker threads in the parallel setting (like MVHashMap). @vusirikala: should address some issues from https://github.com/aptos-labs/aptos-core/pull/9000 for generating ephemeral IDs for aggregators
- Expose traits for the output to be able to process data vs modules vs aggregator_v1 changes more granularly, separate the v1 aggregator so v2 can be implemented and gated separately.
- Improve MVHashMap interfaces to avoid dispatching on module_path per key (also expensive).
- Change unnecessary BTreeMaps to HashMap.