### PR TITLE
[docker][rosetta] use buildx-setup at main

### DIFF
--- a/.github/workflows/docker-build-rosetta.yaml
+++ b/.github/workflows/docker-build-rosetta.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: ./.github/actions/buildx-setup
+      - uses: aptos-labs/aptos-core/.github/actions/buildx-setup@main
 
       - name: Build rosetta
         run: GIT_REF=main docker/rosetta/docker-build-rosetta.sh


### PR DESCRIPTION
### Description

For best practices in CI, so we can build against any revision, even those which predate the recent CI changes

### Test Plan

CI running `docker-build-rosetta.yaml`, now that `buildx-setup` has been merged into `main` via https://github.com/aptos-labs/aptos-core/pull/9897. The build currently fails for an unrelated reason, but the buildx-setup step uses the main branch.

<!-- Please provide us with clear details for verifying that your changes work. -->
