### PR TITLE
[consensus][dag] Truncate bytes when debug logging network message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,7 @@ dependencies = [
  "fail 0.5.0",
  "futures",
  "futures-channel",
+ "hex",
  "itertools",
  "maplit",
  "mirai-annotations",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -55,6 +55,7 @@ dashmap = { workspace = true }
 fail = { workspace = true }
 futures = { workspace = true }
 futures-channel = { workspace = true }
+hex = { workspace = true }
 itertools = { workspace = true }
 maplit = { workspace = true }
 mirai-annotations = { workspace = true }

--- a/consensus/src/dag/tests/types_test.rs
+++ b/consensus/src/dag/tests/types_test.rs
@@ -4,8 +4,8 @@ use super::helpers::new_node;
 use crate::dag::{
     tests::helpers::new_certified_node,
     types::{
-        CertifiedNode, DagSnapshotBitmask, Extensions, Node, NodeCertificate, NodeMetadata,
-        RemoteFetchRequest, TDAGMessage,
+        CertifiedNode, DAGNetworkMessage, DagSnapshotBitmask, Extensions, Node, NodeCertificate,
+        NodeMetadata, RemoteFetchRequest, TDAGMessage,
     },
 };
 use aptos_consensus_types::common::Payload;
@@ -141,4 +141,30 @@ fn test_dag_snapshot_bitmask() {
     assert!(bitmask.has(2, 1));
     assert!(!bitmask.has(10, 10));
     assert_eq!(bitmask.first_round(), 1);
+}
+
+#[test]
+fn test_dag_network_message() {
+    let short_data = vec![10; 10];
+    let long_data = vec![20; 30];
+
+    let short_message = DAGNetworkMessage {
+        epoch: 1,
+        data: short_data,
+    };
+
+    assert_eq!(
+        format!("{:?}", short_message),
+        "DAGNetworkMessage { epoch: 1, data: \"0a0a0a0a0a0a0a0a0a0a\" }"
+    );
+
+    let long_message = DAGNetworkMessage {
+        epoch: 2,
+        data: long_data,
+    };
+
+    assert_eq!(
+        format!("{:?}", long_message),
+        "DAGNetworkMessage { epoch: 2, data: \"1414141414141414141414141414141414141414\" }"
+    );
 }

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -20,7 +20,7 @@ use aptos_types::{
     validator_verifier::ValidatorVerifier,
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, ops::Deref, sync::Arc};
+use std::{cmp::min, collections::HashSet, ops::Deref, sync::Arc};
 
 pub trait TDAGMessage: Into<DAGMessage> + TryFrom<DAGMessage> {
     fn verify(&self, verifier: &ValidatorVerifier) -> anyhow::Result<()>;
@@ -599,11 +599,20 @@ impl FetchResponse {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct DAGNetworkMessage {
     pub epoch: u64,
     #[serde(with = "serde_bytes")]
     pub data: Vec<u8>,
+}
+
+impl core::fmt::Debug for DAGNetworkMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DAGNetworkMessage")
+            .field("epoch", &self.epoch)
+            .field("data", &hex::encode(&self.data[..min(20, self.data.len())]))
+            .finish()
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, EnumConversion)]


### PR DESCRIPTION
### Description

Implement Debug trait to truncate bytes when debug logging DAG Network message.


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

unit test
