### PR TITLE
[scripts] fixes to arch linux (pacman)

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -672,7 +672,7 @@ function install_lld {
 # this is needed for hdpi crate from aptos-ledger
 function install_libudev-dev {
   # Need to install libudev-dev for linux
-  if [[ "$(uname)" == "Linux" ]]; then
+  if [[ "$(uname)" == "Linux" && "$PACKAGE_MANAGER" != "pacman" ]]; then
     install_pkg libudev-dev "$PACKAGE_MANAGER"
   fi
 }
@@ -1034,9 +1034,12 @@ if [[ "$INSTALL_JSTS" == "true" ]]; then
 fi
 
 install_python3
-pip3 install pre-commit
-
-install_libudev-dev
+if [[ "$PACKAGE_MANAGER" != "pacman" ]]; then
+  pip3 install pre-commit
+  install_libudev-dev
+else
+  install_pkg python-pre-commit "$PACKAGE_MANAGER"
+fi
 
 # For now best effort install, will need to improve later
 if command -v pre-commit; then


### PR DESCRIPTION
* Archlinux / python / pip insist that you use the package manager solutions not python for pip
* The `libudev-dev` seems to exist in the default system install and under a wildly different name.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
