### PR TITLE
Delegate all the methods from sub classes

### DIFF
--- a/ecosystem/typescript/sdk_v2/src/api/account.ts
+++ b/ecosystem/typescript/sdk_v2/src/api/account.ts
@@ -33,7 +33,7 @@ export class Account {
    * }
    * ```
    */
-  async getInfo(args: { accountAddress: HexInput }): Promise<AccountData> {
+  async getAccountInfo(args: { accountAddress: HexInput }): Promise<AccountData> {
     const data = await getInfo({ aptosConfig: this.config, ...args });
     return data;
   }
@@ -48,7 +48,7 @@ export class Account {
    * @returns Account modules
    */
 
-  async getModules(args: {
+  async getAccountModules(args: {
     accountAddress: HexInput;
     options?: PaginationArgs & LedgerVersion;
   }): Promise<MoveModuleBytecode[]> {
@@ -72,7 +72,7 @@ export class Account {
    * }
    * ```
    */
-  async getModule(args: {
+  async getAccountModule(args: {
     accountAddress: HexInput;
     moduleName: string;
     options?: LedgerVersion;
@@ -91,7 +91,7 @@ export class Account {
    *
    * @returns The account transactions
    */
-  async getTransactions(args: { accountAddress: HexInput; options?: PaginationArgs }): Promise<Transaction[]> {
+  async getAccountTransactions(args: { accountAddress: HexInput; options?: PaginationArgs }): Promise<Transaction[]> {
     const transactions = await getTransactions({ aptosConfig: this.config, ...args });
     return transactions;
   }
@@ -105,7 +105,7 @@ export class Account {
    * @param accountAddress Aptos account address
    * @returns Account resources
    */
-  async getResources(args: {
+  async getAccountResources(args: {
     accountAddress: HexInput;
     options?: PaginationArgs & LedgerVersion;
   }): Promise<MoveResource[]> {
@@ -129,7 +129,7 @@ export class Account {
    * }
    * ```
    */
-  async getResource(args: {
+  async getAccountResource(args: {
     accountAddress: HexInput;
     resourceType: MoveResourceType;
     options?: LedgerVersion;

--- a/ecosystem/typescript/sdk_v2/src/api/account.ts
+++ b/ecosystem/typescript/sdk_v2/src/api/account.ts
@@ -6,7 +6,7 @@ import {
   MoveResource,
   MoveResourceType,
   PaginationArgs,
-  Transaction,
+  TransactionResponse,
   HexInput,
 } from "../types";
 import { getInfo, getModule, getModules, getResource, getResources, getTransactions } from "../internal/account";
@@ -91,7 +91,10 @@ export class Account {
    *
    * @returns The account transactions
    */
-  async getAccountTransactions(args: { accountAddress: HexInput; options?: PaginationArgs }): Promise<Transaction[]> {
+  async getAccountTransactions(args: {
+    accountAddress: HexInput;
+    options?: PaginationArgs;
+  }): Promise<TransactionResponse[]> {
     const transactions = await getTransactions({ aptosConfig: this.config, ...args });
     return transactions;
   }

--- a/ecosystem/typescript/sdk_v2/src/api/aptos.ts
+++ b/ecosystem/typescript/sdk_v2/src/api/aptos.ts
@@ -28,3 +28,28 @@ export class Aptos {
     this.account = new Account(this.config);
   }
 }
+
+export interface Aptos extends Account {}
+
+/**
+In TypeScript, we can’t inherit or extend from more than one class,
+Mixins helps us to get around that by creating a partial classes 
+that we can combine to form a single class that contains all the methods and properties from the partial classes.
+{@link https://www.typescriptlang.org/docs/handbook/mixins.html#alternative-pattern}
+
+Here, we combine any sub-class and the Aptos class.
+*/
+function applyMixin(targetClass: any, baseClass: any, baseClassProp: string) {
+  // Mixin instance methods
+  Object.getOwnPropertyNames(baseClass.prototype).forEach((propertyName) => {
+    const propertyDescriptor = Object.getOwnPropertyDescriptor(baseClass.prototype, propertyName);
+    if (!propertyDescriptor) return;
+    // eslint-disable-next-line func-names
+    propertyDescriptor.value = function (...args: any) {
+      return (this as any)[baseClassProp][propertyName](...args);
+    };
+    Object.defineProperty(targetClass.prototype, propertyName, propertyDescriptor);
+  });
+}
+
+applyMixin(Aptos, Account, "account");

--- a/ecosystem/typescript/sdk_v2/src/internal/account.ts
+++ b/ecosystem/typescript/sdk_v2/src/internal/account.ts
@@ -6,7 +6,7 @@ import {
   MoveResource,
   MoveResourceType,
   PaginationArgs,
-  Transaction,
+  TransactionResponse,
   HexInput,
 } from "../types";
 import { get } from "../client";
@@ -77,9 +77,9 @@ export async function getTransactions(args: {
   aptosConfig: AptosConfig;
   accountAddress: HexInput;
   options?: PaginationArgs;
-}): Promise<Transaction[]> {
+}): Promise<TransactionResponse[]> {
   const { aptosConfig, accountAddress, options } = args;
-  const data = await paginateWithCursor<{}, Transaction[]>({
+  const data = await paginateWithCursor<{}, TransactionResponse[]>({
     url: aptosConfig.getRequestUrl(AptosApiType.FULLNODE),
     endpoint: `accounts/${AccountAddress.fromHexInput({ input: accountAddress }).toString()}/transactions`,
     originMethod: "getTransactions",

--- a/ecosystem/typescript/sdk_v2/tests/e2e/api/account.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/e2e/api/account.test.ts
@@ -10,7 +10,7 @@ describe("account api", () => {
       const aptos = new Aptos(config);
       expect(
         async () =>
-          await aptos.account.getInfo({
+          await aptos.getAccountInfo({
             accountAddress: "ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0",
           }),
       ).rejects.toThrow();
@@ -19,7 +19,7 @@ describe("account api", () => {
     test("it throws when invalid account address", () => {
       const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      expect(async () => await aptos.account.getInfo({ accountAddress: "0x123" })).rejects.toThrow();
+      expect(async () => await aptos.getAccountInfo({ accountAddress: "0x123" })).rejects.toThrow();
     });
   });
 
@@ -27,7 +27,7 @@ describe("account api", () => {
     test("it fetches account data", async () => {
       const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const data = await aptos.account.getInfo({
+      const data = await aptos.getAccountInfo({
         accountAddress: "0x1",
       });
       expect(data).toHaveProperty("sequence_number");
@@ -39,7 +39,7 @@ describe("account api", () => {
     test("it fetches account modules", async () => {
       const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const data = await aptos.account.getModules({
+      const data = await aptos.getAccountModules({
         accountAddress: "0x1",
       });
       expect(data.length).toBeGreaterThan(0);
@@ -48,7 +48,7 @@ describe("account api", () => {
     test("it fetches account module", async () => {
       const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const data = await aptos.account.getModule({
+      const data = await aptos.getAccountModule({
         accountAddress: "0x1",
         moduleName: "coin",
       });
@@ -58,7 +58,7 @@ describe("account api", () => {
     test("it fetches account resources", async () => {
       const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const data = await aptos.account.getResources({
+      const data = await aptos.getAccountResources({
         accountAddress: "0x1",
       });
       expect(data.length).toBeGreaterThan(0);
@@ -67,7 +67,7 @@ describe("account api", () => {
     test("it fetches account resource", async () => {
       const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const data = await aptos.account.getResource({
+      const data = await aptos.getAccountResource({
         accountAddress: "0x1",
         resourceType: "0x1::account::Account",
       });
@@ -79,7 +79,7 @@ describe("account api", () => {
     test("it fetches account data", async () => {
       const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const data = await aptos.account.getInfo({
+      const data = await aptos.getAccountInfo({
         accountAddress: new Uint8Array([
           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
         ]),
@@ -93,7 +93,7 @@ describe("account api", () => {
     test("it fetches account modules", async () => {
       const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const data = await aptos.account.getModules({
+      const data = await aptos.getAccountModules({
         accountAddress: new Uint8Array([
           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
         ]),
@@ -104,7 +104,7 @@ describe("account api", () => {
     test("it fetches account module", async () => {
       const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const data = await aptos.account.getModule({
+      const data = await aptos.getAccountModule({
         accountAddress: new Uint8Array([
           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
         ]),
@@ -116,7 +116,7 @@ describe("account api", () => {
     test("it fetches account resources", async () => {
       const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const data = await aptos.account.getResources({
+      const data = await aptos.getAccountResources({
         accountAddress: new Uint8Array([
           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
         ]),
@@ -127,7 +127,7 @@ describe("account api", () => {
     test("it fetches account resource", async () => {
       const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const data = await aptos.account.getResource({
+      const data = await aptos.getAccountResource({
         accountAddress: "0x1",
         resourceType: "0x1::account::Account",
       });


### PR DESCRIPTION
### Description

EDIT: following PR comments we will roll with this idea.

This is an idea for how the end user would use the new sdk.

Currently, one initializes `Aptos`. i.e `const aptos = new Aptos()`, and then has access to all the sub classes, i.e `account` and for all future sub classes.
```
const aptos = new Aptos();
aptos.account.getInfo("0x1")
```

This PR proposes to delegate all sub classes methods to the Aptos class, so user would not need to use the namespace but simply call any sub class function
```
const aptos = new Aptos();
aptos.getInfo("0x1")
```

<img width="576" alt="image" src="https://github.com/aptos-labs/aptos-core/assets/29798064/7ccf7804-dc0e-4035-82f6-3b250f0eb49c">



This way, sdk users can find the query they are looking for easily without trying to figure out what namespace a function lives in, and sdk maintainers can keep functions in different files and under different namespaces which helps with maintenance and development process.

note: it would not work for static methods, which is expected. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
