### PR TITLE
[NFT Metadata Crawler] Update GCS client initialization logic

### DIFF
--- a/ecosystem/nft-metadata-crawler-parser/src/utils/constants.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/constants.rs
@@ -10,4 +10,8 @@ pub const MAX_JSON_REQUEST_RETRY_SECONDS: u64 = 30;
 pub const MAX_IMAGE_REQUEST_RETRY_SECONDS: u64 = 180;
 
 /// Skip URIs that contain the following strings
-pub const URI_SKIP_LIST: [&str; 1] = ["aptoslabs.com/nft_images/aptos-zero"];
+pub const URI_SKIP_LIST: [&str; 3] = [
+    "aptoslabs.com/nft_images/aptos-zero",
+    "svg.souffl3.com",
+    "api.apt.store",
+];

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/counters.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/counters.rs
@@ -198,3 +198,32 @@ pub static FAILED_TO_OPTIMIZE_IMAGE_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+/// GCS METRICS
+
+/// Number of times the NFT Metadata Crawler Parser has attempted to upload to GCS
+pub static GCS_UPLOAD_INVOCATION_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "nft_metadata_crawler_parser_gcs_upload_invocation_count",
+        "Number of times the NFT Metadata Crawler Parser has attempted to upload to GCS"
+    )
+    .unwrap()
+});
+
+/// Number of times the NFT Metadata Crawler Parser has successfully uploaded to GCS
+pub static SUCCESSFULLY_UPLOADED_TO_GCS_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "nft_metadata_crawler_parser_successfully_uploaded_to_gcs_count",
+        "Number of times the NFT Metadata Crawler Parser has successfully uploaded to GCS"
+    )
+    .unwrap()
+});
+
+/// Number of times the NFT Metadata Crawler Parser has failed to upload to GCS
+pub static FAILED_TO_UPLOAD_TO_GCS_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "nft_metadata_crawler_parser_failed_to_upload_to_gcs_count",
+        "Number of times the NFT Metadata Crawler Parser has failed to upload to GCS"
+    )
+    .unwrap()
+});

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/gcs.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/gcs.rs
@@ -1,17 +1,30 @@
 // Copyright © Aptos Foundation
 
+use crate::utils::{
+    constants::MAX_RETRY_TIME_SECONDS,
+    counters::{
+        FAILED_TO_UPLOAD_TO_GCS_COUNT, GCS_UPLOAD_INVOCATION_COUNT,
+        SUCCESSFULLY_UPLOADED_TO_GCS_COUNT,
+    },
+};
 use anyhow::Context;
+use backoff::{future::retry, ExponentialBackoff};
+use futures::FutureExt;
 use google_cloud_storage::{
-    client::{Client, ClientConfig},
+    client::Client,
     http::objects::upload::{Media, UploadObjectRequest, UploadType},
 };
 use image::ImageFormat;
 use serde_json::Value;
+use std::time::Duration;
 
 /// Writes JSON Value to GCS
-pub async fn write_json_to_gcs(bucket: String, id: String, json: Value) -> anyhow::Result<String> {
-    let client = init_client().await?;
-
+pub async fn write_json_to_gcs(
+    bucket: String,
+    id: String,
+    json: Value,
+    client: &Client,
+) -> anyhow::Result<String> {
     let filename = format!("cdn/{}.json", id);
     let json_string = json.to_string();
     let json_bytes = json_string.into_bytes();
@@ -22,19 +35,38 @@ pub async fn write_json_to_gcs(bucket: String, id: String, json: Value) -> anyho
         content_length: Some(json_bytes.len() as u64),
     });
 
-    client
-        .upload_object(
-            &UploadObjectRequest {
-                bucket,
-                ..Default::default()
-            },
-            json_bytes,
-            &upload_type,
-        )
-        .await
-        .context("Error uploading JSON to GCS")?;
+    let op = || {
+        async {
+            Ok(client
+                .upload_object(
+                    &UploadObjectRequest {
+                        bucket: bucket.clone(),
+                        ..Default::default()
+                    },
+                    json_bytes.clone(),
+                    &upload_type,
+                )
+                .await
+                .context("Error uploading JSON to GCS")?)
+        }
+        .boxed()
+    };
 
-    Ok(filename)
+    let backoff = ExponentialBackoff {
+        max_elapsed_time: Some(Duration::from_secs(MAX_RETRY_TIME_SECONDS)),
+        ..Default::default()
+    };
+
+    match retry(backoff, op).await {
+        Ok(_) => {
+            SUCCESSFULLY_UPLOADED_TO_GCS_COUNT.inc();
+            Ok(filename)
+        },
+        Err(e) => {
+            FAILED_TO_UPLOAD_TO_GCS_COUNT.inc();
+            Err(e)
+        },
+    }
 }
 
 /// Infers file type and writes image to GCS
@@ -43,9 +75,9 @@ pub async fn write_image_to_gcs(
     bucket: String,
     id: String,
     buffer: Vec<u8>,
+    client: &Client,
 ) -> anyhow::Result<String> {
-    let client = init_client().await?;
-
+    GCS_UPLOAD_INVOCATION_COUNT.inc();
     let extension = match img_format {
         ImageFormat::Gif | ImageFormat::Avif => img_format
             .extensions_str()
@@ -56,29 +88,42 @@ pub async fn write_image_to_gcs(
     };
 
     let filename = format!("cdn/{}.{}", id, extension);
-
     let upload_type = UploadType::Simple(Media {
         name: filename.clone().into(),
         content_type: format!("image/{}", extension).into(),
         content_length: Some(buffer.len() as u64),
     });
 
-    client
-        .upload_object(
-            &UploadObjectRequest {
-                bucket,
-                ..Default::default()
-            },
-            buffer,
-            &upload_type,
-        )
-        .await?;
+    let op = || {
+        async {
+            Ok(client
+                .upload_object(
+                    &UploadObjectRequest {
+                        bucket: bucket.clone(),
+                        ..Default::default()
+                    },
+                    buffer.clone(),
+                    &upload_type,
+                )
+                .await
+                .context("Error uploading image to GCS")?)
+        }
+        .boxed()
+    };
 
-    Ok(filename)
-}
+    let backoff = ExponentialBackoff {
+        max_elapsed_time: Some(Duration::from_secs(MAX_RETRY_TIME_SECONDS)),
+        ..Default::default()
+    };
 
-/// Creates a GCS client using auth from env variable
-async fn init_client() -> anyhow::Result<Client> {
-    let config = ClientConfig::default().with_auth().await?;
-    Ok(Client::new(config))
+    match retry(backoff, op).await {
+        Ok(_) => {
+            SUCCESSFULLY_UPLOADED_TO_GCS_COUNT.inc();
+            Ok(filename)
+        },
+        Err(e) => {
+            FAILED_TO_UPLOAD_TO_GCS_COUNT.inc();
+            Err(e)
+        },
+    }
 }

--- a/ecosystem/nft-metadata-crawler-parser/src/utils/gcs.rs
+++ b/ecosystem/nft-metadata-crawler-parser/src/utils/gcs.rs
@@ -25,6 +25,7 @@ pub async fn write_json_to_gcs(
     json: Value,
     client: &Client,
 ) -> anyhow::Result<String> {
+    GCS_UPLOAD_INVOCATION_COUNT.inc();
     let filename = format!("cdn/{}.json", id);
     let json_string = json.to_string();
     let json_bytes = json_string.into_bytes();


### PR DESCRIPTION
### Description
Updated logic so the GCS client would only be queried once so that it wouldn't need to continuously query for credentials from the metadata server (issue with Cloud Run). 

### Test Plan
Tested locally, looks good
