### PR TITLE
Fix Python example tests

### DIFF
--- a/ecosystem/python/sdk/aptos_sdk/account_sequence_number.py
+++ b/ecosystem/python/sdk/aptos_sdk/account_sequence_number.py
@@ -178,7 +178,7 @@ class Test(unittest.IsolatedAsyncioTestCase):
 
         rest_client = RestClient("https://fullnode.devnet.aptoslabs.com/v1")
         account_sequence_number = AccountSequenceNumber(
-            rest_client, AccountAddress.from_str("b0b")
+            rest_client, AccountAddress.from_str("0xf")
         )
         last_seq_num = 0
         for seq_num in range(5):

--- a/ecosystem/python/sdk/aptos_sdk/transaction_worker.py
+++ b/ecosystem/python/sdk/aptos_sdk/transaction_worker.py
@@ -182,7 +182,7 @@ class TransactionQueue:
 class Test(unittest.IsolatedAsyncioTestCase):
     async def test_common_path(self):
         transaction_arguments = [
-            TransactionArgument(AccountAddress.from_str("b0b"), Serializer.struct),
+            TransactionArgument(AccountAddress.from_str("0xf"), Serializer.struct),
             TransactionArgument(100, Serializer.u64),
         ]
         payload = EntryFunction.natural(


### PR DESCRIPTION
### Description
Odds are this is broken because of the new from_str handling. Not sure how this slipped through though.

The error was coming from the fact that with strict parsing, `b0b` is not a valid address string. I fix it by changing the example address we use to `0xf`.

### Test Plan
```
$ make test
poetry run python -m unittest discover -s aptos_sdk/ -p '*.py' -t ..
.....................................
----------------------------------------------------------------------
Ran 37 tests in 0.395s

OK
```
