### PR TITLE
[node] Fix parsing of test seed

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -155,13 +155,9 @@ impl AptosNodeArgs {
     }
 }
 
-pub fn load_seed(input: &str) -> Result<Option<[u8; 32]>, FromHexError> {
+pub fn load_seed(input: &str) -> Result<[u8; 32], FromHexError> {
     let trimmed_input = input.trim();
-    if !trimmed_input.is_empty() {
-        FromHex::from_hex(trimmed_input).map(Some)
-    } else {
-        Ok(None)
-    }
+    FromHex::from_hex(trimmed_input)
 }
 
 /// Runtime handle to ensure that all inner runtimes stay in scope


### PR DESCRIPTION
### Description
Test seed parsing interface changed with a clap upgrade, and that caused all seed inputs to fail.

### Test Plan
Previously:
```
$ ./target/release/aptos-node --test --seed 0101010101010101010101010101010101010101010101010101010101010101 
thread 'main' panicked at 'Mismatch between definition and access of `seed`. Could not downcast to TypeId { t: 16824886518787423740 }, need to downcast to TypeId { t: 4718723824409586242 }
'

$ ./target/debug/aptos-node --test --seed 0101010101010101010101010101010101010101010101010101010101010101 
thread 'main' panicked at 'Mismatch between definition and access of `seed`. Could not downcast to [u8; 32], need to downcast to core::option::Option<[u8; 32]>
'
```

Now:
```
$ ./target/debug/aptos-node --test --seed 0101010101010101010101010101010101010101010101010101010101010101 
WARNING: Entering test mode! This should never be used in production!
Completed generating configuration:
        Log file: "/private/var/folders/1c/n_v_74m52fn50xf0y2c46byh0000gn/T/667bd5c0f905365a0583570b4679072a/validator.log"
        Test dir: "/private/var/folders/1c/n_v_74m52fn50xf0y2c46byh0000gn/T/667bd5c0f905365a0583570b4679072a"
        Aptos root key path: "/private/var/folders/1c/n_v_74m52fn50xf0y2c46byh0000gn/T/667bd5c0f905365a0583570b4679072a/mint.key"
        Waypoint: 0:68345c7b995ed2203ebf198c03af0f5bb8b8597ebf16c6693c185770e4111977
        ChainId: testing
        REST API endpoint: http://0.0.0.0:8080
        Metrics endpoint: http://0.0.0.0:9101/metrics
        Aptosnet fullnode network endpoint: /ip4/0.0.0.0/tcp/6181

Aptos is running, press ctrl-c to exit

```