### PR TITLE
Quick and dirty integration of transaction orderer to non-sharded BlockSTM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,6 +1222,7 @@ dependencies = [
  "aptos-storage-interface",
  "aptos-temppath",
  "aptos-transaction-generator-lib",
+ "aptos-transaction-orderer",
  "aptos-types",
  "aptos-vm",
  "async-trait",

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -32,6 +32,7 @@ aptos-sdk = { workspace = true }
 aptos-state-view = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-transaction-generator-lib = { workspace = true }
+aptos-transaction-orderer = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
 async-trait = { workspace = true }


### PR DESCRIPTION
Improves the Execution TPS from ~15k to ~22k on a MacBook Pro, with [this](https://www.notion.so/aptoslabs/Single-Node-Benchmarks-778d10cbb1e84acb83e945d1072e40d4?pvs=4#d2153221a9994db8ba6c224a025579b8) benchmark setup.

The overall TPS improvement is smaller since the current orderer implementation is sequential.
However, the orderer algorithm is easily parallelizable.

This PR is not intended to be ever merged as the integration is done in a completely inappropriate place. I'm sharing the code as a proof-of-concept. 