### PR TITLE
[TS-SDK] Fix the coin client transfer/checkBalance functions to allow custom CoinTypes

### DIFF
--- a/ecosystem/typescript/sdk/src/plugins/coin_client.ts
+++ b/ecosystem/typescript/sdk/src/plugins/coin_client.ts
@@ -130,7 +130,7 @@ export class CoinClient {
       // The coin type to use, defaults to 0x1::aptos_coin::AptosCoin.
       // If you want to check the balance of a fungible asset, set this param to be the
       // fungible asset address
-      coinType?: string | MaybeHexString;
+      coinType?: MaybeHexString;
     },
   ): Promise<bigint> {
     const isTypeTag = (extraArgs?.coinType ?? "").toString().includes("::");

--- a/ecosystem/typescript/sdk/src/plugins/coin_client.ts
+++ b/ecosystem/typescript/sdk/src/plugins/coin_client.ts
@@ -67,12 +67,13 @@ export class CoinClient {
       createReceiverIfMissing?: boolean;
     },
   ): Promise<string> {
-    // Since we can receive either a fully qualified type tag like "0x1::coin_type::CoinType" or a fungible object address "0x1234...6789"
-    // we first check to see if the raw string value includes "::" to make sure it's not supposed to be a fungible asset object address.
+    // Since we can receive either a fully qualified type tag like "0x1::coin_type::CoinType"
+    // or a fungible object address "0x1234...6789" we first check to see if the raw string value includes "::"
+    // This is to make sure it's not supposed to be a fungible asset object address.
     const isTypeTag = (extraArgs?.coinType ?? "").toString().includes("::");
 
-    // If the coin type exists, definitely isn't a type tag, and is a valid account address, then we enter this if block
-    // under the assumption that it's a fungible asset object address.
+    // If the coin type exists, definitely isn't a type tag, and is a valid account address,
+    // then we enter this if block under the assumption that it's a fungible asset object address.
     if (extraArgs?.coinType && !isTypeTag && AccountAddress.isValid(extraArgs.coinType)) {
       /* eslint-disable no-console */
       console.warn("to transfer a fungible asset, use `FungibleAssetClient()` class for better support");
@@ -138,12 +139,13 @@ export class CoinClient {
       coinType?: string | MaybeHexString;
     },
   ): Promise<bigint> {
-    // Since we can receive either a fully qualified type tag like "0x1::coin_type::CoinType" or a fungible object address "0x1234...6789"
-    // we first check to see if the raw string value includes "::" to make sure it's not supposed to be a fungible asset object address.
+    // Since we can receive either a fully qualified type tag like "0x1::coin_type::CoinType"
+    // or a fungible object address "0x1234...6789" we first check to see if the raw string value includes "::"
+    // This is to make sure it's not supposed to be a fungible asset object address.
     const isTypeTag = (extraArgs?.coinType ?? "").toString().includes("::");
 
-    // If the coin type exists, definitely isn't a type tag, and is a valid account address, then we enter this if block
-    // under the assumption that it's a fungible asset object address.
+    // If the coin type exists, definitely isn't a type tag, and is a valid account address,
+    // then we enter this if block under the assumption that it's a fungible asset object address.
     if (extraArgs?.coinType && !isTypeTag && AccountAddress.isValid(extraArgs.coinType)) {
       /* eslint-disable no-console */
       console.warn("to check balance of a fungible asset, use `FungibleAssetClient()` class for better support");

--- a/ecosystem/typescript/sdk/src/plugins/coin_client.ts
+++ b/ecosystem/typescript/sdk/src/plugins/coin_client.ts
@@ -71,7 +71,8 @@ export class CoinClient {
     // we first check to see if the raw string value includes "::" to make sure it's not supposed to be a fungible asset object address.
     const isTypeTag = (extraArgs?.coinType ?? "").toString().includes("::");
 
-    // If the coin type exists and definitely isn't a type tag, and is a valid account address, then we assume it's a fungible asset object address.
+    // If the coin type exists, definitely isn't a type tag, and is a valid account address, then we enter this if block
+    // under the assumption that it's a fungible asset object address.
     if (extraArgs?.coinType && !isTypeTag && AccountAddress.isValid(extraArgs.coinType)) {
       /* eslint-disable no-console */
       console.warn("to transfer a fungible asset, use `FungibleAssetClient()` class for better support");
@@ -141,7 +142,8 @@ export class CoinClient {
     // we first check to see if the raw string value includes "::" to make sure it's not supposed to be a fungible asset object address.
     const isTypeTag = (extraArgs?.coinType ?? "").toString().includes("::");
 
-    // If the coin type exists and definitely isn't a type tag, and is a valid account address, then we assume it's a fungible asset object address.
+    // If the coin type exists, definitely isn't a type tag, and is a valid account address, then we enter this if block
+    // under the assumption that it's a fungible asset object address.
     if (extraArgs?.coinType && !isTypeTag && AccountAddress.isValid(extraArgs.coinType)) {
       /* eslint-disable no-console */
       console.warn("to check balance of a fungible asset, use `FungibleAssetClient()` class for better support");

--- a/ecosystem/typescript/sdk/src/plugins/coin_client.ts
+++ b/ecosystem/typescript/sdk/src/plugins/coin_client.ts
@@ -67,7 +67,11 @@ export class CoinClient {
       createReceiverIfMissing?: boolean;
     },
   ): Promise<string> {
+    // Since we can receive either a fully qualified type tag like "0x1::coin_type::CoinType" or a fungible object address "0x1234...6789"
+    // we first check to see if the raw string value includes "::" to make sure it's not supposed to be a fungible asset object address.
     const isTypeTag = (extraArgs?.coinType ?? "").toString().includes("::");
+
+    // If the coin type exists and definitely isn't a type tag, and is a valid account address, then we assume it's a fungible asset object address.
     if (extraArgs?.coinType && !isTypeTag && AccountAddress.isValid(extraArgs.coinType)) {
       /* eslint-disable no-console */
       console.warn("to transfer a fungible asset, use `FungibleAssetClient()` class for better support");
@@ -130,10 +134,14 @@ export class CoinClient {
       // The coin type to use, defaults to 0x1::aptos_coin::AptosCoin.
       // If you want to check the balance of a fungible asset, set this param to be the
       // fungible asset address
-      coinType?: MaybeHexString;
+      coinType?: string | MaybeHexString;
     },
   ): Promise<bigint> {
+    // Since we can receive either a fully qualified type tag like "0x1::coin_type::CoinType" or a fungible object address "0x1234...6789"
+    // we first check to see if the raw string value includes "::" to make sure it's not supposed to be a fungible asset object address.
     const isTypeTag = (extraArgs?.coinType ?? "").toString().includes("::");
+
+    // If the coin type exists and definitely isn't a type tag, and is a valid account address, then we assume it's a fungible asset object address.
     if (extraArgs?.coinType && !isTypeTag && AccountAddress.isValid(extraArgs.coinType)) {
       /* eslint-disable no-console */
       console.warn("to check balance of a fungible asset, use `FungibleAssetClient()` class for better support");

--- a/ecosystem/typescript/sdk/src/plugins/coin_client.ts
+++ b/ecosystem/typescript/sdk/src/plugins/coin_client.ts
@@ -67,7 +67,8 @@ export class CoinClient {
       createReceiverIfMissing?: boolean;
     },
   ): Promise<string> {
-    if (extraArgs?.coinType && AccountAddress.isValid(extraArgs.coinType)) {
+    const isTypeTag = (extraArgs?.coinType ?? "").toString().includes("::");
+    if (extraArgs?.coinType && !isTypeTag && AccountAddress.isValid(extraArgs.coinType)) {
       /* eslint-disable no-console */
       console.warn("to transfer a fungible asset, use `FungibleAssetClient()` class for better support");
       const provider = new Provider({
@@ -129,10 +130,11 @@ export class CoinClient {
       // The coin type to use, defaults to 0x1::aptos_coin::AptosCoin.
       // If you want to check the balance of a fungible asset, set this param to be the
       // fungible asset address
-      coinType?: string;
+      coinType?: string | MaybeHexString;
     },
   ): Promise<bigint> {
-    if (extraArgs?.coinType && AccountAddress.isValid(extraArgs.coinType)) {
+    const isTypeTag = (extraArgs?.coinType ?? "").toString().includes("::");
+    if (extraArgs?.coinType && !isTypeTag && AccountAddress.isValid(extraArgs.coinType)) {
       /* eslint-disable no-console */
       console.warn("to check balance of a fungible asset, use `FungibleAssetClient()` class for better support");
       const provider = new Provider({

--- a/ecosystem/typescript/sdk/src/tests/e2e/coin_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/coin_client.test.ts
@@ -6,6 +6,7 @@ import { getFaucetClient, longTestTimeout, NODE_URL } from "../unit/test_helper.
 import { AptosAccount } from "../../account/aptos_account";
 import { COIN_TRANSFER, CoinClient, TRANSFER_COINS } from "../../plugins/coin_client";
 import { EntryFunctionPayload, Transaction_UserTransaction } from "../../generated";
+import { APTOS_COIN } from "../../utils";
 
 test(
   "transfer and checkBalance works",
@@ -19,10 +20,10 @@ test(
     await faucetClient.fundAccount(alice.address(), 100_000_000);
     await faucetClient.fundAccount(bob.address(), 0);
 
-    const txnHash1 = await coinClient.transfer(alice, bob, 42);
+    const txnHash1 = await coinClient.transfer(alice, bob, 42, { coinType: APTOS_COIN });
     await client.waitForTransaction(txnHash1, { checkSuccess: true });
 
-    expect(await coinClient.checkBalance(bob)).toBe(BigInt(42));
+    expect(await coinClient.checkBalance(bob, { coinType: APTOS_COIN })).toBe(BigInt(42));
     let txn1 = (await client.getTransactionByHash(txnHash1)) as Transaction_UserTransaction;
     expect((txn1.payload as EntryFunctionPayload).function).toBe(TRANSFER_COINS);
 


### PR DESCRIPTION
### Description

Updating `CoinClient` `transfer()` and `checkBalance()` to check for a custom `CoinType` first before converting to a `HexString` address.

As of right now, the function assumes it's an address and tries to parse it as such, resulting in a failed conversion to `HexString`:

```typescript
throw new Error('Invalid byte sequence');
```

Added a simple `.includes("::")` check to skip the hex string conversion so it doesn't error if the user sends in a custom cointype.

```typescript
const isTypeTag = (extraArgs?.coinType ?? "").toString().includes("::");
if (extraArgs?.coinType && !isTypeTag && AccountAddress.isValid(extraArgs.coinType)) {
```

Also made the `coinType` arg consistent between the two functions by changing the `checkBalance` type to `string | MaybeHexString` instead of just `string`.

Also added two unit tests that use a custom cointype in the form of `APTOS_COIN` aka `0x1::aptos_coin::AptosCoin` to test it (even that didn't work before).

### Test Plan
```shell
yarn run jest coin_client.test.ts
```