### PR TITLE
Fix number of accounts in transaction benchmark

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -20,7 +20,7 @@ proposals:
       title: "Enable Block Gas Limit"
       description: "AIP-33: The block gas limit is a feature that terminates block execution when the gas consumed by the committed prefix of transactions exceeds the limit, thus providing predictable latency."
       discussion_url: "https://github.com/aptos-foundation/AIPs/issues/132"
-    execution_mode: SingleStep
+    execution_mode: MultiStep
     update_sequence:
     - Execution:
         V3:
@@ -33,7 +33,7 @@ proposals:
       title: "Enable Transaction Shuffling"
       description : "AIP-27: Sender Aware Transaction Shuffling"
       discussion_url: "https://github.com/aptos-foundation/AIPs/issues/109"
-    execution_mode: SingleStep
+    execution_mode: MultiStep
     update_sequence:
       - Execution:
           V3:

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -23,7 +23,21 @@ proposals:
     execution_mode: MultiStep
     update_sequence:
     - Execution:
-        V2:
+        V3:
           transaction_shuffler_type:
             deprecated_sender_aware_v1: 32
           block_gas_limit : 35000
+          transaction_deduper_type: txn_hash_and_authenticator_v1
+  - name: enable_transaction_shuffling
+    metadata:
+      title: "Enable Transaction Shuffling"
+      description : "AIP-33: The block gas limit is a feature that terminates block execution when the gas consumed by the committed prefix of transactions exceeds the limit, thus providing predictable latency."
+      discussion_url: "https://github.com/aptos-foundation/AIPs/issues/109"
+    execution_mode: MultiStep
+    update_sequence:
+      - Execution:
+          V3:
+            transaction_shuffler_type:
+              sender_aware_v2: 32
+            block_gas_limit: 35000
+            transaction_deduper_type: txn_hash_and_authenticator_v1

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -31,7 +31,7 @@ proposals:
   - name: enable_transaction_shuffling
     metadata:
       title: "Enable Transaction Shuffling"
-      description : "AIP-33: The block gas limit is a feature that terminates block execution when the gas consumed by the committed prefix of transactions exceeds the limit, thus providing predictable latency."
+      description : "AIP-27: Sender Aware Transaction Shuffling"
       discussion_url: "https://github.com/aptos-foundation/AIPs/issues/109"
     execution_mode: MultiStep
     update_sequence:

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -20,7 +20,7 @@ proposals:
       title: "Enable Block Gas Limit"
       description: "AIP-33: The block gas limit is a feature that terminates block execution when the gas consumed by the committed prefix of transactions exceeds the limit, thus providing predictable latency."
       discussion_url: "https://github.com/aptos-foundation/AIPs/issues/132"
-    execution_mode: MultiStep
+    execution_mode: SingleStep
     update_sequence:
     - Execution:
         V3:
@@ -33,7 +33,7 @@ proposals:
       title: "Enable Transaction Shuffling"
       description : "AIP-27: Sender Aware Transaction Shuffling"
       discussion_url: "https://github.com/aptos-foundation/AIPs/issues/109"
-    execution_mode: MultiStep
+    execution_mode: SingleStep
     update_sequence:
       - Execution:
           V3:

--- a/aptos-move/aptos-transaction-benchmarks/src/main.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/main.rs
@@ -58,13 +58,13 @@ struct ParamSweepOpt {
 
 #[derive(Debug, Parser)]
 struct ExecuteOpt {
-    #[clap(long, default_value_t = 10000)]
+    #[clap(long, default_value_t = 100000)]
     pub num_accounts: usize,
 
     #[clap(long, default_value_t = 5)]
     pub num_warmups: usize,
 
-    #[clap(long, default_value_t = 100000)]
+    #[clap(long, default_value_t = 10000)]
     pub block_size: usize,
 
     #[clap(long, default_value_t = 15)]


### PR DESCRIPTION
### Description

The number of accounts was smaller than the block size which causes issue with no conflict txn case (default)

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
