### PR TITLE
[SDKv2] Migrate crypto classes over to sdk v2

### DIFF
--- a/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
@@ -15,7 +15,7 @@ import { Ed25519PublicKey } from "./ed25519";
  * Account addresses can be derived from AuthenticationKey
  */
 export class AuthenticationKey {
-  // Length of AuthenticationKey in bytes(UInt8Array)
+  // Length of AuthenticationKey in bytes(Uint8Array)
   static readonly LENGTH: number = 32;
 
   // Scheme identifier for MultiEd25519 signatures used to derive authentication keys for MultiEd25519 public keys
@@ -28,18 +28,23 @@ export class AuthenticationKey {
   // authentication key) of a resource account.
   static readonly DERIVE_RESOURCE_ACCOUNT_SCHEME: number = 255;
 
-  private readonly _data: Hex;
+  public readonly data: Hex;
 
-  constructor(hexInput: HexInput) {
-    const hex = Hex.fromHexInput({ hexInput });
+  constructor(args: { data: HexInput }) {
+    const { data } = args;
+    const hex = Hex.fromHexInput({ hexInput: data });
     if (hex.toUint8Array().length !== AuthenticationKey.LENGTH) {
       throw new Error(`Authentication Key length should be ${AuthenticationKey.LENGTH}`);
     }
-    this._data = hex;
+    this.data = hex;
   }
 
-  get data(): Hex {
-    return this._data;
+  toString(): string {
+    return this.data.toString();
+  }
+
+  toUint8Array(): Uint8Array {
+    return this.data.toUint8Array();
   }
 
   /**
@@ -57,7 +62,7 @@ export class AuthenticationKey {
     const hash = sha3Hash.create();
     hash.update(bytes);
 
-    return new AuthenticationKey(hash.digest());
+    return new AuthenticationKey({ data: hash.digest() });
   }
 
   static fromEd25519PublicKey(publicKey: Ed25519PublicKey): AuthenticationKey {
@@ -70,7 +75,7 @@ export class AuthenticationKey {
     const hash = sha3Hash.create();
     hash.update(bytes);
 
-    return new AuthenticationKey(hash.digest());
+    return new AuthenticationKey({ data: hash.digest() });
   }
 
   /**

--- a/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
@@ -1,0 +1,73 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
+import { AccountAddress, Hex } from "../core";
+import { HexInput } from "../types";
+import { MultiEd25519PublicKey } from "./multi_ed25519";
+import { Ed25519PublicKey } from "./ed25519";
+
+/**
+ * Each account stores an authentication key. Authentication key enables account owners to rotate
+ * their private key(s) associated with the account without changing the address that hosts their account.
+ * @see {@link * https://aptos.dev/concepts/accounts | Account Basics}
+ *
+ * Account addresses can be derived from AuthenticationKey
+ */
+export class AuthenticationKey {
+  static readonly LENGTH: number = 32;
+
+  static readonly MULTI_ED25519_SCHEME: number = 1;
+
+  static readonly ED25519_SCHEME: number = 0;
+
+  static readonly DERIVE_RESOURCE_ACCOUNT_SCHEME: number = 255;
+
+  readonly data: Hex;
+
+  constructor(hexInput: HexInput) {
+    if (hexInput.length !== AuthenticationKey.LENGTH) {
+      throw new Error("Expected a byte array of length 32");
+    }
+    this.data = Hex.fromHexInput({ hexInput });
+  }
+
+  /**
+   * Converts a K-of-N MultiEd25519PublicKey to AuthenticationKey with:
+   * `auth_key = sha3-256(p_1 | … | p_n | K | 0x01)`. `K` represents the K-of-N required for
+   * authenticating the transaction. `0x01` is the 1-byte scheme for multisig.
+   */
+  static fromMultiEd25519PublicKey(publicKey: MultiEd25519PublicKey): AuthenticationKey {
+    const pubKeyBytes = publicKey.toUint8Array();
+
+    const bytes = new Uint8Array(pubKeyBytes.length + 1);
+    bytes.set(pubKeyBytes);
+    bytes.set([AuthenticationKey.MULTI_ED25519_SCHEME], pubKeyBytes.length);
+
+    const hash = sha3Hash.create();
+    hash.update(bytes);
+
+    return new AuthenticationKey(hash.digest());
+  }
+
+  static fromEd25519PublicKey(publicKey: Ed25519PublicKey): AuthenticationKey {
+    const pubKeyBytes = publicKey.value.toUint8Array();
+
+    const bytes = new Uint8Array(pubKeyBytes.length + 1);
+    bytes.set(pubKeyBytes);
+    bytes.set([AuthenticationKey.ED25519_SCHEME], pubKeyBytes.length);
+
+    const hash = sha3Hash.create();
+    hash.update(bytes);
+
+    return new AuthenticationKey(hash.digest());
+  }
+
+  /**
+   * Derives an account address from AuthenticationKey. Since current AccountAddress is 32 bytes,
+   * AuthenticationKey bytes are directly translated to AccountAddress.
+   */
+  derivedAddress(): AccountAddress {
+    return new AccountAddress({ data: this.data.toUint8Array() });
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
@@ -26,10 +26,11 @@ export class AuthenticationKey {
   readonly data: Hex;
 
   constructor(hexInput: HexInput) {
-    if (hexInput.length !== AuthenticationKey.LENGTH) {
-      throw new Error("Expected a byte array of length 32");
+    const hex = Hex.fromHexInput({ hexInput });
+    if (hex.toUint8Array().length !== AuthenticationKey.LENGTH) {
+      throw new Error("Expected a hexinput of length 32");
     }
-    this.data = Hex.fromHexInput({ hexInput });
+    this.data = hex;
   }
 
   /**

--- a/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
@@ -15,22 +15,31 @@ import { Ed25519PublicKey } from "./ed25519";
  * Account addresses can be derived from AuthenticationKey
  */
 export class AuthenticationKey {
+  // Length of AuthenticationKey in bytes(UInt8Array)
   static readonly LENGTH: number = 32;
 
+  // Scheme identifier for MultiEd25519 signatures used to derive authentication keys for MultiEd25519 public keys
   static readonly MULTI_ED25519_SCHEME: number = 1;
 
+  // Scheme identifier for Ed25519 signatures used to derive authentication key for MultiEd25519 public key
   static readonly ED25519_SCHEME: number = 0;
 
+  // Scheme identifier used when hashing an account's address together with a seed to derive the address (not the
+  // authentication key) of a resource account.
   static readonly DERIVE_RESOURCE_ACCOUNT_SCHEME: number = 255;
 
-  readonly data: Hex;
+  private readonly _data: Hex;
 
   constructor(hexInput: HexInput) {
     const hex = Hex.fromHexInput({ hexInput });
     if (hex.toUint8Array().length !== AuthenticationKey.LENGTH) {
-      throw new Error("Expected a hexinput of length 32");
+      throw new Error(`Authentication Key length should be ${AuthenticationKey.LENGTH}`);
     }
-    this.data = hex;
+    this._data = hex;
+  }
+
+  get data(): Hex {
+    return this._data;
   }
 
   /**

--- a/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
@@ -1,0 +1,51 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Deserializer, Serializer } from "../bcs";
+import { Hex } from "../core";
+import { HexInput } from "../types";
+
+export class Ed25519PublicKey {
+  static readonly LENGTH: number = 32;
+
+  readonly value: Hex;
+
+  constructor(value: HexInput) {
+    if (value.length !== Ed25519PublicKey.LENGTH) {
+      throw new Error(`Ed25519PublicKey length should be ${Ed25519PublicKey.LENGTH}`);
+    }
+    this.value = Hex.fromHexInput({ hexInput: value });
+  }
+
+  toUint8Array(): Uint8Array {
+    return this.value.toUint8Array();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeBytes(this.value.toUint8Array());
+  }
+
+  static deserialize(deserializer: Deserializer): Ed25519PublicKey {
+    const value = deserializer.deserializeBytes();
+    return new Ed25519PublicKey(value);
+  }
+}
+
+export class Ed25519Signature {
+  static readonly LENGTH = 64;
+
+  constructor(public readonly value: Uint8Array) {
+    if (value.length !== Ed25519Signature.LENGTH) {
+      throw new Error(`Ed25519Signature length should be ${Ed25519Signature.LENGTH}`);
+    }
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeBytes(this.value);
+  }
+
+  static deserialize(deserializer: Deserializer): Ed25519Signature {
+    const value = deserializer.deserializeBytes();
+    return new Ed25519Signature(value);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
@@ -35,10 +35,13 @@ export class Ed25519PublicKey {
 export class Ed25519Signature {
   static readonly LENGTH = 64;
 
-  constructor(public readonly value: Uint8Array) {
+  public readonly value: Uint8Array;
+
+  constructor(value: Uint8Array) {
     if (value.length !== Ed25519Signature.LENGTH) {
       throw new Error(`Ed25519Signature length should be ${Ed25519Signature.LENGTH}`);
     }
+    this.value = value;
   }
 
   serialize(serializer: Serializer): void {

--- a/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
@@ -6,24 +6,30 @@ import { Hex } from "../core";
 import { HexInput } from "../types";
 
 export class Ed25519PublicKey {
+  // Correct length of the public key in bytes (Uint8Array)
   static readonly LENGTH: number = 32;
 
-  readonly value: Hex;
+  // The public key in hex format
+  readonly data: Hex;
 
   constructor(hexInput: HexInput) {
     const hex = Hex.fromHexInput({ hexInput });
     if (hex.toUint8Array().length !== Ed25519PublicKey.LENGTH) {
       throw new Error(`Ed25519PublicKey length should be ${Ed25519PublicKey.LENGTH}`);
     }
-    this.value = hex;
+    this.data = hex;
   }
 
   toUint8Array(): Uint8Array {
-    return this.value.toUint8Array();
+    return this.data.toUint8Array();
+  }
+
+  toString(): string {
+    return this.data.toString();
   }
 
   serialize(serializer: Serializer): void {
-    serializer.serializeBytes(this.value.toUint8Array());
+    serializer.serializeBytes(this.data.toUint8Array());
   }
 
   static deserialize(deserializer: Deserializer): Ed25519PublicKey {
@@ -35,17 +41,17 @@ export class Ed25519PublicKey {
 export class Ed25519Signature {
   static readonly LENGTH = 64;
 
-  public readonly value: Uint8Array;
+  public readonly data: Uint8Array;
 
   constructor(value: Uint8Array) {
     if (value.length !== Ed25519Signature.LENGTH) {
       throw new Error(`Ed25519Signature length should be ${Ed25519Signature.LENGTH}`);
     }
-    this.value = value;
+    this.data = value;
   }
 
   serialize(serializer: Serializer): void {
-    serializer.serializeBytes(this.value);
+    serializer.serializeBytes(this.data);
   }
 
   static deserialize(deserializer: Deserializer): Ed25519Signature {

--- a/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/ed25519.ts
@@ -10,11 +10,12 @@ export class Ed25519PublicKey {
 
   readonly value: Hex;
 
-  constructor(value: HexInput) {
-    if (value.length !== Ed25519PublicKey.LENGTH) {
+  constructor(hexInput: HexInput) {
+    const hex = Hex.fromHexInput({ hexInput });
+    if (hex.toUint8Array().length !== Ed25519PublicKey.LENGTH) {
       throw new Error(`Ed25519PublicKey length should be ${Ed25519PublicKey.LENGTH}`);
     }
-    this.value = Hex.fromHexInput({ hexInput: value });
+    this.value = hex;
   }
 
   toUint8Array(): Uint8Array {

--- a/ecosystem/typescript/sdk_v2/src/crypto/multi_ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/multi_ed25519.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /* eslint-disable no-bitwise */
-import { Deserializer, Serializer, Uint8 } from "../bcs";
+import { Deserializer, Serializer } from "../bcs";
+import { Uint8 } from "../types";
 import { Ed25519PublicKey, Ed25519Signature } from "./ed25519";
 
 /**

--- a/ecosystem/typescript/sdk_v2/src/crypto/multi_ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/multi_ed25519.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /* eslint-disable no-bitwise */
-import { Deserializer, Seq, Serializer, Uint8 } from "../bcs";
+import { Deserializer, Serializer, Uint8 } from "../bcs";
 import { Ed25519PublicKey, Ed25519Signature } from "./ed25519";
 
 /**
@@ -22,7 +22,7 @@ export class MultiEd25519PublicKey {
    * @param public_keys A list of public keys
    * @param threshold At least "threshold" signatures must be valid
    */
-  constructor(public readonly public_keys: Seq<Ed25519PublicKey>, public readonly threshold: Uint8) {
+  constructor(public readonly public_keys: Ed25519PublicKey[], public readonly threshold: Uint8) {
     if (threshold > MAX_SIGNATURES_SUPPORTED) {
       throw new Error(`"threshold" cannot be larger than ${MAX_SIGNATURES_SUPPORTED}`);
     }
@@ -43,14 +43,14 @@ export class MultiEd25519PublicKey {
   }
 
   serialize(serializer: Serializer): void {
-    serializer.serializeByteVector(this.toUint8Array());
+    serializer.serializeBytes(this.toUint8Array());
   }
 
   static deserialize(deserializer: Deserializer): MultiEd25519PublicKey {
     const bytes = deserializer.deserializeBytes();
     const threshold = bytes[bytes.length - 1];
 
-    const keys: Seq<Ed25519PublicKey> = [];
+    const keys: Ed25519PublicKey[] = [];
 
     for (let i = 0; i < bytes.length - 1; i += Ed25519PublicKey.LENGTH) {
       const begin = i;
@@ -73,7 +73,7 @@ export class MultiEd25519Signature {
    * @param bitmap 4 bytes, at most 32 signatures are supported. If Nth bit value is `1`, the Nth
    * signature should be provided in `signatures`. Bits are read from left to right
    */
-  constructor(public readonly signatures: Seq<Ed25519Signature>, public readonly bitmap: Uint8Array) {
+  constructor(public readonly signatures: Ed25519Signature[], public readonly bitmap: Uint8Array) {
     if (bitmap.length !== MultiEd25519Signature.BITMAP_LEN) {
       throw new Error(`"bitmap" length should be ${MultiEd25519Signature.BITMAP_LEN}`);
     }
@@ -107,7 +107,7 @@ export class MultiEd25519Signature {
    *
    * @returns bitmap that is 32bit long
    */
-  static createBitmap(bits: Seq<Uint8>): Uint8Array {
+  static createBitmap(bits: Uint8[]): Uint8Array {
     // Bits are read from left to right. e.g. 0b10000000 represents the first bit is set in one byte.
     // The decimal value of 0b10000000 is 128.
     const firstBitInByte = 128;
@@ -140,14 +140,14 @@ export class MultiEd25519Signature {
   }
 
   serialize(serializer: Serializer): void {
-    serializer.serializeByteVector(this.toUint8Array());
+    serializer.serializeBytes(this.toUint8Array());
   }
 
   static deserialize(deserializer: Deserializer): MultiEd25519Signature {
     const bytes = deserializer.deserializeBytes();
     const bitmap = bytes.subarray(bytes.length - 4);
 
-    const sigs: Seq<Ed25519Signature> = [];
+    const sigs: Ed25519Signature[] = [];
 
     for (let i = 0; i < bytes.length - bitmap.length; i += Ed25519Signature.LENGTH) {
       const begin = i;

--- a/ecosystem/typescript/sdk_v2/src/crypto/multi_ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/multi_ed25519.ts
@@ -11,7 +11,7 @@ export class MultiEd25519PublicKey {
 
   public readonly public_keys: Ed25519PublicKey[];
 
-  public readonly threshold: Uint8;
+  public readonly threshold: number;
 
   /**
    * Public key for a K-of-N multisig transaction. A K-of-N multisig transaction means that for such a
@@ -24,7 +24,7 @@ export class MultiEd25519PublicKey {
    * @param public_keys A list of public keys
    * @param threshold At least "threshold" signatures must be valid
    */
-  constructor(public_keys: Ed25519PublicKey[], threshold: Uint8) {
+  constructor(public_keys: Ed25519PublicKey[], threshold: number) {
     if (threshold < 0 || threshold > MultiEd25519PublicKey.MAX_SIGNATURES_SUPPORTED) {
       throw new Error(
         `"threshold" cannot be greater than 0 and larger than ${MultiEd25519PublicKey.MAX_SIGNATURES_SUPPORTED}`,

--- a/ecosystem/typescript/sdk_v2/src/crypto/multi_ed25519.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/multi_ed25519.ts
@@ -1,0 +1,158 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable no-bitwise */
+import { Deserializer, Seq, Serializer, Uint8 } from "../bcs";
+import { Ed25519PublicKey, Ed25519Signature } from "./ed25519";
+
+/**
+ * MultiEd25519 currently supports at most 32 signatures.
+ */
+const MAX_SIGNATURES_SUPPORTED = 32;
+
+export class MultiEd25519PublicKey {
+  /**
+   * Public key for a K-of-N multisig transaction. A K-of-N multisig transaction means that for such a
+   * transaction to be executed, at least K out of the N authorized signers have signed the transaction
+   * and passed the check conducted by the chain.
+   *
+   * @see {@link
+   * https://aptos.dev/guides/creating-a-signed-transaction#multisignature-transactions | Creating a Signed Transaction}
+   *
+   * @param public_keys A list of public keys
+   * @param threshold At least "threshold" signatures must be valid
+   */
+  constructor(public readonly public_keys: Seq<Ed25519PublicKey>, public readonly threshold: Uint8) {
+    if (threshold > MAX_SIGNATURES_SUPPORTED) {
+      throw new Error(`"threshold" cannot be larger than ${MAX_SIGNATURES_SUPPORTED}`);
+    }
+  }
+
+  /**
+   * Converts a MultiEd25519PublicKey into Uint8Array (bytes) with: bytes = p1_bytes | ... | pn_bytes | threshold
+   */
+  toUint8Array(): Uint8Array {
+    const bytes = new Uint8Array(this.public_keys.length * Ed25519PublicKey.LENGTH + 1);
+    this.public_keys.forEach((k: Ed25519PublicKey, i: number) => {
+      bytes.set(k.value.toUint8Array(), i * Ed25519PublicKey.LENGTH);
+    });
+
+    bytes[this.public_keys.length * Ed25519PublicKey.LENGTH] = this.threshold;
+
+    return bytes;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeByteVector(this.toUint8Array());
+  }
+
+  static deserialize(deserializer: Deserializer): MultiEd25519PublicKey {
+    const bytes = deserializer.deserializeBytes();
+    const threshold = bytes[bytes.length - 1];
+
+    const keys: Seq<Ed25519PublicKey> = [];
+
+    for (let i = 0; i < bytes.length - 1; i += Ed25519PublicKey.LENGTH) {
+      const begin = i;
+      keys.push(new Ed25519PublicKey(bytes.subarray(begin, begin + Ed25519PublicKey.LENGTH)));
+    }
+    return new MultiEd25519PublicKey(keys, threshold);
+  }
+}
+
+export class MultiEd25519Signature {
+  static BITMAP_LEN: Uint8 = 4;
+
+  /**
+   * Signature for a K-of-N multisig transaction.
+   *
+   * @see {@link
+   * https://aptos.dev/guides/creating-a-signed-transaction#multisignature-transactions | Creating a Signed Transaction}
+   *
+   * @param signatures A list of ed25519 signatures
+   * @param bitmap 4 bytes, at most 32 signatures are supported. If Nth bit value is `1`, the Nth
+   * signature should be provided in `signatures`. Bits are read from left to right
+   */
+  constructor(public readonly signatures: Seq<Ed25519Signature>, public readonly bitmap: Uint8Array) {
+    if (bitmap.length !== MultiEd25519Signature.BITMAP_LEN) {
+      throw new Error(`"bitmap" length should be ${MultiEd25519Signature.BITMAP_LEN}`);
+    }
+  }
+
+  /**
+   * Converts a MultiEd25519Signature into Uint8Array (bytes) with `bytes = s1_bytes | ... | sn_bytes | bitmap`
+   */
+  toUint8Array(): Uint8Array {
+    const bytes = new Uint8Array(this.signatures.length * Ed25519Signature.LENGTH + MultiEd25519Signature.BITMAP_LEN);
+    this.signatures.forEach((k: Ed25519Signature, i: number) => {
+      bytes.set(k.value, i * Ed25519Signature.LENGTH);
+    });
+
+    bytes.set(this.bitmap, this.signatures.length * Ed25519Signature.LENGTH);
+
+    return bytes;
+  }
+
+  /**
+   * Helper method to create a bitmap out of the specified bit positions
+   * @param bits The bitmap positions that should be set. A position starts at index 0.
+   * Valid position should range between 0 and 31.
+   * @example
+   * Here's an example of valid `bits`
+   * ```
+   * [0, 2, 31]
+   * ```
+   * `[0, 2, 31]` means the 1st, 3rd and 32nd bits should be set in the bitmap.
+   * The result bitmap should be 0b1010000000000000000000000000001
+   *
+   * @returns bitmap that is 32bit long
+   */
+  static createBitmap(bits: Seq<Uint8>): Uint8Array {
+    // Bits are read from left to right. e.g. 0b10000000 represents the first bit is set in one byte.
+    // The decimal value of 0b10000000 is 128.
+    const firstBitInByte = 128;
+    const bitmap = new Uint8Array([0, 0, 0, 0]);
+
+    // Check if duplicates exist in bits
+    const dupCheckSet = new Set();
+
+    bits.forEach((bit: number) => {
+      if (bit >= MAX_SIGNATURES_SUPPORTED) {
+        throw new Error(`Invalid bit value ${bit}.`);
+      }
+
+      if (dupCheckSet.has(bit)) {
+        throw new Error("Duplicated bits detected.");
+      }
+
+      dupCheckSet.add(bit);
+
+      const byteOffset = Math.floor(bit / 8);
+
+      let byte = bitmap[byteOffset];
+
+      byte |= firstBitInByte >> bit % 8;
+
+      bitmap[byteOffset] = byte;
+    });
+
+    return bitmap;
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeByteVector(this.toUint8Array());
+  }
+
+  static deserialize(deserializer: Deserializer): MultiEd25519Signature {
+    const bytes = deserializer.deserializeBytes();
+    const bitmap = bytes.subarray(bytes.length - 4);
+
+    const sigs: Seq<Ed25519Signature> = [];
+
+    for (let i = 0; i < bytes.length - bitmap.length; i += Ed25519Signature.LENGTH) {
+      const begin = i;
+      sigs.push(new Ed25519Signature(bytes.subarray(begin, begin + Ed25519Signature.LENGTH)));
+    }
+    return new MultiEd25519Signature(sigs, bitmap);
+  }
+}

--- a/ecosystem/typescript/sdk_v2/tests/unit/authentication_key.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/authentication_key.test.ts
@@ -1,0 +1,45 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { AuthenticationKey } from "../../src/crypto/authentication_key";
+import { Ed25519PublicKey } from "../../src/crypto/ed25519";
+import { MultiEd25519PublicKey } from "../../src/crypto/multi_ed25519";
+
+// Auth key and Public key pair for testing
+const auth_key_hexInput = '0x6324287105756b0338e0f84025bd0ac80e58154eb94257b0d4f06ec6497e656e';
+const public_key = '0x719ab6a6d406931ca80efa922e3377390a8d2803e42ecdbf394e979f9a5e57bc';
+
+describe('AuthenticationKey', () => {
+  it('should create an instance with save the hexinput correctly', () => {
+    const authKey = new AuthenticationKey(auth_key_hexInput);
+    expect(authKey).toBeInstanceOf(AuthenticationKey);
+    expect(authKey.data.toString()).toEqual(auth_key_hexInput);
+  });
+
+  it('should throw an error with invalid hex input length', () => {
+    const invalidHexInput = '0123456789abcdef'; // Invalid length
+    expect(() => new AuthenticationKey(invalidHexInput)).toThrowError(
+      'Expected a hexinput of length 32'
+    );
+  });
+
+  it('should create AuthenticationKey from Ed25519PublicKey', () => {
+    const publicKey = new Ed25519PublicKey(public_key);
+    const authKey = AuthenticationKey.fromEd25519PublicKey(publicKey);
+    expect(authKey).toBeInstanceOf(AuthenticationKey);
+    expect(authKey.data.toString()).toEqual(auth_key_hexInput);
+  });
+
+  it('should create AuthenticationKey from MultiEd25519PublicKey', () => {
+    const publicKey = new MultiEd25519PublicKey([new Ed25519PublicKey(public_key)], 1);
+    const authKey = AuthenticationKey.fromMultiEd25519PublicKey(publicKey);
+    expect(authKey).toBeInstanceOf(AuthenticationKey);
+    expect(authKey.data.toString()).toEqual('0xd0cb1ed17413857dd59f4ee948b6678c339ad6d5cc97246f65825439f53fd944');
+  });
+
+  it('should derive an AccountAddress from AuthenticationKey with same string', () => {
+    const authKey = new AuthenticationKey(auth_key_hexInput);
+    const accountAddress = authKey.derivedAddress();
+    expect(accountAddress.toString()).toEqual(auth_key_hexInput)
+  });
+});

--- a/ecosystem/typescript/sdk_v2/tests/unit/authentication_key.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/authentication_key.test.ts
@@ -6,40 +6,38 @@ import { Ed25519PublicKey } from "../../src/crypto/ed25519";
 import { MultiEd25519PublicKey } from "../../src/crypto/multi_ed25519";
 
 // Auth key and Public key pair for testing
-const auth_key_hexInput = '0x6324287105756b0338e0f84025bd0ac80e58154eb94257b0d4f06ec6497e656e';
-const public_key = '0x719ab6a6d406931ca80efa922e3377390a8d2803e42ecdbf394e979f9a5e57bc';
+const auth_key_hexInput = "0x6324287105756b0338e0f84025bd0ac80e58154eb94257b0d4f06ec6497e656e";
+const public_key = "0x719ab6a6d406931ca80efa922e3377390a8d2803e42ecdbf394e979f9a5e57bc";
 
-describe('AuthenticationKey', () => {
-  it('should create an instance with save the hexinput correctly', () => {
+describe("AuthenticationKey", () => {
+  it("should create an instance with save the hexinput correctly", () => {
     const authKey = new AuthenticationKey(auth_key_hexInput);
     expect(authKey).toBeInstanceOf(AuthenticationKey);
     expect(authKey.data.toString()).toEqual(auth_key_hexInput);
   });
 
-  it('should throw an error with invalid hex input length', () => {
-    const invalidHexInput = '0123456789abcdef'; // Invalid length
-    expect(() => new AuthenticationKey(invalidHexInput)).toThrowError(
-      'Expected a hexinput of length 32'
-    );
+  it("should throw an error with invalid hex input length", () => {
+    const invalidHexInput = "0123456789abcdef"; // Invalid length
+    expect(() => new AuthenticationKey(invalidHexInput)).toThrowError("Expected a hexinput of length 32");
   });
 
-  it('should create AuthenticationKey from Ed25519PublicKey', () => {
+  it("should create AuthenticationKey from Ed25519PublicKey", () => {
     const publicKey = new Ed25519PublicKey(public_key);
     const authKey = AuthenticationKey.fromEd25519PublicKey(publicKey);
     expect(authKey).toBeInstanceOf(AuthenticationKey);
     expect(authKey.data.toString()).toEqual(auth_key_hexInput);
   });
 
-  it('should create AuthenticationKey from MultiEd25519PublicKey', () => {
+  it("should create AuthenticationKey from MultiEd25519PublicKey", () => {
     const publicKey = new MultiEd25519PublicKey([new Ed25519PublicKey(public_key)], 1);
     const authKey = AuthenticationKey.fromMultiEd25519PublicKey(publicKey);
     expect(authKey).toBeInstanceOf(AuthenticationKey);
-    expect(authKey.data.toString()).toEqual('0xd0cb1ed17413857dd59f4ee948b6678c339ad6d5cc97246f65825439f53fd944');
+    expect(authKey.data.toString()).toEqual("0xd0cb1ed17413857dd59f4ee948b6678c339ad6d5cc97246f65825439f53fd944");
   });
 
-  it('should derive an AccountAddress from AuthenticationKey with same string', () => {
+  it("should derive an AccountAddress from AuthenticationKey with same string", () => {
     const authKey = new AuthenticationKey(auth_key_hexInput);
     const accountAddress = authKey.derivedAddress();
-    expect(accountAddress.toString()).toEqual(auth_key_hexInput)
+    expect(accountAddress.toString()).toEqual(auth_key_hexInput);
   });
 });

--- a/ecosystem/typescript/sdk_v2/tests/unit/authentication_key.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/authentication_key.test.ts
@@ -12,7 +12,7 @@ const public_key = "0x719ab6a6d406931ca80efa922e3377390a8d2803e42ecdbf394e979f9a
 
 describe("AuthenticationKey", () => {
   it("should create an instance with provided hexinput correctly", () => {
-    const authKey = new AuthenticationKey(auth_key_hexInput);
+    const authKey = new AuthenticationKey({ data: auth_key_hexInput});
     expect(authKey).toBeInstanceOf(AuthenticationKey);
     expect(authKey.data.toString()).toEqual(auth_key_hexInput);
     expect(authKey.data).toBeInstanceOf(Hex);
@@ -20,7 +20,7 @@ describe("AuthenticationKey", () => {
 
   it("should throw an error with invalid hex input length", () => {
     const invalidHexInput = "0123456789abcdef"; // Invalid length
-    expect(() => new AuthenticationKey(invalidHexInput)).toThrowError(`Authentication Key length should be ${AuthenticationKey.LENGTH}`);
+    expect(() => new AuthenticationKey({ data: invalidHexInput })).toThrowError(`Authentication Key length should be ${AuthenticationKey.LENGTH}`);
   });
 
   it("should create AuthenticationKey from Ed25519PublicKey", () => {
@@ -31,14 +31,15 @@ describe("AuthenticationKey", () => {
   });
 
   it("should create AuthenticationKey from MultiEd25519PublicKey", () => {
-    const publicKey = new MultiEd25519PublicKey([new Ed25519PublicKey(public_key)], 1);
+    const publicKey = new MultiEd25519PublicKey({ publieKeys: [new Ed25519PublicKey(public_key)], threshold: 1 });
     const authKey = AuthenticationKey.fromMultiEd25519PublicKey(publicKey);
+    const expectedAuthKey = "0xd0cb1ed17413857dd59f4ee948b6678c339ad6d5cc97246f65825439f53fd944";
     expect(authKey).toBeInstanceOf(AuthenticationKey);
-    expect(authKey.data.toString()).toEqual("0xd0cb1ed17413857dd59f4ee948b6678c339ad6d5cc97246f65825439f53fd944");
+    expect(authKey.data.toString()).toEqual(expectedAuthKey);
   });
 
   it("should derive an AccountAddress from AuthenticationKey with same string", () => {
-    const authKey = new AuthenticationKey(auth_key_hexInput);
+    const authKey = new AuthenticationKey({ data: auth_key_hexInput });
     const accountAddress = authKey.derivedAddress();
     expect(accountAddress.toString()).toEqual(auth_key_hexInput);
   });

--- a/ecosystem/typescript/sdk_v2/tests/unit/authentication_key.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/authentication_key.test.ts
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+import { Hex } from "../../src/core/hex";
 import { AuthenticationKey } from "../../src/crypto/authentication_key";
 import { Ed25519PublicKey } from "../../src/crypto/ed25519";
 import { MultiEd25519PublicKey } from "../../src/crypto/multi_ed25519";
@@ -10,15 +11,16 @@ const auth_key_hexInput = "0x6324287105756b0338e0f84025bd0ac80e58154eb94257b0d4f
 const public_key = "0x719ab6a6d406931ca80efa922e3377390a8d2803e42ecdbf394e979f9a5e57bc";
 
 describe("AuthenticationKey", () => {
-  it("should create an instance with save the hexinput correctly", () => {
+  it("should create an instance with provided hexinput correctly", () => {
     const authKey = new AuthenticationKey(auth_key_hexInput);
     expect(authKey).toBeInstanceOf(AuthenticationKey);
     expect(authKey.data.toString()).toEqual(auth_key_hexInput);
+    expect(authKey.data).toBeInstanceOf(Hex);
   });
 
   it("should throw an error with invalid hex input length", () => {
     const invalidHexInput = "0123456789abcdef"; // Invalid length
-    expect(() => new AuthenticationKey(invalidHexInput)).toThrowError("Expected a hexinput of length 32");
+    expect(() => new AuthenticationKey(invalidHexInput)).toThrowError(`Authentication Key length should be ${AuthenticationKey.LENGTH}`);
   });
 
   it("should create AuthenticationKey from Ed25519PublicKey", () => {

--- a/ecosystem/typescript/sdk_v2/tests/unit/ed25519.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/ed25519.test.ts
@@ -1,0 +1,18 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Hex } from "../../src/core/hex";
+import { Ed25519PublicKey, Ed25519Signature } from "../../src/crypto/ed25519";
+
+describe("Ed25519", () => {
+  it("public key serializes to bytes correctly", async () => {
+    const publicKey = "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200";
+    const ed25519PublicKey = new Ed25519PublicKey(publicKey);
+
+    expect(Hex.fromHexInput({ hexInput: ed25519PublicKey.toUint8Array() }).toStringWithoutPrefix()).toEqual(
+      "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200",
+    );
+  });
+
+  // TODO: Add test for deserializing
+});

--- a/ecosystem/typescript/sdk_v2/tests/unit/ed25519.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/ed25519.test.ts
@@ -1,18 +1,62 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+import { Deserializer } from "../../src/bcs/deserializer";
+import { Serializer } from "../../src/bcs/serializer";
 import { Hex } from "../../src/core/hex";
 import { Ed25519PublicKey, Ed25519Signature } from "../../src/crypto/ed25519";
 
-describe("Ed25519", () => {
-  it("public key serializes to bytes correctly", async () => {
-    const publicKey = "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200";
-    const ed25519PublicKey = new Ed25519PublicKey(publicKey);
+describe("Ed25519PublicKey", () => {
+  it("should create instance correctly without error", () => {
+    const hexInput = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const publicKey = new Ed25519PublicKey(hexInput);
+    expect(publicKey).toBeInstanceOf(Ed25519PublicKey);
+  });
 
-    expect(Hex.fromHexInput({ hexInput: ed25519PublicKey.toUint8Array() }).toStringWithoutPrefix()).toEqual(
-      "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200",
+  it("should throw an error with invalid hex input length", () => {
+    const invalidHexInput = "0123456789abcdef"; // Invalid length
+    expect(() => new Ed25519PublicKey(invalidHexInput)).toThrowError(
+      `Ed25519PublicKey length should be ${Ed25519PublicKey.LENGTH}`,
     );
   });
 
-  // TODO: Add test for deserializing
+  it("should serialize and deserialize correctly", () => {
+    const hexInput = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const publicKey = new Ed25519PublicKey(hexInput);
+    const serializer = new Serializer();
+    publicKey.serialize(serializer);
+
+    const deserializer = new Deserializer(serializer.toUint8Array());
+    const deserializedPublicKey = Ed25519PublicKey.deserialize(deserializer);
+
+    expect(deserializedPublicKey).toEqual(publicKey);
+  });
+});
+
+describe("Ed25519Signature", () => {
+  it("should create an instance correctly without error", () => {
+    const signatureValue = new Uint8Array(Ed25519Signature.LENGTH);
+    const signature = new Ed25519Signature(signatureValue);
+    expect(signature).toBeInstanceOf(Ed25519Signature);
+  });
+
+  it("should throw an error with invalid value length", () => {
+    const invalidSignatureValue = new Uint8Array(Ed25519Signature.LENGTH - 1); // Invalid length
+    expect(() => new Ed25519Signature(invalidSignatureValue)).toThrowError(
+      `Ed25519Signature length should be ${Ed25519Signature.LENGTH}`,
+    );
+  });
+
+  it("should serialize and deserialize correctly", () => {
+    const signatureValue = new Uint8Array(Ed25519Signature.LENGTH);
+    // Initialize the signatureValue with some data if needed
+    const signature = new Ed25519Signature(signatureValue);
+    const serializer = new Serializer();
+    signature.serialize(serializer);
+
+    const deserializer = new Deserializer(serializer.toUint8Array());
+    const deserializedSignature = Ed25519Signature.deserialize(deserializer);
+
+    expect(deserializedSignature).toEqual(signature);
+  });
 });

--- a/ecosystem/typescript/sdk_v2/tests/unit/helper.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/helper.ts
@@ -1,0 +1,23 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+export const multiEd25519PkTestObject = {
+  public_keys: [
+    "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200",
+    "aef3f4a4b8eca1dfc343361bf8e436bd42de9259c04b8314eb8e2054dd6e82ab",
+    "8a5762e21ac1cdb3870442c77b4c3af58c7cedb8779d0270e6d4f1e2f7367d74",
+  ],
+  threshold: 2,
+  bytesInStringWithoutPrefix:
+    "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200aef3f4a4b8eca1dfc343361bf8e436bd42de9259c04b8314eb8e2054dd6e82ab8a5762e21ac1cdb3870442c77b4c3af58c7cedb8779d0270e6d4f1e2f7367d7402",
+};
+
+export const multiEd25519SigTestObject = {
+  signatures: [
+    "e6f3ba05469b2388492397840183945d4291f0dd3989150de3248e06b4cefe0ddf6180a80a0f04c045ee8f362870cb46918478cd9b56c66076f94f3efd5a8805",
+    "2ae0818b7e51b853f1e43dc4c89a1f5fabc9cb256030a908f9872f3eaeb048fb1e2b4ffd5a9d5d1caedd0c8b7d6155ed8071e913536fa5c5a64327b6f2d9a102",
+  ],
+  bitmap: "c0000000",
+  bytesInStringWithoutPrefix:
+    "e6f3ba05469b2388492397840183945d4291f0dd3989150de3248e06b4cefe0ddf6180a80a0f04c045ee8f362870cb46918478cd9b56c66076f94f3efd5a88052ae0818b7e51b853f1e43dc4c89a1f5fabc9cb256030a908f9872f3eaeb048fb1e2b4ffd5a9d5d1caedd0c8b7d6155ed8071e913536fa5c5a64327b6f2d9a102c0000000",
+};

--- a/ecosystem/typescript/sdk_v2/tests/unit/multi_ed25519.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/multi_ed25519.test.ts
@@ -1,0 +1,110 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Deserializer } from "../../src/bcs/deserializer";
+import { Hex } from "../../src/core/hex";
+import { Ed25519PublicKey, Ed25519Signature } from "../../src/crypto/ed25519";
+import { MultiEd25519PublicKey, MultiEd25519Signature } from "../../src/crypto/multi_ed25519";
+
+describe("MultiEd25519", () => {
+  it("public key serializes to bytes correctly", async () => {
+    const publicKey1 = "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200";
+    const publicKey2 = "aef3f4a4b8eca1dfc343361bf8e436bd42de9259c04b8314eb8e2054dd6e82ab";
+    const publicKey3 = "8a5762e21ac1cdb3870442c77b4c3af58c7cedb8779d0270e6d4f1e2f7367d74";
+
+    const pubKeyMultiSig = new MultiEd25519PublicKey(
+      [
+        new Ed25519PublicKey(publicKey1),
+        new Ed25519PublicKey(publicKey2),
+        new Ed25519PublicKey(publicKey3),
+      ],
+      2,
+    );
+
+    expect(pubKeyMultiSig.toUint8Array()).toEqual(
+      "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200aef3f4a4b8eca1dfc343361bf8e436bd42de9259c04b8314eb8e2054dd6e82ab8a5762e21ac1cdb3870442c77b4c3af58c7cedb8779d0270e6d4f1e2f7367d7402",
+    );
+  });
+
+  it("public key deserializes from bytes correctly", async () => {
+    const publicKey1 = "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200";
+    const publicKey2 = "aef3f4a4b8eca1dfc343361bf8e436bd42de9259c04b8314eb8e2054dd6e82ab";
+    const publicKey3 = "8a5762e21ac1cdb3870442c77b4c3af58c7cedb8779d0270e6d4f1e2f7367d74";
+
+    const pubKeyMultiSig = new MultiEd25519PublicKey(
+      [
+        new Ed25519PublicKey(publicKey1),
+        new Ed25519PublicKey(publicKey2),
+        new Ed25519PublicKey(publicKey3),
+      ],
+      2,
+    );
+    const deserialzed = MultiEd25519PublicKey.deserialize(new Deserializer(bcsToBytes(pubKeyMultiSig)));
+    expect(new Hex({ data: deserialzed.toUint8Array() })).toEqual(
+      new Hex({ data: pubKeyMultiSig.toUint8Array() })
+    );
+  });
+
+  it("signature serializes to bytes correctly", async () => {
+    // eslint-disable-next-line operator-linebreak
+    const sig1 =
+      "e6f3ba05469b2388492397840183945d4291f0dd3989150de3248e06b4cefe0ddf6180a80a0f04c045ee8f362870cb46918478cd9b56c66076f94f3efd5a8805";
+    // eslint-disable-next-line operator-linebreak
+    const sig2 =
+      "2ae0818b7e51b853f1e43dc4c89a1f5fabc9cb256030a908f9872f3eaeb048fb1e2b4ffd5a9d5d1caedd0c8b7d6155ed8071e913536fa5c5a64327b6f2d9a102";
+    const bitmap = "c0000000";
+
+    const multisig = new MultiEd25519Signature(
+      [
+        new Ed25519Signature(Hex.fromString({ str: sig1}).toUint8Array()),
+        new Ed25519Signature(Hex.fromString({ str: sig2}).toUint8Array()),
+      ],
+      Hex.fromString({ str: bitmap}).toUint8Array(),
+    );
+
+    expect(Hex.fromHexInput({ hexInput: multisig.toUint8Array()}).toStringWithoutPrefix()).toEqual(
+      "e6f3ba05469b2388492397840183945d4291f0dd3989150de3248e06b4cefe0ddf6180a80a0f04c045ee8f362870cb46918478cd9b56c66076f94f3efd5a88052ae0818b7e51b853f1e43dc4c89a1f5fabc9cb256030a908f9872f3eaeb048fb1e2b4ffd5a9d5d1caedd0c8b7d6155ed8071e913536fa5c5a64327b6f2d9a102c0000000",
+    );
+  });
+
+  it("signature deserializes from bytes correctly", async () => {
+    // eslint-disable-next-line operator-linebreak
+    const sig1 =
+      "e6f3ba05469b2388492397840183945d4291f0dd3989150de3248e06b4cefe0ddf6180a80a0f04c045ee8f362870cb46918478cd9b56c66076f94f3efd5a8805";
+    // eslint-disable-next-line operator-linebreak
+    const sig2 =
+      "2ae0818b7e51b853f1e43dc4c89a1f5fabc9cb256030a908f9872f3eaeb048fb1e2b4ffd5a9d5d1caedd0c8b7d6155ed8071e913536fa5c5a64327b6f2d9a102";
+    const bitmap = "c0000000";
+
+    const multisig = new MultiEd25519Signature(
+      [
+        new Ed25519Signature(Hex.fromString({ str: sig1}).toUint8Array()),
+        new Ed25519Signature(Hex.fromString({ str: sig2}).toUint8Array()),
+      ],
+      Hex.fromString({ str: bitmap}).toUint8Array(),
+    );
+
+    const deserialzed = MultiEd25519Signature.deserialize(new Deserializer(bcsToBytes(multisig)));
+    expect(Hex.fromHexInput({ hexInput: deserialzed.toUint8Array() })).toEqual(
+      Hex.fromHexInput({ hexInput: multisig.toUint8Array() }),
+    );
+  });
+
+  it("creates a valid bitmap", () => {
+    expect(MultiEd25519Signature.createBitmap([0, 2, 31])).toEqual(
+      new Uint8Array([0b10100000, 0b00000000, 0b00000000, 0b00000001]),
+    );
+  });
+
+  it("throws exception when creating a bitmap with wrong bits", async () => {
+    expect(() => {
+      MultiEd25519Signature.createBitmap([32]);
+    }).toThrow("Invalid bit value 32.");
+  });
+
+  it("throws exception when creating a bitmap with duplicate bits", async () => {
+    expect(() => {
+      MultiEd25519Signature.createBitmap([2, 2]);
+    }).toThrow("Duplicated bits detected.");
+  });
+});

--- a/ecosystem/typescript/sdk_v2/tests/unit/multi_ed25519.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/multi_ed25519.test.ts
@@ -6,32 +6,30 @@ import { Serializer } from "../../src/bcs/serializer";
 import { Hex } from "../../src/core/hex";
 import { Ed25519PublicKey, Ed25519Signature } from "../../src/crypto/ed25519";
 import { MultiEd25519PublicKey, MultiEd25519Signature } from "../../src/crypto/multi_ed25519";
+import { multiEd25519PkTestObject, multiEd25519SigTestObject } from "./helper";
 
 describe("MultiEd25519", () => {
   it("public key serializes to bytes correctly", async () => {
-    const publicKey1 = "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200";
-    const publicKey2 = "aef3f4a4b8eca1dfc343361bf8e436bd42de9259c04b8314eb8e2054dd6e82ab";
-    const publicKey3 = "8a5762e21ac1cdb3870442c77b4c3af58c7cedb8779d0270e6d4f1e2f7367d74";
+    let edPksArray = [];
+    for (let i = 0; i < multiEd25519PkTestObject.public_keys.length; i++) {
+      edPksArray.push(new Ed25519PublicKey(multiEd25519PkTestObject.public_keys[i]));
+    }
 
-    const pubKeyMultiSig = new MultiEd25519PublicKey(
-      [new Ed25519PublicKey(publicKey1), new Ed25519PublicKey(publicKey2), new Ed25519PublicKey(publicKey3)],
-      2,
-    );
+    const pubKeyMultiSig = new MultiEd25519PublicKey(edPksArray, multiEd25519PkTestObject.threshold);
 
     expect(Hex.fromHexInput({ hexInput: pubKeyMultiSig.toUint8Array() }).toStringWithoutPrefix()).toEqual(
-      "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200aef3f4a4b8eca1dfc343361bf8e436bd42de9259c04b8314eb8e2054dd6e82ab8a5762e21ac1cdb3870442c77b4c3af58c7cedb8779d0270e6d4f1e2f7367d7402",
+      multiEd25519PkTestObject.bytesInStringWithoutPrefix,
     );
   });
 
   it("public key deserializes from bytes correctly", async () => {
-    const publicKey1 = "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200";
-    const publicKey2 = "aef3f4a4b8eca1dfc343361bf8e436bd42de9259c04b8314eb8e2054dd6e82ab";
-    const publicKey3 = "8a5762e21ac1cdb3870442c77b4c3af58c7cedb8779d0270e6d4f1e2f7367d74";
+    let edPksArray = [];
+    for (let i = 0; i < multiEd25519PkTestObject.public_keys.length; i++) {
+      edPksArray.push(new Ed25519PublicKey(multiEd25519PkTestObject.public_keys[i]));
+    }
 
-    const pubKeyMultiSig = new MultiEd25519PublicKey(
-      [new Ed25519PublicKey(publicKey1), new Ed25519PublicKey(publicKey2), new Ed25519PublicKey(publicKey3)],
-      2,
-    );
+    const pubKeyMultiSig = new MultiEd25519PublicKey(edPksArray, multiEd25519PkTestObject.threshold);
+
     const serializer = new Serializer();
     serializer.serialize(pubKeyMultiSig);
     const deserialzed = MultiEd25519PublicKey.deserialize(new Deserializer(serializer.toUint8Array()));
@@ -39,42 +37,34 @@ describe("MultiEd25519", () => {
   });
 
   it("signature serializes to bytes correctly", async () => {
-    // eslint-disable-next-line operator-linebreak
-    const sig1 =
-      "e6f3ba05469b2388492397840183945d4291f0dd3989150de3248e06b4cefe0ddf6180a80a0f04c045ee8f362870cb46918478cd9b56c66076f94f3efd5a8805";
-    // eslint-disable-next-line operator-linebreak
-    const sig2 =
-      "2ae0818b7e51b853f1e43dc4c89a1f5fabc9cb256030a908f9872f3eaeb048fb1e2b4ffd5a9d5d1caedd0c8b7d6155ed8071e913536fa5c5a64327b6f2d9a102";
-    const bitmap = "c0000000";
+    let edSigsArray = [];
+    for (let i = 0; i < multiEd25519SigTestObject.signatures.length; i++) {
+      edSigsArray.push(
+        new Ed25519Signature(Hex.fromString({ str: multiEd25519SigTestObject.signatures[i] }).toUint8Array()),
+      );
+    }
 
     const multisig = new MultiEd25519Signature(
-      [
-        new Ed25519Signature(Hex.fromString({ str: sig1 }).toUint8Array()),
-        new Ed25519Signature(Hex.fromString({ str: sig2 }).toUint8Array()),
-      ],
-      Hex.fromString({ str: bitmap }).toUint8Array(),
+      edSigsArray,
+      Hex.fromString({ str: multiEd25519SigTestObject.bitmap }).toUint8Array(),
     );
 
     expect(Hex.fromHexInput({ hexInput: multisig.toUint8Array() }).toStringWithoutPrefix()).toEqual(
-      "e6f3ba05469b2388492397840183945d4291f0dd3989150de3248e06b4cefe0ddf6180a80a0f04c045ee8f362870cb46918478cd9b56c66076f94f3efd5a88052ae0818b7e51b853f1e43dc4c89a1f5fabc9cb256030a908f9872f3eaeb048fb1e2b4ffd5a9d5d1caedd0c8b7d6155ed8071e913536fa5c5a64327b6f2d9a102c0000000",
+      multiEd25519SigTestObject.bytesInStringWithoutPrefix,
     );
   });
 
   it("signature deserializes from bytes correctly", async () => {
-    // eslint-disable-next-line operator-linebreak
-    const sig1 =
-      "e6f3ba05469b2388492397840183945d4291f0dd3989150de3248e06b4cefe0ddf6180a80a0f04c045ee8f362870cb46918478cd9b56c66076f94f3efd5a8805";
-    // eslint-disable-next-line operator-linebreak
-    const sig2 =
-      "2ae0818b7e51b853f1e43dc4c89a1f5fabc9cb256030a908f9872f3eaeb048fb1e2b4ffd5a9d5d1caedd0c8b7d6155ed8071e913536fa5c5a64327b6f2d9a102";
-    const bitmap = "c0000000";
+    let edSigsArray = [];
+    for (let i = 0; i < multiEd25519SigTestObject.signatures.length; i++) {
+      edSigsArray.push(
+        new Ed25519Signature(Hex.fromString({ str: multiEd25519SigTestObject.signatures[i] }).toUint8Array()),
+      );
+    }
 
     const multisig = new MultiEd25519Signature(
-      [
-        new Ed25519Signature(Hex.fromString({ str: sig1 }).toUint8Array()),
-        new Ed25519Signature(Hex.fromString({ str: sig2 }).toUint8Array()),
-      ],
-      Hex.fromString({ str: bitmap }).toUint8Array(),
+      edSigsArray,
+      Hex.fromString({ str: multiEd25519SigTestObject.bitmap }).toUint8Array(),
     );
 
     const serializer = new Serializer();

--- a/ecosystem/typescript/sdk_v2/tests/unit/multi_ed25519.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/multi_ed25519.test.ts
@@ -15,7 +15,7 @@ describe("MultiEd25519", () => {
       edPksArray.push(new Ed25519PublicKey(multiEd25519PkTestObject.public_keys[i]));
     }
 
-    const pubKeyMultiSig = new MultiEd25519PublicKey(edPksArray, multiEd25519PkTestObject.threshold);
+    const pubKeyMultiSig = new MultiEd25519PublicKey({ publieKeys: edPksArray, threshold: multiEd25519PkTestObject.threshold });
 
     expect(Hex.fromHexInput({ hexInput: pubKeyMultiSig.toUint8Array() }).toStringWithoutPrefix()).toEqual(
       multiEd25519PkTestObject.bytesInStringWithoutPrefix,
@@ -28,7 +28,7 @@ describe("MultiEd25519", () => {
       edPksArray.push(new Ed25519PublicKey(multiEd25519PkTestObject.public_keys[i]));
     }
 
-    const pubKeyMultiSig = new MultiEd25519PublicKey(edPksArray, multiEd25519PkTestObject.threshold);
+    const pubKeyMultiSig = new MultiEd25519PublicKey({ publieKeys: edPksArray, threshold: multiEd25519PkTestObject.threshold });
 
     const serializer = new Serializer();
     serializer.serialize(pubKeyMultiSig);

--- a/ecosystem/typescript/sdk_v2/tests/unit/multi_ed25519.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/multi_ed25519.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Deserializer } from "../../src/bcs/deserializer";
+import { Serializer } from "../../src/bcs/serializer";
 import { Hex } from "../../src/core/hex";
 import { Ed25519PublicKey, Ed25519Signature } from "../../src/crypto/ed25519";
 import { MultiEd25519PublicKey, MultiEd25519Signature } from "../../src/crypto/multi_ed25519";
@@ -13,15 +14,11 @@ describe("MultiEd25519", () => {
     const publicKey3 = "8a5762e21ac1cdb3870442c77b4c3af58c7cedb8779d0270e6d4f1e2f7367d74";
 
     const pubKeyMultiSig = new MultiEd25519PublicKey(
-      [
-        new Ed25519PublicKey(publicKey1),
-        new Ed25519PublicKey(publicKey2),
-        new Ed25519PublicKey(publicKey3),
-      ],
+      [new Ed25519PublicKey(publicKey1), new Ed25519PublicKey(publicKey2), new Ed25519PublicKey(publicKey3)],
       2,
     );
 
-    expect(pubKeyMultiSig.toUint8Array()).toEqual(
+    expect(Hex.fromHexInput({ hexInput: pubKeyMultiSig.toUint8Array() }).toStringWithoutPrefix()).toEqual(
       "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200aef3f4a4b8eca1dfc343361bf8e436bd42de9259c04b8314eb8e2054dd6e82ab8a5762e21ac1cdb3870442c77b4c3af58c7cedb8779d0270e6d4f1e2f7367d7402",
     );
   });
@@ -32,17 +29,13 @@ describe("MultiEd25519", () => {
     const publicKey3 = "8a5762e21ac1cdb3870442c77b4c3af58c7cedb8779d0270e6d4f1e2f7367d74";
 
     const pubKeyMultiSig = new MultiEd25519PublicKey(
-      [
-        new Ed25519PublicKey(publicKey1),
-        new Ed25519PublicKey(publicKey2),
-        new Ed25519PublicKey(publicKey3),
-      ],
+      [new Ed25519PublicKey(publicKey1), new Ed25519PublicKey(publicKey2), new Ed25519PublicKey(publicKey3)],
       2,
     );
-    const deserialzed = MultiEd25519PublicKey.deserialize(new Deserializer(bcsToBytes(pubKeyMultiSig)));
-    expect(new Hex({ data: deserialzed.toUint8Array() })).toEqual(
-      new Hex({ data: pubKeyMultiSig.toUint8Array() })
-    );
+    const serializer = new Serializer();
+    serializer.serialize(pubKeyMultiSig);
+    const deserialzed = MultiEd25519PublicKey.deserialize(new Deserializer(serializer.toUint8Array()));
+    expect(new Hex({ data: deserialzed.toUint8Array() })).toEqual(new Hex({ data: pubKeyMultiSig.toUint8Array() }));
   });
 
   it("signature serializes to bytes correctly", async () => {
@@ -56,13 +49,13 @@ describe("MultiEd25519", () => {
 
     const multisig = new MultiEd25519Signature(
       [
-        new Ed25519Signature(Hex.fromString({ str: sig1}).toUint8Array()),
-        new Ed25519Signature(Hex.fromString({ str: sig2}).toUint8Array()),
+        new Ed25519Signature(Hex.fromString({ str: sig1 }).toUint8Array()),
+        new Ed25519Signature(Hex.fromString({ str: sig2 }).toUint8Array()),
       ],
-      Hex.fromString({ str: bitmap}).toUint8Array(),
+      Hex.fromString({ str: bitmap }).toUint8Array(),
     );
 
-    expect(Hex.fromHexInput({ hexInput: multisig.toUint8Array()}).toStringWithoutPrefix()).toEqual(
+    expect(Hex.fromHexInput({ hexInput: multisig.toUint8Array() }).toStringWithoutPrefix()).toEqual(
       "e6f3ba05469b2388492397840183945d4291f0dd3989150de3248e06b4cefe0ddf6180a80a0f04c045ee8f362870cb46918478cd9b56c66076f94f3efd5a88052ae0818b7e51b853f1e43dc4c89a1f5fabc9cb256030a908f9872f3eaeb048fb1e2b4ffd5a9d5d1caedd0c8b7d6155ed8071e913536fa5c5a64327b6f2d9a102c0000000",
     );
   });
@@ -78,13 +71,15 @@ describe("MultiEd25519", () => {
 
     const multisig = new MultiEd25519Signature(
       [
-        new Ed25519Signature(Hex.fromString({ str: sig1}).toUint8Array()),
-        new Ed25519Signature(Hex.fromString({ str: sig2}).toUint8Array()),
+        new Ed25519Signature(Hex.fromString({ str: sig1 }).toUint8Array()),
+        new Ed25519Signature(Hex.fromString({ str: sig2 }).toUint8Array()),
       ],
-      Hex.fromString({ str: bitmap}).toUint8Array(),
+      Hex.fromString({ str: bitmap }).toUint8Array(),
     );
 
-    const deserialzed = MultiEd25519Signature.deserialize(new Deserializer(bcsToBytes(multisig)));
+    const serializer = new Serializer();
+    serializer.serialize(multisig);
+    const deserialzed = MultiEd25519Signature.deserialize(new Deserializer(serializer.toUint8Array()));
     expect(Hex.fromHexInput({ hexInput: deserialzed.toUint8Array() })).toEqual(
       Hex.fromHexInput({ hexInput: multisig.toUint8Array() }),
     );


### PR DESCRIPTION
### Description

Everything stay the same, except the use of following

1. Bytes -> UInt8Array
2. Hex for key value
3. HexInput for hex input param

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

pnpm jest

```
Test Suites: 9 passed, 9 total
Tests:       127 passed, 127 total
Snapshots:   0 total
Time:        2.352 s
```
