### PR TITLE
Fix Issue 6907: A verifier failure related to inline functions

### DIFF
--- a/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/bug_9459_notworking.exp
+++ b/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/bug_9459_notworking.exp
@@ -1,0 +1,1 @@
+processed 1 task

--- a/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/bug_9459_notworking.move
+++ b/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/bug_9459_notworking.move
@@ -1,0 +1,28 @@
+//# publish
+module 0x1337::reproduce {
+    use std::option::{Self, Option};
+    #[test_only]
+    use aptos_framework::account;
+
+    const ESpaceAlreadyMarked: u64 = 0;
+
+    public entry fun init(_account: &signer) {
+        let space: Option<u8> = option::none();
+        check_if_space_is_open(&mut space);
+    }
+
+    inline fun check_if_space_is_open(space: &Option<u8>) {
+        // TODO: Ensure given space is not already marked. If it is, abort with code:
+        //          ESpaceAlreadyMarked
+        assert!(
+            option::is_none(space),
+            ESpaceAlreadyMarked
+        );
+    }
+
+    #[test]
+    fun test() {
+        let account = account::create_account_for_test(@0x1337);
+        init(&account);
+    }
+}

--- a/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/bug_9459_working.exp
+++ b/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/bug_9459_working.exp
@@ -1,0 +1,1 @@
+processed 1 task

--- a/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/bug_9459_working.move
+++ b/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/bug_9459_working.move
@@ -1,0 +1,22 @@
+//# publish
+module 0x1337::reproduce {
+    use std::option::{Self, Option};
+    #[test_only]
+    use aptos_framework::account;
+
+    const ESpaceAlreadyMarked: u64 = 0;
+
+    public entry fun init(_account: &signer) {
+        let space: Option<u8> = option::none();
+        assert!(
+            option::is_none(&mut space),
+            ESpaceAlreadyMarked
+        );
+    }
+
+    #[test]
+    fun test() {
+        let account = account::create_account_for_test(@0x1337);
+        init(&account);
+    }
+}

--- a/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/gerbens_test.exp
+++ b/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/gerbens_test.exp
@@ -2,7 +2,7 @@ processed 1 task
 
 task 0 'publish'. lines 1-93:
 Error: error[E04024]: invalid usage of function type
-  ┌─ /var/folders/hx/_s_6fyh529bgmvl6z4m8m9fm0000gn/T/.tmpgXTKt8:9:62
+  ┌─ TEMPFILE:9:62
   │
 9 │     public fun for_each_ref<Element>(v: &vector<Element>, f: |&Element|) {
   │                                                              ^^^^^^^^^^ function type only allowed for inline function arguments

--- a/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/gerbens_test.exp
+++ b/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/gerbens_test.exp
@@ -1,0 +1,10 @@
+processed 1 task
+
+task 0 'publish'. lines 1-93:
+Error: error[E04024]: invalid usage of function type
+  ┌─ /var/folders/hx/_s_6fyh529bgmvl6z4m8m9fm0000gn/T/.tmpgXTKt8:9:62
+  │
+9 │     public fun for_each_ref<Element>(v: &vector<Element>, f: |&Element|) {
+  │                                                              ^^^^^^^^^^ function type only allowed for inline function arguments
+
+

--- a/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/gerbens_test.move
+++ b/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/gerbens_test.move
@@ -1,0 +1,82 @@
+//# publish
+module 0x42::test_case {
+    use std::vector;
+
+    /// The index into the vector is out of bounds
+    const EINVALID_RANGE: u64 = 0x20001;
+
+    /// Map the function over the references of the elements of the vector, producing a new vector without modifying the
+    /// original map.
+    public inline fun map_ref<Element, NewElement>(
+        v: &vector<Element>,
+        f: |&Element|NewElement
+    ): vector<NewElement> {
+        let result = vector<NewElement>[];
+        vector::for_each_ref(v, |elem| vector::push_back(&mut result, f(elem)));
+        result
+    }
+
+    /// Reverses the order of the elements [left, right) in the vector `v` in place.
+    public fun reverse_slice<Element>(v: &mut vector<Element>, left: u64, right: u64) {
+        assert!(left <= right, EINVALID_RANGE);
+        if (left == right) return;
+        right = right - 1;
+        while (left < right) {
+            vector::swap(v, left, right);
+            left = left + 1;
+            right = right - 1;
+        }
+    }
+    /// Same as above but on a sub-slice of an array [left, right) with left <= rot <= right
+    /// returns the
+    public fun rotate_slice<Element>(
+        v: &mut vector<Element>,
+        left: u64,
+        rot: u64,
+        right: u64
+    ): u64 {
+        reverse_slice(v, left, rot);
+        reverse_slice(v, rot, right);
+        reverse_slice(v, left, right);
+        left + (right - rot)
+    }
+
+    /// For in-place stable partition we need recursion so we cannot use inline functions
+    /// and thus we cannot use lambdas. Luckily it so happens that we can precompute the predicate
+    /// in a secondary array. Note how the algorithm belows only start shuffling items after the
+    /// predicate is checked.
+    public fun stable_partition_internal<Element>(
+        v: &mut vector<Element>,
+        pred: &vector<bool>,
+        left: u64,
+        right: u64
+    ): u64 {
+        if (left == right) {
+            left
+        } else if (left + 1 == right) {
+            if (*vector::borrow(pred, left)) right else left
+        } else {
+            let mid = left + ((right - left) >> 1);
+            let p1 = stable_partition_internal(v, pred, left, mid);
+            let p2 = stable_partition_internal(v, pred, mid, right);
+            rotate_slice(v, p1, mid, p2)
+        }
+    }
+
+    /// Partition the array based on a predicate p, this routine is stable and thus
+    /// preserves the relative order of the elements in the two partitions.
+    public inline fun stable_partition<Element>(
+        v: &mut vector<Element>,
+        p: |&Element|bool
+    ): u64 {
+        let pred = map_ref(v, |e| p(e));
+        let len = vector::length(v);
+        stable_partition_internal(v, &pred,0, len)
+    }
+
+    fun test_stable_partition() {
+        let v = vector[1, 2, 3, 4, 5];
+        assert!(stable_partition(&mut v, |n| *n % 2 == 0) == 2, 0);
+        assert!(&v == &vector[2, 4, 1, 3, 5], 1);
+    }
+}

--- a/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/gerbens_test1.exp
+++ b/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/gerbens_test1.exp
@@ -1,0 +1,1 @@
+processed 1 task

--- a/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/gerbens_test1.move
+++ b/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/gerbens_test1.move
@@ -1,6 +1,5 @@
 //# publish
-// Try to pass a lambda to a non-inline function by mistake.
-// Should generate an error.
+// Should succeed.
 module 0x42::test_case {
     use std::vector;
 
@@ -8,7 +7,7 @@ module 0x42::test_case {
     const EINVALID_RANGE: u64 = 0x20001;
 
     /// Apply the function to a reference of each element in the vector.
-    public fun for_each_ref<Element>(v: &vector<Element>, f: |&Element|) {
+    public inline fun for_each_ref<Element>(v: &vector<Element>, f: |&Element|) {
         let i = 0;
         while (i < vector::length(v)) {
             f(vector::borrow(v, i));

--- a/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/gerbens_test1.move
+++ b/third_party/move/move-bytecode-verifier/transactional-tests/tests/type_safety/gerbens_test1.move
@@ -86,7 +86,8 @@ module 0x42::test_case {
 
     fun test_stable_partition() {
         let v = vector[1, 2, 3, 4, 5];
-        assert!(stable_partition(&mut v, |n| *n % 2 == 0) == 2, 0);
+        let t = stable_partition(&mut v, |n| *n % 2 == 0);
+        assert!(t == 2, 0);
         assert!(&v == &vector[2, 4, 1, 3, 5], 1);
     }
 }

--- a/third_party/move/move-compiler/src/diagnostics/codes.rs
+++ b/third_party/move/move-compiler/src/diagnostics/codes.rs
@@ -248,6 +248,7 @@ codes!(
         Recursion: { msg: "recursion during function inlining not allowed", severity: BlockingError },
         AfterExpansion: {  msg: "Inlined code invalid in this context", severity: BlockingError },
         Unsupported: { msg: "feature not supported in inlined functions", severity: BlockingError },
+        UnexpectedLambda: { msg: "lambda parameter only permitted as parameter to inlined function", severity: BlockingError },
     ],
 );
 

--- a/third_party/move/move-compiler/src/hlir/translate.rs
+++ b/third_party/move/move-compiler/src/hlir/translate.rs
@@ -1375,7 +1375,13 @@ fn exp_impl(
             };
             HE::Spec(hanchor)
         },
-        TE::Lambda(..) => panic!("ICE unexpected lambda"),
+        TE::Lambda(_lvalue_list, _boxed_exp) => {
+            context.env.add_diag(diag!(
+                Inlining::UnexpectedLambda,
+                (eloc, "unexpected lambda")
+            ));
+            HE::UnresolvedError
+        },
         TE::UnresolvedError => {
             assert!(context.env.has_errors());
             HE::UnresolvedError

--- a/third_party/move/move-compiler/src/inlining/translate.rs
+++ b/third_party/move/move-compiler/src/inlining/translate.rs
@@ -102,7 +102,7 @@ impl<'l> Inliner<'l> {
                 if !fdef.inline {
                     let mut visitor = OuterVisitor { inliner };
                     Dispatcher::new(&mut visitor).function(fdef);
-                    //DEBUG Self::eprint_fdef(&format!("fun {} ", _name), fdef);
+                    //Self::eprint_fdef(&format!("fun {} ", _name), fdef);
                 }
             },
         );
@@ -736,8 +736,8 @@ impl<'l> Inliner<'l> {
         };
 
         let spanned_lvalues = sp(loc, lvalues);
-        let lvalue_ty = lvalues_expected_types(&spanned_lvalues); // BUGBUG - added
-                                                                  // substitute
+        let lvalue_ty = lvalues_expected_types(&spanned_lvalues);
+
         let decl = sp(
             loc,
             SequenceItem_::Bind(spanned_lvalues, lvalue_ty, Box::new(exp)),

--- a/third_party/move/move-compiler/src/inlining/visitor.rs
+++ b/third_party/move/move-compiler/src/inlining/visitor.rs
@@ -28,8 +28,8 @@ pub trait Visitor {
         VisitorContinuation::Descend
     }
     fn enter_scope(&mut self) {}
-    fn var_decl(&mut self, _var: &mut Var) {}
-    fn var_use(&mut self, _var: &mut Var) {}
+    fn var_decl(&mut self, _ty: &mut Type, _var: &mut Var) {}
+    fn var_use(&mut self, _ty: &mut Type, _var: &mut Var) {}
     fn exit_scope(&mut self) {}
     fn infer_abilities(&mut self, _ty: &mut Type) {}
 }
@@ -45,9 +45,11 @@ impl<'l, V: Visitor> Dispatcher<'l, V> {
 
     pub fn function(&mut self, fdef: &mut Function) {
         self.visitor.enter_scope();
-        for (var, _) in fdef.signature.parameters.iter_mut() {
-            self.visitor.var_decl(var)
+        for (var, ty) in fdef.signature.parameters.iter_mut() {
+            self.type_(ty);
+            self.visitor.var_decl(ty, var);
         }
+        self.type_(&mut fdef.signature.return_type);
         match &mut fdef.body.value {
             FunctionBody_::Native => {},
             FunctionBody_::Defined(seq) => self.sequence(seq),
@@ -84,10 +86,10 @@ impl<'l, V: Visitor> Dispatcher<'l, V> {
         if self.visitor.exp(ex) == VisitorContinuation::Stop {
             return;
         }
-        self.exp_unannotated(ex.exp.loc, &mut ex.exp.value)
+        self.exp_unannotated(ex.exp.loc, &mut ex.ty, &mut ex.exp.value)
     }
 
-    pub fn exp_unannotated(&mut self, _loc: Loc, ex: &mut UnannotatedExp_) {
+    pub fn exp_unannotated(&mut self, _loc: Loc, ty: &mut Type, ex: &mut UnannotatedExp_) {
         match ex {
             UnannotatedExp_::ModuleCall(mc) => {
                 let ModuleCall {
@@ -98,284 +100,6 @@ impl<'l, V: Visitor> Dispatcher<'l, V> {
                 } = mc.as_mut();
                 self.types(type_arguments.iter_mut());
                 self.types(parameter_types.iter_mut());
-                self.exp(arguments)
-            },
-            UnannotatedExp_::Use(var)
-            | UnannotatedExp_::Copy { from_user: _, var }
-            | UnannotatedExp_::Move { from_user: _, var }
-            | UnannotatedExp_::BorrowLocal(_, var) => self.visitor.var_use(var),
-
-            UnannotatedExp_::VarCall(var, ex) => {
-                self.visitor.var_use(var);
-                self.exp(ex)
-            },
-            UnannotatedExp_::Lambda(decls, body) => {
-                self.visitor.enter_scope();
-                self.lvalue_list(decls, /*declared*/ true);
-                self.exp(body);
-                self.visitor.exit_scope();
-            },
-
-            UnannotatedExp_::IfElse(cex, iex, eex) => {
-                self.exp(cex.as_mut());
-                self.exp(iex.as_mut());
-                self.exp(eex.as_mut());
-            },
-            UnannotatedExp_::While(cex, bex) => {
-                self.exp(cex.as_mut());
-                self.exp(bex.as_mut());
-            },
-            UnannotatedExp_::Block(seq) => self.sequence(seq),
-            UnannotatedExp_::Mutate(dex, sex) => {
-                self.exp(dex.as_mut());
-                self.exp(sex.as_mut());
-            },
-            UnannotatedExp_::BinopExp(lex, _, ty, rex) => {
-                self.type_(ty.as_mut());
-                self.exp(lex.as_mut());
-                self.exp(rex.as_mut());
-            },
-            UnannotatedExp_::Pack(_, _, tys, fields) => {
-                self.types(tys.iter_mut());
-                for (_, _, (_, (ty, ex))) in fields.iter_mut() {
-                    self.type_(ty);
-                    self.exp(ex);
-                }
-            },
-            UnannotatedExp_::ExpList(items) => {
-                for item in items.iter_mut() {
-                    match item {
-                        ExpListItem::Single(ex, ty) => {
-                            self.type_(ty.as_mut());
-                            self.exp(ex)
-                        },
-                        ExpListItem::Splat(_, ex, tys) => {
-                            self.types(tys.iter_mut());
-                            self.exp(ex)
-                        },
-                    }
-                }
-            },
-            UnannotatedExp_::Assign(lhs, tys, ex) => {
-                self.lvalue_list(lhs, /*declared*/ false);
-                self.types(tys.iter_mut().filter_map(|f| f.as_mut()));
-                self.exp(ex.as_mut());
-            },
-            UnannotatedExp_::Vector(_, _, ty, ex) => {
-                self.type_(ty.as_mut());
-                self.exp(ex.as_mut())
-            },
-            UnannotatedExp_::Cast(ex, ty) | UnannotatedExp_::Annotate(ex, ty) => {
-                self.type_(ty.as_mut());
-                self.exp(ex.as_mut())
-            },
-
-            UnannotatedExp_::Loop { body: ex, .. }
-            | UnannotatedExp_::Return(ex)
-            | UnannotatedExp_::Abort(ex)
-            | UnannotatedExp_::Dereference(ex)
-            | UnannotatedExp_::UnaryExp(_, ex)
-            | UnannotatedExp_::Borrow(_, ex, _)
-            | UnannotatedExp_::TempBorrow(_, ex) => self.exp(ex.as_mut()),
-
-            UnannotatedExp_::Builtin(fun, ex) => {
-                self.builtin_function(fun.as_mut());
-                self.exp(ex.as_mut())
-            },
-
-            UnannotatedExp_::Spec(anchor) => {
-                let SpecAnchor {
-                    id: _,
-                    origin: _,
-                    used_locals,
-                    used_lambda_funs,
-                } = anchor;
-
-                // re-organize the locals
-                {
-                    let keys: Vec<_> = used_locals.keys().cloned().collect();
-                    let mut temp = BTreeMap::new();
-                    for key in keys {
-                        let (orig_var, (mut ty, mut var)) = used_locals.remove_entry(&key).unwrap();
-                        self.type_(&mut ty);
-                        self.visitor.var_use(&mut var);
-                        temp.insert(orig_var, (ty, var));
-                    }
-                    used_locals.append(&mut temp);
-                }
-
-                // re-organize the lambdas
-                {
-                    let keys: Vec<_> = used_lambda_funs.keys().cloned().collect();
-                    let mut temp = BTreeMap::new();
-                    for key in keys {
-                        let (name, mut fun) = used_lambda_funs.remove_entry(&key).unwrap();
-
-                        self.visitor.enter_scope();
-                        for (v, t) in fun.signature.parameters.iter_mut() {
-                            self.type_(t);
-                            self.visitor.var_decl(v);
-                        }
-                        self.type_(&mut fun.signature.return_type);
-                        self.exp(fun.body.as_mut());
-                        self.visitor.exit_scope();
-
-                        temp.insert(name, fun);
-                    }
-                    used_lambda_funs.append(&mut temp);
-                }
-            },
-
-            UnannotatedExp_::Unit { .. }
-            | UnannotatedExp_::Value(_)
-            | UnannotatedExp_::Constant(_, _)
-            | UnannotatedExp_::Break
-            | UnannotatedExp_::Continue
-            | UnannotatedExp_::UnresolvedError => {},
-        }
-    }
-
-    fn builtin_function(&mut self, fun: &mut BuiltinFunction) {
-        match &mut fun.value {
-            BuiltinFunction_::MoveTo(ty)
-            | BuiltinFunction_::MoveFrom(ty)
-            | BuiltinFunction_::BorrowGlobal(_, ty)
-            | BuiltinFunction_::Exists(ty)
-            | BuiltinFunction_::Freeze(ty) => self.type_(ty),
-            BuiltinFunction_::Assert(_) => {},
-        }
-    }
-
-    pub fn sequence(&mut self, seq: &mut Sequence) {
-        let mut scope_cnt = 0;
-        for item in seq.iter_mut() {
-            match &mut item.value {
-                SequenceItem_::Bind(decls, tys, e) => {
-                    self.exp(e.as_mut());
-                    self.types(tys.iter_mut().filter_map(|t| t.as_mut()));
-                    self.visitor.enter_scope();
-                    self.lvalue_list(decls, /*declared*/ true);
-                    scope_cnt += 1;
-                },
-                SequenceItem_::Declare(decls) => {
-                    self.visitor.enter_scope();
-                    self.lvalue_list(decls, /*declared*/ true);
-                    scope_cnt += 1;
-                },
-                SequenceItem_::Seq(e) => self.exp(e.as_mut()),
-            }
-        }
-        while scope_cnt > 0 {
-            self.visitor.exit_scope();
-            scope_cnt -= 1
-        }
-    }
-
-    pub fn lvalue_list(&mut self, decls: &mut LValueList, declared: bool) {
-        for lv in &mut decls.value {
-            self.lvalue(lv, declared)
-        }
-    }
-
-    fn lvalue(&mut self, lv: &mut LValue, declared: bool) {
-        match &mut lv.value {
-            LValue_::Var(var, ty) => {
-                self.type_(ty.as_mut());
-                if declared {
-                    self.visitor.var_decl(var)
-                } else {
-                    self.visitor.var_use(var)
-                }
-            },
-            LValue_::Unpack(_, _, tys, fields) | LValue_::BorrowUnpack(_, _, _, tys, fields) => {
-                self.types(tys.iter_mut());
-                for (_, _, (_, (ty, slv))) in fields.iter_mut() {
-                    self.type_(ty);
-                    self.lvalue(slv, declared);
-                }
-            },
-            LValue_::Ignore => {},
-        }
-    }
-}
-
-pub trait TypedVisitor {
-    fn exp(&mut self, _ex: &mut Exp) -> VisitorContinuation {
-        VisitorContinuation::Descend
-    }
-    fn ty(&mut self, _t: &mut Type) -> VisitorContinuation {
-        VisitorContinuation::Descend
-    }
-    fn enter_scope(&mut self) {}
-    fn var_decl(&mut self, _ty: &mut Type, _var: &mut Var) {}
-    fn var_use(&mut self, _ty: &mut Type, _var: &mut Var) {}
-    fn exit_scope(&mut self) {}
-}
-
-pub struct TypedDispatcher<'l, V: TypedVisitor> {
-    visitor: &'l mut V,
-}
-
-impl<'l, V: TypedVisitor> TypedDispatcher<'l, V> {
-    pub fn new(visitor: &'l mut V) -> Self {
-        Self { visitor }
-    }
-
-    #[allow(unused)]
-    pub fn function(&mut self, fdef: &mut Function) {
-        self.visitor.enter_scope();
-        for (var, ty) in fdef.signature.parameters.iter_mut() {
-            self.type_(ty);
-            self.visitor.var_decl(ty, var);
-        }
-        self.type_(&mut fdef.signature.return_type);
-        match &mut fdef.body.value {
-            FunctionBody_::Native => {},
-            FunctionBody_::Defined(seq) => self.sequence(seq),
-        }
-        self.visitor.exit_scope()
-    }
-
-    pub fn type_(&mut self, ty: &mut Type) {
-        if self.visitor.ty(ty) == VisitorContinuation::Stop {
-            return;
-        }
-        match &mut ty.value {
-            Type_::Ref(_, ty) => self.type_(ty.as_mut()),
-            Type_::Apply(_, _, tys) => {
-                self.types(tys.iter_mut());
-            },
-            Type_::Unit
-            | Type_::Param(_)
-            | Type_::Var(_)
-            | Type_::Anything
-            | Type_::UnresolvedError => {},
-        }
-    }
-
-    fn types<'r>(&mut self, tys: impl Iterator<Item = &'r mut Type>) {
-        for ty in tys {
-            self.type_(ty)
-        }
-    }
-
-    pub fn exp(&mut self, ex: &mut Exp) {
-        self.type_(&mut ex.ty);
-        if self.visitor.exp(ex) == VisitorContinuation::Stop {
-            return;
-        }
-        self.exp_unannotated(ex.exp.loc, &mut ex.ty, &mut ex.exp.value)
-    }
-
-    pub fn exp_unannotated(&mut self, _loc: Loc, ty: &mut Type, ex: &mut UnannotatedExp_) {
-        match ex {
-            UnannotatedExp_::ModuleCall(mc) => {
-                let ModuleCall {
-                    arguments,
-                    type_arguments,
-                    ..
-                } = mc.as_mut();
-                self.types(type_arguments.iter_mut());
                 self.exp(arguments)
             },
             UnannotatedExp_::Use(var)
@@ -417,7 +141,7 @@ impl<'l, V: TypedVisitor> TypedDispatcher<'l, V> {
                 self.exp(sex.as_mut());
             },
             UnannotatedExp_::BinopExp(lex, _, ty, rex) => {
-                self.type_(ty);
+                self.type_(ty.as_mut());
                 self.exp(lex.as_mut());
                 self.exp(rex.as_mut());
             },
@@ -533,7 +257,7 @@ impl<'l, V: TypedVisitor> TypedDispatcher<'l, V> {
     }
 
     pub fn sequence(&mut self, seq: &mut Sequence) {
-        let mut scoped = false;
+        let mut scope_cnt = 0;
         for item in seq.iter_mut() {
             match &mut item.value {
                 SequenceItem_::Bind(decls, tys, e) => {
@@ -541,18 +265,19 @@ impl<'l, V: TypedVisitor> TypedDispatcher<'l, V> {
                     self.types(tys.iter_mut().filter_map(|t| t.as_mut()));
                     self.visitor.enter_scope();
                     self.lvalue_list(decls, /*declared*/ true);
-                    scoped = true;
+                    scope_cnt += 1;
                 },
                 SequenceItem_::Declare(decls) => {
                     self.visitor.enter_scope();
                     self.lvalue_list(decls, /*declared*/ true);
-                    scoped = true;
+                    scope_cnt += 1;
                 },
                 SequenceItem_::Seq(e) => self.exp(e.as_mut()),
             }
         }
-        if scoped {
+        while scope_cnt > 0 {
             self.visitor.exit_scope();
+            scope_cnt -= 1
         }
     }
 
@@ -565,7 +290,7 @@ impl<'l, V: TypedVisitor> TypedDispatcher<'l, V> {
     fn lvalue(&mut self, lv: &mut LValue, declared: bool) {
         match &mut lv.value {
             LValue_::Var(var, ty) => {
-                self.type_(ty);
+                self.type_(ty.as_mut());
                 if declared {
                     self.visitor.var_decl(ty, var)
                 } else {

--- a/third_party/move/move-compiler/src/inlining/visitor.rs
+++ b/third_party/move/move-compiler/src/inlining/visitor.rs
@@ -290,7 +290,7 @@ impl<'l, V: Visitor> Dispatcher<'l, V> {
     fn lvalue(&mut self, lv: &mut LValue, declared: bool) {
         match &mut lv.value {
             LValue_::Var(var, ty) => {
-                self.type_(ty.as_mut());
+                self.type_(ty);
                 if declared {
                     self.visitor.var_decl(ty, var)
                 } else {

--- a/third_party/move/move-compiler/src/typing/translate.rs
+++ b/third_party/move/move-compiler/src/typing/translate.rs
@@ -1064,7 +1064,7 @@ fn sequence(context: &mut Context, seq: N::Sequence) -> T::Sequence {
                 e,
             } => {
                 context.close_locals_scope(old_locals, declared);
-                let lvalue_ty = lvalues_expected_types(context, &b);
+                let lvalue_ty = lvalues_expected_types(&b);
                 resulting_sequence.push_front(sp(loc, TS::Bind(b, lvalue_ty, e)))
             },
         }
@@ -1343,7 +1343,7 @@ fn exp_inner(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
         NE::Assign(na, nr) => {
             let er = exp(context, nr);
             let a = assign_list(context, na, er.ty.clone());
-            let lvalue_ty = lvalues_expected_types(context, &a);
+            let lvalue_ty = lvalues_expected_types(&a);
             (sp(eloc, Type_::Unit), TE::Assign(a, lvalue_ty, er))
         },
 
@@ -1626,16 +1626,11 @@ fn loop_body(
 // Locals and LValues
 //**************************************************************************************************
 
-fn lvalues_expected_types(
-    context: &mut Context,
-    sp!(_loc, bs_): &T::LValueList,
-) -> Vec<Option<N::Type>> {
-    bs_.iter()
-        .map(|b| lvalue_expected_types(context, b))
-        .collect()
+pub fn lvalues_expected_types(sp!(_loc, bs_): &T::LValueList) -> Vec<Option<N::Type>> {
+    bs_.iter().map(lvalue_expected_types).collect()
 }
 
-fn lvalue_expected_types(_context: &mut Context, sp!(loc, b_): &T::LValue) -> Option<N::Type> {
+fn lvalue_expected_types(sp!(loc, b_): &T::LValue) -> Option<N::Type> {
     use N::Type_::*;
     use T::LValue_ as L;
     let loc = *loc;

--- a/third_party/move/testing-infra/transactional-test-runner/src/framework.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/framework.rs
@@ -935,14 +935,20 @@ fn handle_known_task<'a, Adapter: MoveTestAdapter<'a>>(
     let task_name = task.name.to_owned();
     let start_line = task.start_line;
     let stop_line = task.stop_line;
+    let data_path = match &task.data {
+        Some(f) => f.path().to_str().unwrap().to_string(),
+        None => "".to_string(),
+    };
     let result = adapter.handle_command(task);
-    let result_string = match result {
+    let mut result_string = match result {
         Ok(None) => return,
         Ok(Some(s)) => s,
         Err(e) => format!("Error: {}", e),
     };
+    if !data_path.is_empty() {
+        result_string = result_string.replace(&data_path, "TEMPFILE");
+    }
     assert!(!result_string.is_empty());
-
     writeln!(
         output,
         "\ntask {} '{}'. lines {}-{}:\n{}",


### PR DESCRIPTION
Fix Issue 6907: A verifier failure related to inline functions

### Description

- provide 2 test cases related to Gerben's bug:
  - gerbens_test.move: ICE in hlir/translate.rs if lambda is provided to unknown or non-inline
  - gerbens_test1.move: byte verifier error when (&mut vector) actual is passed to (&vector) param
- fix both errors:
  - generate a useful diagnostic error instead of the ICE
  - retain formal parameter types when inlining, but also
    - substitute all type parameters appropriately in them

### Test Plan
Added test cases to illustrate bug.  Any collateral damage should show up in existing test cases.

### Fixes
https://github.com/aptos-labs/aptos-core/issues/6907
