### PR TITLE
[CLI] Updated rotated key to save without default profile

### DIFF
--- a/crates/aptos/src/account/key_rotation.rs
+++ b/crates/aptos/src/account/key_rotation.rs
@@ -232,25 +232,25 @@ impl CliCommand<RotateSummary> for RotateKey {
             Err(_) => {
                 let (rest_url, faucet_url) = if let Some(url) = self.txn_options.rest_options.url {
                     let url_str = url.to_string();
-                    if url_str.contains("testnet") {
+                    if url_str == "https://fullnode.testnet.aptoslabs.com" {
                         (
                             Some(url_str),
                             Some("https://faucet.testnet.aptoslabs.com".to_string()),
                         )
-                    } else if url_str.contains("devnet") {
+                    } else if url_str == "https://fullnode.devnet.aptoslabs.com" {
                         (
                             Some(url_str),
                             Some("https://faucet.devnet.aptoslabs.com".to_string()),
                         )
-                    } else if url_str.contains("localhost") {
-                        (Some(url_str), Some("http://localhost:8081".to_string()))
-                    } else {
-                        // no faucet for mainnet
+                    } else if url_str == "https://fullnode.mainnet.aptoslabs.com" {
                         (Some(url.to_string()), None)
+                    } else {
+                        // Default to localhost
+                        (Some(url_str), Some("http://localhost:8081".to_string()))
                     }
                 } else {
                     return Err(CliError::CommandArgumentError(
-                        "Either [--url or --profile] argument is needed".to_string(),
+                        "Either [--url or --profile] argument is required".to_string(),
                     ));
                 };
                 ProfileConfig {


### PR DESCRIPTION
### Description

This resolves #9547 

Problem:
If user try to rotate key without specifying a profile and there is not default profile defined. They will see error similar to following

```
{
  "Error": "Unable to find config default, have you run `aptos init`?"
}
```

After the fix:
We are now expecting the user either have to provide an `url` or `profile`. When `url` is used for rotating key, the `fauceet_url` is derived based on the url (mainnet, devnet, testnet) is used.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Make sure rotated-key can be saved into new profile without default profile
```
➜  aptos-core git:(main) ✗ aptos-debug account rotate-key --private-key 0x20b7ee0b22167a1f04b706e559fc9114cb4c4e6a517ee5d19b8b596eda0c8b6b --new-private-key 3A5BB02E39212E71B66F8508464B671BA168C34C3A905A960C72C3C9177E7961 --url https://fullnode.devnet.aptoslabs.com
Do you want to submit a transaction for a range of [52000 - 78000] Octas at a gas unit price of 100 Octas? [yes/no] >
yes
{
  "transaction_hash": "0x11e8e094b636887aa64c6d8e144d43104ed8f114e4364e4b311a25dcaede08fc",
  "gas_used": 521,
  "gas_unit_price": 100,
  "sender": "cdf94c25e63ebb8ddb11455d7bcde44ecc6162f7988d5198d3a5cf7277a86b5a",
  "sequence_number": 0,
  "success": true,
  "timestamp_us": 1694124220968518,
  "version": 5199209,
  "vm_status": "Executed successfully"
}
Do you want to create a profile for the new key? [yes/no] >
yes
Enter the name for the profile
rotated
Profile name: rotated
Profile rotated is saved.
{
  "Result": {
    "message": "Profile rotated is saved.",
    "transaction": {
      "transaction_hash": "0x11e8e094b636887aa64c6d8e144d43104ed8f114e4364e4b311a25dcaede08fc",
      "gas_used": 521,
      "gas_unit_price": 100,
      "sender": "cdf94c25e63ebb8ddb11455d7bcde44ecc6162f7988d5198d3a5cf7277a86b5a",
      "sequence_number": 0,
      "success": true,
      "timestamp_us": 1694124220968518,
      "version": 5199209,
      "vm_status": "Executed successfully"
    }
  }
}
```
