### PR TITLE
[TS SDK v2] Add BCS serialization/deserialization

### DIFF
--- a/ecosystem/typescript/sdk_v2/src/aptos_types/abi.ts
+++ b/ecosystem/typescript/sdk_v2/src/aptos_types/abi.ts
@@ -1,0 +1,139 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Deserializer, Serializer } from "../bcs";
+
+import { ModuleId } from "./transaction";
+
+import { TypeTag } from "./type_tag";
+
+export class TypeArgumentABI {
+  /**
+   * Constructs a TypeArgumentABI instance.
+   * @param name
+   */
+  constructor(public readonly name: string) {}
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeStr(this.name);
+  }
+
+  static deserialize(deserializer: Deserializer): TypeArgumentABI {
+    const name = deserializer.deserializeStr();
+    return new TypeArgumentABI(name);
+  }
+}
+
+export class ArgumentABI {
+  /**
+   * Constructs an ArgumentABI instance.
+   * @param name
+   * @param type_tag
+   */
+  constructor(public readonly name: string, public readonly type_tag: TypeTag) {}
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeStr(this.name);
+    this.type_tag.serialize(serializer);
+  }
+
+  static deserialize(deserializer: Deserializer): ArgumentABI {
+    const name = deserializer.deserializeStr();
+    const typeTag = TypeTag.deserialize(deserializer);
+    return new ArgumentABI(name, typeTag);
+  }
+}
+
+export abstract class ScriptABI {
+  abstract serialize(serializer: Serializer): void;
+
+  static deserialize(deserializer: Deserializer): ScriptABI {
+    const index = deserializer.deserializeUleb128AsU32();
+    switch (index) {
+      case 0:
+        return TransactionScriptABI.load(deserializer);
+      case 1:
+        return EntryFunctionABI.load(deserializer);
+      default:
+        throw new Error(`Unknown variant index for TransactionPayload: ${index}`);
+    }
+  }
+}
+
+export class TransactionScriptABI extends ScriptABI {
+  /**
+   * Constructs a TransactionScriptABI instance.
+   * @param name Entry function name
+   * @param doc
+   * @param code
+   * @param ty_args
+   * @param args
+   */
+  constructor(
+    public readonly name: string,
+    public readonly doc: string,
+    public readonly code: Uint8Array,
+    public readonly ty_args: Array<TypeArgumentABI>,
+    public readonly args: Array<ArgumentABI>,
+  ) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer
+        .serializeU32AsUleb128(0)
+        .serializeStr(this.name)
+        .serializeStr(this.doc)
+        .serializeByteVector(this.code)
+        .serializeVector<TypeArgumentABI>(this.ty_args)
+        .serializeVector<ArgumentABI>(this.args)
+  }
+
+  static load(deserializer: Deserializer): TransactionScriptABI {
+    const name = deserializer.deserializeStr();
+    const doc = deserializer.deserializeStr();
+    const code = deserializer.deserializeBytes();
+    const tyArgs = deserializer.deserializeVector(TypeArgumentABI);
+    const args = deserializer.deserializeVector(ArgumentABI);
+    return new TransactionScriptABI(name, doc, code, tyArgs, args);
+  }
+}
+
+export class EntryFunctionABI extends ScriptABI {
+  /**
+   * Constructs a EntryFunctionABI instance
+   * @param name
+   * @param module_name Fully qualified module id
+   * @param doc
+   * @param ty_args
+   * @param args
+   */
+  constructor(
+    public readonly name: string,
+    public readonly module_name: ModuleId,
+    public readonly doc: string,
+    public readonly ty_args: Array<TypeArgumentABI>,
+    public readonly args: Array<ArgumentABI>,
+  ) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer
+        .serializeU32AsUleb128(1)
+        .serializeStr(this.name)
+        .serialize(this.module_name)
+        .serializeStr(this.doc)
+        .serializeVector<TypeArgumentABI>(this.ty_args)
+        .serializeVector<ArgumentABI>(this.args)
+  }
+
+  static load(deserializer: Deserializer): EntryFunctionABI {
+    const name = deserializer.deserializeStr();
+    const moduleName = ModuleId.deserialize(deserializer);
+    const doc = deserializer.deserializeStr();
+    const tyArgs = deserializer.deserializeVector(TypeArgumentABI);
+    const args = deserializer.deserializeVector(ArgumentABI);
+    return new EntryFunctionABI(name, moduleName, doc, tyArgs, args);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/aptos_types/account_address.ts
+++ b/ecosystem/typescript/sdk_v2/src/aptos_types/account_address.ts
@@ -1,0 +1,106 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { HexString, MaybeHexString } from "../utils/hex_string";
+import { Serializer, Deserializer } from "../bcs";
+
+/**
+ * Exported as TransactionBuilderTypes.AccountAddress
+ */
+export class AccountAddress {
+  static readonly LENGTH: number = 32;
+
+  readonly address: Uint8Array;
+
+  static CORE_CODE_ADDRESS: AccountAddress = AccountAddress.fromHex("0x1");
+
+  constructor(address: Uint8Array) {
+    if (address.length !== AccountAddress.LENGTH) {
+      throw new Error("Expected address of length 32");
+    }
+    this.address = address;
+  }
+
+  /**
+   * Creates AccountAddress from a hex string.
+   * @param addr Hex string can be with a prefix or without a prefix,
+   *   e.g. '0x1aa' or '1aa'. Hex string will be left padded with 0s if too short.
+   */
+  static fromHex(addr: MaybeHexString): AccountAddress {
+    let address = HexString.ensure(addr);
+
+    // If an address hex has odd number of digits, padd the hex string with 0
+    // e.g. '1aa' would become '01aa'.
+    if (address.noPrefix().length % 2 !== 0) {
+      address = new HexString(`0${address.noPrefix()}`);
+    }
+
+    const addressBytes = address.toUint8Array();
+
+    if (addressBytes.length > AccountAddress.LENGTH) {
+      // eslint-disable-next-line quotes
+      throw new Error("Hex string is too long. Address's length is 32 bytes.");
+    } else if (addressBytes.length === AccountAddress.LENGTH) {
+      return new AccountAddress(addressBytes);
+    }
+
+    const res: Uint8Array = new Uint8Array(AccountAddress.LENGTH);
+    res.set(addressBytes, AccountAddress.LENGTH - addressBytes.length);
+
+    return new AccountAddress(res);
+  }
+
+  /**
+   * Checks if the string is a valid AccountAddress
+   * @param addr Hex string can be with a prefix or without a prefix,
+   *   e.g. '0x1aa' or '1aa'. Hex string will be left padded with 0s if too short.
+   */
+  static isValid(addr: MaybeHexString): boolean {
+    // At least one zero is required
+    if (addr === "") {
+      return false;
+    }
+
+    let address = HexString.ensure(addr);
+
+    // If an address hex has odd number of digits, padd the hex string with 0
+    // e.g. '1aa' would become '01aa'.
+    if (address.noPrefix().length % 2 !== 0) {
+      address = new HexString(`0${address.noPrefix()}`);
+    }
+
+    const addressBytes = address.toUint8Array();
+
+    return addressBytes.length <= AccountAddress.LENGTH;
+  }
+
+  /**
+   * Return a hex string from account Address.
+   */
+  toHexString(): MaybeHexString {
+    return HexString.fromUint8Array(this.address).hex();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeFixedBytes(this.address);
+  }
+
+  static deserialize(deserializer: Deserializer): AccountAddress {
+    return new AccountAddress(deserializer.deserializeFixedBytes(AccountAddress.LENGTH));
+  }
+
+  /**
+   * Standardizes an address to the format "0x" followed by 64 lowercase hexadecimal digits.
+   */
+  static standardizeAddress(address: string): string {
+    // Convert the address to lowercase
+    const lowercaseAddress = address.toLowerCase();
+    // Remove the "0x" prefix if present
+    const addressWithoutPrefix = lowercaseAddress.startsWith("0x") ? lowercaseAddress.slice(2) : lowercaseAddress;
+    // Pad the address with leading zeros if necessary
+    // to ensure it has exactly 64 characters (excluding the "0x" prefix)
+    const addressWithPadding = addressWithoutPrefix.padStart(64, "0");
+    // Return the standardized address with the "0x" prefix
+    return `0x${addressWithPadding}`;
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/aptos_types/authenticator.ts
+++ b/ecosystem/typescript/sdk_v2/src/aptos_types/authenticator.ts
@@ -1,0 +1,187 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable @typescript-eslint/naming-convention */
+import { AccountAddress } from "./account_address";
+import { Serializer, Deserializer } from "../bcs";
+import { Ed25519PublicKey, Ed25519Signature } from "./ed25519";
+import { MultiEd25519PublicKey, MultiEd25519Signature } from "./multi_ed25519";
+
+export abstract class TransactionAuthenticator {
+  abstract serialize(serializer: Serializer): void;
+
+  static deserialize(deserializer: Deserializer): TransactionAuthenticator {
+    const index = deserializer.deserializeUleb128AsU32();
+    switch (index) {
+      case 0:
+        return TransactionAuthenticatorEd25519.load(deserializer);
+      case 1:
+        return TransactionAuthenticatorMultiEd25519.load(deserializer);
+      case 2:
+        return TransactionAuthenticatorMultiAgent.load(deserializer);
+      case 3:
+        return TransactionAuthenticatorFeePayer.load(deserializer);
+      default:
+        throw new Error(`Unknown variant index for TransactionAuthenticator: ${index}`);
+    }
+  }
+}
+
+export class TransactionAuthenticatorEd25519 extends TransactionAuthenticator {
+  /**
+   * An authenticator for single signature.
+   *
+   * @param public_key Client's public key.
+   * @param signature Signature of a raw transaction.
+   * @see {@link https://aptos.dev/guides/creating-a-signed-transaction/ | Creating a Signed Transaction}
+   * for details about generating a signature.
+   */
+  constructor(public readonly public_key: Ed25519PublicKey, public readonly signature: Ed25519Signature) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(0);
+    serializer.serialize(this.public_key);
+    serializer.serialize(this.signature);
+  }
+
+  static load(deserializer: Deserializer): TransactionAuthenticatorEd25519 {
+    const public_key = deserializer.deserialize(Ed25519PublicKey);
+    const signature = deserializer.deserialize(Ed25519Signature);
+    return new TransactionAuthenticatorEd25519(public_key, signature);
+  }
+}
+
+export class TransactionAuthenticatorMultiEd25519 extends TransactionAuthenticator {
+  /**
+   * An authenticator for multiple signatures.
+   *
+   * @param public_key
+   * @param signature
+   *
+   */
+  constructor(public readonly public_key: MultiEd25519PublicKey, public readonly signature: MultiEd25519Signature) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(1);
+    serializer.serialize(this.public_key);
+    serializer.serialize(this.signature);
+  }
+
+  static load(deserializer: Deserializer): TransactionAuthenticatorMultiEd25519 {
+    const public_key = deserializer.deserialize(MultiEd25519PublicKey);
+    const signature = deserializer.deserialize(MultiEd25519Signature);
+    return new TransactionAuthenticatorMultiEd25519(public_key, signature);
+  }
+}
+
+export class TransactionAuthenticatorMultiAgent extends TransactionAuthenticator {
+  constructor(
+    public readonly sender: AccountAuthenticator,
+    public readonly secondary_signer_addresses: Array<AccountAddress>,
+    public readonly secondary_signers: Array<AccountAuthenticator>,
+  ) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer
+        .serializeU32AsUleb128(2)
+        .serialize(this.sender)
+        .serializeVector<AccountAddress>(this.secondary_signer_addresses)
+        .serializeVector<AccountAuthenticator>(this.secondary_signers);
+  }
+
+  static load(deserializer: Deserializer): TransactionAuthenticatorMultiAgent {
+    const sender = deserializer.deserialize(AccountAuthenticator);
+    const secondary_signer_addresses = deserializer.deserializeVector(AccountAddress);
+    const secondary_signers = deserializer.deserializeVector(AccountAuthenticator);
+    return new TransactionAuthenticatorMultiAgent(sender, secondary_signer_addresses, secondary_signers);
+  }
+}
+
+export class TransactionAuthenticatorFeePayer extends TransactionAuthenticator {
+  constructor(
+    public readonly sender: AccountAuthenticator,
+    public readonly secondary_signer_addresses: Array<AccountAddress>,
+    public readonly secondary_signers: Array<AccountAuthenticator>,
+    public readonly fee_payer: { address: AccountAddress; authenticator: AccountAuthenticator },
+  ) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer
+        .serializeU32AsUleb128(3)
+        .serialize(this.sender)
+        .serializeVector<AccountAddress>(this.secondary_signer_addresses)
+        .serializeVector<AccountAuthenticator>(this.secondary_signers)
+        .serialize(this.fee_payer.address)
+        .serialize(this.fee_payer.authenticator);
+  }
+
+  static load(deserializer: Deserializer): TransactionAuthenticatorMultiAgent {
+    const sender = deserializer.deserialize(AccountAuthenticator);
+    const secondary_signer_addresses = deserializer.deserializeVector(AccountAddress);
+    const secondary_signers = deserializer.deserializeVector(AccountAuthenticator);
+    const address = deserializer.deserialize(AccountAddress);
+    const authenticator = deserializer.deserialize(AccountAuthenticator);
+    const fee_payer = { address, authenticator };
+    return new TransactionAuthenticatorFeePayer(sender, secondary_signer_addresses, secondary_signers, fee_payer);
+  }
+}
+
+export abstract class AccountAuthenticator {
+  abstract serialize(serializer: Serializer): void;
+
+  static deserialize(deserializer: Deserializer): AccountAuthenticator {
+    const index = deserializer.deserializeUleb128AsU32();
+    switch (index) {
+      case 0:
+        return AccountAuthenticatorEd25519.load(deserializer);
+      case 1:
+        return AccountAuthenticatorMultiEd25519.load(deserializer);
+      default:
+        throw new Error(`Unknown variant index for AccountAuthenticator: ${index}`);
+    }
+  }
+}
+
+export class AccountAuthenticatorEd25519 extends AccountAuthenticator {
+  constructor(public readonly public_key: Ed25519PublicKey, public readonly signature: Ed25519Signature) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(0);
+    serializer.serialize(this.public_key);
+    serializer.serialize(this.signature);
+  }
+
+  static load(deserializer: Deserializer): AccountAuthenticatorEd25519 {
+    const public_key = deserializer.deserialize(Ed25519PublicKey);
+    const signature = deserializer.deserialize(Ed25519Signature);
+    return new AccountAuthenticatorEd25519(public_key, signature);
+  }
+}
+
+export class AccountAuthenticatorMultiEd25519 extends AccountAuthenticator {
+  constructor(public readonly public_key: MultiEd25519PublicKey, public readonly signature: MultiEd25519Signature) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(1);
+    serializer.serialize(this.public_key);
+    serializer.serialize(this.signature);
+  }
+
+  static load(deserializer: Deserializer): AccountAuthenticatorMultiEd25519 {
+    const public_key = deserializer.deserialize(MultiEd25519PublicKey);
+    const signature = deserializer.deserialize(MultiEd25519Signature);
+    return new AccountAuthenticatorMultiEd25519(public_key, signature);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/aptos_types/ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/aptos_types/ed25519.ts
@@ -1,0 +1,49 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Deserializer, Serializer } from "../bcs";
+
+export class Ed25519PublicKey {
+  static readonly LENGTH: number = 32;
+
+  readonly value: Uint8Array;
+
+  constructor(value: Uint8Array) {
+    if (value.length !== Ed25519PublicKey.LENGTH) {
+      throw new Error(`Ed25519PublicKey length should be ${Ed25519PublicKey.LENGTH}`);
+    }
+    this.value = value;
+  }
+
+  toBytes(): Uint8Array {
+    return this.value;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeByteVector(this.value);
+  }
+
+  static deserialize(deserializer: Deserializer): Ed25519PublicKey {
+    const value = deserializer.deserializeBytes();
+    return new Ed25519PublicKey(value);
+  }
+}
+
+export class Ed25519Signature {
+  static readonly LENGTH = 64;
+
+  constructor(public readonly value: Uint8Array) {
+    if (value.length !== Ed25519Signature.LENGTH) {
+      throw new Error(`Ed25519Signature length should be ${Ed25519Signature.LENGTH}`);
+    }
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeByteVector(this.value);
+  }
+
+  static deserialize(deserializer: Deserializer): Ed25519Signature {
+    const value = deserializer.deserializeBytes();
+    return new Ed25519Signature(value);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/aptos_types/identifier.ts
+++ b/ecosystem/typescript/sdk_v2/src/aptos_types/identifier.ts
@@ -1,0 +1,17 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Deserializer, Serializer } from "../bcs";
+
+export class Identifier {
+  constructor(public value: string) {}
+
+  public serialize(serializer: Serializer): void {
+    serializer.serializeStr(this.value);
+  }
+
+  static deserialize(deserializer: Deserializer): Identifier {
+    const value = deserializer.deserializeStr();
+    return new Identifier(value);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/aptos_types/index.ts
+++ b/ecosystem/typescript/sdk_v2/src/aptos_types/index.ts
@@ -1,0 +1,13 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+export * from "./abi";
+export * from "./account_address";
+export * from "./authenticator";
+export * from "./transaction";
+export * from "./type_tag";
+export * from "./identifier";
+export * from "./ed25519";
+export * from "./multi_ed25519";
+
+export type SigningMessage = Uint8Array;

--- a/ecosystem/typescript/sdk_v2/src/aptos_types/multi_ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/aptos_types/multi_ed25519.ts
@@ -1,0 +1,158 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable no-bitwise */
+import { Deserializer, Serializer, Uint8 } from "../bcs";
+import { Ed25519PublicKey, Ed25519Signature } from "./ed25519";
+
+/**
+ * MultiEd25519 currently supports at most 32 signatures.
+ */
+const MAX_SIGNATURES_SUPPORTED = 32;
+
+export class MultiEd25519PublicKey {
+  /**
+   * Public key for a K-of-N multisig transaction. A K-of-N multisig transaction means that for such a
+   * transaction to be executed, at least K out of the N authorized signers have signed the transaction
+   * and passed the check conducted by the chain.
+   *
+   * @see {@link
+   * https://aptos.dev/guides/creating-a-signed-transaction#multisignature-transactions | Creating a Signed Transaction}
+   *
+   * @param public_keys A list of public keys
+   * @param threshold At least "threshold" signatures must be valid
+   */
+  constructor(public readonly public_keys: Array<Ed25519PublicKey>, public readonly threshold: Uint8) {
+    if (threshold > MAX_SIGNATURES_SUPPORTED) {
+      throw new Error(`"threshold" cannot be larger than ${MAX_SIGNATURES_SUPPORTED}`);
+    }
+  }
+
+  /**
+   * Converts a MultiEd25519PublicKey into bytes with: bytes = p1_bytes | ... | pn_bytes | threshold
+   */
+  toBytes(): Uint8Array {
+    const bytes = new Uint8Array(this.public_keys.length * Ed25519PublicKey.LENGTH + 1);
+    this.public_keys.forEach((k: Ed25519PublicKey, i: number) => {
+      bytes.set(k.value, i * Ed25519PublicKey.LENGTH);
+    });
+
+    bytes[this.public_keys.length * Ed25519PublicKey.LENGTH] = this.threshold;
+
+    return bytes;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeByteVector(this.toBytes());
+  }
+
+  static deserialize(deserializer: Deserializer): MultiEd25519PublicKey {
+    const bytes = deserializer.deserializeBytes();
+    const threshold = bytes[bytes.length - 1];
+
+    const keys: Array<Ed25519PublicKey> = [];
+
+    for (let i = 0; i < bytes.length - 1; i += Ed25519PublicKey.LENGTH) {
+      const begin = i;
+      keys.push(new Ed25519PublicKey(bytes.subarray(begin, begin + Ed25519PublicKey.LENGTH)));
+    }
+    return new MultiEd25519PublicKey(keys, threshold);
+  }
+}
+
+export class MultiEd25519Signature {
+  static BITMAP_LEN: Uint8 = 4;
+
+  /**
+   * Signature for a K-of-N multisig transaction.
+   *
+   * @see {@link
+   * https://aptos.dev/guides/creating-a-signed-transaction#multisignature-transactions | Creating a Signed Transaction}
+   *
+   * @param signatures A list of ed25519 signatures
+   * @param bitmap 4 bytes, at most 32 signatures are supported. If Nth bit value is `1`, the Nth
+   * signature should be provided in `signatures`. Bits are read from left to right
+   */
+  constructor(public readonly signatures: Array<Ed25519Signature>, public readonly bitmap: Uint8Array) {
+    if (bitmap.length !== MultiEd25519Signature.BITMAP_LEN) {
+      throw new Error(`"bitmap" length should be ${MultiEd25519Signature.BITMAP_LEN}`);
+    }
+  }
+
+  /**
+   * Converts a MultiEd25519Signature into bytes with `bytes = s1_bytes | ... | sn_bytes | bitmap`
+   */
+  toBytes(): Uint8Array {
+    const bytes = new Uint8Array(this.signatures.length * Ed25519Signature.LENGTH + MultiEd25519Signature.BITMAP_LEN);
+    this.signatures.forEach((k: Ed25519Signature, i: number) => {
+      bytes.set(k.value, i * Ed25519Signature.LENGTH);
+    });
+
+    bytes.set(this.bitmap, this.signatures.length * Ed25519Signature.LENGTH);
+
+    return bytes;
+  }
+
+  /**
+   * Helper method to create a bitmap out of the specified bit positions
+   * @param bits The bitmap positions that should be set. A position starts at index 0.
+   * Valid position should range between 0 and 31.
+   * @example
+   * Here's an example of valid `bits`
+   * ```
+   * [0, 2, 31]
+   * ```
+   * `[0, 2, 31]` means the 1st, 3rd and 32nd bits should be set in the bitmap.
+   * The result bitmap should be 0b1010000000000000000000000000001
+   *
+   * @returns bitmap that is 32bit long
+   */
+  static createBitmap(bits: Array<Uint8>): Uint8Array {
+    // Bits are read from left to right. e.g. 0b10000000 represents the first bit is set in one byte.
+    // The decimal value of 0b10000000 is 128.
+    const firstBitInByte = 128;
+    const bitmap = new Uint8Array([0, 0, 0, 0]);
+
+    // Check if duplicates exist in bits
+    const dupCheckSet = new Set();
+
+    bits.forEach((bit: number) => {
+      if (bit >= MAX_SIGNATURES_SUPPORTED) {
+        throw new Error(`Invalid bit value ${bit}.`);
+      }
+
+      if (dupCheckSet.has(bit)) {
+        throw new Error("Duplicated bits detected.");
+      }
+
+      dupCheckSet.add(bit);
+
+      const byteOffset = Math.floor(bit / 8);
+
+      let byte = bitmap[byteOffset];
+
+      byte |= firstBitInByte >> bit % 8;
+
+      bitmap[byteOffset] = byte;
+    });
+
+    return bitmap;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeByteVector(this.toBytes());
+  }
+
+  static deserialize(deserializer: Deserializer): MultiEd25519Signature {
+    const bytes = deserializer.deserializeBytes();
+    const bitmap = bytes.subarray(bytes.length - 4);
+
+    const sigs: Array<Ed25519Signature> = [];
+
+    for (let i = 0; i < bytes.length - bitmap.length; i += Ed25519Signature.LENGTH) {
+      const begin = i;
+      sigs.push(new Ed25519Signature(bytes.subarray(begin, begin + Ed25519Signature.LENGTH)));
+    }
+    return new MultiEd25519Signature(sigs, bitmap);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/aptos_types/transaction.ts
+++ b/ecosystem/typescript/sdk_v2/src/aptos_types/transaction.ts
@@ -1,0 +1,722 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable class-methods-use-this */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable max-classes-per-file */
+import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
+import { HexString } from "../utils/hex_string";
+import {
+  Deserializer,
+  Serializer,
+  Uint64,
+  Uint8,
+  Uint128,
+  Uint16,
+  Uint256,
+} from "../bcs";
+import {  TransactionAuthenticator } from "./authenticator";
+import { Identifier } from "./identifier";
+import { TypeTag } from "./type_tag";
+import { AccountAddress } from "./account_address";
+
+export class RawTransaction {
+  /**
+   * RawTransactions contain the metadata and payloads that can be submitted to Aptos chain for execution.
+   * RawTransactions must be signed before Aptos chain can execute them.
+   *
+   * @param sender Account address of the sender.
+   * @param sequence_number Sequence number of this transaction. This must match the sequence number stored in
+   *   the sender's account at the time the transaction executes.
+   * @param payload Instructions for the Aptos Blockchain, including publishing a module,
+   *   execute a entry function or execute a script payload.
+   * @param max_gas_amount Maximum total gas to spend for this transaction. The account must have more
+   *   than this gas or the transaction will be discarded during validation.
+   * @param gas_unit_price Price to be paid per gas unit.
+   * @param expiration_timestamp_secs The blockchain timestamp at which the blockchain would discard this transaction.
+   * @param chain_id The chain ID of the blockchain that this transaction is intended to be run on.
+   */
+  constructor(
+    public readonly sender: AccountAddress,
+    public readonly sequence_number: Uint64,
+    public readonly payload: TransactionPayload,
+    public readonly max_gas_amount: Uint64,
+    public readonly gas_unit_price: Uint64,
+    public readonly expiration_timestamp_secs: Uint64,
+    public readonly chain_id: ChainId,
+  ) {}
+
+  serialize(serializer: Serializer): void {
+    this.sender.serialize(serializer);
+    serializer.serializeU64(this.sequence_number);
+    this.payload.serialize(serializer);
+    serializer.serializeU64(this.max_gas_amount);
+    serializer.serializeU64(this.gas_unit_price);
+    serializer.serializeU64(this.expiration_timestamp_secs);
+    this.chain_id.serialize(serializer);
+  }
+
+  static deserialize(deserializer: Deserializer): RawTransaction {
+    const sender = AccountAddress.deserialize(deserializer);
+    const sequence_number = deserializer.deserializeU64();
+    const payload = TransactionPayload.deserialize(deserializer);
+    const max_gas_amount = deserializer.deserializeU64();
+    const gas_unit_price = deserializer.deserializeU64();
+    const expiration_timestamp_secs = deserializer.deserializeU64();
+    const chain_id = ChainId.deserialize(deserializer);
+    return new RawTransaction(
+      sender,
+      sequence_number,
+      payload,
+      max_gas_amount,
+      gas_unit_price,
+      expiration_timestamp_secs,
+      chain_id,
+    );
+  }
+}
+
+export class Script {
+  /**
+   * Scripts contain the Move bytecodes payload that can be submitted to Aptos chain for execution.
+   * @param code Move bytecode
+   * @param ty_args Type arguments that bytecode requires.
+   *
+   * @example
+   * A coin transfer function has one type argument "CoinType".
+   * ```
+   * public(script) fun transfer<CoinType>(from: &signer, to: address, amount: u64,)
+   * ```
+   * @param args Arugments to bytecode function.
+   *
+   * @example
+   * A coin transfer function has three arugments "from", "to" and "amount".
+   * ```
+   * public(script) fun transfer<CoinType>(from: &signer, to: address, amount: u64,)
+   * ```
+   */
+  constructor(
+    public readonly code: Uint8Array,
+    public readonly ty_args: Array<TypeTag>,
+    public readonly args: Array<TransactionArgument>,
+  ) {}
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeByteVector(this.code);
+    serializer.serializeVector<TypeTag>(this.ty_args);
+    serializer.serializeVector<TransactionArgument>(this.args);
+  }
+
+  static deserialize(deserializer: Deserializer): Script {
+    const code = deserializer.deserializeBytes();
+    const ty_args = deserializer.deserializeVector(TypeTag);
+    const args = deserializer.deserializeVector(TransactionArgument);
+    return new Script(code, ty_args, args);
+  }
+}
+
+export class EntryFunction {
+  /**
+   * Contains the payload to run a function within a module.
+   * @param module_name Fully qualified module name. ModuleId consists of account address and module name.
+   * @param function_name The function to run.
+   * @param ty_args Type arguments that move function requires.
+   *
+   * @example
+   * A coin transfer function has one type argument "CoinType".
+   * ```
+   * public(script) fun transfer<CoinType>(from: &signer, to: address, amount: u64,)
+   * ```
+   * @param args Arugments to the move function.
+   *
+   * @example
+   * A coin transfer function has three arugments "from", "to" and "amount".
+   * ```
+   * public(script) fun transfer<CoinType>(from: &signer, to: address, amount: u64,)
+   * ```
+   */
+  constructor(
+    public readonly module_name: ModuleId,
+    public readonly function_name: Identifier,
+    public readonly ty_args: Array<TypeTag>,
+    public readonly args: Array<Uint8Array>,
+  ) {}
+
+  /**
+   *
+   * @param module Fully qualified module name in format "AccountAddress::module_name" e.g. "0x1::coin"
+   * @param func Function name
+   * @param ty_args Type arguments that move function requires.
+   *
+   * @example
+   * A coin transfer function has one type argument "CoinType".
+   * ```
+   * public(script) fun transfer<CoinType>(from: &signer, to: address, amount: u64,)
+   * ```
+   * @param args Arugments to the move function.
+   *
+   * @example
+   * A coin transfer function has three arugments "from", "to" and "amount".
+   * ```
+   * public(script) fun transfer<CoinType>(from: &signer, to: address, amount: u64,)
+   * ```
+   * @returns
+   */
+  static natural(module: string, func: string, ty_args: Array<TypeTag>, args: Array<Uint8Array>): EntryFunction {
+    return new EntryFunction(ModuleId.fromStr(module), new Identifier(func), ty_args, args);
+  }
+
+  /**
+   * `natual` is deprecated, please use `natural`
+   *
+   * @deprecated.
+   */
+  static natual(module: string, func: string, ty_args: Array<TypeTag>, args: Array<Uint8Array>): EntryFunction {
+    return EntryFunction.natural(module, func, ty_args, args);
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serialize(this.module_name);
+    serializer.serialize(this.function_name);
+    serializer.serializeVector<TypeTag>(this.ty_args);
+
+    serializer.serializeU32AsUleb128(this.args.length);
+    this.args.forEach((item: Uint8Array) => {
+      serializer.serializeByteVector(item);
+    });
+  }
+
+  static deserialize(deserializer: Deserializer): EntryFunction {
+    const module_name = deserializer.deserialize(ModuleId);
+    const function_name = deserializer.deserialize(Identifier);
+    const ty_args = deserializer.deserializeVector(TypeTag);
+
+    const length = deserializer.deserializeUleb128AsU32();
+    const list: Array<Uint8Array> = [];
+    for (let i = 0; i < length; i += 1) {
+      list.push(deserializer.deserializeBytes());
+    }
+
+    const args = list;
+    return new EntryFunction(module_name, function_name, ty_args, args);
+  }
+}
+
+export class MultiSigTransactionPayload {
+  /**
+   * Contains the payload to run a multisig account transaction.
+   * @param transaction_payload The payload of the multisig transaction. This can only be EntryFunction for now but
+   * Script might be supported in the future.
+   */
+  constructor(public readonly transaction_payload: EntryFunction) {}
+
+  serialize(serializer: Serializer): void {
+    // We can support multiple types of inner transaction payload in the future.
+    // For now it's only EntryFunction but if we support more types, we need to serialize with the right enum values
+    // here
+    serializer.serializeU32AsUleb128(0);
+    serializer.serialize(this.transaction_payload);
+  }
+
+  static deserialize(deserializer: Deserializer): MultiSigTransactionPayload {
+    // TODO: Support other types of payload beside EntryFunction.
+    // This is the enum value indicating which type of payload the multisig tx contains.
+    deserializer.deserializeUleb128AsU32();
+    return new MultiSigTransactionPayload(deserializer.deserialize(EntryFunction));
+  }
+}
+
+export class MultiSig {
+  /**
+   * Contains the payload to run a multisig account transaction.
+   * @param multisig_address The multisig account address the transaction will be executed as.
+   * @param transaction_payload The payload of the multisig transaction. This is optional when executing a multisig
+   *  transaction whose payload is already stored on chain.
+   */
+  constructor(
+    public readonly multisig_address: AccountAddress,
+    public readonly transaction_payload?: MultiSigTransactionPayload,
+  ) {}
+
+  serialize(serializer: Serializer): void {
+    serializer.serialize(this.multisig_address);
+    // Options are encoded with an extra u8 field before the value - 0x0 is none and 0x1 is present.
+    // We use serializeBool below to create this prefix value.
+    if (this.transaction_payload === undefined) {
+      serializer.serializeBool(false);
+    } else {
+      serializer.serializeBool(true);
+      serializer.serialize(this.transaction_payload);
+    }
+  }
+
+  static deserialize(deserializer: Deserializer): MultiSig {
+    const multisig_address = deserializer.deserialize(AccountAddress);
+    const payloadPresent = deserializer.deserializeBool();
+    let transaction_payload;
+    if (payloadPresent) {
+      transaction_payload = deserializer.deserialize(MultiSigTransactionPayload);
+    }
+    return new MultiSig(multisig_address, transaction_payload);
+  }
+}
+
+export class Module {
+  /**
+   * Contains the bytecode of a Move module that can be published to the Aptos chain.
+   * @param code Move bytecode of a module.
+   */
+  constructor(public readonly code: Uint8Array) {}
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeByteVector(this.code);
+  }
+
+  static deserialize(deserializer: Deserializer): Module {
+    const code = deserializer.deserializeBytes();
+    return new Module(code);
+  }
+}
+
+export class ModuleId {
+  /**
+   * Full name of a module.
+   * @param address The account address.
+   * @param name The name of the module under the account at "address".
+   */
+  constructor(public readonly address: AccountAddress, public readonly name: Identifier) {}
+
+  /**
+   * Converts a string literal to a ModuleId
+   * @param moduleId String literal in format "AccountAddress::module_name", e.g. "0x1::coin"
+   * @returns
+   */
+  static fromStr(moduleId: string): ModuleId {
+    const parts = moduleId.split("::");
+    if (parts.length !== 2) {
+      throw new Error("Invalid module id.");
+    }
+    return new ModuleId(AccountAddress.fromHex(new HexString(parts[0])), new Identifier(parts[1]));
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serialize(this.address);
+    serializer.serialize(this.name);
+  }
+
+  static deserialize(deserializer: Deserializer): ModuleId {
+    const address = deserializer.deserialize(AccountAddress);
+    const name = deserializer.deserialize(Identifier);
+    return new ModuleId(address, name);
+  }
+}
+
+export class ChangeSet {
+  serialize(serializer: Serializer): void {
+    throw new Error("Not implemented.");
+  }
+
+  static deserialize(deserializer: Deserializer): ChangeSet {
+    throw new Error("Not implemented.");
+  }
+}
+
+export class WriteSet {
+  serialize(serializer: Serializer): void {
+    throw new Error("Not implmented.");
+  }
+
+  static deserialize(deserializer: Deserializer): WriteSet {
+    throw new Error("Not implmented.");
+  }
+}
+
+export class SignedTransaction {
+  /**
+   * A SignedTransaction consists of a raw transaction and an authenticator. The authenticator
+   * contains a client's public key and the signature of the raw transaction.
+   *
+   * @see {@link https://aptos.dev/guides/creating-a-signed-transaction/ | Creating a Signed Transaction}
+   *
+   * @param raw_txn
+   * @param authenticator Contains a client's public key and the signature of the raw transaction.
+   *   Authenticator has 3 flavors: single signature, multi-signature and multi-agent.
+   *   @see authenticator.ts for details.
+   */
+  constructor(public readonly raw_txn: RawTransaction, public readonly authenticator: TransactionAuthenticator) {}
+
+  serialize(serializer: Serializer): void {
+    serializer.serialize(this.raw_txn);
+    serializer.serialize(this.authenticator);
+  }
+
+  static deserialize(deserializer: Deserializer): SignedTransaction {
+    const raw_txn = deserializer.deserialize(RawTransaction);
+    const authenticator = deserializer.deserialize(TransactionAuthenticator);
+    return new SignedTransaction(raw_txn, authenticator);
+  }
+}
+
+export abstract class RawTransactionWithData {
+  abstract serialize(serializer: Serializer): void;
+
+  static deserialize(deserializer: Deserializer): RawTransactionWithData {
+    const index = deserializer.deserializeUleb128AsU32();
+    switch (index) {
+      case 0:
+        return MultiAgentRawTransaction.load(deserializer);
+      case 1:
+        return FeePayerRawTransaction.load(deserializer);
+      default:
+        throw new Error(`Unknown variant index for RawTransactionWithData: ${index}`);
+    }
+  }
+}
+
+export class MultiAgentRawTransaction extends RawTransactionWithData {
+  constructor(
+    public readonly raw_txn: RawTransaction,
+    public readonly secondary_signer_addresses: Array<AccountAddress>,
+  ) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    // enum variant index
+    serializer.serializeU32AsUleb128(0);
+    serializer.serialize(this.raw_txn);
+    serializer.serializeVector<TransactionArgument>(this.secondary_signer_addresses);
+  }
+
+  static load(deserializer: Deserializer): MultiAgentRawTransaction {
+    const rawTxn = deserializer.deserialize(RawTransaction);
+    const secondarySignerAddresses = deserializer.deserializeVector(AccountAddress);
+
+    return new MultiAgentRawTransaction(rawTxn, secondarySignerAddresses);
+  }
+}
+
+export class FeePayerRawTransaction extends RawTransactionWithData {
+  constructor(
+    public readonly raw_txn: RawTransaction,
+    public readonly secondary_signer_addresses: Array<AccountAddress>,
+    public readonly fee_payer_address: AccountAddress,
+  ) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    // enum variant index
+    serializer.serializeU32AsUleb128(1);
+    serializer.serialize(this.raw_txn);
+    serializer.serializeVector<TransactionArgument>(this.secondary_signer_addresses);
+    serializer.serialize(this.fee_payer_address);
+  }
+
+  static load(deserializer: Deserializer): FeePayerRawTransaction {
+    const rawTxn = RawTransaction.deserialize(deserializer);
+    const secondarySignerAddresses = deserializer.deserializeVector(AccountAddress);
+    const feePayerAddress = deserializer.deserialize(AccountAddress);
+
+    return new FeePayerRawTransaction(rawTxn, secondarySignerAddresses, feePayerAddress);
+  }
+}
+
+export abstract class TransactionPayload {
+  abstract serialize(serializer: Serializer): void;
+
+  static deserialize(deserializer: Deserializer): TransactionPayload {
+    const index = deserializer.deserializeUleb128AsU32();
+    switch (index) {
+      case 0:
+        return TransactionPayloadScript.load(deserializer);
+      // TODO: change to 1 once ModuleBundle has been removed from rust
+      case 2:
+        return TransactionPayloadEntryFunction.load(deserializer);
+      case 3:
+        return TransactionPayloadMultisig.load(deserializer);
+      default:
+        throw new Error(`Unknown variant index for TransactionPayload: ${index}`);
+    }
+  }
+}
+
+export class TransactionPayloadScript extends TransactionPayload {
+  constructor(public readonly value: Script) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(0);
+    serializer.serialize(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionPayloadScript {
+    const value = Script.deserialize(deserializer);
+    return new TransactionPayloadScript(value);
+  }
+}
+
+export class TransactionPayloadEntryFunction extends TransactionPayload {
+  constructor(public readonly value: EntryFunction) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(2);
+    serializer.serialize(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionPayloadEntryFunction {
+    const value = deserializer.deserialize(EntryFunction);
+    return new TransactionPayloadEntryFunction(value);
+  }
+}
+
+export class TransactionPayloadMultisig extends TransactionPayload {
+  constructor(public readonly value: MultiSig) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(3);
+    serializer.serialize(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionPayloadMultisig {
+    const value = deserializer.deserialize(MultiSig);
+    return new TransactionPayloadMultisig(value);
+  }
+}
+
+export class ChainId {
+  constructor(public readonly value: Uint8) {}
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU8(this.value);
+  }
+
+  static deserialize(deserializer: Deserializer): ChainId {
+    const value = deserializer.deserializeU8();
+    return new ChainId(value);
+  }
+}
+
+export abstract class TransactionArgument {
+  abstract serialize(serializer: Serializer): void;
+
+  static deserialize(deserializer: Deserializer): TransactionArgument {
+    const index = deserializer.deserializeUleb128AsU32();
+    switch (index) {
+      case 0:
+        return TransactionArgumentU8.load(deserializer);
+      case 1:
+        return TransactionArgumentU64.load(deserializer);
+      case 2:
+        return TransactionArgumentU128.load(deserializer);
+      case 3:
+        return TransactionArgumentAddress.load(deserializer);
+      case 4:
+        return TransactionArgumentU8Vector.load(deserializer);
+      case 5:
+        return TransactionArgumentBool.load(deserializer);
+      case 6:
+        return TransactionArgumentU16.load(deserializer);
+      case 7:
+        return TransactionArgumentU32.load(deserializer);
+      case 8:
+        return TransactionArgumentU256.load(deserializer);
+      default:
+        throw new Error(`Unknown variant index for TransactionArgument: ${index}`);
+    }
+  }
+}
+
+export class TransactionArgumentU8 extends TransactionArgument {
+  constructor(public readonly value: Uint8) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(0);
+    serializer.serializeU8(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentU8 {
+    const value = deserializer.deserializeU8();
+    return new TransactionArgumentU8(value);
+  }
+}
+
+export class TransactionArgumentU16 extends TransactionArgument {
+  constructor(public readonly value: Uint16) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(6);
+    serializer.serializeU16(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentU16 {
+    const value = deserializer.deserializeU16();
+    return new TransactionArgumentU16(value);
+  }
+}
+
+export class TransactionArgumentU32 extends TransactionArgument {
+  constructor(public readonly value: Uint16) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(7);
+    serializer.serializeU32(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentU32 {
+    const value = deserializer.deserializeU32();
+    return new TransactionArgumentU32(value);
+  }
+}
+
+export class TransactionArgumentU64 extends TransactionArgument {
+  constructor(public readonly value: Uint64) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(1);
+    serializer.serializeU64(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentU64 {
+    const value = deserializer.deserializeU64();
+    return new TransactionArgumentU64(value);
+  }
+}
+
+export class TransactionArgumentU128 extends TransactionArgument {
+  constructor(public readonly value: Uint128) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(2);
+    serializer.serializeU128(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentU128 {
+    const value = deserializer.deserializeU128();
+    return new TransactionArgumentU128(value);
+  }
+}
+
+export class TransactionArgumentU256 extends TransactionArgument {
+  constructor(public readonly value: Uint256) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(8);
+    serializer.serializeU256(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentU256 {
+    const value = deserializer.deserializeU256();
+    return new TransactionArgumentU256(value);
+  }
+}
+
+export class TransactionArgumentAddress extends TransactionArgument {
+  constructor(public readonly value: AccountAddress) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(3);
+    serializer.serialize(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentAddress {
+    const value = AccountAddress.deserialize(deserializer);
+    return new TransactionArgumentAddress(value);
+  }
+}
+
+export class TransactionArgumentU8Vector extends TransactionArgument {
+  constructor(public readonly value: Uint8Array) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(4);
+    serializer.serializeByteVector(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentU8Vector {
+    const value = deserializer.deserializeBytes();
+    return new TransactionArgumentU8Vector(value);
+  }
+}
+
+export class TransactionArgumentBool extends TransactionArgument {
+  constructor(public readonly value: boolean) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(5);
+    serializer.serializeBool(this.value);
+  }
+
+  static load(deserializer: Deserializer): TransactionArgumentBool {
+    const value = deserializer.deserializeBool();
+    return new TransactionArgumentBool(value);
+  }
+}
+
+export abstract class Transaction {
+  abstract serialize(serializer: Serializer): void;
+
+  abstract hash(): Uint8Array;
+
+  getHashSalt(): Uint8Array {
+    const hash = sha3Hash.create();
+    hash.update("APTOS::Transaction");
+    return hash.digest();
+  }
+
+  static deserialize(deserializer: Deserializer): Transaction {
+    const index = deserializer.deserializeUleb128AsU32();
+    switch (index) {
+      case 0:
+        return UserTransaction.load(deserializer);
+      default:
+        throw new Error(`Unknown variant index for Transaction: ${index}`);
+    }
+  }
+}
+
+export class UserTransaction extends Transaction {
+  constructor(public readonly value: SignedTransaction) {
+    super();
+  }
+
+  hash(): Uint8Array {
+    const hash = sha3Hash.create();
+    hash.update(this.getHashSalt());
+    hash.update(new Serializer().serialize(this).getBytes());
+    return hash.digest();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(0);
+    serializer.serialize(this.value);
+  }
+
+  static load(deserializer: Deserializer): UserTransaction {
+    return new UserTransaction(deserializer.deserialize(SignedTransaction));
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/aptos_types/type_tag.ts
+++ b/ecosystem/typescript/sdk_v2/src/aptos_types/type_tag.ts
@@ -1,0 +1,483 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable class-methods-use-this */
+/* eslint-disable max-classes-per-file */
+import { AccountAddress } from "./account_address";
+import { Deserializer, Serializer } from "../bcs";
+import { Identifier } from "./identifier";
+
+export abstract class TypeTag {
+  abstract serialize(serializer: Serializer): void;
+
+  static deserialize(deserializer: Deserializer): TypeTag {
+    const index = deserializer.deserializeUleb128AsU32();
+    switch (index) {
+      case 0:
+        return TypeTagBool.load(deserializer);
+      case 1:
+        return TypeTagU8.load(deserializer);
+      case 2:
+        return TypeTagU64.load(deserializer);
+      case 3:
+        return TypeTagU128.load(deserializer);
+      case 4:
+        return TypeTagAddress.load(deserializer);
+      case 5:
+        return TypeTagSigner.load(deserializer);
+      case 6:
+        return TypeTagVector.load(deserializer);
+      case 7:
+        return TypeTagStruct.load(deserializer);
+      case 8:
+        return TypeTagU16.load(deserializer);
+      case 9:
+        return TypeTagU32.load(deserializer);
+      case 10:
+        return TypeTagU256.load(deserializer);
+      default:
+        throw new Error(`Unknown variant index for TypeTag: ${index}`);
+    }
+  }
+}
+
+export class TypeTagBool extends TypeTag {
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(0);
+  }
+
+  static load(_deserializer: Deserializer): TypeTagBool {
+    return new TypeTagBool();
+  }
+}
+
+export class TypeTagU8 extends TypeTag {
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(1);
+  }
+
+  static load(_deserializer: Deserializer): TypeTagU8 {
+    return new TypeTagU8();
+  }
+}
+
+export class TypeTagU16 extends TypeTag {
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(8);
+  }
+
+  static load(_deserializer: Deserializer): TypeTagU16 {
+    return new TypeTagU16();
+  }
+}
+
+export class TypeTagU32 extends TypeTag {
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(9);
+  }
+
+  static load(_deserializer: Deserializer): TypeTagU32 {
+    return new TypeTagU32();
+  }
+}
+
+export class TypeTagU64 extends TypeTag {
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(2);
+  }
+
+  static load(_deserializer: Deserializer): TypeTagU64 {
+    return new TypeTagU64();
+  }
+}
+
+export class TypeTagU128 extends TypeTag {
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(3);
+  }
+
+  static load(_deserializer: Deserializer): TypeTagU128 {
+    return new TypeTagU128();
+  }
+}
+
+export class TypeTagU256 extends TypeTag {
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(10);
+  }
+
+  static load(_deserializer: Deserializer): TypeTagU256 {
+    return new TypeTagU256();
+  }
+}
+
+export class TypeTagAddress extends TypeTag {
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(4);
+  }
+
+  static load(_deserializer: Deserializer): TypeTagAddress {
+    return new TypeTagAddress();
+  }
+}
+
+export class TypeTagSigner extends TypeTag {
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(5);
+  }
+
+  static load(_deserializer: Deserializer): TypeTagSigner {
+    return new TypeTagSigner();
+  }
+}
+
+export class TypeTagVector extends TypeTag {
+  constructor(public readonly value: TypeTag) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(6);
+    this.value.serialize(serializer);
+  }
+
+  static load(deserializer: Deserializer): TypeTagVector {
+    const value = TypeTag.deserialize(deserializer);
+    return new TypeTagVector(value);
+  }
+}
+
+export class TypeTagStruct extends TypeTag {
+  constructor(public readonly value: StructTag) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(7);
+    this.value.serialize(serializer);
+  }
+
+  static load(deserializer: Deserializer): TypeTagStruct {
+    const value = StructTag.deserialize(deserializer);
+    return new TypeTagStruct(value);
+  }
+
+  isStringTypeTag(): boolean {
+    if (
+      this.value.module_name.value === "string" &&
+      this.value.name.value === "String" &&
+      this.value.address.toHexString() === AccountAddress.CORE_CODE_ADDRESS.toHexString()
+    ) {
+      return true;
+    }
+    return false;
+  }
+}
+
+export class StructTag {
+  constructor(
+    public readonly address: AccountAddress,
+    public readonly module_name: Identifier,
+    public readonly name: Identifier,
+    public readonly type_args: Array<TypeTag>,
+  ) {}
+
+  /**
+   * Converts a string literal to a StructTag
+   * @param structTag String literal in format "AcountAddress::module_name::ResourceName",
+   *   e.g. "0x1::aptos_coin::AptosCoin"
+   * @returns
+   */
+  static fromString(structTag: string): StructTag {
+    // Use the TypeTagParser to parse the string literal into a TypeTagStruct
+    const typeTagStruct = new TypeTagParser(structTag).parseTypeTag() as TypeTagStruct;
+
+    // Convert and return as a StructTag
+    return new StructTag(
+      typeTagStruct.value.address,
+      typeTagStruct.value.module_name,
+      typeTagStruct.value.name,
+      typeTagStruct.value.type_args,
+    );
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer
+        .serialize(this.address)
+        .serialize(this.module_name)
+        .serialize(this.name)
+        .serializeVector<TypeTag>(this.type_args);
+  }
+
+  static deserialize(deserializer: Deserializer): StructTag {
+    const address = deserializer.deserialize(AccountAddress);
+    const moduleName = deserializer.deserialize(Identifier);
+    const name = deserializer.deserialize(Identifier);
+    const typeArgs = deserializer.deserializeVector(TypeTag);
+    return new StructTag(address, moduleName, name, typeArgs);
+  }
+}
+
+export const stringStructTag = new StructTag(
+  AccountAddress.fromHex("0x1"),
+  new Identifier("string"),
+  new Identifier("String"),
+  [],
+);
+
+export function optionStructTag(typeArg: TypeTag): StructTag {
+  return new StructTag(AccountAddress.fromHex("0x1"), new Identifier("option"), new Identifier("Option"), [typeArg]);
+}
+
+export function objectStructTag(typeArg: TypeTag): StructTag {
+  return new StructTag(AccountAddress.fromHex("0x1"), new Identifier("object"), new Identifier("Object"), [typeArg]);
+}
+
+function bail(message: string) {
+  throw new TypeTagParserError(message);
+}
+
+function isWhiteSpace(c: string): boolean {
+  if (c.match(/\s/)) {
+    return true;
+  }
+  return false;
+}
+
+function isValidAlphabetic(c: string): boolean {
+  if (c.match(/[_A-Za-z0-9]/g)) {
+    return true;
+  }
+  return false;
+}
+
+// Generic format is T<digits> - for example T1, T2, T10
+function isGeneric(c: string): boolean {
+  if (c.match(/T\d+/g)) {
+    return true;
+  }
+  return false;
+}
+
+type TokenType = string;
+type TokenValue = string;
+type Token = [TokenType, TokenValue];
+
+// Returns Token and Token byte size
+function nextToken(tagStr: string, pos: number): [Token, number] {
+  const c = tagStr[pos];
+  if (c === ":") {
+    if (tagStr.slice(pos, pos + 2) === "::") {
+      return [["COLON", "::"], 2];
+    }
+    bail("Unrecognized token.");
+  } else if (c === "<") {
+    return [["LT", "<"], 1];
+  } else if (c === ">") {
+    return [["GT", ">"], 1];
+  } else if (c === ",") {
+    return [["COMMA", ","], 1];
+  } else if (isWhiteSpace(c)) {
+    let res = "";
+    for (let i = pos; i < tagStr.length; i += 1) {
+      const char = tagStr[i];
+      if (isWhiteSpace(char)) {
+        res = `${res}${char}`;
+      } else {
+        break;
+      }
+    }
+    return [["SPACE", res], res.length];
+  } else if (isValidAlphabetic(c)) {
+    let res = "";
+    for (let i = pos; i < tagStr.length; i += 1) {
+      const char = tagStr[i];
+      if (isValidAlphabetic(char)) {
+        res = `${res}${char}`;
+      } else {
+        break;
+      }
+    }
+    if (isGeneric(res)) {
+      return [["GENERIC", res], res.length];
+    }
+    return [["IDENT", res], res.length];
+  }
+  throw new Error("Unrecognized token.");
+}
+
+function tokenize(tagStr: string): Token[] {
+  let pos = 0;
+  const tokens = [];
+  while (pos < tagStr.length) {
+    const [token, size] = nextToken(tagStr, pos);
+    if (token[0] !== "SPACE") {
+      tokens.push(token);
+    }
+    pos += size;
+  }
+  return tokens;
+}
+
+/**
+ * Parser to parse a type tag string
+ */
+export class TypeTagParser {
+  private readonly tokens: Token[];
+
+  private readonly typeTags: string[] = [];
+
+  constructor(tagStr: string, typeTags?: string[]) {
+    this.tokens = tokenize(tagStr);
+    this.typeTags = typeTags || [];
+  }
+
+  private consume(targetToken: string) {
+    const token = this.tokens.shift();
+    if (!token || token[1] !== targetToken) {
+      bail("Invalid type tag.");
+    }
+  }
+
+  /**
+   * Consumes all of an unused generic field, mostly applicable to object
+   *
+   * Note: This is recursive.  it can be problematic if there's bad input
+   * @private
+   */
+  private consumeWholeGeneric() {
+    this.consume("<");
+    while (this.tokens[0][1] !== ">") {
+      // If it is nested, we have to consume another nested generic
+      if (this.tokens[0][1] === "<") {
+        this.consumeWholeGeneric();
+      }
+      this.tokens.shift();
+    }
+    this.consume(">");
+  }
+
+  private parseCommaList(endToken: TokenValue, allowTraillingComma: boolean): TypeTag[] {
+    const res: TypeTag[] = [];
+    if (this.tokens.length <= 0) {
+      bail("Invalid type tag.");
+    }
+
+    while (this.tokens[0][1] !== endToken) {
+      res.push(this.parseTypeTag());
+
+      if (this.tokens.length > 0 && this.tokens[0][1] === endToken) {
+        break;
+      }
+
+      this.consume(",");
+      if (this.tokens.length > 0 && this.tokens[0][1] === endToken && allowTraillingComma) {
+        break;
+      }
+
+      if (this.tokens.length <= 0) {
+        bail("Invalid type tag.");
+      }
+    }
+    return res;
+  }
+
+  parseTypeTag(): TypeTag {
+    if (this.tokens.length === 0) {
+      bail("Invalid type tag.");
+    }
+
+    // Pop left most element out
+    const [tokenTy, tokenVal] = this.tokens.shift()!;
+
+    if (tokenVal === "u8") {
+      return new TypeTagU8();
+    }
+    if (tokenVal === "u16") {
+      return new TypeTagU16();
+    }
+    if (tokenVal === "u32") {
+      return new TypeTagU32();
+    }
+    if (tokenVal === "u64") {
+      return new TypeTagU64();
+    }
+    if (tokenVal === "u128") {
+      return new TypeTagU128();
+    }
+    if (tokenVal === "u256") {
+      return new TypeTagU256();
+    }
+    if (tokenVal === "bool") {
+      return new TypeTagBool();
+    }
+    if (tokenVal === "address") {
+      return new TypeTagAddress();
+    }
+    if (tokenVal === "vector") {
+      this.consume("<");
+      const res = this.parseTypeTag();
+      this.consume(">");
+      return new TypeTagVector(res);
+    }
+    if (tokenVal === "string") {
+      return new TypeTagStruct(stringStructTag);
+    }
+    if (tokenTy === "IDENT" && (tokenVal.startsWith("0x") || tokenVal.startsWith("0X"))) {
+      const address = AccountAddress.fromHex(tokenVal);
+      this.consume("::");
+      const [moduleTokenTy, module] = this.tokens.shift()!;
+      if (moduleTokenTy !== "IDENT") {
+        bail("Invalid type tag.");
+      }
+      this.consume("::");
+      const [nameTokenTy, name] = this.tokens.shift()!;
+      if (nameTokenTy !== "IDENT") {
+        bail("Invalid type tag.");
+      }
+
+      // Objects can contain either concrete types e.g. 0x1::object::ObjectCore or generics e.g. T
+      // Neither matter as we can't do type checks, so just the address applies and we consume the entire generic.
+      // TODO: Support parsing structs that don't come from core code address
+      if (
+        AccountAddress.CORE_CODE_ADDRESS.toHexString() === address.toHexString() &&
+        module === "object" &&
+        name === "Object"
+      ) {
+        this.consumeWholeGeneric();
+        return new TypeTagAddress();
+      }
+
+      let tyTags: TypeTag[] = [];
+      // Check if the struct has ty args
+      if (this.tokens.length > 0 && this.tokens[0][1] === "<") {
+        this.consume("<");
+        tyTags = this.parseCommaList(">", true);
+        this.consume(">");
+      }
+
+      const structTag = new StructTag(address, new Identifier(module), new Identifier(name), tyTags);
+      return new TypeTagStruct(structTag);
+    }
+    if (tokenTy === "GENERIC") {
+      if (this.typeTags.length === 0) {
+        bail("Can't convert generic type since no typeTags were specified.");
+      }
+      // a generic tokenVal has the format of `T<digit>`, for example `T1`.
+      // The digit (i.e 1) indicates the the index of this type in the typeTags array.
+      // For a tokenVal == T1, should be parsed as the type in typeTags[1]
+      const idx = parseInt(tokenVal.substring(1), 10);
+      return new TypeTagParser(this.typeTags[idx]).parseTypeTag();
+    }
+
+    throw new Error("Invalid type tag.");
+  }
+}
+
+export class TypeTagParserError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TypeTagParserError";
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/bcs/consts.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/consts.ts
@@ -1,0 +1,12 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Uint128, Uint16, Uint32, Uint64, Uint8, Uint256 } from "./types";
+
+// Upper bound values for uint8, uint16, uint64 and uint128
+export const MAX_U8_NUMBER: Uint8 = 2 ** 8 - 1;
+export const MAX_U16_NUMBER: Uint16 = 2 ** 16 - 1;
+export const MAX_U32_NUMBER: Uint32 = 2 ** 32 - 1;
+export const MAX_U64_BIG_INT: Uint64 = BigInt(2 ** 64) - BigInt(1);
+export const MAX_U128_BIG_INT: Uint128 = BigInt(2 ** 128) - BigInt(1);
+export const MAX_U256_BIG_INT: Uint256 = BigInt(2 ** 256) - BigInt(1);

--- a/ecosystem/typescript/sdk_v2/src/bcs/deserializer.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/deserializer.ts
@@ -5,6 +5,11 @@
 import { MAX_U32_NUMBER } from "./consts";
 import { Uint128, Uint16, Uint256, Uint32, Uint64, Uint8 } from "./types";
 
+// The class must implement a static deserialize method.
+interface Deserializable<T> {
+  deserialize(deserializer: Deserializer): T;
+}
+
 export class Deserializer {
   private buffer: ArrayBuffer;
 
@@ -183,5 +188,24 @@ export class Deserializer {
     }
 
     return Number(value);
+  }
+
+  // Require that the input value is a class that extends Deserializable.
+  deserialize<T>(cls: Deserializable<T>): T {
+    // NOTE: The `deserialize` method called by `cls` is defined in the `cls`'s
+    // Deserializable interface, not the one defined in this class.
+    return cls.deserialize(this);
+  }
+
+  /**
+   * Deserializes a vector of values.
+   */
+  deserializeVector<T>(cls: Deserializable<T>): T[] {
+      const length = this.deserializeUleb128AsU32();
+      const list: T[] = [];
+      for (let i = 0; i < length; i += 1) {
+        list.push(this.deserialize(cls));
+      }
+      return list;
   }
 }

--- a/ecosystem/typescript/sdk_v2/src/bcs/deserializer.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/deserializer.ts
@@ -1,0 +1,187 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable no-bitwise */
+import { MAX_U32_NUMBER } from "./consts";
+import { Uint128, Uint16, Uint256, Uint32, Uint64, Uint8 } from "./types";
+
+export class Deserializer {
+  private buffer: ArrayBuffer;
+
+  private offset: number;
+
+  constructor(data: Uint8Array) {
+    // copies data to prevent outside mutation of buffer.
+    this.buffer = new ArrayBuffer(data.length);
+    new Uint8Array(this.buffer).set(data, 0);
+    this.offset = 0;
+  }
+
+  private read(length: number): ArrayBuffer {
+    if (this.offset + length > this.buffer.byteLength) {
+      throw new Error("Reached to the end of buffer");
+    }
+
+    const bytes = this.buffer.slice(this.offset, this.offset + length);
+    this.offset += length;
+    return bytes;
+  }
+
+  /**
+   * Deserializes a string. UTF8 string is supported. Reads the string's bytes length "l" first,
+   * and then reads "l" bytes of content. Decodes the byte array into a string.
+   *
+   * BCS layout for "string": string_length | string_content
+   * where string_length is a u32 integer encoded as a uleb128 integer, equal to the number of bytes in string_content.
+   *
+   * @example
+   * ```ts
+   * const deserializer = new Deserializer(new Uint8Array([8, 49, 50, 51, 52, 97, 98, 99, 100]));
+   * assert(deserializer.deserializeStr() === "1234abcd");
+   * ```
+   */
+  deserializeStr(): string {
+    const value = this.deserializeBytes();
+    const textDecoder = new TextDecoder();
+    return textDecoder.decode(value);
+  }
+
+  /**
+   * Deserializes an array of bytes.
+   *
+   * BCS layout for "bytes": bytes_length | bytes
+   * where bytes_length is a u32 integer encoded as a uleb128 integer, equal to the length of the bytes array.
+   */
+  deserializeBytes(): Uint8Array {
+    const len = this.deserializeUleb128AsU32();
+    return new Uint8Array(this.read(len));
+  }
+
+  /**
+   * Deserializes an array of bytes. The number of bytes to read is already known.
+   *
+   */
+  deserializeFixedBytes(len: number): Uint8Array {
+    return new Uint8Array(this.read(len));
+  }
+
+  /**
+   * Deserializes a boolean value.
+   *
+   * BCS layout for "boolean": One byte. "0x01" for true and "0x00" for false.
+   */
+  deserializeBool(): boolean {
+    const bool = new Uint8Array(this.read(1))[0];
+    if (bool !== 1 && bool !== 0) {
+      throw new Error("Invalid boolean value");
+    }
+    return bool === 1;
+  }
+
+  /**
+   * Deserializes a uint8 number.
+   *
+   * BCS layout for "uint8": One byte. Binary format in little-endian representation.
+   */
+  deserializeU8(): Uint8 {
+    return new DataView(this.read(1)).getUint8(0);
+  }
+
+  /**
+   * Deserializes a uint16 number.
+   *
+   * BCS layout for "uint16": Two bytes. Binary format in little-endian representation.
+   * @example
+   * ```ts
+   * const deserializer = new Deserializer(new Uint8Array([0x34, 0x12]));
+   * assert(deserializer.deserializeU16() === 4660);
+   * ```
+   */
+  deserializeU16(): Uint16 {
+    return new DataView(this.read(2)).getUint16(0, true);
+  }
+
+  /**
+   * Deserializes a uint32 number.
+   *
+   * BCS layout for "uint32": Four bytes. Binary format in little-endian representation.
+   * @example
+   * ```ts
+   * const deserializer = new Deserializer(new Uint8Array([0x78, 0x56, 0x34, 0x12]));
+   * assert(deserializer.deserializeU32() === 305419896);
+   * ```
+   */
+  deserializeU32(): Uint32 {
+    return new DataView(this.read(4)).getUint32(0, true);
+  }
+
+  /**
+   * Deserializes a uint64 number.
+   *
+   * BCS layout for "uint64": Eight bytes. Binary format in little-endian representation.
+   * @example
+   * ```ts
+   * const deserializer = new Deserializer(new Uint8Array([0x00, 0xEF, 0xCD, 0xAB, 0x78, 0x56, 0x34, 0x12]));
+   * assert(deserializer.deserializeU64() === 1311768467750121216);
+   * ```
+   */
+  deserializeU64(): Uint64 {
+    const low = this.deserializeU32();
+    const high = this.deserializeU32();
+
+    // combine the two 32-bit values and return (little endian)
+    return BigInt((BigInt(high) << BigInt(32)) | BigInt(low));
+  }
+
+  /**
+   * Deserializes a uint128 number.
+   *
+   * BCS layout for "uint128": Sixteen bytes. Binary format in little-endian representation.
+   */
+  deserializeU128(): Uint128 {
+    const low = this.deserializeU64();
+    const high = this.deserializeU64();
+
+    // combine the two 64-bit values and return (little endian)
+    return BigInt((high << BigInt(64)) | low);
+  }
+
+  /**
+   * Deserializes a uint256 number.
+   *
+   * BCS layout for "uint256": Thirty-two bytes. Binary format in little-endian representation.
+   */
+  deserializeU256(): Uint256 {
+    const low = this.deserializeU128();
+    const high = this.deserializeU128();
+
+    // combine the two 128-bit values and return (little endian)
+    return BigInt((high << BigInt(128)) | low);
+  }
+
+  /**
+   * Deserializes a uleb128 encoded uint32 number.
+   *
+   * BCS use uleb128 encoding in two cases: (1) lengths of variable-length sequences and (2) tags of enum values
+   */
+  deserializeUleb128AsU32(): Uint32 {
+    let value: bigint = BigInt(0);
+    let shift = 0;
+
+    while (value < MAX_U32_NUMBER) {
+      const byte = this.deserializeU8();
+      value |= BigInt(byte & 0x7f) << BigInt(shift);
+
+      if ((byte & 0x80) === 0) {
+        break;
+      }
+      shift += 7;
+    }
+
+    if (value > MAX_U32_NUMBER) {
+      throw new Error("Overflow while parsing uleb128-encoded uint32 value");
+    }
+
+    return Number(value);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/bcs/index.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/index.ts
@@ -1,0 +1,6 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+export * from "./types";
+export * from "./serializer";
+export * from "./deserializer";

--- a/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
@@ -12,6 +12,10 @@ import {
 } from "./consts";
 import { AnyNumber, Uint16, Uint32, Uint8 } from "./types";
 
+export interface Serializable {
+  serialize(serializer: Serializer): void;
+}
+
 export class Serializer {
   private buffer: ArrayBuffer;
 
@@ -30,7 +34,7 @@ export class Serializer {
     }
   }
 
-  protected serialize(values: Uint8Array) {
+  protected appendToBuffer(values: Uint8Array) {
     this.ensureBufferWillHandleSize(values.length);
     new Uint8Array(this.buffer, this.offset).set(values);
     this.offset += values.length;
@@ -49,7 +53,7 @@ export class Serializer {
 
   /**
    * Serializes a string. UTF8 string is supported.
-   * 
+   *
    * The number of bytes in the string content is serialized first, as a uleb128-encoded u32 integer.
    * Then the string content is serialized as UTF8 encoded bytes.
    *
@@ -63,9 +67,10 @@ export class Serializer {
    * assert(serializer.getBytes() === new Uint8Array([8, 49, 50, 51, 52, 97, 98, 99, 100]));
    * ```
    */
-  serializeStr(value: string): void {
+  serializeStr(value: string): this {
     const textEncoder = new TextEncoder();
     this.serializeBytes(textEncoder.encode(value));
+    return this;
   }
 
   /**
@@ -74,19 +79,21 @@ export class Serializer {
    * BCS layout for "bytes": bytes_length | bytes
    * where bytes_length is a u32 integer encoded as a uleb128 integer, equal to the length of the bytes array.
    */
-  serializeBytes(value: Uint8Array): void {
+  serializeBytes(value: Uint8Array): this {
     this.serializeU32AsUleb128(value.length);
-    this.serialize(value);
+    this.appendToBuffer(value);
+    return this;
   }
 
   /**
    * Serializes an array of bytes with known length. Therefore length doesn't need to be
    * serialized to help deserialization.
-   * 
+   *
    * When deserializing, the number of bytes to deserialize needs to be passed in.
    */
-  serializeFixedBytes(value: Uint8Array): void {
-    this.serialize(value);
+  serializeFixedBytes(value: Uint8Array): this {
+    this.appendToBuffer(value);
+    return this;
   }
 
   /**
@@ -94,12 +101,13 @@ export class Serializer {
    *
    * BCS layout for "boolean": One byte. "0x01" for true and "0x00" for false.
    */
-  serializeBool(value: boolean): void {
+  serializeBool(value: boolean): this {
     if (typeof value !== "boolean") {
       throw new Error("Value needs to be a boolean");
     }
     const byteValue = value ? 1 : 0;
-    this.serialize(new Uint8Array([byteValue]));
+    this.appendToBuffer(new Uint8Array([byteValue]));
+    return this;
   }
 
   /**
@@ -108,8 +116,9 @@ export class Serializer {
    * BCS layout for "uint8": One byte. Binary format in little-endian representation.
    */
   @checkNumberRange(0, MAX_U8_NUMBER)
-  serializeU8(value: Uint8): void {
-    this.serialize(new Uint8Array([value]));
+  serializeU8(value: Uint8): this {
+    this.appendToBuffer(new Uint8Array([value]));
+    return this;
   }
 
   /**
@@ -124,8 +133,9 @@ export class Serializer {
    * ```
    */
   @checkNumberRange(0, MAX_U16_NUMBER)
-  serializeU16(value: Uint16): void {
+  serializeU16(value: Uint16): this {
     this.serializeWithFunction(DataView.prototype.setUint16, 2, value);
+    return this;
   }
 
   /**
@@ -140,8 +150,9 @@ export class Serializer {
    * ```
    */
   @checkNumberRange(0, MAX_U32_NUMBER)
-  serializeU32(value: Uint32): void {
+  serializeU32(value: Uint32): this {
     this.serializeWithFunction(DataView.prototype.setUint32, 4, value);
+    return this;
   }
 
   /**
@@ -156,13 +167,14 @@ export class Serializer {
    * ```
    */
   @checkNumberRange(BigInt(0), MAX_U64_BIG_INT)
-  serializeU64(value: AnyNumber): void {
+  serializeU64(value: AnyNumber): this {
     const low = BigInt(value.toString()) & BigInt(MAX_U32_NUMBER);
     const high = BigInt(value.toString()) >> BigInt(32);
 
     // write little endian number
     this.serializeU32(Number(low));
     this.serializeU32(Number(high));
+    return this;
   }
 
   /**
@@ -171,13 +183,14 @@ export class Serializer {
    * BCS layout for "uint128": Sixteen bytes. Binary format in little-endian representation.
    */
   @checkNumberRange(BigInt(0), MAX_U128_BIG_INT)
-  serializeU128(value: AnyNumber): void {
+  serializeU128(value: AnyNumber): this {
     const low = BigInt(value.toString()) & MAX_U64_BIG_INT;
     const high = BigInt(value.toString()) >> BigInt(64);
 
     // write little endian number
     this.serializeU64(low);
     this.serializeU64(high);
+    return this;
   }
 
   /**
@@ -186,13 +199,14 @@ export class Serializer {
    * BCS layout for "uint256": Sixteen bytes. Binary format in little-endian representation.
    */
   @checkNumberRange(BigInt(0), MAX_U256_BIG_INT)
-  serializeU256(value: AnyNumber): void {
+  serializeU256(value: AnyNumber): this {
     const low = BigInt(value.toString()) & MAX_U128_BIG_INT;
     const high = BigInt(value.toString()) >> BigInt(128);
 
     // write little endian number
     this.serializeU128(low);
     this.serializeU128(high);
+    return this;
   }
 
   /**
@@ -201,7 +215,7 @@ export class Serializer {
    * BCS uses uleb128 encoding in two cases: (1) lengths of variable-length sequences and (2) tags of enum values
    */
   @checkNumberRange(0, MAX_U32_NUMBER)
-  serializeU32AsUleb128(val: Uint32): void {
+  serializeU32AsUleb128(val: Uint32): this {
     let value = val;
     const valueArray = [];
     while (value >>> 7 !== 0) {
@@ -209,7 +223,46 @@ export class Serializer {
       value >>>= 7;
     }
     valueArray.push(value);
-    this.serialize(new Uint8Array(valueArray));
+    this.appendToBuffer(new Uint8Array(valueArray));
+    return this;
+  }
+
+  /**
+   * Serializes a `Serializable` value, facilitating composable serialization.
+   *
+   * @param value The value to serialize
+   *
+   * @example
+   * // Define the MoveStruct class that implements the Serializable interface
+   * class MoveStruct implements Serializable {
+   *     constructor(
+   *         public creator_address: AccountAddress,
+   *         public collection_name: string,
+   *         public token_name: string
+   *     ) {}
+   *
+   *     serialize(serializer: Serializer): void {
+   *         serializer
+   *             .serialize(this.creator_address)  // Composable serialization of another Serializable object
+   *             .serializeStr(this.collection_name)
+   *             .serializeStr(this.token_name);
+   *     }
+   * }
+   *
+   * // Serialize a string, a u64 number, and a MoveStruct.
+   * const serializedData = new Serializer()
+   *     .serializeStr("ExampleString")
+   *     .serializeU64(12345678)
+   *     .serialize(new MoveStruct(new AccountAddress(...), "MyCollection", "TokenA"))
+   *     .getBytes();
+   *
+   * @returns the serializer instance
+   */
+  serialize<T extends Serializable>(value: T): this {
+    // NOTE: The `serialize` method called by `value` is defined in the
+    // Serializable interface, not the one defined in this class.
+    value.serialize(this);
+    return this;
   }
 
   /**
@@ -230,12 +283,12 @@ function checkNumberRange<T extends AnyNumber>(minValue: T, maxValue: T, message
   return (target: unknown, propertyKey: string, descriptor: PropertyDescriptor) => {
     const childFunction = descriptor.value;
     // eslint-disable-next-line no-param-reassign
-    descriptor.value = function deco(value: AnyNumber) {
+    descriptor.value = function deco(value: AnyNumber): Serializer {
       const valueBigInt = BigInt(value.toString());
       if (valueBigInt > BigInt(maxValue.toString()) || valueBigInt < BigInt(minValue.toString())) {
         throw new Error(message || "Value is out of range");
       }
-      childFunction.apply(this, [value]);
+      return childFunction.apply(this, [value]);
     };
     return descriptor;
   };

--- a/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
@@ -79,7 +79,7 @@ export class Serializer {
    * BCS layout for "bytes": bytes_length | bytes
    * where bytes_length is a u32 integer encoded as a uleb128 integer, equal to the length of the bytes array.
    */
-  serializeBytes(value: Uint8Array): this {
+  serializeByteVector(value: Uint8Array): this {
     this.serializeU32AsUleb128(value.length);
     this.appendToBuffer(value);
     return this;
@@ -262,6 +262,14 @@ export class Serializer {
     // NOTE: The `serialize` method called by `value` is defined in the
     // Serializable interface, not the one defined in this class.
     value.serialize(this);
+    return this;
+  }
+
+  serializeVector<T extends Serializable>(values: Array<T>): this {
+    this.serializeU32AsUleb128(values.length);
+    values.forEach((value) => {
+      this.serialize(value);
+    });
     return this;
   }
 

--- a/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
@@ -1,0 +1,242 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable no-bitwise */
+import {
+  MAX_U128_BIG_INT,
+  MAX_U16_NUMBER,
+  MAX_U32_NUMBER,
+  MAX_U64_BIG_INT,
+  MAX_U8_NUMBER,
+  MAX_U256_BIG_INT,
+} from "./consts";
+import { AnyNumber, Uint16, Uint32, Uint8 } from "./types";
+
+export class Serializer {
+  private buffer: ArrayBuffer;
+
+  private offset: number;
+
+  constructor() {
+    this.buffer = new ArrayBuffer(64);
+    this.offset = 0;
+  }
+
+  private ensureBufferWillHandleSize(bytes: number) {
+    while (this.buffer.byteLength < this.offset + bytes) {
+      const newBuffer = new ArrayBuffer(this.buffer.byteLength * 2);
+      new Uint8Array(newBuffer).set(new Uint8Array(this.buffer));
+      this.buffer = newBuffer;
+    }
+  }
+
+  protected serialize(values: Uint8Array) {
+    this.ensureBufferWillHandleSize(values.length);
+    new Uint8Array(this.buffer, this.offset).set(values);
+    this.offset += values.length;
+  }
+
+  private serializeWithFunction(
+    fn: (byteOffset: number, value: number, littleEndian?: boolean) => void,
+    bytesLength: number,
+    value: number,
+  ) {
+    this.ensureBufferWillHandleSize(bytesLength);
+    const dv = new DataView(this.buffer, this.offset);
+    fn.apply(dv, [0, value, true]);
+    this.offset += bytesLength;
+  }
+
+  /**
+   * Serializes a string. UTF8 string is supported.
+   * 
+   * The number of bytes in the string content is serialized first, as a uleb128-encoded u32 integer.
+   * Then the string content is serialized as UTF8 encoded bytes.
+   *
+   * BCS layout for "string": string_length | string_content
+   * where string_length is a u32 integer encoded as a uleb128 integer, equal to the number of bytes in string_content.
+   *
+   * @example
+   * ```ts
+   * const serializer = new Serializer();
+   * serializer.serializeStr("1234abcd");
+   * assert(serializer.getBytes() === new Uint8Array([8, 49, 50, 51, 52, 97, 98, 99, 100]));
+   * ```
+   */
+  serializeStr(value: string): void {
+    const textEncoder = new TextEncoder();
+    this.serializeBytes(textEncoder.encode(value));
+  }
+
+  /**
+   * Serializes an array of bytes.
+   *
+   * BCS layout for "bytes": bytes_length | bytes
+   * where bytes_length is a u32 integer encoded as a uleb128 integer, equal to the length of the bytes array.
+   */
+  serializeBytes(value: Uint8Array): void {
+    this.serializeU32AsUleb128(value.length);
+    this.serialize(value);
+  }
+
+  /**
+   * Serializes an array of bytes with known length. Therefore length doesn't need to be
+   * serialized to help deserialization.
+   * 
+   * When deserializing, the number of bytes to deserialize needs to be passed in.
+   */
+  serializeFixedBytes(value: Uint8Array): void {
+    this.serialize(value);
+  }
+
+  /**
+   * Serializes a boolean value.
+   *
+   * BCS layout for "boolean": One byte. "0x01" for true and "0x00" for false.
+   */
+  serializeBool(value: boolean): void {
+    if (typeof value !== "boolean") {
+      throw new Error("Value needs to be a boolean");
+    }
+    const byteValue = value ? 1 : 0;
+    this.serialize(new Uint8Array([byteValue]));
+  }
+
+  /**
+   * Serializes a uint8 number.
+   *
+   * BCS layout for "uint8": One byte. Binary format in little-endian representation.
+   */
+  @checkNumberRange(0, MAX_U8_NUMBER)
+  serializeU8(value: Uint8): void {
+    this.serialize(new Uint8Array([value]));
+  }
+
+  /**
+   * Serializes a uint16 number.
+   *
+   * BCS layout for "uint16": Two bytes. Binary format in little-endian representation.
+   * @example
+   * ```ts
+   * const serializer = new Serializer();
+   * serializer.serializeU16(4660);
+   * assert(serializer.getBytes() === new Uint8Array([0x34, 0x12]));
+   * ```
+   */
+  @checkNumberRange(0, MAX_U16_NUMBER)
+  serializeU16(value: Uint16): void {
+    this.serializeWithFunction(DataView.prototype.setUint16, 2, value);
+  }
+
+  /**
+   * Serializes a uint32 number.
+   *
+   * BCS layout for "uint32": Four bytes. Binary format in little-endian representation.
+   * @example
+   * ```ts
+   * const serializer = new Serializer();
+   * serializer.serializeU32(305419896);
+   * assert(serializer.getBytes() === new Uint8Array([0x78, 0x56, 0x34, 0x12]));
+   * ```
+   */
+  @checkNumberRange(0, MAX_U32_NUMBER)
+  serializeU32(value: Uint32): void {
+    this.serializeWithFunction(DataView.prototype.setUint32, 4, value);
+  }
+
+  /**
+   * Serializes a uint64 number.
+   *
+   * BCS layout for "uint64": Eight bytes. Binary format in little-endian representation.
+   * @example
+   * ```ts
+   * const serializer = new Serializer();
+   * serializer.serializeU64(1311768467750121216);
+   * assert(serializer.getBytes() === new Uint8Array([0x00, 0xEF, 0xCD, 0xAB, 0x78, 0x56, 0x34, 0x12]));
+   * ```
+   */
+  @checkNumberRange(BigInt(0), MAX_U64_BIG_INT)
+  serializeU64(value: AnyNumber): void {
+    const low = BigInt(value.toString()) & BigInt(MAX_U32_NUMBER);
+    const high = BigInt(value.toString()) >> BigInt(32);
+
+    // write little endian number
+    this.serializeU32(Number(low));
+    this.serializeU32(Number(high));
+  }
+
+  /**
+   * Serializes a uint128 number.
+   *
+   * BCS layout for "uint128": Sixteen bytes. Binary format in little-endian representation.
+   */
+  @checkNumberRange(BigInt(0), MAX_U128_BIG_INT)
+  serializeU128(value: AnyNumber): void {
+    const low = BigInt(value.toString()) & MAX_U64_BIG_INT;
+    const high = BigInt(value.toString()) >> BigInt(64);
+
+    // write little endian number
+    this.serializeU64(low);
+    this.serializeU64(high);
+  }
+
+  /**
+   * Serializes a uint256 number.
+   *
+   * BCS layout for "uint256": Sixteen bytes. Binary format in little-endian representation.
+   */
+  @checkNumberRange(BigInt(0), MAX_U256_BIG_INT)
+  serializeU256(value: AnyNumber): void {
+    const low = BigInt(value.toString()) & MAX_U128_BIG_INT;
+    const high = BigInt(value.toString()) >> BigInt(128);
+
+    // write little endian number
+    this.serializeU128(low);
+    this.serializeU128(high);
+  }
+
+  /**
+   * Serializes a uint32 number with uleb128.
+   *
+   * BCS uses uleb128 encoding in two cases: (1) lengths of variable-length sequences and (2) tags of enum values
+   */
+  @checkNumberRange(0, MAX_U32_NUMBER)
+  serializeU32AsUleb128(val: Uint32): void {
+    let value = val;
+    const valueArray = [];
+    while (value >>> 7 !== 0) {
+      valueArray.push((value & 0x7f) | 0x80);
+      value >>>= 7;
+    }
+    valueArray.push(value);
+    this.serialize(new Uint8Array(valueArray));
+  }
+
+  /**
+   * Returns the buffered bytes
+   */
+  getBytes(): Uint8Array {
+    return new Uint8Array(this.buffer).slice(0, this.offset);
+  }
+}
+
+/**
+ * A decorator that ensures the input argument for a function is within a range.
+ * @param minValue The input argument must be >= minValue
+ * @param maxValue The input argument must be <= maxValue
+ * @param message Error message
+ */
+function checkNumberRange<T extends AnyNumber>(minValue: T, maxValue: T, message?: string) {
+  return (target: unknown, propertyKey: string, descriptor: PropertyDescriptor) => {
+    const childFunction = descriptor.value;
+    // eslint-disable-next-line no-param-reassign
+    descriptor.value = function deco(value: AnyNumber) {
+      const valueBigInt = BigInt(value.toString());
+      if (valueBigInt > BigInt(maxValue.toString()) || valueBigInt < BigInt(minValue.toString())) {
+        throw new Error(message || "Value is out of range");
+      }
+      childFunction.apply(this, [value]);
+    };
+    return descriptor;
+  };
+}

--- a/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/serializer.ts
@@ -69,7 +69,7 @@ export class Serializer {
    */
   serializeStr(value: string): this {
     const textEncoder = new TextEncoder();
-    this.serializeBytes(textEncoder.encode(value));
+    this.serializeByteVector(textEncoder.encode(value));
     return this;
   }
 
@@ -259,7 +259,7 @@ export class Serializer {
    * @returns the serializer instance
    */
   serialize<T extends Serializable>(value: T): this {
-    // NOTE: The `serialize` method called by `value` is defined in the
+    // NOTE: The `serialize` method called by `value` is defined in `value`'s
     // Serializable interface, not the one defined in this class.
     value.serialize(this);
     return this;
@@ -278,6 +278,11 @@ export class Serializer {
    */
   getBytes(): Uint8Array {
     return new Uint8Array(this.buffer).slice(0, this.offset);
+  }
+
+  // A static helper method to serialize a BCS `Serializable` value and return the bytes.
+  static toBCSBytes<T extends Serializable>(value: T): Uint8Array {
+    return new Serializer().serialize(value).getBytes();
   }
 }
 

--- a/ecosystem/typescript/sdk_v2/src/bcs/types.ts
+++ b/ecosystem/typescript/sdk_v2/src/bcs/types.ts
@@ -1,0 +1,10 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+export type Uint8 = number;
+export type Uint16 = number;
+export type Uint32 = number;
+export type Uint64 = bigint;
+export type Uint128 = bigint;
+export type Uint256 = bigint;
+export type AnyNumber = bigint | number;

--- a/ecosystem/typescript/sdk_v2/src/index.ts
+++ b/ecosystem/typescript/sdk_v2/src/index.ts
@@ -3,3 +3,4 @@
 
 export * from "./api";
 export * from "./client";
+export * from "./bcs";

--- a/ecosystem/typescript/sdk_v2/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk_v2/src/transaction_builder/builder.ts
@@ -1,0 +1,441 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
+import {
+  Ed25519PublicKey,
+  Ed25519Signature,
+  MultiEd25519PublicKey,
+  MultiEd25519Signature,
+  RawTransaction,
+  SignedTransaction,
+  TransactionAuthenticatorEd25519,
+  TransactionAuthenticatorMultiEd25519,
+  SigningMessage,
+  MultiAgentRawTransaction,
+  FeePayerRawTransaction,
+  AccountAddress,
+  EntryFunction,
+  Identifier,
+  ChainId,
+  Script,
+  TransactionPayload,
+  TransactionArgument,
+  TransactionPayloadEntryFunction,
+  TransactionPayloadScript,
+  ModuleId,
+  TypeTagParser,
+} from "../aptos_types";
+import { Deserializer, Serializer, Uint64, Uint8 } from "../bcs";
+import { ArgumentABI, EntryFunctionABI, ScriptABI, TransactionScriptABI, TypeArgumentABI } from "../aptos_types/abi";
+import { argToTransactionArgument, serializeArg } from "./builder_utils";
+import {
+  DEFAULT_TXN_EXP_SEC_FROM_NOW,
+  DEFAULT_MAX_GAS_AMOUNT,
+  HexString,
+  MaybeHexString,
+  MemoizeExpiring,
+} from "../utils";
+import { AccountData, MoveModuleBytecode } from "../types";
+import { EntryFunctionId, GasEstimation, MoveFunction, MoveType } from "../types/generated";
+
+export { TypeTagParser } from "../aptos_types";
+
+const RAW_TRANSACTION_SALT = "APTOS::RawTransaction";
+const RAW_TRANSACTION_WITH_DATA_SALT = "APTOS::RawTransactionWithData";
+
+export type AnyRawTransaction = RawTransaction | MultiAgentRawTransaction | FeePayerRawTransaction;
+
+/**
+ * Function that takes in a Signing Message (serialized raw transaction)
+ *  and returns a signature
+ */
+export type SigningFn = (txn: SigningMessage) => Ed25519Signature | MultiEd25519Signature;
+
+export class TransactionBuilder<F extends SigningFn> {
+  protected readonly signingFunction: F;
+
+  constructor(signingFunction: F, public readonly rawTxnBuilder?: TransactionBuilderABI) {
+    this.signingFunction = signingFunction;
+  }
+
+  /**
+   * Builds a RawTransaction. Relays the call to TransactionBuilderABI.build
+   * @param func
+   * @param ty_tags
+   * @param args
+   */
+  build(func: string, ty_tags: string[], args: any[]): RawTransaction {
+    if (!this.rawTxnBuilder) {
+      throw new Error("this.rawTxnBuilder doesn't exist.");
+    }
+
+    return this.rawTxnBuilder.build(func, ty_tags, args);
+  }
+
+  /** Generates a Signing Message out of a raw transaction. */
+  static getSigningMessage(rawTxn: AnyRawTransaction): SigningMessage {
+    const hash = sha3Hash.create();
+    if (rawTxn instanceof RawTransaction) {
+      hash.update(RAW_TRANSACTION_SALT);
+    } else if (rawTxn instanceof MultiAgentRawTransaction) {
+      hash.update(RAW_TRANSACTION_WITH_DATA_SALT);
+    } else if (rawTxn instanceof FeePayerRawTransaction) {
+      hash.update(RAW_TRANSACTION_WITH_DATA_SALT);
+    } else {
+      throw new Error("Unknown transaction type.");
+    }
+
+    const prefix = hash.digest();
+
+    const body = Serializer.toBCSBytes(rawTxn);
+
+    const mergedArray = new Uint8Array(prefix.length + body.length);
+    mergedArray.set(prefix);
+    mergedArray.set(body, prefix.length);
+
+    return mergedArray;
+  }
+}
+
+/**
+ * Provides signing method for signing a raw transaction with single public key.
+ */
+export class TransactionBuilderEd25519 extends TransactionBuilder<SigningFn> {
+  private readonly publicKey: Uint8Array;
+
+  constructor(signingFunction: SigningFn, publicKey: Uint8Array, rawTxnBuilder?: TransactionBuilderABI) {
+    super(signingFunction, rawTxnBuilder);
+    this.publicKey = publicKey;
+  }
+
+  rawToSigned(rawTxn: RawTransaction): SignedTransaction {
+    const signingMessage = TransactionBuilder.getSigningMessage(rawTxn);
+    const signature = this.signingFunction(signingMessage);
+
+    const authenticator = new TransactionAuthenticatorEd25519(
+      new Ed25519PublicKey(this.publicKey),
+      signature as Ed25519Signature,
+    );
+
+    return new SignedTransaction(rawTxn, authenticator);
+  }
+
+  /** Signs a raw transaction and returns a bcs serialized transaction. */
+  sign(rawTxn: RawTransaction): Uint8Array {
+    return Serializer.toBCSBytes(this.rawToSigned(rawTxn));
+  }
+}
+
+/**
+ * Provides signing method for signing a raw transaction with multisig public key.
+ */
+export class TransactionBuilderMultiEd25519 extends TransactionBuilder<SigningFn> {
+  private readonly publicKey: MultiEd25519PublicKey;
+
+  constructor(signingFunction: SigningFn, publicKey: MultiEd25519PublicKey) {
+    super(signingFunction);
+    this.publicKey = publicKey;
+  }
+
+  rawToSigned(rawTxn: RawTransaction): SignedTransaction {
+    const signingMessage = TransactionBuilder.getSigningMessage(rawTxn);
+    const signature = this.signingFunction(signingMessage);
+
+    const authenticator = new TransactionAuthenticatorMultiEd25519(this.publicKey, signature as MultiEd25519Signature);
+
+    return new SignedTransaction(rawTxn, authenticator);
+  }
+
+  /** Signs a raw transaction and returns a bcs serialized transaction. */
+  sign(rawTxn: RawTransaction): Uint8Array {
+    return Serializer.toBCSBytes(this.rawToSigned(rawTxn));
+  }
+}
+
+/**
+ * Config for creating raw transactions.
+ */
+export interface ABIBuilderConfig {
+  sender: MaybeHexString | AccountAddress;
+  sequenceNumber: Uint64 | string;
+  gasUnitPrice: Uint64 | string;
+  maxGasAmount?: Uint64 | string;
+  expSecFromNow?: number | string;
+  chainId: Uint8 | string;
+}
+
+/**
+ * Builds raw transactions based on ABI
+ */
+export class TransactionBuilderABI {
+  private readonly abiMap: Map<string, ScriptABI>;
+
+  private readonly builderConfig: Partial<ABIBuilderConfig>;
+
+  /**
+   * Constructs a TransactionBuilderABI instance
+   * @param abis List of binary ABIs.
+   * @param builderConfig Configs for creating a raw transaction.
+   */
+  constructor(abis: Uint8Array[], builderConfig?: ABIBuilderConfig) {
+    this.abiMap = new Map<string, ScriptABI>();
+
+    abis.forEach((abi) => {
+      const deserializer = new Deserializer(abi);
+      const scriptABI = ScriptABI.deserialize(deserializer);
+      let k: string;
+      if (scriptABI instanceof EntryFunctionABI) {
+        const funcABI = scriptABI as EntryFunctionABI;
+        const { address: addr, name: moduleName } = funcABI.module_name;
+        k = `${HexString.fromUint8Array(addr.address).toShortString()}::${moduleName.value}::${funcABI.name}`;
+      } else {
+        const funcABI = scriptABI as TransactionScriptABI;
+        k = funcABI.name;
+      }
+
+      if (this.abiMap.has(k)) {
+        throw new Error("Found conflicting ABI interfaces");
+      }
+
+      this.abiMap.set(k, scriptABI);
+    });
+
+    this.builderConfig = {
+      maxGasAmount: BigInt(DEFAULT_MAX_GAS_AMOUNT),
+      expSecFromNow: DEFAULT_TXN_EXP_SEC_FROM_NOW,
+      ...builderConfig,
+    };
+  }
+
+  private static toBCSArgs(abiArgs: any[], args: any[]): Uint8Array[] {
+    if (abiArgs.length !== args.length) {
+      throw new Error("Wrong number of args provided.");
+    }
+
+    return args.map((arg, i) => {
+      const serializer = new Serializer();
+      serializeArg(arg, abiArgs[i].type_tag, serializer);
+      return serializer.getBytes();
+    });
+  }
+
+  private static toTransactionArguments(abiArgs: any[], args: any[]): TransactionArgument[] {
+    if (abiArgs.length !== args.length) {
+      throw new Error("Wrong number of args provided.");
+    }
+
+    return args.map((arg, i) => argToTransactionArgument(arg, abiArgs[i].type_tag));
+  }
+
+  setSequenceNumber(seqNumber: Uint64 | string) {
+    this.builderConfig.sequenceNumber = BigInt(seqNumber);
+  }
+
+  /**
+   * Builds a TransactionPayload. For dApps, chain ID and account sequence numbers are only known to the wallet.
+   * Instead of building a RawTransaction (requires chainID and sequenceNumber), dApps can build a TransactionPayload
+   * and pass the payload to the wallet for signing and sending.
+   * @param func Fully qualified func names, e.g. 0x1::aptos_account::transfer
+   * @param ty_tags TypeTag strings
+   * @param args Function arguments
+   * @returns TransactionPayload
+   */
+  buildTransactionPayload(func: string, ty_tags: string[], args: any[]): TransactionPayload {
+    const typeTags = ty_tags.map((ty_arg) => new TypeTagParser(ty_arg).parseTypeTag());
+
+    let payload: TransactionPayload;
+
+    if (!this.abiMap.has(func)) {
+      throw new Error(`Cannot find function: ${func}`);
+    }
+
+    const scriptABI = this.abiMap.get(func);
+
+    if (scriptABI instanceof EntryFunctionABI) {
+      const funcABI = scriptABI as EntryFunctionABI;
+      const bcsArgs = TransactionBuilderABI.toBCSArgs(funcABI.args, args);
+      payload = new TransactionPayloadEntryFunction(
+        new EntryFunction(funcABI.module_name, new Identifier(funcABI.name), typeTags, bcsArgs),
+      );
+    } else if (scriptABI instanceof TransactionScriptABI) {
+      const funcABI = scriptABI as TransactionScriptABI;
+      const scriptArgs = TransactionBuilderABI.toTransactionArguments(funcABI.args, args);
+
+      payload = new TransactionPayloadScript(new Script(funcABI.code, typeTags, scriptArgs));
+    } else {
+      /* istanbul ignore next */
+      throw new Error("Unknown ABI format.");
+    }
+
+    return payload;
+  }
+
+  /**
+   * Builds a RawTransaction
+   * @param func Fully qualified func names, e.g. 0x1::aptos_account::transfer
+   * @param ty_tags TypeTag strings.
+   * @example Below are valid value examples
+   * ```
+   * // Structs are in format `AccountAddress::ModuleName::StructName`
+   * 0x1::aptos_coin::AptosCoin
+   * // Vectors are in format `vector<other_tag_string>`
+   * vector<0x1::aptos_coin::AptosCoin>
+   * bool
+   * u8
+   * u16
+   * u32
+   * u64
+   * u128
+   * u256
+   * address
+   * ```
+   * @param args Function arguments
+   * @returns RawTransaction
+   */
+  build(func: string, ty_tags: string[], args: any[]): RawTransaction {
+    const { sender, sequenceNumber, gasUnitPrice, maxGasAmount, expSecFromNow, chainId } = this.builderConfig;
+
+    if (!gasUnitPrice) {
+      throw new Error("No gasUnitPrice provided.");
+    }
+
+    const senderAccount = sender instanceof AccountAddress ? sender : AccountAddress.fromHex(sender!);
+    const expTimestampSec = BigInt(Math.floor(Date.now() / 1000) + Number(expSecFromNow));
+    const payload = this.buildTransactionPayload(func, ty_tags, args);
+
+    if (payload) {
+      return new RawTransaction(
+        senderAccount,
+        BigInt(sequenceNumber!),
+        payload,
+        BigInt(maxGasAmount!),
+        BigInt(gasUnitPrice!),
+        expTimestampSec,
+        new ChainId(Number(chainId)),
+      );
+    }
+
+    throw new Error("Invalid ABI.");
+  }
+}
+
+export type RemoteABIBuilderConfig = Partial<Omit<ABIBuilderConfig, "sender">> & {
+  sender: MaybeHexString | AccountAddress;
+};
+
+export interface AptosClientInterface {
+  getAccountModules: (accountAddress: MaybeHexString) => Promise<MoveModuleBytecode[]>;
+  getAccount: (accountAddress: MaybeHexString) => Promise<AccountData>;
+  getChainId: () => Promise<number>;
+  estimateGasPrice: () => Promise<GasEstimation>;
+}
+
+/**
+ * This transaction builder downloads JSON ABIs from the fullnodes.
+ * It then translates the JSON ABIs to the format that is accepted by TransactionBuilderABI
+ */
+export class TransactionBuilderRemoteABI {
+  // We don't want the builder to depend on the actual AptosClient. There might be circular dependencies.
+  constructor(
+    private readonly aptosClient: AptosClientInterface,
+    private readonly builderConfig: RemoteABIBuilderConfig,
+  ) {}
+
+  // Cache for 10 minutes
+  @MemoizeExpiring(10 * 60 * 1000)
+  async fetchABI(addr: string) {
+    const modules = await this.aptosClient.getAccountModules(addr);
+    const abis = modules
+      .map((module) => module.abi)
+      .flatMap((abi) =>
+        abi!.exposed_functions
+          .filter((ef) => ef.is_entry)
+          .map(
+            (ef) =>
+              ({
+                fullName: `${abi!.address}::${abi!.name}::${ef.name}`,
+                ...ef,
+              } as MoveFunction & { fullName: string }),
+          ),
+      );
+
+    const abiMap = new Map<string, MoveFunction & { fullName: string }>();
+    abis.forEach((abi) => {
+      abiMap.set(abi.fullName, abi);
+    });
+
+    return abiMap;
+  }
+
+  /**
+   * Builds a raw transaction. Only support script function a.k.a entry function payloads
+   *
+   * @param func fully qualified function name in format <address>::<module>::<function>, e.g. 0x1::coin::transfer
+   * @param ty_tags
+   * @param args
+   * @returns RawTransaction
+   */
+  async build(func: EntryFunctionId, ty_tags: MoveType[], args: any[]): Promise<RawTransaction> {
+    /* eslint no-param-reassign: ["off"] */
+    const normlize = (s: string) => s.replace(/^0[xX]0*/g, "0x");
+    func = normlize(func);
+    const funcNameParts = func.split("::");
+    if (funcNameParts.length !== 3) {
+      throw new Error(
+        // eslint-disable-next-line max-len
+        "'func' needs to be a fully qualified function name in format <address>::<module>::<function>, e.g. 0x1::coin::transfer",
+      );
+    }
+
+    const [addr, module] = func.split("::");
+
+    // Downloads the JSON abi
+    const abiMap = await this.fetchABI(addr);
+    if (!abiMap.has(func)) {
+      throw new Error(`${func} doesn't exist.`);
+    }
+
+    const funcAbi = abiMap.get(func);
+
+    // Remove all `signer` and `&signer` from argument list because the Move VM injects those arguments. Clients do not
+    // need to care about those args. `signer` and `&signer` are required be in the front of the argument list. But we
+    // just loop through all arguments and filter out `signer` and `&signer`.
+    const abiArgs = funcAbi!.params.filter((param) => param !== "signer" && param !== "&signer");
+
+    // Convert abi string arguments to TypeArgumentABI
+    const typeArgABIs = abiArgs.map(
+      (abiArg, i) => new ArgumentABI(`var${i}`, new TypeTagParser(abiArg, ty_tags).parseTypeTag()),
+    );
+
+    const entryFunctionABI = new EntryFunctionABI(
+      funcAbi!.name,
+      ModuleId.fromStr(`${addr}::${module}`),
+      "", // Doc string
+      funcAbi!.generic_type_params.map((_, i) => new TypeArgumentABI(`${i}`)),
+      typeArgABIs,
+    );
+
+    const { sender, ...rest } = this.builderConfig;
+
+    const senderAddress = sender instanceof AccountAddress ? HexString.fromUint8Array(sender.address) : sender;
+
+    const [{ sequence_number: sequenceNumber }, chainId, { gas_estimate: gasUnitPrice }] = await Promise.all([
+      rest?.sequenceNumber
+        ? Promise.resolve({ sequence_number: rest?.sequenceNumber })
+        : this.aptosClient.getAccount(senderAddress),
+      rest?.chainId ? Promise.resolve(rest?.chainId) : this.aptosClient.getChainId(),
+      rest?.gasUnitPrice ? Promise.resolve({ gas_estimate: rest?.gasUnitPrice }) : this.aptosClient.estimateGasPrice(),
+    ]);
+
+    const builderABI = new TransactionBuilderABI([Serializer.toBCSBytes(entryFunctionABI)], {
+      sender,
+      sequenceNumber,
+      chainId,
+      gasUnitPrice: BigInt(gasUnitPrice),
+      ...rest,
+    });
+
+    return builderABI.build(func, ty_tags, args);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/transaction_builder/builder_utils.ts
+++ b/ecosystem/typescript/sdk_v2/src/transaction_builder/builder_utils.ts
@@ -1,0 +1,216 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { HexString } from "../utils/hex_string";
+import {
+  TypeTag,
+  TypeTagBool,
+  TypeTagU8,
+  TypeTagU16,
+  TypeTagU32,
+  TypeTagU64,
+  TypeTagU128,
+  TypeTagU256,
+  TypeTagAddress,
+  AccountAddress,
+  TypeTagVector,
+  TypeTagStruct,
+  TransactionArgument,
+  TransactionArgumentBool,
+  TransactionArgumentU16,
+  TransactionArgumentU32,
+  TransactionArgumentU64,
+  TransactionArgumentU128,
+  TransactionArgumentU256,
+  TransactionArgumentAddress,
+  TransactionArgumentU8,
+  TransactionArgumentU8Vector,
+} from "../aptos_types";
+import { Serializer } from "../bcs";
+
+function assertType(val: any, types: string[] | string, message?: string) {
+  if (!types?.includes(typeof val)) {
+    throw new Error(
+      message || `Invalid arg: ${val} type should be ${types instanceof Array ? types.join(" or ") : types}`,
+    );
+  }
+}
+
+export function ensureBoolean(val: boolean | string): boolean {
+  assertType(val, ["boolean", "string"]);
+  if (typeof val === "boolean") {
+    return val;
+  }
+
+  if (val === "true") {
+    return true;
+  }
+  if (val === "false") {
+    return false;
+  }
+
+  throw new Error("Invalid boolean string.");
+}
+
+export function ensureNumber(val: number | string): number {
+  assertType(val, ["number", "string"]);
+  if (typeof val === "number") {
+    return val;
+  }
+
+  const res = Number.parseInt(val, 10);
+  if (Number.isNaN(res)) {
+    throw new Error("Invalid number string.");
+  }
+
+  return res;
+}
+
+export function ensureBigInt(val: number | bigint | string): bigint {
+  assertType(val, ["number", "bigint", "string"]);
+  return BigInt(val);
+}
+
+export function serializeArg(argVal: any, argType: TypeTag, serializer: Serializer) {
+  serializeArgInner(argVal, argType, serializer, 0);
+}
+
+function serializeArgInner(argVal: any, argType: TypeTag, serializer: Serializer, depth: number) {
+  if (argType instanceof TypeTagBool) {
+    serializer.serializeBool(ensureBoolean(argVal));
+  } else if (argType instanceof TypeTagU8) {
+    serializer.serializeU8(ensureNumber(argVal));
+  } else if (argType instanceof TypeTagU16) {
+    serializer.serializeU16(ensureNumber(argVal));
+  } else if (argType instanceof TypeTagU32) {
+    serializer.serializeU32(ensureNumber(argVal));
+  } else if (argType instanceof TypeTagU64) {
+    serializer.serializeU64(ensureBigInt(argVal));
+  } else if (argType instanceof TypeTagU128) {
+    serializer.serializeU128(ensureBigInt(argVal));
+  } else if (argType instanceof TypeTagU256) {
+    serializer.serializeU256(ensureBigInt(argVal));
+  } else if (argType instanceof TypeTagAddress) {
+    serializeAddress(argVal, serializer);
+  } else if (argType instanceof TypeTagVector) {
+    serializeVector(argVal, argType, serializer, depth);
+  } else if (argType instanceof TypeTagStruct) {
+    serializeStruct(argVal, argType, serializer, depth);
+  } else {
+    throw new Error("Unsupported arg type.");
+  }
+}
+
+function serializeAddress(argVal: any, serializer: Serializer) {
+  let addr: AccountAddress;
+  if (typeof argVal === "string" || argVal instanceof HexString) {
+    addr = AccountAddress.fromHex(argVal);
+  } else if (argVal instanceof AccountAddress) {
+    addr = argVal;
+  } else {
+    throw new Error("Invalid account address.");
+  }
+  addr.serialize(serializer);
+}
+
+function serializeVector(argVal: any, argType: TypeTagVector, serializer: Serializer, depth: number) {
+  // We are serializing a vector<u8>
+  if (argType.value instanceof TypeTagU8) {
+    if (argVal instanceof Uint8Array) {
+      serializer.serializeByteVector(argVal);
+      return;
+    }
+    if (argVal instanceof HexString) {
+      serializer.serializeByteVector(argVal.toUint8Array());
+      return;
+    }
+    if (typeof argVal === "string") {
+      serializer.serializeStr(argVal);
+      return;
+    }
+    // If it isn't any of those types, then it must just be an actual array of numbers
+  }
+
+  if (!Array.isArray(argVal)) {
+    throw new Error("Invalid vector args.");
+  }
+
+  serializer.serializeU32AsUleb128(argVal.length);
+
+  argVal.forEach((arg) => serializeArgInner(arg, argType.value, serializer, depth + 1));
+}
+
+function serializeStruct(argVal: any, argType: TypeTag, serializer: Serializer, depth: number) {
+  const { address, module_name: moduleName, name, type_args: typeArgs } = (argType as TypeTagStruct).value;
+  const structType = `${HexString.fromUint8Array(address.address).toShortString()}::${moduleName.value}::${name.value}`;
+  if (structType === "0x1::string::String") {
+    assertType(argVal, ["string"]);
+    serializer.serializeStr(argVal);
+  } else if (structType === "0x1::object::Object") {
+    serializeAddress(argVal, serializer);
+  } else if (structType === "0x1::option::Option") {
+    if (typeArgs.length !== 1) {
+      throw new Error(`Option has the wrong number of type arguments ${typeArgs.length}`);
+    }
+    serializeOption(argVal, typeArgs[0], serializer, depth);
+  } else {
+    throw new Error("Unsupported struct type in function argument");
+  }
+}
+
+function serializeOption(argVal: any, argType: TypeTag, serializer: Serializer, depth: number) {
+  // For option, we determine if it's empty or not empty first
+  // empty option is nothing, we specifically check for undefined to prevent fuzzy matching
+  if (argVal === undefined || argVal === null) {
+    serializer.serializeU32AsUleb128(0);
+  } else {
+    // Something means we need an array of 1
+    serializer.serializeU32AsUleb128(1);
+
+    // Serialize the inner type arg, ensuring that depth is tracked
+    serializeArgInner(argVal, argType, serializer, depth + 1);
+  }
+}
+
+export function argToTransactionArgument(argVal: any, argType: TypeTag): TransactionArgument {
+  if (argType instanceof TypeTagBool) {
+    return new TransactionArgumentBool(ensureBoolean(argVal));
+  }
+  if (argType instanceof TypeTagU8) {
+    return new TransactionArgumentU8(ensureNumber(argVal));
+  }
+  if (argType instanceof TypeTagU16) {
+    return new TransactionArgumentU16(ensureNumber(argVal));
+  }
+  if (argType instanceof TypeTagU32) {
+    return new TransactionArgumentU32(ensureNumber(argVal));
+  }
+  if (argType instanceof TypeTagU64) {
+    return new TransactionArgumentU64(ensureBigInt(argVal));
+  }
+  if (argType instanceof TypeTagU128) {
+    return new TransactionArgumentU128(ensureBigInt(argVal));
+  }
+  if (argType instanceof TypeTagU256) {
+    return new TransactionArgumentU256(ensureBigInt(argVal));
+  }
+  if (argType instanceof TypeTagAddress) {
+    let addr: AccountAddress;
+    if (typeof argVal === "string" || argVal instanceof HexString) {
+      addr = AccountAddress.fromHex(argVal);
+    } else if (argVal instanceof AccountAddress) {
+      addr = argVal;
+    } else {
+      throw new Error("Invalid account address.");
+    }
+    return new TransactionArgumentAddress(addr);
+  }
+  if (argType instanceof TypeTagVector && argType.value instanceof TypeTagU8) {
+    if (!(argVal instanceof Uint8Array)) {
+      throw new Error(`${argVal} should be an instance of Uint8Array`);
+    }
+    return new TransactionArgumentU8Vector(argVal);
+  }
+
+  throw new Error("Unknown type for TransactionArgument.");
+}

--- a/ecosystem/typescript/sdk_v2/src/utils/hex_string.ts
+++ b/ecosystem/typescript/sdk_v2/src/utils/hex_string.ts
@@ -1,0 +1,121 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
+
+// eslint-disable-next-line no-use-before-define
+export type MaybeHexString = HexString | string;
+
+/**
+ * A util class for working with hex strings.
+ * Hex strings are strings that are prefixed with `0x`
+ */
+export class HexString {
+  /// We want to make sure this hexString has the `0x` hex prefix
+  private readonly hexString: string;
+
+  /**
+   * Creates new hex string from Buffer
+   * @param buffer A buffer to convert
+   * @returns New HexString
+   */
+  static fromBuffer(buffer: Uint8Array): HexString {
+    return HexString.fromUint8Array(buffer);
+  }
+
+  /**
+   * Creates new hex string from Uint8Array
+   * @param arr Uint8Array to convert
+   * @returns New HexString
+   */
+  static fromUint8Array(arr: Uint8Array): HexString {
+    return new HexString(bytesToHex(arr));
+  }
+
+  /**
+   * Ensures `hexString` is instance of `HexString` class
+   * @param hexString String to check
+   * @returns New HexString if `hexString` is regular string or `hexString` if it is HexString instance
+   * @example
+   * ```
+   *  const regularString = "string";
+   *  const hexString = new HexString("string"); // "0xstring"
+   *  HexString.ensure(regularString); // "0xstring"
+   *  HexString.ensure(hexString); // "0xstring"
+   * ```
+   */
+  static ensure(hexString: MaybeHexString): HexString {
+    if (typeof hexString === "string") {
+      return new HexString(hexString);
+    }
+    return hexString;
+  }
+
+  /**
+   * Creates new HexString instance from regular string. If specified string already starts with "0x" prefix,
+   * it will not add another one
+   * @param hexString String to convert
+   * @example
+   * ```
+   *  const string = "string";
+   *  new HexString(string); // "0xstring"
+   * ```
+   */
+  constructor(hexString: string) {
+    if (hexString.startsWith("0x")) {
+      this.hexString = hexString;
+    } else {
+      this.hexString = `0x${hexString}`;
+    }
+  }
+
+  /**
+   * Getter for inner hexString
+   * @returns Inner hex string
+   */
+  hex(): string {
+    return this.hexString;
+  }
+
+  /**
+   * Getter for inner hexString without prefix
+   * @returns Inner hex string without prefix
+   * @example
+   * ```
+   *  const hexString = new HexString("string"); // "0xstring"
+   *  hexString.noPrefix(); // "string"
+   * ```
+   */
+  noPrefix(): string {
+    return this.hexString.slice(2);
+  }
+
+  /**
+   * Overrides default `toString` method
+   * @returns Inner hex string
+   */
+  toString(): string {
+    return this.hex();
+  }
+
+  /**
+   * Trimmes extra zeroes in the begining of a string
+   * @returns Inner hexString without leading zeroes
+   * @example
+   * ```
+   *  new HexString("0x000000string").toShortString(); // result = "0xstring"
+   * ```
+   */
+  toShortString(): string {
+    const trimmed = this.hexString.replace(/^0x0*/, "");
+    return `0x${trimmed}`;
+  }
+
+  /**
+   * Converts hex string to a Uint8Array
+   * @returns Uint8Array from inner hexString without prefix
+   */
+  toUint8Array(): Uint8Array {
+    return Uint8Array.from(hexToBytes(this.noPrefix()));
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/utils/index.ts
+++ b/ecosystem/typescript/sdk_v2/src/utils/index.ts
@@ -1,0 +1,4 @@
+export * from "./misc";
+export * from "./memoize-decorator";
+export * from "./api-endpoints";
+export * from "./hex_string";

--- a/ecosystem/typescript/sdk_v2/src/utils/memoize-decorator.ts
+++ b/ecosystem/typescript/sdk_v2/src/utils/memoize-decorator.ts
@@ -1,0 +1,152 @@
+/**
+ * Credits to https://github.com/darrylhodgins/typescript-memoize
+ */
+
+/* eslint-disable no-param-reassign */
+/* eslint-disable no-restricted-syntax */
+
+interface MemoizeArgs {
+    // ttl in milliseconds for cached items. After `ttlMs`, cached items are evicted automatically. If no `ttlMs`
+    // is provided, cached items won't get auto-evicted.
+    ttlMs?: number;
+    // produces the cache key based on `args`.
+    hashFunction?: boolean | ((...args: any[]) => any);
+    // cached items can be taged with `tags`. `tags` can be used to evict cached items
+    tags?: string[];
+  }
+  
+  export function Memoize(args?: MemoizeArgs | MemoizeArgs["hashFunction"]) {
+    let hashFunction: MemoizeArgs["hashFunction"];
+    let ttlMs: MemoizeArgs["ttlMs"];
+    let tags: MemoizeArgs["tags"];
+  
+    if (typeof args === "object") {
+      hashFunction = args.hashFunction;
+      ttlMs = args.ttlMs;
+      tags = args.tags;
+    } else {
+      hashFunction = args;
+    }
+  
+    return (target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<any>) => {
+      if (descriptor.value != null) {
+        descriptor.value = getNewFunction(descriptor.value, hashFunction, ttlMs, tags);
+      } else if (descriptor.get != null) {
+        descriptor.get = getNewFunction(descriptor.get, hashFunction, ttlMs, tags);
+      } else {
+        throw new Error("Only put a Memoize() decorator on a method or get accessor.");
+      }
+    };
+  }
+  
+  export function MemoizeExpiring(ttlMs: number, hashFunction?: MemoizeArgs["hashFunction"]) {
+    return Memoize({
+      ttlMs,
+      hashFunction,
+    });
+  }
+  
+  const clearCacheTagsMap: Map<string, Map<any, any>[]> = new Map();
+  
+  export function clear(tags: string[]): number {
+    const cleared: Set<Map<any, any>> = new Set();
+    for (const tag of tags) {
+      const maps = clearCacheTagsMap.get(tag);
+      if (maps) {
+        for (const mp of maps) {
+          if (!cleared.has(mp)) {
+            mp.clear();
+            cleared.add(mp);
+          }
+        }
+      }
+    }
+    return cleared.size;
+  }
+  
+  function getNewFunction(
+    originalMethod: () => void,
+    hashFunction?: MemoizeArgs["hashFunction"],
+    ttlMs: number = 0,
+    tags?: MemoizeArgs["tags"],
+  ) {
+    const propMapName = Symbol("__memoized_map__");
+  
+    // The function returned here gets called instead of originalMethod.
+    // eslint-disable-next-line func-names
+    return function (...args: any[]) {
+      let returnedValue: any;
+  
+      // @ts-ignore
+      const that: any = this;
+  
+      // Get or create map
+      // eslint-disable-next-line no-prototype-builtins
+      if (!that.hasOwnProperty(propMapName)) {
+        Object.defineProperty(that, propMapName, {
+          configurable: false,
+          enumerable: false,
+          writable: false,
+          value: new Map<any, any>(),
+        });
+      }
+      const myMap: Map<any, any> = that[propMapName];
+  
+      if (Array.isArray(tags)) {
+        for (const tag of tags) {
+          if (clearCacheTagsMap.has(tag)) {
+            clearCacheTagsMap.get(tag)!.push(myMap);
+          } else {
+            clearCacheTagsMap.set(tag, [myMap]);
+          }
+        }
+      }
+  
+      if (hashFunction || args.length > 0 || ttlMs > 0) {
+        let hashKey: any;
+  
+        // If true is passed as first parameter, will automatically use every argument, passed to string
+        if (hashFunction === true) {
+          hashKey = args.map((a) => a.toString()).join("!");
+        } else if (hashFunction) {
+          hashKey = hashFunction.apply(that, args);
+        } else {
+          // eslint-disable-next-line prefer-destructuring
+          hashKey = args[0];
+        }
+  
+        const timestampKey = `${hashKey}__timestamp`;
+        let isExpired: boolean = false;
+        if (ttlMs > 0) {
+          if (!myMap.has(timestampKey)) {
+            // "Expired" since it was never called before
+            isExpired = true;
+          } else {
+            const timestamp = myMap.get(timestampKey);
+            isExpired = Date.now() - timestamp > ttlMs;
+          }
+        }
+  
+        if (myMap.has(hashKey) && !isExpired) {
+          returnedValue = myMap.get(hashKey);
+        } else {
+          returnedValue = originalMethod.apply(that, args as any);
+          myMap.set(hashKey, returnedValue);
+          if (ttlMs > 0) {
+            myMap.set(timestampKey, Date.now());
+          }
+        }
+      } else {
+        const hashKey = that;
+        if (myMap.has(hashKey)) {
+          returnedValue = myMap.get(hashKey);
+        } else {
+          returnedValue = originalMethod.apply(that, args as any);
+          myMap.set(hashKey, returnedValue);
+        }
+      }
+  
+      return returnedValue;
+    };
+  }
+  

--- a/ecosystem/typescript/sdk_v2/src/utils/misc.ts
+++ b/ecosystem/typescript/sdk_v2/src/utils/misc.ts
@@ -1,0 +1,32 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { VERSION } from "../version";
+
+export async function sleep(timeMs: number): Promise<null> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeMs);
+  });
+}
+
+export const DEFAULT_VERSION_PATH_BASE = "/v1";
+
+export function fixNodeUrl(nodeUrl: string): string {
+  let out = `${nodeUrl}`;
+  if (out.endsWith("/")) {
+    out = out.substring(0, out.length - 1);
+  }
+  if (!out.endsWith(DEFAULT_VERSION_PATH_BASE)) {
+    out = `${out}${DEFAULT_VERSION_PATH_BASE}`;
+  }
+  return out;
+}
+
+export const DEFAULT_MAX_GAS_AMOUNT = 200000;
+// Transaction expire timestamp
+export const DEFAULT_TXN_EXP_SEC_FROM_NOW = 20;
+// How long does SDK wait for txn to finish
+export const DEFAULT_TXN_TIMEOUT_SEC = 20;
+export const APTOS_COIN = "0x1::aptos_coin::AptosCoin";
+
+export const CUSTOM_REQUEST_HEADER = { "x-aptos-client": `aptos-ts-sdk/${VERSION}` };

--- a/ecosystem/typescript/sdk_v2/tests/unit/abi.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/abi.test.ts
@@ -1,0 +1,67 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { HexString } from "../../src/utils/hex_string";
+import { Deserializer, Serializer } from "../../src/bcs";
+import { ScriptABI, EntryFunctionABI, TransactionScriptABI, ArgumentABI } from "../../src/aptos_types";
+import { TypeTagAddress, TypeTagU64 } from "../../src/aptos_types";
+import { ModuleId } from "../../src/aptos_types";
+
+// eslint-disable-next-line operator-linebreak
+const SCRIPT_FUNCTION_ABI =
+  // eslint-disable-next-line max-len
+  "010E6372656174655F6163636F756E740000000000000000000000000000000000000000000000000000000000000001074163636F756E7420204261736963206163636F756E74206372656174696F6E206D6574686F64732E000108617574685F6B657904";
+
+// eslint-disable-next-line operator-linebreak
+const TRANSACTION_SCRIPT_ABI =
+  // eslint-disable-next-line max-len
+  "00046D61696E0F20412074657374207363726970742E8B01A11CEB0B050000000501000403040A050E0B071924083D200000000101020301000003010400020C0301050001060C0101074163636F756E74065369676E65720A616464726573735F6F66096578697374735F617400000000000000000000000000000000000000000000000000000000000000010000010A0E0011000C020B021101030705090B0127020001016902";
+
+describe("ABI", () => {
+  it("parses create_account successfully", async () => {
+    const name = "create_account";
+    const doc = " Basic account creation methods.";
+    const typeArgABIs = [new ArgumentABI("auth_key", new TypeTagAddress())];
+
+    const abi = new EntryFunctionABI(name, ModuleId.fromStr("0x1::Account"), doc, [], typeArgABIs);
+    const serializer = new Serializer();
+    abi.serialize(serializer);
+    expect(HexString.fromUint8Array(serializer.getBytes()).noPrefix()).toBe(SCRIPT_FUNCTION_ABI.toLowerCase());
+
+    const deserializer = new Deserializer(new HexString(SCRIPT_FUNCTION_ABI).toUint8Array());
+    const entryFunctionABI = ScriptABI.deserialize(deserializer) as EntryFunctionABI;
+    const { address: moduleAddress, name: moduleName } = entryFunctionABI.module_name;
+    expect(entryFunctionABI.name).toBe("create_account");
+    expect(HexString.fromUint8Array(moduleAddress.address).toShortString()).toBe("0x1");
+    expect(moduleName.value).toBe("Account");
+    expect(entryFunctionABI.doc.trim()).toBe("Basic account creation methods.");
+
+    const arg = entryFunctionABI.args[0];
+    expect(arg.name).toBe("auth_key");
+    expect(arg.type_tag instanceof TypeTagAddress).toBeTruthy();
+  });
+
+  it("parses script abi successfully", async () => {
+    const name = "main";
+    // eslint-disable-next-line max-len
+    const code =
+      "0xa11ceb0b050000000501000403040a050e0b071924083d200000000101020301000003010400020c0301050001060c0101074163636f756e74065369676e65720a616464726573735f6f66096578697374735f617400000000000000000000000000000000000000000000000000000000000000010000010a0e0011000c020b021101030705090b012702";
+    const doc = " A test script.";
+    const typeArgABIs = [new ArgumentABI("i", new TypeTagU64())];
+    const abi = new TransactionScriptABI(name, doc, HexString.ensure(code).toUint8Array(), [], typeArgABIs);
+    const serializer = new Serializer();
+    abi.serialize(serializer);
+    expect(HexString.fromUint8Array(serializer.getBytes()).noPrefix()).toBe(TRANSACTION_SCRIPT_ABI.toLowerCase());
+
+    const deserializer = new Deserializer(new HexString(TRANSACTION_SCRIPT_ABI).toUint8Array());
+    const transactionScriptABI = ScriptABI.deserialize(deserializer) as TransactionScriptABI;
+    expect(transactionScriptABI.name).toBe("main");
+    expect(transactionScriptABI.doc.trim()).toBe("A test script.");
+
+    expect(HexString.fromUint8Array(transactionScriptABI.code).hex()).toBe(code);
+
+    const arg = transactionScriptABI.args[0];
+    expect(arg.name).toBe("i");
+    expect(arg.type_tag instanceof TypeTagU64).toBeTruthy();
+  });
+});

--- a/ecosystem/typescript/sdk_v2/tests/unit/account_address_old.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/account_address_old.test.ts
@@ -1,0 +1,88 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { AccountAddress } from "../../src/aptos_types";
+
+const ADDRESS_LONG = "000000000000000000000000000000000000000000000000000000000a550c18";
+const ADDRESS_SHORT = "a550c18";
+
+describe("AccountAddress", () => {
+  it("gets created from full hex string", async () => {
+    const addr = AccountAddress.fromHex(ADDRESS_LONG);
+    expect(Buffer.from(addr.address).toString("hex")).toBe(ADDRESS_LONG);
+  });
+
+  it("gets created from short hex string", async () => {
+    const addr = AccountAddress.fromHex(ADDRESS_SHORT);
+    expect(Buffer.from(addr.address).toString("hex")).toBe(ADDRESS_LONG);
+  });
+
+  it("gets created from prefixed full hex string", async () => {
+    const addr = AccountAddress.fromHex(`0x${ADDRESS_LONG}`);
+    expect(Buffer.from(addr.address).toString("hex")).toBe(ADDRESS_LONG);
+  });
+
+  it("gets created from prefixed short hex string", async () => {
+    const addr = AccountAddress.fromHex(`0x${ADDRESS_SHORT}`);
+    expect(Buffer.from(addr.address).toString("hex")).toBe(ADDRESS_LONG);
+  });
+
+  it("gets created from prefixed short hex string with leading 0s", async () => {
+    const addr = AccountAddress.fromHex(`0x000${ADDRESS_SHORT}`);
+    expect(Buffer.from(addr.address).toString("hex")).toBe(ADDRESS_LONG);
+  });
+
+  it("throws exception when initiating from a long hex string", async () => {
+    expect(() => {
+      AccountAddress.fromHex(`1${ADDRESS_LONG}`);
+      // eslint-disable-next-line quotes
+    }).toThrow("Hex string is too long. Address's length is 32 bytes.");
+  });
+
+  it("throws exception when initiating from a long hex string", async () => {
+    expect(() => {
+      AccountAddress.fromHex(`1${ADDRESS_LONG}`);
+      // eslint-disable-next-line quotes
+    }).toThrow("Hex string is too long. Address's length is 32 bytes.");
+  });
+
+  it("isValid short with 0x", async () => {
+    expect(AccountAddress.isValid(`0x${ADDRESS_SHORT}`)).toBe(true);
+  });
+
+  it("isValid short with leading 0s 0x", async () => {
+    expect(AccountAddress.isValid(`0x000${ADDRESS_SHORT}`)).toBe(true);
+  });
+
+  it("isValid short with leading 0s 0x", async () => {
+    expect(AccountAddress.isValid(`0x000${ADDRESS_SHORT}`)).toBe(true);
+  });
+
+  it("isValid long with leading 0s without 0x", async () => {
+    expect(AccountAddress.isValid(`${ADDRESS_LONG}`)).toBe(true);
+  });
+
+  it("isValid long with leading 0s with 0x", async () => {
+    expect(AccountAddress.isValid(`0x${ADDRESS_LONG}`)).toBe(true);
+  });
+
+  it("not isValid empty string", async () => {
+    expect(AccountAddress.isValid("")).toBe(false);
+  });
+
+  it("not isValid too long without 0x", async () => {
+    expect(AccountAddress.isValid(`00${ADDRESS_LONG}`)).toBe(false);
+  });
+
+  it("not isValid too long with 0x", async () => {
+    expect(AccountAddress.isValid(`0x00${ADDRESS_LONG}`)).toBe(false);
+  });
+
+  it("standardize address", () => {
+    const validAddress = "0x08743724fea179336994e9a66cff08676e3be6f8b227450cb3148288ba20a2e5";
+    expect(AccountAddress.standardizeAddress(validAddress)).toBe(validAddress);
+
+    const invalidAddress = "0x8743724fea179336994e9a66cff08676e3be6f8b227450cb3148288ba20a2e5";
+    expect(AccountAddress.standardizeAddress(invalidAddress)).toBe(validAddress);
+  });
+});

--- a/ecosystem/typescript/sdk_v2/tests/unit/deserializer.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/deserializer.test.ts
@@ -1,0 +1,132 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Deserializer } from "../../src/bcs/deserializer";
+
+describe("BCS Deserializer", () => {
+  it("deserializes a non-empty string", () => {
+    const deserializer = new Deserializer(
+      new Uint8Array([
+        24, 0xc3, 0xa7, 0xc3, 0xa5, 0xe2, 0x88, 0x9e, 0xe2, 0x89, 0xa0, 0xc2, 0xa2, 0xc3, 0xb5, 0xc3, 0x9f, 0xe2, 0x88,
+        0x82, 0xc6, 0x92, 0xe2, 0x88, 0xab,
+      ]),
+    );
+    expect(deserializer.deserializeStr()).toBe("çå∞≠¢õß∂ƒ∫");
+  });
+
+  it("deserializes an empty string", () => {
+    const deserializer = new Deserializer(new Uint8Array([0]));
+    expect(deserializer.deserializeStr()).toBe("");
+  });
+
+  it("deserializes dynamic length bytes", () => {
+    const deserializer = new Deserializer(new Uint8Array([5, 0x41, 0x70, 0x74, 0x6f, 0x73]));
+    expect(deserializer.deserializeBytes()).toEqual(new Uint8Array([0x41, 0x70, 0x74, 0x6f, 0x73]));
+  });
+
+  it("deserializes dynamic length bytes with zero elements", () => {
+    const deserializer = new Deserializer(new Uint8Array([0]));
+    expect(deserializer.deserializeBytes()).toEqual(new Uint8Array([]));
+  });
+
+  it("deserializes fixed length bytes", () => {
+    const deserializer = new Deserializer(new Uint8Array([0x41, 0x70, 0x74, 0x6f, 0x73]));
+    expect(deserializer.deserializeFixedBytes(5)).toEqual(new Uint8Array([0x41, 0x70, 0x74, 0x6f, 0x73]));
+  });
+
+  it("deserializes fixed length bytes with zero element", () => {
+    const deserializer = new Deserializer(new Uint8Array([]));
+    expect(deserializer.deserializeFixedBytes(0)).toEqual(new Uint8Array([]));
+  });
+
+  it("deserializes a boolean value", () => {
+    let deserializer = new Deserializer(new Uint8Array([0x01]));
+    expect(deserializer.deserializeBool()).toEqual(true);
+    deserializer = new Deserializer(new Uint8Array([0x00]));
+    expect(deserializer.deserializeBool()).toEqual(false);
+  });
+
+  it("throws when deserializing a boolean with disallowed values", () => {
+    expect(() => {
+      const deserializer = new Deserializer(new Uint8Array([0x12]));
+      deserializer.deserializeBool();
+    }).toThrow("Invalid boolean value");
+  });
+
+  it("deserializes a uint8", () => {
+    const deserializer = new Deserializer(new Uint8Array([0xff]));
+    expect(deserializer.deserializeU8()).toEqual(255);
+  });
+
+  it("deserializes a uint16", () => {
+    let deserializer = new Deserializer(new Uint8Array([0xff, 0xff]));
+    expect(deserializer.deserializeU16()).toEqual(65535);
+    deserializer = new Deserializer(new Uint8Array([0x34, 0x12]));
+    expect(deserializer.deserializeU16()).toEqual(4660);
+  });
+
+  it("deserializes a uint32", () => {
+    let deserializer = new Deserializer(new Uint8Array([0xff, 0xff, 0xff, 0xff]));
+    expect(deserializer.deserializeU32()).toEqual(4294967295);
+    deserializer = new Deserializer(new Uint8Array([0x78, 0x56, 0x34, 0x12]));
+    expect(deserializer.deserializeU32()).toEqual(305419896);
+  });
+
+  it("deserializes a uint64", () => {
+    let deserializer = new Deserializer(new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]));
+    expect(deserializer.deserializeU64()).toEqual(BigInt("18446744073709551615"));
+    deserializer = new Deserializer(new Uint8Array([0x00, 0xef, 0xcd, 0xab, 0x78, 0x56, 0x34, 0x12]));
+    expect(deserializer.deserializeU64()).toEqual(BigInt("1311768467750121216"));
+  });
+
+  it("deserializes a uint128", () => {
+    let deserializer = new Deserializer(
+      new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+    );
+    expect(deserializer.deserializeU128()).toEqual(BigInt("340282366920938463463374607431768211455"));
+    deserializer = new Deserializer(
+      new Uint8Array([0x00, 0xef, 0xcd, 0xab, 0x78, 0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+    );
+    expect(deserializer.deserializeU128()).toEqual(BigInt("1311768467750121216"));
+  });
+  it("deserializes a uint256", () => {
+    let deserializer = new Deserializer(
+      new Uint8Array([
+        0x31, 0x30, 0x29, 0x28, 0x27, 0x26, 0x25, 0x24, 0x23, 0x22, 0x21, 0x20, 0x19, 0x18, 0x17, 0x16, 0x15, 0x14,
+        0x13, 0x12, 0x11, 0x10, 0x09, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00,
+      ]),
+    );
+    expect(deserializer.deserializeU256()).toEqual(
+      BigInt("0x0001020304050607080910111213141516171819202122232425262728293031"),
+    );
+  });
+
+  it("deserializes a uleb128", () => {
+    let deserializer = new Deserializer(new Uint8Array([0xcd, 0xea, 0xec, 0x31]));
+    expect(deserializer.deserializeUleb128AsU32()).toEqual(104543565);
+
+    deserializer = new Deserializer(new Uint8Array([0xff, 0xff, 0xff, 0xff, 0x0f]));
+    expect(deserializer.deserializeUleb128AsU32()).toEqual(4294967295);
+  });
+
+  it("throws when deserializing a uleb128 with out ranged value", () => {
+    expect(() => {
+      const deserializer = new Deserializer(new Uint8Array([0x80, 0x80, 0x80, 0x80, 0x10]));
+      deserializer.deserializeUleb128AsU32();
+    }).toThrow("Overflow while parsing uleb128-encoded uint32 value");
+  });
+
+  it("throws when deserializing against buffer that has been drained", () => {
+    expect(() => {
+      const deserializer = new Deserializer(
+        new Uint8Array([
+          24, 0xc3, 0xa7, 0xc3, 0xa5, 0xe2, 0x88, 0x9e, 0xe2, 0x89, 0xa0, 0xc2, 0xa2, 0xc3, 0xb5, 0xc3, 0x9f, 0xe2,
+          0x88, 0x82, 0xc6, 0x92, 0xe2, 0x88, 0xab,
+        ]),
+      );
+
+      deserializer.deserializeStr();
+      deserializer.deserializeStr();
+    }).toThrow("Reached to the end of buffer");
+  });
+});

--- a/ecosystem/typescript/sdk_v2/tests/unit/multi_ed25519.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/multi_ed25519.test.ts
@@ -1,0 +1,111 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable max-len */
+import { HexString } from "../../src/utils/hex_string";
+import { Serializer, Deserializer } from "../../src/bcs";
+import { Ed25519PublicKey, Ed25519Signature } from "../../src/aptos_types";
+import { MultiEd25519PublicKey, MultiEd25519Signature } from "../../src/aptos_types";
+
+describe("MultiEd25519", () => {
+  it("public key serializes to bytes correctly", async () => {
+    const publicKey1 = "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200";
+    const publicKey2 = "aef3f4a4b8eca1dfc343361bf8e436bd42de9259c04b8314eb8e2054dd6e82ab";
+    const publicKey3 = "8a5762e21ac1cdb3870442c77b4c3af58c7cedb8779d0270e6d4f1e2f7367d74";
+
+    const pubKeyMultiSig = new MultiEd25519PublicKey(
+      [
+        new Ed25519PublicKey(new HexString(publicKey1).toUint8Array()),
+        new Ed25519PublicKey(new HexString(publicKey2).toUint8Array()),
+        new Ed25519PublicKey(new HexString(publicKey3).toUint8Array()),
+      ],
+      2,
+    );
+
+    expect(HexString.fromUint8Array(pubKeyMultiSig.toBytes()).noPrefix()).toEqual(
+      "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200aef3f4a4b8eca1dfc343361bf8e436bd42de9259c04b8314eb8e2054dd6e82ab8a5762e21ac1cdb3870442c77b4c3af58c7cedb8779d0270e6d4f1e2f7367d7402",
+    );
+  });
+
+  it("public key deserializes from bytes correctly", async () => {
+    const publicKey1 = "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200";
+    const publicKey2 = "aef3f4a4b8eca1dfc343361bf8e436bd42de9259c04b8314eb8e2054dd6e82ab";
+    const publicKey3 = "8a5762e21ac1cdb3870442c77b4c3af58c7cedb8779d0270e6d4f1e2f7367d74";
+
+    const pubKeyMultiSig = new MultiEd25519PublicKey(
+      [
+        new Ed25519PublicKey(new HexString(publicKey1).toUint8Array()),
+        new Ed25519PublicKey(new HexString(publicKey2).toUint8Array()),
+        new Ed25519PublicKey(new HexString(publicKey3).toUint8Array()),
+      ],
+      2,
+    );
+    const deserialzed = MultiEd25519PublicKey.deserialize(new Deserializer(Serializer.toBCSBytes(pubKeyMultiSig)));
+    expect(HexString.fromUint8Array(deserialzed.toBytes()).noPrefix()).toEqual(
+      HexString.fromUint8Array(pubKeyMultiSig.toBytes()).noPrefix(),
+    );
+  });
+
+  it("signature serializes to bytes correctly", async () => {
+    // eslint-disable-next-line operator-linebreak
+    const sig1 =
+      "e6f3ba05469b2388492397840183945d4291f0dd3989150de3248e06b4cefe0ddf6180a80a0f04c045ee8f362870cb46918478cd9b56c66076f94f3efd5a8805";
+    // eslint-disable-next-line operator-linebreak
+    const sig2 =
+      "2ae0818b7e51b853f1e43dc4c89a1f5fabc9cb256030a908f9872f3eaeb048fb1e2b4ffd5a9d5d1caedd0c8b7d6155ed8071e913536fa5c5a64327b6f2d9a102";
+    const bitmap = "c0000000";
+
+    const multisig = new MultiEd25519Signature(
+      [
+        new Ed25519Signature(new HexString(sig1).toUint8Array()),
+        new Ed25519Signature(new HexString(sig2).toUint8Array()),
+      ],
+      new HexString(bitmap).toUint8Array(),
+    );
+
+    expect(HexString.fromUint8Array(multisig.toBytes()).noPrefix()).toEqual(
+      "e6f3ba05469b2388492397840183945d4291f0dd3989150de3248e06b4cefe0ddf6180a80a0f04c045ee8f362870cb46918478cd9b56c66076f94f3efd5a88052ae0818b7e51b853f1e43dc4c89a1f5fabc9cb256030a908f9872f3eaeb048fb1e2b4ffd5a9d5d1caedd0c8b7d6155ed8071e913536fa5c5a64327b6f2d9a102c0000000",
+    );
+  });
+
+  it("signature deserializes from bytes correctly", async () => {
+    // eslint-disable-next-line operator-linebreak
+    const sig1 =
+      "e6f3ba05469b2388492397840183945d4291f0dd3989150de3248e06b4cefe0ddf6180a80a0f04c045ee8f362870cb46918478cd9b56c66076f94f3efd5a8805";
+    // eslint-disable-next-line operator-linebreak
+    const sig2 =
+      "2ae0818b7e51b853f1e43dc4c89a1f5fabc9cb256030a908f9872f3eaeb048fb1e2b4ffd5a9d5d1caedd0c8b7d6155ed8071e913536fa5c5a64327b6f2d9a102";
+    const bitmap = "c0000000";
+
+    const multisig = new MultiEd25519Signature(
+      [
+        new Ed25519Signature(new HexString(sig1).toUint8Array()),
+        new Ed25519Signature(new HexString(sig2).toUint8Array()),
+      ],
+      new HexString(bitmap).toUint8Array(),
+    );
+
+    const deserialzed = MultiEd25519Signature.deserialize(new Deserializer(Serializer.toBCSBytes(multisig)));
+    expect(HexString.fromUint8Array(deserialzed.toBytes()).noPrefix()).toEqual(
+      HexString.fromUint8Array(multisig.toBytes()).noPrefix(),
+    );
+  });
+
+  it("creates a valid bitmap", () => {
+    expect(MultiEd25519Signature.createBitmap([0, 2, 31])).toEqual(
+      new Uint8Array([0b10100000, 0b00000000, 0b00000000, 0b00000001]),
+    );
+  });
+
+  it("throws exception when creating a bitmap with wrong bits", async () => {
+    expect(() => {
+      MultiEd25519Signature.createBitmap([32]);
+    }).toThrow("Invalid bit value 32.");
+  });
+
+  it("throws exception when creating a bitmap with duplicate bits", async () => {
+    expect(() => {
+      MultiEd25519Signature.createBitmap([2, 2]);
+    }).toThrow("Duplicated bits detected.");
+  });
+});

--- a/ecosystem/typescript/sdk_v2/tests/unit/serializer.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/serializer.test.ts
@@ -209,10 +209,19 @@ describe("BCS Serializer", () => {
 
   it("serializes multiple Serializable values", () => {
     class MoveStructA implements Serializable {
-      constructor(public name: string, public description: string, public numbers: Array<number>) {}
+      constructor(
+        public name: string,
+        public description: string,
+        public enabled: boolean,
+        public numbers: Array<number>,
+      ) {}
 
       serialize(serializer: Serializer): void {
-        serializer.serializeStr(this.name).serializeStr(this.description).serializeBytes(new Uint8Array(this.numbers));
+        serializer
+          .serializeStr(this.name)
+          .serializeStr(this.description)
+          .serializeBool(this.enabled)
+          .serializeBytes(new Uint8Array(this.numbers));
       }
     }
     class MoveStructB implements Serializable {
@@ -232,15 +241,14 @@ describe("BCS Serializer", () => {
       }
     }
 
-    const moveStructA = new MoveStructA("abc", "123", [1, 2, 3, 4]);
+    const moveStructA = new MoveStructA("abc", "123", false, [1, 2, 3, 4]);
     const moveStructB = new MoveStructB(moveStructA, "def", "456", [5, 6, 7, 8]);
 
-    // Serialize a string, a u64 number, and a MoveStruct.
     const serializedBytes = serializer.serialize(moveStructB).getBytes();
 
     expect(serializedBytes).toEqual(
       new Uint8Array([
-        3, 0x61, 0x62, 0x63, 3, 0x31, 0x32, 0x33, 4, 0x01, 0x02, 0x03, 0x04, 3, 0x64, 0x65, 0x66, 3, 0x34, 0x35, 0x36,
+        3, 0x61, 0x62, 0x63, 3, 0x31, 0x32, 0x33, 0x00, 4, 0x01, 0x02, 0x03, 0x04, 3, 0x64, 0x65, 0x66, 3, 0x34, 0x35, 0x36,
         4, 0x05, 0x06, 0x07, 0x08,
       ]),
     );

--- a/ecosystem/typescript/sdk_v2/tests/unit/serializer.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/serializer.test.ts
@@ -1,0 +1,179 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Serializer } from "../../src/bcs/serializer";
+
+describe("BCS Serializer", () => {
+  let serializer: Serializer;
+
+  beforeEach(() => {
+    serializer = new Serializer();
+  });
+
+  it("serializes a non-empty string", () => {
+    serializer.serializeStr("çå∞≠¢õß∂ƒ∫");
+    expect(serializer.getBytes()).toEqual(
+      new Uint8Array([
+        24, 0xc3, 0xa7, 0xc3, 0xa5, 0xe2, 0x88, 0x9e, 0xe2, 0x89, 0xa0, 0xc2, 0xa2, 0xc3, 0xb5, 0xc3, 0x9f, 0xe2, 0x88,
+        0x82, 0xc6, 0x92, 0xe2, 0x88, 0xab,
+      ]),
+    );
+  });
+
+  it("serializes an empty string", () => {
+    serializer.serializeStr("");
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0]));
+  });
+
+  it("serializes dynamic length bytes", () => {
+    serializer.serializeBytes(new Uint8Array([0x41, 0x70, 0x74, 0x6f, 0x73]));
+    expect(serializer.getBytes()).toEqual(new Uint8Array([5, 0x41, 0x70, 0x74, 0x6f, 0x73]));
+  });
+
+  it("serializes dynamic length bytes with zero elements", () => {
+    serializer.serializeBytes(new Uint8Array([]));
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0]));
+  });
+
+  it("serializes fixed length bytes", () => {
+    serializer.serializeFixedBytes(new Uint8Array([0x41, 0x70, 0x74, 0x6f, 0x73]));
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0x41, 0x70, 0x74, 0x6f, 0x73]));
+  });
+
+  it("serializes fixed length bytes with zero element", () => {
+    serializer.serializeFixedBytes(new Uint8Array([]));
+    expect(serializer.getBytes()).toEqual(new Uint8Array([]));
+  });
+
+  it("serializes a boolean value", () => {
+    serializer.serializeBool(true);
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0x01]));
+
+    serializer = new Serializer();
+    serializer.serializeBool(false);
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0x00]));
+  });
+
+  it("throws when serializing a boolean value with wrong data type", () => {
+    expect(() => {
+      // @ts-ignore
+      serializer.serializeBool(12);
+    }).toThrow("Value needs to be a boolean");
+  });
+
+  it("serializes a uint8", () => {
+    serializer.serializeU8(255);
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0xff]));
+  });
+
+  it("throws when serializing uint8 with out of range value", () => {
+    expect(() => {
+      serializer.serializeU8(256);
+    }).toThrow("Value is out of range");
+
+    expect(() => {
+      serializer = new Serializer();
+      serializer.serializeU8(-1);
+    }).toThrow("Value is out of range");
+  });
+
+  it("serializes a uint16", () => {
+    serializer.serializeU16(65535);
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0xff, 0xff]));
+
+    serializer = new Serializer();
+    serializer.serializeU16(4660);
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0x34, 0x12]));
+  });
+
+  it("throws when serializing uint16 with out of range value", () => {
+    expect(() => {
+      serializer.serializeU16(65536);
+    }).toThrow("Value is out of range");
+
+    expect(() => {
+      serializer = new Serializer();
+      serializer.serializeU16(-1);
+    }).toThrow("Value is out of range");
+  });
+
+  it("serializes a uint32", () => {
+    serializer.serializeU32(4294967295);
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0xff, 0xff, 0xff, 0xff]));
+
+    serializer = new Serializer();
+    serializer.serializeU32(305419896);
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0x78, 0x56, 0x34, 0x12]));
+  });
+
+  it("throws when serializing uint32 with out of range value", () => {
+    expect(() => {
+      serializer.serializeU32(4294967296);
+    }).toThrow("Value is out of range");
+
+    expect(() => {
+      serializer = new Serializer();
+      serializer.serializeU32(-1);
+    }).toThrow("Value is out of range");
+  });
+
+  it("serializes a uint64", () => {
+    serializer.serializeU64(BigInt("18446744073709551615"));
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]));
+
+    serializer = new Serializer();
+    serializer.serializeU64(BigInt("1311768467750121216"));
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0x00, 0xef, 0xcd, 0xab, 0x78, 0x56, 0x34, 0x12]));
+  });
+
+  it("throws when serializing uint64 with out of range value", () => {
+    expect(() => {
+      serializer.serializeU64(BigInt("18446744073709551616"));
+    }).toThrow("Value is out of range");
+
+    expect(() => {
+      serializer = new Serializer();
+      serializer.serializeU64(-1);
+    }).toThrow("Value is out of range");
+  });
+
+  it("serializes a uint128", () => {
+    serializer.serializeU128(BigInt("340282366920938463463374607431768211455"));
+    expect(serializer.getBytes()).toEqual(
+      new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+    );
+
+    serializer = new Serializer();
+    serializer.serializeU128(BigInt("1311768467750121216"));
+    expect(serializer.getBytes()).toEqual(
+      new Uint8Array([0x00, 0xef, 0xcd, 0xab, 0x78, 0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+    );
+  });
+
+  it("throws when serializing uint128 with out of range value", () => {
+    expect(() => {
+      serializer.serializeU128(BigInt("340282366920938463463374607431768211456"));
+    }).toThrow("Value is out of range");
+
+    expect(() => {
+      serializer = new Serializer();
+      serializer.serializeU128(-1);
+    }).toThrow("Value is out of range");
+  });
+
+  it("serializes a uleb128", () => {
+    serializer.serializeU32AsUleb128(104543565);
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0xcd, 0xea, 0xec, 0x31]));
+  });
+
+  it("throws when serializing uleb128 with out of range value", () => {
+    expect(() => {
+      serializer.serializeU32AsUleb128(4294967296);
+    }).toThrow("Value is out of range");
+
+    expect(() => {
+      serializer = new Serializer();
+      serializer.serializeU32AsUleb128(-1);
+    }).toThrow("Value is out of range");
+  });
+});

--- a/ecosystem/typescript/sdk_v2/tests/unit/serializer.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/serializer.test.ts
@@ -30,12 +30,12 @@ describe("BCS Serializer", () => {
   });
 
   it("serializes dynamic length bytes", () => {
-    serializer.serializeBytes(new Uint8Array([0x41, 0x70, 0x74, 0x6f, 0x73]));
+    serializer.serializeByteVector(new Uint8Array([0x41, 0x70, 0x74, 0x6f, 0x73]));
     expect(serializer.getBytes()).toEqual(new Uint8Array([5, 0x41, 0x70, 0x74, 0x6f, 0x73]));
   });
 
   it("serializes dynamic length bytes with zero elements", () => {
-    serializer.serializeBytes(new Uint8Array([]));
+    serializer.serializeByteVector(new Uint8Array([]));
     expect(serializer.getBytes()).toEqual(new Uint8Array([0]));
   });
 
@@ -183,7 +183,7 @@ describe("BCS Serializer", () => {
 
   it("serializes multiple values procedurally", () => {
     const serializedBytes = serializer
-      .serializeBytes(new Uint8Array([0x41, 0x70, 0x74, 0x6f, 0x73]))
+      .serializeByteVector(new Uint8Array([0x41, 0x70, 0x74, 0x6f, 0x73]))
       .serializeBool(true)
       .serializeBool(false)
       .serializeU8(254)
@@ -221,7 +221,7 @@ describe("BCS Serializer", () => {
           .serializeStr(this.name)
           .serializeStr(this.description)
           .serializeBool(this.enabled)
-          .serializeBytes(new Uint8Array(this.numbers));
+          .serializeByteVector(new Uint8Array(this.numbers));
       }
     }
     class MoveStructB implements Serializable {
@@ -237,7 +237,7 @@ describe("BCS Serializer", () => {
           .serialize(this.moveStructA)
           .serializeStr(this.name)
           .serializeStr(this.description)
-          .serializeBytes(new Uint8Array(this.numbers));
+          .serializeByteVector(new Uint8Array(this.numbers));
       }
     }
 

--- a/ecosystem/typescript/sdk_v2/tests/unit/transaction_builder.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/transaction_builder.test.ts
@@ -1,0 +1,337 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable max-len */
+import nacl from "tweetnacl";
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
+import { Serializer } from "../../src/bcs";
+import { HexString } from "../../src/utils/hex_string";
+
+import { TransactionBuilderEd25519, TransactionBuilder } from "../../src/transaction_builder/builder";
+import {
+    ChainId,
+    Ed25519Signature,
+    RawTransaction,
+    Script,
+    EntryFunction,
+    StructTag,
+    TransactionArgumentAddress,
+    TransactionArgumentU8,
+    TransactionArgumentU8Vector,
+    TransactionPayloadScript,
+    TransactionPayloadEntryFunction,
+    TypeTagStruct,
+    TransactionArgumentU16,
+    TransactionArgumentU32,
+    TransactionArgumentU256,
+    AccountAddress,
+    TypeTagBool,
+} from "../../src/aptos_types";
+
+const ADDRESS_1 = "0x1222";
+const ADDRESS_2 = "0xdd";
+const ADDRESS_3 = "0x0a550c18";
+const ADDRESS_4 = "0x01";
+const PRIVATE_KEY = "9bf49a6a0755f953811fce125f2683d50429c3bb49e074147e0089a52eae155f";
+const TXN_EXPIRE = "18446744073709551615";
+
+function hexSignedTxn(signedTxn: Uint8Array): string {
+    return bytesToHex(signedTxn);
+}
+
+function sign(rawTxn: RawTransaction): Uint8Array {
+    const privateKeyBytes = new HexString(PRIVATE_KEY).toUint8Array();
+    const signingKey = nacl.sign.keyPair.fromSeed(privateKeyBytes.slice(0, 32));
+    const { publicKey } = signingKey;
+
+    const txnBuilder = new TransactionBuilderEd25519(
+        (signingMessage) => new Ed25519Signature(nacl.sign(signingMessage, signingKey.secretKey).slice(0, 64)),
+        publicKey,
+    );
+
+    return txnBuilder.sign(rawTxn);
+}
+
+test("throws when preparing signing message with invalid payload", () => {
+    expect(() => {
+        // @ts-ignore
+        TransactionBuilder.getSigningMessage("invalid");
+    }).toThrow("Unknown transaction type.");
+});
+
+test("gets the signing message", () => {
+    const entryFunctionPayload = new TransactionPayloadEntryFunction(
+        EntryFunction.natural(
+            `${ADDRESS_1}::aptos_coin`,
+            "transfer",
+            [],
+            [
+                new Serializer().serialize(AccountAddress.fromHex(ADDRESS_2)).getBytes(),
+                new Serializer().serializeU64(1).getBytes(),
+            ],
+        ),
+    );
+
+    const rawTxn = new RawTransaction(
+        AccountAddress.fromHex(new HexString(ADDRESS_3)),
+        BigInt(0),
+        entryFunctionPayload,
+        BigInt(2000),
+        BigInt(0),
+        BigInt(TXN_EXPIRE),
+        new ChainId(4),
+    );
+
+    const message = TransactionBuilder.getSigningMessage(rawTxn);
+
+    expect(message instanceof Uint8Array).toBeTruthy();
+
+    expect(HexString.fromUint8Array(message).hex()).toBe(
+        "0xb5e97db07fa0bd0e5598aa3643a9bc6f6693bddc1a9fec9e674a461eaa00b193000000000000000000000000000000000000000000000000000000000a550c1800000000000000000200000000000000000000000000000000000000000000000000000000000012220a6170746f735f636f696e087472616e7366657200022000000000000000000000000000000000000000000000000000000000000000dd080100000000000000d0070000000000000000000000000000ffffffffffffffff04",
+    );
+});
+
+test("serialize entry function payload with no type args", () => {
+    const entryFunctionPayload = new TransactionPayloadEntryFunction(
+        EntryFunction.natural(
+            `${ADDRESS_1}::aptos_coin`,
+            "transfer",
+            [],
+            [
+                new Serializer().serialize(AccountAddress.fromHex(ADDRESS_2)).getBytes(),
+                new Serializer().serializeU64(1).getBytes(),
+            ],
+        ),
+    );
+
+    const rawTxn = new RawTransaction(
+        AccountAddress.fromHex(new HexString(ADDRESS_3)),
+        BigInt(0),
+        entryFunctionPayload,
+        BigInt(2000),
+        BigInt(0),
+        BigInt(TXN_EXPIRE),
+        new ChainId(4),
+    );
+
+    const signedTxn = sign(rawTxn);
+
+    expect(hexSignedTxn(signedTxn)).toBe(
+        "000000000000000000000000000000000000000000000000000000000a550c1800000000000000000200000000000000000000000000000000000000000000000000000000000012220a6170746f735f636f696e087472616e7366657200022000000000000000000000000000000000000000000000000000000000000000dd080100000000000000d0070000000000000000000000000000ffffffffffffffff040020b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200409c570996380897f38b8d7008d726fb45d6ded0689216e56b73f523492cba92deb6671c27e9a44d2a6fdfdb497420d00c621297a23d6d0298895e0d58cff6060c",
+    );
+});
+
+test("serialize entry function payload with type args", () => {
+    const token = new TypeTagStruct(StructTag.fromString(`${ADDRESS_4}::aptos_coin::AptosCoin`));
+
+    const entryFunctionPayload = new TransactionPayloadEntryFunction(
+        EntryFunction.natural(
+            `${ADDRESS_1}::coin`,
+            "transfer",
+            [token],
+            [
+                new Serializer().serialize(AccountAddress.fromHex(ADDRESS_2)).getBytes(),
+                new Serializer().serializeU64(1).getBytes(),
+            ],
+        ),
+    );
+
+    const rawTxn = new RawTransaction(
+        AccountAddress.fromHex(ADDRESS_3),
+        BigInt(0),
+        entryFunctionPayload,
+        BigInt(2000),
+        BigInt(0),
+        BigInt(TXN_EXPIRE),
+        new ChainId(4),
+    );
+
+    const signedTxn = sign(rawTxn);
+
+    expect(hexSignedTxn(signedTxn)).toBe(
+        "000000000000000000000000000000000000000000000000000000000a550c18000000000000000002000000000000000000000000000000000000000000000000000000000000122204636f696e087472616e73666572010700000000000000000000000000000000000000000000000000000000000000010a6170746f735f636f696e094170746f73436f696e00022000000000000000000000000000000000000000000000000000000000000000dd080100000000000000d0070000000000000000000000000000ffffffffffffffff040020b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a4920040112162f543ca92b4f14c1b09b7f52894a127f5428b0d407c09c8efb3a136cff50e550aea7da1226f02571d79230b80bd79096ea0d796789ad594b8fbde695404",
+    );
+});
+
+test("serialize entry function payload with type args but no function args", () => {
+    const token = new TypeTagStruct(StructTag.fromString(`${ADDRESS_4}::aptos_coin::AptosCoin`));
+
+    const entryFunctionPayload = new TransactionPayloadEntryFunction(
+        EntryFunction.natural(`${ADDRESS_1}::coin`, "fake_func", [token], []),
+    );
+
+    const rawTxn = new RawTransaction(
+        AccountAddress.fromHex(ADDRESS_3),
+        BigInt(0),
+        entryFunctionPayload,
+        BigInt(2000),
+        BigInt(0),
+        BigInt(TXN_EXPIRE),
+        new ChainId(4),
+    );
+
+    const signedTxn = sign(rawTxn);
+
+    expect(hexSignedTxn(signedTxn)).toBe(
+        "000000000000000000000000000000000000000000000000000000000a550c18000000000000000002000000000000000000000000000000000000000000000000000000000000122204636f696e0966616b655f66756e63010700000000000000000000000000000000000000000000000000000000000000010a6170746f735f636f696e094170746f73436f696e0000d0070000000000000000000000000000ffffffffffffffff040020b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200400e2d1cc4a27893cbae36d8b6a7150977c7620e065f359840413c5478a25f20a383250a9cdcb4fd71f7d171856f38972da30a9d10072e164614d96379004aa500",
+    );
+});
+
+test("serialize entry function payload with generic type args and function args", () => {
+    const token = new TypeTagStruct(StructTag.fromString(`0x14::token::Token`));
+
+    const entryFunctionPayload = new TransactionPayloadEntryFunction(
+        EntryFunction.natural(
+            `${ADDRESS_1}::aptos_token`,
+            "fake_typed_func",
+            [token, new TypeTagBool()],
+            [
+                new Serializer().serialize(AccountAddress.fromHex(ADDRESS_2)).getBytes(),
+                new Serializer().serializeBool(true).getBytes(),
+            ],
+        ),
+    );
+
+    const rawTxn = new RawTransaction(
+        AccountAddress.fromHex(ADDRESS_3),
+        BigInt(0),
+        entryFunctionPayload,
+        BigInt(2000),
+        BigInt(0),
+        BigInt(TXN_EXPIRE),
+        new ChainId(4),
+    );
+
+    const signedTxn = sign(rawTxn);
+
+    expect(hexSignedTxn(signedTxn)).toBe(
+        "000000000000000000000000000000000000000000000000000000000a550c1800000000000000000200000000000000000000000000000000000000000000000000000000000012220b6170746f735f746f6b656e0f66616b655f74797065645f66756e630207000000000000000000000000000000000000000000000000000000000000001405746f6b656e05546f6b656e0000022000000000000000000000000000000000000000000000000000000000000000dd0101d0070000000000000000000000000000ffffffffffffffff040020b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a4920040367085186aeef58a0256fc64ecb86b88a86f8a8e42151e0e9aae1ab6d426c4968f2cab664261ea6bb868869154fe6e946c082774741d5143e57a1d802fd1b700",
+    );
+});
+
+test("serialize script payload with no type args and no function args", () => {
+    const script = hexToBytes("a11ceb0b030000000105000100000000050601000000000000000600000000000000001a0102");
+
+    const scriptPayload = new TransactionPayloadScript(new Script(script, [], []));
+
+    const rawTxn = new RawTransaction(
+        AccountAddress.fromHex(ADDRESS_3),
+        BigInt(0),
+        scriptPayload,
+        BigInt(2000),
+        BigInt(0),
+        BigInt(TXN_EXPIRE),
+        new ChainId(4),
+    );
+
+    const signedTxn = sign(rawTxn);
+
+    expect(hexSignedTxn(signedTxn)).toBe(
+        "000000000000000000000000000000000000000000000000000000000a550c1800000000000000000026a11ceb0b030000000105000100000000050601000000000000000600000000000000001a01020000d0070000000000000000000000000000ffffffffffffffff040020b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a4920040266935990105df40f3a82a3f41ad9ceb4b79451495403dd976191382bb07f8c9b401702968a64b5176762e62036f75c6fc2b770a0988716e41d469fff2349a08",
+    );
+});
+
+test("serialize script payload with type args but no function args", () => {
+    const token = new TypeTagStruct(StructTag.fromString(`${ADDRESS_4}::aptos_coin::AptosCoin`));
+
+    const script = hexToBytes("a11ceb0b030000000105000100000000050601000000000000000600000000000000001a0102");
+
+    const scriptPayload = new TransactionPayloadScript(new Script(script, [token], []));
+
+    const rawTxn = new RawTransaction(
+        AccountAddress.fromHex(ADDRESS_3),
+        BigInt(0),
+        scriptPayload,
+        BigInt(2000),
+        BigInt(0),
+        BigInt(TXN_EXPIRE),
+        new ChainId(4),
+    );
+
+    const signedTxn = sign(rawTxn);
+
+    expect(hexSignedTxn(signedTxn)).toBe(
+        "000000000000000000000000000000000000000000000000000000000a550c1800000000000000000026a11ceb0b030000000105000100000000050601000000000000000600000000000000001a0102010700000000000000000000000000000000000000000000000000000000000000010a6170746f735f636f696e094170746f73436f696e0000d0070000000000000000000000000000ffffffffffffffff040020b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a4920040bd241a6f31dfdfca0031ca5874fbf81800b5f632642321a11c41b4fead4b41d808617e91dd655fde7e9f263127f07bb5d56c7c925fe797728dcc9b55be120604",
+    );
+});
+
+test("serialize script payload with type arg and function arg", () => {
+    const token = new TypeTagStruct(StructTag.fromString(`${ADDRESS_4}::aptos_coin::AptosCoin`));
+
+    const argU8 = new TransactionArgumentU8(2);
+
+    const script = hexToBytes("a11ceb0b030000000105000100000000050601000000000000000600000000000000001a0102");
+
+    const scriptPayload = new TransactionPayloadScript(new Script(script, [token], [argU8]));
+    const rawTxn = new RawTransaction(
+        AccountAddress.fromHex(ADDRESS_3),
+        BigInt(0),
+        scriptPayload,
+        BigInt(2000),
+        BigInt(0),
+        BigInt(TXN_EXPIRE),
+        new ChainId(4),
+    );
+
+    const signedTxn = sign(rawTxn);
+
+    expect(hexSignedTxn(signedTxn)).toBe(
+        "000000000000000000000000000000000000000000000000000000000a550c1800000000000000000026a11ceb0b030000000105000100000000050601000000000000000600000000000000001a0102010700000000000000000000000000000000000000000000000000000000000000010a6170746f735f636f696e094170746f73436f696e00010002d0070000000000000000000000000000ffffffffffffffff040020b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200409936b8d22cec685e720761f6c6135e020911f1a26e220e2a0f3317f5a68942531987259ac9e8688158c77df3e7136637056047d9524edad88ee45d61a9346602",
+    );
+});
+
+test("serialize script payload with one type arg and two function args", () => {
+    const token = new TypeTagStruct(StructTag.fromString(`${ADDRESS_4}::aptos_coin::AptosCoin`));
+
+    const bcsU64 = new Serializer().serializeU64(1).getBytes();
+    const argU8Vec = new TransactionArgumentU8Vector(bcsU64);
+    const argAddress = new TransactionArgumentAddress(AccountAddress.fromHex("0x01"));
+
+    const script = hexToBytes("a11ceb0b030000000105000100000000050601000000000000000600000000000000001a0102");
+
+    const scriptPayload = new TransactionPayloadScript(new Script(script, [token], [argU8Vec, argAddress]));
+
+    const rawTxn = new RawTransaction(
+        AccountAddress.fromHex(ADDRESS_3),
+        BigInt(0),
+        scriptPayload,
+        BigInt(2000),
+        BigInt(0),
+        BigInt(TXN_EXPIRE),
+        new ChainId(4),
+    );
+
+    const signedTxn = sign(rawTxn);
+
+    expect(hexSignedTxn(signedTxn)).toBe(
+        "000000000000000000000000000000000000000000000000000000000a550c1800000000000000000026a11ceb0b030000000105000100000000050601000000000000000600000000000000001a0102010700000000000000000000000000000000000000000000000000000000000000010a6170746f735f636f696e094170746f73436f696e000204080100000000000000030000000000000000000000000000000000000000000000000000000000000001d0070000000000000000000000000000ffffffffffffffff040020b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a492004055c7499795ea68d7acfa64a58f19efa2ba3b977fa58ae93ae8c0732c0f6d6dd084d92bbe4edc2a0d687031cae90da117abfac16ebd902e764bdc38a2154a2102",
+    );
+});
+
+test("serialize script payload with new integer types (u16, u32, u256) as args", () => {
+    const argU16 = new TransactionArgumentU16(0xf111);
+    const argU32 = new TransactionArgumentU32(0xf1111111);
+    const argU256 = new TransactionArgumentU256(
+        BigInt("0xf111111111111111111111111111111111111111111111111111111111111111"),
+    );
+
+    const script = hexToBytes("");
+
+    const scriptPayload = new TransactionPayloadScript(new Script(script, [], [argU16, argU32, argU256]));
+
+    const rawTxn = new RawTransaction(
+        AccountAddress.fromHex(ADDRESS_3),
+        BigInt(0),
+        scriptPayload,
+        BigInt(2000),
+        BigInt(0),
+        BigInt(TXN_EXPIRE),
+        new ChainId(4),
+    );
+
+    const signedTxn = sign(rawTxn);
+
+    expect(hexSignedTxn(signedTxn)).toBe(
+        "000000000000000000000000000000000000000000000000000000000a550c180000000000000000000000030611f107111111f10811111111111111111111111111111111111111111111111111111111111111f1d0070000000000000000000000000000ffffffffffffffff040020b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200409402b773f66cf5444efe4de38a026cf9b34e0327798ea01f0695db8e8e0888e20387b08f504b620dcffbc382e3ac141c0ec9a820c5f58b5da2eec589a9e86b0b",
+    );
+});

--- a/ecosystem/typescript/sdk_v2/tests/unit/transaction_vector.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/transaction_vector.test.ts
@@ -1,0 +1,226 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Do fuzzing tests with test vectors. The test vectors are produced by the same code
+ * used by the Aptos Blockchain. The test vectors are arrays of JSON objects.
+ * Each JSON object contains randomized inputs to Transaction Builder and BCS and
+ * the expected outputs.
+ */
+
+import path from "path";
+import nacl from "tweetnacl";
+import fs from "fs";
+import { bytesToHex } from "@noble/hashes/utils";
+import {
+  AccountAddress,
+  ChainId,
+  RawTransaction,
+  EntryFunction,
+  StructTag,
+  TypeTag,
+  TypeTagVector,
+  TransactionPayloadEntryFunction,
+  Identifier,
+  TypeTagStruct,
+  TypeTagAddress,
+  TypeTagBool,
+  TypeTagU8,
+  TypeTagU64,
+  TypeTagU128,
+  TypeTagSigner,
+  Ed25519Signature,
+  TransactionPayloadScript,
+  Script,
+  TransactionArgument,
+  TransactionArgumentBool,
+  TransactionArgumentU8,
+  TransactionArgumentU64,
+  TransactionArgumentAddress,
+  TransactionArgumentU8Vector,
+  TransactionArgumentU128,
+} from "../../src/aptos_types";
+import { HexString } from "../../src/utils/hex_string";
+import { TransactionBuilderEd25519 } from "../../src/transaction_builder/builder";
+
+// eslint-disable-next-line operator-linebreak
+const VECTOR_FILES_ROOT_DIR =
+  process.env.VECTOR_FILES_ROOT_DIR || path.resolve(__dirname, "..", "..", "..", "..", "..", "api", "goldens");
+
+const ENTRY_FUNCTION_VECTOR = path.join(
+  VECTOR_FILES_ROOT_DIR,
+  "aptos_api__tests__transaction_vector_test__test_entry_function_payload.json",
+);
+
+const SCRIPT_VECTOR = path.join(
+  VECTOR_FILES_ROOT_DIR,
+  "aptos_api__tests__transaction_vector_test__test_script_payload.json",
+);
+
+function parseTypeTag(typeTag: any): TypeTag {
+  if (typeTag.vector) {
+    return new TypeTagVector(parseTypeTag(typeTag.vector));
+  }
+
+  if (typeTag.struct) {
+    const {
+      address,
+      module,
+      name,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      type_args,
+    }: {
+      address: string;
+      module: string;
+      name: string;
+      type_args: any[];
+    } = typeTag.struct;
+
+    const typeArgs = type_args.map((arg) => parseTypeTag(arg));
+    const structTag = new StructTag(
+      AccountAddress.fromHex(address),
+      new Identifier(module),
+      new Identifier(name),
+      typeArgs,
+    );
+
+    return new TypeTagStruct(structTag);
+  }
+
+  switch (typeTag) {
+    case "bool":
+      return new TypeTagBool();
+    case "u8":
+      return new TypeTagU8();
+    case "u64":
+      return new TypeTagU64();
+    case "u128":
+      return new TypeTagU128();
+    case "address":
+      return new TypeTagAddress();
+    case "signer":
+      return new TypeTagSigner();
+    default:
+      throw new Error("Unknown type tag");
+  }
+}
+
+function parseTransactionArgument(arg: any): TransactionArgument {
+  const argHasOwnProperty = (propertyName: string) => Object.prototype.hasOwnProperty.call(arg, propertyName);
+  if (argHasOwnProperty("U8")) {
+    // arg.U8 is a number
+    return new TransactionArgumentU8(arg.U8);
+  }
+
+  if (argHasOwnProperty("U64")) {
+    // arg.U64 is a string literal
+    return new TransactionArgumentU64(BigInt(arg.U64));
+  }
+
+  if (argHasOwnProperty("U128")) {
+    // arg.U128 is a string literal
+    return new TransactionArgumentU128(BigInt(arg.U128));
+  }
+
+  if (argHasOwnProperty("Address")) {
+    // arg.Address is a hex string
+    return new TransactionArgumentAddress(AccountAddress.fromHex(arg.Address));
+  }
+
+  if (argHasOwnProperty("U8Vector")) {
+    // arg.U8Vector is a hex string
+    return new TransactionArgumentU8Vector(new HexString(arg.U8Vector).toUint8Array());
+  }
+
+  if (argHasOwnProperty("Bool")) {
+    return new TransactionArgumentBool(arg.Bool);
+  }
+
+  throw new Error("Invalid Transaction Argument");
+}
+
+function sign(rawTxn: RawTransaction, privateKey: string): string {
+  const privateKeyBytes = new HexString(privateKey).toUint8Array();
+  const signingKey = nacl.sign.keyPair.fromSeed(privateKeyBytes.slice(0, 32));
+  const { publicKey } = signingKey;
+
+  const txnBuilder = new TransactionBuilderEd25519(
+    (signingMessage) => new Ed25519Signature(nacl.sign(signingMessage, signingKey.secretKey).slice(0, 64)),
+    publicKey,
+  );
+
+  return bytesToHex(txnBuilder.sign(rawTxn));
+}
+
+type IRawTxn = {
+  // hex string for an AccountAddress
+  sender: string;
+  // u64 string literal
+  sequence_number: string;
+  // u64 string literal
+  max_gas_amount: string;
+  // u64 string literal
+  gas_unit_price: string;
+  // u64 string literal
+  expiration_timestamp_secs: string;
+
+  chain_id: number;
+};
+
+function verify(
+  raw_txn: IRawTxn,
+  payload: TransactionPayloadEntryFunction | TransactionPayloadScript,
+  private_key: string,
+  expected_output: string,
+) {
+  const rawTxn = new RawTransaction(
+    AccountAddress.fromHex(raw_txn.sender),
+    BigInt(raw_txn.sequence_number),
+    payload,
+    BigInt(raw_txn.max_gas_amount),
+    BigInt(raw_txn.gas_unit_price),
+    BigInt(raw_txn.expiration_timestamp_secs),
+    new ChainId(raw_txn.chain_id),
+  );
+
+  const signedTxn = sign(rawTxn, private_key);
+
+  expect(signedTxn).toBe(expected_output);
+}
+
+describe("Transaction builder vector test", () => {
+  it("should pass on entry function payload", () => {
+    const vector: any[] = JSON.parse(fs.readFileSync(ENTRY_FUNCTION_VECTOR, "utf8"));
+    vector.forEach(({ raw_txn, signed_txn_bcs, private_key }) => {
+      const payload = raw_txn.payload.EntryFunction;
+      const entryFunctionPayload = new TransactionPayloadEntryFunction(
+        EntryFunction.natural(
+          `${payload.module.address}::${payload.module.name}`,
+          payload.function,
+          payload.ty_args.map((tag: any) => parseTypeTag(tag)),
+          payload.args.map((arg: any) => new HexString(arg).toUint8Array()),
+        ),
+      );
+
+      verify(raw_txn, entryFunctionPayload, private_key, signed_txn_bcs);
+    });
+  });
+
+  it("should pass on script payload", () => {
+    const vector: any[] = JSON.parse(fs.readFileSync(SCRIPT_VECTOR, "utf8"));
+    vector.forEach(({ raw_txn, signed_txn_bcs, private_key }) => {
+      const payload = raw_txn.payload.Script;
+      // payload.code is hex string
+      const code = new HexString(payload.code).toUint8Array();
+      const scriptPayload = new TransactionPayloadScript(
+        new Script(
+          code,
+          payload.ty_args.map((tag: any) => parseTypeTag(tag)),
+          payload.args.map((arg: any) => parseTransactionArgument(arg)),
+        ),
+      );
+
+      verify(raw_txn, scriptPayload, private_key, signed_txn_bcs);
+    });
+  });
+});

--- a/ecosystem/typescript/sdk_v2/tsconfig.json
+++ b/ecosystem/typescript/sdk_v2/tsconfig.json
@@ -14,7 +14,7 @@
     "outDir": "./dist",
     "sourceMap": true,
     "strict": true,
-    "target": "es6"
+    "target": "es2020"
   },
   "include": ["src", "tests"]
 }


### PR DESCRIPTION
### Description

The following is a WIP. I might remove the ability to make procedural calls, but I want to finish the full loop of transaction serialization first before seeing what makes the most sense.

I've added the ability to serialize values procedurally, because it makes it much clearer to the developer that they should generally be constructing fully Serializable values and getting the bytes, rather than serializing individual fields/arguments.

I renamed `bcsToBytes` to `serialize` and put it in the `Serializable` class.  You can now chain calls to this function like so:

```typescript
    const serializedBytes = serializer
      .serializeBytes(new Uint8Array([0x41, 0x70, 0x74, 0x6f, 0x73]))
      .serializeBool(true)
      .serializeBool(false)
      .serializeU8(254)
      .serializeU8(255)
      .serializeU16(65535)
      .serializeU16(4660)
      .serializeU32(4294967295)
      .serializeU32(305419896)
      .serializeU64(BigInt("18446744073709551615"))
      .serializeU64(BigInt("1311768467750121216"))
      .serializeU128(BigInt("340282366920938463463374607431768211455"))
      .serializeU128(BigInt("1311768467750121216"))
      .getBytes();
```

You can also now call `serialize` easily on `Serializable` values:

```typescript
    class MoveStructB implements Serializable {
      constructor(
        public moveStructA: MoveStructA,
        public name: string,
        public description: string,
        public numbers: Array<number>,
      ) {}

      serialize(serializer: Serializer): void {
        serializer
          .serialize(this.moveStructA)
          .serializeStr(this.name)
          .serializeStr(this.description)
          .serializeBytes(new Uint8Array(this.numbers));
      }
    }

    // where MoveStructA is another Serializable class
    const moveStructA = new MoveStructA("abc", "123", false, [1, 2, 3, 4]);
    const moveStructB = new MoveStructB(moveStructA, "def", "456", [5, 6, 7, 8]);

    const serializedBytes = new Serializer().serialize(moveStructB).getBytes();
```

You can still do everything the old way, it's just possible to chain serialization calls now.

The plan is to discourage developers from serializing individual transaction arguments and encourage them to create Serializable classes that are more intuitive and readable.

If we do it like this, we can offer the developer two choices whenever they need to serialize a value:

1. They can use a Serializable value, and whatever function they're using serializes it for them
2. They can use a Uint8Array, and whatever function they're using assumes it is BCS serialized correctly.

WRT the transaction builder pattern, specifically for say, an entry function, the former would mean they declare and later instantiate the class to use in a payload like this:

```typescript
class MyFunctionPayload implements Serializable {
    constructor(
        public amount: number,
        public enabled: boolean,
        public description: string,
    ) {}
    
    // for standalone usage, maybe this could go in Serializer, though
    toBCSBytes(): Uint8Array {
        const serializer = new Serializer();
        this.serialize(serializer);
        return serializer.getBytes();
    }

    // for composition
    serialize(serializer: Serializer): void {
        serializer
            .serializeU64(this.amount)
            .serializeBool(this.enabled)
            .serializeStr(this.description);
    }
}

const rawTxn = new EntryFunction(
    "0x1::my_module::my_function",
    [], // type args
    new MyFunctionPayload(1, false, "hello world").toBCSBytes(),
    // or
    // new Serializer().serialize(new MyfunctionPayload(1, false, "hello world")).getBytes(),
);
```

Or in the latter case, the developer can serialize their own arguments directly in the transaction entry function call like before:

```typescript
const rawTxn = new EntryFunction(
    "0x1::some_module::some_function",
    [], // type args
    new Serializer()
        .serializeU64(numValue)
        .serializeBool(boolValue)
        .serializeStr(stringValue)
        .getBytes()
);
```

This leaves open the possibility for ABI generation with Serializable types, eventually.

We can also continue to support the ability to serialize args with the remote ABI builder, too.

TODO:

- Add unit tests for `serializeVector<T>`
- Add `deserializeVector<T>`
- Integrate `TypeTag` values, either as `TypeTag` or `MoveType` or something similar
- Add `TypeTag` serialization with `serialize` to unit tests
- Test examples of a new transaction builder that utilizes procedural serialization and composition
- Do the above with `TypeTag`
- Consider whether or not the helper functions need to be as comprehensive as the tx remote abi builder
- Add an example for serializing `StructTags/Structs` either with the old process or some new way

### Test Plan
I've added unit tests for the above in the serializer unit tests. I also included all the old unit tests.