### PR TITLE
[dag] dag rebootstrap

### DIFF
--- a/consensus/src/dag/adapter.rs
+++ b/consensus/src/dag/adapter.rs
@@ -31,9 +31,9 @@ use futures_channel::mpsc::UnboundedSender;
 use std::{collections::HashMap, sync::Arc};
 
 #[async_trait]
-pub trait Notifier: Send {
+pub trait Notifier: Send + Sync {
     fn send_ordered_nodes(
-        &mut self,
+        &self,
         ordered_nodes: Vec<Arc<CertifiedNode>>,
         failed_author: Vec<(Round, Author)>,
     ) -> anyhow::Result<()>;
@@ -62,7 +62,7 @@ impl NotifierAdapter {
 #[async_trait]
 impl Notifier for NotifierAdapter {
     fn send_ordered_nodes(
-        &mut self,
+        &self,
         ordered_nodes: Vec<Arc<CertifiedNode>>,
         failed_author: Vec<(Round, Author)>,
     ) -> anyhow::Result<()> {

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -16,7 +16,7 @@ use super::{
 };
 use crate::{
     dag::{adapter::NotifierAdapter, dag_fetcher::DagFetcher},
-    experimental::{buffer_manager::OrderedBlocks, commit_reliable_broadcast::DropGuard},
+    experimental::buffer_manager::OrderedBlocks,
     network::IncomingDAGRequest,
     state_replication::{PayloadClient, StateComputer},
 };
@@ -35,10 +35,6 @@ use aptos_types::{
     epoch_state::EpochState,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     validator_signer::ValidatorSigner,
-};
-use futures::{
-    stream::{AbortHandle, Abortable},
-    FutureExt, StreamExt,
 };
 use futures_channel::{
     mpsc::{UnboundedReceiver, UnboundedSender},

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -46,7 +46,7 @@ use tokio_retry::strategy::ExponentialBackoff;
 
 struct DagBootstrapper {
     self_peer: Author,
-    signer: ValidatorSigner,
+    signer: Arc<ValidatorSigner>,
     epoch_state: Arc<EpochState>,
     storage: Arc<dyn DAGStorage>,
     rb_network_sender: Arc<dyn RBNetworkSender<DAGMessage>>,
@@ -59,7 +59,7 @@ struct DagBootstrapper {
 impl DagBootstrapper {
     fn new(
         self_peer: Author,
-        signer: ValidatorSigner,
+        signer: Arc<ValidatorSigner>,
         epoch_state: Arc<EpochState>,
         storage: Arc<dyn DAGStorage>,
         rb_network_sender: Arc<dyn RBNetworkSender<DAGMessage>>,
@@ -244,7 +244,7 @@ pub(super) fn bootstrap_dag_for_test(
 ) {
     let bootstraper = DagBootstrapper::new(
         self_peer,
-        signer,
+        signer.into(),
         epoch_state,
         storage.clone(),
         rb_network_sender,

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -1,12 +1,13 @@
 // Copyright © Aptos Foundation
 
 use super::{
+    adapter::Notifier,
     anchor_election::RoundRobinAnchorElection,
     dag_driver::DagDriver,
     dag_fetcher::{DagFetcherService, FetchRequestHandler},
     dag_handler::NetworkHandler,
     dag_network::TDAGNetworkSender,
-    dag_state_sync::DAG_WINDOW,
+    dag_state_sync::{DagStateSynchronizer, StateSyncTrigger, DAG_WINDOW},
     dag_store::Dag,
     order_rule::OrderRule,
     rb_handler::NodeBroadcastHandler,
@@ -14,21 +15,233 @@ use super::{
     types::DAGMessage,
 };
 use crate::{
-    dag::adapter::NotifierAdapter, experimental::buffer_manager::OrderedBlocks,
-    network::IncomingDAGRequest, state_replication::PayloadClient,
+    dag::{adapter::NotifierAdapter, dag_fetcher::DagFetcher},
+    experimental::buffer_manager::OrderedBlocks,
+    network::IncomingDAGRequest,
+    state_replication::{PayloadClient, StateComputer},
 };
-use aptos_channels::{aptos_channel, message_queues::QueueStyle};
-use aptos_consensus_types::common::Author;
+use aptos_channels::{
+    aptos_channel::{self, Receiver},
+    message_queues::QueueStyle,
+};
+use aptos_consensus_types::common::{Author, Round};
+use aptos_crypto::HashValue;
 use aptos_infallible::RwLock;
+use aptos_logger::error;
 use aptos_reliable_broadcast::{RBNetworkSender, ReliableBroadcast};
 use aptos_types::{
-    epoch_state::EpochState, ledger_info::LedgerInfo, validator_signer::ValidatorSigner,
+    aggregate_signature::AggregateSignature,
+    block_info::BlockInfo,
+    epoch_state::EpochState,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    validator_signer::ValidatorSigner,
 };
-use futures::stream::{AbortHandle, Abortable};
+use futures::{FutureExt, StreamExt};
+use futures_channel::{
+    mpsc::{UnboundedReceiver, UnboundedSender},
+    oneshot,
+};
 use std::{sync::Arc, time::Duration};
+use tokio::{select, task::JoinHandle};
 use tokio_retry::strategy::ExponentialBackoff;
 
-pub fn bootstrap_dag(
+struct DagBootstrapper {
+    self_peer: Author,
+    signer: ValidatorSigner,
+    epoch_state: Arc<EpochState>,
+    storage: Arc<dyn DAGStorage>,
+    rb_network_sender: Arc<dyn RBNetworkSender<DAGMessage>>,
+    dag_network_sender: Arc<dyn TDAGNetworkSender>,
+    time_service: aptos_time_service::TimeService,
+    payload_client: Arc<dyn PayloadClient>,
+    state_computer: Arc<dyn StateComputer>,
+}
+
+impl DagBootstrapper {
+    fn new(
+        self_peer: Author,
+        signer: ValidatorSigner,
+        epoch_state: Arc<EpochState>,
+        storage: Arc<dyn DAGStorage>,
+        rb_network_sender: Arc<dyn RBNetworkSender<DAGMessage>>,
+        dag_network_sender: Arc<dyn TDAGNetworkSender>,
+        time_service: aptos_time_service::TimeService,
+        payload_client: Arc<dyn PayloadClient>,
+        state_computer: Arc<dyn StateComputer>,
+    ) -> Self {
+        Self {
+            self_peer,
+            signer,
+            epoch_state,
+            storage,
+            rb_network_sender,
+            dag_network_sender,
+            time_service,
+            payload_client,
+            state_computer,
+        }
+    }
+
+    fn bootstrap_dag_store(
+        &self,
+        initial_round: Round,
+        latest_ledger_info: LedgerInfo,
+        notifier: Arc<dyn Notifier>,
+    ) -> (Arc<RwLock<Dag>>, OrderRule) {
+        let dag = Arc::new(RwLock::new(Dag::new(
+            self.epoch_state.clone(),
+            self.storage.clone(),
+            initial_round,
+            DAG_WINDOW,
+        )));
+
+        let validators = self.epoch_state.verifier.get_ordered_account_addresses();
+        let anchor_election = Box::new(RoundRobinAnchorElection::new(validators));
+
+        let order_rule = OrderRule::new(
+            self.epoch_state.clone(),
+            latest_ledger_info,
+            dag.clone(),
+            anchor_election,
+            notifier,
+            self.storage.clone(),
+        );
+
+        (dag, order_rule)
+    }
+
+    fn bootstrap_components(
+        &self,
+        dag: Arc<RwLock<Dag>>,
+        order_rule: OrderRule,
+        state_sync_trigger: StateSyncTrigger,
+    ) -> (NetworkHandler, DagFetcherService) {
+        let validators = self.epoch_state.verifier.get_ordered_account_addresses();
+
+        // A backoff policy that starts at 100ms and doubles each iteration.
+        let rb_backoff_policy = ExponentialBackoff::from_millis(2).factor(50);
+        let rb = Arc::new(ReliableBroadcast::new(
+            validators.clone(),
+            self.rb_network_sender.clone(),
+            rb_backoff_policy,
+            self.time_service.clone(),
+            // TODO: add to config
+            Duration::from_millis(500),
+        ));
+
+        let (dag_fetcher, fetch_requester, node_fetch_waiter, certified_node_fetch_waiter) =
+            DagFetcherService::new(
+                self.epoch_state.clone(),
+                self.dag_network_sender.clone(),
+                dag.clone(),
+                self.time_service.clone(),
+            );
+        let fetch_requester = Arc::new(fetch_requester);
+
+        let dag_driver = DagDriver::new(
+            self.self_peer,
+            self.epoch_state.clone(),
+            dag.clone(),
+            self.payload_client.clone(),
+            rb,
+            self.time_service.clone(),
+            self.storage.clone(),
+            order_rule,
+            fetch_requester.clone(),
+        );
+        let rb_handler = NodeBroadcastHandler::new(
+            dag.clone(),
+            self.signer.clone(),
+            self.epoch_state.clone(),
+            self.storage.clone(),
+            fetch_requester,
+        );
+        let fetch_handler = FetchRequestHandler::new(dag, self.epoch_state.clone());
+
+        let dag_handler = NetworkHandler::new(
+            self.epoch_state.clone(),
+            rb_handler,
+            dag_driver,
+            fetch_handler,
+            node_fetch_waiter,
+            certified_node_fetch_waiter,
+            state_sync_trigger,
+        );
+
+        (dag_handler, dag_fetcher)
+    }
+
+    async fn bootstrapper(
+        self,
+        mut dag_rpc_rx: Receiver<Author, IncomingDAGRequest>,
+        ordered_nodes_tx: UnboundedSender<OrderedBlocks>,
+        shutdown_rx: oneshot::Receiver<()>,
+    ) -> anyhow::Result<()> {
+        let adapter = Arc::new(NotifierAdapter::new(
+            ordered_nodes_tx,
+            self.storage.clone(),
+        ));
+
+        let sync_manager = DagStateSynchronizer::new(
+            self.epoch_state.clone(),
+            adapter.clone(),
+            self.time_service.clone(),
+            self.state_computer.clone(),
+            self.storage.clone(),
+        );
+
+        // TODO: fetch the correct block info
+        let ledger_info = LedgerInfoWithSignatures::new(
+            LedgerInfo::new(BlockInfo::empty(), HashValue::zero()),
+            AggregateSignature::empty(),
+        );
+
+        let mut shutdown_rx = shutdown_rx.into_stream();
+
+        loop {
+            let (rebootstrap_notification_tx, mut rebootstrap_notification_rx) =
+                tokio::sync::mpsc::channel(1);
+
+            // TODO: fix
+            let (dag_store, order_rule) =
+                self.bootstrap_dag_store(0, ledger_info.ledger_info().clone(), adapter.clone());
+
+            let state_sync_trigger = StateSyncTrigger::new(
+                dag_store.clone(),
+                adapter.clone(),
+                rebootstrap_notification_tx,
+            );
+
+            let (handler, fetch_service) =
+                self.bootstrap_components(dag_store.clone(), order_rule, state_sync_trigger);
+
+            let df_handle = tokio::spawn(fetch_service.start());
+
+            // poll the network handler while waiting for rebootstrap notification or shutdown notification
+            select! {
+                biased;
+                _ = shutdown_rx.select_next_some() => {
+                    df_handle.abort();
+                    let _ = df_handle.await;
+                    return Ok(());
+                },
+                Some(node) = rebootstrap_notification_rx.recv() => {
+                    df_handle.abort();
+                    let _ = df_handle.await;
+
+                    let dag_fetcher = DagFetcher::new(self.epoch_state.clone(), self.dag_network_sender.clone(), self.time_service.clone());
+
+                    if let Err(e) = sync_manager.sync_dag_to(&node, dag_fetcher, dag_store.clone()).await {
+                        error!(error = ?e, "unable to sync");
+                    }
+                },
+                _ = handler.start(&mut dag_rpc_rx) => {}
+            }
+        }
+    }
+}
+
+pub(super) fn bootstrap_dag_for_test(
     self_peer: Author,
     signer: ValidatorSigner,
     epoch_state: Arc<EpochState>,
@@ -38,96 +251,46 @@ pub fn bootstrap_dag(
     dag_network_sender: Arc<dyn TDAGNetworkSender>,
     time_service: aptos_time_service::TimeService,
     payload_client: Arc<dyn PayloadClient>,
+    state_computer: Arc<dyn StateComputer>,
 ) -> (
-    AbortHandle,
-    AbortHandle,
+    JoinHandle<()>,
+    JoinHandle<()>,
     aptos_channel::Sender<Author, IncomingDAGRequest>,
-    futures_channel::mpsc::UnboundedReceiver<OrderedBlocks>,
+    UnboundedReceiver<OrderedBlocks>,
 ) {
-    let validators = epoch_state.verifier.get_ordered_account_addresses();
-    let current_round = latest_ledger_info.round();
+    let bootstraper = DagBootstrapper::new(
+        self_peer,
+        signer,
+        epoch_state,
+        storage.clone(),
+        rb_network_sender,
+        dag_network_sender,
+        time_service,
+        payload_client,
+        state_computer,
+    );
 
     let (ordered_nodes_tx, ordered_nodes_rx) = futures_channel::mpsc::unbounded();
-    let adapter = Box::new(NotifierAdapter::new(ordered_nodes_tx, storage.clone()));
-    let (dag_rpc_tx, dag_rpc_rx) = aptos_channel::new(QueueStyle::FIFO, 64, None);
+    let adapter = Arc::new(NotifierAdapter::new(ordered_nodes_tx, storage.clone()));
+    let (dag_rpc_tx, mut dag_rpc_rx) = aptos_channel::new(QueueStyle::FIFO, 64, None);
+    let (rebootstrap_notification_tx, _rebootstrap_notification_rx) = tokio::sync::mpsc::channel(1);
 
-    // A backoff policy that starts at 100ms and doubles each iteration.
-    let rb_backoff_policy = ExponentialBackoff::from_millis(2).factor(50);
-    let rb = Arc::new(ReliableBroadcast::new(
-        validators.clone(),
-        rb_network_sender,
-        rb_backoff_policy,
-        time_service.clone(),
-        // TODO: add to config
-        Duration::from_millis(500),
-    ));
+    let (dag_store, order_rule) =
+        bootstraper.bootstrap_dag_store(0, latest_ledger_info, adapter.clone());
 
-    let dag = Arc::new(RwLock::new(Dag::new(
-        epoch_state.clone(),
-        storage.clone(),
-        current_round,
-        DAG_WINDOW,
-    )));
-
-    let anchor_election = Box::new(RoundRobinAnchorElection::new(validators));
-    let order_rule = OrderRule::new(
-        epoch_state.clone(),
-        latest_ledger_info,
-        dag.clone(),
-        anchor_election,
-        adapter,
-        storage.clone(),
+    let state_sync_trigger = StateSyncTrigger::new(
+        dag_store.clone(),
+        adapter.clone(),
+        rebootstrap_notification_tx,
     );
 
-    let (dag_fetcher, fetch_requester, node_fetch_waiter, certified_node_fetch_waiter) =
-        DagFetcherService::new(
-            epoch_state.clone(),
-            dag_network_sender,
-            dag.clone(),
-            time_service.clone(),
-        );
-    let fetch_requester = Arc::new(fetch_requester);
+    let (handler, fetch_service) =
+        bootstraper.bootstrap_components(dag_store.clone(), order_rule, state_sync_trigger);
 
-    let dag_driver = DagDriver::new(
-        self_peer,
-        epoch_state.clone(),
-        dag.clone(),
-        payload_client,
-        rb,
-        time_service,
-        storage.clone(),
-        order_rule,
-        fetch_requester.clone(),
-    );
-    let rb_handler = NodeBroadcastHandler::new(
-        dag.clone(),
-        signer,
-        epoch_state.clone(),
-        storage.clone(),
-        fetch_requester,
-    );
-    let fetch_handler = FetchRequestHandler::new(dag, epoch_state.clone());
+    let dh_handle = tokio::spawn(async move {
+        handler.start(&mut dag_rpc_rx).await
+    });
+    let df_handle = tokio::spawn(fetch_service.start());
 
-    let dag_handler = NetworkHandler::new(
-        epoch_state,
-        dag_rpc_rx,
-        rb_handler,
-        dag_driver,
-        fetch_handler,
-        node_fetch_waiter,
-        certified_node_fetch_waiter,
-    );
-
-    let (nh_abort_handle, nh_abort_registration) = AbortHandle::new_pair();
-    let (df_abort_handle, df_abort_registration) = AbortHandle::new_pair();
-
-    tokio::spawn(Abortable::new(dag_handler.start(), nh_abort_registration));
-    tokio::spawn(Abortable::new(dag_fetcher.start(), df_abort_registration));
-
-    (
-        nh_abort_handle,
-        df_abort_handle,
-        dag_rpc_tx,
-        ordered_nodes_rx,
-    )
+    (dh_handle, df_handle, dag_rpc_tx, ordered_nodes_rx)
 }

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -23,10 +23,8 @@ use aptos_logger::error;
 use aptos_reliable_broadcast::ReliableBroadcast;
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::{
-    aggregate_signature::AggregateSignature,
-    block_info::{BlockInfo, Round},
+    block_info::{Round},
     epoch_state::EpochState,
-    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
 };
 use futures::{
     future::{AbortHandle, Abortable},

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -22,7 +22,12 @@ use aptos_infallible::RwLock;
 use aptos_logger::error;
 use aptos_reliable_broadcast::ReliableBroadcast;
 use aptos_time_service::{TimeService, TimeServiceTrait};
-use aptos_types::{block_info::Round, epoch_state::EpochState};
+use aptos_types::{
+    aggregate_signature::AggregateSignature,
+    block_info::{BlockInfo, Round},
+    epoch_state::EpochState,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+};
 use futures::{
     future::{AbortHandle, Abortable},
     FutureExt,
@@ -160,7 +165,6 @@ impl DagDriver {
             .broadcast(node.clone(), signature_builder)
             .then(move |certificate| {
                 let certified_node = CertifiedNode::new(node, certificate.signatures().to_owned());
-
                 let certified_node_msg =
                     CertifiedNodeMessage::new(certified_node, latest_ledger_info);
                 rb.broadcast(certified_node_msg, cert_ack_set)

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -22,10 +22,7 @@ use aptos_infallible::RwLock;
 use aptos_logger::error;
 use aptos_reliable_broadcast::ReliableBroadcast;
 use aptos_time_service::{TimeService, TimeServiceTrait};
-use aptos_types::{
-    block_info::{Round},
-    epoch_state::EpochState,
-};
+use aptos_types::{block_info::Round, epoch_state::EpochState};
 use futures::{
     future::{AbortHandle, Abortable},
     FutureExt,

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -96,7 +96,7 @@ impl NetworkHandler {
                 .map(|r| r.into()),
             DAGMessage::CertifiedNodeMsg(node) => match node.verify(&self.epoch_state.verifier) {
                 Ok(_) => {
-                    let node = self.state_sync_trigger.check(node).await;
+                    let node = self.state_sync_trigger.check(node).await
                     self.dag_driver
                         .process(node.certified_node())
                         .map(|r| r.into())

--- a/consensus/src/dag/dag_state_sync.rs
+++ b/consensus/src/dag/dag_state_sync.rs
@@ -2,11 +2,10 @@
 
 use super::{
     adapter::Notifier,
-    dag_fetcher::{DagFetcher, TDagFetcher},
+    dag_fetcher::TDagFetcher,
     dag_store::Dag,
     storage::DAGStorage,
     types::{CertifiedNodeMessage, RemoteFetchRequest},
-    TDAGNetworkSender,
 };
 use crate::state_replication::StateComputer;
 use aptos_consensus_types::common::Round;
@@ -24,66 +23,64 @@ use std::sync::Arc;
 pub const DAG_WINDOW: usize = 1;
 pub const STATE_SYNC_WINDOW_MULTIPLIER: usize = 30;
 
-pub(super) struct StateSyncManager {
-    epoch_state: Arc<EpochState>,
-    network: Arc<dyn TDAGNetworkSender>,
-    notifier: Arc<dyn Notifier>,
-    time_service: TimeService,
-    state_computer: Arc<dyn StateComputer>,
-    storage: Arc<dyn DAGStorage>,
+pub(super) struct StateSyncTrigger {
     dag_store: Arc<RwLock<Dag>>,
+    downstream_notifier: Arc<dyn Notifier>,
+    bootstrap_notifier: tokio::sync::mpsc::Sender<CertifiedNodeMessage>,
 }
 
-impl StateSyncManager {
-    pub fn new(
-        epoch_state: Arc<EpochState>,
-        network: Arc<dyn TDAGNetworkSender>,
-        notifier: Arc<dyn Notifier>,
-        time_service: TimeService,
-        state_computer: Arc<dyn StateComputer>,
-        storage: Arc<dyn DAGStorage>,
+impl StateSyncTrigger {
+    pub(super) fn new(
         dag_store: Arc<RwLock<Dag>>,
+        downstream_notifier: Arc<dyn Notifier>,
+        bootstrap_notifier: tokio::sync::mpsc::Sender<CertifiedNodeMessage>,
     ) -> Self {
         Self {
-            epoch_state,
-            network,
-            notifier,
-            time_service,
-            state_computer,
-            storage,
             dag_store,
+            downstream_notifier,
+            bootstrap_notifier,
         }
     }
 
-    pub async fn sync_to(
-        &self,
-        node: &CertifiedNodeMessage,
-    ) -> anyhow::Result<Option<Arc<RwLock<Dag>>>> {
-        self.sync_to_highest_commit_cert(node.ledger_info()).await;
-        self.try_sync_to_highest_ordered_anchor(node).await
+    /// This method checks if a state sync is required, and if so,
+    /// notifies the bootstraper and yields the current task infinitely,
+    /// to let the bootstraper can abort this task.
+    pub(super) async fn check(&self, node: CertifiedNodeMessage) -> CertifiedNodeMessage {
+        let ledger_info = node.ledger_info();
+
+        self.notify_commit_proof(ledger_info).await;
+
+        if self.need_sync_for_ledger_info(ledger_info) {
+            self.bootstrap_notifier.send(node).await;
+            loop {
+                tokio::task::yield_now().await;
+            }
+        }
+        node
     }
 
     /// Fast forward in the decoupled-execution pipeline if the block exists there
-    pub async fn sync_to_highest_commit_cert(&self, ledger_info: &LedgerInfoWithSignatures) {
-        let send_commit_proof = {
-            let dag_reader = self.dag_store.read();
-            dag_reader.highest_committed_anchor_round() < ledger_info.commit_info().round()
-                && dag_reader
-                    .highest_ordered_anchor_round()
-                    .unwrap_or_default()
-                    >= ledger_info.commit_info().round()
-        };
-
+    async fn notify_commit_proof(&self, ledger_info: &LedgerInfoWithSignatures) {
         // if the anchor exists between ledger info round and highest ordered round
         // Note: ledger info round <= highest ordered round
-        if send_commit_proof {
-            self.notifier.send_commit_proof(ledger_info.clone()).await
+        if self.dag_store.read().highest_committed_anchor_round()
+            < ledger_info.commit_info().round()
+            && self
+                .dag_store
+                .read()
+                .highest_ordered_anchor_round()
+                .unwrap_or_default()
+                >= ledger_info.commit_info().round()
+        {
+            self.downstream_notifier
+                .send_commit_proof(ledger_info.clone())
+                .await
         }
     }
 
     /// Check if we're far away from this ledger info and need to sync.
     /// This ensures that the block referred by the ledger info is not in buffer manager.
-    pub fn need_sync_for_ledger_info(&self, li: &LedgerInfoWithSignatures) -> bool {
+    fn need_sync_for_ledger_info(&self, li: &LedgerInfoWithSignatures) -> bool {
         let dag_reader = self.dag_store.read();
         // check whether if DAG order round is behind the given ledger info round
         // (meaning consensus is behind) or
@@ -97,33 +94,54 @@ impl StateSyncManager {
                 + ((STATE_SYNC_WINDOW_MULTIPLIER * DAG_WINDOW) as Round)
                 < li.commit_info().round()
     }
+}
 
-    pub async fn try_sync_to_highest_ordered_anchor(
-        &self,
-        node: &CertifiedNodeMessage,
-    ) -> anyhow::Result<Option<Arc<RwLock<Dag>>>> {
-        // Check whether to actually sync
-        let commit_li = node.ledger_info();
-        if !self.need_sync_for_ledger_info(commit_li) {
-            return Ok(None);
+pub(super) struct DagStateSynchronizer {
+    epoch_state: Arc<EpochState>,
+    notifier: Arc<dyn Notifier>,
+    time_service: TimeService,
+    state_computer: Arc<dyn StateComputer>,
+    storage: Arc<dyn DAGStorage>,
+}
+
+impl DagStateSynchronizer {
+    pub fn new(
+        epoch_state: Arc<EpochState>,
+        notifier: Arc<dyn Notifier>,
+        time_service: TimeService,
+        state_computer: Arc<dyn StateComputer>,
+        storage: Arc<dyn DAGStorage>,
+    ) -> Self {
+        Self {
+            epoch_state,
+            notifier,
+            time_service,
+            state_computer,
+            storage,
         }
-
-        let dag_fetcher = Arc::new(DagFetcher::new(
-            self.epoch_state.clone(),
-            self.network.clone(),
-            self.time_service.clone(),
-        ));
-
-        self.sync_to_highest_ordered_anchor(node, dag_fetcher).await
     }
 
     /// Note: Assumes that the sync checks have been done
-    pub async fn sync_to_highest_ordered_anchor(
+    pub async fn sync_dag_to(
         &self,
         node: &CertifiedNodeMessage,
-        dag_fetcher: Arc<impl TDagFetcher>,
-    ) -> anyhow::Result<Option<Arc<RwLock<Dag>>>> {
+        dag_fetcher: impl TDagFetcher,
+        current_dag_store: Arc<RwLock<Dag>>,
+    ) -> anyhow::Result<()> {
         let commit_li = node.ledger_info();
+
+        {
+            let dag_reader = current_dag_store.read();
+            assert!(
+                dag_reader
+                    .highest_ordered_anchor_round()
+                    .unwrap_or_default()
+                    < commit_li.commit_info().round()
+                    || dag_reader.highest_committed_anchor_round()
+                        + ((STATE_SYNC_WINDOW_MULTIPLIER * DAG_WINDOW) as Round)
+                        < commit_li.commit_info().round()
+            );
+        }
 
         if commit_li.ledger_info().ends_epoch() {
             self.notifier
@@ -133,7 +151,7 @@ impl StateSyncManager {
                 ))
                 .await;
             // TODO: make sure to terminate DAG and yield to epoch manager
-            return Ok(None);
+            return Ok(());
         }
 
         // TODO: there is a case where DAG fetches missing nodes in window and a crash happens and when we restart,
@@ -179,6 +197,6 @@ impl StateSyncManager {
 
         // TODO: the caller should rebootstrap the order rule
 
-        Ok(Some(sync_dag_store))
+        Ok(())
     }
 }

--- a/consensus/src/dag/order_rule.rs
+++ b/consensus/src/dag/order_rule.rs
@@ -21,7 +21,7 @@ pub struct OrderRule {
     lowest_unordered_anchor_round: Round,
     dag: Arc<RwLock<Dag>>,
     anchor_election: Box<dyn AnchorElection>,
-    notifier: Box<dyn Notifier>,
+    notifier: Arc<dyn Notifier>,
     storage: Arc<dyn DAGStorage>,
 }
 

--- a/consensus/src/dag/order_rule.rs
+++ b/consensus/src/dag/order_rule.rs
@@ -31,7 +31,7 @@ impl OrderRule {
         latest_ledger_info: LedgerInfo,
         dag: Arc<RwLock<Dag>>,
         mut anchor_election: Box<dyn AnchorElection>,
-        notifier: Box<dyn Notifier>,
+        notifier: Arc<dyn Notifier>,
         storage: Arc<dyn DAGStorage>,
     ) -> Self {
         let committed_round = if latest_ledger_info.ends_epoch() {

--- a/consensus/src/dag/rb_handler.rs
+++ b/consensus/src/dag/rb_handler.rs
@@ -28,7 +28,7 @@ pub enum NodeBroadcastHandleError {
 pub(crate) struct NodeBroadcastHandler {
     dag: Arc<RwLock<Dag>>,
     votes_by_round_peer: BTreeMap<Round, BTreeMap<Author, Vote>>,
-    signer: ValidatorSigner,
+    signer: Arc<ValidatorSigner>,
     epoch_state: Arc<EpochState>,
     storage: Arc<dyn DAGStorage>,
     fetch_requester: Arc<dyn TFetchRequester>,
@@ -37,7 +37,7 @@ pub(crate) struct NodeBroadcastHandler {
 impl NodeBroadcastHandler {
     pub fn new(
         dag: Arc<RwLock<Dag>>,
-        signer: ValidatorSigner,
+        signer: Arc<ValidatorSigner>,
         epoch_state: Arc<EpochState>,
         storage: Arc<dyn DAGStorage>,
         fetch_requester: Arc<dyn TFetchRequester>,

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -104,7 +104,7 @@ async fn test_certified_node_handler() {
         LedgerInfo::mock_genesis(None),
         dag.clone(),
         Box::new(RoundRobinAnchorElection::new(validators)),
-        Box::new(TestNotifier { tx }),
+        Arc::new(TestNotifier { tx }),
         storage.clone(),
     );
 

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -200,8 +200,5 @@ async fn test_dag_state_sync() {
     assert_eq!(new_dag.lowest_round(), (LI_ROUNDS - DAG_WINDOW) as Round);
     assert_eq!(new_dag.highest_round(), (NUM_ROUNDS - 1) as Round);
     assert_none!(new_dag.highest_ordered_anchor_round(),);
-    assert_eq!(
-        new_dag.highest_committed_anchor_round(),
-        LI_ROUNDS as Round
-    );
+    assert_eq!(new_dag.highest_committed_anchor_round(), LI_ROUNDS as Round);
 }

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -4,7 +4,7 @@ use crate::{
     dag::{
         adapter::Notifier,
         dag_fetcher::{FetchRequestHandler, TDagFetcher},
-        dag_state_sync::DAG_WINDOW,
+        dag_state_sync::{DagStateSynchronizer, DAG_WINDOW},
         dag_store::Dag,
         storage::DAGStorage,
         tests::{dag_test::MockStorage, helpers::generate_dag_nodes},
@@ -112,24 +112,17 @@ impl Notifier for MockNotifier {
     async fn send_commit_proof(&self, _ledger_info: LedgerInfoWithSignatures) {}
 }
 
-fn setup(
-    epoch_state: Arc<EpochState>,
-    dag_store: Arc<RwLock<Dag>>,
-    storage: Arc<dyn DAGStorage>,
-) -> StateSyncManager {
-    let network = Arc::new(MockDAGNetworkSender {});
+fn setup(epoch_state: Arc<EpochState>, storage: Arc<dyn DAGStorage>) -> DagStateSynchronizer {
     let time_service = TimeService::mock();
     let state_computer = Arc::new(EmptyStateComputer {});
-    let upstream_notifier = Arc::new(MockNotifier {});
+    let downstream_notifier = Arc::new(MockNotifier {});
 
-    StateSyncManager::new(
+    DagStateSynchronizer::new(
         epoch_state,
-        network,
-        upstream_notifier,
+        downstream_notifier,
         time_service,
         state_computer,
         storage,
-        dag_store,
     )
 }
 
@@ -193,24 +186,22 @@ async fn test_dag_state_sync() {
 
     let sync_node_li = CertifiedNodeMessage::new(sync_to_node, sync_to_li);
 
-    let state_sync = setup(epoch_state.clone(), slow_dag.clone(), storage.clone());
-    let dag_fetcher = Arc::new(MockDagFetcher {
+    let state_sync = setup(epoch_state.clone(), storage.clone());
+    let dag_fetcher = MockDagFetcher {
         target_dag: fast_dag.clone(),
         epoch_state: epoch_state.clone(),
-    });
+    };
 
     let sync_result = state_sync
-        .sync_to_highest_ordered_anchor(&sync_node_li, dag_fetcher)
+        .sync_dag_to(&sync_node_li, dag_fetcher, slow_dag.clone())
         .await;
     let new_dag = sync_result.unwrap().unwrap();
 
-    let dag_reader = new_dag.read();
-
-    assert_eq!(dag_reader.lowest_round(), (LI_ROUNDS - DAG_WINDOW) as Round);
-    assert_eq!(dag_reader.highest_round(), (NUM_ROUNDS - 1) as Round);
-    assert_none!(dag_reader.highest_ordered_anchor_round(),);
+    assert_eq!(new_dag.lowest_round(), (LI_ROUNDS - DAG_WINDOW) as Round);
+    assert_eq!(new_dag.highest_round(), (NUM_ROUNDS - 1) as Round);
+    assert_none!(new_dag.highest_ordered_anchor_round(),);
     assert_eq!(
-        dag_reader.highest_committed_anchor_round(),
+        new_dag.highest_committed_anchor_round(),
         LI_ROUNDS as Round
     );
 }

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -4,7 +4,7 @@ use crate::{
     dag::{
         adapter::Notifier,
         dag_fetcher::{FetchRequestHandler, TDagFetcher},
-        dag_state_sync::{StateSyncManager, DAG_WINDOW},
+        dag_state_sync::DAG_WINDOW,
         dag_store::Dag,
         storage::DAGStorage,
         tests::{dag_test::MockStorage, helpers::generate_dag_nodes},
@@ -100,7 +100,7 @@ struct MockNotifier {}
 #[async_trait]
 impl Notifier for MockNotifier {
     fn send_ordered_nodes(
-        &mut self,
+        &self,
         _ordered_nodes: Vec<Arc<CertifiedNode>>,
         _failed_author: Vec<(Round, Author)>,
     ) -> anyhow::Result<()> {

--- a/consensus/src/dag/tests/integration_tests.rs
+++ b/consensus/src/dag/tests/integration_tests.rs
@@ -2,14 +2,12 @@
 
 use super::dag_test;
 use crate::{
-    dag::bootstrap::bootstrap_dag_for_test,
+    dag::{bootstrap::bootstrap_dag_for_test, types::CertifiedNodeMessage},
     experimental::buffer_manager::OrderedBlocks,
     network::{DAGNetworkSenderImpl, IncomingDAGRequest, NetworkSender},
     network_interface::{ConsensusMsg, ConsensusNetworkClient, DIRECT_SEND, RPC},
     network_tests::{NetworkPlayground, TwinId},
-    test_utils::{
-        consensus_runtime, EmptyStateComputer, MockPayloadManager, MockStorage,
-    },
+    test_utils::{consensus_runtime, EmptyStateComputer, MockPayloadManager, MockStorage},
 };
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::network_id::{NetworkId, PeerNetworkId};
@@ -43,7 +41,7 @@ use std::sync::Arc;
 use tokio::task::JoinHandle;
 
 struct DagBootstrapUnit {
-    nh_task_handle: JoinHandle<()>,
+    nh_task_handle: JoinHandle<CertifiedNodeMessage>,
     df_task_handle: JoinHandle<()>,
     dag_rpc_tx: aptos_channel::Sender<Author, IncomingDAGRequest>,
     network_events:

--- a/consensus/src/dag/tests/integration_tests.rs
+++ b/consensus/src/dag/tests/integration_tests.rs
@@ -8,7 +8,7 @@ use crate::{
     network_interface::{ConsensusMsg, ConsensusNetworkClient, DIRECT_SEND, RPC},
     network_tests::{NetworkPlayground, TwinId},
     test_utils::{
-        consensus_runtime, EmptyStateComputer, MockPayloadManager, MockStateComputer, MockStorage,
+        consensus_runtime, EmptyStateComputer, MockPayloadManager, MockStorage,
     },
 };
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
@@ -25,7 +25,6 @@ use aptos_network::{
     transport::ConnectionMetadata,
     ProtocolId,
 };
-use aptos_storage_interface::mock::MockDbReaderWriter;
 use aptos_time_service::TimeService;
 use aptos_types::{
     epoch_state::EpochState,
@@ -35,7 +34,7 @@ use aptos_types::{
 };
 use claims::assert_gt;
 use futures::{
-    stream::{select, AbortHandle, Select},
+    stream::{select, Select},
     StreamExt,
 };
 use futures_channel::mpsc::UnboundedReceiver;

--- a/consensus/src/dag/tests/order_rule_tests.rs
+++ b/consensus/src/dag/tests/order_rule_tests.rs
@@ -87,7 +87,7 @@ pub struct TestNotifier {
 #[async_trait]
 impl Notifier for TestNotifier {
     fn send_ordered_nodes(
-        &mut self,
+        &self,
         ordered_nodes: Vec<Arc<CertifiedNode>>,
         _failed_authors: Vec<(Round, Author)>,
     ) -> anyhow::Result<()> {
@@ -118,7 +118,7 @@ fn create_order_rule(
             ledger_info,
             dag,
             anchor_election,
-            Box::new(TestNotifier { tx }),
+            Arc::new(TestNotifier { tx }),
             Arc::new(MockStorage::new()),
         ),
         rx,

--- a/consensus/src/dag/tests/rb_handler_tests.rs
+++ b/consensus/src/dag/tests/rb_handler_tests.rs
@@ -38,6 +38,7 @@ async fn test_node_broadcast_receiver_succeed() {
         epoch: 1,
         verifier: validator_verifier.clone(),
     });
+    let signers: Vec<_> = signers.into_iter().map(Arc::new).collect();
 
     // Scenario: Start DAG from beginning
     let storage = Arc::new(MockStorage::new());
@@ -80,6 +81,7 @@ async fn test_node_broadcast_receiver_failure() {
         epoch: 1,
         verifier: validator_verifier.clone(),
     });
+    let signers: Vec<_> = signers.into_iter().map(Arc::new).collect();
 
     let mut rb_receivers: Vec<_> = signers
         .iter()
@@ -156,10 +158,12 @@ async fn test_node_broadcast_receiver_failure() {
 #[test]
 fn test_node_broadcast_receiver_storage() {
     let (signers, validator_verifier) = random_validator_verifier(4, None, false);
+    let signers: Vec<_> = signers.into_iter().map(Arc::new).collect();
     let epoch_state = Arc::new(EpochState {
         epoch: 1,
         verifier: validator_verifier,
     });
+
     let storage = Arc::new(MockStorage::new());
     let dag = Arc::new(RwLock::new(Dag::new(
         epoch_state.clone(),

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -431,12 +431,12 @@ impl CertifiedNodeMessage {
         }
     }
 
-    pub fn ledger_info(&self) -> &LedgerInfoWithSignatures {
-        &self.ledger_info
-    }
-
     pub fn certified_node(self) -> CertifiedNode {
         self.inner
+    }
+
+    pub fn ledger_info(&self) -> &LedgerInfoWithSignatures {
+        &self.ledger_info
     }
 }
 


### PR DESCRIPTION
### Description

This PR introduces the rebootstrap logic for the DAG. Essentially, when there is a need to state sync the DAG, we abort the existing handlers, return to the bootstrapper and let the bootstrapper state sync the DAG and recreate all the components and start the handlers again. This is to unify the logic such that we use the same bootstraping logic for recovery as well as state sync.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Existing Tests
