### PR TITLE
[move-vm] Log stacktrace for natives

### DIFF
--- a/third_party/move/move-vm/integration-tests/Cargo.toml
+++ b/third_party/move/move-vm/integration-tests/Cargo.toml
@@ -22,7 +22,7 @@ tempfile = "3.2.0"
 move-core-types = { path = "../../move-core/types" }
 move-stdlib = { path = "../../move-stdlib" }
 move-table-extension = { path = "../../extensions/move-table-extension", optional = true }
-move-vm-runtime = { path = "../runtime" }
+move-vm-runtime = { path = "../runtime", features = ["testing"] }
 move-vm-test-utils = { path = "../test-utils" }
 move-vm-types = { path = "../types" }
 

--- a/third_party/move/move-vm/integration-tests/src/tests/mod.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod invariant_violation_tests;
 mod leak_tests;
 mod loader_tests;
 mod mutated_accounts_tests;
+mod native_tests;
 mod nested_loop_tests;
 mod regression_tests;
 mod return_value_tests;

--- a/third_party/move/move-vm/integration-tests/src/tests/native_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/native_tests.rs
@@ -1,0 +1,101 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::compiler::{as_module, compile_units};
+use move_binary_format::errors::PartialVMResult;
+use move_bytecode_verifier::VerifierConfig;
+use move_core_types::{
+    account_address::AccountAddress, gas_algebra::InternalGas, identifier::Identifier,
+};
+use move_vm_runtime::{config::VMConfig, move_vm::MoveVM, native_functions::NativeFunction};
+use move_vm_test_utils::InMemoryStorage;
+use move_vm_types::{gas::UnmeteredGasMeter, natives::function::NativeResult};
+use std::sync::Arc;
+
+const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
+
+fn make_failed_native() -> NativeFunction {
+    Arc::new(move |_, _, _| -> PartialVMResult<NativeResult> {
+        Ok(NativeResult::Abort {
+            cost: InternalGas::new(0),
+            abort_code: 12,
+        })
+    })
+}
+
+#[test]
+fn test_publish_module_with_nested_loops() {
+    // Compile the modules and scripts.
+    // TODO: find a better way to include the Signer module.
+    let code = r#"
+        module {{ADDR}}::M {
+            entry fun foo() {
+                Self::bar();
+            }
+
+            entry fun foo2() {
+                Self::foo1();
+            }
+
+            fun foo1() {
+                Self::bar();
+            }
+
+            native fun bar();
+        }
+    "#;
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_hex()));
+    let mut units = compile_units(&code).unwrap();
+
+    let m = as_module(units.pop().unwrap());
+    let mut m_blob = vec![];
+    m.serialize(&mut m_blob).unwrap();
+
+    // Should succeed with max_loop_depth = 2
+    {
+        let storage = InMemoryStorage::new();
+
+        let natives = vec![(
+            TEST_ADDR,
+            Identifier::new("M").unwrap(),
+            Identifier::new("bar").unwrap(),
+            make_failed_native(),
+        )];
+        let vm = MoveVM::new_with_config(natives.into_iter(), VMConfig {
+            verifier: VerifierConfig {
+                max_loop_depth: Some(2),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .unwrap();
+
+        let mut sess = vm.new_session(&storage);
+        sess.publish_module(m_blob.clone(), TEST_ADDR, &mut UnmeteredGasMeter)
+            .unwrap();
+
+        let err1 = sess
+            .execute_entry_function(
+                &m.self_id(),
+                &Identifier::new("foo").unwrap(),
+                vec![],
+                Vec::<Vec<u8>>::new(),
+                &mut UnmeteredGasMeter,
+            )
+            .unwrap_err();
+
+        assert!(err1.exec_state().unwrap().stack_trace().is_empty());
+
+        let err2 = sess
+            .execute_entry_function(
+                &m.self_id(),
+                &Identifier::new("foo2").unwrap(),
+                vec![],
+                Vec::<Vec<u8>>::new(),
+                &mut UnmeteredGasMeter,
+            )
+            .unwrap_err();
+
+        assert!(err2.exec_state().unwrap().stack_trace().len() == 1);
+    }
+}

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -358,9 +358,15 @@ impl Interpreter {
             ty_args,
         )
         .map_err(|e| match function.module_id() {
-            Some(id) => e
-                .at_code_offset(function.index(), 0)
-                .finish(Location::Module(id.clone())),
+            Some(id) => {
+                let e = if cfg!(feature = "testing") || cfg!(feature = "stacktrace") {
+                    e.with_exec_state(self.get_internal_state())
+                } else {
+                    e
+                };
+                e.at_code_offset(function.index(), 0)
+                    .finish(Location::Module(id.clone()))
+            },
             None => {
                 let err = PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                     .with_message("Unexpected native function not located in a module".to_owned());


### PR DESCRIPTION
### Description

Fixing #7224 

### Test Plan
Ran the test and see following:
```
┌── test_create_and_transfer ──────
│ error[E11001]: test failure
│     ┌─ /config/workspace/aptos-core/aptos-move/framework/aptos-token-objects/../aptos-framework/sources/object.move:207:16
│     │
│ 207 │     native fun exists_at<T: key>(object: address): bool;
│     │                ^^^^^^^^^
│     │                │
│     │                Test was not expected to error, but it aborted with code 10 originating in the module 0000000000000000000000000000000000000000000000000000000000000001::object rooted here
│     │                In this function in 0x1::object
│ 
│ 
│ stack trace
│       token::create_named_token(/config/workspace/aptos-core/aptos-move/framework/aptos-token-objects/sources/token.move:91)
│       token::create_token_helper(/config/workspace/aptos-core/aptos-move/framework/aptos-token-objects/sources/token.move:601-608)
│       token::test_create_and_transfer(/config/workspace/aptos-core/aptos-move/framework/aptos-token-objects/sources/token.move:342)
│ 
└──────────────────
```
