### PR TITLE
Force semgrep container user to root

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -14,6 +14,7 @@ jobs:
 
     container:
       image: returntocorp/semgrep
+      options: --user root
 
     # Skip any PR created by dependabot to avoid permission issues:
     if: (github.actor != 'dependabot[bot]')


### PR DESCRIPTION
### Description
This PR forces the container user for the semgrep workflow to be `root`. There is an [open issue with the checkout action](https://github.com/actions/checkout/issues/956) that produces a permission error when containers are run with standard user. See this [broken test](https://github.com/aptos-labs/aptos-core/actions/runs/6055233984).

### Test Plan
Test passes: https://github.com/aptos-labs/aptos-core/actions/runs/6055240908/job/16433902557?pr=9902