### PR TITLE
[Dev Docs] Update node running instructions to mention testnet requirement.

### DIFF
--- a/developer-docs-site/docs/nodes/full-node/fullnode-source-code-or-docker.md
+++ b/developer-docs-site/docs/nodes/full-node/fullnode-source-code-or-docker.md
@@ -16,6 +16,10 @@ Public fullnodes can be run by anyone. This tutorial explains how to configure a
 This document describes how to start a public fullnode in the Aptos `mainnet` network yet can easily be used to do the same in the `devnet` and `testnet` networks. To do so, instead check out the desired branch and use the `genesis.blob` and `waypoint.txt` node files for the respective branch: [`mainnet`](../node-files-all-networks/node-files.md), [`devnet`](../node-files-all-networks/node-files-devnet.md), and [`testnet`](../node-files-all-networks/node-files-testnet.md).
 :::
 
+:::tip Starting a node in testnet?
+If this is the first time you're starting a fullnode in `testnet`, it is recommended to bootstrap your node first by restoring from a [backup](../full-node/aptos-db-restore.md) or downloading [a snapshot](../full-node/bootstrap-fullnode.md). This will avoid any potential issues with network connectivity and peer discovery.
+:::
+
 ## Hardware requirements
 
 We recommend the following hardware resources:


### PR DESCRIPTION
### Description
This PR updates the `Run a Public Fullnode with the Aptos Source Code or Docker` developer doc page to mention that testnet fullnodes need to use a backup or snapshot when first starting up. This avoids issues with genesis and peer discovery.

### Test Plan
Manual verification, see:
<img width="1718" alt="Screenshot 2023-08-24 at 8 40 46 PM" src="https://github.com/aptos-labs/aptos-core/assets/4578587/41a5ce93-950d-41e5-892c-5e8ff0d4422f">
