### PR TITLE
[monitoring] set the default latency if entry is absent from the map.

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-post-processor/src/pfn_ledger_checker.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-post-processor/src/pfn_ledger_checker.rs
@@ -131,6 +131,8 @@ async fn handle_pfn_response(
     indexer_grpc_response_time_map: IndexerGrpcResponseTimeMap,
 ) -> Result<()> {
     info!("Start processing pfn_address: {}", pfn_address);
+    // Let the map be filled with some data first.
+    tokio::time::sleep(Duration::from_secs(10)).await;
     let client = reqwest::Client::new();
     loop {
         let pfn_ledger_time = SystemTime::now();

--- a/ecosystem/indexer-grpc/indexer-grpc-post-processor/src/pfn_ledger_checker.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-post-processor/src/pfn_ledger_checker.rs
@@ -154,6 +154,11 @@ async fn handle_pfn_response(
             INDEXER_GRPC_LATENCY_AGAINST_PFN_LATENCY_IN_SECS
                 .with_label_values(&[&pfn_address.to_string()])
                 .set(latency);
+        } else {
+            // If it's not shown in the map, we set the latency to 10 seconds.
+            INDEXER_GRPC_LATENCY_AGAINST_PFN_LATENCY_IN_SECS
+                .with_label_values(&[&pfn_address.to_string()])
+                .set(10.0);
         }
     }
 }


### PR DESCRIPTION
### Description

* If the stream stops, we need to default to 10s. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Locally tested; looks good.

![image](https://github.com/aptos-labs/aptos-core/assets/112209412/722b704d-a50d-4618-8c9a-a52d05679a2f)
