### PR TITLE
Make Display impl of AccountAddress conform to AIP-40

### DIFF
--- a/api/src/tests/events_test.rs
+++ b/api/src/tests/events_test.rs
@@ -158,7 +158,7 @@ async fn test_module_events() {
     context
         .api_execute_entry_function(
             &mut user,
-            &format!("0x{}::event::emit", user_addr),
+            &format!("0x{}::event::emit", user_addr.to_hex()),
             json!([]),
             json!(["7"]),
         )

--- a/api/src/tests/objects.rs
+++ b/api/src/tests/objects.rs
@@ -38,14 +38,14 @@ async fn test_gen_object() {
     let token_addr = account_address::create_token_address(user_addr, "Hero Quest!", "Wukong");
     let object_resource = "0x1::object::ObjectCore";
     let token_resource = "0x4::token::Token";
-    let hero_resource = format!("0x{}::hero::Hero", user_addr);
+    let hero_resource = format!("0x{}::hero::Hero", user_addr.to_hex());
 
     let collection0 = context.gen_all_resources(&collection_addr).await;
 
     context
         .api_execute_entry_function(
             &mut user,
-            &format!("0x{}::hero::mint_hero", user_addr),
+            &format!("0x{}::hero::mint_hero", user_addr.to_hex()),
             json!([]),
             json!(["The best hero ever!", "Male", "Wukong", "Monkey God", ""]),
         )

--- a/api/src/tests/resource_groups.rs
+++ b/api/src/tests/resource_groups.rs
@@ -49,8 +49,8 @@ async fn test_gen_resource_group() {
     context.publish_package(&mut admin1, txn).await;
 
     // Read default data
-    let primary = format!("0x{}::{}::{}", admin0.address(), "primary", "Primary");
-    let secondary = format!("0x{}::{}::{}", admin1.address(), "secondary", "Secondary");
+    let primary = format!("{}::{}::{}", admin0.address(), "primary", "Primary");
+    let secondary = format!("{}::{}::{}", admin1.address(), "secondary", "Secondary");
 
     let response = context.gen_resource(&admin0.address(), &primary).await;
     assert_eq!(response.unwrap()["data"]["value"], "3");
@@ -65,7 +65,7 @@ async fn test_gen_resource_group() {
     context
         .api_execute_entry_function(
             &mut user,
-            &format!("0x{}::secondary::init", admin1.address()),
+            &format!("{}::secondary::init", admin1.address()),
             json!([]),
             json!([55]),
         )
@@ -80,7 +80,7 @@ async fn test_gen_resource_group() {
     context
         .api_execute_entry_function(
             &mut user,
-            &format!("0x{}::primary::init", admin0.address()),
+            &format!("{}::primary::init", admin0.address()),
             json!([]),
             json!(["35"]),
         )

--- a/api/types/src/address.rs
+++ b/api/types/src/address.rs
@@ -40,7 +40,11 @@ impl Address {
 
 impl fmt::Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // TODO: This should not be hex literal, it should be the full hex
+        // While the inner type, AccountAddress, has a Display impl already, we don't
+        // use it. As part of the AIP-40 migration, the Display impl of the inner
+        // AccountAddress was changed to conform to AIP-40, but doing that for the API
+        // would constitute a breaking change. So we keep an explicit display impl
+        // here that maintains the existing address formatting behavior.
         write!(f, "{}", self.0.to_hex_literal())
     }
 }

--- a/aptos-move/aptos-vm-benchmarks/src/helper.rs
+++ b/aptos-move/aptos-vm-benchmarks/src/helper.rs
@@ -116,7 +116,9 @@ pub fn get_module_name(
         member_id: _function_id,
     } = str::parse(&format!(
         "0x{}::{}::{}",
-        address, identifier, func_identifier,
+        address.to_hex(),
+        identifier,
+        func_identifier,
     ))
     .unwrap();
 

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1701,7 +1701,7 @@ impl VMAdapter for AptosVM {
             },
             PreprocessedTransaction::UserTransaction(txn) => {
                 fail_point!("aptos_vm::execution::user_transaction");
-                let sender = txn.sender().to_string();
+                let sender = txn.sender().to_hex();
                 let _timer = TXN_TOTAL_SECONDS.start_timer();
                 let (vm_status, output) = self.execute_user_transaction(resolver, txn, log_context);
 

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.rs
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.rs
@@ -225,7 +225,10 @@ fn code_publishing_using_resource_account() {
     let module_address = create_resource_address(*acc.address(), &[]);
     pack.add_source(
         "m",
-        &format!("module 0x{}::m {{ public fun f() {{}} }}", module_address),
+        &format!(
+            "module 0x{}::m {{ public fun f() {{}} }}",
+            module_address.to_hex()
+        ),
     );
     let pack_dir = pack.write_to_temp().unwrap();
     let package = aptos_framework::BuiltPackage::build(

--- a/aptos-move/e2e-move-tests/src/tests/fungible_asset.rs
+++ b/aptos-move/e2e-move-tests/src/tests/fungible_asset.rs
@@ -43,7 +43,7 @@ fn test_basic_fungible_token() {
         .execute_view_function(
             str::parse(&format!(
                 "0x{}::managed_fungible_token::get_metadata",
-                *alice.address()
+                (*alice.address()).to_hex()
             ))
             .unwrap(),
             vec![],
@@ -58,7 +58,7 @@ fn test_basic_fungible_token() {
         &alice,
         str::parse(&format!(
             "0x{}::managed_fungible_asset::mint_to_primary_stores",
-            *alice.address()
+            (*alice.address()).to_hex()
         ))
         .unwrap(),
         vec![],
@@ -74,7 +74,7 @@ fn test_basic_fungible_token() {
         &alice,
         str::parse(&format!(
             "0x{}::managed_fungible_asset::transfer_between_primary_stores",
-            *alice.address()
+            (*alice.address()).to_hex()
         ))
         .unwrap(),
         vec![],
@@ -91,7 +91,7 @@ fn test_basic_fungible_token() {
         &alice,
         str::parse(&format!(
             "0x{}::managed_fungible_asset::burn_from_primary_stores",
-            *alice.address()
+            (*alice.address()).to_hex()
         ))
         .unwrap(),
         vec![],

--- a/aptos-move/e2e-move-tests/src/tests/generate_upgrade_script.rs
+++ b/aptos-move/e2e-move-tests/src/tests/generate_upgrade_script.rs
@@ -24,7 +24,7 @@ module 0x{}::test {{
     public entry fun hi(_s: &signer){{
     }}
 }}",
-            acc.address()
+            acc.address().to_hex()
         ),
     );
     let upgrade_dir = upgrade.write_to_temp().unwrap();

--- a/aptos-move/e2e-move-tests/src/tests/mint_nft.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mint_nft.rs
@@ -116,7 +116,7 @@ fn mint_nft_e2e() {
         &nft_receiver,
         str::parse(&format!(
             "0x{}::create_nft_getting_production_ready::mint_event_ticket",
-            resource_address
+            resource_address.to_hex()
         ))
         .unwrap(),
         vec![],

--- a/aptos-move/e2e-move-tests/src/tests/resource_groups.rs
+++ b/aptos-move/e2e-move-tests/src/tests/resource_groups.rs
@@ -81,7 +81,7 @@ fn test_resource_groups() {
     // Initialize secondary and verify it exists and nothing else does
     let result = h.run_entry_function(
         &user_account,
-        str::parse(&format!("0x{}::secondary::init", secondary_addr)).unwrap(),
+        str::parse(&format!("0x{}::secondary::init", secondary_addr.to_hex())).unwrap(),
         vec![],
         vec![bcs::to_bytes::<u32>(&22).unwrap()],
     );
@@ -112,7 +112,7 @@ fn test_resource_groups() {
     // Initialize primary and verify it exists with secondary
     let result = h.run_entry_function(
         &user_account,
-        str::parse(&format!("0x{}::primary::init", primary_addr)).unwrap(),
+        str::parse(&format!("0x{}::primary::init", primary_addr.to_hex())).unwrap(),
         vec![],
         vec![bcs::to_bytes::<u64>(&11122).unwrap()],
     );
@@ -145,7 +145,11 @@ fn test_resource_groups() {
     // Modify secondary and verify primary stays consistent
     let result = h.run_entry_function(
         &user_account,
-        str::parse(&format!("0x{}::secondary::set_value", secondary_addr)).unwrap(),
+        str::parse(&format!(
+            "0x{}::secondary::set_value",
+            secondary_addr.to_hex()
+        ))
+        .unwrap(),
         vec![],
         vec![bcs::to_bytes::<u32>(&5).unwrap()],
     );
@@ -178,7 +182,7 @@ fn test_resource_groups() {
     // Delete the first and verify the second remains
     let result = h.run_entry_function(
         &user_account,
-        str::parse(&format!("0x{}::primary::remove", primary_addr)).unwrap(),
+        str::parse(&format!("0x{}::primary::remove", primary_addr.to_hex())).unwrap(),
         vec![],
         vec![],
     );
@@ -209,7 +213,7 @@ fn test_resource_groups() {
     // Delete the second and verify nothing remains
     let result = h.run_entry_function(
         &user_account,
-        str::parse(&format!("0x{}::secondary::remove", secondary_addr)).unwrap(),
+        str::parse(&format!("0x{}::secondary::remove", secondary_addr.to_hex())).unwrap(),
         vec![],
         vec![],
     );

--- a/aptos-move/e2e-move-tests/src/tests/simple_defi.rs
+++ b/aptos-move/e2e-move-tests/src/tests/simple_defi.rs
@@ -59,8 +59,11 @@ fn exchange_e2e_test() {
     assert_success!(result);
 
     // verify that we store the signer cap within the module
-    let module_data =
-        parse_struct_tag(&format!("0x{}::simple_defi::ModuleData", resource_address)).unwrap();
+    let module_data = parse_struct_tag(&format!(
+        "0x{}::simple_defi::ModuleData",
+        resource_address.to_hex()
+    ))
+    .unwrap();
 
     assert_eq!(
         h.read_resource::<ModuleData>(&resource_address, module_data)

--- a/aptos-move/e2e-move-tests/src/tests/token_objects.rs
+++ b/aptos-move/e2e-move-tests/src/tests/token_objects.rs
@@ -48,7 +48,7 @@ fn test_basic_token() {
 
     let result = h.run_entry_function(
         &account,
-        str::parse(&format!("0x{}::hero::mint_hero", addr)).unwrap(),
+        str::parse(&format!("0x{}::hero::mint_hero", addr.to_hex())).unwrap(),
         vec![],
         vec![
             bcs::to_bytes("The best hero ever!").unwrap(),
@@ -99,7 +99,7 @@ fn test_basic_token() {
 
     let result = h.run_entry_function(
         &account,
-        str::parse(&format!("0x{}::hero::set_hero_description", addr)).unwrap(),
+        str::parse(&format!("0x{}::hero::set_hero_description", addr.to_hex())).unwrap(),
         vec![],
         vec![
             bcs::to_bytes("Hero Quest!").unwrap(),

--- a/aptos-move/e2e-testsuite/src/tests/data_store.rs
+++ b/aptos-move/e2e-testsuite/src/tests/data_store.rs
@@ -239,7 +239,7 @@ fn add_module_txn(sender: &AccountData, seq_num: u64) -> (CompiledModule, Signed
             }}
         }}
         ",
-        sender.address(),
+        sender.address().to_hex(),
     );
 
     let framework_modules = aptos_cached_packages::head_release_bundle().compiled_modules();
@@ -280,7 +280,7 @@ fn add_resource_txn(
                 return;
             }}
         ",
-        sender.address(),
+        sender.address().to_hex(),
     );
 
     let module = compile_script(&program, extra_deps);
@@ -307,7 +307,7 @@ fn remove_resource_txn(
                 return;
             }}
         ",
-        sender.address(),
+        sender.address().to_hex(),
     );
 
     let module = compile_script(&program, extra_deps);
@@ -334,7 +334,7 @@ fn borrow_resource_txn(
                 return;
             }}
         ",
-        sender.address(),
+        sender.address().to_hex(),
     );
 
     let module = compile_script(&program, extra_deps);
@@ -361,7 +361,7 @@ fn change_resource_txn(
                 return;
             }}
         ",
-        sender.address(),
+        sender.address().to_hex(),
     );
 
     let module = compile_script(&program, extra_deps);

--- a/aptos-move/e2e-testsuite/src/tests/module_publishing.rs
+++ b/aptos-move/e2e-testsuite/src/tests/module_publishing.rs
@@ -30,7 +30,7 @@ fn bad_module_address() {
         module 0x{}.M {{
         }}
         ",
-        account1.address()
+        account1.address().to_hex()
     );
 
     // compile with account 1's address
@@ -275,7 +275,7 @@ pub fn test_publishing_modules_proper_sender() {
         module 0x{}.M {{
         }}
         ",
-        sender.address(),
+        sender.address().to_hex(),
     );
 
     let random_script = compile_module(&program).1;
@@ -339,7 +339,7 @@ pub fn test_publishing_allow_modules() {
         module 0x{}.M {{
         }}
         ",
-        sender.address(),
+        sender.address().to_hex(),
     );
 
     let random_script = compile_module(&program).1;

--- a/aptos-move/e2e-testsuite/src/tests/verify_txn.rs
+++ b/aptos-move/e2e-testsuite/src/tests/verify_txn.rs
@@ -544,7 +544,7 @@ pub fn test_open_publishing_invalid_address() {
             }}
         }}
         ",
-        receiver.address(),
+        receiver.address().to_hex(),
     );
 
     let random_module = compile_module(&module).1;
@@ -607,7 +607,7 @@ pub fn test_open_publishing() {
             }}
         }}
         ",
-        sender.address(),
+        sender.address().to_hex(),
     );
 
     let random_module = compile_module(&program).1;
@@ -671,7 +671,7 @@ fn good_module_uses_bad(
         }}
     }}
     ",
-        address,
+        address.to_hex(),
     );
 
     let framework_modules = aptos_cached_packages::head_release_bundle().compiled_modules();
@@ -904,7 +904,7 @@ fn test_module_transitive_dependency_fails_verification() {
         }}
     }}
     ",
-        sender.address()
+        sender.address().to_hex()
     );
     let module = {
         let compiler = Compiler {

--- a/crates/aptos-faucet/cli/src/main.rs
+++ b/crates/aptos-faucet/cli/src/main.rs
@@ -108,17 +108,13 @@ impl FaucetCliArgs {
             match response {
                 Ok(response) => println!(
                     "SUCCESS: Account: {}, txn hashes: {:?}",
-                    account.to_hex_literal(),
+                    account,
                     response
                         .into_iter()
-                        .map(|r| r.committed_hash().to_hex_literal())
+                        .map(|r| r.committed_hash().to_string())
                         .collect::<Vec<_>>()
                 ),
-                Err(err) => println!(
-                    "FAILURE: Account: {} Response: {:#}",
-                    account.to_hex_literal(),
-                    err
-                ),
+                Err(err) => println!("FAILURE: Account: {} Response: {:#}", account, err),
             }
         }
 
@@ -129,9 +125,7 @@ impl FaucetCliArgs {
 /// Allow 0x to be in front of addresses.
 fn process_account_address(str: &str) -> AccountAddress {
     let str = str.trim();
-    if let Ok(address) = AccountAddress::from_hex_literal(str) {
-        address
-    } else if let Ok(address) = AccountAddress::from_str(str) {
+    if let Ok(address) = AccountAddress::from_str(str) {
         address
     } else {
         panic!("Account address is in an invalid format {}", str)

--- a/crates/aptos-faucet/core/src/funder/common.rs
+++ b/crates/aptos-faucet/core/src/funder/common.rs
@@ -386,7 +386,7 @@ pub async fn submit_transaction(
     match result {
         Ok(_) => {
             info!(
-                hash = signed_transaction.clone().committed_hash().to_hex_literal(),
+                hash = signed_transaction.clone().committed_hash(),
                 address = receiver_address,
                 event = event_on_success,
             );
@@ -395,7 +395,7 @@ pub async fn submit_transaction(
         Err(e) => {
             faucet_account.write().await.decrement_sequence_number();
             warn!(
-                hash = signed_transaction.clone().committed_hash().to_hex_literal(),
+                hash = signed_transaction.clone().committed_hash(),
                 address = receiver_address,
                 event = "transaction_failure",
                 error_message = format!("{:#}", e)

--- a/crates/aptos-faucet/core/src/funder/mint.rs
+++ b/crates/aptos-faucet/core/src/funder/mint.rs
@@ -191,7 +191,7 @@ impl MintFunder {
 
         info!(
             "Successfully configured MintFunder to use delegated account: {}",
-            delegated_account.address().to_hex_literal()
+            delegated_account.address()
         );
 
         self.faucet_account = RwLock::new(delegated_account);

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -879,7 +879,7 @@ impl Client {
         start: Option<u64>,
         limit: Option<u64>,
     ) -> AptosResult<Response<Vec<Transaction>>> {
-        let url = self.build_path(&format!("accounts/{}/transactions", address))?;
+        let url = self.build_path(&format!("accounts/{}/transactions", address.to_hex()))?;
 
         let mut request = self.inner.get(url);
         if let Some(start) = start {
@@ -901,7 +901,7 @@ impl Client {
         start: Option<u64>,
         limit: Option<u16>,
     ) -> AptosResult<Response<Vec<TransactionOnChainData>>> {
-        let url = self.build_path(&format!("accounts/{}/transactions", address))?;
+        let url = self.build_path(&format!("accounts/{}/transactions", address.to_hex()))?;
         let response = self.get_bcs_with_page(url, start, limit).await?;
         Ok(response.and_then(|inner| bcs::from_bytes(&inner))?)
     }
@@ -911,7 +911,7 @@ impl Client {
         address: AccountAddress,
     ) -> AptosResult<Response<Vec<Resource>>> {
         self.paginate_with_cursor(
-            &format!("accounts/{}/resources", address),
+            &format!("accounts/{}/resources", address.to_hex()),
             RESOURCES_PER_CALL_PAGINATION,
             None,
         )
@@ -923,7 +923,7 @@ impl Client {
         address: AccountAddress,
     ) -> AptosResult<Response<BTreeMap<StructTag, Vec<u8>>>> {
         self.paginate_with_cursor_bcs(
-            &format!("accounts/{}/resources", address),
+            &format!("accounts/{}/resources", address.to_hex()),
             RESOURCES_PER_CALL_PAGINATION,
             None,
         )
@@ -936,7 +936,7 @@ impl Client {
         version: u64,
     ) -> AptosResult<Response<Vec<Resource>>> {
         self.paginate_with_cursor(
-            &format!("accounts/{}/resources", address),
+            &format!("accounts/{}/resources", address.to_hex()),
             RESOURCES_PER_CALL_PAGINATION,
             Some(version),
         )
@@ -949,7 +949,7 @@ impl Client {
         version: u64,
     ) -> AptosResult<Response<BTreeMap<StructTag, Vec<u8>>>> {
         self.paginate_with_cursor_bcs(
-            &format!("accounts/{}/resources", address),
+            &format!("accounts/{}/resources", address.to_hex()),
             RESOURCES_PER_CALL_PAGINATION,
             Some(version),
         )
@@ -982,7 +982,11 @@ impl Client {
         address: AccountAddress,
         resource_type: &str,
     ) -> AptosResult<Response<Option<Resource>>> {
-        let url = self.build_path(&format!("accounts/{}/resource/{}", address, resource_type))?;
+        let url = self.build_path(&format!(
+            "accounts/{}/resource/{}",
+            address.to_hex(),
+            resource_type
+        ))?;
 
         let response = self
             .inner
@@ -998,7 +1002,11 @@ impl Client {
         address: AccountAddress,
         resource_type: &str,
     ) -> AptosResult<Response<T>> {
-        let url = self.build_path(&format!("accounts/{}/resource/{}", address, resource_type))?;
+        let url = self.build_path(&format!(
+            "accounts/{}/resource/{}",
+            address.to_hex(),
+            resource_type
+        ))?;
         let response = self.get_bcs(url).await?;
         Ok(response.and_then(|inner| bcs::from_bytes(&inner))?)
     }
@@ -1011,7 +1019,9 @@ impl Client {
     ) -> AptosResult<Response<T>> {
         let url = self.build_path(&format!(
             "accounts/{}/resource/{}?ledger_version={}",
-            address, resource_type, version
+            address.to_hex(),
+            resource_type,
+            version
         ))?;
 
         let response = self.get_bcs(url).await?;
@@ -1026,7 +1036,9 @@ impl Client {
     ) -> AptosResult<Response<Vec<u8>>> {
         let url = self.build_path(&format!(
             "accounts/{}/resource/{}?ledger_version={}",
-            address, resource_type, version
+            address.to_hex(),
+            resource_type,
+            version
         ))?;
 
         let response = self.get_bcs(url).await?;
@@ -1038,7 +1050,11 @@ impl Client {
         address: AccountAddress,
         resource_type: &str,
     ) -> AptosResult<Response<Vec<u8>>> {
-        let url = self.build_path(&format!("accounts/{}/resource/{}", address, resource_type))?;
+        let url = self.build_path(&format!(
+            "accounts/{}/resource/{}",
+            address.to_hex(),
+            resource_type
+        ))?;
 
         let response = self.get_bcs(url).await?;
         Ok(response.map(|inner| inner.to_vec()))
@@ -1052,7 +1068,9 @@ impl Client {
     ) -> AptosResult<Response<Option<Resource>>> {
         let url = self.build_path(&format!(
             "accounts/{}/resource/{}?ledger_version={}",
-            address, resource_type, version
+            address.to_hex(),
+            resource_type,
+            version
         ))?;
 
         let response = self.inner.get(url).send().await?;
@@ -1064,7 +1082,7 @@ impl Client {
         address: AccountAddress,
     ) -> AptosResult<Response<Vec<MoveModuleBytecode>>> {
         self.paginate_with_cursor(
-            &format!("accounts/{}/modules", address),
+            &format!("accounts/{}/modules", address.to_hex()),
             MODULES_PER_CALL_PAGINATION,
             None,
         )
@@ -1076,7 +1094,7 @@ impl Client {
         address: AccountAddress,
     ) -> AptosResult<Response<BTreeMap<MoveModuleId, Vec<u8>>>> {
         self.paginate_with_cursor_bcs(
-            &format!("accounts/{}/modules", address),
+            &format!("accounts/{}/modules", address.to_hex()),
             MODULES_PER_CALL_PAGINATION,
             None,
         )
@@ -1088,7 +1106,11 @@ impl Client {
         address: AccountAddress,
         module_name: &str,
     ) -> AptosResult<Response<MoveModuleBytecode>> {
-        let url = self.build_path(&format!("accounts/{}/module/{}", address, module_name))?;
+        let url = self.build_path(&format!(
+            "accounts/{}/module/{}",
+            address.to_hex(),
+            module_name
+        ))?;
         self.get(url).await
     }
 
@@ -1097,7 +1119,11 @@ impl Client {
         address: AccountAddress,
         module_name: &str,
     ) -> AptosResult<Response<bytes::Bytes>> {
-        let url = self.build_path(&format!("accounts/{}/module/{}", address, module_name))?;
+        let url = self.build_path(&format!(
+            "accounts/{}/module/{}",
+            address.to_hex(),
+            module_name
+        ))?;
         self.get_bcs(url).await
     }
 
@@ -1109,7 +1135,9 @@ impl Client {
     ) -> AptosResult<Response<bytes::Bytes>> {
         let url = self.build_path(&format!(
             "accounts/{}/module/{}?ledger_version={}",
-            address, module_name, version
+            address.to_hex(),
+            module_name,
+            version
         ))?;
         self.get_bcs(url).await
     }
@@ -1283,7 +1311,7 @@ impl Client {
     }
 
     pub async fn get_account(&self, address: AccountAddress) -> AptosResult<Response<Account>> {
-        let url = self.build_path(&format!("accounts/{}", address))?;
+        let url = self.build_path(&format!("accounts/{}", address.to_hex()))?;
         let response = self.inner.get(url).send().await?;
         self.json(response).await
     }
@@ -1292,7 +1320,7 @@ impl Client {
         &self,
         address: AccountAddress,
     ) -> AptosResult<Response<AccountResource>> {
-        let url = self.build_path(&format!("accounts/{}", address))?;
+        let url = self.build_path(&format!("accounts/{}", address.to_hex()))?;
         let response = self.get_bcs(url).await?;
         Ok(response.and_then(|inner| bcs::from_bytes(&inner))?)
     }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1178,11 +1178,7 @@ impl FromStr for AccountAddressWrapper {
 
 /// Loads an account arg and allows for naming based on profiles
 pub fn load_account_arg(str: &str) -> Result<AccountAddress, CliError> {
-    if str.starts_with("0x") {
-        AccountAddress::from_hex_literal(str).map_err(|err| {
-            CliError::CommandArgumentError(format!("Failed to parse AccountAddress {}", err))
-        })
-    } else if let Ok(account_address) = AccountAddress::from_str(str) {
+    if let Ok(account_address) = AccountAddress::from_str(str) {
         Ok(account_address)
     } else if let Some(Some(account_address)) =
         CliConfig::load_profile(Some(str), ConfigSearchMode::CurrentDirAndParents)?
@@ -1222,12 +1218,6 @@ impl FromStr for MoveManifestAccountWrapper {
 pub fn load_manifest_account_arg(str: &str) -> Result<Option<AccountAddress>, CliError> {
     if str == "_" {
         Ok(None)
-    } else if str.starts_with("0x") {
-        AccountAddress::from_hex_literal(str)
-            .map(Some)
-            .map_err(|err| {
-                CliError::CommandArgumentError(format!("Failed to parse AccountAddress {}", err))
-            })
     } else if let Ok(account_address) = AccountAddress::from_str(str) {
         Ok(Some(account_address))
     } else if let Some(Some(private_key)) =

--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -133,13 +133,13 @@ async fn test_genesis_transaction_flow() {
             use aptos_framework::block;
 
             fun main(vm_signer: &signer, framework_signer: &signer) {{
-                stake::remove_validators(framework_signer, &vector[@0x{:?}]);
+                stake::remove_validators(framework_signer, &vector[@0x{}]);
                 block::emit_writeset_block_event(vm_signer, @0x1);
                 aptos_governance::reconfigure(framework_signer);
             }}
     }}
     "#,
-        first_validator_address
+        first_validator_address.to_hex()
     );
 
     let temp_script_path = TempPath::new();

--- a/third_party/move/evm/move-to-yul/src/events.rs
+++ b/third_party/move/evm/move-to-yul/src/events.rs
@@ -227,7 +227,7 @@ pub(crate) fn define_emit_fun_for_send(
         // example: 0x00000000000000000000000000000003::AccountStateMachine::deposit
         let message_str = format!(
             "0x{}::{}",
-            fun.module_env.self_address().expect_numerical(),
+            fun.module_env.self_address().expect_numerical().to_hex(),
             fun.get_full_name_str().replace("send_", "")
         );
         let hash_bytes = Sha3_256::digest(message_str.as_bytes());

--- a/third_party/move/extensions/async/move-async-vm/src/actor_metadata.rs
+++ b/third_party/move/extensions/async/move-async-vm/src/actor_metadata.rs
@@ -23,7 +23,7 @@ pub struct ActorMetadata {
 pub fn message_hash(module_id: &ModuleId, handler_id: &IdentStr) -> u64 {
     let hash_str = format!(
         "0x{}::{}::{}",
-        module_id.address(),
+        module_id.address().to_hex(),
         module_id.name(),
         handler_id
     );

--- a/third_party/move/move-compiler/src/command_line/compiler.rs
+++ b/third_party/move/move-compiler/src/command_line/compiler.rs
@@ -697,7 +697,7 @@ pub fn generate_interface_files(
     {
         let (id, interface_contents) =
             interface_generator::write_file_to_string(module_to_named_address, &path)?;
-        let addr_dir = dir_path!(all_addr_dir.clone(), format!("{}", id.address()));
+        let addr_dir = dir_path!(all_addr_dir.clone(), format!("{}", id.address().to_hex()));
         let file_path = file_path!(addr_dir.clone(), format!("{}", id.name()), MOVE_EXTENSION);
         result.push(IndexedPackagePath {
             path: Symbol::from(file_path.clone().into_os_string().into_string().unwrap()),

--- a/third_party/move/move-core/types/src/account_address.rs
+++ b/third_party/move/move-core/types/src/account_address.rs
@@ -229,7 +229,7 @@ impl std::ops::Deref for AccountAddress {
 
 impl fmt::Display for AccountAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{:x}", self)
+        write!(f, "{}", self.to_standard_string())
     }
 }
 
@@ -588,7 +588,7 @@ mod tests {
 
         let address = AccountAddress::from_hex(hex).unwrap();
 
-        assert_eq!(format!("{}", address), hex);
+        assert_eq!(format!("{}", address), format!("0x{}", hex));
         assert_eq!(format!("{:?}", address), hex);
         assert_eq!(format!("{:X}", address), upper_hex);
         assert_eq!(format!("{:x}", address), hex);

--- a/third_party/move/move-core/types/src/language_storage.rs
+++ b/third_party/move/move-core/types/src/language_storage.rs
@@ -247,7 +247,7 @@ impl Display for ModuleId {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         // Can't change, because it can be part of TransactionExecutionFailedEvent
         // which is emitted on chain.
-        write!(f, "{}::{}", self.address, self.name)
+        write!(f, "{}::{}", self.address.to_hex(), self.name)
     }
 }
 

--- a/third_party/move/move-core/types/src/unit_tests/language_storage_test.rs
+++ b/third_party/move/move-core/types/src/unit_tests/language_storage_test.rs
@@ -41,14 +41,14 @@ fn test_type_tag_deserialize_case_insensitive() {
 
     let upper_case_json = format!(
         r##"{{"address":"{}","module":"TestModule","name":"TestStruct","type_params":["U8","U16","U32","U64","U128","U256","Bool","Address","Signer"]}}"##,
-        AccountAddress::ONE
+        AccountAddress::ONE.to_hex()
     );
     let upper_case_decoded = serde_json::from_str(upper_case_json.as_str()).unwrap();
     assert_eq!(org_struct_tag, upper_case_decoded);
 
     let lower_case_json = format!(
         r##"{{"address":"{}","module":"TestModule","name":"TestStruct","type_args":["u8","u16","u32","u64","u128","u256","bool","address","signer"]}}"##,
-        AccountAddress::ONE
+        AccountAddress::ONE.to_hex()
     );
     let lower_case_decoded = serde_json::from_str(lower_case_json.as_str()).unwrap();
     assert_eq!(org_struct_tag, lower_case_decoded);

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -1556,7 +1556,7 @@ impl GlobalEnv {
     /// Converts a storage module id into an AST module name.
     pub fn to_module_name(&self, storage_id: &language_storage::ModuleId) -> ModuleName {
         ModuleName::from_str(
-            &storage_id.address().to_string(),
+            &storage_id.address().to_hex(),
             self.symbol_pool.make(storage_id.name().as_str()),
         )
     }

--- a/third_party/move/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
@@ -43,7 +43,7 @@ fn call_non_existent_function() {
     let code = r#"
         module {{ADDR}}::M {}
     "#;
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_hex()));
 
     let mut units = compile_units(&code).unwrap();
     let m = as_module(units.pop().unwrap());

--- a/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -66,7 +66,7 @@ fn test_malformed_resource() {
             }
         }
     "#;
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_hex()));
     let mut units = compile_units(&code).unwrap();
 
     let s2 = as_script(units.pop().unwrap());
@@ -161,7 +161,7 @@ fn test_malformed_module() {
         }
     "#;
 
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_hex()));
     let mut units = compile_units(&code).unwrap();
 
     let m = as_module(units.pop().unwrap());
@@ -225,7 +225,7 @@ fn test_unverifiable_module() {
         }
     "#;
 
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_hex()));
     let mut units = compile_units(&code).unwrap();
     let m = as_module(units.pop().unwrap());
 
@@ -295,7 +295,7 @@ fn test_missing_module_dependency() {
             public fun bar() { M::foo(); }
         }
     "#;
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_hex()));
     let mut units = compile_units(&code).unwrap();
     let n = as_module(units.pop().unwrap());
     let m = as_module(units.pop().unwrap());
@@ -365,7 +365,7 @@ fn test_malformed_module_dependency() {
             public fun bar() { M::foo(); }
         }
     "#;
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_hex()));
     let mut units = compile_units(&code).unwrap();
     let n = as_module(units.pop().unwrap());
     let m = as_module(units.pop().unwrap());
@@ -441,7 +441,7 @@ fn test_unverifiable_module_dependency() {
             public fun bar() { M::foo(); }
         }
     "#;
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_hex()));
     let mut units = compile_units(&code).unwrap();
     let n = as_module(units.pop().unwrap());
     let m = as_module(units.pop().unwrap());
@@ -594,7 +594,7 @@ fn test_storage_returns_bogus_error_when_loading_resource() {
             }
         }
     "#;
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_hex()));
 
     let mut units = compile_units(&code).unwrap();
     let m = as_module(units.pop().unwrap());

--- a/third_party/move/move-vm/integration-tests/src/tests/exec_func_effects_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/exec_func_effects_tests.rs
@@ -74,7 +74,11 @@ fn setup_module() -> ModuleCode {
             fun {}(_a: & u64) {{ }}
         }}
     "#,
-        TEST_ADDR, TEST_MODULE_ID, USE_MUTREF_LABEL, EXPECT_MUTREF_OUT_VALUE, USE_REF_LABEL
+        TEST_ADDR.to_hex(),
+        TEST_MODULE_ID,
+        USE_MUTREF_LABEL,
+        EXPECT_MUTREF_OUT_VALUE,
+        USE_REF_LABEL
     );
 
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new(TEST_MODULE_ID).unwrap());

--- a/third_party/move/move-vm/integration-tests/src/tests/function_arg_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/function_arg_tests.rs
@@ -45,7 +45,9 @@ fn run(
             fun foo<{}>({}) {{ }}
         }}
     "#,
-        TEST_ADDR, ty_params, params
+        TEST_ADDR.to_hex(),
+        ty_params,
+        params
     );
 
     let mut units = compile_units(&code).unwrap();

--- a/third_party/move/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
@@ -33,7 +33,7 @@ fn mutated_accounts() {
         }
     "#;
 
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_hex()));
     let mut units = compile_units(&code).unwrap();
     let m = as_module(units.pop().unwrap());
     let mut blob = vec![];

--- a/third_party/move/move-vm/integration-tests/src/tests/nested_loop_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/nested_loop_tests.rs
@@ -28,7 +28,7 @@ fn test_publish_module_with_nested_loops() {
             }
         }
     "#;
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_hex()));
     let mut units = compile_units(&code).unwrap();
 
     let m = as_module(units.pop().unwrap());
@@ -100,7 +100,7 @@ fn test_run_script_with_nested_loops() {
             }
         }
     "#;
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_hex()));
     let mut units = compile_units(&code).unwrap();
 
     let s = as_script(units.pop().unwrap());

--- a/third_party/move/move-vm/integration-tests/src/tests/return_value_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/return_value_tests.rs
@@ -35,7 +35,10 @@ fn run(
             }}
         }}
     "#,
-        TEST_ADDR, structs, fun_sig, fun_body
+        TEST_ADDR.to_hex(),
+        structs,
+        fun_sig,
+        fun_body
     );
 
     let mut units = compile_units(&code).unwrap();

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -707,7 +707,7 @@ impl Interpreter {
 
         debug_write!(buf, "    [{}] ", idx)?;
         if let Some(module) = func.module_id() {
-            debug_write!(buf, "{}::{}::", module.address(), module.name(),)?;
+            debug_write!(buf, "{}::{}::", module.address().to_hex(), module.name(),)?;
         }
         debug_write!(buf, "{}", func.name())?;
         let ty_args = frame.ty_args();

--- a/third_party/move/move-vm/runtime/src/loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader.rs
@@ -2614,7 +2614,7 @@ impl Function {
             Scope::Script(_) => "Script::main".into(),
             Scope::Module(id) => format!(
                 "0x{}::{}::{}",
-                id.address(),
+                id.address().to_hex(),
                 id.name().as_str(),
                 self.name.as_str()
             ),

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -2779,7 +2779,7 @@ pub mod debug {
     }
 
     fn print_address<B: Write>(buf: &mut B, x: &AccountAddress) -> PartialVMResult<()> {
-        debug_write!(buf, "{}", x)
+        debug_write!(buf, "{}", x.to_hex())
     }
 
     fn print_value_impl<B: Write>(buf: &mut B, val: &ValueImpl) -> PartialVMResult<()> {

--- a/third_party/move/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/third_party/move/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -93,7 +93,7 @@ impl OnDiskStateView {
 
     fn get_addr_path(&self, addr: &AccountAddress) -> PathBuf {
         let mut path = self.storage_dir.clone();
-        path.push(format!("0x{}", addr));
+        path.push(format!("0x{}", addr.to_hex()));
         path
     }
 
@@ -403,7 +403,7 @@ impl ToString for StructID {
         // Would be nice to expose a StructTag parser and get rid of the 0x here
         format!(
             "0x{}::{}::{}{}",
-            tag.address,
+            tag.address.to_hex(),
             tag.module,
             tag.name,
             Generics(tag.type_params.clone()).to_string()

--- a/third_party/move/tools/move-coverage/src/summary.rs
+++ b/third_party/move/tools/move-coverage/src/summary.rs
@@ -47,7 +47,7 @@ impl ModuleSummary {
     pub fn summarize_csv<W: Write>(&self, summary_writer: &mut W) -> io::Result<()> {
         let module = format!(
             "{}::{}",
-            self.module_name.address(),
+            self.module_name.address().to_hex(),
             self.module_name.name()
         );
 
@@ -83,7 +83,7 @@ impl ModuleSummary {
         writeln!(
             summary_writer,
             "Module {}::{}",
-            self.module_name.address(),
+            self.module_name.address().to_hex(),
             self.module_name.name()
         )?;
 

--- a/third_party/move/tools/move-disassembler/src/disassembler.rs
+++ b/third_party/move/tools/move-disassembler/src/disassembler.rs
@@ -171,14 +171,14 @@ impl<'a> Disassembler<'a> {
         } else if let Some(alias) = self.module_aliases.get(&module_id) {
             Some(format!(
                 "use {}::{} as {};",
-                module_id.address(),
+                module_id.address().to_hex(),
                 module_id.name(),
                 alias
             ))
         } else {
             Some(format!(
                 "use {}::{};",
-                module_id.address(),
+                module_id.address().to_hex(),
                 module_id.name()
             ))
         }

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -28,13 +28,13 @@ pub struct AccountAddressWithChecks(AccountAddress);
 
 impl Display for AccountAddressWithChecks {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.0.to_hex())
     }
 }
 
 impl Debug for AccountAddressWithChecks {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.0)
+        write!(f, "{:?}", self.0.to_hex())
     }
 }
 


### PR DESCRIPTION
### Description
This PR makes the Display impl of AccountAddress use to_standard_string. The motivation behind this change is to make it that when people use AccountAddress, they get standard compliant behavior by default.

I've taken particular care to try and make sure everything that uses AccountAddress is unchanged as a result of this PR, except in these specific cases where I think the change won't cause any issues. I have a previous attempt at this where I also try to change the Debug and Serialize impls, but it got out of hand quickly: https://github.com/aptos-labs/aptos-core/pull/9183. This PR just changes Display. Beyond that, it doesn't try to update the rest of the code to adopt the new Display implementation, but rather switches it to use the old underlying implementation. For example:

Before:
```rust
format!("0x{}::{}", addr, module_name);
```

After:
```rust
format!("0x{}::{}", addr.to_hex(), module_name);
```

This way nothing is changed. We can then go change these if we like later on piece by piece.

There are some cases where I have opted to keep the new Display impl because I know it is safe:
- Logging in the faucet

Places I’ve confirmed are unchanged:

- The CLI, e.g. `aptos init`, `aptos node show-validator-set`, `aptos config show-profiles --profile default`
- The validator configs, tested with `aptos node run-local-testnet`. The addresses are all still the same.
- Any storage of addresses by the node.
- How addresses are returned by the v1 node API.
- How addresses are returned by any existing indexer API.
- The Rust REST API client.
- Use of addresses in aptos-move and third_party/move.

### Test Plan
Manually running the CLI E2E tests:
```
DOCKER_DEFAULT_PLATFORM=linux/amd64 poetry run python main.py -d --base-network testnet --test-cli-path ~/a/core/target/debug/aptos
```

Confirming that the new CLI works with an older config.
```
cd /tmp/testing
aptos init
~/aptos-core/target/debug/aptos show-profiles
```

Confirming that a node from before this change happily starts with a set of configs generated by the new CLI (once I remove config sections that the new CLI generates that the node in the existing CLI doesn't know about, but not fixing any address stuff).
```
cd /tmp/node
~/aptos-core/target/debug/aptos node run-local-testnet
aptos node run-local-testnet
```

Beyond that I've gone through all the tests in third_party/move/, aptos-move/, api/, and more to make sure nothing is changed.