### PR TITLE
Andrew/webauthn p256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,6 +932,8 @@ dependencies = [
  "thiserror",
  "tiny-keccak",
  "trybuild",
+ "webauthn-authenticator-rs",
+ "webauthn-rs-core",
  "x25519-dalek",
 ]
 
@@ -1413,7 +1415,7 @@ dependencies = [
  "bcs 0.1.4",
  "dashmap",
  "fail 0.5.0",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.2",
  "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
@@ -4368,6 +4370,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ff05a702273012438132f449575dbc804e27b2f3cbe3069aa237d26c98fa33"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.24",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b7511298d5b7784b40b092d9e9dcd3a627a5707e4b5e507931ab0d44eeebf"
+dependencies = [
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 1.0.105",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+dependencies = [
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 1.0.105",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4769,6 +4810,27 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "base64urlsafedata"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b3d30abb74120a9d5267463b9e0045fdccc4dd152e7249d966612dc1721384"
+dependencies = [
+ "base64 0.21.2",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "base64urlsafedata"
+version = "0.1.3"
+source = "git+https://github.com/aptos-labs/webauthn-rs?branch=master#5e022a866b98590221123ea60f26360b7ec67cf5"
+dependencies = [
+ "base64 0.21.2",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "basic-cookies"
@@ -5539,6 +5601,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_jwt"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aa76ef19968577838a34d02848136bb9b6bdbfd7675fb968fe9c931bc434b33"
+dependencies = [
+ "base64 0.13.0",
+ "base64urlsafedata 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex",
+ "openssl",
+ "serde",
+ "serde_json",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6103,6 +6182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+[[package]]
 name = "datatest-stable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6183,6 +6268,20 @@ dependencies = [
  "const-oid 0.9.5",
  "pem-rfc7468 0.7.0",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe398ac75057914d7d07307bf67dc7f3f574a26783b4fc7805a20ffa9f506e82"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint 0.4.3",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -6419,6 +6518,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+dependencies = [
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 2.0.32",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6494,9 +6604,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
  "serde",
  "signature 1.6.0",
@@ -7147,9 +7257,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -7162,9 +7272,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -7178,9 +7288,9 @@ checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -7189,9 +7299,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-lite"
@@ -7210,9 +7320,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2 1.0.64",
  "quote 1.0.29",
@@ -7221,15 +7331,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-timer"
@@ -7239,9 +7349,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -7755,9 +7865,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 dependencies = [
  "ahash 0.8.3",
  "allocator-api2",
@@ -8292,12 +8402,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.2",
  "serde",
 ]
 
@@ -10732,6 +10842,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e20717fa0541f39bd146692035c37bedfa532b3e5071b35761082407546b2a"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12630,6 +12749,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.35.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13082,6 +13210,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor_2"
+version = "0.12.0-dev"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46d75f449e01f1eddbe9b00f432d616fbbd899b809c837d0fbc380496a0dd55"
+dependencies = [
+ "half 1.8.2",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13167,7 +13305,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.0.1",
+ "indexmap 2.0.2",
  "serde",
  "serde_json",
  "time 0.3.24",
@@ -14344,6 +14482,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util 0.7.3",
 ]
 
 [[package]]
@@ -15333,6 +15472,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "webauthn-attestation-ca"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/webauthn-rs?branch=master#5e022a866b98590221123ea60f26360b7ec67cf5"
+dependencies = [
+ "base64urlsafedata 0.1.3 (git+https://github.com/aptos-labs/webauthn-rs?branch=master)",
+ "openssl",
+ "serde",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "webauthn-authenticator-rs"
+version = "0.5.0-dev"
+source = "git+https://github.com/aptos-labs/webauthn-rs?branch=master#5e022a866b98590221123ea60f26360b7ec67cf5"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64urlsafedata 0.1.3 (git+https://github.com/aptos-labs/webauthn-rs?branch=master)",
+ "bitflags 1.3.2",
+ "futures",
+ "hex",
+ "nom",
+ "num-derive",
+ "num-traits",
+ "openssl",
+ "serde",
+ "serde_bytes",
+ "serde_cbor_2",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "unicode-normalization",
+ "url",
+ "uuid",
+ "webauthn-rs-core",
+ "webauthn-rs-proto",
+]
+
+[[package]]
+name = "webauthn-rs-core"
+version = "0.5.0-dev"
+source = "git+https://github.com/aptos-labs/webauthn-rs?branch=master#5e022a866b98590221123ea60f26360b7ec67cf5"
+dependencies = [
+ "base64 0.21.2",
+ "base64urlsafedata 0.1.3 (git+https://github.com/aptos-labs/webauthn-rs?branch=master)",
+ "bcs 0.1.4",
+ "compact_jwt",
+ "der-parser",
+ "indexmap 2.0.2",
+ "nom",
+ "openssl",
+ "p256",
+ "rand 0.8.5",
+ "serde",
+ "serde_cbor_2",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-attestation-ca",
+ "webauthn-rs-proto",
+ "x509-parser",
+]
+
+[[package]]
+name = "webauthn-rs-proto"
+version = "0.5.0-dev"
+source = "git+https://github.com/aptos-labs/webauthn-rs?branch=master#5e022a866b98590221123ea60f26360b7ec67cf5"
+dependencies = [
+ "base64urlsafedata 0.1.3 (git+https://github.com/aptos-labs/webauthn-rs?branch=master)",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "webpki"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15665,6 +15883,24 @@ dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
  "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9bace5b5589ffead1afb76e43e34cff39cd0f3ce7e170ae0c29e53b88eb1c"
+dependencies = [
+ "asn1-rs",
+ "base64 0.13.0",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.24",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -498,8 +498,8 @@ event-listener = "2.5.3"
 fail = "0.5.0"
 field_count = "0.1.1"
 flate2 = "1.0.24"
-futures = "= 0.3.24" # Previously futures v0.3.23 caused some consensus network_tests to fail. We now pin the dependency to v0.3.24.
-futures-channel = "= 0.3.24"
+futures = "= 0.3.25" # Previously futures v0.3.23 caused some consensus network_tests to fail. We now pin the dependency to v0.3.25.
+futures-channel = "= 0.3.25"
 futures-core = "0.3.25"
 futures-util = "0.3.21"
 gcp-bigquery-client = "0.13.0"
@@ -666,6 +666,8 @@ uuid = { version = "1.0.0", features = ["v4", "serde"] }
 walkdir = "2.3.3"
 warp = { version = "0.3.5", features = ["tls"] }
 warp-reverse-proxy = "1.0.0"
+webauthn-rs-core = { git = "https://github.com/aptos-labs/webauthn-rs", branch = "master" }
+webauthn-authenticator-rs = { git = "https://github.com/aptos-labs/webauthn-rs", branch = "master", features = ["softpasskey"] }
 which = "4.2.5"
 x25519-dalek = { git = "https://github.com/aptos-labs/x25519-dalek", rev = "b9cdbaf36bf2a83438d9f660e5a708c82ed60d8e" }
 

--- a/crates/aptos-crypto/Cargo.toml
+++ b/crates/aptos-crypto/Cargo.toml
@@ -42,6 +42,7 @@ rand = { workspace = true }
 rand_core = { workspace = true }
 ring = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 serde-name = { workspace = true }
 serde_bytes = { workspace = true }
 sha2 = { workspace = true }
@@ -51,6 +52,8 @@ static_assertions = { workspace = true }
 thiserror = { workspace = true }
 tiny-keccak = { workspace = true }
 x25519-dalek = { workspace = true }
+webauthn-rs-core = { workspace = true }
+webauthn-authenticator-rs = { workspace = true }
 
 [dev-dependencies]
 ark-bls12-381 = { workspace = true }
@@ -63,7 +66,6 @@ byteorder = { workspace = true }
 criterion = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
-serde_json = { workspace = true }
 sha3 = { workspace = true }
 trybuild = { workspace = true }
 

--- a/crates/aptos-crypto/src/lib.rs
+++ b/crates/aptos-crypto/src/lib.rs
@@ -21,6 +21,7 @@ pub mod secp256k1_ecdsa;
 pub mod test_utils;
 pub mod traits;
 pub mod validatable;
+pub mod webauthn;
 pub mod x25519;
 
 #[cfg(test)]

--- a/crates/aptos-crypto/src/unit_tests/mod.rs
+++ b/crates/aptos-crypto/src/unit_tests/mod.rs
@@ -14,3 +14,4 @@ mod hkdf_test;
 mod multi_ed25519_test;
 mod noise_test;
 mod secp256k1_ecdsa_test;
+mod webauthn_p256_test;

--- a/crates/aptos-crypto/src/unit_tests/webauthn_p256_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/webauthn_p256_test.rs
@@ -1,0 +1,485 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+use crate::p256_ecdsa::P256PublicKey;
+use crate::test_utils::KeyPair;
+use crate::webauthn::webauthn_p256_keys::WebAuthnP256PrivateKey;
+use crate::webauthn::{webauthn_p256_keys, WebAuthnP256PublicKey, WebAuthnP256Signature};
+use crate::{HashValue, Signature, Uniform};
+use p256::elliptic_curve::generic_array;
+use rand_core::{OsRng, RngCore};
+use webauthn_authenticator_rs::prelude::{RequestChallengeResponse, Url};
+use webauthn_authenticator_rs::softpasskey::SoftPasskey;
+use webauthn_authenticator_rs::WebauthnAuthenticator;
+use webauthn_rs_core::assertion::generate_bcs_encoded_paarr_vector;
+use webauthn_rs_core::encoding::SerializableCollectedClientData;
+use webauthn_rs_core::interface::{AuthenticationState, COSEEC2Key, COSEKeyType, Credential};
+use webauthn_rs_core::internals::Challenge;
+use webauthn_rs_core::proto::{
+    AttestationConveyancePreference, Base64UrlSafeData, COSEAlgorithm, CollectedClientData,
+    PublicKeyCredential, RegisterPublicKeyCredential, UserVerificationPolicy,
+};
+use webauthn_rs_core::WebauthnCore;
+
+type Base64UrlChallenge = Base64UrlSafeData;
+type RawTxnByteVector = Vec<u8>;
+
+/// This helper function generates random bytes to simulate a raw transaction and challenge. Returns:
+/// 1. Fake, fixed byte raw txn, `t`
+/// 2. The challenge -> SHA3_256(t)
+///
+/// For context, during a WebAuthn assertion, the device authenticator signs over the binary
+/// concatenation of `authenticatorData` and SHA256(`clientDataJSON`).
+///
+/// `ClientDataJSON` contains a `challenge` field which is used to store the SHA3_256 of the `RawTransaction`.
+fn generate_random_challenge_data(raw_txn_size: usize) -> (RawTxnByteVector, Base64UrlSafeData) {
+    let mut raw_txn_bytes: Vec<u8> = vec![0; raw_txn_size];
+    let mut rng = OsRng;
+    rng.fill_bytes(&mut raw_txn_bytes);
+    let challenge = Base64UrlSafeData::from(HashValue::sha3_256_of(&raw_txn_bytes).to_vec());
+    (raw_txn_bytes, challenge)
+}
+
+/// Helper function that creates boilerplate for a WebAuthn registration (creation of a new passkey)
+/// Uses [`SoftPasskey`](webauthn_authenticator_rs::SoftPasskey) to simulate the creation of a
+/// [`PublicKeyCredential`](webauthn_rs_core::proto::PublicKeyCredential) (Passkey credential).
+fn registration_helper(
+    challenge_data: Option<(RawTxnByteVector, Base64UrlChallenge)>,
+) -> (
+    WebauthnCore,
+    WebauthnAuthenticator<SoftPasskey>,
+    Credential,
+    RequestChallengeResponse,
+    AuthenticationState,
+    RawTxnByteVector,
+) {
+    let wan = WebauthnCore::new_unsafe_experts_only(
+        "https://localhost:8080/auth",
+        "localhost",
+        vec![Url::parse("https://localhost:8080").unwrap()],
+        None,
+        None,
+        None,
+    );
+
+    let unique_id = [
+        158, 170, 228, 89, 68, 28, 73, 194, 134, 19, 227, 153, 107, 220, 150, 238,
+    ];
+    let name = "andrew";
+
+    // These registration options create
+    let (chal, reg_state) = wan
+        .generate_challenge_register_options(
+            &unique_id,
+            name,
+            name,
+            AttestationConveyancePreference::Direct,
+            Some(UserVerificationPolicy::Preferred),
+            None,
+            None,
+            vec![COSEAlgorithm::ES256],
+            false,
+            None,
+            false,
+        )
+        .unwrap();
+
+    let mut wa = WebauthnAuthenticator::new(SoftPasskey::new(true));
+    let reg_credential = wa
+        .do_registration(Url::parse("https://localhost:8080").unwrap(), chal)
+        .expect("Failed to register");
+
+    let credential = wan
+        .register_credential(&reg_credential, &reg_state, None)
+        .unwrap();
+
+    let (mut req_challenge_resp, mut auth_state) = wan
+        .generate_challenge_authenticate(vec![credential.clone()], None)
+        .unwrap();
+
+    let (raw_txn, challenge) = match challenge_data {
+        None => generate_random_challenge_data(512),
+        Some((raw_txn_bytes, challenge_base64)) => (raw_txn_bytes, challenge_base64),
+    };
+
+    // We don't want to use the default challenge from `generate_challenge_authenticate`
+    // we are replacing the default challenge in the `RequestChallengeResponse` and the
+    // `AuthenticationState` with the fake challenge created above
+    req_challenge_resp.public_key.challenge = challenge.clone();
+    auth_state.set_challenge(challenge.clone());
+
+    (wan, wa, credential, req_challenge_resp, auth_state, raw_txn)
+}
+
+/// Generates a `WebAuthnP256PublicKey` from the `key` of a WebAuthn [`Credential`](webauthn_rs_core::interface::Credential)
+fn generate_webauthn_pubkey(key: COSEEC2Key) -> WebAuthnP256PublicKey {
+    let x_bytes = &key.x.0;
+    let y_bytes = &key.y.0;
+
+    let generic_array_x = generic_array::GenericArray::clone_from_slice(x_bytes.as_slice());
+    let generic_array_y = generic_array::GenericArray::clone_from_slice(y_bytes.as_slice());
+    let encoded_point =
+        p256::EncodedPoint::from_affine_coordinates(&generic_array_x, &generic_array_y, false);
+    let verifying_key = p256::ecdsa::VerifyingKey::from_encoded_point(&encoded_point);
+
+    let webauthn_pubkey = WebAuthnP256PublicKey(P256PublicKey(verifying_key.unwrap()));
+    webauthn_pubkey
+}
+
+/// Test to ensure an error occurs when the bytes used for signature is malformed due to incorrect bcs encoding of
+/// [`PartialAuthenticatorAssertionResponseRaw`](webauthn_rs_core::assertion::PartialAuthenticatorAssertionResponseRaw)
+/// Test to ensure it errors
+#[test]
+fn signature_serialization_failure_test() {
+    let (_wan, mut wa, _credential, req_challenge_resp, _auth_state, ..) =
+        registration_helper(None);
+
+    let assertion_credential = wa
+        .do_authentication(
+            Url::parse("https://localhost:8080").unwrap(),
+            req_challenge_resp,
+        )
+        .expect("Failed to auth");
+
+    // Wrongly encoded bcs_paarr -> client_data and authenticator_data are switched
+    let wrong_bcs_paarr = generate_bcs_encoded_paarr_vector(
+        assertion_credential.response.signature.0.as_slice(),
+        assertion_credential.response.client_data_json.0.as_slice(),
+        assertion_credential
+            .response
+            .authenticator_data
+            .0
+            .as_slice(),
+    );
+
+    assert!(wrong_bcs_paarr.is_err());
+}
+
+/// According to the WebAuthn specification [§5.8.1](https://www.w3.org/TR/webauthn-3/#dictionary-client-data),
+/// the [`CollectedClientData`](CollectedClientData) struct can be
+/// extended in the future. This tests that signature verification still holds even in the
+/// event that the struct is extended.
+///
+/// In this test we use the Secure Payment Confirmation (SPC) specification as an example where
+/// `CollectedClientData` could be extended. SPC assertion responses include a
+/// [`CollectedClientPaymentData`](https://www.w3.org/TR/secure-payment-confirmation/#sctn-collectedclientpaymentdata-dictionary)
+/// struct that extends `CollectedClientData`.
+#[test]
+fn extended_client_data_verification_test() {
+    let wan = WebauthnCore::new_unsafe_experts_only(
+        "http://localhost:4000",
+        "localhost",
+        vec![Url::parse("http://localhost:4000").unwrap()],
+        None,
+        None,
+        None,
+    );
+
+    // for reference, the plaintext, utf-8 encoded raw_txn is "hello world"
+    let fake_raw_txn = Base64UrlSafeData::try_from("aGVsbG8gd29ybGQ").unwrap();
+    let actual_sha3_256_fake_raw_txn =
+        Base64UrlSafeData::try_from("ZEvMflZDcwQJmarInnYi88px-6HZcv2Uoxw7-_JOOTg").unwrap();
+    let expected_sha3_256_fake_raw_txn = HashValue::sha3_256_of(fake_raw_txn.0.as_slice()).to_vec();
+
+    // confirm that the sha3_256 is correctly computed
+    assert_eq!(
+        actual_sha3_256_fake_raw_txn.clone().0.to_vec(),
+        expected_sha3_256_fake_raw_txn
+    );
+
+    let registration_client_data_json = format!(
+        r#"{{
+        "type": "webauthn.create",
+        "challenge": "{}",
+        "origin": "http://localhost:4000",
+        "crossOrigin": false
+    }}"#,
+        actual_sha3_256_fake_raw_txn.clone().to_string()
+    );
+
+    let registration_collected_client_data: CollectedClientData =
+        serde_json::from_str(registration_client_data_json.as_str()).unwrap();
+    let registration_client_data_base_64_url =
+        serde_json::to_vec(&registration_collected_client_data)
+            .map(Base64UrlSafeData)
+            .unwrap();
+    let registration_client_data_base_64_url_string =
+        registration_client_data_base_64_url.to_string();
+
+    let registration_rsp: RegisterPublicKeyCredential = serde_json::from_str(format!(r#"{{
+            "id": "5XMfH5f3cwTiiQ680WrMK-_dIOlcmcMYpHXK5a6vBjc",
+            "rawId": "5XMfH5f3cwTiiQ680WrMK-_dIOlcmcMYpHXK5a6vBjc",
+            "response": {{
+                "attestationObject": "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVikSZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2NFAAAAAK3OAAI1vMYKZIsLJfHwVQMAIOVzHx-X93ME4okOvNFqzCvv3SDpXJnDGKR1yuWurwY3pQECAyYgASFYILb4mrp6cCBeb5Clre8Gw1khoxVM2ni8WM7scgghamReIlggFmKfY_3vaYdim8-8XEQBDwb1u1F3a5wTzmFkxwBgHqA",
+                "clientDataJSON": "{}"
+            }},
+            "type": "public-key"
+        }}"#, registration_client_data_base_64_url_string).as_str()).unwrap();
+
+    let credential = wan
+        .register_credential_internal(
+            &registration_rsp,
+            Default::default(),
+            &Challenge::new(registration_collected_client_data.challenge.0),
+            &[],
+            &[COSEAlgorithm::ES256],
+            None,
+            false,
+            &Default::default(),
+            true,
+        )
+        .unwrap();
+
+    // ensure client_data_json for registration_rsp was serialized / deserialized properly
+    assert_eq!(
+        registration_rsp.response.client_data_json,
+        registration_client_data_base_64_url
+    );
+
+    // This is a sample Secure Payment Confirmation (SPC) client_data response
+    // It will help us test for any issues in extensibility of the CollectedClientData struct
+    // More info: https://www.w3.org/TR/secure-payment-confirmation/#sctn-collectedclientpaymentdata-dictionary
+    let auth_client_data = r#"{
+        "type": "payment.get",
+        "challenge": "ZEvMflZDcwQJmarInnYi88px-6HZcv2Uoxw7-_JOOTg",
+        "origin": "http://localhost:4000",
+        "crossOrigin": false,
+        "payment": {
+            "rpId": "localhost",
+            "topOrigin": "http://localhost:4000",
+            "payeeOrigin": "https://localhost:4000",
+            "total": {
+                "value": "1.01",
+                "currency": "APT"
+            },
+            "instrument": {
+                "icon": "https://aptoslabs.com/assets/favicon-2c9e23abc3a3f4c45038e8c784b0a4ecb9051baa.ico",
+                "displayName": "Petra test"
+            }
+        }
+    }"#;
+
+    // Using custom SerializableCollectedClientData to ensure bytes are serialized correctly
+    let client_data: SerializableCollectedClientData = serde_json::from_str(&auth_client_data).unwrap();
+    let auth_client_data_base64_url = Base64UrlSafeData::from(client_data.to_bytes());
+
+    let assertion_credential: PublicKeyCredential = serde_json::from_str(
+        format!(
+            r#"{{
+            "id": "5XMfH5f3cwTiiQ680WrMK-_dIOlcmcMYpHXK5a6vBjc",
+            "rawId": "5XMfH5f3cwTiiQ680WrMK-_dIOlcmcMYpHXK5a6vBjc",
+            "response": {{
+                "authenticatorData": "SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2MFAAAAAA",
+                "clientDataJSON": "{}",
+                "signature": "MEUCIQCl5RgiE754do1km7YCjlFZKR65cv7NUbBagrbx-BXzIwIgTVC7iAWwkKFAyNkFR-5DrVrpxiItDU0Lw7JsJyUBJ6M",
+                "userHandle": "AQABAgMIAwYGAAYEAQYIAgcB"
+            }},
+            "type": "public-key"
+        }}"#,
+            auth_client_data_base64_url.to_string().as_str()
+        )
+        .as_str(),
+    )
+    .unwrap();
+
+    // This is the signature the client would include in a SignedTransaction
+    // Its a BCS encoded vector representation of PartialAuthenticatorAssertionResponseRaw
+    // that contains the following items in order:
+    // 1. signature
+    // 2. authenticator_data
+    // 3. client_data_json
+    let bcs_paarr = generate_bcs_encoded_paarr_vector(
+        assertion_credential.response.signature.0.as_slice(),
+        assertion_credential
+            .response
+            .authenticator_data
+            .0
+            .as_slice(),
+        assertion_credential.response.client_data_json.0.as_slice(),
+    )
+    .unwrap();
+
+    let webauthn_sig = WebAuthnP256Signature::try_from(bcs_paarr.as_slice());
+    assert!(webauthn_sig.is_ok());
+
+    // Now verify it!
+    match credential.cred.key {
+        COSEKeyType::EC_EC2(key) => {
+            let webauthn_pubkey = generate_webauthn_pubkey(key);
+
+            let verification_result = webauthn_sig
+                .unwrap()
+                .verify_arbitrary_msg(fake_raw_txn.0.as_slice(), &webauthn_pubkey);
+
+            assert!(verification_result.is_ok());
+        },
+        _ => {
+            panic!("Test failed, credential key is not of type EC_EC2 and COSE Algorithm ES256")
+        },
+    }
+}
+
+#[test]
+fn verify_failure_test() {
+    let (wan, mut wa, _credential, req_challenge_resp, auth_state, raw_txn) =
+        registration_helper(None);
+
+    let assertion_credential = wa
+        .do_authentication(
+            Url::parse("https://localhost:8080").unwrap(),
+            req_challenge_resp,
+        )
+        .expect("Failed to auth");
+
+    wan.authenticate_credential(&assertion_credential, &auth_state)
+        .expect("webauth authentication denied");
+
+    // This is the signature the client would include in a SignedTransaction
+    // Its a BCS encoded vector representation of PartialAuthenticatorAssertionResponseRaw
+    // that contains the following items in order:
+    // 1. signature
+    // 2. authenticator_data
+    // 3. client_data_json
+    let bcs_paarr = generate_bcs_encoded_paarr_vector(
+        assertion_credential.response.signature.0.as_slice(),
+        assertion_credential
+            .response
+            .authenticator_data
+            .0
+            .as_slice(),
+        assertion_credential.response.client_data_json.0.as_slice(),
+    )
+    .unwrap();
+
+    let webauthn_sig = WebAuthnP256Signature::try_from(bcs_paarr.as_slice());
+    assert!(webauthn_sig.is_ok());
+
+    // Create a new public key credential
+    let (.., credential, _req_challenge_resp, _auth_state, _raw_txn) = registration_helper(None);
+
+    // Now verify it!
+    match credential.cred.key {
+        COSEKeyType::EC_EC2(key) => {
+            let webauthn_pubkey = generate_webauthn_pubkey(key);
+
+            let verification_result = webauthn_sig
+                .unwrap()
+                .verify_arbitrary_msg(&raw_txn, &webauthn_pubkey);
+
+            // Should error since this is using the wrong public key to verify the signature
+            assert!(verification_result.is_err());
+        },
+        _ => {
+            panic!("Test failed, credential key is not of type EC_EC2 and COSE Algorithm ES256")
+        },
+    }
+}
+
+#[test]
+fn verify_test() {
+    let (wan, mut wa, credential, req_challenge_resp, auth_state, raw_txn) =
+        registration_helper(None);
+
+    let assertion_credential = wa
+        .do_authentication(
+            Url::parse("https://localhost:8080").unwrap(),
+            req_challenge_resp,
+        )
+        .expect("Failed to auth");
+
+    // This is the signature the client would include in a SignedTransaction
+    // Its a BCS encoded vector representation of PartialAuthenticatorAssertionResponseRaw
+    // that contains the following items in order:
+    // 1. signature
+    // 2. authenticator_data
+    // 3. client_data_json
+    let bcs_paarr = generate_bcs_encoded_paarr_vector(
+        assertion_credential.response.signature.0.as_slice(),
+        assertion_credential
+            .response
+            .authenticator_data
+            .0
+            .as_slice(),
+        assertion_credential.response.client_data_json.0.as_slice(),
+    )
+    .unwrap();
+
+    let webauthn_sig = WebAuthnP256Signature::try_from(bcs_paarr.as_slice());
+    assert!(webauthn_sig.is_ok());
+
+    // Now verify it!
+    match credential.cred.key {
+        COSEKeyType::EC_EC2(key) => {
+            let webauthn_pubkey = generate_webauthn_pubkey(key);
+
+            let verification_result = webauthn_sig
+                .unwrap()
+                .verify_arbitrary_msg(&raw_txn, &webauthn_pubkey);
+
+            assert!(verification_result.is_ok());
+
+            // This is an extra check, using the webauthn_rs built-in authenticate_credential method
+            // Note: this will not work for non-"webauthn.get" payloads, like Secure Payment Confirmation (SPC)
+            wan.authenticate_credential(&assertion_credential, &auth_state)
+                .expect("webauth authentication denied");
+        },
+        _ => {
+            panic!("Test failed, credential key is not of type EC_EC2 and COSE Algorithm ES256")
+        },
+    }
+}
+
+/// Tests public key private key (de)serialization
+#[test]
+fn key_serialization_test() {
+    let mut rng = OsRng;
+    let key_pair = KeyPair::<WebAuthnP256PrivateKey, WebAuthnP256PublicKey>::generate(&mut rng);
+
+    let private_key_bytes = key_pair.private_key.to_bytes();
+    let private_key_deserialized =
+        WebAuthnP256PrivateKey::try_from(&private_key_bytes[..]).unwrap();
+    assert_eq!(key_pair.private_key, private_key_deserialized);
+
+    let public_key_bytes = key_pair.public_key.to_bytes();
+    let public_key_deserialized = WebAuthnP256PublicKey::try_from(&public_key_bytes[..]).unwrap();
+    assert_eq!(key_pair.public_key, public_key_deserialized);
+}
+
+/// Tests signature (de)serialization
+#[test]
+fn signature_serialization_test() {
+    let (wan, mut wa, _credential, req_challenge_resp, auth_state, ..) = registration_helper(None);
+
+    let assertion_credential = wa
+        .do_authentication(
+            Url::parse("https://localhost:8080").unwrap(),
+            req_challenge_resp,
+        )
+        .expect("Failed to auth");
+
+    wan.authenticate_credential(&assertion_credential, &auth_state)
+        .expect("webauth authentication denied");
+
+    let bcs_paarr = generate_bcs_encoded_paarr_vector(
+        assertion_credential.response.signature.0.as_slice(),
+        assertion_credential
+            .response
+            .authenticator_data
+            .0
+            .as_slice(),
+        assertion_credential.response.client_data_json.0.as_slice(),
+    )
+    .unwrap();
+
+    let signature = WebAuthnP256Signature::try_from(bcs_paarr.as_slice()).unwrap();
+    let signature_bytes = signature.to_bytes();
+    let signature_deserialized = WebAuthnP256Signature::try_from(&signature_bytes[..]).unwrap();
+    assert_eq!(signature, signature_deserialized);
+}
+
+/// Test deserialization_failures
+#[test]
+fn deserialization_failure() {
+    let fake = [0u8, 31];
+    webauthn_p256_keys::WebAuthnP256PrivateKey::try_from(fake.as_slice()).unwrap_err();
+    webauthn_p256_keys::WebAuthnP256PublicKey::try_from(fake.as_slice()).unwrap_err();
+}

--- a/crates/aptos-crypto/src/webauthn/mod.rs
+++ b/crates/aptos-crypto/src/webauthn/mod.rs
@@ -1,0 +1,12 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+//! This module provides an API for the WebAuthn account authenticator as defined in [W3C WebAuthn Level 2](https://www.w3.org/TR/webauthn-2/).
+
+pub mod webauthn_p256_keys;
+pub mod webauthn_p256_sigs;
+
+/// Webauthn traits that all signature schemes should implement
+pub mod webauthn_traits;
+
+pub use webauthn_p256_keys::{WebAuthnP256PublicKey, WebAuthnP256PublicKey as PublicKey};
+pub use webauthn_p256_sigs::{WebAuthnP256Signature, WebAuthnP256Signature as Signature};

--- a/crates/aptos-crypto/src/webauthn/webauthn_p256_keys.rs
+++ b/crates/aptos-crypto/src/webauthn/webauthn_p256_keys.rs
@@ -1,0 +1,286 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This file implements traits for WebAuthn P256 private keys and public keys.
+
+#[cfg(any(test, feature = "fuzzing"))]
+use crate::test_utils::{self, KeyPair};
+use crate::{
+    hash::CryptoHash,
+    p256_ecdsa::{P256PrivateKey, P256PublicKey, P256_PUBLIC_KEY_LENGTH},
+    traits::*,
+    webauthn::webauthn_p256_sigs::WebAuthnP256Signature,
+};
+use aptos_crypto_derive::{DeserializeKey, SerializeKey, SilentDebug, SilentDisplay};
+use core::convert::TryFrom;
+use p256::{self, ecdsa};
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest::prelude::*;
+use serde::Serialize;
+use std::fmt;
+
+
+/// A WebAuthn P256 private key
+#[derive(DeserializeKey, SerializeKey, SilentDebug, SilentDisplay)]
+pub struct WebAuthnP256PrivateKey(pub(crate) P256PrivateKey);
+
+impl private::Sealed for WebAuthnP256PrivateKey {}
+
+#[cfg(feature = "assert-private-keys-not-cloneable")]
+static_assertions::assert_not_impl_any!(WebAuthnP256PrivateKey: Clone);
+
+#[cfg(any(test, feature = "cloneable-private-keys"))]
+impl Clone for WebAuthnP256PrivateKey {
+    fn clone(&self) -> Self {
+        let serialized: &[u8] = &(self.to_bytes());
+        WebAuthnP256PrivateKey::try_from(serialized).unwrap()
+    }
+}
+
+/// A WebAuthn P256 public key
+#[derive(DeserializeKey, Clone, SerializeKey)]
+pub struct WebAuthnP256PublicKey(pub(crate) P256PublicKey);
+
+impl private::Sealed for WebAuthnP256PublicKey {}
+
+impl WebAuthnP256PrivateKey {
+    /// The length of the WebAuthnP256PrivateKey
+    pub const LENGTH: usize = P256PrivateKey::LENGTH;
+
+    /// Serialize a WebAuthnP256PrivateKey.
+    pub fn to_bytes(&self) -> [u8; P256PrivateKey::LENGTH] {
+        self.0.to_bytes()
+    }
+
+    /// Deserialize a WebAuthnP256PrivateKey without any validation checks apart from expected key size.
+    fn from_bytes_unchecked(
+        bytes: &[u8],
+    ) -> std::result::Result<WebAuthnP256PrivateKey, CryptoMaterialError> {
+        match p256::ecdsa::SigningKey::from_slice(bytes) {
+            Ok(p256_secret_key) => Ok(WebAuthnP256PrivateKey(P256PrivateKey(p256_secret_key))),
+            Err(_) => Err(CryptoMaterialError::DeserializationError),
+        }
+    }
+
+    /// This may be problematic
+    ///
+    /// Trait method is required but does NOT work well for WebAuthn signatures
+    /// because auth_data and client_data_json are not known. Normally, this method is expected to return
+    /// a `WebAuthnP256Signature` which is supposed to include both of those fields.
+    ///
+    /// Additionally, a `P256Signature` cannot be returned as this results in a type mismatch
+    /// error resolving `<P256Signature as Signature>::SigningKeyMaterial == WebAuthnP256PrivateKey`
+    ///
+    /// Note also that these raw, fixed byte P256 signatures are different from the ASN.1 DER encoded
+    /// signatures used in the WebAuthn specification.
+    ///
+    /// WebAuthn private keys are never exposed to the user, so in practice
+    /// this would never happen. It is just meant to be a dummy signer function
+    ///
+    /// More info: [WebAuthn §7.2](https://www.w3.org/TR/webauthn-3/#sctn-verifying-assertion)
+    ///
+    /// Private function aimed at minimizing code duplication between sign
+    /// methods of the SigningKey implementation. This should remain private.
+    fn sign_arbitrary_message(&self, _message: &[u8]) -> WebAuthnP256Signature {
+        WebAuthnP256Signature(vec![])
+    }
+}
+
+impl WebAuthnP256PublicKey {
+    /// Serialize a WebAuthnP256PublicKey.
+    pub fn to_bytes(&self) -> [u8; P256_PUBLIC_KEY_LENGTH] {
+        self.0.to_bytes()
+    }
+
+    /// Deserialize a WebAuthnP256PublicKey, checking expected key size
+    /// and that it is a valid curve point.
+    pub(crate) fn from_bytes_unchecked(
+        bytes: &[u8],
+    ) -> Result<WebAuthnP256PublicKey, CryptoMaterialError> {
+        match ecdsa::VerifyingKey::from_sec1_bytes(bytes) {
+            Ok(p256_public_key) => Ok(WebAuthnP256PublicKey(P256PublicKey(p256_public_key))),
+            Err(_) => Err(CryptoMaterialError::DeserializationError),
+        }
+    }
+}
+
+///////////////////////
+// PrivateKey Traits //
+///////////////////////
+
+impl PrivateKey for WebAuthnP256PrivateKey {
+    type PublicKeyMaterial = WebAuthnP256PublicKey;
+}
+
+impl SigningKey for WebAuthnP256PrivateKey {
+    type VerifyingKeyMaterial = WebAuthnP256PublicKey;
+    type SignatureMaterial = WebAuthnP256Signature;
+
+    fn sign<T: CryptoHash + Serialize>(
+        &self,
+        message: &T,
+    ) -> Result<WebAuthnP256Signature, CryptoMaterialError> {
+        Ok(WebAuthnP256PrivateKey::sign_arbitrary_message(
+            self,
+            signing_message(message)?.as_ref(),
+        ))
+    }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    fn sign_arbitrary_message(&self, message: &[u8]) -> WebAuthnP256Signature {
+        WebAuthnP256PrivateKey::sign_arbitrary_message(self, message)
+    }
+}
+
+impl Uniform for WebAuthnP256PrivateKey {
+    fn generate<R>(rng: &mut R) -> Self
+    where
+        R: ::rand::RngCore + ::rand::CryptoRng + ::rand_core::CryptoRng + ::rand_core::RngCore,
+    {
+        let mut bytes: [u8; P256PrivateKey::LENGTH] = Default::default();
+        rng.fill_bytes(&mut bytes);
+        WebAuthnP256PrivateKey(P256PrivateKey(
+            p256::ecdsa::SigningKey::from_slice(&bytes[..]).unwrap(),
+        ))
+    }
+}
+
+impl PartialEq<Self> for WebAuthnP256PrivateKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_bytes() == other.to_bytes()
+    }
+}
+
+impl Eq for WebAuthnP256PrivateKey {}
+
+// We could have a distinct kind of validation for the PrivateKey: e.g., checking the derived
+// PublicKey is valid?
+impl TryFrom<&[u8]> for WebAuthnP256PrivateKey {
+    type Error = CryptoMaterialError;
+
+    /// Deserialize a WebAuthnP256PrivateKey. This method will check for private key validity: i.e.,
+    /// correct key length.
+    fn try_from(bytes: &[u8]) -> std::result::Result<WebAuthnP256PrivateKey, CryptoMaterialError> {
+        // Note that the only requirement is that the size of the key is 32 bytes, something that
+        // is already checked during deserialization of p256::ecdsa::SigningKey
+        WebAuthnP256PrivateKey::from_bytes_unchecked(bytes)
+    }
+}
+
+impl Length for WebAuthnP256PrivateKey {
+    fn length(&self) -> usize {
+        Self::LENGTH
+    }
+}
+
+impl ValidCryptoMaterial for WebAuthnP256PrivateKey {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_bytes().to_vec()
+    }
+}
+
+impl Genesis for WebAuthnP256PrivateKey {
+    fn genesis() -> Self {
+        let mut buf = [0u8; P256PrivateKey::LENGTH];
+        buf[P256PrivateKey::LENGTH - 1] = 1;
+        Self::try_from(buf.as_ref()).unwrap()
+    }
+}
+
+//////////////////////
+// PublicKey Traits //
+//////////////////////
+
+// Implementing From<&PrivateKey<...>> allows to derive a public key in a more elegant fashion
+impl From<&WebAuthnP256PrivateKey> for WebAuthnP256PublicKey {
+    fn from(private_key: &WebAuthnP256PrivateKey) -> Self {
+        let secret = &private_key.0 .0;
+        let public: p256::ecdsa::VerifyingKey = secret.into();
+        WebAuthnP256PublicKey(P256PublicKey(public))
+    }
+}
+
+// We deduce PublicKey from this
+impl PublicKey for WebAuthnP256PublicKey {
+    type PrivateKeyMaterial = WebAuthnP256PrivateKey;
+}
+
+impl std::hash::Hash for WebAuthnP256PublicKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let encoded_pubkey = self.to_bytes();
+        state.write(&encoded_pubkey);
+    }
+}
+
+// Those are required by the implementation of hash above
+impl PartialEq for WebAuthnP256PublicKey {
+    fn eq(&self, other: &WebAuthnP256PublicKey) -> bool {
+        self.to_bytes() == other.to_bytes()
+    }
+}
+
+impl Eq for WebAuthnP256PublicKey {}
+
+// We deduce VerifyingKey from pointing to the signature material
+// we get the ability to do `pubkey.validate(msg, signature)`
+impl VerifyingKey for WebAuthnP256PublicKey {
+    type SignatureMaterial = WebAuthnP256Signature;
+    type SigningKeyMaterial = WebAuthnP256PrivateKey;
+}
+
+impl fmt::Display for WebAuthnP256PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.0 .0.to_sec1_bytes()))
+    }
+}
+
+impl fmt::Debug for WebAuthnP256PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "WebAuthnP256PublicKey({})", self)
+    }
+}
+
+impl TryFrom<&[u8]> for WebAuthnP256PublicKey {
+    type Error = CryptoMaterialError;
+
+    /// Deserialize a WebAuthnP256PublicKey.
+    fn try_from(bytes: &[u8]) -> std::result::Result<WebAuthnP256PublicKey, CryptoMaterialError> {
+        WebAuthnP256PublicKey::from_bytes_unchecked(bytes)
+    }
+}
+
+impl Length for WebAuthnP256PublicKey {
+    fn length(&self) -> usize {
+        P256_PUBLIC_KEY_LENGTH
+    }
+}
+
+impl ValidCryptoMaterial for WebAuthnP256PublicKey {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.0 .0.to_sec1_bytes().to_vec()
+    }
+}
+
+/////////////
+// Fuzzing //
+/////////////
+
+/// Produces a uniformly random P256 keypair from a seed
+#[cfg(any(test, feature = "fuzzing"))]
+pub fn keypair_strategy(
+) -> impl Strategy<Value = KeyPair<WebAuthnP256PrivateKey, WebAuthnP256PublicKey>> {
+    test_utils::uniform_keypair_strategy::<WebAuthnP256PrivateKey, WebAuthnP256PublicKey>()
+}
+
+/// Produces a uniformly random P256 public key
+#[cfg(any(test, feature = "fuzzing"))]
+impl proptest::arbitrary::Arbitrary for WebAuthnP256PublicKey {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        crate::test_utils::uniform_keypair_strategy::<WebAuthnP256PrivateKey, WebAuthnP256PublicKey>()
+            .prop_map(|v| v.public_key)
+            .boxed()
+    }
+}

--- a/crates/aptos-crypto/src/webauthn/webauthn_p256_sigs.rs
+++ b/crates/aptos-crypto/src/webauthn/webauthn_p256_sigs.rs
@@ -1,0 +1,196 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This file implements traits for WebAuthn signatures over NIST-P256.
+
+use crate::webauthn::webauthn_traits::WebAuthnSignature;
+use crate::{
+    hash::CryptoHash,
+    p256_ecdsa::P256Signature,
+    traits::*,
+    webauthn::{webauthn_p256_keys::WebAuthnP256PrivateKey, WebAuthnP256PublicKey},
+};
+use anyhow::anyhow;
+use aptos_crypto_derive::{DeserializeKey, SerializeKey};
+use core::convert::TryFrom;
+use serde::Serialize;
+use signature::Verifier;
+use std::fmt;
+use webauthn_rs_core::assertion::{
+    generate_verification_data, p256_der_to_fixed_size_signature, parse_bcs_encoded_paarr_vector,
+};
+
+/// A WebAuthn P256 signature
+/// This is a BCS Serialized vector of bytes that contains
+/// [`PartialAuthenticatorAssertionResponseRaw`](webauthn_rs_core::assertion::PartialAuthenticatorAssertionResponseRaw)
+/// fields as a BCS serialized vector.
+///
+/// Vector items were serialized in the following order:
+/// 1. `signature`
+/// 2. `authenticator_data`
+/// 3. `client_data_json`
+///
+/// See [`parse_bcs_encoded_paarr_vector`](webauthn_rs_core::assertion::parse_bcs_encoded_paarr_vector)
+/// for more info on how its serialized
+#[derive(DeserializeKey, Clone, SerializeKey)]
+pub struct WebAuthnP256Signature(pub(crate) Vec<u8>);
+
+impl private::Sealed for WebAuthnP256Signature {}
+
+impl WebAuthnP256Signature {
+    /// Serialize a WebAuthnP256Signature.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.as_slice().to_vec()
+    }
+
+    /// Deserialize a WebAuthnP256Signature
+    pub(crate) fn from_bytes_unchecked(
+        bytes: &[u8],
+    ) -> Result<WebAuthnP256Signature, CryptoMaterialError> {
+        Ok(WebAuthnP256Signature(bytes.to_vec()))
+    }
+
+    /// return an all-zero signature (for test only)
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn dummy_signature() -> Self {
+        WebAuthnP256Signature { 0: vec![] }
+    }
+}
+
+/////////////////////
+// WebAuthn Traits //
+/////////////////////
+
+impl WebAuthnSignature for WebAuthnP256Signature {
+    type VerifyingKeyMaterial = WebAuthnP256PublicKey;
+    type SigningKeyMaterial = WebAuthnP256PrivateKey;
+
+    /// Verifies an arbitrary challenge
+    /// 1.  Decodes `PartialAuthenticatorAssertionResponse` from the bcs encoded bytes of the signature
+    /// 2.  Deep equal check to see if the provided `message` (RawTransaction) matches the `actual_challenge`
+    ///     stored on the `WebAuthnP256Signature`.
+    /// 3.  Uses the public key to verify the signature on `verification_data`
+    #[inline]
+    fn verify_arbitrary_challenge(
+        &self,
+        message: &[u8],
+        public_key: &Self::VerifyingKeyMaterial,
+    ) -> anyhow::Result<()> {
+        // Decode PartialAuthenticatorAssertionResponse from bytes
+        let paarr = parse_bcs_encoded_paarr_vector(self.0.as_slice())?;
+        // Generate P256 Signature object from signature bytes
+        let p256_sig = p256_der_to_fixed_size_signature(paarr.signature.as_slice())?;
+
+        // Check if message (RawTransaction) matches actual challenge in signature
+        let is_equal = self.verify_expected_challenge_from_message_matches_actual(
+            message,
+            paarr.client_data.challenge.0.as_slice(),
+        );
+
+        // Check if expected challenge and actual challenge match. If there's no match, throw error
+        if !is_equal {
+            return Err(anyhow!(
+                "Error: WebAuthn expected challenge did not match actual challenge"
+            ));
+        }
+
+        // Generate verification data
+        let verification_data = generate_verification_data(
+            paarr.authenticator_data_bytes.as_slice(),
+            paarr.client_data_bytes.as_slice(),
+        );
+
+        // Verify signature against verification data
+        public_key
+            .0
+             .0
+            .verify(verification_data.as_slice(), &p256_sig)
+            .map_err(|e| anyhow!("{}", e))
+            .and(Ok(()))
+    }
+}
+
+//////////////////////
+// Signature Traits //
+//////////////////////
+
+impl Signature for WebAuthnP256Signature {
+    type VerifyingKeyMaterial = WebAuthnP256PublicKey;
+    type SigningKeyMaterial = WebAuthnP256PrivateKey;
+
+    /// Verifies that the provided signature is valid for the provided message, going beyond the
+    /// [NIST SP 800-186](https://csrc.nist.gov/publications/detail/sp/800-186/final) specification,
+    /// to prevent scalar malleability as done in [BIP146](https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki).
+    ///
+    /// NOTE: this is a feature of the underlying P256 implementation rather than the WebAuthP256 implementation
+    fn verify<T: CryptoHash + Serialize>(
+        &self,
+        message: &T,
+        public_key: &WebAuthnP256PublicKey,
+    ) -> anyhow::Result<()> {
+        Self::verify_arbitrary_msg(self, &signing_message(message)?, public_key)
+    }
+
+    /// Checks that `self` is valid for an arbitrary &[u8] `message` using `public_key`.
+    /// Outside of this crate, this particular function should only be used for native signature
+    /// verification in Move.
+    fn verify_arbitrary_msg(
+        &self,
+        message: &[u8],
+        public_key: &WebAuthnP256PublicKey,
+    ) -> anyhow::Result<()> {
+        self.verify_arbitrary_challenge(message, public_key)
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_bytes().to_vec()
+    }
+}
+
+impl Length for WebAuthnP256Signature {
+    fn length(&self) -> usize {
+        P256Signature::LENGTH
+    }
+}
+
+impl ValidCryptoMaterial for WebAuthnP256Signature {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_bytes().to_vec()
+    }
+}
+
+impl std::hash::Hash for WebAuthnP256Signature {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let encoded_signature = self.to_bytes();
+        state.write(&encoded_signature);
+    }
+}
+
+impl TryFrom<&[u8]> for WebAuthnP256Signature {
+    type Error = CryptoMaterialError;
+
+    fn try_from(bytes: &[u8]) -> std::result::Result<WebAuthnP256Signature, CryptoMaterialError> {
+        WebAuthnP256Signature::from_bytes_unchecked(bytes)
+    }
+}
+
+// Those are required by the implementation of hash above
+impl PartialEq for WebAuthnP256Signature {
+    fn eq(&self, other: &WebAuthnP256Signature) -> bool {
+        self.to_bytes()[..] == other.to_bytes()[..]
+    }
+}
+
+impl Eq for WebAuthnP256Signature {}
+
+impl fmt::Display for WebAuthnP256Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(&self.to_bytes()[..]))
+    }
+}
+
+impl fmt::Debug for WebAuthnP256Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "WebAuthnP256Signature({})", self)
+    }
+}

--- a/crates/aptos-crypto/src/webauthn/webauthn_traits.rs
+++ b/crates/aptos-crypto/src/webauthn/webauthn_traits.rs
@@ -1,0 +1,49 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module provides traits for all WebAuthn based keys and signatures
+
+use crate::{hash::HashValue, SigningKey, VerifyingKey};
+
+/// WebAuthn Signature trait
+pub trait WebAuthnSignature {
+    /// The associated verifying key type for this signature.
+    type VerifyingKeyMaterial: VerifyingKey<SignatureMaterial = Self>;
+    /// The associated signing key type for this signature
+    type SigningKeyMaterial: SigningKey<SignatureMaterial = Self>;
+
+    /// WebAuthn adaptation of [`verify_arbitrary_message`](crate::traits::Signature).
+    ///
+    /// For WebAuthn, the `challenge` provided to `authenticatorGetAssertion` is the
+    /// SHA3-256 of the `RawTransaction`.
+    /// See §6.3.3 `authenticatorGetAssertion` for more info
+    ///
+    /// This function should do the following:
+    /// 1. Verify `actual_challenge` and expected challenge from message are equal
+    /// 2. Signature verification
+    fn verify_arbitrary_challenge(
+        &self,
+        message: &[u8],
+        public_key: &Self::VerifyingKeyMaterial,
+    ) -> anyhow::Result<()>;
+
+    /// This checks that the SHA3-256 of the message (`RawTransaction`)
+    /// is equal to the actual challenge from the WebAuthn signature
+    fn verify_expected_challenge_from_message_matches_actual(
+        &self,
+        message: &[u8],
+        actual_challenge: &[u8],
+    ) -> bool {
+        // Expected challenge is SHA3-256 digest of RawTransaction bytes
+        let expected_challenge = HashValue::sha3_256_of(message);
+
+        // Compute deep equal of actual challenge and message (expected challenge)
+        let deep_equal_challenge = actual_challenge
+            .iter()
+            .zip(expected_challenge.to_vec().iter())
+            .all(|(a, b)| a == b);
+
+        // Verify that message is equal to challenge
+        deep_equal_challenge
+    }
+}

--- a/experimental/execution/ptx-executor/Cargo.toml
+++ b/experimental/execution/ptx-executor/Cargo.toml
@@ -51,4 +51,4 @@ smallvec = { workspace = true }
 tracing = { workspace = true }
 
 # experimental
-hashbrown = "0.14.0"
+hashbrown = "0.14.2"


### PR DESCRIPTION
## This is an OLD PR

This PR used `webauthn-rs` which contained an `openssl` dependency. We are opting to use a different dependency (`passkey-rs`) to avoid `openssl`.

Additionally the Authenticator design has changed.

NEW PR is WIP, and available here -> https://github.com/aptos-labs/aptos-core/pull/10755

<hr />
## Summary
This PR introduces the first WebAuthn Authenticator to Aptos. We are choosing to use `NIST P256` aka `secp256r1` as the first supported WebAuthn signature scheme because of its broad support across most modern operating systems (MacOS 13+, iOS 16+, Android 9+, and Windows 11 H2 via Windows Hello - to be confirmed). Once complete, this will enable users to sign and submit transactions with a passkey on Aptos.

### `WebAuthnP256` Signatures
`WebAuthnP256Signature` composes a BCS serialized vector of bytes, containing the following elements in order:
1. [`signature`](https://www.w3.org/TR/webauthn-2/#sctn-signature-attestation-types) -> ASN.1 DER Ecdsa-Sig-Value encoded P256 Signature from the [`AuthenticatorAssertionResponse`](https://www.w3.org/TR/webauthn-2/#iface-authenticatorassertionresponse). The signature is computed over the binary concatenation of `authenticator_data` and `SHA256(client_data_json)`.
2. [`authenticator_data`](https://www.w3.org/TR/webauthn-2/#authenticator-data) -> Byte buffer from the [`AuthenticatorAssertionResponse`](https://www.w3.org/TR/webauthn-2/#iface-authenticatorassertionresponse)
3. [`clientDataJSON`](https://www.w3.org/TR/webauthn-2/#dom-authenticatorresponse-clientdatajson) -> attribute name is misleading, but this is a byte buffer that comes from the [`AuthenticatorAssertionResponse`](https://www.w3.org/TR/webauthn-2/#iface-authenticatorassertionresponse). The deserialized version of `clientDataJSON` is known as `CollectedClientData`. It contains a `challenge` field which holds the `SHA3_256(raw_txn)`

### Signature verification
Section [§7.2](https://www.w3.org/TR/webauthn-3/#sctn-verifying-assertion) of the  WebAuthn specification contains a long list of expected verification steps for a WebAuthn assertion. Many of these steps will NOT be checked during verification as the blockchain simply does not have access to the required information or does not need that information to verify a signature. Instead, the WebAuthnP256 AccountAuthenticator will perform the following:

1. Successfully decode the BCS serialized vector of bytes via `parse_bcs_encoded_paarr_vector` and construct a `PartialAuthenticatorAssertionResponse` which includes key fields like `authenticator_data`, `client_data`, and `signature`
2. Determine if the `challenge` in `client_data` is equal to the `SHA3_256(raw_txn)`
3. Verify the signature over `verification_data` - the binary concatenation of `authenticator_data_bytes` and `SHA256(client_data_bytes)` - with the public key

More implementation details on signature verification can be found in `verify_arbitrary_challenge` under `webauthn_p256_sigs.rs`

### `webauthn-rs` fork
To support the WebAuthnP256 AccountAuthenticator I have created a fork of `webauthn-rs` which can be found in [aptos-labs/webauthn-rs](https://github.com/aptos-labs/webauthn-rs). This was needed in order to manually change dependency versions to avoid dependency conflicts as well as to implement custom logic and structs for use with Aptos' AccountAuthenticator. You may see some of the changes [here](https://github.com/kanidm/webauthn-rs/compare/master...aptos-labs:webauthn-rs:master)

## Questions
- I am upgrading `futures` and `hashbrown` deps. Should other futures deps like  `futures-util` be bumped to `0.3.25`?
- `sign_arbitrary_message` on `WebAuthnP256PrivateKey` is challenging to implement due to the complexity of `WebAuthnP256Signatures` and the requirement of variables such as `authenticator_data` and client_data_json`. Are there any suggestions on how it could be made better?

## Test Plan
Unit tests test the following functionality: 
- [x] Verify a standard WebAuthn signature
- [x] Verify a WebAuthn signature when `CollectedClientData` is extended
- [x] Signature verification failure -> fail to decode signature
- [x] Signature verification failure -> wrong public key
- [x] Serialization and deserialization of keys 
- [x] Serialization and deserialization of signatures

Also tested for:
- [x] consensus network_tests pass (related to futures dep upgrade)