### PR TITLE
[indexer-docs] Use absolute paths for links

### DIFF
--- a/developer-docs-site/docs/indexer/api/example-queries.md
+++ b/developer-docs-site/docs/indexer/api/example-queries.md
@@ -6,7 +6,7 @@ title: "Example Queries"
 
 ## Running example queries
 
-1. Open the Hasura Explorer for the network you want to query. You can find the URLs [here](./labs-hosted#hasura-explorer).
+1. Open the Hasura Explorer for the network you want to query. You can find the URLs [here](/indexer/api/labs-hosted#hasura-explorer).
 1. Paste the **Query** code from an example into the main query section, and the **Query Variables** code from the same example into the Query Variables section (below the main query section).
 
 ## More Examples

--- a/developer-docs-site/docs/indexer/api/index.md
+++ b/developer-docs-site/docs/indexer/api/index.md
@@ -14,4 +14,4 @@ When making a query where one of the query params is an account address (e.g. ow
 
 ### TypeScript Client
 
-The Aptos TypeScript SDK provides an IndexerClient for making queries to the Aptos Indexer API. Learn more [here](../../sdks/ts-sdk/typescript-sdk-indexer-client-class).
+The Aptos TypeScript SDK provides an IndexerClient for making queries to the Aptos Indexer API. Learn more [here](/sdks/ts-sdk/typescript-sdk-indexer-client-class).

--- a/developer-docs-site/docs/indexer/api/labs-hosted.md
+++ b/developer-docs-site/docs/indexer/api/labs-hosted.md
@@ -26,4 +26,4 @@ The following rate limit applies for the Aptos Labs hosted indexer API:
 
 - For a web application that calls this Aptos-provided indexer API directly from the client (for example, wallet or explorer), the rate limit is currently 5000 requests per five minutes by IP address. **Note that this limit can change with or without prior notice.**
 
-If you need a higher rate limit, consider running the Aptos Indexer API yourself. See the guide to self hosting [here](./self-hosted).
+If you need a higher rate limit, consider running the Aptos Indexer API yourself. See the guide to self hosting [here](/indexer/api/self-hosted).

--- a/developer-docs-site/docs/indexer/api/self-hosted.md
+++ b/developer-docs-site/docs/indexer/api/self-hosted.md
@@ -49,7 +49,7 @@ This is the connection string to your PostgreSQL database. It should be in the f
 This is the URL for the Transaction Stream Service. If you are using the Labs-Hosted instance you can find the URLs for each network at [this page](../txn-stream/labs-hosted). Make sure to select the correct URL for the network you want to index. If you are running this service locally the value should be `127.0.0.1:50051`.
 
 ### `auth_token`
-This is the auth token used to connect to the Transaction Stream Service. If you are using the Labs-Hosted instance you can use the API Gateway to get an auth token. Learn more at [this page](../txn-stream/labs-hosted).
+This is the auth token used to connect to the Transaction Stream Service. If you are using the Labs-Hosted instance you can use the API Gateway to get an auth token. Learn more at [this page](/indexer/txn-stream/labs-hosted).
 
 ## Run with source code
 Clone the repo:

--- a/developer-docs-site/docs/indexer/custom-processors/index.md
+++ b/developer-docs-site/docs/indexer/custom-processors/index.md
@@ -4,5 +4,5 @@ title: "Custom Processors"
 
 # Custom Processors
 
-This section explains what a custom processor is, how to write and deploy one, and how to parse transactions from the [Transaction Stream Service](../txn-stream).
+This section explains what a custom processor is, how to write and deploy one, and how to parse transactions from the [Transaction Stream Service](/indexer/txn-stream).
 

--- a/developer-docs-site/docs/indexer/custom-processors/parsing-txns.md
+++ b/developer-docs-site/docs/indexer/custom-processors/parsing-txns.md
@@ -13,7 +13,7 @@ Fundamentally an indexer processor is just something that consumes a stream of a
 
 ## What is a transaction?
 
-A transaction is a unit of execution on the Aptos blockchain. If the execution of the program in a transaction (e.g. starting with an entry function in a Move module) is successful, the resulting change in state will be applied to the ledger. Learn more about the transaction lifecycle at [this page](../../concepts/blockchain/#life-of-a-transaction).
+A transaction is a unit of execution on the Aptos blockchain. If the execution of the program in a transaction (e.g. starting with an entry function in a Move module) is successful, the resulting change in state will be applied to the ledger. Learn more about the transaction lifecycle at [this page](/concepts/blockchain/#life-of-a-transaction).
 
 There are four types of transactions on Aptos:
 - Genesis
@@ -23,7 +23,7 @@ There are four types of transactions on Aptos:
 
 The first 3 of these are internal to the system and are not relevant to most processors; we do not cover them in this guide.
 
-Generally speaking, most user transactions originate from a user calling an entry function in a Move module deployed on chain, for example `0x1::coin::transfer`. In all other cases they originate from [Move scripts](../../move/move-on-aptos/move-scripts). You can learn more about the different types of transactions [here](../../concepts/txns-states##types-of-transactions).
+Generally speaking, most user transactions originate from a user calling an entry function in a Move module deployed on chain, for example `0x1::coin::transfer`. In all other cases they originate from [Move scripts](/move/move-on-aptos/move-scripts). You can learn more about the different types of transactions [here](../../concepts/txns-states##types-of-transactions).
 
 A user transaction that a processor handles contains a variety of information. At a high level it contains:
 - The payload that was submitted.
@@ -40,7 +40,7 @@ The payload is what the user submits to the blockchain when they wish to execute
 - The address + module name + function name of the function being executed.
 - The arguments to the function.
 
-There is other potentially interesting information in the payload that you can learn about at [this page](../../concepts/txns-states#contents-of-a-transaction).
+There is other potentially interesting information in the payload that you can learn about at [this page](/concepts/txns-states#contents-of-a-transaction).
 
 ### Events
 

--- a/developer-docs-site/docs/indexer/indexer-landing.md
+++ b/developer-docs-site/docs/indexer/indexer-landing.md
@@ -12,14 +12,14 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 Refer to this role-oriented guide to help you quickly find the relevant docs:
 
 - Core Infra Provider: You want to run your own Transaction Stream Service in addition to the rest of the stack.
-  - See docs for [Self-Hosted Transaction Stream Service](txn-stream/self-hosted).
+  - See docs for [Self-Hosted Transaction Stream Service](/indexer/txn-stream/self-hosted).
 - API Operator: You want to run the Indexer API on top of a hosted Transaction Stream Service.
-  - See docs for [Self-Hosted Indexer API](api/self-hosted).
+  - See docs for [Self-Hosted Indexer API](/indexer/api/self-hosted).
 - Custom Processor Builder: You want to build a custom processor on top of a hosted Transaction Stream Service.
-  - See docs for [Custom Processors](custom-processors).
+  - See docs for [Custom Processors](/indexer/custom-processors).
 - Indexer API Consumer: You want to use a hosted Indexer API.
-  - See docs for the [Labs-Hosted Indexer API](api/labs-hosted).
-  - See the [Indexer API Usage Guide](api/usage-guide).
+  - See docs for the [Labs-Hosted Indexer API](/indexer/api/labs-hosted).
+  - See the [Indexer API Usage Guide](/indexer/api/usage-guide).
 
 # Architecture Overview
 
@@ -49,13 +49,13 @@ Step 2 is facilitated by the Aptos Indexer. The diagram above is a simplified vi
 
 Aptos supports the following ways to access indexed data.
 
-1. [Labs hosted Indexer API](api/labs-hosted): This API is rate-limited and is intended only for lightweight applications such as wallets. This option is not recommended for high-bandwidth applications.
-2. [Self hosted Indexer API](api/self-hosted): Run your own deployment of the Labs hosted indexer stack.
-3. [Custom processor](custom-processors): Write and deploy a custom processor to index and expose data in a way specific to your needs.
+1. [Labs hosted Indexer API](/indexer/api/labs-hosted): This API is rate-limited and is intended only for lightweight applications such as wallets. This option is not recommended for high-bandwidth applications.
+2. [Self hosted Indexer API](/indexer/api/self-hosted): Run your own deployment of the Labs hosted indexer stack.
+3. [Custom processor](/indexer/custom-processors): Write and deploy a custom processor to index and expose data in a way specific to your needs.
 
 ## Transaction Stream Service
 
-The Indexer API and Custom Processors depend on the Transaction Stream Service. In short, this service provides a GRPC stream of transactions that processors consume. Learn more about this service [here](txn-stream/). Aptos Labs offers a [hosted instance of this service](txn-stream/labs-hosted) but you may also [run your own](txn-stream/self-hosted).
+The Indexer API and Custom Processors depend on the Transaction Stream Service. In short, this service provides a GRPC stream of transactions that processors consume. Learn more about this service [here](/indexer/txn-stream/). Aptos Labs offers a [hosted instance of this service](/indexer/txn-stream/labs-hosted) but you may also [run your own](/indexer/txn-stream/self-hosted).
 
 ## Detailed Overview
 
@@ -76,4 +76,4 @@ This diagram explains how the Aptos Indexer tech stack works in greater detail.
 <!-- TODO: Write an explanation of this diagram. -->
 
 ## Legacy Indexer
-Find information about the legacy indexer [here](legacy/).
+Find information about the legacy indexer [here](/indexer/legacy/).

--- a/developer-docs-site/docs/indexer/legacy/custom-data-model.md
+++ b/developer-docs-site/docs/indexer/legacy/custom-data-model.md
@@ -3,7 +3,7 @@ title: "Custom Data Model"
 ---
 
 :::warning Legacy Indexer
-This is documentation for the legacy indexer. To learn how to write a custom processor with the latest indexer stack, see [Custom Processors](../custom-processors).
+This is documentation for the legacy indexer. To learn how to write a custom processor with the latest indexer stack, see [Custom Processors](/indexer/custom-processors).
 :::
 
 ## Define your own data model

--- a/developer-docs-site/docs/indexer/legacy/indexer-fullnode.md
+++ b/developer-docs-site/docs/indexer/legacy/indexer-fullnode.md
@@ -4,7 +4,7 @@ slug: "indexer-fullnode"
 ---
 
 :::warning Legacy Indexer
-This is documentation for the legacy indexer. To learn how to run the underlying infrastructure for the latest indexer stack, see [Transaction Stream Service](../txn-stream).
+This is documentation for the legacy indexer. To learn how to run the underlying infrastructure for the latest indexer stack, see [Transaction Stream Service](/indexer/txn-stream).
 :::
 
 # Run an Aptos Indexer
@@ -18,13 +18,13 @@ The below installation steps are verified only on macOS with Apple silicon. They
 To run an indexer fullnode, these are the steps in summary:
 
 1. Make sure that you have all the required tools and packages described below in this document.
-1. Follow the instructions to [set up a public fullnode](../../nodes/full-node/fullnode-source-code-or-docker.md) but do not start the fullnode yet.
+1. Follow the instructions to [set up a public fullnode](/nodes/full-node/fullnode-source-code-or-docker.md) but do not start the fullnode yet.
 1. Edit the `fullnode.yaml` as described below in this document.
 1. Run the indexer fullnode per the instructions below.
 
 ## Prerequisites
 
-Install the packages below. Note, you may have already installed many of these while [preparing your development environment](../../guides/building-from-source). You can confirm by running `which command-name` and ensuring the package appears in the output (although `libpq` will not be returned even when installed).
+Install the packages below. Note, you may have already installed many of these while [preparing your development environment](/guides/building-from-source). You can confirm by running `which command-name` and ensuring the package appears in the output (although `libpq` will not be returned even when installed).
 
 > Important: If you are on macOS, you will need to [install Docker following the official guidance](https://docs.docker.com/desktop/install/mac-install/) rather than `brew`.
 
@@ -60,7 +60,7 @@ For an Aptos indexer fullnode, install these packages:
 
 ## Start the fullnode indexer
 
-1. Follow the instructions to set up a [public fullnode](../../nodes/full-node/fullnode-source-code-or-docker.md) and prepare the setup, but **do not** yet start the indexer (with `cargo run` or `docker run`).
+1. Follow the instructions to set up a [public fullnode](/nodes/full-node/fullnode-source-code-or-docker.md) and prepare the setup, but **do not** yet start the indexer (with `cargo run` or `docker run`).
 1. Pull the latest indexer Docker image with:
     ```bash
     docker pull aptoslabs/validator:nightly_indexer
@@ -83,9 +83,9 @@ For an Aptos indexer fullnode, install these packages:
     ```
 
 :::tip Bootstap the fullnode
-Instead of syncing your indexer fullnode from genesis, which may take a long period of time, you can choose to bootstrap your fullnode using backup data before starting it. To do so, follow the instructions to [restore from a backup](../../nodes/full-node/aptos-db-restore.md).
+Instead of syncing your indexer fullnode from genesis, which may take a long period of time, you can choose to bootstrap your fullnode using backup data before starting it. To do so, follow the instructions to [restore from a backup](/nodes/full-node/aptos-db-restore.md).
 
-Note: indexers cannot be bootstrapped using [a snapshot](../../nodes/full-node/bootstrap-fullnode.md) or [fast sync](../../guides/state-sync.md#fast-syncing).
+Note: indexers cannot be bootstrapped using [a snapshot](/nodes/full-node/bootstrap-fullnode.md) or [fast sync](../../guides/state-sync.md#fast-syncing).
 :::
 
 1. Run the indexer fullnode with either `cargo run` or `docker run` depending upon your setup. Remember to supply the arguments you need for your specific node:

--- a/developer-docs-site/docs/indexer/txn-stream/labs-hosted.md
+++ b/developer-docs-site/docs/indexer/txn-stream/labs-hosted.md
@@ -4,7 +4,7 @@ title: "Labs-Hosted Transaction Stream Service"
 
 # Labs-Hosted Transaction Stream Service
 
-If you are running your own instance of the [Indexer API](../api), or a [custom processor](../custom-processors), you must have access to an instance of the Transaction Stream Service. This page contains information about how to use the Labs-Hosted Transaction Stream Service.
+If you are running your own instance of the [Indexer API](/indexer/api), or a [custom processor](/indexer/custom-processors), you must have access to an instance of the Transaction Stream Service. This page contains information about how to use the Labs-Hosted Transaction Stream Service.
 
 ## Endpoints
 All endpoints are in GCP us-central1 unless otherwise specified.
@@ -35,5 +35,5 @@ curl -H 'Authorization: Bearer aptoslabs_yj4donpaKy_Q6RBP4cdBmjA8T51hto1GcVX5ZS9
 ```
 
 For more comprehensive information about how to use the Transaction Stream Service, see the docs for the downstream systems:
-- [Indexer API](../api/self-hosted)
-- [Custom Processors](../custom-processors)
+- [Indexer API](/indexer/api/self-hosted)
+- [Custom Processors](/indexer/custom-processors)

--- a/developer-docs-site/docs/indexer/txn-stream/local-development.md
+++ b/developer-docs-site/docs/indexer/txn-stream/local-development.md
@@ -15,7 +15,7 @@ This script sets up the following:
   - [data-service](https://github.com/aptos-labs/aptos-core/tree/main/ecosystem/indexer-grpc/indexer-grpc-data-service): Serves transactions via a GRPC stream to downstream clients. It pulls from either the cache or the file store depending on the age of the transaction.
 - Shared volumes and networking to hook it all up.
 
-You can learn more about the Transaction Stream Service architecture [here](./index) (todo update link) and the Docker compose file [here](https://github.com/aptos-labs/aptos-core/blob/main/docker/compose/indexer-grpc/docker-compose.yaml).
+You can learn more about the Transaction Stream Service architecture [here](/indexer/txn-stream) and the Docker compose file [here](https://github.com/aptos-labs/aptos-core/blob/main/docker/compose/indexer-grpc/docker-compose.yaml).
 
 ## Prerequisites
 In order to use the local development script you must have the following installed:

--- a/developer-docs-site/scripts/additional_dict.txt
+++ b/developer-docs-site/scripts/additional_dict.txt
@@ -141,6 +141,7 @@ GUID
 Gbps
 Grafana
 GraphQL
+hasura
 HSM
 Homebrew
 HotStuff


### PR DESCRIPTION
### Description
There is some weird behavior in docusaurus where relative links don't work when the current URL has a trialing slash. See more information here: https://aptos-org.slack.com/archives/C04PF1X2UKY/p1693348785934909. I fix this by using absolute links instead.

### Test Plan
CI.
