### PR TITLE
[Execution][Benchmark] Add support for a pre-generating all transactions in the block-stm benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3602,6 +3602,7 @@ dependencies = [
  "aptos-language-e2e-tests",
  "aptos-logger",
  "aptos-metrics-core",
+ "aptos-node-resource-metrics",
  "aptos-push-metrics",
  "aptos-types",
  "aptos-vm",

--- a/aptos-move/aptos-transaction-benchmarks/Cargo.toml
+++ b/aptos-move/aptos-transaction-benchmarks/Cargo.toml
@@ -22,6 +22,7 @@ aptos-gas-schedule = { workspace = true, features = ["testing"] }
 aptos-language-e2e-tests = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
+aptos-node-resource-metrics = { workspace = true }
 aptos-push-metrics =  { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }

--- a/aptos-move/aptos-transaction-benchmarks/src/benchmark_runner.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/benchmark_runner.rs
@@ -1,0 +1,149 @@
+// Copyright © Aptos Foundation
+
+use crate::transaction_bench_state::TransactionBenchState;
+use aptos_language_e2e_tests::account_universe::{AUTransactionGen, AccountPickStyle};
+use aptos_types::transaction::Transaction;
+use proptest::strategy::Strategy;
+use std::net::SocketAddr;
+
+pub(crate) trait BenchmarkRunner {
+    fn run_benchmark(
+        &mut self,
+        run_par: bool,
+        run_seq: bool,
+        conurrency_level_per_shard: usize,
+        maybe_block_gas_limit: Option<u64>,
+    ) -> (usize, usize);
+}
+
+pub struct TransactionBenchmarkRunner<S> {
+    strategy: S,
+    num_accounts: usize,
+    num_txn: usize,
+    num_executor_shards: usize,
+    remote_executor_addresses: Option<Vec<SocketAddr>>,
+    account_pick_style: AccountPickStyle,
+}
+
+impl<S> TransactionBenchmarkRunner<S>
+where
+    S: Strategy,
+{
+    pub fn new(
+        strategy: S,
+        num_accounts: usize,
+        num_txn: usize,
+        num_executor_shards: usize,
+        remote_executor_addresses: Option<Vec<SocketAddr>>,
+        account_pick_style: AccountPickStyle,
+    ) -> Self {
+        Self {
+            strategy,
+            num_accounts,
+            num_txn,
+            num_executor_shards,
+            remote_executor_addresses,
+            account_pick_style,
+        }
+    }
+}
+
+impl<S> BenchmarkRunner for TransactionBenchmarkRunner<S>
+where
+    S: Strategy,
+    S::Value: AUTransactionGen,
+{
+    fn run_benchmark(
+        &mut self,
+        run_par: bool,
+        run_seq: bool,
+        concurrency_level_per_shard: usize,
+        maybe_block_gas_limit: Option<u64>,
+    ) -> (usize, usize) {
+        let mut state = TransactionBenchState::with_size(
+            &self.strategy,
+            self.num_accounts,
+            self.num_txn,
+            self.num_executor_shards,
+            self.remote_executor_addresses.clone(),
+            self.account_pick_style.clone(),
+        );
+        let transactions = state.gen_transaction();
+        state.execute_blockstm_benchmark(
+            transactions,
+            run_par,
+            run_seq,
+            concurrency_level_per_shard,
+            maybe_block_gas_limit,
+        )
+    }
+}
+
+pub struct PreGeneratedTxnsBenchmarkRunner<'a, S> {
+    states: Vec<TransactionBenchState<&'a S>>,
+    // pre-generated transactions
+    transactions: Vec<Vec<Transaction>>,
+}
+
+impl<'a, S> PreGeneratedTxnsBenchmarkRunner<'a, S>
+where
+    S: Strategy,
+    S::Value: AUTransactionGen,
+{
+    pub fn new(
+        strategy: &'a S,
+        num_accounts: usize,
+        num_txn: usize,
+        num_executor_shards: usize,
+        remote_executor_addresses: Option<Vec<SocketAddr>>,
+        account_pick_style: AccountPickStyle,
+        num_runs: usize,
+    ) -> Self {
+        println!("Generating transactions for {} runs", num_runs);
+        let mut states: Vec<_> = (0..num_runs)
+            .map(|_| {
+                TransactionBenchState::with_size(
+                    strategy,
+                    num_accounts,
+                    num_txn,
+                    num_executor_shards,
+                    remote_executor_addresses.clone(),
+                    account_pick_style.clone(),
+                )
+            })
+            .collect();
+        let transactions = states
+            .iter_mut()
+            .map(|state| state.gen_transaction())
+            .collect();
+        println!("Done generating transactions for {} runs", num_runs);
+        Self {
+            states,
+            transactions,
+        }
+    }
+}
+
+impl<S> BenchmarkRunner for PreGeneratedTxnsBenchmarkRunner<'_, S>
+where
+    S: Strategy,
+    S::Value: AUTransactionGen,
+{
+    fn run_benchmark(
+        &mut self,
+        run_par: bool,
+        run_seq: bool,
+        concurrency_level_per_shard: usize,
+        maybe_block_gas_limit: Option<u64>,
+    ) -> (usize, usize) {
+        let mut state = self.states.pop().unwrap();
+        let transactions = self.transactions.pop().unwrap();
+        state.execute_blockstm_benchmark(
+            transactions,
+            run_par,
+            run_seq,
+            concurrency_level_per_shard,
+            maybe_block_gas_limit,
+        )
+    }
+}

--- a/aptos-move/aptos-transaction-benchmarks/src/lib.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/lib.rs
@@ -4,5 +4,7 @@
 
 #![forbid(unsafe_code)]
 
+mod benchmark_runner;
 pub mod measurement;
+pub mod transaction_bench_state;
 pub mod transactions;

--- a/aptos-move/aptos-transaction-benchmarks/src/main.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/main.rs
@@ -186,8 +186,7 @@ fn execute(opt: ExecuteOpt) {
         opt.num_executor_shards,
         opt.concurrency_level_per_shard,
         opt.remote_executor_addresses,
-        false,
-        //opt.no_conflict_txns,
+        opt.no_conflict_txns,
         opt.maybe_block_gas_limit,
         opt.generate_then_execute,
     );

--- a/aptos-move/aptos-transaction-benchmarks/src/main.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/main.rs
@@ -204,6 +204,7 @@ fn main() {
             .unwrap()
             .as_millis() as i64,
     );
+    aptos_node_resource_metrics::register_node_metrics_collector();
     let _mp = MetricsPusher::start_for_local_run("block-stm-benchmark");
     let args = Args::parse();
 

--- a/aptos-move/aptos-transaction-benchmarks/src/main.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/main.rs
@@ -84,6 +84,9 @@ struct ExecuteOpt {
 
     #[clap(long)]
     pub maybe_block_gas_limit: Option<u64>,
+
+    #[clap(long, default_value_t = false)]
+    pub generate_then_execute: bool,
 }
 
 fn param_sweep(opt: ParamSweepOpt) {
@@ -121,6 +124,7 @@ fn param_sweep(opt: ParamSweepOpt) {
                 None,
                 false,
                 maybe_block_gas_limit,
+                false,
             );
             par_tps.sort();
             seq_tps.sort();
@@ -169,6 +173,7 @@ fn param_sweep(opt: ParamSweepOpt) {
 }
 
 fn execute(opt: ExecuteOpt) {
+    disable_speculative_logging();
     let bencher = TransactionBencher::new(any_with::<P2PTransferGen>((1_000, 1_000_000)));
 
     let (par_tps, _) = bencher.blockstm_benchmark(
@@ -181,8 +186,10 @@ fn execute(opt: ExecuteOpt) {
         opt.num_executor_shards,
         opt.concurrency_level_per_shard,
         opt.remote_executor_addresses,
-        opt.no_conflict_txns,
+        false,
+        //opt.no_conflict_txns,
         opt.maybe_block_gas_limit,
+        opt.generate_then_execute,
     );
 
     let sum: usize = par_tps.iter().sum();

--- a/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
@@ -171,7 +171,7 @@ where
                         .skip(1)
                         .map(|txn| txn.clone().into())
                         .collect::<Vec<AnalyzedTransaction>>(),
-                    self.sharded_block_executor.as_ref().unwrap().num_shards()
+                    self.sharded_block_executor.as_ref().unwrap().num_shards(),
                 ),
             )
         } else {

--- a/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
@@ -1,0 +1,290 @@
+// Copyright © Aptos Foundation
+
+use crate::{transactions, transactions::RAYON_EXEC_POOL};
+use aptos_bitvec::BitVec;
+use aptos_block_executor::txn_commit_hook::NoOpTransactionCommitHook;
+use aptos_block_partitioner::{
+    sharded_block_partitioner::config::PartitionerV1Config, BlockPartitioner,
+};
+use aptos_crypto::HashValue;
+use aptos_language_e2e_tests::{
+    account_universe::{AUTransactionGen, AccountPickStyle, AccountUniverse, AccountUniverseGen},
+    data_store::FakeDataStore,
+    executor::FakeExecutor,
+};
+use aptos_types::{
+    block_metadata::BlockMetadata,
+    on_chain_config::{OnChainConfig, ValidatorSet},
+    transaction::{
+        analyzed_transaction::AnalyzedTransaction, ExecutionStatus, Transaction, TransactionOutput,
+        TransactionStatus,
+    },
+    vm_status::VMStatus,
+};
+use aptos_vm::{
+    block_executor::{AptosTransactionOutput, BlockAptosVM},
+    data_cache::AsMoveResolver,
+    sharded_block_executor::{
+        local_executor_shard::{LocalExecutorClient, LocalExecutorService},
+        ShardedBlockExecutor,
+    },
+};
+use proptest::{collection::vec, prelude::Strategy, strategy::ValueTree, test_runner::TestRunner};
+use std::{net::SocketAddr, sync::Arc, time::Instant};
+
+pub struct TransactionBenchState<S> {
+    num_transactions: usize,
+    strategy: S,
+    account_universe: AccountUniverse,
+    parallel_block_executor:
+        Option<Arc<ShardedBlockExecutor<FakeDataStore, LocalExecutorClient<FakeDataStore>>>>,
+    block_partitioner: Option<Box<dyn BlockPartitioner>>,
+    validator_set: ValidatorSet,
+    state_view: Arc<FakeDataStore>,
+}
+
+impl<S> TransactionBenchState<S>
+where
+    S: Strategy,
+    S::Value: AUTransactionGen,
+{
+    /// Creates a new benchmark state with the given number of accounts and transactions.
+    pub(crate) fn with_size(
+        strategy: S,
+        num_accounts: usize,
+        num_transactions: usize,
+        num_executor_shards: usize,
+        remote_executor_addresses: Option<Vec<SocketAddr>>,
+        account_pick_style: AccountPickStyle,
+    ) -> Self {
+        Self::with_universe(
+            strategy,
+            transactions::universe_strategy(num_accounts, num_transactions, account_pick_style),
+            num_transactions,
+            num_executor_shards,
+            remote_executor_addresses,
+        )
+    }
+
+    /// Creates a new benchmark state with the given account universe strategy and number of
+    /// transactions.
+    fn with_universe(
+        strategy: S,
+        universe_strategy: impl Strategy<Value = AccountUniverseGen>,
+        num_transactions: usize,
+        num_executor_shards: usize,
+        // TODO(skedia): add support for remote executor addresses.
+        _remote_executor_addresses: Option<Vec<SocketAddr>>,
+    ) -> Self {
+        let mut runner = TestRunner::default();
+        let universe_gen = universe_strategy
+            .new_tree(&mut runner)
+            .expect("creating a new value should succeed")
+            .current();
+
+        let mut executor = FakeExecutor::from_head_genesis();
+        // Run in gas-cost-stability mode for now -- this ensures that new accounts are ignored.
+        // XXX We may want to include new accounts in case they have interesting performance
+        // characteristics.
+        let universe = universe_gen.setup_gas_cost_stability(&mut executor);
+
+        let state_view = Arc::new(executor.get_state_view().clone());
+        let (parallel_block_executor, block_partitioner) = if num_executor_shards == 1 {
+            (None, None)
+        } else {
+            let client =
+                LocalExecutorService::setup_local_executor_shards(num_executor_shards, None);
+            let parallel_block_executor = Arc::new(ShardedBlockExecutor::new(client));
+            (
+                Some(parallel_block_executor),
+                Some(
+                    PartitionerV1Config::default()
+                        .num_shards(num_executor_shards)
+                        .max_partitioning_rounds(4)
+                        .cross_shard_dep_avoid_threshold(0.9)
+                        .partition_last_round(true)
+                        .build(),
+                ),
+            )
+        };
+
+        let validator_set = ValidatorSet::fetch_config(
+            &FakeExecutor::from_head_genesis()
+                .get_state_view()
+                .as_move_resolver(),
+        )
+        .expect("Unable to retrieve the validator set from storage");
+
+        Self {
+            num_transactions,
+            strategy,
+            account_universe: universe,
+            parallel_block_executor,
+            block_partitioner,
+            validator_set,
+            state_view,
+        }
+    }
+
+    pub fn gen_transaction(&mut self) -> Vec<Transaction> {
+        let mut runner = TestRunner::default();
+        let transaction_gens = vec(&self.strategy, self.num_transactions)
+            .new_tree(&mut runner)
+            .expect("creating a new value should succeed")
+            .current();
+        let mut transactions: Vec<Transaction> = transaction_gens
+            .into_iter()
+            .map(|txn_gen| {
+                Transaction::UserTransaction(txn_gen.apply(&mut self.account_universe).0)
+            })
+            .collect();
+
+        // Insert a blockmetadata transaction at the beginning to better simulate the real life traffic.
+        let new_block = BlockMetadata::new(
+            HashValue::zero(),
+            0,
+            0,
+            *self
+                .validator_set
+                .payload()
+                .next()
+                .unwrap()
+                .account_address(),
+            BitVec::with_num_bits(self.validator_set.num_validators() as u16).into(),
+            vec![],
+            1,
+        );
+
+        transactions.insert(0, Transaction::BlockMetadata(new_block));
+        transactions
+    }
+
+    /// Executes this state in a single block.
+    pub(crate) fn execute_sequential(mut self) {
+        // The output is ignored here since we're just testing transaction performance, not trying
+        // to assert correctness.
+        let txns = self.gen_transaction();
+        self.execute_benchmark_sequential(txns, None);
+    }
+
+    /// Executes this state in a single block.
+    pub(crate) fn execute_parallel(mut self) {
+        // The output is ignored here since we're just testing transaction performance, not trying
+        // to assert correctness.
+        let txns = self.gen_transaction();
+        self.execute_benchmark_parallel(txns, num_cpus::get(), None);
+    }
+
+    fn execute_benchmark_sequential(
+        &self,
+        transactions: Vec<Transaction>,
+        maybe_block_gas_limit: Option<u64>,
+    ) -> (Vec<TransactionOutput>, usize) {
+        let block_size = transactions.len();
+        let timer = Instant::now();
+        let output = BlockAptosVM::execute_block::<
+            _,
+            NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
+        >(
+            Arc::clone(&RAYON_EXEC_POOL),
+            transactions,
+            self.state_view.as_ref(),
+            1,
+            maybe_block_gas_limit,
+            None,
+        )
+        .expect("VM should not fail to start");
+        let exec_time = timer.elapsed().as_millis();
+
+        (output, block_size * 1000 / exec_time as usize)
+    }
+
+    fn execute_benchmark_parallel(
+        &self,
+        transactions: Vec<Transaction>,
+        concurrency_level_per_shard: usize,
+        maybe_block_gas_limit: Option<u64>,
+    ) -> (Vec<TransactionOutput>, usize) {
+        let block_size = transactions.len();
+        let timer = Instant::now();
+        let output = if let Some(parallel_block_executor) = self.parallel_block_executor.as_ref() {
+            // TODO(skedia) partition in a pipelined way and evaluate how expensive it is to
+            // parse the txns in a single thread.
+            let partitioned_block = self.block_partitioner.as_ref().unwrap().partition(
+                transactions
+                    .into_iter()
+                    .map(|txn| txn.into())
+                    .collect::<Vec<AnalyzedTransaction>>(),
+                self.parallel_block_executor.as_ref().unwrap().num_shards(),
+            );
+            parallel_block_executor
+                .execute_block(
+                    self.state_view.clone(),
+                    partitioned_block,
+                    concurrency_level_per_shard,
+                    maybe_block_gas_limit,
+                )
+                .expect("VM should not fail to start")
+        } else {
+            BlockAptosVM::execute_block::<
+                _,
+                NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
+            >(
+                Arc::clone(&RAYON_EXEC_POOL),
+                transactions,
+                self.state_view.as_ref(),
+                concurrency_level_per_shard,
+                maybe_block_gas_limit,
+                None,
+            )
+            .expect("VM should not fail to start")
+        };
+        let exec_time = timer.elapsed().as_millis();
+
+        (output, block_size * 1000 / exec_time as usize)
+    }
+
+    pub(crate) fn execute_blockstm_benchmark(
+        &mut self,
+        transactions: Vec<Transaction>,
+        run_par: bool,
+        run_seq: bool,
+        conurrency_level_per_shard: usize,
+        maybe_block_gas_limit: Option<u64>,
+    ) -> (usize, usize) {
+        let (output, par_tps) = if run_par {
+            println!("Parallel execution starts...");
+            let (output, tps) = self.execute_benchmark_parallel(
+                transactions.clone(),
+                conurrency_level_per_shard,
+                maybe_block_gas_limit,
+            );
+            println!("Parallel execution finishes, TPS = {}", tps);
+            (output, tps)
+        } else {
+            (vec![], 0)
+        };
+        output.iter().for_each(|txn_output| {
+            assert_eq!(
+                txn_output.status(),
+                &TransactionStatus::Keep(ExecutionStatus::Success)
+            );
+        });
+        let (output, seq_tps) = if run_seq {
+            println!("Sequential execution starts...");
+            let (output, tps) =
+                self.execute_benchmark_sequential(transactions, maybe_block_gas_limit);
+            println!("Sequential execution finishes, TPS = {}", tps);
+            (output, tps)
+        } else {
+            (vec![], 0)
+        };
+        output.iter().for_each(|txn_output| {
+            assert_eq!(
+                txn_output.status(),
+                &TransactionStatus::Keep(ExecutionStatus::Success)
+            );
+        });
+        (par_tps, seq_tps)
+    }
+}

--- a/aptos-move/aptos-transaction-benchmarks/src/transactions.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/transactions.rs
@@ -2,43 +2,20 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_bitvec::BitVec;
-use aptos_block_executor::txn_commit_hook::NoOpTransactionCommitHook;
-use aptos_block_partitioner::{
-    sharded_block_partitioner::config::PartitionerV1Config, BlockPartitioner,
+use crate::{
+    benchmark_runner::{
+        BenchmarkRunner, PreGeneratedTxnsBenchmarkRunner, TransactionBenchmarkRunner,
+    },
+    transaction_bench_state::TransactionBenchState,
 };
-use aptos_crypto::HashValue;
 use aptos_language_e2e_tests::{
-    account_universe::{AUTransactionGen, AccountPickStyle, AccountUniverse, AccountUniverseGen},
-    data_store::FakeDataStore,
-    executor::FakeExecutor,
+    account_universe::{AUTransactionGen, AccountPickStyle, AccountUniverseGen},
     gas_costs::TXN_RESERVED,
-};
-use aptos_types::{
-    block_metadata::BlockMetadata,
-    on_chain_config::{OnChainConfig, ValidatorSet},
-    transaction::{
-        analyzed_transaction::AnalyzedTransaction, ExecutionStatus, Transaction, TransactionOutput,
-        TransactionStatus,
-    },
-    vm_status::VMStatus,
-};
-use aptos_vm::{
-    block_executor::{AptosTransactionOutput, BlockAptosVM},
-    data_cache::AsMoveResolver,
-    sharded_block_executor::{
-        local_executor_shard::{LocalExecutorClient, LocalExecutorService},
-        ShardedBlockExecutor,
-    },
 };
 use criterion::{measurement::Measurement, BatchSize, Bencher};
 use once_cell::sync::Lazy;
-use proptest::{
-    collection::vec,
-    strategy::{Strategy, ValueTree},
-    test_runner::TestRunner,
-};
-use std::{net::SocketAddr, sync::Arc, time::Instant};
+use proptest::strategy::Strategy;
+use std::{net::SocketAddr, sync::Arc};
 
 pub static RAYON_EXEC_POOL: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
     Arc::new(
@@ -141,6 +118,7 @@ where
         remote_executor_addresses: Option<Vec<SocketAddr>>,
         no_conflict_txn: bool,
         maybe_block_gas_limit: Option<u64>,
+        generate_then_execute: bool,
     ) -> (Vec<usize>, Vec<usize>) {
         let mut par_tps = Vec::new();
         let mut seq_tps = Vec::new();
@@ -158,29 +136,39 @@ where
         } else {
             AccountPickStyle::Unlimited
         };
-        for i in 0..total_runs {
-            let mut state = TransactionBenchState::with_size(
+        let mut runner: Box<dyn BenchmarkRunner> = if generate_then_execute {
+            Box::new(PreGeneratedTxnsBenchmarkRunner::new(
                 &self.strategy,
                 num_accounts,
                 num_txn,
                 num_executor_shards,
-                remote_executor_addresses.clone(),
-                account_pick_style.clone(),
-            );
+                remote_executor_addresses,
+                account_pick_style,
+                total_runs,
+            ))
+        } else {
+            Box::new(TransactionBenchmarkRunner::new(
+                &self.strategy,
+                num_accounts,
+                num_txn,
+                num_executor_shards,
+                remote_executor_addresses,
+                account_pick_style,
+            ))
+        };
+        for i in 0..total_runs {
             if i < num_warmups {
                 println!("WARMUP - ignore results");
-                state.execute_blockstm_benchmark(
+                runner.run_benchmark(
                     run_par,
                     run_seq,
-                    no_conflict_txn,
                     concurrency_level_per_shard,
                     maybe_block_gas_limit,
                 );
             } else {
-                let tps = state.execute_blockstm_benchmark(
+                let tps = runner.run_benchmark(
                     run_par,
                     run_seq,
-                    no_conflict_txn,
                     concurrency_level_per_shard,
                     maybe_block_gas_limit,
                 );
@@ -193,272 +181,9 @@ where
     }
 }
 
-struct TransactionBenchState<S> {
-    num_transactions: usize,
-    strategy: S,
-    account_universe: AccountUniverse,
-    parallel_block_executor:
-        Option<Arc<ShardedBlockExecutor<FakeDataStore, LocalExecutorClient<FakeDataStore>>>>,
-    block_partitioner: Option<Box<dyn BlockPartitioner>>,
-    validator_set: ValidatorSet,
-    state_view: Arc<FakeDataStore>,
-}
-
-impl<S> TransactionBenchState<S>
-where
-    S: Strategy,
-    S::Value: AUTransactionGen,
-{
-    /// Creates a new benchmark state with the given number of accounts and transactions.
-    fn with_size(
-        strategy: S,
-        num_accounts: usize,
-        num_transactions: usize,
-        num_executor_shards: usize,
-        remote_executor_addresses: Option<Vec<SocketAddr>>,
-        account_pick_style: AccountPickStyle,
-    ) -> Self {
-        Self::with_universe(
-            strategy,
-            universe_strategy(num_accounts, num_transactions, account_pick_style),
-            num_transactions,
-            num_executor_shards,
-            remote_executor_addresses,
-        )
-    }
-
-    /// Creates a new benchmark state with the given account universe strategy and number of
-    /// transactions.
-    fn with_universe(
-        strategy: S,
-        universe_strategy: impl Strategy<Value = AccountUniverseGen>,
-        num_transactions: usize,
-        num_executor_shards: usize,
-        // TODO(skedia): add support for remote executor addresses.
-        _remote_executor_addresses: Option<Vec<SocketAddr>>,
-    ) -> Self {
-        let mut runner = TestRunner::default();
-        let universe_gen = universe_strategy
-            .new_tree(&mut runner)
-            .expect("creating a new value should succeed")
-            .current();
-
-        let mut executor = FakeExecutor::from_head_genesis();
-        // Run in gas-cost-stability mode for now -- this ensures that new accounts are ignored.
-        // XXX We may want to include new accounts in case they have interesting performance
-        // characteristics.
-        let universe = universe_gen.setup_gas_cost_stability(&mut executor);
-
-        let state_view = Arc::new(executor.get_state_view().clone());
-        let (parallel_block_executor, block_partitioner) = if num_executor_shards == 1 {
-            (None, None)
-        } else {
-            let client =
-                LocalExecutorService::setup_local_executor_shards(num_executor_shards, None);
-            let parallel_block_executor = Arc::new(ShardedBlockExecutor::new(client));
-            (
-                Some(parallel_block_executor),
-                Some(
-                    PartitionerV1Config::default()
-                        .num_shards(num_executor_shards)
-                        .max_partitioning_rounds(4)
-                        .cross_shard_dep_avoid_threshold(0.9)
-                        .partition_last_round(true)
-                        .build(),
-                ),
-            )
-        };
-
-        let validator_set = ValidatorSet::fetch_config(
-            &FakeExecutor::from_head_genesis()
-                .get_state_view()
-                .as_move_resolver(),
-        )
-        .expect("Unable to retrieve the validator set from storage");
-
-        Self {
-            num_transactions,
-            strategy,
-            account_universe: universe,
-            parallel_block_executor,
-            block_partitioner,
-            validator_set,
-            state_view,
-        }
-    }
-
-    pub fn gen_transaction(&mut self, no_conflict_txns: bool) -> Vec<Transaction> {
-        if no_conflict_txns {
-            // resetting the picker here so that we can re-use the same accounts from last block
-            // but still generate non conflicting transactions for this block.
-            self.account_universe.reset_picker()
-        }
-        let mut runner = TestRunner::default();
-        let transaction_gens = vec(&self.strategy, self.num_transactions)
-            .new_tree(&mut runner)
-            .expect("creating a new value should succeed")
-            .current();
-        let mut transactions: Vec<Transaction> = transaction_gens
-            .into_iter()
-            .map(|txn_gen| {
-                Transaction::UserTransaction(txn_gen.apply(&mut self.account_universe).0)
-            })
-            .collect();
-
-        // Insert a blockmetadata transaction at the beginning to better simulate the real life traffic.
-        let new_block = BlockMetadata::new(
-            HashValue::zero(),
-            0,
-            0,
-            *self
-                .validator_set
-                .payload()
-                .next()
-                .unwrap()
-                .account_address(),
-            BitVec::with_num_bits(self.validator_set.num_validators() as u16).into(),
-            vec![],
-            1,
-        );
-
-        transactions.insert(0, Transaction::BlockMetadata(new_block));
-        transactions
-    }
-
-    /// Executes this state in a single block.
-    fn execute_sequential(mut self) {
-        // The output is ignored here since we're just testing transaction performance, not trying
-        // to assert correctness.
-        let txns = self.gen_transaction(false);
-        self.execute_benchmark_sequential(txns, None);
-    }
-
-    /// Executes this state in a single block.
-    fn execute_parallel(mut self) {
-        // The output is ignored here since we're just testing transaction performance, not trying
-        // to assert correctness.
-        let txns = self.gen_transaction(false);
-        self.execute_benchmark_parallel(txns, num_cpus::get(), None);
-    }
-
-    fn execute_benchmark_sequential(
-        &self,
-        transactions: Vec<Transaction>,
-        maybe_block_gas_limit: Option<u64>,
-    ) -> (Vec<TransactionOutput>, usize) {
-        let block_size = transactions.len();
-        let timer = Instant::now();
-        let output = BlockAptosVM::execute_block::<
-            _,
-            NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
-        >(
-            Arc::clone(&RAYON_EXEC_POOL),
-            transactions,
-            self.state_view.as_ref(),
-            1,
-            maybe_block_gas_limit,
-            None,
-        )
-        .expect("VM should not fail to start");
-        let exec_time = timer.elapsed().as_millis();
-
-        (output, block_size * 1000 / exec_time as usize)
-    }
-
-    fn execute_benchmark_parallel(
-        &self,
-        transactions: Vec<Transaction>,
-        concurrency_level_per_shard: usize,
-        maybe_block_gas_limit: Option<u64>,
-    ) -> (Vec<TransactionOutput>, usize) {
-        let block_size = transactions.len();
-        let timer = Instant::now();
-        let output = if let Some(parallel_block_executor) = self.parallel_block_executor.as_ref() {
-            // TODO(skedia) partition in a pipelined way and evaluate how expensive it is to
-            // parse the txns in a single thread.
-            let partitioned_block = self.block_partitioner.as_ref().unwrap().partition(
-                transactions
-                    .into_iter()
-                    .map(|txn| txn.into())
-                    .collect::<Vec<AnalyzedTransaction>>(),
-                self.parallel_block_executor.as_ref().unwrap().num_shards(),
-            );
-            parallel_block_executor
-                .execute_block(
-                    self.state_view.clone(),
-                    partitioned_block,
-                    concurrency_level_per_shard,
-                    maybe_block_gas_limit,
-                )
-                .expect("VM should not fail to start")
-        } else {
-            BlockAptosVM::execute_block::<
-                _,
-                NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
-            >(
-                Arc::clone(&RAYON_EXEC_POOL),
-                transactions,
-                self.state_view.as_ref(),
-                concurrency_level_per_shard,
-                maybe_block_gas_limit,
-                None,
-            )
-            .expect("VM should not fail to start")
-        };
-        let exec_time = timer.elapsed().as_millis();
-
-        (output, block_size * 1000 / exec_time as usize)
-    }
-
-    fn execute_blockstm_benchmark(
-        &mut self,
-        run_par: bool,
-        run_seq: bool,
-        no_conflict_txns: bool,
-        conurrency_level_per_shard: usize,
-        maybe_block_gas_limit: Option<u64>,
-    ) -> (usize, usize) {
-        let transactions = self.gen_transaction(no_conflict_txns);
-        let (output, par_tps) = if run_par {
-            println!("Parallel execution starts...");
-            let (output, tps) = self.execute_benchmark_parallel(
-                transactions.clone(),
-                conurrency_level_per_shard,
-                maybe_block_gas_limit,
-            );
-            println!("Parallel execution finishes, TPS = {}", tps);
-            (output, tps)
-        } else {
-            (vec![], 0)
-        };
-        output.iter().for_each(|txn_output| {
-            assert_eq!(
-                txn_output.status(),
-                &TransactionStatus::Keep(ExecutionStatus::Success)
-            );
-        });
-        let (output, seq_tps) = if run_seq {
-            println!("Sequential execution starts...");
-            let (output, tps) =
-                self.execute_benchmark_sequential(transactions, maybe_block_gas_limit);
-            println!("Sequential execution finishes, TPS = {}", tps);
-            (output, tps)
-        } else {
-            (vec![], 0)
-        };
-        output.iter().for_each(|txn_output| {
-            assert_eq!(
-                txn_output.status(),
-                &TransactionStatus::Keep(ExecutionStatus::Success)
-            );
-        });
-        (par_tps, seq_tps)
-    }
-}
-
 /// Returns a strategy for the account universe customized for benchmarks, i.e. having
 /// sufficiently large balance for gas.
-fn universe_strategy(
+pub(crate) fn universe_strategy(
     num_accounts: usize,
     num_transactions: usize,
     account_pick_style: AccountPickStyle,


### PR DESCRIPTION
### Description

Add a change to support pre-generating all transactions - this helps to isolate the noise from CPU usage in generating the transactions and also measures CPU utilization of execution only phase.

### Test Plan

```
cargo run --release -p aptos-transaction-benchmarks execute --generate-then-execute --num-accounts 100000 --block-size 50000 --concurrency-level-per-shard 10
```