### PR TITLE
[framework] Reset the release yaml for upcoming 1.7 release

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -1,28 +1,17 @@
 ---
 remote_endpoint: ~
-name: "v1.6"
+name: "v1.7"
 proposals:
   - name: upgrade_framework
     metadata:
-      title: "Multi-step proposal to upgrade mainnet framework to v1.6"
-      description: "This includes changes outlined in https://github.com/aptos-labs/aptos-core/releases/aptos-node-v1.6"
+      title: "Multi-step proposal to upgrade mainnet framework to v1.7"
+      description: "This includes changes outlined in https://github.com/aptos-labs/aptos-core/releases/aptos-node-v1.7"
     execution_mode: MultiStep
     update_sequence:
       - DefaultGas
       - Framework:
           bytecode_version: 6
           git_hash: ~
-  - name: enable_fee_payer
-    metadata:
-      title: "Enable fee payer"
-      description: "AIP-39: Support secondary fee payer to pay gas cost on behalf of the sender."
-      source_code_url: "https://github.com/aptos-labs/aptos-core/pull/8904"
-      discussion_url: "https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-39.md"
-    execution_mode: MultiStep
-    update_sequence:
-    - FeatureFlag:
-        enabled:
-          - gas_payer_enabled
   - name: enable_block_gas_limit
     metadata:
       title: "Enable Block Gas Limit"
@@ -35,37 +24,3 @@ proposals:
           transaction_shuffler_type:
             deprecated_sender_aware_v1: 32
           block_gas_limit : 35000
-  - name: enable_aptos_unique_identifiers
-    metadata:
-      title: "Enable Aptos Unique Identifiers"
-      description: "AIP-36: Support for aptos unique identifiers (generated using native function generate_unique_address)"
-      discussion_url: "https://github.com/aptos-foundation/AIPs/issues/154"
-    execution_mode: MultiStep
-    update_sequence:
-    - FeatureFlag:
-        enabled:
-          - aptos_unique_identifiers
-  - name: enable_partial_voting
-    metadata:
-      title: "Enable partial voting"
-      description: "AIP-28:  Partial voting for on chain governance."
-      source_code_url: "https://github.com/aptos-labs/aptos-core/pull/8090"
-      discussion_url: "https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-28.md"
-    execution_mode: MultiStep
-    update_sequence:
-    - RawScript: aptos-move/aptos-release-builder/data/proposals/aip_28_initialization.move
-    - FeatureFlag:
-        enabled:
-          - partial_governance_voting
-          - delegation_pool_partial_governance_voting
-  - name: bulletproofs_natives
-    metadata:
-      title: "Bulletproofs natives"
-      description: "AIP-xx: TBD"
-      source_code_url: "https://github.com/aptos-labs/aptos-core/pull/3444"
-      discussion_url: "https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-xx.md"
-    execution_mode: MultiStep
-    update_sequence:
-      - FeatureFlag:
-          enabled:
-            - aptos_unique_identifiers


### PR DESCRIPTION
Test Plan: ran yq / generate proposals locally

```
target/performance/aptos-release-builder generate-proposals --release-config aptos-move/aptos-release-builder/data/release.yaml --output-dir output
```
