### PR TITLE
adjustments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1330,7 @@ dependencies = [
  "bcs 0.1.4",
  "dashmap",
  "fail 0.5.0",
+ "hashbrown 0.14.0",
  "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
@@ -7237,6 +7244,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash 0.8.3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
 ]
 
 [[package]]

--- a/experimental/execution/ptx-executor/Cargo.toml
+++ b/experimental/execution/ptx-executor/Cargo.toml
@@ -48,3 +48,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 smallvec = { workspace = true }
 tracing = { workspace = true }
+
+# experimental
+hashbrown = "0.14.0"

--- a/experimental/execution/ptx-executor/src/analyzer.rs
+++ b/experimental/execution/ptx-executor/src/analyzer.rs
@@ -6,6 +6,7 @@
 //! TODO(aldenhu): doc
 
 use crate::{metrics::TIMER, sorter::PtxSorterClient};
+use aptos_logger::trace;
 use aptos_metrics_core::TimerHelper;
 use aptos_types::transaction::Transaction;
 use rayon::Scope;
@@ -26,6 +27,7 @@ impl PtxAnalyzer {
                     },
                     Command::Finish => {
                         sorter.finish_block();
+                        trace!("finish_block.");
                         break;
                     },
                 }

--- a/experimental/execution/ptx-executor/src/common.rs
+++ b/experimental/execution/ptx-executor/src/common.rs
@@ -14,3 +14,35 @@ pub(crate) type VersionedKey = (StateKey, TxnIdx);
 pub(crate) const BASE_VERSION: TxnIdx = TxnIdx::MAX;
 pub(crate) const EXPECTANT_BLOCK_SIZE: usize = 10_000;
 pub(crate) const EXPECTANT_BLOCK_KEYS: usize = 100_000;
+
+// pub(crate) use hashbrown::{hash_map::Entry, HashMap, HashSet};
+pub(crate) use std::collections::{hash_map::Entry, HashMap, HashSet};
+
+pub(crate) trait VersionedKeyHelper {
+    fn key(&self) -> &StateKey;
+
+    fn txn_idx(&self) -> TxnIdx;
+
+    fn txn_idx_shifted(&self) -> TxnIdx;
+}
+
+impl VersionedKeyHelper for VersionedKey {
+    fn key(&self) -> &StateKey {
+        let (key, _idx) = self;
+        key
+    }
+
+    fn txn_idx(&self) -> TxnIdx {
+        let (_key, idx) = self;
+        *idx
+    }
+
+    fn txn_idx_shifted(&self) -> TxnIdx {
+        let (_key, idx) = self;
+        if *idx == BASE_VERSION {
+            0
+        } else {
+            *idx + 1
+        }
+    }
+}

--- a/experimental/execution/ptx-executor/src/runner.rs
+++ b/experimental/execution/ptx-executor/src/runner.rs
@@ -64,6 +64,7 @@ impl PtxRunner {
                     },
                     Command::FinishBlock => {
                         manager.finish_block();
+                        trace!("finish_block.");
                         break;
                     },
                     Command::SpawnWorkers { .. } => panic!("SpawnWorkers called twice."),

--- a/experimental/execution/ptx-executor/src/runner.rs
+++ b/experimental/execution/ptx-executor/src/runner.rs
@@ -288,7 +288,7 @@ impl<'scope, 'view: 'scope, BaseView: StateView + Sync> Worker<'view, BaseView> 
                     // inform output state values to the manager
                     for (key, op) in vm_output.change_set().write_set_iter() {
                         self.scheduler
-                            .inform_state_value((key.clone(), txn_idx), op.as_state_value());
+                            .try_inform_state_value((key.clone(), txn_idx), op.as_state_value());
                     }
 
                     self.finalizer.add_vm_output(txn_idx, vm_output);

--- a/experimental/execution/ptx-executor/src/runner.rs
+++ b/experimental/execution/ptx-executor/src/runner.rs
@@ -6,7 +6,7 @@
 //! TODO(aldenhu): doc
 
 use crate::{
-    common::TxnIdx,
+    common::{HashMap, TxnIdx},
     finalizer::PtxFinalizerClient,
     metrics::{PER_WORKER_TIMER, TIMER},
     scheduler::PtxSchedulerClient,
@@ -27,10 +27,7 @@ use aptos_vm::{
 };
 use aptos_vm_logging::log_schema::AdapterLogSchema;
 use rayon::Scope;
-use std::{
-    collections::HashMap,
-    sync::mpsc::{channel, Receiver, Sender},
-};
+use std::sync::mpsc::{channel, Receiver, Sender};
 
 pub(crate) struct PtxRunner;
 

--- a/experimental/execution/ptx-executor/src/scheduler.rs
+++ b/experimental/execution/ptx-executor/src/scheduler.rs
@@ -70,6 +70,13 @@ impl PtxSchedulerClient {
         self.send_to_worker(Command::InformStateValue { key, value });
     }
 
+    pub fn try_inform_state_value(&self, key: VersionedKey, value: Option<StateValue>) {
+        // TODO(aldenhu): hack: scheduler quits before runner
+        self.work_tx
+            .send(Command::InformStateValue { key, value })
+            .ok();
+    }
+
     pub fn add_transaction(
         &self,
         txn_idx: TxnIdx,

--- a/experimental/execution/ptx-executor/src/sorter.rs
+++ b/experimental/execution/ptx-executor/src/sorter.rs
@@ -11,6 +11,7 @@ use crate::{
     scheduler::PtxSchedulerClient,
     state_reader::PtxStateReaderClient,
 };
+use aptos_logger::trace;
 use aptos_metrics_core::TimerHelper;
 use aptos_types::{
     state_store::state_key::StateKey, transaction::analyzed_transaction::AnalyzedTransaction,
@@ -41,6 +42,7 @@ impl PtxSorter {
                     },
                     Command::FinishBlock => {
                         worker.finish_block();
+                        trace!("finish_block.");
                         break;
                     },
                 }

--- a/experimental/execution/ptx-executor/src/sorter.rs
+++ b/experimental/execution/ptx-executor/src/sorter.rs
@@ -6,7 +6,7 @@
 //! TODO(aldenhu): doc
 
 use crate::{
-    common::{TxnIdx, VersionedKey, BASE_VERSION, EXPECTANT_BLOCK_KEYS},
+    common::{Entry, HashMap, HashSet, TxnIdx, VersionedKey, BASE_VERSION, EXPECTANT_BLOCK_KEYS},
     metrics::TIMER,
     scheduler::PtxSchedulerClient,
     state_reader::PtxStateReaderClient,
@@ -17,10 +17,7 @@ use aptos_types::{
     state_store::state_key::StateKey, transaction::analyzed_transaction::AnalyzedTransaction,
 };
 use rayon::Scope;
-use std::{
-    collections::{hash_map::Entry, HashMap, HashSet},
-    sync::mpsc::{channel, Sender},
-};
+use std::sync::mpsc::{channel, Sender};
 
 #[derive(Clone)]
 pub(crate) struct PtxSorter;

--- a/experimental/execution/ptx-executor/src/state_reader.rs
+++ b/experimental/execution/ptx-executor/src/state_reader.rs
@@ -53,6 +53,7 @@ impl PtxStateReader {
                     scheduler.inform_state_value((state_key, BASE_VERSION), value);
                 }),
                 Command::FinishBlock => {
+                    trace!("finish_block.");
                     break;
                 },
             }

--- a/experimental/execution/ptx-executor/src/state_view.rs
+++ b/experimental/execution/ptx-executor/src/state_view.rs
@@ -3,12 +3,11 @@
 
 #![forbid(unsafe_code)]
 
+use crate::common::HashMap;
 use aptos_state_view::{StateView, TStateView};
 use aptos_types::state_store::{
     state_key::StateKey, state_storage_usage::StateStorageUsage, state_value::StateValue,
 };
-use std::collections::HashMap;
-
 pub struct OverlayedStateView<'view> {
     base_view: &'view dyn StateView,
     overlay: HashMap<StateKey, Option<StateValue>>,


### PR DESCRIPTION
### Description
Fix a bug where runners are still pushing state values that don't block any txns to the scheduler when the latter has already quit (because all dependencies were fullfilled).

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
