### PR TITLE
Remove explicit copy statement for vector

### DIFF
--- a/developer-docs-site/docs/move/book/variables.md
+++ b/developer-docs-site/docs/move/book/variables.md
@@ -714,14 +714,11 @@ before it is assigned a value.
 As mentioned above, the Move compiler will infer a `copy` or `move` if one is not indicated. The
 algorithm for doing so is quite simple:
 
-- Any scalar value with the `copy` [ability](./abilities.md) is given a `copy`.
+- Any value with the `copy` [ability](./abilities.md) is given a `copy`.
 - Any reference (both mutable `&mut` and immutable `&`) is given a `copy`.
   - Except under special circumstances where it is made a `move` for predictable borrow checker
     errors.
 - Any other value is given a `move`.
-  - This means that even though other values might be have the `copy` [ability](./abilities.md), it
-    must be done _explicitly_ by the programmer.
-  - This is to prevent accidental copies of large data structures.
 
 For example:
 

--- a/developer-docs-site/docs/move/book/variables.md
+++ b/developer-docs-site/docs/move/book/variables.md
@@ -723,13 +723,21 @@ algorithm for doing so is quite simple:
 For example:
 
 ```move
+struct Foo {
+    f: u64
+}
+
+struct Coin has copy {
+    value: u64
+}
+
 let s = b"hello";
 let foo = Foo { f: 0 };
 let coin = Coin { value: 0 };
 
-let s2 = s; // move
+let s2 = s; // copy
 let foo2 = foo; // move
-let coin2 = coin; // move
+let coin2 = coin; // copy
 
 let x = 0;
 let b = false;

--- a/developer-docs-site/docs/move/book/variables.md
+++ b/developer-docs-site/docs/move/book/variables.md
@@ -719,6 +719,9 @@ algorithm for doing so is quite simple:
   - Except under special circumstances where it is made a `move` for predictable borrow checker
     errors.
 - Any other value is given a `move`.
+- If the compiler can prove that the source value with copy ability is not used after the 
+  assignment, then a move may be used instead of a copy for performance, but this will be invisible
+  to the programmer (except in possible decreased time or gas cost).
 
 For example:
 

--- a/developer-docs-site/docs/move/book/vector.md
+++ b/developer-docs-site/docs/move/book/vector.md
@@ -157,7 +157,8 @@ fun destroy_droppable_vector<T: drop>(vec: vector<T>) {
 }
 ```
 
-Similarly, vectors cannot be copied unless the element type has `copy`. 
+Similarly, vectors cannot be copied unless the element type has `copy`. In other words, a
+`vector<T>` has `copy` if and only if `T` has `copy`.
 
 For more details see the sections on [type abilities](./abilities.md) and [generics](./generics.md).
 

--- a/developer-docs-site/docs/move/book/vector.md
+++ b/developer-docs-site/docs/move/book/vector.md
@@ -157,22 +157,11 @@ fun destroy_droppable_vector<T: drop>(vec: vector<T>) {
 }
 ```
 
-Similarly, vectors cannot be copied unless the element type has `copy`. In other words, a
-`vector<T>` has `copy` if and only if `T` has `copy`. However, even copyable vectors are never
-implicitly copied:
-
-```move
-let x = vector::singleton<u64>(10);
-let y = copy x; // compiler error without the copy!
-```
-
-Copies of large vectors can be expensive, so the compiler requires explicit `copy`'s to make it
-easier to see where they are happening.
+Similarly, vectors cannot be copied unless the element type has `copy`. 
 
 For more details see the sections on [type abilities](./abilities.md) and [generics](./generics.md).
 
 ## Ownership
 
 As mentioned [above](#destroying-and-copying-vectors), `vector` values can be copied only if the
-elements can be copied. In that case, the copy must be explicit via a
-[`copy`](./variables.md#move-and-copy) or a [dereference `*`](./references.md#reading-and-writing-through-references).
+elements can be copied.


### PR DESCRIPTION
### Description
Seems the `copy` keyword is not needed for a copyable vector, Tried with aptos-move `2.0.3`. 
Also talked about this with Matt on Discord.

By the way, the original statement makes sense for why explicit copy is needed. Very grateful if reviewers could talk about the reason for this change.

> Copies of large vectors can be expensive, so the compiler requires explicit copy's to make it easier to see where they are happening. 

### Test Plan
The following test passed.

```move
module 0xcafe::capy {
    #[test_only]
    use std::vector;

    struct Book has copy, drop {}

    #[test]
    fun implicty_copy() {
        let v0 = vector[Book {}, Book {}, Book {}];

        let v1 = v0; // implicit copy. The keyword `copy` is not required.

        assert!(vector::length(&v0) == 3, 0);
        assert!(vector::length(&v1) == 3, 1);

        let _ = vector::pop_back(&mut v1);

        assert!(vector::length(&v0) == 3, 2); // the original vector is not modified
        assert!(vector::length(&v1) == 2, 3);

    }
}
```