### PR TITLE
Fix number of accounts in transaction benchmark

### DIFF
--- a/aptos-move/aptos-transaction-benchmarks/src/main.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/main.rs
@@ -58,13 +58,13 @@ struct ParamSweepOpt {
 
 #[derive(Debug, Parser)]
 struct ExecuteOpt {
-    #[clap(long, default_value_t = 10000)]
+    #[clap(long, default_value_t = 100000)]
     pub num_accounts: usize,
 
     #[clap(long, default_value_t = 5)]
     pub num_warmups: usize,
 
-    #[clap(long, default_value_t = 100000)]
+    #[clap(long, default_value_t = 10000)]
     pub block_size: usize,
 
     #[clap(long, default_value_t = 15)]


### PR DESCRIPTION
### Description
The number of accounts was smaller than the block size which causes issue with no conflict txn case (default)



### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
