### PR TITLE
[Executor-benchmark] Fix a bug in measuring 'vm_start_time' when '--generate-then-execute' flag is used

### DIFF
--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -241,7 +241,7 @@ pub fn run_benchmark<V>(
         .collect::<HashMap<_, _>>();
     let start_commit_total = APTOS_EXECUTOR_COMMIT_BLOCKS_SECONDS.get_sample_sum();
 
-    let start_vm_time = APTOS_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS.get_sample_sum();
+    let mut start_vm_time = APTOS_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS.get_sample_sum();
     if let Some(transaction_generator_creator) = transaction_generator_creator {
         generator.run_workload(
             block_size,
@@ -259,6 +259,7 @@ pub fn run_benchmark<V>(
         );
     }
     if pipeline_config.delay_execution_start {
+        start_vm_time = APTOS_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS.get_sample_sum();
         start_time = Instant::now();
     }
     pipeline.start_execution();


### PR DESCRIPTION
[Executor-benchmark] Fix a bug in measuring 'vm_start_time' when '--generate-then-execute' flag is used

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
