### PR TITLE
[NFT Metadata Crawler] Increase HTTP request for large files

### DIFF
--- a/ecosystem/nft-metadata-crawler-parser/src/utils/constants.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/constants.rs
@@ -2,3 +2,9 @@
 
 /// Maximum retry time for exponential backoff (5 sec = 3-4 retries)
 pub const MAX_RETRY_TIME_SECONDS: u64 = 5;
+
+/// Allocate 30 seconds for downloading large JSON files
+pub const MAX_JSON_REQUEST_RETRY_SECONDS: u64 = 30;
+
+/// Allocate 180 seconds for downloading large image files
+pub const MAX_IMAGE_REQUEST_RETRY_SECONDS: u64 = 180;

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/image_optimizer.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/image_optimizer.rs
@@ -33,7 +33,7 @@ impl ImageOptimizer {
         let op = || {
             async {
                 let client = Client::builder()
-                    .timeout(Duration::from_secs(MAX_RETRY_TIME_SECONDS / 3))
+                    .timeout(Duration::from_secs(180)) // Allocate three minutes for downloading large images
                     .build()
                     .context("Failed to build reqwest client")?;
 

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/image_optimizer.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/image_optimizer.rs
@@ -1,6 +1,9 @@
 // Copyright © Aptos Foundation
 
-use crate::{get_uri_metadata, utils::constants::MAX_RETRY_TIME_SECONDS};
+use crate::{
+    get_uri_metadata,
+    utils::constants::{MAX_IMAGE_REQUEST_RETRY_SECONDS, MAX_RETRY_TIME_SECONDS},
+};
 use anyhow::Context;
 use backoff::{future::retry, ExponentialBackoff};
 use futures::FutureExt;
@@ -33,7 +36,7 @@ impl ImageOptimizer {
         let op = || {
             async {
                 let client = Client::builder()
-                    .timeout(Duration::from_secs(180)) // Allocate three minutes for downloading large images
+                    .timeout(Duration::from_secs(MAX_IMAGE_REQUEST_RETRY_SECONDS)) // Allocate three minutes for downloading large images
                     .build()
                     .context("Failed to build reqwest client")?;
 

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/image_optimizer.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/image_optimizer.rs
@@ -36,7 +36,7 @@ impl ImageOptimizer {
         let op = || {
             async {
                 let client = Client::builder()
-                    .timeout(Duration::from_secs(MAX_IMAGE_REQUEST_RETRY_SECONDS)) // Allocate three minutes for downloading large images
+                    .timeout(Duration::from_secs(MAX_IMAGE_REQUEST_RETRY_SECONDS))
                     .build()
                     .context("Failed to build reqwest client")?;
 

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/json_parser.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/json_parser.rs
@@ -1,6 +1,9 @@
 // Copyright © Aptos Foundation
 
-use crate::{get_uri_metadata, utils::constants::MAX_RETRY_TIME_SECONDS};
+use crate::{
+    get_uri_metadata,
+    utils::constants::{MAX_JSON_REQUEST_RETRY_SECONDS, MAX_RETRY_TIME_SECONDS},
+};
 use anyhow::Context;
 use backoff::{future::retry, ExponentialBackoff};
 use futures::FutureExt;
@@ -37,7 +40,7 @@ impl JSONParser {
                 info!("Sending request for token_uri {}", uri);
 
                 let client = Client::builder()
-                    .timeout(Duration::from_secs(30)) // Allocate 30 seconds for downloading large JSON files
+                    .timeout(Duration::from_secs(MAX_JSON_REQUEST_RETRY_SECONDS))
                     .build()
                     .context("Failed to build reqwest client")?;
 

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/json_parser.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/json_parser.rs
@@ -37,7 +37,7 @@ impl JSONParser {
                 info!("Sending request for token_uri {}", uri);
 
                 let client = Client::builder()
-                    .timeout(Duration::from_secs(MAX_RETRY_TIME_SECONDS / 3))
+                    .timeout(Duration::from_secs(30)) // Allocate 30 seconds for downloading large JSON files
                     .build()
                     .context("Failed to build reqwest client")?;
 


### PR DESCRIPTION
### Description
Previously the timeout was too short so many of the semi-large could not finish downloading, this increases that timeout. 
