### PR TITLE
[State Sync] Add fast sync support to genesis.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12642,6 +12642,7 @@ dependencies = [
  "aptos-global-constants",
  "aptos-indexer",
  "aptos-infallible",
+ "aptos-inspection-service",
  "aptos-keygen",
  "aptos-logger",
  "aptos-release-builder",

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -59,6 +59,11 @@ impl BootstrappingMode {
             BootstrappingMode::ExecuteOrApplyFromGenesis => "execute_or_apply_from_genesis",
         }
     }
+
+    /// Returns true iff the bootstrapping mode is fast sync
+    pub fn is_fast_sync(&self) -> bool {
+        *self == BootstrappingMode::DownloadLatestStates
+    }
 }
 
 /// The continuous syncing mode determines how the node will stay up-to-date
@@ -298,10 +303,35 @@ impl Default for AptosDataClientConfig {
 
 impl ConfigSanitizer for StateSyncConfig {
     fn sanitize(
-        _node_config: &mut NodeConfig,
+        node_config: &mut NodeConfig,
+        node_type: NodeType,
+        chain_id: ChainId,
+    ) -> Result<(), Error> {
+        // Sanitize the state sync driver config
+        StateSyncDriverConfig::sanitize(node_config, node_type, chain_id)
+    }
+}
+
+impl ConfigSanitizer for StateSyncDriverConfig {
+    fn sanitize(
+        node_config: &mut NodeConfig,
         _node_type: NodeType,
         _chain_id: ChainId,
     ) -> Result<(), Error> {
+        let sanitizer_name = Self::get_sanitizer_name();
+        let state_sync_driver_config = &mut node_config.state_sync.state_sync_driver;
+
+        // Verify that auto-bootstrapping is not enabled for
+        // nodes that are fast syncing.
+        let fast_sync_enabled = state_sync_driver_config.bootstrapping_mode.is_fast_sync();
+        if state_sync_driver_config.enable_auto_bootstrapping && fast_sync_enabled {
+            return Err(Error::ConfigSanitizerFailed(
+                sanitizer_name,
+                "Auto-bootstrapping should not be enabled for nodes that are fast syncing!"
+                    .to_string(),
+            ));
+        }
+
         Ok(())
     }
 }
@@ -425,10 +455,8 @@ mod tests {
         assert!(modified_config);
 
         // Verify that the bootstrapping mode is now set to fast sync
-        assert_eq!(
-            node_config.state_sync.state_sync_driver.bootstrapping_mode,
-            BootstrappingMode::DownloadLatestStates
-        );
+        let state_sync_driver_config = node_config.state_sync.state_sync_driver;
+        assert!(state_sync_driver_config.bootstrapping_mode.is_fast_sync());
     }
 
     #[test]
@@ -447,10 +475,8 @@ mod tests {
         assert!(modified_config);
 
         // Verify that the bootstrapping mode is now set to fast sync
-        assert_eq!(
-            node_config.state_sync.state_sync_driver.bootstrapping_mode,
-            BootstrappingMode::DownloadLatestStates
-        );
+        let state_sync_driver_config = node_config.state_sync.state_sync_driver;
+        assert!(state_sync_driver_config.bootstrapping_mode.is_fast_sync());
     }
 
     #[test]
@@ -583,6 +609,29 @@ mod tests {
             data_streaming_service_config.max_concurrent_state_requests,
             100
         );
+    }
+
+    #[test]
+    fn test_sanitize_auto_bootstrapping_fast_sync() {
+        // Create a node config with fast sync and
+        // auto bootstrapping enabled.
+        let mut node_config = NodeConfig {
+            state_sync: StateSyncConfig {
+                state_sync_driver: StateSyncDriverConfig {
+                    bootstrapping_mode: BootstrappingMode::DownloadLatestStates,
+                    enable_auto_bootstrapping: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Verify that sanitization fails
+        let error =
+            StateSyncConfig::sanitize(&mut node_config, NodeType::Validator, ChainId::testnet())
+                .unwrap_err();
+        assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
     }
 
     /// Creates and returns a node config with the syncing modes set to execution

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -28,6 +28,7 @@ aptos-gas-algebra = { workspace = true }
 aptos-gas-schedule = { workspace = true, features = ["testing"] }
 aptos-global-constants = { workspace = true }
 aptos-indexer = { workspace = true }
+aptos-inspection-service = { workspace = true }
 aptos-keygen = { workspace = true }
 aptos-release-builder = { workspace = true }
 aptos-rest-client = { workspace = true }

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use aptos_config::config::{BootstrappingMode, ContinuousSyncingMode, NodeConfig};
 use aptos_forge::{LocalSwarm, Node, NodeExt, Swarm, SwarmExt};
+use aptos_inspection_service::inspection_client::InspectionClient;
 use aptos_rest_client::Client as RestClient;
 use aptos_sdk::types::LocalAccount;
 use aptos_types::{account_address::AccountAddress, PeerId};
@@ -21,61 +22,14 @@ use std::{
 
 #[tokio::test]
 async fn test_full_node_bootstrap_state_snapshot() {
-    // Create a validator swarm of 1 validator node
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    // Test snapshot (fast) syncing in the presence of epoch changes
+    perform_full_node_bootstrap_state_snapshot(true).await;
+}
 
-    // Create a fullnode config that uses snapshot syncing
-    let mut vfn_config = NodeConfig::get_default_vfn_config();
-    vfn_config.state_sync.state_sync_driver.bootstrapping_mode =
-        BootstrappingMode::DownloadLatestStates;
-
-    // Create (and stop) the fullnode
-    let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
-    swarm.fullnode_mut(vfn_peer_id).unwrap().stop();
-
-    // Set at most 2 values per storage request for the validator
-    let validator = swarm.validators_mut().next().unwrap();
-    let mut config = validator.config().clone();
-    config.state_sync.storage_service.max_state_chunk_size = 2;
-    config.save_to_path(validator.config_path()).unwrap();
-    validator.restart().await.unwrap();
-    validator
-        .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_HEALTHY_WAIT_SECS))
-        .await
-        .unwrap();
-
-    // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_peer_id, &mut swarm, true).await;
-
-    // Verify that the vfn no longer has the genesis transaction
-    let vfn_client = swarm.fullnode_mut(vfn_peer_id).unwrap().rest_client();
-    let ledger_information = vfn_client.get_ledger_information().await.unwrap();
-    assert_ne!(ledger_information.inner().oldest_ledger_version, 0);
-
-    let inspection_client = swarm.fullnode(vfn_peer_id).unwrap().inspection_client();
-    let state_merkle_pruner_version = inspection_client
-        .get_node_metric_i64(
-            "aptos_pruner_versions{pruner_name=state_merkle_pruner,tag=min_readable}",
-        )
-        .await
-        .unwrap()
-        .unwrap();
-    let epoch_snapshot_pruner_version = inspection_client
-        .get_node_metric_i64(
-            "aptos_pruner_versions{pruner_name=epoch_snapshot_pruner,tag=min_readable}",
-        )
-        .await
-        .unwrap()
-        .unwrap();
-    let ledger_pruner_version = inspection_client
-        .get_node_metric_i64("aptos_pruner_versions{pruner_name=ledger_pruner,tag=min_readable}")
-        .await
-        .unwrap()
-        .unwrap();
-
-    assert!(state_merkle_pruner_version > 0);
-    assert!(epoch_snapshot_pruner_version > 0);
-    assert!(ledger_pruner_version > 0);
+#[tokio::test]
+async fn test_full_node_bootstrap_state_snapshot_genesis() {
+    // Test snapshot (fast) syncing without epoch changes
+    perform_full_node_bootstrap_state_snapshot(false).await;
 }
 
 #[tokio::test]
@@ -97,7 +51,7 @@ async fn test_full_node_bootstrap_outputs() {
     let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_peer_id, &mut swarm, true).await;
+    test_full_node_sync(vfn_peer_id, &mut swarm, true, false).await;
 }
 
 #[tokio::test]
@@ -119,7 +73,7 @@ async fn test_full_node_bootstrap_outputs_no_compression() {
     let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_peer_id, &mut swarm, true).await;
+    test_full_node_sync(vfn_peer_id, &mut swarm, true, false).await;
 }
 
 #[tokio::test]
@@ -141,7 +95,7 @@ async fn test_full_node_bootstrap_outputs_exponential_backoff() {
     let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_peer_id, &mut swarm, true).await;
+    test_full_node_sync(vfn_peer_id, &mut swarm, true, false).await;
 }
 
 #[tokio::test]
@@ -173,7 +127,7 @@ async fn test_full_node_bootstrap_transactions_or_outputs() {
     let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_peer_id, &mut swarm, true).await;
+    test_full_node_sync(vfn_peer_id, &mut swarm, true, false).await;
 }
 
 #[tokio::test]
@@ -205,7 +159,7 @@ async fn test_full_node_bootstrap_snapshot_transactions_or_outputs() {
     let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_peer_id, &mut swarm, true).await;
+    test_full_node_sync(vfn_peer_id, &mut swarm, true, false).await;
 }
 
 #[tokio::test]
@@ -227,7 +181,7 @@ async fn test_full_node_bootstrap_transactions() {
     let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_peer_id, &mut swarm, true).await;
+    test_full_node_sync(vfn_peer_id, &mut swarm, true, false).await;
 }
 
 #[tokio::test]
@@ -246,7 +200,7 @@ async fn test_full_node_continuous_sync_outputs() {
     let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_peer_id, &mut swarm, false).await;
+    test_full_node_sync(vfn_peer_id, &mut swarm, false, false).await;
 }
 
 #[tokio::test]
@@ -265,7 +219,7 @@ async fn test_full_node_continuous_sync_transactions() {
     let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_peer_id, &mut swarm, false).await;
+    test_full_node_sync(vfn_peer_id, &mut swarm, false, false).await;
 }
 
 /// Creates a new full node using the given config and swarm
@@ -289,9 +243,18 @@ async fn create_full_node(full_node_config: NodeConfig, swarm: &mut LocalSwarm) 
 
 /// A helper method that tests that a full node can sync from a validator after
 /// a failure and continue to stay up-to-date.
-async fn test_full_node_sync(vfn_peer_id: PeerId, swarm: &mut LocalSwarm, epoch_changes: bool) {
-    // Stop the fullnode
-    swarm.fullnode_mut(vfn_peer_id).unwrap().stop();
+async fn test_full_node_sync(
+    vfn_peer_id: PeerId,
+    swarm: &mut LocalSwarm,
+    epoch_changes: bool,
+    clear_storage: bool,
+) {
+    // Stop the fullnode and potentially clear storage
+    if clear_storage {
+        stop_fullnode_and_delete_storage(swarm, vfn_peer_id).await;
+    } else {
+        swarm.fullnode_mut(vfn_peer_id).unwrap().stop();
+    }
 
     // Execute a number of transactions on the validator
     let validator_peer_id = swarm.validators().next().unwrap().peer_id();
@@ -341,31 +304,19 @@ async fn test_validator_bootstrap_outputs() {
         .await;
 
     // Test the ability of the validators to sync
-    test_validator_sync(&mut swarm, 1).await;
+    test_validator_sync(&mut swarm, 1, true).await;
 }
 
 #[tokio::test]
 async fn test_validator_bootstrap_state_snapshot() {
-    // Create a swarm of 4 validators using snapshot syncing and a chunk size = 1
-    let mut swarm = SwarmBuilder::new_local(4)
-        .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
-            config.state_sync.state_sync_driver.bootstrapping_mode =
-                BootstrappingMode::DownloadLatestStates;
-            config.state_sync.storage_service.max_state_chunk_size = 1;
-        }))
-        .build()
-        .await;
+    // Test snapshot (fast) syncing in the presence of epoch changes
+    perform_validator_bootstrap_state_snapshot(true).await;
+}
 
-    // Test the ability of the validators to sync
-    let validator_index_to_test = 1;
-    test_validator_sync(&mut swarm, validator_index_to_test).await;
-
-    // Verify that the bootstrapped validator no longer has the genesis transaction
-    let bootstrapped_validator = swarm.validators().collect::<Vec<_>>()[validator_index_to_test];
-    let validator_client = bootstrapped_validator.rest_client();
-    let ledger_information = validator_client.get_ledger_information().await.unwrap();
-    assert_ne!(ledger_information.inner().oldest_ledger_version, 0);
+#[tokio::test]
+async fn test_validator_bootstrap_state_snapshot_genesis() {
+    // Test snapshot (fast) syncing without epoch changes
+    perform_validator_bootstrap_state_snapshot(false).await;
 }
 
 #[ignore] // We ignore this test because it takes a long time. But, it works, so it shouldn't be removed.
@@ -385,7 +336,7 @@ async fn test_validator_bootstrap_outputs_network_limit() {
         .await;
 
     // Test the ability of the validators to sync
-    test_validator_sync(&mut swarm, 1).await;
+    test_validator_sync(&mut swarm, 1, true).await;
 }
 
 #[ignore] // We ignore this test because it takes a long time. But, it works, so it shouldn't be removed.
@@ -406,7 +357,7 @@ async fn test_validator_bootstrap_outputs_network_limit_tiny() {
         .await;
 
     // Test the ability of the validators to sync
-    test_validator_sync(&mut swarm, 1).await;
+    test_validator_sync(&mut swarm, 1, true).await;
 }
 
 #[tokio::test]
@@ -425,7 +376,7 @@ async fn test_validator_bootstrap_state_snapshot_no_compression() {
         .await;
 
     // Test the ability of the validators to sync
-    test_validator_sync(&mut swarm, 1).await;
+    test_validator_sync(&mut swarm, 1, true).await;
 }
 
 #[ignore] // We ignore this test because it takes a long time. But, it works, so it shouldn't be removed.
@@ -445,7 +396,7 @@ async fn test_validator_bootstrap_state_snapshot_network_limit() {
         .await;
 
     // Test the ability of the validators to sync
-    test_validator_sync(&mut swarm, 1).await;
+    test_validator_sync(&mut swarm, 1, true).await;
 }
 
 #[ignore] // We ignore this test because it takes a long time. But, it works, so it shouldn't be removed.
@@ -466,27 +417,21 @@ async fn test_validator_bootstrap_state_snapshot_network_limit_tiny() {
         .await;
 
     // Test the ability of the validators to sync
-    test_validator_sync(&mut swarm, 1).await;
+    test_validator_sync(&mut swarm, 1, true).await;
 }
 
 #[tokio::test]
 async fn test_validator_bootstrap_state_snapshot_exponential_backoff() {
-    // Create a swarm of 4 validators using state snapshot syncing and a small response timeout
-    let mut swarm = SwarmBuilder::new_local(4)
-        .with_aptos()
-        .with_init_config(Arc::new(|_, config, _| {
-            config.state_sync.state_sync_driver.bootstrapping_mode =
-                BootstrappingMode::DownloadLatestStates;
-            config.state_sync.state_sync_driver.continuous_syncing_mode =
-                ContinuousSyncingMode::ApplyTransactionOutputs;
-            config.state_sync.aptos_data_client.use_compression = false;
-            config.state_sync.aptos_data_client.response_timeout_ms = 1;
-        }))
-        .build()
-        .await;
+    // Test snapshot (fast) syncing in the presence of
+    // exponential backoff and epoch changes.
+    perform_validator_bootstrap_state_snapshot_exponential_backoff(true).await;
+}
 
-    // Test the ability of the validators to sync
-    test_validator_sync(&mut swarm, 1).await;
+#[tokio::test]
+async fn test_validator_bootstrap_state_snapshot_exponential_backoff_genesis() {
+    // Test snapshot (fast) syncing in the presence of
+    // exponential backoff without epoch changes.
+    perform_validator_bootstrap_state_snapshot_exponential_backoff(false).await;
 }
 
 #[tokio::test]
@@ -504,7 +449,7 @@ async fn test_validator_bootstrap_transactions() {
         .await;
 
     // Test the ability of the validators to sync
-    test_validator_sync(&mut swarm, 1).await;
+    test_validator_sync(&mut swarm, 1, true).await;
 }
 
 #[tokio::test]
@@ -528,7 +473,7 @@ async fn test_validator_bootstrap_transactions_or_outputs() {
         .await;
 
     // Test the ability of the validators to sync
-    test_validator_sync(&mut swarm, 1).await;
+    test_validator_sync(&mut swarm, 1, true).await;
 }
 
 #[ignore] // We ignore this test because it takes a long time. But, it works, so it shouldn't be removed.
@@ -548,7 +493,7 @@ async fn test_validator_bootstrap_transactions_network_limit() {
         .await;
 
     // Test the ability of the validators to sync
-    test_validator_sync(&mut swarm, 1).await;
+    test_validator_sync(&mut swarm, 1, true).await;
 }
 
 #[ignore] // We ignore this test because it takes a long time. But, it works, so it shouldn't be removed.
@@ -569,7 +514,7 @@ async fn test_validator_bootstrap_transactions_network_limit_tiny() {
         .await;
 
     // Test the ability of the validators to sync
-    test_validator_sync(&mut swarm, 1).await;
+    test_validator_sync(&mut swarm, 1, true).await;
 }
 
 #[tokio::test]
@@ -588,7 +533,7 @@ async fn test_validator_bootstrap_outputs_network_exponential_backoff() {
         .await;
 
     // Test the ability of the validators to sync
-    test_validator_sync(&mut swarm, 1).await;
+    test_validator_sync(&mut swarm, 1, true).await;
 }
 
 #[tokio::test]
@@ -607,12 +552,127 @@ async fn test_validator_bootstrap_transactions_no_compression() {
         .await;
 
     // Test the ability of the validators to sync
-    test_validator_sync(&mut swarm, 1).await;
+    test_validator_sync(&mut swarm, 1, true).await;
+}
+
+/// A test method that verifies that a fullnode can fast sync from
+/// a validator after a data wipe. If `epoch_changes` are enabled
+/// then epoch changes can occur during test execution and fullnode syncing.
+async fn perform_full_node_bootstrap_state_snapshot(epoch_changes: bool) {
+    // Create a swarm with 2 validators
+    let mut swarm = SwarmBuilder::new_local(2)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
+            config.state_sync.state_sync_driver.bootstrapping_mode =
+                BootstrappingMode::DownloadLatestStates;
+        }))
+        .with_init_genesis_config(Arc::new(|genesis_config| {
+            genesis_config.epoch_duration_secs = 10_000; // Prevent epoch changes from occurring unnecessarily
+        }))
+        .build()
+        .await;
+
+    // Verify the oldest ledger info and pruning metrics for the validators
+    for validator in swarm.validators() {
+        // Verify the oldest ledger info
+        let validator_rest_client = validator.rest_client();
+        verify_oldest_version_after_fast_sync(validator_rest_client, true).await;
+
+        // Verify the pruning metrics
+        let inspection_client = validator.inspection_client();
+        verify_pruning_metrics_after_fast_sync(inspection_client, true).await;
+    }
+
+    // Create a fullnode config that uses snapshot syncing
+    let mut vfn_config = NodeConfig::get_default_vfn_config();
+    vfn_config.state_sync.state_sync_driver.bootstrapping_mode =
+        BootstrappingMode::DownloadLatestStates;
+
+    // Test the ability of a fullnode to sync
+    let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
+    test_full_node_sync(vfn_peer_id, &mut swarm, epoch_changes, true).await;
+
+    // Verify the oldest ledger info and pruning metrics for the fullnode
+    if epoch_changes {
+        // Verify the oldest ledger info
+        let vfn_rest_client = swarm.fullnode_mut(vfn_peer_id).unwrap().rest_client();
+        verify_oldest_version_after_fast_sync(vfn_rest_client, false).await;
+
+        // Verify the fullnode pruning metrics
+        let inspection_client = swarm.fullnode(vfn_peer_id).unwrap().inspection_client();
+        verify_pruning_metrics_after_fast_sync(inspection_client, false).await;
+    }
+}
+
+/// A test method that verifies that a validator can fast sync from
+/// other validators after a data wipe. If `epoch_changes` are enabled
+/// then epoch changes can occur during test execution and validator syncing.
+async fn perform_validator_bootstrap_state_snapshot(epoch_changes: bool) {
+    // Create a swarm of 4 validators using snapshot (fast) syncing and a chunk size = 30
+    let mut swarm = SwarmBuilder::new_local(4)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
+            config.state_sync.state_sync_driver.bootstrapping_mode =
+                BootstrappingMode::DownloadLatestStates;
+            config.state_sync.storage_service.max_state_chunk_size = 30;
+        }))
+        .with_init_genesis_config(Arc::new(|genesis_config| {
+            genesis_config.epoch_duration_secs = 10_000; // Prevent epoch changes from occurring unnecessarily
+        }))
+        .build()
+        .await;
+
+    // Test the ability of the validators to sync
+    let validator_index_to_test = 1;
+    test_validator_sync(&mut swarm, validator_index_to_test, epoch_changes).await;
+
+    // Verify the oldest ledger info and pruning metrics for the validator
+    if epoch_changes {
+        // Verify the oldest ledger info for the validator
+        let bootstrapped_validator =
+            swarm.validators().collect::<Vec<_>>()[validator_index_to_test];
+        let validator_client = bootstrapped_validator.rest_client();
+        verify_oldest_version_after_fast_sync(validator_client, false).await;
+
+        // Verify the validator pruning metrics
+        let inspection_client = bootstrapped_validator.inspection_client();
+        verify_pruning_metrics_after_fast_sync(inspection_client, false).await;
+    }
+}
+
+/// A test method that verifies that a validator can fast sync from other
+/// validators after a data wipe and while requiring exponential backoff.
+/// If `epoch_changes` are enabled then epoch changes can occur during
+/// test execution and validator syncing.
+async fn perform_validator_bootstrap_state_snapshot_exponential_backoff(epoch_changes: bool) {
+    // Create a swarm of 4 validators using state snapshot syncing and a small response timeout
+    let mut swarm = SwarmBuilder::new_local(4)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
+            config.state_sync.state_sync_driver.bootstrapping_mode =
+                BootstrappingMode::DownloadLatestStates;
+            config.state_sync.state_sync_driver.continuous_syncing_mode =
+                ContinuousSyncingMode::ApplyTransactionOutputs;
+            config.state_sync.aptos_data_client.use_compression = false;
+            config.state_sync.aptos_data_client.response_timeout_ms = 1;
+        }))
+        .with_init_genesis_config(Arc::new(|genesis_config| {
+            genesis_config.epoch_duration_secs = 10_000; // Prevent epoch changes from occurring unnecessarily
+        }))
+        .build()
+        .await;
+
+    // Test the ability of the validators to sync
+    test_validator_sync(&mut swarm, 1, epoch_changes).await;
 }
 
 /// A helper method that tests that a validator can sync after a failure and
 /// continue to stay up-to-date.
-async fn test_validator_sync(swarm: &mut LocalSwarm, validator_index_to_test: usize) {
+async fn test_validator_sync(
+    swarm: &mut LocalSwarm,
+    validator_index_to_test: usize,
+    epoch_changes: bool,
+) {
     // Execute multiple transactions through validator 0
     let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
     let validator_client_0 = swarm
@@ -620,23 +680,42 @@ async fn test_validator_sync(swarm: &mut LocalSwarm, validator_index_to_test: us
         .unwrap()
         .rest_client();
     let (mut account_0, mut account_1) = create_test_accounts(swarm).await;
-    execute_transactions_and_wait(swarm, &validator_client_0, &mut account_0, &account_1, true)
-        .await;
+    execute_transactions_and_wait(
+        swarm,
+        &validator_client_0,
+        &mut account_0,
+        &account_1,
+        epoch_changes,
+    )
+    .await;
 
     // Stop the validator and delete the storage
     let validator = validator_peer_ids[validator_index_to_test];
     stop_validator_and_delete_storage(swarm, validator).await;
 
     // Execute more transactions
-    execute_transactions(swarm, &validator_client_0, &mut account_1, &account_0, true).await;
+    execute_transactions(
+        swarm,
+        &validator_client_0,
+        &mut account_1,
+        &account_0,
+        epoch_changes,
+    )
+    .await;
 
     // Restart the validator and wait for all nodes to catchup
     swarm.validator_mut(validator).unwrap().start().unwrap();
     wait_for_all_nodes(swarm).await;
 
     // Execute multiple transactions and verify the validator can sync
-    execute_transactions_and_wait(swarm, &validator_client_0, &mut account_0, &account_1, true)
-        .await;
+    execute_transactions_and_wait(
+        swarm,
+        &validator_client_0,
+        &mut account_0,
+        &account_1,
+        epoch_changes,
+    )
+    .await;
 }
 
 // Ignore this test because it's become increasingly flaky recently
@@ -774,7 +853,7 @@ async fn test_single_validator_failure() {
 }
 
 /// Executes transactions using the given transaction factory, client and
-/// accounts. If `force_epoch_changes` is true, also execute transactions to
+/// accounts. If `execute_epoch_changes` is true, also execute transactions to
 /// force reconfigurations.
 async fn execute_transactions(
     swarm: &mut LocalSwarm,
@@ -783,8 +862,8 @@ async fn execute_transactions(
     receiver: &LocalAccount,
     execute_epoch_changes: bool,
 ) {
+    // Execute several transactions
     let num_transfers = 10;
-
     let transaction_factory = swarm.chain_info().transaction_factory();
     if execute_epoch_changes {
         transfer_and_maybe_reconfig(
@@ -801,6 +880,16 @@ async fn execute_transactions(
             // Execute simple transfer transactions
             transfer_coins(client, &transaction_factory, sender, receiver, 1).await;
         }
+    }
+
+    // Always ensure that at least one reconfiguration transaction is executed
+    if !execute_epoch_changes {
+        aptos_forge::reconfig(
+            client,
+            &transaction_factory,
+            swarm.chain_info().root_account,
+        )
+        .await;
     }
 }
 
@@ -832,9 +921,77 @@ async fn create_test_accounts(swarm: &mut LocalSwarm) -> (LocalAccount, LocalAcc
     (account_0, account_1)
 }
 
+/// Stops the specified fullnode and deletes storage
+async fn stop_fullnode_and_delete_storage(swarm: &mut LocalSwarm, fullnode: AccountAddress) {
+    let fullnode = swarm.full_node_mut(fullnode).unwrap();
+
+    // The fullnode is stopped during the clear_storage() call
+    fullnode.clear_storage().await.unwrap();
+}
+
 /// Stops the specified validator and deletes storage
 async fn stop_validator_and_delete_storage(swarm: &mut LocalSwarm, validator: AccountAddress) {
     let validator = swarm.validator_mut(validator).unwrap();
-    // the validator is stopped during the clear_storage step as well
+
+    // The validator is stopped during the clear_storage() call
     validator.clear_storage().await.unwrap();
+}
+
+/// Verifies the oldest ledger version on a node after fast syncing
+async fn verify_oldest_version_after_fast_sync(
+    node_rest_client: RestClient,
+    sync_to_genesis: bool,
+) {
+    // Fetch the oldest ledger version from the node
+    let ledger_information = node_rest_client.get_ledger_information().await.unwrap();
+    let oldest_ledger_version = ledger_information.inner().oldest_ledger_version;
+
+    // Verify the oldest ledger version after fast syncing
+    if sync_to_genesis {
+        // The node should have fast synced to genesis
+        assert_eq!(oldest_ledger_version, 0);
+    } else {
+        // The node should have fast synced to the latest epoch
+        assert!(oldest_ledger_version > 0);
+    }
+}
+
+/// Verifies the pruning metrics on a node after fast syncing
+async fn verify_pruning_metrics_after_fast_sync(
+    node_inspection_client: InspectionClient,
+    sync_to_genesis: bool,
+) {
+    // Fetch the pruning metrics from the node
+    let state_merkle_pruner_version = node_inspection_client
+        .get_node_metric_i64(
+            "aptos_pruner_versions{pruner_name=state_merkle_pruner,tag=min_readable}",
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    let epoch_snapshot_pruner_version = node_inspection_client
+        .get_node_metric_i64(
+            "aptos_pruner_versions{pruner_name=epoch_snapshot_pruner,tag=min_readable}",
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    let ledger_pruner_version = node_inspection_client
+        .get_node_metric_i64("aptos_pruner_versions{pruner_name=ledger_pruner,tag=min_readable}")
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Verify that the pruning metrics are valid
+    if sync_to_genesis {
+        // The node should have fast synced to genesis
+        assert_eq!(state_merkle_pruner_version, 0);
+        assert_eq!(epoch_snapshot_pruner_version, 0);
+        assert_eq!(ledger_pruner_version, 0);
+    } else {
+        // The node should have fast synced to the latest epoch
+        assert!(state_merkle_pruner_version > 0);
+        assert!(epoch_snapshot_pruner_version > 0);
+        assert!(ledger_pruner_version > 0);
+    }
 }


### PR DESCRIPTION
### Description
This PR updates state sync to support fast syncing to genesis. When a node starts up using fast sync and no epoch changes have occurred in the network, the node will fast sync to genesis before continuing. If an epoch change has occurred, fast sync will still choose the latest epoch ending ledger version (as it already does).

This is required to unblock genesis-less fast syncing (i.e., fast syncing a node without writing the genesis transaction to the DB at all).

### Test Plan
New and existing tests!