### PR TITLE
[VM] Expose WriteOpConverter

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -261,6 +261,10 @@ impl AptosVM {
         )
     }
 
+    pub(crate) fn is_storage_slot_metadata_enabled(&self) -> bool {
+        self.0.get_features().is_storage_slot_metadata_enabled()
+    }
+
     fn fee_statement_from_gas_meter(
         txn_data: &TransactionMetadata,
         gas_meter: &impl AptosGasMeter,

--- a/aptos-move/aptos-vm/src/move_vm_ext/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/mod.rs
@@ -7,6 +7,7 @@ mod resolver;
 mod respawned_session;
 mod session;
 mod vm;
+pub(crate) mod write_op_converter;
 
 pub use crate::move_vm_ext::{
     resolver::{AptosMoveResolver, MoveResolverExt, StateValueMetadataResolver},

--- a/aptos-move/aptos-vm/src/move_vm_ext/write_op_converter.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/write_op_converter.rs
@@ -1,0 +1,136 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::move_vm_ext::AptosMoveResolver;
+use aptos_aggregator::delta_change_set::serialize;
+use aptos_types::{
+    on_chain_config::{CurrentTimeMicroseconds, OnChainConfig},
+    state_store::{state_key::StateKey, state_value::StateValueMetadata},
+    write_set::WriteOp,
+};
+use move_core_types::{
+    effects::Op as MoveStorageOp,
+    vm_status::{err_msg, StatusCode, VMStatus},
+};
+
+pub(crate) struct WriteOpConverter<'r> {
+    remote: &'r dyn AptosMoveResolver,
+    new_slot_metadata: Option<StateValueMetadata>,
+}
+
+impl<'r> WriteOpConverter<'r> {
+    pub(crate) fn new(
+        remote: &'r dyn AptosMoveResolver,
+        is_storage_slot_metadata_enabled: bool,
+    ) -> Self {
+        let mut new_slot_metadata: Option<StateValueMetadata> = None;
+        if is_storage_slot_metadata_enabled {
+            if let Some(current_time) = CurrentTimeMicroseconds::fetch_config(remote) {
+                // The deposit on the metadata is a placeholder (0), it will be updated later when
+                // storage fee is charged.
+                new_slot_metadata = Some(StateValueMetadata::new(0, &current_time));
+            }
+        }
+
+        Self {
+            remote,
+            new_slot_metadata,
+        }
+    }
+
+    pub(crate) fn convert(
+        &self,
+        state_key: &StateKey,
+        move_storage_op: MoveStorageOp<Vec<u8>>,
+        legacy_creation_as_modification: bool,
+    ) -> Result<WriteOp, VMStatus> {
+        use MoveStorageOp::*;
+        use WriteOp::*;
+
+        let maybe_existing_metadata =
+            self.remote
+                .get_state_value_metadata(state_key)
+                .map_err(|_| {
+                    VMStatus::error(
+                        StatusCode::STORAGE_ERROR,
+                        err_msg("Storage read failed when converting change set."),
+                    )
+                })?;
+
+        let write_op = match (maybe_existing_metadata, move_storage_op) {
+            (None, Modify(_) | Delete) => {
+                return Err(VMStatus::error(
+                    // Possible under speculative execution, returning storage error waiting for re-execution
+                    StatusCode::STORAGE_ERROR,
+                    err_msg("When converting write op: updating non-existent value."),
+                ));
+            },
+            (Some(_), New(_)) => {
+                return Err(VMStatus::error(
+                    // Possible under speculative execution, returning storage error waiting for re-execution
+                    StatusCode::STORAGE_ERROR,
+                    err_msg("When converting write op: Recreating existing value."),
+                ));
+            },
+            (None, New(data)) => match &self.new_slot_metadata {
+                None => {
+                    if legacy_creation_as_modification {
+                        Modification(data)
+                    } else {
+                        Creation(data)
+                    }
+                },
+                Some(metadata) => CreationWithMetadata {
+                    data,
+                    metadata: metadata.clone(),
+                },
+            },
+            (Some(existing_metadata), Modify(data)) => {
+                // Inherit metadata even if the feature flags is turned off, for compatibility.
+                match existing_metadata {
+                    None => Modification(data),
+                    Some(metadata) => ModificationWithMetadata { data, metadata },
+                }
+            },
+            (Some(existing_metadata), Delete) => {
+                // Inherit metadata even if the feature flags is turned off, for compatibility.
+                match existing_metadata {
+                    None => Deletion,
+                    Some(metadata) => DeletionWithMetadata { metadata },
+                }
+            },
+        };
+        Ok(write_op)
+    }
+
+    pub(crate) fn convert_aggregator_mod(
+        &self,
+        state_key: &StateKey,
+        value: u128,
+    ) -> Result<WriteOp, VMStatus> {
+        let maybe_existing_metadata = self
+            .remote
+            .get_state_value_metadata(state_key)
+            .map_err(|_| VMStatus::error(StatusCode::STORAGE_ERROR, None))?;
+        let data = serialize(&value);
+
+        let op = match maybe_existing_metadata {
+            None => {
+                match &self.new_slot_metadata {
+                    // n.b. Aggregator writes historically did not distinguish Create vs Modify.
+                    None => WriteOp::Modification(data),
+                    Some(metadata) => WriteOp::CreationWithMetadata {
+                        data,
+                        metadata: metadata.clone(),
+                    },
+                }
+            },
+            Some(existing_metadata) => match existing_metadata {
+                None => WriteOp::Modification(data),
+                Some(metadata) => WriteOp::ModificationWithMetadata { data, metadata },
+            },
+        };
+
+        Ok(op)
+    }
+}

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -550,6 +550,16 @@ where
             MockTransaction::Abort => ExecutionStatus::Abort(txn_idx as usize),
         }
     }
+
+    fn convert_to_value(
+        &self,
+        _view: &impl TStateView<Key = K>,
+        _key: &K,
+        _maybe_blob: Option<Vec<u8>>,
+        _creation: bool,
+    ) -> anyhow::Result<V> {
+        unimplemented!("TODO: implement for AggregatorV2 testing");
+    }
 }
 
 #[derive(Debug)]

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -67,6 +67,15 @@ pub trait ExecutorTask: Sync {
         txn_idx: TxnIndex,
         materialize_deltas: bool,
     ) -> ExecutionStatus<Self::Output, Self::Error>;
+
+    /// Trait that allows converting blobs to proper values.
+    fn convert_to_value(
+        &self,
+        view: &impl TStateView<Key = <Self::Txn as Transaction>::Key>,
+        key: &<Self::Txn as Transaction>::Key,
+        maybe_blob: Option<Vec<u8>>,
+        creation: bool,
+    ) -> anyhow::Result<<Self::Txn as Transaction>::Value>;
 }
 
 /// Trait for execution result of a single transaction.


### PR DESCRIPTION
Need to expose WriteOpConverter in order to prepare proper write-ops (with the beautiful storage metadata) from block executor. This will be required for proper resource group handling (as they are now combined in block executor and need to be converted to a WriteOp), which in turn is required for AggregatorV2 (among other benefits).