### PR TITLE
[State Sync] Add client-side support for subscription syncing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,6 +3450,7 @@ dependencies = [
  "aptos-compression",
  "aptos-config",
  "aptos-crypto",
+ "aptos-time-service",
  "aptos-types",
  "bcs 0.1.4",
  "claims",

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -204,6 +204,9 @@ impl Default for StorageServiceConfig {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct DataStreamingServiceConfig {
+    /// Whether or not to enable data subscription streaming.
+    pub enable_subscription_streaming: bool,
+
     /// The interval (milliseconds) at which to refresh the global data summary.
     pub global_summary_refresh_interval_ms: u64,
 
@@ -226,6 +229,10 @@ pub struct DataStreamingServiceConfig {
     /// memory. Once the number grows beyond this value, garbage collection occurs.
     pub max_notification_id_mappings: u64,
 
+    /// Maxinum number of consecutive subscriptions that can be made before
+    /// the subscription stream is terminated and a new stream must be created.
+    pub max_num_consecutive_subscriptions: u64,
+
     /// The interval (milliseconds) at which to check the progress of each stream.
     pub progress_check_interval_ms: u64,
 }
@@ -233,12 +240,14 @@ pub struct DataStreamingServiceConfig {
 impl Default for DataStreamingServiceConfig {
     fn default() -> Self {
         Self {
+            enable_subscription_streaming: false,
             global_summary_refresh_interval_ms: 50,
             max_concurrent_requests: MAX_CONCURRENT_REQUESTS,
             max_concurrent_state_requests: MAX_CONCURRENT_STATE_REQUESTS,
             max_data_stream_channel_sizes: 300,
             max_request_retry: 5,
             max_notification_id_mappings: 300,
+            max_num_consecutive_subscriptions: 50,
             progress_check_interval_ms: 50,
         }
     }
@@ -257,14 +266,14 @@ pub struct AptosDataClientConfig {
     pub max_num_in_flight_regular_polls: u64,
     /// Maximum number of output reductions before transactions are returned
     pub max_num_output_reductions: u64,
-    /// Maximum version lag we'll tolerate when sending optimistic fetch requests
-    pub max_optimistic_fetch_version_lag: u64,
+    /// Maximum lag (in seconds) we'll tolerate when sending optimistic fetch requests
+    pub max_optimistic_fetch_lag_secs: u64,
     /// Maximum timeout (in ms) when waiting for a response (after exponential increases)
     pub max_response_timeout_ms: u64,
     /// Maximum number of state keys and values per chunk
     pub max_state_chunk_size: u64,
-    /// Maximum version lag we'll tolerate when sending subscription requests
-    pub max_subscription_version_lag: u64,
+    /// Maximum lag (in seconds) we'll tolerate when sending subscription requests
+    pub max_subscription_lag_secs: u64,
     /// Maximum number of transactions per chunk
     pub max_transaction_chunk_size: u64,
     /// Maximum number of transaction outputs per chunk
@@ -273,6 +282,8 @@ pub struct AptosDataClientConfig {
     pub optimistic_fetch_timeout_ms: u64,
     /// First timeout (in ms) when waiting for a response
     pub response_timeout_ms: u64,
+    /// Timeout (in ms) when waiting for a subscription response
+    pub subscription_response_timeout_ms: u64,
     /// Interval (in ms) between data summary poll loop executions
     pub summary_poll_loop_interval_ms: u64,
     /// Whether or not to request compression for incoming data
@@ -287,15 +298,16 @@ impl Default for AptosDataClientConfig {
             max_num_in_flight_priority_polls: 10,
             max_num_in_flight_regular_polls: 10,
             max_num_output_reductions: 0,
-            max_optimistic_fetch_version_lag: 50_000, // Assumes 5K TPS for 10 seconds, which should be plenty
-            max_response_timeout_ms: 60_000,          // 60 seconds
+            max_optimistic_fetch_lag_secs: 30, // 30 seconds
+            max_response_timeout_ms: 60_000,   // 60 seconds
             max_state_chunk_size: MAX_STATE_CHUNK_SIZE,
-            max_subscription_version_lag: 100_000, // Assumes 5K TPS for 20 seconds, which should be plenty
+            max_subscription_lag_secs: 60, // 60 seconds
             max_transaction_chunk_size: MAX_TRANSACTION_CHUNK_SIZE,
             max_transaction_output_chunk_size: MAX_TRANSACTION_OUTPUT_CHUNK_SIZE,
             optimistic_fetch_timeout_ms: 5000, // 5 seconds
             response_timeout_ms: 10_000,       // 10 seconds
             summary_poll_loop_interval_ms: 200,
+            subscription_response_timeout_ms: 20_000, // 20 seconds (must be longer than a regular timeout because of pre-fetching)
             use_compression: true,
         }
     }

--- a/state-sync/aptos-data-client/src/error.rs
+++ b/state-sync/aptos-data-client/src/error.rs
@@ -35,6 +35,11 @@ impl Error {
             Self::UnexpectedErrorEncountered(_) => "unexpected_error_encountered",
         }
     }
+
+    /// Returns true iff the error is a timeout error
+    pub fn is_timeout(&self) -> bool {
+        matches!(self, Self::TimeoutWaitingForResponse(_))
+    }
 }
 
 impl From<aptos_storage_service_client::Error> for Error {

--- a/state-sync/aptos-data-client/src/interface.rs
+++ b/state-sync/aptos-data-client/src/interface.rs
@@ -129,6 +129,52 @@ pub trait AptosDataClientInterface {
         include_events: bool,
         request_timeout_ms: u64,
     ) -> error::Result<Response<TransactionOrOutputListWithProof>>;
+
+    /// Subscribes to new transaction output lists with proofs. Subscriptions
+    /// start at `known_version + 1` and `known_epoch` (inclusive), as
+    /// specified by the stream metadata. The end version and proof version
+    /// are specified by the server. If the data cannot be fetched, an
+    /// error is returned.
+    async fn subscribe_to_transaction_outputs_with_proof(
+        &self,
+        subscription_request_metadata: SubscriptionRequestMetadata,
+        request_timeout_ms: u64,
+    ) -> error::Result<Response<(TransactionOutputListWithProof, LedgerInfoWithSignatures)>>;
+
+    /// Subscribes to new transaction lists with proofs. Subscriptions start
+    /// at `known_version + 1` and `known_epoch` (inclusive), as specified
+    /// by the subscription metadata. If `include_events` is true,
+    /// events are included in the proof. The end version and proof version
+    /// are specified by the server. If the data cannot be fetched, an error
+    /// is returned.
+    async fn subscribe_to_transactions_with_proof(
+        &self,
+        subscription_request_metadata: SubscriptionRequestMetadata,
+        include_events: bool,
+        request_timeout_ms: u64,
+    ) -> error::Result<Response<(TransactionListWithProof, LedgerInfoWithSignatures)>>;
+
+    /// Subscribes to new transaction or output lists with proofs. Subscriptions
+    /// start at `known_version + 1` and `known_epoch` (inclusive), as
+    /// specified by the subscription metadata. If `include_events` is true,
+    /// events are included in the proof. The end version and proof version
+    /// are specified by the server. If the data cannot be fetched, an error
+    /// is returned.
+    async fn subscribe_to_transactions_or_outputs_with_proof(
+        &self,
+        subscription_request_metadata: SubscriptionRequestMetadata,
+        include_events: bool,
+        request_timeout_ms: u64,
+    ) -> error::Result<Response<(TransactionOrOutputListWithProof, LedgerInfoWithSignatures)>>;
+}
+
+/// Subscription stream metadata associated with each subscription request
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct SubscriptionRequestMetadata {
+    pub known_version_at_stream_start: u64, // The highest known transaction version at stream start
+    pub known_epoch_at_stream_start: u64,   // The highest known epoch at stream start
+    pub subscription_stream_id: u64,        // The unique id of the subscription stream
+    pub subscription_stream_index: u64,     // The index of the request in the subscription stream
 }
 
 /// A response error that users of the Aptos Data Client can use to notify

--- a/state-sync/aptos-data-client/src/peer_states.rs
+++ b/state-sync/aptos-data-client/src/peer_states.rs
@@ -16,6 +16,7 @@ use aptos_network::application::storage::PeersAndMetadata;
 use aptos_storage_service_types::{
     requests::StorageServiceRequest, responses::StorageServerSummary,
 };
+use aptos_time_service::TimeService;
 use itertools::Itertools;
 use std::{
     cmp::min,
@@ -137,6 +138,7 @@ impl PeerStates {
     pub fn can_service_request(
         &self,
         peer: &PeerNetworkId,
+        time_service: TimeService,
         request: &StorageServiceRequest,
     ) -> bool {
         // Storage services can always respond to data advertisement requests.
@@ -152,7 +154,7 @@ impl PeerStates {
         self.peer_to_state
             .get(peer)
             .and_then(PeerState::storage_summary_if_not_ignored)
-            .map(|summary| summary.can_service(&self.data_client_config, request))
+            .map(|summary| summary.can_service(&self.data_client_config, time_service, request))
             .unwrap_or(false)
     }
 

--- a/state-sync/aptos-data-client/src/tests/mock.rs
+++ b/state-sync/aptos-data-client/src/tests/mock.rs
@@ -5,7 +5,7 @@ use crate::{
     client::AptosDataClient,
     error::Result,
     global_summary::GlobalDataSummary,
-    interface::{AptosDataClientInterface, Response},
+    interface::{AptosDataClientInterface, Response, SubscriptionRequestMetadata},
     poller::DataSummaryPoller,
 };
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
@@ -270,6 +270,26 @@ mock! {
             include_events: bool,
             request_timeout_ms: u64,
         ) -> Result<Response<TransactionOrOutputListWithProof>>;
+
+        async fn subscribe_to_transaction_outputs_with_proof(
+            &self,
+            subscription_request_metadata: SubscriptionRequestMetadata,
+            request_timeout_ms: u64,
+        ) -> Result<Response<(TransactionOutputListWithProof, LedgerInfoWithSignatures)>>;
+
+        async fn subscribe_to_transactions_with_proof(
+            &self,
+            subscription_request_metadata: SubscriptionRequestMetadata,
+            include_events: bool,
+            request_timeout_ms: u64,
+        ) -> Result<Response<(TransactionListWithProof, LedgerInfoWithSignatures)>>;
+
+        async fn subscribe_to_transactions_or_outputs_with_proof(
+            &self,
+            subscription_request_metadata: SubscriptionRequestMetadata,
+            include_events: bool,
+            request_timeout_ms: u64,
+        ) -> Result<Response<(TransactionOrOutputListWithProof, LedgerInfoWithSignatures)>>;
     }
 }
 

--- a/state-sync/aptos-data-client/src/tests/utils.rs
+++ b/state-sync/aptos-data-client/src/tests/utils.rs
@@ -12,19 +12,35 @@ use aptos_types::{
     transaction::Version,
 };
 
-/// Creates a test ledger info at the given version
-fn create_ledger_info(version: Version) -> LedgerInfoWithSignatures {
+/// Creates a test ledger info at the given version and timestamp
+fn create_ledger_info(version: Version, timestamp_usecs: u64) -> LedgerInfoWithSignatures {
     LedgerInfoWithSignatures::new(
         LedgerInfo::new(
-            BlockInfo::new(0, 0, HashValue::zero(), HashValue::zero(), version, 0, None),
+            BlockInfo::new(
+                0,
+                0,
+                HashValue::zero(),
+                HashValue::zero(),
+                version,
+                timestamp_usecs,
+                None,
+            ),
             HashValue::zero(),
         ),
         AggregateSignature::empty(),
     )
 }
 
-/// Creates a test storage server summary at the given version
+/// Creates a test storage server summary at the given version and timestamp
 pub fn create_storage_summary(version: Version) -> StorageServerSummary {
+    create_storage_summary_with_timestamp(version, 0)
+}
+
+/// Creates a test storage server summary at the given version and timestamp
+pub fn create_storage_summary_with_timestamp(
+    version: Version,
+    timestamp_usecs: u64,
+) -> StorageServerSummary {
     StorageServerSummary {
         protocol_metadata: ProtocolMetadata {
             max_epoch_chunk_size: 1000,
@@ -33,7 +49,7 @@ pub fn create_storage_summary(version: Version) -> StorageServerSummary {
             max_transaction_output_chunk_size: 1000,
         },
         data_summary: DataSummary {
-            synced_ledger_info: Some(create_ledger_info(version)),
+            synced_ledger_info: Some(create_ledger_info(version, timestamp_usecs)),
             epoch_ending_ledger_infos: None,
             transactions: Some(CompleteDataRange::new(0, version).unwrap()),
             transaction_outputs: Some(CompleteDataRange::new(0, version).unwrap()),

--- a/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
@@ -46,6 +46,9 @@ pub enum DataClientRequest {
     TransactionOutputsWithProof(TransactionOutputsWithProofRequest),
     NewTransactionsOrOutputsWithProof(NewTransactionsOrOutputsWithProofRequest),
     TransactionsOrOutputsWithProof(TransactionsOrOutputsWithProofRequest),
+    SubscribeTransactionsWithProof(SubscribeTransactionsWithProofRequest),
+    SubscribeTransactionOutputsWithProof(SubscribeTransactionOutputsWithProofRequest),
+    SubscribeTransactionsOrOutputsWithProof(SubscribeTransactionsOrOutputsWithProofRequest),
 }
 
 impl DataClientRequest {
@@ -61,6 +64,13 @@ impl DataClientRequest {
             Self::TransactionOutputsWithProof(_) => "transaction_outputs_with_proof",
             Self::NewTransactionsOrOutputsWithProof(_) => "new_transactions_or_outputs_with_proof",
             Self::TransactionsOrOutputsWithProof(_) => "transactions_or_outputs_with_proof",
+            Self::SubscribeTransactionsWithProof(_) => "subscribe_transactions_with_proof",
+            Self::SubscribeTransactionOutputsWithProof(_) => {
+                "subscribe_transaction_outputs_with_proof"
+            },
+            Self::SubscribeTransactionsOrOutputsWithProof(_) => {
+                "subscribe_transactions_or_outputs_with_proof"
+            },
         }
     }
 }
@@ -107,6 +117,35 @@ pub struct NewTransactionOutputsWithProofRequest {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NumberOfStatesRequest {
     pub version: Version,
+}
+
+/// A client request for subscribing to transactions with proofs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SubscribeTransactionsWithProofRequest {
+    pub known_version: Version,
+    pub known_epoch: Epoch,
+    pub include_events: bool,
+    pub subscription_stream_id: u64,
+    pub subscription_stream_index: u64,
+}
+
+/// A client request for subscribing to transaction outputs with proofs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SubscribeTransactionOutputsWithProofRequest {
+    pub known_version: Version,
+    pub known_epoch: Epoch,
+    pub subscription_stream_id: u64,
+    pub subscription_stream_index: u64,
+}
+
+/// A client request for subscribing to transactions or outputs with proofs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SubscribeTransactionsOrOutputsWithProofRequest {
+    pub known_version: Version,
+    pub known_epoch: Epoch,
+    pub include_events: bool,
+    pub subscription_stream_id: u64,
+    pub subscription_stream_index: u64,
 }
 
 /// A client request for fetching transactions with proofs.

--- a/state-sync/state-sync-v2/data-streaming-service/src/logging.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/logging.rs
@@ -30,15 +30,16 @@ impl<'a> LogSchema<'a> {
 #[derive(Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LogEntry {
-    CheckStreamProgress,
     AptosDataClient,
+    CheckStreamProgress,
+    CreatedSubscriptionStream,
     EndOfStreamNotification,
-    HandleTerminateRequest,
     HandleStreamRequest,
+    HandleTerminateRequest,
     InitializeStream,
     ReceivedDataResponse,
     RefreshGlobalData,
-    RequestTimeout,
+    RequestError,
     RespondToStreamRequest,
     RetryDataRequest,
     SendDataRequests,

--- a/state-sync/state-sync-v2/data-streaming-service/src/metrics.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/metrics.rs
@@ -42,6 +42,15 @@ pub static CREATE_DATA_STREAM: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Counter for the creation of new subscription streams
+pub static CREATE_SUBSCRIPTION_STREAM: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_data_streaming_service_create_subscription_stream",
+        "Counters related to the creation of new subscription streams",
+    )
+    .unwrap()
+});
+
 /// Counter for the termination of existing data streams
 pub static TERMINATE_DATA_STREAM: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
@@ -9,6 +9,7 @@ use aptos_data_client::{
     global_summary::{AdvertisedData, GlobalDataSummary, OptimalChunkSizes},
     interface::{
         AptosDataClientInterface, Response, ResponseCallback, ResponseContext, ResponseError,
+        SubscriptionRequestMetadata,
     },
 };
 use aptos_infallible::Mutex;
@@ -611,6 +612,38 @@ impl AptosDataClientInterface for MockAptosDataClient {
             (None, Some(outputs_with_proof.payload))
         };
         Ok(create_data_client_response(transactions_or_outputs))
+    }
+
+    async fn subscribe_to_transaction_outputs_with_proof(
+        &self,
+        _subscription_request_metadata: SubscriptionRequestMetadata,
+        _request_timeout_ms: u64,
+    ) -> aptos_data_client::error::Result<
+        Response<(TransactionOutputListWithProof, LedgerInfoWithSignatures)>,
+    > {
+        unimplemented!("TODO: Support me when we add unit tests!")
+    }
+
+    async fn subscribe_to_transactions_with_proof(
+        &self,
+        _subscription_request_metadata: SubscriptionRequestMetadata,
+        _include_events: bool,
+        _request_timeout_ms: u64,
+    ) -> aptos_data_client::error::Result<
+        Response<(TransactionListWithProof, LedgerInfoWithSignatures)>,
+    > {
+        unimplemented!("TODO: Support me when we add unit tests!")
+    }
+
+    async fn subscribe_to_transactions_or_outputs_with_proof(
+        &self,
+        _subscription_request_metadata: SubscriptionRequestMetadata,
+        _include_events: bool,
+        _request_timeout_ms: u64,
+    ) -> aptos_data_client::error::Result<
+        Response<(TransactionOrOutputListWithProof, LedgerInfoWithSignatures)>,
+    > {
+        unimplemented!("TODO: Support me when we add unit tests!")
     }
 }
 

--- a/state-sync/storage-service/server/src/handler.rs
+++ b/state-sync/storage-service/server/src/handler.rs
@@ -7,7 +7,7 @@ use crate::{
     metrics,
     metrics::{
         increment_counter, start_timer, LRU_CACHE_HIT, LRU_CACHE_PROBE, OPTIMISTIC_FETCH_ADD,
-        SUBSCRIPTION_ADD, SUBSCRIPTION_FAILURE,
+        SUBSCRIPTION_ADD, SUBSCRIPTION_FAILURE, SUBSCRIPTION_NEW_STREAM,
     },
     moderator::RequestModerator,
     network::ResponseSender,
@@ -312,6 +312,13 @@ impl<T: StorageReaderInterface> Handler<T> {
             let subscription_stream_requests =
                 SubscriptionStreamRequests::new(subscription_request, self.time_service.clone());
             subscriptions.insert(peer_network_id, subscription_stream_requests);
+
+            // Update the subscription metrics
+            increment_counter(
+                &metrics::SUBSCRIPTION_EVENTS,
+                peer_network_id.network_id(),
+                SUBSCRIPTION_NEW_STREAM.into(),
+            );
         }
 
         // Update the subscription metrics

--- a/state-sync/storage-service/server/src/metrics.rs
+++ b/state-sync/storage-service/server/src/metrics.rs
@@ -17,6 +17,7 @@ pub const OPTIMISTIC_FETCH_EXPIRE: &str = "optimistic_fetch_expire";
 pub const SUBSCRIPTION_ADD: &str = "subscription_add";
 pub const SUBSCRIPTION_EXPIRE: &str = "subscription_expire";
 pub const SUBSCRIPTION_FAILURE: &str = "subscription_failure";
+pub const SUBSCRIPTION_NEW_STREAM: &str = "subscription_new_stream";
 
 /// Gauge for tracking the number of actively ignored peers
 pub static IGNORED_PEER_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {

--- a/state-sync/storage-service/server/src/moderator.rs
+++ b/state-sync/storage-service/server/src/moderator.rs
@@ -151,7 +151,11 @@ impl RequestModerator {
         let storage_server_summary = self.cached_storage_server_summary.load();
 
         // Verify the request is serviceable using the current storage server summary
-        if !storage_server_summary.can_service(&self.aptos_data_client_config, request) {
+        if !storage_server_summary.can_service(
+            &self.aptos_data_client_config,
+            self.time_service.clone(),
+            request,
+        ) {
             // Increment the invalid request count for the peer
             let mut unhealthy_peer_states = self.unhealthy_peer_states.write();
             let unhealthy_peer_state = unhealthy_peer_states

--- a/state-sync/storage-service/types/Cargo.toml
+++ b/state-sync/storage-service/types/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = { workspace = true }
 aptos-compression = { workspace = true }
 aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }
+aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
 num-traits = { workspace = true }
@@ -23,6 +24,7 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+aptos-time-service = { workspace = true, features = ["testing"] }
 claims = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }

--- a/state-sync/storage-service/types/src/responses.rs
+++ b/state-sync/storage-service/types/src/responses.rs
@@ -17,6 +17,7 @@ use aptos_compression::{metrics::CompressionClient, CompressedData, CompressionE
 use aptos_config::config::{
     AptosDataClientConfig, StorageServiceConfig, MAX_APPLICATION_MESSAGE_SIZE,
 };
+use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::{
     epoch_change::EpochChangeProof,
     ledger_info::LedgerInfoWithSignatures,
@@ -32,6 +33,9 @@ use std::{
     fmt::{Display, Formatter},
 };
 use thiserror::Error;
+
+// Useful file constants
+pub const NUM_MICROSECONDS_IN_SECOND: u64 = 1_000_000;
 
 #[derive(Clone, Debug, Deserialize, Error, PartialEq, Eq, Serialize)]
 pub enum Error {
@@ -360,12 +364,13 @@ impl StorageServerSummary {
     pub fn can_service(
         &self,
         aptos_data_client_config: &AptosDataClientConfig,
+        time_service: TimeService,
         request: &StorageServiceRequest,
     ) -> bool {
         self.protocol_metadata.can_service(request)
             && self
                 .data_summary
-                .can_service(aptos_data_client_config, request)
+                .can_service(aptos_data_client_config, time_service, request)
     }
 }
 
@@ -428,6 +433,7 @@ impl DataSummary {
     pub fn can_service(
         &self,
         aptos_data_client_config: &AptosDataClientConfig,
+        time_service: TimeService,
         request: &StorageServiceRequest,
     ) -> bool {
         match &request.data_request {
@@ -442,12 +448,21 @@ impl DataSummary {
                     .map(|range| range.superset_of(&desired_range))
                     .unwrap_or(false)
             },
-            GetNewTransactionOutputsWithProof(request) => {
-                self.can_service_optimistic_request(aptos_data_client_config, request.known_version)
-            },
-            GetNewTransactionsWithProof(request) => {
-                self.can_service_optimistic_request(aptos_data_client_config, request.known_version)
-            },
+            GetNewTransactionOutputsWithProof(_) => can_service_optimistic_request(
+                aptos_data_client_config,
+                time_service,
+                self.synced_ledger_info.as_ref(),
+            ),
+            GetNewTransactionsWithProof(_) => can_service_optimistic_request(
+                aptos_data_client_config,
+                time_service,
+                self.synced_ledger_info.as_ref(),
+            ),
+            GetNewTransactionsOrOutputsWithProof(_) => can_service_optimistic_request(
+                aptos_data_client_config,
+                time_service,
+                self.synced_ledger_info.as_ref(),
+            ),
             GetNumberOfStatesAtVersion(version) => self
                 .states
                 .map(|range| range.contains(*version))
@@ -508,9 +523,6 @@ impl DataSummary {
 
                 can_serve_txns && can_create_proof
             },
-            GetNewTransactionsOrOutputsWithProof(request) => {
-                self.can_service_optimistic_request(aptos_data_client_config, request.known_version)
-            },
             GetTransactionsOrOutputsWithProof(request) => {
                 let desired_range =
                     match CompleteDataRange::new(request.start_version, request.end_version) {
@@ -536,53 +548,22 @@ impl DataSummary {
 
                 can_serve_txns && can_serve_outputs && can_create_proof
             },
-            SubscribeTransactionOutputsWithProof(request) => {
-                let known_version = request
-                    .subscription_stream_metadata
-                    .known_version_at_stream_start;
-                self.can_service_subscription_request(aptos_data_client_config, known_version)
-            },
-            SubscribeTransactionsOrOutputsWithProof(request) => {
-                let known_version = request
-                    .subscription_stream_metadata
-                    .known_version_at_stream_start;
-                self.can_service_subscription_request(aptos_data_client_config, known_version)
-            },
-            SubscribeTransactionsWithProof(request) => {
-                let known_version = request
-                    .subscription_stream_metadata
-                    .known_version_at_stream_start;
-                self.can_service_subscription_request(aptos_data_client_config, known_version)
-            },
+            SubscribeTransactionOutputsWithProof(_) => can_service_subscription_request(
+                aptos_data_client_config,
+                time_service,
+                self.synced_ledger_info.as_ref(),
+            ),
+            SubscribeTransactionsOrOutputsWithProof(_) => can_service_subscription_request(
+                aptos_data_client_config,
+                time_service,
+                self.synced_ledger_info.as_ref(),
+            ),
+            SubscribeTransactionsWithProof(_) => can_service_subscription_request(
+                aptos_data_client_config,
+                time_service,
+                self.synced_ledger_info.as_ref(),
+            ),
         }
-    }
-
-    /// Returns true iff the optimistic data request can be serviced
-    fn can_service_optimistic_request(
-        &self,
-        aptos_data_client_config: &AptosDataClientConfig,
-        known_version: u64,
-    ) -> bool {
-        let max_version_lag = aptos_data_client_config.max_optimistic_fetch_version_lag;
-        self.check_synced_version_lag(known_version, max_version_lag)
-    }
-
-    /// Returns true iff the subscription data request can be serviced
-    fn can_service_subscription_request(
-        &self,
-        aptos_data_client_config: &AptosDataClientConfig,
-        known_version: u64,
-    ) -> bool {
-        let max_version_lag = aptos_data_client_config.max_subscription_version_lag;
-        self.check_synced_version_lag(known_version, max_version_lag)
-    }
-
-    /// Returns true iff the synced version is within the given lag range
-    fn check_synced_version_lag(&self, known_version: u64, max_version_lag: u64) -> bool {
-        self.synced_ledger_info
-            .as_ref()
-            .map(|li| (li.ledger_info().version() + max_version_lag) > known_version)
-            .unwrap_or(false)
     }
 
     /// Returns the version of the synced ledger info (if one exists)
@@ -590,6 +571,50 @@ impl DataSummary {
         self.synced_ledger_info
             .as_ref()
             .map(|ledger_info| ledger_info.ledger_info().version())
+    }
+}
+
+/// Returns true iff an optimistic data request can be serviced
+/// by the peer with the given synced ledger info.
+fn can_service_optimistic_request(
+    aptos_data_client_config: &AptosDataClientConfig,
+    time_service: TimeService,
+    synced_ledger_info: Option<&LedgerInfoWithSignatures>,
+) -> bool {
+    let max_lag_secs = aptos_data_client_config.max_optimistic_fetch_lag_secs;
+    check_synced_ledger_lag(synced_ledger_info, time_service, max_lag_secs)
+}
+
+/// Returns true iff a subscription data request can be serviced
+/// by the peer with the given synced ledger info.
+fn can_service_subscription_request(
+    aptos_data_client_config: &AptosDataClientConfig,
+    time_service: TimeService,
+    synced_ledger_info: Option<&LedgerInfoWithSignatures>,
+) -> bool {
+    let max_lag_secs = aptos_data_client_config.max_subscription_lag_secs;
+    check_synced_ledger_lag(synced_ledger_info, time_service, max_lag_secs)
+}
+
+/// Returns true iff the synced ledger info timestamp
+/// is within the given lag (in seconds).
+fn check_synced_ledger_lag(
+    synced_ledger_info: Option<&LedgerInfoWithSignatures>,
+    time_service: TimeService,
+    max_lag_secs: u64,
+) -> bool {
+    if let Some(synced_ledger_info) = synced_ledger_info {
+        // Get the ledger info timestamp (in microseconds)
+        let ledger_info_timestamp_usecs = synced_ledger_info.ledger_info().timestamp_usecs();
+
+        // Get the current timestamp and max version lag (in microseconds)
+        let current_timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
+        let max_version_lag_usecs = max_lag_secs * NUM_MICROSECONDS_IN_SECOND;
+
+        // Return true iff the synced ledger info timestamp is within the max version lag
+        ledger_info_timestamp_usecs + max_version_lag_usecs > current_timestamp_usecs
+    } else {
+        false // No synced ledger info was found!
     }
 }
 

--- a/state-sync/storage-service/types/src/responses.rs
+++ b/state-sync/storage-service/types/src/responses.rs
@@ -360,6 +360,8 @@ pub struct StorageServerSummary {
     pub data_summary: DataSummary,
 }
 
+// TODO: it probably makes sense to move this logic to the data client,
+// instead of having it attached to the storage server summary.
 impl StorageServerSummary {
     pub fn can_service(
         &self,


### PR DESCRIPTION
### Description
This PR adds client-side support for subscription syncing. It builds on the server-side support that has already landed in: https://github.com/aptos-labs/aptos-core/pull/9104.

At a high-level, the PR:
1. Modifies the data streaming service and data client to support "subscription syncing", where subscription requests are sent to peers when no new data is being advertised.
2. All subscription requests for the same stream will be sent to the same peer. A stream will be terminated if: (i) any subscription request fails (e.g., we get a timeout or a bad response); (ii) the peer is no longer able to "satisfy" subscription requests (e.g., the peer is lagging too much); or (iii) the stream hits the maximum number of consecutive subscription requests (forcing a new one to be created). All of these conditions prevent the node from being blocked by faulty or malicious peers.
3. Updates the definition for peer lag when sending subscription and optimistic fetch requests. Previously, peer lag was defined in a hard coded number of versions (e.g., a peer is advertising version X, but we're at version Y > X). Instead, we now define peer lag in terms of seconds (i.e., we use the timestamp advertised by the peer's highest synced ledger info. If the timestamp is too old, we determine the peer to be lagging). This is more robust to different transaction throughputs.

The PR offers several commits:
1. Add support for subscription syncing to the data streaming service and data client.
5. Modify the existing unit tests to verify basic subscription syncing properties. More unit tests will follow.

Note:
1. I'll add some more comprehensive tests in a follow-up PR. This PR is already quite large.
3. We'll need to benchmark subscription syncing before we enable it by default. It is currently disabled in the configs.

### Test Plan
New and existing testing infrastructure.