### PR TITLE
disable module_event feature after framework update is done

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -15,6 +15,9 @@ proposals:
       - Framework:
           bytecode_version: 6
           git_hash: ~
+      - FeatureFlag:
+          disabled:
+            - module_event
   - name: enable_block_gas_limit
     metadata:
       title: "Enable Block Gas Limit"

--- a/aptos-move/aptos-release-builder/src/components/mod.rs
+++ b/aptos-move/aptos-release-builder/src/components/mod.rs
@@ -48,6 +48,33 @@ pub struct Proposal {
     pub update_sequence: Vec<ReleaseEntry>,
 }
 
+impl Proposal {
+    fn consolidated_side_effects(&self) -> Vec<ReleaseEntry> {
+        let mut ret = vec![];
+        let mut features_diff = Features::empty();
+        for entry in &self.update_sequence {
+            match entry {
+                ReleaseEntry::FeatureFlag(feature_flags) => {
+                    features_diff.squash(feature_flags.clone())
+                },
+                ReleaseEntry::Framework(_)
+                | ReleaseEntry::CustomGas(_)
+                | ReleaseEntry::DefaultGas
+                | ReleaseEntry::Version(_)
+                | ReleaseEntry::Consensus(_)
+                | ReleaseEntry::Execution(_)
+                | ReleaseEntry::RawScript(_) => ret.push(entry.clone()),
+            }
+        }
+
+        if !features_diff.is_empty() {
+            ret.push(ReleaseEntry::FeatureFlag(features_diff));
+        }
+
+        ret
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ProposalMetadata {
     title: String,
@@ -489,7 +516,7 @@ impl ReleaseConfig {
     pub fn validate_upgrade(&self, endpoint: Url) -> Result<()> {
         let client = Client::new(endpoint);
         for proposal in &self.proposals {
-            for entry in &proposal.update_sequence {
+            for entry in proposal.consolidated_side_effects() {
                 entry.validate_upgrade(&client)?;
             }
         }


### PR DESCRIPTION
### Description
The module event feature is supposed to be enabled only briefly during framework upgrade to allow the new framework to publish, until the feature is approved by governance and enabled again. This tests the workflow and tooling work.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

framework_upgrade forge test
