### PR TITLE
[State Sync] Update latency monitor to track all advertised versions.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -282,7 +282,7 @@ pub struct AptosDataClientConfig {
 impl Default for AptosDataClientConfig {
     fn default() -> Self {
         Self {
-            latency_monitor_loop_interval_ms: 50, // 50 milliseconds
+            latency_monitor_loop_interval_ms: 100,
             max_epoch_chunk_size: MAX_EPOCH_CHUNK_SIZE,
             max_num_in_flight_priority_polls: 10,
             max_num_in_flight_regular_polls: 10,

--- a/state-sync/aptos-data-client/src/latency_monitor.rs
+++ b/state-sync/aptos-data-client/src/latency_monitor.rs
@@ -18,14 +18,14 @@ use std::{
 };
 
 // Useful constants
-const LATENCY_MONITOR_LOG_FREQ_SECS: u64 = 5;
+const LATENCY_MONITOR_LOG_FREQ_SECS: u64 = 10;
 const MAX_NUM_TRACKED_VERSION_ENTRIES: usize = 10_000;
 const MAX_VERSION_LAG_TO_TOLERATE: u64 = 10_000;
 
 /// A simple monitor that tracks the latencies taken to see
 /// and sync new blockchain data (i.e., transactions).
 pub struct LatencyMonitor {
-    advertised_version_timestamps: BTreeMap<u64, (Instant, u64)>, // The timestamps when advertised versions were first seen
+    advertised_versions: BTreeMap<u64, AdvertisedVersionMetadata>, // A map from advertised versions to metadata
     caught_up_to_latest: bool, // Whether the node has ever caught up to the latest blockchain version
     data_client: Arc<dyn AptosDataClientInterface + Send + Sync>, // The data client through which to see advertised data
     monitor_loop_interval: Duration, // The interval between latency monitor loop executions
@@ -44,7 +44,7 @@ impl LatencyMonitor {
             Duration::from_millis(data_client_config.latency_monitor_loop_interval_ms);
 
         Self {
-            advertised_version_timestamps: BTreeMap::new(),
+            advertised_versions: BTreeMap::new(),
             caught_up_to_latest: false,
             data_client,
             monitor_loop_interval,
@@ -115,15 +115,16 @@ impl LatencyMonitor {
     fn update_latency_metrics(&mut self, highest_synced_version: u64) {
         // Split the advertised versions into synced and unsynced versions
         let unsynced_advertised_versions = self
-            .advertised_version_timestamps
+            .advertised_versions
             .split_off(&(highest_synced_version + 1));
 
         // Update the metrics for all synced versions
-        for (synced_version, (seen_time, seen_timestamp_usecs)) in
-            self.advertised_version_timestamps.iter()
-        {
+        for (synced_version, advertised_version_metadata) in self.advertised_versions.iter() {
             // Update the seen to synced latencies
-            let duration_from_seen_to_synced = self.time_service.now().duration_since(*seen_time);
+            let duration_from_seen_to_synced = calculate_duration_from_seen_to_synced(
+                advertised_version_metadata,
+                self.time_service.clone(),
+            );
             metrics::observe_value_with_label(
                 &metrics::SYNC_LATENCIES,
                 metrics::SEEN_TO_SYNC_LATENCY_LABEL,
@@ -131,34 +132,48 @@ impl LatencyMonitor {
             );
 
             // Update the proposal latencies
-            if let Ok(block_timestamp_usecs) = self.storage.get_block_timestamp(*synced_version) {
-                // Update the propose to seen latencies
-                if let Some(duration_from_propose_to_seen) =
-                    calculate_duration_from_proposal(block_timestamp_usecs, *seen_timestamp_usecs)
-                {
-                    metrics::observe_value_with_label(
-                        &metrics::SYNC_LATENCIES,
-                        metrics::PROPOSE_TO_SEEN_LATENCY_LABEL,
-                        duration_from_propose_to_seen.as_secs_f64(),
-                    );
-                }
+            match self.storage.get_block_timestamp(*synced_version) {
+                Ok(block_timestamp_usecs) => {
+                    // Update the propose to seen latencies
+                    let seen_timestamp_usecs = advertised_version_metadata.seen_timestamp_usecs;
+                    if let Some(duration_from_propose_to_seen) = calculate_duration_from_proposal(
+                        block_timestamp_usecs,
+                        seen_timestamp_usecs,
+                    ) {
+                        metrics::observe_value_with_label(
+                            &metrics::SYNC_LATENCIES,
+                            metrics::PROPOSE_TO_SEEN_LATENCY_LABEL,
+                            duration_from_propose_to_seen.as_secs_f64(),
+                        );
+                    }
 
-                // Update the propose to synced latencies
-                let timestamp_now_usecs = self.get_timestamp_now_usecs();
-                if let Some(duration_from_propose_to_sync) =
-                    calculate_duration_from_proposal(block_timestamp_usecs, timestamp_now_usecs)
-                {
-                    metrics::observe_value_with_label(
-                        &metrics::SYNC_LATENCIES,
-                        metrics::PROPOSE_TO_SYNC_LATENCY_LABEL,
-                        duration_from_propose_to_sync.as_secs_f64(),
+                    // Update the propose to synced latencies
+                    let timestamp_now_usecs = self.get_timestamp_now_usecs();
+                    if let Some(duration_from_propose_to_sync) =
+                        calculate_duration_from_proposal(block_timestamp_usecs, timestamp_now_usecs)
+                    {
+                        metrics::observe_value_with_label(
+                            &metrics::SYNC_LATENCIES,
+                            metrics::PROPOSE_TO_SYNC_LATENCY_LABEL,
+                            duration_from_propose_to_sync.as_secs_f64(),
+                        );
+                    }
+                },
+                Err(error) => {
+                    sample!(
+                        SampleRate::Duration(Duration::from_secs(LATENCY_MONITOR_LOG_FREQ_SECS)),
+                        warn!(
+                            (LogSchema::new(LogEntry::LatencyMonitor)
+                                .event(LogEvent::StorageReadFailed)
+                                .message(&format!("Unable to read the block timestamp for version {}: {:?}", synced_version, error)))
+                        );
                     );
-                }
+                },
             }
         }
 
         // Update the advertised versions with those we still need to sync
-        self.advertised_version_timestamps = unsynced_advertised_versions;
+        self.advertised_versions = unsynced_advertised_versions;
     }
 
     /// Updates the advertised version timestamps by inserting any newly seen versions
@@ -180,38 +195,86 @@ impl LatencyMonitor {
                 );
                 self.caught_up_to_latest = true; // We've caught up
             } else {
+                sample!(
+                    SampleRate::Duration(Duration::from_secs(LATENCY_MONITOR_LOG_FREQ_SECS)),
+                    info!(
+                        (LogSchema::new(LogEntry::LatencyMonitor)
+                            .event(LogEvent::WaitingForCatchup)
+                            .message("Waiting for the node to catch up to the latest version before starting the latency monitor."))
+                    );
+                );
+
                 return; // We're still catching up, so we shouldn't update the advertised version timestamps
             }
         }
 
-        // If we're already synced with the highest advertised version, there's nothing to do
-        if highest_synced_version >= highest_advertised_version {
-            return;
-        }
-
-        // Get the current time and timestamp (note: we store both because
-        // there isn't a clean way of converting between them when relying
-        // on the time service).
+        // Get the current time (instant and timestamp)
         let time_now_instant = self.time_service.now();
         let timestamp_now_usecs = self.get_timestamp_now_usecs();
 
+        // Create the advertised version metadata
+        let seen_after_sync = highest_synced_version >= highest_advertised_version;
+        let advertised_version_metadata =
+            AdvertisedVersionMetadata::new(time_now_instant, timestamp_now_usecs, seen_after_sync);
+
         // Insert the newly seen version into the advertised version timestamps
-        self.advertised_version_timestamps.insert(
-            highest_advertised_version,
-            (time_now_instant, timestamp_now_usecs),
-        );
+        self.advertised_versions
+            .insert(highest_advertised_version, advertised_version_metadata);
 
         // If the map is too large, garbage collect the old versions
-        while self.advertised_version_timestamps.len() > MAX_NUM_TRACKED_VERSION_ENTRIES {
+        while self.advertised_versions.len() > MAX_NUM_TRACKED_VERSION_ENTRIES {
             // Remove the lowest version from the map by popping the first
             // item. This is possible because BTreeMaps are sorted by key.
-            self.advertised_version_timestamps.pop_first();
+            self.advertised_versions.pop_first();
         }
     }
 
     /// Returns the current timestamp (in microseconds) since the Unix epoch
     fn get_timestamp_now_usecs(&self) -> u64 {
         self.time_service.now_unix_time().as_micros() as u64
+    }
+}
+
+/// A simple struct that holds the metadata of an advertised version.
+///
+/// Note: the struct stores both the seen time as an Instant, as well
+/// as the seen timestamp (in microseconds since the Unix epoch). This
+/// is because there's no clean way of converting between the two when
+/// relying on the time service.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct AdvertisedVersionMetadata {
+    pub seen_time_instant: Instant, // The time (instant) when the version was first seen
+    pub seen_timestamp_usecs: u64, // The time (ms since the Unix epoch) when the version was first seen
+    pub seen_after_sync: bool, // Whether the version was seen after the node had already synced it
+}
+
+impl AdvertisedVersionMetadata {
+    pub fn new(
+        seen_time_instant: Instant,
+        seen_timestamp_usecs: u64,
+        seen_after_sync: bool,
+    ) -> Self {
+        Self {
+            seen_time_instant,
+            seen_timestamp_usecs,
+            seen_after_sync,
+        }
+    }
+}
+
+/// Calculates the duration between the seen timestamp and the synced
+/// timestamp. If the advertised version was only seen after it was
+/// synced, this returns a duration of 0.
+fn calculate_duration_from_seen_to_synced(
+    advertised_version_metadata: &AdvertisedVersionMetadata,
+    time_service: TimeService,
+) -> Duration {
+    if advertised_version_metadata.seen_after_sync {
+        Duration::from_secs(0)
+    } else {
+        time_service
+            .now()
+            .duration_since(advertised_version_metadata.seen_time_instant)
     }
 }
 
@@ -224,7 +287,7 @@ fn calculate_duration_from_proposal(
     propose_timestamp_usecs: u64,
     given_timestamp_usecs: u64,
 ) -> Option<Duration> {
-    if given_timestamp_usecs > propose_timestamp_usecs {
+    if given_timestamp_usecs >= propose_timestamp_usecs {
         Some(Duration::from_micros(
             given_timestamp_usecs - propose_timestamp_usecs,
         ))
@@ -247,14 +310,15 @@ mod tests {
     use crate::{
         latency_monitor,
         latency_monitor::{
-            calculate_duration_from_proposal, LatencyMonitor, MAX_NUM_TRACKED_VERSION_ENTRIES,
+            calculate_duration_from_proposal, calculate_duration_from_seen_to_synced,
+            AdvertisedVersionMetadata, LatencyMonitor, MAX_NUM_TRACKED_VERSION_ENTRIES,
             MAX_VERSION_LAG_TO_TOLERATE,
         },
         tests::mock::{create_mock_data_client, create_mock_db_reader},
     };
     use aptos_config::config::AptosDataClientConfig;
     use aptos_time_service::{TimeService, TimeServiceTrait};
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     #[test]
     fn test_calculate_duration_from_proposal() {
@@ -270,11 +334,11 @@ mod tests {
             ))
         );
 
-        // Test an invalid duration (i.e., where proposal time is equal to the given time)
+        // Test a valid duration (i.e., where proposal time is equal to the given time)
         let timestamp_usecs = 100_000;
         let calculated_duration =
             calculate_duration_from_proposal(timestamp_usecs, timestamp_usecs);
-        assert_eq!(calculated_duration, None);
+        assert_eq!(calculated_duration, Some(Duration::from_micros(0)));
 
         // Test an invalid duration (i.e., where proposal time is after the given time)
         let propose_timestamp_usecs = 100_000_001;
@@ -282,6 +346,46 @@ mod tests {
         let calculated_duration =
             calculate_duration_from_proposal(propose_timestamp_usecs, given_timestamp_usecs);
         assert_eq!(calculated_duration, None);
+    }
+
+    #[test]
+    fn test_calculate_duration_from_seen_to_synced() {
+        // Create an advertised version metadata that has been seen after it was synced
+        let time_service = TimeService::mock();
+        let advertised_version_metadata = AdvertisedVersionMetadata::new(
+            time_service.now(),
+            time_service.now_unix_time().as_micros() as u64,
+            true,
+        );
+
+        // Elapse some time
+        elapse_time(time_service.clone(), 1000);
+
+        // Verify the seen to synced duration is 0
+        let duration_from_seen_to_synced = calculate_duration_from_seen_to_synced(
+            &advertised_version_metadata,
+            time_service.clone(),
+        );
+        assert_eq!(duration_from_seen_to_synced, Duration::from_secs(0));
+
+        // Create an advertised version metadata that has been seen before it was synced
+        let advertised_version_metadata = AdvertisedVersionMetadata::new(
+            time_service.now(),
+            time_service.now_unix_time().as_micros() as u64,
+            false,
+        );
+
+        // Elapse some time
+        let elapsed_time_ms = 1000;
+        elapse_time(time_service.clone(), elapsed_time_ms);
+
+        // Verify the seen to synced duration is correct
+        let duration_from_seen_to_synced =
+            calculate_duration_from_seen_to_synced(&advertised_version_metadata, time_service);
+        assert_eq!(
+            duration_from_seen_to_synced,
+            Duration::from_millis(elapsed_time_ms)
+        );
     }
 
     #[tokio::test]
@@ -302,7 +406,6 @@ mod tests {
         );
 
         // Verify that we still haven't caught up (the sync lag is too large)
-        let time_service = time_service.into_mock();
         assert!(!latency_monitor.caught_up_to_latest);
         verify_advertised_version_timestamps_length(&mut latency_monitor, 0);
 
@@ -318,17 +421,17 @@ mod tests {
         assert!(latency_monitor.caught_up_to_latest);
         verify_advertised_version_timestamps_length(&mut latency_monitor, 1);
 
-        // Verify the timestamps of the highest advertised version
-        let (time_now_instant, timestamp_now_usecs) =
-            get_advertised_version_timestamps(&mut latency_monitor, &highest_advertised_version);
-        assert_eq!(time_now_instant, time_service.now());
-        assert_eq!(
-            timestamp_now_usecs,
-            time_service.now_unix_time().as_micros() as u64
-        );
+        // Verify the metadata of the highest advertised version
+        let advertised_version_metadata =
+            get_advertised_version_metadata(&mut latency_monitor, &highest_advertised_version);
+        assert_eq!(advertised_version_metadata, AdvertisedVersionMetadata {
+            seen_time_instant: time_service.now(),
+            seen_timestamp_usecs: time_service.now_unix_time().as_micros() as u64,
+            seen_after_sync: false,
+        });
 
         // Elapse the time
-        time_service.advance_ms(1000);
+        elapse_time(time_service.clone(), 1000);
 
         // Update the advertised version timestamps again
         highest_advertised_version += 100;
@@ -340,14 +443,14 @@ mod tests {
         // Verify the number of tracked versions
         verify_advertised_version_timestamps_length(&mut latency_monitor, 2);
 
-        // Verify the timestamps of the highest advertised version
-        let (time_now_instant, timestamp_now_usecs) =
-            get_advertised_version_timestamps(&mut latency_monitor, &highest_advertised_version);
-        assert_eq!(time_now_instant, time_service.now());
-        assert_eq!(
-            timestamp_now_usecs,
-            time_service.now_unix_time().as_micros() as u64
-        );
+        // Verify the metadata of the highest advertised version
+        let advertised_version_metadata =
+            get_advertised_version_metadata(&mut latency_monitor, &highest_advertised_version);
+        assert_eq!(advertised_version_metadata, AdvertisedVersionMetadata {
+            seen_time_instant: time_service.now(),
+            seen_timestamp_usecs: time_service.now_unix_time().as_micros() as u64,
+            seen_after_sync: false,
+        });
     }
 
     #[tokio::test]
@@ -374,11 +477,10 @@ mod tests {
         verify_advertised_version_timestamps_length(&mut latency_monitor, 0);
 
         // Update the advertised versions many more times than the max (again)
-        let time_service = time_service.into_mock();
         let start_time_usecs = time_service.now_unix_time().as_micros() as u64;
         for advertised_version in 0..num_advertised_versions {
             // Elapse some time (1 ms)
-            time_service.advance_ms(1);
+            elapse_time(time_service.clone(), 1);
 
             // Update the advertised version timestamps
             latency_monitor.update_advertised_version_timestamps(0, advertised_version);
@@ -388,13 +490,82 @@ mod tests {
         let lowest_tracked_version =
             num_advertised_versions - (MAX_NUM_TRACKED_VERSION_ENTRIES as u64);
         for advertised_version in lowest_tracked_version..num_advertised_versions {
-            let (_, timestamp_now_usecs) =
-                get_advertised_version_timestamps(&mut latency_monitor, &advertised_version);
+            let advertised_version_metadata =
+                get_advertised_version_metadata(&mut latency_monitor, &advertised_version);
             assert_eq!(
-                timestamp_now_usecs,
+                advertised_version_metadata.seen_timestamp_usecs,
                 start_time_usecs + ((advertised_version + 1) * 1000)
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_advertised_version_timestamps_seen_after_synced() {
+        // Create a latency monitor
+        let (time_service, mut latency_monitor) = create_latency_monitor();
+
+        // Update the advertised version timestamps
+        let highest_advertised_version = MAX_VERSION_LAG_TO_TOLERATE + 100;
+        let highest_synced_version = 100;
+        latency_monitor.update_advertised_version_timestamps(
+            highest_synced_version,
+            highest_advertised_version,
+        );
+
+        // Verify the metadata of the highest advertised version
+        verify_advertised_version_timestamps_length(&mut latency_monitor, 1);
+        let advertised_version_metadata =
+            get_advertised_version_metadata(&mut latency_monitor, &highest_advertised_version);
+        assert_eq!(advertised_version_metadata, AdvertisedVersionMetadata {
+            seen_time_instant: time_service.now(),
+            seen_timestamp_usecs: time_service.now_unix_time().as_micros() as u64,
+            seen_after_sync: false,
+        });
+
+        // Elapse some time
+        elapse_time(time_service.clone(), 1000);
+
+        // Update the advertised version timestamps again. But, this time
+        // the highest synced version is equal to the highest advertised version.
+        let highest_advertised_version = MAX_VERSION_LAG_TO_TOLERATE + 200;
+        let highest_synced_version = highest_advertised_version;
+        latency_monitor.update_advertised_version_timestamps(
+            highest_synced_version,
+            highest_advertised_version,
+        );
+
+        // Verify the number of tracked versions
+        verify_advertised_version_timestamps_length(&mut latency_monitor, 2);
+
+        // Verify the metadata of the highest advertised version
+        let advertised_version_metadata =
+            get_advertised_version_metadata(&mut latency_monitor, &highest_advertised_version);
+        assert_eq!(advertised_version_metadata, AdvertisedVersionMetadata {
+            seen_time_instant: time_service.now(),
+            seen_timestamp_usecs: time_service.now_unix_time().as_micros() as u64,
+            seen_after_sync: true,
+        });
+
+        // Update the advertised version timestamps again. But, this time
+        // the highest synced version is greater than the highest advertised version.
+        let highest_advertised_version = MAX_VERSION_LAG_TO_TOLERATE + 300;
+        let highest_synced_version = highest_advertised_version + 100;
+        latency_monitor.update_advertised_version_timestamps(
+            highest_synced_version,
+            highest_advertised_version,
+        );
+
+        // Verify the number of tracked versions
+        verify_advertised_version_timestamps_length(&mut latency_monitor, 3);
+
+        // Verify the metadata of the highest advertised version
+        let advertised_version_metadata =
+            get_advertised_version_metadata(&mut latency_monitor, &highest_advertised_version);
+        assert_eq!(advertised_version_metadata, AdvertisedVersionMetadata {
+            seen_time_instant: time_service.now(),
+            seen_timestamp_usecs: time_service.now_unix_time().as_micros() as u64,
+            seen_after_sync: true,
+        });
     }
 
     #[tokio::test]
@@ -450,7 +621,7 @@ mod tests {
         latency_monitor.update_advertised_version_timestamps(200, 200);
 
         // Verify that we're tracking the correct number of advertised version timestamps
-        verify_advertised_version_timestamps_length(&mut latency_monitor, 0);
+        verify_advertised_version_timestamps_length(&mut latency_monitor, 1);
     }
 
     /// Creates a latency monitor for testing
@@ -469,17 +640,21 @@ mod tests {
         (time_service, latency_monitor)
     }
 
-    /// Returns the advertised version timestamps for the given version
-    fn get_advertised_version_timestamps(
+    /// Elapses the given time (in milliseconds) on the specified time service
+    fn elapse_time(time_service: TimeService, time_ms: u64) {
+        time_service.into_mock().advance_ms(time_ms);
+    }
+
+    /// Returns the advertised version metadata for the given version
+    fn get_advertised_version_metadata(
         latency_monitor: &mut LatencyMonitor,
         highest_advertised_version: &u64,
-    ) -> (Instant, u64) {
-        let (time_now_instant, timestamp_now_usecs) = latency_monitor
-            .advertised_version_timestamps
+    ) -> AdvertisedVersionMetadata {
+        latency_monitor
+            .advertised_versions
             .get(highest_advertised_version)
-            .unwrap();
-
-        (*time_now_instant, *timestamp_now_usecs)
+            .unwrap()
+            .clone()
     }
 
     /// Verifies that the length of the advertised version timestamps is correct
@@ -488,7 +663,7 @@ mod tests {
         expected_length: u64,
     ) {
         assert_eq!(
-            latency_monitor.advertised_version_timestamps.len(),
+            latency_monitor.advertised_versions.len(),
             expected_length as usize
         );
     }

--- a/state-sync/aptos-data-client/src/logging.rs
+++ b/state-sync/aptos-data-client/src/logging.rs
@@ -65,4 +65,5 @@ pub enum LogEvent {
     SendRequest,
     StorageReadFailed,
     UnexpectedError,
+    WaitingForCatchup,
 }


### PR DESCRIPTION
### Description
This PR updates the latency monitor to track all advertised versions, even if the versions were only advertised *after* they were synced by the node.

Currently, if a version is advertised after it was synced by the node, it is not tracked for latency purposes, and this results in several missing metrics. Instead, this PR updates the code such that if we've already synced an advertised version, we'll still track the version latencies and the calculated "seen to synced" latency will instead be set to 0.

### Test Plan
Existing test infrastructure.