### PR TITLE
[CLI][Coverage] Reduce execution time of coverage tool

### DIFF
--- a/third_party/move/move-vm/runtime/src/lib.rs
+++ b/third_party/move/move-vm/runtime/src/lib.rs
@@ -20,7 +20,7 @@ pub mod native_functions;
 mod runtime;
 pub mod session;
 #[macro_use]
-mod tracing;
+pub mod tracing;
 pub mod config;
 
 // Only include debugging functionality in debug builds

--- a/third_party/move/tools/move-cli/src/base/test.rs
+++ b/third_party/move/tools/move-cli/src/base/test.rs
@@ -18,6 +18,7 @@ use move_package::{
     BuildConfig, CompilerConfig,
 };
 use move_unit_test::UnitTestingConfig;
+use move_vm_runtime::tracing::{LOGGING_FILE_WRITER, TRACING_ENABLED};
 use move_vm_test_utils::gas_schedule::CostTable;
 // if unix
 #[cfg(target_family = "unix")]
@@ -268,6 +269,10 @@ pub fn run_move_unit_tests<W: Write + Send>(
 
     // Compute the coverage map. This will be used by other commands after this.
     if compute_coverage && !no_tests {
+        if *TRACING_ENABLED {
+            let buf_writer = &mut *LOGGING_FILE_WRITER.lock().unwrap();
+            buf_writer.flush().unwrap();
+        }
         let coverage_map = CoverageMap::from_trace_file(trace_path);
         output_map_to_file(coverage_map_path, &coverage_map).unwrap();
     }

--- a/third_party/move/tools/move-cli/src/sandbox/commands/test.rs
+++ b/third_party/move/tools/move-cli/src/sandbox/commands/test.rs
@@ -46,6 +46,10 @@ pub const TEST_ARGS_FILENAME: &str = "args.txt";
 /// enabled in the move VM.
 const MOVE_VM_TRACING_ENV_VAR_NAME: &str = "MOVE_VM_TRACE";
 
+/// Name of the environment variable we need to set in order to flush
+/// after every trace call.
+const MOVE_VM_TRACING_FLUSH_ENV_VAR_NAME: &str = "MOVE_VM_TRACE_FLUSH";
+
 /// The default file name (inside the build output dir) for the runtime to
 /// dump the execution trace to. The trace will be used by the coverage tool
 /// if --track-cov is set. If --track-cov is not set, then no trace file will
@@ -266,7 +270,10 @@ pub fn run_one(
                 // then, when running <args-B.txt>, coverage will not be tracked nor printed
                 env::remove_var(MOVE_VM_TRACING_ENV_VAR_NAME);
             },
-            Some(path) => env::set_var(MOVE_VM_TRACING_ENV_VAR_NAME, path.as_os_str()),
+            Some(path) => {
+                env::set_var(MOVE_VM_TRACING_ENV_VAR_NAME, path.as_os_str());
+                env::set_var(MOVE_VM_TRACING_FLUSH_ENV_VAR_NAME, path.as_os_str());
+            },
         }
 
         let cmd_output = cli_command_template().args(args_iter).output()?;

--- a/third_party/move/tools/move-coverage/src/coverage_map.rs
+++ b/third_party/move/tools/move-coverage/src/coverage_map.rs
@@ -68,7 +68,8 @@ impl CoverageMap {
         for line in BufReader::new(file).lines() {
             let line = line.unwrap();
             let mut splits = line.split(',');
-            let exec_id = splits.next().unwrap();
+            // Use a dummy key so that the data structure of the coverage map does not need to be changed
+            let exec_id = "dummy_exec_id";
             let context = splits.next().unwrap();
             let pc = splits.next().unwrap().parse::<u64>().unwrap();
 
@@ -277,7 +278,8 @@ impl TraceMap {
         for line in BufReader::new(file).lines() {
             let line = line.unwrap();
             let mut splits = line.split(',');
-            let exec_id = splits.next().unwrap();
+            // Use a dummy key so that the data structure of the coverage map does not need to be changed
+            let exec_id = "dummy_exec_id";
             let context = splits.next().unwrap();
             let pc = splits.next().unwrap().parse::<u64>().unwrap();
 


### PR DESCRIPTION
### Description

This PR reduces execution time of coverage tool by 1) only printing necessary data items to the trace file; 2) using buffer writer. Close #7295

### Test Plan

`time aptos move test --coverage`

After this change, the execution time of 1) aptos-framework is reduced from 3.5mins to 30s; 2) aptos-stdlib is reduced from 3.5mins to 30s and 3) move-stdlib is reduced from 2mins to 13s.
