### PR TITLE
[CLI][Openssl] Update CLI script and documentation to include openssl3

### DIFF
--- a/developer-docs-site/docs/tools/aptos-cli/install-cli/download-cli-binaries.md
+++ b/developer-docs-site/docs/tools/aptos-cli/install-cli/download-cli-binaries.md
@@ -35,6 +35,27 @@ These instructions have been tested on macOS Monterey (12.6)
 1. Follow the simple steps recommended by the Apple support in [Open a Mac app from an unidentified developer](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac) to remove the "unknown developer" blocker.
 1. Type `~/bin/aptos help` to read help instructions.
 1. Add `~/bin` to your path in your `.bashrc` or `.zshrc` file for future use.
+1. Run `aptos help` to see the list of commands.
+
+Note: If you encounter an error message like the following. You will need to manually install `openssl3`.
+```
+dyld[81095]: Library not loaded: /usr/local/opt/openssl@3/lib/libssl.3.dylib
+  Referenced from: <56FDDCBF-43F4-381E-9ECA-ACEBC556EAB7> /Users/jinhou/.local/bin/aptos
+  Reason: tried: '/usr/local/opt/openssl@3/lib/libssl.3.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/opt/openssl@3/lib/libssl.3.dylib' (no such file), '/usr/local/opt/openssl@3/lib/libssl.3.dylib' (no such file), '/usr/local/lib/libssl.3.dylib' (no such file), '/usr/lib/libssl.3.dylib' (no such file, not in dyld cache)
+[1]    81095 abort      aptos
+```
+
+Install `openssl3` with the following command:
+1. Download latest version from https://www.openssl.org/source/
+2. Unzip the downloaded file
+3. `cd` into the unzipped folder e.g. `cd openssl-3.1.2`
+4. Run `./config --prefix /usr/local darwin64-x86_64-cc` configure openssl3
+5. Run `make` to build openssl3
+6. Run `sudo make install` to install openssl3. Notice that `sudo` is required to install openssl3 to `/usr/local` folder.
+7. Run `openssl version` to verify the installation. You should see something similar to the following output:
+```
+OpenSSL 3.1.2 1 Aug 2023
+```
 
 </details>
 


### PR DESCRIPTION
### Description

Updated the CLI script to install `openssl3` when running from `macos` and out-dated openssl

Basically pull down the binary from openssl site and run configure/make/install. TBH I am not sure if this is really the experience we want. installing openssl from source takes a long time, and user will see MANY things updated/installed on their terminal. (If you ask me, it almost looks like the terminal got hacked)

NOTE: I did a check to see if `brew` installed before hand, because IMO user should not use the script to install CLI when they already have `brew` installed. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

I removed the check for brew, and make sure the script runs on my mac. After everything ran. Aptos CLI works

```
...
...
install doc/html/man7/provider-keyexch.html -> /usr/local/share/doc/openssl/html/man7/provider-keyexch.html
install doc/html/man7/provider-keymgmt.html -> /usr/local/share/doc/openssl/html/man7/provider-keymgmt.html
install doc/html/man7/provider-mac.html -> /usr/local/share/doc/openssl/html/man7/provider-mac.html
install doc/html/man7/provider-object.html -> /usr/local/share/doc/openssl/html/man7/provider-object.html
install doc/html/man7/provider-rand.html -> /usr/local/share/doc/openssl/html/man7/provider-rand.html
install doc/html/man7/provider-signature.html -> /usr/local/share/doc/openssl/html/man7/provider-signature.html
install doc/html/man7/provider-storemgmt.html -> /usr/local/share/doc/openssl/html/man7/provider-storemgmt.html
install doc/html/man7/provider.html -> /usr/local/share/doc/openssl/html/man7/provider.html
install doc/html/man7/proxy-certificates.html -> /usr/local/share/doc/openssl/html/man7/proxy-certificates.html
install doc/html/man7/ssl.html -> /usr/local/share/doc/openssl/html/man7/ssl.html
install doc/html/man7/x509.html -> /usr/local/share/doc/openssl/html/man7/x509.html
OpenSSL3 installed successfully!
Determined target to be: MacOSX-x86_64

Welcome to the Aptos CLI installer!

This will download and install the latest version of the Aptos CLI at this location:

/Users/jinhou/.local/bin

Installing Aptos CLI (2.1.0): Downloading...
Installing Aptos CLI (2.1.0): Done!

The Aptos CLI (2.1.0) is installed now. Great!

You can test that everything is set up by executing this command:

aptos info

➜  aptos-core git:(main) ✗ aptos
Command Line Interface (CLI) for developing and interacting with the Aptos blockchain

Usage: aptos <COMMAND>

Commands:
  account     Tool for interacting with accounts
  config      Tool for interacting with configuration of the Aptos CLI tool
  genesis     Tool for setting up an Aptos chain Genesis transaction
  governance  Tool for on-chain governance
  info        Show build information about the CLI
  init        Tool to initialize current directory for the aptos tool
  key         Tool for generating, inspecting, and interacting with keys
  move        Tool for Move related operations
  multisig    Tool for interacting with multisig accounts
  node        Tool for operations related to nodes
  stake       Tool for manipulating stake and stake pools
  update      Update the CLI itself
  help        Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```
