### PR TITLE
add release step to enable AIP-32

### DIFF
--- a/aptos-move/aptos-release-builder/data/proposals/aip_32_initialization.move
+++ b/aptos-move/aptos-release-builder/data/proposals/aip_32_initialization.move
@@ -1,0 +1,15 @@
+// Initialize AIP-28 parital governance voting.
+// This script MUST be run before enabling the feature flag, otherwise emitting the fee statement will fail.
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::transaction_fee;
+
+    fun main(proposal_id: u64) {
+        let framework_signer = aptos_governance::resolve_multi_step_proposal(
+            proposal_id,
+            @0x1,
+            {{ script_hash }},
+        );
+        transaction_fee::initialize_storage_refund(&framework_signer);
+    }
+}

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -52,3 +52,16 @@ proposals:
               sender_aware_v2: 32
             block_gas_limit: 35000
             transaction_deduper_type: txn_hash_and_authenticator_v1
+  - name: enable_storage_deletion_refund
+    metadata:
+      title: "Enable Storage Deletion Refund"
+      description: "AIP-32: Storage Deletion Refund"
+      discussion_url: "https://github.com/aptos-foundation/AIPs/issues/127"
+    execution_mode: MultiStep
+    update_sequence:
+      - RawScript: aptos-move/aptos-release-builder/data/proposals/aip_32_initialization.move
+      - FeatureFlag:
+          enabled:
+            - storage_slot_metadata
+            - emit_fee_statement
+            - storage_deletion_refund


### PR DESCRIPTION
### Description
enable storage refund feature flags.

requires module events https://github.com/aptos-labs/aptos-core/pull/9811/commits/80afd5dd525a357ebc648150c84202ebaf8bbcc7

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

framework upgrade test
