### PR TITLE
[CLI] Add support for setting faucet auth token

### DIFF
--- a/crates/aptos-rest-client/src/faucet.rs
+++ b/crates/aptos-rest-client/src/faucet.rs
@@ -17,15 +17,7 @@ pub struct FaucetClient {
 
 impl FaucetClient {
     pub fn new(faucet_url: Url, rest_url: Url) -> Self {
-        Self {
-            faucet_url,
-            inner: ReqwestClient::builder()
-                .timeout(Duration::from_secs(10))
-                .build()
-                .unwrap(),
-            rest_client: Client::new(rest_url),
-            token: None,
-        }
+        Self::new_from_rest_client(faucet_url, Client::new(rest_url))
     }
 
     pub fn new_for_testing(faucet_url: Url, rest_url: Url) -> Self {
@@ -41,6 +33,18 @@ impl FaucetClient {
                 // versioned API however, so we just set it to `/`.
                 .version_path_base("/".to_string())
                 .unwrap(),
+            token: None,
+        }
+    }
+
+    pub fn new_from_rest_client(faucet_url: Url, rest_client: Client) -> Self {
+        Self {
+            faucet_url,
+            inner: ReqwestClient::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .unwrap(),
+            rest_client,
             token: None,
         }
     }

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -47,7 +47,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 bcs = { workspace = true }
 chrono = { workspace = true }
-clap = { workspace = true, features = ["unstable-styles"] }
+clap = { workspace = true, features = ["env", "unstable-styles"] }
 clap_complete = { workspace = true }
 codespan-reporting = { workspace = true }
 dirs = { workspace = true }

--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -5,7 +5,7 @@ use crate::{
     account::create::DEFAULT_FUNDED_COINS,
     common::{
         types::{CliCommand, CliTypedResult, FaucetOptions, ProfileOptions, RestOptions},
-        utils::{fund_account, wait_for_transactions},
+        utils::wait_for_transactions,
     },
 };
 use aptos_types::account_address::AccountAddress;
@@ -51,12 +51,10 @@ impl CliCommand<String> for FundWithFaucet {
         } else {
             self.profile_options.account_address()?
         };
-        let hashes = fund_account(
-            self.faucet_options.faucet_url(&self.profile_options)?,
-            self.amount,
-            address,
-        )
-        .await?;
+        let hashes = self
+            .faucet_options
+            .fund_account(&self.profile_options, self.amount, &address)
+            .await?;
         let client = self.rest_options.client(&self.profile_options)?;
         wait_for_transactions(&client, hashes).await?;
         return Ok(format!(

--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -3,10 +3,7 @@
 
 use crate::{
     account::create::DEFAULT_FUNDED_COINS,
-    common::{
-        types::{CliCommand, CliTypedResult, FaucetOptions, ProfileOptions, RestOptions},
-        utils::wait_for_transactions,
-    },
+    common::types::{CliCommand, CliTypedResult, FaucetOptions, ProfileOptions, RestOptions},
 };
 use aptos_types::account_address::AccountAddress;
 use async_trait::async_trait;
@@ -51,12 +48,10 @@ impl CliCommand<String> for FundWithFaucet {
         } else {
             self.profile_options.account_address()?
         };
-        let hashes = self
-            .faucet_options
-            .fund_account(&self.profile_options, self.amount, &address)
-            .await?;
         let client = self.rest_options.client(&self.profile_options)?;
-        wait_for_transactions(&client, hashes).await?;
+        self.faucet_options
+            .fund_account(client, &self.profile_options, self.amount, address)
+            .await?;
         return Ok(format!(
             "Added {} Octas to account {}",
             self.amount, address

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -45,6 +45,11 @@ pub struct InitTool {
     #[clap(long)]
     pub faucet_url: Option<Url>,
 
+    /// Auth token, if we're using the faucet. This is only used this time, we don't
+    /// store it.
+    #[clap(long, env)]
+    pub faucet_auth_token: Option<String>,
+
     /// Whether to skip the faucet for a non-faucet endpoint
     #[clap(long)]
     pub skip_faucet: bool,
@@ -226,10 +231,11 @@ impl CliCommand<()> for InitTool {
                     address, NUM_DEFAULT_OCTAS
                 );
                 let hashes = fund_account(
-                    Url::parse(faucet_url)
+                    &Url::parse(faucet_url)
                         .map_err(|err| CliError::UnableToParse("rest_url", err.to_string()))?,
+                    self.faucet_auth_token.as_deref(),
                     NUM_DEFAULT_OCTAS,
-                    address,
+                    &address,
                 )
                 .await?;
                 wait_for_transactions(&client, hashes).await?;

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1296,22 +1296,24 @@ impl FaucetOptions {
             reqwest::Url::parse(&url)
                 .map_err(|err| CliError::UnableToParse("config faucet_url", err.to_string()))
         } else {
-            Err(CliError::CommandArgumentError("No faucet given.  Please add --faucet-url or add a faucet URL to the .aptos/config.yaml for the current profile".to_string()))
+            Err(CliError::CommandArgumentError("No faucet given. Please add --faucet-url or add a faucet URL to the .aptos/config.yaml for the current profile".to_string()))
         }
     }
 
     /// Fund an account with the faucet.
     pub async fn fund_account(
         &self,
+        rest_client: Client,
         profile: &ProfileOptions,
         num_octas: u64,
-        address: &AccountAddress,
-    ) -> CliTypedResult<Vec<HashValue>> {
+        address: AccountAddress,
+    ) -> CliTypedResult<()> {
         fund_account(
-            &self.faucet_url(profile)?,
+            rest_client,
+            self.faucet_url(profile)?,
             self.faucet_auth_token.as_deref(),
-            num_octas,
             address,
+            num_octas,
         )
         .await
     }

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -13,7 +13,7 @@ use aptos_build_info::build_information;
 use aptos_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use aptos_keygen::KeyGen;
 use aptos_logger::{debug, Level};
-use aptos_rest_client::{aptos_api_types::HashValue, Account, Client, State, Client as RestClient, FaucetClient};
+use aptos_rest_client::{aptos_api_types::HashValue, Account, Client, FaucetClient, State};
 use aptos_telemetry::service::telemetry_is_disabled;
 use aptos_types::{
     account_address::create_multisig_account_address,
@@ -416,42 +416,23 @@ pub fn read_line(input_name: &'static str) -> CliTypedResult<String> {
     Ok(input_buf)
 }
 
-/// Fund account (and possibly create it) from a faucet. This returns txn hashes that
-/// you must wait for before the account is funded.
+/// Fund account (and possibly create it) from a faucet. This function waits for the
+/// transaction on behalf of the caller.
 pub async fn fund_account(
-    rest_url: &Url,
-    faucet_url: &Url,
+    rest_client: Client,
+    faucet_url: Url,
     faucet_auth_token: Option<&str>,
+    address: AccountAddress,
     num_octas: u64,
-    address: &AccountAddress,
-) -> CliTypedResult<Vec<HashValue>> {
-    FaucetClient::new(faucet_url.clone(), rest_url.clone(), faucet_auth_token)
-        .fund(*address, num_octas)
+) -> CliTypedResult<()> {
+    let mut client = FaucetClient::new_from_rest_client(faucet_url, rest_client);
+    if let Some(token) = faucet_auth_token {
+        client = client.with_auth_token(token.to_string());
+    }
+    client
+        .fund(address, num_octas)
         .await
-    let mut builder = reqwest::Client::new()
-        .post(format!(
-            "{}mint?amount={}&auth_key={}",
-            faucet_url, num_octas, address
-        ))
-        .body("{}");
-    if let Some(ref faucet_auth_token) = faucet_auth_token {
-        builder = builder.header("Authorization", format!("Bearer {}", faucet_auth_token))
-    }
-    let response = builder.send().await.map_err(|err| {
-        CliError::ApiError(format!("Failed to fund account with faucet: {:#}", err))
-    })?;
-    if response.status() == 200 {
-        let hashes: Vec<HashValue> = response
-            .json()
-            .await
-            .map_err(|err| CliError::UnexpectedError(err.to_string()))?;
-        Ok(hashes)
-    } else {
-        Err(CliError::ApiError(format!(
-            "Faucet issue: {}",
-            response.status()
-        )))
-    }
+        .map_err(|err| CliError::ApiError(format!("Faucet issue: {:#}", err)))
 }
 
 /// Wait for transactions, returning an error if any of them fail.

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -541,6 +541,7 @@ impl CliTestFramework {
             network: Some(Network::Custom),
             rest_url: Some(self.endpoint.clone()),
             faucet_url: Some(self.faucet_endpoint.clone()),
+            faucet_auth_token: None,
             rng_args: RngArgs::from_seed([0; 32]),
             private_key_options: PrivateKeyInputOptions::from_private_key(private_key)?,
             profile_options: Default::default(),
@@ -1079,7 +1080,7 @@ impl CliTestFramework {
     }
 
     pub fn faucet_options(&self) -> FaucetOptions {
-        FaucetOptions::new(Some(self.faucet_endpoint.clone()))
+        FaucetOptions::new(Some(self.faucet_endpoint.clone()), None)
     }
 
     fn transaction_options(


### PR DESCRIPTION
### Description
Might be nice to use the FaucetClient but for now there is no way to set the auth token (pending https://github.com/aptos-labs/aptos-core/pull/9577). So for now I just modify what we have already.

### Test Plan
Without auth token:
```
cargo run -p aptos -- account fund-with-faucet --account 0x5 --url https://fullnode.testnet.aptoslabs.com --faucet-url https://faucet.testnet.aptoslabs.com
```
```
{
  "Error": "API error: Faucet issue: 429 Too Many Requests"
}
```

With auth token:
```
FAUCET_AUTH_TOKEN=123 cargo run -p aptos -- account fund-with-faucet --account 0x5 --url https://fullnode.testnet.aptoslabs.com --faucet-url https://faucet.testnet.aptoslabs.com
```
```
{
  "Result": "Added 100000000 Octas to account 0000000000000000000000000000000000000000000000000000000000000005"
}
```