### PR TITLE
Fix indexer-grpc-integration-tests

### DIFF
--- a/.github/workflows/indexer-grpc-integration-tests.yaml
+++ b/.github/workflows/indexer-grpc-integration-tests.yaml
@@ -41,6 +41,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install grpcurl
+        run: curl -sSL "https://github.com/fullstorydev/grpcurl/releases/download/v1.8.7/grpcurl_1.8.7_linux_x86_64.tar.gz" | sudo tar -xz -C /usr/local/bin
+
       - name: Set up Rust
         uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
         with:
@@ -55,9 +58,14 @@ jobs:
           AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
 
-      - name: Run indexer gRPC dependnencies locally (${{ env.IMAGE_TAG }})
+      - uses: ./.github/actions/python-setup
+        with:
+          pyproject_directory: ./testsuite
+
+      - name: Run indexer gRPC dependencies locally (devnet)
         shell: bash
-        run: ./testsuite/indexer_grpc_local.py --verbose start --no-indexer-grpc
+        working-directory: ./testsuite
+        run: poetry run python indexer_grpc_local.py --verbose start --no-indexer-grpc
 
       - name: Run indexer gRPC integration tests
         shell: bash


### PR DESCRIPTION
### Description
We weren't installing grpcurl or the necessary Python deps.

### Test Plan
I temporarily changed it to `pull_request`. Here is the successful run: https://github.com/aptos-labs/aptos-core/actions/runs/6084690892/job/16507158429?pr=9920.
```
    Starting 3 tests across 1 binary
        PASS [   0.020s] aptos-indexer-grpc-integration-tests tests::fullnode_tests::verify_docker_compose_setup
        PASS [  18.904s] aptos-indexer-grpc-integration-tests tests::fullnode_tests::test_cold_start_file_store_worker_progress
        PASS [  30.406s] aptos-indexer-grpc-integration-tests tests::fullnode_tests::test_cold_start_cache_worker_progress
------------
     Summary [  30.406s] 3 tests run: 3 passed, 0 skipped
```