### PR TITLE
[BlockSTM] Value exchange infrastructure on reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,6 +585,7 @@ dependencies = [
  "itertools",
  "move-binary-format",
  "move-core-types",
+ "move-vm-types",
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.1",

--- a/aptos-move/block-executor/Cargo.toml
+++ b/aptos-move/block-executor/Cargo.toml
@@ -30,6 +30,7 @@ crossbeam = { workspace = true }
 dashmap = { workspace = true }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
+move-vm-types = { workspace = true }
 num_cpus = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }

--- a/aptos-move/block-executor/src/lib.rs
+++ b/aptos-move/block-executor/src/lib.rs
@@ -139,6 +139,7 @@ subsequent incarnation to finish.
 pub mod counters;
 pub mod errors;
 pub mod executor;
+mod liftings;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
 mod scheduler;

--- a/aptos-move/block-executor/src/liftings.rs
+++ b/aptos-move/block-executor/src/liftings.rs
@@ -1,6 +1,13 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+//! Implementation of sync and unsync versions of data structures which are used
+//! to process aggregator liftings.
+//!
+//! Both have:
+//!   1. A counter used to generate a new unique (per-block) identifier.
+//!   2. A map from identifiers to lifted Move values.
+
 use dashmap::{mapref::one::Ref, DashMap};
 use move_vm_types::values::Value;
 use std::{

--- a/aptos-move/block-executor/src/liftings.rs
+++ b/aptos-move/block-executor/src/liftings.rs
@@ -1,0 +1,58 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use dashmap::{mapref::one::Ref, DashMap};
+use move_vm_types::values::Value;
+use std::{
+    collections::HashMap,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+pub(crate) struct UnsyncLiftings {
+    counter: u64,
+    lifted_values: HashMap<u64, Value>,
+}
+
+impl UnsyncLiftings {
+    pub(crate) fn new(counter: u64) -> Self {
+        Self {
+            counter,
+            lifted_values: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn insert(&mut self, value: Value) -> u64 {
+        let identifier = self.counter;
+        self.lifted_values.insert(identifier, value);
+        self.counter += 1;
+        identifier
+    }
+
+    pub(crate) fn get(&self, identifier: u64) -> Option<&Value> {
+        self.lifted_values.get(&identifier)
+    }
+}
+
+pub(crate) struct SyncLiftings<'a> {
+    counter: &'a AtomicU64,
+    lifted_values: DashMap<u64, Value>,
+}
+
+impl<'a> SyncLiftings<'a> {
+    pub(crate) fn new(shared_counter: &'a AtomicU64) -> Self {
+        Self {
+            counter: shared_counter,
+            lifted_values: DashMap::new(),
+        }
+    }
+
+    pub(crate) fn insert(&self, value: Value) -> u64 {
+        let identifier = self.counter.fetch_add(1, Ordering::SeqCst);
+        self.lifted_values.insert(identifier, value);
+        identifier
+    }
+
+    pub(crate) fn get(&self, identifier: u64) -> Option<Ref<u64, Value>> {
+        self.lifted_values.get(&identifier)
+    }
+}

--- a/aptos-move/block-executor/src/liftings.rs
+++ b/aptos-move/block-executor/src/liftings.rs
@@ -21,6 +21,13 @@ impl UnsyncLiftings {
         }
     }
 
+    #[allow(unused)]
+    pub(crate) fn increment(&mut self) -> u64 {
+        let value = self.counter;
+        self.counter += 1;
+        value
+    }
+
     pub(crate) fn insert(&mut self, value: Value) -> u64 {
         let identifier = self.counter;
         self.lifted_values.insert(identifier, value);
@@ -44,6 +51,11 @@ impl<'a> SyncLiftings<'a> {
             counter: shared_counter,
             lifted_values: DashMap::new(),
         }
+    }
+
+    #[allow(unused)]
+    pub(crate) fn increment(&self) -> u64 {
+        self.counter.fetch_add(1, Ordering::SeqCst)
     }
 
     pub(crate) fn insert(&self, value: Value) -> u64 {

--- a/types/src/state_store/state_value.rs
+++ b/types/src/state_store/state_value.rs
@@ -160,6 +160,8 @@ impl StateValue {
         }
     }
 
+    /// Applies a bytes-to-bytes transformation on the state value contents,
+    /// leaving the state value metadata untouched.
     pub fn try_transform_bytes<F: FnOnce(Vec<u8>) -> anyhow::Result<Vec<u8>>>(
         self,
         f: F,

--- a/types/src/state_store/state_value.rs
+++ b/types/src/state_store/state_value.rs
@@ -159,6 +159,19 @@ impl StateValue {
             StateValueInner::WithMetadata { metadata, .. } => Some(metadata),
         }
     }
+
+    pub fn try_transform_bytes<F: FnOnce(Vec<u8>) -> anyhow::Result<Vec<u8>>>(
+        self,
+        f: F,
+    ) -> anyhow::Result<StateValue> {
+        Ok(StateValue::new_impl(match self.inner {
+            StateValueInner::V0(data) => StateValueInner::V0(f(data)?),
+            StateValueInner::WithMetadata { data, metadata } => StateValueInner::WithMetadata {
+                data: f(data)?,
+                metadata,
+            },
+        }))
+    }
 }
 
 #[cfg(any(test, feature = "fuzzing"))]


### PR DESCRIPTION
Implementation of value exchange for reading. Note that it
is not connected to resolvers because the move type layout
is not propagated to the BlockSTM yet.

- [ ] add tests? 
