### PR TITLE
[consensus-only] execution and fakeaptosdb bugfix and realistic env test

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -349,11 +349,11 @@ jobs:
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
-      FORGE_TEST_SUITE: consensus_only_perf_benchmark
+      FORGE_TEST_SUITE: consensus_only_realistic_env_max_tps
       IMAGE_TAG: consensus_only_perf_test_${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_RUNNER_DURATION_SECS: 300
-      COMMENT_HEADER: forge-consensus-only-perf-test
-      FORGE_NAMESPACE: forge-consensus-only-perf-test-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
+      COMMENT_HEADER: consensus-only-realistic-env-max-tps
+      FORGE_NAMESPACE: forge-consensus-only-realistic-env-max-tps-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
 
   # Run forge multiregion test. This test uses the multiregion forge cluster that deploys pods in three GCP regions.
   forge-multiregion-test:

--- a/execution/executor-types/src/executed_chunk.rs
+++ b/execution/executor-types/src/executed_chunk.rs
@@ -133,7 +133,9 @@ impl ExecutedChunk {
                     .ledger_info()
                     .transaction_accumulator_hash()
                     == result_accumulator.root_hash(),
-                "Root hash in target ledger info does not match local computation."
+                "Root hash in target ledger info does not match local computation. {:?} != {:?}",
+                verified_target_li,
+                result_accumulator
             );
             Ok(Some(verified_target_li.clone()))
         } else if let Some(epoch_change_li) = epoch_change_li {

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -146,9 +146,9 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
             chunk_output.apply_to_ledger(latest_view, None)?;
         ensure_no_discard(to_discard)?;
         ensure_no_retry(to_retry)?;
+        executed_chunk.ensure_transaction_infos_match(transaction_infos)?;
         executed_chunk.ledger_info = executed_chunk
             .maybe_select_chunk_ending_ledger_info(verified_target_li, epoch_change_li)?;
-        executed_chunk.ensure_transaction_infos_match(transaction_infos)?;
 
         Ok(executed_chunk)
     }

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -225,7 +225,7 @@ impl ChunkOutput {
                     TransactionOutput::new(
                         WriteSet::default(),
                         Vec::new(),
-                        100,
+                        0, // Keep gas zero to match with StateCheckpoint txn output
                         TransactionStatus::Keep(ExecutionStatus::Success),
                     )
                 })

--- a/execution/executor/src/tests/chunk_executor_tests.rs
+++ b/execution/executor/src/tests/chunk_executor_tests.rs
@@ -324,7 +324,7 @@ fn test_executor_execute_and_commit_chunk_without_verify() {
             .map(|_| encode_mint_transaction(tests::gen_address(rng.gen::<u64>()), 100))
             .collect::<Vec<_>>();
         let output = executor
-            .execute_block((block_id, block(txns)).into(), parent_block_id)
+            .execute_block((block_id, block(txns, None)).into(), parent_block_id, None)
             .unwrap();
         let ledger_info = tests::gen_ledger_info(6, output.root_hash(), block_id, 1);
         executor.commit_blocks(vec![block_id], ledger_info).unwrap();

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -184,6 +184,7 @@ fn test_executor_status_consensus_only() {
         .execute_block(
             (block_id, block(vec![txn0, txn1, txn2], BLOCK_GAS_LIMIT)).into(),
             parent_block_id,
+            BLOCK_GAS_LIMIT,
         )
         .unwrap();
 

--- a/storage/aptosdb/src/fake_aptosdb.rs
+++ b/storage/aptosdb/src/fake_aptosdb.rs
@@ -46,11 +46,18 @@ use aptos_types::{
     },
     write_set::WriteSet,
 };
-use arc_swap::ArcSwapOption;
 use dashmap::DashMap;
 use itertools::zip_eq;
 use move_core_types::move_resource::MoveStructType;
-use std::{borrow::Borrow, collections::HashMap, mem::swap, sync::Arc};
+use std::{
+    borrow::Borrow,
+    collections::HashMap,
+    mem::swap,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
 
 /// Alternate implementation of [crate::state_store::buffered_state::BufferedState] for use with consensus-only-perf-test feature.
 /// It stores the [StateDelta]s in memory similar to [crate::state_store::buffered_state::BufferedState] except that it does not
@@ -144,10 +151,10 @@ pub struct FakeAptosDB {
     txn_info_by_version: Arc<DashMap<Version, TransactionInfo>>,
     // A map of Position to transaction HashValue
     txn_hash_by_position: Arc<DashMap<Position, HashValue>>,
-    // Max version and transaction
-    latest_txn_info: ArcSwapOption<(Version, TransactionInfo)>,
     // A map of account address to the highest executed sequence number
     account_seq_num: Arc<DashMap<AccountAddress, u64>>,
+    // A map of transaction version to block timestamp
+    latest_block_timestamp: AtomicU64,
     ledger_commit_lock: std::sync::Mutex<()>,
     buffered_state: Mutex<FakeBufferedState>,
 }
@@ -160,8 +167,8 @@ impl FakeAptosDB {
             txn_version_by_hash: Arc::new(DashMap::new()),
             txn_info_by_version: Arc::new(DashMap::new()),
             txn_hash_by_position: Arc::new(DashMap::new()),
-            latest_txn_info: ArcSwapOption::from(None),
             account_seq_num: Arc::new(DashMap::new()),
+            latest_block_timestamp: AtomicU64::new(0),
             ledger_commit_lock: std::sync::Mutex::new(()),
             buffered_state: Mutex::new(FakeBufferedState::new_empty()),
         }
@@ -273,14 +280,6 @@ impl FakeAptosDB {
                     buffered_state.state_after_checkpoint.current_version,
                 );
 
-                // Ensure the incoming committing requests are always consecutive and the version in
-                // buffered state is consistent with that in db.
-                let next_version_in_buffered_state = buffered_state
-                    .state_after_checkpoint
-                    .current_version
-                    .map(|version| version + 1)
-                    .unwrap_or(0);
-
                 let updates_until_latest_checkpoint_since_current = if let Some(
                     latest_checkpoint_version,
                 ) =
@@ -321,15 +320,11 @@ impl FakeAptosDB {
             // Iterate through the transactions and update the in-memory maps
             zip_eq(first_version..=last_version, txns_to_commit).try_for_each(
                 |(ver, txn_to_commit)| -> Result<(), anyhow::Error> {
-                    let txn_to_commit = txn_to_commit.borrow();
+                    let txn_to_commit: &TransactionToCommit = txn_to_commit.borrow();
                     self.txn_by_version
                         .insert(ver, txn_to_commit.transaction().clone());
                     self.txn_info_by_version
                         .insert(ver, txn_to_commit.transaction_info().clone());
-                    self.latest_txn_info.store(Some(Arc::new((
-                        ver,
-                        txn_to_commit.transaction_info().clone(),
-                    ))));
                     self.txn_version_by_hash
                         .insert(txn_to_commit.transaction().hash(), ver);
 
@@ -342,6 +337,12 @@ impl FakeAptosDB {
                             })
                             .or_insert(user_txn.sequence_number());
                     }
+
+                    if let Some(txn) = txn_to_commit.transaction().try_as_block_metadata() {
+                        self.latest_block_timestamp
+                            .fetch_max(txn.timestamp_usecs(), Ordering::Relaxed);
+                    }
+
                     Ok::<(), anyhow::Error>(())
                 },
             )?;
@@ -604,7 +605,16 @@ impl DbReader for FakeAptosDB {
     }
 
     fn get_block_timestamp(&self, version: Version) -> Result<u64> {
-        self.inner.get_block_timestamp(version)
+        gauged_api("get_block_timestamp", || {
+            ensure!(version <= self.get_latest_version()?);
+
+            let timestamp = self.latest_block_timestamp.load(Ordering::Relaxed);
+            if timestamp > 0 {
+                Ok(timestamp)
+            } else {
+                Err(AptosDbError::NotFound("NewBlockEvent".to_string()).into())
+            }
+        })
     }
 
     fn get_next_block_event(&self, version: Version) -> Result<(Version, NewBlockEvent)> {


### PR DESCRIPTION
### Description

This PR fixes/improves the consensus only benchmark:
- It fixes a bug that prevented running the benchmark due to execution results divergence during state-sync because we now add the StateCheckpoint transaction output with zero gas post-execution in the normal flow that conflicted with state-sync execution flow where in consensus-only mode, the StateCheckpoint transaction output set a non-zero gas.
- Mocks the `get_block_timestamp()` call to return the highest known block timestamp instead of passing through to the underlying aptosdb that made the call to fail and txn-emitter to consequentially fail.
- It also a realistic env forge test with tuned parameters to achieve 50-60k tps with up to 100 replicas. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Now able to get 50-60k tps consistently.

https://github.com/aptos-labs/aptos-core/pull/9844#issuecomment-1704424974
