### PR TITLE
bump node.js to 18.x

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -606,7 +606,7 @@ function install_xsltproc {
 
 function install_nodejs {
     if [[ "$PACKAGE_MANAGER" == "apt-get" ]]; then
-      curl -fsSL https://deb.nodesource.com/setup_14.x | "${PRE_COMMAND[@]}" bash -
+      curl -fsSL https://deb.nodesource.com/setup_18.x | "${PRE_COMMAND[@]}" bash -
     fi
     install_pkg nodejs "$PACKAGE_MANAGER"
     install_pkg npm "$PACKAGE_MANAGER"


### PR DESCRIPTION
### Description

node.js 14.x is no longer receiving updates, 18.x is the latest LTS release

### Test Plan

This is hopefully a fully compatible no-op. Let the automated test suite handle things.