### PR TITLE
Minor improvement to partitioning phase in executor benchmark

### DIFF
--- a/execution/block-partitioner/src/sharded_block_partitioner/mod.rs
+++ b/execution/block-partitioner/src/sharded_block_partitioner/mod.rs
@@ -36,7 +36,7 @@ use std::{
 
 pub mod config;
 mod conflict_detector;
-mod counters;
+pub mod counters;
 mod cross_shard_messages;
 mod dependency_analysis;
 mod dependent_edges;

--- a/execution/block-partitioner/src/v2/config.rs
+++ b/execution/block-partitioner/src/v2/config.rs
@@ -51,7 +51,7 @@ impl PartitionerV2Config {
 impl Default for PartitionerV2Config {
     fn default() -> Self {
         Self {
-            num_threads: 8,
+            num_threads: 4,
             max_partitioning_rounds: 4,
             cross_shard_dep_avoid_threshold: 0.9,
             dashmap_num_shards: 64,

--- a/execution/block-partitioner/src/v2/mod.rs
+++ b/execution/block-partitioner/src/v2/mod.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     pre_partition::{uniform_partitioner::UniformPartitioner, PrePartitioner},
+    sharded_block_partitioner::counters::BLOCK_PARTITIONING_SECONDS,
     v2::counters::MISC_TIMERS_SECONDS,
     BlockPartitioner,
 };
@@ -77,10 +78,7 @@ impl BlockPartitioner for PartitionerV2 {
         txns: Vec<AnalyzedTransaction>,
         num_executor_shards: usize,
     ) -> PartitionedTransactions {
-        let _timer = MISC_TIMERS_SECONDS
-            .with_label_values(&["total"])
-            .start_timer();
-
+        let _timer = BLOCK_PARTITIONING_SECONDS.start_timer();
         // Step 0: pre-partition. Divide a list of transactions into `num_executor_shards` chunks.
         let pre_partitioned = self.pre_partition(txns.as_slice(), num_executor_shards);
 

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -101,8 +101,6 @@ pub struct PipelineOpt {
     #[clap(long, default_value = "1")]
     num_executor_shards: usize,
     #[clap(long)]
-    async_partitioning: bool,
-    #[clap(long)]
     use_global_executor: bool,
     #[clap(long, default_value = "4")]
     num_generator_workers: usize,
@@ -127,7 +125,6 @@ impl PipelineOpt {
             allow_discards: self.allow_discards,
             allow_aborts: self.allow_aborts,
             num_executor_shards: self.num_executor_shards,
-            async_partitioning: self.async_partitioning,
             use_global_executor: self.use_global_executor,
             num_generator_workers: self.num_generator_workers,
             partitioner_config: self.partitioner_config(),

--- a/execution/executor-benchmark/src/pipeline.rs
+++ b/execution/executor-benchmark/src/pipeline.rs
@@ -35,7 +35,6 @@ pub struct PipelineConfig {
     pub allow_aborts: bool,
     #[derivative(Default(value = "1"))]
     pub num_executor_shards: usize,
-    pub async_partitioning: bool,
     pub use_global_executor: bool,
     #[derivative(Default(value = "4"))]
     pub num_generator_workers: usize,
@@ -121,112 +120,63 @@ where
             config.allow_aborts,
         );
 
-        if config.async_partitioning {
-            let (executable_block_sender, executable_block_receiver) =
-                mpsc::sync_channel::<ExecuteBlockMessage>(3);
+        let (executable_block_sender, executable_block_receiver) =
+            mpsc::sync_channel::<ExecuteBlockMessage>(3);
 
-            let partitioning_thread = std::thread::Builder::new()
-                .name("block_partitioning".to_string())
-                .spawn(move || {
-                    while let Ok(txns) = raw_block_receiver.recv() {
-                        let exe_block_msg = partitioning_stage.process(txns);
-                        executable_block_sender.send(exe_block_msg).unwrap();
-                    }
-                })
-                .expect("Failed to spawn block partitioner thread.");
-            join_handles.push(partitioning_thread);
+        let partitioning_thread = std::thread::Builder::new()
+            .name("block_partitioning".to_string())
+            .spawn(move || {
+                while let Ok(txns) = raw_block_receiver.recv() {
+                    let exe_block_msg = partitioning_stage.process(txns);
+                    executable_block_sender.send(exe_block_msg).unwrap();
+                }
+            })
+            .expect("Failed to spawn block partitioner thread.");
+        join_handles.push(partitioning_thread);
 
-            let exe_thread = std::thread::Builder::new()
-                .name("txn_executor".to_string())
-                .spawn(move || {
-                    start_execution_rx.map(|rx| rx.recv());
-                    let start_time = Instant::now();
-                    let mut executed = 0;
-                    let start_gas_measurement = GasMesurement::start();
-                    while let Ok(msg) = executable_block_receiver.recv() {
-                        let ExecuteBlockMessage {
-                            current_block_start_time,
-                            partition_time,
-                            block,
-                        } = msg;
-                        let block_size = block.transactions.num_transactions();
-                        info!("Received block of size {:?} to execute", block_size);
-                        executed += block_size;
-                        exe.execute_block(current_block_start_time, partition_time, block);
-                        info!("Finished executing block");
-                    }
+        let exe_thread = std::thread::Builder::new()
+            .name("txn_executor".to_string())
+            .spawn(move || {
+                start_execution_rx.map(|rx| rx.recv());
+                let start_time = Instant::now();
+                let mut executed = 0;
+                let start_gas_measurement = GasMesurement::start();
+                while let Ok(msg) = executable_block_receiver.recv() {
+                    let ExecuteBlockMessage {
+                        current_block_start_time,
+                        partition_time,
+                        block,
+                    } = msg;
+                    let block_size = block.transactions.num_transactions();
+                    info!("Received block of size {:?} to execute", block_size);
+                    executed += block_size;
+                    exe.execute_block(current_block_start_time, partition_time, block);
+                    info!("Finished executing block");
+                }
 
-                    let (delta_gas, delta_gas_count) = start_gas_measurement.end();
+                let (delta_gas, delta_gas_count) = start_gas_measurement.end();
 
-                    let elapsed = start_time.elapsed().as_secs_f64();
-                    info!(
-                        "Overall execution TPS: {} txn/s (over {} txns)",
-                        executed as f64 / elapsed,
-                        executed
-                    );
-                    info!(
-                        "Overall execution GPS: {} gas/s (over {} txns)",
-                        delta_gas / elapsed,
-                        executed
-                    );
-                    info!(
-                        "Overall execution GPT: {} gas/txn (over {} txns)",
-                        delta_gas / (delta_gas_count as f64).max(1.0),
-                        executed
-                    );
+                let elapsed = start_time.elapsed().as_secs_f64();
+                info!(
+                    "Overall execution TPS: {} txn/s (over {} txns)",
+                    executed as f64 / elapsed,
+                    executed
+                );
+                info!(
+                    "Overall execution GPS: {} gas/s (over {} txns)",
+                    delta_gas / elapsed,
+                    executed
+                );
+                info!(
+                    "Overall execution GPT: {} gas/txn (over {} txns)",
+                    delta_gas / (delta_gas_count as f64).max(1.0),
+                    executed
+                );
 
-                    start_commit_tx.map(|tx| tx.send(()));
-                })
-                .expect("Failed to spawn transaction executor thread.");
-            join_handles.push(exe_thread);
-        } else {
-            let par_exe_thread = std::thread::Builder::new()
-                .name("txn_partitioner_executor".to_string())
-                .spawn(move || {
-                    start_execution_rx.map(|rx| rx.recv());
-                    let start_time = Instant::now();
-                    let mut executed = 0;
-                    let start_gas_measurement = GasMesurement::start();
-                    while let Ok(raw_block) = raw_block_receiver.recv() {
-                        info!(
-                            "Received block of size {:?} to partition-then-execute.",
-                            raw_block.len()
-                        );
-                        let ExecuteBlockMessage {
-                            current_block_start_time,
-                            partition_time,
-                            block,
-                        } = partitioning_stage.process(raw_block);
-                        let block_size = block.transactions.num_transactions();
-                        executed += block_size;
-                        exe.execute_block(current_block_start_time, partition_time, block);
-                        info!("Finished executing block");
-                    }
-
-                    let (delta_gas, delta_gas_count) = start_gas_measurement.end();
-
-                    let elapsed = start_time.elapsed().as_secs_f64();
-                    info!(
-                        "Overall execution TPS: {} txn/s (over {} txns)",
-                        executed as f64 / elapsed,
-                        executed
-                    );
-                    info!(
-                        "Overall execution GPS: {} gas/s (over {} txns)",
-                        delta_gas / elapsed,
-                        executed
-                    );
-                    info!(
-                        "Overall execution GPT: {} gas/txn (over {} txns)",
-                        delta_gas / (delta_gas_count as f64).max(1.0),
-                        executed
-                    );
-
-                    start_commit_tx.map(|tx| tx.send(()));
-                })
-                .expect("Failed to spawn transaction executor thread.");
-            join_handles.push(par_exe_thread);
-        }
+                start_commit_tx.map(|tx| tx.send(()));
+            })
+            .expect("Failed to spawn transaction executor thread.");
+        join_handles.push(exe_thread);
 
         let ledger_update_thread = std::thread::Builder::new()
             .name("ledger_update".to_string())


### PR DESCRIPTION
### Description

- Remove `--async-partioning` flag as we default to it now and this also reduces unnecessary code duplication.
- Add stats for partitioning at the end of the log
- Reduce number of threads from 8 to 4 - this will help reduce some context switch overhead. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
