### PR TITLE
[dag][bugfix] reverse nodes before adding to dag store

### DIFF
--- a/consensus/src/dag/dag_fetcher.rs
+++ b/consensus/src/dag/dag_fetcher.rs
@@ -266,7 +266,7 @@ impl TDagFetcher for DagFetcher {
                 // TODO: support chunk response or fallback to state sync
                 {
                     let mut dag_writer = dag.write();
-                    for node in certified_nodes {
+                    for node in certified_nodes.into_iter().rev() {
                         if let Err(e) = dag_writer.add_node(node) {
                             error!("Failed to add node {}", e);
                         }

--- a/consensus/src/dag/order_rule.rs
+++ b/consensus/src/dag/order_rule.rs
@@ -76,7 +76,7 @@ impl OrderRule {
                         .dag
                         .write()
                         .reachable_mut(&anchor, None)
-                        .for_each(|node_statue| node_statue.mark_as_ordered());
+                        .for_each(|node_status| node_status.mark_as_ordered());
                 }
             } else {
                 // re-process pending anchors


### PR DESCRIPTION
### Description

Fix a bug where the fetched nodes should be reversed before inserting into the DAG.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
