### PR TITLE
[aptos-release-v1.6] [consensus][dag] Truncate bytes when debug logging network message (#9872)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,6 +694,7 @@ dependencies = [
  "fail 0.5.0",
  "futures",
  "futures-channel",
+ "hex",
  "itertools",
  "maplit",
  "mirai-annotations",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -53,6 +53,7 @@ dashmap = { workspace = true }
 fail = { workspace = true }
 futures = { workspace = true }
 futures-channel = { workspace = true }
+hex = { workspace = true }
 itertools = { workspace = true }
 maplit = { workspace = true }
 mirai-annotations = { workspace = true }

--- a/consensus/src/dag/tests/types_test.rs
+++ b/consensus/src/dag/tests/types_test.rs
@@ -1,0 +1,29 @@
+// Copyright © Aptos Foundation
+
+use crate::dag::types::DAGNetworkMessage;
+
+#[test]
+fn test_dag_network_message() {
+    let short_data = vec![10; 10];
+    let long_data = vec![20; 30];
+
+    let short_message = DAGNetworkMessage {
+        epoch: 1,
+        data: short_data,
+    };
+
+    assert_eq!(
+        format!("{:?}", short_message),
+        "DAGNetworkMessage { epoch: 1, data: \"0a0a0a0a0a0a0a0a0a0a\" }"
+    );
+
+    let long_message = DAGNetworkMessage {
+        epoch: 2,
+        data: long_data,
+    };
+
+    assert_eq!(
+        format!("{:?}", long_message),
+        "DAGNetworkMessage { epoch: 2, data: \"1414141414141414141414141414141414141414\" }"
+    );
+}

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -22,7 +22,7 @@ use aptos_types::{
     validator_verifier::ValidatorVerifier,
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, ops::Deref, sync::Arc};
+use std::{cmp::min, collections::HashSet, ops::Deref, sync::Arc};
 
 pub trait TDAGMessage: Into<DAGMessage> + TryFrom<DAGMessage> {
     fn verify(&self, verifier: &ValidatorVerifier) -> anyhow::Result<()>;
@@ -432,11 +432,20 @@ impl FetchResponse {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct DAGNetworkMessage {
     pub epoch: u64,
     #[serde(with = "serde_bytes")]
     pub data: Vec<u8>,
+}
+
+impl core::fmt::Debug for DAGNetworkMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DAGNetworkMessage")
+            .field("epoch", &self.epoch)
+            .field("data", &hex::encode(&self.data[..min(20, self.data.len())]))
+            .finish()
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, EnumConversion)]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `aptos-release-v1.6`:
 - [[consensus][dag] Truncate bytes when debug logging network message (#9872)](https://github.com/aptos-labs/aptos-core/pull/9872)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)