### PR TITLE
adds gas metering to execute_entry_function fuzzer

### DIFF
--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/execute_entry_function.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/execute_entry_function.rs
@@ -5,9 +5,15 @@
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
 use move_binary_format::file_format::CompiledModule;
-use move_core_types::{account_address::AccountAddress, identifier::IdentStr, language_storage::TypeTag, gas_algebra::GasQuantity};
+use move_core_types::{
+    account_address::AccountAddress, gas_algebra::GasQuantity, identifier::IdentStr,
+    language_storage::TypeTag,
+};
 use move_vm_runtime::move_vm::MoveVM;
-use move_vm_test_utils::{gas_schedule::{GasStatus, CostTable, GasCost}, InMemoryStorage};
+use move_vm_test_utils::{
+    gas_schedule::{CostTable, GasCost, GasStatus},
+    InMemoryStorage,
+};
 
 #[derive(Arbitrary, Debug)]
 struct FuzzData {
@@ -35,7 +41,7 @@ fuzz_target!(|fuzz_data: FuzzData| {
     let cost_table = CostTable {
         instruction_table: vec![GasCost::new(1, 1); 255],
     };
-    let mut gas = GasStatus::new(&cost_table,GasQuantity::new(1_000));
+    let mut gas = GasStatus::new(&cost_table, GasQuantity::new(1_000));
 
     if session
         .publish_module(cm_serialized, fuzz_data.account_address, &mut gas)

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/execute_entry_function.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/execute_entry_function.rs
@@ -5,11 +5,9 @@
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
 use move_binary_format::file_format::CompiledModule;
-use move_core_types::{
-    account_address::AccountAddress, identifier::IdentStr, language_storage::TypeTag,
-};
+use move_core_types::{account_address::AccountAddress, identifier::IdentStr, language_storage::TypeTag, gas_algebra::GasQuantity};
 use move_vm_runtime::move_vm::MoveVM;
-use move_vm_test_utils::{gas_schedule::GasStatus, InMemoryStorage};
+use move_vm_test_utils::{gas_schedule::{GasStatus, CostTable, GasCost}, InMemoryStorage};
 
 #[derive(Arbitrary, Debug)]
 struct FuzzData {
@@ -33,7 +31,11 @@ fuzz_target!(|fuzz_data: FuzzData| {
     let vm = MoveVM::new(vec![]).unwrap();
     let storage = InMemoryStorage::new();
     let mut session = vm.new_session(&storage);
-    let mut gas = GasStatus::new_unmetered();
+
+    let cost_table = CostTable {
+        instruction_table: vec![GasCost::new(1, 1); 255],
+    };
+    let mut gas = GasStatus::new(&cost_table,GasQuantity::new(1_000));
 
     if session
         .publish_module(cm_serialized, fuzz_data.account_address, &mut gas)

--- a/testsuite/fuzzer/google-oss-fuzz/project.yaml
+++ b/testsuite/fuzzer/google-oss-fuzz/project.yaml
@@ -3,10 +3,10 @@ language: rust
 primary_contact: "gerardo@aptoslabs.com"
 main_repo: "https://github.com/aptos-labs/aptos-core"
 auto_ccs:
-  - "davidiw@aptoslabs.com"
+  - "oss-fuzz-notifications@aptoslabs.com"
   - "security@aptoslabs.com"
-  - "wg@aptoslabs.com"
 sanitizers:
   - address
 fuzzing_engines:
   - libfuzzer
+coverage_extra_args: -ignore-filename-regex=.*/rustc/.*

--- a/testsuite/fuzzer/repro.sh
+++ b/testsuite/fuzzer/repro.sh
@@ -1,16 +1,52 @@
 #!/bin/bash
 
-if [ "$#" -ne 2 ]; then
-  echo "Usage: $0 <fuzzer_name> <testcase>"
+# Function to display usage
+usage() {
+  echo "Usage: $0 (fuzz|build) <fuzzer_name> [testcase]"
   exit 1
-fi
+}
 
-FUZZER_NAME="$1"
-TESTCASE="$2"
-
-if [ ! -f "$TESTCASE" ]; then
-  echo "Testcase not found: $TESTCASE"
+# Function to display errors
+error() {
+  echo "ERROR: $1"
   exit 1
-fi
+}
 
-RUSTFLAGS="--cfg tokio_unstable" cargo +nightly fuzz run $FUZZER_NAME $TESTCASE
+# Function to display info
+info() {
+  echo "INFO: $1"
+}
+
+# Check minimum number of arguments
+[ "$#" -lt 2 ] && usage
+
+MODE="$1"
+FUZZER_NAME="$2"
+TESTCASE="$3"
+
+# Common command prefix
+CMD_PREFIX="cargo +nightly fuzz"
+
+# Set environment variable
+export RUSTFLAGS="--cfg tokio_unstable"
+
+# Validate options and execute corresponding actions
+case "$MODE" in
+  "build")
+    [ -n "$TESTCASE" ] && info "Testcase ignored for build mode"
+    eval "$CMD_PREFIX build -O --target-dir ./target $FUZZER_NAME"
+    if [ $? -eq 0 ]; then
+      info "Fuzzer binary ===> $(echo ./target/*/release/$FUZZER_NAME)"
+    else
+      error "Build failed"
+    fi
+    ;;
+  "fuzz")
+    CMD="$CMD_PREFIX run $FUZZER_NAME"
+    [ -n "$TESTCASE" ] && CMD="$CMD $TESTCASE"
+    eval "$CMD"
+    ;;
+  *)
+    usage
+    ;;
+esac


### PR DESCRIPTION
### Description
- adds gas metering to `execute_entry_function` fuzzer
- improves `repro.sh` to support multiple modes (fuzz/build)
- updates `projects.yaml` with correct values

### Test Plan
- `./test-fuzzer.sh` passes