### PR TITLE
[dag] broadcast CertifiedNodeMsg with LedgerInfo

### DIFF
--- a/consensus/src/dag/adapter.rs
+++ b/consensus/src/dag/adapter.rs
@@ -280,4 +280,9 @@ impl DAGStorage for StorageAdapter {
         }
         Ok(commit_events)
     }
+
+    fn get_latest_ledger_info(&self) -> anyhow::Result<LedgerInfoWithSignatures> {
+        // TODO: use callback from notifier to cache the latest ledger info
+        self.aptos_db.get_latest_ledger_info()   
+    }    
 }

--- a/consensus/src/dag/adapter.rs
+++ b/consensus/src/dag/adapter.rs
@@ -283,6 +283,6 @@ impl DAGStorage for StorageAdapter {
 
     fn get_latest_ledger_info(&self) -> anyhow::Result<LedgerInfoWithSignatures> {
         // TODO: use callback from notifier to cache the latest ledger info
-        self.aptos_db.get_latest_ledger_info()   
-    }    
+        self.aptos_db.get_latest_ledger_info()
+    }
 }

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -21,6 +21,7 @@ use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_consensus_types::common::Author;
 use aptos_infallible::RwLock;
 use aptos_reliable_broadcast::{RBNetworkSender, ReliableBroadcast};
+use aptos_storage_interface::DbReader;
 use aptos_types::{
     epoch_state::EpochState, ledger_info::LedgerInfo, validator_signer::ValidatorSigner,
 };
@@ -38,6 +39,7 @@ pub fn bootstrap_dag(
     dag_network_sender: Arc<dyn TDAGNetworkSender>,
     time_service: aptos_time_service::TimeService,
     payload_client: Arc<dyn PayloadClient>,
+    db: Arc<dyn DbReader>,
 ) -> (
     AbortHandle,
     AbortHandle,
@@ -98,6 +100,7 @@ pub fn bootstrap_dag(
         storage.clone(),
         order_rule,
         fetch_requester.clone(),
+        db,
     );
     let rb_handler = NodeBroadcastHandler::new(
         dag.clone(),

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -21,7 +21,6 @@ use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_consensus_types::common::Author;
 use aptos_infallible::RwLock;
 use aptos_reliable_broadcast::{RBNetworkSender, ReliableBroadcast};
-use aptos_storage_interface::DbReader;
 use aptos_types::{
     epoch_state::EpochState, ledger_info::LedgerInfo, validator_signer::ValidatorSigner,
 };
@@ -39,7 +38,6 @@ pub fn bootstrap_dag(
     dag_network_sender: Arc<dyn TDAGNetworkSender>,
     time_service: aptos_time_service::TimeService,
     payload_client: Arc<dyn PayloadClient>,
-    db: Arc<dyn DbReader>,
 ) -> (
     AbortHandle,
     AbortHandle,
@@ -100,7 +98,6 @@ pub fn bootstrap_dag(
         storage.clone(),
         order_rule,
         fetch_requester.clone(),
-        db,
     );
     let rb_handler = NodeBroadcastHandler::new(
         dag.clone(),

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -21,7 +21,6 @@ use aptos_consensus_types::common::{Author, Payload};
 use aptos_infallible::RwLock;
 use aptos_logger::error;
 use aptos_reliable_broadcast::ReliableBroadcast;
-use aptos_storage_interface::DbReader;
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::{block_info::Round, epoch_state::EpochState};
 use futures::{
@@ -50,7 +49,6 @@ pub(crate) struct DagDriver {
     storage: Arc<dyn DAGStorage>,
     order_rule: OrderRule,
     fetch_requester: Arc<FetchRequester>,
-    db: Arc<dyn DbReader>,
 }
 
 impl DagDriver {
@@ -64,7 +62,6 @@ impl DagDriver {
         storage: Arc<dyn DAGStorage>,
         order_rule: OrderRule,
         fetch_requester: Arc<FetchRequester>,
-        db: Arc<dyn DbReader>,
     ) -> Self {
         let pending_node = storage
             .get_pending_node()
@@ -86,7 +83,6 @@ impl DagDriver {
             storage,
             order_rule,
             fetch_requester,
-            db,
         };
 
         // If we were broadcasting the node for the round already, resume it
@@ -156,7 +152,7 @@ impl DagDriver {
             SignatureBuilder::new(node.metadata().clone(), self.epoch_state.clone());
         let cert_ack_set = CertificateAckState::new(self.epoch_state.verifier.len());
         let latest_ledger_info = self
-            .db
+            .storage
             .get_latest_ledger_info()
             .expect("latest ledger info must exist");
         let task = self

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -92,7 +92,7 @@ impl NetworkHandler {
                 .map(|r| r.into()),
             DAGMessage::CertifiedNodeMsg(node) => node
                 .verify(&self.epoch_state.verifier)
-                .and_then(|_| self.dag_driver.process(node))
+                .and_then(|_| self.dag_driver.process(node.certified_node()))
                 .map(|r| r.into()),
             DAGMessage::FetchRequest(request) => request
                 .verify(&self.epoch_state.verifier)

--- a/consensus/src/dag/dag_handler.rs
+++ b/consensus/src/dag/dag_handler.rs
@@ -90,9 +90,9 @@ impl NetworkHandler {
                 .verify(&self.epoch_state.verifier)
                 .and_then(|_| self.node_receiver.process(node))
                 .map(|r| r.into()),
-            DAGMessage::CertifiedNodeMsg(node) => node
+            DAGMessage::CertifiedNodeMsg(certified_node_msg) => certified_node_msg
                 .verify(&self.epoch_state.verifier)
-                .and_then(|_| self.dag_driver.process(node.certified_node()))
+                .and_then(|_| self.dag_driver.process(certified_node_msg.certified_node()))
                 .map(|r| r.into()),
             DAGMessage::FetchRequest(request) => request
                 .verify(&self.epoch_state.verifier)

--- a/consensus/src/dag/storage.rs
+++ b/consensus/src/dag/storage.rs
@@ -5,6 +5,7 @@ use super::{types::Vote, NodeId};
 use crate::dag::{CertifiedNode, Node};
 use aptos_consensus_types::common::Author;
 use aptos_crypto::HashValue;
+use aptos_types::ledger_info::LedgerInfoWithSignatures;
 
 pub struct CommitEvent {
     node_id: NodeId,
@@ -48,4 +49,6 @@ pub trait DAGStorage: Send + Sync {
     fn delete_ordered_anchor_ids(&self, node_ids: Vec<NodeId>) -> anyhow::Result<()>;
 
     fn get_latest_k_committed_events(&self, k: u64) -> anyhow::Result<Vec<CommitEvent>>;
+
+    fn get_latest_ledger_info(&self) -> anyhow::Result<LedgerInfoWithSignatures>;
 }

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -114,7 +114,7 @@ async fn test_certified_node_handler() {
         dag.clone(),
         aptos_time_service::TimeService::mock(),
     );
-    let fetch_requester = Arc::new(fetch_requester); 
+    let fetch_requester = Arc::new(fetch_requester);
 
     let mut driver = DagDriver::new(
         signers[0].author(),

--- a/consensus/src/dag/tests/dag_test.rs
+++ b/consensus/src/dag/tests/dag_test.rs
@@ -12,8 +12,8 @@ use crate::dag::{
 use aptos_crypto::HashValue;
 use aptos_infallible::Mutex;
 use aptos_types::{
-    epoch_state::EpochState, validator_signer::ValidatorSigner,
-    validator_verifier::random_validator_verifier,
+    epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
+    validator_signer::ValidatorSigner, validator_verifier::random_validator_verifier,
 };
 use std::{collections::HashMap, sync::Arc};
 
@@ -21,6 +21,7 @@ pub struct MockStorage {
     node_data: Mutex<Option<Node>>,
     vote_data: Mutex<HashMap<NodeId, Vote>>,
     certified_node_data: Mutex<HashMap<HashValue, CertifiedNode>>,
+    latest_ledger_info: Option<LedgerInfoWithSignatures>,
 }
 
 impl MockStorage {
@@ -29,6 +30,16 @@ impl MockStorage {
             node_data: Mutex::new(None),
             vote_data: Mutex::new(HashMap::new()),
             certified_node_data: Mutex::new(HashMap::new()),
+            latest_ledger_info: None,
+        }
+    }
+
+    pub fn new_with_ledger_info(ledger_info: LedgerInfoWithSignatures) -> Self {
+        Self {
+            node_data: Mutex::new(None),
+            vote_data: Mutex::new(HashMap::new()),
+            certified_node_data: Mutex::new(HashMap::new()),
+            latest_ledger_info: Some(ledger_info),
         }
     }
 }
@@ -101,6 +112,12 @@ impl DAGStorage for MockStorage {
 
     fn get_latest_k_committed_events(&self, _k: u64) -> anyhow::Result<Vec<CommitEvent>> {
         Ok(vec![])
+    }
+
+    fn get_latest_ledger_info(&self) -> anyhow::Result<LedgerInfoWithSignatures> {
+        self.latest_ledger_info
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("ledger info not set"))
     }
 }
 

--- a/consensus/src/dag/tests/integration_tests.rs
+++ b/consensus/src/dag/tests/integration_tests.rs
@@ -26,8 +26,9 @@ use aptos_network::{
 use aptos_time_service::TimeService;
 use aptos_types::{
     epoch_state::EpochState,
+    ledger_info::generate_ledger_info_with_sig,
     validator_signer::ValidatorSigner,
-    validator_verifier::{random_validator_verifier, ValidatorVerifier}, ledger_info::generate_ledger_info_with_sig,
+    validator_verifier::{random_validator_verifier, ValidatorVerifier},
 };
 use claims::assert_gt;
 use futures::{

--- a/consensus/src/dag/tests/integration_tests.rs
+++ b/consensus/src/dag/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 // Copyright © Aptos Foundation
 
-use super::{dag_driver_tests::MockDbReader, dag_test};
+use super::dag_test;
 use crate::{
     dag::bootstrap::bootstrap_dag,
     experimental::buffer_manager::OrderedBlocks,
@@ -26,9 +26,8 @@ use aptos_network::{
 use aptos_time_service::TimeService;
 use aptos_types::{
     epoch_state::EpochState,
-    ledger_info::generate_ledger_info_with_sig,
     validator_signer::ValidatorSigner,
-    validator_verifier::{random_validator_verifier, ValidatorVerifier},
+    validator_verifier::{random_validator_verifier, ValidatorVerifier}, ledger_info::generate_ledger_info_with_sig,
 };
 use claims::assert_gt;
 use futures::{
@@ -64,15 +63,12 @@ impl DagBootstrapUnit {
             epoch,
             verifier: storage.get_validator_set().into(),
         };
-        let dag_storage = dag_test::MockStorage::new();
+        let ledger_info = generate_ledger_info_with_sig(&all_signers, storage.get_ledger_info());
+        let dag_storage = dag_test::MockStorage::new_with_ledger_info(ledger_info);
 
         let network = Arc::new(DAGNetworkSenderImpl::new(Arc::new(network)));
 
         let payload_client = Arc::new(MockPayloadManager::new(None));
-
-        let mock_storage = Arc::new(MockDbReader {
-            ledger_info: generate_ledger_info_with_sig(&all_signers, storage.get_ledger_info()),
-        });
 
         let (nh_abort_handle, df_abort_handle, dag_rpc_tx, ordered_nodes_rx) = bootstrap_dag(
             self_peer,
@@ -84,7 +80,6 @@ impl DagBootstrapUnit {
             network.clone(),
             time_service,
             payload_client,
-            mock_storage,
         );
 
         (

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -453,7 +453,7 @@ impl TDAGMessage for CertifiedNodeMessage {
         self.inner.verify(verifier)?;
 
         self.ledger_info
-            .verify_signatures(&verifier)
+            .verify_signatures(verifier)
             .map_err(|e| anyhow::anyhow!("unable to verify ledger info: {}", e))
     }
 }

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -399,6 +399,14 @@ impl CertifiedNode {
     pub fn certificate(&self) -> NodeCertificate {
         NodeCertificate::new(self.node.metadata.clone(), self.signatures.clone())
     }
+
+    pub fn verify(&self, verifier: &ValidatorVerifier) -> anyhow::Result<()> {
+        ensure!(self.digest() == self.calculate_digest(), "invalid digest");
+
+        verifier
+            .verify_multi_signatures(self.metadata(), self.certificate().signatures())
+            .map_err(|e| anyhow::anyhow!("unable to verify: {}", e))
+    }
 }
 
 impl Deref for CertifiedNode {
@@ -406,16 +414,6 @@ impl Deref for CertifiedNode {
 
     fn deref(&self) -> &Self::Target {
         &self.node
-    }
-}
-
-impl TDAGMessage for CertifiedNode {
-    fn verify(&self, verifier: &ValidatorVerifier) -> anyhow::Result<()> {
-        ensure!(self.digest() == self.calculate_digest(), "invalid digest");
-
-        verifier
-            .verify_multi_signatures(self.metadata(), self.certificate().signatures())
-            .map_err(|e| anyhow::anyhow!("unable to verify: {}", e))
     }
 }
 
@@ -436,6 +434,10 @@ impl CertifiedNodeMessage {
     pub fn ledger_info(&self) -> &LedgerInfoWithSignatures {
         &self.ledger_info
     }
+
+    pub fn certified_node(self) -> CertifiedNode {
+        self.inner
+    }
 }
 
 impl Deref for CertifiedNodeMessage {
@@ -443,6 +445,16 @@ impl Deref for CertifiedNodeMessage {
 
     fn deref(&self) -> &Self::Target {
         &self.inner
+    }
+}
+
+impl TDAGMessage for CertifiedNodeMessage {
+    fn verify(&self, verifier: &ValidatorVerifier) -> anyhow::Result<()> {
+        self.inner.verify(verifier)?;
+
+        self.ledger_info
+            .verify_signatures(&verifier)
+            .map_err(|e| anyhow::anyhow!("unable to verify ledger info: {}", e))
     }
 }
 
@@ -533,7 +545,7 @@ impl CertifiedAck {
 impl BroadcastStatus<DAGMessage> for CertificateAckState {
     type Ack = CertifiedAck;
     type Aggregated = ();
-    type Message = CertifiedNode;
+    type Message = CertifiedNodeMessage;
 
     fn add(&mut self, peer: Author, _ack: Self::Ack) -> anyhow::Result<Option<Self::Aggregated>> {
         self.received.insert(peer);
@@ -647,7 +659,7 @@ impl core::fmt::Debug for DAGNetworkMessage {
 pub enum DAGMessage {
     NodeMsg(Node),
     VoteMsg(Vote),
-    CertifiedNodeMsg(CertifiedNode),
+    CertifiedNodeMsg(CertifiedNodeMessage),
     CertifiedAckMsg(CertifiedAck),
     FetchRequest(RemoteFetchRequest),
     FetchResponse(FetchResponse),


### PR DESCRIPTION
### Description

This PR enables broadcasting latest ledger info with the CertifiedNode for state syncing. It obtains the ledger info from the storage adapter.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Fixed unit tests.
