### PR TITLE
[GHA] Use versioned actions/checkout instead of pinning a commit

### DIFF
--- a/.github/actions/docker-setup/action.yaml
+++ b/.github/actions/docker-setup/action.yaml
@@ -74,7 +74,7 @@ runs:
 
     - id: auth
       name: "Authenticate to Google Cloud"
-      uses: "google-github-actions/auth@dac4e13deb3640f22e3ffe758fd3f95e6e89f712" # pin@v0
+      uses: "google-github-actions/auth@v1"
       with:
         create_credentials_file: false
         token_format: "access_token"

--- a/.github/actions/docker-setup/action.yaml
+++ b/.github/actions/docker-setup/action.yaml
@@ -84,21 +84,21 @@ runs:
         export_environment_variables: ${{ inputs.EXPORT_GCP_PROJECT_VARIABLES }}
 
     - name: Login to us-west1 Google Artifact Registry
-      uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # pin@v2
+      uses: docker/login-action@v2
       with:
         registry: us-west1-docker.pkg.dev
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
 
     - name: Login to US multi-region Google Artifact Registry
-      uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # pin@v2
+      uses: docker/login-action@v2
       with:
         registry: us-docker.pkg.dev
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
 
     - name: Login to ECR
-      uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # pin@v2
+      uses: docker/login-action@v2
       with:
         registry: ${{ inputs.AWS_DOCKER_ARTIFACT_REPO }}
         username: ${{ inputs.AWS_ACCESS_KEY_ID }}

--- a/.github/actions/get-latest-cli/action.yaml
+++ b/.github/actions/get-latest-cli/action.yaml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Setup python
-      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4
+      uses: actions/setup-python@v4
     - name: Get installation script
       shell: bash
       run: |

--- a/.github/actions/get-latest-docker-image-tag/action.yml
+++ b/.github/actions/get-latest-docker-image-tag/action.yml
@@ -18,7 +18,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+    - uses: actions/checkout@v3
       with:
         ref: ${{ inputs.branch }}
         path: checkout_branch

--- a/.github/actions/python-lint-tests/action.yaml
+++ b/.github/actions/python-lint-tests/action.yaml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+    - uses: actions/checkout@v3
       with:
         ref: ${{ inputs.GIT_SHA }}
         # Get enough commits to compare to

--- a/.github/actions/python-setup/action.yaml
+++ b/.github/actions/python-setup/action.yaml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - name: Setup python
-      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4
+      uses: actions/setup-python@v4
 
     # Install Poetry.
     - uses: snok/install-poetry@d45b6d76012debf457ab49dffc7fb7b2efe8071d # pin@v1.3.3

--- a/.github/actions/run-local-testnet/action.yaml
+++ b/.github/actions/run-local-testnet/action.yaml
@@ -23,7 +23,7 @@ runs:
       shell: bash
 
     # Install node + npm.
-    - uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # pin@v3
+    - uses: actions/setup-node@v3
       with:
         node-version-file: .node-version
         registry-url: "https://registry.npmjs.org"

--- a/.github/actions/run-ts-sdk-e2e-tests/action.yaml
+++ b/.github/actions/run-ts-sdk-e2e-tests/action.yaml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     # Install node and pnpm.
-    - uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # pin@v3
+    - uses: actions/setup-node@v3
       with:
         node-version-file: .node-version
         registry-url: "https://registry.npmjs.org"

--- a/.github/actions/run-ts-sdk-e2e-tests/action.yaml
+++ b/.github/actions/run-ts-sdk-e2e-tests/action.yaml
@@ -17,7 +17,7 @@ runs:
       with:
         node-version-file: .node-version
         registry-url: "https://registry.npmjs.org"
-    - uses: pnpm/action-setup@537643d491d20c2712d11533497cb47b2d0eb9d5 # pin https://github.com/pnpm/action-setup/releases/tag/v2.2.3
+    - uses: pnpm/action-setup@v2
 
     # Find a docker image to use for the testnet.
     - uses: ./.github/actions/get-latest-docker-image-tag

--- a/.github/workflows/aptos-node-release.yaml
+++ b/.github/workflows/aptos-node-release.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
 
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4
+      - uses: actions/setup-python@v4
 
       - name: Bump aptos-node version
         uses: aptos-labs/aptos-core/.github/actions/release-aptos-node@main

--- a/.github/workflows/aptos-node-release.yaml
+++ b/.github/workflows/aptos-node-release.yaml
@@ -19,7 +19,7 @@ jobs:
   release-aptos-node:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.branch }}
 

--- a/.github/workflows/build-node-binaries.yaml
+++ b/.github/workflows/build-node-binaries.yaml
@@ -41,7 +41,7 @@ jobs:
           mv "$TARNAME" ../../
 
       - name: Upload Binary
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        uses: actions/upload-artifact@v3
         with:
           name: aptos-node-${{ matrix.os }}
           path: aptos-node-*.tgz

--- a/.github/workflows/build-node-binaries.yaml
+++ b/.github/workflows/build-node-binaries.yaml
@@ -22,7 +22,7 @@ jobs:
     name: "Build Aptos Node Binary on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           # ref: ${{ github.event.inputs.git_ref }}
           ref: aptos-node-v1.4.3

--- a/.github/workflows/cargo-metadata-upload.yaml
+++ b/.github/workflows/cargo-metadata-upload.yaml
@@ -16,11 +16,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
       - id: auth
-        uses: "google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033" # pin@v
+        uses: "google-github-actions/auth@v1"
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-      - uses: 'google-github-actions/setup-gcloud@v1'
+      - uses: "google-github-actions/setup-gcloud@v1"
       - shell: bash
         run: |
           cargo metadata --all-features | gsutil cp - gs://aptos-core-cargo-metadata-public/metadata-${{ github.sha }}.json

--- a/.github/workflows/check-minimum-revision.yaml
+++ b/.github/workflows/check-minimum-revision.yaml
@@ -20,7 +20,7 @@ jobs:
   check-minimum-revision:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ env.GIT_SHA }}
           fetch-depth: 1000

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Ubuntu"
       - name: Upload Binary
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        uses: actions/upload-artifact@v3
         with:
           name: cli-builds
           path: aptos-cli-*.zip
@@ -48,7 +48,7 @@ jobs:
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Ubuntu-22.04"
       - name: Upload Binary
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        uses: actions/upload-artifact@v3
         with:
           name: cli-builds
           path: aptos-cli-*.zip
@@ -63,7 +63,7 @@ jobs:
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "MacOSX"
       - name: Upload Binary
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        uses: actions/upload-artifact@v3
         with:
           name: cli-builds
           path: aptos-cli-*.zip
@@ -78,7 +78,7 @@ jobs:
       - name: Build CLI
         run: scripts\cli\build_cli_release.ps1
       - name: Upload Binary
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+        uses: actions/upload-artifact@v3
         with:
           name: cli-builds
           path: aptos-cli-*.zip

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -97,7 +97,7 @@ jobs:
     if: ${{ inputs.dry_run }} == 'false'
     steps:
       - name: Download prebuilt binaries
-        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin@v3
+        uses: actions/download-artifact@v3
         with:
           name: cli-builds
       - name: Create GitHub Release

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -25,7 +25,7 @@ jobs:
     name: "Build Ubuntu 20.04 binary"
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
@@ -41,7 +41,7 @@ jobs:
     name: "Build Ubuntu 22.04 binary"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
@@ -57,7 +57,7 @@ jobs:
     name: "Build OS X binary"
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - name: Build CLI
@@ -72,7 +72,7 @@ jobs:
     name: "Build Windows binary"
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - name: Build CLI

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        uses: actions/checkout@v3
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -52,7 +52,7 @@ jobs:
         with:
           node-version-file: .node-version
 
-      - uses: pnpm/action-setup@537643d491d20c2712d11533497cb47b2d0eb9d5 # pin https://github.com/pnpm/action-setup/releases/tag/v2.2.3
+      - uses: pnpm/action-setup@v2
 
       - name: Release Images
         env:

--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -43,7 +43,7 @@ jobs:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # pin@v2
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
           password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}

--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -31,7 +31,7 @@ jobs:
     # Run on a machine with more local storage for large docker images
     runs-on: medium-perf-docker-with-local-ssd
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
 
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -31,7 +31,7 @@ jobs:
       - run: cargo llvm-cov --ignore-run-fail --workspace --exclude smoke-test --exclude aptos-testcases --lcov --jobs 32 --output-path lcov_unit.info
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
-      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+      - uses: actions/upload-artifact@v3
         with:
           name: lcov_unit
           path: lcov_unit.info
@@ -53,7 +53,7 @@ jobs:
       - run: cargo llvm-cov --ignore-run-fail --package smoke-test --lcov --output-path lcov_smoke.info
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
-      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
+      - uses: actions/upload-artifact@v3
         with:
           name: lcov_smoke
           path: lcov_smoke.info

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -64,10 +64,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin@v3
+      - uses: actions/download-artifact@v3
         with:
           name: lcov_unit
-      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin@v3
+      - uses: actions/download-artifact@v3
         with:
           name: lcov_smoke
       - name: Upload coverage to Codecov

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 120
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 120
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
@@ -63,7 +63,7 @@ jobs:
     needs: [ rust-unit-coverage, rust-smoke-coverage ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin@v3
         with:
           name: lcov_unit

--- a/.github/workflows/cut-release-branch.yaml
+++ b/.github/workflows/cut-release-branch.yaml
@@ -31,7 +31,7 @@ jobs:
   cut-release-branch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.CUT_RELEASE_BRANCH_CREDENTIALS }}
           fetch-depth: 0

--- a/.github/workflows/docker-build-rosetta.yaml
+++ b/.github/workflows/docker-build-rosetta.yaml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
 
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:

--- a/.github/workflows/docker-indexer-grpc-test.yaml
+++ b/.github/workflows/docker-indexer-grpc-test.yaml
@@ -23,7 +23,7 @@ jobs:
       IMAGE_TAG: ${{ inputs.GIT_SHA || 'devnet' }} # hardcode to a known good build when not running on workflow_call
 
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.GIT_SHA || github.event.pull_request.head.sha || github.sha }}
 

--- a/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
+++ b/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
@@ -6,6 +6,6 @@ jobs:
   find-packages-with-undeclared-feature-dependencies:
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - run: scripts/find-packages-with-undeclared-feature-dependencies.sh

--- a/.github/workflows/forge-pfn.yaml
+++ b/.github/workflows/forge-pfn.yaml
@@ -44,7 +44,7 @@ jobs:
       IMAGE_TAG: ${{ steps.get-docker-image-tag.outputs.IMAGE_TAG }}
       BRANCH: ${{ steps.determine-test-branch.outputs.BRANCH }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
 
       - name: Determine branch based on cadence
         id: determine-test-branch

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -46,7 +46,7 @@ jobs:
       IMAGE_TAG: ${{ steps.get-docker-image-tag.outputs.IMAGE_TAG }}
       BRANCH: ${{ steps.determine-test-branch.outputs.BRANCH }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
 
       - name: Determine branch based on cadence
         id: determine-test-branch

--- a/.github/workflows/forge-unstable.yaml
+++ b/.github/workflows/forge-unstable.yaml
@@ -40,7 +40,7 @@ jobs:
       IMAGE_TAG: ${{ steps.get-docker-image-tag.outputs.IMAGE_TAG }}
       BRANCH: ${{ steps.determine-test-branch.outputs.BRANCH }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
 
       - name: Determine branch based on cadence
         id: determine-test-branch

--- a/.github/workflows/grafana-sync.yaml
+++ b/.github/workflows/grafana-sync.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@537643d491d20c2712d11533497cb47b2d0eb9d5 # pin https://github.com/pnpm/action-setup/releases/tag/v2.2.3
+      - uses: pnpm/action-setup@v2
         with:
           run_install: |
             - recursive: false

--- a/.github/workflows/grafana-sync.yaml
+++ b/.github/workflows/grafana-sync.yaml
@@ -17,7 +17,7 @@ jobs:
   grafana-sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
       - uses: pnpm/action-setup@537643d491d20c2712d11533497cb47b2d0eb9d5 # pin https://github.com/pnpm/action-setup/releases/tag/v2.2.3
         with:
           run_install: |

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -73,7 +73,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
+      - uses: actions/setup-python@v4
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -72,7 +72,7 @@ jobs:
     runs-on: high-perf-docker
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:

--- a/.github/workflows/node-api-compatibility-tests.yaml
+++ b/.github/workflows/node-api-compatibility-tests.yaml
@@ -48,7 +48,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ env.GIT_SHA }}

--- a/.github/workflows/node-api-compatibility-tests.yaml
+++ b/.github/workflows/node-api-compatibility-tests.yaml
@@ -71,7 +71,7 @@ jobs:
 
       # Self hosted runners don't have pnpm preinstalled.
       # https://github.com/actions/setup-node/issues/182
-      - uses: pnpm/action-setup@537643d491d20c2712d11533497cb47b2d0eb9d5 # pin https://github.com/pnpm/action-setup/releases/tag/v2.2.3
+      - uses: pnpm/action-setup@v2
         if: ${{ !inputs.SKIP_JOB }}
 
       # When using high-perf-docker, the CI is actually run with two containers

--- a/.github/workflows/node-api-compatibility-tests.yaml
+++ b/.github/workflows/node-api-compatibility-tests.yaml
@@ -63,7 +63,7 @@ jobs:
           AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
 
-      - uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # pin@v3
+      - uses: actions/setup-node@v3
         if: ${{ !inputs.SKIP_JOB }}
         with:
           node-version-file: .node-version

--- a/.github/workflows/prover-daily-test.yaml
+++ b/.github/workflows/prover-daily-test.yaml
@@ -20,7 +20,7 @@ jobs:
   prover-inconsistency-test:
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main

--- a/.github/workflows/prover-test.yaml
+++ b/.github/workflows/prover-test.yaml
@@ -36,7 +36,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'CICD:run-prover-test')
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main

--- a/.github/workflows/prune-old-workflow-runs.yaml
+++ b/.github/workflows/prune-old-workflow-runs.yaml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'aptos-labs/aptos-core'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # pin@v3
         with:
           node-version-file: .node-version

--- a/.github/workflows/prune-old-workflow-runs.yaml
+++ b/.github/workflows/prune-old-workflow-runs.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: .node-version
-      - uses: pnpm/action-setup@537643d491d20c2712d11533497cb47b2d0eb9d5 # pin https://github.com/pnpm/action-setup/releases/tag/v2.2.3
+      - uses: pnpm/action-setup@v2
 
       - run: pnpm i && pnpm pruneGithubWorkflowRuns
         env:

--- a/.github/workflows/prune-old-workflow-runs.yaml
+++ b/.github/workflows/prune-old-workflow-runs.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # pin@v3
+      - uses: actions/setup-node@v3
         with:
           node-version-file: .node-version
       - uses: pnpm/action-setup@537643d491d20c2712d11533497cb47b2d0eb9d5 # pin https://github.com/pnpm/action-setup/releases/tag/v2.2.3

--- a/.github/workflows/replay-verify.yaml
+++ b/.github/workflows/replay-verify.yaml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # checkout the repo first, so check-aptos-core can use it and cancel the workflow if necessary
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/run-fullnode-sync.yaml
+++ b/.github/workflows/run-fullnode-sync.yaml
@@ -60,7 +60,7 @@ jobs:
     runs-on: medium-perf-docker-with-local-ssd
     timeout-minutes: ${{ inputs.TIMEOUT_MINUTES || 300 }} # the default run is 300 minutes (5 hours). Specified here because workflow_dispatch uses string rather than number
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
 
       - uses: ./.github/actions/fullnode-sync
         with:
@@ -105,6 +105,6 @@ jobs:
       # Because we have to checkout the actions and then check out a different
       # git ref, it's possible the actions directory will be modified. So, we
       # need to check it out again for the Post Run actions/checkout to succeed.
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           path: actions

--- a/.github/workflows/rust-client-tests.yaml
+++ b/.github/workflows/rust-client-tests.yaml
@@ -33,7 +33,7 @@ jobs:
     needs: [permission-check]
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -52,7 +52,7 @@ jobs:
     needs: [permission-check]
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -71,7 +71,7 @@ jobs:
     needs: [permission-check]
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -49,7 +49,7 @@ jobs:
     needs: [permission-check, file_change_determinator]
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         with:
           ref: ${{ env.GIT_SHA }}
@@ -80,7 +80,7 @@ jobs:
     needs: [permission-check]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ env.GIT_SHA }}
       - uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # pin@v3

--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -87,7 +87,7 @@ jobs:
         with:
           node-version-file: .node-version
           registry-url: "https://registry.npmjs.org"
-      - uses: pnpm/action-setup@537643d491d20c2712d11533497cb47b2d0eb9d5 # pin https://github.com/pnpm/action-setup/releases/tag/v2.2.3
+      - uses: pnpm/action-setup@v2
 
       # Run package install. If install fails, it probably means the lockfile
       # was not included in the commit.

--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ env.GIT_SHA }}
-      - uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # pin@v3
+      - uses: actions/setup-node@v3
         with:
           node-version-file: .node-version
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -76,7 +76,7 @@ jobs:
   rust-all:
     runs-on: experimental-docker
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ env.GIT_SHA }}
 

--- a/.github/workflows/workflow-run-execution-performance.yaml
+++ b/.github/workflows/workflow-run-execution-performance.yaml
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ${{ inputs.RUNNER_NAME }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.GIT_SHA }}
         if: ${{ needs.file_change_determinator.outputs.only_docs_changed != 'true' && !inputs.RUN_ONLY_SINGLE_NODE_PERF }}
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ${{ inputs.RUNNER_NAME }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.GIT_SHA }}
         if: ${{ needs.file_change_determinator.outputs.only_docs_changed != 'true' && !inputs.RUN_ONLY_SINGLE_NODE_PERF }}
@@ -104,7 +104,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ${{ inputs.RUNNER_NAME }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.GIT_SHA }}
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'

--- a/.github/workflows/workflow-run-forge.yaml
+++ b/.github/workflows/workflow-run-forge.yaml
@@ -115,7 +115,7 @@ jobs:
           # get the last 10 commits if GIT_SHA is not specified
           fetch-depth: inputs.GIT_SHA != null && 0 || 10
 
-      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4
+      - uses: actions/setup-python@v4
         if: ${{ !inputs.SKIP_JOB }}
 
       - name: Install python deps

--- a/.github/workflows/workflow-run-forge.yaml
+++ b/.github/workflows/workflow-run-forge.yaml
@@ -153,7 +153,7 @@ jobs:
 
       - name: "Install GCloud SDK"
         if: ${{ !inputs.SKIP_JOB }}
-        uses: "google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587" # pin@v1
+        uses: "google-github-actions/setup-gcloud@v1"
         with:
           version: ">= 418.0.0"
           install_components: "kubectl,gke-gcloud-auth-plugin"

--- a/.github/workflows/workflow-run-forge.yaml
+++ b/.github/workflows/workflow-run-forge.yaml
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.TIMEOUT_MINUTES }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ inputs.GIT_SHA }}

--- a/.github/workflows/workflow-run-module-verify.yaml
+++ b/.github/workflows/workflow-run-module-verify.yaml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: ${{ inputs.TIMEOUT_MINUTES }}
     runs-on: ${{ inputs.RUNS_ON }}
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.GIT_SHA }}
 

--- a/.github/workflows/workflow-run-replay-verify.yaml
+++ b/.github/workflows/workflow-run-replay-verify.yaml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - name: Echo Runner Number
         run: echo "Runner is ${{ matrix.number }}"
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.GIT_SHA }}
 


### PR DESCRIPTION
### Description

Trying to get rid of annoying warnings that "The `save-state` command is deprecated and will be disabled soon."