### PR TITLE
[NFT Metadata Crawler] Fix double slash URI parsing error, add ACKing PubSub message on receive

### DIFF
--- a/ecosystem/nft-metadata-crawler-parser/src/utils/uri_parser.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/uri_parser.rs
@@ -42,7 +42,7 @@ impl URIParser {
 mod tests {
     use super::*;
 
-    const IPFS_PREFIX: &str = "https://testipfsprefix.com/ipfs";
+    const IPFS_PREFIX: &str = "https://testipfsprefix.com/ipfs/";
     const CID: &str = "testcid";
     const PATH: &str = "testpath";
 
@@ -50,12 +50,12 @@ mod tests {
     fn test_parse_ipfs_uri() {
         let test_ipfs_uri = format!("ipfs://{}/{}", CID, PATH);
         let parsed_uri = URIParser::parse(IPFS_PREFIX.to_string(), test_ipfs_uri).unwrap();
-        assert_eq!(parsed_uri, format!("{IPFS_PREFIX}/{CID}/{PATH}"));
+        assert_eq!(parsed_uri, format!("{IPFS_PREFIX}{CID}/{PATH}"));
 
         // Path is optional for IPFS URIs
         let test_ipfs_uri_no_path = format!("ipfs://{}/{}", CID, "");
         let parsed_uri = URIParser::parse(IPFS_PREFIX.to_string(), test_ipfs_uri_no_path).unwrap();
-        assert_eq!(parsed_uri, format!("{}/{}/{}", IPFS_PREFIX, CID, ""));
+        assert_eq!(parsed_uri, format!("{}{}/{}", IPFS_PREFIX, CID, ""));
 
         // IPFS URIs must contain a CID, expect error here
         let test_ipfs_uri_no_cid = format!("ipfs://{}/{}", "", PATH);
@@ -68,13 +68,13 @@ mod tests {
         let test_public_gateway_uri = format!("https://ipfs.io/ipfs/{}/{}", CID, PATH);
         let parsed_uri =
             URIParser::parse(IPFS_PREFIX.to_string(), test_public_gateway_uri).unwrap();
-        assert_eq!(parsed_uri, format!("{IPFS_PREFIX}/{CID}/{PATH}",));
+        assert_eq!(parsed_uri, format!("{IPFS_PREFIX}{CID}/{PATH}",));
 
         // Path is optional for public gateway URIs
         let test_public_gateway_uri_no_path = format!("https://ipfs.io/ipfs/{}/{}", CID, "");
         let parsed_uri =
             URIParser::parse(IPFS_PREFIX.to_string(), test_public_gateway_uri_no_path).unwrap();
-        assert_eq!(parsed_uri, format!("{}/{}/{}", IPFS_PREFIX, CID, ""));
+        assert_eq!(parsed_uri, format!("{}{}/{}", IPFS_PREFIX, CID, ""));
 
         // Public gateway URIs must contain a CID, expect error here
         let test_public_gateway_uri_no_cid = format!("https://ipfs.io/ipfs/{}/{}", "", PATH);

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/uri_parser.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/uri_parser.rs
@@ -27,7 +27,7 @@ impl URIParser {
             let path = captures.name("path").map(|m| m.as_str().to_string());
 
             Ok(format!(
-                "{}/{}{}",
+                "{}{}{}",
                 ipfs_prefix,
                 cid,
                 path.unwrap_or_default()

--- a/ecosystem/nft-metadata-crawler-parser/src/worker.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/worker.rs
@@ -120,15 +120,15 @@ async fn spawn_parser(
     semaphore: Arc<Semaphore>,
     receiver: Arc<Mutex<Receiver<(Worker, String)>>>,
     subscription: Subscription,
-    send_ack: bool,
+    ack_parsed_uris: bool,
 ) -> anyhow::Result<()> {
     loop {
         // Pulls worker from Channel
         let _ = semaphore.acquire().await?;
         let (mut worker, ack) = receiver.lock().await.recv()?;
 
-        // Sends ack to PubSub only if running on release mode
-        if send_ack {
+        // Sends ack to PubSub only if ack_parsed_uris flag is true
+        if ack_parsed_uris {
             info!(
                 token_data_id = worker.token_data_id,
                 token_uri = worker.token_uri,

--- a/ecosystem/nft-metadata-crawler-parser/src/worker.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/worker.rs
@@ -120,27 +120,34 @@ async fn spawn_parser(
     semaphore: Arc<Semaphore>,
     receiver: Arc<Mutex<Receiver<(Worker, String)>>>,
     subscription: Subscription,
-    release: bool,
+    send_ack: bool,
 ) -> anyhow::Result<()> {
     loop {
-        let _ = semaphore.acquire().await?;
-
         // Pulls worker from Channel
+        let _ = semaphore.acquire().await?;
         let (mut worker, ack) = receiver.lock().await.recv()?;
-        worker.parse().await?;
 
         // Sends ack to PubSub only if running on release mode
-        if release {
+        if send_ack {
             info!(
                 token_data_id = worker.token_data_id,
                 token_uri = worker.token_uri,
                 last_transaction_version = worker.last_transaction_version,
                 force = worker.force,
-                "[NFT Metadata Crawler] Acking message"
+                "[NFT Metadata Crawler] Received worker, acking message"
             );
             subscription.ack(vec![ack]).await?;
         }
 
+        worker.parse().await?;
+
+        info!(
+            token_data_id = worker.token_data_id,
+            token_uri = worker.token_uri,
+            last_transaction_version = worker.last_transaction_version,
+            force = worker.force,
+            "[NFT Metadata Crawler] Worker finished"
+        );
         sleep(Duration::from_millis(500)).await;
     }
 }
@@ -256,14 +263,6 @@ impl Worker {
 
     /// Main parsing flow
     pub async fn parse(&mut self) -> anyhow::Result<()> {
-        info!(
-            token_data_id = self.token_data_id,
-            token_uri = self.token_uri,
-            last_transaction_version = self.last_transaction_version,
-            force = self.force,
-            "[NFT Metadata Crawler] Starting worker"
-        );
-
         // Deduplicate token_uri
         // Exit if not force or if token_uri has already been parsed
         if !self.force


### PR DESCRIPTION
### Description
Fixed an error with the URI parsing where there is an extra `/` and changed the ACKing logic to reduce queue ingestion. 

### Test Plan
Works locally
