### PR TITLE
[gha] set up buildx independently of login, for rosetta build

### DIFF
--- a/.github/actions/buildx-setup/action.yml
+++ b/.github/actions/buildx-setup/action.yml
@@ -1,0 +1,29 @@
+name: "Docker buildx setup"
+description: Sets up buildx for docker builds
+
+runs:
+  using: composite
+  steps: 
+    - name: setup docker context for buildx
+      id: buildx-context
+      shell: bash
+      run: docker context create builders
+
+    - name: setup docker buildx
+      uses: aptos-labs/setup-buildx-action@7952e9cf0debaf1f3f3e5dc7d9c5ea6ececb127e # pin v2.4.0
+      with:
+        endpoint: builders
+        version: v0.11.0
+        custom-name: "core-builder"
+        keep-state: true
+        config-inline: |
+          [worker.oci]
+            gc = true
+            gckeepstorage = 900000000000 # Use 900GB out of 1TB for builder storage
+            [[worker.oci.gcpolicy]]
+              keepBytes = 700000000000 # Use 700GB out of 900GB for cache storage
+              keepDuration = 604800 # Keep cache for 7 days
+              filters = [ "type==source.local", "type==exec.cachemount", "type==source.git.checkout"]
+            [[worker.oci.gcpolicy]]
+              all = true
+              keepBytes = 900000000000

--- a/.github/actions/docker-setup/action.yaml
+++ b/.github/actions/docker-setup/action.yaml
@@ -70,29 +70,7 @@ runs:
         fi
         echo "AWS args were supplied and are vaild, we will log into ECR"
 
-    - name: setup docker context for buildx
-      id: buildx-context
-      shell: bash
-      run: docker context create builders
-
-    - name: setup docker buildx
-      uses: aptos-labs/setup-buildx-action@7952e9cf0debaf1f3f3e5dc7d9c5ea6ececb127e # pin v2.4.0
-      with:
-        endpoint: builders
-        version: v0.11.0
-        custom-name: "core-builder"
-        keep-state: true
-        config-inline: |
-          [worker.oci]
-            gc = true
-            gckeepstorage = 900000000000 # Use 900GB out of 1TB for builder storage
-            [[worker.oci.gcpolicy]]
-              keepBytes = 700000000000 # Use 700GB out of 900GB for cache storage
-              keepDuration = 604800 # Keep cache for 7 days
-              filters = [ "type==source.local", "type==exec.cachemount", "type==source.git.checkout"]
-            [[worker.oci.gcpolicy]]
-              all = true
-              keepBytes = 900000000000
+    - uses: aptos-labs/aptos-core/.github/actions/buildx-setup@main
 
     - uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # pin@v0.3
       with:

--- a/.github/workflows/docker-build-rosetta.yaml
+++ b/.github/workflows/docker-build-rosetta.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
     paths:
       - ".github/workflows/docker-build-rosetta.yaml"
+      # build on changes to dockerfile and build script
+      - "docker/rosetta/docker-build-rosetta.sh"
+      - "docker/rosetta/rosetta.Dockerfile"
 
 permissions:
   contents: read
@@ -18,14 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
-        with:
-          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
-          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - uses: ./.github/actions/buildx-setup
 
       - name: Build rosetta
         run: GIT_REF=main docker/rosetta/docker-build-rosetta.sh


### PR DESCRIPTION
### Description

So rosetta can build on `pull_request` . It only builds, and does not push to any repo

### Test Plan

Rosetta build should run on this PR : https://github.com/aptos-labs/aptos-core/actions/runs/6054089308/job/16430849134?pr=9897

It runs, but failing due to deps that are added in this dependent PR https://github.com/aptos-labs/aptos-core/pull/9895#pullrequestreview-1607676897 

<!-- Please provide us with clear details for verifying that your changes work. -->
