### PR TITLE
[Execution][Storage] Split the ledger update to a separate phase

### DIFF
--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -331,6 +331,7 @@ async fn test_commit_sync_race() {
         transaction_shuffler::create_transaction_shuffler,
     };
     use aptos_consensus_notifications::Error;
+    use aptos_executor_types::state_checkpoint_output::StateCheckpointOutput;
     use aptos_types::{
         aggregate_signature::AggregateSignature,
         block_executor::partitioner::ExecutableBlock,
@@ -360,6 +361,24 @@ async fn test_commit_sync_race() {
             _maybe_block_gas_limit: Option<u64>,
         ) -> Result<StateComputeResult, ExecutionError> {
             Ok(StateComputeResult::new_dummy())
+        }
+
+        fn execute_and_state_checkpoint(
+            &self,
+            _block: ExecutableBlock,
+            _parent_block_id: HashValue,
+            _maybe_block_gas_limit: Option<u64>,
+        ) -> Result<StateCheckpointOutput, ExecutionError> {
+            todo!()
+        }
+
+        fn ledger_update(
+            &self,
+            _block_id: HashValue,
+            _parent_block_id: HashValue,
+            _state_checkpoint_output: StateCheckpointOutput,
+        ) -> Result<StateComputeResult, ExecutionError> {
+            todo!()
         }
 
         fn commit_blocks_ext(

--- a/execution/executor-benchmark/src/ledger_update_stage.rs
+++ b/execution/executor-benchmark/src/ledger_update_stage.rs
@@ -1,0 +1,128 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::pipeline::{CommitBlockMessage, LedgerUpdateMessage};
+use aptos_executor::block_executor::{BlockExecutor, TransactionBlockExecutor};
+use aptos_executor_types::BlockExecutorTrait;
+use aptos_types::transaction::Version;
+use std::sync::{mpsc, Arc};
+
+pub struct LedgerUpdateStage<V> {
+    executor: Arc<BlockExecutor<V>>,
+    // If commit_sender is `None`, we will commit all the execution result immediately in this struct.
+    commit_sender: Option<mpsc::SyncSender<CommitBlockMessage>>,
+    version: Version,
+    allow_discards: bool,
+    allow_aborts: bool,
+}
+
+impl<V> LedgerUpdateStage<V>
+where
+    V: TransactionBlockExecutor,
+{
+    pub fn new(
+        executor: Arc<BlockExecutor<V>>,
+        commit_sender: Option<mpsc::SyncSender<CommitBlockMessage>>,
+        version: Version,
+        allow_discards: bool,
+        allow_aborts: bool,
+    ) -> Self {
+        Self {
+            executor,
+            version,
+            commit_sender,
+            allow_discards,
+            allow_aborts,
+        }
+    }
+
+    pub fn ledger_update(&mut self, ledger_update_message: LedgerUpdateMessage) {
+        // let ledger_update_start_time = Instant::now();
+        let LedgerUpdateMessage {
+            current_block_start_time,
+            execution_time,
+            partition_time,
+            block_id,
+            parent_block_id,
+            state_checkpoint_output,
+            first_block_start_time,
+        } = ledger_update_message;
+
+        let output = self
+            .executor
+            .ledger_update(block_id, parent_block_id, state_checkpoint_output)
+            .unwrap();
+
+        let num_txns = output.compute_status().len();
+        self.version += num_txns as Version;
+        let discards = output
+            .compute_status()
+            .iter()
+            .flat_map(|status| match status.status() {
+                Ok(_) => None,
+                Err(error_code) => Some(format!("{:?}", error_code)),
+            })
+            .collect::<Vec<_>>();
+
+        let aborts = output
+            .compute_status()
+            .iter()
+            .flat_map(|status| match status.status() {
+                Ok(execution_status) => {
+                    if execution_status.is_success() {
+                        None
+                    } else {
+                        Some(format!("{:?}", execution_status))
+                    }
+                },
+                Err(_) => None,
+            })
+            .collect::<Vec<_>>();
+        if !discards.is_empty() || !aborts.is_empty() {
+            println!(
+                "Some transactions were not successful: {} discards and {} aborts out of {}, examples: discards: {:?}, aborts: {:?}",
+                discards.len(),
+                aborts.len(),
+                output.compute_status().len(),
+                &discards[..(discards.len().min(3))],
+                &aborts[..(aborts.len().min(3))]
+            )
+        }
+
+        assert!(
+            self.allow_discards || discards.is_empty(),
+            "No discards allowed, {}, examples: {:?}",
+            discards.len(),
+            &discards[..(discards.len().min(3))]
+        );
+        assert!(
+            self.allow_aborts || aborts.is_empty(),
+            "No aborts allowed, {}, examples: {:?}",
+            aborts.len(),
+            &aborts[..(aborts.len().min(3))]
+        );
+
+        if let Some(commit_sender) = &self.commit_sender {
+            let msg = CommitBlockMessage {
+                block_id,
+                root_hash: output.root_hash(),
+                first_block_start_time,
+                current_block_start_time,
+                partition_time,
+                execution_time,
+                num_txns: num_txns - discards.len(),
+            };
+            commit_sender.send(msg).unwrap();
+        } else {
+            let ledger_info_with_sigs = super::transaction_committer::gen_li_with_sigs(
+                block_id,
+                output.root_hash(),
+                self.version,
+            );
+            self.executor
+                .commit_blocks(vec![block_id], ledger_info_with_sigs)
+                .unwrap();
+        }
+    }
+}

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -27,7 +27,8 @@ use aptos_executor::{
     block_executor::{BlockExecutor, TransactionBlockExecutor},
     metrics::{
         APTOS_EXECUTOR_COMMIT_BLOCKS_SECONDS, APTOS_EXECUTOR_EXECUTE_BLOCK_SECONDS,
-        APTOS_EXECUTOR_OTHER_TIMERS_SECONDS, APTOS_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS,
+        APTOS_EXECUTOR_LEDGER_UPDATE_SECONDS, APTOS_EXECUTOR_OTHER_TIMERS_SECONDS,
+        APTOS_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS,
     },
 };
 use aptos_jellyfish_merkle::metrics::{
@@ -216,17 +217,13 @@ pub fn run_benchmark<V>(
     let start_vm_only = APTOS_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS.get_sample_sum();
     let other_labels = vec![
         ("1.", true, "verified_state_view"),
-        ("2.", true, "apply_to_ledger"),
+        ("2.", true, "state_checkpoint"),
         ("2.1.", false, "sort_transactions"),
         ("2.2.", false, "calculate_for_transaction_block"),
         ("2.2.1.", false, "get_sharded_state_updates"),
         ("2.2.2.", false, "calculate_block_state_updates"),
         ("2.2.3.", false, "calculate_usage"),
         ("2.2.4.", false, "make_checkpoint"),
-        ("2.3.", false, "assemble_ledger_diff_for_block"),
-        ("2.3.1.", false, "calculate_events_and_writeset_hashes"),
-        ("3.", true, "as_state_compute_result"),
-        ("4.", true, "get_txns_to_commit"),
     ];
 
     let start_by_other = other_labels
@@ -240,6 +237,7 @@ pub fn run_benchmark<V>(
             )
         })
         .collect::<HashMap<_, _>>();
+    let start_ledger_update_total = APTOS_EXECUTOR_LEDGER_UPDATE_SECONDS.get_sample_sum();
     let start_commit_total = APTOS_EXECUTOR_COMMIT_BLOCKS_SECONDS.get_sample_sum();
 
     let start_vm_time = APTOS_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS.get_sample_sum();
@@ -318,9 +316,18 @@ pub fn run_benchmark<V>(
             );
         }
     }
+
+    let time_in_ledger_update =
+        APTOS_EXECUTOR_LEDGER_UPDATE_SECONDS.get_sample_sum() - start_ledger_update_total;
+    info!(
+        "Overall fraction of total: {:.3} in ledger update (component TPS: {})",
+        time_in_ledger_update / elapsed,
+        delta_v / time_in_ledger_update
+    );
+
     let time_in_commit = APTOS_EXECUTOR_COMMIT_BLOCKS_SECONDS.get_sample_sum() - start_commit_total;
     info!(
-        "Overall fraction of total: {:.3} in commit (component TPS: {})",
+        "Overall fraction of total: {:.4} in commit (component TPS: {})",
         time_in_commit / elapsed,
         delta_v / time_in_commit
     );

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -7,6 +7,7 @@ pub mod block_partitioning;
 pub mod db_access;
 pub mod db_generator;
 mod db_reliable_submitter;
+mod ledger_update_stage;
 mod metrics;
 pub mod native_executor;
 pub mod pipeline;

--- a/execution/executor-benchmark/src/transaction_executor.rs
+++ b/execution/executor-benchmark/src/transaction_executor.rs
@@ -2,12 +2,12 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::pipeline::CommitBlockMessage;
+use crate::pipeline::LedgerUpdateMessage;
 use aptos_crypto::hash::HashValue;
 use aptos_executor::block_executor::{BlockExecutor, TransactionBlockExecutor};
 use aptos_executor_types::BlockExecutorTrait;
 use aptos_logger::info;
-use aptos_types::{block_executor::partitioner::ExecutableBlock, transaction::Version};
+use aptos_types::block_executor::partitioner::ExecutableBlock;
 use std::{
     sync::{mpsc, Arc},
     time::{Duration, Instant},
@@ -18,11 +18,7 @@ pub struct TransactionExecutor<V> {
     executor: Arc<BlockExecutor<V>>,
     parent_block_id: HashValue,
     maybe_first_block_start_time: Option<Instant>,
-    version: Version,
-    // If commit_sender is `None`, we will commit all the execution result immediately in this struct.
-    commit_sender: Option<mpsc::SyncSender<CommitBlockMessage>>,
-    allow_discards: bool,
-    allow_aborts: bool,
+    ledger_update_sender: mpsc::SyncSender<LedgerUpdateMessage>,
 }
 
 impl<V> TransactionExecutor<V>
@@ -32,20 +28,14 @@ where
     pub fn new(
         executor: Arc<BlockExecutor<V>>,
         parent_block_id: HashValue,
-        version: Version,
-        commit_sender: Option<mpsc::SyncSender<CommitBlockMessage>>,
-        allow_discards: bool,
-        allow_aborts: bool,
+        ledger_update_sender: mpsc::SyncSender<LedgerUpdateMessage>,
     ) -> Self {
         Self {
             num_blocks_processed: 0,
             executor,
             parent_block_id,
-            version,
             maybe_first_block_start_time: None,
-            commit_sender,
-            allow_discards,
-            allow_aborts,
+            ledger_update_sender,
         }
     }
 
@@ -65,81 +55,23 @@ where
             self.num_blocks_processed, block_id
         );
         let num_txns = executable_block.transactions.num_transactions();
-        self.version += num_txns as Version;
         let output = self
             .executor
-            .execute_block(executable_block, self.parent_block_id, None)
+            .execute_and_state_checkpoint(executable_block, self.parent_block_id, None)
             .unwrap();
 
-        assert_eq!(output.compute_status().len(), num_txns);
-        let discards = output
-            .compute_status()
-            .iter()
-            .flat_map(|status| match status.status() {
-                Ok(_) => None,
-                Err(error_code) => Some(format!("{:?}", error_code)),
-            })
-            .collect::<Vec<_>>();
+        assert_eq!(output.txn_statuses().len(), num_txns);
 
-        let aborts = output
-            .compute_status()
-            .iter()
-            .flat_map(|status| match status.status() {
-                Ok(execution_status) => {
-                    if execution_status.is_success() {
-                        None
-                    } else {
-                        Some(format!("{:?}", execution_status))
-                    }
-                },
-                Err(_) => None,
-            })
-            .collect::<Vec<_>>();
-        if !discards.is_empty() || !aborts.is_empty() {
-            println!(
-                "Some transactions were not successful: {} discards and {} aborts out of {}, examples: discards: {:?}, aborts: {:?}",
-                discards.len(),
-                aborts.len(),
-                output.compute_status().len(),
-                &discards[..(discards.len().min(3))],
-                &aborts[..(aborts.len().min(3))]
-            )
-        }
-
-        assert!(
-            self.allow_discards || discards.is_empty(),
-            "No discards allowed, {}, examples: {:?}",
-            discards.len(),
-            &discards[..(discards.len().min(3))]
-        );
-        assert!(
-            self.allow_aborts || aborts.is_empty(),
-            "No aborts allowed, {}, examples: {:?}",
-            aborts.len(),
-            &aborts[..(aborts.len().min(3))]
-        );
-
-        if let Some(commit_sender) = &self.commit_sender {
-            let msg = CommitBlockMessage {
-                block_id,
-                root_hash: output.root_hash(),
-                first_block_start_time: *self.maybe_first_block_start_time.as_ref().unwrap(),
-                current_block_start_time,
-                partition_time,
-                execution_time: Instant::now().duration_since(execution_start_time),
-                num_txns: num_txns - discards.len(),
-            };
-            commit_sender.send(msg).unwrap();
-        } else {
-            let ledger_info_with_sigs = super::transaction_committer::gen_li_with_sigs(
-                block_id,
-                output.root_hash(),
-                self.version,
-            );
-            self.executor
-                .commit_blocks(vec![block_id], ledger_info_with_sigs)
-                .unwrap();
-        }
+        let msg = LedgerUpdateMessage {
+            current_block_start_time,
+            first_block_start_time: *self.maybe_first_block_start_time.as_ref().unwrap(),
+            partition_time,
+            execution_time: Instant::now().duration_since(execution_start_time),
+            block_id,
+            parent_block_id: self.parent_block_id,
+            state_checkpoint_output: output,
+        };
+        self.ledger_update_sender.send(msg).unwrap();
         self.parent_block_id = block_id;
         self.num_blocks_processed += 1;
     }

--- a/execution/executor-types/src/execution_output.rs
+++ b/execution/executor-types/src/execution_output.rs
@@ -1,0 +1,60 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::LedgerUpdateOutput;
+use aptos_storage_interface::state_delta::StateDelta;
+use once_cell::sync::OnceCell;
+
+pub struct ExecutionOutput {
+    state: StateDelta,
+    ledger_update_output: OnceCell<LedgerUpdateOutput>,
+}
+
+impl ExecutionOutput {
+    pub fn new(state: StateDelta) -> Self {
+        Self {
+            state,
+            ledger_update_output: OnceCell::new(),
+        }
+    }
+
+    pub fn new_with_ledger_update(
+        state: StateDelta,
+        ledger_update_output: LedgerUpdateOutput,
+    ) -> Self {
+        let ledger_update = OnceCell::new();
+        ledger_update.set(ledger_update_output).unwrap();
+        Self {
+            state,
+            ledger_update_output: ledger_update,
+        }
+    }
+
+    pub fn has_ledger_update(&self) -> bool {
+        self.ledger_update_output.get().is_some()
+    }
+
+    pub fn get_ledger_update(&self) -> &LedgerUpdateOutput {
+        self.ledger_update_output.get().unwrap()
+    }
+
+    pub fn set_ledger_update(&self, ledger_update_output: LedgerUpdateOutput) {
+        self.ledger_update_output
+            .set(ledger_update_output)
+            .expect("LedgerUpdateOutput already set");
+    }
+
+    pub fn next_version(&self) -> u64 {
+        self.state().current_version.unwrap()
+    }
+
+    pub fn is_same_state(&self, rhs: &Self) -> bool {
+        self.state().has_same_current_state(rhs.state())
+    }
+
+    pub fn state(&self) -> &StateDelta {
+        &self.state
+    }
+}

--- a/execution/executor-types/src/execution_output.rs
+++ b/execution/executor-types/src/execution_output.rs
@@ -47,7 +47,7 @@ impl ExecutionOutput {
     }
 
     pub fn next_version(&self) -> u64 {
-        self.state().current_version.unwrap()
+        self.state().current_version.unwrap() + 1
     }
 
     pub fn is_same_state(&self, rhs: &Self) -> bool {

--- a/execution/executor-types/src/ledger_update_output.rs
+++ b/execution/executor-types/src/ledger_update_output.rs
@@ -6,7 +6,7 @@
 use crate::StateComputeResult;
 use anyhow::{ensure, Result};
 use aptos_crypto::{hash::TransactionAccumulatorHasher, HashValue};
-use aptos_storage_interface::{cached_state_view::ShardedStateCache};
+use aptos_storage_interface::cached_state_view::ShardedStateCache;
 use aptos_types::{
     contract_event::ContractEvent,
     epoch_state::EpochState,

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #![forbid(unsafe_code)]
 
+use crate::state_checkpoint_output::StateCheckpointOutput;
 use anyhow::Result;
 use aptos_crypto::{
     hash::{EventAccumulatorHasher, TransactionAccumulatorHasher, ACCUMULATOR_PLACEHOLDER_HASH},
@@ -23,8 +24,8 @@ use aptos_types::{
     write_set::WriteSet,
 };
 pub use error::Error;
-pub use executed_block::ExecutedBlock;
 pub use executed_chunk::ExecutedChunk;
+pub use ledger_update_output::LedgerUpdateOutput;
 pub use parsed_transaction_output::ParsedTransactionOutput;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -38,10 +39,12 @@ use std::{
 };
 
 mod error;
-mod executed_block;
 mod executed_chunk;
+pub mod execution_output;
 pub mod in_memory_state_calculator;
+mod ledger_update_output;
 mod parsed_transaction_output;
+pub mod state_checkpoint_output;
 
 pub trait ChunkExecutorTrait: Send + Sync {
     /// Verifies the transactions based on the provided proofs and ledger info. If the transactions
@@ -87,12 +90,33 @@ pub trait BlockExecutorTrait: Send + Sync {
     /// Reset the internal state including cache with newly fetched latest committed block from storage.
     fn reset(&self) -> Result<()>;
 
-    /// Executes a block.
+    /// Executes a block - TBD, this API will be removed in favor of `execute_and_state_checkpoint`, followed
+    /// by `ledger_update` once we have ledger update as a separate pipeline phase.
     fn execute_block(
         &self,
         block: ExecutableBlock,
         parent_block_id: HashValue,
         maybe_block_gas_limit: Option<u64>,
+    ) -> Result<StateComputeResult, Error> {
+        let block_id = block.block_id;
+        let state_checkpoint_output =
+            self.execute_and_state_checkpoint(block, parent_block_id, maybe_block_gas_limit)?;
+        self.ledger_update(block_id, parent_block_id, state_checkpoint_output)
+    }
+
+    /// Executes a block and returns the state checkpoint output.
+    fn execute_and_state_checkpoint(
+        &self,
+        block: ExecutableBlock,
+        parent_block_id: HashValue,
+        maybe_block_gas_limit: Option<u64>,
+    ) -> Result<StateCheckpointOutput, Error>;
+
+    fn ledger_update(
+        &self,
+        block_id: HashValue,
+        parent_block_id: HashValue,
+        state_checkpoint_output: StateCheckpointOutput,
     ) -> Result<StateComputeResult, Error>;
 
     /// Saves eligible blocks to persistent storage.

--- a/execution/executor-types/src/state_checkpoint_output.rs
+++ b/execution/executor-types/src/state_checkpoint_output.rs
@@ -1,0 +1,100 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::ParsedTransactionOutput;
+use aptos_crypto::HashValue;
+use aptos_storage_interface::cached_state_view::ShardedStateCache;
+use aptos_types::{
+    epoch_state::EpochState,
+    state_store::ShardedStateUpdates,
+    transaction::{Transaction, TransactionStatus},
+};
+
+pub struct TransactionsByStatus {
+    status: Vec<TransactionStatus>,
+    to_keep: Vec<(Transaction, ParsedTransactionOutput)>,
+    to_discard: Vec<Transaction>,
+    to_retry: Vec<Transaction>,
+}
+
+impl TransactionsByStatus {
+    pub fn new(
+        status: Vec<TransactionStatus>,
+        to_keep: Vec<(Transaction, ParsedTransactionOutput)>,
+        to_discard: Vec<Transaction>,
+        to_retry: Vec<Transaction>,
+    ) -> Self {
+        Self {
+            status,
+            to_keep,
+            to_discard,
+            to_retry,
+        }
+    }
+
+    pub fn num_txns_to_keep(&self) -> usize {
+        self.to_keep.len()
+    }
+
+    pub fn into_inner(
+        self,
+    ) -> (
+        Vec<TransactionStatus>,
+        Vec<(Transaction, ParsedTransactionOutput)>,
+        Vec<Transaction>,
+        Vec<Transaction>,
+    ) {
+        (self.status, self.to_keep, self.to_discard, self.to_retry)
+    }
+}
+
+pub struct StateCheckpointOutput {
+    txns: TransactionsByStatus,
+    state_updates_vec: Vec<ShardedStateUpdates>,
+    state_checkpoint_hashes: Vec<Option<HashValue>>,
+    next_epoch_state: Option<EpochState>,
+    block_state_updates: ShardedStateUpdates,
+    sharded_state_cache: ShardedStateCache,
+}
+
+impl StateCheckpointOutput {
+    pub fn new(
+        txns: TransactionsByStatus,
+        state_updates_vec: Vec<ShardedStateUpdates>,
+        state_checkpoint_hashes: Vec<Option<HashValue>>,
+        next_epoch_state: Option<EpochState>,
+        block_state_updates: ShardedStateUpdates,
+        sharded_state_cache: ShardedStateCache,
+    ) -> Self {
+        Self {
+            txns,
+            state_updates_vec,
+            state_checkpoint_hashes,
+            next_epoch_state,
+            block_state_updates,
+            sharded_state_cache,
+        }
+    }
+
+    pub fn into_inner(
+        self,
+    ) -> (
+        TransactionsByStatus,
+        Vec<ShardedStateUpdates>,
+        Vec<Option<HashValue>>,
+        Option<EpochState>,
+        ShardedStateUpdates,
+        ShardedStateCache,
+    ) {
+        (
+            self.txns,
+            self.state_updates_vec,
+            self.state_checkpoint_hashes,
+            self.next_epoch_state,
+            self.block_state_updates,
+            self.sharded_state_cache,
+        )
+    }
+}

--- a/execution/executor-types/src/state_checkpoint_output.rs
+++ b/execution/executor-types/src/state_checkpoint_output.rs
@@ -13,7 +13,7 @@ use aptos_types::{
 };
 
 pub struct TransactionsByStatus {
-    status: Vec<TransactionStatus>,
+    statuses: Vec<TransactionStatus>,
     to_keep: Vec<(Transaction, ParsedTransactionOutput)>,
     to_discard: Vec<Transaction>,
     to_retry: Vec<Transaction>,
@@ -27,7 +27,7 @@ impl TransactionsByStatus {
         to_retry: Vec<Transaction>,
     ) -> Self {
         Self {
-            status,
+            statuses: status,
             to_keep,
             to_discard,
             to_retry,
@@ -38,6 +38,10 @@ impl TransactionsByStatus {
         self.to_keep.len()
     }
 
+    pub fn txn_statuses(&self) -> &[TransactionStatus] {
+        &self.statuses
+    }
+
     pub fn into_inner(
         self,
     ) -> (
@@ -46,7 +50,7 @@ impl TransactionsByStatus {
         Vec<Transaction>,
         Vec<Transaction>,
     ) {
-        (self.status, self.to_keep, self.to_discard, self.to_retry)
+        (self.statuses, self.to_keep, self.to_discard, self.to_retry)
     }
 }
 
@@ -76,6 +80,10 @@ impl StateCheckpointOutput {
             block_state_updates,
             sharded_state_cache,
         }
+    }
+
+    pub fn txn_statuses(&self) -> &[TransactionStatus] {
+        self.txns.txn_statuses()
     }
 
     pub fn into_inner(

--- a/execution/executor-types/src/state_checkpoint_output.rs
+++ b/execution/executor-types/src/state_checkpoint_output.rs
@@ -7,11 +7,11 @@ use crate::ParsedTransactionOutput;
 use aptos_crypto::HashValue;
 use aptos_storage_interface::cached_state_view::ShardedStateCache;
 use aptos_types::{
-    epoch_state::EpochState,
     state_store::ShardedStateUpdates,
     transaction::{Transaction, TransactionStatus},
 };
 
+#[derive(Default)]
 pub struct TransactionsByStatus {
     statuses: Vec<TransactionStatus>,
     to_keep: Vec<(Transaction, ParsedTransactionOutput)>,
@@ -54,11 +54,11 @@ impl TransactionsByStatus {
     }
 }
 
+#[derive(Default)]
 pub struct StateCheckpointOutput {
     txns: TransactionsByStatus,
     state_updates_vec: Vec<ShardedStateUpdates>,
     state_checkpoint_hashes: Vec<Option<HashValue>>,
-    next_epoch_state: Option<EpochState>,
     block_state_updates: ShardedStateUpdates,
     sharded_state_cache: ShardedStateCache,
 }
@@ -68,7 +68,6 @@ impl StateCheckpointOutput {
         txns: TransactionsByStatus,
         state_updates_vec: Vec<ShardedStateUpdates>,
         state_checkpoint_hashes: Vec<Option<HashValue>>,
-        next_epoch_state: Option<EpochState>,
         block_state_updates: ShardedStateUpdates,
         sharded_state_cache: ShardedStateCache,
     ) -> Self {
@@ -76,7 +75,6 @@ impl StateCheckpointOutput {
             txns,
             state_updates_vec,
             state_checkpoint_hashes,
-            next_epoch_state,
             block_state_updates,
             sharded_state_cache,
         }
@@ -92,7 +90,6 @@ impl StateCheckpointOutput {
         TransactionsByStatus,
         Vec<ShardedStateUpdates>,
         Vec<Option<HashValue>>,
-        Option<EpochState>,
         ShardedStateUpdates,
         ShardedStateCache,
     ) {
@@ -100,7 +97,6 @@ impl StateCheckpointOutput {
             self.txns,
             self.state_updates_vec,
             self.state_checkpoint_hashes,
-            self.next_epoch_state,
             self.block_state_updates,
             self.sharded_state_cache,
         )

--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -222,6 +222,7 @@ where
             let _timer = APTOS_EXECUTOR_OTHER_TIMERS_SECONDS
                 .with_label_values(&["verified_state_view"])
                 .start_timer();
+            info!("next_version: {}", parent_output.next_version());
             CachedStateView::new(
                 StateViewId::BlockExecution { block_id },
                 Arc::clone(&self.db.reader),

--- a/execution/executor/src/components/apply_chunk_output.rs
+++ b/execution/executor/src/components/apply_chunk_output.rs
@@ -101,7 +101,6 @@ impl ApplyChunkOutput {
     }
 
     pub fn calculate_ledger_update(
-        state: StateDelta,
         state_checkpoint_output: StateCheckpointOutput,
         base_txn_accumulator: Arc<InMemoryAccumulator<TransactionAccumulatorHasher>>,
     ) -> Result<(LedgerUpdateOutput, Vec<Transaction>, Vec<Transaction>)> {
@@ -126,22 +125,18 @@ impl ApplyChunkOutput {
                 state_updates_vec,
                 state_checkpoint_hashes,
             );
-        // TODO get rid of the ExecutedTree here.
-        let result_view = ExecutedTrees::new(
-            state,
-            Arc::new(base_txn_accumulator.append(&transaction_info_hashes)),
-        );
-
+        let transaction_accumulator =
+            Arc::new(base_txn_accumulator.append(&transaction_info_hashes));
         Ok((
             LedgerUpdateOutput {
                 status,
                 to_commit,
-                result_view,
                 next_epoch_state,
                 reconfig_events,
                 transaction_info_hashes,
                 block_state_updates,
                 sharded_state_cache,
+                transaction_accumulator,
             },
             to_discard,
             to_retry,

--- a/execution/executor/src/components/apply_chunk_output.rs
+++ b/execution/executor/src/components/apply_chunk_output.rs
@@ -24,6 +24,7 @@ use aptos_logger::error;
 use aptos_storage_interface::{state_delta::StateDelta, ExecutedTrees};
 use aptos_types::{
     contract_event::ContractEvent,
+    epoch_state::EpochState,
     proof::accumulator::InMemoryAccumulator,
     state_store::{state_key::StateKey, state_value::StateValue, ShardedStateUpdates},
     transaction::{
@@ -46,7 +47,7 @@ impl ApplyChunkOutput {
         chunk_output: ChunkOutput,
         parent_state: &StateDelta,
         append_state_checkpoint_to_block: Option<HashValue>,
-    ) -> Result<(StateDelta, StateCheckpointOutput)> {
+    ) -> Result<(StateDelta, Option<EpochState>, StateCheckpointOutput)> {
         let ChunkOutput {
             state_cache,
             transactions,
@@ -89,11 +90,11 @@ impl ApplyChunkOutput {
 
         Ok((
             result_state,
+            next_epoch_state,
             StateCheckpointOutput::new(
                 TransactionsByStatus::new(status, to_keep, to_discard, to_retry),
                 state_updates_vec,
                 state_checkpoint_hashes,
-                next_epoch_state,
                 block_state_updates,
                 sharded_state_cache,
             ),
@@ -108,7 +109,6 @@ impl ApplyChunkOutput {
             txns,
             state_updates_vec,
             state_checkpoint_hashes,
-            next_epoch_state,
             block_state_updates,
             sharded_state_cache,
         ) = state_checkpoint_output.into_inner();
@@ -131,7 +131,6 @@ impl ApplyChunkOutput {
             LedgerUpdateOutput {
                 status,
                 to_commit,
-                next_epoch_state,
                 reconfig_events,
                 transaction_info_hashes,
                 block_state_updates,

--- a/execution/executor/src/components/apply_chunk_output.rs
+++ b/execution/executor/src/components/apply_chunk_output.rs
@@ -12,15 +12,16 @@ use crate::{
 };
 use anyhow::{ensure, Result};
 use aptos_crypto::{
-    hash::{CryptoHash, EventAccumulatorHasher},
+    hash::{CryptoHash, EventAccumulatorHasher, TransactionAccumulatorHasher},
     HashValue,
 };
 use aptos_executor_types::{
-    in_memory_state_calculator::InMemoryStateCalculator, ExecutedBlock, ExecutedChunk,
-    ParsedTransactionOutput, TransactionData,
+    in_memory_state_calculator::InMemoryStateCalculator,
+    state_checkpoint_output::{StateCheckpointOutput, TransactionsByStatus},
+    ExecutedChunk, LedgerUpdateOutput, ParsedTransactionOutput, TransactionData,
 };
 use aptos_logger::error;
-use aptos_storage_interface::ExecutedTrees;
+use aptos_storage_interface::{state_delta::StateDelta, ExecutedTrees};
 use aptos_types::{
     contract_event::ContractEvent,
     proof::accumulator::InMemoryAccumulator,
@@ -41,11 +42,11 @@ use std::{
 pub struct ApplyChunkOutput;
 
 impl ApplyChunkOutput {
-    pub fn apply_block(
+    pub fn calculate_state_checkpoint(
         chunk_output: ChunkOutput,
-        base_view: &ExecutedTrees,
+        parent_state: &StateDelta,
         append_state_checkpoint_to_block: Option<HashValue>,
-    ) -> Result<(ExecutedBlock, Vec<Transaction>, Vec<Transaction>)> {
+    ) -> Result<(StateDelta, StateCheckpointOutput)> {
         let ChunkOutput {
             state_cache,
             transactions,
@@ -79,12 +80,41 @@ impl ApplyChunkOutput {
                 .with_label_values(&["calculate_for_transaction_block"])
                 .start_timer();
             InMemoryStateCalculatorV2::calculate_for_transaction_block(
-                base_view.state(),
+                parent_state,
                 state_cache,
                 &to_keep,
                 new_epoch,
             )?
         };
+
+        Ok((
+            result_state,
+            StateCheckpointOutput::new(
+                TransactionsByStatus::new(status, to_keep, to_discard, to_retry),
+                state_updates_vec,
+                state_checkpoint_hashes,
+                next_epoch_state,
+                block_state_updates,
+                sharded_state_cache,
+            ),
+        ))
+    }
+
+    pub fn calculate_ledger_update(
+        state: StateDelta,
+        state_checkpoint_output: StateCheckpointOutput,
+        base_txn_accumulator: Arc<InMemoryAccumulator<TransactionAccumulatorHasher>>,
+    ) -> Result<(LedgerUpdateOutput, Vec<Transaction>, Vec<Transaction>)> {
+        let (
+            txns,
+            state_updates_vec,
+            state_checkpoint_hashes,
+            next_epoch_state,
+            block_state_updates,
+            sharded_state_cache,
+        ) = state_checkpoint_output.into_inner();
+
+        let (status, to_keep, to_discard, to_retry) = txns.into_inner();
 
         // Calculate TransactionData and TransactionInfo, i.e. the ledger history diff.
         let _timer = APTOS_EXECUTOR_OTHER_TIMERS_SECONDS
@@ -96,13 +126,14 @@ impl ApplyChunkOutput {
                 state_updates_vec,
                 state_checkpoint_hashes,
             );
+        // TODO get rid of the ExecutedTree here.
         let result_view = ExecutedTrees::new(
-            result_state,
-            Arc::new(base_view.txn_accumulator().append(&transaction_info_hashes)),
+            state,
+            Arc::new(base_txn_accumulator.append(&transaction_info_hashes)),
         );
 
         Ok((
-            ExecutedBlock {
+            LedgerUpdateOutput {
                 status,
                 to_commit,
                 result_view,

--- a/execution/executor/src/components/block_tree/mod.rs
+++ b/execution/executor/src/components/block_tree/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 use anyhow::{anyhow, ensure, Result};
 use aptos_consensus_types::block::Block as ConsensusBlock;
 use aptos_crypto::HashValue;
-use aptos_executor_types::{Error, ExecutedBlock};
+use aptos_executor_types::{execution_output::ExecutionOutput, Error, LedgerUpdateOutput};
 use aptos_infallible::Mutex;
 use aptos_logger::{debug, info};
 use aptos_storage_interface::DbReader;
@@ -29,7 +29,7 @@ use std::{
 
 pub struct Block {
     pub id: HashValue,
-    pub output: ExecutedBlock,
+    pub output: ExecutionOutput,
     children: Mutex<Vec<Arc<Block>>>,
     block_lookup: Arc<BlockLookup>,
 }
@@ -50,7 +50,11 @@ impl Block {
     }
 
     pub fn num_persisted_transactions(&self) -> LeafCount {
-        self.output.result_view.txn_accumulator().num_leaves()
+        self.output
+            .get_ledger_update()
+            .result_view
+            .txn_accumulator()
+            .num_leaves()
     }
 
     pub fn ensure_has_child(&self, child_id: HashValue) -> Result<()> {
@@ -94,7 +98,7 @@ impl BlockLookupInner {
     fn fetch_or_add_block(
         &mut self,
         id: HashValue,
-        output: ExecutedBlock,
+        output: ExecutionOutput,
         parent_id: Option<HashValue>,
         block_lookup: &Arc<BlockLookup>,
     ) -> Result<(Arc<Block>, bool, Option<Arc<Block>>)> {
@@ -112,10 +116,7 @@ impl BlockLookupInner {
                     .upgrade()
                     .ok_or_else(|| anyhow!("block dropped unexpected."))?;
                 ensure!(
-                    existing
-                        .output
-                        .result_view
-                        .is_same_view(&output.result_view),
+                    existing.output.is_same_state(&output),
                     "Different block with same id {:x}",
                     id,
                 );
@@ -153,7 +154,7 @@ impl BlockLookup {
     fn fetch_or_add_block(
         self: &Arc<Self>,
         id: HashValue,
-        output: ExecutedBlock,
+        output: ExecutionOutput,
         parent_id: Option<HashValue>,
     ) -> Result<Arc<Block>> {
         let (block, existing, parent_block) = self
@@ -229,7 +230,12 @@ impl BlockTree {
             ledger_info.consensus_block_id()
         };
 
-        block_lookup.fetch_or_add_block(id, ExecutedBlock::new_empty(ledger_view), None)
+        let output = ExecutionOutput::new_with_ledger_update(
+            ledger_view.state().clone(),
+            LedgerUpdateOutput::new_empty(ledger_view),
+        );
+
+        block_lookup.fetch_or_add_block(id, output, None)
     }
 
     // Set the root to be at `ledger_info`, drop blocks that are no longer descendants of the
@@ -249,11 +255,23 @@ impl BlockTree {
                     .original_reconfiguration_block_id(committed_block_id),
                 "Updated with a new root block as a virtual block of reconfiguration block"
             );
-            self.block_lookup.fetch_or_add_block(
-                epoch_genesis_id,
-                ExecutedBlock::new_empty(last_committed_block.output.result_view.clone()),
-                None,
-            )?
+            let output = ExecutionOutput::new_with_ledger_update(
+                last_committed_block
+                    .output
+                    .get_ledger_update()
+                    .result_view
+                    .state()
+                    .clone(),
+                LedgerUpdateOutput::new_empty(
+                    last_committed_block
+                        .output
+                        .get_ledger_update()
+                        .result_view
+                        .clone(),
+                ),
+            );
+            self.block_lookup
+                .fetch_or_add_block(epoch_genesis_id, output, None)?
         } else {
             info!(
                 LogSchema::new(LogEntry::SpeculationCache).root_block_id(committed_block_id),
@@ -287,7 +305,7 @@ impl BlockTree {
         &self,
         parent_block_id: HashValue,
         id: HashValue,
-        output: ExecutedBlock,
+        output: ExecutionOutput,
     ) -> Result<Arc<Block>> {
         self.block_lookup
             .fetch_or_add_block(id, output, Some(parent_block_id))

--- a/execution/executor/src/components/block_tree/mod.rs
+++ b/execution/executor/src/components/block_tree/mod.rs
@@ -52,7 +52,6 @@ impl Block {
     pub fn num_persisted_transactions(&self) -> LeafCount {
         self.output
             .get_ledger_update()
-            .result_view
             .txn_accumulator()
             .num_leaves()
     }
@@ -232,7 +231,7 @@ impl BlockTree {
 
         let output = ExecutionOutput::new_with_ledger_update(
             ledger_view.state().clone(),
-            LedgerUpdateOutput::new_empty(ledger_view),
+            LedgerUpdateOutput::new_empty(ledger_view.txn_accumulator().clone()),
         );
 
         block_lookup.fetch_or_add_block(id, output, None)
@@ -256,17 +255,12 @@ impl BlockTree {
                 "Updated with a new root block as a virtual block of reconfiguration block"
             );
             let output = ExecutionOutput::new_with_ledger_update(
-                last_committed_block
-                    .output
-                    .get_ledger_update()
-                    .result_view
-                    .state()
-                    .clone(),
+                last_committed_block.output.state().clone(),
                 LedgerUpdateOutput::new_empty(
                     last_committed_block
                         .output
                         .get_ledger_update()
-                        .result_view
+                        .txn_accumulator()
                         .clone(),
                 ),
             );

--- a/execution/executor/src/components/block_tree/mod.rs
+++ b/execution/executor/src/components/block_tree/mod.rs
@@ -231,6 +231,7 @@ impl BlockTree {
 
         let output = ExecutionOutput::new_with_ledger_update(
             ledger_view.state().clone(),
+            None,
             LedgerUpdateOutput::new_empty(ledger_view.txn_accumulator().clone()),
         );
 
@@ -256,6 +257,7 @@ impl BlockTree {
             );
             let output = ExecutionOutput::new_with_ledger_update(
                 last_committed_block.output.state().clone(),
+                None,
                 LedgerUpdateOutput::new_empty(
                     last_committed_block
                         .output

--- a/execution/executor/src/components/block_tree/test.rs
+++ b/execution/executor/src/components/block_tree/test.rs
@@ -4,7 +4,7 @@
 
 use crate::components::block_tree::{epoch_genesis_block_id, BlockLookup, BlockTree};
 use aptos_crypto::{hash::PRE_GENESIS_BLOCK_ID, HashValue};
-use aptos_executor_types::ExecutedBlock;
+use aptos_executor_types::{execution_output::ExecutionOutput, LedgerUpdateOutput};
 use aptos_infallible::Mutex;
 use aptos_storage_interface::ExecutedTrees;
 use aptos_types::{block_info::BlockInfo, epoch_state::EpochState, ledger_info::LedgerInfo};
@@ -13,13 +13,8 @@ use std::sync::Arc;
 impl BlockTree {
     pub fn new_empty() -> Self {
         let block_lookup = Arc::new(BlockLookup::new());
-        let result_view = ExecutedTrees::new_empty();
         let root = block_lookup
-            .fetch_or_add_block(
-                *PRE_GENESIS_BLOCK_ID,
-                ExecutedBlock::new_empty(result_view),
-                None,
-            )
+            .fetch_or_add_block(*PRE_GENESIS_BLOCK_ID, empty_block(), None)
             .unwrap();
 
         Self {
@@ -41,8 +36,12 @@ fn id(index: u64) -> HashValue {
     HashValue::new(buf)
 }
 
-fn empty_block() -> ExecutedBlock {
-    ExecutedBlock::new_empty(ExecutedTrees::new_empty())
+fn empty_block() -> ExecutionOutput {
+    let result_view = ExecutedTrees::new_empty();
+    ExecutionOutput::new_with_ledger_update(
+        result_view.state().clone(),
+        LedgerUpdateOutput::new_empty(ExecutedTrees::new_empty()),
+    )
 }
 
 fn gen_ledger_info(block_id: HashValue, reconfig: bool) -> LedgerInfo {

--- a/execution/executor/src/components/block_tree/test.rs
+++ b/execution/executor/src/components/block_tree/test.rs
@@ -40,6 +40,7 @@ fn empty_block() -> ExecutionOutput {
     let result_view = ExecutedTrees::new_empty();
     ExecutionOutput::new_with_ledger_update(
         result_view.state().clone(),
+        None,
         LedgerUpdateOutput::new_empty(ExecutedTrees::new_empty().txn_accumulator().clone()),
     )
 }

--- a/execution/executor/src/components/block_tree/test.rs
+++ b/execution/executor/src/components/block_tree/test.rs
@@ -40,7 +40,7 @@ fn empty_block() -> ExecutionOutput {
     let result_view = ExecutedTrees::new_empty();
     ExecutionOutput::new_with_ledger_update(
         result_view.state().clone(),
-        LedgerUpdateOutput::new_empty(ExecutedTrees::new_empty()),
+        LedgerUpdateOutput::new_empty(ExecutedTrees::new_empty().txn_accumulator().clone()),
     )
 }
 

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -7,11 +7,12 @@
 use crate::{components::apply_chunk_output::ApplyChunkOutput, metrics};
 use anyhow::Result;
 use aptos_crypto::HashValue;
-use aptos_executor_types::{ExecutedBlock, ExecutedChunk};
+use aptos_executor_types::{state_checkpoint_output::StateCheckpointOutput, ExecutedChunk};
 use aptos_infallible::Mutex;
-use aptos_logger::{sample, sample::SampleRate, trace, warn};
+use aptos_logger::{sample, sample::SampleRate, warn};
 use aptos_storage_interface::{
     cached_state_view::{CachedStateView, StateCache},
+    state_delta::StateDelta,
     ExecutedTrees,
 };
 use aptos_types::{
@@ -154,30 +155,21 @@ impl ChunkOutput {
         ApplyChunkOutput::apply_chunk(self, base_view, append_state_checkpoint_to_block)
     }
 
-    pub fn apply_to_ledger_for_block(
+    pub fn into_state_checkpoint_output(
         self,
-        base_view: &ExecutedTrees,
+        parent_state: &StateDelta,
         append_state_checkpoint_to_block: Option<HashValue>,
-    ) -> Result<(ExecutedBlock, Vec<Transaction>, Vec<Transaction>)> {
-        fail_point!("executor::apply_to_ledger_for_block", |_| {
+    ) -> Result<(StateDelta, StateCheckpointOutput)> {
+        fail_point!("executor::into_state_checkpoint_output", |_| {
             Err(anyhow::anyhow!(
-                "Injected error in apply_to_ledger_for_block."
+                "Injected error in into_state_checkpoint_output."
             ))
         });
-        ApplyChunkOutput::apply_block(self, base_view, append_state_checkpoint_to_block)
-    }
-
-    pub fn trace_log_transaction_status(&self) {
-        let status: Vec<_> = self
-            .transaction_outputs
-            .iter()
-            .map(TransactionOutput::status)
-            .cloned()
-            .collect();
-
-        if !status.is_empty() {
-            trace!("Execution status: {:?}", status);
-        }
+        ApplyChunkOutput::calculate_state_checkpoint(
+            self,
+            parent_state,
+            append_state_checkpoint_to_block,
+        )
     }
 
     fn execute_block_sharded<V: VMExecutor>(

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -19,6 +19,7 @@ use aptos_types::{
     account_config::CORE_CODE_ADDRESS,
     block_executor::partitioner::{ExecutableTransactions, PartitionedTransactions},
     contract_event::ContractEvent,
+    epoch_state::EpochState,
     transaction::{ExecutionStatus, Transaction, TransactionOutput, TransactionStatus},
 };
 use aptos_vm::{
@@ -159,7 +160,7 @@ impl ChunkOutput {
         self,
         parent_state: &StateDelta,
         append_state_checkpoint_to_block: Option<HashValue>,
-    ) -> Result<(StateDelta, StateCheckpointOutput)> {
+    ) -> Result<(StateDelta, Option<EpochState>, StateCheckpointOutput)> {
         fail_point!("executor::into_state_checkpoint_output", |_| {
             Err(anyhow::anyhow!(
                 "Injected error in into_state_checkpoint_output."

--- a/execution/executor/src/metrics.rs
+++ b/execution/executor/src/metrics.rs
@@ -79,6 +79,29 @@ pub static APTOS_EXECUTOR_EXECUTE_BLOCK_SECONDS: Lazy<Histogram> = Lazy::new(|| 
     .unwrap()
 });
 
+pub static APTOS_EXECUTOR_LEDGER_UPDATE_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        // metric name
+        "aptos_executor_ledger_update_seconds",
+        // metric description
+        "The total time spent in ledger update in the block executor.",
+        exponential_buckets(/*start=*/ 1e-3, /*factor=*/ 2.0, /*count=*/ 20).unwrap(),
+    )
+    .unwrap()
+});
+
+pub static APTOS_EXECUTOR_LEDGER_UPDATE_OTHER_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        // metric name
+        "aptos_executor_ledger_update_other_seconds",
+        // metric description
+        "The time spent in seconds of others in ledger update stage in Aptos executor",
+        &["name"],
+        exponential_buckets(/*start=*/ 1e-3, /*factor=*/ 2.0, /*count=*/ 20).unwrap(),
+    )
+    .unwrap()
+});
+
 pub static APTOS_EXECUTOR_VM_EXECUTE_CHUNK_SECONDS: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         // metric name

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -625,6 +625,7 @@ fn test_reconfig_suffix_empty_blocks() {
         .unwrap();
 
     let ledger_info = gen_ledger_info(20002, output.root_hash(), block_d.id, 1);
+
     executor
         .commit_blocks(
             vec![block_a.id, block_b.id, block_c.id, block_d.id],

--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -17,21 +17,21 @@ from dataclasses import dataclass
 # Calibrate from https://gist.github.com/igor-aptos/7b12ca28de03894cddda8e415f37889e
 # Local machine numbers will be higher.
 EXPECTED_TPS = {
-    ("no-op", False, 1): (18000.0, True),
+    ("no-op", False, 1): (20500.0, True),
     ("no-op", False, 1000): (2800.0, True),
-    ("coin-transfer", False, 1): (12500.0, True),
+    ("coin-transfer", False, 1): (13000.0, True),
     ("coin-transfer", True, 1): (30300.0, True),
-    ("account-generation", False, 1): (10500.0, True),
+    ("account-generation", False, 1): (12500.0, True),
     # ("account-generation", True, 1): (26500.0, True),
-    ("account-resource32-b", False, 1): (15400.0, True),
-    ("modify-global-resource", False, 1): (3400.0, True),
-    ("modify-global-resource", False, 10): (10100.0, True),
-    ("publish-package", False, 1): (120.0, True),
-    ("mix_publish_transfer", False, 1): (1400.0, False),
-    ("batch100-transfer", False, 1): (370, True),
+    ("account-resource32-b", False, 1): (18500.0, True),
+    ("modify-global-resource", False, 1): (3550.0, True),
+    ("modify-global-resource", False, 10): (10600.0, True),
+    ("publish-package", False, 1): (125.0, True),
+    ("mix_publish_transfer", False, 1): (1600.0, False),
+    ("batch100-transfer", False, 1): (390, True),
     # ("batch100-transfer", True, 1): (940, True),
     ("token-v1ft-mint-and-transfer", False, 1): (1550.0, True),
-    ("token-v1ft-mint-and-transfer", False, 20): (7000.0, True),
+    ("token-v1ft-mint-and-transfer", False, 20): (7700.0, True),
     # ("token-v1nft-mint-and-transfer-sequential", False, 1): (1000.0, True),
     # ("token-v1nft-mint-and-transfer-sequential", False, 20): (5150.0, True),
     # ("token-v1nft-mint-and-transfer-parallel", False, 1): (1300.0, True),
@@ -42,7 +42,7 @@ EXPECTED_TPS = {
     # ("no-op2-signers", False, 1): (18000.0, True),
     # ("no-op5-signers", False, 1): (18000.0, True),
     ("token-v2-ambassador-mint", False, 1): (1500.0, True),
-    ("token-v2-ambassador-mint", False, 20): (5000.0, True),
+    ("token-v2-ambassador-mint", False, 20): (5500.0, True),
 }
 
 NOISE_LOWER_LIMIT = 0.8


### PR DESCRIPTION
### Description

Today the ledger update being sequential and in the critical path of execution consumes around ~15% of the execution. This change introduces a new phase for ledger update. Please note that the change only affects the executor benchmark, and current production path should not be affected. We will have a separate change to add a new pipeline stage for this. 


### Test Plan

Ran the benchmark and observed ~10% TPS gain in sharded execution. 
