### PR TITLE
[ptx executor] small tweaks 

### DIFF
--- a/experimental/execution/ptx-executor/src/common.rs
+++ b/experimental/execution/ptx-executor/src/common.rs
@@ -15,8 +15,8 @@ pub(crate) const BASE_VERSION: TxnIdx = TxnIdx::MAX;
 pub(crate) const EXPECTANT_BLOCK_SIZE: usize = 10_000;
 pub(crate) const EXPECTANT_BLOCK_KEYS: usize = 100_000;
 
-// pub(crate) use hashbrown::{hash_map::Entry, HashMap, HashSet};
-pub(crate) use std::collections::{hash_map::Entry, HashMap, HashSet};
+pub(crate) use hashbrown::{hash_map::Entry, HashMap, HashSet};
+// pub(crate) use std::collections::{hash_map::Entry, HashMap, HashSet};
 
 pub(crate) trait VersionedKeyHelper {
     fn key(&self) -> &StateKey;


### PR DESCRIPTION
### Description

A few tweaks to improve my easy workload (10k out of 1M active users, 50k block size) from 60k VM TPS to 64k vm TPS.

finalizer hack to only look at the total_supply - 60k → 62k
use hashbrown - 62k -> 64k


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
