### PR TITLE
[spec] add partial specification for index_of function for big_vector

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/big_vector.md
+++ b/aptos-move/framework/aptos-stdlib/doc/big_vector.md
@@ -654,36 +654,22 @@ Disclaimer: This function is costly. Use it at your own discretion.
     <b>while</b> ({
         <b>spec</b> {
             <b>invariant</b> bucket_index &lt;= num_buckets;
-            <b>assert</b> v.end_index &gt;= (bucket_index - 1) * v.bucket_size;
-            <b>assert</b> v.end_index &lt;= num_buckets * v.bucket_size;
-            // <b>assert</b> <b>forall</b> j in 0..((bucket_index - 1) * v.bucket_size) : <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(v, j) != val;
         };
         (bucket_index &lt; num_buckets)
     }) {
         <b>let</b> cur = <a href="table_with_length.md#0x1_table_with_length_borrow">table_with_length::borrow</a>(&v.buckets, bucket_index);
-        <b>spec</b>{
-            <b>assert</b> (bucket_index &lt; num_buckets - 1) ==&gt; <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(cur) == v.bucket_size;
-            <b>assert</b> (bucket_index == num_buckets - 1) ==&gt; <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(cur) &lt;= v.bucket_size;
-        };
         <b>let</b> (found, i) = <a href="../../move-stdlib/doc/vector.md#0x1_vector_index_of">vector::index_of</a>(cur, val);
         <b>if</b> (found) {
             <b>spec</b>{
                 <b>assert</b> <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(cur, i) == val;
-                <b>assert</b> <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(cur, i) == <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(v, bucket_index * v.bucket_size + i);
                 <b>assert</b> <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(v, bucket_index * v.bucket_size + i) == val;
             };
             <b>return</b> (<b>true</b>, bucket_index * v.bucket_size + i)
-        };
-        <b>spec</b>{
-            <b>assert</b> <b>forall</b> j in 0..<a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(cur): <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(cur, i) != val;
-            <b>assert</b> <b>forall</b> j in 0..<a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(cur): <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(v, bucket_index * v.bucket_size + j) == <a href="../../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(cur, j);
         };
         bucket_index = bucket_index + 1;
     };
     <b>spec</b>{
         <b>assert</b> bucket_index == num_buckets;
-        // <b>assert</b> v.end_index &lt;= v.bucket_size * num_buckets;
-        // <b>assert</b> <b>forall</b> i in 0..v.end_index: <a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(v, i) != val;
     };
     (<b>false</b>, 0)
 }
@@ -1111,8 +1097,7 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 
 
 
-<pre><code><b>pragma</b> verify=<b>false</b>;
-<b>ensures</b> !(result_1 == <b>true</b>) || (<a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(v, result_2) == val);
+<pre><code><b>ensures</b> (result_1 == <b>true</b>) ==&gt; (<a href="big_vector.md#0x1_big_vector_spec_at">spec_at</a>(v, result_2) == val);
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/big_vector.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/big_vector.move
@@ -81,10 +81,7 @@ module aptos_std::big_vector {
         let other_len = length(&other);
         let half_other_len = other_len / 2;
         let i = 0;
-        while ({spec {
-            invariant true;
-        };
-            (i < half_other_len)}) {
+        while (i < half_other_len) {
             push_back(lhs, swap_remove(&mut other, i));
             i = i + 1;
         };

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/big_vector.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/big_vector.spec.move
@@ -55,6 +55,10 @@ spec aptos_std::big_vector {
         aborts_if !is_empty(v);
     }
 
+    spec destroy<T: drop>(v: BigVector<T>) {
+        pragma verify=false;
+    }
+
     spec borrow<T>(v: &BigVector<T>, i: u64): &T {
         aborts_if i >= length(v);
         ensures result == spec_at(v, i);
@@ -63,6 +67,12 @@ spec aptos_std::big_vector {
     spec borrow_mut<T>(v: &mut BigVector<T>, i: u64): &mut T {
         aborts_if i >= length(v);
         ensures result == spec_at(v, i);
+    }
+
+    spec append<T: store>(lhs: &mut BigVector<T>, other: BigVector<T>) {
+        pragma verify=false;
+        // ensures forall i in 0..old(lhs).end_index: spec_at(old(lhs), i) == spec_at(lhs, i);
+        // ensures forall i in 0..other.end_index: spec_at(other, i) == spec_at(lhs, i + old(lhs).end_index);
     }
 
     spec push_back<T: store>(v: &mut BigVector<T>, val: T) {
@@ -80,6 +90,13 @@ spec aptos_std::big_vector {
         ensures length(v) == length(old(v)) - 1;
         ensures result == old(spec_at(v, v.end_index-1));
         ensures forall i in 0..v.end_index: spec_at(v, i) == spec_at(old(v), i);
+    }
+
+    spec remove<T>(v: &mut BigVector<T>, i: u64): T {
+        aborts_if i >= length(v);
+        ensures result == spec_at(old(v), i);
+        // ensures forall j in 0..(i): spec_at(v, j) == spec_at(old(v), j);
+        // ensures forall j in (i+1)..old(v).end_index: spec_at(v, j - 1) == spec_at(old(v), j);
     }
 
     spec swap_remove<T>(v: &mut BigVector<T>, i: u64): T {
@@ -100,20 +117,14 @@ spec aptos_std::big_vector {
             spec_at(v, idx) == spec_at(old(v), idx);
     }
 
-    spec append<T: store>(lhs: &mut BigVector<T>, other: BigVector<T>) {
-        pragma verify=false;
-    }
-
-    spec remove<T>(v: &mut BigVector<T>, i: u64): T {
-        pragma verify=false;
-    }
-
     spec reverse<T>(v: &mut BigVector<T>) {
         pragma verify=false;
+        // ensures forall i in 0..v.end_index: spec_at(v, i) == spec_at(old(v), v.end_index - (i + 1));
     }
 
     spec index_of<T>(v: &BigVector<T>, val: &T): (bool, u64) {
-        pragma verify=false;
+        ensures (result_1 == true) ==> (spec_at(v, result_2) == val);
+        // ensures (result_1 == false) ==> (forall i in 0..v.end_index: spec_at(v, i) != val);
     }
 
     // ---------------------


### PR DESCRIPTION
### Description

Add functional specification for the big_vector module. If `index_of(v, val)` returns `(true, i)`, then `val` must occur in `v` at index `i`.