### PR TITLE
calibrate latency numbers on stable test based on longer history of runs

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -893,9 +893,9 @@ fn realistic_env_workload_sweep_test() -> ForgeConfig {
         // Investigate/improve to make latency more predictable on different workloads
         criteria: [
             (3700, 0.35, 0.5, 0.8, 0.65),
-            (2800, 0.35, 0.5, 1.2, 1.2),
+            (2800, 0.35, 0.5, 1.2, 1.3),
             (1800, 0.35, 0.5, 1.5, 2.7),
-            (950, 0.35, 0.65, 1.5, 2.7),
+            (950, 0.35, 0.65, 1.5, 2.9),
             // (150, 0.5, 1.0, 1.5, 0.65),
         ]
         .into_iter()


### PR DESCRIPTION
we calibrated from one weeks of runs, but variance is a bit higher, so we had some sporadic failures. re-calibrating for most issues (some things that happened only once, and few weeks back, I haven't loosened, until they re-appear)

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
