### PR TITLE
Upgrade version of Python used in SDK to fix tomllib dep

### DIFF
--- a/ecosystem/python/sdk/pyproject.toml
+++ b/ecosystem/python/sdk/pyproject.toml
@@ -13,7 +13,7 @@ keywords = ["web3", "sdk", "aptos", "blockchain"]
 h2 = "^4.1.0"
 httpx = "^0.24.0"
 PyNaCl = "^1.5.0"
-python = ">=3.8.1,<4.0"
+python = ">=3.11,<4.0"
 
 [tool.poetry.dev-dependencies]
 autoflake = "2.2.0"


### PR DESCRIPTION
### Description
The new package publishing stuff depends on tomllib, which was only added in Python 3.11. This is one way to fix it, though I think we should not rely on 3.11 features because most folks are probably still on Python 3.9 ish.

### Test Plan
CI.
