### PR TITLE
[dag] add block id to anchor storage

### DIFF
--- a/consensus/src/consensusdb/consensusdb_test.rs
+++ b/consensus/src/consensusdb/consensusdb_test.rs
@@ -109,7 +109,7 @@ fn test_dag() {
     let anchor_id = node.id();
     test_dag_type::<OrderedAnchorIdSchema, <OrderedAnchorIdSchema as Schema>::Key>(
         anchor_id,
-        (),
+        node.digest(),
         &db,
     );
 }

--- a/consensus/src/consensusdb/schema/dag/mod.rs
+++ b/consensus/src/consensusdb/schema/dag/mod.rs
@@ -10,7 +10,6 @@
 //! ```
 
 use crate::{
-    consensusdb::schema::ensure_slice_len_eq,
     dag::{CertifiedNode, Node, NodeId, Vote},
     define_schema,
 };
@@ -20,7 +19,6 @@ use aptos_schemadb::{
     schema::{KeyCodec, ValueCodec},
     ColumnFamilyName,
 };
-use std::mem::size_of;
 
 pub const NODE_CF_NAME: ColumnFamilyName = "node";
 
@@ -101,7 +99,12 @@ impl ValueCodec<CertifiedNodeSchema> for CertifiedNode {
 
 pub const ORDERED_ANCHOR_ID_CF_NAME: ColumnFamilyName = "ordered_anchor_id";
 
-define_schema!(OrderedAnchorIdSchema, NodeId, (), ORDERED_ANCHOR_ID_CF_NAME);
+define_schema!(
+    OrderedAnchorIdSchema,
+    NodeId,
+    HashValue,
+    ORDERED_ANCHOR_ID_CF_NAME
+);
 
 impl KeyCodec<OrderedAnchorIdSchema> for NodeId {
     fn encode_key(&self) -> Result<Vec<u8>> {
@@ -113,13 +116,12 @@ impl KeyCodec<OrderedAnchorIdSchema> for NodeId {
     }
 }
 
-impl ValueCodec<OrderedAnchorIdSchema> for () {
+impl ValueCodec<OrderedAnchorIdSchema> for HashValue {
     fn encode_value(&self) -> Result<Vec<u8>> {
-        Ok(vec![])
+        Ok(self.to_vec())
     }
 
     fn decode_value(data: &[u8]) -> Result<Self> {
-        ensure_slice_len_eq(data, size_of::<Self>())?;
-        Ok(())
+        Ok(HashValue::from_slice(data)?)
     }
 }

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -56,7 +56,11 @@ pub fn bootstrap_dag(
         time_service.clone(),
     ));
 
-    let dag = Arc::new(RwLock::new(Dag::new(epoch_state.clone(), storage.clone())));
+    let dag = Arc::new(RwLock::new(Dag::new(
+        epoch_state.clone(),
+        storage.clone(),
+        latest_ledger_info.clone(),
+    )));
 
     let anchor_election = Box::new(RoundRobinAnchorElection::new(validators));
     let order_rule = OrderRule::new(

--- a/consensus/src/dag/storage.rs
+++ b/consensus/src/dag/storage.rs
@@ -27,9 +27,9 @@ pub trait DAGStorage: Send + Sync {
 
     fn delete_certified_nodes(&self, digests: Vec<HashValue>) -> anyhow::Result<()>;
 
-    fn save_ordered_anchor_id(&self, node_id: &NodeId) -> anyhow::Result<()>;
+    fn save_ordered_anchor_id(&self, node_id: &NodeId, block_id: &HashValue) -> anyhow::Result<()>;
 
-    fn get_ordered_anchor_ids(&self) -> anyhow::Result<Vec<(NodeId, ())>>;
+    fn get_ordered_anchor_ids(&self) -> anyhow::Result<Vec<(NodeId, HashValue)>>;
 
     fn delete_ordered_anchor_ids(&self, node_ids: Vec<NodeId>) -> anyhow::Result<()>;
 }
@@ -67,11 +67,11 @@ impl DAGStorage for ConsensusDB {
         Ok(self.delete_data::<CertifiedNodeSchema>(digests)?)
     }
 
-    fn save_ordered_anchor_id(&self, node_id: &NodeId) -> anyhow::Result<()> {
-        Ok(self.save_data::<OrderedAnchorIdSchema>(node_id, &())?)
+    fn save_ordered_anchor_id(&self, node_id: &NodeId, block_id: &HashValue) -> anyhow::Result<()> {
+        Ok(self.save_data::<OrderedAnchorIdSchema>(node_id, &block_id)?)
     }
 
-    fn get_ordered_anchor_ids(&self) -> anyhow::Result<Vec<(NodeId, ())>> {
+    fn get_ordered_anchor_ids(&self) -> anyhow::Result<Vec<(NodeId, HashValue)>> {
         Ok(self.get_all_data::<OrderedAnchorIdSchema>()?)
     }
 

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -72,7 +72,11 @@ fn test_certified_node_handler() {
         verifier: validator_verifier,
     });
     let storage = Arc::new(MockStorage::new());
-    let dag = Arc::new(RwLock::new(Dag::new(epoch_state.clone(), storage.clone())));
+    let dag = Arc::new(RwLock::new(Dag::new(
+        epoch_state.clone(),
+        storage.clone(),
+        LedgerInfo::mock_genesis(Some((&epoch_state.verifier).into())),
+    )));
 
     let zeroth_round_node = new_certified_node(0, signers[0].author(), vec![]);
 

--- a/consensus/src/dag/tests/fetcher_test.rs
+++ b/consensus/src/dag/tests/fetcher_test.rs
@@ -9,7 +9,9 @@ use crate::dag::{
     RpcHandler,
 };
 use aptos_infallible::RwLock;
-use aptos_types::{epoch_state::EpochState, validator_verifier::random_validator_verifier};
+use aptos_types::{
+    epoch_state::EpochState, ledger_info::LedgerInfo, validator_verifier::random_validator_verifier,
+};
 use claims::assert_ok_eq;
 use std::sync::Arc;
 
@@ -21,7 +23,11 @@ fn test_dag_fetcher_receiver() {
         verifier: validator_verifier,
     });
     let storage = Arc::new(MockStorage::new());
-    let dag = Arc::new(RwLock::new(Dag::new(epoch_state.clone(), storage)));
+    let dag = Arc::new(RwLock::new(Dag::new(
+        epoch_state.clone(),
+        storage,
+        LedgerInfo::mock_genesis(Some((&epoch_state.verifier).into())),
+    )));
 
     let mut fetcher = FetchRequestHandler::new(dag.clone(), epoch_state);
 

--- a/consensus/src/dag/tests/order_rule_tests.rs
+++ b/consensus/src/dag/tests/order_rule_tests.rs
@@ -15,7 +15,7 @@ use crate::{
 use aptos_consensus_types::common::Author;
 use aptos_infallible::{Mutex, RwLock};
 use aptos_types::{
-    aggregate_signature::AggregateSignature, epoch_state::EpochState,
+    aggregate_signature::AggregateSignature, epoch_state::EpochState, ledger_info::LedgerInfo,
     validator_verifier::random_validator_verifier,
 };
 use futures_channel::mpsc::{unbounded, UnboundedReceiver};
@@ -153,7 +153,7 @@ proptest! {
             epoch: 1,
             verifier: validator_verifier,
         });
-        let mut dag = Dag::new(epoch_state.clone(), Arc::new(MockStorage::new()));
+        let mut dag = Dag::new(epoch_state.clone(), Arc::new(MockStorage::new()), LedgerInfo::mock_genesis(Some((&epoch_state.verifier).into())));
         for round_nodes in &nodes {
             for node in round_nodes.iter().flatten() {
                 dag.add_node(node.clone()).unwrap();
@@ -231,7 +231,11 @@ fn test_order_rule_basic() {
         epoch: 1,
         verifier: validator_verifier,
     });
-    let mut dag = Dag::new(epoch_state.clone(), Arc::new(MockStorage::new()));
+    let mut dag = Dag::new(
+        epoch_state.clone(),
+        Arc::new(MockStorage::new()),
+        LedgerInfo::mock_genesis(Some((&epoch_state.verifier).into())),
+    );
     for round_nodes in &nodes {
         for node in round_nodes.iter().flatten() {
             dag.add_node(node.clone()).unwrap();

--- a/consensus/src/dag/tests/rb_handler_tests.rs
+++ b/consensus/src/dag/tests/rb_handler_tests.rs
@@ -11,7 +11,7 @@ use crate::dag::{
 };
 use aptos_infallible::RwLock;
 use aptos_types::{
-    aggregate_signature::PartialSignatures, epoch_state::EpochState,
+    aggregate_signature::PartialSignatures, epoch_state::EpochState, ledger_info::LedgerInfo,
     validator_verifier::random_validator_verifier,
 };
 use claims::{assert_ok, assert_ok_eq};
@@ -25,7 +25,11 @@ async fn test_node_broadcast_receiver_succeed() {
         verifier: validator_verifier,
     });
     let storage = Arc::new(MockStorage::new());
-    let dag = Arc::new(RwLock::new(Dag::new(epoch_state.clone(), storage.clone())));
+    let dag = Arc::new(RwLock::new(Dag::new(
+        epoch_state.clone(),
+        storage.clone(),
+        LedgerInfo::mock_genesis(Some((&epoch_state.verifier).into())),
+    )));
 
     let wellformed_node = new_node(0, 10, signers[0].author(), vec![]);
     let equivocating_node = new_node(0, 20, signers[0].author(), vec![]);
@@ -56,7 +60,11 @@ async fn test_node_broadcast_receiver_failure() {
         .iter()
         .map(|signer| {
             let storage = Arc::new(MockStorage::new());
-            let dag = Arc::new(RwLock::new(Dag::new(epoch_state.clone(), storage.clone())));
+            let dag = Arc::new(RwLock::new(Dag::new(
+                epoch_state.clone(),
+                storage.clone(),
+                LedgerInfo::mock_genesis(Some((&epoch_state.verifier).into())),
+            )));
 
             NodeBroadcastHandler::new(dag, signer.clone(), epoch_state.clone(), storage)
         })
@@ -121,7 +129,11 @@ fn test_node_broadcast_receiver_storage() {
         verifier: validator_verifier,
     });
     let storage = Arc::new(MockStorage::new());
-    let dag = Arc::new(RwLock::new(Dag::new(epoch_state.clone(), storage.clone())));
+    let dag = Arc::new(RwLock::new(Dag::new(
+        epoch_state.clone(),
+        storage.clone(),
+        LedgerInfo::mock_genesis(Some((&epoch_state.verifier).into())),
+    )));
 
     let node = new_node(1, 10, signers[0].author(), vec![]);
 


### PR DESCRIPTION
LedgerInfo doesn't have the author for the block, so we can't recover the NodeId corresponding to the anchor nodes, this commit adds the block id to the anchor storage, so we can match that to the ledger info.
