### PR TITLE
Aptos Node - Fix load_seed

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -155,7 +155,7 @@ impl AptosNodeArgs {
     }
 }
 
-pub fn load_seed(input: &str) -> Result<Option<[u8; 32]>, FromHexError> {
+pub fn load_seed(input: &str) -> Result<[u8; 32]>, FromHexError> {
     let trimmed_input = input.trim();
     if !trimmed_input.is_empty() {
         FromHex::from_hex(trimmed_input).map(Some)


### PR DESCRIPTION
### Description
Running using `Docker` image of aptoslabs/validator:testnet  `sha256:3dd12caa0b7e67e2f3f7f3b29feb53405455526293df02f77b023b03d3ec26ee` the following command:
`/usr/local/bin/aptos-node --test --seed 0101010101010101010101010101010101010101010101010101010101010101 --test-dir /aptos/regnet` the following error is being returned:
```
thread 'main' panicked at 'Mismatch between definition and access of `seed`. Could not downcast to TypeId { t: 16824886518787423740 }, need to downcast to TypeId { t: 6835968432056230788 }
 ', /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.3.5/src/parser/error.rs:32:9
 stack backtrace:
    0: rust_begin_unwind
              at ./rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:578:5
    1: core::panicking::panic_fmt
              at ./rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/panicking.rs:67:14
    2: clap_builder::parser::error::MatchesError::unwrap
              at ./usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.3.5/src/parser/error.rs:32:9
    3: clap_builder::parser::matches::arg_matches::ArgMatches::remove_one
              at ./usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.3.5/src/parser/matches/arg_matches.rs:405:9
    4: <aptos_node::AptosNodeArgs as clap_builder::derive::FromArgMatches>::from_arg_matches_mut
              at ./aptos/aptos-node/src/lib.rs:45:24
    5: clap_builder::derive::Parser::parse
              at ./usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.3.5/src/derive.rs:28:19
    6: aptos_node::main
              at ./aptos/aptos-node/src/main.rs:19:5
    7: core::ops::function::FnOnce::call_once
              at ./rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/ops/function.rs:250:5
 note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

Based on [this Stack Overflow post](https://stackoverflow.com/questions/75728058/mismatch-between-definition-and-access-of-clap-argument), I believe this is the change required.
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
None. I did not test since I'm using Docker.